### PR TITLE
Add 100% audience sign in gate test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -116,6 +116,16 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+    Switch(
+    ABTests,
+    "ab-sign-in-gate-centesimus",
+    "Show sign in gate to 100% of users on 3rd article view",
+    owners = Seq(Owner.withGithub("vlbee")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 12, 1),
+    exposeClientSide = true
+  )
+
   Switch(
     ABTests,
     "ab-amp-zero-test-experiment",

--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -58,6 +58,7 @@ declare type ABTest = {
     showForSensitive: boolean,
     idealOutcome?: string,
     dataLinkNames?: string,
+    ophanComponentId?: string,
     variants: $ReadOnlyArray<Variant>,
     canRun: () => boolean,
     notInTest?: () => void,

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -9,7 +9,8 @@ import { pangaeaAdapterTest } from 'common/modules/experiments/tests/commercial-
 import { amazonA9Test } from 'common/modules/experiments/tests/amazon-a9';
 import { connatixTest } from 'common/modules/experiments/tests/connatix-ab-test';
 import { remoteEpicVariants } from 'common/modules/experiments/tests/remote-epic-variants';
-import { signInGate } from 'common/modules/experiments/tests/sign-in-gate';
+import { signInGatePatientia } from 'common/modules/experiments/tests/sign-in-gate-patientia';
+import { signInGateCentesimus } from 'common/modules/experiments/tests/sign-in-gate-centesimus';
 import { contributionsCovidBannerRoundTwo } from 'common/modules/experiments/tests/contribs-banner-covid-round-two';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
@@ -19,7 +20,8 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     xaxisAdapterTest,
     appnexusUSAdapter,
     pangaeaAdapterTest,
-    signInGate,
+    signInGatePatientia,
+    signInGateCentesimus,
 ];
 
 export const priorityEpicTest: AcquisitionsABTest = remoteEpicVariants;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-centesimus.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-centesimus.js
@@ -1,4 +1,8 @@
 // @flow
+
+// Trigger test in Dev
+// http://m.thegulocal.com/uk#ab-SignInGateCentesimus=centesimus-control-1
+
 export const signInGateCentesimus: ABTest = {
     id: 'SignInGateCentesimus',
     start: '2020-05-20',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-centesimus.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-centesimus.js
@@ -1,0 +1,30 @@
+// @flow
+export const signInGateCentesimus: ABTest = {
+    id: 'SignInGateCentesimus',
+    start: '2020-05-20',
+    expiry: '2020-12-01',
+    author: 'vlbee',
+    description:
+        'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic',
+    audience: 0.9999,
+    audienceOffset: 0.0,
+    successMeasure: 'Users sign in or create a Guardian account',
+    audienceCriteria:
+        '3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
+    ophanComponentId: 'centesimus_test',
+    dataLinkNames: 'SignInGateCentesimus',
+    idealOutcome:
+        'Increase the number of users signed in whilst running at a reasonable scale',
+    showForSensitive: false,
+    canRun: () => true,
+    variants: [
+        {
+            id: 'centesimus-control-1',
+            test: (): void => {},
+        },
+        // {
+        //     id: 'centesimus-variant-1',
+        //     test: (): void => {},
+        // },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-patientia.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-patientia.js
@@ -7,7 +7,7 @@ export const signInGatePatientia: ABTest = {
     description:
         'Marathon sign in gate test on 3nd article view of simple article templates, with higher priority over banners and epic',
     audience: 0.0001,
-    audienceOffset: 0.98,
+    audienceOffset: 0.9999,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:
         '2nd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-patientia.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-patientia.js
@@ -1,5 +1,5 @@
 // @flow
-export const signInGate: ABTest = {
+export const signInGatePatientia: ABTest = {
     id: 'SignInGatePatientia',
     start: '2020-04-30',
     expiry: '2020-12-01',
@@ -12,6 +12,7 @@ export const signInGate: ABTest = {
     audienceCriteria:
         '2nd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
     dataLinkNames: 'SignInGatePatientia',
+    ophanComponentId: 'patientia_test',
     idealOutcome:
         'Conversion to sign in is higher when the gate is shown over a longer period of time, with no sustained negative impact to engagement levels or supporter acquisition',
     showForSensitive: false,

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/component.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/component.js
@@ -4,7 +4,9 @@
 export const componentName = 'sign-in-gate';
 
 // set the ophan component tracking vars
-export const component: OphanComponent = {
+export const withComponentId: (id: string) => OphanComponent = (
+    id: string = ''
+) => ({
     componentType: 'SIGN_IN_GATE',
-    id: 'patientia_test',
-};
+    id,
+});

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
@@ -3,10 +3,11 @@ import config from 'lib/config';
 import { getCookie } from 'lib/cookies';
 import { constructQuery } from 'lib/url';
 import type { Banner } from 'common/modules/ui/bannerPicker';
-import { signInGate as signInGateTest } from 'common/modules/experiments/tests/sign-in-gate';
+import { signInGatePatientia } from 'common/modules/experiments/tests/sign-in-gate-patientia';
+import { signInGateCentesimus } from 'common/modules/experiments/tests/sign-in-gate-centesimus';
 import { submitViewEventTracking } from './component-event-tracking';
 import { getVariant, isInTest, getTestforMultiTest } from './helper';
-import { component, componentName } from './component';
+import { withComponentId, componentName } from './component';
 import { variants } from './variants';
 import type {
     CurrentABTest,
@@ -15,7 +16,7 @@ import type {
 } from './types';
 
 // if using multiple tests, then add them all in this array. (all the variant names in each test in the array must be unique)
-const tests = [signInGateTest];
+const tests = [signInGatePatientia, signInGateCentesimus];
 
 const canShow: () => Promise<boolean> = () =>
     new Promise(resolve => {
@@ -37,7 +38,7 @@ const canShow: () => Promise<boolean> = () =>
 const show: () => Promise<boolean> = () =>
     new Promise(resolve => {
         // get the test the user is in
-        const test = getTestforMultiTest(tests);
+        const test: ABTest = getTestforMultiTest(tests); // todo what is test is undefined?????
 
         // get the variant
         const variant: SignInGateVariant | void = variants.find(
@@ -59,7 +60,7 @@ const show: () => Promise<boolean> = () =>
         // set the component event params to be included in the query
         const queryParams: ComponentEventParams = {
             componentType: 'signingate',
-            componentId: component.id,
+            componentId: test.ophanComponentId,
             abTestName: test.dataLinkNames || test.id,
             abTestVariant: variant.name,
         };
@@ -84,10 +85,15 @@ const show: () => Promise<boolean> = () =>
             constructQuery(queryParams)
         )}`;
 
+        const ophanComponentId: string = test.ophanComponentId
+            ? test.ophanComponentId
+            : '';
+        const ophanComponent = withComponentId(ophanComponentId);
+
         // in any variant
         // fire view tracking event
         submitViewEventTracking({
-            component,
+            component: ophanComponent,
             abTest,
         });
 
@@ -97,6 +103,7 @@ const show: () => Promise<boolean> = () =>
                 guUrl,
                 signInUrl,
                 abTest,
+                ophanComponentId,
             })
         );
     });

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
@@ -38,7 +38,9 @@ const canShow: () => Promise<boolean> = () =>
 const show: () => Promise<boolean> = () =>
     new Promise(resolve => {
         // get the test the user is in
-        const test: ABTest = getTestforMultiTest(tests); // todo what is test is undefined?????
+        const test: ABTest = getTestforMultiTest(tests);
+
+        if (!test) return resolve(false);
 
         // get the variant
         const variant: SignInGateVariant | void = variants.find(

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
@@ -15,6 +15,7 @@ jest.mock('common/modules/experiments/ab', () => ({
             variantToRun: {
                 id: 'patientia-variant-1', // Update for each new test
             },
+            ophanComponentId: 'patientia_test',
         },
     ]),
 }));
@@ -109,7 +110,7 @@ describe('Sign in gate test', () => {
             });
         });
 
-        it('should return false if user has dismissed the gate', () => {
+        fit('should return false if user has dismissed the gate', () => {
             fakeUserPrefs.get.mockReturnValueOnce({
                 'SignInGatePatientia-variant': Date.now(),
             });

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
@@ -110,7 +110,7 @@ describe('Sign in gate test', () => {
             });
         });
 
-        fit('should return false if user has dismissed the gate', () => {
+        it('should return false if user has dismissed the gate', () => {
             fakeUserPrefs.get.mockReturnValueOnce({
                 'SignInGatePatientia-variant': Date.now(),
             });

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
@@ -112,7 +112,7 @@ describe('Sign in gate test', () => {
 
         it('should return false if user has dismissed the gate', () => {
             fakeUserPrefs.get.mockReturnValueOnce({
-                'SignInGatePatientia-variant': Date.now(),
+                'SignInGatePatientia-patientia-variant-1': Date.now(),
             });
             return signInGate.canShow().then(show => {
                 expect(show).toBe(false);

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/types.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/types.js
@@ -20,6 +20,7 @@ export type SignInGateVariant = {
         abTest: CurrentABTest,
         guUrl: string,
         signInUrl: string,
+        ophanComponentId: string,
     }) => boolean,
     canShow: (name?: string) => boolean,
     name: string,

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/centesimus/control.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/centesimus/control.js
@@ -11,7 +11,7 @@ import {
 } from '../../helper';
 
 // pull in the show method from the design folder, which has the html template and and click handlers etc.
-import { designShow } from '../design/patientia'; // using the same design as patientia-variant-1
+import { designShow } from '../design/centesimus';
 
 // define the variant name here
 const variant = 'centesimus-control-1';

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/centesimus/control.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/centesimus/control.js
@@ -1,19 +1,20 @@
 // @flow
-import type { CurrentABTest, SignInGateVariant } from '../types';
-import { componentName } from '../component';
+import type { CurrentABTest, SignInGateVariant } from '../../types';
+import { componentName } from '../../component';
 import {
     hasUserDismissedGate,
     isNPageOrHigherPageView,
     isLoggedIn,
     isInvalidArticleType,
     isInvalidSection,
-} from '../helper';
+    isIOS9,
+} from '../../helper';
 
 // pull in the show method from the design folder, which has the html template and and click handlers etc.
-import { designShow } from './design/example';
+import { designShow } from '../design/patientia'; // using the same design as patientia-variant-1
 
 // define the variant name here
-const variant = 'example';
+const variant = 'centesimus-control-1';
 
 // method which returns a boolean determining if this variant can be shown on the current pageview
 const canShow: (name?: string) => boolean = (name = '') =>
@@ -22,10 +23,11 @@ const canShow: (name?: string) => boolean = (name = '') =>
         variant,
         componentName,
     }) &&
-    isNPageOrHigherPageView(2) &&
+    isNPageOrHigherPageView(3) &&
     !isLoggedIn() &&
     !isInvalidArticleType() &&
-    !isInvalidSection();
+    !isInvalidSection() &&
+    !isIOS9();
 
 // method which runs if the canShow method returns true, used to display the gate and logic associated with it
 // it returns a boolean, since the sign in gate is based on a `Banner` type who's show method returns a Promise<boolean>

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/centesimus.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/centesimus.js
@@ -1,0 +1,151 @@
+// @flow
+import mediator from 'lib/mediator';
+import type { CurrentABTest } from '../../types';
+import { componentName, withComponentId } from '../../component';
+import {
+    addOpinionBgColour,
+    addClickHandler,
+    setUserDismissedGate,
+    showGate,
+} from '../../helper';
+
+// add the html template as the return of the function below
+// signInUrl - parameter which holds the link to the sign in/register page with the tracking parameters added
+// guUrl - url of the STAGE frontend site, e.g. in DEV stage it would be https://m.thegulocal.com,
+//         and for PROD it would be https://theguardian.com
+const htmlTemplate: ({
+    signInUrl: string,
+    guUrl: string,
+}) => string = ({ signInUrl, guUrl }) => `
+<div class="signin-gate">
+    <div class="signin-gate__content">
+        <div class="signin-gate__header">
+            <h1 class="signin-gate__header--text">Register for free and continue reading</h1>
+        </div>
+        <div class="signin-gate__benefits syndication--bottom">
+            <p class="signin-gate__benefits--text">
+                The Guardian’s independent journalism is still free to read
+            </p>
+        </div>
+        <div class="signin-gate__paragraph syndication--bottom">
+            <p class="signin-gate__paragraph--text">
+                Registering lets us understand you better. This means that we can build better products and start to personalise the adverts you see so we can charge more from advertisers in the future.
+            </p>
+        </div>
+        <div class="signin-gate__buttons">
+            <a class="signin-gate__button signin-gate__button--primary js-signin-gate__register-button" href="${signInUrl}">
+                Register for free
+            </a>
+            <a class="signin-gate__dismiss js-signin-gate__dismiss" href="#maincontent">Not Now</a>
+        </div>
+        <div class="signin-gate__padding-bottom signin-gate__buttons">
+            Already registered, contributed or subscribed?&nbsp;<a class="signin-gate__link js-signin-gate__sign-in signin-gate__link-no-ptm signin-gate__center-424" href="${signInUrl}">Sign in</a>
+        </div>
+        <div class="signin-gate__buttons">
+            <a class="signin-gate__link js-signin-gate__why" href="${guUrl}/membership/2019/dec/20/signing-in-to-the-guardian">Why register & how does it help?</a>
+        </div>
+        <div class="signin-gate__buttons">
+            <a class="signin-gate__link js-signin-gate__how" href="${guUrl}/info/2014/nov/03/why-your-data-matters-to-us-full-text">How will my information & data be used?</a>
+        </div>
+        <div class="signin-gate__buttons">
+            <a class="signin-gate__link js-signin-gate__help" href="${guUrl}/help/identity-faq">Get help with registering or signing in</a>
+        </div>
+    </div>
+</div>
+`;
+
+// method which runs if the canShow method from the test returns true, used to display the gate and logic associated with it
+// it returns a boolean, since the sign in gate is based on a `Banner` type who's show method returns a Promise<boolean>
+// in our case it returns true if the design ran successfully, and false if there were any problems encountered
+export const designShow: ({
+    abTest: CurrentABTest,
+    guUrl: string,
+    signInUrl: string,
+    ophanComponentId: string,
+}) => boolean = ({ abTest, guUrl, signInUrl, ophanComponentId }) =>
+    showGate({
+        template: htmlTemplate({
+            signInUrl,
+            guUrl,
+        }),
+        handler: ({ articleBody, shadowArticleBody }) => {
+            // check if comment, and add comment/opinion bg colour
+            addOpinionBgColour({
+                element: shadowArticleBody,
+                selector: '.signin-gate__first-paragraph-overlay',
+            });
+
+            const ophanComponent: OphanComponent = withComponentId(
+                ophanComponentId
+            );
+
+            // add click handler for the dismiss of the gate
+            addClickHandler({
+                element: shadowArticleBody,
+                selector: '.js-signin-gate__dismiss',
+                abTest,
+                component: ophanComponent,
+                value: 'not-now',
+                callback: () => {
+                    // show the current body. Remove the shadow one
+                    articleBody.style.display = 'block';
+                    shadowArticleBody.remove();
+
+                    // Tell other things the article has been redisplayed
+                    mediator.emit('page:article:redisplayed');
+
+                    // user pref dismissed gate
+                    setUserDismissedGate({
+                        componentName,
+                        name: abTest.name,
+                        variant: abTest.variant,
+                    });
+                },
+            });
+
+            // add click handler for sign in link click
+            addClickHandler({
+                element: shadowArticleBody,
+                selector: '.js-signin-gate__register-button',
+                abTest,
+                component: ophanComponent,
+                value: 'register-link',
+            });
+
+            // add click handler for sign in link click
+            addClickHandler({
+                element: shadowArticleBody,
+                selector: '.js-signin-gate__sign-in',
+                abTest,
+                component: ophanComponent,
+                value: 'sign-in-link',
+            });
+
+            // add click handler for the why sign in link
+            addClickHandler({
+                element: shadowArticleBody,
+                selector: '.js-signin-gate__why',
+                abTest,
+                component: ophanComponent,
+                value: 'why-link',
+            });
+
+            // add click handler for the how info used link
+            addClickHandler({
+                element: shadowArticleBody,
+                selector: '.js-signin-gate__how',
+                abTest,
+                component: ophanComponent,
+                value: 'how-link',
+            });
+
+            // add click handler for the help link
+            addClickHandler({
+                element: shadowArticleBody,
+                selector: '.js-signin-gate__help',
+                abTest,
+                component: ophanComponent,
+                value: 'help-link',
+            });
+        },
+    });

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/example.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/example.js
@@ -1,7 +1,7 @@
 // @flow
 import mediator from 'lib/mediator';
 import type { CurrentABTest } from '../../types';
-import { component, componentName } from '../../component';
+import { withComponentId, componentName } from '../../component';
 import {
     addOpinionBgColour,
     addClickHandler,
@@ -61,7 +61,8 @@ export const designShow: ({
     abTest: CurrentABTest,
     guUrl: string,
     signInUrl: string,
-}) => boolean = ({ abTest, guUrl, signInUrl }) =>
+    ophanComponentId: string,
+}) => boolean = ({ abTest, guUrl, signInUrl, ophanComponentId }) =>
     showGate({
         template: htmlTemplate({
             signInUrl,
@@ -74,12 +75,16 @@ export const designShow: ({
                 selector: '.signin-gate__first-paragraph-overlay',
             });
 
+            const ophanComponent: OphanComponent = withComponentId(
+                ophanComponentId
+            );
+
             // add click handler for the dismiss of the gate
             addClickHandler({
                 element: shadowArticleBody,
                 selector: '.js-signin-gate__dismiss',
                 abTest,
-                component,
+                component: ophanComponent,
                 value: 'not-now',
                 callback: () => {
                     // show the current body. Remove the shadow one
@@ -103,7 +108,7 @@ export const designShow: ({
                 element: shadowArticleBody,
                 selector: '.js-signin-gate__register-button',
                 abTest,
-                component,
+                component: ophanComponent,
                 value: 'register-link',
             });
 
@@ -112,7 +117,7 @@ export const designShow: ({
                 element: shadowArticleBody,
                 selector: '.js-signin-gate__sign-in',
                 abTest,
-                component,
+                component: ophanComponent,
                 value: 'sign-in-link',
             });
 
@@ -121,7 +126,7 @@ export const designShow: ({
                 element: shadowArticleBody,
                 selector: '.js-signin-gate__why',
                 abTest,
-                component,
+                component: ophanComponent,
                 value: 'why-link',
             });
 
@@ -130,7 +135,7 @@ export const designShow: ({
                 element: shadowArticleBody,
                 selector: '.js-signin-gate__how',
                 abTest,
-                component,
+                component: ophanComponent,
                 value: 'how-link',
             });
 
@@ -139,7 +144,7 @@ export const designShow: ({
                 element: shadowArticleBody,
                 selector: '.js-signin-gate__help',
                 abTest,
-                component,
+                component: ophanComponent,
                 value: 'help-link',
             });
         },

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/patientia.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/patientia.js
@@ -1,7 +1,7 @@
 // @flow
 import mediator from 'lib/mediator';
 import type { CurrentABTest } from '../../types';
-import { component, componentName } from '../../component';
+import { componentName, withComponentId } from '../../component';
 import {
     addOpinionBgColour,
     addClickHandler,
@@ -61,7 +61,8 @@ export const designShow: ({
     abTest: CurrentABTest,
     guUrl: string,
     signInUrl: string,
-}) => boolean = ({ abTest, guUrl, signInUrl }) =>
+    ophanComponentId: string,
+}) => boolean = ({ abTest, guUrl, signInUrl, ophanComponentId }) =>
     showGate({
         template: htmlTemplate({
             signInUrl,
@@ -74,12 +75,16 @@ export const designShow: ({
                 selector: '.signin-gate__first-paragraph-overlay',
             });
 
+            const ophanComponent: OphanComponent = withComponentId(
+                ophanComponentId
+            );
+
             // add click handler for the dismiss of the gate
             addClickHandler({
                 element: shadowArticleBody,
                 selector: '.js-signin-gate__dismiss',
                 abTest,
-                component,
+                component: ophanComponent,
                 value: 'not-now',
                 callback: () => {
                     // show the current body. Remove the shadow one
@@ -103,7 +108,7 @@ export const designShow: ({
                 element: shadowArticleBody,
                 selector: '.js-signin-gate__register-button',
                 abTest,
-                component,
+                component: ophanComponent,
                 value: 'register-link',
             });
 
@@ -112,7 +117,7 @@ export const designShow: ({
                 element: shadowArticleBody,
                 selector: '.js-signin-gate__sign-in',
                 abTest,
-                component,
+                component: ophanComponent,
                 value: 'sign-in-link',
             });
 
@@ -121,7 +126,7 @@ export const designShow: ({
                 element: shadowArticleBody,
                 selector: '.js-signin-gate__why',
                 abTest,
-                component,
+                component: ophanComponent,
                 value: 'why-link',
             });
 
@@ -130,7 +135,7 @@ export const designShow: ({
                 element: shadowArticleBody,
                 selector: '.js-signin-gate__how',
                 abTest,
-                component,
+                component: ophanComponent,
                 value: 'how-link',
             });
 
@@ -139,7 +144,7 @@ export const designShow: ({
                 element: shadowArticleBody,
                 selector: '.js-signin-gate__help',
                 abTest,
-                component,
+                component: ophanComponent,
                 value: 'help-link',
             });
         },

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/index.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/index.js
@@ -2,12 +2,14 @@
 import type { SignInGateVariant } from '../types';
 // import the variants from their respective files e.g.
 // import { signInGateVariant as example } from './example';
-import { signInGateVariant as control } from './control';
-import { signInGateVariant as variant } from './variant';
+import { signInGateVariant as patientiaControl } from './patientia/control';
+import { signInGateVariant as patientiaVariant } from './patientia/variant';
+import { signInGateVariant as centesimusControl } from './centesimus/control';
 
 // to add a variant, first import the variant in the SignInGateVariant type, and then add to this exported array
 export const variants: Array<SignInGateVariant> = [
     // example,
-    control,
-    variant,
+    patientiaControl,
+    patientiaVariant,
+    centesimusControl,
 ];

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/patientia/control.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/patientia/control.js
@@ -1,6 +1,6 @@
 // @flow
-import type { SignInGateVariant } from '../types';
-import { componentName } from '../component';
+import type { SignInGateVariant } from '../../types';
+import { componentName } from '../../component';
 import {
     hasUserDismissedGate,
     isNPageOrHigherPageView,
@@ -8,7 +8,7 @@ import {
     isInvalidArticleType,
     isInvalidSection,
     isIOS9,
-} from '../helper';
+} from '../../helper';
 
 // pull in the show method from the design folder, which has the html template and and click handlers etc.
 // No design needed as not showing a sign in gate in the control

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/patientia/variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/patientia/variant.js
@@ -1,6 +1,6 @@
 // @flow
-import type { CurrentABTest, SignInGateVariant } from '../types';
-import { componentName } from '../component';
+import type { CurrentABTest, SignInGateVariant } from '../../types';
+import { componentName } from '../../component';
 import {
     hasUserDismissedGate,
     isNPageOrHigherPageView,
@@ -8,10 +8,10 @@ import {
     isInvalidArticleType,
     isInvalidSection,
     isIOS9,
-} from '../helper';
+} from '../../helper';
 
 // pull in the show method from the design folder, which has the html template and and click handlers etc.
-import { designShow } from './design/patientia';
+import { designShow } from '../design/patientia';
 
 // define the variant name here
 const variant = 'patientia-variant-1';
@@ -36,8 +36,9 @@ const show: ({
     abTest: CurrentABTest,
     guUrl: string,
     signInUrl: string,
-}) => boolean = ({ abTest, guUrl, signInUrl }) =>
-    designShow({ abTest, guUrl, signInUrl });
+    ophanComponentId: string,
+}) => boolean = ({ abTest, guUrl, signInUrl, ophanComponentId }) =>
+    designShow({ abTest, guUrl, signInUrl, ophanComponentId });
 
 // export the variant as a SignInGateVariant type
 export const signInGateVariant: SignInGateVariant = {


### PR DESCRIPTION
## What does this change?

- Adds an Identity sign in gate test for 100% audience coverage - `"ab-sign-in-gate-centesimus"`
- Refactors hard coded Component Id string out of `component.js` and into `experiments/tests` file


## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
