### PR TITLE
Add ccpa state to page targeting

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -168,7 +168,7 @@ const getUrlKeywords = (pageId: string): Array<string> => {
         const lastPathname = segments.pop() || segments.pop(); // This handles a trailing slash
         return lastPathname.split('-');
     }
-    return []
+    return [];
 };
 
 const formatAppNexusTargeting = (obj: { [string]: string }): string =>
@@ -211,8 +211,16 @@ const buildAppNexusTargeting = once(
         formatAppNexusTargeting(buildAppNexusTargetingObject(pageTargeting))
 );
 
+const getCcpaValue = (ccpaState: boolean | null): string => {
+    if (ccpaState === null) {
+        return 'n/a';
+    }
+    return ccpaState ? 't' : 'f';
+};
+
 const buildPageTargetting = (
-    adConsentState: boolean | null
+    adConsentState: boolean | null,
+    ccpaState: boolean | null
 ): { [key: string]: mixed } => {
     const page = config.get('page');
     // personalised ads targeting
@@ -255,6 +263,7 @@ const buildPageTargetting = (
             // and can be decomissioned after Pascal and D&I no longer need the flag.
             inskin: inskinTargetting(),
             urlkw: getUrlKeywords(page.pageId),
+            ccpa: getCcpaValue(ccpaState),
         },
         page.sharedAdTargeting,
         paTargeting,
@@ -290,7 +299,8 @@ const getPageTargeting = (): { [key: string]: mixed } => {
                 : state[1] && state[2] && state[3] && state[4] && state[5];
 
         if (canRun !== latestConsentCanRun) {
-            myPageTargetting = buildPageTargetting(canRun);
+            const ccpaState = typeof state === 'boolean' ? state : null;
+            myPageTargetting = buildPageTargetting(canRun, ccpaState);
             latestConsentCanRun = canRun;
         }
     });

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -213,7 +213,7 @@ const buildAppNexusTargeting = once(
 
 const getCcpaValue = (ccpaState: boolean | null): string => {
     if (ccpaState === null) {
-        return 'n/a';
+        return 'na';
     }
     return ccpaState ? 't' : 'f';
 };

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -186,6 +186,31 @@ describe('Build Page Targeting', () => {
         expect(getPageTargeting().pa).toBe('f');
     });
 
+    it('Should correctly set the CCPA state (ccpa) param', () => {
+        onIabConsentNotification.mockImplementation(tcfWithConsentMock);
+        expect(getPageTargeting().ccpa).toBe('n/a');
+
+        _.resetPageTargeting();
+        onIabConsentNotification.mockImplementation(tcfWithoutConsentMock);
+        expect(getPageTargeting().ccpa).toBe('n/a');
+
+        _.resetPageTargeting();
+        onIabConsentNotification.mockImplementation(tcfNullConsentMock);
+        expect(getPageTargeting().ccpa).toBe('n/a');
+
+        _.resetPageTargeting();
+        onIabConsentNotification.mockImplementation(tcfMixedConsentMock);
+        expect(getPageTargeting().ccpa).toBe('n/a');
+
+        _.resetPageTargeting();
+        onIabConsentNotification.mockImplementation(ccpaWithConsentMock);
+        expect(getPageTargeting().ccpa).toBe('f');
+
+        _.resetPageTargeting();
+        onIabConsentNotification.mockImplementation(ccpaWithoutConsentMock);
+        expect(getPageTargeting().ccpa).toBe('t');
+    });
+
     it('should set correct edition param', () => {
         expect(getPageTargeting().edition).toBe('us');
     });
@@ -236,6 +261,7 @@ describe('Build Page Targeting', () => {
             cc: 'US',
             rp: 'dotcom-platform',
             dcre: 'f',
+            ccpa: 'n/a',
         });
     });
 
@@ -347,17 +373,37 @@ describe('Build Page Targeting', () => {
 
     describe('URL Keywords', () => {
         it('should return correct keywords from pageId', () => {
-            expect(getPageTargeting().urlkw).toEqual(['footballweekly'])
+            expect(getPageTargeting().urlkw).toEqual(['footballweekly']);
         });
 
         it('should extract multiple url keywords correctly', () => {
-            config.page.pageId = 'stage/2016/jul/26/harry-potter-cursed-child-review-palace-theatre-london'
-            expect(getPageTargeting().urlkw).toEqual(['harry','potter','cursed','child','review','palace','theatre','london'])
+            config.page.pageId =
+                'stage/2016/jul/26/harry-potter-cursed-child-review-palace-theatre-london';
+            expect(getPageTargeting().urlkw).toEqual([
+                'harry',
+                'potter',
+                'cursed',
+                'child',
+                'review',
+                'palace',
+                'theatre',
+                'london',
+            ]);
         });
 
         it('should get correct keywords when trailing slash is present', () => {
-            config.page.pageId = 'stage/2016/jul/26/harry-potter-cursed-child-review-palace-theatre-london/'
-            expect(getPageTargeting().urlkw).toEqual(['harry','potter','cursed','child','review','palace','theatre','london'])
+            config.page.pageId =
+                'stage/2016/jul/26/harry-potter-cursed-child-review-palace-theatre-london/';
+            expect(getPageTargeting().urlkw).toEqual([
+                'harry',
+                'potter',
+                'cursed',
+                'child',
+                'review',
+                'palace',
+                'theatre',
+                'london',
+            ]);
         });
-    })
+    });
 });

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -188,19 +188,19 @@ describe('Build Page Targeting', () => {
 
     it('Should correctly set the CCPA state (ccpa) param', () => {
         onIabConsentNotification.mockImplementation(tcfWithConsentMock);
-        expect(getPageTargeting().ccpa).toBe('n/a');
+        expect(getPageTargeting().ccpa).toBe('na');
 
         _.resetPageTargeting();
         onIabConsentNotification.mockImplementation(tcfWithoutConsentMock);
-        expect(getPageTargeting().ccpa).toBe('n/a');
+        expect(getPageTargeting().ccpa).toBe('na');
 
         _.resetPageTargeting();
         onIabConsentNotification.mockImplementation(tcfNullConsentMock);
-        expect(getPageTargeting().ccpa).toBe('n/a');
+        expect(getPageTargeting().ccpa).toBe('na');
 
         _.resetPageTargeting();
         onIabConsentNotification.mockImplementation(tcfMixedConsentMock);
-        expect(getPageTargeting().ccpa).toBe('n/a');
+        expect(getPageTargeting().ccpa).toBe('na');
 
         _.resetPageTargeting();
         onIabConsentNotification.mockImplementation(ccpaWithConsentMock);
@@ -261,7 +261,7 @@ describe('Build Page Targeting', () => {
             cc: 'US',
             rp: 'dotcom-platform',
             dcre: 'f',
-            ccpa: 'n/a',
+            ccpa: 'na',
         });
     });
 


### PR DESCRIPTION
## What does this change?
This PR adds the CCPA state as a key-value pair to our page targeting so we are able to run data analysis based on that information. Updated unit testing based on the changes.

Details:
- `ccpa` key added to page targeting, representing the state of the CCPA consent state. This key will be present in every page.
- `ccpa`'s value will differ according to the following cases:
  - User is not in a region/variant where CCPA applies: 'na'  
  - User has opted out of of selling their data: 't'
  - User has not opted out of of selling their data: 'f'
  

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
