### PR TITLE
[TEST] Try longer warmupGrace for deployments

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -8,6 +8,7 @@ templates:
     type: autoscaling
     parameters:
       bucket: aws-frontend-artifacts
+      warmupGrace: 60
     dependencies:
     - frontend-static
     - update-ami


### PR DESCRIPTION
## What does this change?
Adds a warmupGrace of 60 seconds to see if giving new instances longer to warm up before terminating older ones. This is a test to see if CPU spikes on the article box are alleviated by providing a longer warm up window.

I'm going to try this on CODE first for a sanity check, but realistically it needs to be tried on PROD to see if it's effective under real conditions. 