### PR TITLE
Refactor commercial geo utils functions

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
@@ -3,7 +3,7 @@
 import config from 'lib/config';
 import { commercialFeatures } from "common/modules/commercial/commercial-features";
 import { onIabConsentNotification } from "@guardian/consent-management-platform";
-import { isInAuRegion } from "commercial/modules/header-bidding/utils";
+import { isInAuOrNz } from "common/modules/commercial/geo-utils";
 import { isInVariantSynchronous } from "common/modules/experiments/ab";
 import { commercialRedplanet } from "common/modules/experiments/tests/commercial-redplanet-aus";
 
@@ -43,7 +43,7 @@ const setupRedplanet: () => Promise<void> = () => {
 };
 
 export const init = (): Promise<void> => {
-    if (commercialFeatures.launchpad && isInAuRegion() && isInVariantSynchronous(commercialRedplanet, 'variant')) {
+    if (commercialFeatures.launchpad && isInAuOrNz() && isInVariantSynchronous(commercialRedplanet, 'variant')) {
         return setupRedplanet();
     }
     return Promise.resolve();

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.spec.js
@@ -2,14 +2,14 @@
 
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { onIabConsentNotification as onIabConsentNotification_ } from '@guardian/consent-management-platform';
-import { isInAuRegion as isInAuRegion_ } from 'commercial/modules/header-bidding/utils';
+import { isInAuOrNz as isInAuOrNz_ } from 'common/modules/commercial/geo-utils';
 import { isInVariantSynchronous as isInVariantSynchronous_ } from 'common/modules/experiments/ab';
 import config from 'lib/config';
 import { init } from './redplanet';
 
 
 const onIabConsentNotification: any = onIabConsentNotification_;
-const isInAuRegion: any = isInAuRegion_;
+const isInAuOrNz: any = isInAuOrNz_;
 const trueConsentMock = (callback): void =>
     callback({ '1': true, '2': true, '3': true, '4': true, '5': true });
 
@@ -27,7 +27,7 @@ jest.mock('commercial/modules/dfp/Advert', () =>
     jest.fn().mockImplementation(() => ({ advert: jest.fn() }))
 );
 
-jest.mock('commercial/modules/header-bidding/utils');
+jest.mock('common/modules/commercial/geo-utils');
 
 jest.mock('common/modules/experiments/ab', () => ({
     isInVariantSynchronous: jest.fn(),
@@ -69,7 +69,7 @@ describe('init', () => {
 
     it('should initialise redplanet when all conditions are true with right params', async () => {
         commercialFeatures.launchpad = true;
-        isInAuRegion.mockReturnValue(true);
+        isInAuOrNz.mockReturnValue(true);
         config.set('ophan.browserId', '123');
         config.set('page.section', 'uk');
         config.set('page.sectionName', 'Politics');
@@ -102,7 +102,7 @@ describe('init', () => {
 
     it('should not initialise redplanet when user consented false', async () => {
         commercialFeatures.launchpad = true;
-        isInAuRegion.mockReturnValue(true);
+        isInAuOrNz.mockReturnValue(true);
         onIabConsentNotification.mockImplementation(falseConsentMock);
         await init();
         expect(window.launchpad).not.toBeCalled();
@@ -110,7 +110,7 @@ describe('init', () => {
 
     it('should not initialise redplanet when launchpad conditions are false', async () => {
         commercialFeatures.launchpad = false;
-        isInAuRegion.mockReturnValue(true);
+        isInAuOrNz.mockReturnValue(true);
         onIabConsentNotification.mockImplementation(trueConsentMock);
         await init();
         expect(window.launchpad).not.toBeCalled();
@@ -118,7 +118,7 @@ describe('init', () => {
 
     it('should not initialise redplanet when user not in AUS regions', async () => {
         commercialFeatures.launchpad = true;
-        isInAuRegion.mockReturnValue(false);
+        isInAuOrNz.mockReturnValue(false);
         onIabConsentNotification.mockImplementation(trueConsentMock);
         await init();
         expect(window.launchpad).not.toBeCalled();

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.js
@@ -7,14 +7,16 @@ import {
 } from 'common/modules/commercial/build-page-targeting';
 
 import {
+    isInUsOrCa,
+    isInAuOrNz } from 'common/modules/commercial/geo-utils';
+
+import {
     getLargestSize,
     containsLeaderboard,
     containsLeaderboardOrBillboard,
     containsMpu,
     containsMpuOrDmpu,
-    getBreakpointKey,
-    isInAuRegion,
-    isInUsRegion,
+    getBreakpointKey
 } from '../utils';
 
 import type { PrebidAppNexusParams, HeaderBiddingSize } from '../types';
@@ -34,7 +36,7 @@ const getAppNexusInvCode = (sizes: Array<HeaderBiddingSize>): ?string => {
 
 export const getAppNexusPlacementId = (sizes: HeaderBiddingSize[]): string => {
     const defaultPlacementId: string = '13915593';
-    if (isInUsRegion() || isInAuRegion()) {
+    if (isInUsOrCa() || isInAuOrNz()) {
         return defaultPlacementId;
     }
     switch (getBreakpointKey()) {
@@ -67,11 +69,11 @@ export const getAppNexusPlacementId = (sizes: HeaderBiddingSize[]): string => {
 export const getAppNexusDirectPlacementId = (
     sizes: HeaderBiddingSize[]
 ): string => {
-    if (isInAuRegion()) {
+    if (isInAuOrNz()) {
         return '11016434';
     }
 
-    if (isInUsRegion()) {
+    if (isInUsOrCa()) {
         return '4848330';
     }
 
@@ -106,7 +108,7 @@ export const getAppNexusDirectPlacementId = (
 export const getAppNexusDirectBidParams = (
     sizes: HeaderBiddingSize[]
 ): PrebidAppNexusParams => {
-    if (isInAuRegion() && config.get('switches.prebidAppnexusInvcode')) {
+    if (isInAuOrNz() && config.get('switches.prebidAppnexusInvcode')) {
         const invCode = getAppNexusInvCode(sizes);
         // flowlint sketchy-null-string:warn
         if (invCode) {

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.spec.js
@@ -1,14 +1,14 @@
 // @flow
 import config from 'lib/config';
+import { isInUsOrCa as isInUsOrCa_,
+    isInAuOrNz as isInAuOrNz_} from 'common/modules/commercial/geo-utils';
 import {
     _,
     getAppNexusDirectBidParams,
     getAppNexusServerSideBidParams,
 } from './appnexus';
 import {
-    getBreakpointKey as getBreakpointKey_,
-    isInAuRegion as isInAuRegion_,
-    isInUsRegion as isInUsRegion_,
+    getBreakpointKey as getBreakpointKey_
 } from '../utils';
 import type { HeaderBiddingSize } from '../types';
 
@@ -28,10 +28,13 @@ jest.mock('../utils', () => {
     return {
         ...original,
         getBreakpointKey: jest.fn(),
-        isInAuRegion: jest.fn(),
-        isInUsRegion: jest.fn(),
     };
 });
+
+jest.mock('common/modules/commercial/geo-utils', () => ({
+        isInAuOrNz: jest.fn(),
+        isInUsOrCa: jest.fn(),
+}));
 
 jest.mock('lib/cookies', () => ({
     getCookie: jest.fn(),
@@ -50,8 +53,8 @@ const {
 } = _;
 
 const getBreakpointKey: any = getBreakpointKey_;
-const isInAuRegion: any = isInAuRegion_;
-const isInUsRegion: any = isInUsRegion_;
+const isInAuOrNz: any = isInAuOrNz_;
+const isInUsOrCa: any = isInUsOrCa_;
 
 /* eslint-disable guardian-frontend/no-direct-access-config */
 const resetConfig = () => {
@@ -135,21 +138,21 @@ describe('getAppNexusDirectPlacementId', () => {
     ];
 
     test('should return the expected values when in AU region and desktop device', () => {
-        isInAuRegion.mockReturnValue(true);
+        isInAuOrNz.mockReturnValue(true);
         expect(
             prebidSizes.map(size => getAppNexusDirectPlacementId(size))
         ).toEqual(['11016434', '11016434', '11016434', '11016434', '11016434']);
     });
 
     test('should return the expected values when in US  and desktop device', () => {
-        isInUsRegion.mockReturnValue(true);
+        isInUsOrCa.mockReturnValue(true);
         expect(
             prebidSizes.map(size => getAppNexusDirectPlacementId(size))
         ).toEqual(['4848330', '4848330', '4848330', '4848330', '4848330']);
     });
 
     test('should return the expected values for ROW when on desktop device', () => {
-        isInAuRegion.mockReturnValue(false);
+        isInAuOrNz.mockReturnValue(false);
         getBreakpointKey.mockReturnValue('D');
         expect(
             prebidSizes.map(size => getAppNexusDirectPlacementId(size))
@@ -158,7 +161,7 @@ describe('getAppNexusDirectPlacementId', () => {
 
     test('should return the expected values for ROW when on tablet device', () => {
         getBreakpointKey.mockReturnValue('T');
-        isInAuRegion.mockReturnValue(false);
+        isInAuOrNz.mockReturnValue(false);
         expect(
             prebidSizes.map(size => getAppNexusDirectPlacementId(size))
         ).toEqual(['4371641', '9251752', '9251752', '4371640', '9251752']);
@@ -168,8 +171,8 @@ describe('getAppNexusDirectPlacementId', () => {
 describe('getAppNexusPlacementId', () => {
     beforeEach(() => {
         resetConfig();
-        isInAuRegion.mockReturnValue(false);
-        isInUsRegion.mockReturnValue(false);
+        isInAuOrNz.mockReturnValue(false);
+        isInUsOrCa.mockReturnValue(false);
         window.OzoneLotameData = { some: 'lotamedata' };
     });
 
@@ -225,8 +228,8 @@ describe('getAppNexusPlacementId', () => {
 
     test('should return the default value if in US or AU regions', () => {
         getBreakpointKey.mockReturnValue('D');
-        isInAuRegion.mockReturnValueOnce(true);
-        isInUsRegion.mockReturnValueOnce(true);
+        isInAuOrNz.mockReturnValueOnce(true);
+        isInUsOrCa.mockReturnValueOnce(true);
         expect(getAppNexusPlacementId([[300, 250]])).toEqual('13915593');
         expect(getAppNexusPlacementId([[970, 250]])).toEqual('13915593');
         expect(getAppNexusPlacementId([[1, 2]])).toEqual('13915593');
@@ -275,7 +278,7 @@ describe('getAppNexusDirectBidParams', () => {
 
     test('should include placementId for AU region when invCode switch is off', () => {
         getBreakpointKey.mockReturnValue('M');
-        isInAuRegion.mockReturnValue(true);
+        isInAuOrNz.mockReturnValue(true);
         expect(getAppNexusDirectBidParams([[300, 250]])).toEqual({
             keywords: { edition: 'UK', sens: 'f', url: 'gu.com' },
             placementId: '11016434',
@@ -285,7 +288,7 @@ describe('getAppNexusDirectBidParams', () => {
     test('should exclude placementId for AU region when including member and invCode', () => {
         config.set('switches.prebidAppnexusInvcode', true);
         getBreakpointKey.mockReturnValue('M');
-        isInAuRegion.mockReturnValueOnce(true);
+        isInAuOrNz.mockReturnValueOnce(true);
         expect(getAppNexusDirectBidParams([[300, 250]])).toEqual({
             keywords: {
                 edition: 'UK',

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
@@ -11,6 +11,10 @@ import {
 import { commercialPrebidSafeframe } from 'common/modules/experiments/tests/commercial-prebid-safeframe';
 import { xaxisAdapterTest } from 'common/modules/experiments/tests/commercial-xaxis-adapter';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { isInUk,
+    isInUsOrCa,
+    isInAuOrNz,
+    isInRow } from 'common/modules/commercial/geo-utils';
 import type {
     PrebidAdYouLikeParams,
     PrebidAppNexusParams,
@@ -37,10 +41,6 @@ import {
     containsMobileSticky,
     containsWS,
     getBreakpointKey,
-    isInAuRegion,
-    isInRowRegion,
-    isInUkRegion,
-    isInUsRegion,
     shouldIncludeAdYouLike,
     shouldIncludeAppNexus,
     shouldIncludeImproveDigital,
@@ -172,7 +172,7 @@ const getImprovePlacementId = (sizes: HeaderBiddingSize[]): number => {
                 return -1;
         }
     }
-    if (isInUkRegion()) {
+    if (isInUk()) {
         switch (getBreakpointKey()) {
             case 'D':
                 if (containsMpuOrDmpu(sizes)) {
@@ -199,7 +199,7 @@ const getImprovePlacementId = (sizes: HeaderBiddingSize[]): number => {
                 return -1;
         }
     }
-    if (isInRowRegion()) {
+    if (isInRow()) {
         switch (getBreakpointKey()) {
             case 'D':
                 if (containsMpuOrDmpu(sizes)) {
@@ -250,8 +250,8 @@ const getXhbPlacementId = (sizes: HeaderBiddingSize[]): number => {
 };
 
 const getPangaeaPlacementIdForUsAndAu = (): string => {
-    if (isInUsRegion()) return '13892369';
-    if (isInAuRegion()) return '13892409';
+    if (isInUsOrCa()) return '13892369';
+    if (isInAuOrNz()) return '13892409';
     return '';
 };
 
@@ -310,14 +310,14 @@ const openxClientSideBidder: PrebidBidder = {
     name: 'oxd',
     switchName: 'prebidOpenx',
     bidParams: (): PrebidOpenXParams => {
-        if (isInUsRegion()) {
+        if (isInUsOrCa()) {
             return {
                 delDomain: 'guardian-us-d.openx.net',
                 unit: '540279544',
                 customParams: buildAppNexusTargetingObject(getPageTargeting()),
             };
         }
-        if (isInAuRegion()) {
+        if (isInAuOrNz()) {
             return {
                 delDomain: 'guardian-aus-d.openx.net',
                 unit: '540279542',
@@ -372,10 +372,10 @@ const sonobiBidder: PrebidBidder = {
 };
 
 const getPubmaticPublisherId = (): string => {
-    if (isInUsRegion()) {
+    if (isInUsOrCa()) {
         return '157206';
     }
-    if (isInAuRegion()) {
+    if (isInAuOrNz()) {
         return '157203';
     }
     return '157207';
@@ -450,17 +450,17 @@ const adYouLikeBidder: PrebidBidder = {
     name: 'adyoulike',
     switchName: 'prebidAdYouLike',
     bidParams: (): PrebidAdYouLikeParams => {
-        if (isInUkRegion()) {
+        if (isInUk()) {
             return {
                 placement: '2b4d757e0ec349583ce704699f1467dd',
             };
         }
-        if (isInUsRegion()) {
+        if (isInUsOrCa()) {
             return {
                 placement: '7fdf0cd05e1d4bf39a2d3df9c61b3495',
             };
         }
-        if (isInAuRegion()) {
+        if (isInAuOrNz()) {
             return {
                 placement: '5cf05e1705a2d57ba5d51e03f2af9208',
             };

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.spec.js
@@ -3,8 +3,13 @@
 
 import config from 'lib/config';
 import { isInVariantSynchronous as isInVariantSynchronous_ } from 'common/modules/experiments/ab';
+import {isInUk as isInUk_,
+    isInUsOrCa as isInUsOrCa_,
+    isInAuOrNz as isInAuOrNz_,
+    isInRow as isInRow_} from "common/modules/commercial/geo-utils";
 import { _, bids } from './bid-config';
 import type { PrebidBidder, HeaderBiddingSize } from '../types';
+
 import {
     containsBillboard as containsBillboard_,
     containsDmpu as containsDmpu_,
@@ -14,10 +19,6 @@ import {
     containsMpu as containsMpu_,
     containsMpuOrDmpu as containsMpuOrDmpu_,
     getBreakpointKey as getBreakpointKey_,
-    isInAuRegion as isInAuRegion_,
-    isInRowRegion as isInRowRegion_,
-    isInUkRegion as isInUkRegion_,
-    isInUsRegion as isInUsRegion_,
     shouldIncludeAdYouLike as shouldIncludeAdYouLike_,
     shouldIncludeAppNexus as shouldIncludeAppNexus_,
     shouldIncludeImproveDigital as shouldIncludeImproveDigital_,
@@ -48,10 +49,10 @@ const shouldIncludePangaea: any = shouldIncludePangaea_;
 const shouldIncludeTripleLift: any = shouldIncludeTripleLift_;
 const stripMobileSuffix: any = stripMobileSuffix_;
 const getBreakpointKey: any = getBreakpointKey_;
-const isInAuRegion: any = isInAuRegion_;
-const isInRowRegion: any = isInRowRegion_;
-const isInUkRegion: any = isInUkRegion_;
-const isInUsRegion: any = isInUsRegion_;
+const isInAuOrNz: any = isInAuOrNz_;
+const isInRow: any = isInRow_;
+const isInUk: any = isInUk_;
+const isInUsOrCa: any = isInUsOrCa_;
 const isInVariantSynchronous: any = isInVariantSynchronous_;
 
 const getBidders = () =>
@@ -71,6 +72,8 @@ jest.mock('common/modules/commercial/build-page-targeting', () => ({
 }));
 
 jest.mock('../utils');
+
+jest.mock('common/modules/commercial/geo-utils');
 
 jest.mock('common/modules/experiments/ab', () => ({
     isInVariantSynchronous: jest.fn(),
@@ -125,7 +128,7 @@ describe('getImprovePlacementId', () => {
     });
 
     test('should return the expected values when geolocated in UK and on desktop device', () => {
-        isInUkRegion.mockReturnValue(true);
+        isInUk.mockReturnValue(true);
         getBreakpointKey.mockReturnValue('D');
         containsMpuOrDmpu.mockReturnValueOnce(true);
         containsMpuOrDmpu.mockReturnValueOnce(true);
@@ -143,7 +146,7 @@ describe('getImprovePlacementId', () => {
     });
 
     test('should return the expected values when geolocated in UK and on tablet device', () => {
-        isInUkRegion.mockReturnValue(true);
+        isInUk.mockReturnValue(true);
         getBreakpointKey.mockReturnValue('T');
         containsMpuOrDmpu.mockReturnValueOnce(true);
         containsMpuOrDmpu.mockReturnValueOnce(true);
@@ -161,7 +164,7 @@ describe('getImprovePlacementId', () => {
     });
 
     test('should return the expected values when geolocated in UK and on mobile device', () => {
-        isInUkRegion.mockReturnValue(true);
+        isInUk.mockReturnValue(true);
         getBreakpointKey.mockReturnValue('M');
         containsMpuOrDmpu.mockReturnValueOnce(true);
         containsMpuOrDmpu.mockReturnValueOnce(true);
@@ -173,7 +176,7 @@ describe('getImprovePlacementId', () => {
     });
 
     test('should return the expected values when geolocated in ROW region and on desktop device', () => {
-        isInRowRegion.mockReturnValue(true);
+        isInRow.mockReturnValue(true);
         getBreakpointKey.mockReturnValue('D');
         containsMpuOrDmpu.mockReturnValueOnce(true);
         containsMpuOrDmpu.mockReturnValueOnce(true);
@@ -191,7 +194,7 @@ describe('getImprovePlacementId', () => {
     });
 
     test('should return the expected values when not geolocated in ROW region and on tablet device', () => {
-        isInRowRegion.mockReturnValue(true);
+        isInRow.mockReturnValue(true);
         getBreakpointKey.mockReturnValue('T');
         containsMpuOrDmpu.mockReturnValueOnce(true);
         containsMpuOrDmpu.mockReturnValueOnce(true);
@@ -209,7 +212,7 @@ describe('getImprovePlacementId', () => {
     });
 
     test('should return the expected values when geolocated in ROW region and on mobile device', () => {
-        isInRowRegion.mockReturnValue(true);
+        isInRow.mockReturnValue(true);
         getBreakpointKey.mockReturnValue('M');
         containsMpuOrDmpu.mockReturnValueOnce(true);
         containsMpuOrDmpu.mockReturnValueOnce(true);
@@ -218,9 +221,9 @@ describe('getImprovePlacementId', () => {
     });
 
     test('should return -1 if geolocated in US or AU regions', () => {
-        isInUsRegion.mockReturnValue(true);
+        isInUsOrCa.mockReturnValue(true);
         expect(generateTestIds()).toEqual([-1, -1, -1, -1, -1]);
-        isInAuRegion.mockReturnValue(true);
+        isInAuOrNz.mockReturnValue(true);
         expect(generateTestIds()).toEqual([-1, -1, -1, -1, -1]);
     });
 
@@ -514,7 +517,7 @@ describe('bids', () => {
 
     test('should use correct parameters in OpenX bids geolocated in UK', () => {
         shouldIncludeOpenx.mockReturnValue(true);
-        isInUkRegion.mockReturnValue(true);
+        isInUk.mockReturnValue(true);
         const openXBid = bids('dfp-ad--top-above-nav', [[728, 90]])[2];
         expect(openXBid.params).toEqual({
             customParams: 'someAppNexusTargetingObject',
@@ -525,7 +528,7 @@ describe('bids', () => {
 
     test('should use correct parameters in OpenX bids geolocated in US', () => {
         shouldIncludeOpenx.mockReturnValue(true);
-        isInUsRegion.mockReturnValue(true);
+        isInUsOrCa.mockReturnValue(true);
         const openXBid = bids('dfp-ad--top-above-nav', [[728, 90]])[2];
         expect(openXBid.params).toEqual({
             customParams: 'someAppNexusTargetingObject',
@@ -536,7 +539,7 @@ describe('bids', () => {
 
     test('should use correct parameters in OpenX bids geolocated in AU', () => {
         shouldIncludeOpenx.mockReturnValue(true);
-        isInAuRegion.mockReturnValue(true);
+        isInAuOrNz.mockReturnValue(true);
         const openXBid = bids('dfp-ad--top-above-nav', [[728, 90]])[2];
         expect(openXBid.params).toEqual({
             customParams: 'someAppNexusTargetingObject',
@@ -547,7 +550,7 @@ describe('bids', () => {
 
     test('should use correct parameters in OpenX bids geolocated in FR', () => {
         shouldIncludeOpenx.mockReturnValue(true);
-        isInRowRegion.mockReturnValue(true);
+        isInRow.mockReturnValue(true);
         const openXBid = bids('dfp-ad--top-above-nav', [[728, 90]])[2];
         expect(openXBid.params).toEqual({
             customParams: 'someAppNexusTargetingObject',
@@ -699,19 +702,19 @@ describe('pangaea adapter', () => {
         {
             name: 'US',
             expectedPlacementId: '13892369',
-            mockFn: isInUsRegion,
+            mockFn: isInUsOrCa,
             mockReturn: true,
         },
         {
             name: 'AU',
             expectedPlacementId: '13892409',
-            mockFn: isInAuRegion,
+            mockFn: isInAuOrNz,
             mockReturn: true,
         },
         {
             name: 'GB',
             expectedPlacementId: '',
-            mockFn: isInUsRegion,
+            mockFn: isInUsOrCa,
             mockReturn: false,
         },
     ];

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/utils.spec.js
@@ -6,11 +6,10 @@ import {
     isBreakpoint as isBreakpoint_,
 } from 'lib/detect';
 import config from 'lib/config';
+import { _} from "common/modules/commercial/geo-utils";
 import {
     getLargestSize,
     getBreakpointKey,
-    isInRowRegion,
-    isInUkRegion,
     shouldIncludeAdYouLike,
     shouldIncludeAppNexus,
     shouldIncludeImproveDigital,
@@ -70,6 +69,7 @@ const resetConfig = () => {
 describe('Utils', () => {
     beforeEach(() => {
         jest.resetAllMocks();
+        _.resetModule();
         resetConfig();
     });
 
@@ -276,35 +276,6 @@ describe('Utils', () => {
         expect(result).toEqual({
             testString: 'non empty string',
         });
-    });
-
-    test('isInUkRegion should return true if geolocation is GB', () => {
-        getSync.mockReturnValue('GB');
-        expect(isInUkRegion()).toBe(true);
-    });
-
-    test('isInUkRegion should return false if geolocation is not GB', () => {
-        const testGeos = ['FK', 'GI', 'GG', 'IM', 'JE', 'SH', 'AU'];
-        for (let i = 0; i < testGeos.length; i += 1) {
-            getSync.mockReturnValue(testGeos[i]);
-            expect(isInUkRegion()).toBe(false);
-        }
-    });
-
-    test('isInRowRegion should return false if geolocation is GB, US, CA, AU or NZ', () => {
-        const testGeos = ['GB', 'US', 'CA', 'AU', 'NZ'];
-        for (let i = 0; i < testGeos.length; i += 1) {
-            getSync.mockReturnValue(testGeos[i]);
-            expect(isInRowRegion()).toBe(false);
-        }
-    });
-
-    test('isInRowRegion should return true if geolocation is not GB, US, CA, AU or NZ', () => {
-        const testGeos = ['FK', 'GI', 'GG', 'IM', 'JE', 'SH'];
-        for (let i = 0; i < testGeos.length; i += 1) {
-            getSync.mockReturnValue(testGeos[i]);
-            expect(isInRowRegion()).toBe(true);
-        }
     });
 
     ['US', 'CA', 'AU', 'NZ'].forEach(region => {

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide-legacy.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide-legacy.js
@@ -1,6 +1,6 @@
 // @flow
 import config from 'lib/config';
-import { isInAuRegion } from "commercial/modules/header-bidding/utils";
+import { isInAuOrNz } from 'common/modules/commercial/geo-utils';
 
 // nol_t is a global function defined by the IMR worldwide library
 // eslint-disable-next-line camelcase
@@ -18,7 +18,7 @@ const onLoad = () => {
 };
 
 export const imrWorldwideLegacy: ThirdPartyTag = {
-    shouldRun: config.get('switches.imrWorldwide') && isInAuRegion(),
+    shouldRun: config.get('switches.imrWorldwide') && isInAuOrNz(),
     url: '//secure-au.imrworldwide.com/v60.js',
     onLoad,
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide-legacy.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide-legacy.spec.js
@@ -3,14 +3,9 @@ import { imrWorldwideLegacy } from './imr-worldwide-legacy';
 
 const { shouldRun, url, onLoad } = imrWorldwideLegacy;
 
-jest.mock('commercial/modules/header-bidding/utils', () => {
-    // $FlowFixMe property requireActual is actually not missing Flow.
-    const original = jest.requireActual('commercial/modules/header-bidding/utils');
-    return {
-        ...original,
-        isInAuRegion: jest.fn().mockReturnValue(true),
-    };
-});
+jest.mock('common/modules/commercial/geo-utils', () => ({
+    isInAuOrNz: jest.fn().mockReturnValue(true)
+}));
 
 jest.mock('common/modules/experiments/ab', () => ({
     isInVariantSynchronous: jest.fn(),

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide.js
@@ -1,6 +1,6 @@
 // @flow
 import config from 'lib/config';
-import {isInAuRegion} from "commercial/modules/header-bidding/utils";
+import { isInAuOrNz } from 'common/modules/commercial/geo-utils';
 
 // NOLCMB is a global function defined by the IMR worldwide library
 declare var NOLCMB: Object;
@@ -89,7 +89,7 @@ const onLoad = () => {
 };
 
 export const imrWorldwide: ThirdPartyTag = {
-    shouldRun: config.get('switches.imrWorldwide') && isInAuRegion(),
+    shouldRun: config.get('switches.imrWorldwide') && isInAuOrNz(),
     url: '//secure-dcr.imrworldwide.com/novms/js/2/ggcmb510.js',
     onLoad,
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide.spec.js
@@ -37,14 +37,9 @@ jest.mock('lib/config', () => {
     });
 });
 
-jest.mock('commercial/modules/header-bidding/utils', () => {
-    // $FlowFixMe property requireActual is actually not missing Flow.
-    const original = jest.requireActual('commercial/modules/header-bidding/utils');
-    return {
-        ...original,
-        isInAuRegion: jest.fn().mockReturnValue(true),
-    };
-});
+jest.mock('common/modules/commercial/geo-utils', () => ({
+        isInAuOrNz: jest.fn().mockReturnValue(true)
+}));
 
 jest.mock('common/modules/experiments/ab', () => ({
     isInVariantSynchronous: jest.fn(),


### PR DESCRIPTION
## What does this change?
Continuing from https://github.com/guardian/frontend/pull/22643 this PR utilises the newly created geo-utils.js functions and removes the ones that existed inside header-bidding/utils.js

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)

