### PR TITLE
Distinguish between UK, US & AUS newsletters

### DIFF
--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -13,7 +13,7 @@
     </div>
     <div class="newsletter-card__wrapper">
         @emailListings.zipWithRowInfo.map { case (emailListing, row) =>
-            <div class="newsletter-card" data-component="newsletter-card @emailListing.name">
+            <div class="newsletter-card" data-component="newsletter-card @emailListing.identityName">
                 <div class="newsletter-card__content js-newsletter-content">
 
                     <div class="newsletter-card__name">@emailListing.name
@@ -52,7 +52,7 @@
                           placeholder="Email address" required/>
                         <input class="js-email-sub__listname-input" type="hidden" name="listName" value="@emailListing.identityName" />
                         <button class="newsletter-card__lozenge js-newsletter-signup-button newsletter-card__lozenge--submit"
-                          data-link-name="Subscribe to @emailListing.name"
+                          data-link-name="Subscribe to @emailListing.identityName"
                           type="submit"
                           value="@emailListing.listIdV1">
                           <span>Sign up</span>
@@ -66,7 +66,7 @@
                         @if(emailListing.exampleUrl.isDefined){
                           <a href="@emailListing.exampleUrl" target="preview-email-@emailListing.listId">
                               <button class="newsletter-card__lozenge newsletter-card__lozenge--preview"
-                                  data-link-name="Preview @emailListing.name"
+                                  data-link-name="Preview @emailListing.identityName"
                                   type="button">
                                   <span class="newsletter-card__preview">Preview  @fragments.inlineSvg("arrow-right", "icon")</span>
                               </button>

--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -13,7 +13,7 @@
     </div>
     <div class="newsletter-card__wrapper">
         @emailListings.zipWithRowInfo.map { case (emailListing, row) =>
-            <div class="newsletter-card" data-component="newsletter-card @emailListing.identityNameOverride.getOrElse(emailListing.name)">
+            <div class="newsletter-card" data-component="newsletter-card @emailListing.identityName">
                 <div class="newsletter-card__content js-newsletter-content">
 
                     <div class="newsletter-card__name">@emailListing.name
@@ -50,9 +50,9 @@
                           type="email"
                           name="email"
                           placeholder="Email address" required/>
-                        <input class="js-email-sub__listname-input" type="hidden" name="listName" value="@emailListing.identityNameOverride.getOrElse(emailListing.name)" />
+                        <input class="js-email-sub__listname-input" type="hidden" name="listName" value="@emailListing.identityName" />
                         <button class="newsletter-card__lozenge js-newsletter-signup-button newsletter-card__lozenge--submit"
-                          data-link-name="Subscribe to @emailListing.identityNameOverride.getOrElse(emailListing.name)"
+                          data-link-name="Subscribe to @emailListing.identityName"
                           type="submit"
                           value="@emailListing.listIdV1">
                           <span>Sign up</span>
@@ -66,7 +66,7 @@
                         @if(emailListing.exampleUrl.isDefined){
                           <a href="@emailListing.exampleUrl" target="preview-email-@emailListing.listId">
                               <button class="newsletter-card__lozenge newsletter-card__lozenge--preview"
-                                  data-link-name="Preview @emailListing.identityNameOverride.getOrElse(emailListing.name)"
+                                  data-link-name="Preview @emailListing.identityName"
                                   type="button">
                                   <span class="newsletter-card__preview">Preview  @fragments.inlineSvg("arrow-right", "icon")</span>
                               </button>

--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -13,7 +13,7 @@
     </div>
     <div class="newsletter-card__wrapper">
         @emailListings.zipWithRowInfo.map { case (emailListing, row) =>
-            <div class="newsletter-card" data-component="newsletter-card @emailListing.identityName">
+            <div class="newsletter-card" data-component="newsletter-card @emailListing.identityNameOverride.getOrElse(emailListing.name)">
                 <div class="newsletter-card__content js-newsletter-content">
 
                     <div class="newsletter-card__name">@emailListing.name
@@ -50,9 +50,9 @@
                           type="email"
                           name="email"
                           placeholder="Email address" required/>
-                        <input class="js-email-sub__listname-input" type="hidden" name="listName" value="@emailListing.identityName" />
+                        <input class="js-email-sub__listname-input" type="hidden" name="listName" value="@emailListing.identityNameOverride.getOrElse(emailListing.name)" />
                         <button class="newsletter-card__lozenge js-newsletter-signup-button newsletter-card__lozenge--submit"
-                          data-link-name="Subscribe to @emailListing.identityName"
+                          data-link-name="Subscribe to @emailListing.identityNameOverride.getOrElse(emailListing.name)"
                           type="submit"
                           value="@emailListing.listIdV1">
                           <span>Sign up</span>
@@ -66,7 +66,7 @@
                         @if(emailListing.exampleUrl.isDefined){
                           <a href="@emailListing.exampleUrl" target="preview-email-@emailListing.listId">
                               <button class="newsletter-card__lozenge newsletter-card__lozenge--preview"
-                                  data-link-name="Preview @emailListing.identityName"
+                                  data-link-name="Preview @emailListing.identityNameOverride.getOrElse(emailListing.name)"
                                   type="button">
                                   <span class="newsletter-card__preview">Preview  @fragments.inlineSvg("arrow-right", "icon")</span>
                               </button>


### PR DESCRIPTION
## What does this change?
The Guardian Today and Best of Guardian Opinion newsletters are currently using the same `data-link-name` across all geographies.

By instead using the `identityNameOverride` we better distinguish between these different newsletters and move to using what should be a more unique identifier. If `identityNameOverride` isn't available we default back to using the `name`

### To Do
- [x] Implement new `data-link-name`  
- [ ] Test that the new `data-link-name` gets sent through to the lake correctly
- [ ] Confirm with data tech and D&I that this change can be handled on their side.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No - don't think `/email-newsletters` is currently in DCR
- [ ] Yes (please indicate your plans for DCR Implementation)


## What is the value of this and can you measure success?
Better tracking of the newsletters with different versions based on location.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
