### PR TITLE
Updating tech feedback user help page

### DIFF
--- a/onward/app/views/feedback.scala.html
+++ b/onward/app/views/feedback.scala.html
@@ -30,6 +30,13 @@
 
                                     <h2>Contact us</h2>
 
+                                    <p>Due to the ongoing Coronavirus outbreak, the Customer Service team is operating at a reduced service. This means we may take longer than usual to answer your queries. Please bear with us and we will try to answer your query as soon as possible.</p>
+
+                                    <p>In the meantime, many of your queries can be answered online by visiting our <a href="https://www.theguardian.com/help">help page</a>, or, if you hold an account with us, your <a href="http://manage.theguardian.com">Manage My Account area.</a></p>
+
+                                    <p>This page will be updated when normal service resumes, please check back. We apologise for any inconvenience.</p>
+
+
                                     <form id="feedback__form" action="tech-feedback/send" method="post">
 
                                         <!-- category dropdown -->


### PR DESCRIPTION
## What does this change?
Due to operational constraints, we're updating the userhelp page in order to infor our readers that there may be delays in responding to them.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
<img width="721" alt="Screen Shot 2020-03-20 at 15 35 27" src="https://user-images.githubusercontent.com/2051501/77179852-fd0d6500-6ac0-11ea-9771-d2e26e3aa7bc.png">