### PR TITLE
Remove old remote epic test switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -128,16 +128,6 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-remote-render-epic-round-two",
-    "A/B test local vs remote render of default epic, to validate Slot Machine approach and work to date",
-    owners = Seq(Owner.withGithub("tjmw"), Owner.withGithub("nicl")),
-    safeState = Off,
-    sellByDate = new LocalDate(2020, 4, 2),
-    exposeClientSide = true
-  )
-
-  Switch(
-    ABTests,
     "ab-sign-in-gate-tertius",
     "Test new sign in component on 2nd article view",
     owners = Seq(Owner.withGithub("coldlink"),Owner.withGithub("dominickendrick")),


### PR DESCRIPTION
## What does this change?

Removes the now complete `ab-remote-render-epic-round-two` test switch.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)