### PR TITLE
Enable ExplainerAtomBlockElement

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -140,6 +140,7 @@ object PageElement {
       case _: AudioAtomBlockElement => true
       case _: VideoBlockElement => true
       case _: ContentAtomBlockElement => true
+      case _: ExplainerAtomBlockElement => true
 
       // TODO we should quick fail here for these rather than pointlessly go to DCR
       case table: TableBlockElement if table.isMandatory.exists(identity) => true


### PR DESCRIPTION
## What does this change?

Enable `ExplainerAtomBlockElement`.

Previous attempt ( https://github.com/guardian/frontend/pull/22627 ) was reverted ( https://github.com/guardian/frontend/pull/22628 ) due to validations errors on DCR, those have been corrected ( https://github.com/guardian/dotcom-rendering/pull/1528 )
