### PR TITLE
Fix browser navigation on sign in gate dismissal

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/centesimus-control-1.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/centesimus-control-1.js
@@ -37,7 +37,7 @@ const htmlTemplate: ({
             <a class="signin-gate__button signin-gate__button--primary js-signin-gate__register-button" href="${signInUrl}">
                 Register for free
             </a>
-            <a class="signin-gate__dismiss js-signin-gate__dismiss" href="#maincontent">Not Now</a>
+            <button class="signin-gate__dismiss js-signin-gate__dismiss" href="">Not Now</button>
         </div>
         <div class="signin-gate__padding-bottom signin-gate__buttons">
             Already registered, contributed or subscribed?&nbsp;<a class="signin-gate__link js-signin-gate__sign-in signin-gate__link-no-ptm signin-gate__center-424" href="${signInUrl}">Sign in</a>
@@ -88,6 +88,10 @@ export const designShow: ({
                 component: ophanComponent,
                 value: 'not-now',
                 callback: () => {
+                    // reposition window to top of page without affecting browser's 'back' navigation
+                    const maincontent = document.getElementById('maincontent');
+                    if (maincontent) maincontent.scrollIntoView(true);
+
                     // show the current body. Remove the shadow one
                     articleBody.style.display = 'block';
                     shadowArticleBody.remove();

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/example.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/example.js
@@ -37,7 +37,7 @@ const htmlTemplate: ({
             <a class="signin-gate__button signin-gate__button--primary js-signin-gate__register-button" href="${signInUrl}">
                 Register for free
             </a>
-            <a class="signin-gate__dismiss js-signin-gate__dismiss" href="#maincontent">Not Now</a>
+            <button class="signin-gate__dismiss js-signin-gate__dismiss" href="">Not Now</button>
         </div>
         <div class="signin-gate__padding-bottom signin-gate__buttons">
             Already registered, contributed or subscribed?&nbsp;<a class="signin-gate__link js-signin-gate__sign-in signin-gate__link-no-ptm signin-gate__center-424" href="${signInUrl}">Sign in</a>
@@ -88,6 +88,10 @@ export const designShow: ({
                 component: ophanComponent,
                 value: 'not-now',
                 callback: () => {
+                    // reposition window to top of page without affecting browser's 'back' navigation
+                    const maincontent = document.getElementById('maincontent');
+                    if (maincontent) maincontent.scrollIntoView(true);
+
                     // show the current body. Remove the shadow one
                     articleBody.style.display = 'block';
                     shadowArticleBody.remove();

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/gate-test-vii-variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/gate-test-vii-variant.js
@@ -43,7 +43,7 @@ const htmlTemplate: ({
             <a class="signin-gate__button signin-gate__button--primary--var js-signin-gate__register-button" href="${signInUrl}">
                 Register for free
             </a>
-            <a class="signin-gate__dismiss--var js-signin-gate__dismiss" href="#maincontent">I’ll do it later</a>
+            <button class="signin-gate__dismiss--var js-signin-gate__dismiss" href="">I’ll do it later</button>
         </div>
         <div class="signin-gate__benefits--var signin-gate__margin-top--var">
          <p class="signin-gate__benefits--text--var">
@@ -106,6 +106,10 @@ export const designShow: ({
                 component: ophanComponent,
                 value: 'not-now',
                 callback: () => {
+                    // reposition window to top of page without affecting browser's 'back' navigation
+                    const maincontent = document.getElementById('maincontent');
+                    if (maincontent) maincontent.scrollIntoView(true);
+
                     // show the current body. Remove the shadow one
                     articleBody.style.display = 'block';
                     shadowArticleBody.remove();

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/patientia.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/patientia.js
@@ -37,7 +37,7 @@ const htmlTemplate: ({
             <a class="signin-gate__button signin-gate__button--primary js-signin-gate__register-button" href="${signInUrl}">
                 Register for free
             </a>
-            <a class="signin-gate__dismiss js-signin-gate__dismiss" href="#maincontent">Not Now</a>
+            <button class="signin-gate__dismiss js-signin-gate__dismiss" href="">Not Now</button>
         </div>
         <div class="signin-gate__padding-bottom signin-gate__buttons">
             Already registered, contributed or subscribed?&nbsp;<a class="signin-gate__link js-signin-gate__sign-in signin-gate__link-no-ptm signin-gate__center-424" href="${signInUrl}">Sign in</a>
@@ -88,6 +88,10 @@ export const designShow: ({
                 component: ophanComponent,
                 value: 'not-now',
                 callback: () => {
+                    // reposition window to top of page without affecting browser's 'back' navigation
+                    const maincontent = document.getElementById('maincontent');
+                    if (maincontent) maincontent.scrollIntoView(true);
+
                     // show the current body. Remove the shadow one
                     articleBody.style.display = 'block';
                     shadowArticleBody.remove();

--- a/static/src/stylesheets/module/identity/_sign-in-gate.scss
+++ b/static/src/stylesheets/module/identity/_sign-in-gate.scss
@@ -82,6 +82,8 @@
 
 .signin-gate__dismiss {
     @include fs-textSans(5);
+    background: 0;
+    border: 0;
     color: $brightness-7 !important;
     text-decoration: underline;
     font-weight: 700;
@@ -266,6 +268,8 @@
 .signin-gate__dismiss--var {
     @include fs-textSans(5);
     color: $brand-main !important;
+    background: 0;
+    border: 0;
     font-weight: 700;
     font-size: 17px;
     align-self: center;


### PR DESCRIPTION
## What does this change?

#### Before

When a user dismissed the gate, they were redirected to the article's main content via a local anchor tag. This registered in the browser's history stack, so back navigation was broken. 

#### Now

Replaces the dismiss <a> tag with a button that scrolls the article's main content into view, so that browser history navigation is not affected. 

#### Implementation

 An alternative option is `location.replace()` with [widespread support](https://caniuse.com/#feat=mdn-api_location_replace) but this seems slighty hacky
```
window.location.replace(`${window.location.href}#maincontent`);
``` 
`scrollIntoView` still has very [widespread support](https://caniuse.com/#search=scrollIntoView)

![Kapture 2020-06-09 at 10 24 11](https://user-images.githubusercontent.com/32312712/84130653-71f69800-aa3b-11ea-88ee-2353ec9b5456.gif)



## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
