### PR TITLE
Send campaign values to Automat for comparison

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -137,6 +137,10 @@ export const getEpicTestToRun = memoize(
                             expectedVariant: result
                                 ? result.variantToRun.id
                                 : '',
+                            expectedCampaignId: result ? result.campaignId : '',
+                            expectedCampaignCode: result
+                                ? result.variantToRun.campaignCode
+                                : '',
                             frontendLog: automatLog,
                         });
                     }


### PR DESCRIPTION
## What does this change?

Start sending campaign code and id to the Automat comparison endpoint.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

So that we can be confident that Automat is building the same values as frontend.

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)