### PR TITLE
Show byline image depending on article tone

### DIFF
--- a/article/app/views/fragments/email/emailArticleBody.scala.html
+++ b/article/app/views/fragments/email/emailArticleBody.scala.html
@@ -151,23 +151,26 @@
 
     @fragments.emailMainMedia(article)
 
-    @page.article.trail.byline.map { byline =>
-        @* Show byline if there is exactly one contributor *@
-        @* and this is the Coronavirus: the week explained *@
-        @* and the contributor has a contributor image *@
-        @if(article.tags.contributors.length == 1 &&
-            article.tags.series.exists {
-                _.id == "world/series/coronavirus-the-week-explained"
-            }) {
-            @article.tags.contributors.headOption.map { profile =>
-                @if(profile.properties.contributorLargeImagePath.isEmpty) {
-                    @bylineWithoutImage(byline, page.article.tags.contributors.headOption)
-                } else {
-                    @bylineWithImage(byline, page.article.tags.contributors.headOption)
+    @defining(
+        article.tags.tones.exists { _.id == "tone/features" } ||
+        article.tags.tones.exists { _.id == "tone/reviews" } ||
+        article.tags.tones.exists { _.id == "tone/comment"} ||
+        article.tags.tones.exists { _.id == "tone/interview"}) { case (shouldShowBylineImage) =>
+        @page.article.trail.byline.map { byline =>
+            @* Show byline if there is exactly one contributor *@
+            @* and this is the Coronavirus: the week explained *@
+            @* and the contributor has a contributor image *@
+            @if(article.tags.contributors.length == 1 && shouldShowBylineImage) {
+                @article.tags.contributors.headOption.map { profile =>
+                    @if(profile.properties.contributorLargeImagePath.isEmpty) {
+                        @bylineWithoutImage(byline, page.article.tags.contributors.headOption)
+                    } else {
+                        @bylineWithImage(byline, page.article.tags.contributors.headOption)
+                    }
                 }
+            } else {
+                @bylineWithoutImage(byline, page.article.tags.contributors.headOption)
             }
-        } else {
-            @bylineWithoutImage(byline, page.article.tags.contributors.headOption)
         }
     }
 

--- a/article/app/views/fragments/email/emailArticleBody.scala.html
+++ b/article/app/views/fragments/email/emailArticleBody.scala.html
@@ -90,7 +90,7 @@
             <tr>
                 @firstContributor.properties.contributorLargeImagePath.map { src =>
                     <td class="byline-img">
-                        <img width="80" src="@src" alt="@firstContributor.name" />
+                        <img class="byline-img__img" width="80" src="@src" alt="@firstContributor.name" />
                     </td>
                 }
                 <td>

--- a/article/app/views/fragments/email/emailArticleBody.scala.html
+++ b/article/app/views/fragments/email/emailArticleBody.scala.html
@@ -84,26 +84,24 @@
     </div>
 }
 
-@bylineWithImage(byline: String, firstContributor: Option[Tag]) = {
+@bylineWithImage(byline: String, firstContributor: Tag) = {
     @row(Seq("padded-x", "author")) {
         <table>
             <tr>
-                @firstContributor.map { profile =>
-                    @profile.properties.contributorLargeImagePath.map { src =>
-                        <td class="byline-img">
-                            <img width="80" src="@src" alt="@profile.name" />
-                        </td>
-                    }
-                    <td>
-                        <h3 class="byline">@byline</h3>
-                        @profile.properties.twitterHandle.map { twitterHandle =>
-                            @bylineTwitter(twitterHandle)
-                        }
-                        @profile.properties.emailAddress.map { emailAddress =>
-                            @bylineEmail(emailAddress)
-                        }
+                @firstContributor.properties.contributorLargeImagePath.map { src =>
+                    <td class="byline-img">
+                        <img width="80" src="@src" alt="@firstContributor.name" />
                     </td>
                 }
+                <td>
+                    <h3 class="byline">@byline</h3>
+                    @firstContributor.properties.twitterHandle.map { twitterHandle =>
+                        @bylineTwitter(twitterHandle)
+                    }
+                    @firstContributor.properties.emailAddress.map { emailAddress =>
+                        @bylineEmail(emailAddress)
+                    }
+                </td>
             </tr>
         </table>
         <hr class="rule--flush" />
@@ -152,24 +150,25 @@
     @fragments.emailMainMedia(article)
 
     @defining(
+        article.tags.contributors,
         article.tags.tones.exists { _.id == "tone/features" } ||
         article.tags.tones.exists { _.id == "tone/reviews" } ||
         article.tags.tones.exists { _.id == "tone/comment"} ||
-        article.tags.tones.exists { _.id == "tone/interview"}) { case (shouldShowBylineImage) =>
+        article.tags.tones.exists { _.id == "tone/interview"}) { case (contributors, shouldShowBylineImage) =>
         @page.article.trail.byline.map { byline =>
-            @* Show byline if there is exactly one contributor *@
-            @* and this is the Coronavirus: the week explained *@
-            @* and the contributor has a contributor image *@
-            @if(article.tags.contributors.length == 1 && shouldShowBylineImage) {
-                @article.tags.contributors.headOption.map { profile =>
-                    @if(profile.properties.contributorLargeImagePath.isEmpty) {
-                        @bylineWithoutImage(byline, page.article.tags.contributors.headOption)
-                    } else {
-                        @bylineWithImage(byline, page.article.tags.contributors.headOption)
-                    }
+            @* Show byline if there is exactly one contributor      *@
+            @* and this article is for one of the whitelisted tones *@
+            @* and the contributor has a contributor image          *@
+            @(contributors, shouldShowBylineImage) match {
+                case (head :: Nil, true) if head.properties.contributorLargeImagePath.isDefined => {
+                    @bylineWithImage(byline, head)
                 }
-            } else {
-                @bylineWithoutImage(byline, page.article.tags.contributors.headOption)
+                case (head :: _, _) => {
+                    @bylineWithoutImage(byline, Some(head))
+                }
+                case _ => {
+                    @bylineWithoutImage(byline, None)
+                }
             }
         }
     }

--- a/static/src/stylesheets/email/_article.scss
+++ b/static/src/stylesheets/email/_article.scss
@@ -142,6 +142,10 @@ blockquote {
     width: 80px;
 }
 
+.byline-img__img {
+    width: 80px;
+}
+
 .caption {
     font-family: Helvetica, Arial, sans-serif;
     font-size: 12px;


### PR DESCRIPTION
## What does this change?

Email articles will show a byline image for articles of the following tones:

- Review
- Comment
- Feature
- Interview

This replaces and expands on #22430 (Coronavirus newsletter will always have a feature tone)

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<img width="594" alt="Screenshot 2020-03-24 at 16 18 26" src="https://user-images.githubusercontent.com/5931528/77450425-209b1d00-6deb-11ea-8f0a-83cb5b184525.png">


## What is the value of this and can you measure success?

Improves the look of email articles, and brings them into line with how articles appear on the web.

## Checklist
### Tested

- [x] Locally
- [x] On CODE (optional) <-- I'll do this so I can test via Braze's inbox vision

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
