### PR TITLE
Introduce Experiment discussion-rendering

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -108,7 +108,6 @@ object ArticlePicker {
       ("hasBlocks", ArticlePageChecks.hasBlocks(page)),
       ("hasOnlySupportedElements", ArticlePageChecks.hasOnlySupportedElements(page)),
       ("hasOnlySupportedMainElements", ArticlePageChecks.hasOnlySupportedMainElements(page)),
-      ("isDiscussionDisabled", ArticlePageChecks.isDiscussionDisabled(page)),
       ("isNotImmersive", ArticlePageChecks.isNotImmersive(page)),
       ("isNotLiveBlog", ArticlePageChecks.isNotLiveBlog(page)),
       ("isNotAReview", ArticlePageChecks.isNotAReview(page)),
@@ -154,14 +153,12 @@ object ArticlePicker {
     // dcrShouldRender provides an override to let us force rendering by DCR even
     // when an article is not supportted
     val forceDCR = request.forceDCR
-
     forceDCR || isInWhitelist(request.path)
   }
 
   def dcrShouldNotRender(request: RequestHeader): Boolean = {
     val forceDCROff = request.forceDCROff
     val dcrEnabled = conf.switches.Switches.DotcomRendering.isSwitchedOn
-
     forceDCROff || !dcrEnabled
   }
 
@@ -176,7 +173,7 @@ object ArticlePicker {
       LocalRenderArticle
     } else if (dcrShouldRender(request)) {
       RemoteRender
-    } else if (dcrCouldRender(page, request) && userIsInCohort) {
+    } else if (dcrCouldRender(page, request) && userIsInCohort && ArticlePageChecks.isDiscussionDisabled(page)) {
       RemoteRender
     } else {
       LocalRenderArticle

--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -183,7 +183,11 @@ object ArticlePicker {
     }
 
     // include features that we wish to log but not whitelist against
-    val features = whitelistFeatures + ("userIsInCohort" -> userIsInDotcomRenderingCohort) + ("isAdFree" -> isAddFree) + ("isArticle100PercentPage" -> isArticle100PercentPage)
+    val features = whitelistFeatures +
+      ("userIsInCohort" -> userIsInDotcomRenderingCohort) +
+      ("userIsInCohortDiscussion" -> userIsInDiscussionRenderingCohort) +
+      ("isAdFree" -> isAddFree) +
+      ("isArticle100PercentPage" -> isArticle100PercentPage)
 
     if (tier == RemoteRender) {
       logRequest(s"path executing in dotcomponents", features, page)

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -29,3 +29,11 @@ object DotcomRendering extends Experiment(
   sellByDate = new LocalDate(2020, 12, 1),
   participationGroup = Perc20A // Also see ArticlePicker.scala - our main filter mechanism is by page features
 )
+
+object DiscussionRendering extends Experiment(
+  name = "discussion-rendering",
+  description = "Show DCR pages to users including those with comments",
+  owners = Seq(Owner.withGithub("shtukas")),
+  sellByDate = new LocalDate(2020, 12, 1),
+  participationGroup = Perc0A // Also see ArticlePicker.scala - our main filter mechanism is by page features
+)


### PR DESCRIPTION
## What does this change?

This introduces a new (currently 0%) server side experiment:  `discussion-rendering`. 

This new experiment behaves like the old `dotcom-rendering`, but default to DCR rendering if
 the page has comments enabled.  There is no change to the existing DCR server side experiment `dotcom-rendering`.
