### PR TITLE
Add ExplainerAtomBlockElement to DCR object

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -308,6 +308,13 @@ object PageElement {
             ))
           }
 
+          case Some(explainer: ExplainerAtom) => {
+            // author: Pascal
+            // date: 27th May 2020
+            // The display type is hardcoded for he moment, to be updated shortly
+            Some(ExplainerAtomBlockElement(explainer.id, explainer.title, explainer.body, "flat"))
+          }
+
           case Some(guide: GuideAtom) => {
             Some(ProfileBlockElement(
               id = guide.id,


### PR DESCRIPTION
## What does this change?

Add ExplainerAtomBlockElement to DCR object. 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No (It's handled with `return null` on DCR)