### PR TITLE
[DO NOT MERGE] Put CCPA AB test behind Geolocation check for US

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/cmp-ccpa-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/cmp-ccpa-test.js
@@ -1,5 +1,10 @@
 // @flow strict
 
+import { getSync as geolocationGetSync } from 'lib/geolocation';
+import once from 'lodash/once';
+
+const currentGeoLocation = once((): string => geolocationGetSync());
+
 export const ccpaCmpTest: ABTest = {
     id: 'CmpCcpaTest',
     start: '2020-06-04',
@@ -14,7 +19,7 @@ export const ccpaCmpTest: ABTest = {
     dataLinkNames: 'n/a',
     idealOutcome: 'The Sourcepoint CCPA CMP works with the existing TCFv1 CMP',
     showForSensitive: true,
-    canRun: () => true,
+    canRun: () => ['US'].includes(currentGeoLocation()),
     variants: [
         {
             id: 'control',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/cmp-ccpa-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/cmp-ccpa-test.js
@@ -1,9 +1,6 @@
 // @flow strict
 
-import { getSync as geolocationGetSync } from 'lib/geolocation';
-import once from 'lodash/once';
-
-const currentGeoLocation = once((): string => geolocationGetSync());
+import {isInUsa} from "common/modules/commercial/geo-utils";
 
 export const ccpaCmpTest: ABTest = {
     id: 'CmpCcpaTest',
@@ -19,7 +16,7 @@ export const ccpaCmpTest: ABTest = {
     dataLinkNames: 'n/a',
     idealOutcome: 'The Sourcepoint CCPA CMP works with the existing TCFv1 CMP',
     showForSensitive: true,
-    canRun: () => ['US'].includes(currentGeoLocation()),
+    canRun: () => isInUsa(),
     variants: [
         {
             id: 'control',


### PR DESCRIPTION
## What does this change?
Ensures that the AB test for the CCPA CMP is only accessible for users in America.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)