### PR TITLE
DCR Native ads fixes

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -33,15 +33,23 @@ const addClassIfHasClass = (newClassNames: Array<string>) =>
                     newClassNames.forEach(className => {
                         advert.node.classList.add(className);
                     });
-                    // Add 100% width from _adslot.scss
+                    // Add fluid styles from _adslot.scss
+                    // mark: 9473ae05-a901-4a8d-a51d-1b9c894d6e1f
                     if (
                         config.get('isDotcomRendering', false) &&
-                        !newClassNames.includes('ad-slot--im') &&
-                        !newClassNames.includes('ad-slot--carrot') &&
-                        !newClassNames.includes('ad-slot--offset-right') &&
                         newClassNames.includes('ad-slot--fluid')
-                    )
-                        advert.node.style.width = '100%';
+                    ) {
+                        advert.node.style.minHeight = '250px';
+                        advert.node.style.lineHeight = '10px';
+                        advert.node.style.padding = '0';
+                        advert.node.style.margin = '0';
+                        if (
+                            !newClassNames.includes('ad-slot--im') &&
+                            !newClassNames.includes('ad-slot--carrot') &&
+                            !newClassNames.includes('ad-slot--offset-right')
+                        )
+                            advert.node.style.width = '100%';
+                    }
                 });
             }
             return Promise.resolve();

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.js
@@ -100,6 +100,7 @@ const setBackground = (specs: AdSpec, adSlot: HTMLElement): Promise<any> => {
         backgroundParent.appendChild(background);
 
         // Inject styles in DCR (from _creatives.scss)
+        // mark: 0bf74539-5466-4907-ae7b-c0d8fc41112d
         if (config.get('isDotcomRendering', false)) {
             backgroundParent.style.position = 'absolute';
             backgroundParent.style.top = '0';

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -402,6 +402,7 @@
 
 /**
  * Fluid ad slots don't have widths
+ * mark: 9473ae05-a901-4a8d-a51d-1b9c894d6e1f
  */
 .ad-slot--fluid {
     min-height: 250px;

--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -655,6 +655,7 @@
 
 // In DCR, these styles are injected via JS via:
 // static/src/javascripts/projects/commercial/modules/messenger/background.js
+// mark: 0bf74539-5466-4907-ae7b-c0d8fc41112d
 .creative__background-parent {
     contain: size layout style;
     position: absolute;


### PR DESCRIPTION
## What does this change?

Some further styling fixes were required following #22751 

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes (please indicate your plans for DCR Implementation)

## Screenshots

![image](https://user-images.githubusercontent.com/76776/86453111-2de27480-bd15-11ea-96cb-c41621122d02.png)

![image](https://user-images.githubusercontent.com/76776/86453278-6da95c00-bd15-11ea-9742-a9026066be21.png)


## What is the value of this and can you measure success?

All native ads (fabric, interscoller, parallax mpu) render correctly.

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
