### PR TITLE
setup european-union ReaderRevenueRegion for subscription banner targetting

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -67,16 +67,19 @@ export type ReaderRevenueRegion =
     | 'united-kingdom'
     | 'united-states'
     | 'australia'
+    | 'european-union'
     | 'rest-of-world';
 
 const getReaderRevenueRegion = (geolocation: string): ReaderRevenueRegion => {
-    switch (geolocation) {
-        case 'GB':
+    switch (true) {
+        case geolocation === 'GB':
             return 'united-kingdom';
-        case 'US':
+        case geolocation === 'US':
             return 'united-states';
-        case 'AU':
+        case geolocation === 'AU':
             return 'australia';
+        case  countryCodeToCountryGroupId(geolocation) === 'EURCountries':
+            return 'european-union';
         default:
             return 'rest-of-world';
     }

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-tracking.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-tracking.js
@@ -38,7 +38,7 @@ const createTracking = (
     region: ReaderRevenueRegion,
     defaultTracking: BannerTracking
 ) => {
-    const isGuardianWeeklyRegion = region === 'australia';
+    const isGuardianWeeklyRegion = (region === 'australia' || region === 'rest-of-world');
 
     const guardianWeeklyTracking = {
         signInUrl: `${signinHostname}/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_gWeekly&CMP_TU=mrtn&CMP_BUNIT=subs`,

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.js
@@ -56,8 +56,11 @@ const hasAcknowledged = bannerRedeploymentDate => {
 const selectorName = (bannerName: string) => (actionId: ?string) =>
     `#js-site-message--${bannerName}${actionId ? `__${actionId}` : ''}`;
 
-const hasAcknowledgedBanner = region =>
-    fetchJson(`/reader-revenue/subscriptions-banner-deploy-log/${region}`, {
+/**
+ * We're temporarily using the "/united-kingdom" route
+ * for users in the "european-union" region.
+ */
+const hasAcknowledgedBanner = (region: ReaderRevenueRegion): Promise<boolean> => fetchJson(`/reader-revenue/subscriptions-banner-deploy-log/${region === 'european-union' ? 'united-kingdom' : region}`, {
         mode: 'cors',
     })
         .then(resp => hasAcknowledged(resp.time))
@@ -70,7 +73,7 @@ const hasAcknowledgedBanner = region =>
                 false
             );
             return true;
-        });
+        })
 
 const twoOrMorePageViews = (currentPageViews: number) =>
     currentPageViews >= 2;
@@ -181,7 +184,7 @@ const createBannerShow = (
 };
 
 const chooseBanner = (region: ReaderRevenueRegion) =>
-    region === 'australia' ? gwBannerTemplate : subscriptionBannerTemplate;
+(region === 'australia' || region === 'rest-of-world') ? gwBannerTemplate : subscriptionBannerTemplate;
 
 const show = createBannerShow(
     bannerTracking(currentRegion),

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.js
@@ -73,7 +73,7 @@ const hasAcknowledgedBanner = (region: ReaderRevenueRegion): Promise<boolean> =>
                 false
             );
             return true;
-        })
+        });
 
 const twoOrMorePageViews = (currentPageViews: number) =>
     currentPageViews >= 2;


### PR DESCRIPTION
## What does this change?

Currently we have 4 ReaderRevenueRegions: `united-kingdom`, `united-states`, `australia` and `rest-of-world`. We don't differentiate EU from `rest-of-world`. We put users into one of the 4 regional groups mentioned above based on their geolocation: 

Ultimately we'd like to be able to differentiate EU users, so we can target banners directly to them and also redeploy banners to them using https://frontend.gutools.co.uk/reader-revenue/subscriptions-banner independently from the `rest-of-world` region.

This PR is the first step in that. This PR now differentiates EU users and adds them to the newly created `european-union` `ReaderRevenueRegion`, this means we can target banners towards them independently of the `rest-of-world`.

In the interim we're grouping EU with the UK when it comes to redeploying Banners. This PR therefore makes used of endpoint `/reader-revenue/subscriptions-banner-deploy-log/united-kingdom` route for both UK/EU users when checking whether a user `hasAcknowledgedBanner`.

**Note:** I've also switched the targeting back so the `rest-of-world` region will now see The Guardian Weekly as was initially requested.

Trello: https://trello.com/c/KyCducfS/3058-map-geolocations-from-eu-countries-to-new-eu-readerrevenueregion

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)