### PR TITLE
Revert "setup european-union ReaderRevenueRegion for subscription banner targetting"

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -67,19 +67,16 @@ export type ReaderRevenueRegion =
     | 'united-kingdom'
     | 'united-states'
     | 'australia'
-    | 'european-union'
     | 'rest-of-world';
 
 const getReaderRevenueRegion = (geolocation: string): ReaderRevenueRegion => {
-    switch (true) {
-        case geolocation === 'GB':
+    switch (geolocation) {
+        case 'GB':
             return 'united-kingdom';
-        case geolocation === 'US':
+        case 'US':
             return 'united-states';
-        case geolocation === 'AU':
+        case 'AU':
             return 'australia';
-        case  countryCodeToCountryGroupId(geolocation) === 'EURCountries':
-            return 'european-union';
         default:
             return 'rest-of-world';
     }

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-tracking.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-tracking.js
@@ -38,7 +38,7 @@ const createTracking = (
     region: ReaderRevenueRegion,
     defaultTracking: BannerTracking
 ) => {
-    const isGuardianWeeklyRegion = (region === 'australia' || region === 'rest-of-world');
+    const isGuardianWeeklyRegion = region === 'australia';
 
     const guardianWeeklyTracking = {
         signInUrl: `${signinHostname}/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_gWeekly&CMP_TU=mrtn&CMP_BUNIT=subs`,

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.js
@@ -56,11 +56,8 @@ const hasAcknowledged = bannerRedeploymentDate => {
 const selectorName = (bannerName: string) => (actionId: ?string) =>
     `#js-site-message--${bannerName}${actionId ? `__${actionId}` : ''}`;
 
-/**
- * We're temporarily using the "/united-kingdom" route
- * for users in the "european-union" region.
- */
-const hasAcknowledgedBanner = (region: ReaderRevenueRegion): Promise<boolean> => fetchJson(`/reader-revenue/subscriptions-banner-deploy-log/${region === 'european-union' ? 'united-kingdom' : region}`, {
+const hasAcknowledgedBanner = region =>
+    fetchJson(`/reader-revenue/subscriptions-banner-deploy-log/${region}`, {
         mode: 'cors',
     })
         .then(resp => hasAcknowledged(resp.time))
@@ -184,7 +181,7 @@ const createBannerShow = (
 };
 
 const chooseBanner = (region: ReaderRevenueRegion) =>
-(region === 'australia' || region === 'rest-of-world') ? gwBannerTemplate : subscriptionBannerTemplate;
+    region === 'australia' ? gwBannerTemplate : subscriptionBannerTemplate;
 
 const show = createBannerShow(
     bannerTracking(currentRegion),


### PR DESCRIPTION
Reverts guardian/frontend#22612

This PR affects the targeting of the membership-banner as well as the subscriptions banner so I'm reverting as we'll need to look at how the membership banner is targetted.