### PR TITLE
Run A9 only in US and pass in CCPA string

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
@@ -34,19 +34,24 @@ const bidderTimeout: number = 1500;
 
 const initialise = (): void => {
     onIabConsentNotification(state => {
-        // typeof state === 'boolean' means CCPA mode is on
-        const canRun =
-            typeof state === 'boolean'
-                ? !state
-                : state[1] && state[2] && state[3] && state[4] && state[5];
-
-        if (!initialised && canRun) {
-            initialised = true;
-            window.apstag.init({
+        if (!initialised) {
+            const apstagConfig = {
                 pubID: config.get('page.a9PublisherId'),
                 adServer: 'googletag',
                 bidTimeout: bidderTimeout,
-            });
+            }
+            // typeof state === 'boolean' means CCPA mode is on
+            if (typeof state === 'boolean') {
+                initialised = true;
+                window.apstag.init({
+                    ...apstagConfig,
+                    us_privacy: `1Y${  state ? 'Y' : 'N'  }N`
+                });
+            } else if (state[1] && state[2] && state[3] && state[4] && state[5]){
+                // TCF Mode
+                initialised = true;
+                window.apstag.init(apstagConfig);
+            }
         }
     });
 };

--- a/static/src/javascripts/projects/common/modules/experiments/tests/amazon-a9.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/amazon-a9.js
@@ -1,5 +1,7 @@
 // @flow strict
 
+import { isInUsOrCa } from 'common/modules/commercial/geo-utils';
+
 export const amazonA9Test: ABTest = {
     id: 'CommercialA9',
     start: '2019-05-09',
@@ -13,7 +15,7 @@ export const amazonA9Test: ABTest = {
     dataLinkNames: 'n/a',
     idealOutcome: 'Amazon a9 successfully run in parallel with prebid',
     showForSensitive: false,
-    canRun: () => true,
+    canRun: () => isInUsOrCa(),
     variants: [
         {
             id: 'control',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/amazon-a9.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/amazon-a9.js
@@ -1,6 +1,6 @@
 // @flow strict
 
-import { isInUsOrCa } from 'common/modules/commercial/geo-utils';
+import { isInUsa } from 'common/modules/commercial/geo-utils';
 
 export const amazonA9Test: ABTest = {
     id: 'CommercialA9',
@@ -15,7 +15,7 @@ export const amazonA9Test: ABTest = {
     dataLinkNames: 'n/a',
     idealOutcome: 'Amazon a9 successfully run in parallel with prebid',
     showForSensitive: false,
-    canRun: () => isInUsOrCa(),
+    canRun: () => isInUsa(),
     variants: [
         {
             id: 'control',


### PR DESCRIPTION
## What does this change?
In preparation to run A9 in US only, we are passing the CCPA string to the init method and make sure the AB test only runs in US

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)

