### PR TITLE
Implement ad refresh on blocked ad callback

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.js
+++ b/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.js
@@ -1,11 +1,69 @@
 // @flow strict
 import config from 'lib/config';
 import { loadScript } from 'lib/load-script';
+import { refreshAdvert } from 'commercial/modules/dfp/load-advert';
+import { getAdvertById } from 'commercial/modules/dfp/get-advert-by-id';
 
 const errorHandler = (error: Error) => {
     // Looks like some plugins block ad-verification
     // Avoid barraging Sentry with errors from these pageviews
     console.log('Failed to load Confiant:', error);
+};
+
+interface impressionsDfpObject {
+    s: string; // Slot element ID
+    ad: string; // Advertiser ID
+    c: string; // Creative ID
+    I: string; // Line item ID
+    o: string; // Order ID
+    A: string; // Ad unit name
+    y: string; // Yield group ID (Exchange Bidder)
+}
+
+const confiantRefreshedSlots = [];
+
+const refreshBlockedSlotOnce = (
+    blockingType: number,
+    blockingId: string,
+    isBlocked: boolean,
+    wrapperId: string,
+    tagId: string,
+    impressionsData: {
+        prebid?: { adId?: string, cpm?: number, s: string },
+        dfp?: impressionsDfpObject,
+    }
+): Promise<void> => {
+    const prebidSlotElementId =
+        typeof impressionsData !== 'undefined' &&
+        typeof impressionsData.prebid !== 'undefined'
+            ? impressionsData.prebid.s
+            : '';
+    const dfpSlotElementId =
+        typeof impressionsData !== 'undefined' &&
+        typeof impressionsData.dfp !== 'undefined'
+            ? impressionsData.dfp.s
+            : '';
+    const blockedSlotPath: string =
+        prebidSlotElementId !== '' ? prebidSlotElementId : dfpSlotElementId;
+    const blockedSlotPathExists = !!blockedSlotPath;
+    // check if ad is blocked and haven't refreshed the slot yet.
+    if (
+        isBlocked &&
+        blockedSlotPathExists &&
+        !confiantRefreshedSlots.includes(blockedSlotPath)
+    ) {
+        const slots = window.googletag.pubads().getSlots();
+        slots.forEach(currentSlot => {
+            if (blockedSlotPath === currentSlot.getSlotElementId()) {
+                // refresh the blocked slot to get new ad
+                const advert = getAdvertById(blockedSlotPath);
+                if (advert) refreshAdvert(advert);
+                // mark it as refreshed so it won't refresh multiple time
+                confiantRefreshedSlots.push(blockedSlotPath);
+            }
+        });
+    }
+    return Promise.resolve();
 };
 
 export const init = (): Promise<void> => {
@@ -15,7 +73,11 @@ export const init = (): Promise<void> => {
         return loadScript(
             `//${host}/7oDgiTsq88US4rrBG0_Nxpafkrg/gpt_and_prebid/config.js`,
             { async: true }
-        ).catch(errorHandler);
+        )
+            .then(() => {
+                window.confiant.settings.callback = refreshBlockedSlotOnce;
+            })
+            .catch(errorHandler);
     }
 
     return Promise.resolve();


### PR DESCRIPTION
This closes https://github.com/guardian/frontend/pull/22715 which had a bad commit history due to a bad rebase.

## What does this change?
When Confiant blocks an ad we want to recover lost revenue by refreshing the ad slot at most once to find an alternative solution. We can do that using Confiant's callback mechanism.

This is tested locally by setting `window.confiant.settings.devMode=true` in order to block all ads and observe the behaviour that triggers a callback.

Co-authored-by: Ioanna Kyprianou <ioanna.kyprianou.contractor@guardian.co.uk>
Co-authored-by: Max Duval <max@mxdvl.com>

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
Will allow us to refresh a blocked ad slot, reducing lost revenue. Success should be reflected in increased earnings. This may require a long AB test in order to determine if this is successful.

## Checklist

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
