### PR TITLE
Add share images for old comment articles with dates

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -134,11 +134,13 @@ final case class Content(
 
     () match {
       case paid if isPaidContent => Paid
+      case oldcommentObserver if isOldOpinion && isFromTheObserver => CommentObserverOldContent(trail.webPublicationDate.getYear)
+      case oldComment if isOldOpinion => CommentGuardianOldContent(trail.webPublicationDate.getYear)
       case commentObserver if tags.isComment && isFromTheObserver => ObserverOpinion
       case comment if tags.isComment => GuardianOpinion
       case live if tags.isLiveBlog => Live
-      case oldObserver if (isOldNews || isOldOpinion) && isFromTheObserver => ObserverOldContent(trail.webPublicationDate.getYear)
-      case old if isOldNews || isOldOpinion => GuardianOldContent(trail.webPublicationDate.getYear)
+      case oldObserver if isOldNews && isFromTheObserver => ObserverOldContent(trail.webPublicationDate.getYear)
+      case old if isOldNews => GuardianOldContent(trail.webPublicationDate.getYear)
       case ratingObserver if starRating.isDefined && isFromTheObserver => ObserverStarRating(starRating.get)
       case rating if starRating.isDefined => GuardianStarRating(starRating.get)
       case observerDefault if isFromTheObserver => ObserverDefault

--- a/common/app/views/support/ImageProfile.scala
+++ b/common/app/views/support/ImageProfile.scala
@@ -153,6 +153,8 @@ class ShareImage(
 sealed trait ShareImageCategory
 case object GuardianDefault extends ShareImageCategory
 case object ObserverDefault extends ShareImageCategory
+case class CommentObserverOldContent(publicationYear: Int) extends ShareImageCategory
+case class CommentGuardianOldContent(publicationYear: Int) extends ShareImageCategory
 case object ObserverOpinion extends ShareImageCategory
 case object GuardianOpinion extends ShareImageCategory
 case object Live extends ShareImageCategory
@@ -175,6 +177,8 @@ object OpenGraphImage extends OverlayBase64 {
       case ObserverOpinion => new ShareImage(s"overlay-base64=${overlayUrlBase64("to-opinions.png")}", shouldIncludeOverlay, shouldUpscale)
       case GuardianOpinion => new ShareImage(s"overlay-base64=${overlayUrlBase64("tg-opinions.png")}", shouldIncludeOverlay, shouldUpscale)
       case Live => new ShareImage(s"overlay-base64=${overlayUrlBase64("tg-live.png")}", shouldIncludeOverlay, shouldUpscale)
+      case CommentObserverOldContent(year) => contentAgeNoticeCommentObserver(year, shouldIncludeOverlay, shouldUpscale)
+      case CommentGuardianOldContent(year) => contentAgeNoticeComment(year, shouldIncludeOverlay, shouldUpscale)
       case ObserverOldContent(year) => contentAgeNoticeObserver(year, shouldIncludeOverlay, shouldUpscale)
       case GuardianOldContent(year) => contentAgeNotice(year, shouldIncludeOverlay, shouldUpscale)
       case ObserverStarRating(rating) => starRatingObserver(rating, shouldIncludeOverlay, shouldUpscale)
@@ -215,6 +219,16 @@ object OpenGraphImage extends OverlayBase64 {
 
   private[this] def contentAgeNoticeObserver(publicationYear: Int, shouldIncludeOverlay: Boolean, shouldUpscale: Boolean): ShareImage = {
     val image = s"overlay-base64=${overlayUrlBase64(getContentAgeFileName("to", publicationYear))}"
+    new ShareImage(image, shouldIncludeOverlay, shouldUpscale)
+  }
+
+  private[this] def contentAgeNoticeComment(publicationYear: Int, shouldIncludeOverlay: Boolean, shouldUpscale: Boolean = false): ShareImage = {
+    val image = s"overlay-base64=${overlayUrlBase64(getContentAgeFileName("tg-opinions", publicationYear))}"
+    new ShareImage(image, shouldIncludeOverlay, shouldUpscale)
+  }
+
+  private[this] def contentAgeNoticeCommentObserver(publicationYear: Int, shouldIncludeOverlay: Boolean, shouldUpscale: Boolean): ShareImage = {
+    val image = s"overlay-base64=${overlayUrlBase64(getContentAgeFileName("to-opinions", publicationYear))}"
     new ShareImage(image, shouldIncludeOverlay, shouldUpscale)
   }
 }


### PR DESCRIPTION
## What does this change?

Adds the share images for old comment articles.

![Screen Shot 2020-04-23 at 10 30 55](https://user-images.githubusercontent.com/638051/80083805-ea69ce00-854d-11ea-9b2c-1740e4b28e4c.png)

![Screen Shot 2020-04-22 at 17 47 57](https://user-images.githubusercontent.com/638051/80083811-ed64be80-854d-11ea-813f-ba8d1d31be52.png)

![2020-04-23 10 36 29](https://user-images.githubusercontent.com/638051/80084103-56e4cd00-854e-11ea-828c-fec8c829c11a.gif)

Thanks @HarryFischer !

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

It cascades through from the CAPI response.