### PR TITLE
Limit the special handling to RSS

### DIFF
--- a/common/app/services/repositories.scala
+++ b/common/app/services/repositories.scala
@@ -126,7 +126,7 @@ trait Index extends ConciergeRepository with Collections {
     val queryPath = maybeSection.fold(path)(s => SectionTagLookUp.tagId(s.id))
 
     // This is a temporary hack to confirm a theory
-    val pageSize = if (path == "profile/helenasmith") 5 else IndexPagePagination.pageSize
+    val pageSize = if (isRss && (path == "profile/helenasmith")) 5 else IndexPagePagination.pageSize
 
     val promiseOfResponse = contentApiClient.getResponse(contentApiClient.item(queryPath, edition).page(pageNum)
       .pageSize(pageSize)


### PR DESCRIPTION
## What does this change?

Follow up of https://github.com/guardian/frontend/pull/22455 (Still a work in progress...)