### PR TITLE
Reduce font-size for specific email header

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -463,4 +463,14 @@ trait FeatureSwitches {
     sellByDate = never,
     exposeClientSide = true,
   )
+
+  val vodafoneEmailHack = Switch(
+    SwitchGroup.Feature,
+    "vodafone-email-hack",
+    "If on, will use smaller heading font for Vodafone slogan title on email fronts. This is to keep it from introducing horizontal scrolling at the mobile breakpoint. We can remove this once their campaign is over. Editorial owner is celine.bijleveld.",
+    owners = Seq(Owner.withEmail("dotcom.platform@guardian.co.uk")),
+    safeState = On,
+    sellByDate = new LocalDate(2020, 6, 1),
+    exposeClientSide = false,
+  )
 }

--- a/facia/app/views/fragments/emailFrontBody.scala.html
+++ b/facia/app/views/fragments/emailFrontBody.scala.html
@@ -18,7 +18,7 @@
 @import fragments.email._
 @import common.LinkTo
 @import conf.audio.FlagshipEmailContainer
-@import conf.switches.Switches.FlagshipEmailContainerDynamicImageSwitch
+@import conf.switches.Switches.{FlagshipEmailContainerDynamicImageSwitch, vodafoneEmailHack}
 
 @headline(card: ContentCard, isLarge: Boolean = false, isTrailText: Boolean = false) = {
 
@@ -210,14 +210,23 @@
     @imgForFront(page.banner, page.email.map(_.name))
 }
 
+@* Temporary hack - see associated switch for who to contact/expiry *@
+@smallIfVodafone(displayName: String) = {
+    @if(displayName == "#KeepingTheUKConnected" && vodafoneEmailHack.isSwitchedOn) {
+        <span style="font-size: 22px">@displayName</span>
+    } else {
+        @displayName
+    }
+}
+
 @renderContentContainer(collection: EmailContentContainer, collectionIndex: Int) = {
     @brazePlaceholder(s"Above Collection ${collectionIndex + 1}")
     @containerTitle((if(collectionIndex > 0) Seq("ct--not-top") else Nil) ++ (if (collection.branding.isDefined) Seq("ct-branded") else Nil)) {
 
         @collection.href.map { href =>
-            <a class="ct-link" href="@LinkTo {/@Html(href)}">@collection.displayName</a>
+            <a class="ct-link" href="@LinkTo {/@Html(href)}">@smallIfVodafone(collection.displayName)</a>
         }.getOrElse {
-            @collection.displayName
+            @smallIfVodafone(collection.displayName)
         }
     }
 


### PR DESCRIPTION
## What does this change?

The Vodafone brand campaign is long enough that it introduces horizontal scrolling on the mobile breakpoint.

Note, this is definitely code we don't want to keep for too long. The switch should act as a reminder to review/remove in June.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

![Screenshot 2020-04-20 at 14 49 15](https://user-images.githubusercontent.com/858402/79759081-24e92600-8316-11ea-8b36-25493ab13e4d.png)

to:

![Screenshot 2020-04-20 at 14 41 01](https://user-images.githubusercontent.com/858402/79759033-13078300-8316-11ea-9e9a-416f9d8d6a2b.png)
