### PR TITLE
Sign In Gate: Fix issue on articles with aside element

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
@@ -260,7 +260,7 @@ export const showGate: ({
                 const pIndexes = Array.from(articleBody.children).map((elem, idx) => elem.tagName === "P" ? idx : '').filter(i => i !== '');
 
                 // found some "p" tags, add the first "p" to the fade
-                if (pIndexes.length > 0) {
+                if (pIndexes.length > 1) {
                     shadowOverlay.appendChild(
                         articleBody.children[pIndexes[1]].cloneNode(true)
                     );

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
@@ -257,7 +257,7 @@ export const showGate: ({
                 articleBody.children.length > 1
             ) {
                 // find the indexes of the articles "p" tag, to include in the sign in gate fade
-                const pIndexes: Array<number> = Array.from(articleBody.children).map(i => i.tagName).map((a, i) => a === "P" ? i : 0).filter(i => i);
+                const pIndexes: Array<number> = Array.from(articleBody.children).map((elem, idx) => elem.tagName === "P" ? idx : 0).filter(i => i);
 
                 // found some "p" tags, add the first "p" to the fade
                 if (pIndexes.length) {

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
@@ -257,12 +257,12 @@ export const showGate: ({
                 articleBody.children.length > 1
             ) {
                 // find the indexes of the articles "p" tag, to include in the sign in gate fade
-                const pIndexes: Array<number> = Array.from(articleBody.children).map((elem, idx) => elem.tagName === "P" ? idx : 0).filter(i => i);
+                const pIndexes = Array.from(articleBody.children).map((elem, idx) => elem.tagName === "P" ? idx : '').filter(i => i !== '');
 
                 // found some "p" tags, add the first "p" to the fade
-                if (pIndexes.length) {
+                if (pIndexes.length > 0) {
                     shadowOverlay.appendChild(
-                        articleBody.children[pIndexes[0]].cloneNode(true)
+                        articleBody.children[pIndexes[1]].cloneNode(true)
                     );
                 }
             }

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
@@ -256,9 +256,15 @@ export const showGate: ({
                 articleBody.children[0].clientHeight < 125 &&
                 articleBody.children.length > 1
             ) {
-                shadowOverlay.appendChild(
-                    articleBody.children[1].cloneNode(true)
-                );
+                // find the indexes of the articles "p" tag, to include in the sign in gate fade
+                const pIndexes: Array<number> = Array.from(articleBody.children).map(i => i.tagName).map((a, i) => a === "P" ? i : 0).filter(i => i);
+
+                // found some "p" tags, add the first "p" to the fade
+                if (pIndexes.length) {
+                    shadowOverlay.appendChild(
+                        articleBody.children[pIndexes[0]].cloneNode(true)
+                    );
+                }
             }
 
             // set the new article body to be first paragraph with transparent overlay, with the sign in gate component


### PR DESCRIPTION
## What does this change?

On articles which include an `aside` element after the first paragraph would cause an unusually large gap to appear above the sign in gate.

Now when the gate is inserted it will look only for `p` elements to include in the fade above the gate, solving this issue. The `aside` will be shown again when dismissing the gate, or signing in in.

## Screenshots
Broken:
![hmmmm](https://user-images.githubusercontent.com/13315440/78689000-c5d6ea80-78ed-11ea-92b0-1968dfc048e8.png)

Fixed:
![Screenshot 2020-04-07 at 16 36 09](https://user-images.githubusercontent.com/13315440/78689170-eef77b00-78ed-11ea-8879-1b8cf2bdf357.png)


### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
