### PR TITLE
Don't initialise comment ad slot on mobile

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.js
@@ -13,6 +13,7 @@ import { refreshAdvert } from 'commercial/modules/dfp/load-advert';
 
 import type { Advert } from 'commercial/modules/dfp/Advert';
 import type bonzo from 'bonzo';
+import {getBreakpoint} from 'lib/detect';
 
 const createCommentSlots = (
     canBeDmpu: boolean
@@ -99,8 +100,8 @@ const runSecondStage = (
 
 export const initCommentAdverts = (): Promise<boolean> => {
     const $adSlotContainer: bonzo = $('.js-discussion__ad-slot');
-
-    if (!commercialFeatures.commentAdverts || !$adSlotContainer.length) {
+    const isMobile = getBreakpoint() === 'mobile';
+    if (!commercialFeatures.commentAdverts || !$adSlotContainer.length || isMobile) {
         return Promise.resolve(false);
     }
 

--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.js
@@ -10,10 +10,11 @@ import { commercialFeatures } from 'common/modules/commercial/commercial-feature
 import { createSlots } from 'commercial/modules/dfp/create-slots';
 import { getAdvertById } from 'commercial/modules/dfp/get-advert-by-id';
 import { refreshAdvert } from 'commercial/modules/dfp/load-advert';
+import { getBreakpoint } from 'lib/detect';
 
 import type { Advert } from 'commercial/modules/dfp/Advert';
 import type bonzo from 'bonzo';
-import {getBreakpoint} from 'lib/detect';
+
 
 const createCommentSlots = (
     canBeDmpu: boolean

--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.spec.js
@@ -8,6 +8,7 @@ import { commercialFeatures } from 'common/modules/commercial/commercial-feature
 import { initCommentAdverts, _ } from 'commercial/modules/comment-adverts';
 import { refreshAdvert as refreshAdvert_ } from 'commercial/modules/dfp/load-advert';
 import { getAdvertById as getAdvertById_ } from 'commercial/modules/dfp/get-advert-by-id';
+import { getBreakpoint as getBreakpoint_ } from 'lib/detect';
 
 // Workaround to fix issue where dataset is missing from jsdom, and solve the
 // 'cannot set property [...] which has only a getter' TypeError
@@ -31,6 +32,10 @@ jest.mock('commercial/modules/dfp/get-advert-by-id', () => ({
     getAdvertById: jest.fn(),
 }));
 
+jest.mock('lib/detect', () => ({
+    getBreakpoint: jest.fn(),
+}));
+
 jest.mock('common/modules/commercial/commercial-features', () => ({
     commercialFeatures: {
         commentAdverts: true,
@@ -45,6 +50,7 @@ const { createCommentSlots, runSecondStage, maybeUpgradeSlot } = _;
 const commercialFeaturesMock: any = commercialFeatures;
 const isUserLoggedIn: any = isUserLoggedIn_;
 const getAdvertById: any = getAdvertById_;
+const getBreakpoint: any = getBreakpoint_;
 const refreshAdvert: any = refreshAdvert_;
 
 const mockHeight = (height: number) => {
@@ -236,6 +242,20 @@ describe('initCommentAdverts', () => {
             document.body.innerHTML = `<div class="js-comments">
                 <div class="content__main-column"></div></div>`;
         }
+        initCommentAdverts().then(result => {
+            expect(result).toBe(false);
+            done();
+        });
+    });
+
+    it('should return false if on mobile', done => {
+        if (document.body) {
+            document.body.innerHTML = `<div class="js-comments">
+                <div class="content__main-column"></div></div>`;
+        }
+
+        getBreakpoint.mockReturnValue('mobile')
+
         initCommentAdverts().then(result => {
             expect(result).toBe(false);
             done();


### PR DESCRIPTION
## What does this change?
Prior to this change we had the problem of serving ads that weren't visible on mobile devices in the comments ad slot.
This prevents the comments ad slot from loading on mobile. The ad isn't visible on mobile and by doing this we prevent ads being served but not visible.


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
### On Desktop
![image](https://user-images.githubusercontent.com/9122944/84509874-4209f780-acbc-11ea-932f-0a12d4dd8430.png)

We can see that the ads are being served and the network requests are being made.

### On Mobile
![image](https://user-images.githubusercontent.com/9122944/84509980-6c5bb500-acbc-11ea-9ea3-2d1dda0039ef.png)

We can see no ad and no ad request - this is the desired behaviour. 

## What is the value of this and can you measure success?
We should stop seeing ad impressions with zero viewability on mobile.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
