### PR TITLE
Revert "Merge pull request #22772 from guardian/bump-identity-lib-removing-media

### DIFF
--- a/common/app/views/fragments/email/signup/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/emailSignUp.scala.html
@@ -15,6 +15,7 @@
     bestOfOpinionUS.identityName -> "comment",
     bookmarks.identityName -> "review",
     theFiver.identityName -> "feature",
+    mediaBriefing.identityName -> "media",
     theLongRead.identityName -> "feature",
     documentaries.identityName -> "plaindark",
     theFlyer.identityName -> "feature",

--- a/identity/app/controllers/editprofile/ConsentsJourney.scala
+++ b/identity/app/controllers/editprofile/ConsentsJourney.scala
@@ -162,7 +162,7 @@ trait ConsentsJourney
           emailFilledForm,
           guestPasswordSetForm.getOrElse(GuestPasswordForm.form()),
           newsletterService.getEmailSubscriptions(emailFilledForm),
-          EmailNewsletters.publicNewsletters)
+          EmailNewsletters.all)
       )(page, request, context))
     }
   }
@@ -186,7 +186,7 @@ trait ConsentsJourney
           idUrlBuilder,
           emailFilledForm,
           newsletterService.getEmailSubscriptions(emailFilledForm),
-          EmailNewsletters.publicNewsletters,
+          EmailNewsletters.all,
           consentHint,
           skin = None
         ))(page, request, context)

--- a/identity/app/controllers/editprofile/EditProfileFormHandling.scala
+++ b/identity/app/controllers/editprofile/EditProfileFormHandling.scala
@@ -130,7 +130,7 @@ trait EditProfileFormHandling extends EditProfileControllerComponents {
             idUrlBuilder,
             emailFilledForm,
             newsletterService.getEmailSubscriptions(emailFilledForm),
-            EmailNewsletters.publicNewsletters,
+            EmailNewsletters.all,
             consentsUpdated,
             consentHint,
             changedEmail

--- a/identity/app/views/completeConsents.scala.html
+++ b/identity/app/views/completeConsents.scala.html
@@ -1,7 +1,7 @@
+@import com.gu.identity.model.EmailNewsletters
 @import services.EmailPrefsData
 
 @import controllers.editprofile.GuestPasswordFormData
-@import com.gu.identity.model.EmailNewsletter
 @(
     idRequest: services.IdentityRequest,
     idUrlBuilder: services.IdentityUrlBuilder,
@@ -10,7 +10,7 @@
     emailPrefsForm: Form[EmailPrefsData],
     setPasswordForm: Form[GuestPasswordFormData],
     emailSubscriptions: List[String],
-    availableLists: List[EmailNewsletter],
+    availableLists: EmailNewsletters,
 )(implicit request: RequestHeader, messages: play.api.i18n.Messages)
 
 @import common.LinkTo

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -2,6 +2,7 @@
 @import conf.Configuration
 @import views.support.RenderClasses
 @import model.{ApplicationContext, IdentityPage}
+@import com.gu.identity.model.EmailNewsletters
 @import services.EmailPrefsData
 @import form.IdFormHelpers.nonInputFields
 @import views.support.`package`.Seq2zipWithRowInfo
@@ -12,7 +13,6 @@
 @import controllers.editprofile.ProfileForms
 @import _root_.utils.ConsentsJourneyType._
 
-@import com.gu.identity.model.EmailNewsletter
 @(
     user: com.gu.identity.model.User,
     forms: ProfileForms,
@@ -22,7 +22,7 @@
     idUrlBuilder: services.IdentityUrlBuilder,
     emailPrefsForm: Form[EmailPrefsData],
     emailSubscriptions: List[String],
-    availableLists: List[EmailNewsletter],
+    availableLists: EmailNewsletters,
     consentHint: Option[String] = None,
     skin: Option[String] = None)(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
 

--- a/identity/app/views/fragments/emailListCategories.scala.html
+++ b/identity/app/views/fragments/emailListCategories.scala.html
@@ -1,11 +1,11 @@
 @import _root_.form.IdFormHelpers.nonInputFields
-@import _root_.com.gu.identity.model.EmailNewsletter
+@import _root_.com.gu.identity.model.{EmailNewsletter, EmailNewsletters}
 @import services.EmailPrefsData
 @import views.support.`package`.Seq2zipWithRowInfo
 
 @(
     emailPrefsForm: Form[EmailPrefsData],
-    availableLists: List[EmailNewsletter],
+    availableLists: EmailNewsletters,
     emailSubscriptions: List[String],
     startsOpen: Boolean = false
 )(implicit request: RequestHeader, messages: play.api.i18n.Messages)
@@ -41,7 +41,7 @@
     ).zipWithIndex.map { case (theme, index) =>
         @emailListCategoryList(
             theme,
-            availableLists.filter(_.theme == theme),
+            availableLists.subscriptions.filter(_.theme == theme),
             (startsOpen == true && index == 0)
         )
     }

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -1,12 +1,13 @@
+@import com.gu.identity.model.EmailNewsletters
+
 @import services.EmailPrefsData
 
 @import com.gu.identity.model.User
-@import com.gu.identity.model.EmailNewsletter
 @(
     page: model.Page,
     emailPrefsForm: Form[EmailPrefsData],
     emailSubscriptions: List[String],
-    availableLists: List[EmailNewsletter],
+    availableLists: EmailNewsletters,
     idRequest: services.IdentityRequest,
     idUrlBuilder: services.IdentityUrlBuilder)(implicit request: RequestHeader, messages: play.api.i18n.Messages)
 

--- a/identity/app/views/profile/privacyForm.scala.html
+++ b/identity/app/views/profile/privacyForm.scala.html
@@ -3,18 +3,18 @@
 @import com.gu.identity.model.Consent
 @import com.gu.identity.model.Consent._
 @import model.IdentityPage
+@import com.gu.identity.model.EmailNewsletters
 @import services.EmailPrefsData
 @import views.support.fragment.Switch._
 @import views.support.fragment.ConsentChannel._
 
-@import com.gu.identity.model.EmailNewsletter
 @(idUrlBuilder: services.IdentityUrlBuilder,
   idRequest: services.IdentityRequest,
   user: com.gu.identity.model.User,
   privacyForm: Form[_root_.form.PrivacyFormData],
   emailPrefsForm: Form[EmailPrefsData],
   emailSubscriptions: List[String],
-  availableLists: List[EmailNewsletter],
+  availableLists: EmailNewsletters,
   consentsUpdated: Boolean = false,
   consentHint: Option[String] = None
 )(implicit request: RequestHeader, messages: play.api.i18n.Messages)

--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -1,8 +1,8 @@
 @import views.support.RenderClasses
+@import com.gu.identity.model.EmailNewsletters
 @import services.EmailPrefsData
 @import controllers.editprofile.ProfileForms
 
-@import com.gu.identity.model.EmailNewsletter
 @(
     activeUrl: String,
     user: com.gu.identity.model.User,
@@ -11,7 +11,7 @@
     idUrlBuilder: services.IdentityUrlBuilder,
     emailPrefsForm: Form[EmailPrefsData],
     emailSubscriptions: List[String],
-    availableLists: List[EmailNewsletter],
+    availableLists: EmailNewsletters,
     consentsUpdated: Boolean,
     consentHint: Option[String],
     changedEmail: Option[String] = None

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.217"
+  val identityLibVersion = "3.207"
   val awsVersion = "1.11.240"
   val capiVersion = "17.1"
   val faciaVersion = "3.0.20"


### PR DESCRIPTION
revert dependency hell introduced after bumping identity library.

This issue didn't seem to occur when deploying to CODE. These dependency issues can be non-deterministic 😢 

```
Exception in thread "main" java.lang.NoClassDefFoundError: com/fasterxml/jackson/core/exc/InputCoercionException
        at com.fasterxml.jackson.databind.deser.std.JdkDeserializers.<clinit>(JdkDeserializers.java:26)
        at com.fasterxml.jackson.databind.deser.BasicDeserializerFactory.findDefaultDeserializer(BasicDeserializerFactory.java:1926)
        at com.fasterxml.jackson.databind.deser.BeanDeserializerFactory.findStdDeserializer(BeanDeserializerFactory.java:167)
        at com.fasterxml.jackson.databind.deser.BeanDeserializerFactory.createBeanDeserializer(BeanDeserializerFactory.java:131)
        at com.fasterxml.jackson.databind.deser.DeserializerCache._createDeserializer2(DeserializerCache.java:414)
        at com.fasterxml.jackson.databind.deser.DeserializerCache._createDeserializer(DeserializerCache.java:349)
        at com.fasterxml.jackson.databind.deser.DeserializerCache._createAndCache2(DeserializerCache.java:264)
        at com.fasterxml.jackson.databind.deser.DeserializerCache._createAndCacheValueDeserializer(DeserializerCache.java:244)
        at com.fasterxml.jackson.databind.deser.DeserializerCache.findValueDeserializer(DeserializerCache.java:142)
        at com.fasterxml.jackson.databind.DeserializationContext.findRootValueDeserializer(DeserializationContext.java:491)
        at com.fasterxml.jackson.databind.ObjectMapper._findRootDeserializer(ObjectMapper.java:4669)
        at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4478)
        at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3365)
        at com.amazonaws.internal.config.InternalConfig.loadfrom(InternalConfig.java:250)
        at com.amazonaws.internal.config.InternalConfig.load(InternalConfig.java:263)
        at com.amazonaws.internal.config.InternalConfig$Factory.<clinit>(InternalConfig.java:336)
        at com.amazonaws.util.VersionInfoUtils.userAgent(VersionInfoUtils.java:142)
        at com.amazonaws.util.VersionInfoUtils.initializeUserAgent(VersionInfoUtils.java:137)
        at com.amazonaws.util.VersionInfoUtils.getUserAgent(VersionInfoUtils.java:100)
        at com.amazonaws.internal.EC2CredentialsUtils.<clinit>(EC2CredentialsUtils.java:46)
        at com.amazonaws.auth.EC2CredentialsFetcher.fetchCredentials(EC2CredentialsFetcher.java:121)
        at com.amazonaws.auth.EC2CredentialsFetcher.getCredentials(EC2CredentialsFetcher.java:82)
        at com.amazonaws.auth.InstanceProfileCredentialsProvider.getCredentials(InstanceProfileCredentialsProvider.java:172)
        at com.amazonaws.auth.AWSCredentialsProviderChain.getCredentials(AWSCredentialsProviderChain.java:117)
        at common.GuardianConfiguration$aws$.liftedTree1$1(configuration.scala:621)
        at common.GuardianConfiguration$aws$.<init>(configuration.scala:620)
        at common.GuardianConfiguration.aws$lzycompute$1(configuration.scala:601)
        at common.GuardianConfiguration.aws(configuration.scala:601)
        at services.ParameterStore.client$lzycompute(ParameterStore.scala:13)
        at services.ParameterStore.client(ParameterStore.scala:13)
        at services.ParameterStore.pagination$1(ParameterStore.scala:38)
        at services.ParameterStore.getPath(ParameterStore.scala:50)
        at common.GuardianConfiguration$.configFromParameterStore(configuration.scala:77)
        at common.GuardianConfiguration$.configuration$lzycompute(configuration.scala:92)
        at common.GuardianConfiguration$.configuration(configuration.scala:86)
        at common.GuardianConfiguration$id$.accountDeletionApiKey$lzycompute(configuration.scala:341)
        at common.GuardianConfiguration$id$.accountDeletionApiKey(configuration.scala:341)
        at conf.IdentityConfiguration.<init>(IdentityConfiguration.scala:7)
        at conf.IdentityConfigurationComponents.$init$(IdentityConfigurationComponents.scala:13)
        at AppLoader$$anon$1.<init>(AppLoader.scala:24)
        at AppLoader.buildComponents(AppLoader.scala:24)
        at app.FrontendApplicationLoader.load(FrontendApplicationLoader.scala:22)
        at app.FrontendApplicationLoader.load$(FrontendApplicationLoader.scala:18)
        at AppLoader.load(AppLoader.scala:23)
        at play.core.server.ProdServerStart$.start(ProdServerStart.scala:51)
        at play.core.server.ProdServerStart$.main(ProdServerStart.scala:25)
        at play.core.server.ProdServerStart.main(ProdServerStart.scala)
Caused by: java.lang.ClassNotFoundException: com.fasterxml.jackson.core.exc.InputCoercionException
        at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
        ... 47 more
```