### PR TITLE
Send received epic tests to contributions service for logging

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -42,7 +42,10 @@ import {
     isRecurringContributor,
     shouldNotBeShownSupportMessaging,
 } from 'common/modules/commercial/user-features';
-import { automatLog } from 'common/modules/experiments/automatLog';
+import {
+    automatLog,
+    logAutomatEvent,
+} from 'common/modules/experiments/automatLog';
 
 // Tmp for Slot Machine work - can remove shortly
 const buildKeywordTags = page => {
@@ -66,6 +69,13 @@ export const getEpicTestToRun = memoize(
 
         if (config.get('switches.useConfiguredEpicTests')) {
             return getConfiguredEpicTests().then(configuredEpicTests => {
+                // We want to confirm that the epic tests are getting loaded as we see a
+                // lot of cases where we suspect they are not.
+                logAutomatEvent({
+                    key: 'testIDs',
+                    value: configuredEpicTests.map(test => test.id),
+                });
+
                 configuredEpicTests.forEach(test =>
                     config.set(`switches.ab${test.id}`, true)
                 );


### PR DESCRIPTION
We see a lot of error cases in our comparison logging in the contributions service where we suspect the configured JSON tests are not loading. This will help us confirm/reject this.

Note, we are not seeing errors in Sentry either.

Builds on: https://github.com/guardian/frontend/pull/22452