### PR TITLE
Modify metadata for remote epic comparison

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -106,8 +106,9 @@ export const getEpicTestToRun = memoize(
                                 sectionName: page.section,
                                 shouldHideReaderRevenue:
                                     page.shouldHideReaderRevenue,
-                                isMinuteArticle: config.hasTone('Minute'),
-                                isPaidContent: page.isPaidContent,
+                                isMinuteArticle: page.isMinuteArticle,
+                                isPaidContent:
+                                    page.sponsorshipType === 'paid-content',
                                 tags: buildKeywordTags(page),
                                 countryCode,
                                 showSupportMessaging: !shouldNotBeShownSupportMessaging(),


### PR DESCRIPTION
To align with how we get the values in the existing Frontend code.

'Modify' rather than fix as it's unclear if this is an issue, but the only way to know is to test! And I have seen prod comparison failures that I am unable to replicate, suggesting that we might be sending the wrong/different data to our remote service.