### PR TITLE
More aggressive CSS targeting

### DIFF
--- a/static/src/stylesheets/module/site-messages/_engagement-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_engagement-banner.scss
@@ -221,8 +221,8 @@
 }
 
 // Override the css that is added to the container when an ad takeover happens
-.remote-banner {
-    width: auto !important;
+.site-message--banner.remote-banner {
+    width: 100% !important;
     z-index: 999 !important;
     background: none !important;
     top: auto !important;


### PR DESCRIPTION
Follow-up on https://github.com/guardian/frontend/pull/22744

## What does this change?

A 3rd-party library (Bonzai Ads?) can takeover the page, and then targets the `.site-banner` in Australia, which is a call to support The Guardian. The css breaks the banner and makes the page hard to navigate. @tomrf1 proposed a temporary fix with CSS, which was not aggressive enough, and only partly fixed the issue. This PR further tweaks the CSS overrides so the page displays as expected.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

Before:
![image](https://user-images.githubusercontent.com/76776/86026401-47d73b00-ba27-11ea-9833-26801afe697c.png)

After:
![image](https://user-images.githubusercontent.com/76776/86026324-2bd39980-ba27-11ea-9ced-3eec1f00cebf.png)

## What is the value of this and can you measure success?

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
