### PR TITLE
Remove AMP AB test switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -148,16 +148,6 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-amp-zero-test-experiment",
-    "A/B test to test amp-experiment tag functionality on prod",
-    owners = Seq(Owner.withGithub("buck06191")),
-    safeState = Off,
-    sellByDate = new LocalDate(2020, 8, 3),
-    exposeClientSide = true
-  )
-
-  Switch(
-    ABTests,
     "ab-remote-epic-variants",
     "Serve epics from remote service for subset of audience",
     owners = Seq(Owner.withGithub("nicl")),


### PR DESCRIPTION
## What does this change?
Removes no longer needed AB test for the `amp-experiment` removed in https://github.com/guardian/dotcom-rendering/pull/1692

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

