### PR TITLE
added pseudo-element as real element

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/messenger/background.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.js
@@ -142,7 +142,7 @@ const setBackground = (specs: AdSpec, adSlot: HTMLElement): Promise<any> => {
                             );
                         }
 
-                        if (config.get('isDotcomRendering', false) || true) {
+                        if (config.get('isDotcomRendering', false)) {
                             background.style.position = 'fixed';
                             const bottomLine = document.createElement('div');
                             bottomLine.classList.add('ad-slot__line');

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.js
@@ -131,9 +131,6 @@ const setBackground = (specs: AdSpec, adSlot: HTMLElement): Promise<any> => {
                         adSlot.style.height = '85vh';
                         adSlot.style.marginBottom = '12px';
 
-                        if (config.get('isDotcomRendering', false))
-                            background.style.position = 'fixed';
-
                         if (specs.ctaUrl != null) {
                             const ctaURLAnchor = document.createElement('a');
                             ctaURLAnchor.href = specs.ctaUrl;
@@ -143,6 +140,17 @@ const setBackground = (specs: AdSpec, adSlot: HTMLElement): Promise<any> => {
                                 ctaURLAnchor,
                                 adSlot.firstChild
                             );
+                        }
+
+                        if (config.get('isDotcomRendering', false) || true) {
+                            background.style.position = 'fixed';
+                            const bottomLine = document.createElement('div');
+                            bottomLine.classList.add('ad-slot__line');
+                            bottomLine.style.position = 'absolute';
+                            bottomLine.style.width = '100%';
+                            bottomLine.style.bottom = '0';
+                            bottomLine.style.borderBottom = '1px solid #dcdcdc';
+                            backgroundParent.appendChild(bottomLine);
                         }
                     } else {
                         adSlot.insertBefore(


### PR DESCRIPTION
## What does this change?

This change fixes aesthetic discrepancies of native ads between frontend and DCR
- [X] adds a grey line at the bottom of Interscroller ads.
- [x] allows fabric videos to be 1920px wide --> https://github.com/guardian/dotcom-rendering/pull/1706

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes (The commercial bundle will handle this automatically)

## Screenshots

![image](https://user-images.githubusercontent.com/76776/86598636-4eb8fd00-bf95-11ea-8173-7b36a9f5c97f.png)

The grey line is an actual element rather than a pseudo-element, as these cannot be injected via JS.

## What is the value of this and can you measure success?

The look of ads should be identical between frontend and DCR.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
