### PR TITLE
Update PFP ads custom metrics

### DIFF
--- a/static/src/javascripts/projects/common/modules/video/ga-helper.js
+++ b/static/src/javascripts/projects/common/modules/video/ga-helper.js
@@ -59,7 +59,7 @@ const buildPfpEvent = (
     pfpEventType: PfpEventType,
     videoId: string
 ): PfpEventParams => {
-    const pfpEventMetric = pfpEventType === 'adStart' ? 17 : 18;
+    const pfpEventMetric = pfpEventType === 'adStart' ? 24 : 25;
     return {
         eventCategory: 'media',
         eventAction: 'video preroll',


### PR DESCRIPTION
## What does this change?

Updates the metrics ids for pfp ad start and ad end. Looks like the previous ids were taken without updating our docs.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)


## Checklist

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
