### PR TITLE
Bump identity library to remove retired newsletters

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,7 @@ val common = library("common").settings(
     capiAws,
     okhttp,
     jsonSchema
-  )
+  ) ++ jackson
 ).settings(
     mappings in TestAssets ~= filterAssets
 )

--- a/common/app/views/fragments/email/signup/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/emailSignUp.scala.html
@@ -15,7 +15,6 @@
     bestOfOpinionUS.identityName -> "comment",
     bookmarks.identityName -> "review",
     theFiver.identityName -> "feature",
-    mediaBriefing.identityName -> "media",
     theLongRead.identityName -> "feature",
     documentaries.identityName -> "plaindark",
     theFlyer.identityName -> "feature",

--- a/identity/app/controllers/editprofile/ConsentsJourney.scala
+++ b/identity/app/controllers/editprofile/ConsentsJourney.scala
@@ -162,7 +162,7 @@ trait ConsentsJourney
           emailFilledForm,
           guestPasswordSetForm.getOrElse(GuestPasswordForm.form()),
           newsletterService.getEmailSubscriptions(emailFilledForm),
-          EmailNewsletters.all)
+          EmailNewsletters.publicNewsletters)
       )(page, request, context))
     }
   }
@@ -186,7 +186,7 @@ trait ConsentsJourney
           idUrlBuilder,
           emailFilledForm,
           newsletterService.getEmailSubscriptions(emailFilledForm),
-          EmailNewsletters.all,
+          EmailNewsletters.publicNewsletters,
           consentHint,
           skin = None
         ))(page, request, context)

--- a/identity/app/controllers/editprofile/EditProfileFormHandling.scala
+++ b/identity/app/controllers/editprofile/EditProfileFormHandling.scala
@@ -130,7 +130,7 @@ trait EditProfileFormHandling extends EditProfileControllerComponents {
             idUrlBuilder,
             emailFilledForm,
             newsletterService.getEmailSubscriptions(emailFilledForm),
-            EmailNewsletters.all,
+            EmailNewsletters.publicNewsletters,
             consentsUpdated,
             consentHint,
             changedEmail

--- a/identity/app/views/completeConsents.scala.html
+++ b/identity/app/views/completeConsents.scala.html
@@ -1,7 +1,7 @@
-@import com.gu.identity.model.EmailNewsletters
 @import services.EmailPrefsData
 
 @import controllers.editprofile.GuestPasswordFormData
+@import com.gu.identity.model.EmailNewsletter
 @(
     idRequest: services.IdentityRequest,
     idUrlBuilder: services.IdentityUrlBuilder,
@@ -10,7 +10,7 @@
     emailPrefsForm: Form[EmailPrefsData],
     setPasswordForm: Form[GuestPasswordFormData],
     emailSubscriptions: List[String],
-    availableLists: EmailNewsletters,
+    availableLists: List[EmailNewsletter],
 )(implicit request: RequestHeader, messages: play.api.i18n.Messages)
 
 @import common.LinkTo

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -2,7 +2,6 @@
 @import conf.Configuration
 @import views.support.RenderClasses
 @import model.{ApplicationContext, IdentityPage}
-@import com.gu.identity.model.EmailNewsletters
 @import services.EmailPrefsData
 @import form.IdFormHelpers.nonInputFields
 @import views.support.`package`.Seq2zipWithRowInfo
@@ -13,6 +12,7 @@
 @import controllers.editprofile.ProfileForms
 @import _root_.utils.ConsentsJourneyType._
 
+@import com.gu.identity.model.EmailNewsletter
 @(
     user: com.gu.identity.model.User,
     forms: ProfileForms,
@@ -22,7 +22,7 @@
     idUrlBuilder: services.IdentityUrlBuilder,
     emailPrefsForm: Form[EmailPrefsData],
     emailSubscriptions: List[String],
-    availableLists: EmailNewsletters,
+    availableLists: List[EmailNewsletter],
     consentHint: Option[String] = None,
     skin: Option[String] = None)(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
 

--- a/identity/app/views/fragments/emailListCategories.scala.html
+++ b/identity/app/views/fragments/emailListCategories.scala.html
@@ -1,11 +1,11 @@
 @import _root_.form.IdFormHelpers.nonInputFields
-@import _root_.com.gu.identity.model.{EmailNewsletter, EmailNewsletters}
+@import _root_.com.gu.identity.model.EmailNewsletter
 @import services.EmailPrefsData
 @import views.support.`package`.Seq2zipWithRowInfo
 
 @(
     emailPrefsForm: Form[EmailPrefsData],
-    availableLists: EmailNewsletters,
+    availableLists: List[EmailNewsletter],
     emailSubscriptions: List[String],
     startsOpen: Boolean = false
 )(implicit request: RequestHeader, messages: play.api.i18n.Messages)
@@ -41,7 +41,7 @@
     ).zipWithIndex.map { case (theme, index) =>
         @emailListCategoryList(
             theme,
-            availableLists.subscriptions.filter(_.theme == theme),
+            availableLists.filter(_.theme == theme),
             (startsOpen == true && index == 0)
         )
     }

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -1,13 +1,12 @@
-@import com.gu.identity.model.EmailNewsletters
-
 @import services.EmailPrefsData
 
 @import com.gu.identity.model.User
+@import com.gu.identity.model.EmailNewsletter
 @(
     page: model.Page,
     emailPrefsForm: Form[EmailPrefsData],
     emailSubscriptions: List[String],
-    availableLists: EmailNewsletters,
+    availableLists: List[EmailNewsletter],
     idRequest: services.IdentityRequest,
     idUrlBuilder: services.IdentityUrlBuilder)(implicit request: RequestHeader, messages: play.api.i18n.Messages)
 

--- a/identity/app/views/profile/privacyForm.scala.html
+++ b/identity/app/views/profile/privacyForm.scala.html
@@ -3,18 +3,18 @@
 @import com.gu.identity.model.Consent
 @import com.gu.identity.model.Consent._
 @import model.IdentityPage
-@import com.gu.identity.model.EmailNewsletters
 @import services.EmailPrefsData
 @import views.support.fragment.Switch._
 @import views.support.fragment.ConsentChannel._
 
+@import com.gu.identity.model.EmailNewsletter
 @(idUrlBuilder: services.IdentityUrlBuilder,
   idRequest: services.IdentityRequest,
   user: com.gu.identity.model.User,
   privacyForm: Form[_root_.form.PrivacyFormData],
   emailPrefsForm: Form[EmailPrefsData],
   emailSubscriptions: List[String],
-  availableLists: EmailNewsletters,
+  availableLists: List[EmailNewsletter],
   consentsUpdated: Boolean = false,
   consentHint: Option[String] = None
 )(implicit request: RequestHeader, messages: play.api.i18n.Messages)

--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -1,8 +1,8 @@
 @import views.support.RenderClasses
-@import com.gu.identity.model.EmailNewsletters
 @import services.EmailPrefsData
 @import controllers.editprofile.ProfileForms
 
+@import com.gu.identity.model.EmailNewsletter
 @(
     activeUrl: String,
     user: com.gu.identity.model.User,
@@ -11,7 +11,7 @@
     idUrlBuilder: services.IdentityUrlBuilder,
     emailPrefsForm: Form[EmailPrefsData],
     emailSubscriptions: List[String],
-    availableLists: EmailNewsletters,
+    availableLists: List[EmailNewsletter],
     consentsUpdated: Boolean,
     consentHint: Option[String],
     changedEmail: Option[String] = None

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -78,13 +78,17 @@ object Dependencies {
   val okhttp = "com.squareup.okhttp3" % "okhttp" % "3.10.0"
   val jsonSchema = "com.eclipsesource"  %% "play-json-schema-validator" % "0.9.5-M4"
 
-  // Fixing transient dependency issue
-  // AWS SDK (1.11.181), which kinesis-logback-appender depends on, brings com.fasterxml.jackson.core and com.fasterxml.jackson.dataformat libs in version 2.6.9
-  // play-json comes with com.fasterxml.core 2.8.9 (without jackson.dataformat) which will evict jackson.core 2.6.9
-  // This lead to incompatible version of jackson.core and jackson.dataformat to be present in the class path
-  // This forces jackson.dataformat to the same version as the one brough by play-json
-  // This line could be remove as soon as the AWS SDK is updated to use the same version coming with play-json
-  val jacksonDataFormat = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % "2.8.9"
+  // sbt-native-packager does not seem respect the latestRevision conflict manager when building the
+  // classpath in the executable shell file for the service. The classpath output is different to the
+  // dependencies indicated by the dependency tree plugin. Specifying jackson versions manually seems
+  // to be the only way of making sbt-native-packager build a classpath with consistent jackson versions.
+  val jacksonVersion = "2.11.0"
+  val jacksonDataFormat = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor"  % jacksonVersion
+  val jacksonCore = "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion
+  val jacksonDataType = "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion
+  val jacksonDataTypeJdk8 = "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion
+  val jacksonAnnotations = "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion
+  val jackson = Seq(jacksonDataFormat, jacksonCore, jacksonDataType, jacksonAnnotations)
 
   // Web jars
   val bootstrap = "org.webjars" % "bootstrap" % "3.3.7"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.207"
+  val identityLibVersion = "3.217"
   val awsVersion = "1.11.240"
   val capiVersion = "17.1"
   val faciaVersion = "3.0.20"


### PR DESCRIPTION
## What does this change?

Bump identity library to remove retired newsletters, "Coronavirus: the week explained" and "Media Briefing". Also refactor since library has changed slightly

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

![image](https://user-images.githubusercontent.com/29203769/86474681-3fd70e00-bd3b-11ea-9980-a8aa0a049ae5.png)


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [X] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
