### PR TITLE
Aus moment header

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -500,7 +500,7 @@ trait FeatureSwitches {
     "Enables the Aus moment special header",
     owners = Seq(Owner.withGithub("tomrf1")),
     safeState = Off,
-    sellByDate = new LocalDate(2020, 8, 1),
+    sellByDate = new LocalDate(2020, 8, 3),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -494,4 +494,14 @@ trait FeatureSwitches {
     exposeClientSide = true
   )
 
+  val ausMoment2020Header = Switch(
+    SwitchGroup.Feature,
+    "aus-moment-2020-header",
+    "Enables the Aus moment special header",
+    owners = Seq(Owner.withGithub("tomrf1")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 8, 1),
+    exposeClientSide = true
+  )
+
 }

--- a/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
+++ b/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
@@ -141,7 +141,7 @@
         documentElement.style.fontSize = baseFontSize
     }
 
-    if (!shouldHideSupportMessaging()) {
+    if (shouldHideSupportMessaging()) {
         docClass += ' hide-support-messaging';
     }
 

--- a/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
+++ b/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
@@ -141,7 +141,7 @@
         documentElement.style.fontSize = baseFontSize
     }
 
-    if (shouldHideSupportMessaging()) {
+    if (!shouldHideSupportMessaging()) {
         docClass += ' hide-support-messaging';
     }
 

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -32,80 +32,90 @@
             </a>
 
             @defining(Edition(request).id.toLowerCase()) { editionId =>
-                <div class="@{if (editionId == "au") "new-header__cta-bar-aus-moment" else "new-header__cta-bar"} hide-until-mobile">
-                    @if(!page.metadata.hasSlimHeader) {
-                        @if(editionId == "au" && ausMoment2020Header.isSwitchedOn) {
-                            <div class="cta-bar__text hide-until-tablet js-aus-moment-header-supporter">
-                                <div class="cta-bar__heading">
-                                    Welcome back
+                @defining(editionId == "au" && ausMoment2020Header.isSwitchedOn) { ausMomentEnabled =>
+                    <div class="@{
+                        if(ausMomentEnabled) "new-header__cta-bar-aus-moment" else "new-header__cta-bar"
+                    } hide-until-mobile">
+                        @if(!page.metadata.hasSlimHeader) {
+                            @if(ausMomentEnabled) {
+                                <div class="cta-bar__text hide-until-tablet js-aus-moment-header-supporter">
+                                    <div class="cta-bar__heading">
+                                        Welcome back
+                                    </div>
+                                    <div class="cta-bar__subheading">
+                                        We're funded by <span class="cta-bar__aus-moment-count"></span>
+                                        readers across Australia.
+                                        <br/>
+                                        Thank you for supporting us
+                                    </div>
                                 </div>
-                                <div class="cta-bar__subheading">
-                                    We're funded by <span class="cta-bar__aus-moment-count"></span>readers across Australia.
-                                    <br/>
-                                    Thank you for supporting us
-                                </div>
-                            </div>
 
-                            <div class="cta-bar__text hide-until-tablet js-aus-moment-header-non-supporter">
-                                <div class="cta-bar__heading">
-                                    Support The Guardian
+                                <div class="cta-bar__text hide-until-tablet js-aus-moment-header-non-supporter">
+                                    <div class="cta-bar__heading">
+                                        Support The Guardian
+                                    </div>
+                                    <div class="cta-bar__subheading">
+                                        We're funded by <span class="cta-bar__aus-moment-count"></span>
+                                        readers across Australia
+                                    </div>
                                 </div>
-                                <div class="cta-bar__subheading">
-                                    We're funded by <span class="cta-bar__aus-moment-count"></span>readers across Australia
+                            } else {
+                                <div class="cta-bar__text hide-until-tablet">
+                                    <div class="cta-bar__heading">
+                                        Support The Guardian
+                                    </div>
+                                    <div class="cta-bar__subheading">
+                                        Available for everyone, funded by readers
+                                    </div>
                                 </div>
-                            </div>
-                        } else {
-                            <div class="cta-bar__text hide-until-tablet">
-                                <div class="cta-bar__heading">
-                                    Support The Guardian
-                                </div>
-                                <div class="cta-bar__subheading">
-                                    Available for everyone, funded by readers
-                                </div>
-                            </div>
+                            }
                         }
-                    }
 
-                    <a class="cta-bar__cta hide-until-tablet js-change-become-member-link js-acquisition-link"
+                        <a class="cta-bar__cta hide-until-tablet js-change-become-member-link js-acquisition-link"
                         data-link-name="nav2 : contribute-cta"
-                        data-edition="@{editionId}"
+                        data-edition="@{
+                            editionId
+                        }"
                         href="@getReaderRevenueUrl(SupportContribute, Header)">
-                        Contribute
-                        @fragments.inlineSvg("arrow-right", "icon")
-                    </a>
-
-                    @if(editionId != "us" || UsHeaderAndFooterSubscribeLinkSwitch.isSwitchedOn) {
-                        <a class="cta-bar__cta hide-until-tablet js-subscribe js-acquisition-link"
-                        data-link-name="nav2 : subscribe-cta"
-                        data-edition="@{
-                            editionId
-                        }"
-                        href="@getReaderRevenueUrl(SupportSubscribe, Header)">
-                            Subscribe
-                            @fragments.inlineSvg("arrow-right", "icon")
-                        </a>
-                    }
-
-                    @if(editionId == "uk") {
-                        <a class="cta-bar__cta hide-from-tablet js-change-become-member-link js-acquisition-link"
-                        data-link-name="nav2 : support-cta"
-                        data-edition="@{
-                            editionId
-                        }"
-                        href="@getReaderRevenueUrl(SupportSubscribe, Header)">
-                            Subscribe
-                            @fragments.inlineSvg("arrow-right", "icon")
-                        </a>
-                    } else {
-                        <a class="cta-bar__cta hide-from-tablet js-change-become-member-link js-acquisition-link"
-                            data-link-name="nav2 : contribute-cta"
-                            data-edition="@{editionId}"
-                            href="@getReaderRevenueUrl(SupportContribute, Header)">
                             Contribute
                             @fragments.inlineSvg("arrow-right", "icon")
                         </a>
-                    }
-                </div>
+
+                        @if(editionId != "us" || UsHeaderAndFooterSubscribeLinkSwitch.isSwitchedOn) {
+                            <a class="cta-bar__cta hide-until-tablet js-subscribe js-acquisition-link"
+                            data-link-name="nav2 : subscribe-cta"
+                            data-edition="@{
+                                editionId
+                            }"
+                            href="@getReaderRevenueUrl(SupportSubscribe, Header)">
+                                Subscribe
+                                @fragments.inlineSvg("arrow-right", "icon")
+                            </a>
+                        }
+
+                        @if(editionId == "uk") {
+                            <a class="cta-bar__cta hide-from-tablet js-change-become-member-link js-acquisition-link"
+                            data-link-name="nav2 : support-cta"
+                            data-edition="@{
+                                editionId
+                            }"
+                            href="@getReaderRevenueUrl(SupportSubscribe, Header)">
+                                Subscribe
+                                @fragments.inlineSvg("arrow-right", "icon")
+                            </a>
+                        } else {
+                            <a class="cta-bar__cta hide-from-tablet js-change-become-member-link js-acquisition-link"
+                            data-link-name="nav2 : contribute-cta"
+                            data-edition="@{
+                                editionId
+                            }"
+                            href="@getReaderRevenueUrl(SupportContribute, Header)">
+                                Contribute
+                                @fragments.inlineSvg("arrow-right", "icon")
+                            </a>
+                        }
+                    </div>
+                }
             }
 
             <div class="new-header__top-bar hide-until-mobile">

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -5,7 +5,7 @@
 @import navigation.NavMenu
 @import navigation.UrlHelpers.{getJobUrl, Header, getReaderRevenueUrl}
 @import navigation.ReaderRevenueSite.{Support, SupportSubscribe, SupportContribute}
-@import conf.switches.Switches.{ IdentityProfileNavigationSwitch, SearchSwitch, UsHeaderAndFooterSubscribeLinkSwitch }
+@import conf.switches.Switches.{ IdentityProfileNavigationSwitch, SearchSwitch, UsHeaderAndFooterSubscribeLinkSwitch, ausMoment2020Header }
 
 @defining(NavMenu(page, Edition(request))) { navMenu: NavMenu =>
     <header class="@RenderClasses(Map(
@@ -34,7 +34,7 @@
             @defining(Edition(request).id.toLowerCase()) { editionId =>
                 <div class="@{if (editionId == "au") "new-header__cta-bar-aus-moment" else "new-header__cta-bar"} hide-until-mobile">
                     @if(!page.metadata.hasSlimHeader) {
-                        @if(editionId == "au") {
+                        @if(editionId == "au" && ausMoment2020Header.isSwitchedOn) {
                             <div class="cta-bar__text hide-until-tablet js-aus-moment-header-supporter">
                                 <div class="cta-bar__heading">
                                     Welcome back

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -31,17 +31,39 @@
                 }
             </a>
 
-            <div class="new-header__cta-bar hide-until-mobile">
-                @defining(Edition(request).id.toLowerCase()) { editionId =>
+            @defining(Edition(request).id.toLowerCase()) { editionId =>
+                <div class="@{if (editionId == "au") "new-header__cta-bar-aus-moment" else "new-header__cta-bar"} hide-until-mobile">
                     @if(!page.metadata.hasSlimHeader) {
-                        <div class="cta-bar__text hide-until-tablet">
-                            <div class="cta-bar__heading">
-                                Support The Guardian
+                        @if(editionId == "au") {
+                            <div class="cta-bar__text hide-until-tablet js-aus-moment-header-supporter">
+                                <div class="cta-bar__heading">
+                                    Welcome back
+                                </div>
+                                <div class="cta-bar__subheading">
+                                    <span class="cta-bar__subheading-aus-moment">We're funded by readers across Australia.</span>
+                                    <br/>
+                                    Thank you for supporting us
+                                </div>
                             </div>
-                            <div class="cta-bar__subheading">
-                                Available for everyone, funded by readers
+
+                            <div class="cta-bar__text hide-until-tablet js-aus-moment-header-non-supporter">
+                                <div class="cta-bar__heading">
+                                    Support The Guardian
+                                </div>
+                                <div class="cta-bar__subheading">
+                                    <span class="cta-bar__subheading-aus-moment">We're funded by readers across Australia.</span>
+                                </div>
                             </div>
-                        </div>
+                        } else {
+                            <div class="cta-bar__text hide-until-tablet">
+                                <div class="cta-bar__heading">
+                                    Support The Guardian
+                                </div>
+                                <div class="cta-bar__subheading">
+                                    Available for everyone, funded by readers
+                                </div>
+                            </div>
+                        }
                     }
 
                     <a class="cta-bar__cta hide-until-tablet js-change-become-member-link js-acquisition-link"
@@ -83,8 +105,8 @@
                             @fragments.inlineSvg("arrow-right", "icon")
                         </a>
                     }
-                }
-            </div>
+                </div>
+            }
 
             <div class="new-header__top-bar hide-until-mobile">
                 @defining(Edition(request).id.toLowerCase()) { editionId =>

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -40,7 +40,7 @@
                                     Welcome back
                                 </div>
                                 <div class="cta-bar__subheading">
-                                    <span class="cta-bar__subheading-aus-moment">We're funded by readers across Australia.</span>
+                                    We're funded by <span class="cta-bar__aus-moment-count"></span>readers across Australia.
                                     <br/>
                                     Thank you for supporting us
                                 </div>
@@ -51,7 +51,7 @@
                                     Support The Guardian
                                 </div>
                                 <div class="cta-bar__subheading">
-                                    <span class="cta-bar__subheading-aus-moment">We're funded by readers across Australia.</span>
+                                    We're funded by <span class="cta-bar__aus-moment-count"></span>readers across Australia
                                 </div>
                             </div>
                         } else {

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -1,6 +1,8 @@
-// @flow
+ACQUISITION_LINK_CLASS// @flow
 import { addReferrerData } from 'common/modules/commercial/acquisitions-ophan';
 import { addCountryGroupToSupportLink } from 'common/modules/commercial/support-utilities';
+import fetchJSON from 'lib/fetch-json';
+import { getSync as geolocationGetSync } from 'lib/geolocation';
 
 // Currently the only acquisition components on the site are
 // from the Mother Load campaign and the Wide Brown Land campaign.
@@ -111,7 +113,30 @@ const addReferrerDataToAcquisitionLinksInInteractiveIframes = (): void => {
     });
 };
 
+const setupAusMomentHeader = () => {
+    const ausHeading = document.querySelector('.new-header__cta-bar-aus-moment');
+    if (ausHeading) {
+        const subHeadings = ausHeading.getElementsByClassName('cta-bar__subheading-aus-moment');
+        if (subHeadings) {
+            // TODO - store in cookie
+            fetchJSON('https://support.theguardian.com/supporters-ticker.json', {
+                mode: 'cors',
+            }).then(data => {
+                const total = parseInt(data.total, 10);
+
+                if (!Number.isNaN(Number(total))) {
+                    for (let i = 0; i < subHeadings.length; i++) {
+                        // TODO - punctuation
+                        subHeadings.item(i).innerHTML = `We're funded by ${total} readers across Australia`
+                    }
+                }
+            })
+        }
+    }
+};
+
 export const init = (): void => {
     addReferrerDataToAcquisitionLinksInInteractiveIframes();
     enrichAcquisitionLinksOnPage();
+    setupAusMomentHeader();
 };

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -1,8 +1,9 @@
-ACQUISITION_LINK_CLASS// @flow
+// @flow
 import { addReferrerData } from 'common/modules/commercial/acquisitions-ophan';
 import { addCountryGroupToSupportLink } from 'common/modules/commercial/support-utilities';
 import fetchJSON from 'lib/fetch-json';
 import { getCookie, addCookie } from 'lib/cookies';
+import config from "lib/config";
 
 // Currently the only acquisition components on the site are
 // from the Mother Load campaign and the Wide Brown Land campaign.
@@ -126,8 +127,11 @@ const setupAusMomentHeader = () => {
                 const total = parseInt(totalRaw, 10);
 
                 if (!Number.isNaN(Number(total))) {
-                    for (let i = 0; i < countElements.length; i++) {
-                        countElements.item(i).innerHTML = `${total.toLocaleString()} `
+                    for (let i = 0; i < countElements.length; i+=1) {
+                        const element = countElements.item(i);
+                        if (element) {
+                            element.innerHTML = `${total.toLocaleString()} `
+                        }
                     }
                 }
             };
@@ -154,5 +158,8 @@ const setupAusMomentHeader = () => {
 export const init = (): void => {
     addReferrerDataToAcquisitionLinksInInteractiveIframes();
     enrichAcquisitionLinksOnPage();
-    setupAusMomentHeader();
+
+    if (config.get('switches.ausMoment2020Header')) {
+        setupAusMomentHeader();
+    }
 };

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -2,7 +2,7 @@
 import { addReferrerData } from 'common/modules/commercial/acquisitions-ophan';
 import { addCountryGroupToSupportLink } from 'common/modules/commercial/support-utilities';
 import fetchJSON from 'lib/fetch-json';
-import { getCookie, addCookie } from 'lib/cookies';
+import { getCookie, addForMinutes as addCookie } from 'lib/cookies';
 import config from "lib/config";
 
 // Currently the only acquisition components on the site are
@@ -146,7 +146,7 @@ const setupAusMomentHeader = () => {
                     const total = data.total;
 
                     if (total) {
-                        addCookie(AUS_MOMENT_SUPPORTER_COUNT_COOKIE_NAME, total, 1);
+                        addCookie(AUS_MOMENT_SUPPORTER_COUNT_COOKIE_NAME, total, 60);
                         insertCount(total)
                     }
                 })

--- a/static/src/stylesheets/layout/nav/_cta-bar.scss
+++ b/static/src/stylesheets/layout/nav/_cta-bar.scss
@@ -39,6 +39,28 @@
     }
 }
 
+.new-header__cta-bar-aus-moment {
+    .js-aus-moment-header-supporter {
+        display: none;
+    }
+}
+
+.new-header__cta-bar-aus-moment {
+    .hide-support-messaging &,
+    .is-recent-contributor & {
+        .js-aus-moment-header-non-supporter {
+            display: none;
+        }
+        .js-aus-moment-header-supporter {
+            display: block;
+        }
+
+        .cta-bar__cta {
+            display: none;
+        }
+    }
+}
+
 .cta-bar__text {
     display: block;
     margin: ($gs-baseline / 4) 0 9px;

--- a/static/src/stylesheets/layout/nav/_cta-bar.scss
+++ b/static/src/stylesheets/layout/nav/_cta-bar.scss
@@ -63,6 +63,11 @@
     }
 }
 
+.cta-bar__aus-moment-count {
+    color: $highlight-main;
+    font-weight: 700;
+}
+
 .cta-bar__text {
     display: block;
     margin: ($gs-baseline / 4) 0 9px;

--- a/static/src/stylesheets/layout/nav/_cta-bar.scss
+++ b/static/src/stylesheets/layout/nav/_cta-bar.scss
@@ -5,7 +5,7 @@
     }
 }
 
-.new-header__cta-bar-aus-moment {
+.new-header__cta-bar, .new-header__cta-bar-aus-moment {
     position: absolute;
     top: 30px;
     left: $gs-gutter / 2;

--- a/static/src/stylesheets/layout/nav/_cta-bar.scss
+++ b/static/src/stylesheets/layout/nav/_cta-bar.scss
@@ -1,12 +1,14 @@
 .new-header__cta-bar {
-    position: absolute;
-    top: 30px;
-    left: $gs-gutter / 2;
-
     .hide-support-messaging &,
     .is-recent-contributor & {
         display: none;
     }
+}
+
+.new-header__cta-bar-aus-moment {
+    position: absolute;
+    top: 30px;
+    left: $gs-gutter / 2;
 
     @include mq(mobileMedium) {
         top: 37px;


### PR DESCRIPTION
A custom header for the upcoming Australia moment.
A special message is displayed if edition is 'au'. It includes the supporter count, which is fetched client-side and stored in a cookie for future page loads.
Also, if the user is a supporter they'll see 'Welcome back' with no ctas.

Note - we fetch the latest data client-side and store in a cookie for an hour. It would be preferable to cache server-side, but that introduces more complexity because the value would be fetched asynchronously.

1. not signed in, not supporter
- desktop
![Screen Shot 2020-06-17 at 11 00 31](https://user-images.githubusercontent.com/1513454/84884570-d2b05100-b089-11ea-9379-2a53a5502541.png)

- mobile
![Screen Shot 2020-06-17 at 11 00 50](https://user-images.githubusercontent.com/1513454/84884581-d5ab4180-b089-11ea-9b1f-b0b530d6704c.png)

2. not signed in, supporter
- desktop
![Screen Shot 2020-06-17 at 11 02 04](https://user-images.githubusercontent.com/1513454/84884721-fecbd200-b089-11ea-82e1-899dee9606b0.png)

- mobile
![Screen Shot 2020-06-17 at 09 21 40](https://user-images.githubusercontent.com/1513454/84874066-f9678b00-b07b-11ea-8c68-314192d24024.png)

3. signed in, not supporter
- desktop
![Screen Shot 2020-06-17 at 11 03 55](https://user-images.githubusercontent.com/1513454/84884943-42bed700-b08a-11ea-9e17-c5b6a5105325.png)

- mobile
![Screen Shot 2020-06-17 at 09 19 32](https://user-images.githubusercontent.com/1513454/84873817-af7ea500-b07b-11ea-85bc-a719bfc6c87b.png)

4. signed in, supporter
- desktop
![Screen Shot 2020-06-17 at 11 05 35](https://user-images.githubusercontent.com/1513454/84885117-7c8fdd80-b08a-11ea-8450-bb1815999fca.png)

- mobile
![Screen Shot 2020-06-17 at 09 12 36](https://user-images.githubusercontent.com/1513454/84873265-e43e2c80-b07a-11ea-8e7e-80e710611494.png)
