### PR TITLE
Filter 2 more network errors from Sentry

### DIFF
--- a/static/src/javascripts/lib/raven.js
+++ b/static/src/javascripts/lib/raven.js
@@ -34,7 +34,7 @@ const sentryOptions = {
         'This video is no longer available.',
         'UnknownError',
         'TypeError: Failed to fetch',
-        'TypeError: NetworkError when attempting to fetch resource.',
+        'TypeError: NetworkError when attempting to fetch resource',
 
         // weatherapi/city.json frequently 404s and lib/fetch-json throws an error
         'Fetch error while requesting https://api.nextgen.guardianapps.co.uk/weatherapi/city.json:',

--- a/static/src/javascripts/lib/raven.js
+++ b/static/src/javascripts/lib/raven.js
@@ -33,6 +33,8 @@ const sentryOptions = {
         'Network request failed',
         'This video is no longer available.',
         'UnknownError',
+        'TypeError: Failed to fetch',
+        'TypeError: NetworkError when attempting to fetch resource.',
 
         // weatherapi/city.json frequently 404s and lib/fetch-json throws an error
         'Fetch error while requesting https://api.nextgen.guardianapps.co.uk/weatherapi/city.json:',


### PR DESCRIPTION
## What does this change?
We already filter several variations of fetch network errors from Sentry. Here we add 2 more:

```typescript
        'TypeError: Failed to fetch',
        'TypeError: NetworkError when attempting to fetch resource',
```

The trigger for this change was errors seen when making calls for CMP to get the vendorList.json file but we also want to ignore network requests in principle because we have no control over them. This error in particular is [known to occur](https://forum.sentry.io/t/typeerror-failed-to-fetch-reported-over-and-overe/8447) when the user navigates away from the page early.

## Does this change need to be reproduced in dotcom-rendering ?
Yes. https://github.com/guardian/dotcom-rendering/pull/1501
