### PR TITLE
Only request remote banner in AU

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/reader-revenue-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/reader-revenue-banner.js
@@ -3,6 +3,7 @@
 import type { Banner } from 'common/modules/ui/bannerPicker';
 import { fetchBannerData, renderBanner, type BannerDataResponse } from 'common/modules/commercial/contributions-service';
 import config from "lib/config";
+import { getSync as geolocationGetSync } from 'lib/geolocation';
 
 
 const messageCode = 'reader-revenue-banner';
@@ -12,7 +13,8 @@ let data: ?BannerDataResponse = null;
 const show = () => data ? renderBanner(data) : Promise.resolve(false);
 
 const canShow = (): Promise<boolean> => {
-    const enabled = config.get('switches.remoteBanner');
+    const countryCode = geolocationGetSync();
+    const enabled = config.get('switches.remoteBanner') && countryCode === 'AU';
 
     if (!enabled) {
         return Promise.resolve(false);


### PR DESCRIPTION
Currently the contributions-service only serves a banner to AU users.
But all clients make the request to contributions-service. This is costly while it's still a lambda.