### PR TITLE
Return a 404 if CAPI 404s on advertiser content

### DIFF
--- a/commercial/app/controllers/HostedContentController.scala
+++ b/commercial/app/controllers/HostedContentController.scala
@@ -7,7 +7,7 @@ import commercial.model.hosted.HostedTrails
 import common.commercial.hosted._
 import common.{Edition, ImplicitControllerExecutionContext, JsonComponent, JsonNotFound, Logging}
 import contentapi.ContentApiClient
-import model.Cached.RevalidatableResult
+import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model.{ApplicationContext, Cached, NoCache}
 import play.api.libs.json.{JsArray, Json}
 import play.api.mvc._
@@ -50,7 +50,7 @@ class HostedContentController(
       case e: ContentApiError if e.httpStatus == 410 =>
         cached(commercialExpired(wasAHostedPage = true))
       case e: ContentApiError if e.httpStatus == 404 =>
-        NoCache(NotFound)
+        Cached(cacheDuration)(WithoutRevalidationResult(NotFound))
     }
   }
 

--- a/commercial/app/controllers/HostedContentController.scala
+++ b/commercial/app/controllers/HostedContentController.scala
@@ -49,6 +49,8 @@ class HostedContentController(
     } recover {
       case e: ContentApiError if e.httpStatus == 410 =>
         cached(commercialExpired(wasAHostedPage = true))
+      case e: ContentApiError if e.httpStatus == 404 =>
+        NoCache(NotFound)
     }
   }
 


### PR DESCRIPTION
## What does this change?

When CAPI returns a 404 for advertiser content, this will now result in returning a 404 to the browser.

Previously a 404 from CAPI wasn't handled explicitly which resulted in a 500 being returned to the browser. This meant that it wasn't possible to take down advertiser content and setup a redirect (the redirect requires the original URL to return a 404).

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No (I don't think we handle advertiser content in DCR)
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
