### PR TITLE
Add Guardian Puzzles app

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -195,6 +195,7 @@ private object NavLinks {
   val discountCodes = NavLink("Discount Codes", s"https://discountcode.theguardian.com", classList = Seq("js-discount-code-link")) // this gets manipulated client side in navigation.js
   val discountCoupons = NavLink("Coupons", s"https://discountcode.theguardian.com", classList = Seq("js-discount-code-link")) // this gets manipulated client side in navigation.js
   val guardianLive = NavLink("Live events", "https://membership.theguardian.com/events?INTCMP=live_uk_header_dropdown")
+  val guardianPuzzlesApp = NavLink("Guardian Puzzles app", s"https://puzzles.theguardian.com/download")
   val guardianMasterClasses = NavLink("Guardian Masterclasses", "/guardian-masterclasses",
     children = List(
       NavLink("Journalism", "/guardian-masterclasses/journalism"),
@@ -521,24 +522,28 @@ private object NavLinks {
     digitalNewspaperArchive,
     printShop,
     ukPatrons,
-    discountCodes
+    discountCodes,
+    guardianPuzzlesApp
   )
   val auBrandExtensions = List(
     auEvents,
     digitalNewspaperArchive,
-    discountCodes
+    discountCodes,
+    guardianPuzzlesApp
   )
   val usBrandExtensions= List(
     jobs.copy(url = jobs.url + "?INTCMP=jobs_us_web_newheader_dropdown"),
     digitalNewspaperArchive,
-    discountCoupons
+    discountCoupons,
+    guardianPuzzlesApp
   )
   val intBrandExtensions = List(
     jobs.copy(url = jobs.url + "?INTCMP=jobs_int_web_newheader_dropdown"),
     dating.copy(url = dating.url + "?INTCMP=soulmates_int_web_newheader_dropdown"),
     holidays.copy(url = holidays.url + "?INTCMP=holidays_int_web_newheader"),
     digitalNewspaperArchive,
-    discountCodes
+    discountCodes,
+    guardianPuzzlesApp
   )
 
   // Tertiary Navigation


### PR DESCRIPTION
## What does this change?

Adds Guardian Puzzles app to the Navigation brand links for all editions. Currently no tracking query params.

![image](https://user-images.githubusercontent.com/638051/76977524-547acc00-692d-11ea-9edf-33082cdf2aa1.png)


## Does this change need to be reproduced in dotcom-rendering ?

Automatically reflected.

## What is the value of this and can you measure success?

Money, visit increases.

## Checklist

### Does this affect other platforms?

- [X] AMP Will automatically be update
- [ ] Apps maybe @davidfurey @alexduf ?

### Tested

- [x] Locally
