### PR TITLE
 make client side fetch new EU region for subs banner deployment

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.js
@@ -56,11 +56,7 @@ const hasAcknowledged = bannerRedeploymentDate => {
 const selectorName = (bannerName: string) => (actionId: ?string) =>
     `#js-site-message--${bannerName}${actionId ? `__${actionId}` : ''}`;
 
-/**
- * We're temporarily using the "/united-kingdom" route
- * for users in the "european-union" region.
- */
-const hasAcknowledgedBanner = (region: ReaderRevenueRegion): Promise<boolean> => fetchJson(`/reader-revenue/subscriptions-banner-deploy-log/${region === 'european-union' ? 'united-kingdom' : region}`, {
+const hasAcknowledgedBanner = (region: ReaderRevenueRegion): Promise<boolean> => fetchJson(`/reader-revenue/subscriptions-banner-deploy-log/${region}`, {
         mode: 'cors',
     })
         .then(resp => hasAcknowledged(resp.time))


### PR DESCRIPTION
Rerun of #22786 

I found after checking the fastly logs for api.nextgen that the new EU route was showing 404 every time.  I realised that I had tested the wrong url
The correct one was this and didn't work:
https://api.nextgen.guardianapps.co.uk/reader-revenue/subscriptions-banner-deploy-log/european-union
The existing ones were OK:
https://api.nextgen.guardianapps.co.uk/reader-revenue/subscriptions-banner-deploy-log/united-kingdom
This is the url I tested by mistake which DID work in prod the whole time!
https://theguardian.com/reader-revenue/subscriptions-banner-deploy-log/european-union


Once https://github.com/guardian/platform/pull/1409 is shipped and this url is returning 200 OK:
https://api.nextgen.guardianapps.co.uk/reader-revenue/subscriptions-banner-deploy-log/european-union

we can ship this PR.