### PR TITLE
Update CMP version to 3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@emotion/core": "^10.0.21",
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/automat-client": "^0.2.16",
-    "@guardian/consent-management-platform": "3.0.1",
+    "@guardian/consent-management-platform": "3.0.2",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/src-button": "^0.16.1",
     "@guardian/src-foundations": "^0.16.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1171,10 +1171,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.16.tgz#3ef47e7f49e633aea51c67f061d8d313a26fa9bc"
   integrity sha512-SgNU2bgiyQaXNfqanx4SDmxqAhXW6QBCTk4tRnCgV9Ht6noRl7UsDfx4I0u+M4H3TRnK4I/i2mmlJBtnuwhxEg==
 
-"@guardian/consent-management-platform@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-3.0.1.tgz#c15bef93c1d1153e5c5133ae7d36b9164fc8b26d"
-  integrity sha512-heu7DgEcmlBNhU61xXthx2TmomvCwKJPySyhvbr9txgz6XKffD4WBrtZjHgmSWxam0IZSvEz0XMcb3kBjLTVUA==
+"@guardian/consent-management-platform@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-3.0.2.tgz#d817ee720657dc3b3e52d8e62cac8ea2b550e1e5"
+  integrity sha512-QTy4ZMbbLwgADuyYAB2sc74TuwIRSXed/6mrH9ytkSrGWxYeH8Yu67l3vcriV0btTMz3dbtNv7HTwR8xiWIftQ==
   dependencies:
     consent-string "^1.5.1"
     js-cookie "^2.2.1"


### PR DESCRIPTION
## What does this change?
Bump version of CMP to 3.0.3, improving IAB compliance. (release notes: https://github.com/guardian/consent-management-platform/releases/tag/3.0.2  & https://github.com/guardian/consent-management-platform/releases/tag/3.0.3)

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
![Screenshot 2020-04-23 at 17 41 21](https://user-images.githubusercontent.com/48949546/80125560-c0360180-8589-11ea-9eab-533c6856e62b.png)


## Checklist

### Tested

- [X] Locally
- [ ] On CODE (optional)