### PR TITLE
Pass isSensitive for remote epic

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/consent-management-platform": "2.0.10",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
-    "@guardian/slot-machine-client": "^0.2.6",
+    "@guardian/automat-client": "^0.2.10",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",
     "bootstrap-sass": "^3.4.1",

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -36,7 +36,7 @@ import {
     compareVariantDecision,
     getViewLog,
     getWeeklyArticleHistory,
-} from '@guardian/slot-machine-client';
+} from '@guardian/automat-client';
 import {
     getLastOneOffContributionDate,
     isRecurringContributor,
@@ -109,6 +109,7 @@ export const getEpicTestToRun = memoize(
                                 isMinuteArticle: page.isMinuteArticle,
                                 isPaidContent:
                                     page.sponsorshipType === 'paid-content',
+                                isSensitive: page.isSensitive,
                                 tags: buildKeywordTags(page),
                                 countryCode,
                                 showSupportMessaging: !shouldNotBeShownSupportMessaging(),

--- a/static/src/javascripts/projects/common/modules/experiments/tests/frontend-dotcom-rendering-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/frontend-dotcom-rendering-epic.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { getBodyEnd } from '@guardian/slot-machine-client';
+import { getBodyEnd } from '@guardian/automat-client';
 import { getSync as geolocationGetSync } from 'lib/geolocation';
 import {
     makeEpicABTest,
@@ -111,6 +111,7 @@ const frontendDotcomRenderingTest = {
                     shouldHideReaderRevenue: page.shouldHideReaderRevenue,
                     isMinuteArticle: config.hasTone('Minute'),
                     isPaidContent: page.isPaidContent,
+                    isSensitive: page.isSensitive,
                     tags: buildKeywordTags(page),
                     // This test is already subjected to the 3 checks below, but
                     // we're passing these properties to the Contributions

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,6 +1166,11 @@
     style-loader "1.0.0"
     webpack "^4.2.0"
 
+"@guardian/automat-client@^0.2.10":
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.10.tgz#4b3abbc7c32944e2d9643af27c07aa9e3224379f"
+  integrity sha512-VVJ09UuMOnbYksjwlhuSCUFpToYm6XVpXtvrFqps15GXDb65g/WU9MmT8KcsejB9EGH77kSdEDhMR/fbOqFHUA==
+
 "@guardian/consent-management-platform@2.0.10":
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-2.0.10.tgz#b1d322f7fa5da858353102fb584224218fffbf37"
@@ -1189,11 +1194,6 @@
     filesizegzip "^2.0.0"
     inquirer "^5.2.0"
     pretty-bytes "^4.0.2"
-
-"@guardian/slot-machine-client@^0.2.6":
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/@guardian/slot-machine-client/-/slot-machine-client-0.2.6.tgz#4d323d31322ad4ae56bd9cc578516ec28e3ef36f"
-  integrity sha512-2rPLnFOs0kBp6rvWYyZURSLcsD6gzP9WSiN3bv/ZSC07LLnKyQwhGB8q/sNtFkkgCdt1sbVcMtlzmCAKsNudBA==
 
 "@guardian/src-button@^0.13.0":
   version "0.13.0"


### PR DESCRIPTION
As part of this, we need to update the client library to the latest version and also update the comparison requests.

See also: https://github.com/guardian/contributions-service/pulls.