### PR TITLE
Add Interactive Atoms to the list of supported elements

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -51,7 +51,7 @@ object ArticlePageChecks {
       case ContentAtomBlockElement(_, atomtype) => {
         // ContentAtomBlockElement was expanded to include atomtype.
         // To support an atom type, just add it to supportedAtomTypes
-        val supportedAtomTypes = List("explainer")
+        val supportedAtomTypes = List("explainer", "interactive")
         !supportedAtomTypes.contains(atomtype)
       }
       case _ => true


### PR DESCRIPTION
## What does this change?

Following recent developments in DCR. Add Interactive Atoms to the list of supported elements.
