### PR TITLE
Extend A9 switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -102,7 +102,7 @@ trait ABTestSwitches {
     "Test Amazon A9 header bidding",
     owners = Seq(Owner.withGithub("ioanna0")),
     safeState = Off,
-    sellByDate = new LocalDate(2020, 7, 1),
+    sellByDate = new LocalDate(2020, 10, 1),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/amazon-a9.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/amazon-a9.js
@@ -3,7 +3,7 @@
 export const amazonA9Test: ABTest = {
     id: 'CommercialA9',
     start: '2019-05-09',
-    expiry: '2020-07-01',
+    expiry: '2020-10-01',
     author: 'Ioanna Kyprianou',
     description: 'This is to test amazon a9 header bidding',
     audience: 0.01,


### PR DESCRIPTION
## What does this change?
Extend A9 switch that expires today. There's another PR for removing it completely but it is blocked at the moment 

