### PR TITLE
Remove semicolons from hosted pages

### DIFF
--- a/common/app/views/fragments/head.scala.html
+++ b/common/app/views/fragments/head.scala.html
@@ -29,7 +29,5 @@
 
 @fragments.page.head.fixIEReferenceErrors();
 
-@fragments.page.head.checkModuleSupport();
-
 @* inline JS - blocking *@
 @fragments.inlineJSBlocking()


### PR DESCRIPTION
## What does this change?
Removes the checkmodule fragment that was adding semicolons to the hosted pages 

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

Problem:

<img width="1402" alt="Screenshot 2020-06-23 at 15 56 30" src="https://user-images.githubusercontent.com/51630004/85426580-95a8fa80-b572-11ea-98cf-8150d830c8ea.png">


## What is the value of this and can you measure success?
Removes semicolons which then moves back the header at the top 


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
