### PR TITLE
Show Guardian Weekly Banner to the rest-of-world Reader Revenue Region

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-tracking.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-tracking.js
@@ -28,7 +28,7 @@ const CLICK_EVENT_CLOSE_BUTTON = `${BANNER_KEY} close`;
 const CLICK_EVENT_SIGN_IN = `${BANNER_KEY} sign in`;
 const OPHAN_EVENT_ID = 'acquisitions-subscription-banner';
 const CAMPAIGN_CODE = 'gdnwb_copts_banner_subscribe_SubscriptionBanner_digital';
-const AUS_CAMPAIGN_CODE =
+const GUARDIAN_WEEKLY_CAMPAIGN_CODE =
     'gdnwb_copts_banner_subscribe_SubscriptionBanner_gWeekly';
 
 const subscriptionHostname: string = config.get('page.supportUrl');
@@ -38,20 +38,20 @@ const createTracking = (
     region: ReaderRevenueRegion,
     defaultTracking: BannerTracking
 ) => {
-    const isAustralianRegion = region === 'australia';
+    const isGuardianWeeklyRegion = (region === 'australia' || region === 'rest-of-world');
 
-    const australianTracking = {
+    const guardianWeeklyTracking = {
         signInUrl: `${signinHostname}/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_gWeekly&CMP_TU=mrtn&CMP_BUNIT=subs`,
         subscriptionUrl: addTrackingCodesToUrl({
             base: `${subscriptionHostname}/subscribe/weekly`,
             componentType: COMPONENT_TYPE,
             componentId: OPHAN_EVENT_ID,
-            campaignCode: AUS_CAMPAIGN_CODE,
+            campaignCode: GUARDIAN_WEEKLY_CAMPAIGN_CODE,
         }),
     };
 
-    return isAustralianRegion
-        ? { ...defaultTracking, ...australianTracking }
+    return isGuardianWeeklyRegion
+        ? { ...defaultTracking, ...guardianWeeklyTracking }
         : defaultTracking;
 };
 

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.js
@@ -18,7 +18,7 @@ import reportError from 'lib/report-error';
 import type { ReaderRevenueRegion } from 'common/modules/commercial/contributions-utilities';
 import type { Banner } from 'common/modules/ui/bannerPicker';
 
-import { bannerTemplate as subscripionBannerTemplate } from './subscription-banner-template';
+import { bannerTemplate as subscriptionBannerTemplate } from './subscription-banner-template';
 import { bannerTemplate as gwBannerTemplate } from './guardian-weekly-banner-template';
 import { bannerTracking } from './subscription-banner-tracking';
 import type { BannerTracking } from './subscription-banner-tracking';
@@ -181,7 +181,7 @@ const createBannerShow = (
 };
 
 const chooseBanner = (region: ReaderRevenueRegion) =>
-    (region === 'australia' || region === 'rest-of-world') ? gwBannerTemplate : subscripionBannerTemplate;
+    (region === 'australia' || region === 'rest-of-world') ? gwBannerTemplate : subscriptionBannerTemplate;
 
 const show = createBannerShow(
     bannerTracking(currentRegion),

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.js
@@ -181,7 +181,7 @@ const createBannerShow = (
 };
 
 const chooseBanner = (region: ReaderRevenueRegion) =>
-    region === 'australia' ? gwBannerTemplate : subscripionBannerTemplate;
+    (region === 'australia' || region === 'rest-of-world') ? gwBannerTemplate : subscripionBannerTemplate;
 
 const show = createBannerShow(
     bannerTracking(currentRegion),

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.spec.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { bannerTemplate as subscripionBannerTemplate } from './subscription-banner-template';
+import { bannerTemplate as subscriptionBannerTemplate } from './subscription-banner-template';
 import { selectorName, createBannerShow } from './subscription-banner';
 
 jest.mock('ophan/ng', () => null);
@@ -33,12 +33,12 @@ describe('Subscription Banner', () => {
     it('Should append a Subscription Banner to the document', () => {
         const show = createBannerShow(
             mockTracking,
-            subscripionBannerTemplate,
+            subscriptionBannerTemplate,
             false
         );
         show();
 
-        const banner = subscripionBannerTemplate(
+        const banner = subscriptionBannerTemplate(
             mockTracking.subscriptionUrl,
             mockTracking.signInUrl,
             false
@@ -59,7 +59,7 @@ describe('Subscription Banner', () => {
         beforeEach(() => {
             const show = createBannerShow(
                 mockTracking,
-                subscripionBannerTemplate,
+                subscriptionBannerTemplate,
                 false
             );
 
@@ -132,7 +132,7 @@ describe('Subscription Banner', () => {
 
             const show = createBannerShow(
                 mockTrackingSUT,
-                subscripionBannerTemplate,
+                subscriptionBannerTemplate,
                 false
             );
             show();
@@ -157,7 +157,7 @@ describe('Subscription Banner', () => {
 
             const show = createBannerShow(
                 mockTrackingSUT,
-                subscripionBannerTemplate,
+                subscriptionBannerTemplate,
                 false
             );
             show();
@@ -182,7 +182,7 @@ describe('Subscription Banner', () => {
 
             const show = createBannerShow(
                 mockTrackingSUT,
-                subscripionBannerTemplate,
+                subscriptionBannerTemplate,
                 false
             );
             show();
@@ -196,7 +196,7 @@ describe('Subscription Banner', () => {
 
             const show = createBannerShow(
                 mockTrackingSUT,
-                subscripionBannerTemplate,
+                subscriptionBannerTemplate,
                 false
             );
             show();
@@ -213,7 +213,7 @@ describe('Subscription Banner', () => {
 
             const show = createBannerShow(
                 mockTrackingSUT,
-                subscripionBannerTemplate,
+                subscriptionBannerTemplate,
                 false
             );
             show();
@@ -236,7 +236,7 @@ describe('Subscription Banner', () => {
 
             const show = createBannerShow(
                 mockTrackingSUT,
-                subscripionBannerTemplate,
+                subscriptionBannerTemplate,
                 false
             );
             show();
@@ -262,7 +262,7 @@ describe('Subscription Banner', () => {
 
             const show = createBannerShow(
                 mockTrackingSUT,
-                subscripionBannerTemplate,
+                subscriptionBannerTemplate,
                 isUserSignedIn
             );
             show();


### PR DESCRIPTION
## What does this change?

Ticket: 
https://trello.com/c/3KtcCpE5/2996-replace-ds-banner-with-gw-banner-in-row

This PR updates `chooseBanner` to return the `gwBannerTemplate` if the user's reader revenue region is equal to 'australia' OR 'rest-of-world'. Previously it only returned the `gwBannerTemplate` for 'australia'.

The ticket also specifies "Tracking code for GW Banner in ROW is the same as GW Banner in AUS", I've therefore updated  `subscription-banner-tracking.js` to reflect this.


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)