### PR TITLE
New background colour and packshot for subscription banner

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-template.js
@@ -67,8 +67,8 @@ const subscriptionBannerTemplate = (
 
         <div class="site-message--packshot-container">
             <img
-                srcset="https://media.guim.co.uk/28370863b7bb19c5e8e0dc50fe871d4cca99778b/0_0_1894_1156/500.png"
-                src="https://media.guim.co.uk/28370863b7bb19c5e8e0dc50fe871d4cca99778b/0_0_1894_1156/500.png"
+                srcset="https://i.guim.co.uk/img/media/773ead1bd414781052c0983858e6859993870dd3/34_72_1825_1084/1825.png?quality=85&s=7650036e50d9f2c8a8f49871bb6065ac"
+                src="https://i.guim.co.uk/img/media/773ead1bd414781052c0983858e6859993870dd3/34_72_1825_1084/1825.png?quality=85&s=7650036e50d9f2c8a8f49871bb6065ac"
                 alt="the guardian mobile app, the guardian daily"
             >
         </div>

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-template.js
@@ -68,7 +68,7 @@ const subscriptionBannerTemplate = (
         <div class="site-message--packshot-container">
             <picture>
                 <source srcset="https://i.guim.co.uk/img/media/773ead1bd414781052c0983858e6859993870dd3/34_72_1825_1084/1825.png?width=500&dpr=2&quality=85&s=64835c94471dfdbd85f174ee85d901c8" media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)">
-                <source srcset="https://i.guim.co.uk/img/media/773ead1bd414781052c0983858e6859993870dd3/34_72_1825_1084/1825.png?width=500&dpr=2&quality=85&s=64835c94471dfdbd85f174ee85d901c8" >
+                <source srcset="https://i.guim.co.uk/img/media/773ead1bd414781052c0983858e6859993870dd3/34_72_1825_1084/1825.png?width=500&quality=85&s=24cb49b459c52c9d25868ca20979defb" >
                 <img
                     srcset="https://i.guim.co.uk/img/media/773ead1bd414781052c0983858e6859993870dd3/34_72_1825_1084/1825.png?width=500&quality=85&s=24cb49b459c52c9d25868ca20979defb"
                     alt="the guardian mobile app, the guardian daily"

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-template.js
@@ -66,11 +66,14 @@ const subscriptionBannerTemplate = (
         </div>
 
         <div class="site-message--packshot-container">
-            <img
-                srcset="https://i.guim.co.uk/img/media/773ead1bd414781052c0983858e6859993870dd3/34_72_1825_1084/1825.png?quality=85&s=7650036e50d9f2c8a8f49871bb6065ac"
-                src="https://i.guim.co.uk/img/media/773ead1bd414781052c0983858e6859993870dd3/34_72_1825_1084/1825.png?quality=85&s=7650036e50d9f2c8a8f49871bb6065ac"
-                alt="the guardian mobile app, the guardian daily"
-            >
+            <picture>
+                <source srcset="https://i.guim.co.uk/img/media/773ead1bd414781052c0983858e6859993870dd3/34_72_1825_1084/1825.png?width=500&dpr=2&quality=85&s=64835c94471dfdbd85f174ee85d901c8" media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)">
+                <source srcset="https://i.guim.co.uk/img/media/773ead1bd414781052c0983858e6859993870dd3/34_72_1825_1084/1825.png?width=500&dpr=2&quality=85&s=64835c94471dfdbd85f174ee85d901c8" >
+                <img
+                    srcset="https://i.guim.co.uk/img/media/773ead1bd414781052c0983858e6859993870dd3/34_72_1825_1084/1825.png?width=500&quality=85&s=24cb49b459c52c9d25868ca20979defb"
+                    alt="the guardian mobile app, the guardian daily"
+                />
+            </picture>
         </div>
 
         <div

--- a/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
@@ -1,3 +1,5 @@
+$teal-green: #006d67;
+
 *[class^='site-message--subscription-banner'] {
     box-sizing: border-box;
 }
@@ -7,8 +9,8 @@
     display: flex;
     flex-wrap: wrap;
     overflow: hidden;
-    background: $highlight-main;
-    color: $brightness-7;
+    background: $teal-green;
+    color: $brightness-97;
     width: 100%;
     padding: 10px;
 
@@ -141,9 +143,9 @@
     font-size: 16px;
     padding: 10px 20px 12px;
     border-radius: 50px;
-    background: $brightness-7;
+    background: $highlight-main;
     font-family: $f-sans-serif-text;
-    color: $brightness-97;
+    color: $brightness-7;
     text-align: center;
     cursor: pointer;
     width: auto;
@@ -163,7 +165,7 @@
 
 .site-message--subscription-banner__cta-dismiss {
     display: block;
-    color: $brightness-7;
+    color: $brightness-97;
     font-family: $f-sans-serif-text;
     font-size: 16px;
     width: 100%;
@@ -175,7 +177,7 @@
     font-size: 15px;
     font-weight: normal;
     font-family: $f-sans-serif-text;
-    color: $brightness-7;
+    color: $brightness-97;
     margin-top: 10px;
 
     @include mq($from: tablet) {
@@ -190,7 +192,7 @@
     }
 
     a {
-        color: $brightness-7;
+        color: $brightness-97;
     }
 
     &.site-message--subscription-banner__sign-in--already-signed-in {
@@ -295,7 +297,7 @@
     svg {
         border-radius: 50%;
         padding: 2px;
-        border: 1px solid $brightness-7;
+        border: 1px solid $brightness-97;
         transition: background-color .5s ease;
     }
 
@@ -305,12 +307,16 @@
     }
 
     svg path {
-        fill: $brightness-7;
+        fill: $brightness-97;
     }
 }
 
 .site-message--subscription-banner__gu-logo {
     display: none;
+
+    svg path {
+        fill: $brightness-97;
+    }
 
     @include mq($from: desktop) {
         display: block;


### PR DESCRIPTION
Marketing wanted to try a new background colour and pack shot to improve the noticeability of the Subscription Banner

## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
