### PR TITLE
Send client name to the contributions service

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/consent-management-platform": "2.0.10",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
-    "@guardian/automat-client": "^0.2.10",
+    "@guardian/automat-client": "^0.2.13",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",
     "bootstrap-sass": "^3.4.1",

--- a/static/src/javascripts/projects/common/modules/experiments/tests/frontend-dotcom-rendering-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/frontend-dotcom-rendering-epic.js
@@ -94,6 +94,7 @@ const frontendDotcomRenderingTest = {
                     ophanPageId: ophan.pageViewId,
                     ophanComponentId: 'ACQUISITIONS_EPIC',
                     platformId: 'GUARDIAN_WEB',
+                    clientName: 'frontend',
                     campaignCode: variant.campaignCode,
                     abTestName: test.id,
                     abTestVariant: variant.id,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,10 +1166,10 @@
     style-loader "1.0.0"
     webpack "^4.2.0"
 
-"@guardian/automat-client@^0.2.10":
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.10.tgz#4b3abbc7c32944e2d9643af27c07aa9e3224379f"
-  integrity sha512-VVJ09UuMOnbYksjwlhuSCUFpToYm6XVpXtvrFqps15GXDb65g/WU9MmT8KcsejB9EGH77kSdEDhMR/fbOqFHUA==
+"@guardian/automat-client@^0.2.13":
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.13.tgz#69ad5559160726ca49714d44d6ab77f3db25f5ef"
+  integrity sha512-OHAZv3MZkuFHJkEoWLkiR5nWnzG0i3Unt3w972n6SmkbOr0xLaUhyM+WZvetNn8dOPzHPVwHW6IYi7Z+TQ5Gug==
 
 "@guardian/consent-management-platform@2.0.10":
   version "2.0.10"


### PR DESCRIPTION
## What does this change?

Start sending the client name in requests to the contributions service.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (guardian/dotcom-rendering#1307)

## What is the value of this and can you measure success?

This is useful for comparing results across DCR and frontend.

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)