### PR TITLE
Introduce ExplainerAtomBlockElement

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -59,6 +59,7 @@ case class AtomEmbedUrlBlockElement(url: String) extends PageElement
 case class AudioAtomBlockElement(id: String, kicker: String, coverUrl: String, trackUrl: String, duration: Int, contentId: String) extends PageElement
 case class AudioBlockElement(assets: Seq[AudioAsset]) extends PageElement
 case class BlockquoteBlockElement(html: String) extends PageElement
+case class ExplainerAtomBlockElement(id: String, title: String, body: String, displayType: String) extends PageElement
 case class CodeBlockElement(html: Option[String], isMandatory: Boolean) extends PageElement
 case class CommentBlockElement(body: String, avatarURL: String, profileURL: String, profileName: String, permalink: String, dateTime: String) extends PageElement
 case class ContentAtomBlockElement(atomId: String) extends PageElement
@@ -510,6 +511,7 @@ object PageElement {
   implicit val UnknownBlockElementWrites: Writes[UnknownBlockElement] = Json.writes[UnknownBlockElement]
   implicit val DisclaimerBlockElementWrites: Writes[DisclaimerBlockElement] = Json.writes[DisclaimerBlockElement]
   implicit val HTMLBlockElementWrites: Writes[HTMLFallbackBlockElement] = Json.writes[HTMLFallbackBlockElement]
+  implicit val ExplainerAtomBlockElementWrites: Writes[ExplainerAtomBlockElement] = Json.writes[ExplainerAtomBlockElement]
 
   // atoms
   implicit val TimelineEventWrites = Json.writes[TimelineEvent]


### PR DESCRIPTION
## What does this change?

Introduce `ExplainerAtomBlockElement`, in preparation of its support in DCR. This comes together with this PR ( https://github.com/guardian/dotcom-rendering/pull/1520 ).

