### PR TITLE
Remove shady pie from abtests (again)

### DIFF
--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -27,6 +27,7 @@ import { trackPerformance } from 'common/modules/analytics/google';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { initCheckDispatcher } from 'commercial/modules/check-dispatcher';
 import { initCommentAdverts } from 'commercial/modules/comment-adverts';
+import { initAdblockAsk } from 'common/modules/commercial/adblock-ask';
 
 const commercialModules: Array<Array<any>> = [
     ['cm-adFreeSlotRemove', adFreeSlotRemove],
@@ -55,7 +56,8 @@ if (!commercialFeatures.adFree) {
         ['cm-stickyTopBanner', initStickyTopBanner],
         ['cm-paidContainers', paidContainers],
         ['cm-paidforBand', initPaidForBand],
-        ['cm-commentAdverts', initCommentAdverts]
+        ['cm-commentAdverts', initCommentAdverts],
+        ['rr-adblock-ask', initAdblockAsk]
     );
 }
 

--- a/static/src/javascripts/projects/common/modules/commercial/adblock-ask.js
+++ b/static/src/javascripts/projects/common/modules/commercial/adblock-ask.js
@@ -1,7 +1,7 @@
 // @flow
+import { supportSubscribeDigitalURL } from 'common/modules/commercial/support-utilities';
 import { shouldHideSupportMessaging } from 'common/modules/commercial/user-features';
 import { pageShouldHideReaderRevenue } from 'common/modules/commercial/contributions-utilities';
-import { supportSubscribeDigitalURL } from 'common/modules/commercial/support-utilities';
 import config from 'lib/config';
 
 const supportUrl = `${supportSubscribeDigitalURL()}?acquisitionData=%7B%22componentType%22%3A%22ACQUISITIONS_OTHER%22%2C%22source%22%3A%22GUARDIAN_WEB%22%2C%22campaignCode%22%3A%22shady_pie_open_2019%22%2C%22componentId%22%3A%22shady_pie_open_2019%22%7D&INTCMP=shady_pie_open_2019`;
@@ -25,35 +25,14 @@ const askHtml = `
 </div>
 `;
 
-export const adblockTest: ABTest = {
-    id: 'AdblockAsk',
-    start: '2019-02-20',
-    expiry: '2021-02-16',
-    author: 'Tom Forbes',
-    description:
-        'Places a contributions ask underneath the right-hand ad slot on articles.',
-    audience: 1,
-    audienceOffset: 0,
-    successMeasure: '',
-    audienceCriteria: '',
-    showForSensitive: true,
-    canRun() {
-        return (
-            !shouldHideSupportMessaging() &&
-            !pageShouldHideReaderRevenue() &&
-            !config.get('page.hasShowcaseMainElement')
-        );
-    },
+const canShow = () =>
+    !shouldHideSupportMessaging() &&
+    !pageShouldHideReaderRevenue() &&
+    !config.get('page.hasShowcaseMainElement');
 
-    variants: [
-        {
-            id: 'control',
-            test: (): void => {
-                const slot = document.querySelector('.js-aside-slot-container');
-                if (slot) {
-                    slot.innerHTML += askHtml;
-                }
-            },
-        },
-    ],
+export const initAdblockAsk = () => {
+    const slot = document.querySelector('.js-aside-slot-container');
+    if (slot && canShow()) {
+        slot.innerHTML += askHtml;
+    }
 };

--- a/static/src/javascripts/projects/common/modules/commercial/adblock-ask.js
+++ b/static/src/javascripts/projects/common/modules/commercial/adblock-ask.js
@@ -35,13 +35,13 @@ const canShow = () =>
     !config.get('page.hasShowcaseMainElement');
 
 export const initAdblockAsk = () => {
-    fastdom
-        .read(() => $('.js-aside-slot-container'))
-        .then(slot => {
-            if (canShow()) {
-                return fastdom.write(() => {
+    if (canShow()) {
+        fastdom
+            .read(() => $('.js-aside-slot-container'))
+            .then(slot =>
+                fastdom.write(() => {
                     slot.append(askHtml);
-                });
-            }
-        });
+                })
+            );
+    }
 };

--- a/static/src/javascripts/projects/common/modules/commercial/adblock-ask.js
+++ b/static/src/javascripts/projects/common/modules/commercial/adblock-ask.js
@@ -38,10 +38,12 @@ export const initAdblockAsk = () => {
     if (canShow()) {
         fastdom
             .read(() => $('.js-aside-slot-container'))
-            .then(slot =>
-                fastdom.write(() => {
-                    slot.append(askHtml);
-                })
-            );
+            .then(slot => {
+                if (slot) {
+                    fastdom.write(() => {
+                        slot.append(askHtml);
+                    });
+                }
+            });
     }
 };

--- a/static/src/javascripts/projects/common/modules/commercial/adblock-ask.js
+++ b/static/src/javascripts/projects/common/modules/commercial/adblock-ask.js
@@ -1,4 +1,8 @@
 // @flow
+
+import fastdom from 'lib/fastdom-promise';
+import $ from 'lib/$';
+
 import { supportSubscribeDigitalURL } from 'common/modules/commercial/support-utilities';
 import { shouldHideSupportMessaging } from 'common/modules/commercial/user-features';
 import { pageShouldHideReaderRevenue } from 'common/modules/commercial/contributions-utilities';
@@ -31,8 +35,13 @@ const canShow = () =>
     !config.get('page.hasShowcaseMainElement');
 
 export const initAdblockAsk = () => {
-    const slot = document.querySelector('.js-aside-slot-container');
-    if (slot && canShow()) {
-        slot.innerHTML += askHtml;
-    }
+    fastdom
+        .read(() => $('.js-aside-slot-container'))
+        .then(slot => {
+            if (canShow()) {
+                return fastdom.write(() => {
+                    slot.append(askHtml);
+                });
+            }
+        });
 };

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -2,7 +2,6 @@
 import { commercialPrebidSafeframe } from 'common/modules/experiments/tests/commercial-prebid-safeframe.js';
 import { askFourEarning } from 'common/modules/experiments/tests/contributions-epic-ask-four-earning';
 import { acquisitionsEpicAlwaysAskIfTagged } from 'common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged';
-import { adblockTest } from 'common/modules/experiments/tests/adblock-ask';
 import { articlesViewedBanner } from 'common/modules/experiments/tests/contribs-banner-articles-viewed';
 import { xaxisAdapterTest } from 'common/modules/experiments/tests/commercial-xaxis-adapter';
 import { appnexusUSAdapter } from 'common/modules/experiments/tests/commercial-appnexus-us-adapter';
@@ -15,7 +14,6 @@ import { contributionsEpicPrecontributionReminderRoundTwo } from 'common/modules
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
-    adblockTest,
     amazonA9Test,
     connatixTest,
     xaxisAdapterTest,


### PR DESCRIPTION
## What does this change?
The adblock-ask feature was formerly run with an ab test and then seems to have switched to being run 100% of the time as one variant. Given this it made sense to move it out of the testing zone.

This change was made first last week and was reverted due to it breaking full-page ads in some cases.

## Does this change need to be reproduced in dotcom-rendering ?
- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
![Screen Shot 2020-03-19 at 12 38 07](https://user-images.githubusercontent.com/16781258/77068563-c2330080-69de-11ea-9b42-5d50af04253b.png)

## What is the value of this and can you measure success?
It simplifies the code.

## Checklist
N/A

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?
- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?
- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist
N/A

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested
- [x] Locally
- [ ] On CODE (optional)
