### PR TITLE
Fix Sign In Gate Background Bug on Opinion

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
@@ -211,6 +211,20 @@ export const showPrivacySettingsCMPModule: () => void = () => {
     }
 };
 
+// add extra css on a given selector on an opinion page
+export const addCSSOnOpinion: ({
+    element: HTMLElement,
+    selector: string,
+    css: string
+}) => void = ({ element, selector, css }) => {
+    if (config.get(`page.tones`) === 'Comment') {
+        const selection = element.querySelector(selector);
+        if (selection) {
+            selection.classList.add(css);
+        }
+    }
+}
+
 // add the background color if the page the user is on is the opinion section
 export const addOpinionBgColour: ({
     element: HTMLElement,
@@ -277,6 +291,7 @@ export const setTemplate: ({
     ${template}
 `;
 
+// add opinion bg colour to gate fade
 export const addOverlayVariantCSS: ({
     element: HTMLElement,
     selector: string,
@@ -290,6 +305,15 @@ export const addOverlayVariantCSS: ({
         }
     }
 };
+
+// helper method to fix the border on the faqlinks bg colour
+export const gateBorderFix = () => {
+    const contentMainColumn = document.querySelector('.js-content-main-column');
+
+    if (contentMainColumn) {
+        contentMainColumn.classList.add('signin-gate__content-main-column__border-fix');
+    }
+}
 
 // helper method which first shows the gate based on the template supplied, adds any
 // handlers, e.g. click events etc. defined in the handler parameter function

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/centesimus-control-2.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/centesimus-control-2.js
@@ -10,6 +10,8 @@ import {
     showPrivacySettingsCMPModule,
     addOverlayVariantCSS,
     setGatePageTargeting,
+    gateBorderFix,
+    addCSSOnOpinion
 } from '../../helper';
 
 // add the html template as the return of the function below
@@ -82,6 +84,21 @@ export const designShow: ({
             guUrl,
         }),
         handler: ({ articleBody, shadowArticleBody }) => {
+            // fix the border on the faqlinks
+            gateBorderFix();
+
+            addCSSOnOpinion({
+                element: shadowArticleBody,
+                selector: '.signin-gate__faqlinks--fullwidth--var',
+                css: 'signin-gate__faqlinks--fullwidth--var--comment',
+            });
+
+            addCSSOnOpinion({
+                element: shadowArticleBody,
+                selector: '.signin-gate__faqlinks--var',
+                css: 'signin-gate__faqlinks--var--comment',
+            });
+
             addOverlayVariantCSS({
                 element: shadowArticleBody,
                 selector: '.signin-gate__first-paragraph-overlay',

--- a/static/src/stylesheets/module/identity/_sign-in-gate.scss
+++ b/static/src/stylesheets/module/identity/_sign-in-gate.scss
@@ -321,10 +321,15 @@
     padding-top: $gs-baseline * 1;
     position: relative;
 }
+.signin-gate__faqlinks--var--comment {
+    background-color: $brightness-100;
+    padding-bottom: $gs-baseline * 3;
+    padding-top: $gs-baseline * 1;
+    position: relative;
+}
 
 .signin-gate__faqlinks--fullwidth--var {
     background-color: $brightness-97;
-    z-index: -1;
 }
 
 .signin-gate__faqlinks--fullwidth--var:before {
@@ -336,7 +341,25 @@
     right: 0;
     border-left: 9999px solid $brightness-97;
     box-shadow: 9999px 0 0 $brightness-97;
-    z-index: -1;
+}
+
+.signin-gate__faqlinks--fullwidth--var--comment {
+    background-color: $brightness-100;
+}
+
+.signin-gate__faqlinks--fullwidth--var--comment:before {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: -9999px;
+    right: 0;
+    border-left: 9999px solid $brightness-100;
+    box-shadow: 9999px 0 0 $brightness-100;
+}
+
+.signin-gate__content-main-column__border-fix:before {
+    z-index: 1;
 }
 
 // VARIANT DESIGN - article gradient overlay changes // vii-variant


### PR DESCRIPTION
## What does this change?
- Update the grey background for the question links at the bottom of the gate to be white and full width on opinion pages
- Keep as grey on non opinion pages.

## Screenshots
Broken Design:
<img width="910" alt="Screenshot_2020-07-07_at_21 31 46" src="https://user-images.githubusercontent.com/13315440/87058857-837cbc80-c200-11ea-90a7-7cc764c5ac35.png">

Fixed: 
![localhost_3000_commentisfree_2020_jan_17_a-and-e-wait-times-nhs-investment-review](https://user-images.githubusercontent.com/13315440/87058996-ac9d4d00-c200-11ea-92d6-c0eeaf743908.png)

Normal Article:
![localhost_3000_science_grrlscientist_2012_aug_07_3](https://user-images.githubusercontent.com/13315440/87059085-cb9bdf00-c200-11ea-9a28-67d8529de026.png)


## Tested
- [x] Locally
- [ ] On CODE (optional)