### PR TITLE
Run A9 only if user consented

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
@@ -9,6 +9,7 @@ import type {
     HeaderBiddingSize,
     HeaderBiddingSlot,
 } from 'commercial/modules/header-bidding/types';
+import { onIabConsentNotification } from '@guardian/consent-management-platform';
 
 class A9AdUnit {
     slotID: ?string;
@@ -31,12 +32,18 @@ let initialised: boolean = false;
 const bidderTimeout: number = 1500;
 
 const initialise = (): void => {
-    initialised = true;
+    onIabConsentNotification(state => {
+        const consentState =
+            state[1] && state[2] && state[3] && state[4] && state[5];
 
-    window.apstag.init({
-        pubID: config.get('page.a9PublisherId'),
-        adServer: 'googletag',
-        bidTimeout: bidderTimeout,
+        if (!initialised && consentState) {
+            initialised = true;
+            window.apstag.init({
+                pubID: config.get('page.a9PublisherId'),
+                adServer: 'googletag',
+                bidTimeout: bidderTimeout,
+            });
+        }
     });
 };
 

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.spec.js
@@ -1,6 +1,12 @@
 // @flow
 
 import a9 from 'commercial/modules/header-bidding/a9/a9';
+import { onIabConsentNotification as onIabConsentNotification_ } from "@guardian/consent-management-platform";
+
+const onIabConsentNotification: any = onIabConsentNotification_;
+
+const trueConsentMock = (callback): void =>
+    callback({ '1': true, '2': true, '3': true, '4': true, '5': true });
 
 jest.mock('lib/raven');
 jest.mock('commercial/modules/dfp/Advert', () =>
@@ -13,6 +19,10 @@ jest.mock('commercial/modules/header-bidding/slot-config', () => ({
         .mockImplementation(() => [
             { key: 'top-above-nav', sizes: [[970, 250], [728, 90]] },
         ]),
+}));
+
+jest.mock('@guardian/consent-management-platform', () => ({
+    onIabConsentNotification: jest.fn(),
 }));
 
 beforeEach(async () => {
@@ -30,6 +40,7 @@ afterAll(() => {
 
 describe('initialise', () => {
     it('should generate initialise A9 library', () => {
+        onIabConsentNotification.mockImplementation(trueConsentMock);
         a9.initialise();
         expect(window.apstag).toBeDefined();
         expect(window.apstag.init).toHaveBeenCalled();

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.spec.js
@@ -1,7 +1,7 @@
 // @flow
 
 import a9 from 'commercial/modules/header-bidding/a9/a9';
-import { onIabConsentNotification as onIabConsentNotification_ } from "@guardian/consent-management-platform";
+import { onIabConsentNotification as onIabConsentNotification_ } from '@guardian/consent-management-platform';
 
 const onIabConsentNotification: any = onIabConsentNotification_;
 


### PR DESCRIPTION
## What does this change?
Run A9 only if user consented


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
