### PR TITLE
Update sign in gate design to fix scroll issue

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/centesimus-control-2.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/centesimus-control-2.js
@@ -52,8 +52,6 @@ const htmlTemplate: ({
             <a class="signin-gate__link--var signin-gate__signin--var js-signin-gate__sign-in signin-gate__link-no-ptm signin-gate__center-424" href="${signInUrl}">Sign in</a>
         </div>
         <div class="signin-gate__faqlinks--var signin-gate__margin-top--var">
-        <div class="signin-gate__faqlinks--fullwidth--var"></div>
-
             <div class="signin-gate__buttons">
                 <a class="signin-gate__link--var js-signin-gate__why" href="${guUrl}/membership/2019/dec/20/signing-in-to-the-guardian">Why register & how does it help?</a>
             </div>

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/centesimus-control-2.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/centesimus-control-2.js
@@ -52,6 +52,7 @@ const htmlTemplate: ({
             <a class="signin-gate__link--var signin-gate__signin--var js-signin-gate__sign-in signin-gate__link-no-ptm signin-gate__center-424" href="${signInUrl}">Sign in</a>
         </div>
         <div class="signin-gate__faqlinks--var signin-gate__margin-top--var">
+            <div class="signin-gate__faqlinks--fullwidth--var"></div>
             <div class="signin-gate__buttons">
                 <a class="signin-gate__link--var js-signin-gate__why" href="${guUrl}/membership/2019/dec/20/signing-in-to-the-guardian">Why register & how does it help?</a>
             </div>

--- a/static/src/stylesheets/module/identity/_sign-in-gate.scss
+++ b/static/src/stylesheets/module/identity/_sign-in-gate.scss
@@ -316,9 +316,27 @@
 }
 
 .signin-gate__faqlinks--var {
+    background-color: $brightness-97;
     padding-bottom: $gs-baseline * 3;
     padding-top: $gs-baseline * 1;
     position: relative;
+}
+
+.signin-gate__faqlinks--fullwidth--var {
+    background-color: $brightness-97;
+    z-index: -1;
+}
+
+.signin-gate__faqlinks--fullwidth--var:before {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: -9999px;
+    right: 0;
+    border-left: 9999px solid $brightness-97;
+    box-shadow: 9999px 0 0 $brightness-97;
+    z-index: -1;
 }
 
 // VARIANT DESIGN - article gradient overlay changes // vii-variant

--- a/static/src/stylesheets/module/identity/_sign-in-gate.scss
+++ b/static/src/stylesheets/module/identity/_sign-in-gate.scss
@@ -328,7 +328,7 @@
 }
 
 .signin-gate__faqlinks--fullwidth--var:before {
-    content: "";
+    content: '';
     position: absolute;
     top: 0;
     bottom: 0;

--- a/static/src/stylesheets/module/identity/_sign-in-gate.scss
+++ b/static/src/stylesheets/module/identity/_sign-in-gate.scss
@@ -316,21 +316,9 @@
 }
 
 .signin-gate__faqlinks--var {
-    background-color: $brightness-97;
     padding-bottom: $gs-baseline * 3;
     padding-top: $gs-baseline * 1;
     position: relative;
-}
-
-.signin-gate__faqlinks--fullwidth--var {
-    background-color: $brightness-97;
-    width: 100%;
-    height: inherit;
-    position: absolute;
-    left: -$gs-baseline;
-    top: 0;
-    bottom: 0;
-    z-index: -1;
 }
 
 // VARIANT DESIGN - article gradient overlay changes // vii-variant

--- a/static/src/stylesheets/module/identity/_sign-in-gate.scss
+++ b/static/src/stylesheets/module/identity/_sign-in-gate.scss
@@ -324,10 +324,10 @@
 
 .signin-gate__faqlinks--fullwidth--var {
     background-color: $brightness-97;
-    width: 200vw;
+    width: 100%;
     height: inherit;
     position: absolute;
-    left: calc(50% - 50vw);
+    left: -$gs-baseline;
     top: 0;
     bottom: 0;
     z-index: -1;


### PR DESCRIPTION
## What does this change?
Sign in gate causing overflow on the x axis due to background colour spanning the full width.

Changed it to use a box shadow approach to show the extended background colour instead, which doesn't cause the overflow on the x-axis.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

![localhost_9000_science_grrlscientist_2012_aug_07_3 (2)](https://user-images.githubusercontent.com/13315440/86739236-a440e880-c02d-11ea-84ad-e5a7bf82bb5e.png)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
