### PR TITLE
Make merchandising-high lazy load

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/display-lazy-ads.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/display-lazy-ads.js
@@ -4,7 +4,7 @@ import { loadAdvert } from 'commercial/modules/dfp/load-advert';
 import { Advert } from 'commercial/modules/dfp/Advert';
 import { enableLazyLoad } from 'commercial/modules/dfp/lazy-load';
 
-const advertsToInstantlyLoad = ['dfp-ad--merchandising-high', 'dfp-ad--im'];
+const advertsToInstantlyLoad = ['dfp-ad--im'];
 
 const instantLoad = (): void => {
     const instantLoadAdverts = dfpEnv.advertsToLoad.filter(


### PR DESCRIPTION
## What does this change?

The `merchandising-high` ad slot was previously set to instant load to prevent interactions with the Outbrain slot. With outbrain removed, this stops `merchandising-high` from instant loading, reducing ad-serving fees and allowing better exclusionary targeting where needed.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No - not as far as I'm aware
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
