### PR TITLE
Allow multi-line container treats

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_treats.scss
+++ b/static/src/stylesheets/module/facia-garnett/_treats.scss
@@ -26,10 +26,9 @@
 
 .treats__treat {
     @include fs-textSans(1);
-    @include ellipsis();
     @include button-colour(
         #ffffff,
-        $brightness-7, 
+        $brightness-7,
         $brightness-86
     );
     @include button-hover-colour(
@@ -46,8 +45,8 @@
     border-bottom-style: none;
     text-decoration: none;
     max-width: gs-span(4);
-    line-height: $gs-baseline * 2 - 2px;
-    padding-left: $gs-baseline / 2;
+    line-height: $gs-baseline;
+    padding: ($gs-baseline / 4) 0 ($gs-baseline / 6) ($gs-baseline / 2);
     width: 190px;
 
     @include mq(leftCol) {


### PR DESCRIPTION
## What does this change?

Allows treats to fold into more than one line

Currently we have this on the UK front at leftCol:
<img width="288" alt="Screenshot 2020-03-30 at 16 42 21" src="https://user-images.githubusercontent.com/4561/77925804-9c8edc80-72a5-11ea-9177-db9bddaec087.png">

Which should become:
<img width="322" alt="Screenshot 2020-03-30 at 16 44 47" src="https://user-images.githubusercontent.com/4561/77925967-d2cc5c00-72a5-11ea-9eae-027f40a60d0a.png">
