### PR TITLE
Fix Identity verification email wording

### DIFF
--- a/identity/app/views/verificationEmailResent.scala.html
+++ b/identity/app/views/verificationEmailResent.scala.html
@@ -13,7 +13,7 @@
     <div class="identity-forms-email-wrap">
         <header>@user.primaryEmailAddress</header>
         <aside>
-            Is the email not correct? <a href="@idUrlBuilder.buildUrl(controllers.editprofile.routes.EditProfileController.redirectToAccountSettings.url, idRequest)" data-link-name="mma : verify-email : update-email-from-error">Change it here</a>
+            Not the right email? <a href="@idUrlBuilder.buildUrl(controllers.editprofile.routes.EditProfileController.redirectToAccountSettings.url, idRequest)" data-link-name="mma : verify-email : update-email-from-error">Change it here</a>
         </aside>
     </div>
 }
@@ -28,7 +28,7 @@
         @emailBlock
         <div class="identity-forms-message__body">
             @if(isSignupFlow) {
-                <p>We've sent you an email – please open it up and click on the button. This is so we can verify it's you and help you create a password to complete your Guardian account.</p>
+                <p>We've sent you an email – please open it up and click on the verify button to confirm your email address.</p>
             } else {
                 <p>We have sent a link to this email address. Please check your inbox and follow the instructions.</p>
             }


### PR DESCRIPTION
## What does this change?

Address this Trello card : https://trello.com/c/2Cj19z9x/2042-change-the-language-on-the-please-check-your-inbox-page

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
