### PR TITLE
Adds JSX babel plugin and Webpack alias for React/ReactDOM

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -5,7 +5,8 @@ module.exports = {
     ],
     "plugins": [
         "@babel/plugin-proposal-object-rest-spread",
-        "@babel/plugin-syntax-dynamic-import"
+        "@babel/plugin-syntax-dynamic-import",
+        ['@babel/transform-react-jsx', { pragma: 'createElement' }]
     ],
     "env": {
         "production": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@babel/runtime": "^7.2.0",
     "@emotion/core": "^10.0.27",
+    "@emotion/cache": "^10.0.29",
     "@emotion/styled": "^10.0.27",
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/automat-client": "^0.2.16",
@@ -61,6 +62,7 @@
     "@babel/plugin-proposal-class-properties": "^7.1.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
     "@babel/plugin-syntax-dynamic-import": "^7.0.0",
+    "@babel/plugin-transform-react-jsx": "^7.10.3",
     "@babel/plugin-transform-runtime": "^7.1.0",
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-flow": "^7.0.0",

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -66,59 +66,57 @@ const onReminderOpen = (callbackParams: AutomatJsCallback) => {
     });
 };
 
-const renderEpic = (ContributionsEpic: any, props: any): Promise<HTMLElement> => {
-    return fastdom.write(() => {
-        const target = document.querySelector(
-            '.submeta'
+const renderEpic = (ContributionsEpic: any, props: any): Promise<HTMLElement> => fastdom.write(() => {
+    const target = document.querySelector(
+        '.submeta'
+    );
+
+    if (!target) {
+        throw new Error(
+            'Could not find target element for Epic'
         );
+    }
 
-        if (!target) {
-            throw new Error(
-                'Could not find target element for Epic'
+    const parent = target.parentNode;
+
+    if (!parent) {
+        throw new Error(
+            'Could not find parent element for Epic'
+        );
+    }
+
+    const container = document.createElement('div');
+    parent.insertBefore(container, target);
+
+    // use Shadow Dom if found
+    let shadowRoot;
+    const useShadowDomIfAvailable = true;
+    if (useShadowDomIfAvailable && container.attachShadow) {
+        shadowRoot = container.attachShadow({
+            mode: 'open',
+        });
+        const stylesWrapper = document.createElement('div');
+        const contentsWrapper = document.createElement('div');
+        shadowRoot.appendChild(stylesWrapper);
+        shadowRoot.appendChild(contentsWrapper);
+
+        // Rendering module inside Shadow DOM means we won't see styles
+        // added by Emotion to the document head; wrapping the component in
+        // a CacheProvider enables us to copy the styles into the Shadow DOM
+        const { CacheProvider } = emotionCore;
+        const emotionCache = createCache({ container: stylesWrapper });
+        render(
+            <CacheProvider value={emotionCache}>
+                <ContributionsEpic {...props} onReminderOpen={onReminderOpen} />
+            </CacheProvider>,
+            contentsWrapper
             );
-        }
+    } else {
+        render(<ContributionsEpic {...props} onReminderOpen={onReminderOpen} />, container);
+    }
 
-        const parent = target.parentNode;
-
-        if (!parent) {
-            throw new Error(
-                'Could not find parent element for Epic'
-            );
-        }
-
-        const container = document.createElement('div');
-        parent.insertBefore(container, target);
-
-        // use Shadow Dom if found
-        let shadowRoot;
-        const useShadowDomIfAvailable = true;
-        if (useShadowDomIfAvailable && container.attachShadow) {
-            shadowRoot = container.attachShadow({
-                mode: 'open',
-            });
-            const stylesWrapper = document.createElement('div');
-            const contentsWrapper = document.createElement('div');
-            shadowRoot.appendChild(stylesWrapper);
-            shadowRoot.appendChild(contentsWrapper);
-
-            // Rendering module inside Shadow DOM means we won't see styles
-            // added by Emotion to the document head; wrapping the component in
-            // a CacheProvider enables us to copy the styles into the Shadow DOM
-            const { CacheProvider } = emotionCore;
-            const emotionCache = createCache({ container: stylesWrapper });
-            render(
-                <CacheProvider value={emotionCache}>
-                  <ContributionsEpic {...props} onReminderOpen={onReminderOpen} />
-                </CacheProvider>,
-                contentsWrapper
-              );
-        } else {
-            render(<ContributionsEpic {...props} onReminderOpen={onReminderOpen} />, container);
-        }
-
-        return container;
-    });
-};
+    return container;
+});
 
 const buildEpicPayload = () => {
     const ophan = config.get('ophan');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -67,11 +67,14 @@ module.exports = {
             // #wp-rjs weird old aliasing from requirejs
             videojs: 'video.js',
 
+            'react': 'preact-x/compat',
+            'react-dom': 'preact-x/compat',
+
             svgs: path.join(__dirname, 'static', 'src', 'inline-svgs'),
             'ophan/ng': 'ophan-tracker-js',
             'ophan/embed': 'ophan-tracker-js/build/ophan.embed',
         },
-        symlinks: false // Inserted to enable linking @guardian/consent-management-platform
+        symlinks: false, // Inserted to enable linking @guardian/consent-management-platform
     },
     resolveLoader: {
         modules: [
@@ -104,10 +107,10 @@ module.exports = {
                 loader: 'svg-loader',
             },
             {
-              include: path.resolve(__dirname, "node_modules/preact-x"),
-              resolve: {
-                alias: { 'preact': 'preact-x' },
-              }
+                include: path.resolve(__dirname, 'node_modules/preact-x'),
+                resolve: {
+                    alias: { preact: 'preact-x' },
+                },
             },
             // Atoms rely on locally defined variables (see atoms/vars.scss)
             // to exhibit the same styles of the underlying platform. This

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -74,7 +74,7 @@ module.exports = {
             'ophan/ng': 'ophan-tracker-js',
             'ophan/embed': 'ophan-tracker-js/build/ophan.embed',
         },
-        symlinks: false, // Inserted to enable linking @guardian/consent-management-platform
+        symlinks: false // Inserted to enable linking @guardian/consent-management-platform
     },
     resolveLoader: {
         modules: [
@@ -107,10 +107,10 @@ module.exports = {
                 loader: 'svg-loader',
             },
             {
-                include: path.resolve(__dirname, 'node_modules/preact-x'),
-                resolve: {
-                    alias: { preact: 'preact-x' },
-                },
+              include: path.resolve(__dirname, "node_modules/preact-x"),
+              resolve: {
+                alias: { 'preact': 'preact-x' },
+              }
             },
             // Atoms rely on locally defined variables (see atoms/vars.scss)
             // to exhibit the same styles of the underlying platform. This

--- a/yarn.lock
+++ b/yarn.lock
@@ -88,6 +88,13 @@
   dependencies:
     "@babel/types" "^7.0.0"
 
+"@babel/helper-annotate-as-pure@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.1.tgz#f6d08acc6f70bbd59b436262553fb2e259a1a268"
+  integrity sha512-ewp3rvJEwLaHgyWGe4wQssC2vjks3E80WiUe2BpMb0KhreTjMROCbxXcEovTrbeGVdQct5VjQfrv9EgC+xMzCw==
+  dependencies:
+    "@babel/types" "^7.10.1"
+
 "@babel/helper-builder-binary-assignment-operator-visitor@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz#6b69628dfe4087798e0c4ed98e3d4a6b2fbd2f5f"
@@ -95,12 +102,29 @@
     "@babel/helper-explode-assignable-expression" "^7.1.0"
     "@babel/types" "^7.0.0"
 
+"@babel/helper-builder-react-jsx-experimental@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.10.1.tgz#9a7d58ad184d3ac3bafb1a452cec2bad7e4a0bc8"
+  integrity sha512-irQJ8kpQUV3JasXPSFQ+LCCtJSc5ceZrPFVj6TElR6XCHssi3jV8ch3odIrNtjJFRZZVbrOEfJMI79TPU/h1pQ==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.10.1"
+    "@babel/helper-module-imports" "^7.10.1"
+    "@babel/types" "^7.10.1"
+
 "@babel/helper-builder-react-jsx@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.0.0.tgz#fa154cb53eb918cf2a9a7ce928e29eb649c5acdb"
   dependencies:
     "@babel/types" "^7.0.0"
     esutils "^2.0.0"
+
+"@babel/helper-builder-react-jsx@^7.10.3":
+  version "7.10.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.10.3.tgz#62c4b7bb381153a0a5f8d83189b94b9fb5384fc5"
+  integrity sha512-vkxmuFvmovtqTZknyMGj9+uQAZzz5Z9mrbnkJnPkaYGfKTaSsYcjQdXP0lgrWLVh8wU6bCjOmXOpx+kqUi+S5Q==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.10.1"
+    "@babel/types" "^7.10.3"
 
 "@babel/helper-call-delegate@^7.1.0":
   version "7.1.0"
@@ -157,6 +181,13 @@
   dependencies:
     "@babel/types" "^7.0.0"
 
+"@babel/helper-module-imports@^7.10.1":
+  version "7.10.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.10.3.tgz#766fa1d57608e53e5676f23ae498ec7a95e1b11a"
+  integrity sha512-Jtqw5M9pahLSUWA+76nhK9OG8nwYXzhQzVIGFoNaHnXF/r4l7kz4Fl0UAW7B6mqC5myoJiBP5/YQlXQTMfHI9w==
+  dependencies:
+    "@babel/types" "^7.10.3"
+
 "@babel/helper-module-transforms@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.1.0.tgz#470d4f9676d9fad50b324cdcce5fbabbc3da5787"
@@ -177,6 +208,11 @@
 "@babel/helper-plugin-utils@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz#bbb3fbee98661c569034237cc03967ba99b4f250"
+
+"@babel/helper-plugin-utils@^7.10.1", "@babel/helper-plugin-utils@^7.10.3":
+  version "7.10.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.3.tgz#aac45cccf8bc1873b99a85f34bceef3beb5d3244"
+  integrity sha512-j/+j8NAWUTxOtx4LKHybpSClxHoq6I91DQ/mKgAXn5oNUPIUiGppjPIX3TDtJWPrdfP9Kfl7e4fgVMiQR9VE/g==
 
 "@babel/helper-regex@^7.0.0":
   version "7.0.0"
@@ -215,6 +251,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz#3aae285c0311c2ab095d997b8c9a94cad547d813"
   dependencies:
     "@babel/types" "^7.0.0"
+
+"@babel/helper-validator-identifier@^7.10.3":
+  version "7.10.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.3.tgz#60d9847f98c4cea1b279e005fdb7c28be5412d15"
+  integrity sha512-bU8JvtlYpJSBPuj1VUmKpFGaDZuLxASky3LhaKj3bmpSTY6VWooSM8msk+Z0CZoErFye2tlABF6yDkT3FOPAXw==
 
 "@babel/helper-wrap-function@^7.1.0":
   version "7.1.0"
@@ -389,6 +430,13 @@
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0.tgz#034d5e2b4e14ccaea2e4c137af7e4afb39375ffd"
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-jsx@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.10.1.tgz#0ae371134a42b91d5418feb3c8c8d43e1565d2da"
+  integrity sha512-+OxyOArpVFXQeXKLO9o+r2I4dIoVoy6+Uu0vKELrlweDM3QJADZj+Z+5ERansZqIZBcLj42vHnDI8Rz9BnRIuQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.1"
 
 "@babel/plugin-syntax-object-rest-spread@^7.0.0":
   version "7.0.0"
@@ -733,6 +781,16 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-jsx" "^7.0.0"
 
+"@babel/plugin-transform-react-jsx@^7.10.3":
+  version "7.10.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.10.3.tgz#c07ad86b7c159287c89b643f201f59536231048e"
+  integrity sha512-Y21E3rZmWICRJnvbGVmDLDZ8HfNDIwjGF3DXYHx1le0v0mIHCs0Gv5SavyW5Z/jgAHLaAoJPiwt+Dr7/zZKcOQ==
+  dependencies:
+    "@babel/helper-builder-react-jsx" "^7.10.3"
+    "@babel/helper-builder-react-jsx-experimental" "^7.10.1"
+    "@babel/helper-plugin-utils" "^7.10.3"
+    "@babel/plugin-syntax-jsx" "^7.10.1"
+
 "@babel/plugin-transform-regenerator@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0.tgz#5b41686b4ed40bef874d7ed6a84bdd849c13e0c1"
@@ -1016,6 +1074,15 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
+"@babel/types@^7.10.1", "@babel/types@^7.10.3":
+  version "7.10.3"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.10.3.tgz#6535e3b79fea86a6b09e012ea8528f935099de8e"
+  integrity sha512-nZxaJhBXBQ8HVoIcGsf9qWep3Oh3jCENK54V4mRF7qaJabVsAYdbTtmSD8WmAp1R6ytPiu5apMwSXyxB1WlaBA==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.3"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
 "@babel/types@^7.2.2", "@babel/types@^7.3.0", "@babel/types@^7.3.4":
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.3.4.tgz#bf482eaeaffb367a28abbf9357a94963235d90ed"
@@ -1024,7 +1091,7 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@emotion/cache@^10.0.27":
+"@emotion/cache@^10.0.27", "@emotion/cache@^10.0.29":
   version "10.0.29"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"
   integrity sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==


### PR DESCRIPTION
Simple change to fix the error with `<CacheProvider>` that was stopping us from rendering the module inside the Shadow DOM. This is a step forward but not yet a fully functional solution as the Emotion styles don't seem to get copied from the document head into the Shadow DOM, but this might be a separate/unrelated issue. 

### Without Shadow DOM
![Screenshot 2020-06-25 at 17 27 15](https://user-images.githubusercontent.com/1692169/85759797-274a7080-b709-11ea-8842-bf62ed2a7ff0.png)

### With Shadow DOM
![Screenshot 2020-06-25 at 17 26 28](https://user-images.githubusercontent.com/1692169/85759839-303b4200-b709-11ea-8aa5-6e429739811a.png)
