### PR TITLE
Extend remote epic switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -172,7 +172,7 @@ trait ABTestSwitches {
     "Serve epics from remote service for subset of audience",
     owners = Seq(Owner.withGithub("nicl")),
     safeState = Off,
-    sellByDate = new LocalDate(2020, 7, 1),
+    sellByDate = new LocalDate(2020, 7, 21),
     exposeClientSide = true,
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/remote-epic-variants.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/remote-epic-variants.js
@@ -15,7 +15,7 @@ const remoteVariant: Variant = {
 export const remoteEpicVariants: Runnable<AcquisitionsABTest> = {
     id,
     start: '2020-05-01',
-    expiry: '2020-07-01',
+    expiry: '2020-07-21',
     author: "Nicolas Long",
     description: "Pseudo-test to use remote service for % of contribution epics. Expected to run as highest priority test; the canRun will then narrow the audience.",
     audience: 1,


### PR DESCRIPTION
## What does this change?
Extends the expiring switch for remote epic variants until we can look closer at the data and make a decision of what to do next.