### PR TITLE
Update Digital Subscriptions Banner Copy

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-template.js
@@ -16,12 +16,13 @@ const subscriptionBannerTemplate = (
 <div id="js-site-message--subscription-banner" class="site-message--subscription-banner">
     <div class="site-message--subscription-banner__inner">
         <h3 class="site-message--subscription-banner__title">
-            Make us part of your new normal
+            <div class="site-message--subscription-banner__no-wrap">The world is changing by the minute.</div>
+            <div class="site-message--subscription-banner__no-wrap">Keep up with a digital subscription.</div>
         </h3>
 
         <div class="site-message--subscription-banner__description">
             <p>Two Guardian apps, with you every day. <b>The Daily</b>,
-            joining you in time for breakfast to share politics, culture, food and opinion.
+            joining you in the morning to share politics, culture, food and opinion.
             <b>Live</b>, constantly by your side, keeping you connected with the outside world.</p>
         </div>
 

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-template.js
@@ -16,8 +16,8 @@ const subscriptionBannerTemplate = (
 <div id="js-site-message--subscription-banner" class="site-message--subscription-banner">
     <div class="site-message--subscription-banner__inner">
         <h3 class="site-message--subscription-banner__title">
-            <span class="site-message--subscription-banner__no-wrap">The world is changing by the minute.</span>
-            <span class="site-message--subscription-banner__no-wrap">Keep up with a digital subscription.</span>
+            <div class="site-message--subscription-banner__no-wrap">The world is changing by the minute.</div>
+            <div class="site-message--subscription-banner__no-wrap">Keep up with a digital subscription.</div>
         </h3>
 
         <div class="site-message--subscription-banner__description">

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-template.js
@@ -16,8 +16,8 @@ const subscriptionBannerTemplate = (
 <div id="js-site-message--subscription-banner" class="site-message--subscription-banner">
     <div class="site-message--subscription-banner__inner">
         <h3 class="site-message--subscription-banner__title">
-            <div>The world is changing by the minute.</div>
-            <div>Keep up with a digital subscription.</div>
+            <div class="site-message--subscription-banner__no-wrap">The world is changing by the minute.</div>
+            <div class="site-message--subscription-banner__no-wrap">Keep up with a digital subscription.</div>
         </h3>
 
         <div class="site-message--subscription-banner__description">

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-template.js
@@ -16,8 +16,8 @@ const subscriptionBannerTemplate = (
 <div id="js-site-message--subscription-banner" class="site-message--subscription-banner">
     <div class="site-message--subscription-banner__inner">
         <h3 class="site-message--subscription-banner__title">
-            <div class="site-message--subscription-banner__no-wrap">The world is changing by the minute.</div>
-            <div class="site-message--subscription-banner__no-wrap">Keep up with a digital subscription.</div>
+            <span class="site-message--subscription-banner__no-wrap">The world is changing by the minute.</span>
+            <span class="site-message--subscription-banner__no-wrap">Keep up with a digital subscription.</span>
         </h3>
 
         <div class="site-message--subscription-banner__description">

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-template.js
@@ -16,8 +16,8 @@ const subscriptionBannerTemplate = (
 <div id="js-site-message--subscription-banner" class="site-message--subscription-banner">
     <div class="site-message--subscription-banner__inner">
         <h3 class="site-message--subscription-banner__title">
-            <div class="site-message--subscription-banner__no-wrap">The world is changing by the minute.</div>
-            <div class="site-message--subscription-banner__no-wrap">Keep up with a digital subscription.</div>
+            <div>The world is changing by the minute.</div>
+            <div>Keep up with a digital subscription.</div>
         </h3>
 
         <div class="site-message--subscription-banner__description">

--- a/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
@@ -109,9 +109,7 @@ $teal-green: #006d67;
 }
 
 .site-message--subscription-banner__no-wrap {
-    @include mq($from: mobileLandscape) {
-        white-space: nowrap;
-    }
+    white-space: nowrap;
 }
 
 .site-message--subscription-banner__cta-container {

--- a/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_subscription-medium-banner.scss
@@ -109,7 +109,9 @@ $teal-green: #006d67;
 }
 
 .site-message--subscription-banner__no-wrap {
-    white-space: nowrap;
+    @include mq($from: mobileLandscape) {
+        white-space: nowrap;
+    }
 }
 
 .site-message--subscription-banner__cta-container {


### PR DESCRIPTION
## What does this change?

Updates Digital Subscriptions Banner Copy as requested here: https://trello.com/c/XBEWOYr4/3103-urgent-ds-banner-headline-and-standfirst-copy-tweaks-to-support-the-brand-moment-launch-friday-12-june

## Does this change need to be reproduced in dotcom-rendering ?

N/A

## Screenshots

## Mobile
<img width="392" alt="Screenshot 2020-06-11 at 12 46 47" src="https://user-images.githubusercontent.com/1590704/84383083-85446780-abe3-11ea-97dc-ff98ccd69c44.png">

## Tablet
<img width="447" alt="Screenshot 2020-06-11 at 12 46 28" src="https://user-images.githubusercontent.com/1590704/84383103-92615680-abe3-11ea-934d-b2d1a845c8a4.png">

## Desktop
<img width="1603" alt="Screenshot 2020-06-11 at 12 47 06" src="https://user-images.githubusercontent.com/1590704/84383073-81b0e080-abe3-11ea-9584-0b5047b068c6.png">




