### PR TITLE
Log epic can run decisions to send to remote service

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/ab-core.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-core.js
@@ -6,6 +6,7 @@ import {
 } from 'common/modules/analytics/mvt-cookie';
 import config from 'lib/config';
 import { isExpired } from 'lib/time-utils';
+import { logAutomatEvent } from 'common/modules/experiments/ab';
 import { getVariantFromLocalStorage } from './ab-local-storage';
 import { getVariantFromUrl } from './ab-url';
 import { NOT_IN_TEST } from './ab-constants';
@@ -22,6 +23,18 @@ const testCanBeRun = (test: ABTest): boolean => {
     const shouldShowForSensitive = !!test.showForSensitive;
     const isTestOn = isTestSwitchedOn(test.id);
     const canTestBeRun = !test.canRun || test.canRun();
+
+    logAutomatEvent({
+        key: test.id,
+        value: {
+            test,
+            expired,
+            isSensitive,
+            shouldShowForSensitive,
+            isTestOn,
+            canTestBeRun,
+        },
+    });
 
     return (
         (isSensitive ? shouldShowForSensitive : true) &&

--- a/static/src/javascripts/projects/common/modules/experiments/ab-core.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-core.js
@@ -6,7 +6,7 @@ import {
 } from 'common/modules/analytics/mvt-cookie';
 import config from 'lib/config';
 import { isExpired } from 'lib/time-utils';
-import { logAutomatEvent } from 'common/modules/experiments/ab';
+import { logAutomatEvent } from 'common/modules/experiments/automatLog';
 import { getVariantFromLocalStorage } from './ab-local-storage';
 import { getVariantFromUrl } from './ab-url';
 import { NOT_IN_TEST } from './ab-constants';

--- a/static/src/javascripts/projects/common/modules/experiments/ab-core.spec.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-core.spec.js
@@ -15,6 +15,10 @@ import { runnableTestsToParticipations } from 'common/modules/experiments/ab-uti
 jest.mock('common/modules/analytics/mvt-cookie');
 jest.mock('common/modules/experiments/ab-tests');
 
+jest.mock('common/modules/experiments/ab', () => ({
+    logAutomatEvent: () => {},
+}));
+
 /* eslint guardian-frontend/global-config: "off" */
 /* eslint guardian-frontend/no-direct-access-config: "off" */
 const cfg = window.guardian.config;

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -54,7 +54,7 @@ const buildKeywordTags = page => {
     }));
 };
 
-const automatLog = {};
+const automatLog = { url: window.location.href };
 
 type Event = { key: string, value: any };
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -54,6 +54,14 @@ const buildKeywordTags = page => {
     }));
 };
 
+const automatLog = {};
+
+type Event = { key: string, value: any };
+
+export const logAutomatEvent = (event: Event): void => {
+    automatLog[event.key] = event.value;
+};
+
 export const getEpicTestToRun = memoize(
     (): Promise<?Runnable<EpicABTest>> => {
         const highPriorityHardCodedTests = hardCodedEpicTests.filter(
@@ -123,6 +131,7 @@ export const getEpicTestToRun = memoize(
                             expectedVariant: result
                                 ? result.variantToRun.id
                                 : '',
+                            frontendLog: automatLog,
                         });
                     }
                 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -42,6 +42,7 @@ import {
     isRecurringContributor,
     shouldNotBeShownSupportMessaging,
 } from 'common/modules/commercial/user-features';
+import { automatLog } from 'common/modules/experiments/automatLog';
 
 // Tmp for Slot Machine work - can remove shortly
 const buildKeywordTags = page => {
@@ -52,14 +53,6 @@ const buildKeywordTags = page => {
         type: 'Keyword',
         title: keywords[idx],
     }));
-};
-
-const automatLog = { url: window.location.href };
-
-type Event = { key: string, value: any };
-
-export const logAutomatEvent = (event: Event): void => {
-    automatLog[event.key] = event.value;
 };
 
 export const getEpicTestToRun = memoize(

--- a/static/src/javascripts/projects/common/modules/experiments/automatLog.js
+++ b/static/src/javascripts/projects/common/modules/experiments/automatLog.js
@@ -1,0 +1,9 @@
+// @flow
+// Entirely temporary
+type Event = { key: string, value: any };
+
+export const automatLog = { url: window.location.href };
+
+export const logAutomatEvent = (event: Event): void => {
+    automatLog[event.key] = event.value;
+};


### PR DESCRIPTION
We've been struggling to locally replicate some of the decisions we
are logging. This should help a bit.