### PR TITLE
add european-union region to RR banners (backend only)

### DIFF
--- a/admin/app/controllers/admin/ReaderRevenueAdminController.scala
+++ b/admin/app/controllers/admin/ReaderRevenueAdminController.scala
@@ -23,7 +23,7 @@ class ReaderRevenueAdminController(wsClient: WSClient, val controllerComponents:
   }
 
   def renderContributionsBannerAdmin: Action[AnyContent] = Action { implicit request =>
-    NoCache(Ok(views.html.readerRevenue.bannerDeploys(ReaderRevenueRegion.allRegions)))
+    NoCache(Ok(views.html.readerRevenue.bannerDeploys(ReaderRevenueRegion.allRegions.filterNot(_ == EU))))
   }
 
   def renderSubscriptionsBannerAdmin: Action[AnyContent] = Action { implicit request =>

--- a/admin/app/controllers/admin/ReaderRevenueAdminController.scala
+++ b/admin/app/controllers/admin/ReaderRevenueAdminController.scala
@@ -35,7 +35,7 @@ class ReaderRevenueAdminController(wsClient: WSClient, val controllerComponents:
   def redeploySubscriptionsBanner(region: String): Action[AnyContent] = redeployBanner(region, SubscriptionsBanner)
 
   def redeployBanner(region: String, bannerType: BannerType): Action[AnyContent] = Action.async { implicit request =>
-    ReaderRevenueRegion.fromString(region).fold(Future.successful(redeployFailed(new Throwable("attempted to redeploy banner in unknown region"), bannerType))){ region: ReaderRevenueRegion =>
+    ReaderRevenueRegion.fromName(region).fold(Future.successful(redeployFailed(new Throwable("attempted to redeploy banner in unknown region"), bannerType))){ region: ReaderRevenueRegion =>
       val requester: String = UserIdentity.fromRequest(request) map(_.fullName) getOrElse "unknown user (dev-build?)"
       val millisSinceEpoch = DateTime.now.getMillis()
       val jsonLog: JsValue = Json.toJson(BannerDeploy(millisSinceEpoch))

--- a/admin/app/views/readerRevenue/subscriptionsBannerDeploys.scala.html
+++ b/admin/app/views/readerRevenue/subscriptionsBannerDeploys.scala.html
@@ -11,7 +11,7 @@
     </form>
 }
 
-@admin_main("Redeploy Contributions Banner", isAuthed = true) {
+@admin_main("Redeploy Subscriptions Banner", isAuthed = true) {
 
     <h1>Subscriptions Banner Redeploy</h1>
 

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -62,7 +62,7 @@ GET         /reader-revenue                                                     
 GET         /reader-revenue/contributions-banner                                                    controllers.admin.ReaderRevenueAdminController.renderContributionsBannerAdmin()
 GET         /reader-revenue/subscriptions-banner                                                    controllers.admin.ReaderRevenueAdminController.renderSubscriptionsBannerAdmin()
 POST        /reader-revenue/redeploy-contributions-banner/$region<united-kingdom|united-states|australia|rest-of-world>                     controllers.admin.ReaderRevenueAdminController.redeployContributionsBanner(region)
-POST        /reader-revenue/redeploy-subscriptions-banner/$region<united-kingdom|united-states|australia|rest-of-world>                     controllers.admin.ReaderRevenueAdminController.redeploySubscriptionsBanner(region)
+POST        /reader-revenue/redeploy-subscriptions-banner/$region<united-kingdom|united-states|australia|rest-of-world|european-union>                     controllers.admin.ReaderRevenueAdminController.redeploySubscriptionsBanner(region)
 
 # Commercial
 GET         /commercial                                                                             controllers.admin.CommercialController.renderCommercialMenu()

--- a/applications/app/controllers/ReaderRevenueAppController.scala
+++ b/applications/app/controllers/ReaderRevenueAppController.scala
@@ -15,7 +15,7 @@ class ReaderRevenueAppController(val controllerComponents: ControllerComponents)
   extends BaseController with ImplicitControllerExecutionContext with Logging {
 
   private[this] def getBannerDeployLog(strRegion: String, bannerType: BannerType): Option[String] = {
-    ReaderRevenueRegion.fromString(strRegion).fold(Option.empty[String]){ region: ReaderRevenueRegion =>
+    ReaderRevenueRegion.fromName(strRegion).fold(Option.empty[String]){ region: ReaderRevenueRegion =>
       S3.get(ReaderRevenueRegion.getBucketKey(region, bannerType))
     }
   }

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -8,7 +8,7 @@ GET         /assets/*path                                                       
 GET        /_healthcheck                                                        controllers.HealthCheck.healthCheck()
 
 GET        /reader-revenue/contributions-banner-deploy-log/$region<united-kingdom|united-states|australia|rest-of-world>                    controllers.ReaderRevenueAppController.contributionsBannerDeployLog(region: String)
-GET        /reader-revenue/subscriptions-banner-deploy-log/$region<united-kingdom|united-states|australia|rest-of-world>                    controllers.ReaderRevenueAppController.subscriptionsBannerDeployLog(region: String)
+GET        /reader-revenue/subscriptions-banner-deploy-log/$region<united-kingdom|united-states|australia|rest-of-world|european-union>                    controllers.ReaderRevenueAppController.subscriptionsBannerDeployLog(region: String)
 
 GET        /sitemaps/news.xml                                                   controllers.SiteMapController.renderNewsSiteMap()
 GET        /sitemaps/video.xml                                                  controllers.SiteMapController.renderVideoSiteMap()

--- a/common/app/model/readerRevenue/BannerDeploy.scala
+++ b/common/app/model/readerRevenue/BannerDeploy.scala
@@ -19,16 +19,15 @@ case object UK extends ReaderRevenueRegion { val name = "united-kingdom"}
 case object US extends ReaderRevenueRegion { val name = "united-states"}
 case object AU extends ReaderRevenueRegion { val name = "australia"}
 case object ROW extends ReaderRevenueRegion { val name = "rest-of-world"}
+case object EU extends ReaderRevenueRegion { val name = "european-union"}
 
 object ReaderRevenueRegion {
-  def fromString(region: String): Option[ReaderRevenueRegion] = {
-    region.toLowerCase() match {
-      case "united-kingdom" => Some(UK)
-      case "united-states" => Some(US)
-      case "australia" => Some(AU)
-      case "rest-of-world" => Some(ROW)
-      case _ => None
-    }
+
+  val allRegions: List[ReaderRevenueRegion] = List(UK, US, AU, ROW, EU)
+
+  def fromName(region: String): Option[ReaderRevenueRegion] = {
+    val toFind = region.toLowerCase()
+    allRegions.find(_.name == toFind)
   }
 
   def getBucketKey(region: ReaderRevenueRegion, bannerType: BannerType): String = {
@@ -39,7 +38,6 @@ object ReaderRevenueRegion {
     bucketKey + "-" + region.name + ".json"
   }
 
-  val allRegions: List[ReaderRevenueRegion] = List(UK, US, AU, ROW)
 }
 
 sealed trait BannerType {

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -9,9 +9,9 @@ GET            /reader-revenue                                                  
 GET            /reader-revenue/contributions-banner                                                                              controllers.admin.ReaderRevenueAdminController.renderContributionsBannerAdmin()
 GET            /reader-revenue/subscriptions-banner                                                                              controllers.admin.ReaderRevenueAdminController.renderSubscriptionsBannerAdmin()
 POST           /reader-revenue/redeploy-contributions-banner/$region<united-kingdom|united-states|australia|rest-of-world>       controllers.admin.ReaderRevenueAdminController.redeployContributionsBanner(region)
-POST           /reader-revenue/redeploy-subscriptions-banner/$region<united-kingdom|united-states|australia|rest-of-world>       controllers.admin.ReaderRevenueAdminController.redeploySubscriptionsBanner(region)
+POST           /reader-revenue/redeploy-subscriptions-banner/$region<united-kingdom|united-states|australia|rest-of-world|european-union>       controllers.admin.ReaderRevenueAdminController.redeploySubscriptionsBanner(region)
 GET            /reader-revenue/contributions-banner-deploy-log/$region<united-kingdom|united-states|australia|rest-of-world>     controllers.ReaderRevenueAppController.contributionsBannerDeployLog(region: String)
-GET            /reader-revenue/subscriptions-banner-deploy-log/$region<united-kingdom|united-states|australia|rest-of-world>     controllers.ReaderRevenueAppController.subscriptionsBannerDeployLog(region: String)
+GET            /reader-revenue/subscriptions-banner-deploy-log/$region<united-kingdom|united-states|australia|rest-of-world|european-union>     controllers.ReaderRevenueAppController.subscriptionsBannerDeployLog(region: String)
 
 GET            /email-newsletters                                                                                                controllers.SignupPageController.renderNewslettersPage()
 


### PR DESCRIPTION
## What does this change?

Following on from @GHaberis PR doing the client side work https://github.com/guardian/frontend/pull/22617

This PR adds a backend concept of EU.

I have copied the united kingdom file in the S3 bucket for PROD/CODE/DEV

https://console.aws.amazon.com/s3/buckets/aws-frontend-store/PROD/reader-revenue/?region=eu-west-1&tab=overview
![image](https://user-images.githubusercontent.com/7304387/86949004-ee1cf200-c145-11ea-8119-ed9b87c2c1aa.png)

The admin console at http://frontend.gutools.co.uk/reader-revenue/subscriptions-banner will have the extra button
![image](https://user-images.githubusercontent.com/7304387/86950646-52d94c00-c148-11ea-9019-1acecc49f7ff.png)

And the new endpoint will work rather than 404 (with a duplicate of the UK deployment date) 
API_NEXTGEN.co.uk/reader-revenue/subscriptions-banner-deploy-log/european-union

There will be a following PR to actually switch over once things are OK in the backend.

## Does this change need to be reproduced in dotcom-rendering ?

No this is just a tweak. Banners in DCR is a separate stream now.

## What is the value of this and can you measure success?

Customer targeting team want to be able to deploy EU separately depending on the news cycle. At the moment they can only deploy the two together.  Think of it as part of Brexit.

### Tested

- [x] Locally
- [ ] On CODE (optional)
