### PR TITLE
Better extraction of the calloutsUrl

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -466,7 +466,7 @@ object DotcomponentsDataModel {
     // This is meant to ensure that DCP and DCR use the same dates.
     val displayedDateTimes: DisplayedDateTimesDCR = ArticleDateTimes.makeDisplayedDateTimesDCR(articleDateTimes, request)
     val campaigns = page.getJavascriptConfig.get("campaigns")
-    val calloutsUrl = page.getJavascriptConfig.get("calloutsUrl").map(_.toString())
+    val calloutsUrl: Option[String] = page.getJavascriptConfig.get("calloutsUrl").flatMap(_.asOpt[String])
 
     Block(
       id = block.id,


### PR DESCRIPTION
## What does this change?

Better extraction of the `calloutsUrl`. Follow up of https://github.com/guardian/frontend/pull/22770
