### PR TITLE
update 'My account' dropdown links following 'Account overview' overhaul in MMA

### DIFF
--- a/common/app/views/support/DropdownMenus.scala
+++ b/common/app/views/support/DropdownMenus.scala
@@ -18,49 +18,42 @@ object DropdownMenus {
 
   val accountDropdownMenu: List[DropdownMenuItem] = List(
     DropdownMenuItem(
-      linkName = Some("comment activity"),
-      label = "Comments & replies",
-      classList = List("js-add-comment-activity-link"),
-      parentClassList = List("u-h","js-show-comment-activity")
+      href = Some(Configuration.id.mmaUrl),
+      linkName = Some("account overview"),
+      label = "Account overview",
     ),
     DropdownMenuItem(
-      href = Some(s"${Configuration.id.url}/public/edit"),
-      linkName = Some("edit profile"),
-      label = "Public profile",
+      href = Some(s"${Configuration.id.mmaUrl}/public-settings"),
+      linkName = Some("profile"),
+      label = "Profile",
     ),
     DropdownMenuItem(
-      href = Some(s"${Configuration.id.url}/account/edit"),
-      linkName = Some("account details"),
-      label = "Account details",
-    ),
-    DropdownMenuItem(
-      href = Some(s"${Configuration.id.url}/email-prefs"),
+      href = Some(s"${Configuration.id.mmaUrl}/email-prefs"),
       linkName = Some("email prefs"),
       label = "Emails & marketing"
     ),
     DropdownMenuItem(
-      href = Some(s"${Configuration.id.mmaUrl}/membership"),
-      linkName = Some("membership"),
-      label = "Membership",
+      href = Some(s"${Configuration.id.mmaUrl}/account-settings"),
+      linkName = Some("settings"),
+      label = "Settings",
+    ),
+    DropdownMenuItem(
+      href = Some(s"${Configuration.id.mmaUrl}/help"),
+      linkName = Some("help"),
+      label = "Help",
+    ),
+    DropdownMenuItem(
+      linkName = Some("comment activity"),
+      label = "Comments & replies",
+      classList = List("js-add-comment-activity-link"),
+      parentClassList = List("u-h","js-show-comment-activity"),
       divider = true,
-    ),
-    DropdownMenuItem(
-      href = Some(s"${Configuration.id.mmaUrl}/contributions"),
-      linkName = Some("contributions"),
-      label = "Contributions",
-    ),
-    DropdownMenuItem(
-      href = Some(s"${Configuration.id.mmaUrl}/subscriptions"),
-      linkName = Some("subscriptions"),
-      label = "Subscriptions",
     ),
     DropdownMenuItem(
       href = Some(s"${Configuration.id.url}/signout"),
       linkName = Some("sign out"),
       label = "Sign out",
-      icon = Some(
-        "log-off"
-      ),
+      icon = Some("log-off"),
       divider = true,
     )
   )


### PR DESCRIPTION
**_Accompanying: https://github.com/guardian/dotcom-rendering/pull/1599_**

Following the 'Account overview' overhaul in MMA (as presented by Jian in the all-hands on Thu 11 June 2020) the links in the 'My account' dropdown navigation on theguardian.com need to respect the new structure in MMA (see guardian/manage-frontend#438).

## What does this change?
**For now this just changed the dropdown list items/links following the MMA re-structure.**

It's worth noting that there are some style/layout inconsistencies between this and the implementation [`dotcom-rendering`](https://github.com/guardian/dotcom-rendering) which isn't ideal but is beyond the scope of this ticket.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)
see https://github.com/guardian/dotcom-rendering/pull/1599

## Screenshots
| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/19289579/84889765-53bf1680-b091-11ea-9299-c28788ca74bc.png)  | ![image](https://user-images.githubusercontent.com/19289579/84890123-e3fd5b80-b091-11ea-962b-88c0c31bdf84.png)  |

## What is the value of this and can you measure success?
The MMA overhaul has been thoroughly considered and heavily user-tested, this change is just to make the links consistent with MMA which has been through A/B testing etc.
https://trello.com/c/09kqpMhF/1207-update-my-account-navigation-drop-down-on-dotcom

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
