### PR TITLE
Fix privacy manager showing on page load

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -26,7 +26,9 @@ export const show = (forceModal: ?boolean): Promise<boolean> => {
                     },
                     () => {
                         if (isInVariantSynchronous(ccpaCmpTest, 'variant')) {
-                            showPrivacyManager();
+                            if (forceModal) {
+                                showPrivacyManager();
+                            }
                         } else {
                             require('common/modules/cmp-ui').init(!!forceModal);
                         }
@@ -93,6 +95,5 @@ export const consentManagementPlatformUi = {
             config.get('switches.cmpUi', true) && shouldShow()
         );
     },
-
     show,
 };


### PR DESCRIPTION
## What does this change?
Fix a bug that was causing the CCPA privacy manager to surface on every pageloader when a user was in the CCPA variant.

PR in collaboration with @sndrs 

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)