### PR TITLE
adding instagram embeds to picker

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -4,7 +4,7 @@ import controllers.ArticlePage
 import experiments.{ActiveExperiments, Control, DCRBubble, DiscussionRendering, DotcomRendering, Excluded, Experiment, Participant}
 import model.PageWithStoryPackage
 import implicits.Requests._
-import model.liveblog.{BlockElement, ImageBlockElement, PullquoteBlockElement, RichLinkBlockElement, TextBlockElement, TweetBlockElement}
+import model.liveblog.{BlockElement, ImageBlockElement, PullquoteBlockElement, RichLinkBlockElement, TextBlockElement, TweetBlockElement, InstagramBlockElement}
 import play.api.mvc.RequestHeader
 import views.support.Commercial
 
@@ -40,6 +40,7 @@ object ArticlePageChecks {
       case _: TweetBlockElement => false
       case _: PullquoteBlockElement => false
       case _: RichLinkBlockElement => false
+      case _: InstagramBlockElement => false
       case _ => true
     }
 
@@ -242,7 +243,7 @@ object ArticlePicker {
       ("isArticle100PercentPage" -> isArticle100PercentPage.toString) +
       ("dcrCouldRender" -> canRender.toString) +
       ("pageTones" -> pageTones)
-    
+
     if (tier == RemoteRender) {
       logRequest(s"path executing in dotcomponents", features, page)
     } else {


### PR DESCRIPTION
## What does this change?
Enables DCR to show Instagram embeds, once this has been merged https://github.com/guardian/dotcom-rendering/pull/1420