### PR TITLE
Use ChartAtomBlockElement for the ChartAtom

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -60,6 +60,7 @@ case class AudioAtomBlockElement(id: String, kicker: String, coverUrl: String, t
 case class AudioBlockElement(assets: Seq[AudioAsset]) extends PageElement
 case class BlockquoteBlockElement(html: String) extends PageElement
 case class ExplainerAtomBlockElement(id: String, title: String, body: String) extends PageElement
+case class ChartAtomBlockElement(id: String, url: String) extends PageElement
 case class CodeBlockElement(html: Option[String], isMandatory: Boolean) extends PageElement
 case class CommentBlockElement(body: String, avatarURL: String, profileURL: String, profileName: String, permalink: String, dateTime: String) extends PageElement
 case class ContentAtomBlockElement(atomId: String) extends PageElement
@@ -117,6 +118,7 @@ object PageElement {
       case _: AudioBlockElement => true
       case _: AudioAtomBlockElement => true
       case _: BlockquoteBlockElement => true
+      case _: ChartAtomBlockElement => true
       case _: CommentBlockElement => true
       case _: ContentAtomBlockElement => true
       case _: DisclaimerBlockElement => true
@@ -305,7 +307,7 @@ object PageElement {
           case Some(chart: ChartAtom) => {
             val encodedId = URLEncoder.encode(chart.id, "UTF-8")
             // chart.id is a uuid, so there is no real need to url-encode it but just to be safe
-            Some(AtomEmbedUrlBlockElement(
+            Some(ChartAtomBlockElement(
               id = chart.id,
               url = s"${Configuration.ajax.url}/embed/atom/chart/$encodedId"
             ))
@@ -499,6 +501,7 @@ object PageElement {
   implicit val AudioBlockElementWrites: Writes[AudioBlockElement] = Json.writes[AudioBlockElement]
   implicit val AudioAtomBlockElementWrites: Writes[AudioAtomBlockElement] = Json.writes[AudioAtomBlockElement]
   implicit val BlockquoteBlockElementWrites: Writes[BlockquoteBlockElement] = Json.writes[BlockquoteBlockElement]
+  implicit val ChartAtomBlockElementWrites: Writes[ChartAtomBlockElement] = Json.writes[ChartAtomBlockElement]
   implicit val CodeBlockElementWrites: Writes[CodeBlockElement] = Json.writes[CodeBlockElement]
   implicit val CommentBlockElementWrites: Writes[CommentBlockElement] = Json.writes[CommentBlockElement]
   implicit val ContentAtomBlockElementWrites: Writes[ContentAtomBlockElement] = Json.writes[ContentAtomBlockElement]


### PR DESCRIPTION
## What does this change?

Use ChartAtomBlockElement for the ChartAtom. This is the follow up of: https://github.com/guardian/dotcom-rendering/pull/1583


## Does this change need to be reproduced in dotcom-rendering ?

- [ ] Yes. Already did.
