### PR TITLE
Update privacy setting button text for CCPA

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -57,7 +57,12 @@ export const addPrivacySettingsLink = (): void => {
 
             newPrivacyLink.dataset.linkName = 'privacy-settings';
             newPrivacyLink.removeAttribute('href');
-            newPrivacyLink.innerText = 'Privacy settings';
+            newPrivacyLink.innerText = isInVariantSynchronous(
+                ccpaCmpTest,
+                'variant'
+            )
+                ? 'California resident – Do Not Sell'
+                : 'Privacy settings';
 
             const newPrivacyLinkListItem: Element = privacyLinkListItem.cloneNode(
                 false


### PR DESCRIPTION
## What does this change?
Updates the text used for the privacy settings button at the bottom of the page for users in our CCPA test.


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

### Tested

- [x] Locally
- [ ] On CODE (optional)