### PR TITLE
Implement CCPA CMP behind 0% AB test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -179,7 +179,7 @@ trait ABTestSwitches {
   Switch(
     ABTests,
     "ab-cmp-ccpa-test",
-    "Check participation in CCPA variant",
+    "Test new CMP implementation for CCPA alongside TCFv1",
     owners = Seq(Owner.withGithub("buck06191"),
       Owner.withGithub("ripecosta"),
       Owner.withGithub("sndrs")),

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@emotion/core": "^10.0.21",
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/automat-client": "^0.2.16",
-    "@guardian/consent-management-platform": "3.0.4",
+    "@guardian/consent-management-platform": "3.1.0",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/src-button": "^0.16.1",
     "@guardian/src-foundations": "^0.16.1",

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -10,6 +10,9 @@ import { markTime } from 'lib/user-timing';
 import { captureOphanInfo } from 'lib/capture-ophan-info';
 import reportError from 'lib/report-error';
 import 'projects/commercial/modules/cmp/stub';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { ccpaCmpTest } from 'common/modules/experiments/tests/cmp-ccpa-test';
+import { init } from '@guardian/consent-management-platform';
 
 // Let webpack know where to get files from
 // __webpack_public_path__ is a special webpack variable
@@ -28,6 +31,11 @@ const go = () => {
         // 1. boot standard, always
         markTime('standard boot');
         bootStandard();
+
+        // Start CMP
+        if (isInVariantSynchronous(ccpaCmpTest, 'variant')) {
+            init({ useCppa: true });
+        }
 
         // 2. once standard is done, next is commercial
         if (process.env.NODE_ENV !== 'production') {

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -34,7 +34,7 @@ const go = () => {
 
         // Start CMP
         if (isInVariantSynchronous(ccpaCmpTest, 'variant')) {
-            init({ useCppa: true });
+            init({ useCcpa: true });
         }
 
         // 2. once standard is done, next is commercial

--- a/static/src/javascripts/bootstraps/commercial.dcr.js
+++ b/static/src/javascripts/bootstraps/commercial.dcr.js
@@ -28,16 +28,21 @@ import { trackPerformance } from 'common/modules/analytics/google';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { initCommentAdverts } from 'commercial/modules/comment-adverts';
 import { init as prepareA9 } from 'commercial/modules/dfp/prepare-a9';
-import {init as initRedplanet} from "commercial/modules/dfp/redplanet";
+import { init as initRedplanet } from 'commercial/modules/dfp/redplanet';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { ccpaCmpTest } from 'common/modules/experiments/tests/cmp-ccpa-test';
 
 const commercialModules: Array<Array<any>> = [
     ['cm-adFreeSlotRemove', adFreeSlotRemove],
     ['cm-closeDisabledSlots', closeDisabledSlots],
-    ['cm-prepare-cmp', initCmpService],
     ['cm-lotame-cmp', initLotameCmp],
     ['cm-lotame-data-extract', initLotameDataExtract],
     ['cm-comscore', initComscore],
 ];
+
+if (!isInVariantSynchronous(ccpaCmpTest, 'variant')) {
+    commercialModules.push(['cm-prepare-cmp', initCmpService]);
+}
 
 if (!commercialFeatures.adFree) {
     commercialModules.push(

--- a/static/src/javascripts/bootstraps/commercial.dcr.js
+++ b/static/src/javascripts/bootstraps/commercial.dcr.js
@@ -29,20 +29,15 @@ import { commercialFeatures } from 'common/modules/commercial/commercial-feature
 import { initCommentAdverts } from 'commercial/modules/comment-adverts';
 import { init as prepareA9 } from 'commercial/modules/dfp/prepare-a9';
 import { init as initRedplanet } from 'commercial/modules/dfp/redplanet';
-import { isInVariantSynchronous } from 'common/modules/experiments/ab';
-import { ccpaCmpTest } from 'common/modules/experiments/tests/cmp-ccpa-test';
 
 const commercialModules: Array<Array<any>> = [
     ['cm-adFreeSlotRemove', adFreeSlotRemove],
     ['cm-closeDisabledSlots', closeDisabledSlots],
+    ['cm-prepare-cmp', initCmpService],
     ['cm-lotame-cmp', initLotameCmp],
     ['cm-lotame-data-extract', initLotameDataExtract],
     ['cm-comscore', initComscore],
 ];
-
-if (!isInVariantSynchronous(ccpaCmpTest, 'variant')) {
-    commercialModules.push(['cm-prepare-cmp', initCmpService]);
-}
 
 if (!commercialFeatures.adFree) {
     commercialModules.push(

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -28,20 +28,15 @@ import { trackPerformance } from 'common/modules/analytics/google';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { initCommentAdverts } from 'commercial/modules/comment-adverts';
 import { initAdblockAsk } from 'common/modules/commercial/adblock-ask';
-import { isInVariantSynchronous } from 'common/modules/experiments/ab';
-import { ccpaCmpTest } from 'common/modules/experiments/tests/cmp-ccpa-test';
 
 const commercialModules: Array<Array<any>> = [
     ['cm-adFreeSlotRemove', adFreeSlotRemove],
     ['cm-closeDisabledSlots', closeDisabledSlots],
+    ['cm-prepare-cmp', initCmpService],
     ['cm-lotame-cmp', initLotameCmp],
     ['cm-lotame-data-extract', initLotameDataExtract],
     ['cm-comscore', initComscore],
 ];
-
-if (!isInVariantSynchronous(ccpaCmpTest, 'variant')) {
-    commercialModules.push(['cm-prepare-cmp', initCmpService]);
-}
 
 if (!commercialFeatures.adFree) {
     commercialModules.push(

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -28,15 +28,20 @@ import { trackPerformance } from 'common/modules/analytics/google';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { initCommentAdverts } from 'commercial/modules/comment-adverts';
 import { initAdblockAsk } from 'common/modules/commercial/adblock-ask';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { ccpaCmpTest } from 'common/modules/experiments/tests/cmp-ccpa-test';
 
 const commercialModules: Array<Array<any>> = [
     ['cm-adFreeSlotRemove', adFreeSlotRemove],
     ['cm-closeDisabledSlots', closeDisabledSlots],
-    ['cm-prepare-cmp', initCmpService],
     ['cm-lotame-cmp', initLotameCmp],
     ['cm-lotame-data-extract', initLotameDataExtract],
     ['cm-comscore', initComscore],
 ];
+
+if (!isInVariantSynchronous(ccpaCmpTest, 'variant')) {
+    commercialModules.push(['cm-prepare-cmp', initCmpService]);
+}
 
 if (!commercialFeatures.adFree) {
     commercialModules.push(

--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
@@ -5,6 +5,8 @@ import { getCookie } from 'lib/cookies';
 import { getUrlVars } from 'lib/url';
 import fetchJSON from 'lib/fetch-json';
 import { onIabConsentNotification } from '@guardian/consent-management-platform';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { ccpaCmpTest } from 'common/modules/experiments/tests/cmp-ccpa-test';
 import { log } from './log';
 import { CmpStore } from './store';
 import { encodeVendorConsentData } from './cookie';
@@ -278,7 +280,10 @@ class CmpService {
 
 export const init = (): void => {
     // Only run our CmpService if prepareCmp has added the CMP stub
-    if (window[CMP_GLOBAL_NAME]) {
+    if (
+        window[CMP_GLOBAL_NAME] &&
+        !isInVariantSynchronous(ccpaCmpTest, 'variant')
+    ) {
         let cmp: ?CmpService;
         // Pull queued commands from the CMP stub
         const { commandQueue = [] } = window[CMP_GLOBAL_NAME] || {};

--- a/static/src/javascripts/projects/commercial/modules/cmp/stub.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/stub.js
@@ -1,8 +1,13 @@
 // @flow
 /* eslint-disable no-underscore-dangle */
 import config from 'lib/config';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { ccpaCmpTest } from 'common/modules/experiments/tests/cmp-ccpa-test';
 
-if (config.get('switches.enableConsentManagementService')) {
+if (
+    config.get('switches.enableConsentManagementService') &&
+    !isInVariantSynchronous(ccpaCmpTest, 'variant')
+) {
     try {
         (function stubCMP(document, window) {
             if (!window.__cmp) {

--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
@@ -116,7 +116,7 @@ const reset = () => {
     fillAdvertSlots.mockReset();
 };
 
-const fakeTrueConsent = {
+const tcfWithConsent = {
     '1': true,
     '2': true,
     '3': true,
@@ -124,7 +124,7 @@ const fakeTrueConsent = {
     '5': true,
 };
 
-const fakeFalseConsent = {
+const tcfWithoutConsent = {
     '1': false,
     '2': false,
     '3': false,
@@ -132,7 +132,7 @@ const fakeFalseConsent = {
     '5': false,
 };
 
-const fakeNullConsent = {
+const tcfNullConsent = {
     '1': null,
     '2': null,
     '3': null,
@@ -140,13 +140,17 @@ const fakeNullConsent = {
     '5': null,
 };
 
-const fakeMixedConsent = {
+const tcfMixedConsent = {
     '1': true,
     '2': false,
     '3': false,
     '4': false,
     '5': false,
 };
+
+const ccpaWithConsent = false;
+
+const ccpaWithoutConsent = true;
 
 describe('DFP', () => {
     const domSnippet = `
@@ -444,9 +448,9 @@ describe('DFP', () => {
     });
 
     describe('NPA flag is set correctly', () => {
-        it('when full IAB consent was given', () => {
+        it('when full TCF consent was given', () => {
             onIabConsentNotification.mockImplementation(callback =>
-                callback(fakeTrueConsent)
+                callback(tcfWithConsent)
             );
             prepareGoogletag().then(() => {
                 expect(
@@ -454,9 +458,9 @@ describe('DFP', () => {
                 ).toHaveBeenCalledWith(0);
             });
         });
-        it('when no IAB consent preferences were specified', () => {
+        it('when no TCF consent preferences were specified', () => {
             onIabConsentNotification.mockImplementation(callback =>
-                callback(fakeNullConsent)
+                callback(tcfNullConsent)
             );
             prepareGoogletag().then(() => {
                 expect(
@@ -464,9 +468,9 @@ describe('DFP', () => {
                 ).toHaveBeenCalledWith(0);
             });
         });
-        it('when full IAB consent was denied', () => {
+        it('when full TCF consent was denied', () => {
             onIabConsentNotification.mockImplementation(callback =>
-                callback(fakeFalseConsent)
+                callback(tcfWithoutConsent)
             );
             prepareGoogletag().then(() => {
                 expect(
@@ -474,14 +478,34 @@ describe('DFP', () => {
                 ).toHaveBeenCalledWith(1);
             });
         });
-        it('when only partial IAB consent was given', () => {
+        it('when only partial TCF consent was given', () => {
             onIabConsentNotification.mockImplementation(callback =>
-                callback(fakeMixedConsent)
+                callback(tcfMixedConsent)
             );
             prepareGoogletag().then(() => {
                 expect(
                     window.googletag.pubads().setRequestNonPersonalizedAds
                 ).toHaveBeenCalledWith(1);
+            });
+        });
+        it('when CCPA consent was given', () => {
+            onIabConsentNotification.mockImplementation(callback =>
+                callback(ccpaWithConsent)
+            );
+            prepareGoogletag().then(() => {
+                expect(
+                    window.googletag.pubads().setRequestNonPersonalizedAds
+                ).toHaveBeenCalledWith(0);
+            });
+        });
+        it('when CCPA consent was denied', () => {
+            onIabConsentNotification.mockImplementation(callback =>
+                callback(ccpaWithoutConsent)
+            );
+            prepareGoogletag().then(() => {
+                expect(
+                    window.googletag.pubads().setRequestNonPersonalizedAds
+                ).toHaveBeenCalledWith(0);
             });
         });
     });

--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
@@ -201,6 +201,7 @@ describe('DFP', () => {
             collapseEmptyDivs: jest.fn(),
             refresh: jest.fn(),
             setRequestNonPersonalizedAds: jest.fn(),
+            setPrivacySettings: jest.fn(),
         };
         const sizeMapping = {
             sizes: [],
@@ -488,14 +489,18 @@ describe('DFP', () => {
                 ).toHaveBeenCalledWith(1);
             });
         });
+    });
+    describe('restrictDataProcessing flag is set correctly', () => {
         it('when CCPA consent was given', () => {
             onIabConsentNotification.mockImplementation(callback =>
                 callback(ccpaWithConsent)
             );
             prepareGoogletag().then(() => {
                 expect(
-                    window.googletag.pubads().setRequestNonPersonalizedAds
-                ).toHaveBeenCalledWith(0);
+                    window.googletag.pubads().setPrivacySettings
+                ).toHaveBeenCalledWith({
+                    restrictDataProcessing: false,
+                });
             });
         });
         it('when CCPA consent was denied', () => {
@@ -504,8 +509,10 @@ describe('DFP', () => {
             );
             prepareGoogletag().then(() => {
                 expect(
-                    window.googletag.pubads().setRequestNonPersonalizedAds
-                ).toHaveBeenCalledWith(0);
+                    window.googletag.pubads().setPrivacySettings
+                ).toHaveBeenCalledWith({
+                    restrictDataProcessing: true,
+                });
             });
         });
     });

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -104,16 +104,20 @@ export const init = (): Promise<void> => {
 
         onIabConsentNotification(state => {
             // typeof state === 'boolean' means CCPA mode is on
-            const npaFlag =
-                typeof state === 'boolean'
-                    ? state
-                    : Object.values(state).includes(false);
-
-            window.googletag.cmd.push(() => {
-                window.googletag
-                    .pubads()
-                    .setRequestNonPersonalizedAds(npaFlag ? 1 : 0);
-            });
+            if (typeof state === 'boolean') {
+                window.googletag.cmd.push(() => {
+                    window.googletag.pubads().setPrivacySettings({
+                        restrictDataProcessing: state,
+                    });
+                });
+            } else {
+                const npaFlag = Object.values(state).includes(false);
+                window.googletag.cmd.push(() => {
+                    window.googletag
+                        .pubads()
+                        .setRequestNonPersonalizedAds(npaFlag ? 1 : 0);
+                });
+            }
         });
 
         // Just load googletag. Prebid will already be loaded, and googletag is already added to the window by Prebid.

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -103,7 +103,11 @@ export const init = (): Promise<void> => {
         );
 
         onIabConsentNotification(state => {
-            const npaFlag = Object.values(state).includes(false);
+            // typeof state === 'boolean' means CCPA mode is on
+            const npaFlag =
+                typeof state === 'boolean'
+                    ? state
+                    : Object.values(state).includes(false);
 
             window.googletag.cmd.push(() => {
                 window.googletag

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
@@ -32,17 +32,19 @@ const initialise = (): void => {
 const setupRedplanet: () => Promise<void> = () => {
     onIabConsentNotification(state => {
         // typeof state === 'boolean' means CCPA mode is on
-        const canRun =
-            typeof state === 'boolean'
-                ? !state
-                : state[1] && state[2] && state[3] && state[4] && state[5];
+        // CCPA only runs in the US and Redplanet only runs in Australia
+        // so this should never happen
+        if (typeof state !== 'boolean') {
+            const canRun =
+                state[1] && state[2] && state[3] && state[4] && state[5];
 
-        if (!initialised && canRun) {
-            initialised = true;
-            return import('lib/launchpad.js').then(() => {
-                initialise();
-                return Promise.resolve();
-            });
+            if (!initialised && canRun) {
+                initialised = true;
+                return import('lib/launchpad.js').then(() => {
+                    initialise();
+                    return Promise.resolve();
+                });
+            }
         }
     });
     return Promise.resolve();

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
@@ -1,38 +1,44 @@
 // @flow strict
 
 import config from 'lib/config';
-import { commercialFeatures } from "common/modules/commercial/commercial-features";
-import { onIabConsentNotification } from "@guardian/consent-management-platform";
-import { isInAuOrNz } from "common/modules/commercial/geo-utils";
-import { isInVariantSynchronous } from "common/modules/experiments/ab";
-import { commercialRedplanet } from "common/modules/experiments/tests/commercial-redplanet-aus";
+import { commercialFeatures } from 'common/modules/commercial/commercial-features';
+import { onIabConsentNotification } from '@guardian/consent-management-platform';
+import { isInAuOrNz } from 'common/modules/commercial/geo-utils';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { commercialRedplanet } from 'common/modules/experiments/tests/commercial-redplanet-aus';
+
+let initialised = false;
 
 const initialise = (): void => {
     // Initialise Launchpad Tracker
     window.launchpad('newTracker', 'launchpad', 'lpx.qantas.com', {
         discoverRootDomain: true,
-        appId: 'the-guardian'
+        appId: 'the-guardian',
     });
 
     // Track Page Views
     window.launchpad('trackUnstructEvent', {
-        'schema': 'iglu:com.qantas.launchpad/hierarchy/jsonschema/1-0-0',
-        'data': {
-            'u1': 'theguardian.com',
-            'u2':  config.get('page.section'),
-            'u3':  config.get('page.sectionName'),
-            'u4': config.get('page.contentType'),
-            'uid': config.get('ophan', {}).browserId,
-        }
+        schema: 'iglu:com.qantas.launchpad/hierarchy/jsonschema/1-0-0',
+        data: {
+            u1: 'theguardian.com',
+            u2: config.get('page.section'),
+            u3: config.get('page.sectionName'),
+            u4: config.get('page.contentType'),
+            uid: config.get('ophan', {}).browserId,
+        },
     });
 };
 
 const setupRedplanet: () => Promise<void> = () => {
     onIabConsentNotification(state => {
-        const consentState =
-            state[1] && state[2] && state[3] && state[4] && state[5];
+        // typeof state === 'boolean' means CCPA mode is on
+        const canRun =
+            typeof state === 'boolean'
+                ? !state
+                : state[1] && state[2] && state[3] && state[4] && state[5];
 
-        if (consentState) {
+        if (!initialised && canRun) {
+            initialised = true;
             return import('lib/launchpad.js').then(() => {
                 initialise();
                 return Promise.resolve();
@@ -43,8 +49,12 @@ const setupRedplanet: () => Promise<void> = () => {
 };
 
 export const init = (): Promise<void> => {
-    if (commercialFeatures.launchpad && isInAuOrNz() && isInVariantSynchronous(commercialRedplanet, 'variant')) {
+    if (
+        commercialFeatures.launchpad &&
+        isInAuOrNz() &&
+        isInVariantSynchronous(commercialRedplanet, 'variant')
+    ) {
         return setupRedplanet();
     }
     return Promise.resolve();
-}
+};

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.spec.js
@@ -114,14 +114,6 @@ describe('init', () => {
         expect(window.launchpad).not.toBeCalled();
     });
 
-    it('should not initialise redplanet when user CCPA consent has not been given', async () => {
-        commercialFeatures.launchpad = true;
-        isInAuOrNz.mockReturnValue(true);
-        onIabConsentNotification.mockReturnValue(true);
-        await init();
-        expect(window.launchpad).not.toBeCalled();
-    });
-
     it('should not initialise redplanet when launchpad conditions are false', async () => {
         commercialFeatures.launchpad = false;
         isInAuOrNz.mockReturnValue(true);

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.spec.js
@@ -116,7 +116,7 @@ describe('init', () => {
 
     it('should not initialise redplanet when user CCPA consent has not been given', async () => {
         commercialFeatures.launchpad = true;
-        isInAuRegion.mockReturnValue(true);
+        isInAuOrNz.mockReturnValue(true);
         onIabConsentNotification.mockReturnValue(true);
         await init();
         expect(window.launchpad).not.toBeCalled();

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
@@ -27,16 +27,20 @@ class A9AdUnit {
     }
 }
 
-let requestQueue: Promise<void> = Promise.resolve();
 let initialised: boolean = false;
+let requestQueue: Promise<void> = Promise.resolve();
+
 const bidderTimeout: number = 1500;
 
 const initialise = (): void => {
     onIabConsentNotification(state => {
-        const consentState =
-            state[1] && state[2] && state[3] && state[4] && state[5];
+        // typeof state === 'boolean' means CCPA mode is on
+        const canRun =
+            typeof state === 'boolean'
+                ? !state
+                : state[1] && state[2] && state[3] && state[4] && state[5];
 
-        if (!initialised && consentState) {
+        if (!initialised && canRun) {
             initialised = true;
             window.apstag.init({
                 pubID: config.get('page.a9PublisherId'),
@@ -92,4 +96,11 @@ const requestBids = (
 export default {
     initialise,
     requestBids,
+};
+
+export const _ = {
+    resetModule: () => {
+        initialised = false;
+        requestQueue = Promise.resolve();
+    },
 };

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.spec.js
@@ -1,12 +1,14 @@
 // @flow
 
-import a9 from 'commercial/modules/header-bidding/a9/a9';
+import a9, { _ } from 'commercial/modules/header-bidding/a9/a9';
 import { onIabConsentNotification as onIabConsentNotification_ } from '@guardian/consent-management-platform';
 
 const onIabConsentNotification: any = onIabConsentNotification_;
 
-const trueConsentMock = (callback): void =>
+const TcfWithConsentMock = (callback): void =>
     callback({ '1': true, '2': true, '3': true, '4': true, '5': true });
+
+const CcpaWithConsentMock = (callback): void => callback(false);
 
 jest.mock('lib/raven');
 jest.mock('commercial/modules/dfp/Advert', () =>
@@ -27,6 +29,7 @@ jest.mock('@guardian/consent-management-platform', () => ({
 
 beforeEach(async () => {
     jest.resetModules();
+    _.resetModule();
     window.apstag = {
         init: jest.fn(),
         fetchBids: jest.fn().mockImplementation(() => Promise.resolve([])),
@@ -39,8 +42,15 @@ afterAll(() => {
 });
 
 describe('initialise', () => {
-    it('should generate initialise A9 library', () => {
-        onIabConsentNotification.mockImplementation(trueConsentMock);
+    it('should generate initialise A9 library when TCF consent has been given', () => {
+        onIabConsentNotification.mockImplementation(TcfWithConsentMock);
+        a9.initialise();
+        expect(window.apstag).toBeDefined();
+        expect(window.apstag.init).toHaveBeenCalled();
+    });
+
+    it('should generate initialise A9 library when CCPA consent has been given', () => {
+        onIabConsentNotification.mockImplementation(CcpaWithConsentMock);
         a9.initialise();
         expect(window.apstag).toBeDefined();
         expect(window.apstag.init).toHaveBeenCalled();

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -69,12 +69,12 @@ const insertScripts = (
 
     onIabConsentNotification(state => {
         // typeof state === 'boolean' means CCPA mode is on
-        const conRun =
+        const canRun =
             typeof state === 'boolean'
                 ? !state
                 : state[1] && state[2] && state[3] && state[4] && state[5];
 
-        if (!advertisingScriptsInserted && conRun) {
+        if (!advertisingScriptsInserted && canRun) {
             addScripts(advertisingServices);
             advertisingScriptsInserted = true;
         }

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -68,10 +68,13 @@ const insertScripts = (
     });
 
     onIabConsentNotification(state => {
-        const consentState =
-            state[1] && state[2] && state[3] && state[4] && state[5];
+        // typeof state === 'boolean' means CCPA mode is on
+        const conRun =
+            typeof state === 'boolean'
+                ? !state
+                : state[1] && state[2] && state[3] && state[4] && state[5];
 
-        if (!advertisingScriptsInserted && consentState) {
+        if (!advertisingScriptsInserted && conRun) {
             addScripts(advertisingServices);
             advertisingScriptsInserted = true;
         }

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
@@ -94,7 +94,7 @@ describe('third party tags', () => {
             url: '//fakeThirdPartyPerformanceTag.js',
             onLoad: jest.fn(),
         };
-        it('should add scripts to the document', () => {
+        it('should add scripts to the document when TCF consent has been given', () => {
             _.reset();
             onIabConsentNotification.mockImplementation(callback =>
                 callback({
@@ -114,7 +114,7 @@ describe('third party tags', () => {
             );
             expect(document.scripts.length).toBe(3);
         });
-        it('should not add scripts to the document', () => {
+        it('should not add scripts to the document when TCF consent has not been given', () => {
             _.reset();
             onIabConsentNotification.mockImplementation(callback =>
                 callback({
@@ -124,6 +124,34 @@ describe('third party tags', () => {
                     '4': false,
                     '5': false,
                 })
+            );
+            onGuConsentNotification.mockImplementation((state, callback) =>
+                callback(false)
+            );
+            insertScripts(
+                [fakeThirdPartyAdvertisingTag],
+                [fakeThirdPartyPerformanceTag]
+            );
+            expect(document.scripts.length).toBe(1);
+        });
+        it('should add scripts to the document when CCPA consent has been given', () => {
+            _.reset();
+            onIabConsentNotification.mockImplementation(callback =>
+                callback(false)
+            );
+            onGuConsentNotification.mockImplementation((state, callback) =>
+                callback(true)
+            );
+            insertScripts(
+                [fakeThirdPartyAdvertisingTag],
+                [fakeThirdPartyPerformanceTag]
+            );
+            expect(document.scripts.length).toBe(3);
+        });
+        it('should not add scripts to the document when CCPA consent has not been given', () => {
+            _.reset();
+            onIabConsentNotification.mockImplementation(callback =>
+                callback(true)
             );
             onGuConsentNotification.mockImplementation((state, callback) =>
                 callback(false)

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -37,7 +37,11 @@ type Handlers = {
 
 let consentState;
 onIabConsentNotification(state => {
-    consentState = state[1] && state[2] && state[3] && state[4] && state[5];
+    // typeof state === 'boolean' means CCPA mode is on
+    consentState =
+        typeof state === 'boolean'
+            ? !state
+            : state[1] && state[2] && state[3] && state[4] && state[5];
 });
 
 const onPlayerStateChangeEvent = (

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -40,7 +40,7 @@ type PageTargeting = {
 };
 
 let myPageTargetting: {} = {};
-let latestConsentState;
+let latestConsentCanRun;
 
 const findBreakpoint = (): string => {
     switch (getBreakpoint(true)) {
@@ -272,12 +272,15 @@ const getPageTargeting = (): { [key: string]: mixed } => {
     if (Object.keys(myPageTargetting).length !== 0) return myPageTargetting;
 
     onIabConsentNotification(state => {
-        const consentState =
-            state[1] && state[2] && state[3] && state[4] && state[5];
+        // typeof state === 'boolean' means CCPA mode is on
+        const canRun =
+            typeof state === 'boolean'
+                ? !state
+                : state[1] && state[2] && state[3] && state[4] && state[5];
 
-        if (consentState !== latestConsentState) {
-            myPageTargetting = buildPageTargetting(consentState);
-            latestConsentState = consentState;
+        if (canRun !== latestConsentCanRun) {
+            myPageTargetting = buildPageTargetting(canRun);
+            latestConsentCanRun = canRun;
         }
     });
 
@@ -286,7 +289,7 @@ const getPageTargeting = (): { [key: string]: mixed } => {
 
 const resetPageTargeting = (): void => {
     myPageTargetting = {};
-    latestConsentState = undefined;
+    latestConsentCanRun = undefined;
 };
 
 export {

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -58,14 +58,16 @@ jest.mock('@guardian/consent-management-platform', () => ({
     onIabConsentNotification: jest.fn(),
 }));
 
-const trueConsentMock = (callback): void =>
+const tcfWithConsentMock = (callback): void =>
     callback({ '1': true, '2': true, '3': true, '4': true, '5': true });
-const falseConsentMock = (callback): void =>
+const tcfWithoutConsentMock = (callback): void =>
     callback({ '1': false, '2': false, '3': false, '4': false, '5': false });
-const nullConsentMock = (callback): void =>
+const tcfNullConsentMock = (callback): void =>
     callback({ '1': null, '2': null, '3': null, '4': null, '5': null });
-const mixedConsentMock = (callback): void =>
+const tcfMixedConsentMock = (callback): void =>
     callback({ '1': false, '2': true, '3': true, '4': false, '5': true });
+const ccpaWithConsentMock = (callback): void => callback(false);
+const ccpaWithoutConsentMock = (callback): void => callback(true);
 
 describe('Build Page Targeting', () => {
     beforeEach(() => {
@@ -106,7 +108,7 @@ describe('Build Page Targeting', () => {
         // Reset mocking to default values.
         getCookie.mockReturnValue('ng101');
         _.resetPageTargeting();
-        onIabConsentNotification.mockImplementation(nullConsentMock);
+        onIabConsentNotification.mockImplementation(tcfNullConsentMock);
 
         getBreakpoint.mockReturnValue('mobile');
         getReferrer.mockReturnValue('');
@@ -160,19 +162,27 @@ describe('Build Page Targeting', () => {
     });
 
     it('should set correct personalized ad (pa) param', () => {
-        onIabConsentNotification.mockImplementation(trueConsentMock);
+        onIabConsentNotification.mockImplementation(tcfWithConsentMock);
         expect(getPageTargeting().pa).toBe('t');
 
         _.resetPageTargeting();
-        onIabConsentNotification.mockImplementation(falseConsentMock);
+        onIabConsentNotification.mockImplementation(tcfWithoutConsentMock);
         expect(getPageTargeting().pa).toBe('f');
 
         _.resetPageTargeting();
-        onIabConsentNotification.mockImplementation(nullConsentMock);
+        onIabConsentNotification.mockImplementation(tcfNullConsentMock);
         expect(getPageTargeting().pa).toBe('f');
 
         _.resetPageTargeting();
-        onIabConsentNotification.mockImplementation(mixedConsentMock);
+        onIabConsentNotification.mockImplementation(tcfMixedConsentMock);
+        expect(getPageTargeting().pa).toBe('f');
+
+        _.resetPageTargeting();
+        onIabConsentNotification.mockImplementation(ccpaWithConsentMock);
+        expect(getPageTargeting().pa).toBe('t');
+
+        _.resetPageTargeting();
+        onIabConsentNotification.mockImplementation(ccpaWithoutConsentMock);
         expect(getPageTargeting().pa).toBe('f');
     });
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -15,6 +15,7 @@ import { signInGateCentesimus } from 'common/modules/experiments/tests/sign-in-g
 import { signInGateVii } from 'common/modules/experiments/tests/sign-in-gate-vii';
 import { contributionsCovidBannerRoundTwo } from 'common/modules/experiments/tests/contribs-banner-covid-round-two';
 import { commercialRedplanet } from 'common/modules/experiments/tests/commercial-redplanet-aus';
+import { ccpaCmpTest } from 'common/modules/experiments/tests/cmp-ccpa-test';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
@@ -27,6 +28,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     signInGatePatientia,
     signInGateVii,
     signInGateCentesimus,
+    ccpaCmpTest,
 ];
 
 export const priorityEpicTest: AcquisitionsABTest = remoteEpicVariants;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/cmp-ccpa-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/cmp-ccpa-test.js
@@ -1,14 +1,15 @@
 // @flow strict
 
-export const ccpaCMPTest: ABTest = {
+export const ccpaCmpTest: ABTest = {
     id: 'CmpCcpaTest',
-    start: '2020-06-08',
+    start: '2020-06-04',
     expiry: '2020-07-01',
     author: 'Joshua Buckland',
-    description: 'Test new CMP implementation for CCPA in US',
+    description: 'Test new CMP implementation for CCPA alongside TCFv1',
     audience: 0.0,
     audienceOffset: 0.0,
-    successMeasure: 'CMP is compliant with CCPA in US and is compatible with existing TCFv1 CMP',
+    successMeasure:
+        'CMP is compliant with CCPA in US and is compatible with existing TCFv1 CMP',
     audienceCriteria: 'n/a',
     dataLinkNames: 'n/a',
     idealOutcome: 'The Sourcepoint CCPA CMP works with the existing TCFv1 CMP',

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -1,6 +1,8 @@
 // @flow
 import config from 'lib/config';
 import { shouldShow } from '@guardian/consent-management-platform';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { ccpaCmpTest } from 'common/modules/experiments/tests/cmp-ccpa-test';
 import raven from 'lib/raven';
 
 let initUi;
@@ -71,6 +73,10 @@ export const addPrivacySettingsLink = (): void => {
 export const consentManagementPlatformUi = {
     id: 'cmpUi',
     canShow: (): Promise<boolean> =>
-        Promise.resolve(config.get('switches.cmpUi', true) && shouldShow()),
+        Promise.resolve(
+            config.get('switches.cmpUi', true) &&
+                shouldShow() &&
+                !isInVariantSynchronous(ccpaCmpTest, 'variant')
+        ),
     show,
 };

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.spec.js
@@ -1,4 +1,5 @@
 // @flow
+import { isInVariantSynchronous as isInVariantSynchronous_ } from 'common/modules/experiments/ab';
 import { shouldShow } from '@guardian/consent-management-platform';
 import config from 'lib/config';
 import { consentManagementPlatformUi } from './cmp-ui';
@@ -10,6 +11,11 @@ jest.mock('@guardian/consent-management-platform', () => ({
 }));
 
 jest.mock('lib/report-error', () => jest.fn());
+
+const isInVariantSynchronous: any = isInVariantSynchronous_;
+jest.mock('common/modules/experiments/ab', () => ({
+    isInVariantSynchronous: jest.fn(),
+}));
 
 describe('cmp-ui', () => {
     afterEach(() => {
@@ -34,6 +40,16 @@ describe('cmp-ui', () => {
             });
             it('return false if cmpUi switch is off', () => {
                 config.set('switches.cmpUi', false);
+
+                return consentManagementPlatformUi.canShow().then(show => {
+                    expect(show).toBe(false);
+                });
+            });
+
+            it('return false if user is in CCPA variant', () => {
+                config.set('switches.cmpUi', true);
+                shouldShow.mockReturnValue(true);
+                isInVariantSynchronous.mockReturnValue(true);
 
                 return consentManagementPlatformUi.canShow().then(show => {
                     expect(show).toBe(false);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1171,14 +1171,14 @@
   resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.16.tgz#3ef47e7f49e633aea51c67f061d8d313a26fa9bc"
   integrity sha512-SgNU2bgiyQaXNfqanx4SDmxqAhXW6QBCTk4tRnCgV9Ht6noRl7UsDfx4I0u+M4H3TRnK4I/i2mmlJBtnuwhxEg==
 
-"@guardian/consent-management-platform@3.0.4":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-3.0.4.tgz#8e64bf1c2d92e124c60f0869f2e3b59be786dcaa"
-  integrity sha512-QOd2NbTFWGhh9qhd6wQOU0xyF0dqB9yIFT3W2fZI529Qie+NqPDFU3yVKrvsSQvYpW0ITTZhzCtULQ8rf2kc8w==
+"@guardian/consent-management-platform@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-3.1.0.tgz#aa14137c4d24dc3d1df9af686b67d0ec28a4e3dc"
+  integrity sha512-O4zdXCDbGEN6DdKkMcH/xcBl2xL0MdgOWSgWZ2hvL5RhEjjKt3+UkYyU6hP80/h0rDoMupBA4ZbGnD8Vk2zytw==
   dependencies:
-    consent-string "^1.5.1"
-    js-cookie "^2.2.1"
-    whatwg-fetch "^3.0.0"
+    consent-string "1.5.2"
+    js-cookie "2.2.1"
+    whatwg-fetch "3.0.0"
 
 "@guardian/dotcom-rendering@git://github.com/guardian/dotcom-rendering.git#version-1-alpha":
   version "0.1.0-alpha"
@@ -3184,7 +3184,7 @@ connect@3.6.6:
     parseurl "~1.3.2"
     utils-merge "1.0.1"
 
-consent-string@^1.5.1:
+consent-string@1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/consent-string/-/consent-string-1.5.2.tgz#cd3615f406a1d7649ebc9722960b5e451cf6a685"
   integrity sha512-xzfHnFzHQSupiamNY93UGn8FggPajHYExI45pzadhVpXVaj3ztnhnA7lYjKXl09pKRQKCT4hvjytt+2eoH7Jaw==
@@ -6780,7 +6780,7 @@ js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.1.9"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.1.9.tgz#f0e80ae039a4bd654b5f281fc93f04a914a7fcce"
 
-js-cookie@^2.2.1:
+js-cookie@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
   integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
@@ -11367,6 +11367,11 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   dependencies:
     iconv-lite "0.4.24"
 
+whatwg-fetch@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
+  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
+
 whatwg-fetch@>=0.10.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
@@ -11374,11 +11379,6 @@ whatwg-fetch@>=0.10.0:
 whatwg-fetch@^0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz#0e3684c6cb9995b43efc9df03e4c365d95fd9cc0"
-
-whatwg-fetch@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
-  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
 whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
## What does this change?
Introduces a 0% AB test where a user in the test's variant will be presented with Sourcepoint's CCPA banner instead of our TCFv1 banner.

Detailed changes:
- Supresses inititalisation of TCFv1 framework (when in variant)
- Supresses showing the TCF v1 banner (when in variant)
- Initialises the Sourcepoint's CCPA framework, showing a banner if applicable (when in variant)
- Adds code to all scripts behind consent to be able to handle the CCPA consent in addition to the TCFv1
- Updates the unit testing pertaining to code behind consent checks


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
