### PR TITLE
0% a/b test for new gpt.js path

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -135,4 +135,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2020, 5, 13),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-commercial-gpt-path",
+    "0% a/b test for new gpt.js path",
+    owners = Seq(Owner.withGithub("GHaberis")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 4, 26),
+    exposeClientSide = true
+  )
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -142,7 +142,7 @@ trait ABTestSwitches {
     "0% a/b test for new gpt.js path",
     owners = Seq(Owner.withGithub("GHaberis")),
     safeState = Off,
-    sellByDate = new LocalDate(2020, 4, 26),
+    sellByDate = new LocalDate(2020, 4, 27),
     exposeClientSide = true
   )
 }

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -30,6 +30,8 @@ import { init as resize } from 'commercial/modules/messenger/resize';
 import { init as scroll } from 'commercial/modules/messenger/scroll';
 import { init as type } from 'commercial/modules/messenger/type';
 import { init as viewport } from 'commercial/modules/messenger/viewport';
+import { commercialGptPath } from 'common/modules/experiments/tests/commercial-gpt-path';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 
 initMessenger(
     type,
@@ -112,8 +114,12 @@ export const init = (): Promise<void> => {
             });
         });
 
+        const gptPath = isInVariantSynchronous(commercialGptPath, 'variant')
+            ? '//securepubads.g.doubleclick.net/tag/js/gpt.js'
+            : config.get('libs.googletag');
+
         // Just load googletag. Prebid will already be loaded, and googletag is already added to the window by Prebid.
-        return loadScript(config.get('libs.googletag'), { async: false });
+        return loadScript(gptPath, { async: false });
     };
 
     if (commercialFeatures.dfpAdvertising) {

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -12,6 +12,7 @@ import { connatixTest } from 'common/modules/experiments/tests/connatix-ab-test'
 import { frontendDotcomRenderingEpic } from 'common/modules/experiments/tests/frontend-dotcom-rendering-epic';
 import { signInGate } from 'common/modules/experiments/tests/sign-in-gate';
 import { contributionsEpicPrecontributionReminderRoundTwo } from 'common/modules/experiments/tests/contributions-epic-precontribution-reminder-round-two';
+import { commercialGptPath } from 'common/modules/experiments/tests/commercial-gpt-path';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
@@ -22,6 +23,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     appnexusUSAdapter,
     pangaeaAdapterTest,
     signInGate,
+    commercialGptPath,
 ];
 
 export const priorityEpicTest: EpicABTest = frontendDotcomRenderingEpic;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-gpt-path.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-gpt-path.js
@@ -1,0 +1,21 @@
+// @flow strict
+
+export const commercialGptPath: ABTest = {
+    id: 'CommercialGptPath',
+    start: '2020-03-26',
+    expiry: '2020-04-26',
+    author: 'George Haberis',
+    description: '0% a/b test for new gpt.js path',
+    audience: 0.0,
+    audienceOffset: 0.0,
+    successMeasure: 'n/a',
+    audienceCriteria: 'n/a',
+    dataLinkNames: 'n/a',
+    idealOutcome: 'New gpt.js path does not adversely affect advertisement',
+    variants: [
+        {
+            id: 'variant',
+            test: (): void => {},
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-gpt-path.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-gpt-path.js
@@ -12,6 +12,7 @@ export const commercialGptPath: ABTest = {
     audienceCriteria: 'n/a',
     dataLinkNames: 'n/a',
     idealOutcome: 'New gpt.js path does not adversely affect advertisement',
+    canRun: () => true,
     variants: [
         {
             id: 'variant',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-gpt-path.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-gpt-path.js
@@ -2,8 +2,8 @@
 
 export const commercialGptPath: ABTest = {
     id: 'CommercialGptPath',
-    start: '2020-03-26',
-    expiry: '2020-04-26',
+    start: '2020-03-25',
+    expiry: '2020-04-27',
     author: 'George Haberis',
     description: '0% a/b test for new gpt.js path',
     audience: 0.0,


### PR DESCRIPTION
## What does this change?

0% a/b test for new `gpt.js` path. If in the `variant` of this test `gpt.js` will be downloaded from `https://securepubads.g.doubleclick.net/tag/js/gpt.js`, if not it will be downloaded from `https://www.googletagservices.com/tag/js/gpt.js`.

### Why switch paths? 
Google Ad Manager docs recommend we do so [here](https://support.google.com/admanager/answer/1638622?visit_id=637181511322071279-4007197348&rd=1) 

> The Google Publisher Tag library is now hosted at https://securepubads.g.doubleclick.net/tag/js/gpt.js, in addition to being hosted at the googletagservices.com domain. While not required, we strongly recommend that you update all references to GPT on your pages to use this new domain.
> 
> This change consolidates all ad serving requests to one domain, instead of two, which means the browser only needs to connect to one domain. The library is exactly the same at both domains.
> 
> The result is an improvement in the speed of your tags and fetching ads a bit quicker.

### Why a 0% a/b test? 
When testing this on `CODE` without the change being behind a test I noted the first request initiated by ourselves used the new path, but there were multiple subsequent requests using the old path, these requests are initiated from `VMscriptId`s. An inspection of this code contained many references to `confiant`. I've been in touch with `confiant` and agreed to send them a link so they can opt-in to the variant of this 0% a/b test so they can then inspect the source of these requests.

https://trello.com/c/mwO5RP2m/669-optimize-gpt-speed-by-updating-the-hosted-library-domain