### PR TITLE
Remove displayType attribute from ExplainerAtomBlockElement

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -309,9 +309,6 @@ object PageElement {
           }
 
           case Some(explainer: ExplainerAtom) => {
-            // author: Pascal
-            // date: 27th May 2020
-            // The display type is hardcoded for he moment, to be updated shortly
             Some(ExplainerAtomBlockElement(explainer.id, explainer.title, explainer.body))
           }
 

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -59,7 +59,7 @@ case class AtomEmbedUrlBlockElement(url: String) extends PageElement
 case class AudioAtomBlockElement(id: String, kicker: String, coverUrl: String, trackUrl: String, duration: Int, contentId: String) extends PageElement
 case class AudioBlockElement(assets: Seq[AudioAsset]) extends PageElement
 case class BlockquoteBlockElement(html: String) extends PageElement
-case class ExplainerAtomBlockElement(id: String, title: String, body: String, displayType: String) extends PageElement
+case class ExplainerAtomBlockElement(id: String, title: String, body: String) extends PageElement
 case class CodeBlockElement(html: Option[String], isMandatory: Boolean) extends PageElement
 case class CommentBlockElement(body: String, avatarURL: String, profileURL: String, profileName: String, permalink: String, dateTime: String) extends PageElement
 case class ContentAtomBlockElement(atomId: String) extends PageElement
@@ -312,7 +312,7 @@ object PageElement {
             // author: Pascal
             // date: 27th May 2020
             // The display type is hardcoded for he moment, to be updated shortly
-            Some(ExplainerAtomBlockElement(explainer.id, explainer.title, explainer.body, "flat"))
+            Some(ExplainerAtomBlockElement(explainer.id, explainer.title, explainer.body))
           }
 
           case Some(guide: GuideAtom) => {


### PR DESCRIPTION
## What does this change?

Remove `displayType` attribute from `ExplainerAtomBlockElement`, because it's not being used. 

## Does this change need to be reproduced in dotcom-rendering ?
- [x] Yes. Already done here: https://github.com/guardian/dotcom-rendering/pull/1522 