### PR TITLE
time to upgrade the TLS

### DIFF
--- a/nginx/frontend.conf
+++ b/nginx/frontend.conf
@@ -22,7 +22,7 @@ server {
     ssl_certificate m.thegulocal.com.crt;
     ssl_certificate_key m.thegulocal.com.key;
     ssl_session_timeout 5m;
-    ssl_protocols SSLv2 SSLv3 TLSv1;
+    ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers HIGH:!aNULL:!MD5;
     ssl_prefer_server_ciphers on;
 


### PR DESCRIPTION
## What does this change?

TLS v1.2 is the minimum required [since Chrome 81](https://www.chromestatus.com/feature/5654791610957824) for it not to display a "Not Secure" next to the tab 

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

![image](https://user-images.githubusercontent.com/76776/86223642-b4fde400-bb7f-11ea-9d59-1aef008f804e.png)

## What is the value of this and can you measure success?

The nginx config is now more secure!