### PR TITLE
Temporarily remove shadow dom use for remote epic

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/frontend-dotcom-rendering-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/frontend-dotcom-rendering-epic.js
@@ -181,15 +181,15 @@ const frontendDotcomRenderingTest = {
                                 parent.insertBefore(container, target);
 
                                 // use Shadow Dom if found
-                                let shadowRoot;
-                                if (container.attachShadow) {
-                                    shadowRoot = container.attachShadow({
-                                        mode: 'open',
-                                    });
-                                    shadowRoot.innerHTML = content;
-                                } else {
-                                    container.innerHTML = content;
-                                }
+                                // let shadowRoot;
+                                // if (container.attachShadow) {
+                                //     shadowRoot = container.attachShadow({
+                                //         mode: 'open',
+                                //     });
+                                //     shadowRoot.innerHTML = content;
+                                // } else {
+                                container.innerHTML = content;
+                                // }
 
                                 emitInsertEvent(
                                     test,
@@ -219,7 +219,7 @@ const frontendDotcomRenderingTest = {
                                             'function'
                                         ) {
                                             const initAutomatJsConfig: InitAutomatJsConfig = {
-                                                epicRoot: shadowRoot || container,
+                                                epicRoot: container, // shadowRoot || container,
                                                 onReminderOpen: (callbackParams: AutomatJsCallback) => {
                                                     const { buttonCopyAsString } = callbackParams;
                                                     // Send two separate Ophan events when the Reminder


### PR DESCRIPTION
## What does this change and why?

We are seeing a larger drop off between inserts and views for the
remote epic than on DCR. This is speculative, but one difference
is the use of shadow dom here, so we are going to temporarily
remove it and see if the numbers change.