### PR TITLE
Set youtube's restrictedDataProcessor flag correctly

### DIFF
--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -35,6 +35,29 @@ type Handlers = {
     onPlayerStateChange: (event: Object) => void,
 };
 
+interface AdsConfig {
+    adTagParameters?: {
+        iu: any,
+        cust_params: string,
+    };
+    disableAds?: boolean;
+    nonPersonalizedAd?: boolean;
+    restrictedDataProcessor?: boolean;
+}
+
+// const adsConfig: Object = {
+//     adTagParameters: {
+//         iu: config.get('page.adUnit'),
+//         cust_params: encodeURIComponent(constructQuery(custParams)),
+//     },
+// };
+
+// if (ccpaStateFlag === null) {
+//     adsConfig.nonPersonalizedAd = !tcfStateFlag;
+// } else {
+//     adsConfig.restrictedDataProcessor = ccpaStateFlag;
+// }
+
 let tcfState = null;
 let ccpaState = null;
 onIabConsentNotification(state => {
@@ -110,7 +133,7 @@ const createAdsConfig = (
     adFree: boolean,
     tcfStateFlag: boolean | null,
     ccpaStateFlag: boolean | null
-): Object => {
+): AdsConfig => {
     if (adFree) {
         return { disableAds: true };
     }
@@ -118,7 +141,7 @@ const createAdsConfig = (
     const custParams = getPageTargeting();
     custParams.permutive = getPermutivePFPSegments();
 
-    const adsConfig: Object = {
+    const adsConfig: AdsConfig = {
         adTagParameters: {
             iu: config.get('page.adUnit'),
             cust_params: encodeURIComponent(constructQuery(custParams)),

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -45,19 +45,6 @@ interface AdsConfig {
     restrictedDataProcessor?: boolean;
 }
 
-// const adsConfig: Object = {
-//     adTagParameters: {
-//         iu: config.get('page.adUnit'),
-//         cust_params: encodeURIComponent(constructQuery(custParams)),
-//     },
-// };
-
-// if (ccpaStateFlag === null) {
-//     adsConfig.nonPersonalizedAd = !tcfStateFlag;
-// } else {
-//     adsConfig.restrictedDataProcessor = ccpaStateFlag;
-// }
-
 let tcfState = null;
 let ccpaState = null;
 onIabConsentNotification(state => {

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.js
@@ -39,43 +39,69 @@ describe('create ads config', () => {
     it('disables ads in ad-free', () => {
         const result = youtubePlayer.createAdsConfig(
             true, // ad-free
-            false
+            null,
+            null
         );
 
         expect(result.disableAds).toBeTruthy();
     });
 
     it('does not disable ads when we are not in ad-free', () => {
-        const result = youtubePlayer.createAdsConfig(false, false);
+        const result = youtubePlayer.createAdsConfig(false, null, null);
 
         expect(result.disableAds).toBeFalsy();
     });
 
-    it('in non ad-free, returns false nonPersonalizedAds without consent', () => {
-        const result = youtubePlayer.createAdsConfig(false, false);
+    it('in non ad-free, returns false nonPersonalizedAds without consent in TCF', () => {
+        const result = youtubePlayer.createAdsConfig(false, false, null);
 
         if (result.hasOwnProperty('nonPersonalizedAd')) {
             expect(result.nonPersonalizedAd).toBeTruthy();
         }
     });
 
-    it('in non ad-free, returns true nonPersonalizedAds with consent', () => {
-        const result = youtubePlayer.createAdsConfig(
-            false,
-            true // consent
-        );
+    it('in non ad-free, returns true nonPersonalizedAds with consent in TCF', () => {
+        const result = youtubePlayer.createAdsConfig(false, true, null);
 
         expect(result.nonPersonalizedAd).toBeFalsy();
     });
 
+    it('in non ad-free, returns no restrictedDataProcessor param in TCF', () => {
+        const result = youtubePlayer.createAdsConfig(false, false, null);
+
+        expect(result.restrictedDataProcessor).toBeUndefined();
+    });
+
+    it('in non ad-free, returns true restrictedDataProcessor without consent in CCPA', () => {
+        const result = youtubePlayer.createAdsConfig(false, null, true);
+
+        if (result.hasOwnProperty('restrictedDataProcessor')) {
+            expect(result.restrictedDataProcessor).toBeTruthy();
+        }
+    });
+
+    it('in non ad-free, returns false restrictedDataProcessor with consent in CCPA', () => {
+        const result = youtubePlayer.createAdsConfig(false, null, false);
+
+        if (result.hasOwnProperty('restrictedDataProcessor')) {
+            expect(result.restrictedDataProcessor).toBeFalsy();
+        }
+    });
+
+    it('in non ad-free, returns no nonPersonalizedAds param in CCPA', () => {
+        const result = youtubePlayer.createAdsConfig(false, null, false);
+
+        expect(result.nonPersonalizedAds).toBeUndefined();
+    });
+
     it('in non ad-free includes adUnit', () => {
-        const result = youtubePlayer.createAdsConfig(false, false);
+        const result = youtubePlayer.createAdsConfig(false, null, null);
 
         expect(result.adTagParameters.iu).toEqual('adunit');
     });
 
     it('in non ad-free includes url-escaped targeting params', () => {
-        const result = youtubePlayer.createAdsConfig(false, false);
+        const result = youtubePlayer.createAdsConfig(false, null, null);
 
         expect(result.adTagParameters.cust_params).toEqual(
             'key%3Dvalue%26permutive%3D42'

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.js
@@ -52,7 +52,7 @@ describe('create ads config', () => {
         expect(result.disableAds).toBeFalsy();
     });
 
-    it('in non ad-free, returns false nonPersonalizedAds without consent in TCF', () => {
+    it('in non ad-free, returns false nonPersonalizedAd without consent in TCF', () => {
         const result = youtubePlayer.createAdsConfig(false, false, null);
 
         if (result.hasOwnProperty('nonPersonalizedAd')) {
@@ -60,7 +60,7 @@ describe('create ads config', () => {
         }
     });
 
-    it('in non ad-free, returns true nonPersonalizedAds with consent in TCF', () => {
+    it('in non ad-free, returns true nonPersonalizedAd with consent in TCF', () => {
         const result = youtubePlayer.createAdsConfig(false, true, null);
 
         expect(result.nonPersonalizedAd).toBeFalsy();
@@ -88,23 +88,29 @@ describe('create ads config', () => {
         }
     });
 
-    it('in non ad-free, returns no nonPersonalizedAds param in CCPA', () => {
+    it('in non ad-free, returns no nonPersonalizedAd param in CCPA', () => {
         const result = youtubePlayer.createAdsConfig(false, null, false);
 
-        expect(result.nonPersonalizedAds).toBeUndefined();
+        expect(result.nonPersonalizedAd).toBeUndefined();
     });
 
     it('in non ad-free includes adUnit', () => {
         const result = youtubePlayer.createAdsConfig(false, null, null);
 
-        expect(result.adTagParameters.iu).toEqual('adunit');
+        expect(result.adTagParameters).toBeDefined();
+        if (result.adTagParameters) {
+            expect(result.adTagParameters.iu).toEqual('adunit');
+        }
     });
 
     it('in non ad-free includes url-escaped targeting params', () => {
         const result = youtubePlayer.createAdsConfig(false, null, null);
 
-        expect(result.adTagParameters.cust_params).toEqual(
-            'key%3Dvalue%26permutive%3D42'
-        );
+        expect(result.adTagParameters).toBeDefined();
+        if (result.adTagParameters) {
+            expect(result.adTagParameters.cust_params).toEqual(
+                'key%3Dvalue%26permutive%3D42'
+            );
+        }
     });
 });


### PR DESCRIPTION
## What does this change?
Sets Youtube's `restrictedDataProcessor` flag if the user has oped out of selling their data under the CCPA framework.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

### Tested

- [x] Locally
- [ ] On CODE (optional)