### PR TITLE
Add pageTones to logging

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -242,10 +242,7 @@ object ArticlePicker {
       ("isArticle100PercentPage" -> isArticle100PercentPage.toString) +
       ("dcrCouldRender" -> canRender.toString) +
       ("pageTones" -> pageTones)
-
-      println(features)
-
-
+    
     if (tier == RemoteRender) {
       logRequest(s"path executing in dotcomponents", features, page)
     } else {

--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -223,7 +223,8 @@ object ArticlePicker {
       else LocalRenderArticle
 
     val isArticle100PercentPage = dcrArticle100PercentPage(page, request);
-    val isAddFree = ArticlePageChecks.isAdFree(page, request)
+    val isAddFree = ArticlePageChecks.isAdFree(page, request);
+    val pageTones = page.article.tags.tones.map(_.id).mkString(", ")
 
     def testGroup(experiment: Experiment): String = ActiveExperiments.groupFor(experiment) match {
       case Participant => "participant"
@@ -239,7 +240,11 @@ object ArticlePicker {
       ("userIsInCohortDiscussion" -> userInDiscussionTest.toString) +
       ("isAdFree" -> isAddFree.toString) +
       ("isArticle100PercentPage" -> isArticle100PercentPage.toString) +
-      ("dcrCouldRender" -> canRender.toString)
+      ("dcrCouldRender" -> canRender.toString) +
+      ("pageTones" -> pageTones)
+
+      println(features)
+
 
     if (tier == RemoteRender) {
       logRequest(s"path executing in dotcomponents", features, page)


### PR DESCRIPTION
## What does this change?

Adds logging of *all* page tones, not just the headOption tone tag.

![image](https://user-images.githubusercontent.com/638051/80113253-f79cb200-8579-11ea-9319-e2ebe6783c90.png)
