### PR TITLE
Support for Interactive Atoms on Amp

### DIFF
--- a/applications/app/controllers/AtomPageController.scala
+++ b/applications/app/controllers/AtomPageController.scala
@@ -87,6 +87,9 @@ class AtomPageController(contentApiClient: ContentApiClient, wsClient: WSClient,
         renderAtom(QandaAtomPage(model, withJavaScript = isJsEnabled, withVerticalScrollbar = hasVerticalScrollbar))
       case Left(model: TimelineAtom) =>
         renderAtom(TimelineAtomPage(model, withJavaScript = isJsEnabled, withVerticalScrollbar = hasVerticalScrollbar))
+      case Left(model: InteractiveAtom) => {
+        renderAtom(InteractiveAtomPage(model, withJavaScript = isJsEnabled, withVerticalScrollbar = hasVerticalScrollbar))
+      }
       case Left(_) =>
         renderOther(NotFound)
       case Right(other) =>
@@ -111,9 +114,9 @@ class AtomPageController(contentApiClient: ContentApiClient, wsClient: WSClient,
     apiAtom.profile.map(atom => ProfileAtom.make(atom))                         orElse
     apiAtom.qanda.map(atom => QandaAtom.make(atom))                             orElse
     apiAtom.timeline.map(atom => TimelineAtom.make(atom))                       orElse
+    apiAtom.interactive.map(atom => InteractiveAtom.make(atom))                 orElse
     /*
     apiAtom.quiz.map(atom => Quiz.make(atom))                                   orElse
-    apiAtom.interactive.map(atom => InteractiveAtom.make(atom))                 orElse
     apiAtom.review.map(atom => RecipeAtom.make(atom))                           orElse
     apiAtom.recipe.map(atom => ReviewAtom.make(atom))                           orElse
     */

--- a/applications/app/views/atomEmbed.scala.html
+++ b/applications/app/views/atomEmbed.scala.html
@@ -1,18 +1,31 @@
 @import model.AtomPage
-@import conf.Configuration
 
 @(page: AtomPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 <!DOCTYPE html>
 <html lang="en-GB" class="gu-atom-embed-html">
-<head>
-    <meta charset="utf-8">
-    <title>@page.metadata.webTitle</title>
-    <base target="_top">
-    @fragments.atomPageHead(page)
-</head>
-<body>
-    @page.body
-    @fragments.atomPageFoot(page)
-</body>
+    <head>
+        <meta charset="utf-8">
+        <title>@page.metadata.webTitle</title>
+        <base target="_top">
+        @fragments.atomPageHead(page)
+        <script>
+            // Interactive Atoms expect window.resize to exist. In the context of Amp we want to let the parent know that
+            // the iframe should be resized. See https://amp.dev/documentation/components/amp-iframe/.
+            window.resize = function() {
+                window.parent.postMessage(
+                    {
+                        sentinel: 'amp',
+                        type: 'embed-size',
+                        height: document.body.scrollHeight,
+                    },
+                    '*'
+                );
+            }
+    </script>
+    </head>
+    <body>
+        @page.body
+        @fragments.atomPageFoot(page)
+    </body>
 </html>

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -1,7 +1,10 @@
 package model.dotcomrendering.pageElements
 
+import java.net.{URI, URLEncoder}
+
 import com.gu.contentapi.client.model.v1.ElementType.{Map => _, _}
 import com.gu.contentapi.client.model.v1.{ElementType, SponsorshipType, BlockElement => ApiBlockElement, Sponsorship => ApiSponsorship}
+import conf.Configuration
 import layout.ContentWidths.BodyMedia
 import model.content._
 import model.{AudioAsset, ImageAsset, ImageMedia, VideoAsset}
@@ -335,11 +338,9 @@ object PageElement {
           }
 
           case Some(interactive: InteractiveAtom) => {
-            Some(InteractiveMarkupBlockElement(
-              id = interactive.id,
-              html = Some(interactive.html),
-              css = Some(interactive.css),
-              js = interactive.mainJS
+            val encodedId = URLEncoder.encode(interactive.id, "UTF-8")
+            Some(InteractiveUrlBlockElement(
+              url = s"${Configuration.ajax.url}/embed/atom/interactive/$encodedId"
             ))
           }
 

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -444,6 +444,21 @@ case class MediaAtomPage(
   )
 }
 
+case class InteractiveAtomPage(
+  override val atom: InteractiveAtom,
+  override val withJavaScript: Boolean,
+  override val withVerticalScrollbar: Boolean
+)(implicit request: RequestHeader, context: ApplicationContext) extends AtomPage {
+  override val atomType = "interactive"
+  override val body = views.html.fragments.atoms.interactive(atom, shouldFence = false)
+  override val javascriptModule = "snippet"
+  override val metadata = MetaData.make(
+    id = atom.id,
+    webTitle = atom.title,
+    section = None
+  )
+}
+
 case class GuideAtomPage(
   override val atom: GuideAtom,
   override val withJavaScript: Boolean,


### PR DESCRIPTION
## What does this change?

Interactive Atoms on amp should be rendered in an iframe with a `src` attribute, instead of `srcdoc` as they are right now. This PR adds support for interactive atoms to the `/embed/atom` endpoint. An `InteractiveAtom` now maps to `InteractiveUrlBlockElement` for Amp. The url is an instance of the `/embed/atom` endpoint.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

Example when page loaded with atom offscreen (and then scrolled to):

<img width="595" alt="Screenshot 2020-03-22 at 22 48 44" src="https://user-images.githubusercontent.com/379839/77263072-6f33a480-6c8f-11ea-8f75-e0e3ad86c9a3.png">

Example when page loaded with atom onscreen:

<img width="596" alt="Screenshot 2020-03-22 at 22 48 54" src="https://user-images.githubusercontent.com/379839/77263078-75c21c00-6c8f-11ea-82e6-38f7a9a7ebe2.png">

## What is the value of this and can you measure success?

Support for interactive atoms in Amp.

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

## TODO

- [x] ~~We send a resize message from the iframe to the parent, but it's currently firing too early. We need to integrate with the ready event of the interactive atom.~~

## Notes

Depends on guardian/dotcom-rendering#1282 for links to work correctly (see examples in that PR).