### PR TITLE
Passing the atom id to the [applications] atom template

### DIFF
--- a/applications/app/controllers/AtomPageController.scala
+++ b/applications/app/controllers/AtomPageController.scala
@@ -95,7 +95,7 @@ class AtomPageController(contentApiClient: ContentApiClient, wsClient: WSClient,
         val html1: String = ArticleAtomRenderer.getHTML(atom.atom, articleConfig)
         val css: ArticleAtomRenderer.CSS = ArticleAtomRenderer.getCSS(atom.atom.atomType) // Option[String]
         val js: ArticleAtomRenderer.JS = ArticleAtomRenderer.getJS(atom.atom.atomType)    // Option[String]
-        val html2: Html = views.html.fragments.atoms.audio(Html(html1), css, js)
+        val html2: Html = views.html.fragments.atoms.audio(atom.id, Html(html1), css, js)
         Ok(html2)
       }
       case Left(atom: ChartAtom) =>

--- a/common/app/views/fragments/atoms/audio.scala.html
+++ b/common/app/views/fragments/atoms/audio.scala.html
@@ -9,7 +9,7 @@ showing atoms from first principles. It should not be considered ready for wide 
 the atom is showing fine but there are some missing bits in the HTML template.
 *@
 
-@(html: Html, css: Option[String], js: Option[String])(implicit request: RequestHeader, context: model.ApplicationContext)
+@(atomId:String, html: Html, css: Option[String], js: Option[String])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 <!DOCTYPE html>
 <html lang="en-GB" class="gu-atom-embed-html">
@@ -23,7 +23,7 @@ the atom is showing fine but there are some missing bits in the HTML template.
         }
     </head>
     <body>
-        <div class="element-atom" data-atom-type="audio" data-atom-id="d6d509cf-ca10-407f-8913-e16a3712f415">
+        <div class="element-atom" data-atom-type="audio" data-atom-id="@atomId">
         @html
         </div>
         <script type="text/javascript">


### PR DESCRIPTION
## What does this change?

Passing the atom id to the [applications] atom template.
