### PR TITLE
Sign In Gate - Invisible Test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -138,8 +138,8 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-sign-in-gate-tertius",
-    "Test new sign in component on 2nd article view",
+    "ab-sign-in-gate-latens",
+    "Test new sign in component on 2nd article view vs 3rd article view",
     owners = Seq(Owner.withGithub("coldlink"),Owner.withGithub("dominickendrick")),
     safeState = Off,
     sellByDate = new LocalDate(2020, 5, 1),

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -128,7 +128,7 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-sign-in-gate-tertius",
+    "ab-sign-in-gate-latens",
     "Test new sign in component on 2nd article view",
     owners = Seq(Owner.withGithub("coldlink"),Owner.withGithub("dominickendrick")),
     safeState = Off,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate.js
@@ -1,17 +1,17 @@
 // @flow
 export const signInGate: ABTest = {
-    id: 'SignInGateTertius',
-    start: '2020-02-17',
+    id: 'SignInGateLatens',
+    start: '2020-04-03',
     expiry: '2020-05-01',
-    author: 'Mahesh Makani, Dominic Kendrick',
+    author: 'Mahesh Makani',
     description:
-        'Test adding a sign in component on the 2nd pageview of simple article templates, with higher priority over banners and epic, and a much larget audience size.',
+        'Test adding a sign in component on the 2nd pageview of simple article templates vs 3rd pageview, with higher priority over banners and epic, and a much larget audience size. This test does not display a gate, and only used for tracking users who meet our displayer criteria.',
     audience: 0.1,
     audienceOffset: 0.9,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:
         'The contributions epic is not shown, The consent banner is not shown, The contributions banner is not shown, Should only appear on simple article template, Should not show if they are already signed in, Users will not need to go through the marketing consents as part of signup flow',
-    dataLinkNames: 'n/a',
+    dataLinkNames: 'SignInGateLatens',
     idealOutcome: '60% of users sign in, and dismiss rate is below 40%',
     showForSensitive: false,
     canRun: () => true,

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/component.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/component.js
@@ -6,5 +6,5 @@ export const componentName = 'sign-in-gate';
 // set the ophan component tracking vars
 export const component: OphanComponent = {
     componentType: 'SIGN_IN_GATE',
-    id: 'tertius_test',
+    id: 'latens_test',
 };

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
@@ -10,7 +10,7 @@ jest.mock('common/modules/experiments/ab', () => ({
     getAsyncTestsToRun: jest.fn(() => Promise.resolve([])),
     getSynchronousTestsToRun: jest.fn(() => [
         {
-            id: 'SignInGateTertius',
+            id: 'SignInGateLatens',
             variantToRun: {
                 id: 'variant',
             },
@@ -20,7 +20,7 @@ jest.mock('common/modules/experiments/ab', () => ({
 
 jest.mock('lib/storage', () => ({
     local: {
-        get: jest.fn(() => [{ count: 1, day: 1 }]),
+        get: jest.fn(() => [{ count: 2, day: 1 }]),
     },
 }));
 
@@ -59,7 +59,7 @@ describe('Sign in gate test', () => {
                 expect(show).toBe(true);
             }));
 
-        it('should return true if page view is greater than or equal to 1', () => {
+        it('should return true if page view is greater than or equal to 2', () => {
             fakeLocal.get.mockReturnValueOnce([{ count: 10, day: 1 }]);
             signInGate.canShow().then(show => {
                 expect(show).toBe(true);
@@ -91,7 +91,7 @@ describe('Sign in gate test', () => {
 
         it('should return false if user has dismissed the gate', () => {
             fakeUserPrefs.get.mockReturnValueOnce({
-                'SignInGateTertius-variant': Date.now(),
+                'SignInGateLatens-variant': Date.now(),
             });
         });
 

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/control.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/control.js
@@ -1,51 +1,16 @@
 // @flow
-import mediator from 'lib/mediator';
-import type { CurrentABTest, SignInGateVariant } from '../types';
-import { component, componentName } from '../component';
+import type { SignInGateVariant } from '../types';
+import { componentName } from '../component';
 import {
     hasUserDismissedGate,
     isNPageOrHigherPageView,
     isLoggedIn,
     isInvalidArticleType,
     isInvalidSection,
-    addOpinionBgColour,
-    addPillarColour,
-    addClickHandler,
-    setUserDismissedGate,
-    showGate,
 } from '../helper';
 
 // define the variant name here
 const variant = 'control';
-
-// add the html template as the return of the function below
-// signInUrl - parameter which holds the link to the sign in/register page with the tracking parameters added
-// guUrl - url of the STAGE frontend site, e.g. in DEV stage it would be https://m.thegulocal.com,
-//         and for PROD it would be https://theguardian.com
-const htmlTemplate: ({
-    signInUrl: string,
-    guUrl: string,
-}) => string = ({ signInUrl, guUrl }) => `
-<div class="signin-gate">
-    <div class="signin-gate__content">
-        <div class="signin-gate__header">
-            <h1 class="signin-gate__header--text">Sign in and continue<br />reading for free</h1>
-        </div>
-        <div class="signin-gate__benefits syndication--bottom">
-            <p class="signin-gate__benefits--text">
-                Help keep our independent, progressive journalism alive and thriving by taking a couple of simple steps to sign in
-            </p>
-        </div>
-        <div class="signin-gate__buttons">
-            <a class="signin-gate__button signin-gate__button--primary js-signin-gate__button" href="${signInUrl}">
-                Sign in
-            </a>
-            <a class="signin-gate__padding-left signin-gate__link signin-gate__center-424 js-signin-gate__why" href="${guUrl}/help/identity-faq">Why sign in?</a>
-            <a class="signin-gate__dismiss js-signin-gate__dismiss" href="#maincontent">Not Now</a>
-        </div>
-    </div>
-</div>
-`;
 
 // method which returns a boolean determining if this variant can be shown on the current pageview
 const canShow: (name?: string) => boolean = (name = '') =>
@@ -62,72 +27,7 @@ const canShow: (name?: string) => boolean = (name = '') =>
 // method which runs if the canShow method returns true, used to display the gate and logic associated with it
 // it returns a boolean, since the sign in gate is based on a `Banner` type who's show method returns a Promise<boolean>
 // in our case it returns true if the method ran successfully, and false if there were any problems encountered
-const show: ({
-    abTest: CurrentABTest,
-    guUrl: string,
-    signInUrl: string,
-}) => boolean = ({ abTest, guUrl, signInUrl }) =>
-    showGate({
-        template: htmlTemplate({
-            signInUrl,
-            guUrl,
-        }),
-        handler: ({ articleBody, shadowArticleBody }) => {
-            // check if comment, and add comment/opinion bg colour
-            addOpinionBgColour({
-                element: shadowArticleBody,
-                selector: '.signin-gate__first-paragraph-overlay',
-            });
-
-            // check page type/pillar to change text colour of the sign in gate
-            addPillarColour({
-                element: shadowArticleBody,
-                selector: '.signin-gate__benefits--text',
-            });
-
-            // add click handler for the dismiss of the gate
-            addClickHandler({
-                element: shadowArticleBody,
-                selector: '.js-signin-gate__dismiss',
-                abTest,
-                component,
-                value: 'not-now',
-                callback: () => {
-                    // show the current body. Remove the shadow one
-                    articleBody.style.display = 'block';
-                    shadowArticleBody.remove();
-
-                    // Tell other things the article has been redisplayed
-                    mediator.emit('page:article:redisplayed');
-
-                    // user pref dismissed gate
-                    setUserDismissedGate({
-                        componentName,
-                        name: abTest.name,
-                        variant: abTest.variant,
-                    });
-                },
-            });
-
-            // add click handler for sign in button click
-            addClickHandler({
-                element: shadowArticleBody,
-                selector: '.js-signin-gate__button',
-                abTest,
-                component,
-                value: 'sign-in-link',
-            });
-
-            // add click handler for the why sign in link
-            addClickHandler({
-                element: shadowArticleBody,
-                selector: '.js-signin-gate__why',
-                abTest,
-                component,
-                value: 'why-link',
-            });
-        },
-    });
+const show: () => boolean = () => true;
 
 // export the variant as a SignInGateVariant type
 export const signInGateVariant: SignInGateVariant = {

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/variant.js
@@ -1,61 +1,15 @@
 // @flow
-import mediator from 'lib/mediator';
-import type { CurrentABTest, SignInGateVariant } from '../types';
-import { component, componentName } from '../component';
+import type { SignInGateVariant } from '../types';
+import { componentName } from '../component';
 import {
     hasUserDismissedGate,
     isNPageOrHigherPageView,
     isLoggedIn,
     isInvalidArticleType,
     isInvalidSection,
-    addOpinionBgColour,
-    addClickHandler,
-    setUserDismissedGate,
-    showGate,
 } from '../helper';
 
 const variant = 'variant';
-
-const htmlTemplate: ({
-    signInUrl: string,
-    guUrl: string,
-}) => string = ({ signInUrl, guUrl }) => `
-<div class="signin-gate">
-    <div class="signin-gate__content">
-        <div class="signin-gate__header">
-            <h1 class="signin-gate__header--text">Register for free and continue reading</h1>
-        </div>
-        <div class="signin-gate__benefits syndication--bottom">
-            <p class="signin-gate__benefits--text">
-                The Guardian’s independent journalism is still free to read
-            </p>
-        </div>
-        <div class="signin-gate__paragraph syndication--bottom">
-            <p class="signin-gate__paragraph--text">
-                Registering lets us understand you better. This means that we can build better products and start to personalise the adverts you see so we can charge more from advertisers in the future.
-            </p>
-        </div>
-        <div class="signin-gate__buttons">
-            <a class="signin-gate__button signin-gate__button--primary js-signin-gate__register-button" href="${signInUrl}">
-                Register for free
-            </a>
-            <a class="signin-gate__dismiss js-signin-gate__dismiss" href="#maincontent">Not Now</a>
-        </div>
-        <div class="signin-gate__padding-bottom signin-gate__buttons">
-            Already registered, contributed, or subscribed?&nbsp;<a class="signin-gate__link js-signin-gate__sign-in signin-gate__link-no-ptm signin-gate__center-424" href="${signInUrl}">Sign in</a>
-        </div>
-        <div class="signin-gate__buttons">
-            <a class="signin-gate__link js-signin-gate__why" href="${guUrl}/membership/2019/dec/20/signing-in-to-the-guardian">Why register & how does it help?</a>
-        </div>
-        <div class="signin-gate__buttons">
-            <a class="signin-gate__link js-signin-gate__how" href="${guUrl}/info/2014/nov/03/why-your-data-matters-to-us-full-text">How will my information & data be used?</a>
-        </div>
-        <div class="signin-gate__buttons">
-            <a class="signin-gate__link js-signin-gate__help" href="${guUrl}/help/identity-faq">Get help with registering or signing in</a>
-        </div>
-    </div>
-</div>
-`;
 
 const canShow: (name?: string) => boolean = (name = '') =>
     !hasUserDismissedGate({
@@ -63,98 +17,12 @@ const canShow: (name?: string) => boolean = (name = '') =>
         name,
         variant,
     }) &&
-    isNPageOrHigherPageView(2) &&
+    isNPageOrHigherPageView(3) &&
     !isLoggedIn() &&
     !isInvalidArticleType() &&
     !isInvalidSection();
 
-const show: ({
-    abTest: CurrentABTest,
-    guUrl: string,
-    signInUrl: string,
-}) => boolean = ({ abTest, guUrl, signInUrl }) =>
-    showGate({
-        template: htmlTemplate({
-            signInUrl,
-            guUrl,
-        }),
-        handler: ({ articleBody, shadowArticleBody }) => {
-            // check if comment, and add comment/opinion bg colour
-            addOpinionBgColour({
-                element: shadowArticleBody,
-                selector: '.signin-gate__first-paragraph-overlay',
-            });
-
-            // add click handler for the dismiss of the gate
-            addClickHandler({
-                element: shadowArticleBody,
-                selector: '.js-signin-gate__dismiss',
-                abTest,
-                component,
-                value: 'not-now',
-                callback: () => {
-                    // show the current body. Remove the shadow one
-                    articleBody.style.display = 'block';
-                    shadowArticleBody.remove();
-
-                    // Tell other things the article has been redisplayed
-                    mediator.emit('page:article:redisplayed');
-
-                    // user pref dismissed gate
-                    setUserDismissedGate({
-                        componentName,
-                        name: abTest.name,
-                        variant: abTest.variant,
-                    });
-                },
-            });
-
-            // add click handler for sign in link click
-            addClickHandler({
-                element: shadowArticleBody,
-                selector: '.js-signin-gate__register-button',
-                abTest,
-                component,
-                value: 'register-link',
-            });
-
-            // add click handler for sign in link click
-            addClickHandler({
-                element: shadowArticleBody,
-                selector: '.js-signin-gate__sign-in',
-                abTest,
-                component,
-                value: 'sign-in-link',
-            });
-
-            // add click handler for the why sign in link
-            addClickHandler({
-                element: shadowArticleBody,
-                selector: '.js-signin-gate__why',
-                abTest,
-                component,
-                value: 'why-link',
-            });
-
-            // add click handler for the how info used link
-            addClickHandler({
-                element: shadowArticleBody,
-                selector: '.js-signin-gate__how',
-                abTest,
-                component,
-                value: 'how-link',
-            });
-
-            // add click handler for the help link
-            addClickHandler({
-                element: shadowArticleBody,
-                selector: '.js-signin-gate__help',
-                abTest,
-                component,
-                value: 'help-link',
-            });
-        },
-    });
+const show: () => boolean = () => true;
 
 export const signInGateVariant: SignInGateVariant = {
     name: variant,


### PR DESCRIPTION
## What does this change?

In preparation for a new test next week, we want to see the number of browsers that will get through our display rule criteria compared between the control and variant. Those that get through would be eligible to see the gate, and we'd normally show it to them.

Instead we just fire a `VIEW` component event which lets us know that those browsers would've been eligible to see the test on that particular page.

This test will only be enabled over the weekend, and will be switched off on Monday, for when we'll be launching the new sign in gate test based on the results of this test.

Control - "Sign In Gate" shown on 2nd or higher page view per day
Variant - "Sign In Gate" shown on 3rd or higher page view per day

#### Tracking information:

AB Test Name - `SignInGateLatens`
component id - `latens_test`

### Tested

- [X] Locally
- [x] On CODE (optional)

Test by adding `#ab-SignInGateLatens=variant` or `#ab-SignInGateLatens=control` on url. Successful if you see a `VIEW` ophan event fire from the network tab.

![Screenshot 2020-04-03 at 15 10 31](https://user-images.githubusercontent.com/13315440/78369567-4aa7c880-75bd-11ea-8bf3-233cbeeefcfc.png)


<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
