### PR TITLE
Blacklist print shop tag from DCR

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -76,7 +76,8 @@ object ArticlePageChecks {
     "news/series/nauru-files",
     "us-news/series/counted-us-police-killings",
     "australia-news/series/healthcare-in-detention",
-    "society/series/this-is-the-nhs"
+    "society/series/this-is-the-nhs",
+    "artanddesign/series/guardian-print-shop"
   )
 
   def isNotPhotoEssay(page: PageWithStoryPackage): Boolean = ! page.item.isPhotoEssay


### PR DESCRIPTION
## What does this change?
Removes the print shop tag from the DCR test while we fix an issue with the rendering of immersives with no main media.
