### PR TITLE
Prevent gradient blocking crossword buttons on ipad

### DIFF
--- a/static/src/stylesheets/module/crosswords/_layout.scss
+++ b/static/src/stylesheets/module/crosswords/_layout.scss
@@ -81,6 +81,10 @@
 
 // scrollable clues - only on tablets not in accessible view
 .crossword__container--react {
+    & .crossword__clues--wrapper {
+        position: relative; // required for positioning of .crossword__clues__gradient
+    }
+
     & .crossword__clues--wrapper,
     & .crossword__clues {
         @include mq($from: tablet, $until: leftCol) {


### PR DESCRIPTION
## What does this change?

Should remove gradient blocking crossword buttons on Ipad.

Bug introduced in: https://github.com/guardian/frontend/pull/22518.

![2020-04-29 11 20 34](https://user-images.githubusercontent.com/858402/80597472-ca3f8080-8a1f-11ea-9843-7f86ddd3348c.gif)
