### PR TITLE
Fix AlwaysAsk for epic liveblog design test

### DIFF
--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -142,7 +142,6 @@ declare type InitEpicABTest = {
     userCohort?: AcquisitionsComponentUserCohort,
     pageCheck?: (page: Object) => boolean,
     template?: EpicTemplate,
-    deploymentRules?: DeploymentRules,
     testHasCountryName?: boolean,
     geolocation: ?string,
     highPriority: boolean,

--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -14,7 +14,6 @@ declare type Variant = {
     impression?: ListenerFunction,
     success?: ListenerFunction,
     engagementBannerParams?: EngagementBannerTestParams,
-    deploymentRules?: DeploymentRules,
 };
 
 declare type EpicVariant = Variant & {
@@ -90,13 +89,13 @@ declare type EpicABTest = AcquisitionsABTest & {
     insertEvent: string,
     viewEvent: string,
     highPriority: boolean,
+    deploymentRules: DeploymentRules,
 };
 
 declare type InitEpicABTestVariant = {
     id: string,
     products: $ReadOnlyArray<OphanProduct>,
     test?: (html: string, variant: EpicVariant, parentTest: EpicABTest) => void,
-    deploymentRules?: DeploymentRules,
     countryGroups?: string[],
     tagIds?: string[],
     sections?: string[],
@@ -142,6 +141,7 @@ declare type InitEpicABTest = {
     userCohort?: AcquisitionsComponentUserCohort,
     pageCheck?: (page: Object) => boolean,
     template?: EpicTemplate,
+    deploymentRules?: DeploymentRules,
     testHasCountryName?: boolean,
     geolocation: ?string,
     highPriority: boolean,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -339,7 +339,6 @@ const makeEpicABTestVariant = (
         parentTest.campaignId,
         initVariant.id
     );
-    const deploymentRules = initVariant.deploymentRules || defaultMaxViews;
 
     return {
         id: initVariant.id,
@@ -368,7 +367,6 @@ const makeEpicABTestVariant = (
         showTicker: initVariant.showTicker || false,
         showReminderFields: initVariant.showReminderFields || false,
         backgroundImageUrl: initVariant.backgroundImageUrl,
-        deploymentRules,
 
         countryGroups: initVariant.countryGroups || [],
         tagIds: initVariant.tagIds || [],
@@ -403,8 +401,8 @@ const makeEpicABTestVariant = (
             };
 
             const meetsMaxViewsConditions =
-                deploymentRules === 'AlwaysAsk' ||
-                checkMaxViews(deploymentRules);
+                parentTest.deploymentRules === 'AlwaysAsk' ||
+                checkMaxViews(parentTest.deploymentRules);
 
             const matchesCountryGroups =
                 this.countryGroups.length === 0 ||
@@ -552,6 +550,7 @@ const makeEpicABTest = ({
     template = controlTemplate,
     canRun = () => true,
     articlesViewedSettings,
+    deploymentRules = defaultMaxViews,
 }: InitEpicABTest): EpicABTest => {
     const test = {
         // this is true because we use the reader revenue flag rather than sensitive
@@ -589,6 +588,7 @@ const makeEpicABTest = ({
         userCohort,
         pageCheck,
         useTargetingTool,
+        deploymentRules,
     };
 
     test.variants = variants.map(variant =>
@@ -717,6 +717,7 @@ export const buildConfiguredEpicTestFromJson = (
         // they will be excluded from this test
         testHasCountryName: test.hasCountryName,
         articlesViewedSettings,
+        deploymentRules,
 
         variants: test.variants.map(variant => ({
             id: variant.name,
@@ -753,7 +754,6 @@ export const buildConfiguredEpicTestFromJson = (
             showReminderFields: variant.showReminderFields,
             backgroundImageUrl: filterEmptyString(variant.backgroundImageUrl),
             // TODO - why are these fields at the variant level?
-            deploymentRules,
             countryGroups,
             tagIds,
             sections,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -550,7 +550,7 @@ const makeEpicABTest = ({
     template = controlTemplate,
     canRun = () => true,
     articlesViewedSettings,
-    deploymentRules = defaultMaxViews,
+    deploymentRules,
 }: InitEpicABTest): EpicABTest => {
     const test = {
         // this is true because we use the reader revenue flag rather than sensitive
@@ -588,7 +588,7 @@ const makeEpicABTest = ({
         userCohort,
         pageCheck,
         useTargetingTool,
-        deploymentRules,
+        deploymentRules: deploymentRules || defaultMaxViews,
     };
 
     test.variants = variants.map(variant =>

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
@@ -26,11 +26,6 @@ const rawTest = {
             showTicker: false,
             showReminderFields: null,
             backgroundImageUrl: '',
-            maxViews: {
-                maxViewsDays: 30,
-                maxViewsCount: 4,
-                minDaysBetweenViews: 0,
-            },
         },
     ],
     highPriority: false,
@@ -39,6 +34,11 @@ const rawTest = {
         minViews: 5,
         maxViews: 10,
         periodInWeeks: 4,
+    },
+    maxViews: {
+        maxViewsDays: 30,
+        maxViewsCount: 4,
+        minDaysBetweenViews: 0,
     },
 };
 
@@ -70,7 +70,7 @@ describe('buildConfiguredEpicTestFromJson', () => {
             highlightedText: 'Some highlighted text',
         });
 
-        expect(variant.deploymentRules).toEqual({
+        expect(test.deploymentRules).toEqual({
             days: 30,
             count: 4,
             minDaysBetweenViews: 0,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/acquisitions-epic-always-ask-if-tagged.js
@@ -23,6 +23,7 @@ export const acquisitionsEpicAlwaysAskIfTagged = makeEpicABTest({
     audience: 1,
     audienceOffset: 0,
     useTargetingTool: true,
+    deploymentRules: 'AlwaysAsk',
     pageCheck: page =>
         page.contentType === 'Article' || page.contentType === 'Interactive',
 
@@ -30,8 +31,6 @@ export const acquisitionsEpicAlwaysAskIfTagged = makeEpicABTest({
         {
             id: 'control',
             products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
-
-            deploymentRules: 'AlwaysAsk',
             buttonTemplate: epicButtonsTemplate,
         },
     ],

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-ask-four-earning.js
@@ -11,7 +11,7 @@ export const askFourEarning: EpicABTest = makeEpicABTest({
     highPriority: false,
 
     start: '2017-01-24',
-    expiry: '2020-01-27',
+    expiry: '2021-01-27',
 
     author: 'Jonathan Rankin',
     description:

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-liveblog-design-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-liveblog-design-test.js
@@ -54,6 +54,7 @@ export const contributionsEpicLiveblogDesignTestR1: EpicABTest = makeEpicABTest(
         audienceCriteria: 'All',
         audience: 1,
         audienceOffset: 0,
+        deploymentRules: 'AlwaysAsk',
 
         pageCheck: isCompatibleWithLiveBlogEpic,
 
@@ -64,7 +65,6 @@ export const contributionsEpicLiveblogDesignTestR1: EpicABTest = makeEpicABTest(
                 copy: buildEpicCopy(epicCopy, false, geolocation),
                 template: liveBlogTemplate(lastSentenceTemplateControl),
                 test: setupEpicInLiveblog,
-                deploymentRules: 'AlwaysAsk',
             },
             {
                 id: 'v1',
@@ -72,7 +72,6 @@ export const contributionsEpicLiveblogDesignTestR1: EpicABTest = makeEpicABTest(
                 copy: buildEpicCopy(epicCopy, false, geolocation),
                 template: liveBlogTemplate(lastSentenceTemplateButtonNoArrow),
                 test: setupEpicInLiveblog,
-                deploymentRules: 'AlwaysAsk',
             },
             {
                 id: 'v2',
@@ -80,7 +79,6 @@ export const contributionsEpicLiveblogDesignTestR1: EpicABTest = makeEpicABTest(
                 copy: buildEpicCopy(epicCopy, false, geolocation),
                 template: liveBlogTemplate(lastSentenceTemplateButtonArrow),
                 test: setupEpicInLiveblog,
-                deploymentRules: 'AlwaysAsk',
             },
         ],
     }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-liveblog-design-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-liveblog-design-test.js
@@ -54,7 +54,6 @@ export const contributionsEpicLiveblogDesignTestR1: EpicABTest = makeEpicABTest(
         audienceCriteria: 'All',
         audience: 1,
         audienceOffset: 0,
-        deploymentRules: 'AlwaysAsk',
 
         pageCheck: isCompatibleWithLiveBlogEpic,
 
@@ -65,6 +64,7 @@ export const contributionsEpicLiveblogDesignTestR1: EpicABTest = makeEpicABTest(
                 copy: buildEpicCopy(epicCopy, false, geolocation),
                 template: liveBlogTemplate(lastSentenceTemplateControl),
                 test: setupEpicInLiveblog,
+                deploymentRules: 'AlwaysAsk',
             },
             {
                 id: 'v1',
@@ -72,6 +72,7 @@ export const contributionsEpicLiveblogDesignTestR1: EpicABTest = makeEpicABTest(
                 copy: buildEpicCopy(epicCopy, false, geolocation),
                 template: liveBlogTemplate(lastSentenceTemplateButtonNoArrow),
                 test: setupEpicInLiveblog,
+                deploymentRules: 'AlwaysAsk',
             },
             {
                 id: 'v2',
@@ -79,6 +80,7 @@ export const contributionsEpicLiveblogDesignTestR1: EpicABTest = makeEpicABTest(
                 copy: buildEpicCopy(epicCopy, false, geolocation),
                 template: liveBlogTemplate(lastSentenceTemplateButtonArrow),
                 test: setupEpicInLiveblog,
+                deploymentRules: 'AlwaysAsk',
             },
         ],
     }


### PR DESCRIPTION
The `deploymentRules` field, which we can use to make it an 'AlwaysAsk' epic, is currently on both the Epic and Variant models.
But actually only the field in the Variant model is used, I don't know why.
So when I previously added AlwaysAsk at the Epic-level, it didn't work.

Really it should not be at the variant-level, only the test-level. So I've made this change.