### PR TITLE
Better logging for remote banner

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -305,8 +305,9 @@ export const renderBanner: (BannerDataResponse) => Promise<boolean> = (response)
             });
         })
         .catch(error => {
-            console.log(error);
-            reportError(error, {}, false);
+            console.log(`Error importing remote banner: ${error}`);
+            reportError(new Error(`Error importing remote banner: ${error}`), {}, false);
+            return false;
         });
 };
 

--- a/static/src/javascripts/projects/common/modules/commercial/reader-revenue-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/reader-revenue-banner.js
@@ -4,6 +4,7 @@ import type { Banner } from 'common/modules/ui/bannerPicker';
 import { fetchBannerData, renderBanner, type BannerDataResponse } from 'common/modules/commercial/contributions-service';
 import config from "lib/config";
 import { getSync as geolocationGetSync } from 'lib/geolocation';
+import reportError from "lib/report-error";
 
 
 const messageCode = 'reader-revenue-banner';
@@ -26,6 +27,10 @@ const canShow = (): Promise<boolean> => {
                 data = response;
                 return true;
             }
+            return false;
+        }).catch(error => {
+            console.log(`Error fetching remote banner data: ${error}`);
+            reportError(new Error(`Error fetching remote banner data: ${error}`), {}, false);
             return false;
         });
 };


### PR DESCRIPTION
The remotely-fetched banner (from contributions-service) is having fewer impressions than expected.
Better error logging in sentry may help us discover why