### PR TITLE
Add team id to json response for DCR

### DIFF
--- a/sport/app/football/controllers/MatchController.scala
+++ b/sport/app/football/controllers/MatchController.scala
@@ -48,7 +48,7 @@ sealed trait NsAnswer
 
 case class EventAnswer(eventTime: String, eventType: String) extends NsAnswer
 case class PlayerAnswer(id: String, name: String, position: String, lastName: String, substitute: Boolean, timeOnPitch: String, shirtNumber: String, events: Seq[EventAnswer]) extends NsAnswer
-case class TeamAnswer(name: String, lineup: Seq[PlayerAnswer], possession: Int, shotsOn: Int, shotsOff: Int, corners: Int, fouls: Int, colours: String) extends NsAnswer
+case class TeamAnswer(id: String, name: String, lineup: Seq[PlayerAnswer], possession: Int, shotsOn: Int, shotsOff: Int, corners: Int, fouls: Int, colours: String) extends NsAnswer
 case class MatchDataAnswer(id: String, homeTeam: TeamAnswer, awayTeam: TeamAnswer) extends NsAnswer
 
 object NsAnswer {
@@ -65,7 +65,7 @@ object NsAnswer {
 
   def makeTeam(team: LineUpTeam, teamPossession: Int, teamColour: String): TeamAnswer = {
     val players = makePlayers(team)
-    TeamAnswer(team.name, players, teamPossession, team.shotsOn, team.shotsOff, team.corners, team.fouls, teamColour)
+    TeamAnswer(team.id, team.name, players, teamPossession, team.shotsOn, team.shotsOff, team.corners, team.fouls, teamColour)
   }
 
   def makeFromFootballMatch(matchId: String, lineUp: LineUp): MatchDataAnswer = {


### PR DESCRIPTION
## What does this change?
Adds the `id` property to the team object returned to DCR for match stats

### Before
![Screenshot 2020-06-08 at 17 39 11](https://user-images.githubusercontent.com/1336821/84057094-154d9b80-a9af-11ea-9a7c-609de8c7d091.jpg)

### After
![Screenshot 2020-06-08 at 17 38 00](https://user-images.githubusercontent.com/1336821/84057080-0ff05100-a9af-11ea-9781-d702d395aa9b.jpg)
