### PR TITLE
Log test groups for DCR tests

### DIFF
--- a/article/app/services/dotcomponents/DotcomponentsLogger.scala
+++ b/article/app/services/dotcomponents/DotcomponentsLogger.scala
@@ -29,8 +29,8 @@ case class DotcomponentsLogger(request: Option[RequestHeader]) extends Logging {
 
   private def customFields: List[LogField] = DotcomponentsLoggerFields(request).customFields
 
-  def fieldsFromResults(results: Map[String, Boolean]):List[LogField] =
-    results.map({ case (k, v) => LogFieldString(k, v.toString)}).toList
+  def fieldsFromResults(results: Map[String, String]):List[LogField] =
+    results.map({ case (k, v) => LogFieldString(k, v)}).toList
 
   def elementsLogFieldFromPage(page: PageWithStoryPackage): List[LogField] = List(
     LogFieldString(
@@ -52,7 +52,7 @@ case class DotcomponentsLogger(request: Option[RequestHeader]) extends Logging {
   }
 
 
-  def results(message: String, results: Map[String, Boolean], page: PageWithStoryPackage): Unit = {
+  def results(message: String, results: Map[String, String], page: PageWithStoryPackage): Unit = {
     logInfoWithCustomFields(message, customFields ++ fieldsFromResults(results) ++ elementsLogFieldFromPage(page))
   }
 


### PR DESCRIPTION
## What does this change?

Log test groups (participant, control, excluded) for DCR tests.

I'm unsure if `userIsInCohort` and `userIsInCohortDiscussion` are still needed with this - interested to hear thoughts - but ideally I'd remove them as part of this.

Note, to log string fields, I've updated some of the typings. The result is a bit of boilerplate around `toString`ing the booleans, but I don't think this is terrible as at least it makes explicit what was going on under the hood before.