### PR TITLE
Remove unused epic params

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@babel/runtime": "^7.2.0",
     "@emotion/core": "^10.0.21",
     "@guardian/atom-renderer": "1.1.6",
-    "@guardian/automat-client": "^0.2.13",
+    "@guardian/automat-client": "^0.2.16",
     "@guardian/consent-management-platform": "3.0.0",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/src-button": "^0.16.1",

--- a/static/src/javascripts/projects/common/modules/experiments/tests/frontend-dotcom-rendering-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/frontend-dotcom-rendering-epic.js
@@ -105,15 +105,8 @@ const frontendDotcomRenderingTest = {
                     ophanComponentId: 'ACQUISITIONS_EPIC',
                     platformId: 'GUARDIAN_WEB',
                     clientName: 'frontend',
-                    campaignCode: variant.campaignCode,
-                    abTestName: test.id,
-                    abTestVariant: variant.id,
                     referrerUrl:
                         window.location.origin + window.location.pathname,
-                };
-
-                const localisation = {
-                    countryCode,
                 };
 
                 const targeting = {
@@ -137,7 +130,6 @@ const frontendDotcomRenderingTest = {
 
                 const payload = {
                     tracking,
-                    localisation,
                     targeting,
                 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,10 +1166,10 @@
     style-loader "1.0.0"
     webpack "^4.2.0"
 
-"@guardian/automat-client@^0.2.13":
-  version "0.2.13"
-  resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.13.tgz#69ad5559160726ca49714d44d6ab77f3db25f5ef"
-  integrity sha512-OHAZv3MZkuFHJkEoWLkiR5nWnzG0i3Unt3w972n6SmkbOr0xLaUhyM+WZvetNn8dOPzHPVwHW6IYi7Z+TQ5Gug==
+"@guardian/automat-client@^0.2.16":
+  version "0.2.16"
+  resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.16.tgz#3ef47e7f49e633aea51c67f061d8d313a26fa9bc"
+  integrity sha512-SgNU2bgiyQaXNfqanx4SDmxqAhXW6QBCTk4tRnCgV9Ht6noRl7UsDfx4I0u+M4H3TRnK4I/i2mmlJBtnuwhxEg==
 
 "@guardian/consent-management-platform@3.0.0":
   version "3.0.0"


### PR DESCRIPTION
## What does this change?

Removes some params from the `/epic` payload. Country code is now part of targeting, and the tracking params are derived on the contributions service side.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (guardian/dotcom-rendering#1353)

## What is the value of this and can you measure success?

Removes unused params which would otherwise be confusing/misleading for future developers.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
