### PR TITLE
Narrower subs banner title on mobile to avoid close button overlap

### DIFF
--- a/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
@@ -40,7 +40,7 @@
     line-height: 22px;
     font-family: $f-serif-headline;
     font-weight: bold;
-    width: 100%;
+    width: 90%;
 
     @media (min-width: 350px) {
         font-size: 24px;


### PR DESCRIPTION
## What does this change?
Makes the title width a bit narrower at the smallest breakpoints so we avoid title/button overlaps on some mobile devices.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
Before
![image](https://user-images.githubusercontent.com/8754692/77149041-aab05200-6a88-11ea-8e73-1c96a5945171.png)

After
![image](https://user-images.githubusercontent.com/8754692/77149178-ec40fd00-6a88-11ea-94af-5f1039549994.png)



## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
