### PR TITLE
Mj add post contrib reminder feedback button

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/epic-reminder-email-signup.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic-reminder-email-signup.js
@@ -20,7 +20,7 @@ type Fields = {
 
 const isValidEmail = (email: string) => {
     const re = /[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/;
-    return re.test(email);
+    return (email.replace(/\s+/g, '') === email) ? re.test(email) : false
 };
 
 const getFields = (): ?Fields => {
@@ -120,7 +120,7 @@ const epicReminderEmailSignup = (fields: Fields) => {
     const sendReminderEvent = (): Promise<Response> => {
         const isProd = config.get('page.isProd');
 
-        const email = fields.emailInput.value || '';
+        const email = fields.emailInput.value.trim() || '';
 
         if (!isValidEmail(email)) {
             setState('invalid');

--- a/static/src/javascripts/projects/common/modules/commercial/epic-reminder-email-signup.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic-reminder-email-signup.js
@@ -13,6 +13,7 @@ type Fields = {
     formWrapper: HTMLElement,
     titleField: HTMLElement,
     thankYouText: HTMLElement,
+    surveyRequest: HTMLElement,
     closeButton: HTMLElement,
     reminderPrompt: HTMLElement,
     reminderToggle: HTMLInputElement,
@@ -32,6 +33,7 @@ const getFields = (): ?Fields => {
     const formWrapper = document.querySelector('.epic-reminder__form-wrapper');
     const titleField = document.querySelector('.epic-reminder__form-title');
     const thankYouText = document.querySelector('.epic-reminder__thank-you');
+    const surveyRequest = document.querySelector('.epic-reminder__survey-request-wrapper');
     const closeButton = document.querySelector('.epic-reminder__close-button');
     const reminderPrompt = document.querySelector(
         '.component-button--reminder-prompt'
@@ -46,6 +48,7 @@ const getFields = (): ?Fields => {
         emailInput &&
         titleField &&
         thankYouText &&
+        surveyRequest &&
         formWrapper &&
         closeButton &&
         reminderPrompt &&
@@ -67,6 +70,7 @@ const getFields = (): ?Fields => {
             formWrapper,
             titleField,
             thankYouText,
+            surveyRequest,
             closeButton,
             reminderPrompt,
             reminderToggle,
@@ -102,6 +106,7 @@ const epicReminderEmailSignup = (fields: Fields) => {
                 break;
             case 'success':
                 fields.thankYouText.style.display = 'block';
+                fields.surveyRequest.style.display = 'block';
                 fields.formWrapper.style.display = 'none';
                 fields.closeButton.style.display = 'none';
                 fields.titleField.innerHTML =

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
@@ -31,7 +31,7 @@ export const epicButtonsTemplate = (
 
     const secondaryButton = secondaryCta
         ? `
-            <a class="component-button component-button--greyHollow component-button--greyHollow--for-epic component-button--hasicon-right contributions__contribute--epic-member contributions__secondary-button contributions__secondary-button--epic"
+            <a class="component-button component-button--greyHollow component-button--greyHollow--for-epic component-button--hasicon-right"
               href=${secondaryCta.url}
               target="_blank">
               ${secondaryCta.ctaText}

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
@@ -31,7 +31,7 @@ export const epicButtonsTemplate = (
 
     const secondaryButton = secondaryCta
         ? `
-            <a class="component-button component-button--greyHollow component-button--greyHollow--for-epic component-button--hasicon-right"
+            <a class="component-button component-button--greyHollow component-button--greyHollow--for-epic component-button--hasicon-right contributions__contribute--epic-member contributions__secondary-button contributions__secondary-button--epic"
               href=${secondaryCta.url}
               target="_blank">
               ${secondaryCta.ctaText}

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-reminder.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-reminder.js
@@ -58,7 +58,21 @@ export const acquisitionsEpicReminderTemplate = (
             <div class="epic-reminder__survey-request-wrapper">
                 <div class="epic-reminder__survey-request-title">Have you got a minute?</div>
                 <div class="epic-reminder__survey-request">Please answer four short questions to help us improve how we remind our readers to contribute.</div>
-                <a href="https://www.surveymonkey.co.uk/r/7T78HVR" target="_blank">Share your thoughts</a>
+                <a class="component-button component-button--greyHollow component-button--greyHollow--for-epic component-button--reminder-prompt contributions__secondary-button contributions__secondary-button--epic component-button--hasicon-right epic-reminder__survey-request-button"
+                href="https://www.surveymonkey.co.uk/r/7T78HVR"
+                target="_blank">
+                Share your thoughts
+                    <svg
+                    class="svg-arrow-right-straight"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 20 17.89"
+                    preserveAspectRatio="xMinYMid"
+                    aria-hidden="true"
+                    focusable="false"
+                    >
+                        <path d="M20 9.35l-9.08 8.54-.86-.81 6.54-7.31H0V8.12h16.6L10.06.81l.86-.81L20 8.51v.84z" />
+                    </svg>
+                </a>
             </div>
         </div>
     </div>

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-reminder.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-reminder.js
@@ -54,6 +54,12 @@ export const acquisitionsEpicReminderTemplate = (
                     reminderFields.reminderDateAsString
                 }. If you have any questions about contributing, please <a href="mailto:contribution.support@theguardian.com">contact us here</a>.
             </div>
+
+            <div class="epic-reminder__survey-request-wrapper">
+                <div class="epic-reminder__survey-request-title">Have you got a minute?</div>
+                <div class="epic-reminder__survey-request">Please answer four short questions to help us improve how we remind our readers to contribute.</div>
+                <a href="https://www.surveymonkey.co.uk/r/7T78HVR" target="_blank">Share your thoughts</a>
+            </div>
         </div>
     </div>
 `;

--- a/static/src/stylesheets/module/reader-revenue/_epic-reminder.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic-reminder.scss
@@ -39,7 +39,7 @@
         padding: 0 5px;
     }
 
-    .epic-reminder__form-title {
+    .epic-reminder__form-title, .epic-reminder__survey-request-title {
         @include fs-headline(3);
         padding-top: $gs-baseline * 2;
         font-weight: bold;
@@ -128,6 +128,16 @@
         @include fs-bodyCopy(2);
         line-height: 21px;
         display: none;
+        margin-top: $gs-baseline;
+    }
+
+    .epic-reminder__survey-request-wrapper {
+        display: none;
+    }
+
+    .epic-reminder__survey-request {
+        @include fs-bodyCopy(2);
+        line-height: 21px;
         margin-top: $gs-baseline;
     }
 

--- a/static/src/stylesheets/module/reader-revenue/_epic-reminder.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic-reminder.scss
@@ -145,6 +145,8 @@
         text-decoration: none !important;
         margin-top: $gs-baseline !important;
         margin-bottom: $gs-baseline * 1.5 !important;
+        height: 36px !important;
+        min-height: 36px !important;
     }
 
     // Override link rules for the pillar

--- a/static/src/stylesheets/module/reader-revenue/_epic-reminder.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic-reminder.scss
@@ -141,6 +141,12 @@
         margin-top: $gs-baseline;
     }
 
+    .epic-reminder__survey-request-button {
+        text-decoration: none !important;
+        margin-top: $gs-baseline !important;
+        margin-bottom: $gs-baseline * 1.5 !important;
+    }
+
     // Override link rules for the pillar
     a {
         color: $brightness-7 !important;


### PR DESCRIPTION
Adds a feedback request to the post contribution reminder copy, as per [this card](https://trello.com/c/85KWaulR).

The button opens a new tab/page and links directly to Survey Monkey.

Please see screenshots below for styling implementation.

**Laptop**
<img width="1440" alt="laptop" src="https://user-images.githubusercontent.com/25020231/82452220-e5456380-9aa6-11ea-9cf1-43394a0d500c.png">
<br>

**Tablet**
![tablet](https://user-images.githubusercontent.com/25020231/82452260-eececb80-9aa6-11ea-8b0c-8702e6595d7b.png)
<br>

**Smartphone**
![smartphone](https://user-images.githubusercontent.com/25020231/82452276-f7270680-9aa6-11ea-94a3-bc084aea0b64.png)
<br>