### PR TITLE
Make liveblog epic design test 'always ask'

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-liveblog-design-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-liveblog-design-test.js
@@ -54,6 +54,7 @@ export const contributionsEpicLiveblogDesignTestR1: EpicABTest = makeEpicABTest(
         audienceCriteria: 'All',
         audience: 1,
         audienceOffset: 0,
+        deploymentRules: 'AlwaysAsk',
 
         pageCheck: isCompatibleWithLiveBlogEpic,
 


### PR DESCRIPTION
## What does this change?
To help reach significance earlier.
This overrides the default 4 views per month logic.