### PR TITLE
Add "dismissed" and "signed in" values to gate custom param for ad targeting

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
@@ -10,7 +10,7 @@ import {
 import { isUserLoggedIn } from 'common/modules/identity/api';
 import { show as showCMPModule } from 'common/modules/ui/cmp-ui';
 import { submitClickEventTracking } from './component-event-tracking';
-import type { CurrentABTest } from './types';
+import type { CurrentABTest, GateStatus } from './types';
 
 // wrapper over isLoggedIn
 export const isLoggedIn = isUserLoggedIn;
@@ -51,13 +51,26 @@ export const hasUserDismissedGate: ({
 };
 
 // Dynamically sets the gate custom parameter for Google ad request page targeting
-export const setGatePageTargeting = (canShow: boolean): void => {
-    if (window.googletag) {
-        window.googletag.cmd.push(() => {
-            window.googletag
-                .pubads()
-                .setTargeting('gate', canShow.toString().slice(0, 1)); // must be a short string so we slice "t"/"f"
-        });
+export const setGatePageTargeting = (
+    isGateDismissed: boolean,
+    canShowCheck: boolean
+) => {
+    const setGoogleTargeting = (canShow: GateStatus): void => {
+        if (window.googletag) {
+            window.googletag.cmd.push(() => {
+                window.googletag
+                    .pubads()
+                    .setTargeting('gate', canShow.toString().slice(0, 1)); // must be a short string so we slice to "t"/"f"/"d"/"s"
+            });
+        }
+    };
+
+    if (isUserLoggedIn) {
+        setGoogleTargeting('signed in');
+    } else if (isGateDismissed) {
+        setGoogleTargeting('dismissed');
+    } else {
+        setGoogleTargeting(canShowCheck);
     }
 };
 

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
@@ -12,6 +12,17 @@ import { show as showCMPModule } from 'common/modules/ui/cmp-ui';
 import { submitClickEventTracking } from './component-event-tracking';
 import type { CurrentABTest, GateStatus } from './types';
 
+// Helper for setGatePageTargeting function
+const setGoogleTargeting = (canShow: GateStatus): void => {
+    if (window.googletag) {
+        window.googletag.cmd.push(() => {
+            window.googletag
+                .pubads()
+                .setTargeting('gate', canShow.toString().slice(0, 1)); // must be a short string so we slice to "t"/"f"/"d"/"s"
+        });
+    }
+};
+
 // wrapper over isLoggedIn
 export const isLoggedIn = isUserLoggedIn;
 
@@ -54,18 +65,8 @@ export const hasUserDismissedGate: ({
 export const setGatePageTargeting = (
     isGateDismissed: boolean,
     canShowCheck: boolean
-) => {
-    const setGoogleTargeting = (canShow: GateStatus): void => {
-        if (window.googletag) {
-            window.googletag.cmd.push(() => {
-                window.googletag
-                    .pubads()
-                    .setTargeting('gate', canShow.toString().slice(0, 1)); // must be a short string so we slice to "t"/"f"/"d"/"s"
-            });
-        }
-    };
-
-    if (isUserLoggedIn) {
+): void => {
+    if (isUserLoggedIn()) {
         setGoogleTargeting('signed in');
     } else if (isGateDismissed) {
         setGoogleTargeting('dismissed');

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/types.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/types.js
@@ -15,6 +15,8 @@ export type ComponentEventParams = {
     visitId?: string,
 };
 
+export type GateStatus = boolean | 'dismissed' | 'signed in';
+
 export type SignInGateVariant = {
     show: ({
         abTest: CurrentABTest,

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/centesimus/control.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/centesimus/control.js
@@ -19,19 +19,20 @@ const variant = 'centesimus-control-1';
 
 // method which returns a boolean determining if this variant can be shown on the current pageview
 const canShow: (name?: string) => boolean = (name = '') => {
+    const isGateDismissed = hasUserDismissedGate({
+        name,
+        variant,
+        componentName,
+    });
     const canShowCheck =
-        !hasUserDismissedGate({
-            name,
-            variant,
-            componentName,
-        }) &&
+        !isGateDismissed &&
         isNPageOrHigherPageView(3) &&
         !isLoggedIn() &&
         !isInvalidArticleType() &&
         !isInvalidSection() &&
         !isIOS9();
 
-    setGatePageTargeting(canShowCheck);
+    setGatePageTargeting(isGateDismissed, canShowCheck);
     return canShowCheck;
 };
 

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/centesimus-control-1.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/centesimus-control-1.js
@@ -94,7 +94,7 @@ export const designShow: ({
 
                     // The page does not reload when a user dismisses the gate,
                     // so we must reset page targeting params dynamically via googletags
-                    setGatePageTargeting(false);
+                    setGatePageTargeting(true, false);
 
                     // Tell other things the article has been redisplayed
                     mediator.emit('page:article:redisplayed');

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/example.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/example.js
@@ -94,7 +94,7 @@ export const designShow: ({
 
                     // The page does not reload when a user dismisses the gate,
                     // so we must reset page targeting params dynamically via googletags
-                    setGatePageTargeting(false);
+                    setGatePageTargeting(true, false);
 
                     // Tell other things the article has been redisplayed
                     mediator.emit('page:article:redisplayed');

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/gate-test-vii-variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/gate-test-vii-variant.js
@@ -112,7 +112,7 @@ export const designShow: ({
 
                     // The page does not reload when a user dismisses the gate,
                     // so we must reset page targeting params dynamically via googletags
-                    setGatePageTargeting(false);
+                    setGatePageTargeting(true, false);
 
                     // Tell other things the article has been redisplayed
                     mediator.emit('page:article:redisplayed');

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/patientia.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/patientia.js
@@ -94,7 +94,7 @@ export const designShow: ({
 
                     // The page does not reload when a user dismisses the gate,
                     // so we must reset page targeting params dynamically via googletags
-                    setGatePageTargeting(false);
+                    setGatePageTargeting(true, false);
 
                     // Tell other things the article has been redisplayed
                     mediator.emit('page:article:redisplayed');

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/example.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/example.js
@@ -19,19 +19,20 @@ const variant = 'example';
 
 // method which returns a boolean determining if this variant can be shown on the current pageview
 const canShow: (name?: string) => boolean = (name = '') => {
+    const isGateDismissed = hasUserDismissedGate({
+        name,
+        variant,
+        componentName,
+    });
     const canShowCheck =
-        !hasUserDismissedGate({
-            name,
-            variant,
-            componentName,
-        }) &&
+        !isGateDismissed &&
         isNPageOrHigherPageView(3) &&
         !isLoggedIn() &&
         !isInvalidArticleType() &&
         !isInvalidSection() &&
         !isIOS9();
 
-    setGatePageTargeting(canShowCheck);
+    setGatePageTargeting(isGateDismissed, canShowCheck);
     return canShowCheck;
 };
 

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/gate-test-vii/variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/gate-test-vii/variant.js
@@ -19,19 +19,20 @@ const variant = 'vii-variant';
 
 // method which returns a boolean determining if this variant can be shown on the current pageview
 const canShow: (name?: string) => boolean = (name = '') => {
+    const isGateDismissed = hasUserDismissedGate({
+        name,
+        variant,
+        componentName,
+    });
     const canShowCheck =
-        !hasUserDismissedGate({
-            name,
-            variant,
-            componentName,
-        }) &&
+        !isGateDismissed &&
         isNPageOrHigherPageView(3) &&
         !isLoggedIn() &&
         !isInvalidArticleType() &&
         !isInvalidSection() &&
         !isIOS9();
 
-    setGatePageTargeting(canShowCheck);
+    setGatePageTargeting(isGateDismissed, canShowCheck);
     return canShowCheck;
 };
 

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/patientia/control.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/patientia/control.js
@@ -19,19 +19,20 @@ const variant = 'patientia-control-1';
 
 // method which returns a boolean determining if this variant can be shown on the current pageview
 const canShow: (name?: string) => boolean = (name = '') => {
+    const isGateDismissed = hasUserDismissedGate({
+        name,
+        variant,
+        componentName,
+    });
     const canShowCheck =
-        !hasUserDismissedGate({
-            name,
-            variant,
-            componentName,
-        }) &&
-        isNPageOrHigherPageView(2) &&
+        !isGateDismissed &&
+        isNPageOrHigherPageView(3) &&
         !isLoggedIn() &&
         !isInvalidArticleType() &&
         !isInvalidSection() &&
         !isIOS9();
 
-    setGatePageTargeting(false); // gate is never shown in control
+    setGatePageTargeting(isGateDismissed, false); // gate is never shown in control
     return canShowCheck;
 };
 

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/patientia/variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/patientia/variant.js
@@ -19,19 +19,20 @@ const variant = 'patientia-variant-1';
 
 // method which returns a boolean determining if this variant can be shown on the current pageview
 const canShow: (name?: string) => boolean = (name = '') => {
+    const isGateDismissed = hasUserDismissedGate({
+        name,
+        variant,
+        componentName,
+    });
     const canShowCheck =
-        !hasUserDismissedGate({
-            name,
-            variant,
-            componentName,
-        }) &&
-        isNPageOrHigherPageView(2) &&
+        !isGateDismissed &&
+        isNPageOrHigherPageView(3) &&
         !isLoggedIn() &&
         !isInvalidArticleType() &&
         !isInvalidSection() &&
         !isIOS9();
 
-    setGatePageTargeting(canShowCheck);
+    setGatePageTargeting(isGateDismissed, canShowCheck);
     return canShowCheck;
 };
 


### PR DESCRIPTION
## What does this change?

Before setting the custom gate param to the ad request, we check if the user is signed in or has dismissed the gate to differentiation these from the other reasons the gate may or may not render on a page. 


## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
