### PR TITLE
Sign In Gate Quartus: Increase Audience Numbers

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-scale.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-scale.js
@@ -6,8 +6,8 @@ export const signInGateScale: ABTest = {
     author: 'Mahesh Makani',
     description:
         'Test adding a sign in component on the 3rd pageview, with higher priority over banners and epic, and a much larger audience size. This test does not display a gate, and only used for tracking users who meet our displayer criteria.',
-    audience: 0.25,
-    audienceOffset: 0.75,
+    audience: 0.5,
+    audienceOffset: 0,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:
         'The contributions epic is not shown, The consent banner is not shown, The contributions banner is not shown, Should only appear on simple article template, Should not show if they are already signed in, Users will not need to go through the marketing consents as part of signup flow',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-variant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-variant.js
@@ -6,8 +6,8 @@ export const signInGateVariant: ABTest = {
     author: 'Mahesh Makani',
     description:
         'Test adding a sign in component on the 3rd pageview, with higher priority over banners and epic. This test does not display a gate, and only used for tracking users who meet our displayer criteria.',
-    audience: 0.12,
-    audienceOffset: 0.6,
+    audience: 0.37,
+    audienceOffset: 0.63,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:
         'The contributions epic is not shown, The consent banner is not shown, The contributions banner is not shown, Should only appear on simple article template, Should not show if they are already signed in, Users will not need to go through the marketing consents as part of signup flow',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate.js
@@ -6,7 +6,7 @@ export const signInGate: ABTest = {
     author: 'Mahesh Makani',
     description:
         'Test adding a sign in component on the 2nd pageview of simple article templates, with higher priority over banners and epic, and a much larget audience size. This test does not display a gate, and only used for tracking users who meet our displayer criteria.',
-    audience: 0.06,
+    audience: 0.13,
     audienceOffset: 0.5,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:


### PR DESCRIPTION
## What does this change?

This PR increases the audience size for all 3 of our sign in gate variants, and adjusts the offset, to be able to reach our targeted numbers of unique browser views of the sign in gate for this test.