### PR TITLE
Revert "Merge pull request #22554 from guardian/rp-add-embed-to-picker"

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -4,7 +4,7 @@ import controllers.ArticlePage
 import experiments.{ActiveExperiments, Control, DCRBubble, DiscussionRendering, DotcomRendering, Excluded, Experiment, Participant}
 import model.PageWithStoryPackage
 import implicits.Requests._
-import model.liveblog.{BlockElement, ImageBlockElement, PullquoteBlockElement, RichLinkBlockElement, TextBlockElement, TweetBlockElement, InstagramBlockElement, EmbedBlockElement}
+import model.liveblog.{BlockElement, ImageBlockElement, PullquoteBlockElement, RichLinkBlockElement, TextBlockElement, TweetBlockElement, InstagramBlockElement}
 import play.api.mvc.RequestHeader
 import views.support.Commercial
 
@@ -41,7 +41,6 @@ object ArticlePageChecks {
       case _: PullquoteBlockElement => false
       case _: RichLinkBlockElement => false
       case _: InstagramBlockElement => false
-      case _: EmbedBlockElement => false
       case _ => true
     }
 


### PR DESCRIPTION
Momentarily reverts https://github.com/guardian/frontend/pull/22554 , which is causing small rendering problem on DCR due to incorrect data from CAPI. 


This reverts commit 6b51300a13d1b99c1888d8a361fdd10c40a6f742, reversing
changes made to 76ef672915458d5e377f37c08be180f681a5931e.

## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No