### PR TITLE
Fix problem with format of urlkw as passed to GAM

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -162,13 +162,13 @@ const getWhitelistedQueryParams = (): {} => {
     return pick(getUrlVars(), whiteList);
 };
 
-const getUrlKeywords = (pageId: string): string => {
+const getUrlKeywords = (pageId: string): Array<string> => {
     if (pageId) {
         const segments = pageId.split('/');
         const lastPathname = segments.pop() || segments.pop(); // This handles a trailing slash
-        return lastPathname.replace(/-/g, ',');
+        return lastPathname.split('-');
     }
-    return ''
+    return []
 };
 
 const formatAppNexusTargeting = (obj: { [string]: string }): string =>

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -347,17 +347,17 @@ describe('Build Page Targeting', () => {
 
     describe('URL Keywords', () => {
         it('should return correct keywords from pageId', () => {
-            expect(getPageTargeting().urlkw).toEqual('footballweekly')
+            expect(getPageTargeting().urlkw).toEqual(['footballweekly'])
         });
 
         it('should extract multiple url keywords correctly', () => {
             config.page.pageId = 'stage/2016/jul/26/harry-potter-cursed-child-review-palace-theatre-london'
-            expect(getPageTargeting().urlkw).toEqual('harry,potter,cursed,child,review,palace,theatre,london')
+            expect(getPageTargeting().urlkw).toEqual(['harry','potter','cursed','child','review','palace','theatre','london'])
         });
 
         it('should get correct keywords when trailing slash is present', () => {
             config.page.pageId = 'stage/2016/jul/26/harry-potter-cursed-child-review-palace-theatre-london/'
-            expect(getPageTargeting().urlkw).toEqual('harry,potter,cursed,child,review,palace,theatre,london')
+            expect(getPageTargeting().urlkw).toEqual(['harry','potter','cursed','child','review','palace','theatre','london'])
         });
     })
 });


### PR DESCRIPTION
## What does this change?
Google Ad Manager needs the URL keywords to be passed as an array rather than a single string.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)


## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
