### PR TITLE
William/top above nav race condition

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -43,7 +43,7 @@ const insertAdAtPara = (
 
     return fastdom
         .write(() =>
-            ads.forEach(ad => {
+            ads.map(ad => {
                 if (para.parentNode) {
                     para.parentNode.insertBefore(ad, para);
                 }

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -42,13 +42,13 @@ const insertAdAtPara = (
     });
 
     return fastdom
-        .write(() => {
-            return ads.map(ad => {
+        .write(() =>
+            ads.map(ad => {
                 if (para.parentNode) {
                     para.parentNode.insertBefore(ad, para);
                 }
+                return ad
             })
-        }
         )
         .then(() => {
             const shouldForceDisplay = ['im', 'carrot'].includes(name);

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -42,12 +42,13 @@ const insertAdAtPara = (
     });
 
     return fastdom
-        .write(() =>
-            ads.map(ad => {
+        .write(() => {
+            return ads.map(ad => {
                 if (para.parentNode) {
                     para.parentNode.insertBefore(ad, para);
                 }
             })
+        }
         )
         .then(() => {
             const shouldForceDisplay = ['im', 'carrot'].includes(name);

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -42,15 +42,12 @@ const insertAdAtPara = (
     });
 
     return fastdom
-        .write(() =>
-            ads.map(ad => {
+        .write(() => {
+            ads.forEach(ad => {
                 if (para.parentNode) {
                     para.parentNode.insertBefore(ad, para);
                 }
-                return ad
             })
-        )
-        .then(() => {
             const shouldForceDisplay = ['im', 'carrot'].includes(name);
             // Only add the first ad (the DFP one) to GTP
             addSlot(ads[0], shouldForceDisplay);


### PR DESCRIPTION
## What does this change?
return an array to `fastdom.write` to avoid `.then` being called when forEach operation hasnt finished, causing a race condition

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes (please indicate your plans for DCR Implementation)

The race condition only appear in DCR on the top above nav on mobile view. Likely due to a work around where the [DOM was removed](https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/commercial/modules/dfp/create-slots.js#L157).

## Screenshots
![Screenshot_2020-04-30_at_12 02 26](https://user-images.githubusercontent.com/8831403/82457831-d0200300-9aad-11ea-88c1-4e4ce529e90f.png)

## What is the value of this and can you measure success?
We should see the Ad appear on mobile views in DCR

### Tested

- [ ] Locally
- [ ] On CODE (optional)
