### PR TITLE
Extend email front font-size hack

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -460,7 +460,7 @@ trait FeatureSwitches {
     "If on, will use smaller heading font for Vodafone slogan title on email fronts. This is to keep it from introducing horizontal scrolling at the mobile breakpoint. We can remove this once their campaign is over. Editorial owner is celine.bijleveld.",
     owners = Seq(Owner.withEmail("dotcom.platform@guardian.co.uk")),
     safeState = On,
-    sellByDate = new LocalDate(2020, 6, 1),
+    sellByDate = new LocalDate(2020, 7, 1),
     exposeClientSide = false,
   )
 


### PR DESCRIPTION
## What does this change?
Extends until July a hack that we'd like to remove once the campaign has finished that requires it (27th June).