### PR TITLE
Add AtomEmbedBlockElement removing seperate markup and url

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -54,8 +54,8 @@ object Sponsorship {
 
 sealed trait PageElement
 
-case class AtomEmbedMarkupBlockElement(id: String, html: Option[String], css: Option[String], js: Option[String]) extends PageElement
-case class AtomEmbedUrlBlockElement(id: String, url: String) extends PageElement
+case class AtomEmbedBlockElement(id: String, url: String, html: Option[String], css: Option[String], js: Option[String]) extends PageElement
+case class InteractiveBlockElement(url: String) extends PageElement
 case class AudioAtomBlockElement(id: String, kicker: String, coverUrl: String, trackUrl: String, duration: Int, contentId: String) extends PageElement
 case class AudioBlockElement(assets: Seq[AudioAsset]) extends PageElement
 case class BlockquoteBlockElement(html: String) extends PageElement
@@ -113,8 +113,7 @@ object PageElement {
   def isSupported(element: PageElement): Boolean = {
     // remove unsupported elements. Cross-reference with dotcom-rendering supported elements.
     element match {
-      case _: AtomEmbedUrlBlockElement => true
-      case _: AtomEmbedMarkupBlockElement => true
+      case _: AtomEmbedBlockElement => true
       case _: AudioBlockElement => true
       case _: AudioAtomBlockElement => true
       case _: BlockquoteBlockElement => true
@@ -282,12 +281,15 @@ object PageElement {
             // Using the AudioAtomBlockElement:
             // Some(AudioAtomBlockElement(audio.id, audio.data.kicker, audio.data.coverUrl, audio.data.trackUrl, audio.data.duration, audio.data.contentId))
 
-            // Using the AtomEmbedUrlBlockElement:
+            // Using the AtomEmbedBlockElement:
             val encodedId = URLEncoder.encode(audio.id, "UTF-8") // chart.id is a uuid, so there is no real need
                                                                  // to url-encode it but just to be safe
-            Some(AtomEmbedUrlBlockElement(
+            Some(AtomEmbedBlockElement(
               id = audio.id,
-              url = s"${Configuration.ajax.url}/embed/atom/audio/$encodedId"
+              url = s"${Configuration.ajax.url}/embed/atom/audio/$encodedId",
+              html = None,
+              css = None,
+              js = None
             ))
           }
 
@@ -317,9 +319,12 @@ object PageElement {
 
           case Some(interactive: InteractiveAtom) => {
             val encodedId = URLEncoder.encode(interactive.id, "UTF-8")
-            Some(AtomEmbedUrlBlockElement(
+            Some(AtomEmbedBlockElement(
               id = interactive.id,
-              url = s"${Configuration.ajax.url}/embed/atom/interactive/$encodedId"
+              url = s"${Configuration.ajax.url}/embed/atom/interactive/$encodedId",
+              html = Some(interactive.html),
+              css = Some(interactive.css),
+              js = interactive.mainJS
             ))
           }
 
@@ -396,15 +401,7 @@ object PageElement {
       }.toList
 
       case Pullquote => element.pullquoteTypeData.map(d => PullquoteBlockElement(d.html, Role(d.role), d.attribution)).toList
-      case Interactive => element.interactiveTypeData.flatMap(_.iframeUrl).map(url => AtomEmbedUrlBlockElement("", url)).toList
-        // date: 13th June
-        // author: Pascal
-        // `Interactive`s and `InteractiveAtoms` which are not the same thing, are being both transported to DCR using
-        // the AtomEmbedUrlBlockElement. This was fine as long as we embedded only the URL, but is no longer fine
-        // now that we want to send the atom id across and given that `Interactive`s don't have one. I am putting an
-        // empty Id here for the moment, but will soon give to Interactives their own BlockElement to avoid the confusion
-        // and any problem.
-
+      case Interactive => element.interactiveTypeData.flatMap(_.iframeUrl).map(url => InteractiveBlockElement(url)).toList
       case Table => element.tableTypeData.map(d => TableBlockElement(d.html, Role(d.role), d.isMandatory)).toList
       case Witness => element.witnessTypeData.map(d => WitnessBlockElement(d.html)).toList
       case Document => element.documentTypeData.map(d => DocumentBlockElement(d.html, Role(d.role), d.isMandatory)).toList
@@ -500,12 +497,11 @@ object PageElement {
   implicit val GuideBlockElementWrites = Json.writes[GuideAtomBlockElement]
   implicit val GuVideoBlockElementWrites: Writes[GuVideoBlockElement] = Json.writes[GuVideoBlockElement]
   implicit val HTMLBlockElementWrites: Writes[HTMLFallbackBlockElement] = Json.writes[HTMLFallbackBlockElement]
-
+  implicit val AtomEmbedBlockElementWrites: Writes[AtomEmbedBlockElement] = Json.writes[AtomEmbedBlockElement]
   implicit val ImageWeightingWrites: Writes[ImageSource] = Json.writes[ImageSource]
   implicit val ImageBlockElementWrites: Writes[ImageBlockElement] = Json.writes[ImageBlockElement]
   implicit val InstagramBlockElementWrites: Writes[InstagramBlockElement] = Json.writes[InstagramBlockElement]
-  implicit val InteractiveBlockElementWrites: Writes[AtomEmbedMarkupBlockElement] = Json.writes[AtomEmbedMarkupBlockElement]
-  implicit val InteractiveIframeElementWrites: Writes[AtomEmbedUrlBlockElement] = Json.writes[AtomEmbedUrlBlockElement]
+  implicit val InteractiveBlockElementWrites: Writes[InteractiveBlockElement] = Json.writes[InteractiveBlockElement]
   implicit val MapBlockElementWrites: Writes[MapBlockElement] = Json.writes[MapBlockElement]
   implicit val MembershipBlockElementWrites: Writes[MembershipBlockElement] = Json.writes[MembershipBlockElement]
   implicit val ProfileBlockElementWrites = Json.writes[ProfileAtomBlockElement]

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -284,7 +284,7 @@ object PageElement {
             // Some(AudioAtomBlockElement(audio.id, audio.data.kicker, audio.data.coverUrl, audio.data.trackUrl, audio.data.duration, audio.data.contentId))
 
             // Using the GenericAtomBlockElement:
-            // This will esentially resolve to an InteractiveAtom on DCR
+            // This will be rendered like an InteractiveAtom on DCR
             val encodedId = URLEncoder.encode(audio.id, "UTF-8") // chart.id is a uuid, so there is no real need
                                                                  // to url-encode it but just to be safe
             Some(GenericAtomBlockElement(

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -66,7 +66,11 @@ case class DocumentBlockElement(html: Option[String], role: Role, isMandatory: O
 case class DisclaimerBlockElement(html: String) extends PageElement
 case class EmbedBlockElement(html: String, safe: Option[Boolean], alt: Option[String], isMandatory: Boolean) extends PageElement
 case class FormBlockElement(html: Option[String]) extends PageElement
-case class GenericAtomBlockElement(id: String, url: String, html: Option[String], css: Option[String], js: Option[String]) extends PageElement // The GenericAtomBlockElement is an atom that is modeled as an interactive atom in DCR
+case class GenericAtomBlockElement(id: String, url: String, html: Option[String], css: Option[String], js: Option[String]) extends PageElement 
+           // GenericAtomBlockElement is the only BlockElement, despite following the Atom BlockElement naming convention, that doesn't correspond to a single atom type.
+           // We use it to carry to DCR atoms that do not (yet) have their on dedicated BlockElement and are rendered in DCR as iframes.
+           //     - {url} for src
+           //     - {html, css, js} for srcdoc
 case class GuideAtomBlockElement(id: String, label: String, title: String, img: Option[String], html: String, credit: String) extends PageElement
 case class GuVideoBlockElement(assets: Seq[VideoAsset], imageMedia: ImageMedia, caption:String, url:String, originalUrl:String, role: Role) extends PageElement
 case class ImageBlockElement(media: ImageMedia, data: Map[String, String], displayCredit: Option[Boolean], role: Role, imageSources: Seq[ImageSource]) extends PageElement

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -54,8 +54,6 @@ object Sponsorship {
 
 sealed trait PageElement
 
-case class AtomEmbedBlockElement(id: String, url: String, html: Option[String], css: Option[String], js: Option[String]) extends PageElement
-case class InteractiveBlockElement(url: String) extends PageElement
 case class AudioAtomBlockElement(id: String, kicker: String, coverUrl: String, trackUrl: String, duration: Int, contentId: String) extends PageElement
 case class AudioBlockElement(assets: Seq[AudioAsset]) extends PageElement
 case class BlockquoteBlockElement(html: String) extends PageElement
@@ -68,10 +66,13 @@ case class DocumentBlockElement(html: Option[String], role: Role, isMandatory: O
 case class DisclaimerBlockElement(html: String) extends PageElement
 case class EmbedBlockElement(html: String, safe: Option[Boolean], alt: Option[String], isMandatory: Boolean) extends PageElement
 case class FormBlockElement(html: Option[String]) extends PageElement
+case class GenericAtomBlockElement(id: String, url: String, html: Option[String], css: Option[String], js: Option[String]) extends PageElement // The GenericAtomBlockElement is an atom that is modeled as an interactive atom in DCR
 case class GuideAtomBlockElement(id: String, label: String, title: String, img: Option[String], html: String, credit: String) extends PageElement
 case class GuVideoBlockElement(assets: Seq[VideoAsset], imageMedia: ImageMedia, caption:String, url:String, originalUrl:String, role: Role) extends PageElement
 case class ImageBlockElement(media: ImageMedia, data: Map[String, String], displayCredit: Option[Boolean], role: Role, imageSources: Seq[ImageSource]) extends PageElement
 case class ImageSource(weighting: String, srcSet: Seq[SrcSet])
+case class InteractiveAtomBlockElement(id: String, url: String, html: Option[String], css: Option[String], js: Option[String]) extends PageElement
+case class InteractiveBlockElement(url: String) extends PageElement
 case class InstagramBlockElement(url: String, html: Option[String], hasCaption: Boolean) extends PageElement
 case class MapBlockElement(url: String, originalUrl: String, source: String, caption: String, title: String) extends PageElement
 case class MembershipBlockElement(
@@ -113,7 +114,6 @@ object PageElement {
   def isSupported(element: PageElement): Boolean = {
     // remove unsupported elements. Cross-reference with dotcom-rendering supported elements.
     element match {
-      case _: AtomEmbedBlockElement => true
       case _: AudioBlockElement => true
       case _: AudioAtomBlockElement => true
       case _: BlockquoteBlockElement => true
@@ -123,10 +123,12 @@ object PageElement {
       case _: DisclaimerBlockElement => true
       case _: EmbedBlockElement => true
       case _: ExplainerAtomBlockElement => true
+      case _: GenericAtomBlockElement => true
       case _: GuideAtomBlockElement => true
       case _: GuVideoBlockElement => true
       case _: ImageBlockElement => true
       case _: InstagramBlockElement => true
+      case _: InteractiveAtomBlockElement => true
       case _: MapBlockElement => true
       case _: ProfileAtomBlockElement => true
       case _: PullquoteBlockElement => true
@@ -281,10 +283,11 @@ object PageElement {
             // Using the AudioAtomBlockElement:
             // Some(AudioAtomBlockElement(audio.id, audio.data.kicker, audio.data.coverUrl, audio.data.trackUrl, audio.data.duration, audio.data.contentId))
 
-            // Using the AtomEmbedBlockElement:
+            // Using the GenericAtomBlockElement:
+            // This will esentially resolve to an InteractiveAtom on DCR
             val encodedId = URLEncoder.encode(audio.id, "UTF-8") // chart.id is a uuid, so there is no real need
                                                                  // to url-encode it but just to be safe
-            Some(AtomEmbedBlockElement(
+            Some(GenericAtomBlockElement(
               id = audio.id,
               url = s"${Configuration.ajax.url}/embed/atom/audio/$encodedId",
               html = None,
@@ -319,7 +322,7 @@ object PageElement {
 
           case Some(interactive: InteractiveAtom) => {
             val encodedId = URLEncoder.encode(interactive.id, "UTF-8")
-            Some(AtomEmbedBlockElement(
+            Some(InteractiveAtomBlockElement(
               id = interactive.id,
               url = s"${Configuration.ajax.url}/embed/atom/interactive/$encodedId",
               html = Some(interactive.html),
@@ -494,13 +497,14 @@ object PageElement {
   implicit val EmbedBlockElementWrites: Writes[EmbedBlockElement] = Json.writes[EmbedBlockElement]
   implicit val ExplainerAtomBlockElementWrites: Writes[ExplainerAtomBlockElement] = Json.writes[ExplainerAtomBlockElement]
   implicit val FormBlockElementWrites: Writes[FormBlockElement] = Json.writes[FormBlockElement]
+  implicit val GenericAtomBlockElementWrites: Writes[GenericAtomBlockElement] = Json.writes[GenericAtomBlockElement]
   implicit val GuideBlockElementWrites = Json.writes[GuideAtomBlockElement]
   implicit val GuVideoBlockElementWrites: Writes[GuVideoBlockElement] = Json.writes[GuVideoBlockElement]
   implicit val HTMLBlockElementWrites: Writes[HTMLFallbackBlockElement] = Json.writes[HTMLFallbackBlockElement]
-  implicit val AtomEmbedBlockElementWrites: Writes[AtomEmbedBlockElement] = Json.writes[AtomEmbedBlockElement]
   implicit val ImageWeightingWrites: Writes[ImageSource] = Json.writes[ImageSource]
   implicit val ImageBlockElementWrites: Writes[ImageBlockElement] = Json.writes[ImageBlockElement]
   implicit val InstagramBlockElementWrites: Writes[InstagramBlockElement] = Json.writes[InstagramBlockElement]
+  implicit val InteractiveAtomBlockElementWrites: Writes[InteractiveAtomBlockElement] = Json.writes[InteractiveAtomBlockElement]
   implicit val InteractiveBlockElementWrites: Writes[InteractiveBlockElement] = Json.writes[InteractiveBlockElement]
   implicit val MapBlockElementWrites: Writes[MapBlockElement] = Json.writes[MapBlockElement]
   implicit val MembershipBlockElementWrites: Writes[MembershipBlockElement] = Json.writes[MembershipBlockElement]


### PR DESCRIPTION
##  What does this change?

We don't need to handle atomEmbedMarkupBlockElement and atomEmbedUrlBlockElement different in DCR. In fact, we can just use the URL in AMP and the html, css and js to srcdoc in dotcom when we land in DCR. 

We convert these to `interactiveAtomBlockElement` for Interactive Atoms specifically and introduce `genericAtomBlockElement` which is for atoms that use the interactive atom architecture but are not interactive atoms.

We also create an InteractiveBlockElement proper, as previously it was just writing it to the AtomEmbedUrlBlockElement, and we wanted to do it properly.

[In this PR](https://github.com/guardian/frontend/commit/62bd7f132ce91afd6c12f00ed8e1265122e49999#diff-5775f8f47d521441655ea7d7f0ce47d8L338) we were sending the html, css, js in the block element, but refactored it out as it was needed for AMP, this is adding it back in.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] Yes (please indicate your plans for DCR Implementation)

It requires that we update all usages of these block elements in DCR

## What is the value of this and can you measure success?

### Why can't we just use the URL on DCR dotcom?

Because this will load slowly and create a needless request to load this content. It also makes it difficult to resize the iframe (srcdoc'd iframes have access to their parent to be able to set their size, this supports many existing atoms that do this)

### Why can't we just use the markup and srcdoc on AMP?

It doesn't work, hence https://github.com/guardian/frontend/pull/22425

## Checklist

### Does this affect other platforms?

- [X] AMP

### Tested

- [X] Locally
