### PR TITLE
Introduce ContentRelation DCRExperimental

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -327,7 +327,7 @@ object DotcomponentsDataModel {
       tagPaths = article.content.tags.tags.map(_.id)
     )
 
-    def toBlock(block: APIBlock, shouldAddAffiliateLinks: Boolean, edition: Edition): Block = {
+    def toBlock(block: APIBlock, shouldAddAffiliateLinks: Boolean, edition: Edition, hasShowcaseMainElement: Boolean, isImmersive: Boolean): Block = {
       def format(instant: Long, edition: Edition): String = {
         GUDateTimeFormat.dateTimeToLiveBlogDisplay(new DateTime(instant), edition.timezone)
       }
@@ -341,7 +341,7 @@ object DotcomponentsDataModel {
 
       Block(
         id = block.id,
-        elements = blocksToPageElements(block.elements, shouldAddAffiliateLinks),
+        elements = blocksToPageElements(block.elements, shouldAddAffiliateLinks, hasShowcaseMainElement, isImmersive),
         createdOn = createdOn,
         createdOnDisplay = createdOnDisplay,
         lastUpdated = lastUpdated,
@@ -352,12 +352,14 @@ object DotcomponentsDataModel {
       )
     }
 
-    def blocksToPageElements(capiElems: Seq[ClientBlockElement], affiliateLinks: Boolean): List[PageElement] = {
+    def blocksToPageElements(capiElems: Seq[ClientBlockElement], affiliateLinks: Boolean, hasShowcaseMainElement: Boolean, isImmersive: Boolean): List[PageElement] = {
       val elems = capiElems.toList.flatMap(el => PageElement.make(
         element = el,
         addAffiliateLinks = affiliateLinks,
         pageUrl = request.uri,
-        atoms = atoms
+        atoms = atoms,
+        hasShowcaseMainElement = hasShowcaseMainElement,
+        isImmersive = isImmersive
       )).filter(PageElement.isSupported)
 
       addDisclaimer(elems, capiElems, affiliateLinks)
@@ -425,7 +427,7 @@ object DotcomponentsDataModel {
 
     val bodyBlocks = bodyBlocksRaw
       .filter(_.published)
-      .map(block => toBlock(block, shouldAddAffiliateLinks, Edition(request))).toList
+      .map(block => toBlock(block, shouldAddAffiliateLinks, Edition(request), pageType.hasShowcaseMainElement, article.isImmersive)).toList
 
     val pagination = articlePage match {
       case liveblog: LiveBlogPage => liveblog.currentPage.pagination.map(paginationInfo => {
@@ -442,14 +444,14 @@ object DotcomponentsDataModel {
     }
 
     val mainBlock: Option[Block] = {
-      blocks.main.map(block => toBlock(block, shouldAddAffiliateLinks, Edition(request)))
+      blocks.main.map(block => toBlock(block, shouldAddAffiliateLinks, Edition(request), pageType.hasShowcaseMainElement, article.isImmersive))
     }
 
     val keyEvents: Seq[Block] = {
       blocks.requestedBodyBlocks
         .getOrElse(Map.empty[String, Seq[APIBlock]])
         .getOrElse("body:key-events", Seq.empty[APIBlock])
-        .map(block => toBlock(block, shouldAddAffiliateLinks, Edition(request)))
+        .map(block => toBlock(block, shouldAddAffiliateLinks, Edition(request), pageType.hasShowcaseMainElement, article.isImmersive))
     }
 
     //val dcBlocks = Blocks(mainBlock, bodyBlocks, keyEvents.toList)

--- a/common/app/layout/ContentWidths.scala
+++ b/common/app/layout/ContentWidths.scala
@@ -159,6 +159,15 @@ object ContentWidths {
       wide =            Some(620.px))
   }
 
+  object DCRExperimental extends ContentRelation {
+    override val inline = BodyMedia.inline
+    override val supporting = BodyMedia.supporting
+    override val showcase = MainMedia.showcase
+    override val immersive = ImmersiveMedia.immersive
+    override val thumbnail = BodyMedia.thumbnail
+    override val halfwidth = BodyMedia.inline
+  }
+
   object ImageContentMedia {
     // ImageContentMedia does not support hinting/weighting, so does not extend ContentRelation.
     val inline = WidthsByBreakpoint(

--- a/common/app/layout/ContentWidths.scala
+++ b/common/app/layout/ContentWidths.scala
@@ -17,7 +17,6 @@ object ContentWidths {
   object Immersive  extends ContentHinting (Some("element--immersive"))
   object Halfwidth  extends ContentHinting (Some("element--halfWidth"))
 
-
   sealed trait ContentRelation {
     def inline: WidthsByBreakpoint
     def supporting: WidthsByBreakpoint = unused

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -5,13 +5,14 @@ import java.net.{URI, URLEncoder}
 import com.gu.contentapi.client.model.v1.ElementType.{Map => _, _}
 import com.gu.contentapi.client.model.v1.{ElementType, SponsorshipType, BlockElement => ApiBlockElement, Sponsorship => ApiSponsorship}
 import conf.Configuration
-import layout.ContentWidths.{BodyMedia, ImmersiveMedia, MainMedia}
+import layout.ContentWidths.{DCRExperimental}
 import model.content._
 import model.{AudioAsset, ImageAsset, ImageMedia, VideoAsset}
 import org.jsoup.Jsoup
 import play.api.libs.json._
 import views.support.cleaner.SoundcloudHelper
 import views.support.{AffiliateLinksCleaner, ImgSrc, Item120, Item1200, Item140, Item300, Item640, Item700, SrcSet}
+
 import scala.collection.JavaConverters._
 
 
@@ -204,18 +205,12 @@ object PageElement {
         val signedAssets = element.assets.zipWithIndex
           .map { case (a, i) => ImageAsset.make(a, i) }
 
-        val mediaType = (hasShowcaseMainElement, isImmersive) match {
-          case (true, _) => MainMedia
-          case (_, true) => ImmersiveMedia
-          case _         => BodyMedia
-        }
-
-        val imageSources: Seq[ImageSource] = mediaType.all.map {
+        val imageSources: Seq[ImageSource] = DCRExperimental.all.map {
           case (weighting, widths) =>
             val srcSet: Seq[SrcSet] = widths.breakpoints.flatMap { b =>
               Seq(
-                ImgSrc.srcsetForBreakpoint(b, mediaType.immersive.breakpoints, maybeImageMedia = Some(ImageMedia(signedAssets))),
-                ImgSrc.srcsetForBreakpoint(b, mediaType.immersive.breakpoints, maybeImageMedia = Some(ImageMedia(signedAssets)), hidpi = true)
+                ImgSrc.srcsetForBreakpoint(b, DCRExperimental.immersive.breakpoints, maybeImageMedia = Some(ImageMedia(signedAssets))),
+                ImgSrc.srcsetForBreakpoint(b, DCRExperimental.immersive.breakpoints, maybeImageMedia = Some(ImageMedia(signedAssets)), hidpi = true)
               )
             }.flatten
             // A few very old articles use non-https hosts, which won't render

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -5,15 +5,15 @@ import java.net.{URI, URLEncoder}
 import com.gu.contentapi.client.model.v1.ElementType.{Map => _, _}
 import com.gu.contentapi.client.model.v1.{ElementType, SponsorshipType, BlockElement => ApiBlockElement, Sponsorship => ApiSponsorship}
 import conf.Configuration
-import layout.ContentWidths.BodyMedia
+import layout.ContentWidths.{BodyMedia, ImmersiveMedia, MainMedia}
 import model.content._
 import model.{AudioAsset, ImageAsset, ImageMedia, VideoAsset}
 import org.jsoup.Jsoup
 import play.api.libs.json._
 import views.support.cleaner.SoundcloudHelper
 import views.support.{AffiliateLinksCleaner, ImgSrc, Item120, Item1200, Item140, Item300, Item640, Item700, SrcSet}
-
 import scala.collection.JavaConverters._
+
 
 /*
   These elements are used for the Dotcom Rendering, they are essentially the new version of the
@@ -116,7 +116,6 @@ object Sponsorship {
 
 //noinspection ScalaStyle
 object PageElement {
-  val dotComponentsImageProfiles = List(Item1200, Item700, Item640, Item300, Item140, Item120)
 
   def isSupported(element: PageElement): Boolean = {
     // remove unsupported elements. Cross-reference with dotcom-rendering supported elements.
@@ -159,7 +158,7 @@ object PageElement {
     }
   }
 
-  def make(element: ApiBlockElement, addAffiliateLinks: Boolean, pageUrl: String, atoms: Iterable[Atom]): List[PageElement] = {
+  def make(element: ApiBlockElement, addAffiliateLinks: Boolean, pageUrl: String, atoms: Iterable[Atom], hasShowcaseMainElement: Boolean, isImmersive: Boolean): List[PageElement] = {
     def extractAtom: Option[Atom] = for {
       contentAtom <- element.contentAtomTypeData
       atom <- atoms.find(_.id == contentAtom.atomId)
@@ -199,29 +198,42 @@ object PageElement {
       ))
 
       case Image =>
+
         def ensureHTTPS(src: String): String = src.replace("http:", "https:")
 
         val signedAssets = element.assets.zipWithIndex
           .map { case (a, i) => ImageAsset.make(a, i) }
-        val imageSources: Seq[ImageSource] = BodyMedia.all.map {
+
+        val mediaType = (hasShowcaseMainElement, isImmersive) match {
+          case (true, _) => MainMedia
+          case (_, true) => ImmersiveMedia
+          case _         => BodyMedia
+        }
+
+        val imageSources: Seq[ImageSource] = mediaType.all.map {
           case (weighting, widths) =>
             val srcSet: Seq[SrcSet] = widths.breakpoints.flatMap { b =>
               Seq(
-                ImgSrc.srcsetForBreakpoint(b, BodyMedia.inline.breakpoints, maybeImageMedia = Some(ImageMedia(signedAssets))),
-                ImgSrc.srcsetForBreakpoint(b, BodyMedia.inline.breakpoints, maybeImageMedia = Some(ImageMedia(signedAssets)), hidpi = true)
+                ImgSrc.srcsetForBreakpoint(b, mediaType.immersive.breakpoints, maybeImageMedia = Some(ImageMedia(signedAssets))),
+                ImgSrc.srcsetForBreakpoint(b, mediaType.immersive.breakpoints, maybeImageMedia = Some(ImageMedia(signedAssets)), hidpi = true)
               )
             }.flatten
-
             // A few very old articles use non-https hosts, which won't render
             val httpsSrcSet = srcSet.map(set => set.copy(src = ensureHTTPS(set.src)))
             ImageSource(weighting, httpsSrcSet)
         }.toSeq
 
+        val defaultImageRole = (hasShowcaseMainElement, isImmersive) match {
+          case (true, _) => Showcase
+          case (_, true) => Immersive
+          case _         => Inline
+        }
+
         List(ImageBlockElement(
           ImageMedia(signedAssets),
           imageDataFor(element),
           element.imageTypeData.flatMap(_.displayCredit),
-          Role(element.imageTypeData.flatMap(_.role)),
+          Role.fromOptionalNameWithDefaultRole(element.imageTypeData.flatMap(_.role), defaultImageRole),
           imageSources
         ))
 

--- a/common/app/model/dotcomrendering/pageElements/Role.scala
+++ b/common/app/model/dotcomrendering/pageElements/Role.scala
@@ -3,29 +3,25 @@ package model.dotcomrendering.pageElements
 import play.api.libs.json._
 
 sealed trait Role
-
 case object Inline extends Role
-
 case object Supporting extends Role
-
 case object Showcase extends Role
-
 case object Immersive extends Role
-
 case object Thumbnail extends Role
-
 case object HalfWidth extends Role
 
 object Role {
 
-  def apply(maybeName: Option[String]): Role = maybeName match {
+  def apply(maybeName: Option[String]): Role = fromOptionalNameWithDefaultRole(maybeName, Inline)
+
+  def fromOptionalNameWithDefaultRole(maybeName: Option[String], defaultRole: Role): Role = maybeName match {
     case Some("inline") => Inline
     case Some("supporting") => Supporting
     case Some("showcase") => Showcase
     case Some("immersive") => Immersive
     case Some("thumbnail") => Thumbnail
     case Some("halfWidth") => HalfWidth
-    case _ => Inline //This is the default and composer sends this as a None.
+    case _ => defaultRole
   }
 
   implicit object RoleWrites extends Writes[Role] {
@@ -38,7 +34,6 @@ object Role {
       case HalfWidth => JsString("halfWidth")
     }
   }
-
 }
 
 


### PR DESCRIPTION
## What does this change?

This change supersedes
- https://github.com/guardian/frontend/pull/22538
- https://github.com/guardian/frontend/pull/22543

and reverts 
- https://github.com/guardian/frontend/pull/22550

Here we introduce the experimental `DCRExperimental` ( `ContentRelation` ), as a simple way to solve the immediate problem of missing `supporting` images. This is a small prelude part of the coming refactoring of `PageElement.scala`.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No