### PR TITLE
Subscription Banner copy change

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-template.js
@@ -21,8 +21,9 @@ const subscriptionBannerTemplate = (
         </h3>
 
         <div class="site-message--subscription-banner__description">
-            <p>Support open, independent journalism and enjoy two
-             innovative apps and ad-free reading on theguardian.com</p>
+            <p>Support open and independent journalism and enjoy the Daily,
+            the digital edition of your newspaper,
+            premium access to our Live app and ad-free reading on theguardian.com</p>
         </div>
 
         <div class="site-message--subscription-banner__cta-container">

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-template.js
@@ -21,9 +21,9 @@ const subscriptionBannerTemplate = (
         </h3>
 
         <div class="site-message--subscription-banner__description">
-            <p>Support open and independent journalism and enjoy the Daily,
+            <p>Support open and independent journalism and enjoy <b>the Daily</b>,
             the digital edition of your newspaper,
-            premium access to our Live app and ad-free reading on theguardian.com</p>
+            <b>premium access to our Live app</b> and <b>ad-free</b> reading on theguardian.com</p>
         </div>
 
         <div class="site-message--subscription-banner__cta-container">

--- a/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
@@ -87,39 +87,21 @@
 
     p {
         font-size: 17px;
-        line-height: 18px;
+        line-height: 135%;
         margin: 0;
         font-family: $f-serif-text;
 
         @include mq($from: mobileLandscape) {
             font-size: 18px;
-            line-height: 20px;
         }
 
         // custom breakpoint
         @media (min-width: 550px) {
             font-size: 17px;
-            line-height: 19px;
-        }
-
-        @include mq($from: phablet) {
-            font-size: 17px;
-            line-height: 19px;
-        }
-
-        @include mq($from: tablet) {
-            font-size: 17px;
-            line-height: 19px;
         }
 
         @include mq($from: desktop) {
             font-size: 20px;
-            line-height: 22px;
-        }
-
-        @include mq($from: leftCol) {
-            font-size: 20px;
-            line-height: 26px;
         }
     }
 }


### PR DESCRIPTION
## What does this change?
Due to the increased traffic during the COVID-19 pandemic, the copy for the subscription banner has been changed

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
- Mobile
![Screen Shot 2020-04-02 at 15 03 41](https://user-images.githubusercontent.com/45875444/78264849-9bef8380-74fb-11ea-9ffb-71398fe37fb3.png)

- Tablet
![Screen Shot 2020-04-02 at 15 04 18](https://user-images.githubusercontent.com/45875444/78264860-9e51dd80-74fb-11ea-9875-252bc8c035a6.png)

- Desktop
![Screen Shot 2020-04-02 at 15 04 59](https://user-images.githubusercontent.com/45875444/78264862-9e51dd80-74fb-11ea-93fe-bbb607eed195.png)

## What is the value of this and can you measure success?

## Checklist
- copy change

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
