### PR TITLE
Add sign-in-gate custom param to page targeting

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
@@ -49,6 +49,17 @@ export const hasUserDismissedGate: ({
     return !!prefs[`${name ? `${name}-` : ''}${variant}`];
 };
 
+// Dynamically sets the gate custom parameter for Google ad request page targeting
+export const setGatePageTargeting = (canShow: boolean): void => {
+    if (window && window.googletag) {
+        window.googletag.cmd.push(() => {
+            window.googletag
+                .pubads()
+                .setTargeting('gate', canShow.toString().slice(0, 1)); // must be a short string so we slice "t"/"f"
+        });
+    }
+};
+
 // set in user preferences that the user has dismissed the gate, set the value to the current ISO date string
 // name is optional, but can be used to differentiate between multiple sign in gate tests
 export const setUserDismissedGate: ({
@@ -103,6 +114,8 @@ export const isInvalidArticleType = (include: Array<string> = []): boolean => {
         'isPhotoEssay',
         'isSensitive',
         'isSplash',
+        'isPodcast',
+        'isInvalidArticleType',
     ];
 
     return invalidTypes

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
@@ -51,7 +51,7 @@ export const hasUserDismissedGate: ({
 
 // Dynamically sets the gate custom parameter for Google ad request page targeting
 export const setGatePageTargeting = (canShow: boolean): void => {
-    if (window && window.googletag) {
+    if (window.googletag) {
         window.googletag.cmd.push(() => {
             window.googletag
                 .pubads()
@@ -115,7 +115,6 @@ export const isInvalidArticleType = (include: Array<string> = []): boolean => {
         'isSensitive',
         'isSplash',
         'isPodcast',
-        'isInvalidArticleType',
     ];
 
     return invalidTypes

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/centesimus/control.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/centesimus/control.js
@@ -8,6 +8,7 @@ import {
     isInvalidArticleType,
     isInvalidSection,
     isIOS9,
+    setGatePageTargeting,
 } from '../../helper';
 
 // pull in the show method from the design folder, which has the html template and and click handlers etc.
@@ -17,17 +18,22 @@ import { designShow } from '../design/centesimus';
 const variant = 'centesimus-control-1';
 
 // method which returns a boolean determining if this variant can be shown on the current pageview
-const canShow: (name?: string) => boolean = (name = '') =>
-    !hasUserDismissedGate({
-        name,
-        variant,
-        componentName,
-    }) &&
-    isNPageOrHigherPageView(3) &&
-    !isLoggedIn() &&
-    !isInvalidArticleType() &&
-    !isInvalidSection() &&
-    !isIOS9();
+const canShow: (name?: string) => boolean = (name = '') => {
+    const canShowCheck =
+        !hasUserDismissedGate({
+            name,
+            variant,
+            componentName,
+        }) &&
+        isNPageOrHigherPageView(3) &&
+        !isLoggedIn() &&
+        !isInvalidArticleType() &&
+        !isInvalidSection() &&
+        !isIOS9();
+
+    setGatePageTargeting(canShowCheck);
+    return canShowCheck;
+};
 
 // method which runs if the canShow method returns true, used to display the gate and logic associated with it
 // it returns a boolean, since the sign in gate is based on a `Banner` type who's show method returns a Promise<boolean>

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/centesimus.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/centesimus.js
@@ -7,6 +7,7 @@ import {
     addClickHandler,
     setUserDismissedGate,
     showGate,
+    setGatePageTargeting,
 } from '../../helper';
 
 // add the html template as the return of the function below
@@ -90,6 +91,10 @@ export const designShow: ({
                     // show the current body. Remove the shadow one
                     articleBody.style.display = 'block';
                     shadowArticleBody.remove();
+
+                    // The page does not reload when a user dismisses the gate,
+                    // so we must reset page targeting params dynamically via googletags
+                    setGatePageTargeting(false);
 
                     // Tell other things the article has been redisplayed
                     mediator.emit('page:article:redisplayed');

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/patientia.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/patientia.js
@@ -7,6 +7,7 @@ import {
     addClickHandler,
     setUserDismissedGate,
     showGate,
+    setGatePageTargeting,
 } from '../../helper';
 
 // add the html template as the return of the function below
@@ -90,6 +91,10 @@ export const designShow: ({
                     // show the current body. Remove the shadow one
                     articleBody.style.display = 'block';
                     shadowArticleBody.remove();
+
+                    // The page does not reload when a user dismisses the gate,
+                    // so we must reset page targeting params dynamically via googletags
+                    setGatePageTargeting(false);
 
                     // Tell other things the article has been redisplayed
                     mediator.emit('page:article:redisplayed');

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/patientia/control.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/patientia/control.js
@@ -8,6 +8,7 @@ import {
     isInvalidArticleType,
     isInvalidSection,
     isIOS9,
+    setGatePageTargeting,
 } from '../../helper';
 
 // pull in the show method from the design folder, which has the html template and and click handlers etc.
@@ -17,17 +18,22 @@ import {
 const variant = 'patientia-control-1';
 
 // method which returns a boolean determining if this variant can be shown on the current pageview
-const canShow: (name?: string) => boolean = (name = '') =>
-    !hasUserDismissedGate({
-        name,
-        variant,
-        componentName,
-    }) &&
-    isNPageOrHigherPageView(2) &&
-    !isLoggedIn() &&
-    !isInvalidArticleType() &&
-    !isInvalidSection() &&
-    !isIOS9();
+const canShow: (name?: string) => boolean = (name = '') => {
+    const canShowCheck =
+        !hasUserDismissedGate({
+            name,
+            variant,
+            componentName,
+        }) &&
+        isNPageOrHigherPageView(2) &&
+        !isLoggedIn() &&
+        !isInvalidArticleType() &&
+        !isInvalidSection() &&
+        !isIOS9();
+
+    setGatePageTargeting(false); // gate is never shown in control
+    return canShowCheck;
+};
 
 // method which runs if the canShow method returns true, used to display the gate and logic associated with it
 // it returns a boolean, since the sign in gate is based on a `Banner` type who's show method returns a Promise<boolean>

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/patientia/variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/patientia/variant.js
@@ -8,6 +8,7 @@ import {
     isInvalidArticleType,
     isInvalidSection,
     isIOS9,
+    setGatePageTargeting,
 } from '../../helper';
 
 // pull in the show method from the design folder, which has the html template and and click handlers etc.
@@ -17,17 +18,22 @@ import { designShow } from '../design/patientia';
 const variant = 'patientia-variant-1';
 
 // method which returns a boolean determining if this variant can be shown on the current pageview
-const canShow: (name?: string) => boolean = (name = '') =>
-    !hasUserDismissedGate({
-        name,
-        variant,
-        componentName,
-    }) &&
-    isNPageOrHigherPageView(2) &&
-    !isLoggedIn() &&
-    !isInvalidArticleType() &&
-    !isInvalidSection() &&
-    !isIOS9();
+const canShow: (name?: string) => boolean = (name = '') => {
+    const canShowCheck =
+        !hasUserDismissedGate({
+            name,
+            variant,
+            componentName,
+        }) &&
+        isNPageOrHigherPageView(2) &&
+        !isLoggedIn() &&
+        !isInvalidArticleType() &&
+        !isInvalidSection() &&
+        !isIOS9();
+
+    setGatePageTargeting(canShowCheck);
+    return canShowCheck;
+};
 
 // method which runs if the canShow method returns true, used to display the gate and logic associated with it
 // it returns a boolean, since the sign in gate is based on a `Banner` type who's show method returns a Promise<boolean>


### PR DESCRIPTION
## What does this change?

This PR  adds a 'gate' param dynamically to each Google ad request as a custom param in the  page targeting.
    
- Adds helper method to the Identity Sign-In-Gate codebase: `setGatePageTargeting` which checks if `googltag` object is available in window and sets `gate=f` or `gate=t`. This will custom param will be added to all subsequent ad requests going out, whether the page is refreshed or now.
- We call this helper method twice for each test twice:
          1. when the .canShow method runs 
          2. when a user dismisses the gate.

Notes: the 'gate' param has been set up in Google ad manager.

Tested locally and in CODE


## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
