### PR TITLE
Remote banner: override the css that is added to the container when a…

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -272,7 +272,8 @@ export const renderBanner: (BannerDataResponse) => Promise<boolean> = (response)
 
             return fastdom.write(() => {
                 const container = document.createElement('div');
-                container.classList.add('site-message--banner', 'remote-banner');
+                container.classList.add('site-message--banner');
+                container.classList.add('remote-banner');
 
                 if (document.body) {
                     document.body.insertAdjacentElement('beforeend', container);

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -273,6 +273,13 @@ export const renderBanner: (BannerDataResponse) => Promise<boolean> = (response)
             return fastdom.write(() => {
                 const container = document.createElement('div');
                 container.classList.add('site-message--banner');
+
+                // Override the css that is added to the container when an ad takeover happens
+                container.style.width = 'auto !important';
+                container.style.zIndex = '999 !important';
+                container.style.background = 'none !important';
+                container.style.top = 'auto !important';
+
                 if (document.body) {
                     document.body.insertAdjacentElement('beforeend', container);
                 }

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -272,13 +272,7 @@ export const renderBanner: (BannerDataResponse) => Promise<boolean> = (response)
 
             return fastdom.write(() => {
                 const container = document.createElement('div');
-                container.classList.add('site-message--banner');
-
-                // Override the css that is added to the container when an ad takeover happens
-                container.style.width = 'auto !important';
-                container.style.zIndex = '999 !important';
-                container.style.background = 'none !important';
-                container.style.top = 'auto !important';
+                container.classList.add('site-message--banner', 'remote-banner');
 
                 if (document.body) {
                     document.body.insertAdjacentElement('beforeend', container);

--- a/static/src/stylesheets/module/site-messages/_engagement-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_engagement-banner.scss
@@ -219,3 +219,12 @@
         display: inline;
     }
 }
+
+// Override the css that is added to the container when an ad takeover happens
+.remote-banner {
+    width: auto !important;
+    z-index: 999 !important;
+    background: none !important;
+    top: auto !important;
+    position: sticky !important;
+}


### PR DESCRIPTION
When an ad takeover kicks in something is adding this css to our banner container:
```
{
    margin-left: auto;
    margin-right: auto;
    width: 1300px;
    float: none;
    z-index: 1;
    pointer-events: all;
    background: rgb(255, 255, 255);
    position: relative;
    top: 0px;
}
```