### PR TITLE
Add query string for testing remote banner

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/reader-revenue-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/reader-revenue-banner.js
@@ -15,7 +15,8 @@ const show = () => data ? renderBanner(data) : Promise.resolve(false);
 
 const canShow = (): Promise<boolean> => {
     const countryCode = geolocationGetSync();
-    const enabled = config.get('switches.remoteBanner') && countryCode === 'AU';
+    const forceBanner = window.location.search.includes('force-remote-banner=true');
+    const enabled = (config.get('switches.remoteBanner') && countryCode === 'AU') || forceBanner;
 
     if (!enabled) {
         return Promise.resolve(false);


### PR DESCRIPTION
We need to debug the behaviour of the banner when a take over ad is live.
Currently the banner is switched off in PROD.
Adding `force-remote-banner=true` to the querystring will force the banner to show