### PR TITLE
Re support interactive embeds

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -136,6 +136,7 @@ object PageElement {
       case _: ImageBlockElement => true
       case _: InstagramBlockElement => true
       case _: InteractiveAtomBlockElement => true
+      case _: InteractiveBlockElement => true
       case _: MapBlockElement => true
       case _: ProfileAtomBlockElement => true
       case _: PullquoteBlockElement => true


### PR DESCRIPTION
## What does this change?

In https://github.com/guardian/frontend/pull/22717/files#diff-5775f8f47d521441655ea7d7f0ce47d8L507 I updated the mapping of InteractiveBlockElement from `AtomMarkupBlockElement` to a specific  `InteractiveBlockElement` but did not add this to the allowed block elements.

Along with https://github.com/guardian/dotcom-rendering/pull/1717 this PR allows Interactive Embeds through to DCR for AMP.

This had the effect on pages like [First Dog](https://www.theguardian.com/commentisfree/2020/jul/08/to-the-distress-of-wordists-a-dictionary-has-confirmed-the-lexical-veracity-of-irregardless) of 'allowing' the pages in AMP, but not showing the cartoon. Actually, what happens in this case is that the iframe invalidates the page but that is 'expected' and 'parity' behaviour (though not 100% desirable).

