### PR TITLE
Decommissioning the Stocks widget on the Business front

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -138,7 +138,7 @@ class GuardianConfiguration extends Logging {
   case class OAuthCredentialsWithMultipleCallbacks(oauthClientId: String, oauthSecret: String, authorizedOauthCallbacks: List[String])
 
   object business {
-    lazy val stocksEndpoint = configuration.getMandatoryStringProperty("business_data.url")
+    lazy val stocksEndpoint = configuration.getMandatoryStringProperty("business_data.url") // Decommissioned, see marker: 7dde429f00b1
   }
 
   object feedback {

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -298,10 +298,11 @@ trait FeatureSwitches {
     exposeClientSide = false
   )
 
+  // Decommissioned, see marker: 7dde429f00b1
   val StocksWidgetSwitch = Switch(
     SwitchGroup.Feature,
     "stocks-widget",
-    "If switched on, a stocks widget will be displayed on the business front",
+    "If switched on, a stocks widget will be displayed on the business front (note: code is currently decommissioned, so switch has no effect)",
     owners = Seq(Owner.withGithub("johnduffell")),
     safeState = On,
     sellByDate = never,

--- a/onward/app/business/StocksData.scala
+++ b/onward/app/business/StocksData.scala
@@ -11,7 +11,7 @@ import scala.language.postfixOps
 
 class StocksData(wsClient: WSClient) extends AutoRefresh[Stocks](0 seconds, 1 minute) with Logging {
   override protected def refresh()(implicit executionContext: ExecutionContext): Future[Stocks] = {
-
+    // Decommissioned, see marker: 7dde429f00b1
     try {
       wsClient.url(Configuration.business.stocksEndpoint).get() map { response =>
         Json.fromJson[Indices](response.json) match {

--- a/onward/app/controllers/StocksController.scala
+++ b/onward/app/controllers/StocksController.scala
@@ -10,7 +10,8 @@ import conf.switches.Switches.StocksWidgetSwitch
 
 class StocksController(stocksData: StocksData, val controllerComponents: ControllerComponents) extends BaseController {
   def stocks: Action[AnyContent] = Action { implicit request =>
-    if (StocksWidgetSwitch.isSwitchedOff) {
+    // Decommissioned, see marker: 7dde429f00b1
+    if (false && StocksWidgetSwitch.isSwitchedOff) {
       Cached(1.minute)(JsonComponent(Stocks(Seq.empty)))
     } else {
       stocksData.get match {

--- a/static/src/javascripts/projects/common/modules/business/stocks.js
+++ b/static/src/javascripts/projects/common/modules/business/stocks.js
@@ -62,7 +62,14 @@ const renderData = data => {
 export default () => {
     const $container = $('.js-container--first .js-container__header');
 
-    if (isBusinessFront() && $container) {
+    // Pascal, 23rd March 2020
+    // Marker: 7dde429f00b1
+    // This code is being decommissioned because the end point we are currently using to retrieve the
+    // live data has ceased to be maintained and the business has decided not to move forward with trying
+    // to replace it. I keep the entire frontend and backend logic in place, and just prevent the call
+    // for data retrieval to be made. If one day we get a new data end point, then it will be easy to
+    // display the widget again (this might include updating the code to meet new data schemas).
+    if (false && isBusinessFront() && $container) {
         getStocksData().then(data => {
             if (data && data.stocks && data.stocks.length > 0) {
                 $container.append(renderData(data));


### PR DESCRIPTION
## What does this change?

Decommission the logic (removes the effect of the switch and prevents an unnecessary ajax call to the backend) of the Stock widget on the Business front but without removing the code. Current endpoint is no longer maintained and business decided not to pursue replacing it for the moment.

