### PR TITLE
Provide schema.org NewsArticle Image when Article has no main media image

### DIFF
--- a/article/app/views/fragments/mainMedia.scala.html
+++ b/article/app/views/fragments/mainMedia.scala.html
@@ -1,13 +1,28 @@
 @import views.MainMediaWidths
+@import views.support.{Video640, Item1200, OneByOne, FourByThree}
+@import model.Trail
 @(article: model.Article)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import model.{VideoPlayer}
-@import views.support.Video640
 @import views.{MainCleaner}
+
+@trailPicAsStructuredDataImage(trail: Trail) = {
+    @trail.trailPicture.map { image =>
+        @*
+         * Recommendations for image sizes from https://developers.google.com/search/docs/data-types/article
+         * (also following DCR's lead)
+        *@
+        @List(OneByOne, FourByThree, Item1200).map { size =>
+            <meta itemprop="image" content="@size.bestSrcFor(image).getOrElse("")">
+        }
+    }
+}
 
 @if(article.elements.hasMainEmbed || article.elements.elements("main").isEmpty) {
     <div class="media-primary">
         @MainCleaner(article)
+
+        @trailPicAsStructuredDataImage(article.trail)
     </div>
 } else {
     @if(!article.hasVideoAtTop) {
@@ -48,6 +63,8 @@
 
                 </figure>
             }
+
+            @trailPicAsStructuredDataImage(article.trail)
         } else {
             @article.elements.mainPicture.map { picture =>
                 @fragments.imageFigure(


### PR DESCRIPTION
## What does this change?

For articles we provide structure data (see https://schema.org/) about the content. This includes the data for a [news article](https://schema.org/NewsArticle).

Currently when an article doesn't have an image for its main media (either because it has no main media, or its main media is something else e.g. a video) we omit the image for the NewsArticle. This isn't desirable and causes validation errors in the [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool#). Here's an example:

<img width="1552" alt="Screenshot 2020-05-12 at 09 23 18" src="https://user-images.githubusercontent.com/379839/81660493-bbe76080-9432-11ea-9bf5-f920bdb4acab.png">

After this change (testing against locally generated markup):

<img width="1552" alt="Screenshot 2020-05-13 at 10 29 59" src="https://user-images.githubusercontent.com/379839/81796089-dd188180-9504-11ea-891f-eee1ab464ea1.png">

Specifically the additional markup looks like this:

<img width="914" alt="Screenshot 2020-05-13 at 11 17 11" src="https://user-images.githubusercontent.com/379839/81800940-89f5fd00-950b-11ea-8b6c-16f4d8dc5820.png">

We're providing images at each of the sizes recommended by Google here: https://developers.google.com/search/docs/data-types/article (see the image property). When there is a main media image we specify a full `ImageObject` but here we provide simple URLs. There doesn't seem to be a clear benefit of one of the other, and this way is simpler/more lightweight (I also had a tricky time deriving the true width & height for the `ImageObject`).

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

It looks like DCR already handles this situation and when there isn't an image for main media a list of URLs is provided.

## What is the value of this and can you measure success?

Better/richer visibility of our content to Google.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
