### PR TITLE
Link to aus moment map in header

### DIFF
--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -51,7 +51,7 @@
                                         data-edition="@{
                                             editionId
                                         }"
-                                        href="https://support.theguardian.com/aus-2020-map?INTCMP=Aus_Moment_2020_frontend_header">
+                                        href="https://support.theguardian.com/aus-2020-map?INTCMP=Aus_moment_2020_frontend_header">
                                             Hear from our supporters
                                             @fragments.inlineSvg("arrow-right", "icon")
                                         </a>

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -51,7 +51,7 @@
                                         data-edition="@{
                                             editionId
                                         }"
-                                        href="https://support.theguardian.com/aus-2020-map?acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_HEADER%22%2C%22componentId%22%3A%22Aus_Moment_2020_map_header%22%2C%22campaignCode%22%3A%22Aus_Moment_2020_map_header%22%7D&INTCMP=Aus_Moment_2020_map_header">
+                                        href="https://support.theguardian.com/aus-2020-map?INTCMP=Aus_Moment_2020_frontend_header">
                                             Hear from our supporters
                                             @fragments.inlineSvg("arrow-right", "icon")
                                         </a>

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -46,7 +46,15 @@
                                         We're funded by <span class="cta-bar__aus-moment-count"></span>
                                         readers across Australia.
                                         <br/>
-                                        Thank you for supporting us
+                                        <a class="cta-bar__cta cta-bar__aus-map-cta hide-until-tablet"
+                                        data-link-name="nav2 : aus-map-cta"
+                                        data-edition="@{
+                                            editionId
+                                        }"
+                                        href="https://support.theguardian.com/aus-2020-map?acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_HEADER%22%2C%22componentId%22%3A%22Aus_Moment_2020_map_header%22%2C%22campaignCode%22%3A%22Aus_Moment_2020_map_header%22%7D&INTCMP=Aus_Moment_2020_map_header">
+                                            Hear from our supporters
+                                            @fragments.inlineSvg("arrow-right", "icon")
+                                        </a>
                                     </div>
                                 </div>
 

--- a/static/src/stylesheets/layout/nav/_cta-bar.scss
+++ b/static/src/stylesheets/layout/nav/_cta-bar.scss
@@ -60,6 +60,24 @@
         .cta-bar__cta {
             display: none;
         }
+
+        .cta-bar__aus-map-cta {
+            display: block;
+        }
+    }
+}
+
+.new-header__cta-bar-aus-moment .cta-bar__aus-map-cta {
+    color: $brightness-100;
+    border-radius: 18px;
+    border: 1px solid $brightness-100;
+    background: none;
+    margin-top: 5px;
+
+    &:hover,
+    &:focus {
+        color: $brightness-100;
+        background-color: $brand-dark;
     }
 }
 


### PR DESCRIPTION
## What does this change?
Links to the new aus moment testimonials map in the special aus moment header if you are a supporter.

Wide:
![Screen Shot 2020-07-10 at 13 53 30](https://user-images.githubusercontent.com/1513454/87156602-d87a0a80-c2b4-11ea-87ac-572face72253.png)

Desktop:
![Screen Shot 2020-07-10 at 13 53 41](https://user-images.githubusercontent.com/1513454/87156606-d912a100-c2b4-11ea-9f94-7da58d1625a3.png)

Tablet:
![Screen Shot 2020-07-10 at 13 53 51](https://user-images.githubusercontent.com/1513454/87156607-d9ab3780-c2b4-11ea-9702-ee0d3ffb9553.png)

Mobile:
![Screen Shot 2020-07-10 at 13 54 02](https://user-images.githubusercontent.com/1513454/87156608-d9ab3780-c2b4-11ea-8273-bd8dff510dc3.png)


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
