### PR TITLE
Revert "Updating tech feedback user help page"

### DIFF
--- a/onward/app/views/feedback.scala.html
+++ b/onward/app/views/feedback.scala.html
@@ -30,13 +30,6 @@
 
                                     <h2>Contact us</h2>
 
-                                    <p>Due to the ongoing Coronavirus outbreak, the Customer Service team is operating at a reduced service. This means we may take longer than usual to answer your queries. Please bear with us and we will try to answer your query as soon as possible.</p>
-
-                                    <p>In the meantime, many of your queries can be answered online by visiting our <a href="https://www.theguardian.com/help">help page</a>, or, if you hold an account with us, your <a href="http://manage.theguardian.com">Manage My Account area.</a></p>
-
-                                    <p>This page will be updated when normal service resumes, please check back. We apologise for any inconvenience.</p>
-
-
                                     <form id="feedback__form" action="tech-feedback/send" method="post">
 
                                         <!-- category dropdown -->


### PR DESCRIPTION
This text is no longer required on the userhelp pages, so we can remove it. 

Reverts guardian/frontend#22427