### PR TITLE
Optimize GPT speed by updating the hosted library domain

### DIFF
--- a/admin/test/resources/pagepresser/r2/interactivePageWithJQuery.html
+++ b/admin/test/resources/pagepresser/r2/interactivePageWithJQuery.html
@@ -268,7 +268,7 @@
         gads.async = true;
         gads.type = 'text/javascript';
         var useSSL = 'https:' == document.location.protocol;
-        gads.src = (useSSL ? 'https:' : 'http:') + '//www.googletagservices.com/tag/js/gpt.js';
+        gads.src = (useSSL ? 'https:' : 'http:') + '//securepubads.g.doubleclick.net/tag/js/gpt.js';
         var node = document.getElementsByTagName('script')[0];
         node.parentNode.insertBefore(gads, node);
     })();

--- a/commercial/app/views/passback.scala.html
+++ b/commercial/app/views/passback.scala.html
@@ -4,7 +4,7 @@
   <title>Passback for '@adUnitName' Size: [[@width,@height]]</title>
 </head>
 <body style="margin: 0;">
-  <script src='https://www.googletagservices.com/tag/js/gpt.js'>
+  <script src='https://securepubads.g.doubleclick.net/tag/js/gpt.js'>
     googletag.pubads().definePassback('/@dfpNetworkId/@adUnitName', [[@width,@height]])
       .setTargeting('passback', ['@passbackTarget'])
       .display();

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -243,7 +243,7 @@ class GuardianConfiguration extends Logging {
   }
 
   object googletag {
-    lazy val jsLocation = configuration.getStringProperty("googletag.js.location").getOrElse("//www.googletagservices.com/tag/js/gpt.js")
+    lazy val jsLocation = configuration.getStringProperty("googletag.js.location").getOrElse("//securepubads.g.doubleclick.net/tag/js/gpt.js")
   }
 
   // Amazon A9 APS Transparent Ad Marketplace library


### PR DESCRIPTION
## What does this change?

Uses securepubads.g.doubleclick.net to serve the gpt tag as recommended here:
https://support.google.com/admanager/answer/1638622?visit_id=637181511322071279-4007197348&rd=1

## Does this change need to be reproduced in dotcom-rendering ?

- [X ] No

## What is the value of this and can you measure success?

Load the GPT tag from the same domain as the ad serving one, saving an extra DNS query and connection.


### Tested

- [ X] Locally
