### PR TITLE
Fix problem with slotReady being undefined

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
@@ -83,7 +83,7 @@ const defineSlot = (adSlotNode: Element, sizes: Object): Object => {
     const sizeOpts = getSizeOpts(sizes);
     const id = adSlotNode.id;
     let slot;
-    let slotReady;
+    let slotReady = Promise.resolve();
 
     if (adSlotNode.getAttribute('data-out-of-page')) {
         slot = window.googletag
@@ -190,7 +190,6 @@ const defineSlot = (adSlotNode: Element, sizes: Object): Object => {
 
         slotReady = Promise.race([iasTimeout(), iasDataPromise]);
     }
-
     const isBn = config.get('page.isbn');
 
     if (slotTarget === 'im' && isBn) {


### PR DESCRIPTION
## What does this change?
Errors were occurring for the `slotReady` promise when the `iasAdTargeting` switch was turned off. This was found to be due to the `slotReady` variable being initialised to `undefined` and then never set as a promise outside of the `iasAdTargeting` closure. This would then prevent adverts from being shown on screen.

This change initialises `slotReady` as a `Promise` instead of as an `undefined` variable.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)


## What is the value of this and can you measure success?

Ads will now work when `iasAdTargeting` is off. Notably, this was detected on local dev and fixing this issue improves devX.

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

Tested against localhost with the `iasAdTargeting` switch both on and
off.

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
