### PR TITLE
Mobile Sticky Ad - 1% AB test on UK/ROW regions

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -165,4 +165,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2020, 5, 4),
     exposeClientSide = true
   )
+
+  Switch(
+    ABTests,
+    "ab-commercial-uk-row-mobile-sticky",
+    "1% a/b test for mobile sticky ad in UK and ROW regions",
+    owners = Seq(Owner.withGithub("GHaberis")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 4, 22),
+    exposeClientSide = true
+  )
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -172,7 +172,7 @@ trait ABTestSwitches {
     "1% a/b test for mobile sticky ad in UK and ROW regions",
     owners = Seq(Owner.withGithub("GHaberis")),
     safeState = Off,
-    sellByDate = new LocalDate(2020, 4, 22),
+    sellByDate = new LocalDate(2020, 10, 1),
     exposeClientSide = true
   )
 }

--- a/static/src/javascripts/__flow__/types/ophan.js
+++ b/static/src/javascripts/__flow__/types/ophan.js
@@ -54,14 +54,15 @@ declare type OphanComponentType =
     | 'ACQUISITIONS_EDITORIAL_LINK'
     | 'ACQUISITIONS_SUBSCRIPTIONS_BANNER'
     | 'ACQUISITIONS_OTHER'
-    | 'SIGN_IN_GATE';
+    | 'SIGN_IN_GATE'
+    | 'MOBILE_STICKY_AD';
 
 declare type OphanComponent = {
     componentType: OphanComponentType,
     id?: string,
     products?: $ReadOnlyArray<OphanProduct>,
     campaignCode?: string,
-    labels?: $ReadOnlyArray<string>
+    labels?: $ReadOnlyArray<string>,
 };
 
 declare type OphanComponentEvent = {
@@ -71,6 +72,6 @@ declare type OphanComponentEvent = {
     id?: string,
     abTest?: {
         name: string,
-        variant: string
-    }
+        variant: string,
+    },
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.js
@@ -1,6 +1,9 @@
 // @flow
 import fastdom from 'lib/fastdom-promise';
 import crossIcon from 'svgs/icon/cross.svg';
+import ophan from 'ophan/ng';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { commercialUkRowMobileSticky } from 'common/modules/experiments/tests/commercial-uk-row-mobile-sticky.js';
 
 const shouldRenderLabel = adSlotNode =>
     !(
@@ -13,11 +16,45 @@ const shouldRenderLabel = adSlotNode =>
 
 const createAdCloseDiv = (): HTMLButtonElement => {
     const closeDiv: HTMLButtonElement = document.createElement('button');
+    const CLOSE_BUTTON_ID = 'ad-slot-close-button';
     closeDiv.className = 'ad-slot__close-button';
+    closeDiv.id = CLOSE_BUTTON_ID;
     closeDiv.innerHTML = crossIcon.markup;
     closeDiv.onclick = function onclickMobileStickyCloser() {
         const container = this.closest('.mobilesticky-container');
-        if (container) container.remove();
+        if (container) {
+            container.remove();
+
+            if (
+                isInVariantSynchronous(
+                    commercialUkRowMobileSticky,
+                    'ukVariant'
+                ) ||
+                isInVariantSynchronous(
+                    commercialUkRowMobileSticky,
+                    'rowVariant'
+                )
+            ) {
+                const componentEvent: OphanComponentEvent = {
+                    action: 'CLICK',
+                    component: {
+                        componentType: 'MOBILE_STICKY_AD',
+                        id: CLOSE_BUTTON_ID,
+                    },
+                    abTest: {
+                        name: 'CommercialUkRowMobileSticky',
+                        variant: isInVariantSynchronous(
+                            commercialUkRowMobileSticky,
+                            'ukVariant'
+                        )
+                            ? 'ukVariant'
+                            : 'rowVariant',
+                    },
+                };
+
+                ophan.record({ componentEvent });
+            }
+        }
     };
     return closeDiv;
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.spec.js
@@ -6,6 +6,10 @@ jest.mock('lib/detect', () => {});
 jest.mock('common/modules/commercial/commercial-features', () => ({
     commercialFeatures: {},
 }));
+jest.mock('ophan/ng', () => null);
+jest.mock('common/modules/experiments/ab', () => ({
+    isInVariantSynchronous: () => false,
+}));
 
 const adverts = {};
 const labelSelector = '.ad-slot__label';

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/utils.js
@@ -7,6 +7,7 @@ import config from 'lib/config';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { appnexusUSAdapter } from 'common/modules/experiments/tests/commercial-appnexus-us-adapter';
 import { pangaeaAdapterTest } from 'common/modules/experiments/tests/commercial-pangaea-adapter';
+import { commercialUkRowMobileSticky } from 'common/modules/experiments/tests/commercial-uk-row-mobile-sticky.js';
 import type { HeaderBiddingSize } from './types';
 
 const isInAppnexusUSAdapterTestVariant = (): boolean =>
@@ -158,7 +159,16 @@ export const shouldIncludeMobileSticky = once(
         window.location.hash.indexOf('#mobile-sticky') !== -1 ||
         (config.get('switches.mobileStickyLeaderboard') &&
             isBreakpoint({ min: 'mobile', max: 'mobileLandscape' }) &&
-            (isInUsRegion() || isInAuRegion()) &&
+            (isInUsRegion() ||
+                isInAuRegion() ||
+                isInVariantSynchronous(
+                    commercialUkRowMobileSticky,
+                    'ukVariant'
+                ) ||
+                isInVariantSynchronous(
+                    commercialUkRowMobileSticky,
+                    'rowVariant'
+                )) &&
             config.get('page.contentType') === 'Article' &&
             !config.get('page.isHosted'))
 );

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.spec.js
@@ -1,6 +1,11 @@
 // @flow
 import { _ } from './background';
 
+jest.mock('commercial/modules/dfp/render-advert-label', () => ({
+    renderStickyAdLabel: jest.fn(),
+    renderStickyScrollForMoreLabel: jest.fn(),
+}));
+
 const { setBackground, getStylesFromSpec } = _;
 
 const adSpec = {

--- a/static/src/javascripts/projects/commercial/modules/mobile-sticky.js
+++ b/static/src/javascripts/projects/commercial/modules/mobile-sticky.js
@@ -31,6 +31,7 @@ const createAdWrapper = () => {
 
 export const init = (): Promise<void> => {
     if (shouldIncludeMobileSticky()) {
+        console.log('******* shouldIncludeMobileSticky *******');
         const mobileStickyWrapper = createAdWrapper();
         return fastdom
             .write(() => {

--- a/static/src/javascripts/projects/commercial/modules/mobile-sticky.js
+++ b/static/src/javascripts/projects/commercial/modules/mobile-sticky.js
@@ -31,7 +31,6 @@ const createAdWrapper = () => {
 
 export const init = (): Promise<void> => {
     if (shouldIncludeMobileSticky()) {
-        console.log('******* shouldIncludeMobileSticky *******');
         const mobileStickyWrapper = createAdWrapper();
         return fastdom
             .write(() => {

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -15,6 +15,7 @@ import { signInGateScale } from 'common/modules/experiments/tests/sign-in-gate-s
 import { contributionsEpicPrecontributionReminderRoundTwo } from 'common/modules/experiments/tests/contributions-epic-precontribution-reminder-round-two';
 import { contributionsCovidBannerRoundTwo } from 'common/modules/experiments/tests/contribs-banner-covid-round-two';
 import { commercialCmpCopy } from 'common/modules/experiments/tests/commercial-cmp-copy';
+import { commercialUkRowMobileSticky } from 'common/modules/experiments/tests/commercial-uk-row-mobile-sticky.js';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
@@ -27,6 +28,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     signInGateVariant,
     signInGateScale,
     commercialCmpCopy,
+    commercialUkRowMobileSticky
 ];
 
 export const priorityEpicTest: EpicABTest = frontendDotcomRenderingEpic;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-uk-row-mobile-sticky.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-uk-row-mobile-sticky.js
@@ -13,7 +13,7 @@ const isInRowRegion = (): boolean =>
 export const commercialUkRowMobileSticky: ABTest = {
     id: 'CommercialUkRowMobileSticky',
     start: '2020-04-15',
-    expiry: '2020-04-22',
+    expiry: '2020-10-01',
     author: 'George Haberis',
     description: 'Test mobile sticky ad in UK and ROW regions',
     audience: 0.01,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-uk-row-mobile-sticky.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-uk-row-mobile-sticky.js
@@ -1,0 +1,53 @@
+// @flow strict
+import once from 'lodash/once';
+import { isBreakpoint } from 'lib/detect';
+import { getSync as geolocationGetSync } from 'lib/geolocation';
+
+const currentGeoLocation = once((): string => geolocationGetSync());
+const isInUkRegion = (): boolean => currentGeoLocation() === 'GB';
+const isInUsRegion = (): boolean => ['US', 'CA'].includes(currentGeoLocation());
+const isInAuRegion = (): boolean => ['AU', 'NZ'].includes(currentGeoLocation());
+const isInRowRegion = (): boolean =>
+    !isInUkRegion() && !isInUsRegion() && !isInAuRegion();
+
+export const commercialUkRowMobileSticky: ABTest = {
+    id: 'CommercialUkRowMobileSticky',
+    start: '2020-04-15',
+    expiry: '2020-04-22',
+    author: 'George Haberis',
+    description: 'Test mobile sticky ad in UK and ROW regions',
+    audience: 0.01,
+    audienceOffset: 0.8, // To avoid clashes with other tests and the results on this AB test are already very sensitive to outside factors
+    successMeasure:
+        'No significant impact to performance as well as higher ad yield',
+    audienceCriteria: 'n/a',
+    dataLinkNames: 'n/a',
+    idealOutcome:
+        'No significant impact to performance as well as higher ad yield',
+    showForSensitive: true,
+    canRun: () =>
+        (isInUkRegion() || isInRowRegion()) &&
+        isBreakpoint({ min: 'mobile', max: 'mobileLandscape' }),
+    variants: [
+        {
+            id: 'ukControl',
+            test: (): void => {},
+            canRun: (): boolean => isInUkRegion(),
+        },
+        {
+            id: 'rowControl',
+            test: (): void => {},
+            canRun: (): boolean => isInRowRegion(),
+        },
+        {
+            id: 'ukVariant',
+            test: (): void => {},
+            canRun: (): boolean => isInUkRegion(),
+        },
+        {
+            id: 'rowVariant',
+            test: (): void => {},
+            canRun: (): boolean => isInRowRegion(),
+        },
+    ],
+};


### PR DESCRIPTION
## What does this change?

This PR introduces a 1% AB test for the mobile sticky advert in the UK and ROW regions.

we have a set of conditions that must be met before the test can run. Currently these are:
 
- The user is in the UK or ROW regions
- The user is accessing the site using a mobile device 

When a user satisfies the criteria above and also falls into the `ukVariant` or `rowVariant` groups we'll check these additional conditions before attempting to display a mobile sticky ad:

- The `mobileStickyLeaderboard` switch is turned ON
- The user is reading content of the type "Article".
- The Article is not a "hosted" type

Originally tested against the US region here: https://github.com/guardian/frontend/pull/21460 

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
