### PR TITLE
Introduce ability to ignore can run for a forced test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/ab-core.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-core.js
@@ -8,7 +8,7 @@ import config from 'lib/config';
 import { isExpired } from 'lib/time-utils';
 import { logAutomatEvent } from 'common/modules/experiments/automatLog';
 import { getVariantFromLocalStorage } from './ab-local-storage';
-import { getVariantFromUrl } from './ab-url';
+import { getVariantFromUrl, getIgnoreCanRunFromUrl } from './ab-url';
 import { NOT_IN_TEST } from './ab-constants';
 import { isTestSwitchedOn } from './ab-utils';
 
@@ -77,6 +77,14 @@ export const runnableTest = <T: ABTest>(test: T): ?Runnable<T> => {
     const fromLocalStorage = getVariantFromLocalStorage(test);
     const fromCookie = computeVariantFromMvtCookie(test);
     const variantToRun = fromUrl || fromLocalStorage || fromCookie;
+    const ignoreCanRun = fromUrl && getIgnoreCanRunFromUrl(); // check fromUrl to only ignore can run for forced tests
+
+    if (variantToRun && ignoreCanRun) {
+        return {
+            ...test,
+            variantToRun,
+        };
+    }
 
     if (testCanBeRun(test) && variantToRun && variantCanBeRun(variantToRun)) {
         return {

--- a/static/src/javascripts/projects/common/modules/experiments/ab-url.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-url.js
@@ -21,3 +21,8 @@ export const getForcedParticipationsFromUrl = (): Participations => {
 // If the given test has a variant which is forced by the URL, return it
 export const getVariantFromUrl = (test: ABTest): ?Variant =>
     testAndParticipationsToVariant(test, getForcedParticipationsFromUrl());
+
+// Useful if you want to force a test even when it normally wouldn't run
+// (for example, to display a specific epic variant to verify it renders
+// okay).
+export const getIgnoreCanRunFromUrl = (): boolean => window.location.hash.includes('ignoreCanRun=true');


### PR DESCRIPTION
Specifically, if you want to force a client-side AB test via the URL, you can now also force it to always run by ignoring the canRun. To do this, add `ignoreCanRun=true` to the URL hash, e.g.:

    #ab-SomeTest=SomeVariant,ignoreCanRun=true

where the first bit is the test/variant you want to opt into (#ab- is existing functionality).

Note, canRun is ignored *only for forced tests* - those which you are opting into explicitly using the URL #. This is because ignoring canRun is usually confusing/not sensible.

The initial motivation is to allow easily checking rendering of different epic variants, but it is expected to be useful in other cases too.

Note, this isn't foolproof - if another test matches and can run first, your test might not run. In this case, you can disable the troublesome test to get round this, either with a code/switch change, or via the URL: `#ab-TestMyTest=notintest