### PR TITLE
Sign In Gate: Quartus Test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -132,7 +132,7 @@ trait ABTestSwitches {
     "Test new sign in component on 2nd article view compared to the 3rd article view",
     owners = Seq(Owner.withGithub("coldlink"),Owner.withGithub("dominickendrick")),
     safeState = Off,
-    sellByDate = new LocalDate(2020, 5, 1),
+    sellByDate = new LocalDate(2020, 6, 1),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -128,8 +128,18 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-sign-in-gate-quartus",
-    "Test new sign in component on 2nd article view compared to the 3rd article view",
+    "ab-sign-in-gate-quartus-control",
+    "Test new sign in component on 2nd article view",
+    owners = Seq(Owner.withGithub("coldlink"),Owner.withGithub("dominickendrick")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 6, 1),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
+    "ab-sign-in-gate-quartus-variant",
+    "Test new sign in component on 3nd article view",
     owners = Seq(Owner.withGithub("coldlink"),Owner.withGithub("dominickendrick")),
     safeState = Off,
     sellByDate = new LocalDate(2020, 6, 1),

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -148,6 +148,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-sign-in-gate-quartus-scale",
+    "Test new sign in component on 3nd article view to a larger audience",
+    owners = Seq(Owner.withGithub("coldlink"),Owner.withGithub("dominickendrick")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 6, 1),
+    exposeClientSide = true
+  )
+
+  Switch(
+    ABTests,
     "ab-frontend-dotcom-rendering-epic",
     "A/B test Default Epic on Frontend vs DCR, both from a remote source, to compare Epic performance",
     owners = Seq(Owner.withGithub("andre1050")),

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -128,8 +128,8 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-sign-in-gate-tertius",
-    "Test new sign in component on 2nd article view",
+    "ab-sign-in-gate-quartus",
+    "Test new sign in component on 2nd article view compared to the 3rd article view",
     owners = Seq(Owner.withGithub("coldlink"),Owner.withGithub("dominickendrick")),
     safeState = Off,
     sellByDate = new LocalDate(2020, 5, 1),

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -10,6 +10,7 @@ import { amazonA9Test } from 'common/modules/experiments/tests/amazon-a9';
 import { connatixTest } from 'common/modules/experiments/tests/connatix-ab-test';
 import { frontendDotcomRenderingEpic } from 'common/modules/experiments/tests/frontend-dotcom-rendering-epic';
 import { signInGate } from 'common/modules/experiments/tests/sign-in-gate';
+import { signInGateVariant } from 'common/modules/experiments/tests/sign-in-gate-variant';
 import { contributionsEpicPrecontributionReminderRoundTwo } from 'common/modules/experiments/tests/contributions-epic-precontribution-reminder-round-two';
 import { contributionsEpicLiveblogDesignTestR1 } from 'common/modules/experiments/tests/contributions-epic-liveblog-design-test';
 import { commercialGptPath } from 'common/modules/experiments/tests/commercial-gpt-path';
@@ -23,6 +24,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     appnexusUSAdapter,
     pangaeaAdapterTest,
     signInGate,
+    signInGateVariant,
     commercialGptPath,
 ];
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-scale.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-scale.js
@@ -1,13 +1,13 @@
 // @flow
-export const signInGateVariant: ABTest = {
-    id: 'SignInGateQuartusVariant',
+export const signInGateScale: ABTest = {
+    id: 'SignInGateQuartusScale',
     start: '2020-04-07',
     expiry: '2020-06-01',
     author: 'Mahesh Makani',
     description:
-        'Test adding a sign in component on the 3rd pageview, with higher priority over banners and epic. This test does not display a gate, and only used for tracking users who meet our displayer criteria.',
-    audience: 0.12,
-    audienceOffset: 0.6,
+        'Test adding a sign in component on the 3rd pageview, with higher priority over banners and epic, and a much larger audience size. This test does not display a gate, and only used for tracking users who meet our displayer criteria.',
+    audience: 0.25,
+    audienceOffset: 0.75,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:
         'The contributions epic is not shown, The consent banner is not shown, The contributions banner is not shown, Should only appear on simple article template, Should not show if they are already signed in, Users will not need to go through the marketing consents as part of signup flow',
@@ -21,7 +21,7 @@ export const signInGateVariant: ABTest = {
         //     test: (): void => {},
         // },
         {
-            id: 'variant',
+            id: 'scale',
             test: (): void => {},
         },
     ],

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-variant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-variant.js
@@ -1,8 +1,8 @@
 // @flow
 export const signInGateVariant: ABTest = {
     id: 'SignInGateQuartusVariant',
-    start: '2020-02-17',
-    expiry: '2020-05-01',
+    start: '2020-04-07',
+    expiry: '2020-06-01',
     author: 'Mahesh Makani',
     description:
         'Test adding a sign in component on the 3rd pageview, with higher priority over banners and epic, and a much larget audience size. This test does not display a gate, and only used for tracking users who meet our displayer criteria.',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-variant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-variant.js
@@ -1,13 +1,13 @@
 // @flow
-export const signInGate: ABTest = {
-    id: 'SignInGateQuartusControl',
+export const signInGateVariant: ABTest = {
+    id: 'SignInGateQuartusVariant',
     start: '2020-02-17',
     expiry: '2020-05-01',
     author: 'Mahesh Makani',
     description:
-        'Test adding a sign in component on the 2nd pageview of simple article templates, with higher priority over banners and epic, and a much larget audience size. This test does not display a gate, and only used for tracking users who meet our displayer criteria.',
-    audience: 0.06,
-    audienceOffset: 0.5,
+        'Test adding a sign in component on the 3rd pageview, with higher priority over banners and epic, and a much larget audience size. This test does not display a gate, and only used for tracking users who meet our displayer criteria.',
+    audience: 0.4,
+    audienceOffset: 0.6,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:
         'The contributions epic is not shown, The consent banner is not shown, The contributions banner is not shown, Should only appear on simple article template, Should not show if they are already signed in, Users will not need to go through the marketing consents as part of signup flow',
@@ -21,7 +21,7 @@ export const signInGate: ABTest = {
         //     test: (): void => {},
         // },
         {
-            id: 'control',
+            id: 'variant',
             test: (): void => {},
         },
     ],

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate.js
@@ -1,8 +1,8 @@
 // @flow
 export const signInGate: ABTest = {
     id: 'SignInGateQuartusControl',
-    start: '2020-02-17',
-    expiry: '2020-05-01',
+    start: '2020-04-07',
+    expiry: '2020-06-01',
     author: 'Mahesh Makani',
     description:
         'Test adding a sign in component on the 2nd pageview of simple article templates, with higher priority over banners and epic, and a much larget audience size. This test does not display a gate, and only used for tracking users who meet our displayer criteria.',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate.js
@@ -11,7 +11,7 @@ export const signInGate: ABTest = {
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:
         'The contributions epic is not shown, The consent banner is not shown, The contributions banner is not shown, Should only appear on simple article template, Should not show if they are already signed in, Users will not need to go through the marketing consents as part of signup flow',
-    dataLinkNames: 'n/a',
+    dataLinkNames: 'SignInGateQuartus',
     idealOutcome: '60% of users sign in, and dismiss rate is below 40%',
     showForSensitive: false,
     canRun: () => true,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate.js
@@ -1,6 +1,6 @@
 // @flow
 export const signInGate: ABTest = {
-    id: 'SignInGateTertius',
+    id: 'SignInGateQuartus',
     start: '2020-02-17',
     expiry: '2020-05-01',
     author: 'Mahesh Makani, Dominic Kendrick',

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/component.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/component.js
@@ -6,5 +6,5 @@ export const componentName = 'sign-in-gate';
 // set the ophan component tracking vars
 export const component: OphanComponent = {
     componentType: 'SIGN_IN_GATE',
-    id: 'tertius_test',
+    id: 'quartus_test',
 };

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
@@ -17,7 +17,9 @@ export const isLoggedIn = isUserLoggedIn;
 // wrapper over isInABTestSynchronous
 export const isInTest: ABTest => boolean = test => isInABTestSynchronous(test);
 
-export const getInTest: (Array<ABTest>) => ABTest = tests =>
+// when running multiple tests simultaneously to test the component, we need to get
+// which test the user is in, so that we can check and display the correct logic for that test
+export const getTestforMultiTest: (Array<ABTest>) => ABTest = tests =>
     tests.reduce((acc, test) => {
         const checkTest = getSynchronousTestsToRun().find(
             t => t.id === test.id

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
@@ -17,6 +17,15 @@ export const isLoggedIn = isUserLoggedIn;
 // wrapper over isInABTestSynchronous
 export const isInTest: ABTest => boolean = test => isInABTestSynchronous(test);
 
+export const getInTest: (Array<ABTest>) => ABTest = tests =>
+    tests.reduce((acc, test) => {
+        const checkTest = getSynchronousTestsToRun().find(
+            t => t.id === test.id
+        );
+        if (checkTest) return checkTest;
+        return acc;
+    }, undefined);
+
 // get the current variant id the user is in
 export const getVariant: ABTest => string = test => {
     //  get the current test

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
@@ -6,7 +6,7 @@ import type { Banner } from 'common/modules/ui/bannerPicker';
 import { signInGate as signInGateTestControl } from 'common/modules/experiments/tests/sign-in-gate';
 import { signInGateVariant as signInGateTestVariant } from 'common/modules/experiments/tests/sign-in-gate-variant';
 import { submitViewEventTracking } from './component-event-tracking';
-import { getVariant, isInTest, getInTest } from './helper';
+import { getVariant, isInTest, getTestforMultiTest } from './helper';
 import { component, componentName } from './component';
 import { variants } from './variants';
 import type {
@@ -23,7 +23,7 @@ const canShow: () => Promise<boolean> = () =>
         if (!tests.some(test => isInTest(test))) return resolve(false);
 
         // get the test the user is in
-        const test = getInTest(tests);
+        const test = getTestforMultiTest(tests);
 
         // get the variant
         const variant = variants.find(v => v.name === getVariant(test));
@@ -37,7 +37,7 @@ const canShow: () => Promise<boolean> = () =>
 const show: () => Promise<boolean> = () =>
     new Promise(resolve => {
         // get the test the user is in
-        const test = getInTest(tests);
+        const test = getTestforMultiTest(tests);
 
         // get the variant
         const variant: SignInGateVariant | void = variants.find(

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
@@ -5,6 +5,7 @@ import { constructQuery } from 'lib/url';
 import type { Banner } from 'common/modules/ui/bannerPicker';
 import { signInGate as signInGateTestControl } from 'common/modules/experiments/tests/sign-in-gate';
 import { signInGateVariant as signInGateTestVariant } from 'common/modules/experiments/tests/sign-in-gate-variant';
+import { signInGateScale as signInGateTestScale } from 'common/modules/experiments/tests/sign-in-gate-scale';
 import { submitViewEventTracking } from './component-event-tracking';
 import { getVariant, isInTest, getTestforMultiTest } from './helper';
 import { component, componentName } from './component';
@@ -15,7 +16,11 @@ import type {
     SignInGateVariant,
 } from './types';
 
-const tests = [signInGateTestControl, signInGateTestVariant];
+const tests = [
+    signInGateTestControl,
+    signInGateTestVariant,
+    signInGateTestScale,
+];
 
 const canShow: () => Promise<boolean> = () =>
     new Promise(resolve => {

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
@@ -31,7 +31,7 @@ const canShow: () => Promise<boolean> = () =>
         if (!variant) return resolve(false);
 
         // check if we can show the test for the variant the user is in
-        return resolve(variant.canShow(test.id));
+        return resolve(variant.canShow(test.dataLinkNames));
     });
 
 const show: () => Promise<boolean> = () =>

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
@@ -10,7 +10,7 @@ jest.mock('common/modules/experiments/ab', () => ({
     getAsyncTestsToRun: jest.fn(() => Promise.resolve([])),
     getSynchronousTestsToRun: jest.fn(() => [
         {
-            id: 'SignInGateTertius',
+            id: 'SignInGateQuartus',
             variantToRun: {
                 id: 'variant',
             },
@@ -91,7 +91,7 @@ describe('Sign in gate test', () => {
 
         it('should return false if user has dismissed the gate', () => {
             fakeUserPrefs.get.mockReturnValueOnce({
-                'SignInGateTertius-variant': Date.now(),
+                'SignInGateQuartus-variant': Date.now(),
             });
         });
 

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
@@ -72,6 +72,7 @@ describe('Sign in gate test', () => {
             // mock twice as we have 2 tests
             fakeIsInABTestSynchronous
                 .mockReturnValueOnce(false)
+                .mockReturnValueOnce(false)
                 .mockReturnValueOnce(false);
             return signInGate.canShow().then(show => {
                 expect(show).toBe(false);

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
@@ -10,7 +10,7 @@ jest.mock('common/modules/experiments/ab', () => ({
     getAsyncTestsToRun: jest.fn(() => Promise.resolve([])),
     getSynchronousTestsToRun: jest.fn(() => [
         {
-            id: 'SignInGateQuartus',
+            id: 'SignInGateQuartusVariant',
             variantToRun: {
                 id: 'variant',
             },
@@ -69,7 +69,10 @@ describe('Sign in gate test', () => {
 
     describe('canShow returns false', () => {
         it('should return false if not in correct test', () => {
-            fakeIsInABTestSynchronous.mockReturnValueOnce(false);
+            // mock twice as we have 2 tests
+            fakeIsInABTestSynchronous
+                .mockReturnValueOnce(false)
+                .mockReturnValueOnce(false);
             return signInGate.canShow().then(show => {
                 expect(show).toBe(false);
             });
@@ -91,7 +94,7 @@ describe('Sign in gate test', () => {
 
         it('should return false if user has dismissed the gate', () => {
             fakeUserPrefs.get.mockReturnValueOnce({
-                'SignInGateQuartus-variant': Date.now(),
+                'SignInGateQuartusVariant-variant': Date.now(),
             });
         });
 

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/control.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/control.js
@@ -1,5 +1,5 @@
 // @flow
-import type { SignInGateVariant } from '../types';
+import type { CurrentABTest, SignInGateVariant } from '../types';
 import { componentName } from '../component';
 import {
     hasUserDismissedGate,

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/control.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/control.js
@@ -9,7 +9,6 @@ import {
     isInvalidArticleType,
     isInvalidSection,
     addOpinionBgColour,
-    addPillarColour,
     addClickHandler,
     setUserDismissedGate,
     showGate,
@@ -29,19 +28,35 @@ const htmlTemplate: ({
 <div class="signin-gate">
     <div class="signin-gate__content">
         <div class="signin-gate__header">
-            <h1 class="signin-gate__header--text">Sign in and continue<br />reading for free</h1>
+            <h1 class="signin-gate__header--text">Register for free and continue reading</h1>
         </div>
         <div class="signin-gate__benefits syndication--bottom">
             <p class="signin-gate__benefits--text">
-                Help keep our independent, progressive journalism alive and thriving by taking a couple of simple steps to sign in
+                The Guardian’s independent journalism is still free to read
+            </p>
+        </div>
+        <div class="signin-gate__paragraph syndication--bottom">
+            <p class="signin-gate__paragraph--text">
+                Registering lets us understand you better. This means that we can build better products and start to personalise the adverts you see so we can charge more from advertisers in the future.
             </p>
         </div>
         <div class="signin-gate__buttons">
-            <a class="signin-gate__button signin-gate__button--primary js-signin-gate__button" href="${signInUrl}">
-                Sign in
+            <a class="signin-gate__button signin-gate__button--primary js-signin-gate__register-button" href="${signInUrl}">
+                Register for free
             </a>
-            <a class="signin-gate__padding-left signin-gate__link signin-gate__center-424 js-signin-gate__why" href="${guUrl}/help/identity-faq">Why sign in?</a>
             <a class="signin-gate__dismiss js-signin-gate__dismiss" href="#maincontent">Not Now</a>
+        </div>
+        <div class="signin-gate__padding-bottom signin-gate__buttons">
+            Already registered, contributed, or subscribed?&nbsp;<a class="signin-gate__link js-signin-gate__sign-in signin-gate__link-no-ptm signin-gate__center-424" href="${signInUrl}">Sign in</a>
+        </div>
+        <div class="signin-gate__buttons">
+            <a class="signin-gate__link js-signin-gate__why" href="${guUrl}/membership/2019/dec/20/signing-in-to-the-guardian">Why register & how does it help?</a>
+        </div>
+        <div class="signin-gate__buttons">
+            <a class="signin-gate__link js-signin-gate__how" href="${guUrl}/info/2014/nov/03/why-your-data-matters-to-us-full-text">How will my information & data be used?</a>
+        </div>
+        <div class="signin-gate__buttons">
+            <a class="signin-gate__link js-signin-gate__help" href="${guUrl}/help/identity-faq">Get help with registering or signing in</a>
         </div>
     </div>
 </div>
@@ -79,12 +94,6 @@ const show: ({
                 selector: '.signin-gate__first-paragraph-overlay',
             });
 
-            // check page type/pillar to change text colour of the sign in gate
-            addPillarColour({
-                element: shadowArticleBody,
-                selector: '.signin-gate__benefits--text',
-            });
-
             // add click handler for the dismiss of the gate
             addClickHandler({
                 element: shadowArticleBody,
@@ -109,10 +118,19 @@ const show: ({
                 },
             });
 
-            // add click handler for sign in button click
+            // add click handler for sign in link click
             addClickHandler({
                 element: shadowArticleBody,
-                selector: '.js-signin-gate__button',
+                selector: '.js-signin-gate__register-button',
+                abTest,
+                component,
+                value: 'register-link',
+            });
+
+            // add click handler for sign in link click
+            addClickHandler({
+                element: shadowArticleBody,
+                selector: '.js-signin-gate__sign-in',
                 abTest,
                 component,
                 value: 'sign-in-link',
@@ -125,6 +143,24 @@ const show: ({
                 abTest,
                 component,
                 value: 'why-link',
+            });
+
+            // add click handler for the how info used link
+            addClickHandler({
+                element: shadowArticleBody,
+                selector: '.js-signin-gate__how',
+                abTest,
+                component,
+                value: 'how-link',
+            });
+
+            // add click handler for the help link
+            addClickHandler({
+                element: shadowArticleBody,
+                selector: '.js-signin-gate__help',
+                abTest,
+                component,
+                value: 'help-link',
             });
         },
     });

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/control.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/control.js
@@ -10,7 +10,7 @@ import {
 } from '../helper';
 
 // pull in the show method from the design folder, which has the html template and and click handlers etc.
-import { show } from './design/quartus';
+import { designShow } from './design/quartus';
 
 // define the variant name here
 const variant = 'control';
@@ -26,6 +26,16 @@ const canShow: (name?: string) => boolean = (name = '') =>
     !isLoggedIn() &&
     !isInvalidArticleType() &&
     !isInvalidSection();
+
+// method which runs if the canShow method returns true, used to display the gate and logic associated with it
+// it returns a boolean, since the sign in gate is based on a `Banner` type who's show method returns a Promise<boolean>
+// in our case it returns true if the design ran successfully, and false if there were any problems encountered
+const show: ({
+    abTest: CurrentABTest,
+    guUrl: string,
+    signInUrl: string,
+}) => boolean = ({ abTest, guUrl, signInUrl }) =>
+    designShow({ abTest, guUrl, signInUrl });
 
 // export the variant as a SignInGateVariant type
 export const signInGateVariant: SignInGateVariant = {

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/control.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/control.js
@@ -47,7 +47,7 @@ const htmlTemplate: ({
             <a class="signin-gate__dismiss js-signin-gate__dismiss" href="#maincontent">Not Now</a>
         </div>
         <div class="signin-gate__padding-bottom signin-gate__buttons">
-            Already registered, contributed, or subscribed?&nbsp;<a class="signin-gate__link js-signin-gate__sign-in signin-gate__link-no-ptm signin-gate__center-424" href="${signInUrl}">Sign in</a>
+            Already registered, contributed or subscribed?&nbsp;<a class="signin-gate__link js-signin-gate__sign-in signin-gate__link-no-ptm signin-gate__center-424" href="${signInUrl}">Sign in</a>
         </div>
         <div class="signin-gate__buttons">
             <a class="signin-gate__link js-signin-gate__why" href="${guUrl}/membership/2019/dec/20/signing-in-to-the-guardian">Why register & how does it help?</a>

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/control.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/control.js
@@ -1,4 +1,5 @@
 // @flow
+import mediator from 'lib/mediator';
 import type { CurrentABTest, SignInGateVariant } from '../types';
 import { component, componentName } from '../component';
 import {

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/control.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/control.js
@@ -1,66 +1,19 @@
 // @flow
-import mediator from 'lib/mediator';
-import type { CurrentABTest, SignInGateVariant } from '../types';
-import { component, componentName } from '../component';
+import type { SignInGateVariant } from '../types';
+import { componentName } from '../component';
 import {
     hasUserDismissedGate,
     isNPageOrHigherPageView,
     isLoggedIn,
     isInvalidArticleType,
     isInvalidSection,
-    addOpinionBgColour,
-    addClickHandler,
-    setUserDismissedGate,
-    showGate,
 } from '../helper';
+
+// pull in the show method from the design folder, which has the html template and and click handlers etc.
+import { show } from './design/quartus';
 
 // define the variant name here
 const variant = 'control';
-
-// add the html template as the return of the function below
-// signInUrl - parameter which holds the link to the sign in/register page with the tracking parameters added
-// guUrl - url of the STAGE frontend site, e.g. in DEV stage it would be https://m.thegulocal.com,
-//         and for PROD it would be https://theguardian.com
-const htmlTemplate: ({
-    signInUrl: string,
-    guUrl: string,
-}) => string = ({ signInUrl, guUrl }) => `
-<div class="signin-gate">
-    <div class="signin-gate__content">
-        <div class="signin-gate__header">
-            <h1 class="signin-gate__header--text">Register for free and continue reading</h1>
-        </div>
-        <div class="signin-gate__benefits syndication--bottom">
-            <p class="signin-gate__benefits--text">
-                The Guardian’s independent journalism is still free to read
-            </p>
-        </div>
-        <div class="signin-gate__paragraph syndication--bottom">
-            <p class="signin-gate__paragraph--text">
-                Registering lets us understand you better. This means that we can build better products and start to personalise the adverts you see so we can charge more from advertisers in the future.
-            </p>
-        </div>
-        <div class="signin-gate__buttons">
-            <a class="signin-gate__button signin-gate__button--primary js-signin-gate__register-button" href="${signInUrl}">
-                Register for free
-            </a>
-            <a class="signin-gate__dismiss js-signin-gate__dismiss" href="#maincontent">Not Now</a>
-        </div>
-        <div class="signin-gate__padding-bottom signin-gate__buttons">
-            Already registered, contributed or subscribed?&nbsp;<a class="signin-gate__link js-signin-gate__sign-in signin-gate__link-no-ptm signin-gate__center-424" href="${signInUrl}">Sign in</a>
-        </div>
-        <div class="signin-gate__buttons">
-            <a class="signin-gate__link js-signin-gate__why" href="${guUrl}/membership/2019/dec/20/signing-in-to-the-guardian">Why register & how does it help?</a>
-        </div>
-        <div class="signin-gate__buttons">
-            <a class="signin-gate__link js-signin-gate__how" href="${guUrl}/info/2014/nov/03/why-your-data-matters-to-us-full-text">How will my information & data be used?</a>
-        </div>
-        <div class="signin-gate__buttons">
-            <a class="signin-gate__link js-signin-gate__help" href="${guUrl}/help/identity-faq">Get help with registering or signing in</a>
-        </div>
-    </div>
-</div>
-`;
 
 // method which returns a boolean determining if this variant can be shown on the current pageview
 const canShow: (name?: string) => boolean = (name = '') =>
@@ -73,97 +26,6 @@ const canShow: (name?: string) => boolean = (name = '') =>
     !isLoggedIn() &&
     !isInvalidArticleType() &&
     !isInvalidSection();
-
-// method which runs if the canShow method returns true, used to display the gate and logic associated with it
-// it returns a boolean, since the sign in gate is based on a `Banner` type who's show method returns a Promise<boolean>
-// in our case it returns true if the method ran successfully, and false if there were any problems encountered
-const show: ({
-    abTest: CurrentABTest,
-    guUrl: string,
-    signInUrl: string,
-}) => boolean = ({ abTest, guUrl, signInUrl }) =>
-    showGate({
-        template: htmlTemplate({
-            signInUrl,
-            guUrl,
-        }),
-        handler: ({ articleBody, shadowArticleBody }) => {
-            // check if comment, and add comment/opinion bg colour
-            addOpinionBgColour({
-                element: shadowArticleBody,
-                selector: '.signin-gate__first-paragraph-overlay',
-            });
-
-            // add click handler for the dismiss of the gate
-            addClickHandler({
-                element: shadowArticleBody,
-                selector: '.js-signin-gate__dismiss',
-                abTest,
-                component,
-                value: 'not-now',
-                callback: () => {
-                    // show the current body. Remove the shadow one
-                    articleBody.style.display = 'block';
-                    shadowArticleBody.remove();
-
-                    // Tell other things the article has been redisplayed
-                    mediator.emit('page:article:redisplayed');
-
-                    // user pref dismissed gate
-                    setUserDismissedGate({
-                        componentName,
-                        name: abTest.name,
-                        variant: abTest.variant,
-                    });
-                },
-            });
-
-            // add click handler for sign in link click
-            addClickHandler({
-                element: shadowArticleBody,
-                selector: '.js-signin-gate__register-button',
-                abTest,
-                component,
-                value: 'register-link',
-            });
-
-            // add click handler for sign in link click
-            addClickHandler({
-                element: shadowArticleBody,
-                selector: '.js-signin-gate__sign-in',
-                abTest,
-                component,
-                value: 'sign-in-link',
-            });
-
-            // add click handler for the why sign in link
-            addClickHandler({
-                element: shadowArticleBody,
-                selector: '.js-signin-gate__why',
-                abTest,
-                component,
-                value: 'why-link',
-            });
-
-            // add click handler for the how info used link
-            addClickHandler({
-                element: shadowArticleBody,
-                selector: '.js-signin-gate__how',
-                abTest,
-                component,
-                value: 'how-link',
-            });
-
-            // add click handler for the help link
-            addClickHandler({
-                element: shadowArticleBody,
-                selector: '.js-signin-gate__help',
-                abTest,
-                component,
-                value: 'help-link',
-            });
-        },
-    });
 
 // export the variant as a SignInGateVariant type
 export const signInGateVariant: SignInGateVariant = {

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/control.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/control.js
@@ -1,6 +1,6 @@
 // @flow
-import type { SignInGateVariant } from '../types';
-import { componentName } from '../component';
+import type { CurrentABTest, SignInGateVariant } from '../types';
+import { component, componentName } from '../component';
 import {
     hasUserDismissedGate,
     isNPageOrHigherPageView,

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/example.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/example.js
@@ -54,10 +54,10 @@ const htmlTemplate: ({
 </div>
 `;
 
-// method which runs if the canShow method returns true, used to display the gate and logic associated with it
+// method which runs if the canShow method from the test returns true, used to display the gate and logic associated with it
 // it returns a boolean, since the sign in gate is based on a `Banner` type who's show method returns a Promise<boolean>
-// in our case it returns true if the method ran successfully, and false if there were any problems encountered
-export const show: ({
+// in our case it returns true if the design ran successfully, and false if there were any problems encountered
+export const designShow: ({
     abTest: CurrentABTest,
     guUrl: string,
     signInUrl: string,

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/example.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/example.js
@@ -1,0 +1,146 @@
+// @flow
+import mediator from 'lib/mediator';
+import type { CurrentABTest } from '../../types';
+import { component, componentName } from '../../component';
+import {
+    addOpinionBgColour,
+    addClickHandler,
+    setUserDismissedGate,
+    showGate,
+} from '../../helper';
+
+// add the html template as the return of the function below
+// signInUrl - parameter which holds the link to the sign in/register page with the tracking parameters added
+// guUrl - url of the STAGE frontend site, e.g. in DEV stage it would be https://m.thegulocal.com,
+//         and for PROD it would be https://theguardian.com
+const htmlTemplate: ({
+    signInUrl: string,
+    guUrl: string,
+}) => string = ({ signInUrl, guUrl }) => `
+<div class="signin-gate">
+    <div class="signin-gate__content">
+        <div class="signin-gate__header">
+            <h1 class="signin-gate__header--text">Register for free and continue reading</h1>
+        </div>
+        <div class="signin-gate__benefits syndication--bottom">
+            <p class="signin-gate__benefits--text">
+                The Guardian’s independent journalism is still free to read
+            </p>
+        </div>
+        <div class="signin-gate__paragraph syndication--bottom">
+            <p class="signin-gate__paragraph--text">
+                Registering lets us understand you better. This means that we can build better products and start to personalise the adverts you see so we can charge more from advertisers in the future.
+            </p>
+        </div>
+        <div class="signin-gate__buttons">
+            <a class="signin-gate__button signin-gate__button--primary js-signin-gate__register-button" href="${signInUrl}">
+                Register for free
+            </a>
+            <a class="signin-gate__dismiss js-signin-gate__dismiss" href="#maincontent">Not Now</a>
+        </div>
+        <div class="signin-gate__padding-bottom signin-gate__buttons">
+            Already registered, contributed or subscribed?&nbsp;<a class="signin-gate__link js-signin-gate__sign-in signin-gate__link-no-ptm signin-gate__center-424" href="${signInUrl}">Sign in</a>
+        </div>
+        <div class="signin-gate__buttons">
+            <a class="signin-gate__link js-signin-gate__why" href="${guUrl}/membership/2019/dec/20/signing-in-to-the-guardian">Why register & how does it help?</a>
+        </div>
+        <div class="signin-gate__buttons">
+            <a class="signin-gate__link js-signin-gate__how" href="${guUrl}/info/2014/nov/03/why-your-data-matters-to-us-full-text">How will my information & data be used?</a>
+        </div>
+        <div class="signin-gate__buttons">
+            <a class="signin-gate__link js-signin-gate__help" href="${guUrl}/help/identity-faq">Get help with registering or signing in</a>
+        </div>
+    </div>
+</div>
+`;
+
+// method which runs if the canShow method returns true, used to display the gate and logic associated with it
+// it returns a boolean, since the sign in gate is based on a `Banner` type who's show method returns a Promise<boolean>
+// in our case it returns true if the method ran successfully, and false if there were any problems encountered
+export const show: ({
+    abTest: CurrentABTest,
+    guUrl: string,
+    signInUrl: string,
+}) => boolean = ({ abTest, guUrl, signInUrl }) =>
+    showGate({
+        template: htmlTemplate({
+            signInUrl,
+            guUrl,
+        }),
+        handler: ({ articleBody, shadowArticleBody }) => {
+            // check if comment, and add comment/opinion bg colour
+            addOpinionBgColour({
+                element: shadowArticleBody,
+                selector: '.signin-gate__first-paragraph-overlay',
+            });
+
+            // add click handler for the dismiss of the gate
+            addClickHandler({
+                element: shadowArticleBody,
+                selector: '.js-signin-gate__dismiss',
+                abTest,
+                component,
+                value: 'not-now',
+                callback: () => {
+                    // show the current body. Remove the shadow one
+                    articleBody.style.display = 'block';
+                    shadowArticleBody.remove();
+
+                    // Tell other things the article has been redisplayed
+                    mediator.emit('page:article:redisplayed');
+
+                    // user pref dismissed gate
+                    setUserDismissedGate({
+                        componentName,
+                        name: abTest.name,
+                        variant: abTest.variant,
+                    });
+                },
+            });
+
+            // add click handler for sign in link click
+            addClickHandler({
+                element: shadowArticleBody,
+                selector: '.js-signin-gate__register-button',
+                abTest,
+                component,
+                value: 'register-link',
+            });
+
+            // add click handler for sign in link click
+            addClickHandler({
+                element: shadowArticleBody,
+                selector: '.js-signin-gate__sign-in',
+                abTest,
+                component,
+                value: 'sign-in-link',
+            });
+
+            // add click handler for the why sign in link
+            addClickHandler({
+                element: shadowArticleBody,
+                selector: '.js-signin-gate__why',
+                abTest,
+                component,
+                value: 'why-link',
+            });
+
+            // add click handler for the how info used link
+            addClickHandler({
+                element: shadowArticleBody,
+                selector: '.js-signin-gate__how',
+                abTest,
+                component,
+                value: 'how-link',
+            });
+
+            // add click handler for the help link
+            addClickHandler({
+                element: shadowArticleBody,
+                selector: '.js-signin-gate__help',
+                abTest,
+                component,
+                value: 'help-link',
+            });
+        },
+    });

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/quartus.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/quartus.js
@@ -54,10 +54,10 @@ const htmlTemplate: ({
 </div>
 `;
 
-// method which runs if the canShow method returns true, used to display the gate and logic associated with it
+// method which runs if the canShow method from the test returns true, used to display the gate and logic associated with it
 // it returns a boolean, since the sign in gate is based on a `Banner` type who's show method returns a Promise<boolean>
-// in our case it returns true if the method ran successfully, and false if there were any problems encountered
-export const show: ({
+// in our case it returns true if the design ran successfully, and false if there were any problems encountered
+export const designShow: ({
     abTest: CurrentABTest,
     guUrl: string,
     signInUrl: string,

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/quartus.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/quartus.js
@@ -1,0 +1,146 @@
+// @flow
+import mediator from 'lib/mediator';
+import type { CurrentABTest } from '../../types';
+import { component, componentName } from '../../component';
+import {
+    addOpinionBgColour,
+    addClickHandler,
+    setUserDismissedGate,
+    showGate,
+} from '../../helper';
+
+// add the html template as the return of the function below
+// signInUrl - parameter which holds the link to the sign in/register page with the tracking parameters added
+// guUrl - url of the STAGE frontend site, e.g. in DEV stage it would be https://m.thegulocal.com,
+//         and for PROD it would be https://theguardian.com
+const htmlTemplate: ({
+    signInUrl: string,
+    guUrl: string,
+}) => string = ({ signInUrl, guUrl }) => `
+<div class="signin-gate">
+    <div class="signin-gate__content">
+        <div class="signin-gate__header">
+            <h1 class="signin-gate__header--text">Register for free and continue reading</h1>
+        </div>
+        <div class="signin-gate__benefits syndication--bottom">
+            <p class="signin-gate__benefits--text">
+                The Guardian’s independent journalism is still free to read
+            </p>
+        </div>
+        <div class="signin-gate__paragraph syndication--bottom">
+            <p class="signin-gate__paragraph--text">
+                Registering lets us understand you better. This means that we can build better products and start to personalise the adverts you see so we can charge more from advertisers in the future.
+            </p>
+        </div>
+        <div class="signin-gate__buttons">
+            <a class="signin-gate__button signin-gate__button--primary js-signin-gate__register-button" href="${signInUrl}">
+                Register for free
+            </a>
+            <a class="signin-gate__dismiss js-signin-gate__dismiss" href="#maincontent">Not Now</a>
+        </div>
+        <div class="signin-gate__padding-bottom signin-gate__buttons">
+            Already registered, contributed or subscribed?&nbsp;<a class="signin-gate__link js-signin-gate__sign-in signin-gate__link-no-ptm signin-gate__center-424" href="${signInUrl}">Sign in</a>
+        </div>
+        <div class="signin-gate__buttons">
+            <a class="signin-gate__link js-signin-gate__why" href="${guUrl}/membership/2019/dec/20/signing-in-to-the-guardian">Why register & how does it help?</a>
+        </div>
+        <div class="signin-gate__buttons">
+            <a class="signin-gate__link js-signin-gate__how" href="${guUrl}/info/2014/nov/03/why-your-data-matters-to-us-full-text">How will my information & data be used?</a>
+        </div>
+        <div class="signin-gate__buttons">
+            <a class="signin-gate__link js-signin-gate__help" href="${guUrl}/help/identity-faq">Get help with registering or signing in</a>
+        </div>
+    </div>
+</div>
+`;
+
+// method which runs if the canShow method returns true, used to display the gate and logic associated with it
+// it returns a boolean, since the sign in gate is based on a `Banner` type who's show method returns a Promise<boolean>
+// in our case it returns true if the method ran successfully, and false if there were any problems encountered
+export const show: ({
+    abTest: CurrentABTest,
+    guUrl: string,
+    signInUrl: string,
+}) => boolean = ({ abTest, guUrl, signInUrl }) =>
+    showGate({
+        template: htmlTemplate({
+            signInUrl,
+            guUrl,
+        }),
+        handler: ({ articleBody, shadowArticleBody }) => {
+            // check if comment, and add comment/opinion bg colour
+            addOpinionBgColour({
+                element: shadowArticleBody,
+                selector: '.signin-gate__first-paragraph-overlay',
+            });
+
+            // add click handler for the dismiss of the gate
+            addClickHandler({
+                element: shadowArticleBody,
+                selector: '.js-signin-gate__dismiss',
+                abTest,
+                component,
+                value: 'not-now',
+                callback: () => {
+                    // show the current body. Remove the shadow one
+                    articleBody.style.display = 'block';
+                    shadowArticleBody.remove();
+
+                    // Tell other things the article has been redisplayed
+                    mediator.emit('page:article:redisplayed');
+
+                    // user pref dismissed gate
+                    setUserDismissedGate({
+                        componentName,
+                        name: abTest.name,
+                        variant: abTest.variant,
+                    });
+                },
+            });
+
+            // add click handler for sign in link click
+            addClickHandler({
+                element: shadowArticleBody,
+                selector: '.js-signin-gate__register-button',
+                abTest,
+                component,
+                value: 'register-link',
+            });
+
+            // add click handler for sign in link click
+            addClickHandler({
+                element: shadowArticleBody,
+                selector: '.js-signin-gate__sign-in',
+                abTest,
+                component,
+                value: 'sign-in-link',
+            });
+
+            // add click handler for the why sign in link
+            addClickHandler({
+                element: shadowArticleBody,
+                selector: '.js-signin-gate__why',
+                abTest,
+                component,
+                value: 'why-link',
+            });
+
+            // add click handler for the how info used link
+            addClickHandler({
+                element: shadowArticleBody,
+                selector: '.js-signin-gate__how',
+                abTest,
+                component,
+                value: 'how-link',
+            });
+
+            // add click handler for the help link
+            addClickHandler({
+                element: shadowArticleBody,
+                selector: '.js-signin-gate__help',
+                abTest,
+                component,
+                value: 'help-link',
+            });
+        },
+    });

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/example.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/example.js
@@ -9,7 +9,6 @@ import {
     isInvalidArticleType,
     isInvalidSection,
     addOpinionBgColour,
-    addPillarColour,
     addClickHandler,
     setUserDismissedGate,
     showGate,
@@ -29,19 +28,35 @@ const htmlTemplate: ({
 <div class="signin-gate">
     <div class="signin-gate__content">
         <div class="signin-gate__header">
-            <h1 class="signin-gate__header--text">Sign in and continue<br />reading for free</h1>
+            <h1 class="signin-gate__header--text">Register for free and continue reading</h1>
         </div>
         <div class="signin-gate__benefits syndication--bottom">
             <p class="signin-gate__benefits--text">
-                Help keep our independent, progressive journalism alive and thriving by taking a couple of simple steps to sign in
+                The Guardian’s independent journalism is still free to read
+            </p>
+        </div>
+        <div class="signin-gate__paragraph syndication--bottom">
+            <p class="signin-gate__paragraph--text">
+                Registering lets us understand you better. This means that we can build better products and start to personalise the adverts you see so we can charge more from advertisers in the future.
             </p>
         </div>
         <div class="signin-gate__buttons">
-            <a class="signin-gate__button signin-gate__button--primary js-signin-gate__button" href="${signInUrl}">
-                Sign in
+            <a class="signin-gate__button signin-gate__button--primary js-signin-gate__register-button" href="${signInUrl}">
+                Register for free
             </a>
-            <a class="signin-gate__padding-left signin-gate__link js-signin-gate__why" href="${guUrl}/help/identity-faq">Why sign in?</a>
             <a class="signin-gate__dismiss js-signin-gate__dismiss" href="#maincontent">Not Now</a>
+        </div>
+        <div class="signin-gate__padding-bottom signin-gate__buttons">
+            Already registered, contributed, or subscribed?&nbsp;<a class="signin-gate__link js-signin-gate__sign-in signin-gate__link-no-ptm signin-gate__center-424" href="${signInUrl}">Sign in</a>
+        </div>
+        <div class="signin-gate__buttons">
+            <a class="signin-gate__link js-signin-gate__why" href="${guUrl}/membership/2019/dec/20/signing-in-to-the-guardian">Why register & how does it help?</a>
+        </div>
+        <div class="signin-gate__buttons">
+            <a class="signin-gate__link js-signin-gate__how" href="${guUrl}/info/2014/nov/03/why-your-data-matters-to-us-full-text">How will my information & data be used?</a>
+        </div>
+        <div class="signin-gate__buttons">
+            <a class="signin-gate__link js-signin-gate__help" href="${guUrl}/help/identity-faq">Get help with registering or signing in</a>
         </div>
     </div>
 </div>
@@ -67,30 +82,16 @@ const show: ({
     guUrl: string,
     signInUrl: string,
 }) => boolean = ({ abTest, guUrl, signInUrl }) =>
-    // use the show gate helper to abstract away logic about showing the gate
     showGate({
-        // the template as a string of the gate itself
         template: htmlTemplate({
             signInUrl,
             guUrl,
         }),
-        // the handler function should handle any click events required, including the "dismiss" or "not now" link/button
-        // articleBody - html element that corresponds to the original (now hidden) article
-        // shadowArticleBody - html element that contains the gate, and the overlay
-        // you can show the original article, and hide the gate by using the following in a click event for example:
-        // articleBody.style.display = 'block';
-        // shadowArticleBody.remove();
         handler: ({ articleBody, shadowArticleBody }) => {
             // check if comment, and add comment/opinion bg colour
             addOpinionBgColour({
                 element: shadowArticleBody,
                 selector: '.signin-gate__first-paragraph-overlay',
-            });
-
-            // check page type/pillar to change text colour of the sign in gate
-            addPillarColour({
-                element: shadowArticleBody,
-                selector: '.signin-gate__benefits--text',
             });
 
             // add click handler for the dismiss of the gate
@@ -117,10 +118,19 @@ const show: ({
                 },
             });
 
-            // add click handler for sign in button click
+            // add click handler for sign in link click
             addClickHandler({
                 element: shadowArticleBody,
-                selector: '.js-signin-gate__button',
+                selector: '.js-signin-gate__register-button',
+                abTest,
+                component,
+                value: 'register-link',
+            });
+
+            // add click handler for sign in link click
+            addClickHandler({
+                element: shadowArticleBody,
+                selector: '.js-signin-gate__sign-in',
                 abTest,
                 component,
                 value: 'sign-in-link',
@@ -133,6 +143,24 @@ const show: ({
                 abTest,
                 component,
                 value: 'why-link',
+            });
+
+            // add click handler for the how info used link
+            addClickHandler({
+                element: shadowArticleBody,
+                selector: '.js-signin-gate__how',
+                abTest,
+                component,
+                value: 'how-link',
+            });
+
+            // add click handler for the help link
+            addClickHandler({
+                element: shadowArticleBody,
+                selector: '.js-signin-gate__help',
+                abTest,
+                component,
+                value: 'help-link',
             });
         },
     });

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/example.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/example.js
@@ -1,5 +1,5 @@
 // @flow
-import type { SignInGateVariant } from '../types';
+import type { CurrentABTest, SignInGateVariant } from '../types';
 import { componentName } from '../component';
 import {
     hasUserDismissedGate,

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/example.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/example.js
@@ -1,66 +1,19 @@
 // @flow
-import mediator from 'lib/mediator';
-import type { CurrentABTest, SignInGateVariant } from '../types';
-import { component, componentName } from '../component';
+import type { SignInGateVariant } from '../types';
+import { componentName } from '../component';
 import {
     hasUserDismissedGate,
     isNPageOrHigherPageView,
     isLoggedIn,
     isInvalidArticleType,
     isInvalidSection,
-    addOpinionBgColour,
-    addClickHandler,
-    setUserDismissedGate,
-    showGate,
 } from '../helper';
+
+// pull in the show method from the design folder, which has the html template and and click handlers etc.
+import { show } from './design/example';
 
 // define the variant name here
 const variant = 'example';
-
-// add the html template as the return of the function below
-// signInUrl - parameter which holds the link to the sign in/register page with the tracking parameters added
-// guUrl - url of the STAGE frontend site, e.g. in DEV stage it would be https://m.thegulocal.com,
-//         and for PROD it would be https://theguardian.com
-const htmlTemplate: ({
-    signInUrl: string,
-    guUrl: string,
-}) => string = ({ signInUrl, guUrl }) => `
-<div class="signin-gate">
-    <div class="signin-gate__content">
-        <div class="signin-gate__header">
-            <h1 class="signin-gate__header--text">Register for free and continue reading</h1>
-        </div>
-        <div class="signin-gate__benefits syndication--bottom">
-            <p class="signin-gate__benefits--text">
-                The Guardian’s independent journalism is still free to read
-            </p>
-        </div>
-        <div class="signin-gate__paragraph syndication--bottom">
-            <p class="signin-gate__paragraph--text">
-                Registering lets us understand you better. This means that we can build better products and start to personalise the adverts you see so we can charge more from advertisers in the future.
-            </p>
-        </div>
-        <div class="signin-gate__buttons">
-            <a class="signin-gate__button signin-gate__button--primary js-signin-gate__register-button" href="${signInUrl}">
-                Register for free
-            </a>
-            <a class="signin-gate__dismiss js-signin-gate__dismiss" href="#maincontent">Not Now</a>
-        </div>
-        <div class="signin-gate__padding-bottom signin-gate__buttons">
-            Already registered, contributed, or subscribed?&nbsp;<a class="signin-gate__link js-signin-gate__sign-in signin-gate__link-no-ptm signin-gate__center-424" href="${signInUrl}">Sign in</a>
-        </div>
-        <div class="signin-gate__buttons">
-            <a class="signin-gate__link js-signin-gate__why" href="${guUrl}/membership/2019/dec/20/signing-in-to-the-guardian">Why register & how does it help?</a>
-        </div>
-        <div class="signin-gate__buttons">
-            <a class="signin-gate__link js-signin-gate__how" href="${guUrl}/info/2014/nov/03/why-your-data-matters-to-us-full-text">How will my information & data be used?</a>
-        </div>
-        <div class="signin-gate__buttons">
-            <a class="signin-gate__link js-signin-gate__help" href="${guUrl}/help/identity-faq">Get help with registering or signing in</a>
-        </div>
-    </div>
-</div>
-`;
 
 // method which returns a boolean determining if this variant can be shown on the current pageview
 const canShow: (name?: string) => boolean = (name = '') =>
@@ -73,97 +26,6 @@ const canShow: (name?: string) => boolean = (name = '') =>
     !isLoggedIn() &&
     !isInvalidArticleType() &&
     !isInvalidSection();
-
-// method which runs if the canShow method returns true, used to display the gate and logic associated with it
-// it returns a boolean, since the sign in gate is based on a `Banner` type who's show method returns a Promise<boolean>
-// in our case it returns true if the method ran successfully, and false if there were any problems encountered
-const show: ({
-    abTest: CurrentABTest,
-    guUrl: string,
-    signInUrl: string,
-}) => boolean = ({ abTest, guUrl, signInUrl }) =>
-    showGate({
-        template: htmlTemplate({
-            signInUrl,
-            guUrl,
-        }),
-        handler: ({ articleBody, shadowArticleBody }) => {
-            // check if comment, and add comment/opinion bg colour
-            addOpinionBgColour({
-                element: shadowArticleBody,
-                selector: '.signin-gate__first-paragraph-overlay',
-            });
-
-            // add click handler for the dismiss of the gate
-            addClickHandler({
-                element: shadowArticleBody,
-                selector: '.js-signin-gate__dismiss',
-                abTest,
-                component,
-                value: 'not-now',
-                callback: () => {
-                    // show the current body. Remove the shadow one
-                    articleBody.style.display = 'block';
-                    shadowArticleBody.remove();
-
-                    // Tell other things the article has been redisplayed
-                    mediator.emit('page:article:redisplayed');
-
-                    // user pref dismissed gate
-                    setUserDismissedGate({
-                        componentName,
-                        name: abTest.name,
-                        variant: abTest.variant,
-                    });
-                },
-            });
-
-            // add click handler for sign in link click
-            addClickHandler({
-                element: shadowArticleBody,
-                selector: '.js-signin-gate__register-button',
-                abTest,
-                component,
-                value: 'register-link',
-            });
-
-            // add click handler for sign in link click
-            addClickHandler({
-                element: shadowArticleBody,
-                selector: '.js-signin-gate__sign-in',
-                abTest,
-                component,
-                value: 'sign-in-link',
-            });
-
-            // add click handler for the why sign in link
-            addClickHandler({
-                element: shadowArticleBody,
-                selector: '.js-signin-gate__why',
-                abTest,
-                component,
-                value: 'why-link',
-            });
-
-            // add click handler for the how info used link
-            addClickHandler({
-                element: shadowArticleBody,
-                selector: '.js-signin-gate__how',
-                abTest,
-                component,
-                value: 'how-link',
-            });
-
-            // add click handler for the help link
-            addClickHandler({
-                element: shadowArticleBody,
-                selector: '.js-signin-gate__help',
-                abTest,
-                component,
-                value: 'help-link',
-            });
-        },
-    });
 
 // export the variant as a SignInGateVariant type
 export const signInGateVariant: SignInGateVariant = {

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/example.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/example.js
@@ -10,7 +10,7 @@ import {
 } from '../helper';
 
 // pull in the show method from the design folder, which has the html template and and click handlers etc.
-import { show } from './design/example';
+import { designShow } from './design/example';
 
 // define the variant name here
 const variant = 'example';
@@ -26,6 +26,16 @@ const canShow: (name?: string) => boolean = (name = '') =>
     !isLoggedIn() &&
     !isInvalidArticleType() &&
     !isInvalidSection();
+
+// method which runs if the canShow method returns true, used to display the gate and logic associated with it
+// it returns a boolean, since the sign in gate is based on a `Banner` type who's show method returns a Promise<boolean>
+// in our case it returns true if the design ran successfully, and false if there were any problems encountered
+const show: ({
+    abTest: CurrentABTest,
+    guUrl: string,
+    signInUrl: string,
+}) => boolean = ({ abTest, guUrl, signInUrl }) =>
+    designShow({ abTest, guUrl, signInUrl });
 
 // export the variant as a SignInGateVariant type
 export const signInGateVariant: SignInGateVariant = {

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/scale.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/scale.js
@@ -1,0 +1,45 @@
+// @flow
+import type { CurrentABTest, SignInGateVariant } from '../types';
+import { componentName } from '../component';
+import {
+    hasUserDismissedGate,
+    isNPageOrHigherPageView,
+    isLoggedIn,
+    isInvalidArticleType,
+    isInvalidSection,
+} from '../helper';
+
+// pull in the show method from the design folder, which has the html template and and click handlers etc.
+import { designShow } from './design/quartus';
+
+// define the variant name here
+const variant = 'scale';
+
+// method which returns a boolean determining if this variant can be shown on the current pageview
+const canShow: (name?: string) => boolean = (name = '') =>
+    !hasUserDismissedGate({
+        componentName,
+        name,
+        variant,
+    }) &&
+    isNPageOrHigherPageView(3) &&
+    !isLoggedIn() &&
+    !isInvalidArticleType() &&
+    !isInvalidSection();
+
+// method which runs if the canShow method returns true, used to display the gate and logic associated with it
+// it returns a boolean, since the sign in gate is based on a `Banner` type who's show method returns a Promise<boolean>
+// in our case it returns true if the design ran successfully, and false if there were any problems encountered
+const show: ({
+    abTest: CurrentABTest,
+    guUrl: string,
+    signInUrl: string,
+}) => boolean = ({ abTest, guUrl, signInUrl }) =>
+    designShow({ abTest, guUrl, signInUrl });
+
+// export the variant as a SignInGateVariant type
+export const signInGateVariant: SignInGateVariant = {
+    name: variant,
+    canShow,
+    show,
+};

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/variant.js
@@ -1,5 +1,5 @@
 // @flow
-import type { SignInGateVariant } from '../types';
+import type { CurrentABTest, SignInGateVariant } from '../types';
 import { componentName } from '../component';
 import {
     hasUserDismissedGate,

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/variant.js
@@ -15,7 +15,7 @@ import {
 } from '../helper';
 
 // define the variant name here
-const variant = 'vartiant';
+const variant = 'variant';
 
 // add the html template as the return of the function below
 // signInUrl - parameter which holds the link to the sign in/register page with the tracking parameters added
@@ -47,7 +47,7 @@ const htmlTemplate: ({
             <a class="signin-gate__dismiss js-signin-gate__dismiss" href="#maincontent">Not Now</a>
         </div>
         <div class="signin-gate__padding-bottom signin-gate__buttons">
-            Already registered, contributed, or subscribed?&nbsp;<a class="signin-gate__link js-signin-gate__sign-in signin-gate__link-no-ptm signin-gate__center-424" href="${signInUrl}">Sign in</a>
+            Already registered, contributed or subscribed?&nbsp;<a class="signin-gate__link js-signin-gate__sign-in signin-gate__link-no-ptm signin-gate__center-424" href="${signInUrl}">Sign in</a>
         </div>
         <div class="signin-gate__buttons">
             <a class="signin-gate__link js-signin-gate__why" href="${guUrl}/membership/2019/dec/20/signing-in-to-the-guardian">Why register & how does it help?</a>
@@ -69,7 +69,7 @@ const canShow: (name?: string) => boolean = (name = '') =>
         name,
         variant,
     }) &&
-    isNPageOrHigherPageView(2) &&
+    isNPageOrHigherPageView(3) &&
     !isLoggedIn() &&
     !isInvalidArticleType() &&
     !isInvalidSection();

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/variant.js
@@ -1,66 +1,19 @@
 // @flow
-import mediator from 'lib/mediator';
-import type { CurrentABTest, SignInGateVariant } from '../types';
-import { component, componentName } from '../component';
+import type { SignInGateVariant } from '../types';
+import { componentName } from '../component';
 import {
     hasUserDismissedGate,
     isNPageOrHigherPageView,
     isLoggedIn,
     isInvalidArticleType,
     isInvalidSection,
-    addOpinionBgColour,
-    addClickHandler,
-    setUserDismissedGate,
-    showGate,
 } from '../helper';
+
+// pull in the show method from the design folder, which has the html template and and click handlers etc.
+import { show } from './design/quartus';
 
 // define the variant name here
 const variant = 'variant';
-
-// add the html template as the return of the function below
-// signInUrl - parameter which holds the link to the sign in/register page with the tracking parameters added
-// guUrl - url of the STAGE frontend site, e.g. in DEV stage it would be https://m.thegulocal.com,
-//         and for PROD it would be https://theguardian.com
-const htmlTemplate: ({
-    signInUrl: string,
-    guUrl: string,
-}) => string = ({ signInUrl, guUrl }) => `
-<div class="signin-gate">
-    <div class="signin-gate__content">
-        <div class="signin-gate__header">
-            <h1 class="signin-gate__header--text">Register for free and continue reading</h1>
-        </div>
-        <div class="signin-gate__benefits syndication--bottom">
-            <p class="signin-gate__benefits--text">
-                The Guardian’s independent journalism is still free to read
-            </p>
-        </div>
-        <div class="signin-gate__paragraph syndication--bottom">
-            <p class="signin-gate__paragraph--text">
-                Registering lets us understand you better. This means that we can build better products and start to personalise the adverts you see so we can charge more from advertisers in the future.
-            </p>
-        </div>
-        <div class="signin-gate__buttons">
-            <a class="signin-gate__button signin-gate__button--primary js-signin-gate__register-button" href="${signInUrl}">
-                Register for free
-            </a>
-            <a class="signin-gate__dismiss js-signin-gate__dismiss" href="#maincontent">Not Now</a>
-        </div>
-        <div class="signin-gate__padding-bottom signin-gate__buttons">
-            Already registered, contributed or subscribed?&nbsp;<a class="signin-gate__link js-signin-gate__sign-in signin-gate__link-no-ptm signin-gate__center-424" href="${signInUrl}">Sign in</a>
-        </div>
-        <div class="signin-gate__buttons">
-            <a class="signin-gate__link js-signin-gate__why" href="${guUrl}/membership/2019/dec/20/signing-in-to-the-guardian">Why register & how does it help?</a>
-        </div>
-        <div class="signin-gate__buttons">
-            <a class="signin-gate__link js-signin-gate__how" href="${guUrl}/info/2014/nov/03/why-your-data-matters-to-us-full-text">How will my information & data be used?</a>
-        </div>
-        <div class="signin-gate__buttons">
-            <a class="signin-gate__link js-signin-gate__help" href="${guUrl}/help/identity-faq">Get help with registering or signing in</a>
-        </div>
-    </div>
-</div>
-`;
 
 // method which returns a boolean determining if this variant can be shown on the current pageview
 const canShow: (name?: string) => boolean = (name = '') =>
@@ -73,97 +26,6 @@ const canShow: (name?: string) => boolean = (name = '') =>
     !isLoggedIn() &&
     !isInvalidArticleType() &&
     !isInvalidSection();
-
-// method which runs if the canShow method returns true, used to display the gate and logic associated with it
-// it returns a boolean, since the sign in gate is based on a `Banner` type who's show method returns a Promise<boolean>
-// in our case it returns true if the method ran successfully, and false if there were any problems encountered
-const show: ({
-    abTest: CurrentABTest,
-    guUrl: string,
-    signInUrl: string,
-}) => boolean = ({ abTest, guUrl, signInUrl }) =>
-    showGate({
-        template: htmlTemplate({
-            signInUrl,
-            guUrl,
-        }),
-        handler: ({ articleBody, shadowArticleBody }) => {
-            // check if comment, and add comment/opinion bg colour
-            addOpinionBgColour({
-                element: shadowArticleBody,
-                selector: '.signin-gate__first-paragraph-overlay',
-            });
-
-            // add click handler for the dismiss of the gate
-            addClickHandler({
-                element: shadowArticleBody,
-                selector: '.js-signin-gate__dismiss',
-                abTest,
-                component,
-                value: 'not-now',
-                callback: () => {
-                    // show the current body. Remove the shadow one
-                    articleBody.style.display = 'block';
-                    shadowArticleBody.remove();
-
-                    // Tell other things the article has been redisplayed
-                    mediator.emit('page:article:redisplayed');
-
-                    // user pref dismissed gate
-                    setUserDismissedGate({
-                        componentName,
-                        name: abTest.name,
-                        variant: abTest.variant,
-                    });
-                },
-            });
-
-            // add click handler for sign in link click
-            addClickHandler({
-                element: shadowArticleBody,
-                selector: '.js-signin-gate__register-button',
-                abTest,
-                component,
-                value: 'register-link',
-            });
-
-            // add click handler for sign in link click
-            addClickHandler({
-                element: shadowArticleBody,
-                selector: '.js-signin-gate__sign-in',
-                abTest,
-                component,
-                value: 'sign-in-link',
-            });
-
-            // add click handler for the why sign in link
-            addClickHandler({
-                element: shadowArticleBody,
-                selector: '.js-signin-gate__why',
-                abTest,
-                component,
-                value: 'why-link',
-            });
-
-            // add click handler for the how info used link
-            addClickHandler({
-                element: shadowArticleBody,
-                selector: '.js-signin-gate__how',
-                abTest,
-                component,
-                value: 'how-link',
-            });
-
-            // add click handler for the help link
-            addClickHandler({
-                element: shadowArticleBody,
-                selector: '.js-signin-gate__help',
-                abTest,
-                component,
-                value: 'help-link',
-            });
-        },
-    });
 
 // export the variant as a SignInGateVariant type
 export const signInGateVariant: SignInGateVariant = {

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/variant.js
@@ -14,8 +14,13 @@ import {
     showGate,
 } from '../helper';
 
-const variant = 'variant';
+// define the variant name here
+const variant = 'vartiant';
 
+// add the html template as the return of the function below
+// signInUrl - parameter which holds the link to the sign in/register page with the tracking parameters added
+// guUrl - url of the STAGE frontend site, e.g. in DEV stage it would be https://m.thegulocal.com,
+//         and for PROD it would be https://theguardian.com
 const htmlTemplate: ({
     signInUrl: string,
     guUrl: string,
@@ -57,6 +62,7 @@ const htmlTemplate: ({
 </div>
 `;
 
+// method which returns a boolean determining if this variant can be shown on the current pageview
 const canShow: (name?: string) => boolean = (name = '') =>
     !hasUserDismissedGate({
         componentName,
@@ -68,6 +74,9 @@ const canShow: (name?: string) => boolean = (name = '') =>
     !isInvalidArticleType() &&
     !isInvalidSection();
 
+// method which runs if the canShow method returns true, used to display the gate and logic associated with it
+// it returns a boolean, since the sign in gate is based on a `Banner` type who's show method returns a Promise<boolean>
+// in our case it returns true if the method ran successfully, and false if there were any problems encountered
 const show: ({
     abTest: CurrentABTest,
     guUrl: string,
@@ -156,6 +165,7 @@ const show: ({
         },
     });
 
+// export the variant as a SignInGateVariant type
 export const signInGateVariant: SignInGateVariant = {
     name: variant,
     canShow,

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/variant.js
@@ -1,4 +1,5 @@
 // @flow
+import mediator from 'lib/mediator';
 import type { CurrentABTest, SignInGateVariant } from '../types';
 import { component, componentName } from '../component';
 import {
@@ -7,6 +8,10 @@ import {
     isLoggedIn,
     isInvalidArticleType,
     isInvalidSection,
+    addOpinionBgColour,
+    addClickHandler,
+    setUserDismissedGate,
+    showGate,
 } from '../helper';
 
 // define the variant name here

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/variant.js
@@ -10,7 +10,7 @@ import {
 } from '../helper';
 
 // pull in the show method from the design folder, which has the html template and and click handlers etc.
-import { show } from './design/quartus';
+import { designShow } from './design/quartus';
 
 // define the variant name here
 const variant = 'variant';
@@ -26,6 +26,16 @@ const canShow: (name?: string) => boolean = (name = '') =>
     !isLoggedIn() &&
     !isInvalidArticleType() &&
     !isInvalidSection();
+
+// method which runs if the canShow method returns true, used to display the gate and logic associated with it
+// it returns a boolean, since the sign in gate is based on a `Banner` type who's show method returns a Promise<boolean>
+// in our case it returns true if the design ran successfully, and false if there were any problems encountered
+const show: ({
+    abTest: CurrentABTest,
+    guUrl: string,
+    signInUrl: string,
+}) => boolean = ({ abTest, guUrl, signInUrl }) =>
+    designShow({ abTest, guUrl, signInUrl });
 
 // export the variant as a SignInGateVariant type
 export const signInGateVariant: SignInGateVariant = {

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/variant.js
@@ -1,6 +1,6 @@
 // @flow
-import type { SignInGateVariant } from '../types';
-import { componentName } from '../component';
+import type { CurrentABTest, SignInGateVariant } from '../types';
+import { component, componentName } from '../component';
 import {
     hasUserDismissedGate,
     isNPageOrHigherPageView,

--- a/static/src/stylesheets/module/identity/_sign-in-gate.scss
+++ b/static/src/stylesheets/module/identity/_sign-in-gate.scss
@@ -121,7 +121,7 @@
     font-size: 17px;
     height: 42px;
     min-height: 42px;
-    padding: $gs-baseline $gs-baseline;
+    padding: $gs-baseline;
     border: 0;
     border-radius: 21px;
     box-sizing: border-box;

--- a/static/src/stylesheets/module/identity/_sign-in-gate.scss
+++ b/static/src/stylesheets/module/identity/_sign-in-gate.scss
@@ -1,26 +1,33 @@
 .signin-gate {
     clear: left;
     margin-bottom: $gs-baseline * 2;
-    padding: ($gs-baseline * 3) ($gs-baseline * 2);
+    @include mq(tablet) {
+        padding: ($gs-baseline * 2) 0;
+    }
     @include mq(desktop) {
         min-height: 600px;
     }
 }
 
 .signin-gate__content {
-    padding-top: $gs-baseline * 5;
+    padding-top: $gs-baseline * 3;
+    @include mq(tablet) {
+        padding-top: $gs-baseline * 2;
+    }
 }
 
 .signin-gate__header {
     @include fs-header(3);
-    border-top: 1px solid $brightness-46;
-    margin-bottom: $gs-baseline * 2;
+    padding-bottom: $gs-baseline;
+    @include mq(tablet) {
+        padding-bottom: $gs-baseline * 2;
+    }
 }
 
 .signin-gate__buttons {
     @include fs-textSans(5);
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     flex-wrap: wrap;
     padding-top: 6px;
     padding-bottom: 6px;
@@ -78,12 +85,11 @@
     text-decoration: underline;
     font-weight: 700;
     font-size: 17px;
-    padding-top: 20px;
     align-self: center;
+    padding-left: $gs-baseline * 1.5;
     @include mq(424px) {
-        padding-top: 0px;
-        padding-left: $gs-baseline * 1.5;
         align-self: auto;
+        padding-left: $gs-baseline * 2
     }
 }
 
@@ -115,7 +121,7 @@
     font-size: 17px;
     height: 42px;
     min-height: 42px;
-    padding: 20px 42px;
+    padding: $gs-baseline $gs-baseline;
     border: 0;
     border-radius: 21px;
     box-sizing: border-box;
@@ -142,6 +148,7 @@
     align-self: center;
     @include mq(424px) {
         align-self: auto;
+        padding: $gs-baseline $gs-baseline * 2;
     }
 }
 
@@ -155,7 +162,6 @@
 
 .signin-gate__header--text {
     font-weight: normal;
-    margin-bottom: $gs-baseline;
     line-height: 1.25em;
     font-size: 24px;
     @include mq(tablet) {
@@ -166,11 +172,11 @@
 .signin-gate__paragraph {
     border-top: 1px solid $brightness-46;
     margin-bottom: $gs-baseline * 2;
+    padding-top: $gs-baseline;
 }
 
 .signin-gate__paragraph--text {
     font-size: 16px;
-    padding-top: $gs-baseline;
     @include mq(tablet) {
         font-size: 18px;
     }
@@ -179,7 +185,10 @@
 
 .signin-gate__benefits {
     border-top: 1px solid $brightness-46;
-    margin-bottom: $gs-baseline * 2;
+    padding-bottom: $gs-baseline;
+    @include mq(tablet) {
+        padding-top: $gs-baseline;
+    }
 }
 
 .signin-gate__benefits--text {


### PR DESCRIPTION
## What does this change?
Set up the next sign in gate test with the following changes in the display rules:

Variants:
- `control`: Shown on 2nd pageview or higher per day
- `variant`: Shown on 3rd pageview or higher per day
- `scale`: Shown on 3rd pageview or higher per day, to a higher audience

Minor design changes also made from the previous test too.

Unlike previous tests where we ran 1 test with 2 variants, we'll be running 2 tests with 1 variant each. This gives us more control over the audience numbers who'll see each variant, which is required for this test.

This is because we want to have the `control` seen by a smaller number of browsers compared to the `variant` over the time period of the test, and this wasn't achievable using a single test.

Reporting will use `SignInGateQuartus` as the AB test name in component events as not to break the previous analysis queries we've used before.

To achieve this we used the `ABTest.dataLinkNames` to share this name between the 2 tests.

For testing, append the following to the url depending on the variant to test:

- `control`: `#ab-SignInGateQuartusControl=control`
- `variant`: `#ab-SignInGateQuartusVariant=variant`
- `scale`: `#ab-SignInGateQuartusScale=scale`

Any ophan component events triggered should show the AB test as `SignInGateQuartus`

## Screenshots
![m thegulocal com_politics_2020_apr_05_boris-johnson-admitted-to-hospital-with-coronavirus](https://user-images.githubusercontent.com/13315440/78551513-c1cb9f80-77fd-11ea-8624-971b429f1ad7.png)
![m thegulocal com_politics_2020_apr_05_boris-johnson-admitted-to-hospital-with-coronavirus(iPhone 5_SE)](https://user-images.githubusercontent.com/13315440/78551525-c3956300-77fd-11ea-9daf-9721f81684d3.png)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
