### PR TITLE
Inject creative styles via JS

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -1,6 +1,7 @@
 // @flow
 
 import qwery from 'qwery';
+import config from 'lib/config';
 import reportError from 'lib/report-error';
 import fastdom from 'lib/fastdom-promise';
 import { Advert } from 'commercial/modules/dfp/Advert';

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -34,6 +34,7 @@ const addClassIfHasClass = (newClassNames: Array<string>) =>
                     });
                     // Add 100% width from _adslot.scss
                     if (
+                        config.get('isDotcomRendering', false)
                         !newClassNames.includes('ad-slot--im') &&
                         !newClassNames.includes('ad-slot--carrot') &&
                         !newClassNames.includes('ad-slot--offset-right') &&

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -34,7 +34,7 @@ const addClassIfHasClass = (newClassNames: Array<string>) =>
                     });
                     // Add 100% width from _adslot.scss
                     if (
-                        config.get('isDotcomRendering', false)
+                        config.get('isDotcomRendering', false) &&
                         !newClassNames.includes('ad-slot--im') &&
                         !newClassNames.includes('ad-slot--carrot') &&
                         !newClassNames.includes('ad-slot--offset-right') &&

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -32,6 +32,14 @@ const addClassIfHasClass = (newClassNames: Array<string>) =>
                     newClassNames.forEach(className => {
                         advert.node.classList.add(className);
                     });
+                    // Add 100% width from _adslot.scss
+                    if (
+                        !newClassNames.includes('ad-slot--im') &&
+                        !newClassNames.includes('ad-slot--carrot') &&
+                        !newClassNames.includes('ad-slot--offset-right') &&
+                        newClassNames.includes('ad-slot--fluid')
+                    )
+                        advert.node.style.width = '100%';
                 });
             }
             return Promise.resolve();

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.js
@@ -100,8 +100,7 @@ const setBackground = (specs: AdSpec, adSlot: HTMLElement): Promise<any> => {
         backgroundParent.appendChild(background);
 
         // Inject styles in DCR (from _creatives.scss)
-        if (config.get('isDotcomRendering')) {
-            backgroundParent.style.contain = 'size layout style';
+        if (config.get('isDotcomRendering', false)) {
             backgroundParent.style.position = 'absolute';
             backgroundParent.style.top = '0';
             backgroundParent.style.left = '0';
@@ -121,7 +120,7 @@ const setBackground = (specs: AdSpec, adSlot: HTMLElement): Promise<any> => {
                 if (backgroundParent) {
                     // Create a stacking context in DCR
                     if (
-                        config.get('isDotcomRendering') &&
+                        config.get('isDotcomRendering', false) &&
                         adSlot.firstChild &&
                         adSlot.firstChild instanceof HTMLElement
                     )
@@ -130,6 +129,9 @@ const setBackground = (specs: AdSpec, adSlot: HTMLElement): Promise<any> => {
                     if (specs.scrollType === 'interscroller') {
                         adSlot.style.height = '85vh';
                         adSlot.style.marginBottom = '12px';
+
+                        if (config.get('isDotcomRendering', false))
+                            background.style.position = 'fixed';
 
                         if (specs.ctaUrl != null) {
                             const ctaURLAnchor = document.createElement('a');

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.js
@@ -138,7 +138,6 @@ const setBackground = (specs: AdSpec, adSlot: HTMLElement): Promise<any> => {
                             );
                         }
                     } else {
-                        console.log('we are about to add the element');
                         adSlot.insertBefore(
                             backgroundParent,
                             adSlot.firstChild

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.js
@@ -101,16 +101,16 @@ const setBackground = (specs: AdSpec, adSlot: HTMLElement): Promise<any> => {
         // Inject styles (from _creatives.scss)
         backgroundParent.style.contain = 'size layout style';
         backgroundParent.style.position = 'absolute';
-        backgroundParent.style.top = 0;
-        backgroundParent.style.left = 0;
-        backgroundParent.style.right = 0;
-        backgroundParent.style.bottom = 0;
+        backgroundParent.style.top = '0';
+        backgroundParent.style.left = '0';
+        backgroundParent.style.right = '0';
+        backgroundParent.style.bottom = '0';
         backgroundParent.style.clip = 'rect(0, auto, auto, 0)';
 
-        background.style.top = 0;
-        background.style.left = 0;
-        background.style.right = 0;
-        background.style.bottom = 0;
+        background.style.top = '0';
+        background.style.left = '0';
+        background.style.right = '0';
+        background.style.bottom = '0';
         background.style.transition = 'background 100ms ease';
 
         return fastdom

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.js
@@ -116,7 +116,7 @@ const setBackground = (specs: AdSpec, adSlot: HTMLElement): Promise<any> => {
         return fastdom
             .write(() => {
                 if (backgroundParent) {
-                    adSlot.firstChild.style.contain = 'layout'; // create a stacking context
+                    // adSlot.firstChild.style.contain = 'layout'; // TODO: create a stacking context
                     if (specs.scrollType === 'interscroller') {
                         adSlot.style.height = '85vh';
                         adSlot.style.marginBottom = '12px';

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.js
@@ -163,10 +163,10 @@ const setBackground = (specs: AdSpec, adSlot: HTMLElement): Promise<any> => {
             specs.scrollType
         }`;
 
-        // This is imported from _creatives.css
-        if (specs.scrollType === 'fixed') background.style.position = 'fixed';
-
-        if (specs.scrollType === 'parallax')
+        if (
+            config.get('isDotcomRendering', false) &&
+            specs.scrollType === 'parallax'
+        )
             background.style.position = 'absolute';
 
         Object.assign(background.style, specStyles);
@@ -180,6 +180,9 @@ const setBackground = (specs: AdSpec, adSlot: HTMLElement): Promise<any> => {
                 })
                 .then(rect =>
                     fastdom.write(() => {
+                        if (config.get('isDotcomRendering', false)) {
+                            background.style.position = 'fixed';
+                        }
                         if (specStyles.backgroundColor) {
                             backgroundParent.style.backgroundColor =
                                 specStyles.backgroundColor;

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.js
@@ -98,6 +98,25 @@ const setBackground = (specs: AdSpec, adSlot: HTMLElement): Promise<any> => {
         const background = document.createElement('div');
         backgroundParent.appendChild(background);
 
+        // Inject styles (from _creatives.scss)
+        backgroundParent.setAttribute("style", `
+            contain: size layout style;
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            z-index: -1;
+            clip: rect(0, auto, auto, 0);
+        `)
+        background.setAttribute("style", `
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            transition: background 100ms ease;
+        `)
+
         return fastdom
             .write(() => {
                 if (backgroundParent) {
@@ -134,6 +153,13 @@ const setBackground = (specs: AdSpec, adSlot: HTMLElement): Promise<any> => {
         background.className = `${backgroundClass} creative__background--${
             specs.scrollType
         }`;
+
+        // This is improted from _creatives.css
+        if(specs.scrollType === 'fixed')
+            background.style.position = "fixed";
+
+        if(specs.scrollType === 'parallax')
+            background.style.position = "absolute";
 
         Object.assign(background.style, specStyles);
 

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.js
@@ -158,7 +158,7 @@ const setBackground = (specs: AdSpec, adSlot: HTMLElement): Promise<any> => {
             specs.scrollType
         }`;
 
-        // This is improted from _creatives.css
+        // This is imported from _creatives.css
         if (specs.scrollType === 'fixed') background.style.position = 'fixed';
 
         if (specs.scrollType === 'parallax')

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.js
@@ -116,7 +116,13 @@ const setBackground = (specs: AdSpec, adSlot: HTMLElement): Promise<any> => {
         return fastdom
             .write(() => {
                 if (backgroundParent) {
-                    // adSlot.firstChild.style.contain = 'layout'; // TODO: create a stacking context
+                    // Create a stacking context
+                    if (
+                        adSlot.firstChild &&
+                        adSlot.firstChild instanceof HTMLElement
+                    )
+                        adSlot.firstChild.style.contain = 'layout';
+
                     if (specs.scrollType === 'interscroller') {
                         adSlot.style.height = '85vh';
                         adSlot.style.marginBottom = '12px';

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.js
@@ -1,4 +1,5 @@
 // @flow
+import config from 'lib/config';
 import { addEventListener } from 'lib/events';
 import fastdom from 'lib/fastdom-promise';
 import type { RegisterListeners } from 'commercial/modules/messenger';
@@ -98,26 +99,29 @@ const setBackground = (specs: AdSpec, adSlot: HTMLElement): Promise<any> => {
         const background = document.createElement('div');
         backgroundParent.appendChild(background);
 
-        // Inject styles (from _creatives.scss)
-        backgroundParent.style.contain = 'size layout style';
-        backgroundParent.style.position = 'absolute';
-        backgroundParent.style.top = '0';
-        backgroundParent.style.left = '0';
-        backgroundParent.style.right = '0';
-        backgroundParent.style.bottom = '0';
-        backgroundParent.style.clip = 'rect(0, auto, auto, 0)';
+        // Inject styles in DCR (from _creatives.scss)
+        if (config.get('isDotcomRendering')) {
+            backgroundParent.style.contain = 'size layout style';
+            backgroundParent.style.position = 'absolute';
+            backgroundParent.style.top = '0';
+            backgroundParent.style.left = '0';
+            backgroundParent.style.right = '0';
+            backgroundParent.style.bottom = '0';
+            backgroundParent.style.clip = 'rect(0, auto, auto, 0)';
 
-        background.style.top = '0';
-        background.style.left = '0';
-        background.style.right = '0';
-        background.style.bottom = '0';
-        background.style.transition = 'background 100ms ease';
+            background.style.top = '0';
+            background.style.left = '0';
+            background.style.right = '0';
+            background.style.bottom = '0';
+            background.style.transition = 'background 100ms ease';
+        }
 
         return fastdom
             .write(() => {
                 if (backgroundParent) {
-                    // Create a stacking context
+                    // Create a stacking context in DCR
                     if (
+                        config.get('isDotcomRendering') &&
                         adSlot.firstChild &&
                         adSlot.firstChild instanceof HTMLElement
                     )

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.js
@@ -116,6 +116,7 @@ const setBackground = (specs: AdSpec, adSlot: HTMLElement): Promise<any> => {
         return fastdom
             .write(() => {
                 if (backgroundParent) {
+                    adSlot.firstChild.style.contain = 'layout'; // create a stacking context
                     if (specs.scrollType === 'interscroller') {
                         adSlot.style.height = '85vh';
                         adSlot.style.marginBottom = '12px';

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.js
@@ -105,7 +105,6 @@ const setBackground = (specs: AdSpec, adSlot: HTMLElement): Promise<any> => {
         backgroundParent.style.left = 0;
         backgroundParent.style.right = 0;
         backgroundParent.style.bottom = 0;
-        backgroundParent.style.zIndex = -1;
         backgroundParent.style.clip = 'rect(0, auto, auto, 0)';
 
         background.style.top = 0;

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.js
@@ -99,23 +99,20 @@ const setBackground = (specs: AdSpec, adSlot: HTMLElement): Promise<any> => {
         backgroundParent.appendChild(background);
 
         // Inject styles (from _creatives.scss)
-        backgroundParent.setAttribute("style", `
-            contain: size layout style;
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
-            z-index: -1;
-            clip: rect(0, auto, auto, 0);
-        `)
-        background.setAttribute("style", `
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
-            transition: background 100ms ease;
-        `)
+        backgroundParent.style.contain = 'size layout style';
+        backgroundParent.style.position = 'absolute';
+        backgroundParent.style.top = 0;
+        backgroundParent.style.left = 0;
+        backgroundParent.style.right = 0;
+        backgroundParent.style.bottom = 0;
+        backgroundParent.style.zIndex = -1;
+        backgroundParent.style.clip = 'rect(0, auto, auto, 0)';
+
+        background.style.top = 0;
+        background.style.left = 0;
+        background.style.right = 0;
+        background.style.bottom = 0;
+        background.style.transition = 'background 100ms ease';
 
         return fastdom
             .write(() => {
@@ -135,6 +132,7 @@ const setBackground = (specs: AdSpec, adSlot: HTMLElement): Promise<any> => {
                             );
                         }
                     } else {
+                        console.log('we are about to add the element');
                         adSlot.insertBefore(
                             backgroundParent,
                             adSlot.firstChild
@@ -155,11 +153,10 @@ const setBackground = (specs: AdSpec, adSlot: HTMLElement): Promise<any> => {
         }`;
 
         // This is improted from _creatives.css
-        if(specs.scrollType === 'fixed')
-            background.style.position = "fixed";
+        if (specs.scrollType === 'fixed') background.style.position = 'fixed';
 
-        if(specs.scrollType === 'parallax')
-            background.style.position = "absolute";
+        if (specs.scrollType === 'parallax')
+            background.style.position = 'absolute';
 
         Object.assign(background.style, specStyles);
 

--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -653,6 +653,7 @@
     }
 }
 
+// This is now injected via JS in static/src/javascripts/projects/commercial/modules/messenger/background.js
 .creative__background-parent {
     contain: size layout style;
     position: absolute;

--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -653,7 +653,8 @@
     }
 }
 
-// This is now injected via JS in static/src/javascripts/projects/commercial/modules/messenger/background.js
+// In DCR, these styles are injected via JS via:
+// static/src/javascripts/projects/commercial/modules/messenger/background.js
 .creative__background-parent {
     contain: size layout style;
     position: absolute;


### PR DESCRIPTION
## What does this change?

Some native ads are not working in DCR as they rely on some global CSS ([see Trello card](https://trello.com/c/x2Lv7Y7M/707-check-native-templates-on-dcr)). The temporary fix is to inject only the relevant CSS via the commercial JS bundle where required.

- [X] Background parallax
- [X] Missing backgrounds in Fabric + scroller
- [X] Full-width Fluid ads
- [x] Interscroller

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes (please indicate your plans for DCR Implementation)

Relative positioning https://github.com/guardian/dotcom-rendering/pull/1686 & https://github.com/guardian/dotcom-rendering/pull/1694, scroll label styling https://github.com/guardian/dotcom-rendering/pull/1693

## Screenshots

## What is the value of this and can you measure success?

Native ads are rendered as expected on DCR.

## Checklist

### Tested

- [X] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

## Todo

Further check native ads render properly on all browsers and correct cosmetic changes:
- [ ] pseudo-elements for white background
- [ ] even smoother parallax with css?