### PR TITLE
Adds geo exclusion for AU in remote variants test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/remote-epic-variants.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/remote-epic-variants.js
@@ -12,9 +12,6 @@ const remoteVariant: Variant = {
     canRun: () => true,
 };
 
-const geolocation = geolocationGetSync();
-console.log('geolocation: ', geolocation);
-
 export const remoteEpicVariants: Runnable<AcquisitionsABTest> = {
     id,
     start: '2020-05-01',
@@ -26,8 +23,14 @@ export const remoteEpicVariants: Runnable<AcquisitionsABTest> = {
     successMeasure: "Revenue/impressions equivalent to local variants",
     audienceCriteria: "All",
     variants: [remoteVariant],
-    canRun: () =>
-         config.get("switches.abRemoteEpicVariants") && geolocation !== 'AU' && Math.random() < 0.01// set test % here
+    canRun: () => {
+        // Delay geolocation due to known race condition
+        // https://github.com/guardian/frontend/pull/22322
+        const geolocation = geolocationGetSync();
+        console.log('geolocation: ', geolocation);
+        return config.get("switches.abRemoteEpicVariants") && geolocation !== 'AU' && Math.random() < 0.01// set test % here
+    }
+
     ,
 
     variantToRun: remoteVariant,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/remote-epic-variants.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/remote-epic-variants.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { fetchAndRenderEpic } from "common/modules/commercial/contributions-service";
+import { getSync as geolocationGetSync } from 'lib/geolocation';
 import config from 'lib/config';
 
 const id = 'RemoteEpicVariants';
@@ -10,6 +11,9 @@ const remoteVariant: Variant = {
     test: () => fetchAndRenderEpic(id),
     canRun: () => true,
 };
+
+const geolocation = geolocationGetSync();
+console.log('geolocation: ', geolocation);
 
 export const remoteEpicVariants: Runnable<AcquisitionsABTest> = {
     id,
@@ -23,7 +27,7 @@ export const remoteEpicVariants: Runnable<AcquisitionsABTest> = {
     audienceCriteria: "All",
     variants: [remoteVariant],
     canRun: () =>
-         config.get("switches.abRemoteEpicVariants") && Math.random() < 0.01 // set test % here
+         config.get("switches.abRemoteEpicVariants") && geolocation !== 'AU' && Math.random() < 0.01// set test % here
     ,
 
     variantToRun: remoteVariant,


### PR DESCRIPTION
## What does this change?
Adds a geo exclusion to the "remote epic variants" test to ensure users in Australia don't fall into the 'remote' variant. This is because we're starting a campaign in AU that uses an Epic Ticker, which we don't support in Frontend via Contributions service yet - even though we do support in DCR and in Frontend when rendering locally (the control variant in this test).

This is a temporary workaround to ensure we don't serve a broken test variant until we have full support for this feature.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
Users in AU don't see the epic ticker via Contributions service.