### PR TITLE
Adding more basic tones to our supported list for Article Picker

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -87,7 +87,10 @@ object ArticlePageChecks {
       "tone/albumreview",
       "tone/livereview",
       "tone/explainers",
-      "tone/perfromances"
+      "tone/performances",
+      "tone/polls",
+      "tone/profiles",
+      "tone/timelines"
     ).contains(page.article.tags.tones.headOption.map(_.id).getOrElse("")) || page.article.tags.tones.isEmpty
   }
 
@@ -104,7 +107,10 @@ object ArticlePageChecks {
       "tone/albumreview",
       "tone/livereview",
       "tone/explainers",
-      "tone/performances"
+      "tone/performances",
+      "tone/polls",
+      "tone/profiles",
+      "tone/timelines"
     ).contains(page.article.tags.tones.headOption.map(_.id).getOrElse("")) || page.article.tags.tones.isEmpty
   }
 


### PR DESCRIPTION
## What does this change?
We have visual parity with the following tones between Frontend and DCR.