### PR TITLE
Fix horizontal scroll issue for crosswords

### DIFF
--- a/static/src/stylesheets/module/crosswords/_layout.scss
+++ b/static/src/stylesheets/module/crosswords/_layout.scss
@@ -100,7 +100,8 @@
 .crossword__clues__gradient {
     position: absolute;
     bottom: 0;
-    width: 100%;
+    left: 0;
+    right: 0;
     height: 120px;
     background: linear-gradient(to bottom, rgba(255, 255, 255, 0), #ffffff);
     display: none;


### PR DESCRIPTION
## What does this change?

First noticed as it caused issues with viewport on iPad but seems like a general issue.

Issue appears to only affect tablet breakpoint.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

Before:

![Screenshot 2020-04-22 at 17 53 37](https://user-images.githubusercontent.com/858402/80011220-7b479780-84c3-11ea-904e-5afce45ddfc2.png)

After (no longer horizontal scroll):

![Screenshot 2020-04-22 at 17 53 08](https://user-images.githubusercontent.com/858402/80011266-8b5f7700-84c3-11ea-8acc-1d9e51aa905b.png)

