### PR TITLE
Drop cookie when user signs up for epic reminder

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -37,7 +37,7 @@ import { optOutEnabled, userIsInArticlesViewedOptOutTest, setupArticlesViewedOpt
 import {
     shouldHideSupportMessaging,
     isPostAskPauseOneOffContributor,
-    ARTICLES_VIEWED_OPT_OUT_COOKIE,
+    ARTICLES_VIEWED_OPT_OUT_COOKIE
 } from 'common/modules/commercial/user-features';
 import {
     supportContributeURL,

--- a/static/src/javascripts/projects/common/modules/commercial/epic-reminder-email-signup.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic-reminder-email-signup.js
@@ -3,6 +3,8 @@
 import config from 'lib/config';
 import errorTriangle from 'svgs/icon/error-triangle.svg';
 import {submitClickEvent, submitViewEvent} from 'common/modules/commercial/acquisitions-ophan';
+import {addCookie} from "lib/cookies";
+import {CONTRIBUTIONS_REMINDER_SIGNED_UP} from "common/modules/commercial/user-features";
 
 type ReminderState = 'invalid' | 'pending' | 'success' | 'failure';
 
@@ -106,6 +108,13 @@ const epicReminderEmailSignup = (fields: Fields) => {
                 fields.closeButton.style.display = 'none';
                 fields.titleField.innerHTML =
                     'Thank you! Your reminder is set.';
+
+                addCookie(
+                    CONTRIBUTIONS_REMINDER_SIGNED_UP.name,
+                    new Date().getTime().toString(),
+                    CONTRIBUTIONS_REMINDER_SIGNED_UP.daysToLive
+                );
+
                 break;
             case 'failure':
                 fields.submitButton.innerHTML = 'Something went wrong';

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
@@ -2,7 +2,7 @@
 import { paymentMethodLogosTemplate } from 'common/modules/commercial/templates/payment-method-logos-template';
 import type { ReminderFields } from 'common/modules/commercial/templates/acquisitions-epic-reminder';
 import { defaultReminderFields } from 'common/modules/commercial/templates/acquisitions-epic-control';
-import config from "../../../../../lib/config";
+import { canShowContributionsReminderFeature } from 'common/modules/commercial/user-features';
 
 
 export const epicButtonsTemplate = (
@@ -48,7 +48,7 @@ export const epicButtonsTemplate = (
                 </a>`
         : '';
 
-    const showReminder = config.get('switches.showContributionReminder');
+    const showReminder = canShowContributionsReminderFeature();
     const reminderCta = reminderFields ? reminderFields.reminderCTA : defaultReminderFields.reminderCTA;
 
     const reminderButton = showReminder

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
@@ -1,9 +1,9 @@
 // @flow
-import config from 'lib/config';
 import { appendToLastElement } from 'lib/array-utils';
 import { acquisitionsEpicTickerTemplate } from 'common/modules/commercial/templates/acquisitions-epic-ticker';
 import { acquisitionsEpicReminderTemplate } from 'common/modules/commercial/templates/acquisitions-epic-reminder';
 import type { ReminderFields } from 'common/modules/commercial/templates/acquisitions-epic-reminder';
+import { canShowContributionsReminderFeature } from 'common/modules/commercial/user-features';
 
 const buildFooter = (footer: string[]): string =>
     `<div class="contributions__epic-footer">
@@ -48,8 +48,6 @@ export const acquisitionsEpicControlTemplate = ({
 
     const reminderFields = showReminderFields || defaultReminderFields;
 
-    const showReminder = config.get('switches.showContributionReminder');
-
     return `<div class="contributions__epic ${extraClasses}" data-component="${componentName}" data-link-name="epic">
         <div class="${wrapperClass}">
             <div>
@@ -76,7 +74,7 @@ export const acquisitionsEpicControlTemplate = ({
 
             ${footer ? buildFooter(footer) : ''}
 
-            ${showReminder ? acquisitionsEpicReminderTemplate(reminderFields) : ''}
+            ${canShowContributionsReminderFeature() ? acquisitionsEpicReminderTemplate(reminderFields) : ''}
         </div>
     </div>`;
 };

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -32,7 +32,7 @@ const ARTICLES_VIEWED_OPT_OUT_COOKIE = {
 };
 
 const CONTRIBUTIONS_REMINDER_SIGNED_UP = {
-    name: 'gu_contributions_reminder_signed-up',
+    name: 'gu_contributions_reminder_signed_up',
     daysToLive: 90,
 };
 

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -322,6 +322,11 @@ const extendContribsCookieExpiry = (): void => {
     }
 };
 
+const canShowContributionsReminderFeature = (): boolean => {
+    const signedUpForReminder = !!getCookie(CONTRIBUTIONS_REMINDER_SIGNED_UP.name);
+    return config.get('switches.showContributionReminder') && !signedUpForReminder;
+};
+
 export {
     accountDataUpdateWarning,
     isAdFreeUser,
@@ -341,5 +346,6 @@ export {
     shouldNotBeShownSupportMessaging,
     extendContribsCookieExpiry,
     ARTICLES_VIEWED_OPT_OUT_COOKIE,
-    CONTRIBUTIONS_REMINDER_SIGNED_UP
+    CONTRIBUTIONS_REMINDER_SIGNED_UP,
+    canShowContributionsReminderFeature
 };

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -31,6 +31,11 @@ const ARTICLES_VIEWED_OPT_OUT_COOKIE = {
     daysToLive: 90,
 };
 
+const CONTRIBUTIONS_REMINDER_SIGNED_UP = {
+    name: 'gu_contributions_reminder_signed-up',
+    daysToLive: 90,
+};
+
 const forcedAdFreeMode: boolean = !!window.location.hash.match(
     /[#&]noadsaf(&.*)?$/
 );
@@ -336,4 +341,5 @@ export {
     shouldNotBeShownSupportMessaging,
     extendContribsCookieExpiry,
     ARTICLES_VIEWED_OPT_OUT_COOKIE,
+    CONTRIBUTIONS_REMINDER_SIGNED_UP
 };


### PR DESCRIPTION
## What does this change?
We have a feature in the epic that lets users sign up for a reminder email, rather than contribute now.
With this change, a cookie is dropped when a user signs up. This cookie lasts 3 months, and is used to prevent the reminder feature from being displayed again in the epic.

#### No cookie, reminder button visible:
<img width="687" alt="Screen Shot 2020-05-18 at 12 05 20" src="https://user-images.githubusercontent.com/1513454/82208085-d2922980-9902-11ea-89c7-b61a285a364c.png">

#### With cookie, no reminder button:
<img width="687" alt="Screen Shot 2020-05-18 at 12 05 07" src="https://user-images.githubusercontent.com/1513454/82208119-e473cc80-9902-11ea-9dda-1ea62b1de677.png">


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
