### PR TITLE
Change audience offset for Patientia Sign in Gate test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate.js
@@ -7,7 +7,7 @@ export const signInGate: ABTest = {
     description:
         'Marathon sign in gate test on 3nd article view of simple article templates, with higher priority over banners and epic',
     audience: 0.0001,
-    audienceOffset: 0.99,
+    audienceOffset: 0.98,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:
         '2nd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',


### PR DESCRIPTION
## What does this change?

Change the audience offset to `0.98` to make sure that no one who has seen the test before this PR is in the audience.