### PR TITLE
Match Stats endpoint for DCR

### DIFF
--- a/sport/app/football/controllers/MatchController.scala
+++ b/sport/app/football/controllers/MatchController.scala
@@ -71,10 +71,52 @@ class MatchController(
 
       page map { page =>
         if (request.forceDCR) {
-          println(page)
           Cached(30) {
+            val teamColours = TeamColours(page.lineUp.homeTeam, page.lineUp.awayTeam)
             JsonComponent(
               "id" -> theMatch.id,
+              "homeTeam" -> Json.obj(
+                "lineup" -> Json.arr((page.lineUp.homeTeam.players).map  ( player =>
+                  Json.obj(
+                    "id" -> player.id,
+                    "name" -> player.name,
+                    "position" -> player.position,
+                    "shirtNumber" -> player.shirtNumber,
+                    "events" -> Json.arr(player.events.map( event => Json.obj(
+                      "eventTime" -> event.eventTime,
+                      "eventType" -> event.eventType
+                    )))
+                  )
+                )),
+                "possession" -> page.lineUp.homeTeamPossession,
+                "attemptsOnTarget" -> page.lineUp.homeTeam.shotsOn,
+                "attemptsOffTarget" -> page.lineUp.homeTeam.shotsOff,
+                "corners" -> page.lineUp.homeTeam.corners,
+                "fouls" -> page.lineUp.homeTeam.fouls,
+                "colour" -> teamColours.home
+              ),
+              "awayTeam" -> Json.obj(
+                "lineup" -> Json.arr(
+                  (page.lineUp.homeTeam.players).map ( player =>
+                    Json.obj(
+                      "id" -> player.id,
+                      "name" -> player.name,
+                      "position" -> player.position,
+                      "shirtNumber" -> player.shirtNumber,
+                      "events" -> Json.arr(player.events.map( event => Json.obj(
+                        "eventTime" -> event.eventTime,
+                        "eventType" -> event.eventType
+                      )))
+                    )
+                  )
+                ),
+                "possession" -> page.lineUp.awayTeamPossession,
+                "attemptsOnTarget" -> page.lineUp.awayTeam.shotsOn,
+                "attemptsOffTarget" -> page.lineUp.awayTeam.shotsOff,
+                "corners" -> page.lineUp.awayTeam.corners,
+                "fouls" -> page.lineUp.awayTeam.fouls,
+                "colour" -> teamColours.home
+              )
             )
           }
         } else {

--- a/sport/app/football/controllers/MatchController.scala
+++ b/sport/app/football/controllers/MatchController.scala
@@ -81,6 +81,7 @@ class MatchController(
                     "id" -> player.id,
                     "name" -> player.name,
                     "position" -> player.position,
+                    "lastName" -> player.lastName,
                     "substitute" -> player.substitute,
                     "shirtNumber" -> player.shirtNumber,
                     "events" -> Json.arr(player.events.map( event => Json.obj(
@@ -103,6 +104,7 @@ class MatchController(
                       "id" -> player.id,
                       "name" -> player.name,
                       "position" -> player.position,
+                      "lastName" -> player.lastName,
                       "substitute" -> player.substitute,
                       "shirtNumber" -> player.shirtNumber,
                       "events" -> Json.arr(player.events.map( event => Json.obj(

--- a/sport/app/football/controllers/MatchController.scala
+++ b/sport/app/football/controllers/MatchController.scala
@@ -89,8 +89,8 @@ class MatchController(
                   )
                 )),
                 "possession" -> page.lineUp.homeTeamPossession,
-                "attemptsOnTarget" -> page.lineUp.homeTeam.shotsOn,
-                "attemptsOffTarget" -> page.lineUp.homeTeam.shotsOff,
+                "shotsOn" -> page.lineUp.homeTeam.shotsOn,
+                "shotsOff" -> page.lineUp.homeTeam.shotsOff,
                 "corners" -> page.lineUp.homeTeam.corners,
                 "fouls" -> page.lineUp.homeTeam.fouls,
                 "colour" -> teamColours.home
@@ -111,8 +111,8 @@ class MatchController(
                   )
                 ),
                 "possession" -> page.lineUp.awayTeamPossession,
-                "attemptsOnTarget" -> page.lineUp.awayTeam.shotsOn,
-                "attemptsOffTarget" -> page.lineUp.awayTeam.shotsOff,
+                "shotsOn" -> page.lineUp.awayTeam.shotsOn,
+                "shotsOff" -> page.lineUp.awayTeam.shotsOff,
                 "corners" -> page.lineUp.awayTeam.corners,
                 "fouls" -> page.lineUp.awayTeam.fouls,
                 "colour" -> teamColours.home

--- a/sport/app/football/controllers/MatchController.scala
+++ b/sport/app/football/controllers/MatchController.scala
@@ -68,6 +68,8 @@ class MatchController(
     val response = maybeMatch map { theMatch =>
       val lineup: Future[LineUp] = competitionsService.getLineup(theMatch)
       val page: Future[MatchPage] = lineup map { MatchPage(theMatch, _) }
+      val reportedEventTypes = List("booking", "dismissal", "substitution")
+
 
       page map { page =>
         if (request.forceDCR) {
@@ -85,7 +87,7 @@ class MatchController(
                     "substitute" -> player.substitute,
                     "timeOnPitch" -> player.timeOnPitch,
                     "shirtNumber" -> player.shirtNumber,
-                    "events" -> player.events.map( event => Json.obj(
+                    "events" -> player.events.filter(event => reportedEventTypes.contains(event.eventType)).map( event => Json.obj(
                       "eventTime" -> event.eventTime,
                       "eventType" -> event.eventType
                     )
@@ -108,7 +110,7 @@ class MatchController(
                     "substitute" -> player.substitute,
                     "timeOnPitch" -> player.timeOnPitch,
                     "shirtNumber" -> player.shirtNumber,
-                    "events" ->player.events.map( event => Json.obj(
+                    "events" -> player.events.filter(event => reportedEventTypes.contains(event.eventType)).map( event => Json.obj(
                       "eventTime" -> event.eventTime,
                       "eventType" -> event.eventType
                     ))

--- a/sport/app/football/controllers/MatchController.scala
+++ b/sport/app/football/controllers/MatchController.scala
@@ -81,6 +81,7 @@ class MatchController(
                     "id" -> player.id,
                     "name" -> player.name,
                     "position" -> player.position,
+                    "substitute" -> player.substitute,
                     "shirtNumber" -> player.shirtNumber,
                     "events" -> Json.arr(player.events.map( event => Json.obj(
                       "eventTime" -> event.eventTime,
@@ -102,6 +103,7 @@ class MatchController(
                       "id" -> player.id,
                       "name" -> player.name,
                       "position" -> player.position,
+                      "substitute" -> player.substitute,
                       "shirtNumber" -> player.shirtNumber,
                       "events" -> Json.arr(player.events.map( event => Json.obj(
                         "eventTime" -> event.eventTime,

--- a/sport/app/football/controllers/MatchController.scala
+++ b/sport/app/football/controllers/MatchController.scala
@@ -70,9 +70,18 @@ class MatchController(
       val page: Future[MatchPage] = lineup map { MatchPage(theMatch, _) }
 
       page map { page =>
-        val htmlResponse = () => football.views.html.matchStats.matchStatsPage(page, competitionsService.competitionForMatch(theMatch.id))
-        val jsonResponse = () => football.views.html.matchStats.matchStatsComponent(page)
-        renderFormat(htmlResponse, jsonResponse, page)
+        if (request.forceDCR) {
+          println(page)
+          Cached(30) {
+            JsonComponent(
+              "id" -> theMatch.id,
+            )
+          }
+        } else {
+          val htmlResponse = () => football.views.html.matchStats.matchStatsPage(page, competitionsService.competitionForMatch(theMatch.id))
+          val jsonResponse = () => football.views.html.matchStats.matchStatsComponent(page)
+          renderFormat(htmlResponse, jsonResponse, page)
+        }
       }
     }
 

--- a/sport/app/football/controllers/MatchController.scala
+++ b/sport/app/football/controllers/MatchController.scala
@@ -93,7 +93,7 @@ class MatchController(
                 "shotsOff" -> page.lineUp.homeTeam.shotsOff,
                 "corners" -> page.lineUp.homeTeam.corners,
                 "fouls" -> page.lineUp.homeTeam.fouls,
-                "colour" -> teamColours.home
+                "colours" -> teamColours.home
               ),
               "awayTeam" -> Json.obj(
                 "lineup" -> Json.arr(
@@ -115,7 +115,7 @@ class MatchController(
                 "shotsOff" -> page.lineUp.awayTeam.shotsOff,
                 "corners" -> page.lineUp.awayTeam.corners,
                 "fouls" -> page.lineUp.awayTeam.fouls,
-                "colour" -> teamColours.home
+                "colours" -> teamColours.away
               )
             )
           }

--- a/sport/app/football/controllers/MatchController.scala
+++ b/sport/app/football/controllers/MatchController.scala
@@ -76,7 +76,7 @@ class MatchController(
             JsonComponent(
               "id" -> theMatch.id,
               "homeTeam" -> Json.obj(
-                "lineup" -> Json.arr((page.lineUp.homeTeam.players).map  ( player =>
+                "lineup" -> (page.lineUp.homeTeam.players).map  ( player =>
                   Json.obj(
                     "id" -> player.id,
                     "name" -> player.name,
@@ -88,7 +88,7 @@ class MatchController(
                     "events" -> player.events.map( event => Json.obj(
                       "eventTime" -> event.eventTime,
                       "eventType" -> event.eventType
-                    ))
+                    )
                   )
                 )),
                 "possession" -> page.lineUp.homeTeamPossession,
@@ -99,21 +99,19 @@ class MatchController(
                 "colours" -> teamColours.home
               ),
               "awayTeam" -> Json.obj(
-                "lineup" -> Json.arr(
-                  (page.lineUp.homeTeam.players).map ( player =>
-                    Json.obj(
-                      "id" -> player.id,
-                      "name" -> player.name,
-                      "position" -> player.position,
-                      "lastName" -> player.lastName,
-                      "substitute" -> player.substitute,
-                      "timeOnPitch" -> player.timeOnPitch,
-                      "shirtNumber" -> player.shirtNumber,
-                      "events" ->player.events.map( event => Json.obj(
-                        "eventTime" -> event.eventTime,
-                        "eventType" -> event.eventType
-                      ))
-                    )
+                "lineup" -> (page.lineUp.homeTeam.players).map ( player =>
+                  Json.obj(
+                    "id" -> player.id,
+                    "name" -> player.name,
+                    "position" -> player.position,
+                    "lastName" -> player.lastName,
+                    "substitute" -> player.substitute,
+                    "timeOnPitch" -> player.timeOnPitch,
+                    "shirtNumber" -> player.shirtNumber,
+                    "events" ->player.events.map( event => Json.obj(
+                      "eventTime" -> event.eventTime,
+                      "eventType" -> event.eventType
+                    ))
                   )
                 ),
                 "possession" -> page.lineUp.awayTeamPossession,

--- a/sport/app/football/controllers/MatchController.scala
+++ b/sport/app/football/controllers/MatchController.scala
@@ -85,10 +85,10 @@ class MatchController(
                     "substitute" -> player.substitute,
                     "timeOnPitch" -> player.timeOnPitch,
                     "shirtNumber" -> player.shirtNumber,
-                    "events" -> Json.arr(player.events.map( event => Json.obj(
+                    "events" -> player.events.map( event => Json.obj(
                       "eventTime" -> event.eventTime,
                       "eventType" -> event.eventType
-                    )))
+                    ))
                   )
                 )),
                 "possession" -> page.lineUp.homeTeamPossession,
@@ -109,10 +109,10 @@ class MatchController(
                       "substitute" -> player.substitute,
                       "timeOnPitch" -> player.timeOnPitch,
                       "shirtNumber" -> player.shirtNumber,
-                      "events" -> Json.arr(player.events.map( event => Json.obj(
+                      "events" ->player.events.map( event => Json.obj(
                         "eventTime" -> event.eventTime,
                         "eventType" -> event.eventType
-                      )))
+                      ))
                     )
                   )
                 ),

--- a/sport/app/football/controllers/MatchController.scala
+++ b/sport/app/football/controllers/MatchController.scala
@@ -83,6 +83,7 @@ class MatchController(
                     "position" -> player.position,
                     "lastName" -> player.lastName,
                     "substitute" -> player.substitute,
+                    "timeOnPitch" -> player.timeOnPitch,
                     "shirtNumber" -> player.shirtNumber,
                     "events" -> Json.arr(player.events.map( event => Json.obj(
                       "eventTime" -> event.eventTime,
@@ -106,6 +107,7 @@ class MatchController(
                       "position" -> player.position,
                       "lastName" -> player.lastName,
                       "substitute" -> player.substitute,
+                      "timeOnPitch" -> player.timeOnPitch,
                       "shirtNumber" -> player.shirtNumber,
                       "events" -> Json.arr(player.events.map( event => Json.obj(
                         "eventTime" -> event.eventTime,


### PR DESCRIPTION
## What does this change?
Adds a DCR (json only) version for the `/football/match/:year/:month/:day/$home<[\w\d-\.]+>-v-$away<[\w\d-\.]+> ` endpoint

http://localhost:9000/football/match/2020/mar/11/liverpool-v-atleticomadrid.json?dcr returns

```typescript

```
![Screenshot 2020-05-21 at 09 54 45](https://user-images.githubusercontent.com/1336821/82541970-22fac880-9b49-11ea-8505-1bc6eb7106ab.jpg)

## Why?
We want to support Match Reports in DCR. To do this we need to render the Match Stats component at the end of the page. On frontend this uses a special endpoint that returns the html to put in the page. For DCR, we're taking the approach of the api returning json and using react to render it to html. For this we need an endpoint that gives us the data we need in json format.