### PR TITLE
Sign In Gate Quartus: Add scale test to ab tests list

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -11,6 +11,7 @@ import { connatixTest } from 'common/modules/experiments/tests/connatix-ab-test'
 import { frontendDotcomRenderingEpic } from 'common/modules/experiments/tests/frontend-dotcom-rendering-epic';
 import { signInGate } from 'common/modules/experiments/tests/sign-in-gate';
 import { signInGateVariant } from 'common/modules/experiments/tests/sign-in-gate-variant';
+import { signInGateScale } from 'common/modules/experiments/tests/sign-in-gate-scale';
 import { contributionsEpicPrecontributionReminderRoundTwo } from 'common/modules/experiments/tests/contributions-epic-precontribution-reminder-round-two';
 import { contributionsEpicLiveblogDesignTestR1 } from 'common/modules/experiments/tests/contributions-epic-liveblog-design-test';
 import { commercialGptPath } from 'common/modules/experiments/tests/commercial-gpt-path';
@@ -25,6 +26,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     pangaeaAdapterTest,
     signInGate,
     signInGateVariant,
+    signInGateScale,
     commercialGptPath,
 ];
 


### PR DESCRIPTION
## What does this change?

Forgot to add the 3rd sign in gate test (scale variant) to the ab-tests list in #22474 before I merged that in.
