### PR TITLE
Add retail to business section

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -63,7 +63,7 @@ private object NavLinks {
   val ukEnvironment = NavLink("Environment", "/environment", children = List(climateChange, wildlife, energy, pollution))
   val auEnvironment = ukEnvironment.copy(children = List(globalDevelopment, ourWideBrownLand))
   val money = NavLink("Money", "/money", children = List(property, pensions, savings, borrowing, careers))
-  val ukBusiness = NavLink("Business", "/business", children = List(economics, banking, money, markets, projectSyndicate, businessToBusiness))
+  val ukBusiness = NavLink("Business", "/business", children = List(economics, banking, money, markets, projectSyndicate, businessToBusiness, retail))
   val usBusiness = ukBusiness.copy(children = List(economics, sustainableBusiness, diversityEquality, smallBusiness))
   val auBusiness = ukBusiness.copy(children = List(markets, money, projectSyndicate))
 

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -64,8 +64,8 @@ private object NavLinks {
   val auEnvironment = ukEnvironment.copy(children = List(globalDevelopment, ourWideBrownLand))
   val money = NavLink("Money", "/money", children = List(property, pensions, savings, borrowing, careers))
   val ukBusiness = NavLink("Business", "/business", children = List(economics, banking, money, markets, projectSyndicate, businessToBusiness, retail))
-  val usBusiness = ukBusiness.copy(children = List(economics, sustainableBusiness, diversityEquality, smallBusiness))
-  val auBusiness = ukBusiness.copy(children = List(markets, money, projectSyndicate))
+  val usBusiness = ukBusiness.copy(children = List(economics, sustainableBusiness, diversityEquality, smallBusiness, retail))
+  val auBusiness = ukBusiness.copy(children = List(markets, money, projectSyndicate, retail))
 
   /* OPINION */
   val columnists = NavLink("Columnists", "/index/contributors")


### PR DESCRIPTION
## What does this change?

Previously retail wasn’t in a section so articles with that tag didn’t get any subnav.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

### Before

<img width="1552" alt="Screenshot 2020-03-24 at 11 47 12" src="https://user-images.githubusercontent.com/379839/77422406-4b727a80-6dc5-11ea-9850-46f899b953ae.png">

### After

<img width="1552" alt="Screenshot 2020-03-24 at 11 47 16" src="https://user-images.githubusercontent.com/379839/77422425-54634c00-6dc5-11ea-9b25-ae2f3f6fa865.png">

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)