### PR TITLE
Do not compare epic decision when remote tests fail

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -99,8 +99,11 @@ export const getEpicTestToRun = memoize(
 
                 // No point in going forward with variant comparison unless
                 // we're in an Article (excludes e.g. live blogs which aren't
-                // supported yet)
-                if (page.contentType !== 'Article') {
+                // supported yet) and we have loaded the configured tests successfully
+                if (
+                    page.contentType !== 'Article' ||
+                    configuredEpicTests.length === 0
+                ) {
                     return result;
                 }
 


### PR DESCRIPTION
We've seen quite a few cases where the remotely-defined epic tests fail to load. We want to ignore these cases for our comparison purposes.

https://trello.com/b/w9rPL4nx/automat-q4