### PR TITLE
Put comscore behind consent

### DIFF
--- a/common/app/views/fragments/analytics/comscore.scala.html
+++ b/common/app/views/fragments/analytics/comscore.scala.html
@@ -6,7 +6,7 @@
 @if(ComscoreSwitch.isSwitchedOn) {
     <noscript>
         @defining(getContent(page).map(_.tags.keywords.map(_.name)).map(_.mkString(","))) { keywords =>
-            <img src="https://sb.scorecardresearch.com/p?c1=2&c2=6035250&cv=2.0&cj=1&comscorekw=@keywords.map({kw => URLEncoder.encode(kw, "UTF-8")})" />
+            <img src="https://sb.scorecardresearch.com/p?c1=2&c2=6035250&cv=2.0&cj=1&cs_ucfr=0&comscorekw=@keywords.map({kw => URLEncoder.encode(kw, "UTF-8")})" />
         }
     </noscript>
 }

--- a/static/src/javascripts/projects/commercial/modules/comscore.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.js
@@ -18,13 +18,12 @@ const comscoreC2 = '6035250';
 let initialised = false;
 
 const getGlobals = (
-    consentState: boolean | null,
+    consentState: boolean,
     keywords: string
 ): comscoreGlobals => {
     const globals: comscoreGlobals = {
         c1: comscoreC1,
         c2: comscoreC2,
-        // flowlint-next-line sketchy-null-bool:off
         cs_ucfr: consentState ? '1' : '0',
     };
 
@@ -42,7 +41,7 @@ const initOnConsent = (state: boolean | null) => {
 
         // eslint-disable-next-line no-underscore-dangle
         window._comscore.push(
-            getGlobals(state, config.get('page.keywords', ''))
+            getGlobals(!!state, config.get('page.keywords', ''))
         );
 
         loadScript(comscoreSrc, { id: 'comscore', async: true });

--- a/static/src/javascripts/projects/commercial/modules/comscore.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.spec.js
@@ -1,7 +1,14 @@
 // @flow
+import { onGuConsentNotification as onGuConsentNotification_ } from '@guardian/consent-management-platform';
 import { loadScript } from 'lib/load-script';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { init, _ } from './comscore';
+
+const onGuConsentNotification: any = onGuConsentNotification_;
+
+jest.mock('@guardian/consent-management-platform', () => ({
+    onGuConsentNotification: jest.fn(),
+}));
 
 jest.mock('lib/load-script', () => ({
     loadScript: jest.fn(() => Promise.resolve()),
@@ -13,51 +20,88 @@ jest.mock('common/modules/commercial/commercial-features', () => ({
     },
 }));
 
-const getComscoreScripTags = (): NodeList<HTMLElement> =>
-    document.querySelectorAll('script#comscore');
-
 describe('comscore init', () => {
     it('should do nothing if the comscore is disabled in commercial features', () => {
         commercialFeatures.comscore = false;
         init();
 
-        const comscoreTags = getComscoreScripTags();
-        expect(comscoreTags.length).toBe(0);
+        expect(onGuConsentNotification).not.toBeCalled();
     });
 
-    it('should call loadScript with the expected parameters if enabled in commercial features', () => {
+    it('should register a callback with onGuConsentNotification if enabled in commercial features', () => {
         commercialFeatures.comscore = true;
         init();
+
+        expect(onGuConsentNotification).toBeCalledWith(
+            'performance',
+            _.initOnConsent
+        );
+    });
+});
+
+describe('comscore initOnConsent', () => {
+    it('should call loadScript with the expected parameters', () => {
+        _.initOnConsent(true);
 
         expect(loadScript).toBeCalledWith(_.comscoreSrc, {
             id: 'comscore',
             async: true,
         });
     });
+
+    it('should call loadScript exactly once regardless of how many times it runs', () => {
+        _.initOnConsent(true);
+        _.initOnConsent(true);
+        _.initOnConsent(true);
+
+        // $FlowFixMe
+        expect(loadScript).toBeCalledTimes(1);
+    });
 });
 
 describe('comscore getGlobals', () => {
     it('return an object with the c1 and c2 properties correctly set when called with "Network Front" as keywords', () => {
         const expectedGlobals = { c1: _.comscoreC1, c2: _.comscoreC2 };
-        expect(_.getGlobals('Network Front')).toMatchObject(expectedGlobals);
+        expect(_.getGlobals(true, 'Network Front')).toMatchObject(
+            expectedGlobals
+        );
     });
 
     it('return an object with the c1 and c2 properties correctly set when called with non-"Network Front" as keywords', () => {
         const expectedGlobals = { c1: _.comscoreC1, c2: _.comscoreC2 };
-        expect(_.getGlobals('')).toMatchObject(expectedGlobals);
+        expect(_.getGlobals(true, '')).toMatchObject(expectedGlobals);
     });
 
     it('returns an object with no comscorekw variable set when called with "Network Front" as keywords', () => {
-        const comscoreGlobals = Object.keys(_.getGlobals('Network Front'));
+        const comscoreGlobals = Object.keys(
+            _.getGlobals(true, 'Network Front')
+        );
         expect(comscoreGlobals).not.toContain('comscorekw');
     });
 
-    it('returns an object with the correct comscorekw variable set', () => {
-        const keywords = 'These are the best keywords The greatest!';
+    it('returns an object with the correct comscorekw variable set when called with "Network Front" as keywords', () => {
+        const keywords = 'These are the best keywords. The greatest!';
 
-        expect(_.getGlobals('')).toMatchObject({ comscorekw: '' });
-        expect(_.getGlobals(keywords)).toMatchObject({
+        expect(_.getGlobals(true, keywords)).toMatchObject({
             comscorekw: keywords,
+        });
+    });
+
+    it('returns an object with the correct cs_ucfr variable set when calleed with consent sate as true', () => {
+        expect(_.getGlobals(true, '')).toMatchObject({
+            cs_ucfr: '1',
+        });
+    });
+
+    it('returns an object with the correct cs_ucfr variable set when calleed with consent sate as false', () => {
+        expect(_.getGlobals(false, '')).toMatchObject({
+            cs_ucfr: '0',
+        });
+    });
+
+    it('returns an object with the correct cs_ucfr variable set when calleed with consent sate as null', () => {
+        expect(_.getGlobals(null, '')).toMatchObject({
+            cs_ucfr: '0',
         });
     });
 });

--- a/static/src/javascripts/projects/commercial/modules/comscore.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.spec.js
@@ -98,10 +98,4 @@ describe('comscore getGlobals', () => {
             cs_ucfr: '0',
         });
     });
-
-    it('returns an object with the correct cs_ucfr variable set when calleed with consent sate as null', () => {
-        expect(_.getGlobals(null, '')).toMatchObject({
-            cs_ucfr: '0',
-        });
-    });
 });


### PR DESCRIPTION
## What does this change?
Following the comscore migration from server-side to client-side (https://github.com/guardian/frontend/pull/22393) this PR puts the comscore code behind a consent check. It now runs a slightly different version of the script depending on whether or not the user has consented to the _performance_ PECR purpose, according to its internal categorisation (https://docs.google.com/spreadsheets/d/1sgE3dxBKxmZaKhc8ogjOO4gMjHbgU4P-M_4rIXWZLws). It also updates comscore unit testing.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)