### PR TITLE
Add pointer-events: none; to the gradient to prevent blocking of clicking

### DIFF
--- a/static/src/stylesheets/module/crosswords/_layout.scss
+++ b/static/src/stylesheets/module/crosswords/_layout.scss
@@ -105,6 +105,7 @@
     height: 120px;
     background: linear-gradient(to bottom, rgba(255, 255, 255, 0), #ffffff);
     display: none;
+    pointer-events: none;
 
     @include mq($from: tablet, $until: leftCol) {
         display: block;


### PR DESCRIPTION
## What does this change?

Removes pointer events from the gradient so that the clickable elements underneath the top of the gradient can be clicked by allowing the click to pass through the gradient element.

![2020-05-13 16 45 52](https://user-images.githubusercontent.com/638051/81834728-40bca200-9539-11ea-96dd-2367171f6c61.gif)

Second attempt at https://github.com/guardian/frontend/pull/22540/files