### PR TITLE
Switch discount code links on US content to UK version

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -484,4 +484,14 @@ trait FeatureSwitches {
     exposeClientSide = true
   )
 
+  val discountCodeLinks = Switch(
+    SwitchGroup.Feature,
+    "discount-code-site-links",
+    "This switch is a reminder to remove discount code site links from the nav and footer when no longer needed. It does not control any behaviour.",
+    owners = Seq(Owner.withEmail("dotcom.platform@guardian.co.uk")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 9, 8),
+    exposeClientSide = true
+  )
+
 }

--- a/static/src/javascripts/projects/common/modules/navigation/navigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/navigation.js
@@ -82,7 +82,7 @@ const enableMegaNavToggle = (): void => {
 const getDiscountCodePath = (path: string): string => {
     const firstPart = path.split('/')[1];
     if (firstPart === 'us' || firstPart === 'us-news') {
-        return 'us';
+        return 'uk'; // Send US -> UK for now as requested. All these sites should be decommissioned soon anyway.
     } else if (firstPart === 'uk' || firstPart === 'uk-news') {
         return 'uk';
     } else if (firstPart === 'au' || firstPart === 'australia-news') {

--- a/static/src/javascripts/projects/common/modules/navigation/navigation.spec.js
+++ b/static/src/javascripts/projects/common/modules/navigation/navigation.spec.js
@@ -97,7 +97,7 @@ describe('Navigation', () => {
             '',
         ];
         expect(paths.map(getDiscountCodePath)).toEqual([
-            'us',
+            'uk',
             '',
             'uk',
             'au',


### PR DESCRIPTION
## What does this change?
Sends people reading US news to the UK discount code site, as the US one is being decommissioned. This seems a bit strange, but it should only be temporary (I added a switch to remind us to remove it all).

## Does this change need to be reproduced in dotcom-rendering ?

Good question - it doesn't seem to be localised on DCR. Tempted to leave it that way given they're not expected to last much longer.

## Screenshots

## What is the value of this and can you measure success?


## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
