### PR TITLE
feat: swap the order of the reader revenue banners

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -39,13 +39,12 @@ import { initAccessibilityPreferences } from 'common/modules/ui/accessibility-pr
 import { initClickstream } from 'common/modules/ui/clickstream';
 import { init as initDropdowns } from 'common/modules/ui/dropdowns';
 import { fauxBlockLink } from 'common/modules/ui/faux-block-link';
-import { subscriptionBanner } from 'common/modules/ui/subscription-banners/subscription-banner';
 import { init as initRelativeDates } from 'common/modules/ui/relativedates';
 import { smartAppBanner } from 'common/modules/ui/smartAppBanner';
 import { init as initTabs } from 'common/modules/ui/tabs';
 import { Toggles } from 'common/modules/ui/toggles';
 import { initPinterest } from 'common/modules/social/pinterest';
-import { membershipEngagementBanner } from 'common/modules/commercial/membership-engagement-banner';
+import readerRevenueBanners from 'common/modules/commercial/reader-revenue-banner-selector';
 import { initEmail } from 'common/modules/email/email';
 import { init as initIdentity } from 'bootstraps/enhanced/identity-common';
 import { init as initBannerPicker } from 'common/modules/ui/bannerPicker';
@@ -308,8 +307,7 @@ const initialiseBanner = (): void => {
         breakingNews,
         signInGate,
         membershipBanner,
-        membershipEngagementBanner,
-        subscriptionBanner,
+        ...readerRevenueBanners,
         smartAppBanner,
         adFreeBanner,
         emailSignInBanner,

--- a/static/src/javascripts/projects/common/modules/commercial/reader-revenue-banner-selector.js
+++ b/static/src/javascripts/projects/common/modules/commercial/reader-revenue-banner-selector.js
@@ -1,0 +1,36 @@
+// @flow
+
+// (date: 08/04/2020) This should be a temporary solution for changing the order of the reader revenue banners
+
+import { getReaderRevenueRegion } from 'common/modules/commercial/contributions-utilities';
+import { getSync as geolocationGetSync } from 'lib/geolocation';
+import { local } from 'lib/storage';
+
+import { membershipEngagementBanner } from 'common/modules/commercial/membership-engagement-banner';
+import { subscriptionBanner } from 'common/modules/ui/subscription-banners/subscription-banner';
+
+// types
+import type { ReaderRevenueRegion } from 'common/modules/commercial/contributions-utilities';
+import type { Banner } from 'common/modules/ui/bannerPicker';
+
+const currentRegion: ReaderRevenueRegion = getReaderRevenueRegion(
+    geolocationGetSync()
+);
+
+const pageViews: number = local.get('gu.alreadyVisited');
+
+const orderBanners = (region: ReaderRevenueRegion, ...banners): Banner[] => region === 'united-kingdom' ? banners : banners.reverse();
+
+const showFromFourthPageView = (currentPageViews: number, banners: Banner[]): Banner[] => {
+    if (currentPageViews <= 3) {
+        banners[1].canShow = () => Promise.resolve(false);
+    }
+
+    return banners;
+}
+
+const orderedBanners = orderBanners(currentRegion, subscriptionBanner, membershipEngagementBanner);
+
+const readRevenueBanners = showFromFourthPageView(pageViews, orderedBanners);
+
+export default readRevenueBanners;

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.js
@@ -72,8 +72,8 @@ const hasAcknowledgedBanner = region =>
             return true;
         });
 
-const threeOrMorePageViews = (currentPageViews: number) =>
-    currentPageViews >= 3;
+const twoOrMorePageViews = (currentPageViews: number) =>
+    currentPageViews >= 2;
 
 const pageIsIdentity = (): boolean =>
     config.get('page.contentType') === 'Identity' ||
@@ -195,7 +195,7 @@ const canShow: () => Promise<boolean> = async () => {
     );
 
     const can = Promise.resolve(
-        threeOrMorePageViews(pageviews) &&
+        twoOrMorePageViews(pageviews) &&
             !hasAcknowledgedSinceLastRedeploy &&
             !shouldHideSupportMessaging() &&
             !pageShouldHideReaderRevenue() &&


### PR DESCRIPTION
## What does this change?
This PR swaps the order of the reader revenue banners depending on region, because marketing would like to test if the order of the banners will increase the number of subscriptions we receive. This is meant to be temporary, only lasting two weeks or so. 

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
NA

## What is the value of this and can you measure success?
This will measured using the subscription and contribution data

## Checklist
- Swap banners based on region

### Does this affect other platforms?

- [x] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
