### PR TITLE
DateTime refactorings

### DIFF
--- a/admin/app/views/cricketTroubleshooter.scala.html
+++ b/admin/app/views/cricketTroubleshooter.scala.html
@@ -1,11 +1,11 @@
 @()(implicit request: RequestHeader, context: model.ApplicationContext)
 @import conf.AdminConfiguration.pa
 @import org.joda.time.DateTime
-@import views.support.Format
+@import views.support.GuDateFormatLegacy
 
 @admin_main("Cricket Troubleshooter", isAuthed = true) {
 
-@defining((Format(DateTime.now(), "yyyy-MM-dd"), Format(DateTime.now().minusYears(1), "yyyy-MM-dd"), "a359844f-fc07-9cfa-d4cc-9a9ac0d5d075")){ case (today, lastYear, englandTeam) =>
+@defining((GuDateFormatLegacy(DateTime.now(), "yyyy-MM-dd"), GuDateFormatLegacy(DateTime.now().minusYears(1), "yyyy-MM-dd"), "a359844f-fc07-9cfa-d4cc-9a9ac0d5d075")){ case (today, lastYear, englandTeam) =>
 
     <h1>Cricket Troubleshooter</h1>
 

--- a/admin/app/views/footballTroubleshooter.scala.html
+++ b/admin/app/views/footballTroubleshooter.scala.html
@@ -1,11 +1,11 @@
 @()(implicit request: RequestHeader, context: model.ApplicationContext)
 @import conf.AdminConfiguration.pa
 @import org.joda.time.{DateTime, LocalDate}
-@import views.support.Format
+@import views.support.GuDateFormatLegacy
 
 @admin_main("Football Troubleshooter", isAuthed = true) {
 
-@defining((Format(DateTime.now(), "yyyyMMdd"), "Premier League", "100")){ case (today, competition, competitionId) =>
+@defining((GuDateFormatLegacy(DateTime.now(), "yyyyMMdd"), "Premier League", "100")){ case (today, competition, competitionId) =>
 
     <h1>Football Troubleshooter</h1>
 
@@ -55,7 +55,7 @@
     <p>Here is the API call for results in the <strong>@competition</strong> (id @competitionId). You can get other competition IDs
         from the Competitions feed above and the date format is <i>YYYYMMDD</i>.</p>
 
-    <a href="@pa.footballHost/competition/results/@pa.footballApiKey/@competitionId/@Format(new LocalDate(2014, 6, 12), "yyyyMMdd")">@pa.footballHost/competition/results/@pa.footballApiKey/<strong>@competitionId</strong>/<strong>@Format(new LocalDate(2014, 6, 12), "yyyyMMdd")</strong></a>
+    <a href="@pa.footballHost/competition/results/@pa.footballApiKey/@competitionId/@GuDateFormatLegacy(new LocalDate(2014, 6, 12), "yyyyMMdd")">@pa.footballHost/competition/results/@pa.footballApiKey/<strong>@competitionId</strong>/<strong>@GuDateFormatLegacy(new LocalDate(2014, 6, 12), "yyyyMMdd")</strong></a>
 
     <h2>League table</h2>
 

--- a/applications/app/views/fragments/crosswords/crosswordMeta.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordMeta.scala.html
@@ -1,6 +1,5 @@
+@import model.GUDateTimeFormat
 @(crosswordPage: crosswords.CrosswordPageWithContent)(implicit requestHeader: RequestHeader)
-@import views.support.GUDateTimeFormat
-
 <div class="crossword__meta">
     @crosswordPage.crossword.creator.map { creator =>
 

--- a/applications/app/views/fragments/crosswords/crosswordMeta.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordMeta.scala.html
@@ -1,4 +1,4 @@
-@import model.GUDateTimeFormat
+@import model.GUDateTimeFormatNew
 @(crosswordPage: crosswords.CrosswordPageWithContent)(implicit requestHeader: RequestHeader)
 <div class="crossword__meta">
     @crosswordPage.crossword.creator.map { creator =>
@@ -14,7 +14,7 @@
     <div class="content__dateline content__dateline-crossword">
         <time itemprop="datePublished" datetime="@crosswordPage.crossword.date.toString("yyyy-MM-dd'T'HH:mm:ssZ"))"
         data-timestamp="@crosswordPage.crossword.date.getMillis" class="content__dateline-wpd js-wpd">
-            @GUDateTimeFormat.formatDateForDisplay(crosswordPage.crossword.date, requestHeader) <span class="content__dateline-time">@GUDateTimeFormat.formatTimeForDisplay(crosswordPage.crossword.date, requestHeader)</span>
+            @GUDateTimeFormatNew.formatDateForDisplay(crosswordPage.crossword.date, requestHeader) <span class="content__dateline-time">@GUDateTimeFormatNew.formatTimeForDisplay(crosswordPage.crossword.date, requestHeader)</span>
         </time>
     </div>
 </div>

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -11,7 +11,7 @@ import conf.switches.Switches
 import conf.{Configuration, Static}
 import model.content.Atom
 import model.dotcomrendering.pageElements.{DisclaimerBlockElement, PageElement}
-import model.{Badges, Canonical, LiveBlogPage, PageWithStoryPackage, Pillar, GUDateTimeFormat}
+import model.{Badges, Canonical, LiveBlogPage, PageWithStoryPackage, Pillar, GUDateTimeFormatNew}
 import navigation.ReaderRevenueSite.{Support, SupportContribute, SupportSubscribe}
 import navigation.UrlHelpers._
 import navigation.{FlatSubnav, NavLink, NavMenu, ParentSubnav, Subnav}
@@ -329,7 +329,7 @@ object DotcomponentsDataModel {
 
     def toBlock(block: APIBlock, shouldAddAffiliateLinks: Boolean, edition: Edition, isMainBlock: Boolean, isImmersive: Boolean): Block = {
       def format(instant: Long, edition: Edition): String = {
-        GUDateTimeFormat.dateTimeToLiveBlogDisplay(new DateTime(instant), edition.timezone)
+        GUDateTimeFormatNew.dateTimeToLiveBlogDisplay(new DateTime(instant), edition.timezone)
       }
 
       val createdOn = block.createdDate.map(_.dateTime)
@@ -604,7 +604,7 @@ object DotcomponentsDataModel {
       pagination = pagination,
       author = author,
       webPublicationDate = article.trail.webPublicationDate.toString, // TODO check format
-      webPublicationDateDisplay = GUDateTimeFormat.formatDateTimeForDisplay(article.trail.webPublicationDate, request),
+      webPublicationDateDisplay = GUDateTimeFormatNew.formatDateTimeForDisplay(article.trail.webPublicationDate, request),
       editionLongForm = Edition(request).displayName, // TODO check
       editionId = Edition(request).id,
       pageId = article.metadata.id,

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -2,7 +2,7 @@ package model.dotcomponents
 
 import com.gu.contentapi.client.model.v1.ElementType.Text
 import com.gu.contentapi.client.model.v1.{Block => APIBlock, BlockElement => ClientBlockElement, Blocks => APIBlocks}
-import com.gu.contentapi.client.utils.{DesignType, AdvertisementFeature}
+import com.gu.contentapi.client.utils.{AdvertisementFeature, DesignType}
 import common.Edition
 import common.Maps.RichMap
 import common.commercial.{CommercialProperties, EditionCommercialProperties, PrebidIndexSite}
@@ -11,7 +11,7 @@ import conf.switches.Switches
 import conf.{Configuration, Static}
 import model.content.Atom
 import model.dotcomrendering.pageElements.{DisclaimerBlockElement, PageElement}
-import model.{Badges, Canonical, LiveBlogPage, PageWithStoryPackage, Pillar, GUDateTimeFormatNew}
+import model.{ArticleDateTimes, Badges, Canonical, DisplayedDateTimesDCR, GUDateTimeFormatNew, LiveBlogPage, PageWithStoryPackage, Pillar}
 import navigation.ReaderRevenueSite.{Support, SupportContribute, SupportSubscribe}
 import navigation.UrlHelpers._
 import navigation.{FlatSubnav, NavLink, NavMenu, ParentSubnav, Subnav}
@@ -327,28 +327,30 @@ object DotcomponentsDataModel {
       tagPaths = article.content.tags.tags.map(_.id)
     )
 
-    def toBlock(block: APIBlock, shouldAddAffiliateLinks: Boolean, edition: Edition, isMainBlock: Boolean, isImmersive: Boolean): Block = {
-      def format(instant: Long, edition: Edition): String = {
-        GUDateTimeFormatNew.dateTimeToLiveBlogDisplay(new DateTime(instant), edition.timezone)
-      }
+    def toBlock(block: APIBlock, shouldAddAffiliateLinks: Boolean, edition: Edition, isMainBlock: Boolean, isImmersive: Boolean, articleDateTimes: ArticleDateTimes): Block = {
 
+      // For createdOn and createdOnDisplay we are going to carry on use the block information
+      // I am not sure they are used on DCR and I do not seem to be able to find them as article metadata
+      // Todo: Check whether they are used on DCR or not and if not remove them from the model
       val createdOn = block.createdDate.map(_.dateTime)
-      val createdOnDisplay = createdOn.map(dt => format(dt, edition))
-      val lastUpdated = block.lastModifiedDate.map(_.dateTime)
-      val lastUpdatedDisplay = block.lastModifiedDate.map(dt => format(dt.dateTime, edition))
-      val firstPublished = block.firstPublishedDate.orElse(block.createdDate).map(_.dateTime)
-      val firstPublishedDisplay = firstPublished.map(dt => format(dt, edition))
+      val createdOnDisplay = createdOn.map(dt => GUDateTimeFormatNew.formatTimeForDisplay(new DateTime(dt), request))
+
+      // last updated (in both versions) and first published (in both versions) are going to
+      // be computed from the article metadata.
+      // For this we introduced ArticleDateTimes in DatesAndTimes.
+      // This is meant to ensure that DCP and DCR use the same dates.
+      val displayedDateTimes: DisplayedDateTimesDCR = ArticleDateTimes.makeDisplayedDateTimesDCR(articleDateTimes, request)
 
       Block(
         id = block.id,
         elements = blockElementsToPageElements(block.elements, shouldAddAffiliateLinks, isMainBlock, isImmersive),
         createdOn = createdOn,
         createdOnDisplay = createdOnDisplay,
-        lastUpdated = lastUpdated,
-        lastUpdatedDisplay = lastUpdatedDisplay,
+        lastUpdated = Some(displayedDateTimes.lastUpdated),
+        lastUpdatedDisplay = Some(displayedDateTimes.lastUpdatedDisplay),
         title = block.title,
-        firstPublished = firstPublished,
-        firstPublishedDisplay = firstPublishedDisplay,
+        firstPublished = Some(displayedDateTimes.firstPublished),
+        firstPublishedDisplay = Some(displayedDateTimes.firstPublishedDisplay),
       )
     }
 
@@ -424,9 +426,16 @@ object DotcomponentsDataModel {
       case article => blocks.body.getOrElse(Nil)
     }
 
+    val articleDateTimes = ArticleDateTimes(
+      webPublicationDate = article.trail.webPublicationDate,
+      firstPublicationDate = article.fields.firstPublicationDate,
+      hasBeenModified = article.content.hasBeenModified,
+      lastModificationDate = article.fields.lastModified
+    )
+
     val bodyBlocks = bodyBlocksRaw
       .filter(_.published)
-      .map(block => toBlock(block, shouldAddAffiliateLinks, Edition(request), false, article.isImmersive)).toList
+      .map(block => toBlock(block, shouldAddAffiliateLinks, Edition(request), false, article.isImmersive, articleDateTimes)).toList
 
     val pagination = articlePage match {
       case liveblog: LiveBlogPage => liveblog.currentPage.pagination.map(paginationInfo => {
@@ -443,14 +452,14 @@ object DotcomponentsDataModel {
     }
 
     val mainBlock: Option[Block] = {
-      blocks.main.map(block => toBlock(block, shouldAddAffiliateLinks, Edition(request), true, article.isImmersive))
+      blocks.main.map(block => toBlock(block, shouldAddAffiliateLinks, Edition(request), true, article.isImmersive, articleDateTimes))
     }
 
     val keyEvents: Seq[Block] = {
       blocks.requestedBodyBlocks
         .getOrElse(Map.empty[String, Seq[APIBlock]])
         .getOrElse("body:key-events", Seq.empty[APIBlock])
-        .map(block => toBlock(block, shouldAddAffiliateLinks, Edition(request), false, article.isImmersive))
+        .map(block => toBlock(block, shouldAddAffiliateLinks, Edition(request), false, article.isImmersive, articleDateTimes))
     }
 
     val jsConfig = (k: String) => articlePage.getJavascriptConfig.get(k).map(_.as[String])

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -50,6 +50,8 @@ case class Block(
     firstPublished: Option[Long],
     firstPublishedDisplay: Option[String],
     title: Option[String],
+    primaryDateLine: String,
+    secondaryDateLine: String
 )
 
 case class Pagination(
@@ -351,6 +353,8 @@ object DotcomponentsDataModel {
         title = block.title,
         firstPublished = Some(displayedDateTimes.firstPublished),
         firstPublishedDisplay = Some(displayedDateTimes.firstPublishedDisplay),
+        primaryDateLine = displayedDateTimes.primaryDateLine,
+        secondaryDateLine = displayedDateTimes.secondaryDateLine
       )
     }
 

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -11,7 +11,7 @@ import conf.switches.Switches
 import conf.{Configuration, Static}
 import model.content.Atom
 import model.dotcomrendering.pageElements.{DisclaimerBlockElement, PageElement}
-import model.{Badges, Canonical, LiveBlogPage, PageWithStoryPackage, Pillar, SubMetaLinks}
+import model.{Badges, Canonical, LiveBlogPage, PageWithStoryPackage, Pillar, GUDateTimeFormat}
 import navigation.ReaderRevenueSite.{Support, SupportContribute, SupportSubscribe}
 import navigation.UrlHelpers._
 import navigation.{FlatSubnav, NavLink, NavMenu, ParentSubnav, Subnav}
@@ -20,7 +20,7 @@ import play.api.libs.json._
 import play.api.mvc.RequestHeader
 import common.RichRequestHeader
 import views.html.fragments.affiliateLinksDisclaimer
-import views.support.{AffiliateLinksCleaner, CamelCase, ContentLayout, GUDateTimeFormat, ImgSrc, Item300}
+import views.support.{AffiliateLinksCleaner, CamelCase, ContentLayout, ImgSrc, Item300}
 import controllers.ArticlePage
 import experiments.ActiveExperiments
 import org.joda.time.DateTime

--- a/article/app/model/structuredData/BlogPosting.scala
+++ b/article/app/model/structuredData/BlogPosting.scala
@@ -6,11 +6,11 @@ import model.liveblog.BodyBlock
 import org.joda.time.DateTime
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.RequestHeader
-import views.support.Format
+import views.support.GuDateFormatLegacy
 
 object BlogPosting {
 
-  def zulu(date: DateTime)(implicit request: RequestHeader): String = Format(date, "yyyy-MM-dd'T'HH:mm:ssZ")
+  def zulu(date: DateTime)(implicit request: RequestHeader): String = GuDateFormatLegacy(date, "yyyy-MM-dd'T'HH:mm:ssZ")
 
   def apply(blog: Article, block: BodyBlock)(implicit request: RequestHeader): JsValue = {
 
@@ -18,7 +18,7 @@ object BlogPosting {
       case Some(date) => zulu(date)
       case None => zulu(blog.trail.webPublicationDate)
     }
-    
+
     def blockLastModifiedDate(block: BodyBlock) = block.lastModifiedDate match {
       case Some(date) => zulu(date)
       case None => zulu(blog.content.fields.lastModified)
@@ -57,7 +57,7 @@ object BlogPosting {
       /* Schema.org -- Date of first broadcast/publication */
       "datePublished" -> blockFirstPublishedDate(block),
       /*  Schema.org -- The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed */
-      "dateModified" -> blockLastModifiedDate(block), 
+      "dateModified" -> blockLastModifiedDate(block),
       "articleBody" -> blockBody(block)
     )
 

--- a/article/app/model/structuredData/LiveBlogPosting.scala
+++ b/article/app/model/structuredData/LiveBlogPosting.scala
@@ -6,7 +6,7 @@ import model.liveblog._
 import org.joda.time.DateTime
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
-import views.support.Format
+import views.support.GuDateFormatLegacy
 
 // Since Json-Ld has fields that start with the @ character I can't just marshall it from
 // case classes which would be simpler. I've opted to construct the JsonValues manually. I
@@ -14,7 +14,7 @@ import views.support.Format
 
 object LiveBlogPosting {
 
-  def zulu(date: DateTime)(implicit request: RequestHeader): String = Format(date, "yyyy-MM-dd'T'HH:mm:ssZ")
+  def zulu(date: DateTime)(implicit request: RequestHeader): String = GuDateFormatLegacy(date, "yyyy-MM-dd'T'HH:mm:ssZ")
 
   def apply(blog: Article, blocks: Seq[BodyBlock])(implicit request: RequestHeader): JsValue = {
 

--- a/common/app/model/DatesAndTimes.scala
+++ b/common/app/model/DatesAndTimes.scala
@@ -1,9 +1,34 @@
 package model
 
+import java.text.DecimalFormat
+
 import common.Edition
-import org.joda.time.{DateTime, DateTimeZone}
+import org.joda.time.{DateTime, DateTimeZone, LocalDate}
 import org.joda.time.format.DateTimeFormat
 import play.api.mvc.RequestHeader
+
+/*
+  date: 07th June 2020
+  Note GuDateFormatOld is a copy of views.support.GuDateFormatLegacy
+ */
+
+object GuDateFormatOld {
+  def apply(date: DateTime, pattern: String, tzOverride: Option[DateTimeZone] = None)(implicit request: RequestHeader): String = {
+    apply(date, Edition(request), pattern, tzOverride)
+  }
+
+  def apply(date: DateTime, edition: Edition, pattern: String, tzOverride: Option[DateTimeZone]): String = {
+    val timeZone = tzOverride match {
+      case Some(tz) => tz
+      case _ => edition.timezone
+    }
+    date.toString(DateTimeFormat.forPattern(pattern).withZone(timeZone))
+  }
+
+  def apply(date: LocalDate, pattern: String)(implicit request: RequestHeader): String = this(date.toDateTimeAtStartOfDay, pattern)(request)
+
+  def apply(a: Int): String = new DecimalFormat("#,###").format(a)
+}
 
 object GUDateTimeFormat {
   def formatDateTimeForDisplay(date: DateTime, request: RequestHeader): String = {

--- a/common/app/model/DatesAndTimes.scala
+++ b/common/app/model/DatesAndTimes.scala
@@ -9,10 +9,10 @@ import play.api.mvc.RequestHeader
 
 /*
   date: 07th June 2020
-  Note GuDateFormatOld is a copy of views.support.GuDateFormatLegacy
+  Note GuDateTimeFormatOld is a copy of views.support.GuDateFormatLegacy
  */
 
-object GuDateFormatOld {
+object GuDateTimeFormatOld {
   def apply(date: DateTime, pattern: String, tzOverride: Option[DateTimeZone] = None)(implicit request: RequestHeader): String = {
     apply(date, Edition(request), pattern, tzOverride)
   }
@@ -30,7 +30,7 @@ object GuDateFormatOld {
   def apply(a: Int): String = new DecimalFormat("#,###").format(a)
 }
 
-object GUDateTimeFormat {
+object GUDateTimeFormatNew {
   def formatDateTimeForDisplay(date: DateTime, request: RequestHeader): String = {
     val edition = Edition(request)
     formatDateTimeForDisplayGivenEdition(date: DateTime, edition: Edition)

--- a/common/app/model/DatesAndTimes.scala
+++ b/common/app/model/DatesAndTimes.scala
@@ -18,22 +18,37 @@ case class DisplayedDateTimesDCR(
   firstPublished: Long,
   firstPublishedDisplay: String,
   lastUpdated: Long,
-  lastUpdatedDisplay: String
+  lastUpdatedDisplay: String,
+  primaryDateLine: String,
+  secondaryDateLine: String
 )
 
 object ArticleDateTimes {
   def makeDisplayedDateTimesDCR(articleDateTimes: ArticleDateTimes, request: RequestHeader): DisplayedDateTimesDCR = {
-    val firstPublished = articleDateTimes.firstPublicationDate.getOrElse(articleDateTimes.webPublicationDate).toInstant.getMillis
-    val firstPublishedDisplay = GUDateTimeFormatNew.formatTimeForDisplay(new DateTime(firstPublished), request)
 
-    val lastUpdated = articleDateTimes.lastModificationDate.toInstant.getMillis
-    val lastUpdatedDisplay = GUDateTimeFormatNew.formatTimeForDisplay(new DateTime(lastUpdated), request)
+    val firstPublishedDateTime = articleDateTimes.firstPublicationDate.getOrElse(articleDateTimes.webPublicationDate)
+    val firstPublishedLong = firstPublishedDateTime.toInstant.getMillis
+    val firstPublishedDisplay = GUDateTimeFormatNew.formatTimeForDisplay(firstPublishedDateTime, request)
+
+    val lastUpdatedDateTime = articleDateTimes.lastModificationDate
+    val lastUpdatedLong = lastUpdatedDateTime.toInstant.getMillis
+    val lastUpdatedDisplay = GUDateTimeFormatNew.formatTimeForDisplay(lastUpdatedDateTime, request)
+
+    val primaryDateLine = GUDateTimeFormatNew.formatDateTimeForDisplay(articleDateTimes.webPublicationDate, request)
+    val secondaryDateLine =
+      if (articleDateTimes.hasBeenModified && (articleDateTimes.webPublicationDate != articleDateTimes.firstPublicationDate) ) {
+        s"First published on ${GUDateTimeFormatNew.formatDateTimeForDisplay(articleDateTimes.lastModificationDate, request)}"
+      } else {
+        s"Last modified on ${GUDateTimeFormatNew.formatDateTimeForDisplay(articleDateTimes.lastModificationDate, request)}"
+      }
 
     DisplayedDateTimesDCR(
-      firstPublished,
+      firstPublishedLong,
       firstPublishedDisplay,
-      lastUpdated,
-      lastUpdatedDisplay
+      lastUpdatedLong,
+      lastUpdatedDisplay,
+      primaryDateLine,
+      secondaryDateLine
     )
   }
 }

--- a/common/app/model/DatesAndTimes.scala
+++ b/common/app/model/DatesAndTimes.scala
@@ -7,9 +7,41 @@ import org.joda.time.{DateTime, DateTimeZone, LocalDate}
 import org.joda.time.format.DateTimeFormat
 import play.api.mvc.RequestHeader
 
+case class ArticleDateTimes(
+  webPublicationDate: DateTime,
+  firstPublicationDate: Option[DateTime],
+  hasBeenModified: Boolean,
+  lastModificationDate: DateTime
+)
+
+case class DisplayedDateTimesDCR(
+  firstPublished: Long,
+  firstPublishedDisplay: String,
+  lastUpdated: Long,
+  lastUpdatedDisplay: String
+)
+
+object ArticleDateTimes {
+  def makeDisplayedDateTimesDCR(articleDateTimes: ArticleDateTimes, request: RequestHeader): DisplayedDateTimesDCR = {
+    val firstPublished = articleDateTimes.firstPublicationDate.getOrElse(articleDateTimes.webPublicationDate).toInstant.getMillis
+    val firstPublishedDisplay = GUDateTimeFormatNew.formatTimeForDisplay(new DateTime(firstPublished), request)
+
+    val lastUpdated = articleDateTimes.lastModificationDate.toInstant.getMillis
+    val lastUpdatedDisplay = GUDateTimeFormatNew.formatTimeForDisplay(new DateTime(lastUpdated), request)
+
+    DisplayedDateTimesDCR(
+      firstPublished,
+      firstPublishedDisplay,
+      lastUpdated,
+      lastUpdatedDisplay
+    )
+  }
+}
+
 /*
   date: 07th June 2020
   Note GuDateTimeFormatOld is a copy of views.support.GuDateFormatLegacy
+  This is a temporary measure before decommission views.support.GuDateFormatLegacy
  */
 
 object GuDateTimeFormatOld {

--- a/common/app/model/DatesAndTimes.scala
+++ b/common/app/model/DatesAndTimes.scala
@@ -37,9 +37,9 @@ object ArticleDateTimes {
     val primaryDateLine = GUDateTimeFormatNew.formatDateTimeForDisplay(articleDateTimes.webPublicationDate, request)
     val secondaryDateLine =
       if (articleDateTimes.hasBeenModified && (articleDateTimes.webPublicationDate != articleDateTimes.firstPublicationDate) ) {
-        s"First published on ${GUDateTimeFormatNew.formatDateTimeForDisplay(articleDateTimes.lastModificationDate, request)}"
+        GUDateTimeFormatNew.formatDateTimeForDisplay(articleDateTimes.lastModificationDate, request)
       } else {
-        s"Last modified on ${GUDateTimeFormatNew.formatDateTimeForDisplay(articleDateTimes.lastModificationDate, request)}"
+        GUDateTimeFormatNew.formatDateTimeForDisplay(articleDateTimes.lastModificationDate, request)
       }
 
     DisplayedDateTimesDCR(

--- a/common/app/model/DatesAndTimes.scala
+++ b/common/app/model/DatesAndTimes.scala
@@ -1,0 +1,32 @@
+package model
+
+import common.Edition
+import org.joda.time.{DateTime, DateTimeZone}
+import org.joda.time.format.DateTimeFormat
+import play.api.mvc.RequestHeader
+
+object GUDateTimeFormat {
+  def formatDateTimeForDisplay(date: DateTime, request: RequestHeader): String = {
+    val edition = Edition(request)
+    formatDateTimeForDisplayGivenEdition(date: DateTime, edition: Edition)
+  }
+  def formatDateTimeForDisplayGivenEdition(date: DateTime, edition: Edition): String = {
+    val timezone = edition.timezone
+    date.toString(DateTimeFormat.forPattern("E d MMM yyyy HH.mm").withZone(timezone)) + " " + timezone.getShortName(date.getMillis)
+  }
+  def formatDateForDisplay(date: DateTime, request: RequestHeader): String = {
+    date.toString("E d MMM yyyy")
+  }
+  def formatTimeForDisplay(date: DateTime, request: RequestHeader): String = {
+    val edition = Edition(request)
+    val timezone = edition.timezone
+    edition.id match {
+      case "AU" => date.toString(DateTimeFormat.forPattern("HH.mm").withZone(timezone)) + " " + timezone.getShortName(date.getMillis)
+      case _ => date.toString(DateTimeFormat.forPattern("HH.mm z").withZone(timezone))
+    }
+  }
+  def dateTimeToLiveBlogDisplay(dateTime: DateTime, timezone: DateTimeZone): String = {
+    dateTime.toString(DateTimeFormat.forPattern("HH:mm z").withZone(timezone))
+  }
+}
+

--- a/common/app/views/fragments/containers/facia_cards/date.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/date.scala.html
@@ -1,12 +1,12 @@
 @(date: org.joda.time.DateTime, tzOverride: Option[org.joda.time.DateTimeZone] = None)(implicit requestHeader: RequestHeader)
 
-@import views.support.Format
+@import views.support.GuDateFormatLegacy
 
 <div class="fc-today">
-    <span class="fc-today__dayofweek js-dayofweek">@Format(date, "EEEE", tzOverride)</span>
+    <span class="fc-today__dayofweek js-dayofweek">@GuDateFormatLegacy(date, "EEEE", tzOverride)</span>
     <span class="u-nobr fc-today__sub">
-        <span class="fc-today__dayofmonth js-dayofmonth">@Format(date, "d", tzOverride)</span>
-        <span class="fc-today__month">@Format(date, "MMMM", tzOverride)</span>
-        <span class="fc-today__year">@Format(date, "yyyy", tzOverride)</span>
+        <span class="fc-today__dayofmonth js-dayofmonth">@GuDateFormatLegacy(date, "d", tzOverride)</span>
+        <span class="fc-today__month">@GuDateFormatLegacy(date, "MMMM", tzOverride)</span>
+        <span class="fc-today__year">@GuDateFormatLegacy(date, "yyyy", tzOverride)</span>
     </span>
 </div>

--- a/common/app/views/fragments/containers/facia_cards/latestUpdate.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/latestUpdate.scala.html
@@ -1,6 +1,6 @@
 @(latestUpdate: org.joda.time.DateTime)(implicit requestHeader: RequestHeader)
 
-@import views.support.Format
+@import views.support.GuDateFormatLegacy
 
 <div class="js-container--insert-updates">
     <span class="fc-container__updated">
@@ -9,7 +9,7 @@
               datetime="@latestUpdate.toString("yyyy-MM-dd'T'HH:mm:ssZ")"
               data-relativeformat="long"
               data-timestamp="@latestUpdate.getMillis">
-            <span class="fc-timestamp__text">@Format(latestUpdate, "E, h:ma")</span>
+            <span class="fc-timestamp__text">@GuDateFormatLegacy(latestUpdate, "E, h:ma")</span>
         </time>
     </span>
 </div>

--- a/common/app/views/fragments/items/facia_cards/meta.scala.html
+++ b/common/app/views/fragments/items/facia_cards/meta.scala.html
@@ -1,6 +1,6 @@
 @(item: layout.ContentCard)(implicit request: RequestHeader)
 
-@import views.support.Format
+@import views.support.GuDateFormatLegacy
 
 <div class="fc-item__meta js-item__meta">
     @for(publishedAt <- item.webPublicationDate; timeStampDisplay <- item.timeStampDisplay) {
@@ -10,7 +10,7 @@
         data-relativeformat="short">
             @fragments.inlineSvg("clock", "icon")
         <span class="fc-timestamp__text">
-            <span class="u-h">Published: </span>@Format(publishedAt, timeStampDisplay.formatString)
+            <span class="u-h">Published: </span>@GuDateFormatLegacy(publishedAt, timeStampDisplay.formatString)
         </span>
         </time>
     }

--- a/common/app/views/fragments/meta/dateline.scala.html
+++ b/common/app/views/fragments/meta/dateline.scala.html
@@ -1,5 +1,5 @@
 @import org.joda.time.DateTime
-@import model.GUDateTimeFormat
+@import model.GUDateTimeFormatNew
 @import views.support.{GuDateFormatLegacy}
 
 @(webPublicationDate: DateTime, lastModified: DateTime, hasBeenModified: Boolean, firstPublicationDate: Option[DateTime], isLiveBlog: Boolean = false, isLive: Boolean = false, isMinute: Boolean = false)(implicit request: RequestHeader)
@@ -10,7 +10,7 @@
         @if(isMinute) {
             <span class="content__dateline-time">@GuDateFormatLegacy(webPublicationDate, "E d MMM yyyy")</span>
         } else {
-            @GuDateFormatLegacy(webPublicationDate, "E d MMM yyyy") <span class="content__dateline-time">@GUDateTimeFormat.formatTimeForDisplay(webPublicationDate, request)</span>
+            @GuDateFormatLegacy(webPublicationDate, "E d MMM yyyy") <span class="content__dateline-time">@GUDateTimeFormatNew.formatTimeForDisplay(webPublicationDate, request)</span>
         }
     </time>
     @if(isLiveBlog) {
@@ -22,7 +22,7 @@
         data-timestamp="@date.getMillis" class="content__dateline-lm js-lm u-h"
         @optItemProp.map { itemProp => itemprop="@itemProp" }
         >
-            @label @GuDateFormatLegacy(date, "E d MMM yyyy") <span class="content__dateline-time">@GUDateTimeFormat.formatTimeForDisplay(date, request)</span>
+            @label @GuDateFormatLegacy(date, "E d MMM yyyy") <span class="content__dateline-time">@GUDateTimeFormatNew.formatTimeForDisplay(date, request)</span>
         </time>
     }
 

--- a/common/app/views/fragments/meta/dateline.scala.html
+++ b/common/app/views/fragments/meta/dateline.scala.html
@@ -1,5 +1,6 @@
 @import org.joda.time.DateTime
-@import views.support.{GUDateTimeFormat, Format}
+@import model.GUDateTimeFormat
+@import views.support.{Format}
 
 @(webPublicationDate: DateTime, lastModified: DateTime, hasBeenModified: Boolean, firstPublicationDate: Option[DateTime], isLiveBlog: Boolean = false, isLive: Boolean = false, isMinute: Boolean = false)(implicit request: RequestHeader)
 

--- a/common/app/views/fragments/meta/dateline.scala.html
+++ b/common/app/views/fragments/meta/dateline.scala.html
@@ -1,28 +1,28 @@
 @import org.joda.time.DateTime
 @import model.GUDateTimeFormat
-@import views.support.{Format}
+@import views.support.{GuDateFormatLegacy}
 
 @(webPublicationDate: DateTime, lastModified: DateTime, hasBeenModified: Boolean, firstPublicationDate: Option[DateTime], isLiveBlog: Boolean = false, isLive: Boolean = false, isMinute: Boolean = false)(implicit request: RequestHeader)
 
 <p class="@if(!isMinute){content__dateline}@if(isMinute){content__dateline--minute-article}" aria-hidden="true">
-    <time itemprop="datePublished" datetime='@Format(webPublicationDate, "yyyy-MM-dd'T'HH:mm:ssZ")'
+    <time itemprop="datePublished" datetime='@GuDateFormatLegacy(webPublicationDate, "yyyy-MM-dd'T'HH:mm:ssZ")'
         data-timestamp="@webPublicationDate.getMillis" class="content__dateline-wpd js-wpd">
         @if(isMinute) {
-            <span class="content__dateline-time">@Format(webPublicationDate, "E d MMM yyyy")</span>
+            <span class="content__dateline-time">@GuDateFormatLegacy(webPublicationDate, "E d MMM yyyy")</span>
         } else {
-            @Format(webPublicationDate, "E d MMM yyyy") <span class="content__dateline-time">@GUDateTimeFormat.formatTimeForDisplay(webPublicationDate, request)</span>
+            @GuDateFormatLegacy(webPublicationDate, "E d MMM yyyy") <span class="content__dateline-time">@GUDateTimeFormat.formatTimeForDisplay(webPublicationDate, request)</span>
         }
     </time>
     @if(isLiveBlog) {
-        <meta itemprop="coverageStartTime" content="@Format(webPublicationDate, "yyyy-MM-dd'T'HH:mm:ssZ")">
+        <meta itemprop="coverageStartTime" content="@GuDateFormatLegacy(webPublicationDate, "yyyy-MM-dd'T'HH:mm:ssZ")">
     }
 
     @secondaryDateLine(date: DateTime, label: String, optItemProp: Option[String] = None) = {
-        <time datetime='@Format(date, "yyyy-MM-dd'T'HH:mm:ssZ")'
+        <time datetime='@GuDateFormatLegacy(date, "yyyy-MM-dd'T'HH:mm:ssZ")'
         data-timestamp="@date.getMillis" class="content__dateline-lm js-lm u-h"
         @optItemProp.map { itemProp => itemprop="@itemProp" }
         >
-            @label @Format(date, "E d MMM yyyy") <span class="content__dateline-time">@GUDateTimeFormat.formatTimeForDisplay(date, request)</span>
+            @label @GuDateFormatLegacy(date, "E d MMM yyyy") <span class="content__dateline-time">@GUDateTimeFormat.formatTimeForDisplay(date, request)</span>
         </time>
     }
 
@@ -35,7 +35,7 @@
     }}
 
     @if(isLiveBlog && !isLive) {
-        <meta itemprop="coverageEndTime" content="@Format(lastModified, "yyyy-MM-dd'T'HH:mm:ssZ")">
+        <meta itemprop="coverageEndTime" content="@GuDateFormatLegacy(lastModified, "yyyy-MM-dd'T'HH:mm:ssZ")">
     }
 </p>
-<meta itemprop="dateModified" content="@Format(lastModified, "yyyy-MM-dd'T'HH:mm:ssZ")">
+<meta itemprop="dateModified" content="@GuDateFormatLegacy(lastModified, "yyyy-MM-dd'T'HH:mm:ssZ")">

--- a/common/app/views/fragments/meta/dateline.scala.html
+++ b/common/app/views/fragments/meta/dateline.scala.html
@@ -1,28 +1,28 @@
 @import org.joda.time.DateTime
 @import model.GUDateTimeFormatNew
-@import views.support.{GuDateFormatLegacy}
+@import model.GuDateTimeFormatOld
 
 @(webPublicationDate: DateTime, lastModified: DateTime, hasBeenModified: Boolean, firstPublicationDate: Option[DateTime], isLiveBlog: Boolean = false, isLive: Boolean = false, isMinute: Boolean = false)(implicit request: RequestHeader)
 
 <p class="@if(!isMinute){content__dateline}@if(isMinute){content__dateline--minute-article}" aria-hidden="true">
-    <time itemprop="datePublished" datetime='@GuDateFormatLegacy(webPublicationDate, "yyyy-MM-dd'T'HH:mm:ssZ")'
+    <time itemprop="datePublished" datetime='@GuDateTimeFormatOld(webPublicationDate, "yyyy-MM-dd'T'HH:mm:ssZ")'
         data-timestamp="@webPublicationDate.getMillis" class="content__dateline-wpd js-wpd">
         @if(isMinute) {
-            <span class="content__dateline-time">@GuDateFormatLegacy(webPublicationDate, "E d MMM yyyy")</span>
+            <span class="content__dateline-time">@GuDateTimeFormatOld(webPublicationDate, "E d MMM yyyy")</span>
         } else {
-            @GuDateFormatLegacy(webPublicationDate, "E d MMM yyyy") <span class="content__dateline-time">@GUDateTimeFormatNew.formatTimeForDisplay(webPublicationDate, request)</span>
+            @GuDateTimeFormatOld(webPublicationDate, "E d MMM yyyy") <span class="content__dateline-time">@GUDateTimeFormatNew.formatTimeForDisplay(webPublicationDate, request)</span>
         }
     </time>
     @if(isLiveBlog) {
-        <meta itemprop="coverageStartTime" content="@GuDateFormatLegacy(webPublicationDate, "yyyy-MM-dd'T'HH:mm:ssZ")">
+        <meta itemprop="coverageStartTime" content="@GuDateTimeFormatOld(webPublicationDate, "yyyy-MM-dd'T'HH:mm:ssZ")">
     }
 
     @secondaryDateLine(date: DateTime, label: String, optItemProp: Option[String] = None) = {
-        <time datetime='@GuDateFormatLegacy(date, "yyyy-MM-dd'T'HH:mm:ssZ")'
+        <time datetime='@GuDateTimeFormatOld(date, "yyyy-MM-dd'T'HH:mm:ssZ")'
         data-timestamp="@date.getMillis" class="content__dateline-lm js-lm u-h"
         @optItemProp.map { itemProp => itemprop="@itemProp" }
         >
-            @label @GuDateFormatLegacy(date, "E d MMM yyyy") <span class="content__dateline-time">@GUDateTimeFormatNew.formatTimeForDisplay(date, request)</span>
+            @label @GuDateTimeFormatOld(date, "E d MMM yyyy") <span class="content__dateline-time">@GUDateTimeFormatNew.formatTimeForDisplay(date, request)</span>
         </time>
     }
 
@@ -35,7 +35,7 @@
     }}
 
     @if(isLiveBlog && !isLive) {
-        <meta itemprop="coverageEndTime" content="@GuDateFormatLegacy(lastModified, "yyyy-MM-dd'T'HH:mm:ssZ")">
+        <meta itemprop="coverageEndTime" content="@GuDateTimeFormatOld(lastModified, "yyyy-MM-dd'T'HH:mm:ssZ")">
     }
 </p>
-<meta itemprop="dateModified" content="@GuDateFormatLegacy(lastModified, "yyyy-MM-dd'T'HH:mm:ssZ")">
+<meta itemprop="dateModified" content="@GuDateTimeFormatOld(lastModified, "yyyy-MM-dd'T'HH:mm:ssZ")">

--- a/common/app/views/fragments/pagination.scala.html
+++ b/common/app/views/fragments/pagination.scala.html
@@ -1,5 +1,5 @@
 @import common.{PagePaths, Pagination}
-@import views.support.Format
+@import views.support.GuDateFormatLegacy
 
 @(title: String,
   pagination: Pagination,
@@ -39,7 +39,7 @@
 @if(pagination.lastPage > 1) {
     @if(showFull) {
     <div class="pagination pagination--full u-cf">
-        <span class="pagination__legend hide-on-mobile-inline">About @Format(pagination.totalContent) results for @Html(title)</span>
+        <span class="pagination__legend hide-on-mobile-inline">About @GuDateFormatLegacy(pagination.totalContent) results for @Html(title)</span>
     } else {
     <div class="pagination u-cf">
     }

--- a/common/app/views/fragments/relativeDate.scala.html
+++ b/common/app/views/fragments/relativeDate.scala.html
@@ -1,5 +1,5 @@
 @import org.joda.time.DateTime
-@import views.support.Format
+@import views.support.GuDateFormatLegacy
 
 @(webPublicationDate: DateTime, isLive: Boolean = false, isFront: Boolean = false)(implicit request: RequestHeader)
 
@@ -9,5 +9,5 @@
     } else {
         @fragments.inlineSvg("clock", "icon", List("inline-icon--light-grey", "relative-timestamp__icon"))
     }
-    <time class="js-timestamp" itemprop="datePublished" datetime="@webPublicationDate.toString("yyyy-MM-dd'T'HH:mm:ss'Z'")" data-timestamp="@webPublicationDate.getMillis">@* Anything inside here will be replaced by JS *@@Format(webPublicationDate, "d MMM y")</time>
+    <time class="js-timestamp" itemprop="datePublished" datetime="@webPublicationDate.toString("yyyy-MM-dd'T'HH:mm:ss'Z'")" data-timestamp="@webPublicationDate.getMillis">@* Anything inside here will be replaced by JS *@@GuDateFormatLegacy(webPublicationDate, "d MMM y")</time>
 </p>

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -115,7 +115,7 @@ object `package` {
   }
 }
 
-object Format {
+object GuDateFormatLegacy {
   def apply(date: DateTime, pattern: String, tzOverride: Option[DateTimeZone] = None)(implicit request: RequestHeader): String = {
     apply(date, Edition(request), pattern, tzOverride)
   }

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -115,31 +115,6 @@ object `package` {
   }
 }
 
-object GUDateTimeFormat {
-  def formatDateTimeForDisplay(date: DateTime, request: RequestHeader): String = {
-    val edition = Edition(request)
-    formatDateTimeForDisplayGivenEdition(date: DateTime, edition: Edition)
-  }
-  def formatDateTimeForDisplayGivenEdition(date: DateTime, edition: Edition): String = {
-    val timezone = edition.timezone
-    date.toString(DateTimeFormat.forPattern("E d MMM yyyy HH.mm").withZone(timezone)) + " " + timezone.getShortName(date.getMillis)
-  }
-  def formatDateForDisplay(date: DateTime, request: RequestHeader): String = {
-    date.toString("E d MMM yyyy")
-  }
-  def formatTimeForDisplay(date: DateTime, request: RequestHeader): String = {
-    val edition = Edition(request)
-    val timezone = edition.timezone
-    edition.id match {
-      case "AU" => date.toString(DateTimeFormat.forPattern("HH.mm").withZone(timezone)) + " " + timezone.getShortName(date.getMillis)
-      case _ => date.toString(DateTimeFormat.forPattern("HH.mm z").withZone(timezone))
-    }
-  }
-  def dateTimeToLiveBlogDisplay(dateTime: DateTime, timezone: DateTimeZone): String = {
-    dateTime.toString(DateTimeFormat.forPattern("HH:mm z").withZone(timezone))
-  }
-}
-
 object Format {
   def apply(date: DateTime, pattern: String, tzOverride: Option[DateTimeZone] = None)(implicit request: RequestHeader): String = {
     apply(date, Edition(request), pattern, tzOverride)

--- a/common/test/views/support/GUDateTimeFormatNewTest.scala
+++ b/common/test/views/support/GUDateTimeFormatNewTest.scala
@@ -1,17 +1,18 @@
 package views.support
 
 import common.editions
+import model.GUDateTimeFormatNew
 import org.joda.time.DateTime
 import org.scalatest.{FreeSpec, Matchers}
 
-class GUDateTimeGuDateFormatLegacyTest extends FreeSpec with Matchers {
+class GUDateTimeFormatNewTest extends FreeSpec with Matchers {
   val date = DateTime.parse("2019-05-08T10:26:11.000+10:00")
   "formatDateTimeForDisplayGivenEdition" - {
     "correctly handles Australian to US timezone conversion" in {
-      GUDateTimeFormat.formatDateTimeForDisplayGivenEdition(date, editions.Us) shouldEqual "Tue 7 May 2019 20.26 EDT"
+      GUDateTimeFormatNew.formatDateTimeForDisplayGivenEdition(date, editions.Us) shouldEqual "Tue 7 May 2019 20.26 EDT"
     }
     "correctly handles Australian to UK timezone conversion" in {
-      GUDateTimeFormat.formatDateTimeForDisplayGivenEdition(date, editions.Uk) shouldEqual "Wed 8 May 2019 01.26 BST"
+      GUDateTimeFormatNew.formatDateTimeForDisplayGivenEdition(date, editions.Uk) shouldEqual "Wed 8 May 2019 01.26 BST"
     }
 
   }

--- a/common/test/views/support/GUDateTimeGuDateFormatLegacyTest.scala
+++ b/common/test/views/support/GUDateTimeGuDateFormatLegacyTest.scala
@@ -4,7 +4,7 @@ import common.editions
 import org.joda.time.DateTime
 import org.scalatest.{FreeSpec, Matchers}
 
-class GUDateTimeFormatTest extends FreeSpec with Matchers {
+class GUDateTimeGuDateFormatLegacyTest extends FreeSpec with Matchers {
   val date = DateTime.parse("2019-05-08T10:26:11.000+10:00")
   "formatDateTimeForDisplayGivenEdition" - {
     "correctly handles Australian to US timezone conversion" in {

--- a/discussion/app/views/fragments/comment.scala.html
+++ b/discussion/app/views/fragments/comment.scala.html
@@ -2,7 +2,7 @@
 @import conf.Configuration
 @import conf.switches.Switches.SharingComments
 @import discussion.model.Comment
-@import views.support.{Format, RenderClasses}
+@import views.support.{GuDateFormatLegacy, RenderClasses}
 @import views.support.`package`.withJsoup
 @import views.support.{BulletCleaner, InBodyLinkCleaner}
 
@@ -54,7 +54,7 @@
                         <time class="js-timestamp" itemprop="dateCreated"
                             datetime="@comment.date.toString("yyyy-MM-dd'T'HH:mm:ss'Z'")"
                             data-timestamp="@comment.date.getMillis" data-relativeformat="med"
-                            title="Permalink to this comment (@Format(comment.date, "d MMM y HH:mm"))">@Format(comment.date, "d MMM y HH:mm")</time>
+                            title="Permalink to this comment (@GuDateFormatLegacy(comment.date, "d MMM y HH:mm"))">@GuDateFormatLegacy(comment.date, "d MMM y HH:mm")</time>
                         @fragments.inlineSvg("comment-anchor", "icon")
                     </a>
                 </div>

--- a/discussion/app/views/fragments/commentSchema.scala.html
+++ b/discussion/app/views/fragments/commentSchema.scala.html
@@ -5,7 +5,7 @@
 
 @import common.Edition
 @import discussion.model.Comment
-@import views.support.{BulletCleaner, InBodyLinkCleaner, Format}
+@import views.support.{BulletCleaner, InBodyLinkCleaner, GuDateFormatLegacy}
 
 <div class="comment comment--speechy" itemscope itemtype="http://schema.org/Comment">
     <h2 class="content__meta-heading">Featured comment</h2>
@@ -21,7 +21,7 @@
         <div class="comment__meta">
             @fragments.person(comment.profile)
             <time class="comment__datecreated" datetime="@comment.date.toString("yyyy-MM-dd'T'HH:mm:ss'Z'")" data-timestamp="@comment.date.getMillis">
-                @Format(comment.date, "d MMM y")
+                @GuDateFormatLegacy(comment.date, "d MMM y")
             </time>
         </div>
         @if(showMore){<a href="#comments" data-link-name="CTA Top comment bottom read more" class="comments-link tone-colour">See more comments<i class="i i-comment-light-grey"></i></a>}

--- a/discussion/app/views/fragments/topComment.scala.html
+++ b/discussion/app/views/fragments/topComment.scala.html
@@ -1,6 +1,6 @@
 @import conf.Configuration
 @import discussion.model.Comment
-@import views.support.{BulletCleaner, Format, InBodyLinkCleaner, TruncateCleaner, withJsoup}
+@import views.support.{BulletCleaner, GuDateFormatLegacy, InBodyLinkCleaner, TruncateCleaner, withJsoup}
 
 @(comment: Comment, isClosedForRecommendation: Boolean = true, isResponse: Boolean = false)(implicit request: RequestHeader)
 
@@ -55,7 +55,7 @@ itemscope itemtype="http://schema.org/Comment">
                 <a href="@comment.webUrl" class="d-comment__timestamp">
                     <time class="js-timestamp" itemprop="dateCreated" datetime="@comment.date.toString("yyyy-MM-dd'T'HH:mm:ss'Z'")"
                     data-timestamp="@comment.date.getMillis" data-relativeformat="med" title="Permalink to this comment">
-                    @Format(comment.date, "d MMM y HH:mm")
+                    @GuDateFormatLegacy(comment.date, "d MMM y HH:mm")
                     </time>
                     @fragments.inlineSvg("comment-anchor", "icon")
                 </a>

--- a/onward/app/models/OnwardCollection.scala
+++ b/onward/app/models/OnwardCollection.scala
@@ -1,10 +1,10 @@
 package models
 
-import com.gu.contentapi.client.utils.{Article, DesignType}
+import com.gu.contentapi.client.utils.{Article}
 import common.LinkTo
-import model.pressed.{Image, MediaType, PressedContent}
+import model.pressed.{PressedContent}
 import play.api.mvc.RequestHeader
-import views.support.{ContentOldAgeDescriber, CutOut, GUDateTimeFormat, ImgSrc, RemoveOuterParaHtml}
+import views.support.{ContentOldAgeDescriber, ImgSrc, RemoveOuterParaHtml}
 import play.api.libs.json._
 import implicits.FaciaContentFrontendHelpers._
 import layout.ContentCard

--- a/sport/app/cricket/views/fragments/cricketMatchSummary.scala.html
+++ b/sport/app/cricket/views/fragments/cricketMatchSummary.scala.html
@@ -1,12 +1,12 @@
 @(theMatch: cricketModel.Match, matchUrl: String)(implicit request: RequestHeader)
 @import common.LinkTo
-@import views.support.Format
+@import views.support.GuDateFormatLegacy
 
 <div class="sport-summary sport-summary--cricket" itemscope itemtype="http://schema.org/SportsEvent">
 
     <h2 class="u-h">
         <time class="u-h" datetime="@theMatch.gameDate.toString("yyyy-MM-dd'T'HH:mm:ss'Z'")" data-timestamp="@theMatch.gameDate.getMillis">
-        @Format(theMatch.gameDate, "d MMM y")
+        @GuDateFormatLegacy(theMatch.gameDate, "d MMM y")
         </time>
         @theMatch.competitionName, @theMatch.venueName
     </h2>


### PR DESCRIPTION
## What's happening ?

This PR correct a problem by which the first published time on this page ( https://www.theguardian.com/education/2020/may/11/headteachers-raise-concerns-over-reopening-of-english-primary-schools?dcr=false )

<img width="237" alt="Screenshot 2020-06-08 at 01 02 34" src="https://user-images.githubusercontent.com/6035518/83983116-c0b10e80-a923-11ea-8fe2-3d4ffb2bb711.png">

was now equal to the value in the DCR data model. 

Before change: 

<img width="462" alt="Screenshot 2020-06-08 at 01 03 23" src="https://user-images.githubusercontent.com/6035518/83983137-e1796400-a923-11ea-8881-9110cb304584.png">

After change:

<img width="476" alt="Screenshot 2020-06-08 at 01 03 50" src="https://user-images.githubusercontent.com/6035518/83983148-f1914380-a923-11ea-853c-916d951a05e5.png">

Then we added precomputed primary and secondary datelines

<img width="1052" alt="Screenshot 2020-06-08 at 12 44 40" src="https://user-images.githubusercontent.com/6035518/84026801-e0791e80-a985-11ea-9021-6a142746d0cb.png">

## How it's happening ?

Step 1: 

A bit of refactoring by which I moved some date support objects away from `support/package.scala` into `DatesAndTimes.scala` and renamed them. 

We now have `views.support.GuDateFormatLegacy` which I am going to phase out (in a subsequent PR), `GuDateTimeFormatOld` which is a copy of `GuDateFormatLegacy` and `GUDateTimeFormatNew` (which I had introduced the other day).

Step 2: 

Introduce two classes: `ArticleDateTimes` and `DisplayedDateTimesDCR`. The former contains the article natural times and the latter is designed to carry dates for DCR.

Step 3: 

Decision to leave `createdOn` and `createdOnDisplay` as they were (for the moment) and drive `lastUpdated`, `lastUpdatedDisplay`, `firstPublished` and `firstPublishedDisplay` by `ArticleDateTimes.makeDisplayedDateTimesDCR`.

Step 4: 

Reproduce in `makeDisplayedDateTimesDCR`, the logic found in `dateline.scala.html`

## Conclusion

This fixes the problem we have, but much more importantly pose the foundations for a better DCP/DCR date harmony in the near future.  

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No

