### PR TITLE
Update identity libraries to 3.207 (to update email newsletters)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.205"
+  val identityLibVersion = "3.207"
   val awsVersion = "1.11.240"
   val capiVersion = "17.1"
   val faciaVersion = "3.0.20"


### PR DESCRIPTION
## What does this change?
Bumps the identity libraries to capture this email newsletter change: 

- Update Coronavirus Australia newsletter from every weekday to weekly

The change in identity-models is here: https://github.com/guardian/identity/pull/1760

## Screenshots
without this change, after the user signs up and is presented with newsletters and (incorrectly) informed that coronavirus australia is sent every weekday
![image](https://user-images.githubusercontent.com/3072877/84381870-90969380-abe1-11ea-96ef-7c27045bfc61.png)

with this change, the coronavirus AU newsletter correctly says it is now weekly 🎉 
![image](https://user-images.githubusercontent.com/3072877/84382083-06026400-abe2-11ea-9eee-e5e59197e53d.png)

## What is the value of this and can you measure success?
The frequency of the Coronavirus Australia newsletter the user sees is accurate

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
