### PR TITLE
Enable atom end point for chart atoms

### DIFF
--- a/applications/app/controllers/AtomPageController.scala
+++ b/applications/app/controllers/AtomPageController.scala
@@ -87,9 +87,10 @@ class AtomPageController(contentApiClient: ContentApiClient, wsClient: WSClient,
         renderAtom(QandaAtomPage(model, withJavaScript = isJsEnabled, withVerticalScrollbar = hasVerticalScrollbar))
       case Left(model: TimelineAtom) =>
         renderAtom(TimelineAtomPage(model, withJavaScript = isJsEnabled, withVerticalScrollbar = hasVerticalScrollbar))
-      case Left(model: InteractiveAtom) => {
+      case Left(model: InteractiveAtom) =>
         renderAtom(InteractiveAtomPage(model, withJavaScript = isJsEnabled, withVerticalScrollbar = hasVerticalScrollbar))
-      }
+      case Left(model: ChartAtom) =>
+        renderAtom(ChartAtomPage(model, withJavaScript = isJsEnabled, withVerticalScrollbar = hasVerticalScrollbar))
       case Left(_) =>
         renderOther(NotFound)
       case Right(other) =>
@@ -115,6 +116,7 @@ class AtomPageController(contentApiClient: ContentApiClient, wsClient: WSClient,
     apiAtom.qanda.map(atom => QandaAtom.make(atom))                             orElse
     apiAtom.timeline.map(atom => TimelineAtom.make(atom))                       orElse
     apiAtom.interactive.map(atom => InteractiveAtom.make(atom))                 orElse
+    apiAtom.chart.map(atom => ChartAtom.make(atom))                             orElse
     /*
     apiAtom.quiz.map(atom => Quiz.make(atom))                                   orElse
     apiAtom.review.map(atom => RecipeAtom.make(atom))                           orElse

--- a/applications/app/views/atomEmbed.scala.html
+++ b/applications/app/views/atomEmbed.scala.html
@@ -22,7 +22,7 @@
                     '*'
                 );
             }
-    </script>
+        </script>
     </head>
     <body>
         @page.body

--- a/common/app/model/content/Atoms.scala
+++ b/common/app/model/content/Atoms.scala
@@ -80,7 +80,6 @@ final case class MediaAtom(
   }
 }
 
-
 sealed trait MediaAssetPlatform extends EnumEntry
 
 object MediaAssetPlatform extends Enum[MediaAssetPlatform] with PlayJsonEnum[MediaAssetPlatform] {
@@ -131,6 +130,14 @@ final case class InteractiveAtom(
   mainJS: Option[String],
   docData: Option[String]
 ) extends Atom
+
+final case class ChartAtom(
+  override val id: String,
+  atom: AtomApiAtom,
+  title: String,
+  css: String,
+  html: String,
+  mainJS: Option[String]) extends Atom
 
 final case class RecipeAtom(
   override val id: String,
@@ -215,12 +222,6 @@ final case class AudioAtom(
   override val id: String,
   atom: AtomApiAtom,
   data: atomapi.audio.AudioAtom
-) extends Atom
-
-final case class ChartAtom(
-  override val id: String,
-  atom: AtomApiAtom,
-  data: atomapi.chart.ChartAtom
 ) extends Atom
 
 object Atoms extends common.Logging {
@@ -314,7 +315,6 @@ object Atoms extends common.Logging {
     ImageMedia(imageAssets)
   }
 }
-
 
 object MediaAtom extends common.Logging {
 
@@ -479,6 +479,11 @@ object InteractiveAtom {
   }
 }
 
+object ChartAtom {
+  def make(atom: AtomApiAtom): ChartAtom = {
+    ChartAtom(atom.id, atom, atom.title.getOrElse("Chart"), "", atom.defaultHtml, None)
+  }
+}
 
 object RecipeAtom {
   def make(atom: AtomApiAtom): RecipeAtom = RecipeAtom(atom.id, atom, atom.data.asInstanceOf[AtomData.Recipe].recipe)
@@ -617,9 +622,4 @@ object AudioAtom {
     val audio = atom.data.asInstanceOf[AtomData.Audio].audio
     AudioAtom(atom.id, atom, audio)
   }
-}
-
-object ChartAtom {
-  def make(atom: AtomApiAtom): ChartAtom =
-    ChartAtom(atom.id, atom, atom.data.asInstanceOf[AtomData.Chart].chart)
 }

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -148,6 +148,7 @@ object PageElement {
       case _: AudioBlockElement => true
       case _: AudioAtomBlockElement => true
       case _: VideoBlockElement => true
+      // case _: ContentAtomBlockElement => true // Experimental (to be uncommented shortly)
 
       // TODO we should quick fail here for these rather than pointlessly go to DCR
       case table: TableBlockElement if table.isMandatory.exists(identity) => true

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -459,6 +459,21 @@ case class InteractiveAtomPage(
   )
 }
 
+case class ChartAtomPage(
+  override val atom: ChartAtom,
+  override val withJavaScript: Boolean,
+  override val withVerticalScrollbar: Boolean
+)(implicit request: RequestHeader, context: ApplicationContext) extends AtomPage {
+  override val atomType = "chart"
+  override val body = views.html.fragments.atoms.chart(atom, shouldFence = false)
+  override val javascriptModule = "snippet"
+  override val metadata = MetaData.make(
+    id = atom.id,
+    webTitle = atom.title,
+    section = None
+  )
+}
+
 case class GuideAtomPage(
   override val atom: GuideAtom,
   override val withJavaScript: Boolean,

--- a/common/app/views/fragments/atoms/chart.scala.html
+++ b/common/app/views/fragments/atoms/chart.scala.html
@@ -1,0 +1,50 @@
+@import common.InlineJs
+@import model.content.ChartAtom
+@import templates.inlineJS.nonBlocking.js.{interactiveFonts, interactiveResize}
+@import play.twirl.api.HtmlFormat
+
+@(chart: ChartAtom, shouldFence: Boolean)(implicit context: model.ApplicationContext)
+
+@iframeBody = {
+    <!DOCTYPE html>
+    <html>
+        <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+            <script>
+                @InlineJs(interactiveFonts().body, "interactiveFonts.js")
+            </script>
+            <style>
+                @HtmlFormat.raw(chart.css)
+            </style>
+        </head>
+        <body>
+            @HtmlFormat.raw(chart.html)
+
+            @for(js <- chart.mainJS) {
+                <script>
+                    @HtmlFormat.raw(js)
+                </script>
+            }
+            <script>
+                @InlineJs(interactiveResize().body, "interactiveResize.js")
+            </script>
+        </body>
+    </html>
+}
+
+@if(shouldFence) {
+    <iframe class="interactive-atom-fence" srcdoc="@iframeBody.toString"></iframe>
+} else {
+    <figure class="interactive interactive-atom">
+        <style>
+            @HtmlFormat.raw(chart.css)
+        </style>
+        @HtmlFormat.raw(chart.html)
+        @for(js <- chart.mainJS) {
+            <script>
+                @HtmlFormat.raw(js)
+            </script>
+        }
+    </figure>
+}


### PR DESCRIPTION
## What does this change?

Add support to show chart atoms on their own end points. This is the first step of being able to show them on AMP pages.


<img width="751" alt="Screenshot 2020-04-20 at 10 58 07" src="https://user-images.githubusercontent.com/6035518/79741938-fe1cf680-82f9-11ea-8748-78be4c8011c6.png">

