### PR TITLE
Adding embed blocks to article picker

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -4,7 +4,7 @@ import controllers.ArticlePage
 import experiments.{ActiveExperiments, Control, DCRBubble, DiscussionRendering, DotcomRendering, Excluded, Experiment, Participant}
 import model.PageWithStoryPackage
 import implicits.Requests._
-import model.liveblog.{BlockElement, ImageBlockElement, PullquoteBlockElement, RichLinkBlockElement, TextBlockElement, TweetBlockElement, InstagramBlockElement}
+import model.liveblog.{BlockElement, ImageBlockElement, PullquoteBlockElement, RichLinkBlockElement, TextBlockElement, TweetBlockElement, InstagramBlockElement, EmbedBlockElement}
 import play.api.mvc.RequestHeader
 import views.support.Commercial
 
@@ -41,6 +41,7 @@ object ArticlePageChecks {
       case _: PullquoteBlockElement => false
       case _: RichLinkBlockElement => false
       case _: InstagramBlockElement => false
+      case _: EmbedBlockElement => false
       case _ => true
     }
 


### PR DESCRIPTION
## What does this change?
There's a change in DCR to render embed blocks which needs to go out first. This will start to show them to the DCR audience - https://github.com/guardian/dotcom-rendering/pull/1444 