### PR TITLE
Longer warmupGrace for deployments

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -8,6 +8,7 @@ templates:
     type: autoscaling
     parameters:
       bucket: aws-frontend-artifacts
+      warmupGrace: 60
     dependencies:
     - frontend-static
     - update-ami


### PR DESCRIPTION
This was (reasonably) successfully tested in production along with https://github.com/guardian/platform/pull/1403. Together they seem to alleviate issues with high CPU after a deploy by giving all the instances that come into service enough time to warm up.

![image](https://user-images.githubusercontent.com/8754692/82030535-7de77800-9690-11ea-8083-7af533fd6f64.png)
