### PR TITLE
Reinstate gallery caption titles

### DIFF
--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -598,7 +598,7 @@ object GalleryCaptionCleaner extends HtmlCleaner {
     captionTitle.addClass("gallery__caption__title")
     captionTitle.html(captionTitleText)
 
-    galleryCaption.prependChild(captionTitle)
+    galleryCaption.body.prependChild(captionTitle)
 
     galleryCaption
   }


### PR DESCRIPTION
## What does this change?
Fixes missing gallery caption titles by prepending to the parsed document body rather than outside it 😱 