### PR TITLE
Test opt-out for article count in the epic

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -484,4 +484,14 @@ trait FeatureSwitches {
     exposeClientSide = true
   )
 
+  val articlesViewedOptOut = Switch(
+    SwitchGroup.Feature,
+    "show-articles-viewed-opt-out",
+    "This toggles the articles viewed count opt out in the epic",
+    owners = Seq(Owner.withGithub("tomrf1")),
+    safeState = Off,
+    sellByDate = new LocalDate(2021, 6, 15),
+    exposeClientSide = true
+  )
+
 }

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -89,10 +89,12 @@ const replaceCountryName = (text: string, countryName: ?string): string =>
 
 const replaceArticlesViewed = (text: string, count: ?number): string => {
     if (count) {
+        const countValue = count;   // Flow gets confused about the value in count if we don't reassign to another const
         // A/B test the opt-out feature if the switch is enabled
         if (optOutEnabled() && userIsInArticlesViewedOptOutTest()) {
-            const html = epicArticlesViewedOptOutTemplate(count);
-            return text.replace(/%%ARTICLE_COUNT%%/g, html);
+            return text.replace(/%%ARTICLE_COUNT%% (\w+)/g, (match, nextWord) =>
+                epicArticlesViewedOptOutTemplate(countValue, nextWord)
+            );
         }
 
         return text.replace(/%%ARTICLE_COUNT%%/g, count.toString())

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -968,4 +968,5 @@ export {
     setupClickHandling,
     emitInsertEvent,
     isCompatibleWithLiveBlogEpic,
+    replaceArticlesViewed,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -33,7 +33,7 @@ import { epicButtonsTemplate } from 'common/modules/commercial/templates/acquisi
 import { acquisitionsEpicControlTemplate } from 'common/modules/commercial/templates/acquisitions-epic-control';
 import { epicLiveBlogTemplate } from 'common/modules/commercial/templates/acquisitions-epic-liveblog';
 import { epicArticlesViewedOptOutTemplate } from 'common/modules/commercial/templates/epic-articles-viewed-opt-out-template';
-import { optOutEnabled, userIsInArticlesViewedOptOutTest, setupArticlesViewedOptOut } from 'common/modules/commercial/epic-articles-viewed-opt-out';
+import { optOutEnabled, userIsInArticlesViewedOptOutTest, setupArticlesViewedOptOut, onEpicViewed } from 'common/modules/commercial/epic-articles-viewed-opt-out';
 import {
     shouldHideSupportMessaging,
     isPostAskPauseOneOffContributor,
@@ -97,7 +97,7 @@ const replaceArticlesViewed = (text: string, count: ?number): string => {
             );
         }
 
-        return text.replace(/%%ARTICLE_COUNT%%/g, count.toString())
+        return text.replace(/%%ARTICLE_COUNT%%/g, `<span class="epic-article-count__normal">${count.toString()}<span>`)
     }
     return text;
 };
@@ -314,6 +314,8 @@ const setupOnView = (
                 epicReminderEmailSignup(htmlElements);
             }
         }
+
+        onEpicViewed();
     });
 };
 
@@ -486,9 +488,9 @@ const makeEpicABTestVariant = (
                                     campaignCode
                                 );
 
-                                setupArticlesViewedOptOut();
-
                                 component.each(element => {
+                                    setupArticlesViewedOptOut();
+
                                     setupOnView(
                                         element,
                                         parentTest,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -92,7 +92,7 @@ const replaceArticlesViewed = (text: string, count: ?number): string => {
         const countValue = count;   // Flow gets confused about the value in count if we don't reassign to another const
         // A/B test the opt-out feature if the switch is enabled
         if (optOutEnabled() && userIsInArticlesViewedOptOutTest()) {
-            return text.replace(/%%ARTICLE_COUNT%% (\w+)/g, (match, nextWord) =>
+            return text.replace(/%%ARTICLE_COUNT%%( \w+)?/g, (match, nextWord) =>
                 epicArticlesViewedOptOutTemplate(countValue, nextWord)
             );
         }

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -33,10 +33,11 @@ import { epicButtonsTemplate } from 'common/modules/commercial/templates/acquisi
 import { acquisitionsEpicControlTemplate } from 'common/modules/commercial/templates/acquisitions-epic-control';
 import { epicLiveBlogTemplate } from 'common/modules/commercial/templates/acquisitions-epic-liveblog';
 import { epicArticlesViewedOptOutTemplate } from 'common/modules/commercial/templates/epic-articles-viewed-opt-out-template';
-import { optOutEnabled, userIsInArticlesViewedOptOutTest, setupArticlesViewedOptOut, OPT_OUT_COOKIE_NAME } from 'common/modules/commercial/epic-articles-viewed-opt-out';
+import { optOutEnabled, userIsInArticlesViewedOptOutTest, setupArticlesViewedOptOut } from 'common/modules/commercial/epic-articles-viewed-opt-out';
 import {
     shouldHideSupportMessaging,
     isPostAskPauseOneOffContributor,
+    ARTICLES_VIEWED_OPT_OUT_COOKIE,
 } from 'common/modules/commercial/user-features';
 import {
     supportContributeURL,
@@ -247,7 +248,7 @@ const countryNameIsOk = (
 const articleViewCountIsOk = (
     articlesViewedSettings?: ArticlesViewedSettings
 ): boolean => {
-    if (articlesViewedSettings && getCookie(OPT_OUT_COOKIE_NAME)) {
+    if (articlesViewedSettings && getCookie(ARTICLES_VIEWED_OPT_OUT_COOKIE.name)) {
         // User has opted out of articles viewed counting
         return false;
     } else if (articlesViewedSettings) {

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -33,7 +33,7 @@ import { epicButtonsTemplate } from 'common/modules/commercial/templates/acquisi
 import { acquisitionsEpicControlTemplate } from 'common/modules/commercial/templates/acquisitions-epic-control';
 import { epicLiveBlogTemplate } from 'common/modules/commercial/templates/acquisitions-epic-liveblog';
 import { epicArticlesViewedOptOutTemplate } from 'common/modules/commercial/templates/epic-articles-viewed-opt-out-template';
-import { optOutEnabled, inArticlesViewedOptOutTest, setupArticlesViewedOptOut, OPT_OUT_COOKIE_NAME } from 'common/modules/commercial/epic-articles-viewed-opt-out';
+import { optOutEnabled, userIsInArticlesViewedOptOutTest, setupArticlesViewedOptOut, OPT_OUT_COOKIE_NAME } from 'common/modules/commercial/epic-articles-viewed-opt-out';
 import {
     shouldHideSupportMessaging,
     isPostAskPauseOneOffContributor,
@@ -88,7 +88,8 @@ const replaceCountryName = (text: string, countryName: ?string): string =>
 
 const replaceArticlesViewed = (text: string, count: ?number): string => {
     if (count) {
-        if (optOutEnabled() && inArticlesViewedOptOutTest()) {
+        // A/B test the opt-out feature if the switch is enabled
+        if (optOutEnabled() && userIsInArticlesViewedOptOutTest()) {
             const html = epicArticlesViewedOptOutTemplate(count);
             return text.replace(/%%ARTICLE_COUNT%%/g, html);
         }
@@ -310,11 +311,6 @@ const setupOnView = (
                 epicReminderEmailSignup(htmlElements);
             }
         }
-
-        if (config.get('switches.showArticlesViewedOptOut')) {
-            // TODO - only works if user scrolls
-            setupArticlesViewedOptOut();
-        }
     });
 };
 
@@ -486,6 +482,8 @@ const makeEpicABTestVariant = (
                                     initVariant.products,
                                     campaignCode
                                 );
+
+                                setupArticlesViewedOptOut();
 
                                 component.each(element => {
                                     setupOnView(

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
@@ -94,7 +94,7 @@ describe('replaceArticlesViewed', () => {
 
     it('should replace the template with just the count', () => {
         const text = 'You have read %%ARTICLE_COUNT%% articles.';
-        expect(replaceArticlesViewed(text, 5)).toBe('You have read 5 articles.')
+        expect(replaceArticlesViewed(text, 5)).toBe('You have read <span class="epic-article-count__normal">5<span> articles.')
     });
 
     it('should replace the template with opt-out feature html', () => {

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
@@ -1,9 +1,17 @@
 // @flow
 
-import { buildConfiguredEpicTestFromJson } from './contributions-utilities';
+import { getCookie as getCookie_ } from 'lib/cookies';
+import config from 'lib/config';
+import { buildConfiguredEpicTestFromJson, replaceArticlesViewed } from './contributions-utilities';
 
 jest.mock('lib/raven');
 jest.mock('ophan/ng', () => null);
+
+const getCookie: any = getCookie_;
+
+jest.mock('lib/cookies', () => ({
+    getCookie: jest.fn(),
+}));
 
 const rawTest = {
     name: 'my_test',
@@ -75,5 +83,59 @@ describe('buildConfiguredEpicTestFromJson', () => {
             count: 4,
             minDaysBetweenViews: 0,
         });
+    });
+});
+
+describe('replaceArticlesViewed', () => {
+    it('should do nothing if no template', () => {
+        const text = 'This has no template.';
+        expect(replaceArticlesViewed(text, 5)).toBe(text)
+    });
+
+    it('should replace the template with just the count', () => {
+        const text = 'You have read %%ARTICLE_COUNT%% articles.';
+        expect(replaceArticlesViewed(text, 5)).toBe('You have read 5 articles.')
+    });
+
+    it('should replace the template with opt-out feature html', () => {
+        config.set('switches.showArticlesViewedOptOut', true);
+        getCookie.mockReturnValue(1);   // odd mvt values are in the variant
+
+        const text = 'You have read %%ARTICLE_COUNT%% articles.';
+        const expected = 'You have read \n' +
+            '    <span class="epic-article-count">\n' +
+            '        <input type="checkbox" id="epic-article-count__dialog-checkbox" class="epic-article-count__dialog-checkbox" />\n' +
+            '        <label for="epic-article-count__dialog-checkbox" class="epic-article-count__prompt-label">\n' +
+            '            <a>5  articles</a>\n' +
+            '        </label>\n' +
+            '        <span class="epic-article-count__dialog">\n' +
+            '            <span class="epic-article-count__dialog-close is-hidden">\n' +
+            '                <button tabindex="4" class="epic-article-count__dialog-close-button js-site-message-close" data-link-name="hide release message">\n' +
+            '                    <span class="u-h">Close the articles viewed opt out message</span>\n' +
+            '                    <svg></svg>\n' +
+            '                </button>\n' +
+            '            </span>\n' +
+            '        \n' +
+            '            <span class="epic-article-count__dialog-header">What\'s this?</span>\n' +
+            '            <span class="epic-article-count__dialog-body">Using your cookie consent, we can remind you how many Guardian articles you\'ve enjoyed on this device. Can we continue showing you this?</span>\n' +
+            '            \n' +
+            '            <span class="epic-article-count__buttons">\n' +
+            '                <a class="component-button component-button--hasicon-right contributions__contribute--epic-member epic-article-count__button-opt-out"\n' +
+            '                  target="_blank">\n' +
+            '                  No, opt me out\n' +
+            '                </a>\n' +
+            '                \n' +
+            '                <a class="component-button component-button--hasicon-right contributions__contribute--epic-member epic-article-count__button-opt-in"\n' +
+            '                  target="_blank">\n' +
+            '                  Yes, that\'s OK\n' +
+            '                </a>\n' +
+            '            </span>\n' +
+            '            \n' +
+            '            <span class="epic-article-count__dialog-note">Please note you cannot undo this action or opt back in</span>\n' +
+            '        </span>\n' +
+            '    </span>\n' +
+            '.';
+
+        expect(replaceArticlesViewed(text, 5)).toBe(expected)
     });
 });

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
@@ -99,7 +99,7 @@ describe('replaceArticlesViewed', () => {
 
     it('should replace the template with opt-out feature html', () => {
         config.set('switches.showArticlesViewedOptOut', true);
-        getCookie.mockReturnValue(1);   // odd mvt values are in the variant
+        getCookie.mockReturnValue(1);   // mvt values in the lower half of the range are in the variant
 
         const text = 'You have read %%ARTICLE_COUNT%% articles.';
         const expected = 'You have read \n' +

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
@@ -117,17 +117,17 @@ describe('replaceArticlesViewed', () => {
             '            </span>\n' +
             '        \n' +
             '            <span class="epic-article-count__dialog-header">What\'s this?</span>\n' +
-            '            <span class="epic-article-count__dialog-body">Using your cookie consent, we can remind you how many Guardian articles you\'ve enjoyed on this device. Can we continue showing you this?</span>\n' +
+            '            <span class="epic-article-count__dialog-body">We would like to remind you how many Guardian articles you\'ve enjoyed on this device. Can we continue showing you this?</span>\n' +
             '            \n' +
             '            <span class="epic-article-count__buttons">\n' +
-            '                <a class="component-button component-button--hasicon-right contributions__contribute--epic-member epic-article-count__button-opt-out"\n' +
-            '                  target="_blank">\n' +
-            '                  No, opt me out\n' +
-            '                </a>\n' +
-            '                \n' +
             '                <a class="component-button component-button--hasicon-right contributions__contribute--epic-member epic-article-count__button-opt-in"\n' +
             '                  target="_blank">\n' +
             '                  Yes, that\'s OK\n' +
+            '                </a>\n' +
+            '\n' +
+            '                <a class="component-button component-button--hasicon-right contributions__contribute--epic-member epic-article-count__button-opt-out"\n' +
+            '                  target="_blank">\n' +
+            '                  No, opt me out\n' +
             '                </a>\n' +
             '            </span>\n' +
             '            \n' +

--- a/static/src/javascripts/projects/common/modules/commercial/epic-articles-viewed-opt-out.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic-articles-viewed-opt-out.js
@@ -26,21 +26,20 @@ type ArticlesViewedOptOutElements = {
     note: HTMLElement,
 }
 
-const getElements = (element: HTMLElement): ?ArticlesViewedOptOutElements => {
-    const checkbox = element.querySelector('#epic-article-count__dialog-checkbox');
+const getElements = (container: HTMLElement): ?ArticlesViewedOptOutElements => {
+    const checkbox = container.querySelector('#epic-article-count__dialog-checkbox');
 
-    const labelElement = element.querySelector('.epic-article-count__prompt-label');
-    const optOutButton = element.querySelector('.epic-article-count__button-opt-out');
-    const optInButton = element.querySelector('.epic-article-count__button-opt-in');
+    const labelElement = container.querySelector('.epic-article-count__prompt-label');
+    const optOutButton = container.querySelector('.epic-article-count__button-opt-out');
+    const optInButton = container.querySelector('.epic-article-count__button-opt-in');
 
-    const closeButton = element.querySelector('.epic-article-count__dialog-close');
-    const buttons = element.querySelector('.epic-article-count__buttons');
-    const header = element.querySelector('.epic-article-count__dialog-header');
-    const body = element.querySelector('.epic-article-count__dialog-body');
-    const note = element.querySelector('.epic-article-count__dialog-note');
+    const closeButton = container.querySelector('.epic-article-count__dialog-close');
+    const buttons = container.querySelector('.epic-article-count__buttons');
+    const header = container.querySelector('.epic-article-count__dialog-header');
+    const body = container.querySelector('.epic-article-count__dialog-body');
+    const note = container.querySelector('.epic-article-count__dialog-note');
 
     if (
-        element &&
         checkbox instanceof HTMLInputElement &&
         labelElement &&
         optOutButton &&
@@ -52,7 +51,6 @@ const getElements = (element: HTMLElement): ?ArticlesViewedOptOutElements => {
         note
     ) {
         return {
-            element,
             checkbox,
             labelElement,
             optOutButton,
@@ -134,21 +132,39 @@ const setupHandlers = (elements: ArticlesViewedOptOutElements) => {
     });
 };
 
+const onEpicViewed = () => {
+    if (optOutEnabled()) {
+        // Send the view event if this is an epic with an articles-viewed count.
+        // Send for both the control and the variant, so that we can measure impact on conversions.
+        const getArticleCountViewEventId = (): ?string => {
+            if (document.querySelector('.epic-article-count')) {
+                return 'articles-viewed-opt-out_view-variant';
+            } else if (document.querySelector('.epic-article-count__normal')) {
+                return 'articles-viewed-opt-out_view-control';
+            } 
+                return null;    // no articles-viewed count
+            
+        };
+
+        const viewEventId = getArticleCountViewEventId();
+        if (viewEventId) {
+            submitViewEvent({
+                component: {
+                    componentType: 'ACQUISITIONS_OTHER',
+                    id: viewEventId,
+                },
+            });
+        }
+    }
+};
+
 const setupArticlesViewedOptOut = () => {
     if (optOutEnabled()) {
         // If this element exists then they're in the variant
-        const element = document.querySelector('.epic-article-count');
-        const viewEventId = `articles-viewed-opt-out_view-${element ? 'variant' : 'control'}`;
+        const articleCountElement = document.querySelector('.epic-article-count');
 
-        submitViewEvent({
-            component: {
-                componentType: 'ACQUISITIONS_OTHER',
-                id: viewEventId,
-            },
-        });
-
-        if (element) {
-            const elements: ?ArticlesViewedOptOutElements = getElements(element);
+        if (articleCountElement) {
+            const elements: ?ArticlesViewedOptOutElements = getElements(articleCountElement);
 
             if (elements) {
                 setupHandlers(elements);
@@ -171,4 +187,5 @@ export {
     optOutEnabled,
     userIsInArticlesViewedOptOutTest,
     setupArticlesViewedOptOut,
+    onEpicViewed,
 }

--- a/static/src/javascripts/projects/common/modules/commercial/epic-articles-viewed-opt-out.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic-articles-viewed-opt-out.js
@@ -67,10 +67,7 @@ const setupHandlers = (elements: ArticlesViewedOptOutElements) => {
 
     const hideDialog = () => {
         // This is the hidden checkbox that we use to hide/unhide the dialog using css only
-        const checkbox = document.querySelector('#epic-article-count__dialog-checkbox');
-        if (checkbox instanceof HTMLInputElement) {
-            checkbox.checked = false;
-        }
+        elements.checkbox.checked = false;
     };
 
     const onArticlesViewedClick = () => {

--- a/static/src/javascripts/projects/common/modules/commercial/epic-articles-viewed-opt-out.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic-articles-viewed-opt-out.js
@@ -52,7 +52,7 @@ const onOptOutClick = () => {
     const closeButton = document.querySelector('.epic-article-count__dialog-close');
     if (closeButton) {
         document.querySelector('.epic-article-count__dialog-close').classList.remove('is-hidden');
-        closeButton.addEventListener('click', (event: Event) => {
+        closeButton.addEventListener('click', () => {
             hideDialog();
         });
     }
@@ -94,10 +94,10 @@ const setupArticlesViewedOptOut = () => {
             const labelElement = element.querySelector('.epic-article-count__dialog');
             const optOutButton = element.querySelector('.epic-article-count__button-opt-out');
             const optInButton = element.querySelector('.epic-article-count__button-opt-in');
-            debugger
+            
 
             if (labelElement && optOutButton && optInButton) {
-                labelElement.addEventListener('click', (event: Event) => {
+                labelElement.addEventListener('click', () => {
                     onArticlesViewedClick();
                 });
 

--- a/static/src/javascripts/projects/common/modules/commercial/epic-articles-viewed-opt-out.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic-articles-viewed-opt-out.js
@@ -13,28 +13,20 @@ const optOutEnabled = () => config.get('switches.showArticlesViewedOptOut');
 const userIsInArticlesViewedOptOutTest = () => Number(getMvtValue()) % 2;
 
 const hideDialog = () => {
-    const checkbox = document.querySelector('#epic-article-count__dialog');
+    const checkbox = document.querySelector('#epic-article-count__dialog-checkbox');
     if (checkbox instanceof HTMLInputElement) {
         checkbox.checked = false;
     }
 };
 
-const showDialog = () => {
-    const checkbox = document.querySelector('#epic-article-count__dialog');
-    if (checkbox instanceof HTMLInputElement) {
-        checkbox.checked = true;
-    }
-};
-
 const onArticlesViewedClick = () => {
+    // Only need to send the tracking event here, as the dialog is displayed using only css
     submitClickEvent({
         component: {
             componentType: 'ACQUISITIONS_OTHER',
             id: 'articles-viewed-opt-out_open',
         },
     });
-    // TODO - also show dialog this way? Or use css-only?
-    showDialog();
 };
 
 const onOptOutClick = () => {
@@ -63,8 +55,7 @@ const onOptOutClick = () => {
         buttons.remove();
         header.innerHTML = `You've opted out`;
         body.innerHTML = `Starting from your next page view, we won't count the articles you read or show you this message for three months.`;
-        // TODO - add url
-        note.innerHTML = `If you have any questions, please <a href="">contact us</a>.`;
+        note.innerHTML = `If you have any questions, please <a target="_blank" href="https://www.theguardian.com/help/contact-us">contact us</a>.`;
     }
 };
 
@@ -93,7 +84,7 @@ const setupArticlesViewedOptOut = () => {
         });
 
         if (element) {
-            const labelElement = element.querySelector('.epic-article-count__dialog');
+            const labelElement = element.querySelector('.epic-article-count__prompt-label');
             const optOutButton = element.querySelector('.epic-article-count__button-opt-out');
             const optInButton = element.querySelector('.epic-article-count__button-opt-in');
             

--- a/static/src/javascripts/projects/common/modules/commercial/epic-articles-viewed-opt-out.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic-articles-viewed-opt-out.js
@@ -10,36 +10,34 @@ const COOKIE_DAYS_TO_LIVE = 90;
 
 const optOutEnabled = () => config.get('switches.showArticlesViewedOptOut');
 // Show the opt-out to 50% of the audience
-const inArticlesViewedOptOutTest = () => Number(getMvtValue()) % 2;
+const userIsInArticlesViewedOptOutTest = () => Number(getMvtValue()) % 2;
 
 const hideDialog = () => {
     const checkbox = document.querySelector('#epic-article-count__dialog');
-    if (checkbox) {
+    if (checkbox instanceof HTMLInputElement) {
         checkbox.checked = false;
     }
 };
 
 const showDialog = () => {
     const checkbox = document.querySelector('#epic-article-count__dialog');
-    if (checkbox) {
+    if (checkbox instanceof HTMLInputElement) {
         checkbox.checked = true;
     }
 };
 
 const onArticlesViewedClick = () => {
-    console.log("onArticlesViewedClick")
     submitClickEvent({
         component: {
             componentType: 'ACQUISITIONS_OTHER',
             id: 'articles-viewed-opt-out_open',
         },
-    })
+    });
     // TODO - also show dialog this way? Or use css-only?
     showDialog();
 };
 
 const onOptOutClick = () => {
-    console.log("onOptOutClick")
     submitClickEvent({
         component: {
             componentType: 'ACQUISITIONS_OTHER',
@@ -49,23 +47,28 @@ const onOptOutClick = () => {
 
     addCookie(OPT_OUT_COOKIE_NAME, new Date().getTime().toString(), COOKIE_DAYS_TO_LIVE);
 
+    // Update the dialog message
     const closeButton = document.querySelector('.epic-article-count__dialog-close');
-    if (closeButton) {
-        document.querySelector('.epic-article-count__dialog-close').classList.remove('is-hidden');
+    const buttons = document.querySelector('.epic-article-count__buttons');
+    const header = document.querySelector('.epic-article-count__dialog-header');
+    const body = document.querySelector('.epic-article-count__dialog-body');
+    const note = document.querySelector('.epic-article-count__dialog-note');
+
+    if (closeButton && buttons && header && body && note) {
+        closeButton.classList.remove('is-hidden');
         closeButton.addEventListener('click', () => {
             hideDialog();
         });
-    }
 
-    document.querySelector('.epic-article-count__buttons').remove();
-    document.querySelector('.epic-article-count__dialog-header').innerHTML = `You've opted out`;
-    document.querySelector('.epic-article-count__dialog-body').innerHTML = `Starting from your next page view, we won't count the articles you read or show you this message for three months.`;
-    // TODO - add url
-    document.querySelector('.epic-article-count__dialog-note').innerHTML = `If you have any questions, please <a href="">contact us</a>.`;
+        buttons.remove();
+        header.innerHTML = `You've opted out`;
+        body.innerHTML = `Starting from your next page view, we won't count the articles you read or show you this message for three months.`;
+        // TODO - add url
+        note.innerHTML = `If you have any questions, please <a href="">contact us</a>.`;
+    }
 };
 
 const onOptInClick = () => {
-    console.log("onOptInClick")
     submitClickEvent({
         component: {
             componentType: 'ACQUISITIONS_OTHER',
@@ -88,7 +91,6 @@ const setupArticlesViewedOptOut = () => {
                 id: viewEventId,
             },
         });
-        console.log("submitted view", viewEventId)
 
         if (element) {
             const labelElement = element.querySelector('.epic-article-count__dialog');
@@ -117,7 +119,7 @@ const setupArticlesViewedOptOut = () => {
 
 export {
     optOutEnabled,
-    inArticlesViewedOptOutTest,
+    userIsInArticlesViewedOptOutTest,
     setupArticlesViewedOptOut,
     OPT_OUT_COOKIE_NAME,
 }

--- a/static/src/javascripts/projects/common/modules/commercial/epic-articles-viewed-opt-out.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic-articles-viewed-opt-out.js
@@ -4,7 +4,9 @@ import config from "lib/config";
 import {getMvtNumValues, getMvtValue} from "common/modules/analytics/mvt-cookie";
 import {submitClickEvent, submitViewEvent} from "common/modules/commercial/acquisitions-ophan";
 import { ARTICLES_VIEWED_OPT_OUT_COOKIE } from "common/modules/commercial/user-features";
+import { storageKeyWeeklyArticleCount, storageKeyDailyArticleCount } from "common/modules/onward/history";
 import {addCookie} from "lib/cookies";
+import { local } from 'lib/storage';
 import reportError from "lib/report-error";
 
 const optOutEnabled = () => config.get('switches.showArticlesViewedOptOut');
@@ -89,7 +91,10 @@ const setupHandlers = (elements: ArticlesViewedOptOutElements) => {
             },
         });
 
+        // Stop counting and clear the user's history
         addCookie(ARTICLES_VIEWED_OPT_OUT_COOKIE.name, new Date().getTime().toString(), ARTICLES_VIEWED_OPT_OUT_COOKIE.daysToLive);
+        local.remove(storageKeyWeeklyArticleCount);
+        local.remove(storageKeyDailyArticleCount);
 
         // Update the dialog message
         elements.closeButton.classList.remove('is-hidden');

--- a/static/src/javascripts/projects/common/modules/commercial/epic-articles-viewed-opt-out.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic-articles-viewed-opt-out.js
@@ -3,10 +3,8 @@
 import config from "lib/config";
 import {getMvtValue} from "common/modules/analytics/mvt-cookie";
 import {submitClickEvent, submitViewEvent} from "common/modules/commercial/acquisitions-ophan";
+import { ARTICLES_VIEWED_OPT_OUT_COOKIE } from "common/modules/commercial/user-features";
 import {addCookie} from "lib/cookies";
-
-const OPT_OUT_COOKIE_NAME = 'gu_article_count_opt_out';
-const COOKIE_DAYS_TO_LIVE = 90;
 
 const optOutEnabled = () => config.get('switches.showArticlesViewedOptOut');
 // Show the opt-out to 50% of the audience
@@ -37,7 +35,7 @@ const onOptOutClick = () => {
         },
     });
 
-    addCookie(OPT_OUT_COOKIE_NAME, new Date().getTime().toString(), COOKIE_DAYS_TO_LIVE);
+    addCookie(ARTICLES_VIEWED_OPT_OUT_COOKIE.name, new Date().getTime().toString(), ARTICLES_VIEWED_OPT_OUT_COOKIE.daysToLive);
 
     // Update the dialog message
     const closeButton = document.querySelector('.epic-article-count__dialog-close');
@@ -112,5 +110,4 @@ export {
     optOutEnabled,
     userIsInArticlesViewedOptOutTest,
     setupArticlesViewedOptOut,
-    OPT_OUT_COOKIE_NAME,
 }

--- a/static/src/javascripts/projects/common/modules/commercial/epic-articles-viewed-opt-out.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic-articles-viewed-opt-out.js
@@ -1,0 +1,123 @@
+// @flow
+
+import config from "lib/config";
+import {getMvtValue} from "common/modules/analytics/mvt-cookie";
+import {submitClickEvent, submitViewEvent} from "common/modules/commercial/acquisitions-ophan";
+import {addCookie} from "lib/cookies";
+
+const OPT_OUT_COOKIE_NAME = 'gu_article_count_opt_out';
+const COOKIE_DAYS_TO_LIVE = 90;
+
+const optOutEnabled = () => config.get('switches.showArticlesViewedOptOut');
+// Show the opt-out to 50% of the audience
+const inArticlesViewedOptOutTest = () => Number(getMvtValue()) % 2;
+
+const hideDialog = () => {
+    const checkbox = document.querySelector('#epic-article-count__dialog');
+    if (checkbox) {
+        checkbox.checked = false;
+    }
+};
+
+const showDialog = () => {
+    const checkbox = document.querySelector('#epic-article-count__dialog');
+    if (checkbox) {
+        checkbox.checked = true;
+    }
+};
+
+const onArticlesViewedClick = () => {
+    console.log("onArticlesViewedClick")
+    submitClickEvent({
+        component: {
+            componentType: 'ACQUISITIONS_OTHER',
+            id: 'articles-viewed-opt-out_open',
+        },
+    })
+    // TODO - also show dialog this way? Or use css-only?
+    showDialog();
+};
+
+const onOptOutClick = () => {
+    console.log("onOptOutClick")
+    submitClickEvent({
+        component: {
+            componentType: 'ACQUISITIONS_OTHER',
+            id: 'articles-viewed-opt-out_out',
+        },
+    });
+
+    addCookie(OPT_OUT_COOKIE_NAME, new Date().getTime().toString(), COOKIE_DAYS_TO_LIVE);
+
+    const closeButton = document.querySelector('.epic-article-count__dialog-close');
+    if (closeButton) {
+        document.querySelector('.epic-article-count__dialog-close').classList.remove('is-hidden');
+        closeButton.addEventListener('click', (event: Event) => {
+            hideDialog();
+        });
+    }
+
+    document.querySelector('.epic-article-count__buttons').remove();
+    document.querySelector('.epic-article-count__dialog-header').innerHTML = `You've opted out`;
+    document.querySelector('.epic-article-count__dialog-body').innerHTML = `Starting from your next page view, we won't count the articles you read or show you this message for three months.`;
+    // TODO - add url
+    document.querySelector('.epic-article-count__dialog-note').innerHTML = `If you have any questions, please <a href="">contact us</a>.`;
+};
+
+const onOptInClick = () => {
+    console.log("onOptInClick")
+    submitClickEvent({
+        component: {
+            componentType: 'ACQUISITIONS_OTHER',
+            id: 'articles-viewed-opt-out_in',
+        },
+    });
+
+    hideDialog();
+};
+
+const setupArticlesViewedOptOut = () => {
+    if (optOutEnabled()) {
+        // If this element exists then they're in the variant
+        const element = document.querySelector('.epic-article-count');
+        const viewEventId = `articles-viewed-opt-out_view-${element ? 'variant' : 'control'}`;
+
+        submitViewEvent({
+            component: {
+                componentType: 'ACQUISITIONS_OTHER',
+                id: viewEventId,
+            },
+        });
+        console.log("submitted view", viewEventId)
+
+        if (element) {
+            const labelElement = element.querySelector('.epic-article-count__dialog');
+            const optOutButton = element.querySelector('.epic-article-count__button-opt-out');
+            const optInButton = element.querySelector('.epic-article-count__button-opt-in');
+            debugger
+
+            if (labelElement && optOutButton && optInButton) {
+                labelElement.addEventListener('click', (event: Event) => {
+                    onArticlesViewedClick();
+                });
+
+                optOutButton.addEventListener('click', (event: Event) => {
+                    event.preventDefault();
+                    onOptOutClick();
+                });
+
+                optInButton.addEventListener('click', (event: Event) => {
+                    event.preventDefault();
+                    onOptInClick();
+                });
+            }
+        }
+    }
+};
+
+export {
+    optOutEnabled,
+    inArticlesViewedOptOutTest,
+    setupArticlesViewedOptOut,
+    OPT_OUT_COOKIE_NAME,
+}

--- a/static/src/javascripts/projects/common/modules/commercial/epic-articles-viewed-opt-out.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic-articles-viewed-opt-out.js
@@ -1,15 +1,16 @@
 // @flow
 
 import config from "lib/config";
-import {getMvtValue} from "common/modules/analytics/mvt-cookie";
+import {getMvtNumValues, getMvtValue} from "common/modules/analytics/mvt-cookie";
 import {submitClickEvent, submitViewEvent} from "common/modules/commercial/acquisitions-ophan";
 import { ARTICLES_VIEWED_OPT_OUT_COOKIE } from "common/modules/commercial/user-features";
 import {addCookie} from "lib/cookies";
 import reportError from "lib/report-error";
 
 const optOutEnabled = () => config.get('switches.showArticlesViewedOptOut');
-// Show the opt-out to 50% of the audience
-const userIsInArticlesViewedOptOutTest = () => Number(getMvtValue()) % 2;
+// Show the opt-out to 50% of the audience. We do not use `mvt % 2` here because then it would align
+// with the variants of the underlying A/B tests and distort the results
+const userIsInArticlesViewedOptOutTest = () => Number(getMvtValue()) < getMvtNumValues() / 2;
 
 type ArticlesViewedOptOutElements = {
     checkbox: HTMLInputElement,

--- a/static/src/javascripts/projects/common/modules/commercial/templates/epic-articles-viewed-opt-out-template.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/epic-articles-viewed-opt-out-template.js
@@ -1,11 +1,11 @@
 // @flow
 import closeIcon from 'svgs/icon/close-large.svg';
 
-export const epicArticlesViewedOptOutTemplate = (count: number): string => `
+export const epicArticlesViewedOptOutTemplate = (count: number, nextWord: ?string): string => `
     <span class="epic-article-count">
         <input type="checkbox" id="epic-article-count__dialog-checkbox" class="epic-article-count__dialog-checkbox" />
         <label for="epic-article-count__dialog-checkbox" class="epic-article-count__prompt-label">
-            <a>${count.toString()}</a>
+            <a>${count.toString()}${nextWord ? ` ${nextWord}` : ''}</a>
         </label>
         <span class="epic-article-count__dialog">
             <span class="epic-article-count__dialog-close is-hidden">

--- a/static/src/javascripts/projects/common/modules/commercial/templates/epic-articles-viewed-opt-out-template.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/epic-articles-viewed-opt-out-template.js
@@ -3,8 +3,8 @@ import closeIcon from 'svgs/icon/close-large.svg';
 
 export const epicArticlesViewedOptOutTemplate = (count: number): string => `
     <span class="epic-article-count">
-        <input type="checkbox" id="epic-article-count__dialog" class="epic-article-count__dialog" />
-        <label for="epic-article-count__dialog" class="epic-article-count__prompt-label">
+        <input type="checkbox" id="epic-article-count__dialog-checkbox" class="epic-article-count__dialog-checkbox" />
+        <label for="epic-article-count__dialog-checkbox" class="epic-article-count__prompt-label">
             <a>${count.toString()}</a>
         </label>
         <span class="epic-article-count__dialog">

--- a/static/src/javascripts/projects/common/modules/commercial/templates/epic-articles-viewed-opt-out-template.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/epic-articles-viewed-opt-out-template.js
@@ -16,17 +16,17 @@ export const epicArticlesViewedOptOutTemplate = (count: number, nextWord: ?strin
             </span>
         
             <span class="epic-article-count__dialog-header">What's this?</span>
-            <span class="epic-article-count__dialog-body">Using your cookie consent, we can remind you how many Guardian articles you've enjoyed on this device. Can we continue showing you this?</span>
+            <span class="epic-article-count__dialog-body">We would like to remind you how many Guardian articles you've enjoyed on this device. Can we continue showing you this?</span>
             
             <span class="epic-article-count__buttons">
-                <a class="component-button component-button--hasicon-right contributions__contribute--epic-member epic-article-count__button-opt-out"
-                  target="_blank">
-                  No, opt me out
-                </a>
-                
                 <a class="component-button component-button--hasicon-right contributions__contribute--epic-member epic-article-count__button-opt-in"
                   target="_blank">
                   Yes, that's OK
+                </a>
+
+                <a class="component-button component-button--hasicon-right contributions__contribute--epic-member epic-article-count__button-opt-out"
+                  target="_blank">
+                  No, opt me out
                 </a>
             </span>
             

--- a/static/src/javascripts/projects/common/modules/commercial/templates/epic-articles-viewed-opt-out-template.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/epic-articles-viewed-opt-out-template.js
@@ -1,24 +1,30 @@
 // @flow
+import closeIcon from 'svgs/icon/close-large.svg';
 
-export const epicArticlesViewedOptOut = (count: number): string => `
+export const epicArticlesViewedOptOutTemplate = (count: number): string => `
     <span class="epic-article-count">
-        <input type="checkbox" id="epic-article-count__reveal-reminder" class="epic-article-count__reveal-reminder" />
-        <label for="epic-article-count__reveal-reminder" class="epic-article-count__prompt-label">
+        <input type="checkbox" id="epic-article-count__dialog" class="epic-article-count__dialog" />
+        <label for="epic-article-count__dialog" class="epic-article-count__prompt-label">
             <a>${count.toString()}</a>
         </label>
         <span class="epic-article-count__dialog">
+            <span class="epic-article-count__dialog-close is-hidden">
+                <button tabindex="4" class="epic-article-count__dialog-close-button js-site-message-close" data-link-name="hide release message">
+                    <span class="u-h">Close the articles viewed opt out message</span>
+                    ${closeIcon.markup}
+                </button>
+            </span>
+        
             <span class="epic-article-count__dialog-header">What's this?</span>
             <span class="epic-article-count__dialog-body">Using your cookie consent, we can remind you how many Guardian articles you've enjoyed on this device. Can we continue showing you this?</span>
             
             <span class="epic-article-count__buttons">
                 <a class="component-button component-button--hasicon-right contributions__contribute--epic-member epic-article-count__button-opt-out"
-                  href=""
                   target="_blank">
                   No, opt me out
                 </a>
                 
                 <a class="component-button component-button--hasicon-right contributions__contribute--epic-member epic-article-count__button-opt-in"
-                  href=""
                   target="_blank">
                   Yes, that's OK
                 </a>

--- a/static/src/javascripts/projects/common/modules/commercial/templates/epic-articles-viewed-opt-out.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/epic-articles-viewed-opt-out.js
@@ -1,0 +1,30 @@
+// @flow
+
+export const epicArticlesViewedOptOut = (count: number): string => `
+    <span class="epic-article-count">
+        <input type="checkbox" id="epic-article-count__reveal-reminder" class="epic-article-count__reveal-reminder" />
+        <label for="epic-article-count__reveal-reminder" class="epic-article-count__prompt-label">
+            <a>${count.toString()}</a>
+        </label>
+        <span class="epic-article-count__dialog">
+            <span class="epic-article-count__dialog-header">What's this?</span>
+            <span class="epic-article-count__dialog-body">Using your cookie consent, we can remind you how many Guardian articles you've enjoyed on this device. Can we continue showing you this?</span>
+            
+            <span class="epic-article-count__buttons">
+                <a class="component-button component-button--hasicon-right contributions__contribute--epic-member epic-article-count__button-opt-out"
+                  href=""
+                  target="_blank">
+                  No, opt me out
+                </a>
+                
+                <a class="component-button component-button--hasicon-right contributions__contribute--epic-member epic-article-count__button-opt-in"
+                  href=""
+                  target="_blank">
+                  Yes, that's OK
+                </a>
+            </span>
+            
+            <span class="epic-article-count__dialog-note">Please note you cannot undo this action or opt back in</span>
+        </span>
+    </span>
+`;

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -26,6 +26,11 @@ const SUPPORT_RECURRING_CONTRIBUTOR_ANNUAL_COOKIE =
 const SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE =
     'gu.contributions.contrib-timestamp';
 
+const ARTICLES_VIEWED_OPT_OUT_COOKIE = {
+    name: 'gu_article_count_opt_out',
+    daysToLive: 90,
+};
+
 const forcedAdFreeMode: boolean = !!window.location.hash.match(
     /[#&]noadsaf(&.*)?$/
 );
@@ -330,4 +335,5 @@ export {
     fakeOneOffContributor,
     shouldNotBeShownSupportMessaging,
     extendContribsCookieExpiry,
+    ARTICLES_VIEWED_OPT_OUT_COOKIE,
 };

--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -581,6 +581,8 @@ export {
     getArticleViewCountForDays,
     getArticleViewCountForWeeks,
     getMondayFromDate,
+    storageKeyDailyArticleCount,
+    storageKeyWeeklyArticleCount,
 };
 
 export const _ = {

--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -11,7 +11,7 @@ import isObject from 'lodash/isObject';
 
 import type { bonzo } from 'bonzo';
 import {getCookie} from "lib/cookies";
-import {OPT_OUT_COOKIE_NAME} from "common/modules/commercial/epic-articles-viewed-opt-out";
+import { ARTICLES_VIEWED_OPT_OUT_COOKIE } from "common/modules/commercial/user-features";
 
 const editions = ['uk', 'us', 'au'];
 
@@ -478,7 +478,7 @@ const showInMegaNavEnable = (bool: boolean): void => {
 };
 
 const incrementDailyArticleCount = (pageConfig: Object): void => {
-    if (!pageConfig.isFront && !getCookie(OPT_OUT_COOKIE_NAME)) {
+    if (!pageConfig.isFront && !getCookie(ARTICLES_VIEWED_OPT_OUT_COOKIE.name)) {
         const dailyCount = local.get(storageKeyDailyArticleCount) || [];
 
         if (dailyCount[0] && dailyCount[0].day && dailyCount[0].day === today) {
@@ -502,7 +502,7 @@ const incrementDailyArticleCount = (pageConfig: Object): void => {
 };
 
 const incrementWeeklyArticleCount = (pageConfig: Object): void => {
-    if (!pageConfig.isFront && !getCookie(OPT_OUT_COOKIE_NAME)) {
+    if (!pageConfig.isFront && !getCookie(ARTICLES_VIEWED_OPT_OUT_COOKIE.name)) {
         const weeklyArticleCount =
             local.get(storageKeyWeeklyArticleCount) || [];
         if (

--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -10,6 +10,8 @@ import { getPath } from 'lib/url';
 import isObject from 'lodash/isObject';
 
 import type { bonzo } from 'bonzo';
+import {getCookie} from "lib/cookies";
+import {OPT_OUT_COOKIE_NAME} from "common/modules/commercial/epic-articles-viewed-opt-out";
 
 const editions = ['uk', 'us', 'au'];
 
@@ -476,7 +478,7 @@ const showInMegaNavEnable = (bool: boolean): void => {
 };
 
 const incrementDailyArticleCount = (pageConfig: Object): void => {
-    if (!pageConfig.isFront) {
+    if (!pageConfig.isFront && !getCookie(OPT_OUT_COOKIE_NAME)) {
         const dailyCount = local.get(storageKeyDailyArticleCount) || [];
 
         if (dailyCount[0] && dailyCount[0].day && dailyCount[0].day === today) {
@@ -500,7 +502,7 @@ const incrementDailyArticleCount = (pageConfig: Object): void => {
 };
 
 const incrementWeeklyArticleCount = (pageConfig: Object): void => {
-    if (!pageConfig.isFront) {
+    if (!pageConfig.isFront && !getCookie(OPT_OUT_COOKIE_NAME)) {
         const weeklyArticleCount =
             local.get(storageKeyWeeklyArticleCount) || [];
         if (

--- a/static/src/javascripts/projects/common/modules/onward/history.spec.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.spec.js
@@ -34,6 +34,20 @@ jest.mock('lib/url', () => ({
 
 jest.mock('fastdom');
 
+jest.mock('lib/cookies', () => ({
+    getCookie: jest.fn(),
+}));
+
+jest.mock('raven-js', () => ({
+    config() {
+        return this;
+    },
+    install() {
+        return this;
+    },
+    captureException: jest.fn(),
+}));
+
 const contains = [['/p/3kvgc', 1], ['/p/3kx8f', 1], ['/p/3kx7e', 1]];
 
 const today = Math.floor(Date.now() / 86400000); // 1 day in ms

--- a/static/src/javascripts/projects/common/modules/onward/history.spec.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.spec.js
@@ -17,7 +17,9 @@ import {
     getArticleViewCountForWeeks,
     incrementWeeklyArticleCount,
 } from 'common/modules/onward/history';
+import { getCookie as getCookie_ } from 'lib/cookies';
 import { local as localStorageStub } from 'lib/storage';
+import { ARTICLES_VIEWED_OPT_OUT_COOKIE } from "common/modules/commercial/user-features";
 
 jest.mock('lib/storage', () => ({
     local: {
@@ -33,6 +35,8 @@ jest.mock('lib/url', () => ({
 }));
 
 jest.mock('fastdom');
+
+const getCookie: any = getCookie_;
 
 jest.mock('lib/cookies', () => ({
     getCookie: jest.fn(),
@@ -459,5 +463,15 @@ describe('history', () => {
         expect(localStorageStub.get('gu.history.weeklyArticleCount')).toEqual([
             { week: startOfThisWeek, count: 1 },
         ]);
+    });
+
+    it('does not increment the weekly article count if opt-out cookie set', () => {
+        const counts = [{ week: startOfThisWeek, count: 1 }];
+        localStorageStub.set('gu.history.weeklyArticleCount', counts);
+        getCookie.mockReturnValue(ARTICLES_VIEWED_OPT_OUT_COOKIE.name);
+
+        incrementWeeklyArticleCount(pageConfig);
+
+        expect(getArticleViewCountForWeeks(1)).toEqual(1);
     });
 });

--- a/static/src/javascripts/projects/common/modules/onward/history.spec.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.spec.js
@@ -19,7 +19,6 @@ import {
 } from 'common/modules/onward/history';
 import { getCookie as getCookie_ } from 'lib/cookies';
 import { local as localStorageStub } from 'lib/storage';
-import { ARTICLES_VIEWED_OPT_OUT_COOKIE } from "common/modules/commercial/user-features";
 
 jest.mock('lib/storage', () => ({
     local: {
@@ -468,7 +467,7 @@ describe('history', () => {
     it('does not increment the weekly article count if opt-out cookie set', () => {
         const counts = [{ week: startOfThisWeek, count: 1 }];
         localStorageStub.set('gu.history.weeklyArticleCount', counts);
-        getCookie.mockReturnValue(ARTICLES_VIEWED_OPT_OUT_COOKIE.name);
+        getCookie.mockReturnValue(new Date().getTime().toString());
 
         incrementWeeklyArticleCount(pageConfig);
 

--- a/static/src/stylesheets/_common.garnett.scss
+++ b/static/src/stylesheets/_common.garnett.scss
@@ -34,6 +34,7 @@
 @import 'module/reader-revenue/epic';
 @import 'module/reader-revenue/epic-ticker';
 @import 'module/reader-revenue/epic-reminder';
+@import 'module/reader-revenue/epic-article-count-opt-out';
 @import 'module/reader-revenue/banner-ticker';
 @import 'module/reader-revenue/reader-revenue-button';
 @import 'module/reader-revenue/moment-epic';

--- a/static/src/stylesheets/module/reader-revenue/_epic-article-count-opt-out.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic-article-count-opt-out.scss
@@ -4,21 +4,28 @@
 }
 
 // This is the hidden checkbox that we use to hide/unhide the dialog using css only
-.epic-article-count__dialog {
+.epic-article-count__dialog-checkbox {
     display: none;
 }
 
-.epic-article-count__dialog:checked ~ .epic-article-count__dialog {
+.epic-article-count__dialog-checkbox:checked ~ .epic-article-count__dialog {
     display: block;
 }
 
 .epic-article-count__dialog {
     display: none;
     position: absolute;
-    left: 0;
     top: 23px;
     z-index: 1;
-    min-width: 300px;
+
+    @include mq($until: tablet) {
+        min-width: 280px;
+        margin-left: 5px;
+    }
+    @include mq($from: tablet) {
+        left: 0;
+        min-width: 300px;
+    }
 
     background-color: $brand-main;
     color: $brightness-100;
@@ -62,19 +69,20 @@
 }
 
 .epic-article-count__buttons {
-    display: flex;
+    @include mq($from: tablet) {
+        display: flex;
+    }
+    margin-bottom: 15px;
 }
 
 .epic-article-count a.epic-article-count__button-opt-out {
     background-color: $brightness-100;
     color: $brand-main;
-    margin-bottom: 15px;
 }
 
 .epic-article-count a.epic-article-count__button-opt-in {
     background-color: $brand-main;
     color: $brightness-100;
-    margin-bottom: 15px;
     border: solid 1px $brightness-100;
 }
 

--- a/static/src/stylesheets/module/reader-revenue/_epic-article-count-opt-out.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic-article-count-opt-out.scss
@@ -3,8 +3,13 @@
     display: inline;
 }
 
+// This is the hidden checkbox that we use to hide/unhide the dialog using css only
 .epic-article-count__reveal-reminder {
     display: none;
+}
+
+.epic-article-count__reveal-reminder:checked ~ .epic-article-count__dialog {
+    display: block;
 }
 
 .epic-article-count__dialog {
@@ -42,10 +47,6 @@
         font-style: italic;
         display: block;
     }
-}
-
-.epic-article-count__reveal-reminder:checked ~ .epic-article-count__dialog {
-    display: block;
 }
 
 .epic-article-count .epic-article-count__prompt-label a {

--- a/static/src/stylesheets/module/reader-revenue/_epic-article-count-opt-out.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic-article-count-opt-out.scss
@@ -4,11 +4,11 @@
 }
 
 // This is the hidden checkbox that we use to hide/unhide the dialog using css only
-.epic-article-count__reveal-reminder {
+.epic-article-count__dialog {
     display: none;
 }
 
-.epic-article-count__reveal-reminder:checked ~ .epic-article-count__dialog {
+.epic-article-count__dialog:checked ~ .epic-article-count__dialog {
     display: block;
 }
 
@@ -16,8 +16,9 @@
     display: none;
     position: absolute;
     left: 0;
-    top: 20px;
+    top: 23px;
     z-index: 1;
+    min-width: 300px;
 
     background-color: $brand-main;
     color: $brightness-100;
@@ -46,12 +47,17 @@
         line-height: 15px;
         font-style: italic;
         display: block;
+
+        a {
+            text-decoration: underline;
+            color: $brightness-100;
+        }
     }
 }
 
 .epic-article-count .epic-article-count__prompt-label a {
     text-decoration: none;
-    border-bottom: 1px solid $brightness-86;
+    border-bottom: 1px solid $brightness-7;
     color: $brightness-7;
 }
 
@@ -70,4 +76,21 @@
     color: $brightness-100;
     margin-bottom: 15px;
     border: solid 1px $brightness-100;
+}
+
+.epic-article-count__dialog-close {
+    float: right;
+}
+
+.epic-article-count__dialog-close-button {
+    padding: 2px 0 0;
+    margin: 0;
+    border: none;
+
+    background: transparent;
+    color: $brightness-100;
+
+    svg {
+        fill: $brightness-100;
+    }
 }

--- a/static/src/stylesheets/module/reader-revenue/_epic-article-count-opt-out.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic-article-count-opt-out.scss
@@ -1,0 +1,72 @@
+.epic-article-count {
+    position: relative;
+    display: inline;
+}
+
+.epic-article-count__reveal-reminder {
+    display: none;
+}
+
+.epic-article-count__dialog {
+    display: none;
+    position: absolute;
+    left: 0;
+    top: 20px;
+    z-index: 1;
+
+    background-color: $brand-main;
+    color: $brightness-100;
+    font-family: $f-sans-serif-text;
+    padding: 15px 10px;
+
+    .epic-article-count__dialog-header {
+        font-size: 17px;
+        line-height: 21px;
+        font-weight: bold;
+        margin-bottom: 5px;
+
+        display: block;
+    }
+
+    .epic-article-count__dialog-body {
+        font-size: 15px;
+        line-height: 18px;
+        margin-bottom: 15px;
+
+        display: block;
+    }
+
+    .epic-article-count__dialog-note {
+        font-size: 12px;
+        line-height: 15px;
+        font-style: italic;
+        display: block;
+    }
+}
+
+.epic-article-count__reveal-reminder:checked ~ .epic-article-count__dialog {
+    display: block;
+}
+
+.epic-article-count .epic-article-count__prompt-label a {
+    text-decoration: none;
+    border-bottom: 1px solid $brightness-86;
+    color: $brightness-7;
+}
+
+.epic-article-count__buttons {
+    display: flex;
+}
+
+.epic-article-count a.epic-article-count__button-opt-out {
+    background-color: $brightness-100;
+    color: $brand-main;
+    margin-bottom: 15px;
+}
+
+.epic-article-count a.epic-article-count__button-opt-in {
+    background-color: $brand-main;
+    color: $brightness-100;
+    margin-bottom: 15px;
+    border: solid 1px $brightness-100;
+}

--- a/static/src/stylesheets/module/reader-revenue/_epic-article-count-opt-out.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic-article-count-opt-out.scss
@@ -49,10 +49,10 @@
         display: block;
 
         @include mq($until: tablet) {
-            max-width: 250px;
+            max-width: 255px;
         }
         @include mq($from: tablet) {
-            max-width: 270px;
+            max-width: 275px;
         }
     }
 

--- a/static/src/stylesheets/module/reader-revenue/_epic-article-count-opt-out.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic-article-count-opt-out.scss
@@ -85,7 +85,7 @@
 .epic-article-count__dialog-close-button {
     padding: 2px 0 0;
     margin: 0;
-    border: none;
+    border: 0;
 
     background: transparent;
     color: $brightness-100;

--- a/static/src/stylesheets/module/reader-revenue/_epic-article-count-opt-out.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic-article-count-opt-out.scss
@@ -47,6 +47,13 @@
         margin-bottom: 15px;
 
         display: block;
+
+        @include mq($until: tablet) {
+            max-width: 250px;
+        }
+        @include mq($from: tablet) {
+            max-width: 270px;
+        }
     }
 
     .epic-article-count__dialog-note {


### PR DESCRIPTION
## What does this change?
An A/B test of an opt-out feature on the epic.
Users in the variant will see the count as a link which opens a dialog asking if they want to opt out of article counts.

Clicking "opt out" drops a cookie that ensures:
1. We stop counting how many articles they have read
2. They do not see epics with article counts

The cookie lasts for 3 months.

This is not implemented as a normal standalone epic test.
For each epic test variant with an article count in the copy, split the audience into two (based on mvt cookie).
One half sees the opt-out feature, the other half sees the normal epic.
This test does not affect the underlying epic tests, and nothing is included in the tracking params that are sent to support.theguardian.com when a user clicks ‘Contribute’.
Instead, we send some special component_events to ophan for:
1. Article count impression (send this for both control and variant)
2. Article link clicked
3. Opt-out clicked
4. Opt-in clicked

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
### Desktop:
<img width="627" alt="Screen Shot 2020-05-04 at 14 54 48" src="https://user-images.githubusercontent.com/1513454/80973479-56ceb200-8e17-11ea-9b11-8914a4286f10.png">
<img width="627" alt="Screen Shot 2020-05-04 at 14 54 55" src="https://user-images.githubusercontent.com/1513454/80973481-57674880-8e17-11ea-8e52-92955034ab94.png">
<img width="627" alt="Screen Shot 2020-05-04 at 14 55 00" src="https://user-images.githubusercontent.com/1513454/80973483-57674880-8e17-11ea-8ddd-dc32d032e8a0.png">


### Mobile:
<img width="408" alt="Screen Shot 2020-05-04 at 14 55 29" src="https://user-images.githubusercontent.com/1513454/80973495-5afacf80-8e17-11ea-890a-243c80fba1e2.png">
<img width="408" alt="Screen Shot 2020-05-04 at 14 55 35" src="https://user-images.githubusercontent.com/1513454/80973497-5b936600-8e17-11ea-9cf7-21879c6e0187.png">
<img width="408" alt="Screen Shot 2020-05-04 at 14 55 41" src="https://user-images.githubusercontent.com/1513454/80973498-5c2bfc80-8e17-11ea-9301-3957e4264d08.png">



## What is the value of this and can you measure success?
We are measuring:
1. Impact on epic conversions
2. Number of opt-outs, to see how it would affect advertising if the consent was shared

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
