### PR TITLE
fix bug causing hyperlinks in epic to use the wrong colour

### DIFF
--- a/static/src/stylesheets/module/reader-revenue/_epic-article-count-opt-out.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic-article-count-opt-out.scss
@@ -72,7 +72,7 @@
 .epic-article-count .epic-article-count__prompt-label a {
     text-decoration: none;
     border-bottom: 1px solid $brightness-7;
-    color: $brightness-7;
+    color: $brightness-7 !important;
 }
 
 .epic-article-count__buttons {
@@ -84,12 +84,12 @@
 
 .epic-article-count a.epic-article-count__button-opt-out {
     background-color: $brightness-100;
-    color: $brand-main;
+    color: $brand-main !important;
 }
 
 .epic-article-count a.epic-article-count__button-opt-in {
-    background-color: $brand-main;
-    color: $brightness-100;
+    background-color: $brand-main !important;
+    color: $brightness-100 !important;
     border: solid 1px $brightness-100;
 }
 


### PR DESCRIPTION
Fixes bug causing hyperlinks in epic to use wrong colour for opinion articles. Please see before and after fix screenshots below.

**Before**
<img width="1440" alt="Screenshot 2020-05-21 at 11 43 54" src="https://user-images.githubusercontent.com/25020231/82551626-7294c080-9b58-11ea-9210-709c634bda93.png">

**After**
<img width="1440" alt="Screenshot 2020-05-21 at 11 43 27" src="https://user-images.githubusercontent.com/25020231/82551609-6ad51c00-9b58-11ea-9af7-19d50b0f2420.png">
