### PR TITLE
Stop loading A9 script everytime

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -102,7 +102,7 @@ trait ABTestSwitches {
     "Test Amazon A9 header bidding",
     owners = Seq(Owner.withGithub("ioanna0")),
     safeState = Off,
-    sellByDate = new LocalDate(2020, 9, 4),
+    sellByDate = new LocalDate(2020, 6, 1),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -102,7 +102,7 @@ trait ABTestSwitches {
     "Test Amazon A9 header bidding",
     owners = Seq(Owner.withGithub("ioanna0")),
     safeState = Off,
-    sellByDate = new LocalDate(2020, 6, 1),
+    sellByDate = new LocalDate(2020, 7, 1),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-a9.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-a9.js
@@ -10,26 +10,26 @@ import { shouldIncludeOnlyA9 } from 'commercial/modules/header-bidding/utils';
 import { amazonA9Test } from 'common/modules/experiments/tests/amazon-a9';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 
-let moduleLoadResult = Promise.resolve();
-if (!isGoogleProxy()) {
-    moduleLoadResult = import('lib/a9-apstag.js');
-}
-
-const setupA9: () => Promise<void> = () =>
-    moduleLoadResult.then(() => {
-        if (
-            shouldIncludeOnlyA9 ||
-            (dfpEnv.hbImpl.a9 &&
-                isInVariantSynchronous(amazonA9Test, 'variant') &&
-                commercialFeatures.dfpAdvertising &&
-                !commercialFeatures.adFree &&
-                !config.get('page.hasPageSkin') &&
-                !isGoogleProxy())
-        ) {
+const setupA9: () => Promise<void> = () => {
+    let moduleLoadResult = Promise.resolve();
+    if (
+        shouldIncludeOnlyA9 ||
+        (dfpEnv.hbImpl.a9 &&
+            isInVariantSynchronous(amazonA9Test, 'variant') &&
+            commercialFeatures.dfpAdvertising &&
+            !commercialFeatures.adFree &&
+            !config.get('page.hasPageSkin') &&
+            !isGoogleProxy())
+    ) {
+        moduleLoadResult = import('lib/a9-apstag.js').then(() => {
             a9.initialise();
-        }
-        return Promise.resolve();
-    });
+
+            return Promise.resolve();
+        });
+    }
+
+    return moduleLoadResult;
+};
 
 const setupA9Once: () => Promise<void> = once(setupA9);
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-a9.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-a9.js
@@ -31,7 +31,7 @@ const setupA9: () => Promise<void> = () =>
         return Promise.resolve();
     });
 
-export const setupA9Once: () => Promise<void> = once(setupA9);
+const setupA9Once: () => Promise<void> = once(setupA9);
 
 export const init = (): Promise<void> => {
     setupA9Once();

--- a/static/src/javascripts/projects/common/modules/experiments/tests/amazon-a9.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/amazon-a9.js
@@ -3,7 +3,7 @@
 export const amazonA9Test: ABTest = {
     id: 'CommercialA9',
     start: '2019-05-09',
-    expiry: '2020-06-01',
+    expiry: '2020-07-01',
     author: 'Ioanna Kyprianou',
     description: 'This is to test amazon a9 header bidding',
     audience: 0.01,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/amazon-a9.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/amazon-a9.js
@@ -3,7 +3,7 @@
 export const amazonA9Test: ABTest = {
     id: 'CommercialA9',
     start: '2019-05-09',
-    expiry: '2020-04-09',
+    expiry: '2020-06-01',
     author: 'Ioanna Kyprianou',
     description: 'This is to test amazon a9 header bidding',
     audience: 0.01,


### PR DESCRIPTION
## What does this change?
Amazon A9 needs to load a script in order to work. So far we have been loading this script on every page and then we initialise A9 based on certain condition (like the A9 switch being on or the page being suitable to run A9 ads). This PR moves the script loading code behind these conditions so that it loads only when necessary.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Checklist

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [x] Locally
- [ ] On CODE (optional)