### PR TITLE
special rss handling for profile/helenasmith

### DIFF
--- a/common/app/controllers/IndexControllerCommon.scala
+++ b/common/app/controllers/IndexControllerCommon.scala
@@ -64,22 +64,22 @@ trait IndexControllerCommon extends BaseController with Index with RendersItemRe
   override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = path match {
     //if this is a section tag e.g. football/football
     case TagPattern(left, right) if left == right => successful(Cached(60)(redirect(left, request.isRss)))
-
-    case _ =>
+    case _ => {
       logGoogleBot(request)
       index(Edition(request), path, inferPage(request), request.isRss) map {
         case Left(model) if model.contents.nonEmpty => renderFaciaFront(model)
         // if no content is returned (as often happens with old/expired/migrated microsites) return 404 rather than an empty page
         case Left(model) if model.contents.isEmpty =>
-
           Cached(60)(WithoutRevalidationResult(Gone(
             views.html.gone(
               gonePage,
               "Sorry - there is no content here",
               "This could be, for example, because content associated with it is not yet published, or due to legal reasons such as the expiry of our rights to publish the content.",
-              ))))
+            ))))
         case Right(other) => RenderOtherStatus(other)
       }
+    }
+
   }
 
   override def canRender(item: ItemResponse): Boolean = item.section.orElse(item.tag).isDefined

--- a/common/app/services/repositories.scala
+++ b/common/app/services/repositories.scala
@@ -110,6 +110,7 @@ trait Index extends ConciergeRepository with Collections {
   ))
 
   def index(edition: Edition, path: String, pageNum: Int, isRss: Boolean)(implicit request: RequestHeader): Future[Either[IndexPage, PlayResult]] = {
+
     val fields = if (isRss) rssFields else QueryDefaults.trailFieldsWithMain
 
     val maybeSection = sectionsLookUp.get(path)
@@ -124,8 +125,11 @@ trait Index extends ConciergeRepository with Collections {
       */
     val queryPath = maybeSection.fold(path)(s => SectionTagLookUp.tagId(s.id))
 
+    // This is a temporary hack to confirm a theory
+    val pageSize = if (path == "profile/helenasmith") 5 else IndexPagePagination.pageSize
+
     val promiseOfResponse = contentApiClient.getResponse(contentApiClient.item(queryPath, edition).page(pageNum)
-      .pageSize(IndexPagePagination.pageSize)
+      .pageSize(pageSize)
       .showFields(fields)
     ) map { response =>
       val page = maybeSection.map(s => section(s, response)) orElse


### PR DESCRIPTION
## What does this change?

I am reducing the size of the CAPI answer for this particular profile on the RSS end point. This is to confirm a theory. Another PR will come afterwards.