### PR TITLE
Subs banner mobile tweaks

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
@@ -16,7 +16,8 @@ const subscriptionBannerTemplate = (
 <div id="js-subscription-banner-site-message" class="site-message--subscription-banner">
     <div class="site-message--subscription-banner__inner">
         <h3 class="site-message--subscription-banner__title">
-            Open to all, supported by you
+            <span class="site-message--subscription-banner__no-wrap">Open to all,</span>
+            <span class="site-message--subscription-banner__no-wrap">supported by you</span>
         </h3>
 
         <div class="site-message--subscription-banner__description">

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
@@ -35,9 +35,7 @@ const subscriptionBannerTemplate = (
             >
                 Subscribe now
             </a>
-            <div class="site-message--subscription-banner__cta-dismiss-container ${isUserLoggedIn(
-                userLoggedIn
-            )}">
+            <div class="site-message--subscription-banner__cta-dismiss-container">
                 <a
                     id="js-site-message--subscription-banner__cta-dismiss"
                     class="site-message--subscription-banner__cta-dismiss"
@@ -53,8 +51,7 @@ const subscriptionBannerTemplate = (
             userLoggedIn
         )}"
         >
-            <p>Already a subscriber?</p>
-            <br class="temp-mobile-break" />
+            Already a subscriber?
             <a
                 id="site-message--subscription-banner__sign-in"
                 class="site-message--subscription-banner__subscriber-link"

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
@@ -33,7 +33,8 @@ const subscriptionBannerTemplate = (
                 href="${subscriptionUrl}"
 
             >
-                Subscribe now
+                <span class="site-message--subscription-banner__short-message">Subscribe now</span>
+                <span class="site-message--subscription-banner__full-message">Become a digital subscriber</span>
             </a>
             <div class="site-message--subscription-banner__cta-dismiss-container">
                 <a

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banner-template.js
@@ -32,7 +32,7 @@ const subscriptionBannerTemplate = (
                 href="${subscriptionUrl}"
 
             >
-                Become a digital subscriber
+                Subscribe now
             </a>
             <div class="site-message--subscription-banner__cta-dismiss-container ${isUserLoggedIn(
                 userLoggedIn
@@ -61,8 +61,8 @@ const subscriptionBannerTemplate = (
                 href="${signInUrl}"
 
             >
-                <span class="site-message--subscription-banner__sign-in-link">Sign in</span> to not see this again
-            </a>
+                <span class="site-message--subscription-banner__sign-in-link">Sign in</span></a>
+            to not see this again
         </div>
 
         <div class="site-message--packshot-container">

--- a/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
@@ -129,19 +129,14 @@
 }
 
 .site-message--subscription-banner__cta-container {
-
     font-size: 12px;
     font-weight: bold;
-    margin: 30px 0 0;
-
+    margin: 20px 0 0;
+    display: flex;
+    width: 100%;
 
     @include mq($from: tablet) {
-        display: flex;
-        width: 60%;
-    }
-
-    @include mq($from: desktop) {
-        width: 100%;
+        margin: 30px 0 0;
     }
 }
 
@@ -156,10 +151,7 @@
     color: $brightness-97;
     text-align: center;
     cursor: pointer;
-
-    @include mq($from: tablet) {
-        width: auto;
-    }
+    width: auto;
 }
 
 .site-message--subscription-banner__cta:focus ,
@@ -169,45 +161,31 @@
 
 .site-message--subscription-banner__cta-dismiss-container {
     text-align: center;
-    margin: 20px 0 8px;
+    display: block;
+    margin: 12px 0 0 10px;
 
-    @include mq($from: tablet) {
-        margin: 12px 0 0 10px;
-    }
-
-    &.site-message--subscription-banner__sign-in--already-signed-in {
-        display: none;
-
-        @include mq($from: tablet) {
-            display: block;
-        }
-    }
 }
 
 .site-message--subscription-banner__cta-dismiss {
-    display: none;
+    display: block;
     color: $brightness-7;
     font-family: $f-sans-serif-text;
     font-size: 16px;
     width: 100%;
     cursor: pointer;
-
-    @include mq($from: tablet) {
-        display: block;
-    }
 }
 
 .site-message--subscription-banner__sign-in {
     width: 100%;
-    font-size: 16px;
-    font-weight: 100;
+    font-size: 15px;
+    font-weight: normal;
     font-family: $f-sans-serif-text;
     color: $brightness-7;
     margin-top: 10px;
-    text-align: center;
 
     @include mq($from: tablet) {
         width: 60%;
+        margin-bottom: 10px;
         text-align: left;
     }
 
@@ -252,10 +230,10 @@
 
 .site-message--packshot-container {
     width: 100%;
-    margin: 30px 0 -75px;
+    margin: 17px 0 -20px;
 
     @include mq($from: tablet) {
-        margin-bottom: -105px;
+        margin: 30px 0 -105px;
     }
 
 
@@ -310,14 +288,6 @@
 .site-message--subscription-banner__lockup {
     display: flex;
     position: relative;
-}
-
-.temp-mobile-break {
-    display: block;
-
-    @media (min-width: 380px) {
-        display: none;
-    }
 }
 
 .site-message--subscription-banner__close-button {

--- a/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
@@ -157,7 +157,6 @@
 .site-message--subscription-banner__cta {
     display: inline-block;
     font-size: 16px;
-    width: 100%;
     padding: 10px 20px 12px;
     border-radius: 50px;
     background: $brightness-7;

--- a/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
@@ -140,6 +140,20 @@
     }
 }
 
+.site-message--subscription-banner__short-message {
+    display: inline-block;
+    @include mq($from: tablet) {
+        display: none;
+    }
+}
+
+.site-message--subscription-banner__full-message {
+    display: none;
+    @include mq($from: tablet) {
+        display: inline-block;
+    }
+}
+
 .site-message--subscription-banner__cta {
     display: inline-block;
     font-size: 16px;

--- a/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
@@ -124,8 +124,12 @@
     }
 }
 
+.site-message--subscription-banner__no-wrap {
+    white-space: nowrap;
+}
+
 .site-message--subscription-banner__cta-container {
-    width: 100%;
+
     font-size: 12px;
     font-weight: bold;
     margin: 30px 0 0;


### PR DESCRIPTION
## What does this change?
Some design changes 

- Stop hide the 'Not now' button at this breakpoint
- Shorter copy for the subscribe button
- Left align sign in copy
- Make the title wrap in a nicer way

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
### Old design
![Screen Shot 2020-03-30 at 10 58 38](https://user-images.githubusercontent.com/181371/77900342-d516c200-7275-11ea-88ac-8c1fe31e5cd7.png)

### New design
![Screen Shot 2020-03-30 at 10 57 41](https://user-images.githubusercontent.com/181371/77900389-df38c080-7275-11ea-8ce1-76d9a7a7bad1.png)

## What is the value of this and can you measure success?
The banner will conform more closely to design standards

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
