### PR TITLE
Add byline image to coronavirus weekly email

### DIFF
--- a/article/app/views/fragments/email/emailArticleBody.scala.html
+++ b/article/app/views/fragments/email/emailArticleBody.scala.html
@@ -5,6 +5,7 @@
 @import views.support.{EmailImage, EmailVideoImage}
 @import views.support.EmailHelpers.{imgForArticle, icon, imgForVideo}
 @import fragments.email._
+@import model.Tag
 @import model.liveblog._
 @import model.EmailAddons.EmailContentType
 @import model.content.{MediaAtom, MediaAssetPlatform}
@@ -65,41 +66,64 @@
 
 <table class="article-body">
 
-@bylineWithImage(page: PageWithStoryPackage) = {
+@bylineTwitter(twitterHandle: String) = {
+    <div class="meta__twitter">
+        <a href="https://twitter.com/@twitterHandle" data-link-name="twitter-handle" data-component="meta-twitter-handle" class="button button--small button--secondary tone-colour">
+            @icon("twitter-bird")
+            <span class="contact">@@@twitterHandle</span>
+        </a>
+    </div>
+}
+
+@bylineEmail(emailAddress: String) = {
+    <div class="meta__email">
+        <a href="mailto:@emailAddress" data-link-name="email-address" data-component="meta-email-address" class="button button--small button--secondary tone-colour">
+            @icon("mail")
+            <span class="contact">Email</span>
+        </a>
+    </div>
+}
+
+@bylineWithImage(byline: String, firstContributor: Option[Tag]) = {
     @row(Seq("padded-x", "author")) {
-        @page.article.trail.byline.map { byline =>
-            <table>
-                <tr>
-                    @page.article.tags.contributors.headOption.map { profile =>
-                        @profile.properties.contributorLargeImagePath.map { src =>
-                            <td>
-                                <img class="byline__img" src="@src" alt="@profile.name" />
-                            </td>
-                        }
+        <table>
+            <tr>
+                @firstContributor.map { profile =>
+                    @profile.properties.contributorLargeImagePath.map { src =>
                         <td>
-                            <h3 class="byline">@byline</h3>
-                            @profile.properties.twitterHandle.map { twitter =>
-                                <div class="meta__twitter">
-                                    <a href="https://twitter.com/@twitter" data-link-name="twitter-handle" data-component="meta-twitter-handle" class="button button--small button--secondary tone-colour">
-                                        @icon("twitter-bird")
-                                        <span class="contact">@@@twitter</span>
-                                    </a>
-                                </div>
-                            }
-                            @profile.properties.emailAddress.map { email =>
-                                <div class="meta__email">
-                                    <a href="mailto:@email" data-link-name="email-address" data-component="meta-email-address" class="button button--small button--secondary tone-colour">
-                                        @icon("mail")
-                                        <span class="contact">Email</span>
-                                    </a>
-                                </div>
-                            }
+                            <img class="byline__img" src="@src" alt="@profile.name" />
                         </td>
                     }
-                </tr>
-            </table>
-        }
+                    <td>
+                        <h3 class="byline">@byline</h3>
+                        @profile.properties.twitterHandle.map { twitterHandle =>
+                            @bylineTwitter(twitterHandle)
+                        }
+                        @profile.properties.emailAddress.map { emailAddress =>
+                            @bylineEmail(emailAddress)
+                        }
+                    </td>
+                }
+            </tr>
+        </table>
         <hr class="rule--flush" />
+    }
+}
+
+
+@bylineWithoutImage(byline: String, firstContributor: Option[Tag]) = {
+    @row(Seq("padded", "author")) {
+        <h3 class="byline">@byline</h3>
+
+        @firstContributor.map { profile =>
+            @profile.properties.twitterHandle.map { twitterHandle =>
+                @bylineTwitter(twitterHandle)
+            }
+            @profile.properties.emailAddress.map { emailAddress =>
+                @bylineEmail(emailAddress)
+            }
+        }
+        <hr />
     }
 }
 
@@ -127,34 +151,23 @@
 
     @fragments.emailMainMedia(article)
 
-
-    @if(article.tags.contributors.length == 1) { @* Do not show byline if more than 1 contributor (or zero) *@
-        @bylineWithImage(page: PageWithStoryPackage)
-    } else {
-        @row(Seq("padded", "author")) {
-            @article.trail.byline.map { byline =>
-                <h3 class="byline">@byline</h3>
-
-                @article.tags.contributors.headOption.map { profile =>
-                    @profile.properties.twitterHandle.map { twitter =>
-                        <div class="meta__twitter">
-                            <a href="https://twitter.com/@twitter" data-link-name="twitter-handle" data-component="meta-twitter-handle" class="button button--small button--secondary tone-colour">
-                                @icon("twitter-bird")
-                                <span class="contact">@@ @twitter</span>
-                            </a>
-                        </div>
-                    }
-                    @profile.properties.emailAddress.map { email =>
-                        <div class="meta__email">
-                            <a href="mailto:@email" data-link-name="email-address" data-component="meta-email-address" class="button button--small button--secondary tone-colour">
-                                @icon("mail")
-                                <span class="contact">Email</span>
-                            </a>
-                        </div>
-                    }
+    @page.article.trail.byline.map { byline =>
+        @* Show byline if there is exactly one contributor *@
+        @* and this is the Coronavirus: the week explained *@
+        @* and the contributor has a contributor image *@
+        @if(article.tags.contributors.length == 1 &&
+            article.tags.series.exists {
+                _.id == "world/series/coronavirus-the-week-explained"
+            }) {
+            @article.tags.contributors.headOption.map { profile =>
+                @if(profile.properties.contributorLargeImagePath.isEmpty) {
+                    @bylineWithoutImage(byline, page.article.tags.contributors.headOption)
+                } else {
+                    @bylineWithImage(byline, page.article.tags.contributors.headOption)
                 }
             }
-            <hr />
+        } else {
+            @bylineWithoutImage(byline, page.article.tags.contributors.headOption)
         }
     }
 

--- a/article/app/views/fragments/email/emailArticleBody.scala.html
+++ b/article/app/views/fragments/email/emailArticleBody.scala.html
@@ -90,8 +90,8 @@
             <tr>
                 @firstContributor.map { profile =>
                     @profile.properties.contributorLargeImagePath.map { src =>
-                        <td>
-                            <img class="byline__img" src="@src" alt="@profile.name" />
+                        <td class="byline-img">
+                            <img width="80" src="@src" alt="@profile.name" />
                         </td>
                     }
                     <td>

--- a/article/app/views/fragments/email/emailArticleBody.scala.html
+++ b/article/app/views/fragments/email/emailArticleBody.scala.html
@@ -64,6 +64,45 @@
 }
 
 <table class="article-body">
+
+@bylineWithImage(page: PageWithStoryPackage) = {
+    @row(Seq("padded-x", "author")) {
+        @page.article.trail.byline.map { byline =>
+            <table>
+                <tr>
+                    @page.article.tags.contributors.headOption.map { profile =>
+                        @profile.properties.contributorLargeImagePath.map { src =>
+                            <td>
+                                <img class="byline__img" src="@src" alt="@profile.name" />
+                            </td>
+                        }
+                        <td>
+                            <h3 class="byline">@byline</h3>
+                            @profile.properties.twitterHandle.map { twitter =>
+                                <div class="meta__twitter">
+                                    <a href="https://twitter.com/@twitter" data-link-name="twitter-handle" data-component="meta-twitter-handle" class="button button--small button--secondary tone-colour">
+                                        @icon("twitter-bird")
+                                        <span class="contact">@@@twitter</span>
+                                    </a>
+                                </div>
+                            }
+                            @profile.properties.emailAddress.map { email =>
+                                <div class="meta__email">
+                                    <a href="mailto:@email" data-link-name="email-address" data-component="meta-email-address" class="button button--small button--secondary tone-colour">
+                                        @icon("mail")
+                                        <span class="contact">Email</span>
+                                    </a>
+                                </div>
+                            }
+                        </td>
+                    }
+                </tr>
+            </table>
+        }
+        <hr class="rule--flush" />
+    }
+}
+
 @defining(page.article) { article =>
     @row(Seq("no-pad")) {
         <a href="@article.metadata.webUrl" @page.email.map { email => title="View @email.name online"}>
@@ -88,29 +127,33 @@
 
     @fragments.emailMainMedia(article)
 
-    @row(Seq("padded", "author")) {
-        @article.trail.byline.map { byline =>
-            <h3 class="byline">@byline</h3>
 
-        @article.tags.contributors.headOption.map { profile =>
-            @profile.properties.twitterHandle.map { twitter =>
-                <div class="meta__twitter">
-                    <a href="https://twitter.com/@twitter" data-link-name="twitter-handle" data-component="meta-twitter-handle" class="button button--small button--secondary tone-colour">
-                        @icon("twitter-bird")
-                        <span class="contact">@@@twitter</span>
-                    </a>
-                </div>
-            }
-            @profile.properties.emailAddress.map { email =>
-                <div class="meta__email">
-                    <a href="mailto:@email" data-link-name="email-address" data-component="meta-email-address" class="button button--small button--secondary tone-colour">
-                        @icon("mail")
-                        <span class="contact">Email</span>
-                    </a>
-                </div>
-            }
-        }
+    @if(article.tags.contributors.length == 1) { @* Do not show byline if more than 1 contributor (or zero) *@
+        @bylineWithImage(page: PageWithStoryPackage)
+    } else {
+        @row(Seq("padded", "author")) {
+            @article.trail.byline.map { byline =>
+                <h3 class="byline">@byline</h3>
 
+                @article.tags.contributors.headOption.map { profile =>
+                    @profile.properties.twitterHandle.map { twitter =>
+                        <div class="meta__twitter">
+                            <a href="https://twitter.com/@twitter" data-link-name="twitter-handle" data-component="meta-twitter-handle" class="button button--small button--secondary tone-colour">
+                                @icon("twitter-bird")
+                                <span class="contact">@@ @twitter</span>
+                            </a>
+                        </div>
+                    }
+                    @profile.properties.emailAddress.map { email =>
+                        <div class="meta__email">
+                            <a href="mailto:@email" data-link-name="email-address" data-component="meta-email-address" class="button button--small button--secondary tone-colour">
+                                @icon("mail")
+                                <span class="contact">Email</span>
+                            </a>
+                        </div>
+                    }
+                }
+            }
             <hr />
         }
     }

--- a/static/src/stylesheets/email/_article.scss
+++ b/static/src/stylesheets/email/_article.scss
@@ -34,6 +34,10 @@ $cta-font-color: #000000;
     padding: 5px 10px;
 }
 
+.padded-x {
+    padding: 0 10px;
+}
+
 h1, h2, h3, h4, h5, h6, p, blockquote {
     font-family: 'Guardian Egyptian Text', Georgia, serif;
     font-weight: normal;
@@ -100,6 +104,10 @@ hr.rule--compact {
     margin-top: 5px;
 }
 
+hr.rule--flush {
+    margin-top: 0;
+}
+
 .author a {
     text-decoration: none;
     color: #005689;
@@ -128,6 +136,10 @@ blockquote {
 
 .byline {
     color: #005689
+}
+
+.byline__img {
+    max-width: 80px;
 }
 
 .caption {

--- a/static/src/stylesheets/email/_article.scss
+++ b/static/src/stylesheets/email/_article.scss
@@ -138,7 +138,7 @@ blockquote {
     color: #005689
 }
 
-.byline__img {
+.byline-img {
     width: 80px;
 }
 

--- a/static/src/stylesheets/email/_article.scss
+++ b/static/src/stylesheets/email/_article.scss
@@ -139,7 +139,7 @@ blockquote {
 }
 
 .byline__img {
-    max-width: 80px;
+    width: 80px;
 }
 
 .caption {


### PR DESCRIPTION
## What does this change?

Adds a byline image to the "Coronavirus: the week explained" email.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<img width="602" alt="Screenshot 2020-03-23 at 13 27 25" src="https://user-images.githubusercontent.com/5931528/77321400-0fc6aa80-6d0a-11ea-8f71-7e7853269aa2.png">

## What is the value of this and can you measure success?

We are developing a plan to ensure our content and products have the maximum impact on readers.

Editorial has created a Coronavirus newsletter people can subscribe to. They have asked for a byline image to the newsletter.

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
