### PR TITLE
Whitelist the explainer atom

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -44,6 +44,12 @@ object ArticlePageChecks {
       case _: RichLinkBlockElement => false
       case _: InstagramBlockElement => false
       case _: SoundcloudBlockElement => false
+      case ContentAtomBlockElement(_, atomtype) => {
+        // ContentAtomBlockElement was expanded to include atomtype.
+        // To whitelist an atom type, just add it to supportedAtomTypes
+        val supportedAtomTypes = List("explainer")
+        !supportedAtomTypes.contains(atomtype)
+      }
       case _ => true
     }
 

--- a/article/app/views/fragments/email/emailArticleBody.scala.html
+++ b/article/app/views/fragments/email/emailArticleBody.scala.html
@@ -234,7 +234,7 @@
                         }
                     }
 
-                    case ContentAtomBlockElement(atomId) => {
+                    case ContentAtomBlockElement(atomId, atomtype) => {
                         @page.article.content.media.find(_.id == atomId).map { atom: MediaAtom =>
                             @atom.posterImage.flatMap(EmailVideoImage.bestSrcFor).map { imageUrl =>
                                 @atom.activeAssets.headOption.map { asset =>

--- a/common/app/model/liveblog/BlockElement.scala
+++ b/common/app/model/liveblog/BlockElement.scala
@@ -14,7 +14,7 @@ case class AudioBlockElement(assets: Seq[AudioAsset]) extends BlockElement
 case class GuVideoBlockElement(assets: Seq[VideoAsset], imageMedia: ImageMedia, data: Map[String, String]) extends BlockElement
 case class VideoBlockElement(data: Map[String, String]) extends BlockElement
 case class EmbedBlockElement(html: Option[String], safe: Option[Boolean], alt: Option[String]) extends BlockElement
-case class ContentAtomBlockElement(atomId: String) extends BlockElement
+case class ContentAtomBlockElement(atomId: String, atomtype: String) extends BlockElement
 case class InteractiveBlockElement(html: Option[String]) extends BlockElement
 case class CommentBlockElement(html: Option[String]) extends BlockElement
 case class TableBlockElement(html: Option[String]) extends BlockElement
@@ -117,7 +117,7 @@ object BlockElement {
 
       case Embed => element.embedTypeData.map(d => EmbedBlockElement(d.html, d.safeEmbedCode, d.alt))
 
-      case Contentatom => element.contentAtomTypeData.map(d => ContentAtomBlockElement(d.atomId))
+      case Contentatom => element.contentAtomTypeData.map(d => ContentAtomBlockElement(d.atomId, d.atomType))
 
       case Pullquote => element.pullquoteTypeData.map(d => PullquoteBlockElement(d.html))
       case Interactive => element.interactiveTypeData.map(d => InteractiveBlockElement(d.html))


### PR DESCRIPTION
## What does this change?

This "whitelist" the explainer atom. To do so it was just enough to expand the definition of `ContentAtomBlockElement` to carry the atom type. 
