### PR TITLE
Fix viewId not being picked up by ComponentEventParams

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
@@ -60,12 +60,23 @@ const show: () => Promise<boolean> = () =>
             `${config.get('page.host')}/${config.get('page.pageId')}`
         );
 
+        // get the view id to attach to component event params
+        let viewId = '';
+        if (
+            window.guardian &&
+            window.guardian.ophan &&
+            window.guardian.ophan.viewId
+        ) {
+            viewId = window.guardian.ophan.viewId;
+        }
+
         // set the component event params to be included in the query
         const queryParams: ComponentEventParams = {
             componentType: 'signingate',
             componentId: test.ophanComponentId,
             abTestName: test.dataLinkNames || test.id,
             abTestVariant: variant.name,
+            viewId
         };
 
         // attach the browser id to component event params

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/types.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/types.js
@@ -10,7 +10,7 @@ export type ComponentEventParams = {
     componentId?: string,
     abTestName: string,
     abTestVariant: string,
-    viewId?: string,
+    viewId: string,
     browserId?: string,
     visitId?: string,
 };


### PR DESCRIPTION
## What does this change?
A change made in #22301 removed the `viewId` from the `ComponentEventParams`, this caused an issue where we could no longer track `SIGN_IN` and `CREATE_ACCOUNT` events in identity.

This reintroduces `viewId`, and makes it a required value in the `ComponentEventParams` type too.
