### PR TITLE
bump CMP to 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@emotion/core": "^10.0.21",
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/automat-client": "^0.2.16",
-    "@guardian/consent-management-platform": "3.1.0",
+    "@guardian/consent-management-platform": "3.3.0",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/src-button": "^0.16.1",
     "@guardian/src-foundations": "^0.16.1",

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -1,6 +1,9 @@
 // @flow
 import config from 'lib/config';
-import { shouldShow } from '@guardian/consent-management-platform';
+import {
+    shouldShow,
+    showPrivacyManager,
+} from '@guardian/consent-management-platform';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { ccpaCmpTest } from 'common/modules/experiments/tests/cmp-ccpa-test';
 import raven from 'lib/raven';
@@ -21,7 +24,11 @@ export const show = (forceModal: ?boolean): Promise<boolean> => {
                         },
                     },
                     () => {
-                        require('common/modules/cmp-ui').init(!!forceModal);
+                        if (isInVariantSynchronous(ccpaCmpTest, 'variant')) {
+                            showPrivacyManager();
+                        } else {
+                            require('common/modules/cmp-ui').init(!!forceModal);
+                        }
                     },
                     []
                 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1171,10 +1171,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.16.tgz#3ef47e7f49e633aea51c67f061d8d313a26fa9bc"
   integrity sha512-SgNU2bgiyQaXNfqanx4SDmxqAhXW6QBCTk4tRnCgV9Ht6noRl7UsDfx4I0u+M4H3TRnK4I/i2mmlJBtnuwhxEg==
 
-"@guardian/consent-management-platform@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-3.1.0.tgz#aa14137c4d24dc3d1df9af686b67d0ec28a4e3dc"
-  integrity sha512-O4zdXCDbGEN6DdKkMcH/xcBl2xL0MdgOWSgWZ2hvL5RhEjjKt3+UkYyU6hP80/h0rDoMupBA4ZbGnD8Vk2zytw==
+"@guardian/consent-management-platform@3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-3.3.0.tgz#7a351c95b548f54f6d85d6ab53398758a00b913e"
+  integrity sha512-wBBx5uqMGapCvF0wElGWkbSEcpwLLbx0fCICuznZRl74pKrmIrZBr6ZYZG4KXXIxAX+81PFyoxvI0KSF2xt/dw==
   dependencies:
     consent-string "1.5.2"
     js-cookie "2.2.1"


### PR DESCRIPTION
## What does this change?

- [adds timing instrumentation to CMP](https://github.com/guardian/consent-management-platform/tree/3.2.0)
- [adds sourcepoint PM when CCPA applies](https://github.com/guardian/consent-management-platform/tree/v3.3.0)

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

later on

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
