### PR TITLE
Update Identity library version for newsletter changes

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.199"
+  val identityLibVersion = "3.200"
   val awsVersion = "1.11.240"
   val capiVersion = "17.1"
   val faciaVersion = "3.0.20"


### PR DESCRIPTION
## What does this change?

Bumps the Identity library version to 3.200 to make the following newsletter changes:

Added:
- The Guide: staying in

Removed:
- Observer Picture Archive