### PR TITLE
Pause when at the *end* of the audio

### DIFF
--- a/static/src/javascripts/projects/common/modules/audio/AudioPlayer.js
+++ b/static/src/javascripts/projects/common/modules/audio/AudioPlayer.js
@@ -307,7 +307,7 @@ export class AudioPlayer extends Component<Props, State> {
         const percentPlayed = this.audio.currentTime / this.state.duration;
 
         // pause when it gets to the end
-        if (this.audio.currentTime > this.state.duration - 1) {
+        if (this.audio.currentTime >= this.state.duration) {
             this.resetAudio();
         } else if (!this.state.grabbing) {
             const currentOffsetPx = this.state.waveWidthPx * percentPlayed;


### PR DESCRIPTION
## What does this change?

Audio did not play to the end...

### Before

![2020-06-23 11 49 41](https://user-images.githubusercontent.com/638051/85395458-14d50900-b548-11ea-9494-3cabbb8f27be.gif)


### After

![2020-06-23 11 49 05](https://user-images.githubusercontent.com/638051/85395443-0f77be80-b548-11ea-8b11-fdeb0084bed6.gif)
