### PR TITLE
Liveblog epic design test - round 2

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -28,7 +28,7 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-contributions-epic-liveblog-design-test-r1",
+    "ab-contributions-epic-liveblog-design-test-r2",
     "Test new designs for the liveblog",
     owners = Seq(Owner.withGithub("tomrf1")),
     safeState = Off,

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-liveblog.js
@@ -5,7 +5,7 @@ export type LiveblogEpicLastSentenceTemplate = (
     supportURL: string
 ) => string;
 
-const lastSentenceTemplateControl: LiveblogEpicLastSentenceTemplate = (
+const lastSentenceTemplate = (hasSubscribeLink: boolean): LiveblogEpicLastSentenceTemplate => (
     highlightedText?: string,
     supportURL: string
 ) =>
@@ -13,52 +13,24 @@ const lastSentenceTemplateControl: LiveblogEpicLastSentenceTemplate = (
         highlightedText
             ? `<span className="contributions__highlight">${highlightedText}</span>`
             : ''
-    }
-    <a href="${supportURL}" target="_blank" class="u-underline">Make a contribution</a> - The Guardian`;
-
-const lastSentenceTemplateButtonNoArrow: LiveblogEpicLastSentenceTemplate = (
-    highlightedText?: string,
-    supportURL: string
-) =>
-    `${
-        highlightedText
-            ? `<span className="contributions__highlight">${highlightedText}</span>`
-            : ''
-    }
+        }
     <div class="component-button--liveblog-container">
         <a class="component-button component-button--liveblog component-button--hasicon-right contributions__contribute--epic-member"
           href=${supportURL}
           target="_blank">
           Make a contribution
         </a>
+        ${
+            hasSubscribeLink
+               ? `<a class="component-button--liveblog-subscribe" href="https://support.theguardian.com/subscribe">Subscribe</a>`
+               : ''
+        }
     </div>`;
 
-const lastSentenceTemplateButtonArrow: LiveblogEpicLastSentenceTemplate = (
-    highlightedText?: string,
-    supportURL: string
-) =>
-    `${
-        highlightedText
-            ? `<span className="contributions__highlight">${highlightedText}</span>`
-            : ''
-    }
-    <div class="component-button--liveblog-container">
-        <a class="component-button component-button--liveblog component-button--hasicon-right contributions__contribute--epic-member"
-          href=${supportURL}
-          target="_blank">
-          Make a contribution
-          <svg
-            class="svg-arrow-right-straight"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 20 17.89"
-            preserveAspectRatio="xMinYMid"
-            aria-hidden="true"
-            focusable="false"
-            >
-                <path d="M20 9.35l-9.08 8.54-.86-.81 6.54-7.31H0V8.12h16.6L10.06.81l.86-.81L20 8.51v.84z" />
-            </svg>
-        </a>
-    </div>`;
+
+const lastSentenceTemplateControl: LiveblogEpicLastSentenceTemplate = lastSentenceTemplate(false);
+
+const lastSentenceTemplateButtonAndSubscribe: LiveblogEpicLastSentenceTemplate = lastSentenceTemplate(true);
 
 const epicLiveBlogTemplate = ({
     copy,
@@ -91,7 +63,6 @@ const epicLiveBlogTemplate = ({
 
 export {
     lastSentenceTemplateControl,
-    lastSentenceTemplateButtonNoArrow,
-    lastSentenceTemplateButtonArrow,
+    lastSentenceTemplateButtonAndSubscribe,
     epicLiveBlogTemplate,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-liveblog.js
@@ -5,6 +5,8 @@ export type LiveblogEpicLastSentenceTemplate = (
     supportURL: string
 ) => string;
 
+const subscribeUrl = 'https://support.theguardian.com/subscribe/digital?acquisitionData=%7B%22componentType%22%3A%22ACQUISITIONS_OTHER%22%2C%22source%22%3A%22GUARDIAN_WEB%22%2C%22campaignCode%22%3A%22gdnwb_copts_EPIC_liveblog_subscribe%22%2C%22componentId%22%3A%22gdnwb_copts_EPIC_liveblog_subscribe%22%7D&INTCMP=gdnwb_copts_EPIC_liveblog_subscribe';
+
 const lastSentenceTemplateGenerator = (hasSubscribeLink: boolean): LiveblogEpicLastSentenceTemplate => (
     highlightedText?: string,
     supportURL: string
@@ -22,7 +24,7 @@ const lastSentenceTemplateGenerator = (hasSubscribeLink: boolean): LiveblogEpicL
         </a>
         ${
             hasSubscribeLink
-               ? `<a class="component-button--liveblog-subscribe" href="https://support.theguardian.com/subscribe">Subscribe</a>`
+               ? `<a class="component-button--liveblog-subscribe" href="${subscribeUrl}">Subscribe</a>`
                : ''
         }
     </div>`;

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-liveblog.js
@@ -5,7 +5,7 @@ export type LiveblogEpicLastSentenceTemplate = (
     supportURL: string
 ) => string;
 
-const lastSentenceTemplate = (hasSubscribeLink: boolean): LiveblogEpicLastSentenceTemplate => (
+const lastSentenceTemplateGenerator = (hasSubscribeLink: boolean): LiveblogEpicLastSentenceTemplate => (
     highlightedText?: string,
     supportURL: string
 ) =>
@@ -28,9 +28,9 @@ const lastSentenceTemplate = (hasSubscribeLink: boolean): LiveblogEpicLastSenten
     </div>`;
 
 
-const lastSentenceTemplateControl: LiveblogEpicLastSentenceTemplate = lastSentenceTemplate(false);
+const lastSentenceTemplateControl: LiveblogEpicLastSentenceTemplate = lastSentenceTemplateGenerator(false);
 
-const lastSentenceTemplateButtonAndSubscribe: LiveblogEpicLastSentenceTemplate = lastSentenceTemplate(true);
+const lastSentenceTemplateButtonAndSubscribe: LiveblogEpicLastSentenceTemplate = lastSentenceTemplateGenerator(true);
 
 const epicLiveBlogTemplate = ({
     copy,

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -13,7 +13,7 @@ import { signInGate } from 'common/modules/experiments/tests/sign-in-gate';
 import { signInGateVariant } from 'common/modules/experiments/tests/sign-in-gate-variant';
 import { signInGateScale } from 'common/modules/experiments/tests/sign-in-gate-scale';
 import { contributionsEpicPrecontributionReminderRoundTwo } from 'common/modules/experiments/tests/contributions-epic-precontribution-reminder-round-two';
-import { contributionsEpicLiveblogDesignTestR1 } from 'common/modules/experiments/tests/contributions-epic-liveblog-design-test';
+import { contributionsEpicLiveblogDesignTestR2 } from 'common/modules/experiments/tests/contributions-epic-liveblog-design-test';
 import { commercialGptPath } from 'common/modules/experiments/tests/commercial-gpt-path';
 import { contributionsCovidBannerRoundTwo } from 'common/modules/experiments/tests/contribs-banner-covid-round-two';
 
@@ -33,7 +33,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
 export const priorityEpicTest: EpicABTest = frontendDotcomRenderingEpic;
 
 export const epicTests: $ReadOnlyArray<EpicABTest> = [
-    contributionsEpicLiveblogDesignTestR1,
+    contributionsEpicLiveblogDesignTestR2,
     contributionsEpicPrecontributionReminderRoundTwo,
     askFourEarning,
     acquisitionsEpicAlwaysAskIfTagged,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-liveblog-design-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-liveblog-design-test.js
@@ -39,7 +39,7 @@ export const contributionsEpicLiveblogDesignTestR2: EpicABTest = makeEpicABTest(
         id: 'ContributionsEpicLiveblogDesignTestR2',
         campaignId: 'contributions-epic-liveblog-design-test-r2',
 
-        geolocation: geolocation,
+        geolocation,
         highPriority: true,
 
         start: '2020-03-26',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-liveblog-design-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contributions-epic-liveblog-design-test.js
@@ -8,9 +8,8 @@ import { getSync as geolocationGetSync } from 'lib/geolocation';
 import { setupEpicInLiveblog } from 'common/modules/commercial/contributions-liveblog-utilities';
 import {
     epicLiveBlogTemplate,
+    lastSentenceTemplateButtonAndSubscribe,
     lastSentenceTemplateControl,
-    lastSentenceTemplateButtonNoArrow,
-    lastSentenceTemplateButtonArrow,
 } from 'common/modules/commercial/templates/acquisitions-epic-liveblog';
 import type { LiveblogEpicLastSentenceTemplate } from 'common/modules/commercial/templates/acquisitions-epic-liveblog';
 
@@ -35,12 +34,12 @@ const liveBlogTemplate = (
         lastSentenceTemplate,
     });
 
-export const contributionsEpicLiveblogDesignTestR1: EpicABTest = makeEpicABTest(
+export const contributionsEpicLiveblogDesignTestR2: EpicABTest = makeEpicABTest(
     {
-        id: 'ContributionsEpicLiveblogDesignTestR1',
-        campaignId: 'contributions-epic-liveblog-design-test-r1',
+        id: 'ContributionsEpicLiveblogDesignTestR2',
+        campaignId: 'contributions-epic-liveblog-design-test-r2',
 
-        geolocation: geolocationGetSync(),
+        geolocation: geolocation,
         highPriority: true,
 
         start: '2020-03-26',
@@ -57,6 +56,7 @@ export const contributionsEpicLiveblogDesignTestR1: EpicABTest = makeEpicABTest(
         deploymentRules: 'AlwaysAsk',
 
         pageCheck: isCompatibleWithLiveBlogEpic,
+        canRun: () => geolocation === 'GB',
 
         variants: [
             {
@@ -70,14 +70,7 @@ export const contributionsEpicLiveblogDesignTestR1: EpicABTest = makeEpicABTest(
                 id: 'v1',
                 products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
                 copy: buildEpicCopy(epicCopy, false, geolocation),
-                template: liveBlogTemplate(lastSentenceTemplateButtonNoArrow),
-                test: setupEpicInLiveblog,
-            },
-            {
-                id: 'v2',
-                products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
-                copy: buildEpicCopy(epicCopy, false, geolocation),
-                template: liveBlogTemplate(lastSentenceTemplateButtonArrow),
+                template: liveBlogTemplate(lastSentenceTemplateButtonAndSubscribe),
                 test: setupEpicInLiveblog,
             },
         ],

--- a/static/src/stylesheets/module/reader-revenue/_reader-revenue-button.scss
+++ b/static/src/stylesheets/module/reader-revenue/_reader-revenue-button.scss
@@ -98,6 +98,14 @@ $gu-cta-height: 42px;
     margin-top: 0;
 }
 
+.component-button--liveblog-container a.component-button--liveblog-subscribe {
+    @include fs-textSans(5);
+    font-style: normal;
+    color: $brightness-7;
+    text-decoration: underline;
+    margin-left: 8px;
+}
+
 .component-button--reminder-prompt {
     background-color: transparent;
     border-color: $brightness-7;


### PR DESCRIPTION
## What does this change?
Round 2 of a design test on the liveblog epic.

1. The test is UK only.
2. The control is the winner of round 1 (a button). The variant has a 2nd link to subscriptions.
2. Non-UK now fall back to whatever is in the Epic Test Tool, but the default design is now the winner of round 1.

Control:
![Screen Shot 2020-04-09 at 14 49 32](https://user-images.githubusercontent.com/1513454/78904727-dfef0500-7a74-11ea-9247-5b84fff030bf.png)

Variant with Subscribe link:
![Screen Shot 2020-04-09 at 14 35 11](https://user-images.githubusercontent.com/1513454/78904721-de254180-7a74-11ea-8099-b6075cb31a31.png)


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
