### PR TITLE
Add bottom border to interscroller ad

### DIFF
--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -707,6 +707,12 @@
 }
 
 .creative__background-parent-interscroller::before {
+    content: '';
+    width: 100%;
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    z-index: 1;
     border-bottom: 1px solid $brightness-86;
 }
 

--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -706,6 +706,10 @@
     }
 }
 
+.creative__background-parent-interscroller::before {
+    border-bottom: 1px solid $brightness-86;
+}
+
 .ad-slot__label.sticky {
     position: sticky;
     top: 0;


### PR DESCRIPTION
## What does this change?
Adds bottom border to interscroller ad to allow ads with ligher background to not be mistaken for editorial content.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

## Screenshots

### Before
<img width="477" alt="Screenshot 2020-03-23 at 17 23 22" src="https://user-images.githubusercontent.com/51630004/77345737-f71bbc00-6d2c-11ea-8aa4-4097a0f45b16.png">

### After
<img width="477" alt="Screenshot 2020-03-23 at 17 24 25" src="https://user-images.githubusercontent.com/51630004/77345036-fdf5ff00-6d2b-11ea-906c-bae9e61f050b.png">

### Tested

- [ ] Locally
- [x] On CODE (optional)

