### PR TITLE
Restore Shadow DOM in Epic test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/frontend-dotcom-rendering-epic.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/frontend-dotcom-rendering-epic.js
@@ -181,15 +181,15 @@ const frontendDotcomRenderingTest = {
                                 parent.insertBefore(container, target);
 
                                 // use Shadow Dom if found
-                                // let shadowRoot;
-                                // if (container.attachShadow) {
-                                //     shadowRoot = container.attachShadow({
-                                //         mode: 'open',
-                                //     });
-                                //     shadowRoot.innerHTML = content;
-                                // } else {
-                                container.innerHTML = content;
-                                // }
+                                let shadowRoot;
+                                if (container.attachShadow) {
+                                    shadowRoot = container.attachShadow({
+                                        mode: 'open',
+                                    });
+                                    shadowRoot.innerHTML = content;
+                                } else {
+                                    container.innerHTML = content;
+                                }
 
                                 emitInsertEvent(
                                     test,
@@ -219,7 +219,7 @@ const frontendDotcomRenderingTest = {
                                             'function'
                                         ) {
                                             const initAutomatJsConfig: InitAutomatJsConfig = {
-                                                epicRoot: container, // shadowRoot || container,
+                                                epicRoot: shadowRoot || container,
                                                 onReminderOpen: (callbackParams: AutomatJsCallback) => {
                                                     const { buttonCopyAsString } = callbackParams;
                                                     // Send two separate Ophan events when the Reminder


### PR DESCRIPTION
## What does this change?
Restores the usage of Shadow DOM (if available) in the `FrontendDotcomRenderingEpic`. This was previously implemented and used, until it was temporary commented out to test something else. We should now revert back to using it, as it fixes a visual glitch in the main Epic CTA for that test.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

Before:
![Screenshot 2020-04-27 at 17 53 32](https://user-images.githubusercontent.com/1692169/80399803-b249ee80-88b1-11ea-8d43-b776ac50351f.png)

After:
![Screenshot 2020-04-27 at 18 06 19](https://user-images.githubusercontent.com/1692169/80399865-d1488080-88b1-11ea-886d-ea47a9c17db3.png)
