### PR TITLE
Use better Image Roles for ImageBlockElement

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -198,14 +198,15 @@ object PageElement {
       ))
 
       case Image =>
+
         def ensureHTTPS(src: String): String = src.replace("http:", "https:")
 
         val signedAssets = element.assets.zipWithIndex
           .map { case (a, i) => ImageAsset.make(a, i) }
 
         val mediaType = (hasShowcaseMainElement, isImmersive) match {
-          case (true, _) => ImmersiveMedia
-          case (_, true) => MainMedia
+          case (true, _) => MainMedia
+          case (_, true) => ImmersiveMedia
           case _         => BodyMedia
         }
 
@@ -222,11 +223,17 @@ object PageElement {
             ImageSource(weighting, httpsSrcSet)
         }.toSeq
 
+        val defaultImageRole = (hasShowcaseMainElement, isImmersive) match {
+          case (true, _) => Showcase
+          case (_, true) => Immersive
+          case _         => Inline
+        }
+
         List(ImageBlockElement(
           ImageMedia(signedAssets),
           imageDataFor(element),
           element.imageTypeData.flatMap(_.displayCredit),
-          Role(element.imageTypeData.flatMap(_.role)),
+          Role.fromOptionalNameWithDefaultRole(element.imageTypeData.flatMap(_.role), defaultImageRole),
           imageSources
         ))
 

--- a/common/app/model/dotcomrendering/pageElements/Role.scala
+++ b/common/app/model/dotcomrendering/pageElements/Role.scala
@@ -3,29 +3,25 @@ package model.dotcomrendering.pageElements
 import play.api.libs.json._
 
 sealed trait Role
-
 case object Inline extends Role
-
 case object Supporting extends Role
-
 case object Showcase extends Role
-
 case object Immersive extends Role
-
 case object Thumbnail extends Role
-
 case object HalfWidth extends Role
 
 object Role {
 
-  def apply(maybeName: Option[String]): Role = maybeName match {
+  def apply(maybeName: Option[String]): Role = fromOptionalNameWithDefaultRole(maybeName, Inline)
+
+  def fromOptionalNameWithDefaultRole(maybeName: Option[String], defaultRole: Role): Role = maybeName match {
     case Some("inline") => Inline
     case Some("supporting") => Supporting
     case Some("showcase") => Showcase
     case Some("immersive") => Immersive
     case Some("thumbnail") => Thumbnail
     case Some("halfWidth") => HalfWidth
-    case _ => Inline //This is the default and composer sends this as a None.
+    case _ => defaultRole
   }
 
   implicit object RoleWrites extends Writes[Role] {
@@ -38,7 +34,6 @@ object Role {
       case HalfWidth => JsString("halfWidth")
     }
   }
-
 }
 
 


### PR DESCRIPTION
## What does this change?

This change is the follow up of ( https://github.com/guardian/frontend/pull/22538 ). We also need a better management of image `Role`s. The default's `Inline` is not suitable when a role wasn't provided but the page is immersive. 
