### PR TITLE
Setup european-union ReaderRevenueRegion

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -67,16 +67,19 @@ export type ReaderRevenueRegion =
     | 'united-kingdom'
     | 'united-states'
     | 'australia'
+    | 'european-union'
     | 'rest-of-world';
 
 const getReaderRevenueRegion = (geolocation: string): ReaderRevenueRegion => {
-    switch (geolocation) {
-        case 'GB':
+    switch (true) {
+        case geolocation === 'GB':
             return 'united-kingdom';
-        case 'US':
+        case geolocation === 'US':
             return 'united-states';
-        case 'AU':
+        case geolocation === 'AU':
             return 'australia';
+        case  countryCodeToCountryGroupId(geolocation) === 'EURCountries':
+            return 'european-union';
         default:
             return 'rest-of-world';
     }

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.js
@@ -34,10 +34,14 @@ const minArticlesBeforeShowingBanner = 3;
 
 const lastClosedAtKey = 'engagementBannerLastClosedAt';
 
+/**
+ * We're temporarily using the "/rest-of-world" route
+ * for users in the "european-union" region.
+ */
 const getTimestampOfLastBannerDeployForLocation = (
     region: ReaderRevenueRegion
 ): Promise<string> =>
-    fetchJson(`/reader-revenue/contributions-banner-deploy-log/${region}`, {
+    fetchJson(`/reader-revenue/contributions-banner-deploy-log/${region === 'european-union' ? 'rest-of-world' : region}`, {
         mode: 'cors',
     }).then((resp: BannerDeployLog) => resp && resp.time);
 

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-tracking.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-tracking.js
@@ -38,7 +38,7 @@ const createTracking = (
     region: ReaderRevenueRegion,
     defaultTracking: BannerTracking
 ) => {
-    const isGuardianWeeklyRegion = region === 'australia';
+    const isGuardianWeeklyRegion = (region === 'australia' || region === 'rest-of-world');
 
     const guardianWeeklyTracking = {
         signInUrl: `${signinHostname}/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_gWeekly&CMP_TU=mrtn&CMP_BUNIT=subs`,

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.js
@@ -56,8 +56,11 @@ const hasAcknowledged = bannerRedeploymentDate => {
 const selectorName = (bannerName: string) => (actionId: ?string) =>
     `#js-site-message--${bannerName}${actionId ? `__${actionId}` : ''}`;
 
-const hasAcknowledgedBanner = region =>
-    fetchJson(`/reader-revenue/subscriptions-banner-deploy-log/${region}`, {
+/**
+ * We're temporarily using the "/united-kingdom" route
+ * for users in the "european-union" region.
+ */
+const hasAcknowledgedBanner = (region: ReaderRevenueRegion): Promise<boolean> => fetchJson(`/reader-revenue/subscriptions-banner-deploy-log/${region === 'european-union' ? 'united-kingdom' : region}`, {
         mode: 'cors',
     })
         .then(resp => hasAcknowledged(resp.time))
@@ -181,7 +184,7 @@ const createBannerShow = (
 };
 
 const chooseBanner = (region: ReaderRevenueRegion) =>
-    region === 'australia' ? gwBannerTemplate : subscriptionBannerTemplate;
+(region === 'australia' || region === 'rest-of-world') ? gwBannerTemplate : subscriptionBannerTemplate;
 
 const show = createBannerShow(
     bannerTracking(currentRegion),


### PR DESCRIPTION
## What does this change?

This PR reintroduces the changes to `contributions-utilities.js`, `subscription-banner.js`, `subscription-banner-tracking.js` reverted: https://github.com/guardian/frontend/pull/22616 

PLUS the additional change to `membership-engagement-banner.js`. 

The original PR introduced a bug where a fetch request was originating from `membership-engagement-banner.js` to `contributions-banner-deploy-log/european-union` which returned a 404.

This PR now addresses that bug by using the existing `contributions-banner-deploy-log/rest-of-world` route if a user's region is "european-union".

Context: we're introducing a new "european-union" so we can target subs banners to them independently of "rest-of-world". We have a follow-up task to update the deploy tool so wecan depoly banners independently to "european-union", until then they'll be grouped with redeploys to the "united-kingdom" for Subscriptions and "rest-of-world" for Contributions.