### PR TITLE
Public health banner test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -36,13 +36,12 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
-//  TBD change safe state before deploying:
   Switch(
     ABTests,
     "ab-contributions-covid-banner-round-one",
     "Covid crisis",
     owners = Seq(Owner.withGithub("jlieb10")),
-    safeState = On,
+    safeState = Off,
     sellByDate = new LocalDate(2020, 9, 30),
     exposeClientSide = true
   )

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -36,12 +36,13 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+//  TBD change safe state before deploying:
   Switch(
     ABTests,
     "ab-contributions-covid-banner-round-one",
     "Covid crisis",
     owners = Seq(Owner.withGithub("jlieb10")),
-    safeState = Off,
+    safeState = On,
     sellByDate = new LocalDate(2020, 9, 30),
     exposeClientSide = true
   )

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -38,6 +38,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-contributions-covid-banner-round-one",
+    "Covid crisis",
+    owners = Seq(Owner.withGithub("jlieb10")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 9, 30),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-acquisitions-epic-always-ask-if-tagged",
     "This guarantees that any on any article that is tagged with a tag that is on the allowed list of tags as set by the tagging tool, the epic will be displayed",
     owners = Seq(Owner.withGithub("jranks123")),

--- a/static/src/javascripts/__flow__/types/acquisitions.js
+++ b/static/src/javascripts/__flow__/types/acquisitions.js
@@ -25,6 +25,7 @@ declare type EngagementBannerTemplateParams = {
     signInUrl?: string,
     secondaryLinkUrl?: string,
     secondaryLinkLabel?: string,
+    subsLinkUrl?: string,
 };
 
 /**

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -119,6 +119,15 @@ const bannerParamsToHtml = (params: EngagementBannerParams): string => {
         campaignCode: params.campaignCode,
         ...(params.abTest ? { abTest: params.abTest } : {}),
     });
+
+    const subsLinkUrl = addTrackingCodesToUrl({
+        base: `${config.get('page.supportUrl')}/subscribe`,
+        componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+        componentId: params.campaignCode,
+        campaignCode: params.campaignCode,
+        ...(params.abTest ? { abTest: params.abTest } : {}),
+    });
+
     const buttonCaption = params.buttonCaption;
     const templateParams = {
         titles: params.titles,
@@ -134,6 +143,7 @@ const bannerParamsToHtml = (params: EngagementBannerParams): string => {
         signInUrl: params.signInUrl,
         secondaryLinkUrl: params.secondaryLinkUrl,
         secondaryLinkLabel: params.secondaryLinkLabel,
+        subsLinkUrl,
     };
 
     return params.template

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-covid.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-covid.js
@@ -37,7 +37,7 @@ export const acquisitionsBannerCovidTemplate = (
                         <a tabIndex="3" class="component-button component-button--hasicon-right component-button--secondary" href="${
                             params.linkUrl
                         }">
-                            ${params.buttonCaption}
+                            ${params.ctaText}
                             <svg
                                 class="svg-arrow-right-straight"
                                 xmlns="http://www.w3.org/2000/svg"
@@ -55,8 +55,8 @@ export const acquisitionsBannerCovidTemplate = (
                     ${
                         params.secondaryLinkLabel && params.secondaryLinkUrl
                             ? `
-                        <div class="engagement-banner__cta engagement-banner__cta--editorial">
-                            <a tabIndex="3" class="component-button component-button--hasicon-right component-button--primary" href="${
+                        <div class="engagement-banner__cta engagement-banner__cta--subscribe">
+                            <a tabIndex="3" class="component-button component-button--hasicon-right component-button--primary component-button--primary--covid-banner" href="${
                                 params.secondaryLinkUrl
                             }">
                                     ${params.secondaryLinkLabel}

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-covid.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-covid.js
@@ -17,23 +17,24 @@ export const acquisitionsBannerCovidTemplate = (
         </div>
 
         <div class="engagement-banner__container engagement-banner__container--covid-banner">
+            <div class="engagement-banner__header-container">
                 <div class="engagement-banner__header">
                     <h2 class="engagement-banner__header-text">${
                         params.titles ? params.titles[0] : ''
                     }</h2>
                 </div>
+            </div>
 
-                <div class="engagement-banner__lead-text">
-                    <p>${params.leadSentence ? params.leadSentence : ''}</p>
-                </div>
-
+            <div class="engagement-banner__text-container">
                 <div class="engagement-banner__body">
-                    <p>${params.messageText}</p>
+                    <p><span class="engagement-banner__lead-sentence">${
+                        params.leadSentence ? params.leadSentence : ''
+                    }</span>${params.messageText}</p>
                 </div>
 
                 <div class="engagement-banner__cta-container">
                     <div class="engagement-banner__cta">
-                        <a tabIndex="3" class="component-button component-button--hasicon-right component-button--primary" href="${
+                        <a tabIndex="3" class="component-button component-button--hasicon-right component-button--secondary" href="${
                             params.linkUrl
                         }">
                             ${params.buttonCaption}
@@ -50,28 +51,30 @@ export const acquisitionsBannerCovidTemplate = (
                         </a>
                     </div>
 
-                    <div class="engagement-banner__cta engagement-banner__cta--editorial">
+
                     ${
                         params.secondaryLinkLabel && params.secondaryLinkUrl
                             ? `
-                    <a tabIndex="3" class="component-button component-button--hasicon-right component-button--greyHollow component-button--greyHollow--covid-banner" href="${
-                        params.secondaryLinkUrl
-                    }">
-                            ${params.secondaryLinkLabel}
-                            <svg
-                                class="svg-arrow-right-straight"
-                                xmlns="http://www.w3.org/2000/svg"
-                                viewBox="0 0 20 17.89"
-                                preserveAspectRatio="xMinYMid"
-                                aria-hidden="true"
-                                focusable="false"
-                            >
-                                <path d="M20 9.35l-9.08 8.54-.86-.81 6.54-7.31H0V8.12h16.6L10.06.81l.86-.81L20 8.51v.84z" />
-                            </svg>
-                        </a>
-`
+                        <div class="engagement-banner__cta engagement-banner__cta--editorial">
+                            <a tabIndex="3" class="component-button component-button--hasicon-right component-button--primary" href="${
+                                params.secondaryLinkUrl
+                            }">
+                                    ${params.secondaryLinkLabel}
+                                    <svg
+                                        class="svg-arrow-right-straight"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        viewBox="0 0 20 17.89"
+                                        preserveAspectRatio="xMinYMid"
+                                        aria-hidden="true"
+                                        focusable="false"
+                                    >
+                                        <path d="M20 9.35l-9.08 8.54-.86-.81 6.54-7.31H0V8.12h16.6L10.06.81l.86-.81L20 8.51v.84z" />
+                                    </svg>
+                                </a>
+                            </div>`
                             : ''
                     }
-                    </div>
+
                 </div>
+            </div>
     `;

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-covid.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-covid.js
@@ -19,9 +19,18 @@ export const acquisitionsBannerCovidTemplate = (
         <div class="engagement-banner__container engagement-banner__container--covid-banner">
             <div class="engagement-banner__header-container">
                 <div class="engagement-banner__header">
-                    <h2 class="engagement-banner__header-text">${
-                        params.titles ? params.titles[0] : ''
-                    }</h2>
+                    <h2 class="engagement-banner__header-text">
+                    <span>${
+                        params.titles && params.titles[0]
+                            ? params.titles[0]
+                            : ''
+                    }</span>
+                    <span>${
+                        params.titles && params.titles[1]
+                            ? params.titles[1]
+                            : ''
+                    }</span>
+                    </h2>
                 </div>
             </div>
 
@@ -53,11 +62,11 @@ export const acquisitionsBannerCovidTemplate = (
 
 
                     ${
-                        params.secondaryLinkLabel && params.secondaryLinkUrl
+                        params.secondaryLinkLabel && params.subsLinkUrl
                             ? `
                         <div class="engagement-banner__cta engagement-banner__cta--subscribe">
                             <a tabIndex="3" class="component-button component-button--hasicon-right component-button--primary component-button--primary--covid-banner" href="${
-                                params.secondaryLinkUrl
+                                params.subsLinkUrl
                             }">
                                     ${params.secondaryLinkLabel}
                                     <svg

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-covid.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-banner-covid.js
@@ -1,0 +1,77 @@
+// @flow
+
+import marque36icon from 'svgs/icon/marque-36.svg';
+import closeCentralIcon from 'svgs/icon/close-central.svg';
+
+export const acquisitionsBannerCovidTemplate = (
+    params: EngagementBannerTemplateParams
+): string => `
+        <div class="engagement-banner__close">
+            <div class="engagement-banner__roundel">
+                ${marque36icon.markup}
+            </div>
+            <button tabindex="4" class="button engagement-banner__close-button js-site-message-close js-engagement-banner-close-button" data-link-name="hide release message">
+                <span class="u-h">Close the support banner</span>
+                ${closeCentralIcon.markup}
+            </button>
+        </div>
+
+        <div class="engagement-banner__container engagement-banner__container--covid-banner">
+                <div class="engagement-banner__header">
+                    <h2 class="engagement-banner__header-text">${
+                        params.titles ? params.titles[0] : ''
+                    }</h2>
+                </div>
+
+                <div class="engagement-banner__lead-text">
+                    <p>${params.leadSentence ? params.leadSentence : ''}</p>
+                </div>
+
+                <div class="engagement-banner__body">
+                    <p>${params.messageText}</p>
+                </div>
+
+                <div class="engagement-banner__cta-container">
+                    <div class="engagement-banner__cta">
+                        <a tabIndex="3" class="component-button component-button--hasicon-right component-button--primary" href="${
+                            params.linkUrl
+                        }">
+                            ${params.buttonCaption}
+                            <svg
+                                class="svg-arrow-right-straight"
+                                xmlns="http://www.w3.org/2000/svg"
+                                viewBox="0 0 20 17.89"
+                                preserveAspectRatio="xMinYMid"
+                                aria-hidden="true"
+                                focusable="false"
+                            >
+                                <path d="M20 9.35l-9.08 8.54-.86-.81 6.54-7.31H0V8.12h16.6L10.06.81l.86-.81L20 8.51v.84z" />
+                            </svg>
+                        </a>
+                    </div>
+
+                    <div class="engagement-banner__cta engagement-banner__cta--editorial">
+                    ${
+                        params.secondaryLinkLabel && params.secondaryLinkUrl
+                            ? `
+                    <a tabIndex="3" class="component-button component-button--hasicon-right component-button--greyHollow component-button--greyHollow--covid-banner" href="${
+                        params.secondaryLinkUrl
+                    }">
+                            ${params.secondaryLinkLabel}
+                            <svg
+                                class="svg-arrow-right-straight"
+                                xmlns="http://www.w3.org/2000/svg"
+                                viewBox="0 0 20 17.89"
+                                preserveAspectRatio="xMinYMid"
+                                aria-hidden="true"
+                                focusable="false"
+                            >
+                                <path d="M20 9.35l-9.08 8.54-.86-.81 6.54-7.31H0V8.12h16.6L10.06.81l.86-.81L20 8.51v.84z" />
+                            </svg>
+                        </a>
+`
+                            : ''
+                    }
+                    </div>
+                </div>
+    `;

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -13,6 +13,7 @@ import { frontendDotcomRenderingEpic } from 'common/modules/experiments/tests/fr
 import { signInGate } from 'common/modules/experiments/tests/sign-in-gate';
 import { contributionsEpicPrecontributionReminderRoundTwo } from 'common/modules/experiments/tests/contributions-epic-precontribution-reminder-round-two';
 import { commercialGptPath } from 'common/modules/experiments/tests/commercial-gpt-path';
+import { contributionsCovidBannerRoundOne } from 'common/modules/experiments/tests/contribs-banner-covid-round-one';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
@@ -35,5 +36,6 @@ export const epicTests: $ReadOnlyArray<EpicABTest> = [
 ];
 
 export const engagementBannerTests: $ReadOnlyArray<AcquisitionsABTest> = [
+    contributionsCovidBannerRoundOne,
     articlesViewedBanner,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-covid-round-one.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-covid-round-one.js
@@ -7,13 +7,10 @@ const geolocation = geolocationGetSync();
 const isUSorAU = geolocation === 'US' || geolocation === 'AU';
 
 // Shared parameters:
-const titles = [`Trust has never mattered more`];
+const titles = [`Trust has never`, `mattered more`];
 const ctaText = 'Contribute';
 
 // Shared but geospecific parameters:
-const secondaryLinkUrl = isUSorAU
-    ? undefined
-    : `https://support.theguardian.com/subscribe/digital?acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_ENGAGEMENT_BANNER%22%2C%22componentId%22%3A%22covid_banner_1%22%2C%22campaignCode%22%3A%22covid_banner_1%22%7D&INTCMP=gdnwb_copts_housead_covid_moment_banner`;
 const secondaryLinkLabel = isUSorAU ? undefined : `Subscribe`;
 
 // Variant-specific parameters:
@@ -23,7 +20,7 @@ const openLeadSentence = `Thanks to your support we can continue to provide qual
 
 const controlMessageText = `Millions of readers across the world are visiting the Guardian every day for open, independent, accurate journalism. Trusted news has never been so important, and neither has your support.`;
 const accuracyMessageText = `No matter how uncertain the future feels, you can rely on us. Quality journalism can help us all make critical decisions about our lives, health and security – based on fact, not fiction. Trusted news has never been so important, and neither has your support.`;
-const openMessageText = `We keep our journalism free from a paywall because we believe everyone deserves equal access to accurate news and calm explanation. Trusted news has never been so important and neither has your support.`;
+const openMessageText = `We keep our journalism free from a paywall because we believe everyone deserves equal access to accurate news and calm explanation. Trusted news has never been so important, and neither has your support.`;
 
 export const contributionsCovidBannerRoundOne: AcquisitionsABTest = {
     id: 'ContributionsCovidBannerRoundOne',
@@ -55,7 +52,6 @@ export const contributionsCovidBannerRoundOne: AcquisitionsABTest = {
                 bannerModifierClass: 'covid-banner',
                 minArticlesBeforeShowingBanner: 2,
                 secondaryLinkLabel,
-                secondaryLinkUrl,
             },
         },
         {
@@ -71,7 +67,6 @@ export const contributionsCovidBannerRoundOne: AcquisitionsABTest = {
                 bannerModifierClass: 'covid-banner',
                 minArticlesBeforeShowingBanner: 2,
                 secondaryLinkLabel,
-                secondaryLinkUrl,
             },
         },
         {
@@ -87,7 +82,6 @@ export const contributionsCovidBannerRoundOne: AcquisitionsABTest = {
                 bannerModifierClass: 'covid-banner',
                 minArticlesBeforeShowingBanner: 2,
                 secondaryLinkLabel,
-                secondaryLinkUrl,
             },
         },
     ],

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-covid-round-one.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-covid-round-one.js
@@ -7,7 +7,7 @@ const geolocation = geolocationGetSync();
 const isUSorAU = geolocation === 'US' || geolocation === 'AU';
 
 // Shared parameters:
-const titles = [`Trust has never never mattered more`];
+const titles = [`Trust has never mattered more`];
 const ctaText = 'Contribute';
 
 // Shared but geospecific parameters:
@@ -17,9 +17,9 @@ const secondaryLinkUrl = isUSorAU
 const secondaryLinkLabel = isUSorAU ? undefined : `Subscribe`;
 
 // Variant-specific parameters:
-const controlLeadSentence = `Thanks to your support we can continue to provide our vital reporting – in times of crisis and beyond`;
-const accuracyLeadSentence = `Thanks to your support we can continue to provide accurate, independent news and calm explanation`;
-const openLeadSentence = `Thanks to your support we can continue to provide quality, independent reporting that’s open to readers across the world`;
+const controlLeadSentence = `Thanks to your support we can continue to provide our vital reporting – in times of crisis and beyond. `;
+const accuracyLeadSentence = `Thanks to your support we can continue to provide accurate, independent news and calm explanation. `;
+const openLeadSentence = `Thanks to your support we can continue to provide quality, independent reporting that’s open to readers across the world. `;
 
 const controlMessageText = `Millions of readers across the world are visiting the Guardian every day for open, independent, accurate journalism. Trusted news has never been so important, and neither has your support.`;
 const accuracyMessageText = `No matter how uncertain the future feels, you can rely on us. Quality journalism can help us all make critical decisions about our lives, health and security – based on fact, not fiction. Trusted news has never been so important, and neither has your support.`;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-covid-round-one.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-covid-round-one.js
@@ -28,7 +28,7 @@ export const contributionsCovidBannerRoundOne: AcquisitionsABTest = {
     start: '2020-03-26',
     expiry: '2020-06-26',
     author: 'Joshua Lieberman',
-    description: 'custom banner for the Europe Moment',
+    description: 'custom banner for the public health crisis',
     audience: 1,
     audienceOffset: 0,
     successMeasure: 'AV per impression',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-covid-round-one.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-covid-round-one.js
@@ -1,0 +1,94 @@
+// @flow
+import { getSync as geolocationGetSync } from 'lib/geolocation';
+
+import { acquisitionsBannerCovidTemplate } from 'common/modules/commercial/templates/acquisitions-banner-covid';
+
+const geolocation = geolocationGetSync();
+const isUSorAU = geolocation === 'US' || geolocation === 'AU';
+
+// Shared parameters:
+const titles = [`Trust has never never mattered more`];
+const ctaText = 'Contribute';
+
+// Shared but geospecific parameters:
+const secondaryLinkUrl = isUSorAU
+    ? undefined
+    : `https://support.theguardian.com/subscribe/digital?acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_ENGAGEMENT_BANNER%22%2C%22componentId%22%3A%22covid_banner_1%22%2C%22campaignCode%22%3A%22covid_banner_1%22%7D&INTCMP=gdnwb_copts_housead_covid_moment_banner`;
+const secondaryLinkLabel = isUSorAU ? undefined : `Subscribe`;
+
+// Variant-specific parameters:
+const controlLeadSentence = `Thanks to your support we can continue to provide our vital reporting – in times of crisis and beyond`;
+const accuracyLeadSentence = `Thanks to your support we can continue to provide accurate, independent news and calm explanation`;
+const openLeadSentence = `Thanks to your support we can continue to provide quality, independent reporting that’s open to readers across the world`;
+
+const controlMessageText = `Millions of readers across the world are visiting the Guardian every day for open, independent, accurate journalism. Trusted news has never been so important, and neither has your support.`;
+const accuracyMessageText = `No matter how uncertain the future feels, you can rely on us. Quality journalism can help us all make critical decisions about our lives, health and security – based on fact, not fiction. Trusted news has never been so important, and neither has your support.`;
+const openMessageText = `We keep our journalism free from a paywall because we believe everyone deserves equal access to accurate news and calm explanation. Trusted news has never been so important and neither has your support.`;
+
+export const contributionsCovidBannerRoundOne: AcquisitionsABTest = {
+    id: 'ContributionsCovidBannerRoundOne',
+    campaignId: 'covid_banner_1',
+    start: '2020-03-26',
+    expiry: '2020-06-26',
+    author: 'Joshua Lieberman',
+    description: 'custom banner for the Europe Moment',
+    audience: 1,
+    audienceOffset: 0,
+    successMeasure: 'AV per impression',
+    audienceCriteria: 'All',
+    idealOutcome: 'to learn about copy from how variants perform vs control',
+    showForSensitive: true,
+    componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
+    canRun: () => true,
+    geolocation,
+    variants: [
+        {
+            id: 'control',
+            test: (): void => {},
+            engagementBannerParams: {
+                titles,
+                messageText: controlMessageText,
+                leadSentence: controlLeadSentence,
+                ctaText,
+                template: acquisitionsBannerCovidTemplate,
+                hasTicker: true,
+                bannerModifierClass: 'covid-banner',
+                minArticlesBeforeShowingBanner: 2,
+                secondaryLinkLabel,
+                secondaryLinkUrl,
+            },
+        },
+        {
+            id: 'accuracy',
+            test: (): void => {},
+            engagementBannerParams: {
+                titles,
+                messageText: accuracyMessageText,
+                leadSentence: accuracyLeadSentence,
+                ctaText,
+                template: acquisitionsBannerCovidTemplate,
+                hasTicker: true,
+                bannerModifierClass: 'covid-banner',
+                minArticlesBeforeShowingBanner: 2,
+                secondaryLinkLabel,
+                secondaryLinkUrl,
+            },
+        },
+        {
+            id: 'open',
+            test: (): void => {},
+            engagementBannerParams: {
+                titles,
+                messageText: openMessageText,
+                leadSentence: openLeadSentence,
+                ctaText,
+                template: acquisitionsBannerCovidTemplate,
+                hasTicker: true,
+                bannerModifierClass: 'covid-banner',
+                minArticlesBeforeShowingBanner: 2,
+                secondaryLinkLabel,
+                secondaryLinkUrl,
+            },
+        },
+    ],
+};

--- a/static/src/stylesheets/_common.garnett.scss
+++ b/static/src/stylesheets/_common.garnett.scss
@@ -40,3 +40,4 @@
 @import 'module/experiments/svg';
 @import 'module/experiments/_acquisitions-epic-testimonials';
 @import 'module/experiments/_update-account';
+@import 'module/site-messages/_engagement-banner-covid.scss';

--- a/static/src/stylesheets/module/site-messages/_engagement-banner-covid.scss
+++ b/static/src/stylesheets/module/site-messages/_engagement-banner-covid.scss
@@ -9,16 +9,11 @@
 
 $title: 'Guardian Titlepiece', Georgia, serif !default;
 
-// Extrinsic banner elements like the roundel and the close button:
+// Extrinsic to banner template elements like the roundel and the close button:
 .site-message--covid-banner {
     position: relative;
     overflow: hidden;
-    padding-top: 0;
     color: $brightness-7;
-
-    .site-message__copy {
-        padding: 0;
-    }
 
     .site-message__roundel {
         display: none;
@@ -67,7 +62,7 @@ $title: 'Guardian Titlepiece', Georgia, serif !default;
     }
 }
 
-// Internal banner elements and design:
+// Internal banner template elements and design:
 .engagement-banner__container--covid-banner {
     position: relative;
     display: flex;
@@ -80,7 +75,18 @@ $title: 'Guardian Titlepiece', Georgia, serif !default;
 
     .engagement-banner__header-container {
         @include mq($from: tablet) {
+            position: relative;
             flex: 0 0 37.5%;
+
+            &:after {
+                content: '';
+                position: absolute;
+                right: 0;
+                top: -8px;
+                height: 150%;
+                width: 1px;
+                background-color: $brightness-7;
+            }
         }
     }
 
@@ -99,6 +105,10 @@ $title: 'Guardian Titlepiece', Georgia, serif !default;
     }
 
     .engagement-banner__text-container {
+        @include mq($from: tablet) {
+            margin-left: $gs-gutter;
+        }
+
         @include mq($from: desktop) {
             flex: 0 0 50%;
         }
@@ -117,9 +127,8 @@ $title: 'Guardian Titlepiece', Georgia, serif !default;
             font-size: 17px;
         }
 
-        @include mq($from: tablet) {
-            //padding: $gs-baseline $gs-gutter 0 0;
-            //margin-left: $gs-gutter / 2;
+        p:last-of-type {
+            margin-bottom: 0;
         }
     }
 
@@ -131,24 +140,16 @@ $title: 'Guardian Titlepiece', Georgia, serif !default;
 
         @include mq($from: tablet) {
             display: inline-block;
-            margin-left: $gs-gutter / 2;
         }
     }
 
-    .engagement-banner__cta--editorial {
-        color: $brightness-97;
-
+    .engagement-banner__cta--subscribe {
         @include mq($from: tablet) {
             margin-left: $gs-gutter;
         }
 
-        //.component-button--greyHollow--covid-banner {
-        //    border-color: $highlight-main;
-        //    color: $highlight-main !important;
-        //
-        //    &:hover, &:focus {
-        //        background: transparent;
-        //    }
-        //}
+        .component-button--primary--covid-banner {
+            border: 1px solid $brightness-7;
+        }
     }
 }

--- a/static/src/stylesheets/module/site-messages/_engagement-banner-covid.scss
+++ b/static/src/stylesheets/module/site-messages/_engagement-banner-covid.scss
@@ -1,7 +1,20 @@
+@font-face {
+    font-family: 'Guardian Titlepiece';
+    src:
+    url('https://interactive.guim.co.uk/fonts/garnett/GTGuardianTitlepiece-Bold.woff2') format('woff2'),
+    url('https://interactive.guim.co.uk/fonts/garnett/GTGuardianTitlepiece-Bold.woff') format('woff'),
+    url('https://interactive.guim.co.uk/fonts/garnett/GTGuardianTitlepiece-Bold.ttf') format('truetype');
+    font-style: normal;
+}
+
+$title: 'Guardian Titlepiece', Georgia, serif !default;
+
+// Extrinsic banner elements like the roundel and the close button:
 .site-message--covid-banner {
     position: relative;
     overflow: hidden;
     padding-top: 0;
+    color: $brightness-7;
 
     .site-message__copy {
         padding: 0;
@@ -46,14 +59,15 @@
     }
 
     .engagement-banner__close-button {
-        border-color: $brightness-97;
+        border-color: $brightness-7;
 
         path {
-            fill: $brightness-97;
+            fill: $brightness-7;
         }
     }
 }
 
+// Internal banner elements and design:
 .engagement-banner__container--covid-banner {
     position: relative;
     display: flex;
@@ -64,85 +78,38 @@
         flex-flow: row nowrap;
     }
 
-    @include mq($from: desktop) {
-        &:before {
-            content: '';
-            position: absolute;
-            left: 0;
-            height: 120%;
-            width: 1px;
-            background-color: $brightness-7;
-            top: 0;
-            z-index: 1;
+    .engagement-banner__header-container {
+        @include mq($from: tablet) {
+            flex: 0 0 37.5%;
+        }
+    }
+
+    .engagement-banner__header-text {
+        font-family: $title;
+        font-size: 26px;
+        line-height: 1;
+
+        @include mq($from: tablet) {
+            font-size: 46px;
+        }
+
+        @include mq($from: desktop) {
+            font-size: 60px;
         }
     }
 
     .engagement-banner__text-container {
-        flex: 0 1 50%;
-        position: relative;
-        margin-bottom: $gs-baseline * 2;
-
-        @include mq($from: tablet) {
-            flex: 0 0 75%;
-        }
-
-        @include mq($from: leftCol) {
-            flex: 0 1 50%;
-            margin-bottom: $gs-baseline;
+        @include mq($from: desktop) {
+            flex: 0 0 50%;
         }
     }
 
-    .engagement-banner__image-container--mobile {
-        display: block;
-        position: absolute;
-        bottom: 0;
-        right: 0;
-
-        @include mq($from: tablet) {
-            display: none;
-        }
-    }
-
-    .engagement-banner__image-container--tablet {
-        display: none;
-
-        @include mq($from: tablet, $until: leftCol) {
-            display: block;
-            flex: 0 1 25%;
-            position: relative;
-        }
-
-        svg {
-            position: absolute;
-            right: $gs-gutter;
-            bottom: $gs-baseline;
-        }
-    }
-
-    .engagement-banner__image-container--desktop {
-        display: none;
-
-        @include mq($from: leftCol) {
-            display: block;
-            flex: 1 0 50%;
-
-            svg {
-                height: 100%;
-            }
-        }
-    }
-
-    .engagement-banner__header {
-        padding: 0;
-    }
-
-    .engagement-banner__header-text  {
-        display: none;
+    .engagement-banner__lead-sentence {
+        font-weight: bold;
     }
 
     .engagement-banner__body {
         @include f-bodyCopy;
-        color: $brightness-97;
         font-size: 15px;
         line-height: 1.35;
 
@@ -151,8 +118,8 @@
         }
 
         @include mq($from: tablet) {
-            padding: $gs-baseline $gs-gutter 0 0;
-            margin-left: $gs-gutter / 2;
+            //padding: $gs-baseline $gs-gutter 0 0;
+            //margin-left: $gs-gutter / 2;
         }
     }
 
@@ -175,13 +142,13 @@
             margin-left: $gs-gutter;
         }
 
-        .component-button--greyHollow--covid-banner {
-            border-color: $highlight-main;
-            color: $highlight-main !important;
-
-            &:hover, &:focus {
-                background: transparent;
-            }
-        }
+        //.component-button--greyHollow--covid-banner {
+        //    border-color: $highlight-main;
+        //    color: $highlight-main !important;
+        //
+        //    &:hover, &:focus {
+        //        background: transparent;
+        //    }
+        //}
     }
 }

--- a/static/src/stylesheets/module/site-messages/_engagement-banner-covid.scss
+++ b/static/src/stylesheets/module/site-messages/_engagement-banner-covid.scss
@@ -1,0 +1,187 @@
+.site-message--covid-banner {
+    position: relative;
+    overflow: hidden;
+    padding-top: 0;
+
+    .site-message__copy {
+        padding: 0;
+    }
+
+    .site-message__roundel {
+        display: none;
+    }
+
+    .engagement-banner__close {
+        position: absolute;
+        z-index: 1;
+        right: 0;
+        top: $gs-baseline;
+
+        @include mq($from: tablet) {
+            right: $gs-gutter;
+        }
+
+        @include mq($from: desktop) {
+            display: flex;
+            flex-flow: row nowrap;
+        }
+    }
+
+    .engagement-banner__roundel {
+        display: none;
+
+        @include mq($from: desktop) {
+            display: block;
+            position: relative;
+            margin-right: $gs-gutter / 2;
+        }
+
+        path:first-of-type {
+            fill: $brightness-97;
+        }
+
+        path:nth-of-type(2) {
+            fill: $brand-main;
+        }
+    }
+
+    .engagement-banner__close-button {
+        border-color: $brightness-97;
+
+        path {
+            fill: $brightness-97;
+        }
+    }
+}
+
+.engagement-banner__container--covid-banner {
+    position: relative;
+    display: flex;
+    flex-flow: column nowrap;
+    width: 100%;
+
+    @include mq($from: tablet) {
+        flex-flow: row nowrap;
+    }
+
+    @include mq($from: desktop) {
+        &:before {
+            content: '';
+            position: absolute;
+            left: 0;
+            height: 120%;
+            width: 1px;
+            background-color: $brightness-7;
+            top: 0;
+            z-index: 1;
+        }
+    }
+
+    .engagement-banner__text-container {
+        flex: 0 1 50%;
+        position: relative;
+        margin-bottom: $gs-baseline * 2;
+
+        @include mq($from: tablet) {
+            flex: 0 0 75%;
+        }
+
+        @include mq($from: leftCol) {
+            flex: 0 1 50%;
+            margin-bottom: $gs-baseline;
+        }
+    }
+
+    .engagement-banner__image-container--mobile {
+        display: block;
+        position: absolute;
+        bottom: 0;
+        right: 0;
+
+        @include mq($from: tablet) {
+            display: none;
+        }
+    }
+
+    .engagement-banner__image-container--tablet {
+        display: none;
+
+        @include mq($from: tablet, $until: leftCol) {
+            display: block;
+            flex: 0 1 25%;
+            position: relative;
+        }
+
+        svg {
+            position: absolute;
+            right: $gs-gutter;
+            bottom: $gs-baseline;
+        }
+    }
+
+    .engagement-banner__image-container--desktop {
+        display: none;
+
+        @include mq($from: leftCol) {
+            display: block;
+            flex: 1 0 50%;
+
+            svg {
+                height: 100%;
+            }
+        }
+    }
+
+    .engagement-banner__header {
+        padding: 0;
+    }
+
+    .engagement-banner__header-text  {
+        display: none;
+    }
+
+    .engagement-banner__body {
+        @include f-bodyCopy;
+        color: $brightness-97;
+        font-size: 15px;
+        line-height: 1.35;
+
+        @include mq($from: phablet) {
+            font-size: 17px;
+        }
+
+        @include mq($from: tablet) {
+            padding: $gs-baseline $gs-gutter 0 0;
+            margin-left: $gs-gutter / 2;
+        }
+    }
+
+    .engagement-banner__cta {
+        position: relative;
+        z-index: 1;
+        padding-top: $gs-baseline / 2;
+        display: block;
+
+        @include mq($from: tablet) {
+            display: inline-block;
+            margin-left: $gs-gutter / 2;
+        }
+    }
+
+    .engagement-banner__cta--editorial {
+        color: $brightness-97;
+
+        @include mq($from: tablet) {
+            margin-left: $gs-gutter;
+        }
+
+        .component-button--greyHollow--covid-banner {
+            border-color: $highlight-main;
+            color: $highlight-main !important;
+
+            &:hover, &:focus {
+                background: transparent;
+            }
+        }
+    }
+}

--- a/static/src/stylesheets/module/site-messages/_engagement-banner-covid.scss
+++ b/static/src/stylesheets/module/site-messages/_engagement-banner-covid.scss
@@ -76,7 +76,7 @@ $title: 'Guardian Titlepiece', Georgia, serif !default;
     .engagement-banner__header-container {
         @include mq($from: tablet) {
             position: relative;
-            flex: 0 0 37.5%;
+            flex: 0 0 32.5%;
 
             &:after {
                 content: '';
@@ -87,6 +87,16 @@ $title: 'Guardian Titlepiece', Georgia, serif !default;
                 width: 1px;
                 background-color: $brightness-7;
             }
+        }
+
+        @include mq($from: desktop) {
+            flex: 0 0 37.5%;
+        }
+    }
+
+    .engagement-banner__header {
+        @include mq($until: phablet) {
+            border-bottom: 0;
         }
     }
 
@@ -102,11 +112,19 @@ $title: 'Guardian Titlepiece', Georgia, serif !default;
         @include mq($from: desktop) {
             font-size: 60px;
         }
+
+        span {
+            display: block;
+        }
     }
 
     .engagement-banner__text-container {
         @include mq($from: tablet) {
             margin-left: $gs-gutter;
+        }
+
+        @include mq($from: phablet) {
+            flex: 0 0 58%;
         }
 
         @include mq($from: desktop) {
@@ -145,7 +163,7 @@ $title: 'Guardian Titlepiece', Georgia, serif !default;
 
     .engagement-banner__cta--subscribe {
         @include mq($from: tablet) {
-            margin-left: $gs-gutter;
+            margin-left: $gs-gutter / 2;
         }
 
         .component-button--primary--covid-banner {


### PR DESCRIPTION
## What does this change?
New banner to reflect our importance as a news source during this public health crisis

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
[Control - Desktop]
<img width="1213" alt="control - desktop" src="https://user-images.githubusercontent.com/3300789/77769551-eb393e00-703b-11ea-9fc9-2a77e9ce1867.png">

[Control - Tablet]
<img width="589" alt="control - tablet" src="https://user-images.githubusercontent.com/3300789/77769604-f9875a00-703b-11ea-803e-3839e963a691.png">

[Control - Mobile]
<img width="333" alt="control - mobile" src="https://user-images.githubusercontent.com/3300789/77769601-f8562d00-703b-11ea-8dd5-6762ba9f27d4.png">

[Open - Desktop]
<img width="1217" alt="open - desktop" src="https://user-images.githubusercontent.com/3300789/77769607-fa1ff080-703b-11ea-82c9-e69efd7dc215.png">

[Open - Tablet]
<img width="589" alt="open - tablet" src="https://user-images.githubusercontent.com/3300789/77769616-fb511d80-703b-11ea-8ea9-b0fb1e1cf99e.png">

[Open - Mobile]
<img width="335" alt="open - mobile" src="https://user-images.githubusercontent.com/3300789/77769614-fab88700-703b-11ea-9f0a-15cff4f49906.png">

[Accuracy - Desktop]
<img width="1212" alt="accuracy - desktop" src="https://user-images.githubusercontent.com/3300789/77769782-35222400-703c-11ea-9286-6f367cb9c3f3.png">

[Accuracy - Tablet]
<img width="602" alt="accuracy - tablet" src="https://user-images.githubusercontent.com/3300789/77769816-41a67c80-703c-11ea-99a6-46ad3b902556.png">

[Accuracy - Mobile]
<img width="335" alt="accuracy - mobile" src="https://user-images.githubusercontent.com/3300789/77769814-410de600-703c-11ea-94f3-e6a340ee6750.png">

## What is the value of this and can you measure success?
It's an AB test, all acquisitions are recorded

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [X] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [X] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [X] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
