### PR TITLE
Redirect to HTTPS url

### DIFF
--- a/nginx/frontend.conf
+++ b/nginx/frontend.conf
@@ -7,11 +7,8 @@ server {
     proxy_http_version 1.1; # this is essential for chunked responses to work
     server_name m.thegulocal.com;
 
-    location / {
-        proxy_pass http://frontend;
-        proxy_set_header Host $host;
-        proxy_set_header "X-Forwarded-Proto" "http";
-    }
+    # Enforce HTTPS
+    return https://m.thegulocal.com$request_uri;
 }
 
 server {


### PR DESCRIPTION
## What does this change?

Enforces HTTPS url on local development (m.thegulocal.com) via redirect.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Less potential for issues when developing locally, as the environment more closely matches PROD.

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
