### PR TITLE
Enabling Facebook video embeds in DCR

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -5,7 +5,7 @@ import experiments.{ActiveExperiments, Control, DCRBubble, DotcomRendering1, Dot
 import model.PageWithStoryPackage
 import implicits.Requests._
 import model.liveblog.{BlockElement, ContentAtomBlockElement, ImageBlockElement, InstagramBlockElement, PullquoteBlockElement, RichLinkBlockElement, TableBlockElement, TextBlockElement, TweetBlockElement}
-import model.dotcomrendering.pageElements.{SoundcloudBlockElement, VideoVimeoBlockElement, VideoYoutubeBlockElement}
+import model.dotcomrendering.pageElements.{SoundcloudBlockElement, VideoVimeoBlockElement, VideoYoutubeBlockElement, VideoFacebookBlockElement}
 import play.api.mvc.RequestHeader
 import views.support.Commercial
 
@@ -45,6 +45,7 @@ object ArticlePageChecks {
       case _: InstagramBlockElement => false
       case _: TableBlockElement => false
       case _: SoundcloudBlockElement => false
+      case _: VideoFacebookBlockElement => false
       case _: VideoVimeoBlockElement => false
       case _: VideoYoutubeBlockElement => false
       case ContentAtomBlockElement(_, atomtype) => {

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -487,7 +487,7 @@ object PageElement {
       source match {
         case "YouTube" => VideoYoutubeBlockElement(caption, url, originalUrl, getEmbedUrl(data.html), height, width, Role(data.role))
         case "Vimeo" => VideoVimeoBlockElement(caption, url, originalUrl, getEmbedUrl(data.html), height, width, Role(data.role))
-        case "Facebook" => VideoFacebookBlockElement(caption, url, originalUrl, height, width, Role(data.role))
+        case "Facebook" => VideoFacebookBlockElement(caption, url, originalUrl, getEmbedUrl(data.html), height, width, Role(data.role))
         case _ => VideoBlockElement(caption, url, originalUrl, height, width, Role(data.role))
       }
     }

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -102,7 +102,7 @@ case class TimelineBlockElement(id: String, title: String, description: Option[S
 case class TweetBlockElement(html: String, url: String, id: String, hasMedia: Boolean, role: Role) extends PageElement
 case class UnknownBlockElement(html: Option[String]) extends PageElement
 case class VideoBlockElement(caption: String, url: String, originalUrl: String, height: Int, width: Int, role: Role) extends PageElement
-case class VideoFacebookBlockElement(caption: String, url: String, originalUrl: String, height: Int, width: Int, role: Role) extends PageElement
+case class VideoFacebookBlockElement(caption: String, url: String, originalUrl: String, embedUrl: Option[String], height: Int, width: Int, role: Role) extends PageElement
 case class VideoVimeoBlockElement(caption: String, url: String, originalUrl: String, embedUrl: Option[String], height: Int, width: Int, role: Role) extends PageElement
 case class VideoYoutubeBlockElement(caption: String, url: String, originalUrl: String, embedUrl: Option[String], height: Int, width: Int, role: Role) extends PageElement
 case class VineBlockElement(html: Option[String]) extends PageElement


### PR DESCRIPTION
## What does this change?
Makes it so that frontend passes down the required field into DCR and adds it to the allowlist for rendering in DCR. Will require https://github.com/guardian/dotcom-rendering/pull/1676 to be merged first.
