### PR TITLE
Revert 22543 and 22538 to fix DCR

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -327,7 +327,7 @@ object DotcomponentsDataModel {
       tagPaths = article.content.tags.tags.map(_.id)
     )
 
-    def toBlock(block: APIBlock, shouldAddAffiliateLinks: Boolean, edition: Edition, hasShowcaseMainElement: Boolean, isImmersive: Boolean): Block = {
+    def toBlock(block: APIBlock, shouldAddAffiliateLinks: Boolean, edition: Edition): Block = {
       def format(instant: Long, edition: Edition): String = {
         GUDateTimeFormat.dateTimeToLiveBlogDisplay(new DateTime(instant), edition.timezone)
       }
@@ -341,7 +341,7 @@ object DotcomponentsDataModel {
 
       Block(
         id = block.id,
-        elements = blocksToPageElements(block.elements, shouldAddAffiliateLinks, hasShowcaseMainElement, isImmersive),
+        elements = blocksToPageElements(block.elements, shouldAddAffiliateLinks),
         createdOn = createdOn,
         createdOnDisplay = createdOnDisplay,
         lastUpdated = lastUpdated,
@@ -352,14 +352,12 @@ object DotcomponentsDataModel {
       )
     }
 
-    def blocksToPageElements(capiElems: Seq[ClientBlockElement], affiliateLinks: Boolean, hasShowcaseMainElement: Boolean, isImmersive: Boolean): List[PageElement] = {
+    def blocksToPageElements(capiElems: Seq[ClientBlockElement], affiliateLinks: Boolean): List[PageElement] = {
       val elems = capiElems.toList.flatMap(el => PageElement.make(
         element = el,
         addAffiliateLinks = affiliateLinks,
         pageUrl = request.uri,
-        atoms = atoms,
-        hasShowcaseMainElement = hasShowcaseMainElement,
-        isImmersive = isImmersive
+        atoms = atoms
       )).filter(PageElement.isSupported)
 
       addDisclaimer(elems, capiElems, affiliateLinks)
@@ -427,7 +425,7 @@ object DotcomponentsDataModel {
 
     val bodyBlocks = bodyBlocksRaw
       .filter(_.published)
-      .map(block => toBlock(block, shouldAddAffiliateLinks, Edition(request), pageType.hasShowcaseMainElement, article.isImmersive)).toList
+      .map(block => toBlock(block, shouldAddAffiliateLinks, Edition(request))).toList
 
     val pagination = articlePage match {
       case liveblog: LiveBlogPage => liveblog.currentPage.pagination.map(paginationInfo => {
@@ -444,14 +442,14 @@ object DotcomponentsDataModel {
     }
 
     val mainBlock: Option[Block] = {
-      blocks.main.map(block => toBlock(block, shouldAddAffiliateLinks, Edition(request), pageType.hasShowcaseMainElement, article.isImmersive))
+      blocks.main.map(block => toBlock(block, shouldAddAffiliateLinks, Edition(request)))
     }
 
     val keyEvents: Seq[Block] = {
       blocks.requestedBodyBlocks
         .getOrElse(Map.empty[String, Seq[APIBlock]])
         .getOrElse("body:key-events", Seq.empty[APIBlock])
-        .map(block => toBlock(block, shouldAddAffiliateLinks, Edition(request), pageType.hasShowcaseMainElement, article.isImmersive))
+        .map(block => toBlock(block, shouldAddAffiliateLinks, Edition(request)))
     }
 
     //val dcBlocks = Blocks(mainBlock, bodyBlocks, keyEvents.toList)

--- a/common/app/layout/ContentWidths.scala
+++ b/common/app/layout/ContentWidths.scala
@@ -17,6 +17,7 @@ object ContentWidths {
   object Immersive  extends ContentHinting (Some("element--immersive"))
   object Halfwidth  extends ContentHinting (Some("element--halfWidth"))
 
+
   sealed trait ContentRelation {
     def inline: WidthsByBreakpoint
     def supporting: WidthsByBreakpoint = unused

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -5,15 +5,15 @@ import java.net.{URI, URLEncoder}
 import com.gu.contentapi.client.model.v1.ElementType.{Map => _, _}
 import com.gu.contentapi.client.model.v1.{ElementType, SponsorshipType, BlockElement => ApiBlockElement, Sponsorship => ApiSponsorship}
 import conf.Configuration
-import layout.ContentWidths.{BodyMedia, ImmersiveMedia, MainMedia}
+import layout.ContentWidths.BodyMedia
 import model.content._
 import model.{AudioAsset, ImageAsset, ImageMedia, VideoAsset}
 import org.jsoup.Jsoup
 import play.api.libs.json._
 import views.support.cleaner.SoundcloudHelper
 import views.support.{AffiliateLinksCleaner, ImgSrc, Item120, Item1200, Item140, Item300, Item640, Item700, SrcSet}
-import scala.collection.JavaConverters._
 
+import scala.collection.JavaConverters._
 
 /*
   These elements are used for the Dotcom Rendering, they are essentially the new version of the
@@ -116,6 +116,7 @@ object Sponsorship {
 
 //noinspection ScalaStyle
 object PageElement {
+  val dotComponentsImageProfiles = List(Item1200, Item700, Item640, Item300, Item140, Item120)
 
   def isSupported(element: PageElement): Boolean = {
     // remove unsupported elements. Cross-reference with dotcom-rendering supported elements.
@@ -158,7 +159,7 @@ object PageElement {
     }
   }
 
-  def make(element: ApiBlockElement, addAffiliateLinks: Boolean, pageUrl: String, atoms: Iterable[Atom], hasShowcaseMainElement: Boolean, isImmersive: Boolean): List[PageElement] = {
+  def make(element: ApiBlockElement, addAffiliateLinks: Boolean, pageUrl: String, atoms: Iterable[Atom]): List[PageElement] = {
     def extractAtom: Option[Atom] = for {
       contentAtom <- element.contentAtomTypeData
       atom <- atoms.find(_.id == contentAtom.atomId)
@@ -202,21 +203,15 @@ object PageElement {
 
         val signedAssets = element.assets.zipWithIndex
           .map { case (a, i) => ImageAsset.make(a, i) }
-
-        val mediaType = (hasShowcaseMainElement, isImmersive) match {
-          case (true, _) => ImmersiveMedia
-          case (_, true) => MainMedia
-          case _         => BodyMedia
-        }
-
-        val imageSources: Seq[ImageSource] = mediaType.all.map {
+        val imageSources: Seq[ImageSource] = BodyMedia.all.map {
           case (weighting, widths) =>
             val srcSet: Seq[SrcSet] = widths.breakpoints.flatMap { b =>
               Seq(
-                ImgSrc.srcsetForBreakpoint(b, mediaType.immersive.breakpoints, maybeImageMedia = Some(ImageMedia(signedAssets))),
-                ImgSrc.srcsetForBreakpoint(b, mediaType.immersive.breakpoints, maybeImageMedia = Some(ImageMedia(signedAssets)), hidpi = true)
+                ImgSrc.srcsetForBreakpoint(b, BodyMedia.inline.breakpoints, maybeImageMedia = Some(ImageMedia(signedAssets))),
+                ImgSrc.srcsetForBreakpoint(b, BodyMedia.inline.breakpoints, maybeImageMedia = Some(ImageMedia(signedAssets)), hidpi = true)
               )
             }.flatten
+
             // A few very old articles use non-https hosts, which won't render
             val httpsSrcSet = srcSet.map(set => set.copy(src = ensureHTTPS(set.src)))
             ImageSource(weighting, httpsSrcSet)

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -198,15 +198,14 @@ object PageElement {
       ))
 
       case Image =>
-
         def ensureHTTPS(src: String): String = src.replace("http:", "https:")
 
         val signedAssets = element.assets.zipWithIndex
           .map { case (a, i) => ImageAsset.make(a, i) }
 
         val mediaType = (hasShowcaseMainElement, isImmersive) match {
-          case (true, _) => MainMedia
-          case (_, true) => ImmersiveMedia
+          case (true, _) => ImmersiveMedia
+          case (_, true) => MainMedia
           case _         => BodyMedia
         }
 
@@ -223,17 +222,11 @@ object PageElement {
             ImageSource(weighting, httpsSrcSet)
         }.toSeq
 
-        val defaultImageRole = (hasShowcaseMainElement, isImmersive) match {
-          case (true, _) => Showcase
-          case (_, true) => Immersive
-          case _         => Inline
-        }
-
         List(ImageBlockElement(
           ImageMedia(signedAssets),
           imageDataFor(element),
           element.imageTypeData.flatMap(_.displayCredit),
-          Role.fromOptionalNameWithDefaultRole(element.imageTypeData.flatMap(_.role), defaultImageRole),
+          Role(element.imageTypeData.flatMap(_.role)),
           imageSources
         ))
 

--- a/common/app/model/dotcomrendering/pageElements/Role.scala
+++ b/common/app/model/dotcomrendering/pageElements/Role.scala
@@ -3,25 +3,29 @@ package model.dotcomrendering.pageElements
 import play.api.libs.json._
 
 sealed trait Role
+
 case object Inline extends Role
+
 case object Supporting extends Role
+
 case object Showcase extends Role
+
 case object Immersive extends Role
+
 case object Thumbnail extends Role
+
 case object HalfWidth extends Role
 
 object Role {
 
-  def apply(maybeName: Option[String]): Role = fromOptionalNameWithDefaultRole(maybeName, Inline)
-
-  def fromOptionalNameWithDefaultRole(maybeName: Option[String], defaultRole: Role): Role = maybeName match {
+  def apply(maybeName: Option[String]): Role = maybeName match {
     case Some("inline") => Inline
     case Some("supporting") => Supporting
     case Some("showcase") => Showcase
     case Some("immersive") => Immersive
     case Some("thumbnail") => Thumbnail
     case Some("halfWidth") => HalfWidth
-    case _ => defaultRole
+    case _ => Inline //This is the default and composer sends this as a None.
   }
 
   implicit object RoleWrites extends Writes[Role] {
@@ -34,6 +38,7 @@ object Role {
       case HalfWidth => JsString("halfWidth")
     }
   }
+
 }
 
 


### PR DESCRIPTION
## What does this change?

This revert two recent Images related changes, after noticing that missing images are causing DCR to 500. 

![unnamed](https://user-images.githubusercontent.com/6035518/80821940-9d32cf80-8bd1-11ea-9ca6-a11338765296.png)
## Does this change need to be reproduced in dotcom-rendering ?

- [x] No

