### PR TITLE
Re-add module support check and remove semi-colons

### DIFF
--- a/applications/app/views/survey/surveyMain.scala.html
+++ b/applications/app/views/survey/surveyMain.scala.html
@@ -15,8 +15,8 @@
         @* get the stylesheets downloading ASAP *@
         @fragments.stylesheets(projectName=Option("survey"))
 
-        @fragments.page.head.fixIEReferenceErrors();
-        @fragments.page.head.checkModuleSupport();
+        @fragments.page.head.fixIEReferenceErrors()
+        @fragments.page.head.checkModuleSupport()
 
         @* polyfill, feature detect etc before we try and use the stylesheets *@
         @fragments.inlineJSBlocking()(surveyPage, request, context)

--- a/common/app/views/fragments/head.scala.html
+++ b/common/app/views/fragments/head.scala.html
@@ -27,7 +27,9 @@
     @fragments.stylesheets(projectName, content.exists(_.tags.isCrossword), content.exists(_.tags.isInteractive))
 }
 
-@fragments.page.head.fixIEReferenceErrors();
+@fragments.page.head.fixIEReferenceErrors()
+
+@fragments.page.head.checkModuleSupport()
 
 @* inline JS - blocking *@
 @fragments.inlineJSBlocking()

--- a/identity/app/views/formstack/formstackForm.scala.html
+++ b/identity/app/views/formstack/formstackForm.scala.html
@@ -9,9 +9,9 @@
     @* get the stylesheets downloading ASAP *@
     @fragments.stylesheets(Some(context.applicationIdentity.name))
 
-    @fragments.page.head.fixIEReferenceErrors();
+    @fragments.page.head.fixIEReferenceErrors()
 
-    @fragments.page.head.checkModuleSupport();
+    @fragments.page.head.checkModuleSupport()
 
     @* inline JS - blocking *@
     @fragments.inlineJSBlocking()(page, request, context)


### PR DESCRIPTION
## What does this change?
Removes unnecessary semi-colons

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
