### PR TITLE
Support: Integrate Ozone into AMP

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -591,4 +591,14 @@ trait PrebidSwitches {
     sellByDate = never,
     exposeClientSide = true
   )
+
+  val ampOzone: Switch = Switch(
+    group = CommercialPrebid,
+    name = "amp-ozone",
+    description = "Amp inventory is being auctioned through Ozone",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true // Has to be true so that switch is exposed to dotcom-rendering
+  )
 }

--- a/static/vendor/data/amp-iframe.html
+++ b/static/vendor/data/amp-iframe.html
@@ -10,5 +10,11 @@
             height="0"
             width="0"
         ></iframe>
+        <iframe
+            id="ozone-load-cookie"
+            src="https://elb.the-ozone-project.com/static/load-cookie.html"
+            height="0"
+            width="0"
+        ></iframe>
     </body>
 </html>


### PR DESCRIPTION
## What does this change?
This PR supports the changes made in the DCR PR: https://github.com/guardian/dotcom-rendering/pull/1312
Namely it adds a switch to control when Ozone runs in AMP and add a tracking iframe that is used in AMP to bypass its iframe limitation.