### PR TITLE
Rename Plista switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -62,7 +62,7 @@ trait FeatureSwitches {
     "plista-for-au",
     "Enable the Plista content recommendation widget in Australia",
     owners = group(Commercial),
-    safeState = Off,
+    safeState = On,
     sellByDate = never,
     exposeClientSide = true
   )

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -59,7 +59,7 @@ trait FeatureSwitches {
 
   val PlistaForAU = Switch(
     SwitchGroup.Feature,
-    "plista-for-outbrain-au",
+    "plista-for-au",
     "Enable the Plista content recommendation widget to replace that of Outbrain for AU edition (for web only).",
     owners = Seq(Owner.withGithub("JonNorman")),
     safeState = Off,

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -60,8 +60,8 @@ trait FeatureSwitches {
   val PlistaForAU = Switch(
     SwitchGroup.Feature,
     "plista-for-au",
-    "Enable the Plista content recommendation widget to replace that of Outbrain for AU edition (for web only).",
-    owners = Seq(Owner.withGithub("JonNorman")),
+    "Enable the Plista content recommendation widget in Australia",
+    owners = group(Commercial),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/plista-renderer.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/plista-renderer.js
@@ -38,7 +38,7 @@ const init = (): Promise<void> => {
     */
 
     const edition = config.get('page.edition', '').toLowerCase();
-    const isSwitchOn = config.get('switches.plistaForOutbrainAu');
+    const isSwitchOn = config.get('switches.plistaForAu');
     const shouldUsePlista: boolean = isSwitchOn && edition === 'au';
 
     if (shouldUsePlista) {

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/plista-renderer.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/plista-renderer.spec.js
@@ -37,7 +37,7 @@ afterAll(() => {
 describe('Plista Outbrain renderer', () => {
     it('should display Outbrain for UK, US and International Edition', done => {
         ['uk', 'us', 'int'].forEach((edition, index) => {
-            config.set('switches.plistaForOutbrainAu', true);
+            config.set('switches.plistaForAu', true);
             config.set('page.edition', edition);
             initPlistaRenderer().then(() => {
                 if (index === 2) {
@@ -48,7 +48,7 @@ describe('Plista Outbrain renderer', () => {
     });
 
     it('should pick Plista for AU', done => {
-        config.set('switches.plistaForOutbrainAu', true);
+        config.set('switches.plistaForAu', true);
         config.set('page.edition', 'AU');
         initPlistaRenderer().then(() => {
             expect(plista.init).toHaveBeenCalled();

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
@@ -117,7 +117,7 @@ class CommercialFeatures {
 
         this.plista =
             this.relatedWidgetEnabled &&
-            switches.plistaForOutbrainAu;
+            switches.plistaForAu;
 
         this.commentAdverts =
             this.dfpAdvertising &&

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.js
@@ -58,7 +58,7 @@ describe('Commercial features', () => {
         });
 
         config.set('switches', {
-            plistaForOutbrainAu: true,
+            plistaForAu: true,
             commercial: true,
             enableDiscussionSwitch: true,
         });


### PR DESCRIPTION
## What does this change?
Rename Plista switch to remove reference on outbrain
Tested locally on AUS edition. 
Widget itself does not render locally but we can see that the plista container has been added to the DOM.
Will do a final check on code when it's available

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
<img width="1413" alt="Screenshot 2020-05-29 at 17 06 08" src="https://user-images.githubusercontent.com/51630004/83280598-d1001580-a1ce-11ea-89e4-718e485b339a.png">

### Tested

- [x] Locally
- [ ] On CODE (optional)

