### PR TITLE
Change ccpa flag to rdp in page targeting

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -211,7 +211,7 @@ const buildAppNexusTargeting = once(
         formatAppNexusTargeting(buildAppNexusTargetingObject(pageTargeting))
 );
 
-const getCcpaValue = (ccpaState: boolean | null): string => {
+const getRdpValue = (ccpaState: boolean | null): string => {
     if (ccpaState === null) {
         return 'na';
     }
@@ -263,7 +263,7 @@ const buildPageTargetting = (
             // and can be decomissioned after Pascal and D&I no longer need the flag.
             inskin: inskinTargetting(),
             urlkw: getUrlKeywords(page.pageId),
-            ccpa: getCcpaValue(ccpaState),
+            rdp: getRdpValue(ccpaState),
         },
         page.sharedAdTargeting,
         paTargeting,

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -186,29 +186,29 @@ describe('Build Page Targeting', () => {
         expect(getPageTargeting().pa).toBe('f');
     });
 
-    it('Should correctly set the CCPA state (ccpa) param', () => {
+    it('Should correctly set the RDP flag (rdp) param', () => {
         onIabConsentNotification.mockImplementation(tcfWithConsentMock);
-        expect(getPageTargeting().ccpa).toBe('na');
+        expect(getPageTargeting().rdp).toBe('na');
 
         _.resetPageTargeting();
         onIabConsentNotification.mockImplementation(tcfWithoutConsentMock);
-        expect(getPageTargeting().ccpa).toBe('na');
+        expect(getPageTargeting().rdp).toBe('na');
 
         _.resetPageTargeting();
         onIabConsentNotification.mockImplementation(tcfNullConsentMock);
-        expect(getPageTargeting().ccpa).toBe('na');
+        expect(getPageTargeting().rdp).toBe('na');
 
         _.resetPageTargeting();
         onIabConsentNotification.mockImplementation(tcfMixedConsentMock);
-        expect(getPageTargeting().ccpa).toBe('na');
+        expect(getPageTargeting().rdp).toBe('na');
 
         _.resetPageTargeting();
         onIabConsentNotification.mockImplementation(ccpaWithConsentMock);
-        expect(getPageTargeting().ccpa).toBe('f');
+        expect(getPageTargeting().rdp).toBe('f');
 
         _.resetPageTargeting();
         onIabConsentNotification.mockImplementation(ccpaWithoutConsentMock);
-        expect(getPageTargeting().ccpa).toBe('t');
+        expect(getPageTargeting().rdp).toBe('t');
     });
 
     it('should set correct edition param', () => {
@@ -261,7 +261,7 @@ describe('Build Page Targeting', () => {
             cc: 'US',
             rp: 'dotcom-platform',
             dcre: 'f',
-            ccpa: 'na',
+            rdp: 'na',
         });
     });
 


### PR DESCRIPTION
## What does this change?
Changed the `ccpa` key in our page targeting to `rdp` so it's common between platforms.


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)