### PR TITLE
Commercial Lifecycle now uses its own Execution Context

### DIFF
--- a/commercial/app/CommercialLifecycle.scala
+++ b/commercial/app/CommercialLifecycle.scala
@@ -1,5 +1,7 @@
 package commercial
 
+import java.util.concurrent.Executors
+
 import commercial.model.merchandise.jobs.Industries
 import app.LifecycleComponent
 import commercial.model.feeds._
@@ -21,7 +23,12 @@ class CommercialLifecycle(
   akkaAsync: AkkaAsync,
   feedsFetcher: FeedsFetcher,
   feedsParser: FeedsParser,
-  industries: Industries)(implicit ec: ExecutionContext) extends LifecycleComponent with Logging {
+  industries: Industries) extends LifecycleComponent with Logging {
+
+  // This class does work that should be kept separate from the EC used to serve requests
+  implicit private val ec = ExecutionContext.fromExecutorService(
+    Executors.newFixedThreadPool(10)
+  )
 
   appLifecycle.addStopHook { () => Future {
     stop()


### PR DESCRIPTION
We've been seeing performance problems on the commercial app in Frontend at start time. The webapp's latency spikes significantly, which has a knock-on effect on the router, which in turn affects all the apps in frontend.

This is likely to be the first change in a few tweaks, to see the impact of tuning the EC.

## What does this change?

This change introduces a bespoke execution context for the Commercial Lifecycle class. This means the lifecycle work is done in a separate EC, isolating it from the EC used to serve requests. The choice of EC (FixedThreadpool) also serves to throttle the execution of these jobs, which should stop them consuming so many resources that the webapp's ability to serve timely requests is diminished.

## Does this change need to be reproduced in dotcom-rendering?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<img width="982" alt="Screenshot 2020-04-01 at 12 13 21" src="https://user-images.githubusercontent.com/29761/78131019-3ecbd300-7412-11ea-9d80-9ff3ed3dcd7d.png">
Fig: Correlation between deploy times and commercial latency

## What is the value of this and can you measure success?

We hope to see that deploys have a lessened impact on commercial latency.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [x] Yes (please give details)

Some commercial ads (including GLabs) depend on these feeds, so we will also need to keep an eye on errors to make sure this change isn't breaking them.

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
