### PR TITLE
Implement Confiant callback for blocked ads

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -5,7 +5,7 @@ import common._
 import contentapi.ContentApiClient
 import implicits.{AmpFormat, EmailFormat, HtmlFormat, JsonFormat}
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
-import model.dotcomponents.{DataModelV3, DotcomponentsDataModel, PageType}
+import model.dotcomponents.{DCRDataModel, DotcomponentsDataModel, PageType}
 import model.{ContentType, PageWithStoryPackage, _}
 import pages.{ArticleEmailHtmlPage, ArticleHtmlPage}
 import play.api.libs.json.Json
@@ -86,7 +86,7 @@ class ArticleController(
 
   private def getGuuiJson(article: ArticlePage, blocks: Blocks)(implicit request: RequestHeader): String = {
     val pageType: PageType = PageType(article, request, context)
-    DataModelV3.toJson(DotcomponentsDataModel.fromArticle(article, request, blocks, pageType))
+    DCRDataModel.toJson(DotcomponentsDataModel.fromArticle(article, request, blocks, pageType))
   }
 
   private def render(path: String, article: ArticlePage, blocks: Blocks)(implicit request: RequestHeader): Future[Result] = {

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -14,7 +14,7 @@ import play.api.mvc._
 import services.CAPILookup
 import views.support.RenderOtherStatus
 import implicits.{AmpFormat, HtmlFormat}
-import model.dotcomponents.{DataModelV3, DotcomponentsDataModel}
+import model.dotcomponents.{DCRDataModel, DotcomponentsDataModel}
 import renderers.RemoteRenderer
 
 import scala.concurrent.Future
@@ -158,7 +158,7 @@ class LiveBlogController(
   )(implicit request: RequestHeader): Result = {
     val pageType: PageType = PageType(blog, request, context)
     val model = DotcomponentsDataModel.fromArticle(blog, request, blocks, pageType)
-    val json = DataModelV3.toJson(model)
+    val json = DCRDataModel.toJson(model)
     common.renderJson(json, blog).as("application/json")
   }
 

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -530,11 +530,7 @@ object DotcomponentsDataModel {
     }
 
     val jsConfig = (k: String) => articlePage.getJavascriptConfig.get(k).map(_.as[String])
-
-    val jsPageData = Configuration.javascript.pageData mapKeys { key =>
-      CamelCase.fromHyphenated(key.split('.').lastOption.getOrElse(""))
-    }
-
+    
     val switches = conf.switches.Switches.all.filter(_.exposeClientSide).foldLeft(Map.empty[String,Boolean])( (acc, switch) => {
       acc + (CamelCase.fromHyphenated(switch.name) -> switch.isSwitchedOn)
     })

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -249,6 +249,7 @@ case class DataModelV3(
 )
 
 object DataModelV3 {
+
   implicit val pageElementWrites: Writes[PageElement] = Json.writes[PageElement]
 
   implicit val writes = new Writes[DataModelV3] {
@@ -319,7 +320,6 @@ object DataModelV3 {
 }
 
 object DotcomponentsDataModel {
-  val VERSION = 2
 
   def makeMatchUrl(articlePage: PageWithStoryPackage): Option[String] = {
 

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -318,6 +318,64 @@ object DataModelV3 {
 
 object DotcomponentsDataModel {
   val VERSION = 2
+
+  def makeMatchUrl(articlePage: PageWithStoryPackage): Option[String] = {
+
+    def extraction1(references: JsValue): Option[IndexedSeq[JsValue]] = {
+      val sequence = references match {
+        case JsArray(elements) => Some(elements)
+        case _ => None
+      }
+      sequence
+    }
+
+    def entryToDataPair(entry: JsValue): Option[(String, String)] = {
+      /*
+          Examples:
+          {
+            "esa-football-team": "/\" + \"football/\" + \"team/\" + \"331"
+          }
+          {
+            "pa-football-competition": "500"
+          }
+          {
+            "pa-football-team": "26305"
+          }
+       */
+      val obj = entry.as[JsObject]
+      obj.fields.map(pair => (pair._1, pair._2.as[String])).headOption
+    }
+
+    val optionalUrl: Option[String] = for {
+      references <- articlePage.getJavascriptConfig.get("references")
+      entries1 <- extraction1(references)
+      entries2 = entries1
+        .map(entryToDataPair(_))
+        .filter( _.isDefined )
+        .map( _.get ) // .get is fundamentally dangerous but fine in this case because we filtered the Nones out.
+        .filter( _._1 == "pa-football-team" )
+    } yield {
+      val pageId = URLEncoder.encode(articlePage.article.metadata.id, "UTF-8")
+      entries2.toList match {
+        case e1 :: e2 :: _ => {
+          val year = articlePage.article.trail.webPublicationDate.toString(DateTimeFormat.forPattern("yyy"))
+          val month = articlePage.article.trail.webPublicationDate.toString(DateTimeFormat.forPattern("MM"))
+          val day = articlePage.article.trail.webPublicationDate.toString(DateTimeFormat.forPattern("dd"))
+          s"${Configuration.ajax.url}/football/api/match-nav/${year}/${month}/${day}/${e1._2}/${e2._2}.json?dcr=true&page=${pageId}"
+        }
+        case _ => ""
+      }
+    }
+
+    // We need one more transformation because we could have a Some(""), which we don't want
+
+    if (optionalUrl.getOrElse("").size>0) {
+      optionalUrl
+    } else {
+      None
+    }
+  }
+
   def fromArticle(articlePage: PageWithStoryPackage, request: RequestHeader, blocks: APIBlocks, pageType: PageType): DataModelV3 = {
 
     val article = articlePage.article
@@ -588,63 +646,6 @@ object DotcomponentsDataModel {
       stage = common.Environment.stage,
       frontendAssetsFullURL = Configuration.assets.fullURL(common.Environment.stage)
     )
-
-    def makeMatchUrl(articlePage: PageWithStoryPackage): Option[String] = {
-
-      def extraction1(references: JsValue): Option[IndexedSeq[JsValue]] = {
-        val sequence = references match {
-          case JsArray(elements) => Some(elements)
-          case _ => None
-        }
-        sequence
-      }
-
-      def entryToDataPair(entry: JsValue): Option[(String, String)] = {
-        /*
-            Examples:
-            {
-              "esa-football-team": "/\" + \"football/\" + \"team/\" + \"331"
-            }
-            {
-              "pa-football-competition": "500"
-            }
-            {
-              "pa-football-team": "26305"
-            }
-         */
-        val obj = entry.as[JsObject]
-        obj.fields.map(pair => (pair._1, pair._2.as[String])).headOption
-      }
-
-      val optionalUrl: Option[String] = for {
-        references <- articlePage.getJavascriptConfig.get("references")
-        entries1 <- extraction1(references)
-        entries2 = entries1
-                    .map(entryToDataPair(_))
-                    .filter( _.isDefined )
-                    .map( _.get ) // .get is fundamentally dangerous but fine in this case because we filtered the Nones out.
-                    .filter( _._1 == "pa-football-team" )
-      } yield {
-        val pageId = URLEncoder.encode(articlePage.article.metadata.id, "UTF-8")
-        entries2.toList match {
-          case e1 :: e2 :: _ => {
-            val year = article.trail.webPublicationDate.toString(DateTimeFormat.forPattern("yyy"))
-            val month = article.trail.webPublicationDate.toString(DateTimeFormat.forPattern("MM"))
-            val day = article.trail.webPublicationDate.toString(DateTimeFormat.forPattern("dd"))
-            s"${Configuration.ajax.url}/football/api/match-nav/${year}/${month}/${day}/${e1._2}/${e2._2}.json?dcr=true&page=${pageId}"
-          }
-          case _ => ""
-        }
-      }
-
-      // We need one more transformation because we could have a Some(""), which we don't want
-
-      if (optionalUrl.getOrElse("").size>0) {
-        optionalUrl
-      } else {
-        None
-      }
-    }
 
     val jsPageConfig = JavaScriptPage.getMap(articlePage, Edition(request), false)
     val combinedConfig = Json.toJsObject(config).deepMerge(JsObject(jsPageConfig))

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -384,6 +384,24 @@ object DotcomponentsDataModel {
     designType.map(_.toString).getOrElse("Article")
   }
 
+  private def buildFullCommercialUrl(bundlePath: String): String = {
+    // This function exists because for some reasons `Static` behaves differently in { PROD and CODE } versus LOCAL
+    if(Configuration.environment.isProd || Configuration.environment.isCode){
+      Static(bundlePath)
+    } else {
+      s"${Configuration.site.host}${Static(bundlePath)}"
+    }
+  }
+
+  // note: this is duplicated in the onward service (DotcomponentsOnwardsModels - if duplicating again consider moving to common! :()
+  private def findPillar(pillar: Option[Pillar], designType: Option[DesignType]): String = {
+    pillar.map { pillar =>
+      if (designType == AdvertisementFeature) "labs"
+      else if (pillar.toString.toLowerCase == "arts") "culture"
+      else pillar.toString.toLowerCase()
+    }.getOrElse("news")
+  }
+
   // -----------------------------------------------------------------------
 
   def fromArticle(articlePage: PageWithStoryPackage, request: RequestHeader, blocks: APIBlocks, pageType: PageType): DCRDataModel = {
@@ -461,15 +479,6 @@ object DotcomponentsDataModel {
       } else elems
     }
 
-    def buildFullCommercialUrl(bundlePath: String): String = {
-      // This function exists because for some reasons `Static` behaves differently in { PROD and CODE } versus LOCAL
-      if(Configuration.environment.isProd || Configuration.environment.isCode){
-        Static(bundlePath)
-      } else {
-        s"${Configuration.site.host}${Static(bundlePath)}"
-      }
-    }
-
     def blocksForLiveblogPage(liveblog: LiveBlogPage, blocks: APIBlocks): Seq[APIBlock] = {
       val last60 = blocks.requestedBodyBlocks
         .getOrElse(Map.empty[String, Seq[APIBlock]])
@@ -483,15 +492,6 @@ object DotcomponentsDataModel {
 
       val ids = liveblog.currentPage.currentPage.blocks.map(_.id).toSet
       relevantBlocks.filter(block => ids(block.id))
-    }
-
-    // note: this is duplicated in the onward service (DotcomponentsOnwardsModels - if duplicating again consider moving to common! :()
-    def findPillar(pillar: Option[Pillar], designType: Option[DesignType]): String = {
-      pillar.map { pillar =>
-        if (designType == AdvertisementFeature) "labs"
-        else if (pillar.toString.toLowerCase == "arts") "culture"
-        else pillar.toString.toLowerCase()
-      }.getOrElse("news")
     }
 
     val bodyBlocksRaw = articlePage match {

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -120,7 +120,6 @@ case class Config(
   stage: String,
   frontendAssetsFullURL: String,
   ampIframeUrl: String,
-
 )
 
 object Config {
@@ -190,7 +189,11 @@ object PageFooter {
   implicit val writes = Json.writes[PageFooter]
 }
 
-case class DataModelV3(
+// -----------------------------------------------------------------
+// DCR DataModel
+// -----------------------------------------------------------------
+
+case class DCRDataModel(
   version: Int,
   headline: String,
   standfirst: String,
@@ -248,12 +251,12 @@ case class DataModelV3(
   campaigns: Option[JsValue]
 )
 
-object DataModelV3 {
+object DCRDataModel {
 
   implicit val pageElementWrites: Writes[PageElement] = Json.writes[PageElement]
 
-  implicit val writes = new Writes[DataModelV3] {
-    def writes(model: DataModelV3) = Json.obj(
+  implicit val writes = new Writes[DCRDataModel] {
+    def writes(model: DCRDataModel) = Json.obj(
       "version" -> model.version,
       "headline" -> model.headline,
       "standfirst" -> model.standfirst,
@@ -308,7 +311,7 @@ object DataModelV3 {
     )
   }
 
-  def toJson(model: DataModelV3): String = {
+  def toJson(model: DCRDataModel): String = {
     def withoutNull(json: JsValue): JsValue = json match {
       case JsObject(fields) => JsObject(fields.filterNot{ case (_, value) => value == JsNull })
       case other => other
@@ -378,7 +381,7 @@ object DotcomponentsDataModel {
     }
   }
 
-  def fromArticle(articlePage: PageWithStoryPackage, request: RequestHeader, blocks: APIBlocks, pageType: PageType): DataModelV3 = {
+  def fromArticle(articlePage: PageWithStoryPackage, request: RequestHeader, blocks: APIBlocks, pageType: PageType): DCRDataModel = {
 
     val article = articlePage.article
     val atoms: Iterable[Atom] = article.content.atoms.map(_.all).getOrElse(Seq())
@@ -666,7 +669,7 @@ object DotcomponentsDataModel {
 
     val isPaidContent = article.metadata.designType.contains(AdvertisementFeature)
 
-    DataModelV3(
+    DCRDataModel(
       version = 3,
       headline = article.trail.headline,
       standfirst = article.fields.standfirst.getOrElse(""),

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -244,7 +244,8 @@ case class DataModelV3(
   badge: Option[DCRBadge],
 
   // Match Data
-  matchUrl: Option[String] // Optional url used for match data
+  matchUrl: Option[String], // Optional url used for match data
+  campaigns: Option[JsValue]
 )
 
 object DataModelV3 {
@@ -301,7 +302,8 @@ object DataModelV3 {
       "slotMachineFlags" -> model.slotMachineFlags,
       "contributionsServiceUrl" -> model.contributionsServiceUrl,
       "badge" -> model.badge,
-      "matchUrl" -> model.matchUrl
+      "matchUrl" -> model.matchUrl,
+      "campaigns" -> model.campaigns
     )
   }
 
@@ -530,7 +532,7 @@ object DotcomponentsDataModel {
     }
 
     val jsConfig = (k: String) => articlePage.getJavascriptConfig.get(k).map(_.as[String])
-    
+
     val switches = conf.switches.Switches.all.filter(_.exposeClientSide).foldLeft(Map.empty[String,Boolean])( (acc, switch) => {
       acc + (CamelCase.fromHyphenated(switch.name) -> switch.isSwitchedOn)
     })
@@ -720,7 +722,8 @@ object DotcomponentsDataModel {
       badge = badge,
 
       // Match Data
-      matchUrl = makeMatchUrl(articlePage)
+      matchUrl = makeMatchUrl(articlePage),
+      campaigns = articlePage.getJavascriptConfig.get("campaigns")
     )
   }
 }

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -316,7 +316,6 @@ object DCRDataModel {
       case JsObject(fields) => JsObject(fields.filterNot{ case (_, value) => value == JsNull })
       case other => other
     }
-
     val jsValue = Json.toJson(model)
     Json.stringify(withoutNull(jsValue))
   }
@@ -324,7 +323,7 @@ object DCRDataModel {
 
 object DotcomponentsDataModel {
 
-  def makeMatchUrl(articlePage: PageWithStoryPackage): Option[String] = {
+  private def makeMatchUrl(articlePage: PageWithStoryPackage): Option[String] = {
 
     def extraction1(references: JsValue): Option[IndexedSeq[JsValue]] = {
       val sequence = references match {
@@ -380,6 +379,12 @@ object DotcomponentsDataModel {
       None
     }
   }
+
+  private def designTypeAsString(designType: Option[DesignType]): String = {
+    designType.map(_.toString).getOrElse("Article")
+  }
+
+  // -----------------------------------------------------------------------
 
   def fromArticle(articlePage: PageWithStoryPackage, request: RequestHeader, blocks: APIBlocks, pageType: PageType): DCRDataModel = {
 
@@ -487,10 +492,6 @@ object DotcomponentsDataModel {
         else if (pillar.toString.toLowerCase == "arts") "culture"
         else pillar.toString.toLowerCase()
       }.getOrElse("news")
-    }
-
-    def asString(designType: Option[DesignType]): String = {
-      designType.map(_.toString).getOrElse("Article")
     }
 
     val bodyBlocksRaw = articlePage match {
@@ -712,7 +713,7 @@ object DotcomponentsDataModel {
       trailText = article.trail.fields.trailText.getOrElse(""),
       nav = nav,
       showBottomSocialButtons = ContentLayout.showBottomSocialButtons(article),
-      designType = asString(article.metadata.designType),
+      designType = designTypeAsString(article.metadata.designType),
       pageFooter = pageFooter,
       publication = article.content.publication,
 

--- a/article/app/renderers/RemoteRenderer.scala
+++ b/article/app/renderers/RemoteRenderer.scala
@@ -7,7 +7,7 @@ import concurrent.CircuitBreakerRegistry
 import conf.Configuration
 import conf.switches.Switches.CircuitBreakerSwitch
 import model.Cached.RevalidatableResult
-import model.dotcomponents.{DataModelV3, DotcomponentsDataModel}
+import model.dotcomponents.{DCRDataModel, DotcomponentsDataModel}
 import model.{Cached, PageWithStoryPackage, NoCache}
 import play.api.libs.ws.WSClient
 import play.api.mvc.{RequestHeader, Result}
@@ -73,7 +73,7 @@ class RemoteRenderer extends Logging {
     pageType: PageType
   )(implicit request: RequestHeader): Future[Result] = {
     val dataModel = DotcomponentsDataModel.fromArticle(page, request, blocks, pageType)
-    val json = DataModelV3.toJson(dataModel)
+    val json = DCRDataModel.toJson(dataModel)
     get(ws, json, page, Configuration.rendering.AMPArticleEndpoint)
   }
 
@@ -85,7 +85,7 @@ class RemoteRenderer extends Logging {
     pageType: PageType
   )(implicit request: RequestHeader): Future[Result] = {
     val dataModel = DotcomponentsDataModel.fromArticle(page, request, blocks, pageType)
-    val json = DataModelV3.toJson(dataModel)
+    val json = DCRDataModel.toJson(dataModel)
     get(ws, json, page, Configuration.rendering.renderingEndpoint)
   }
 }

--- a/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.js
+++ b/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.js
@@ -8,14 +8,66 @@ const errorHandler = (error: Error) => {
     console.log('Failed to load Confiant:', error);
 };
 
+interface impressionsDfpObject {
+    s: string;  // Slot element ID
+    ad: string; // Advertiser ID
+    c: string;  // Creative ID
+    I: string;  // Line item ID
+    o: string;  // Order ID
+    A: string;  // Ad unit name
+    y: string;  // Yield group ID (Exchange Bidder)
+}
+
+const confiantRefreshedSlots =[];
+
+const refreshBlockedSlotOnce = (
+    blockingType: number,
+    blockingId: string,
+    isBlocked: boolean,
+    wrapperId: string,
+    tagId: string,
+    impressionsData: {
+        preBid: { adId?: string, cpm?: number },
+        dfp: impressionsDfpObject,
+    }
+): Promise<void> => {
+    console.log('*** Already refreshed slots: ', confiantRefreshedSlots);
+    console.log('*** Callback run for slot ', impressionsData.dfp.s);
+    const blockedSlotPath =
+        typeof impressionsData !== 'undefined' &&
+        typeof impressionsData.dfp !== 'undefined'
+            ? impressionsData.dfp.s
+            : null;
+    console.log("*** Has slot already been refreshed? ", confiantRefreshedSlots.includes(blockedSlotPath))
+    // check if ad is blocked and haven't refreshed the slot yet.
+    if (isBlocked && !confiantRefreshedSlots.includes(blockedSlotPath) ) {
+        console.log('*** Ad slot blocked');
+        const slots = window.googletag.pubads().getSlots();
+        slots.forEach((currentSlot) => {
+            if (blockedSlotPath === currentSlot.getSlotElementId()) {
+                console.log('*** Refreshing blocked ad slot ', currentSlot);
+                // refresh the blocked slot to get new ad
+                window.googletag.pubads().refresh([currentSlot]);
+                // mark it as refreshed so it won't refresh multiple time
+                confiantRefreshedSlots.push(blockedSlotPath);
+            }
+        })
+    }
+    return Promise.resolve();
+};
+
 export const init = (): Promise<void> => {
     const host = 'confiant-integrations.global.ssl.fastly.net';
-
     if (config.get('switches.confiantAdVerification')) {
         return loadScript(
             `//${host}/7oDgiTsq88US4rrBG0_Nxpafkrg/gpt_and_prebid/config.js`,
             { async: true }
-        ).catch(errorHandler);
+        )
+            .then(() => {
+                window.confiant.settings.devMode= true; // This blocks ads on page
+                window.confiant.settings.callback = refreshBlockedSlotOnce;
+            })
+            .catch(errorHandler);
     }
 
     return Promise.resolve();

--- a/static/src/javascripts/projects/commercial/modules/dfp/load-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/load-advert.js
@@ -51,14 +51,14 @@ export const refreshAdvert = (advert: Advert): void => {
     // advert.size contains the effective size being displayed prior to refreshing
     advert.whenSlotReady
         .then(() => {
-            const prepidPromise = prebid.requestBids(advert, prebidSlot =>
+            const prebidPromise = prebid.requestBids(advert, prebidSlot =>
                 forcedSlotSize(advert, prebidSlot)
             );
 
             const a9Promise = a9.requestBids(advert, a9Slot =>
                 forcedSlotSize(advert, a9Slot)
             );
-            return Promise.all([prepidPromise, a9Promise]);
+            return Promise.all([prebidPromise, a9Promise]);
         })
         .then(() => {
             advert.slot.setTargeting('refreshed', 'true');

--- a/static/src/javascripts/projects/common/modules/article/rich-links.js
+++ b/static/src/javascripts/projects/common/modules/article/rich-links.js
@@ -126,11 +126,7 @@ const getSpacefinderRules = (): SpacefinderRules => ({
                 ? 200
                 : 0,
             minBelow: 0,
-        },
-        '.js-article__body--type-numbered-list > h2': {
-            minAbove: 100,
-            minBelow: 200,
-        },
+        }
     },
 });
 
@@ -149,12 +145,16 @@ const insertTagRichLink = (): Promise<void> => {
     const isSensitive: boolean =
         config.get('page.shouldHideAdverts') ||
         !config.get('page.showRelatedContent');
+    // Richlinks are just generally unhappy in numbered list articles
+    // Example https://theguardian.com/environment/2020/jun/19/why-you-should-go-animal-free-arguments-in-favour-of-meat-eating-debunked-plant-based
+    const isNumberedListArticle = document.querySelectorAll('.js-article__body--type-numbered-list').length > 0;
 
     if (
         config.get('page.richLink') &&
         !config.get('page.richLink').includes(config.get('page.pageId')) &&
         !isSensitive &&
-        !isDuplicate
+        !isDuplicate &&
+        !isNumberedListArticle
     ) {
         return spaceFiller
             .fillSpace(getSpacefinderRules(), (paras: HTMLElement[]) => {

--- a/static/src/javascripts/projects/common/modules/audio/AudioPlayer.js
+++ b/static/src/javascripts/projects/common/modules/audio/AudioPlayer.js
@@ -307,7 +307,7 @@ export class AudioPlayer extends Component<Props, State> {
         const percentPlayed = this.audio.currentTime / this.state.duration;
 
         // pause when it gets to the end
-        if (this.audio.currentTime > this.state.duration - 1) {
+        if (this.audio.currentTime >= this.state.duration) {
             this.resetAudio();
         } else if (!this.state.grabbing) {
             const currentOffsetPx = this.state.waveWidthPx * percentPlayed;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/remote-epic-variants.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/remote-epic-variants.js
@@ -12,9 +12,6 @@ const remoteVariant: Variant = {
     canRun: () => true,
 };
 
-const geolocation = geolocationGetSync();
-console.log('geolocation: ', geolocation);
-
 export const remoteEpicVariants: Runnable<AcquisitionsABTest> = {
     id,
     start: '2020-05-01',
@@ -26,8 +23,14 @@ export const remoteEpicVariants: Runnable<AcquisitionsABTest> = {
     successMeasure: "Revenue/impressions equivalent to local variants",
     audienceCriteria: "All",
     variants: [remoteVariant],
-    canRun: () =>
-         config.get("switches.abRemoteEpicVariants") && geolocation !== 'AU' && Math.random() < 0.01// set test % here
+    canRun: () => {
+        // Delay geolocation due to known race condition
+        // https://github.com/guardian/frontend/pull/22322
+        const geolocation = geolocationGetSync();
+        console.log('geolocation: ', geolocation);
+        return config.get("switches.abRemoteEpicVariants") && geolocation !== 'AU' && Math.random() < 0.01// set test % here
+    }
+
     ,
 
     variantToRun: remoteVariant,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/remote-epic-variants.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/remote-epic-variants.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { fetchAndRenderEpic } from "common/modules/commercial/contributions-service";
+import { getSync as geolocationGetSync } from 'lib/geolocation';
 import config from 'lib/config';
 
 const id = 'RemoteEpicVariants';
@@ -10,6 +11,9 @@ const remoteVariant: Variant = {
     test: () => fetchAndRenderEpic(id),
     canRun: () => true,
 };
+
+const geolocation = geolocationGetSync();
+console.log('geolocation: ', geolocation);
 
 export const remoteEpicVariants: Runnable<AcquisitionsABTest> = {
     id,
@@ -23,7 +27,7 @@ export const remoteEpicVariants: Runnable<AcquisitionsABTest> = {
     audienceCriteria: "All",
     variants: [remoteVariant],
     canRun: () =>
-         config.get("switches.abRemoteEpicVariants") && Math.random() < 0.01 // set test % here
+         config.get("switches.abRemoteEpicVariants") && geolocation !== 'AU' && Math.random() < 0.01// set test % here
     ,
 
     variantToRun: remoteVariant,


### PR DESCRIPTION
## What does this change?
When Confiant blocks an ad we want to recover lost revenue by refreshing the ad slot at most once to find an alternative solution.

Co-authored-by: Ioanna Kyprianou <ioanna.kyprianou.contractor@guardian.co.uk>
Co-authored-by: Max Duval <max@mxdvl.com>

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
Will allow us to refresh a blocked ad slot, reducing lost revenue. Success should be reflected in increased earnings. This may require a long AB test in order to determine if this is successful.

## Checklist

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
