### PR TITLE
Update epic reminder date to September

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -468,9 +468,9 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "show-contribution-reminder",
     "This toggles the contribution reminder",
-    owners = Seq(Owner.withGithub("JoeMG")),
+    owners = Seq(Owner.withGithub("tomrf1")),
     safeState = Off,
-    sellByDate = new LocalDate(2020, 6, 15),
+    sellByDate = new LocalDate(2020, 8, 25), //Cut off 1 week before September
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/commercial/epic-reminder-email-signup.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic-reminder-email-signup.js
@@ -184,9 +184,8 @@ const epicReminderEmailSignup = (fields: Fields) => {
             ? ctaAttribute.toLowerCase().replace(/\s/g, '-')
             : '';
 
-        // For second round of testing, the events will be either (tested):
-        // precontribution-reminder-prompt-copy-remind-me-in-july or
-        // precontribution-reminder-prompt-copy-support-us-later
+        // For second round of testing, the events will be
+        // precontribution-reminder-prompt-copy-remind-me-in-september
         submitClickEvent({
             component: {
                 componentType: 'ACQUISITIONS_OTHER',

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
@@ -16,9 +16,9 @@ const buildImage = (url: string): string =>
     </div>`;
 
 export const defaultReminderFields: ReminderFields = {
-    reminderCTA: 'Remind me in July',
-    reminderDate: '2020-07-19 00:00:00',
-    reminderDateAsString: 'July 2020',
+    reminderCTA: 'Remind me in September',
+    reminderDate: '2020-09-15 00:00:00',
+    reminderDateAsString: 'September 2020',
 };
 
 export const acquisitionsEpicControlTemplate = ({


### PR DESCRIPTION
## What does this change?
Update the reminder date from July to September
https://trello.com/c/p76Yr1dJ/2110-update-the-pre-contribution-reminder-from-july-to-september

## Screenshots
![image](https://user-images.githubusercontent.com/30600967/84654454-1fb7ea00-af07-11ea-9929-868e784ec506.png)
![image](https://user-images.githubusercontent.com/30600967/84654499-31998d00-af07-11ea-880b-ed2ef0e4acb2.png)



