### PR TITLE
Update comments on Atoms for future self

### DIFF
--- a/applications/app/controllers/AtomPageController.scala
+++ b/applications/app/controllers/AtomPageController.scala
@@ -85,10 +85,15 @@ class AtomPageController(contentApiClient: ContentApiClient, wsClient: WSClient,
         /*
           mark: 57cadc98-16c0-49ac-8bba-c96144c488a7
           author: Pascal
+          text: This code is experimental and was introduced on May 2020 as a way to demonstrate
+                showing atoms from first principles. It should not be considered ready for wide use because
+                the atom is showing fine but there are some missing bits in the HTML template.
 
-          This code is experimental and was introduced on May 2020 as a way to demonstrate
-          showing atoms from first principles. It should not be considered ready for wide use because
-          the atom is showing fine but there are some missing bits in the HTML template.
+          Last update: 19th June 2020
+          author: Pascal
+          text: I am leaving this cde here as an example that may be useful in the future.
+                As far as he original idea of embedding atoms to be rendered by DCR, we have
+                decided to use atoms-rendering: https://github.com/guardian/atoms-rendering
          */
 
         val articleConfig: ArticleConfiguration = Atoms.articleConfig(true)

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -278,30 +278,17 @@ object PageElement {
         (extractAtom match {
 
           case Some(audio: AudioAtom) => {
-            /*
-              author: Pascal
-              date: 20th May 2020
 
-              Ultimately, meaning when the Component is ready in DCR we want to pass metadata carried by
-              the AudioAtomBlockElement, but for the moment we are going to use the AtomEmbedUrlBlockElement
-              which is experimental.
-
-             */
-
-            // -----------------------------------
             // Using the AudioAtomBlockElement:
-            Some(AudioAtomBlockElement(audio.id, audio.data.kicker, audio.data.coverUrl, audio.data.trackUrl, audio.data.duration, audio.data.contentId))
-            // -----------------------------------
+            // Some(AudioAtomBlockElement(audio.id, audio.data.kicker, audio.data.coverUrl, audio.data.trackUrl, audio.data.duration, audio.data.contentId))
 
-            // -----------------------------------
             // Using the AtomEmbedUrlBlockElement:
-            val encodedId = URLEncoder.encode(audio.id, "UTF-8")
-            // chart.id is a uuid, so there is no real need to url-encode it but just to be safe
+            val encodedId = URLEncoder.encode(audio.id, "UTF-8") // chart.id is a uuid, so there is no real need
+                                                                 // to url-encode it but just to be safe
             Some(AtomEmbedUrlBlockElement(
               id = audio.id,
               url = s"${Configuration.ajax.url}/embed/atom/audio/$encodedId"
             ))
-            // -----------------------------------
           }
 
           case Some(chart: ChartAtom) => {


### PR DESCRIPTION
## What does this change?

Updating a couple of comments. Now that atoms-rendering is going to be the way forward for DCR, I needed to make sure that I leave the applications app in a clean state and also to remove a bit of dust off PageElement.scala

I chose not to remove the experimental audio atom self embedding implementation at [applications], in case somebody might want to learn from it in the future. 
