### PR TITLE
Remove video-js switch and make videojs default fallback for old videos

### DIFF
--- a/applications/app/views/videoEmbed.scala.html
+++ b/applications/app/views/videoEmbed.scala.html
@@ -1,7 +1,6 @@
 @import conf.{Configuration, Static}
 @import model.{EmbedPage, VideoPlayer}
 @import views.support.{SeoOptimisedContentImage, StripHtmlTags, Video640}
-@import conf.switches.Switches.VideoJSSwitch
 
 @(page: EmbedPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
@@ -99,16 +98,7 @@
         document.documentElement.className = docClass;
         </script>
 
-    @if(VideoJSSwitch.isSwitchedOn) {
-        <script>
-            (function (document) {
-                var script = document.createElement('script');
-                var ref = document.getElementsByTagName('script')[0];
-                script.src = '@Static("javascripts/graun.videojs-embed.js")';
-                ref.parentNode.insertBefore(script, ref);
-            })(document);
-            </script>
-    } else {
+
         <script>
             (function (document) {
                 var script = document.createElement('script');
@@ -116,8 +106,8 @@
                 script.src = '@Static("javascripts/graun.video-embed.js")';
                 ref.parentNode.insertBefore(script, ref);
             })(document);
-            </script>
-    }
+        </script>
+
 
         @fragments.analytics.base()(page, request, context)
 

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -198,16 +198,6 @@ trait FeatureSwitches {
     exposeClientSide = true
   )
 
-  val VideoJSSwitch = Switch(
-    SwitchGroup.Feature,
-    "videojs",
-    "If this is switched on then videos are enhanced using VideoJS",
-    owners = Seq(Owner.withGithub("gtrufitt")),
-    safeState = On,
-    sellByDate = new LocalDate(2020, 3, 31),
-    exposeClientSide = true
-  )
-
   val BreakingNewsSwitch = Switch(
     SwitchGroup.Feature,
     "breaking-news",

--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -172,15 +172,8 @@ const bootEnhanced = (): void => {
                 );
             }
 
-            // Old VideoJS player
             fastdom
-                .read(() =>
-                    qwery(
-                        `${
-                            config.get('switches.videojs') ? 'video, ' : ''
-                        } audio`
-                    )
-                )
+                .read(() => qwery('audio'))
                 .then(els => {
                     if (els.length) {
                         require.ensure(
@@ -198,25 +191,23 @@ const bootEnhanced = (): void => {
                 });
 
             // Native video player enhancements
-            if (!config.get('switches.videojs')) {
-                fastdom
-                    .read(() => qwery('video'))
-                    .then(els => {
-                        if (els.length) {
-                            require.ensure(
-                                [],
-                                require => {
-                                    bootstrapContext(
-                                        'video-player',
-                                        require('bootstraps/enhanced/video-player')
-                                            .initVideoPlayer
-                                    );
-                                },
-                                'video-player'
-                            );
-                        }
-                    });
-            }
+            fastdom
+                .read(() => qwery('video'))
+                .then(els => {
+                    if (els.length) {
+                        require.ensure(
+                            [],
+                            require => {
+                                bootstrapContext(
+                                    'video-player',
+                                    require('bootstraps/enhanced/video-player')
+                                        .initVideoPlayer
+                                );
+                            },
+                            'video-player'
+                        );
+                    }
+                });
 
             if (config.get('page.contentType') === 'Gallery') {
                 require.ensure(


### PR DESCRIPTION
## What does this change?

Removes video-js switch and related conditions to remove video-js for videos.

We're removing videojs, the pre-YouTube video player from pre-YouTube videos and allowing them to be native (with some enhancements). It makes this work https://github.com/guardian/frontend/pull/18104 perm (which it should be)

## Before
![Screen Shot 2020-03-31 at 12 47 53](https://user-images.githubusercontent.com/638051/78024985-2b0c6800-7351-11ea-818f-296ae462a0a7.png)

![Screen Shot 2020-03-31 at 12 48 38](https://user-images.githubusercontent.com/638051/78024976-26e04a80-7351-11ea-914a-68b10395be8a.png)


## After
![Screen Shot 2020-03-31 at 12 48 14](https://user-images.githubusercontent.com/638051/78025011-38295700-7351-11ea-9ea9-8b88b0189269.png)


![Screen Shot 2020-03-31 at 12 48 43](https://user-images.githubusercontent.com/638051/78025002-32cc0c80-7351-11ea-86e9-c50679be7a7a.png)
