### PR TITLE
Add includeSubDomains to HSTS on Identity for profile.theguardian.com 

### DIFF
--- a/identity/app/http/StrictTransportSecurityHeaderFilter.scala
+++ b/identity/app/http/StrictTransportSecurityHeaderFilter.scala
@@ -8,7 +8,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class StrictTransportSecurityHeaderFilter(implicit val mat: Materializer, executionContext: ExecutionContext) extends Filter {
 
   private val OneYearInSeconds = 31536000
-  private val Header = "Strict-Transport-Security" -> s"max-age=$OneYearInSeconds; preload"
+  private val Header = "Strict-Transport-Security" -> s"max-age=$OneYearInSeconds; includeSubDomains; preload"
 
   override def apply(nextFilter: (RequestHeader) => Future[Result])(request: RequestHeader): Future[Result] = {
     nextFilter(request).map(_.withHeaders(Header))

--- a/identity/test/filters/StrictTransportSecurityHeaderFilterTest.scala
+++ b/identity/test/filters/StrictTransportSecurityHeaderFilterTest.scala
@@ -25,7 +25,7 @@ import scala.concurrent.duration._
 
     val result = new StrictTransportSecurityHeaderFilter().apply(action _)(request)
 
-    Await.result(result, 1.second).header.headers("Strict-Transport-Security") should equal("max-age=31536000; preload")
+    Await.result(result, 1.second).header.headers("Strict-Transport-Security") should equal("max-age=31536000; includeSubDomains; preload")
   }
 
 }


### PR DESCRIPTION
This adds the includeSubDomains flag to the StrictTransportSecurity Header for profile.theguardian.com 

While neither preload nor includeSubDomains options are strictly necessary on a subdomain like profile.theguardian.com, after discussion with Infosec, it was decided there was no harm in in harmonising the HSTS header across Guardian subdomains. 

This change has been tested in CODE. 
- [x] A user can created an account and is taken through the consent flow which is served from this project
- [x] A user can sign in 
- [x] A social user can created an account and is taken through the consent which is served from this project
- [x] A social user can sign in 
- [x] Updated Header seen in the browser response
