### PR TITLE
Enable Plista separate from Outbrain

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/plista-outbrain-renderer.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/plista-outbrain-renderer.js
@@ -40,22 +40,13 @@ const init = (): Promise<void> => {
 
     const edition = config.get('page.edition', '').toLowerCase();
     const isSwitchOn = config.get('switches.plistaForOutbrainAu');
-    const shouldUseRandomWidget: boolean = isSwitchOn && edition === 'au';
+    const shouldUsePlista: boolean = isSwitchOn && edition === 'au';
 
-    config.set('debug.outbrain.shouldUseRandomWidget', shouldUseRandomWidget);
-
-    if (shouldUseRandomWidget) {
-        const possibleWidgets = ['plista', 'outbrain'];
-        const randomWidget =
-            possibleWidgets[Math.floor(Math.random() * possibleWidgets.length)];
-
-        config.set('debug.outbrain.randomWidget', randomWidget);
-
-        if (randomWidget === 'plista') {
-            return renderWidget('plista', plista.init);
-        }
+    if (shouldUsePlista) {
+        return renderWidget('plista', plista.init);
     }
-    return renderWidget('outbrain', initOutbrain);
+
+    return renderWidget('outbrain', initOutbrain)
 };
 
 export { init };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/plista-outbrain-renderer.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/plista-outbrain-renderer.spec.js
@@ -55,18 +55,7 @@ describe('Plista Outbrain renderer', () => {
         });
     });
 
-    it('should pick Outbrain for AU', done => {
-        global.Math.random = () => 1;
-        config.set('switches.plistaForOutbrainAu', true);
-        config.set('page.edition', 'AU');
-        initPlistaOutbrainRenderer().then(() => {
-            expect(initOutbrain).toHaveBeenCalled();
-            done();
-        });
-    });
-
     it('should pick Plista for AU', done => {
-        global.Math.random = () => 0;
         config.set('switches.plistaForOutbrainAu', true);
         config.set('page.edition', 'AU');
         initPlistaOutbrainRenderer().then(() => {

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/plista.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/plista.js
@@ -70,7 +70,7 @@ module.load = function() {
 };
 
 module.init = function(): Promise<false> {
-    if (commercialFeatures.outbrain) {
+    if (commercialFeatures.plista) {
         return loadInstantly().then(inUse => {
             if (inUse) {
                 module.load();

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/plista.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/plista.spec.js
@@ -14,7 +14,7 @@ jest.mock('commercial/modules/dfp/track-ad-render', () => ({
 jest.mock('common/modules/commercial/commercial-features', () => ({
     commercialFeatures: {
         thirdPartyTags: true,
-        outbrain: true,
+        plista: true,
     },
 }));
 
@@ -114,7 +114,7 @@ describe('Plista', () => {
         });
 
         it('should not load when sensitive content', done => {
-            commercialFeaturesMock.outbrain = false;
+            commercialFeaturesMock.plista = false;
             plista.init().then(resolvedPromise => {
                 expect(resolvedPromise).toEqual(false);
                 expect(loadSpy).not.toHaveBeenCalled();

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
@@ -15,7 +15,9 @@ class CommercialFeatures {
     carrotTrafficDriver: boolean;
     highMerch: boolean;
     thirdPartyTags: boolean;
+    relatedWidgetEnabled: boolean;
     outbrain: boolean;
+    plista: boolean;
     commentAdverts: boolean;
     liveblogAdverts: boolean;
     paidforBand: boolean;
@@ -106,16 +108,23 @@ class CommercialFeatures {
             !isIdentityPage &&
             !isSecureContact;
 
-        this.outbrain =
+        this.relatedWidgetEnabled =
             this.dfpAdvertising &&
             !this.adFree &&
-            switches.outbrain &&
             !noadsUrl &&
             !sensitiveContent &&
             isArticle &&
             !config.get('page.isPreview') &&
             config.get('page.showRelatedContent') &&
             !(isUserLoggedIn() && config.get('page.commentable'));
+
+        this.outbrain =
+            this.relatedWidgetEnabled &&
+            switches.outbrain;
+
+        this.plista =
+            this.relatedWidgetEnabled &&
+            switches.plistaForOutbrainAu;
 
         this.commentAdverts =
             this.dfpAdvertising &&

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.js
@@ -59,6 +59,7 @@ describe('Commercial features', () => {
 
         config.set('switches', {
             outbrain: true,
+            plistaForOutbrainAu: true,
             commercial: true,
             enableDiscussionSwitch: true,
         });
@@ -270,24 +271,28 @@ describe('Commercial features', () => {
         it('Runs by default', () => {
             const features = new CommercialFeatures();
             expect(features.outbrain).toBe(true);
+            expect(features.plista).toBe(true);
         });
 
         it('Is disabled under perf tests', () => {
             window.location.hash = '#noads';
             const features = new CommercialFeatures();
             expect(features.outbrain).toBe(false);
+            expect(features.plista).toBe(false);
         });
 
         it('Is disabled in sensitive content', () => {
             config.set('page.shouldHideAdverts', true);
             const features = new CommercialFeatures();
             expect(features.outbrain).toBe(false);
+            expect(features.plista).toBe(false);
         });
 
         it('Is disabled when related content is hidden', () => {
             config.set('page.showRelatedContent', false);
             const features = new CommercialFeatures();
             expect(features.outbrain).toBe(false);
+            expect(features.plista).toBe(false);
         });
 
         it('Is disabled when user is logged in and page is commentable', () => {
@@ -295,6 +300,7 @@ describe('Commercial features', () => {
             config.set('page.commentable', true);
             const features = new CommercialFeatures();
             expect(features.outbrain).toBe(false);
+            expect(features.plista).toBe(false);
         });
     });
 
@@ -307,30 +313,35 @@ describe('Commercial features', () => {
         it('Does not run by default', () => {
             const features = new CommercialFeatures();
             expect(features.outbrain).toBe(false);
+            expect(features.plista).toBe(false);
         });
 
         it('Is disabled under perf tests', () => {
             window.location.hash = '#noads';
             const features = new CommercialFeatures();
             expect(features.outbrain).toBe(false);
+            expect(features.plista).toBe(false);
         });
 
         it('Is disabled in sensitive content', () => {
             config.set('page.shouldHideAdverts', true);
             const features = new CommercialFeatures();
             expect(features.outbrain).toBe(false);
+            expect(features.plista).toBe(false);
         });
 
         it('Is disabled when related content is hidden', () => {
             config.set('page.showRelatedContent', false);
             const features = new CommercialFeatures();
             expect(features.outbrain).toBe(false);
+            expect(features.plista).toBe(false);
         });
 
         it('Is disabled when user is logged in and page is commentable', () => {
             config.set('page.commentable', true);
             const features = new CommercialFeatures();
             expect(features.outbrain).toBe(false);
+            expect(features.plista).toBe(false);
         });
     });
 


### PR DESCRIPTION
## What does this change?
This change makes sure that Plista is enabled separately from Outbrain in Australia.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)


### Tested

- [ ] Locally - Doesn't seem to work outside Australian IP address
- [x] On CODE (optional)

![image](https://user-images.githubusercontent.com/9122944/79582240-67ff8b00-80c3-11ea-9d2e-f233dc387b7e.png)


<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
