### PR TITLE
Sign In Gate: Add scale to variants array for sign in gate

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -131,7 +131,7 @@ trait ABTestSwitches {
     "ab-sign-in-gate-quartus-control",
     "Test new sign in component on 2nd article view",
     owners = Seq(Owner.withGithub("coldlink"),Owner.withGithub("dominickendrick")),
-    safeState = On,
+    safeState = Off,
     sellByDate = new LocalDate(2020, 6, 1),
     exposeClientSide = true
   )
@@ -141,7 +141,7 @@ trait ABTestSwitches {
     "ab-sign-in-gate-quartus-variant",
     "Test new sign in component on 3nd article view",
     owners = Seq(Owner.withGithub("coldlink"),Owner.withGithub("dominickendrick")),
-    safeState = On,
+    safeState = Off,
     sellByDate = new LocalDate(2020, 6, 1),
     exposeClientSide = true
   )
@@ -151,7 +151,7 @@ trait ABTestSwitches {
     "ab-sign-in-gate-quartus-scale",
     "Test new sign in component on 3nd article view to a larger audience",
     owners = Seq(Owner.withGithub("coldlink"),Owner.withGithub("dominickendrick")),
-    safeState = On,
+    safeState = Off,
     sellByDate = new LocalDate(2020, 6, 1),
     exposeClientSide = true
   )

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -131,7 +131,7 @@ trait ABTestSwitches {
     "ab-sign-in-gate-quartus-control",
     "Test new sign in component on 2nd article view",
     owners = Seq(Owner.withGithub("coldlink"),Owner.withGithub("dominickendrick")),
-    safeState = Off,
+    safeState = On,
     sellByDate = new LocalDate(2020, 6, 1),
     exposeClientSide = true
   )
@@ -141,7 +141,7 @@ trait ABTestSwitches {
     "ab-sign-in-gate-quartus-variant",
     "Test new sign in component on 3nd article view",
     owners = Seq(Owner.withGithub("coldlink"),Owner.withGithub("dominickendrick")),
-    safeState = Off,
+    safeState = On,
     sellByDate = new LocalDate(2020, 6, 1),
     exposeClientSide = true
   )
@@ -151,7 +151,7 @@ trait ABTestSwitches {
     "ab-sign-in-gate-quartus-scale",
     "Test new sign in component on 3nd article view to a larger audience",
     owners = Seq(Owner.withGithub("coldlink"),Owner.withGithub("dominickendrick")),
-    safeState = Off,
+    safeState = On,
     sellByDate = new LocalDate(2020, 6, 1),
     exposeClientSide = true
   )

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/index.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/index.js
@@ -4,10 +4,12 @@ import type { SignInGateVariant } from '../types';
 // import { signInGateVariant as example } from './example';
 import { signInGateVariant as control } from './control';
 import { signInGateVariant as variant } from './variant';
+import { signInGateVariant as scale } from './scale';
 
 // to add a variant, first import the variant in the SignInGateVariant type, and then add to this exported array
 export const variants: Array<SignInGateVariant> = [
     // example,
     control,
     variant,
+    scale,
 ];


### PR DESCRIPTION
## What does this change?
The `scale` variant was missing from a list of variants that the sign in gate was expecting, this means that users in this variant were not seeing the gate.

This PR imports and adds the `scale` variant to the array.

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
