### PR TITLE
Bump CMP version to 3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@emotion/core": "^10.0.21",
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/automat-client": "^0.2.16",
-    "@guardian/consent-management-platform": "3.0.2",
+    "@guardian/consent-management-platform": "3.0.3",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/src-button": "^0.16.1",
     "@guardian/src-foundations": "^0.16.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1171,10 +1171,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.16.tgz#3ef47e7f49e633aea51c67f061d8d313a26fa9bc"
   integrity sha512-SgNU2bgiyQaXNfqanx4SDmxqAhXW6QBCTk4tRnCgV9Ht6noRl7UsDfx4I0u+M4H3TRnK4I/i2mmlJBtnuwhxEg==
 
-"@guardian/consent-management-platform@3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-3.0.2.tgz#d817ee720657dc3b3e52d8e62cac8ea2b550e1e5"
-  integrity sha512-QTy4ZMbbLwgADuyYAB2sc74TuwIRSXed/6mrH9ytkSrGWxYeH8Yu67l3vcriV0btTMz3dbtNv7HTwR8xiWIftQ==
+"@guardian/consent-management-platform@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-3.0.3.tgz#9822b0ddebe4a2a52c44e0ecbd1c54407038b964"
+  integrity sha512-2a+k+dx0pNZItF8gxcYgpNrQJ/ArG7uwHo+ZN4Xi6tz5re4vQ6KMePlAfoHIoMKgosBSaSQRWVb4y8SNiv4xYw==
   dependencies:
     consent-string "^1.5.1"
     js-cookie "^2.2.1"


### PR DESCRIPTION
## What does this change?
Followup to PR https://github.com/guardian/frontend/pull/22525 where a commit was missing.