### PR TITLE
Pre-contribution reminder round 2

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -8,11 +8,11 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-contributions-epic-precontribution-reminder-round-one",
+    "ab-contributions-epic-precontribution-reminder-round-two",
     "Test the effect of the reminder on conversion rate",
     owners = Seq(Owner.withGithub("jlieb10")),
     safeState = Off,
-    sellByDate = new LocalDate(2020, 4, 1),
+    sellByDate = new LocalDate(2020, 5, 1),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -12,7 +12,7 @@ trait ABTestSwitches {
     "Test the effect of the reminder on conversion rate",
     owners = Seq(Owner.withGithub("jlieb10")),
     safeState = Off,
-    sellByDate = new LocalDate(2020, 5, 1),
+    sellByDate = new LocalDate(2020, 7, 1),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -32,7 +32,7 @@ declare type EpicVariant = Variant & {
     showTicker: boolean,
     showReminderFields?: ReminderFields | null,
 
-    buttonTemplate?: (primaryCta: EpicCta, secondaryCta?: EpicCta) => string,
+    buttonTemplate?: (primaryCta: EpicCta, secondaryCta?: EpicCta, reminderCta?: ReminderFields) => string,
     ctaText?: string,
     secondaryCta?: EpicCta,
     copy?: AcquisitionsEpicTemplateCopy,
@@ -102,7 +102,7 @@ declare type InitEpicABTestVariant = {
     sections?: string[],
     excludedTagIds?: string[],
     excludedSections?: string[],
-    buttonTemplate?: (primaryCta: EpicCta, secondaryCta?: EpicCta) => string,
+    buttonTemplate?: (primaryCta: EpicCta, secondaryCta?: EpicCta, reminderCta?: ReminderFields) => string,
     ctaText?: string,
     secondaryCta?: EpicCta,
     copy?: AcquisitionsEpicTemplateCopy,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -293,7 +293,6 @@ const setupOnView = (
         }
 
         if (showReminderFields) {
-            console.log('show reminder fields');
             const htmlElements = getFields();
             if (htmlElements) {
                 epicReminderEmailSignup(htmlElements);

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -108,7 +108,8 @@ const controlTemplate: EpicTemplate = (
                       url: variant.supportURL,
                       ctaText: variant.ctaText || 'Support The Guardian',
                   },
-                  variant.secondaryCta
+                  variant.secondaryCta,
+                  variant.showReminderFields
               )
             : undefined,
         epicClassNames: variant.classNames,
@@ -292,6 +293,7 @@ const setupOnView = (
         }
 
         if (showReminderFields) {
+            console.log('show reminder fields');
             const htmlElements = getFields();
             if (htmlElements) {
                 epicReminderEmailSignup(htmlElements);

--- a/static/src/javascripts/projects/common/modules/commercial/epic-reminder-email-signup.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic-reminder-email-signup.js
@@ -16,6 +16,7 @@ type Fields = {
     closeButton: HTMLElement,
     reminderPrompt: HTMLElement,
     reminderToggle: HTMLInputElement,
+    epicButtons: HTMLElement,
 };
 
 const isValidEmail = (email: string) => {
@@ -33,10 +34,13 @@ const getFields = (): ?Fields => {
     const titleField = document.querySelector('.epic-reminder__form-title');
     const thankYouText = document.querySelector('.epic-reminder__thank-you');
     const closeButton = document.querySelector('.epic-reminder__close-button');
-    const reminderPrompt = document.querySelector('.epic-reminder__prompt');
+    const reminderPrompt = document.querySelector(
+        '.component-button--reminder-prompt'
+    );
     const reminderToggle = document.querySelector(
         '.epic-reminder__reveal-reminder'
     );
+    const epicButtons = document.querySelector('.contributions__buttons');
 
     if (
         helpText &&
@@ -48,6 +52,7 @@ const getFields = (): ?Fields => {
         closeButton &&
         reminderPrompt &&
         reminderToggle &&
+        epicButtons &&
         submitButton instanceof HTMLButtonElement &&
         emailInput instanceof HTMLInputElement &&
         reminderToggle instanceof HTMLInputElement
@@ -68,6 +73,7 @@ const getFields = (): ?Fields => {
             closeButton,
             reminderPrompt,
             reminderToggle,
+            epicButtons,
         };
     }
 };

--- a/static/src/javascripts/projects/common/modules/commercial/epic-reminder-email-signup.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic-reminder-email-signup.js
@@ -165,10 +165,12 @@ const epicReminderEmailSignup = (fields: Fields) => {
     // can be used either in the case that a user clicks or a user
     // hits enter on their keyboard
     const sendPromptClickEvent = () => {
-        const ctaForAnalytics = fields.reminderPrompt
-            .getAttribute('data-cta-copy')
-            .toLowerCase()
-            .replace(/\s/g, '-');
+        const ctaAttribute = fields.reminderPrompt.getAttribute(
+            'data-cta-copy'
+        );
+        const ctaForAnalytics = ctaAttribute
+            ? ctaAttribute.toLowerCase().replace(/\s/g, '-')
+            : '';
 
         submitClickEvent({
             component: {

--- a/static/src/javascripts/projects/common/modules/commercial/epic-reminder-email-signup.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic-reminder-email-signup.js
@@ -102,7 +102,7 @@ const epicReminderEmailSignup = (fields: Fields) => {
                 fields.formWrapper.style.display = 'none';
                 fields.closeButton.style.display = 'none';
                 fields.titleField.innerHTML =
-                    'Thank you! Your support is so valuable.';
+                    'Thank you! Your reminder is set.';
                 break;
             case 'failure':
                 fields.submitButton.innerHTML = 'Something went wrong';
@@ -165,10 +165,25 @@ const epicReminderEmailSignup = (fields: Fields) => {
     // can be used either in the case that a user clicks or a user
     // hits enter on their keyboard
     const sendPromptClickEvent = () => {
+        const ctaForAnalytics = fields.reminderPrompt
+            .getAttribute('data-cta-copy')
+            .toLowerCase()
+            .replace(/\s/g, '-');
+
         submitClickEvent({
             component: {
                 componentType: 'ACQUISITIONS_OTHER',
                 id: 'precontribution-reminder-prompt-clicked',
+            },
+        });
+
+        // For second round of testing, the events will be either (tested):
+        // precontribution-reminder-prompt-copy-remind-me-in-july or
+        // precontribution-reminder-prompt-copy-support-us-later
+        submitClickEvent({
+            component: {
+                componentType: 'ACQUISITIONS_OTHER',
+                id: `precontribution-reminder-prompt-copy-${ctaForAnalytics}`,
             },
         });
     };

--- a/static/src/javascripts/projects/common/modules/commercial/epic-reminder-email-signup.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic-reminder-email-signup.js
@@ -16,7 +16,6 @@ type Fields = {
     closeButton: HTMLElement,
     reminderPrompt: HTMLElement,
     reminderToggle: HTMLInputElement,
-    epicButtons: HTMLElement,
 };
 
 const isValidEmail = (email: string) => {
@@ -40,7 +39,6 @@ const getFields = (): ?Fields => {
     const reminderToggle = document.querySelector(
         '.epic-reminder__reveal-reminder'
     );
-    const epicButtons = document.querySelector('.contributions__buttons');
 
     if (
         helpText &&
@@ -52,7 +50,6 @@ const getFields = (): ?Fields => {
         closeButton &&
         reminderPrompt &&
         reminderToggle &&
-        epicButtons &&
         submitButton instanceof HTMLButtonElement &&
         emailInput instanceof HTMLInputElement &&
         reminderToggle instanceof HTMLInputElement
@@ -73,7 +70,6 @@ const getFields = (): ?Fields => {
             closeButton,
             reminderPrompt,
             reminderToggle,
-            epicButtons,
         };
     }
 };

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
@@ -47,7 +47,9 @@ export const epicButtonsTemplate = (
 
     const reminderButton = reminderCta
         ? `<label for="epic-reminder__reveal-reminder" class="epic-reminder__prompt-label">
-            <div tabindex="0" class="component-button component-button--greyHollow component-button--greyHollow--for-epic component-button--reminder-prompt" role="checkbox">
+            <div data-cta-copy="${
+                reminderCta.reminderCTA
+            }" tabindex="0" class="component-button component-button--greyHollow component-button--greyHollow--for-epic component-button--reminder-prompt" role="checkbox">
                     ${reminderCta.reminderCTA}
             </div>
         </label>`

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
@@ -49,7 +49,7 @@ export const epicButtonsTemplate = (
         ? `<label for="epic-reminder__reveal-reminder" class="epic-reminder__prompt-label">
             <div data-cta-copy="${
                 reminderCta.reminderCTA
-            }" tabindex="0" class="component-button component-button--greyHollow component-button--greyHollow--for-epic component-button--reminder-prompt" role="checkbox">
+            }" tabindex="0" class="component-button component-button--greyHollow component-button--greyHollow--for-epic component-button--reminder-prompt contributions__secondary-button contributions__secondary-button--epic" role="checkbox">
                     ${reminderCta.reminderCTA}
             </div>
         </label>`

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
@@ -1,9 +1,11 @@
 // @flow
 import { paymentMethodLogosTemplate } from 'common/modules/commercial/templates/payment-method-logos-template';
+import type { ReminderFields } from 'common/modules/commercial/templates/acquisitions-epic-reminder';
 
 export const epicButtonsTemplate = (
     primaryCta: EpicCta,
-    secondaryCta?: EpicCta
+    secondaryCta?: EpicCta,
+    reminderCta?: ReminderFields
 ) => {
     const supportButtonSupport = `
         <div>
@@ -43,10 +45,24 @@ export const epicButtonsTemplate = (
             </a>`
         : '';
 
+    const reminderButton = reminderCta
+        ? `<label for="epic-reminder__reveal-reminder" class="epic-reminder__prompt-label">
+            <div tabindex="0" class="component-button component-button--greyHollow component-button--greyHollow--for-epic component-button--reminder-prompt" role="checkbox">
+                    ${reminderCta.reminderCTA}
+            </div>
+        </label>`
+        : '';
+
+    const reminderInput = reminderCta
+        ? `<input type="checkbox" id="epic-reminder__reveal-reminder" class="epic-reminder__reveal-reminder" />`
+        : '';
+
     return `
+        ${reminderInput}
         <div class="contributions__buttons">
             ${supportButtonSupport}
             ${secondaryButton}
+            ${reminderButton}
             ${paymentMethodLogosTemplate(
                 'contributions__payment-logos contributions__contribute--epic-member'
             )}

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
@@ -63,6 +63,7 @@ export const acquisitionsEpicControlTemplate = ({
             ${buttonTemplate || ''}
 
             ${footer ? buildFooter(footer) : ''}
+
             ${
                 showReminderFields
                     ? acquisitionsEpicReminderTemplate(showReminderFields)

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-reminder.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-reminder.js
@@ -54,7 +54,7 @@ export const acquisitionsEpicReminderTemplate = (
             <div class="epic-reminder__thank-you">
                 We will be in touch to invite you to contribute. Look out for a message in your inbox in ${
                     reminderFields.reminderDateAsString
-                }. If you have any questions about contributing, please <a href="mailto:contribution.support@theguardian.com">contact us</a>.
+                }. If you have any questions about contributing, please <a href="mailto:contribution.support@theguardian.com">contact us here</a>.
             </div>
         </div>
     </div>

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-reminder.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-reminder.js
@@ -2,6 +2,7 @@
 import closeCentralIcon from 'svgs/icon/close-central.svg';
 
 export type ReminderFields = {
+    reminderCTA: string,
     reminderDate: string,
     reminderDateAsString: string,
 };
@@ -15,7 +16,7 @@ export const acquisitionsEpicReminderTemplate = (
         <label for="epic-reminder__reveal-reminder" class="epic-reminder__prompt-label">
             <div class="epic-reminder__prompt">
                 <span tabindex="0" class="epic-reminder__prompt-text" role="checkbox">
-                    Not a good time? Remind me later
+                    ${reminderFields.reminderCTA}
                 </span>
             </div>
         </label>

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-reminder.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-reminder.js
@@ -11,16 +11,6 @@ export const acquisitionsEpicReminderTemplate = (
     reminderFields: ReminderFields
 ) => `
     <div id="epic-reminder" class="js-epic-reminder epic-reminder">
-        <input type="checkbox" id="epic-reminder__reveal-reminder" class="epic-reminder__reveal-reminder" />
-
-        <label for="epic-reminder__reveal-reminder" class="epic-reminder__prompt-label">
-            <div class="epic-reminder__prompt">
-                <span tabindex="0" class="epic-reminder__prompt-text" role="checkbox">
-                    ${reminderFields.reminderCTA}
-                </span>
-            </div>
-        </label>
-
         <div class="epic-reminder__signup">
             <label for="epic-reminder__reveal-reminder" class="epic-reminder__close-button-label">
                 <div class="epic-reminder__close-button" tabindex="0">
@@ -45,7 +35,7 @@ export const acquisitionsEpicReminderTemplate = (
                             <button data-reminder-date="${
                                 reminderFields.reminderDate
                             }" type="submit" class="epic-reminder__submit-button component-button component-button--hasicon-right" id="epic-reminder__submit-button">
-                                Set a reminder
+                                Set my reminder
                                 <svg class="svg-arrow-right-straight" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 17.89" preserveAspectRatio="xMinYMid" aria-hidden="true" focusable="false">
                                     <path d="M20 9.35l-9.08 8.54-.86-.81 6.54-7.31H0V8.12h16.6L10.06.81l.86-.81L20 8.51v.84z" />
                                 </svg>

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -11,7 +11,7 @@ import { amazonA9Test } from 'common/modules/experiments/tests/amazon-a9';
 import { connatixTest } from 'common/modules/experiments/tests/connatix-ab-test';
 import { frontendDotcomRenderingEpic } from 'common/modules/experiments/tests/frontend-dotcom-rendering-epic';
 import { signInGate } from 'common/modules/experiments/tests/sign-in-gate';
-import { contributionsEpicPrecontributionReminderRoundOne } from 'common/modules/experiments/tests/contributions-epic-precontribution-reminder-round-one';
+import { contributionsEpicPrecontributionReminderRoundTwo } from 'common/modules/experiments/tests/contributions-epic-precontribution-reminder-round-two';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
@@ -27,7 +27,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
 export const priorityEpicTest: EpicABTest = frontendDotcomRenderingEpic;
 
 export const epicTests: $ReadOnlyArray<EpicABTest> = [
-    contributionsEpicPrecontributionReminderRoundOne,
+    contributionsEpicPrecontributionReminderRoundTwo,
     askFourEarning,
     acquisitionsEpicAlwaysAskIfTagged,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-precontribution-reminder-round-two.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-precontribution-reminder-round-two.js
@@ -15,10 +15,11 @@ const highlightedText =
 const controlCopy = {
     heading: 'Since you’re here...',
     paragraphs: [
-        '... we have a small favour to ask. More people, like you, are reading and supporting the Guardian’s independent, investigative journalism than ever before. And unlike many news organisations, we made the choice to keep our reporting open for all, regardless of where they live or what they can afford to pay.',
-        'The Guardian will engage with the most critical issues of our time – from the escalating climate emergency to widespread inequality to the influence of big tech on our lives. At a time when factual information is a necessity, we believe that each of us, around the world, deserves access to accurate reporting with integrity at its heart.',
-        'Our editorial independence means we set our own agenda and voice our own opinions. Guardian journalism is free from commercial and political bias and not influenced by billionaire owners or shareholders. This means we can give a voice to those less heard, explore where others turn away, and rigorously challenge those in power.',
-        'We hope you will consider supporting us today. We need your support to keep delivering quality journalism that’s open and independent. Every reader contribution, however big or small, is so valuable.',
+        `... we’re asking readers, like you, to make a contribution in support of the Guardian’s open, independent journalism. This is turning into a turbulent year with a succession of international crises. The Guardian is in every corner of the globe, calmly reporting with tenacity, rigour and authority on the most critical events of our lifetimes. At a time when factual information is both scarcer and more essential than ever, we believe that each of us deserves access to accurate reporting with integrity at its heart.`,
+        `More people than ever before are reading and supporting our journalism, in more than 180 countries around the world. And this is only possible because we made a different choice: to keep our reporting open for all, regardless of where they live or what they can afford to pay.`,
+        `We have upheld our editorial independence in the face of the disintegration of traditional media – with social platforms giving rise to misinformation, the seemingly unstoppable rise of big tech and independent voices being squashed by commercial ownership. The Guardian’s independence means we can set our own agenda and voice our own opinions. Our journalism is free from commercial and political bias – never influenced by billionaire owners or shareholders. This makes us different. It means we can challenge the powerful without fear and give a voice to those less heard.`,
+        `None of this would have been attainable without our readers’ generosity – your financial support has meant we can keep investigating, disentangling and interrogating. It has protected our independence, which has never been so critical. We are so grateful.`,
+        `We need your support so we can keep delivering quality journalism that’s open and independent. And that is here for the long term. Every reader contribution, however big or small, is so valuable.`,
     ],
     highlightedText,
 };
@@ -28,8 +29,8 @@ const usCopy = {
     paragraphs: [
         `... in the coming year, and the results will define the country for a generation. These are perilous times. Over the last three years, much of what the Guardian holds dear has been threatened – democracy, civility, truth. This US administration is establishing new norms of behaviour. Anger and cruelty disfigure public discourse and lying is commonplace. Truth is being chased away. But with your help we can continue to put it center stage.`,
         `Rampant disinformation, partisan news sources and social media's tsunami of fake news is no basis on which to inform the American public in 2020. The need for a robust, independent press has never been greater, and with your support we can continue to provide fact-based reporting that offers public scrutiny and oversight. Our journalism is free and open for all, but it's made possible thanks to the support we receive from readers like you across America in all 50 states.`,
-        `On the occasion of its 100th birthday in 1921 the editor of the Guardian said, "Perhaps the chief virtue of a newspaper is its independence. It should have a soul of its own." That is more true than ever. Freed from the influence of an owner or shareholders, the Guardian's editorial independence is our unique driving force and guiding principle.`,
-        `We also want to say a huge thank you to everyone who generously supports the Guardian. You provide us with the motivation and financial support to keep doing what we do. Every reader contribution, big or small is so valuable.`,
+        `Our journalism relies on our readers’ generosity – your financial support has meant we can keep investigating, disentangling and interrogating. It has protected our independence, which has never been so critical. We are so grateful.`,
+        `We hope you will consider supporting us today. We need your support to keep delivering quality journalism that’s open and independent. Every reader contribution, however big or small, is so valuable.`,
     ],
     highlightedText,
 };

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-precontribution-reminder-round-two.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-precontribution-reminder-round-two.js
@@ -38,10 +38,10 @@ const copy = isUS
     ? buildEpicCopy(usCopy, false, geolocation)
     : buildEpicCopy(controlCopy, false, geolocation);
 
-export const contributionsEpicPrecontributionReminderRoundOne: EpicABTest = makeEpicABTest(
+export const contributionsEpicPrecontributionReminderRoundTwo: EpicABTest = makeEpicABTest(
     {
-        id: 'ContributionsEpicPrecontributionReminderRoundOne',
-        campaignId: 'epic_precontribution_reminder_round_one',
+        id: 'ContributionsEpicPrecontributionReminderRoundTwo',
+        campaignId: 'epic_precontribution_reminder_round_two',
 
         start: '2020-02-01',
         expiry: '2020-04-01',
@@ -54,7 +54,7 @@ export const contributionsEpicPrecontributionReminderRoundOne: EpicABTest = make
 
         audienceCriteria: 'All',
         // Run this test for 10% of the audience
-        audience: 0.1,
+        audience: 0.15,
         // Set an offset to not interfere with dotcom's remoteRenderTest
         audienceOffset: 0.1,
 
@@ -74,8 +74,20 @@ export const contributionsEpicPrecontributionReminderRoundOne: EpicABTest = make
                 products: [],
                 copy,
                 showReminderFields: {
-                    reminderDate: '2020-05-19 00:00:00',
-                    reminderDateAsString: 'May 2020',
+                    reminderCTA: 'Not a good time? Remind me later',
+                    reminderDate: '2020-07-19 00:00:00',
+                    reminderDateAsString: 'July 2020',
+                },
+            },
+            {
+                id: 'withReminder',
+                buttonTemplate: epicButtonsTemplate,
+                products: [],
+                copy,
+                showReminderFields: {
+                    reminderCTA: 'Not a good time? Remind me later',
+                    reminderDate: '2020-07-19 00:00:00',
+                    reminderDateAsString: 'July 2020',
                 },
             },
         ],

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-precontribution-reminder-round-two.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-precontribution-reminder-round-two.js
@@ -69,7 +69,7 @@ export const contributionsEpicPrecontributionReminderRoundTwo: EpicABTest = make
                 copy,
             },
             {
-                id: 'withReminder',
+                id: 'support-us',
                 buttonTemplate: epicButtonsTemplate,
                 products: [],
                 copy,
@@ -80,7 +80,7 @@ export const contributionsEpicPrecontributionReminderRoundTwo: EpicABTest = make
                 },
             },
             {
-                id: 'withReminder',
+                id: 'remind-me',
                 buttonTemplate: epicButtonsTemplate,
                 products: [],
                 copy,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-precontribution-reminder-round-two.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-precontribution-reminder-round-two.js
@@ -43,8 +43,8 @@ export const contributionsEpicPrecontributionReminderRoundTwo: EpicABTest = make
         id: 'ContributionsEpicPrecontributionReminderRoundTwo',
         campaignId: 'epic_precontribution_reminder_round_two',
 
-        start: '2020-02-01',
-        expiry: '2020-04-01',
+        start: '2020-03-18',
+        expiry: '2020-07-01',
 
         author: 'Joshua Lieberman',
         description:
@@ -53,7 +53,7 @@ export const contributionsEpicPrecontributionReminderRoundTwo: EpicABTest = make
         idealOutcome: 'Add reminder feature without hurting conversion rate',
 
         audienceCriteria: 'All',
-        // Run this test for 10% of the audience
+        // Run this test for 15% of the audience
         audience: 0.15,
         // Set an offset to not interfere with dotcom's remoteRenderTest
         audienceOffset: 0.1,
@@ -74,7 +74,7 @@ export const contributionsEpicPrecontributionReminderRoundTwo: EpicABTest = make
                 products: [],
                 copy,
                 showReminderFields: {
-                    reminderCTA: 'Not a good time? Remind me later',
+                    reminderCTA: 'Support us later',
                     reminderDate: '2020-07-19 00:00:00',
                     reminderDateAsString: 'July 2020',
                 },
@@ -85,7 +85,7 @@ export const contributionsEpicPrecontributionReminderRoundTwo: EpicABTest = make
                 products: [],
                 copy,
                 showReminderFields: {
-                    reminderCTA: 'Not a good time? Remind me later',
+                    reminderCTA: 'Remind me in July',
                     reminderDate: '2020-07-19 00:00:00',
                     reminderDateAsString: 'July 2020',
                 },

--- a/static/src/stylesheets/module/reader-revenue/_epic-reminder.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic-reminder.scss
@@ -1,21 +1,23 @@
+////////////////////////////////////////////////
+// Logic for opening and closing the reminder
+////////////////////////////////////////////////
+.epic-reminder__reveal-reminder {
+    display: none;
+}
+
+.epic-reminder__reveal-reminder:checked ~ .epic-reminder .epic-reminder__signup {
+    display: block;
+}
+
+.epic-reminder__reveal-reminder:checked ~ .contributions__buttons {
+    display: none;
+}
+
 .epic-reminder {
     ////////////////////////////////////
     // Prompt to open reminder
     // Button to close reminder
     ////////////////////////////////////
-    .epic-reminder__prompt {
-        width: 100%;
-        text-align: right;
-        cursor: pointer;
-    }
-
-    .epic-reminder__prompt-text {
-        @include fs-textSans(5);
-        font-weight: bold;
-        text-decoration: underline;
-        padding-right: 18px;
-    }
-
     .epic-reminder__close-button {
         font-size: 30px;
         cursor: pointer;
@@ -28,20 +30,8 @@
     }
 
     ////////////////////////////////////////////////
-    // Logic for opening and closing the reminder
+    // Reminder sign up form
     ////////////////////////////////////////////////
-    .epic-reminder__reveal-reminder {
-        display: none;
-    }
-
-    .epic-reminder__reveal-reminder:checked ~ .epic-reminder__signup {
-        display: block;
-    }
-
-    .epic-reminder__reveal-reminder:checked ~ .epic-reminder__prompt-label {
-        display: none;
-    }
-
     .epic-reminder__signup {
         @include multiline(4, $brightness-86, top);
         display: none;
@@ -49,9 +39,6 @@
         padding: 0 5px;
     }
 
-    ////////////////////////////////////////////////
-    // Reminder sign up form
-    ////////////////////////////////////////////////
     .epic-reminder__form-title {
         @include fs-headline(3);
         padding-top: $gs-baseline * 2;
@@ -80,6 +67,8 @@
         @include fs-textSans(5);
         font-size: 17px;
         flex: 1 1 100%;
+        line-height: 37px;
+        height: initial;
 
         @include mq($from: tablet) {
             flex: 1 1 auto;

--- a/static/src/stylesheets/module/reader-revenue/_epic.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic.scss
@@ -132,7 +132,8 @@ a[href].contributions__contribute.contributions__contribute--epic,
     }
 }
 
-a[href].contributions__secondary-button.contributions__secondary-button--epic {
+a[href].contributions__secondary-button.contributions__secondary-button--epic,
+div.contributions__secondary-button.contributions__secondary-button--epic{
     margin-top: $gs-baseline / 2;
 
     @include mq($from: mobileLandscape) {
@@ -140,7 +141,8 @@ a[href].contributions__secondary-button.contributions__secondary-button--epic {
     }
 }
 
-.contributions__secondary-button + .contributions__payment-logos {
+.contributions__secondary-button + .contributions__payment-logos,
+.epic-reminder__prompt-label + .contributions__payment-logos {
     width: 100%;
     margin-top: $gs-baseline / 2;
     margin-left: $gs-baseline / 2;

--- a/static/src/stylesheets/module/reader-revenue/_epic.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic.scss
@@ -133,7 +133,7 @@ a[href].contributions__contribute.contributions__contribute--epic,
 }
 
 a[href].contributions__secondary-button.contributions__secondary-button--epic,
-div.contributions__secondary-button.contributions__secondary-button--epic{
+div.contributions__secondary-button.contributions__secondary-button--epic {
     margin-top: $gs-baseline / 2;
 
     @include mq($from: mobileLandscape) {

--- a/static/src/stylesheets/module/reader-revenue/_reader-revenue-button.scss
+++ b/static/src/stylesheets/module/reader-revenue/_reader-revenue-button.scss
@@ -88,6 +88,11 @@ $gu-cta-height: 42px;
     }
 }
 
+.component-button--reminder-prompt {
+    background-color: transparent;
+    border-color: $brightness-7;
+}
+
 .component-button--disabled,
 .component-button[disabled],
 .component-button[data-disabled] {


### PR DESCRIPTION
## What does this change?
New CTA and some new behaviour for the pre-contribution reminder

Will be run as a 15% test with three variables (incl. control)

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
Control:
<img width="573" alt="control" src="https://user-images.githubusercontent.com/3300789/76978501-b12ab680-692e-11ea-8e80-472392983bff.png">

Remind me in July:
<img width="573" alt="remind me in July" src="https://user-images.githubusercontent.com/3300789/76978532-b851c480-692e-11ea-8505-78b5c600420b.png">

Support us later:
<img width="578" alt="support us later " src="https://user-images.githubusercontent.com/3300789/76978541-bbe54b80-692e-11ea-9902-95a5b5123d86.png">

With prompt open:
<img width="571" alt="with prompt open" src="https://user-images.githubusercontent.com/3300789/76978670-e2a38200-692e-11ea-98b2-3d9dd637eb4b.png">

Final Screen:
<img width="577" alt="final screen" src="https://user-images.githubusercontent.com/3300789/76978513-b425a700-692e-11ea-9446-77adf719013c.png">

US Copy:
<img width="581" alt="US Copy" src="https://user-images.githubusercontent.com/3300789/76978704-f0f19e00-692e-11ea-83f4-7bf184b396d9.png">

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [X] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [X] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [X] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
