### PR TITLE
Reduce Sentry sampling to 0.8%

### DIFF
--- a/static/src/javascripts/lib/raven.js
+++ b/static/src/javascripts/lib/raven.js
@@ -57,7 +57,7 @@ const sentryOptions = {
         const isIgnored =
             typeof data.tags.ignored !== 'undefined' && data.tags.ignored;
         const { enableSentryReporting } = config.get('switches');
-        const isInSample = Math.random() < 0.01; // 1%
+        const isInSample = Math.random() < 0.008; // 0.8%
 
         if (isDev && !isIgnored) {
             // Some environments don't support or don't always expose the console Object


### PR DESCRIPTION
## What does this change?

It reduces the sentry sampling by 0.2% to reduce the volume we're sending while serving more traffic.

We are still getting enough throughput into Sentry to catch most errors, including edge cases.

This will mean we have to be aware when looking at the dashboard that the even though an error may not be reported for an hour or two, it's likely still happening.