### PR TITLE
Handle main media pictures of immersives without a set image Role

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -327,7 +327,7 @@ object DotcomponentsDataModel {
       tagPaths = article.content.tags.tags.map(_.id)
     )
 
-    def toBlock(block: APIBlock, shouldAddAffiliateLinks: Boolean, edition: Edition): Block = {
+    def toBlock(block: APIBlock, shouldAddAffiliateLinks: Boolean, edition: Edition, isMainBlock: Boolean, isImmersive: Boolean): Block = {
       def format(instant: Long, edition: Edition): String = {
         GUDateTimeFormat.dateTimeToLiveBlogDisplay(new DateTime(instant), edition.timezone)
       }
@@ -341,7 +341,7 @@ object DotcomponentsDataModel {
 
       Block(
         id = block.id,
-        elements = blockElementsToPageElements(block.elements, shouldAddAffiliateLinks),
+        elements = blockElementsToPageElements(block.elements, shouldAddAffiliateLinks, isMainBlock, isImmersive),
         createdOn = createdOn,
         createdOnDisplay = createdOnDisplay,
         lastUpdated = lastUpdated,
@@ -352,12 +352,14 @@ object DotcomponentsDataModel {
       )
     }
 
-    def blockElementsToPageElements(capiElems: Seq[ClientBlockElement], affiliateLinks: Boolean): List[PageElement] = {
+    def blockElementsToPageElements(capiElems: Seq[ClientBlockElement], affiliateLinks: Boolean, isMainBlock: Boolean, isImmersive: Boolean): List[PageElement] = {
       val elems = capiElems.toList.flatMap(el => PageElement.make(
         element = el,
         addAffiliateLinks = affiliateLinks,
         pageUrl = request.uri,
-        atoms = atoms
+        atoms = atoms,
+        isMainBlock,
+        isImmersive
       )).filter(PageElement.isSupported)
       addDisclaimer(elems, capiElems, affiliateLinks)
     }
@@ -424,7 +426,7 @@ object DotcomponentsDataModel {
 
     val bodyBlocks = bodyBlocksRaw
       .filter(_.published)
-      .map(block => toBlock(block, shouldAddAffiliateLinks, Edition(request))).toList
+      .map(block => toBlock(block, shouldAddAffiliateLinks, Edition(request), false, article.isImmersive)).toList
 
     val pagination = articlePage match {
       case liveblog: LiveBlogPage => liveblog.currentPage.pagination.map(paginationInfo => {
@@ -441,17 +443,15 @@ object DotcomponentsDataModel {
     }
 
     val mainBlock: Option[Block] = {
-      blocks.main.map(block => toBlock(block, shouldAddAffiliateLinks, Edition(request)))
+      blocks.main.map(block => toBlock(block, shouldAddAffiliateLinks, Edition(request), true, article.isImmersive))
     }
 
     val keyEvents: Seq[Block] = {
       blocks.requestedBodyBlocks
         .getOrElse(Map.empty[String, Seq[APIBlock]])
         .getOrElse("body:key-events", Seq.empty[APIBlock])
-        .map(block => toBlock(block, shouldAddAffiliateLinks, Edition(request)))
+        .map(block => toBlock(block, shouldAddAffiliateLinks, Edition(request), false, article.isImmersive))
     }
-
-    //val dcBlocks = Blocks(mainBlock, bodyBlocks, keyEvents.toList)
 
     val jsConfig = (k: String) => articlePage.getJavascriptConfig.get(k).map(_.as[String])
 

--- a/common/app/model/dotcomrendering/pageElements/Role.scala
+++ b/common/app/model/dotcomrendering/pageElements/Role.scala
@@ -22,6 +22,16 @@ object Role {
     case _ => Inline
   }
 
+  def apply(maybeName: Option[String], defaultRole: Role): Role = maybeName match {
+    case Some("inline") => Inline
+    case Some("supporting") => Supporting
+    case Some("showcase") => Showcase
+    case Some("immersive") => Immersive
+    case Some("thumbnail") => Thumbnail
+    case Some("halfWidth") => HalfWidth
+    case _ => defaultRole
+  }
+
   implicit object RoleWrites extends Writes[Role] {
     override def writes(r: Role): JsValue = r match {
       case Inline => JsString("inline")


### PR DESCRIPTION
## What does this change?

The default role is used when an image doesn't have one and that default role is meant to be `Inline`. That having been said, there are exceptions to this rule. For instance, if the page is immersive and the picture is `mainMedia` and the image doesn't have a role, then the role should be `Immersive`, thereby overriding the default `Inline`.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No