### PR TITLE
Fix unintentional double back event from lightbox

### DIFF
--- a/static/src/javascripts/projects/common/modules/gallery/lightbox.js
+++ b/static/src/javascripts/projects/common/modules/gallery/lightbox.js
@@ -82,6 +82,7 @@ class GalleryLightbox {
     endslateEl: bonzo;
     endslate: Object;
     startIndex: number;
+    handleKeyEvents: (KeyboardEvent) => void;
 
     constructor(): void {
         // CONFIG
@@ -91,6 +92,7 @@ class GalleryLightbox {
             config.get('page.contentType') === 'Gallery';
         this.useSwipe = hasTouchScreen();
         this.swipeThreshold = 0.05;
+        this.handleKeyEvents = this.unboundHandleKeyEvents.bind(this);
 
         // TEMPLATE
         const generateButtonHTML = (label: string): string => {
@@ -421,10 +423,8 @@ class GalleryLightbox {
         this.bodyScrollPosition = $body.scrollTop();
         $body.addClass('has-overlay');
         this.$lightboxEl.addClass('gallery-lightbox--open');
-        bean.off(document.body, 'keydown', event =>
-            this.handleKeyEvents(event)
-        ); // prevent double binding
-        bean.on(document.body, 'keydown', event => this.handleKeyEvents(event));
+        bean.off(document.body, 'keydown', this.handleKeyEvents); // prevent double binding
+        bean.on(document.body, 'keydown', this.handleKeyEvents);
     }
 
     close(): void {
@@ -451,7 +451,7 @@ class GalleryLightbox {
         }, 1);
     }
 
-    handleKeyEvents(e: KeyboardEvent): void {
+    unboundHandleKeyEvents(e: KeyboardEvent): void {
         if (e.keyCode === 37) {
             // left
             this.trigger('prev');


### PR DESCRIPTION
##  What does this change?

Opening, closing and then re-opening the lightbox was causing keyboard events to be re-bound without correctly unbinding the previously bound handler. This meant that when exiting the lightbox for the second time using the escape key, the event was being handled twice, resulting in the browser going back twice, instead of just once to the article.

I think this was because the bean.off and on keydown handling was using anonymous arrow functions, which will be unique every time. Instead we now bind this to `handleKeyEvents` in the constructor and can use `this.handleKeyEvents` directly, no arrow function required.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

Before:

![2020-05-15 09 59 05](https://user-images.githubusercontent.com/379839/82032184-c7d15d80-9692-11ea-959f-309b3821e4de.gif)

After:

![2020-05-15 09 58 00](https://user-images.githubusercontent.com/379839/82032382-0535eb00-9693-11ea-8aee-61969f04e35c.gif)

## What is the value of this and can you measure success?

Give our readers the best experience we can (report from a user came via user help). 

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
