### PR TITLE
Extend AMP AB test switch to 03/08/20

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -132,7 +132,7 @@ trait ABTestSwitches {
     "A/B test to test amp-experiment tag functionality on prod",
     owners = Seq(Owner.withGithub("buck06191")),
     safeState = Off,
-    sellByDate = new LocalDate(2020, 6, 1),
+    sellByDate = new LocalDate(2020, 8, 1),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -132,7 +132,7 @@ trait ABTestSwitches {
     "A/B test to test amp-experiment tag functionality on prod",
     owners = Seq(Owner.withGithub("buck06191")),
     safeState = Off,
-    sellByDate = new LocalDate(2020, 8, 1),
+    sellByDate = new LocalDate(2020, 8, 3),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
## What does this change?
The AMP AB testing is waiting for a response from Google around a number of technical aspects. In the meantime we need to extend this test to stop builds breaking.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)
