### PR TITLE
Match Nav endpoint for DCR

### DIFF
--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -61,7 +61,6 @@ class MoreOnMatchController(
 
 
       lazy val competition = competitionsService.competitionForMatch(theMatch.id)
-      lazy val homeTeamResults = competition.map(_.teamResults(theMatch.homeTeam.id).take(5))
 
       related map { _ filter hasExactlyTwoTeams } map { filtered =>
         Cached(if(theMatch.isLive) 10 else 300) {

--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -73,7 +73,6 @@ class MoreOnMatchController(
               "isResult" -> theMatch.isResult,
               "comments" -> theMatch.comments.getOrElse(""),
               "venue" -> theMatch.venue.map(_.name).getOrElse(""),
-              "isLiveOrIsResult" -> (theMatch.isResult || theMatch.isLive),
               "homeTeam" -> Json.obj(
                 "name" -> theMatch.homeTeam.name,
                 "id" -> theMatch.homeTeam.id,

--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -61,14 +61,33 @@ class MoreOnMatchController(
 
       related map { _ filter hasExactlyTwoTeams } map { filtered =>
         Cached(if(theMatch.isLive) 10 else 300) {
-          JsonComponent(
-            "nav" -> football.views.html.fragments.matchNav(populateNavModel(theMatch, filtered)),
-            "matchSummary" -> football.views.html.fragments.matchSummary(theMatch, competitionsService.competitionForMatch(theMatch.id), responsive = true),
-            "hasStarted" -> theMatch.hasStarted,
-            "group" -> group,
-            "matchDate" ->  DateTimeFormat.forPattern("yyyy/MMM/dd").print(theMatch.date).toLowerCase(),
-            "dropdown" -> views.html.fragments.dropdown("")(Html(""))
-          )
+          if (request.forceDCR) {
+            println(theMatch)
+            JsonComponent(
+              "id" -> theMatch.id,
+              "leg" -> theMatch.leg,
+              "venue" -> theMatch.venue,
+              "homeTeam" -> JsonComponent(
+                "name" -> theMatch.homeTeam.name,
+                "scorers" -> theMatch.homeTeam.scorers,
+                "score" -> theMatch.homeTeam.score,
+                "aggregateScore" -> theMatch.homeTeam.aggregateScore,
+                "comments" -> theMatch.comments,
+              ),
+              "hasStarted" -> theMatch.hasStarted,
+              "group" -> group,
+              "matchDate" ->  DateTimeFormat.forPattern("yyyy/MMM/dd").print(theMatch.date).toLowerCase(),
+            )
+          } else {
+            JsonComponent(
+              "nav" -> football.views.html.fragments.matchNav(populateNavModel(theMatch, filtered)),
+              "matchSummary" -> football.views.html.fragments.matchSummary(theMatch, competitionsService.competitionForMatch(theMatch.id), responsive = true),
+              "hasStarted" -> theMatch.hasStarted,
+              "group" -> group,
+              "matchDate" ->  DateTimeFormat.forPattern("yyyy/MMM/dd").print(theMatch.date).toLowerCase(),
+              "dropdown" -> views.html.fragments.dropdown("")(Html(""))
+            )
+          }
         }
       }
     }

--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -77,9 +77,7 @@ class MoreOnMatchController(
                 "score" -> theMatch.homeTeam.score,
                 "crest" -> s"${Configuration.staticSport.path}/football/crests/120/${theMatch.homeTeam.id}.png",
                 "scorers" -> theMatch.homeTeam.scorers.getOrElse("").split(",").map(scorer => {
-                  Json.obj(
-                    "scorer" -> scorer.replace("(", "").replace(")", "")
-                  )
+                  scorer.replace("(", "").replace(")", "")
                 })
               ),
               "awayTeam" -> Json.obj(
@@ -88,9 +86,7 @@ class MoreOnMatchController(
                 "score" -> theMatch.awayTeam.score,
                 "crest" -> s"${Configuration.staticSport.path}/football/crests/120/${theMatch.awayTeam.id}.png",
                 "scorers" -> theMatch.awayTeam.scorers.getOrElse("").split(",").map(scorer => {
-                  Json.obj(
-                    "scorer" -> scorer.replace("(", "").replace(")", "")
-                  )
+                  scorer.replace("(", "").replace(")", "")
                 })
               ),
               "competition" -> Json.obj(

--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -10,7 +10,6 @@ import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model.{Cached, Content, ContentType, NoCache}
 import org.joda.time.{DateTime, Days, LocalDate}
 import org.joda.time.format.DateTimeFormat
-import org.joda.time.format.ISODateTimeFormat
 import com.github.nscala_time.time.Imports
 import com.github.nscala_time.time.Imports._
 import pa.FootballMatch


### PR DESCRIPTION
## What does this change?
Adds a DCR (json only) version for the `match-nav` endpoint

http://localhost:9000/football/api/match-nav/2020/03/11/26305/9.json?page=football%2F2020%2Fmar%2F11%2Fliverpool-atlletico-madrid-champions-league-last-16-second-leg-match-report&dcr returns:

```typescript
{
	homeTeam: {
		name: "Liverpool",
		id: "9",
		score: 2,
		crest: "https://sport.guim.co.uk/football/crests/120/9.png",
		scorers: [
			"Georginio Wijnaldum 43",
			"Roberto Firmino 94"
		]
	},
	isResult: true,
	awayTeam: {
		name: "Atlético",
		id: "26305",
		score: 3,
		crest: "https://sport.guim.co.uk/football/crests/120/26305.png",
		scorers: [
			"Marcos Llorente 97",
			"Marcos Llorente 105 +0:02",
			"Alvaro Morata 120 +0:16"
		]
	},
	id: "4188140",
	refreshStatus: true,
	competition: {
		fullName: "Champions League"
	},
	isLive: false,
	venue: "Anfield",
	comments: "Club Atletico de Madrid win 4-2 on aggregate"
}
```
![Screenshot 2020-05-20 at 09 26 38](https://user-images.githubusercontent.com/1336821/82423692-0b094300-9a7c-11ea-9cd8-0b0606ff0bf0.jpg)


## Why?
We want to support Match Reports in DCR. To do this we need to render the Match Nav component at the top of the page. On frontend this uses a special endpoint that returns the html to put in the page. For DCR, we're taking the approach of the api returning json and using react to render it to html. For this we need an endpoint that gives us the data we need in json format.

