### PR TITLE
Add URL keywords to page targeting

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -37,6 +37,7 @@ type PageTargeting = {
     tn: string,
     slot: string,
     permutive: string,
+    urlkw: string,
 };
 
 let myPageTargetting: {} = {};
@@ -161,6 +162,15 @@ const getWhitelistedQueryParams = (): {} => {
     return pick(getUrlVars(), whiteList);
 };
 
+const getUrlKeywords = (pageId: string): string => {
+    if (pageId) {
+        const segments = pageId.split('/');
+        const lastPathname = segments.pop() || segments.pop(); // This handles a trailing slash
+        return lastPathname.replace(/-/g, ',');
+    }
+    return ''
+};
+
 const formatAppNexusTargeting = (obj: { [string]: string }): string =>
     flattenDeep(
         Object.keys(obj)
@@ -244,6 +254,7 @@ const buildPageTargetting = (
             // validating ad performance on DCR (against DCR eligible pages)
             // and can be decomissioned after Pascal and D&I no longer need the flag.
             inskin: inskinTargetting(),
+            urlkw: getUrlKeywords(page.pageId),
         },
         page.sharedAdTargeting,
         paTargeting,

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -334,4 +334,20 @@ describe('Build Page Targeting', () => {
             expect(getPageTargeting().ref).toEqual(undefined);
         });
     });
+
+    describe('URL Keywords', () => {
+        it('should return correct keywords from pageId', () => {
+            expect(getPageTargeting().urlkw).toEqual('footballweekly')
+        });
+
+        it('should extract multiple url keywords correctly', () => {
+            config.page.pageId = 'stage/2016/jul/26/harry-potter-cursed-child-review-palace-theatre-london'
+            expect(getPageTargeting().urlkw).toEqual('harry,potter,cursed,child,review,palace,theatre,london')
+        });
+
+        it('should get correct keywords when trailing slash is present', () => {
+            config.page.pageId = 'stage/2016/jul/26/harry-potter-cursed-child-review-palace-theatre-london/'
+            expect(getPageTargeting().urlkw).toEqual('harry,potter,cursed,child,review,palace,theatre,london')
+        });
+    })
 });


### PR DESCRIPTION
## What does this change?
This separates the url out into keywords that can be used on ad manager to filter ads based on what is in the url. This is in response to a request from Google during the current Coronavirus pandemic.

### Trello card: 
https://trello.com/c/ypzRcztw/829-extract-keywords-from-urls-for-additional-brand-safety-targeting-in-admanager

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
Allows advertising on articles where currently there is none.

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
