### PR TITLE
update to feedback page

### DIFF
--- a/onward/app/views/feedback.scala.html
+++ b/onward/app/views/feedback.scala.html
@@ -30,6 +30,25 @@
 
                                     <h2>Contact us</h2>
 
+                                    <p>
+                                        Due to the ongoing Coronavirus outbreak, the Technical support team team is operating at a reduced service. Our current response time is in excess of 14 days. Please bear with us and we will try to answer your query as soon as possible. Many of your queries can be answered online by visiting our <a href="https://www.theguardian.com/help">help page</a>, or, if you hold an account with us, your <a href="http://manage.theguardian.com/">Manage My Account</a> area.
+                                    </p>
+
+                                    <p>
+                                        If you have not found your answer on your <a href="https://www.theguardian.com/help">help pages</a>, before contacting us:
+                                    </p>
+
+                                    <p>
+                                        If you are experiencing an issue with the website, please wait and try again later.
+                                    </p>
+
+                                    <p>
+                                        If you are experiencing a problem with one of our apps, please check you are using the latest version and update if necessary. Steps on how to update apps on Android devices can be found <a href="https://support.google.com/googleplay/answer/113412?hl=en">here</a> and steps on how to update apps on iOS devices can be found <a href="https://support.apple.com/en-us/HT202180">here</a>. If updating does not resolve the issue, please report the issue in the app by opening the relevant app and going to Settings>Help>Send feedback. Please include the diagnostic information as this will help us to investigate the problem.
+                                    </p>
+                                    <p>
+                                        This page will be updated when normal service resumes, please check back. We apologise for any inconvenience.
+                                    </p>
+
                                     <form id="feedback__form" action="tech-feedback/send" method="post">
 
                                         <!-- category dropdown -->

--- a/onward/app/views/feedback.scala.html
+++ b/onward/app/views/feedback.scala.html
@@ -31,7 +31,7 @@
                                     <h2>Contact us</h2>
 
                                     <p>
-                                        Due to the ongoing Coronavirus outbreak, the Technical support team team is operating at a reduced service. Our current response time is in excess of 14 days. Please bear with us and we will try to answer your query as soon as possible. Many of your queries can be answered online by visiting our <a href="https://www.theguardian.com/help">help page</a>, or, if you hold an account with us, your <a href="http://manage.theguardian.com/">Manage My Account</a> area.
+                                        Due to the ongoing Coronavirus outbreak, the Technical support team team is operating at a reduced service. Our current response time is in excess of 14 days. Please bear with us and we will try to answer your query as soon as possible. Many of your queries can be answered online by visiting our <a href="https://www.theguardian.com/help">help page</a>, or, if you hold an account with us, your <a href="https://manage.theguardian.com/">Manage My Account</a> area.
                                     </p>
 
                                     <p>


### PR DESCRIPTION
## What does this change?
Adds some extra text to the feedback form due  to the current limitation on the help service.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
<img width="793" alt="Screen Shot 2020-06-09 at 09 15 56" src="https://user-images.githubusercontent.com/2051501/84123604-f6dcb400-aa31-11ea-9a89-8fd83ca99a54.png">
