### PR TITLE
Removing links to soulmates site

### DIFF
--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -120,7 +120,6 @@ object FooterLinks {
     FooterLink("Advertise with us", "https://advertising.theguardian.com", "uk : footer : advertise with us"),
     FooterLink("Guardian Labs", "/guardian-labs", "uk : footer : guardian labs"),
     FooterLink("Search jobs", "https://jobs.theguardian.com?INTCMP=NGW_FOOTER_UK_GU_JOBS", "uk : footer : jobs"),
-    FooterLink("Dating", "https://soulmates.theguardian.com?INTCMP=NGW_FOOTER_UK_GU_SOULMATES", "uk : footer : soulmates"),
     FooterLink("Patrons", "https://patrons.theguardian.com?INTCMP=footer_patrons", "uk : footer : patrons"),
     discountCodes("uk")
   )
@@ -129,7 +128,6 @@ object FooterLinks {
     FooterLink("Advertise with us", "https://advertising.theguardian.com/us/advertising", "us : footer : advertise with us"),
     FooterLink("Guardian Labs", "/guardian-labs-us", "us : footer : guardian labs"),
     FooterLink("Search jobs", "https://jobs.theguardian.com?INTCMP=NGW_FOOTER_US_GU_JOBS", "us : footer : jobs"),
-    FooterLink("Dating", "https://soulmates.theguardian.com?INTCMP=soulmates_us_web_footer", "us : footer : soulmates"),
     discountCodes("us")
   )
 
@@ -137,14 +135,12 @@ object FooterLinks {
     FooterLink("Guardian Labs", "/guardian-labs-australia", "au : footer : guardian labs"),
     FooterLink("Advertise with us", "https://advertising.theguardian.com/", "au : footer : advertise with us"),
     FooterLink("Search UK jobs", "https://jobs.theguardian.com?INTCMP=NGW_FOOTER_AU_GU_JOBS", "au : footer : uk-jobs"),
-    FooterLink("Dating", "https://soulmates.theguardian.com?INTCMP=soulmates_au_web_footer", "au : footer : soulmates"),
     discountCodes("au")
   )
 
   val intListThree = List(
     FooterLink("Advertise with us", "https://advertising.theguardian.com", "international : footer : advertise with us"),
     FooterLink("Search UK jobs", "https://jobs.theguardian.com/?INTCMP=NGW_FOOTER_INT_GU_JOBS", "international : footer : uk-jobs"),
-    FooterLink("Dating", "https://soulmates.theguardian.com/?INTCMP=soulmates_int_web_footer", "international : footer : soulmates"),
     discountCodes("international")
   )
 

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -185,7 +185,6 @@ private object NavLinks {
   val pictures = NavLink("Pictures", "/inpictures")
   val newsletters = NavLink("Newsletters", "/email-newsletters")
   val jobs = NavLink("Search jobs", "https://jobs.theguardian.com")
-  val dating = NavLink("Dating", "https://soulmates.theguardian.com")
   val apps = NavLink("The Guardian app", "https://www.theguardian.com/mobile/2014/may/29/the-guardian-for-mobile-and-tablet")
   val ukMasterClasses = NavLink("Masterclasses", "/guardian-masterclasses")
   val printShop = NavLink("Guardian Print Shop", "/artanddesign/series/gnm-print-sales")
@@ -515,7 +514,6 @@ private object NavLinks {
 
   val ukBrandExtensions = List(
     jobs.copy(url = jobs.url + "?INTCMP=jobs_uk_web_newheader_dropdown"),
-    dating.copy(url = dating.url + "?INTCMP=soulmates_uk_web_newheader_dropdown"),
     holidays.copy(url = holidays.url + "?INTCMP=holidays_uk_web_newheader"),
     guardianLive,
     ukMasterClasses,
@@ -539,7 +537,6 @@ private object NavLinks {
   )
   val intBrandExtensions = List(
     jobs.copy(url = jobs.url + "?INTCMP=jobs_int_web_newheader_dropdown"),
-    dating.copy(url = dating.url + "?INTCMP=soulmates_int_web_newheader_dropdown"),
     holidays.copy(url = holidays.url + "?INTCMP=holidays_int_web_newheader"),
     digitalNewspaperArchive,
     discountCodes,

--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -90,6 +90,4 @@ object UrlHelpers {
     } else {
       s"https://jobs.theguardian.com/?INTCMP=jobs_${editionId}_web_newheader"
     }
-
-  def getSoulmatesUrl: String = "https://soulmates.theguardian.com/?INTCMP=soulmates_uk_web_newheader"
 }

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -3,7 +3,7 @@
 @import common.{LinkTo, Edition}
 @import views.support.RenderClasses
 @import navigation.NavMenu
-@import navigation.UrlHelpers.{getJobUrl, Header, getReaderRevenueUrl, getSoulmatesUrl }
+@import navigation.UrlHelpers.{getJobUrl, Header, getReaderRevenueUrl}
 @import navigation.ReaderRevenueSite.{Support, SupportSubscribe, SupportContribute}
 @import conf.switches.Switches.{ IdentityProfileNavigationSwitch, SearchSwitch, UsHeaderAndFooterSubscribeLinkSwitch }
 
@@ -98,15 +98,6 @@
                                 href="@getJobUrl(editionId)">
                                     Search jobs
                                 </a>
-
-                                @if(editionId == "uk") {
-                                    <a class="top-bar__item hide-until-desktop"
-                                    data-link-name="nav2 : soulmates-cta"
-                                    data-edition="@{editionId}"
-                                    href="@getSoulmatesUrl">
-                                        Dating
-                                    </a>
-                                }
                             </div>
                         }
 


### PR DESCRIPTION
## What does this change?
With the closing down of soulmates, this change removes all links from theguardian.com
## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

Separate PR coming up for DCR

