### PR TITLE
Modify data-link-name based on state

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/newsletters.js
+++ b/static/src/javascripts/bootstraps/enhanced/newsletters.js
@@ -100,8 +100,8 @@ const createSubscriptionFormEventHandlers = (buttonEl: HTMLButtonElement): void 
 };
 
 const modifyFormForSignedIn = (el) => {
-    modifyLinkNamesForSignedInUser(el)
-    createSubscriptionFormEventHandlers(el)
+    modifyLinkNamesForSignedInUser(el);
+    createSubscriptionFormEventHandlers(el);
 }
 
 const showSignupForm = (buttonEl: HTMLButtonElement): void => {

--- a/static/src/javascripts/bootstraps/enhanced/newsletters.js
+++ b/static/src/javascripts/bootstraps/enhanced/newsletters.js
@@ -45,7 +45,7 @@ const addSubscriptionMessage = (buttonEl: HTMLButtonElement): void => {
 };
 
 const modifyDataLinkName = (modifier: string) => (el: HTMLButtonElement) : void => {
-    const firstStageName = el.getAttribute('data-link-name') || ""
+    const firstStageName = el.getAttribute('data-link-name') || "undefined-data-link-name"
     el.setAttribute('data-link-name', firstStageName + modifier)
 }
 

--- a/static/src/javascripts/bootstraps/enhanced/newsletters.js
+++ b/static/src/javascripts/bootstraps/enhanced/newsletters.js
@@ -45,7 +45,7 @@ const addSubscriptionMessage = (buttonEl: HTMLButtonElement): void => {
 };
 
 const modifyDataLinkName = (modifier: string) => (el: HTMLButtonElement) : void => {
-    const firstStageName = el.getAttribute('data-link-name')
+    const firstStageName = el.getAttribute('data-link-name') || ""
     el.setAttribute('data-link-name', firstStageName + modifier)
 }
 

--- a/static/src/javascripts/bootstraps/enhanced/newsletters.js
+++ b/static/src/javascripts/bootstraps/enhanced/newsletters.js
@@ -44,6 +44,15 @@ const addSubscriptionMessage = (buttonEl: HTMLButtonElement): void => {
     });
 };
 
+const modifyDataLinkName = (modifier: string) => (el: HTMLButtonElement) : void => {
+    const firstStageName = el.getAttribute('data-link-name')
+    el.setAttribute('data-link-name', firstStageName + modifier)
+}
+
+const modifyAtSecondStage = (el: HTMLButtonElement) => modifyDataLinkName('-second-stage')(el)
+
+const modifyForSignedIn = (el: HTMLButtonElement) => modifyDataLinkName('-signed-in')(el)
+
 const submitForm = (
     form: ?HTMLFormElement,
     buttonEl: HTMLButtonElement
@@ -114,6 +123,7 @@ const showSecondStageSignup = (buttonEl: HTMLButtonElement): void => {
     fastdom.write(() => {
         buttonEl.setAttribute('type', 'button');
         bean.on(buttonEl, 'click', () => {
+            modifyAtSecondStage(buttonEl)
             showSignupForm(buttonEl);
         });
     });
@@ -125,6 +135,7 @@ const enhanceNewsletters = (): void => {
         getUserFromApi(userFromId => {
             if (userFromId && userFromId.primaryEmailAddress) {
                 updatePageForLoggedIn(userFromId.primaryEmailAddress);
+                $.forEachElement(`.${classes.signupButton}`, modifyForSignedIn);
                 $.forEachElement(`.${classes.signupButton}`, subscribeToEmail);
             }
         });

--- a/static/src/javascripts/bootstraps/enhanced/newsletters.js
+++ b/static/src/javascripts/bootstraps/enhanced/newsletters.js
@@ -49,9 +49,9 @@ const modifyDataLinkName = (modifier: string) => (el: HTMLButtonElement) : void 
     el.setAttribute('data-link-name', firstStageName + modifier)
 }
 
-const modifyAtSecondStage = (el: HTMLButtonElement) => modifyDataLinkName('-second-stage')(el)
+const modifyLinkNamesForSecondStage = (el: HTMLButtonElement) => modifyDataLinkName('-second-stage')(el)
 
-const modifyForSignedIn = (el: HTMLButtonElement) => modifyDataLinkName('-signed-in')(el)
+const modifyLinkNamesForSignedInUser = (el: HTMLButtonElement) => modifyDataLinkName('-signed-in')(el)
 
 const submitForm = (
     form: ?HTMLFormElement,
@@ -89,7 +89,7 @@ const submitForm = (
     });
 };
 
-const subscribeToEmail = (buttonEl: HTMLButtonElement): void => {
+const createSubscriptionFormEventHandlers = (buttonEl: HTMLButtonElement): void => {
     bean.on(buttonEl, 'click', event => {
         event.preventDefault();
         const form = buttonEl.form;
@@ -98,6 +98,11 @@ const subscribeToEmail = (buttonEl: HTMLButtonElement): void => {
         }
     });
 };
+
+const modifyFormForSignedIn = (el) => {
+    modifyLinkNamesForSignedInUser(el)
+    createSubscriptionFormEventHandlers(el)
+}
 
 const showSignupForm = (buttonEl: HTMLButtonElement): void => {
     const form = buttonEl.form;
@@ -108,7 +113,8 @@ const showSignupForm = (buttonEl: HTMLButtonElement): void => {
             .focus();
         $(`.${classes.signupButton}`, form).addClass(classes.styleSignup);
         $(`.${classes.previewButton}`, meta).addClass('is-hidden');
-        subscribeToEmail(buttonEl);
+        modifyLinkNamesForSecondStage(buttonEl)
+        createSubscriptionFormEventHandlers(buttonEl);
     });
 };
 
@@ -123,7 +129,6 @@ const showSecondStageSignup = (buttonEl: HTMLButtonElement): void => {
     fastdom.write(() => {
         buttonEl.setAttribute('type', 'button');
         bean.on(buttonEl, 'click', () => {
-            modifyAtSecondStage(buttonEl)
             showSignupForm(buttonEl);
         });
     });
@@ -135,8 +140,7 @@ const enhanceNewsletters = (): void => {
         getUserFromApi(userFromId => {
             if (userFromId && userFromId.primaryEmailAddress) {
                 updatePageForLoggedIn(userFromId.primaryEmailAddress);
-                $.forEachElement(`.${classes.signupButton}`, modifyForSignedIn);
-                $.forEachElement(`.${classes.signupButton}`, subscribeToEmail);
+                $.forEachElement(`.${classes.signupButton}`, modifyFormForSignedIn);
             }
         });
     } else {


### PR DESCRIPTION
## What does this change?

We currently don't differentiate the `data-link-name` based on whether a user is signed in or if it is the first/second stage of the non-signed in sign up process.

This introduces a set of functions to modify the `data-link-name` based on whether it is the first/second stage of newsletter sign up or if the user is already signed in.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)


## What is the value of this and can you measure success?
Better tracking of the email signup journey. This should be reflected in more granular data within the data lake.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
