### PR TITLE
Remote banner - use shouldHideSupportMessaging

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -27,7 +27,7 @@ import * as emotion from "emotion";
 import {
     getLastOneOffContributionDate,
     isRecurringContributor,
-    shouldNotBeShownSupportMessaging,
+    shouldHideSupportMessaging,
 } from 'common/modules/commercial/user-features';
 import userPrefs from "common/modules/user-prefs";
 
@@ -173,7 +173,7 @@ const buildEpicPayload = () => {
         isPaidContent: page.isPaidContent,
         isSensitive: page.isSensitive,
         tags: buildKeywordTags(page),
-        showSupportMessaging: !shouldNotBeShownSupportMessaging(),
+        showSupportMessaging: !shouldHideSupportMessaging(),
         isRecurringContributor: isRecurringContributor(),
         lastOneOffContributionDate:
             getLastOneOffContributionDate() || undefined,
@@ -204,7 +204,7 @@ const buildBannerPayload = () => {
         alreadyVisitedCount: getVisitCount(),
         shouldHideReaderRevenue: page.shouldHideReaderRevenue,
         isPaidContent: page.isPaidContent,
-        showSupportMessaging: !shouldNotBeShownSupportMessaging(),
+        showSupportMessaging: !shouldHideSupportMessaging(),
         engagementBannerLastClosedAt: userPrefs.get('engagementBannerLastClosedAt') || undefined,
         mvtId: getMvtValue(),
         countryCode: geolocationGetSync(),


### PR DESCRIPTION
We were using the subtly different `shouldNotBeShownSupportMessaging`, which just checks the `gu_hide_support_messaging` cookie but does not check contributions cookies.