### PR TITLE
Adds support for Epic init functions

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/frontend-dotcom-rendering-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/frontend-dotcom-rendering-epic.js
@@ -203,19 +203,23 @@ const frontendDotcomRenderingTest = {
                                     products
                                 );
 
-                                // If the Epic has custom JS code,
-                                // we need to eval it and call the function
-                                // it defines globally
+                                // If the Epic has custom JS code, we need to
+                                // eval it and call the function it defines.
+                                // NOTE: this is a temporary solution to solve a
+                                // particular requirement. The Automat team
+                                // plans to replace/remove this very soon.
                                 try {
-                                    // eslint-disable-next-line no-eval
-                                    window.eval(epicJs);
-                                    if (
-                                        typeof window.initAutomatJs ===
-                                        'function'
-                                    ) {
-                                        const slotRoot =
-                                            shadowRoot || container;
-                                        window.initAutomatJs(slotRoot);
+                                    if (epicJs) {
+                                        // eslint-disable-next-line no-eval
+                                        window.eval(epicJs);
+                                        if (
+                                            typeof window.initAutomatJs ===
+                                            'function'
+                                        ) {
+                                            const slotRoot =
+                                                shadowRoot || container;
+                                            window.initAutomatJs(slotRoot);
+                                        }
                                     }
                                 } catch (error) {
                                     // eslint-disable-next-line no-console

--- a/static/src/javascripts/projects/common/modules/experiments/tests/frontend-dotcom-rendering-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/frontend-dotcom-rendering-epic.js
@@ -52,7 +52,7 @@ const products = ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'];
 //     config.get('page').dcrCouldRender &&
 //     config.get('tests').dotcomRenderingControl === 'control';
 
-const canRun = ():void => true;
+const canRun = (): void => true;
 
 const frontendDotcomRenderingTest = {
     id: 'FrontendDotcomRenderingEpic',
@@ -86,7 +86,6 @@ const frontendDotcomRenderingTest = {
             products,
             // eslint-disable-next-line import/no-shadow
             test: (html: string, variant: EpicVariant, test: EpicABTest) => {
-
                 const ophan = config.get('ophan');
                 const page = config.get('page');
 
@@ -145,7 +144,7 @@ const frontendDotcomRenderingTest = {
                     variant.id
                 );
 
-                getBodyEnd(payload, 'http://localhost:8081/epic')
+                getBodyEnd(payload)
                     .then(checkResponseOk)
                     .then(decodeJson)
                     .then(json => {
@@ -184,16 +183,13 @@ const frontendDotcomRenderingTest = {
                                 // use Shadow Dom if found
                                 let shadowRoot;
                                 if (container.attachShadow) {
-                                    console.log('epic - has shadow dom');
                                     shadowRoot = container.attachShadow({
                                         mode: 'open',
                                     });
                                     shadowRoot.innerHTML = content;
                                 } else {
-                                    console.log('epic - no shadow dom');
                                     container.innerHTML = content;
                                 }
-                                // container.innerHTML = content;
 
                                 emitInsertEvent(
                                     test,
@@ -209,6 +205,9 @@ const frontendDotcomRenderingTest = {
                                     products
                                 );
 
+                                // If the Epic has custom JS code,
+                                // we need to eval it and call the function
+                                // it defines globally
                                 try {
                                     // eslint-disable-next-line no-eval
                                     window.eval(epicJs);

--- a/static/src/javascripts/projects/common/modules/experiments/tests/frontend-dotcom-rendering-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/frontend-dotcom-rendering-epic.js
@@ -47,12 +47,10 @@ const decodeJson = response => response.json();
 
 const products = ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'];
 
-// const canRun = (): boolean =>
-//     geolocation !== 'US' &&
-//     config.get('page').dcrCouldRender &&
-//     config.get('tests').dotcomRenderingControl === 'control';
-
-const canRun = (): void => true;
+const canRun = (): boolean =>
+    geolocation !== 'US' &&
+    config.get('page').dcrCouldRender &&
+    config.get('tests').dotcomRenderingControl === 'control';
 
 const frontendDotcomRenderingTest = {
     id: 'FrontendDotcomRenderingEpic',


### PR DESCRIPTION
## What does this change?
Executes a JS snippet that may have been sent by the Contributions service via JSON. This will be used on some specific Epic variants to add the interaction needed on the client-side when just HTML & CSS isn't enough.

Only use case currently is when the Epic uses 'reminder fields' (i.e. has a form for the user to type in email address and submit to be reminded of making a contribution later on).

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)
