### PR TITLE
Use correct URL for GW banner

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-tracking.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-tracking.js
@@ -43,7 +43,7 @@ const createTracking = (
     const australianTracking = {
         signInUrl: `${signinHostname}/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_gWeekly&CMP_TU=mrtn&CMP_BUNIT=subs`,
         subscriptionUrl: addTrackingCodesToUrl({
-            base: `${subscriptionHostname}/subscribe/digital`,
+            base: `${subscriptionHostname}/subscribe/weekly`,
             componentType: COMPONENT_TYPE,
             componentId: OPHAN_EVENT_ID,
             campaignCode: AUS_CAMPAIGN_CODE,


### PR DESCRIPTION
## What does this change?
We were incorrectly linking to the digital product page from the guardian weekly banner, this fixes that.