### PR TITLE
Subscription Banner - Copy refresh

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-template.js
@@ -16,14 +16,13 @@ const subscriptionBannerTemplate = (
 <div id="js-site-message--subscription-banner" class="site-message--subscription-banner">
     <div class="site-message--subscription-banner__inner">
         <h3 class="site-message--subscription-banner__title">
-            <span class="site-message--subscription-banner__no-wrap">Open to all,</span>
-            <span class="site-message--subscription-banner__no-wrap">supported by you</span>
+            Make us part of your new normal
         </h3>
 
         <div class="site-message--subscription-banner__description">
-            <p>Support open and independent journalism and enjoy <b>the Daily</b>,
-            the digital edition of your newspaper,
-            <b>premium access to our Live app</b> and <b>ad-free</b> reading on theguardian.com</p>
+            <p>Two Guardian apps, with you every day. <b>The Daily</b>,
+            joining you in time for breakfast to share politics, culture, food and opinion.
+            <b>Live</b>, constantly by your side, keeping you connected with the outside world.</p>
         </div>
 
         <div class="site-message--subscription-banner__cta-container">


### PR DESCRIPTION
## What does this change?

Updates the subs banner copy

## Screenshots

<img width="454" alt="Screenshot 2020-05-01 at 09 48 42" src="https://user-images.githubusercontent.com/1590704/80794314-8bc9d300-8b91-11ea-8aac-cb599d7a0372.png">

<img width="398" alt="Screenshot 2020-05-01 at 09 46 03" src="https://user-images.githubusercontent.com/1590704/80794327-92f0e100-8b91-11ea-8fcb-6c740de58072.png">

<img width="1665" alt="Screenshot 2020-05-01 at 09 45 22" src="https://user-images.githubusercontent.com/1590704/80794334-97b59500-8b91-11ea-8b90-1e8e09303e6e.png">


### Tested

- [x] Locally