### PR TITLE
Restrict running Nielsen third party only in Australia

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide-legacy.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide-legacy.js
@@ -1,5 +1,6 @@
 // @flow
 import config from 'lib/config';
+import { isInAuRegion } from "commercial/modules/header-bidding/utils";
 
 // nol_t is a global function defined by the IMR worldwide library
 // eslint-disable-next-line camelcase
@@ -17,7 +18,7 @@ const onLoad = () => {
 };
 
 export const imrWorldwideLegacy: ThirdPartyTag = {
-    shouldRun: config.get('switches.imrWorldwide'),
+    shouldRun: config.get('switches.imrWorldwide') && isInAuRegion(),
     url: '//secure-au.imrworldwide.com/v60.js',
     onLoad,
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide-legacy.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide-legacy.spec.js
@@ -3,12 +3,24 @@ import { imrWorldwideLegacy } from './imr-worldwide-legacy';
 
 const { shouldRun, url, onLoad } = imrWorldwideLegacy;
 
+jest.mock('commercial/modules/header-bidding/utils', () => {
+    // $FlowFixMe property requireActual is actually not missing Flow.
+    const original = jest.requireActual('commercial/modules/header-bidding/utils');
+    return {
+        ...original,
+        isInAuRegion: jest.fn().mockReturnValue(true),
+    };
+});
+
+jest.mock('common/modules/experiments/ab', () => ({
+    isInVariantSynchronous: jest.fn(),
+}));
+
 /**
  * we have to mock config like this because
  * loading imr-worldwide-legacy has side affects
  * that are dependent on config.
  * */
-
 jest.mock('lib/config', () => {
     const defaultConfig = {
         switches: {
@@ -19,7 +31,7 @@ jest.mock('lib/config', () => {
     return Object.assign({}, defaultConfig, {
         get: (path: string = '', defaultValue: any) =>
             path
-                .replace(/\[(.+?)\]/g, '.$1')
+                .replace(/\[(.+?)]/g, '.$1')
                 .split('.')
                 .reduce((o, key) => o[key], defaultConfig) || defaultValue,
     });

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide.js
@@ -1,5 +1,6 @@
 // @flow
 import config from 'lib/config';
+import {isInAuRegion} from "commercial/modules/header-bidding/utils";
 
 // NOLCMB is a global function defined by the IMR worldwide library
 declare var NOLCMB: Object;
@@ -88,7 +89,7 @@ const onLoad = () => {
 };
 
 export const imrWorldwide: ThirdPartyTag = {
-    shouldRun: config.get('switches.imrWorldwide'),
+    shouldRun: config.get('switches.imrWorldwide') && isInAuRegion(),
     url: '//secure-dcr.imrworldwide.com/novms/js/2/ggcmb510.js',
     onLoad,
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide.spec.js
@@ -1,11 +1,8 @@
 // @flow
-import { isInAuRegion as isInAuRegion_ }
-from 'commercial/modules/header-bidding/utils';
 import { imrWorldwide } from './imr-worldwide';
 
 const { shouldRun, url } = imrWorldwide;
 const onLoad: any = imrWorldwide.onLoad;
-const isInAuRegion: any = isInAuRegion_;
 
 /**
  * we have to mock config like this because
@@ -34,7 +31,7 @@ jest.mock('lib/config', () => {
     return Object.assign({}, defaultConfig, {
         get: (path: string = '', defaultValue: any) =>
             path
-                .replace(/\[(.+?)\]/g, '.$1')
+                .replace(/\[(.+?)]/g, '.$1')
                 .split('.')
                 .reduce((o, key) => o[key], defaultConfig) || defaultValue,
     });
@@ -62,12 +59,9 @@ window.NOLCMB = {
     getInstance: jest.fn(() => nSdkInstance),
 };
 
-isInAuRegion.mockReturnValue(true);
-
 describe('third party tag IMR in AUS', () => {
     beforeEach(() => {
         jest.clearAllMocks();
-        isInAuRegion.mockReturnValue(true);
     });
 
     afterAll(() => {

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide.spec.js
@@ -1,8 +1,11 @@
 // @flow
+import { isInAuRegion as isInAuRegion_ }
+from 'commercial/modules/header-bidding/utils';
 import { imrWorldwide } from './imr-worldwide';
 
 const { shouldRun, url } = imrWorldwide;
 const onLoad: any = imrWorldwide.onLoad;
+const isInAuRegion: any = isInAuRegion_;
 
 /**
  * we have to mock config like this because
@@ -37,6 +40,19 @@ jest.mock('lib/config', () => {
     });
 });
 
+jest.mock('commercial/modules/header-bidding/utils', () => {
+    // $FlowFixMe property requireActual is actually not missing Flow.
+    const original = jest.requireActual('commercial/modules/header-bidding/utils');
+    return {
+        ...original,
+        isInAuRegion: jest.fn().mockReturnValue(true),
+    };
+});
+
+jest.mock('common/modules/experiments/ab', () => ({
+    isInVariantSynchronous: jest.fn(),
+}));
+
 const nSdkInstance = {
     ggInitialize: jest.fn(),
     ggPM: jest.fn(),
@@ -46,7 +62,18 @@ window.NOLCMB = {
     getInstance: jest.fn(() => nSdkInstance),
 };
 
-describe('third party tag IMR worldwide', () => {
+isInAuRegion.mockReturnValue(true);
+
+describe('third party tag IMR in AUS', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        isInAuRegion.mockReturnValue(true);
+    });
+
+    afterAll(() => {
+        jest.clearAllMocks();
+    });
+
     it('should exist and have the correct exports', () => {
         expect(shouldRun).toBe(true);
         expect(url).toBe(


### PR DESCRIPTION
## What does this change?
Nielsen script (imrworldwide.com) is used as an external tool to measure audience size of our audience for Australia. This runs on all pages, and geo's of the site with/without consent.

The business deems this as a risk in terms of data protection. A First step in improving this would be to introduce a condition that only allows Nielsen to run on Australian IPs.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)

