### PR TITLE
Restricts rounded corners to images (Numbered List template)

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_article-numbered-list.scss
+++ b/static/src/stylesheets/module/content-garnett/_article-numbered-list.scss
@@ -22,7 +22,7 @@
         }
 
         // Thumnail sized image has rounded corners
-        .element--thumbnail img {
+        .element-image.element--thumbnail img {
             border-radius: 50%;
             overflow: hidden;
         }


### PR DESCRIPTION
## What does this change?

The Numbered List article template adds rounded corners to thumbnail images, but this was unintentionally being applied to rich links. This restricts the rounded links so it no longer catches rich links.

Rich links before:
![localhost_3000_world_2020_mar_28_life-after-coronavirus-panic-buying-cocaine-drug-dealer-spaceman-therapist (1)](https://user-images.githubusercontent.com/4561/78565767-a4f39400-781e-11ea-9a45-945c018aea6d.png)


After:
![localhost_3000_world_2020_mar_28_life-after-coronavirus-panic-buying-cocaine-drug-dealer-spaceman-therapist (2)](https://user-images.githubusercontent.com/4561/78565755-a2913a00-781e-11ea-90a4-17dda516f0d1.png)

