### PR TITLE
Update Epic ticker to show number of supporters

### DIFF
--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -33,7 +33,7 @@ declare type EpicVariant = Variant & {
     template: EpicTemplate,
     classNames: string[],
     showTicker: boolean,    // Deprecated, use tickerSettings instead
-    tickerSettings?: TickerSettings,
+    tickerSettings?: TickerSettings | null,
     showReminderFields?: ReminderFields | null,
 
     buttonTemplate?: (
@@ -121,7 +121,7 @@ declare type InitEpicABTestVariant = {
     copy?: AcquisitionsEpicTemplateCopy,
     classNames?: string[],
     showTicker?: boolean,
-    tickerSettings?: TickerSettings,
+    tickerSettings?: TickerSettings | null,
     showReminderFields?: ReminderFields | null,
     supportBaseURL?: string,
     backgroundImageUrl?: string,

--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -32,7 +32,7 @@ declare type EpicVariant = Variant & {
     componentName: string,
     template: EpicTemplate,
     classNames: string[],
-    showTicker: boolean,    // Deprecated, use tickerSettings instead
+    showTicker?: boolean,    // Deprecated, use tickerSettings instead
     tickerSettings?: TickerSettings | null,
     showReminderFields?: ReminderFields | null,
 

--- a/static/src/javascripts/__flow__/types/ab-tests.js
+++ b/static/src/javascripts/__flow__/types/ab-tests.js
@@ -1,4 +1,5 @@
 import type { ReminderFields } from 'common/modules/commercial/templates/acquisitions-epic-reminder';
+import type { TickerSettings } from 'common/modules/commercial/ticker';
 
 type ListenerFunction = (f: () => void) => void;
 
@@ -31,7 +32,8 @@ declare type EpicVariant = Variant & {
     componentName: string,
     template: EpicTemplate,
     classNames: string[],
-    showTicker: boolean,
+    showTicker: boolean,    // Deprecated, use tickerSettings instead
+    tickerSettings?: TickerSettings,
     showReminderFields?: ReminderFields | null,
 
     buttonTemplate?: (
@@ -119,6 +121,7 @@ declare type InitEpicABTestVariant = {
     copy?: AcquisitionsEpicTemplateCopy,
     classNames?: string[],
     showTicker?: boolean,
+    tickerSettings?: TickerSettings,
     showReminderFields?: ReminderFields | null,
     supportBaseURL?: string,
     backgroundImageUrl?: string,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -199,6 +199,8 @@ export const fetchAndRenderEpic = (id: string) => {
                             trackingCampaignId,
                             componentType,
                             products,
+                            meta.abTestVariant.showTicker,
+                            meta.abTestVariant.tickerSettings,
                         )})
             }
         })

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -61,7 +61,8 @@ import {
     epicReminderEmailSignup,
     getFields,
 } from 'common/modules/commercial/epic-reminder-email-signup';
-import {getCookie} from "lib/cookies";
+import {getCookie} from 'lib/cookies';
+import { parseTickerSettings } from 'common/modules/commercial/ticker';
 
 export type ReaderRevenueRegion =
     | 'united-kingdom'
@@ -407,6 +408,7 @@ const makeEpicABTestVariant = (
         copy: initVariant.copy,
         classNames: initVariant.classNames || [],
         showTicker: initVariant.showTicker || false,
+        // TODO
         showReminderFields: initVariant.showReminderFields || false,
         backgroundImageUrl: initVariant.backgroundImageUrl,
 
@@ -768,6 +770,7 @@ export const buildConfiguredEpicTestFromJson = (
                 `contributions__epic--${test.name}-${variant.name}`,
             ],
             showTicker: variant.showTicker,
+            tickerSettings: variant.tickerSettings ? parseTickerSettings(variant.tickerSettings) : null,
             showReminderFields: variant.showReminderFields,
             backgroundImageUrl: filterEmptyString(variant.backgroundImageUrl),
             // TODO - why are these fields at the variant level?

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -55,15 +55,13 @@ import {
     isArticleWorthAnEpicImpression,
 } from 'common/modules/commercial/epic/epic-exclusion-rules';
 import { getControlEpicCopy } from 'common/modules/commercial/acquisitions-copy';
-import { initTicker } from 'common/modules/commercial/ticker';
+import { type TickerSettings, initTicker, parseTickerSettings } from 'common/modules/commercial/ticker';
 import { getArticleViewCountForWeeks } from 'common/modules/onward/history';
 import {
     epicReminderEmailSignup,
     getFields,
 } from 'common/modules/commercial/epic-reminder-email-signup';
 import {getCookie} from 'lib/cookies';
-import { parseTickerSettings } from 'common/modules/commercial/ticker';
-import type {TickerSettings} from "common/modules/commercial/ticker";
 
 export type ReaderRevenueRegion =
     | 'united-kingdom'

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -55,7 +55,7 @@ import {
     isArticleWorthAnEpicImpression,
 } from 'common/modules/commercial/epic/epic-exclusion-rules';
 import { getControlEpicCopy } from 'common/modules/commercial/acquisitions-copy';
-import { type TickerSettings, initTicker, parseTickerSettings } from 'common/modules/commercial/ticker';
+import { initTicker, parseTickerSettings } from 'common/modules/commercial/ticker';
 import { getArticleViewCountForWeeks } from 'common/modules/onward/history';
 import {
     epicReminderEmailSignup,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -63,6 +63,7 @@ import {
 } from 'common/modules/commercial/epic-reminder-email-signup';
 import {getCookie} from 'lib/cookies';
 import { parseTickerSettings } from 'common/modules/commercial/ticker';
+import type {TickerSettings} from "common/modules/commercial/ticker";
 
 export type ReaderRevenueRegion =
     | 'united-kingdom'
@@ -303,7 +304,8 @@ const setupOphanView = (
     trackingCampaignId: string,
     componentType: OphanComponentType,
     products: $ReadOnlyArray<OphanProduct>,
-    showTicker: boolean = false
+    showTicker: boolean = false,
+    tickerSettings: ?TickerSettings,
 ) => {
     const inView = elementInView(element, window, {
         top: 18,
@@ -328,8 +330,8 @@ const setupOphanView = (
 
         mediator.emit('register:end', trackingCampaignId);
 
-        if (showTicker) {
-            initTicker('.js-epic-ticker');
+        if (showTicker || !!tickerSettings) {
+            initTicker('.js-epic-ticker', tickerSettings);
         }
 
         if (config.get('switches.showContributionReminder')) {
@@ -408,7 +410,7 @@ const makeEpicABTestVariant = (
         copy: initVariant.copy,
         classNames: initVariant.classNames || [],
         showTicker: initVariant.showTicker || false,
-        // TODO
+        tickerSettings: initVariant.tickerSettings,
         showReminderFields: initVariant.showReminderFields || false,
         backgroundImageUrl: initVariant.backgroundImageUrl,
 
@@ -530,6 +532,7 @@ const makeEpicABTestVariant = (
                                         parentTest.componentType,
                                         initVariant.products,
                                         initVariant.showTicker,
+                                        initVariant.tickerSettings,
                                     );
                                 });
                             }

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -131,7 +131,7 @@ const controlTemplate: EpicTemplate = (
               )
             : undefined,
         epicClassNames: variant.classNames,
-        showTicker: variant.showTicker,
+        showTicker: variant.showTicker || !!variant.tickerSettings,
         showReminderFields: variant.showReminderFields,
         backgroundImageUrl: variant.backgroundImageUrl,
     });

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-ticker.js
@@ -1,18 +1,16 @@
 // @flow
 
-import { getLocalCurrencySymbolSync } from 'lib/geolocation';
-
 export const acquisitionsEpicTickerTemplate = `
     <div id="epic-ticker" class="js-epic-ticker epic-ticker is-hidden">
     
         <div class="js-ticker-amounts">
             <div class="js-ticker-so-far epic-ticker__so-far">
                 <div class="js-ticker-count epic-ticker__count"></div>
-                <div class="js-ticker-label epic-ticker__count-label is-hidden">contributed</div>
+                <div class="js-ticker-label epic-ticker__count-label is-hidden"></div>
             </div>
             
             <div class="js-ticker-goal epic-ticker__goal">
-                <div class="js-ticker-count epic-ticker__count">${getLocalCurrencySymbolSync()}0</div>
+                <div class="js-ticker-count epic-ticker__count"></div>
                 <div class="js-ticker-label epic-ticker__count-label">our goal</div>
             </div>
         </div>

--- a/static/src/javascripts/projects/common/modules/commercial/ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ticker.js
@@ -1,14 +1,41 @@
 // @flow
-import { getLocalCurrencySymbolSync } from 'lib/geolocation';
 import fetchJSON from 'lib/fetch-json';
 
-type TickerType = 'unlimited' | 'hardstop';
+type TickerEndType = 'unlimited' | 'hardstop';
+type TickerCountType = 'money' | 'people';
+
+export type TickerSettings = {
+    endType: TickerEndType,
+    countType: TickerCountType,
+    countLabelCopy: string,
+    currencySymbol?: string,
+}
+
+export const parseTickerSettings = (obj: Object): ?TickerSettings => {
+  const endType = obj.endType === 'unlimited' || obj.endType ===  'hardstop' ? obj.endType : null;
+  const countType = obj.countType === 'money' || obj.countType ===  'people' ? obj.countType : null;
+  const countLabelCopy = obj.countLabelCopy;
+
+  if (endType && countType && countLabelCopy && (countType === 'people' || obj.currencySymbol)) {
+      return {
+          endType,
+          countType,
+          countLabelCopy,
+          currencySymbol: obj.currencySymbol,
+      }
+  }
+
+  return null;
+};
 
 const count = {};
 let goal;
 let total;
 
 const goalReached = () => total >= goal;
+
+const getCurrencySymbol: string = (tickerSettings: TickerSettings) =>
+    tickerSettings.countType === 'money' ? tickerSettings.currencySymbol : '';
 
 /**
  * The filled bar begins 100% to the left, and is animated rightwards.
@@ -19,7 +46,7 @@ const percentageToTranslate = (end: number) => {
     return percentage >= 0 ? 0 : percentage;
 };
 
-const animateBar = (parentElement: HTMLElement, tickerType: TickerType) => {
+const animateBar = (parentElement: HTMLElement, tickerType: TickerEndType) => {
     const progressBarElement = parentElement.querySelector(
         '.js-ticker-filled-progress'
     );
@@ -50,7 +77,8 @@ const animateBar = (parentElement: HTMLElement, tickerType: TickerType) => {
 
 const increaseCounter = (
     parentElementSelector: string,
-    counterElement: HTMLElement
+    counterElement: HTMLElement,
+    tickerSettings: TickerSettings,
 ) => {
     // Count is local to the parent element
     const newCount = count[parentElementSelector] + Math.floor(total / 100);
@@ -58,16 +86,18 @@ const increaseCounter = (
     const finishedCounting =
         newCount <= count[parentElementSelector] || newCount >= total; // either we've reached the total or the count isn't going up because total is too small
 
+    const currencySymbol = getCurrencySymbol(tickerSettings);
+
     if (finishedCounting) {
-        counterElement.innerHTML = `${getLocalCurrencySymbolSync()}${total.toLocaleString()}`;
+        counterElement.innerHTML = `${currencySymbol}${total.toLocaleString()}`;
     } else {
         count[parentElementSelector] = newCount;
-        counterElement.innerHTML = `${getLocalCurrencySymbolSync()}${count[
+        counterElement.innerHTML = `${currencySymbol}${count[
             parentElementSelector
         ].toLocaleString()}`;
 
         window.requestAnimationFrame(() =>
-            increaseCounter(parentElementSelector, counterElement)
+            increaseCounter(parentElementSelector, counterElement, tickerSettings)
         );
     }
 };
@@ -75,7 +105,7 @@ const increaseCounter = (
 const populateStatusSoFar = (
     parentElementSelector: string,
     parentElement: HTMLElement,
-    tickerType: TickerType
+    tickerSettings: TickerSettings,
 ) => {
     const counterElement = parentElement.querySelector(
         `.js-ticker-amounts .js-ticker-count`
@@ -88,18 +118,19 @@ const populateStatusSoFar = (
     if (counterElement && labelElement) {
         if (goalReached()) {
             counterElement.innerHTML = `We’ve met our goal — thank you`;
-            if (tickerType === 'unlimited') {
+            if (tickerSettings.endType === 'unlimited') {
                 labelElement.innerHTML = `Contributions are still being accepted`;
                 labelElement.classList.remove('is-hidden');
             }
         } else {
+            labelElement.innerHTML = tickerSettings.countLabelCopy;
             labelElement.classList.remove('is-hidden');
-            increaseCounter(parentElementSelector, counterElement);
+            increaseCounter(parentElementSelector, counterElement, tickerSettings);
         }
     }
 };
 
-const populateGoal = (parentElement: HTMLElement, tickerType: TickerType) => {
+const populateGoal = (parentElement: HTMLElement, tickerSettings: TickerSettings) => {
     const goalElement = parentElement.querySelector('.js-ticker-goal');
 
     if (goalElement) {
@@ -108,17 +139,17 @@ const populateGoal = (parentElement: HTMLElement, tickerType: TickerType) => {
 
         if (countElement && labelElement) {
             const amount =
-                goalReached() && tickerType === 'unlimited' ? total : goal;
-            countElement.innerHTML = `${getLocalCurrencySymbolSync()}${amount.toLocaleString()}`;
+                goalReached() && tickerSettings.endType === 'unlimited' ? total : goal;
+            countElement.innerHTML = `${getCurrencySymbol(tickerSettings)}${amount.toLocaleString()}`;
 
             if (goalReached()) {
-                labelElement.innerHTML = 'contributed';
+                labelElement.innerHTML = tickerSettings.countLabelCopy;
             }
         }
     }
 };
 
-const animate = (parentElementSelector: string, tickerType: TickerType) => {
+const animate = (parentElementSelector: string, tickerSettings: TickerSettings) => {
     const parentElement = document.querySelector(parentElementSelector);
 
     if (parentElement && parentElement instanceof HTMLElement) {
@@ -126,7 +157,7 @@ const animate = (parentElementSelector: string, tickerType: TickerType) => {
             parentElement.classList.add('epic-ticker__goal-reached');
         }
 
-        populateGoal(parentElement, tickerType);
+        populateGoal(parentElement, tickerSettings);
 
         window.setTimeout(() => {
             count[parentElementSelector] = 0;
@@ -134,13 +165,13 @@ const animate = (parentElementSelector: string, tickerType: TickerType) => {
                 populateStatusSoFar(
                     parentElementSelector,
                     parentElement,
-                    tickerType
+                    tickerSettings,
                 )
             );
-            animateBar(parentElement, tickerType);
+            animateBar(parentElement, tickerSettings.endType);
         }, 500);
 
-        parentElement.classList.add(`epic-ticker__${tickerType}`);
+        parentElement.classList.add(`epic-ticker__${tickerSettings.endType}`);
         parentElement.classList.remove('is-hidden');
     }
 };
@@ -148,21 +179,25 @@ const animate = (parentElementSelector: string, tickerType: TickerType) => {
 const dataSuccessfullyFetched = () =>
     !(Number.isNaN(Number(total)) || Number.isNaN(Number(goal)));
 
+const getTickerUrl = (countType: TickerCountType): string =>
+    countType === 'people' ? 'https://support.theguardian.com/supporters-ticker.json' : 'https://support.theguardian.com/ticker.json';
+
 const fetchDataAndAnimate = (
     parentElementSelector: string,
-    tickerType: TickerType
+    tickerSettings: TickerSettings,
 ) => {
     if (dataSuccessfullyFetched()) {
-        animate(parentElementSelector, tickerType);
+        animate(parentElementSelector, tickerSettings);
     } else {
-        fetchJSON('https://support.theguardian.com/ticker.json', {
+        fetchJSON(getTickerUrl(tickerSettings.countType), {
             mode: 'cors',
         }).then(data => {
             total = parseInt(data.total, 10);
             goal = parseInt(data.goal, 10);
+            total = 151000
 
             if (dataSuccessfullyFetched()) {
-                animate(parentElementSelector, tickerType);
+                animate(parentElementSelector, tickerSettings);
             }
         });
     }
@@ -170,7 +205,14 @@ const fetchDataAndAnimate = (
 
 export const initTicker = (
     parentElementSelector: string,
-    tickerType?: TickerType
+    tickerSettings?: TickerSettings = {
+        endType: 'unlimited',
+        countType: 'people',
+        countLabelCopy: 'supporters in Australia'
+    }
 ) => {
-    fetchDataAndAnimate(parentElementSelector, tickerType || 'unlimited');
+    fetchDataAndAnimate(
+        parentElementSelector,
+        tickerSettings,
+    );
 };

--- a/static/src/javascripts/projects/common/modules/commercial/ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ticker.js
@@ -200,7 +200,6 @@ const fetchDataAndAnimate = (
         }).then(data => {
             total = parseInt(data.total, 10);
             goal = parseInt(data.goal, 10);
-            // total = 151000
 
             if (dataSuccessfullyFetched()) {
                 animate(parentElementSelector, tickerSettings);

--- a/static/src/javascripts/projects/common/modules/commercial/ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ticker.js
@@ -10,14 +10,14 @@ type TickerCopy = {
     goalReachedSecondary: string,
 }
 
-export type TickerSettings = {
+type TickerSettings = {
     endType: TickerEndType,
     countType: TickerCountType,
     currencySymbol: string,
     copy: TickerCopy,
 }
 
-export const parseTickerSettings = (obj: Object): ?TickerSettings => {
+const parseTickerSettings = (obj: Object): ?TickerSettings => {
   const endType = obj.endType === 'unlimited' || obj.endType ===  'hardstop' ? obj.endType : null;
   const countType = obj.countType === 'money' || obj.countType ===  'people' ? obj.countType : null;
   const copy = obj.copy && obj.copy.countLabel && obj.copy.goalReachedPrimary && obj.copy.goalReachedSecondary ? obj.copy : null;
@@ -219,7 +219,7 @@ const defaultSettings: TickerSettings = {
     }
 };
 
-export const initTicker = (
+const initTicker = (
     parentElementSelector: string,
     tickerSettings: ?TickerSettings
 ) => {
@@ -228,3 +228,9 @@ export const initTicker = (
         tickerSettings || defaultSettings,
     );
 };
+
+export {
+    TickerSettings,
+    initTicker,
+    parseTickerSettings,
+}

--- a/static/src/javascripts/projects/common/modules/commercial/ticker.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ticker.js
@@ -1,16 +1,16 @@
 // @flow
 import fetchJSON from 'lib/fetch-json';
 
-type TickerEndType = 'unlimited' | 'hardstop';
-type TickerCountType = 'money' | 'people';
+declare type TickerEndType = 'unlimited' | 'hardstop';
+declare type TickerCountType = 'money' | 'people';
 
-type TickerCopy = {
+declare type TickerCopy = {
     countLabel: string,
     goalReachedPrimary: string,
     goalReachedSecondary: string,
 }
 
-type TickerSettings = {
+declare type TickerSettings = {
     endType: TickerEndType,
     countType: TickerCountType,
     currencySymbol: string,
@@ -40,7 +40,7 @@ let total;
 
 const goalReached = () => total >= goal;
 
-const getCurrencySymbol: string = (tickerSettings: TickerSettings) =>
+const getCurrencySymbol = (tickerSettings: TickerSettings): string =>
     tickerSettings.countType === 'money' ? tickerSettings.currencySymbol : '';
 
 /**
@@ -129,7 +129,7 @@ const populateStatusSoFar = (
                 labelElement.classList.remove('is-hidden');
             }
         } else {
-            labelElement.innerHTML = tickerSettings.copy.labelCopy;
+            labelElement.innerHTML = tickerSettings.copy.countLabel;
             labelElement.classList.remove('is-hidden');
             increaseCounter(parentElementSelector, counterElement, tickerSettings);
         }
@@ -149,7 +149,7 @@ const populateGoal = (parentElement: HTMLElement, tickerSettings: TickerSettings
             countElement.innerHTML = `${getCurrencySymbol(tickerSettings)}${amount.toLocaleString()}`;
 
             if (goalReached()) {
-                labelElement.innerHTML = tickerSettings.copy.labelCopy;
+                labelElement.innerHTML = tickerSettings.copy.countLabel;
             }
         }
     }
@@ -213,10 +213,11 @@ const defaultSettings: TickerSettings = {
     endType: 'unlimited',
     countType: 'people',
     copy: {
-        labelCopy: 'supporters in Australia',
+        countLabel: 'supporters in Australia',
         goalReachedPrimary: 'We\'ve hit our goal!',
         goalReachedSecondary: 'but you can still support us',
-    }
+    },
+    currencySymbol: '$',
 };
 
 const initTicker = (
@@ -230,7 +231,6 @@ const initTicker = (
 };
 
 export {
-    TickerSettings,
     initTicker,
     parseTickerSettings,
 }


### PR DESCRIPTION
## What does this change?
The existing Epic ticker displays money raised during a campaign.
In an upcoming moment we will display the number of supporters instead.
The ticker will now support both modes.
A new url is used to fetch data for the supporter count.

I have added a `TickerSettings` type to expand how we configure the epic. It allows us to configure the copy.
In the long term we will configure this from the epic tool.

Note - the ticker in `contributions-service` (for DCR) will need to support this configuration as well.
See also - the change on the contributions landing page: https://github.com/guardian/support-frontend/pull/2522

## Supporter count:
### Before goal
<img width="628" alt="Screen Shot 2020-06-04 at 12 10 33" src="https://user-images.githubusercontent.com/1513454/83751529-e659c180-a65e-11ea-8d97-e8cd794e0b76.png">

### After goal
<img width="628" alt="Screen Shot 2020-06-04 at 12 10 03" src="https://user-images.githubusercontent.com/1513454/83751525-e5c12b00-a65e-11ea-9e2d-05e61111665a.png">

## Money count:
### Before goal
<img width="628" alt="Screen Shot 2020-06-04 at 12 30 22" src="https://user-images.githubusercontent.com/1513454/83751815-61bb7300-a65f-11ea-9ffc-98b6f7e7f24f.png">

### After goal
<img width="628" alt="Screen Shot 2020-06-04 at 12 31 18" src="https://user-images.githubusercontent.com/1513454/83751821-65e79080-a65f-11ea-8fdd-7bc5ce513ed9.png">


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
