### PR TITLE
Update remoteRendered to listen for 404s and return the correct status code

### DIFF
--- a/article/app/renderers/RemoteRenderer.scala
+++ b/article/app/renderers/RemoteRenderer.scala
@@ -80,7 +80,7 @@ class RemoteRenderer extends Logging {
     pageType: PageType
   )(implicit request: RequestHeader): Future[Result] = {
     val dataModel = DotcomponentsDataModel.fromArticle(page, request, blocks, pageType)
-    val json = DCRDataModel.toJson(dataModel)
+    val json = DataModelV3.toJson(dataModel)
     get(ws, json, page, Configuration.rendering.AMPArticleEndpoint)
   }
 
@@ -92,7 +92,7 @@ class RemoteRenderer extends Logging {
     pageType: PageType
   )(implicit request: RequestHeader): Future[Result] = {
     val dataModel = DotcomponentsDataModel.fromArticle(page, request, blocks, pageType)
-    val json = DCRDataModel.toJson(dataModel)
+    val json = DataModelV3.toJson(dataModel)
     get(ws, json, page, Configuration.rendering.renderingEndpoint)
   }
 }

--- a/article/app/renderers/RemoteRenderer.scala
+++ b/article/app/renderers/RemoteRenderer.scala
@@ -46,6 +46,8 @@ class RemoteRenderer extends Logging {
             case 200 =>
               Cached(article)(RevalidatableResult.Ok(Html(response.body)))
                 .withHeaders("X-GU-Dotcomponents" -> "true")
+            case 404 =>
+              NoCache(play.api.mvc.Results.NotFound("Remote renderer page not found (404)"))
             case 400 =>
               // if DCR returns a 400 it's because *we* failed, so frontend should return a 500
               NoCache(play.api.mvc.Results.InternalServerError("Remote renderer validation error (400)"))

--- a/article/app/renderers/RemoteRenderer.scala
+++ b/article/app/renderers/RemoteRenderer.scala
@@ -80,7 +80,7 @@ class RemoteRenderer extends Logging {
     pageType: PageType
   )(implicit request: RequestHeader): Future[Result] = {
     val dataModel = DotcomponentsDataModel.fromArticle(page, request, blocks, pageType)
-    val json = DataModelV3.toJson(dataModel)
+    val json = DCRDataModel.toJson(dataModel)
     get(ws, json, page, Configuration.rendering.AMPArticleEndpoint)
   }
 
@@ -92,7 +92,7 @@ class RemoteRenderer extends Logging {
     pageType: PageType
   )(implicit request: RequestHeader): Future[Result] = {
     val dataModel = DotcomponentsDataModel.fromArticle(page, request, blocks, pageType)
-    val json = DataModelV3.toJson(dataModel)
+    val json = DCRDataModel.toJson(dataModel)
     get(ws, json, page, Configuration.rendering.renderingEndpoint)
   }
 }


### PR DESCRIPTION
## What does this change?

In https://github.com/guardian/dotcom-rendering/pull/1618 we started returning 404s from DCR to Frontend, in order to force an uncached 'Not Found' error into the AMP cache and serve directly from Dotcom. 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] Yes https://github.com/guardian/dotcom-rendering/pull/1618 

## Screenshots

![image](https://user-images.githubusercontent.com/638051/86381646-6b97bc80-bc85-11ea-8199-ea8baa446d63.png)

## Checklist

### Does this affect other platforms?

- [X] AMP <!-- AMP question? https://git.io/v9zIE -->

### Tested

- [X] Locally
- [X] On CODE (optional)

