### PR TITLE
Rename CalloutBlockElementXp into CalloutBlockElement

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/CalloutExtraction.scala
+++ b/common/app/model/dotcomrendering/pageElements/CalloutExtraction.scala
@@ -100,7 +100,7 @@ object CalloutExtraction {
     }
   }
 
-  private def campaignJsObjectToCalloutBlockElement(campaign: JsObject): Option[CalloutBlockElementXp] = {
+  private def campaignJsObjectToCalloutBlockElement(campaign: JsObject): Option[CalloutBlockElement] = {
     for {
       id                 <- (campaign \ "id").asOpt[String]
       activeFrom         <- (campaign \ "activeFrom").asOpt[Long]
@@ -115,11 +115,11 @@ object CalloutExtraction {
         .value
         .flatMap(formFieldItemToCalloutFormField(_))
         .toList
-      CalloutBlockElementXp(id, activeFrom, displayOnSensitive, formId, title, description, tagName, formFields2)
+      CalloutBlockElement(id, activeFrom, displayOnSensitive, formId, title, description, tagName, formFields2)
     }
   }
 
-  def extractCallout(html: String, campaigns: Option[JsValue]): Option[CalloutBlockElementXp] = {
+  def extractCallout(html: String, campaigns: Option[JsValue]): Option[CalloutBlockElement] = {
 
     val campaignsX1: JsValue = Json.parse("""
   [

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -58,7 +58,7 @@ case class AudioAtomBlockElement(id: String, kicker: String, coverUrl: String, t
 case class AudioBlockElement(assets: Seq[AudioAsset]) extends PageElement
 case class BlockquoteBlockElement(html: String) extends PageElement
 case class ExplainerAtomBlockElement(id: String, title: String, body: String) extends PageElement
-case class CalloutBlockElementXp(id: String, activeFrom: Long, displayOnSensitive: Boolean, formId: Int, title: String, description: String, tagName: String, formFields: List[CalloutFormField]) extends PageElement
+case class CalloutBlockElement(id: String, activeFrom: Long, displayOnSensitive: Boolean, formId: Int, title: String, description: String, tagName: String, formFields: List[CalloutFormField]) extends PageElement
 case class ChartAtomBlockElement(id: String, url: String) extends PageElement
 case class CodeBlockElement(html: Option[String], isMandatory: Boolean) extends PageElement
 case class CommentBlockElement(body: String, avatarURL: String, profileURL: String, profileName: String, permalink: String, dateTime: String) extends PageElement
@@ -122,7 +122,7 @@ object PageElement {
       case _: AudioBlockElement => true
       case _: AudioAtomBlockElement => true
       case _: BlockquoteBlockElement => true
-      case _: CalloutBlockElementXp => true
+      case _: CalloutBlockElement => true
       case _: ChartAtomBlockElement => true
       case _: CommentBlockElement => true
       case _: ContentAtomBlockElement => true
@@ -510,7 +510,7 @@ object PageElement {
   implicit val AudioBlockElementWrites: Writes[AudioBlockElement] = Json.writes[AudioBlockElement]
   implicit val AudioAtomBlockElementWrites: Writes[AudioAtomBlockElement] = Json.writes[AudioAtomBlockElement]
   implicit val BlockquoteBlockElementWrites: Writes[BlockquoteBlockElement] = Json.writes[BlockquoteBlockElement]
-  implicit val CalloutBlockElementWrites: Writes[CalloutBlockElementXp] = Json.writes[CalloutBlockElementXp]
+  implicit val CalloutBlockElementWrites: Writes[CalloutBlockElement] = Json.writes[CalloutBlockElement]
   implicit val ChartAtomBlockElementWrites: Writes[ChartAtomBlockElement] = Json.writes[ChartAtomBlockElement]
   implicit val CodeBlockElementWrites: Writes[CodeBlockElement] = Json.writes[CodeBlockElement]
   implicit val CommentBlockElementWrites: Writes[CommentBlockElement] = Json.writes[CommentBlockElement]


### PR DESCRIPTION
## What does this change?

Rename `CalloutBlockElementXp` into `CalloutBlockElement`, thereby matching it with the DCR schema.
