### PR TITLE
Introduce fake AB test to identify DCR renderable pages

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -463,4 +463,14 @@ trait FeatureSwitches {
     sellByDate = never,
     exposeClientSide = true,
   )
+
+  val vodafoneEmailHack = Switch(
+    SwitchGroup.Feature,
+    "vodafone-email-hack",
+    "If on, will use smaller heading font for Vodafone slogan title on email fronts. This is to keep it from introducing horizontal scrolling at the mobile breakpoint. We can remove this once their campaign is over. Editorial owner is celine.bijleveld.",
+    owners = Seq(Owner.withEmail("dotcom.platform@guardian.co.uk")),
+    safeState = On,
+    sellByDate = new LocalDate(2020, 6, 1),
+    exposeClientSide = false,
+  )
 }

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -18,7 +18,7 @@
 @import fragments.email._
 @import common.LinkTo
 @import conf.audio.FlagshipEmailContainer
-@import conf.switches.Switches.FlagshipEmailContainerDynamicImageSwitch
+@import conf.switches.Switches.{FlagshipEmailContainerDynamicImageSwitch, vodafoneEmailHack}
 
 @headline(card: ContentCard, isLarge: Boolean = false, isTrailText: Boolean = false) = {
 
@@ -210,14 +210,23 @@
     @imgForFront(page.banner, page.email.map(_.name))
 }
 
+@* Temporary hack - see associated switch for who to contact/expiry *@
+@smallIfVodafone(displayName: String) = {
+    @if(displayName == "#KeepingTheUKConnected" && vodafoneEmailHack.isSwitchedOn) {
+        <span style="font-size: 22px">@displayName</span>
+    } else {
+        @displayName
+    }
+}
+
 @renderContentContainer(collection: EmailContentContainer, collectionIndex: Int) = {
     @brazePlaceholder(s"Above Collection ${collectionIndex + 1}")
     @containerTitle((if(collectionIndex > 0) Seq("ct--not-top") else Nil) ++ (if (collection.branding.isDefined) Seq("ct-branded") else Nil)) {
 
         @collection.href.map { href =>
-            <a class="ct-link" href="@LinkTo {/@Html(href)}">@collection.displayName</a>
+            <a class="ct-link" href="@LinkTo {/@Html(href)}">@smallIfVodafone(collection.displayName)</a>
         }.getOrElse {
-            @collection.displayName
+            @smallIfVodafone(collection.displayName)
         }
     }
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab-ophan.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-ophan.js
@@ -103,6 +103,12 @@ export const buildOphanPayload = (
             log[`ab${test}`] = makeABEvent(serverSideVariant, 'false');
         });
 
+        // A flag to indicate if a page was DCR renderable for the data lake.
+        // Ideally we'd pass this as a boolean property in the top-level
+        // pageview data. This is a stop-gap until then.
+        const dcrCouldRender = config.get("page.dcrCouldRender", false)
+        log.abDcrCouldRender = { variantName: dcrCouldRender.toString(), complete: true}
+
         return log;
     } catch (error) {
         // Encountering an error should invalidate the logging process.


### PR DESCRIPTION
A better solution is to add `dcrCouldRender` to the page view event as a top-level boolean field. For reasons to do with the Ophan data model/processing this is difficult, so this is a quick
hack until we have that ready.

cc @gtrufitt and @paulmr . Also see:

https://github.com/guardian/frontend/pull/22400#pullrequestreview-394710092