### PR TITLE
make client side fetch new EU region for subs banner deployment

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.js
@@ -56,11 +56,7 @@ const hasAcknowledged = bannerRedeploymentDate => {
 const selectorName = (bannerName: string) => (actionId: ?string) =>
     `#js-site-message--${bannerName}${actionId ? `__${actionId}` : ''}`;
 
-/**
- * We're temporarily using the "/united-kingdom" route
- * for users in the "european-union" region.
- */
-const hasAcknowledgedBanner = (region: ReaderRevenueRegion): Promise<boolean> => fetchJson(`/reader-revenue/subscriptions-banner-deploy-log/${region === 'european-union' ? 'united-kingdom' : region}`, {
+const hasAcknowledgedBanner = (region: ReaderRevenueRegion): Promise<boolean> => fetchJson(`/reader-revenue/subscriptions-banner-deploy-log/${region}`, {
         mode: 'cors',
     })
         .then(resp => hasAcknowledged(resp.time))


### PR DESCRIPTION
## What does this change?

Follow on for https://github.com/guardian/frontend/pull/22785
This PR makes the client side actually check the new EU banner deployment time.

This is separate so I can test the endpoint before releasing the thing that uses it.

### Tested

- [ ] Locally
- [ ] On CODE (optional)
