### PR TITLE
CCPA server side test

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -9,7 +9,8 @@ object ActiveExperiments extends ExperimentsDefinition {
     OldTLSSupportDeprecation,
     DotcomRendering1,
     DotcomRendering2,
-    DCRBubble
+    DCRBubble,
+    CcpaCmp
   )
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -46,4 +47,12 @@ object DCRBubble extends Experiment(
   owners = Seq(Owner.withGithub("shtukas")),
   sellByDate = new LocalDate(2020, 12, 1),
   participationGroup = Perc0B // Also see ArticlePicker.scala - our main filter mechanism is by page features
+)
+
+object CcpaCmp extends Experiment(
+  name = "ccpa-cmp",
+  description = "Shows CCPA banner instead of TCFv1 banner",
+  owners = Seq(Owner.withGithub("ripecosta")),
+  sellByDate = new LocalDate(2020, 7, 3),
+  participationGroup = Perc1C
 )

--- a/docs/03-dev-howtos/01-ab-testing.md
+++ b/docs/03-dev-howtos/01-ab-testing.md
@@ -363,7 +363,7 @@ multiple variants exist for the same request. [More information on how VCL enabl
 
 There are two ways to put yourself into a test:
 
-*1. Use the opt/in link:*
+*1. Use the opt/in link (can't be used on localhost):*
 
 Copy the name of your test and visit this url: `https://www.theguardian.com/opt/in/your-test-name`
 eg: `https://www.theguardian.com/opt/in/audio-page-change` this will redirect to the home page, but sets a cookie in your browser

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@emotion/core": "^10.0.21",
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/automat-client": "^0.2.16",
-    "@guardian/consent-management-platform": "3.4.0",
+    "@guardian/consent-management-platform": "3.4.2",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/src-button": "^0.16.1",
     "@guardian/src-foundations": "^0.16.1",

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -10,8 +10,7 @@ import { markTime } from 'lib/user-timing';
 import { captureOphanInfo } from 'lib/capture-ophan-info';
 import reportError from 'lib/report-error';
 import 'projects/commercial/modules/cmp/stub';
-import { isInVariantSynchronous } from 'common/modules/experiments/ab';
-import { ccpaCmpTest } from 'common/modules/experiments/tests/cmp-ccpa-test';
+import { isInCcpaTest } from 'projects/commercial/modules/cmp/ccpa-ab-test';
 import { init } from '@guardian/consent-management-platform';
 
 // Let webpack know where to get files from
@@ -33,7 +32,7 @@ const go = () => {
         bootStandard();
 
         // Start CMP
-        if (isInVariantSynchronous(ccpaCmpTest, 'variant')) {
+        if (isInCcpaTest()) {
             init({ useCcpa: true });
         }
 

--- a/static/src/javascripts/projects/commercial/modules/cmp/ccpa-ab-test.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/ccpa-ab-test.js
@@ -1,13 +1,14 @@
 // @flow
 // import { isInUsa } from 'common/modules/commercial/geo-utils';
+import config from 'lib/config';
 
 // let isInTest;
 
-// const isInServerSideTest = (): boolean => true;
+const isInServerSideTest = (): boolean => config.get('tests.ccpaCmp', false);
 
 // export const isInCcpaTest = (): boolean => {
 //     isInTest = isInTest || (isInUsa() && isInServerSideTest());
 //     return isInTest;
 // };
 
-export const isInCcpaTest = (): boolean => true;
+export const isInCcpaTest = (): boolean => isInServerSideTest();

--- a/static/src/javascripts/projects/commercial/modules/cmp/ccpa-ab-test.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/ccpa-ab-test.js
@@ -1,14 +1,15 @@
 // @flow
-// import { isInUsa } from 'common/modules/commercial/geo-utils';
+import { isInUsa } from 'common/modules/commercial/geo-utils';
 import config from 'lib/config';
 
-// let isInTest;
+let isInTest;
 
-const isInServerSideTest = (): boolean => config.get('tests.ccpaCmp', false);
+const isInServerSideTest = (): boolean =>
+    config.get('tests.ccpaCmp') === 'variant';
 
-// export const isInCcpaTest = (): boolean => {
-//     isInTest = isInTest || (isInUsa() && isInServerSideTest());
-//     return isInTest;
-// };
-
-export const isInCcpaTest = (): boolean => isInServerSideTest();
+export const isInCcpaTest = (): boolean => {
+    if (typeof isInTest === 'undefined') {
+        isInTest = isInUsa() && isInServerSideTest();
+    }
+    return isInTest;
+};

--- a/static/src/javascripts/projects/commercial/modules/cmp/ccpa-ab-test.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/ccpa-ab-test.js
@@ -5,7 +5,7 @@ import config from 'lib/config';
 let isInTest;
 
 const isInServerSideTest = (): boolean =>
-    config.get('tests.ccpaCmp') === 'variant';
+    config.get('tests.ccpaCmpVariant') === 'variant';
 
 export const isInCcpaTest = (): boolean => {
     if (typeof isInTest === 'undefined') {

--- a/static/src/javascripts/projects/commercial/modules/cmp/ccpa-ab-test.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/ccpa-ab-test.js
@@ -1,0 +1,11 @@
+// @flow
+import { isInUsa } from 'common/modules/commercial/geo-utils';
+
+let isInTest;
+
+const isInServerSideTest = (): boolean => true;
+
+export const isInCcpaTest = (): boolean => {
+    isInTest = isInTest || (isInUsa() && isInServerSideTest());
+    return isInTest;
+};

--- a/static/src/javascripts/projects/commercial/modules/cmp/ccpa-ab-test.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/ccpa-ab-test.js
@@ -1,11 +1,13 @@
 // @flow
-import { isInUsa } from 'common/modules/commercial/geo-utils';
+// import { isInUsa } from 'common/modules/commercial/geo-utils';
 
-let isInTest;
+// let isInTest;
 
-const isInServerSideTest = (): boolean => true;
+// const isInServerSideTest = (): boolean => true;
 
-export const isInCcpaTest = (): boolean => {
-    isInTest = isInTest || (isInUsa() && isInServerSideTest());
-    return isInTest;
-};
+// export const isInCcpaTest = (): boolean => {
+//     isInTest = isInTest || (isInUsa() && isInServerSideTest());
+//     return isInTest;
+// };
+
+export const isInCcpaTest = (): boolean => true;

--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
@@ -5,8 +5,7 @@ import { getCookie } from 'lib/cookies';
 import { getUrlVars } from 'lib/url';
 import fetchJSON from 'lib/fetch-json';
 import { onIabConsentNotification } from '@guardian/consent-management-platform';
-import { isInVariantSynchronous } from 'common/modules/experiments/ab';
-import { ccpaCmpTest } from 'common/modules/experiments/tests/cmp-ccpa-test';
+import { isInCcpaTest } from 'projects/commercial/modules/cmp/ccpa-ab-test';
 import { log } from './log';
 import { CmpStore } from './store';
 import { encodeVendorConsentData } from './cookie';
@@ -280,10 +279,7 @@ class CmpService {
 
 export const init = (): void => {
     // Only run our CmpService if prepareCmp has added the CMP stub
-    if (
-        window[CMP_GLOBAL_NAME] &&
-        !isInVariantSynchronous(ccpaCmpTest, 'variant')
-    ) {
+    if (window[CMP_GLOBAL_NAME] && !isInCcpaTest()) {
         let cmp: ?CmpService;
         // Pull queued commands from the CMP stub
         const { commandQueue = [] } = window[CMP_GLOBAL_NAME] || {};

--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.spec.js
@@ -4,8 +4,8 @@ import fetchJson from 'lib/fetch-json';
 import { _, init } from './cmp';
 import { log as log_ } from './log';
 
-jest.mock('common/modules/experiments/ab', () => ({
-    isInVariantSynchronous: () => false,
+jest.mock('projects/commercial/modules/cmp/ccpa-ab-test', () => ({
+    isInCcpaTest: () => false,
 }));
 
 jest.mock('lib/raven');

--- a/static/src/javascripts/projects/commercial/modules/cmp/stub.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/stub.js
@@ -1,13 +1,9 @@
 // @flow
 /* eslint-disable no-underscore-dangle */
 import config from 'lib/config';
-import { isInVariantSynchronous } from 'common/modules/experiments/ab';
-import { ccpaCmpTest } from 'common/modules/experiments/tests/cmp-ccpa-test';
+import { isInCcpaTest } from 'projects/commercial/modules/cmp/ccpa-ab-test';
 
-if (
-    config.get('switches.enableConsentManagementService') &&
-    !isInVariantSynchronous(ccpaCmpTest, 'variant')
-) {
+if (config.get('switches.enableConsentManagementService') && !isInCcpaTest()) {
     try {
         (function stubCMP(document, window) {
             if (!window.__cmp) {

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -5,8 +5,7 @@ import {
     checkWillShowUi,
     showPrivacyManager,
 } from '@guardian/consent-management-platform';
-import { isInVariantSynchronous } from 'common/modules/experiments/ab';
-import { ccpaCmpTest } from 'common/modules/experiments/tests/cmp-ccpa-test';
+import { isInCcpaTest } from 'projects/commercial/modules/cmp/ccpa-ab-test';
 import raven from 'lib/raven';
 
 let initUi;
@@ -25,7 +24,7 @@ export const show = (forceModal: ?boolean): Promise<boolean> => {
                         },
                     },
                     () => {
-                        if (isInVariantSynchronous(ccpaCmpTest, 'variant')) {
+                        if (isInCcpaTest()) {
                             if (forceModal) {
                                 showPrivacyManager();
                             }
@@ -60,10 +59,7 @@ export const addPrivacySettingsLink = (): void => {
 
             newPrivacyLink.dataset.linkName = 'privacy-settings';
             newPrivacyLink.removeAttribute('href');
-            newPrivacyLink.innerText = isInVariantSynchronous(
-                ccpaCmpTest,
-                'variant'
-            )
+            newPrivacyLink.innerText = isInCcpaTest()
                 ? 'California resident – Do Not Sell'
                 : 'Privacy settings';
 
@@ -88,7 +84,7 @@ export const addPrivacySettingsLink = (): void => {
 export const consentManagementPlatformUi = {
     id: 'cmpUi',
     canShow: (): Promise<boolean> => {
-        if (isInVariantSynchronous(ccpaCmpTest, 'variant')) {
+        if (isInCcpaTest()) {
             return checkWillShowUi();
         }
         return Promise.resolve(

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import { isInVariantSynchronous as isInVariantSynchronous_ } from 'common/modules/experiments/ab';
+import { isInCcpaTest as isInCcpaTest_ } from 'projects/commercial/modules/cmp/ccpa-ab-test';
 import {
     shouldShow,
     checkWillShowUi,
@@ -16,9 +16,9 @@ jest.mock('@guardian/consent-management-platform', () => ({
 
 jest.mock('lib/report-error', () => jest.fn());
 
-const isInVariantSynchronous: any = isInVariantSynchronous_;
-jest.mock('common/modules/experiments/ab', () => ({
-    isInVariantSynchronous: jest.fn(),
+const isInCcpaTest: any = isInCcpaTest_;
+jest.mock('projects/commercial/modules/cmp/ccpa-ab-test', () => ({
+    isInCcpaTest: jest.fn(),
 }));
 
 describe('cmp-ui', () => {
@@ -53,7 +53,7 @@ describe('cmp-ui', () => {
             it('returns checkWillShowUi if user is in CCPA variant', () => {
                 config.set('switches.cmpUi', true);
                 checkWillShowUi.mockReturnValue(Promise.resolve(true));
-                isInVariantSynchronous.mockReturnValue(true);
+                isInCcpaTest.mockReturnValue(true);
 
                 return consentManagementPlatformUi.canShow().then(show => {
                     expect(checkWillShowUi).toHaveBeenCalledTimes(1);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1171,10 +1171,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.16.tgz#3ef47e7f49e633aea51c67f061d8d313a26fa9bc"
   integrity sha512-SgNU2bgiyQaXNfqanx4SDmxqAhXW6QBCTk4tRnCgV9Ht6noRl7UsDfx4I0u+M4H3TRnK4I/i2mmlJBtnuwhxEg==
 
-"@guardian/consent-management-platform@3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-3.4.0.tgz#ff11f7460f1933f87521573890b7a688c843599b"
-  integrity sha512-55Prm/rV3a/m5YiLYubmJAh0/yZje97mXfQaZZHgyYqF+S4h2WBqCj9KdMRDAnkjMs2SmcAzZ+A07LlZ6nq9+Q==
+"@guardian/consent-management-platform@3.4.2":
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-3.4.2.tgz#a732cbe9718198f25e8a5bc7e5f7960954c01bd3"
+  integrity sha512-BiNnJTclkRLqP8fPWATLnOElSm///727Ao5005WoHswdKX+88OGQlmgNc5PnAqdTHE9xy5wVVHi3ulaFpWQReA==
   dependencies:
     consent-string "1.5.2"
     js-cookie "2.2.1"


### PR DESCRIPTION
## What does this change?
Creates a CCPA server side test to test the CCPA banner in the US.

We are creating a server-side test so it doesn't clash with the DCR cohorts.

Further PR will remove the current client-side AB test.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Checklist

### Tested

- [ ] Locally
- [ ] On CODE (optional)