### PR TITLE
Iky/page skin refactoring

### DIFF
--- a/applications/app/pages/ContentHtmlPage.scala
+++ b/applications/app/pages/ContentHtmlPage.scala
@@ -26,7 +26,7 @@ object ContentHtmlPage extends HtmlPage[Page] {
     import views.support.{BulletCleaner, CommercialComponentHigh}
     val edition = Edition(request)
     withJsoup(BulletCleaner(html.toString))(
-      CommercialComponentHigh(isPaidContent = false, isNetworkFront = false, hasPageSkin = page.metadata.hasPageSkin(edition)),
+      CommercialComponentHigh(isPaidContent = false, isNetworkFront = false, hasPageSkin = page.metadata.hasPageSkin(edition, request.getQueryString("adtest"))),
     )
   }
 

--- a/applications/app/pages/ContentHtmlPage.scala
+++ b/applications/app/pages/ContentHtmlPage.scala
@@ -76,7 +76,7 @@ object ContentHtmlPage extends HtmlPage[Page] {
       bodyTag(classes = bodyClasses)(
         tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
-        pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
+        pageSkin() when page.metadata.hasPageSkin(Edition(request), request.getQueryString("adtest")),
         guardianHeaderHtml(),
         mainContent(),
         breakingNewsDiv(),

--- a/applications/app/pages/CrosswordHtmlPage.scala
+++ b/applications/app/pages/CrosswordHtmlPage.scala
@@ -54,7 +54,7 @@ object CrosswordHtmlPage extends HtmlPage[CrosswordPage] {
       bodyTag(classes = defaultBodyClasses)(
         tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
-        pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
+        pageSkin() when page.metadata.hasPageSkin(Edition(request), request.getQueryString("adtest")),
         guardianHeaderHtml(),
         mainContent(),
         breakingNewsDiv(),

--- a/applications/app/pages/GalleryHtmlPage.scala
+++ b/applications/app/pages/GalleryHtmlPage.scala
@@ -49,7 +49,7 @@ object GalleryHtmlPage extends HtmlPage[GalleryPage] {
       bodyTag(classes = bodyClasses)(
         tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
-        pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
+        pageSkin() when page.metadata.hasPageSkin(Edition(request), request.getQueryString("adtest")),
         galleryTop(),
         breakingNewsDiv(),
         galleryBody(page),

--- a/applications/app/pages/IndexHtmlPage.scala
+++ b/applications/app/pages/IndexHtmlPage.scala
@@ -51,7 +51,7 @@ object IndexHtml {
       bodyTag(classes = defaultBodyClasses)(
         tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
-        pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
+        pageSkin() when page.metadata.hasPageSkin(Edition(request), request.getQueryString("adtest")),
         guardianHeaderHtml(),
         mainContent(),
         breakingNewsDiv(),

--- a/applications/app/pages/InteractiveHtmlPage.scala
+++ b/applications/app/pages/InteractiveHtmlPage.scala
@@ -57,7 +57,7 @@ object InteractiveHtmlPage extends HtmlPage[InteractivePage] {
       bodyTag(classes = bodyClasses)(
         tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
-        pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
+        pageSkin() when page.metadata.hasPageSkin(Edition(request), request.getQueryString("adtest")),
         guardianHeaderHtml(),
         mainContent(),
         breakingNewsDiv(),

--- a/applications/app/pages/NewsletterHtmlPage.scala
+++ b/applications/app/pages/NewsletterHtmlPage.scala
@@ -46,7 +46,7 @@ object NewsletterHtmlPage extends HtmlPage[SimplePage] {
       bodyTag(classes = defaultBodyClasses)(
         tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
-        pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
+        pageSkin() when page.metadata.hasPageSkin(Edition(request), request.getQueryString("adtest")),
         guardianHeaderHtml(),
         breakingNewsDiv(),
         newsletterContent(page),

--- a/applications/app/pages/TagIndexHtmlPage.scala
+++ b/applications/app/pages/TagIndexHtmlPage.scala
@@ -55,7 +55,7 @@ object TagIndexHtmlPage extends HtmlPage[StandalonePage] {
       bodyTag(classes = defaultBodyClasses)(
         tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
-        pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
+        pageSkin() when page.metadata.hasPageSkin(Edition(request), request.getQueryString("adtest")),
         guardianHeaderHtml(),
         mainContent(),
         breakingNewsDiv(),

--- a/applications/app/views/package.scala
+++ b/applications/app/views/package.scala
@@ -23,7 +23,7 @@ object IndexCleaner {
  def apply(page: IndexPage, html: Html)(implicit request: RequestHeader, context: ApplicationContext): Html = {
     val edition = Edition(request)
     withJsoup(BulletCleaner(html.toString))(
-      CommercialComponentHigh(isPaidContent = false, isNetworkFront = false, hasPageSkin = page.page.metadata.hasPageSkin(edition)),
+      CommercialComponentHigh(isPaidContent = false, isNetworkFront = false, hasPageSkin = page.page.metadata.hasPageSkin(edition, request.getQueryString("adtest"))),
       CommercialMPUForFronts()
     )
   }

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -500,7 +500,7 @@ object DotcomponentsDataModel {
       frontendAssetsFullURL = Configuration.assets.fullURL(common.Environment.stage)
     )
 
-    val jsPageConfig = JavaScriptPage.getMap(page, Edition(request), false)
+    val jsPageConfig = JavaScriptPage.getMap(page, Edition(request), false, request.getQueryString("adtest"))
     val combinedConfig = Json.toJsObject(config).deepMerge(JsObject(jsPageConfig))
     val calloutsUrl = combinedConfig.fields.toList.filter(entry => entry._1 == "calloutsUrl").headOption.flatMap( entry => entry._2.asOpt[String] )
 

--- a/article/app/model/dotcomponents/PageType.scala
+++ b/article/app/model/dotcomponents/PageType.scala
@@ -20,14 +20,15 @@ object PageType {
   implicit val writes = Json.writes[PageType]
 
   def apply(articlePage: PageWithStoryPackage, request: RequestHeader, context: ApplicationContext): PageType = {
+    val adTestParam = request.getQueryString("adtest");
     PageType(
-      getMap(articlePage, Edition(request), false).getOrElse("hasShowcaseMainElement", JsBoolean(false)).as[Boolean],
-      getMap(articlePage, Edition(request), false).getOrElse("isFront", JsBoolean(false)).as[Boolean],
-      getMap(articlePage, Edition(request), false).getOrElse("isLiveBlog", JsBoolean(false)).as[Boolean],
-      getMap(articlePage, Edition(request), false).getOrElse("isMinuteArticle", JsBoolean(false)).as[Boolean],
-      getMap(articlePage, Edition(request), false).getOrElse("isPaidContent", JsBoolean(false)).as[Boolean],
+      getMap(articlePage, Edition(request), false, adTestParam).getOrElse("hasShowcaseMainElement", JsBoolean(false)).as[Boolean],
+      getMap(articlePage, Edition(request), false, adTestParam).getOrElse("isFront", JsBoolean(false)).as[Boolean],
+      getMap(articlePage, Edition(request), false, adTestParam).getOrElse("isLiveBlog", JsBoolean(false)).as[Boolean],
+      getMap(articlePage, Edition(request), false, adTestParam).getOrElse("isMinuteArticle", JsBoolean(false)).as[Boolean],
+      getMap(articlePage, Edition(request), false, adTestParam).getOrElse("isPaidContent", JsBoolean(false)).as[Boolean],
       context.isPreview,
-      getMap(articlePage, Edition(request), false).getOrElse("isSensitive", JsBoolean(false)).as[Boolean]
+      getMap(articlePage, Edition(request), false, adTestParam).getOrElse("isSensitive", JsBoolean(false)).as[Boolean]
     )
   }
 }

--- a/article/app/pages/StoryHtmlPage.scala
+++ b/article/app/pages/StoryHtmlPage.scala
@@ -61,7 +61,7 @@ object StoryHtmlPage {
       bodyTag(classes = bodyClasses)(
         tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
-        pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
+        pageSkin() when page.metadata.hasPageSkin(Edition(request), request.getQueryString("adtest")),
         survey() when SurveySwitch.isSwitchedOn,
         header,
         mainContent(),

--- a/common/app/common/dfp/PageskinAdAgent.scala
+++ b/common/app/common/dfp/PageskinAdAgent.scala
@@ -55,9 +55,18 @@ trait PageskinAdAgent {
   }
 
   // The ad unit is considered to have a page skin if it has a corresponding sponsorship.
-  def hasPageSkin(fullAdUnitPath: String, metaData: MetaData, edition: Edition): Boolean = {
+  def hasPageSkin(fullAdUnitPath: String, metaData: MetaData, edition: Edition, adTestParam: Option[String]): Boolean = {
+      if (metaData.isFront) {
+         findSponsorships(fullAdUnitPath, metaData, edition).nonEmpty
+      } else false
+
     if (metaData.isFront) {
-      findSponsorships(fullAdUnitPath, metaData, edition).nonEmpty
+      findSponsorships(fullAdUnitPath, metaData, edition) exists (sponsorship =>
+        if (sponsorship.targetsAdTest) {
+          sponsorship.adTestValue.getOrElse("") == adTestParam.getOrElse("")
+        } else {
+          true
+        })
     } else false
   }
 

--- a/common/app/common/dfp/PageskinAdAgent.scala
+++ b/common/app/common/dfp/PageskinAdAgent.scala
@@ -66,11 +66,4 @@ trait PageskinAdAgent {
         })
     } else false
   }
-
-  // True if there is any candidate sponsorship for this ad unit. Used to decide when to render the out-of-page ad slot.
-  def hasPageSkinOrAdTestPageSkin(fullAdUnitPath: String, metaData: MetaData, edition: Edition): Boolean = {
-    if (metaData.isFront) {
-      findSponsorships(fullAdUnitPath, metaData, edition).nonEmpty
-    } else false
-  }
 }

--- a/common/app/common/dfp/PageskinAdAgent.scala
+++ b/common/app/common/dfp/PageskinAdAgent.scala
@@ -55,11 +55,8 @@ trait PageskinAdAgent {
   }
 
   // The ad unit is considered to have a page skin if it has a corresponding sponsorship.
+  // If the sponsorship is targetting an adtest we also consider that the request URL includes the same adtest param
   def hasPageSkin(fullAdUnitPath: String, metaData: MetaData, edition: Edition, adTestParam: Option[String]): Boolean = {
-      if (metaData.isFront) {
-         findSponsorships(fullAdUnitPath, metaData, edition).nonEmpty
-      } else false
-
     if (metaData.isFront) {
       findSponsorships(fullAdUnitPath, metaData, edition) exists (sponsorship =>
         if (sponsorship.targetsAdTest) {

--- a/common/app/html/HtmlPage.scala
+++ b/common/app/html/HtmlPage.scala
@@ -31,8 +31,13 @@ object HtmlPageHelpers {
 
   def defaultBodyClasses()(implicit page: model.Page, request: RequestHeader, applicationContext: ApplicationContext): Map[String, Boolean] = {
     val edition = Edition(request)
+    print("*** page")
+    print(page)
+    print("*** request adtest")
+    print(request.getQueryString("adtest"))
+
     Map(
-      ("has-page-skin", page.metadata.hasPageSkin(edition)),
+      ("has-page-skin", page.metadata.hasPageSkin(edition, request.getQueryString("adtest"))),
       ("has-membership-access-requirement", page.metadata.requiresMembershipAccess),
       ("childrens-books-site", page.metadata.sectionId == "childrens-books-site"))
   }

--- a/common/app/html/HtmlPage.scala
+++ b/common/app/html/HtmlPage.scala
@@ -31,10 +31,6 @@ object HtmlPageHelpers {
 
   def defaultBodyClasses()(implicit page: model.Page, request: RequestHeader, applicationContext: ApplicationContext): Map[String, Boolean] = {
     val edition = Edition(request)
-    print("*** page")
-    print(page)
-    print("*** request adtest")
-    print(request.getQueryString("adtest"))
 
     Map(
       ("has-page-skin", page.metadata.hasPageSkin(edition, request.getQueryString("adtest"))),

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -253,7 +253,7 @@ final case class MetaData (
 
   private val fullAdUnitPath = AdUnitMaker.make(id, adUnitSuffix)
 
-  def hasPageSkin(edition: Edition): Boolean = DfpAgent.hasPageSkin(fullAdUnitPath, this, edition)
+  def hasPageSkin(edition: Edition, adTestParam: Option[String]): Boolean = DfpAgent.hasPageSkin(fullAdUnitPath, this, edition, adTestParam)
   def hasPageSkinOrAdTestPageSkin(edition: Edition): Boolean = DfpAgent.hasPageSkinOrAdTestPageSkin(fullAdUnitPath, this, edition)
 
   def omitMPUsFromContainers(edition: Edition): Boolean = if (isPressedPage) {

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -254,7 +254,6 @@ final case class MetaData (
   private val fullAdUnitPath = AdUnitMaker.make(id, adUnitSuffix)
 
   def hasPageSkin(edition: Edition, adTestParam: Option[String]): Boolean = DfpAgent.hasPageSkin(fullAdUnitPath, this, edition, adTestParam)
-  def hasPageSkinOrAdTestPageSkin(edition: Edition): Boolean = DfpAgent.hasPageSkinOrAdTestPageSkin(fullAdUnitPath, this, edition)
 
   def omitMPUsFromContainers(edition: Edition): Boolean = if (isPressedPage) {
     DfpAgent.omitMPUsFromContainers(id, edition)

--- a/common/app/templates/javaScriptConfig.scala.js
+++ b/common/app/templates/javaScriptConfig.scala.js
@@ -10,7 +10,7 @@
 @defining(Edition(request)) { edition =>
     {
         "isDotcomRendering": false,
-        "page": @JavaScript(StringEncodings.jsonToJS(Json.stringify(JavaScriptPage.get(item, Edition(request), context.isPreview)))),
+        "page": @JavaScript(StringEncodings.jsonToJS(Json.stringify(JavaScriptPage.get(item, Edition(request), context.isPreview, request.getQueryString("adtest"))))),
         "nav": @JavaScript(Json.stringify(Json.toJson(NavMenu(item, edition)))),
         "switches" : { @{JavaScript(conf.switches.Switches.all.filter(_.exposeClientSide).map{ switch =>
             s""""${CamelCase.fromHyphenated(switch.name)}":${switch.isSwitchedOn}"""}.mkString(","))}

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -31,7 +31,7 @@
     <body
         id="top"
         class="@RenderClasses(Map(
-            ("has-page-skin", page.metadata.hasPageSkin(edition)),
+            ("has-page-skin", page.metadata.hasPageSkin(edition, request.getQueryString("adtest"))),
             ("has-membership-access-requirement", page.metadata.requiresMembershipAccess),
             ("childrens-books-site", page.metadata.sectionId == "childrens-books-site"),
             ("has-super-sticky-banner", false),

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -42,7 +42,7 @@
 
         <a class="u-h skip" href="#maincontent" data-link-name="skip : main content">Skip to main content</a>
 
-        @if(page.metadata.hasPageSkinOrAdTestPageSkin(edition)) {
+        @if(page.metadata.hasPageSkin(edition, request.getQueryString("adtest"))) {
             @fragments.commercial.pageSkin()
         }
 

--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -13,9 +13,9 @@ import play.api.libs.json._
 
 object JavaScriptPage {
 
-  def get(page: Page, edition: Edition, isPreview: Boolean): JsValue = Json.toJson(getMap(page, edition, isPreview))
+  def get(page: Page, edition: Edition, isPreview: Boolean, adTestParam: Option[String]): JsValue = Json.toJson(getMap(page, edition, isPreview, adTestParam))
 
-  def getMap(page: Page, edition: Edition, isPreview: Boolean): Map[String,JsValue] = {
+  def getMap(page: Page, edition: Edition, isPreview: Boolean, adTestParam: Option[String]): Map[String,JsValue] = {
     val metaData = page.metadata
     val content: Option[Content] = Page.getContent(page).map(_.content)
 
@@ -41,7 +41,7 @@ object JavaScriptPage {
 
     val commercialMetaData = Map(
       "dfpHost" -> JsString("pubads.g.doubleclick.net"),
-      "hasPageSkin" -> JsBoolean(metaData.hasPageSkin(edition)),
+      "hasPageSkin" -> JsBoolean(metaData.hasPageSkin(edition, adTestParam)),
       "dfpNonRefreshableLineItemIds" -> nonRefreshableLineItemIds,
       "shouldHideAdverts" -> JsBoolean(page match {
         case c: ContentPage if c.item.content.shouldHideAdverts => true

--- a/common/test/common/dfp/PageskinAdAgentTest.scala
+++ b/common/test/common/dfp/PageskinAdAgentTest.scala
@@ -11,6 +11,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class PageskinAdAgentTest extends FlatSpec with Matchers {
   val keywordParamSet: Set[AdTargetParam] = KeywordParam.fromItemId("sport-keyword").toSet
+  val noAdTestParam: Option[String] = None
   val commercialProperties = CommercialProperties(
     editionBrandings = Set.empty,
     editionAdTargetings = Set(EditionAdTargeting(defaultEdition, Some(keywordParamSet))),
@@ -130,42 +131,42 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
   }
 
   "isPageSkinned" should "be true for a front with a pageskin in given edition" in {
-    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/business/front", pressedFrontMeta, Uk) should be(true)
+    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/business/front", pressedFrontMeta, Uk, noAdTestParam) should be(true)
   }
 
   it should "be true for a series front" in {
-    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/fake-series-adunit/new-view-series", colourSeriesMeta, Uk ) should be(true)
+    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/fake-series-adunit/new-view-series", colourSeriesMeta, Uk, noAdTestParam) should be(true)
   }
 
   it should "be false for a front with a pageskin in another edition" in {
-    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/business/front", pressedFrontMeta, Au) should be(false)
+    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/business/front", pressedFrontMeta, Au, noAdTestParam) should be(false)
   }
 
   it should "be false for a front without a pageskin" in {
-    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/culture/front", pressedFrontMeta, defaultEdition) should be(false)
+    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/culture/front", pressedFrontMeta, defaultEdition, noAdTestParam) should be(false)
   }
 
   it should "be false for a front with a pageskin in no edition" in {
-    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/music/front", pressedFrontMeta, defaultEdition) should be(false)
-    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/music/front", pressedFrontMeta, Us) should be(false)
+    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/music/front", pressedFrontMeta, defaultEdition, noAdTestParam) should be(false)
+    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/music/front", pressedFrontMeta, Us, noAdTestParam) should be(false)
   }
 
   it should "be false for a content (non-front) page" in {
-    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/sport", articleMeta, defaultEdition) should be(false)
+    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/sport", articleMeta, defaultEdition, noAdTestParam) should be(false)
   }
 
   it should "be true for an index front (tag page)" in {
-    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/sport-index", sportIndexFrontMeta, defaultEdition) should be(true)
+    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/sport-index", sportIndexFrontMeta, defaultEdition, noAdTestParam) should be(true)
   }
 
   "non production DfpAgent" should "should recognise adtest targetted line items" in {
     NotProductionTestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/testSport/front", pressedFrontMeta,
-      defaultEdition) should be(
+      defaultEdition, noAdTestParam) should be(
       true)
   }
 
   "production DfpAgent" should "should recognise adtest targetted line items" in {
-    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/testSport/front", pressedFrontMeta, defaultEdition) should be(true)
+    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/testSport/front", pressedFrontMeta, defaultEdition, noAdTestParam) should be(true)
   }
 
   "findSponsorships" should "find keyword-targeted sponsorship when keyword page has been overwritten by a pressed front" in {

--- a/common/test/common/dfp/PageskinAdAgentTest.scala
+++ b/common/test/common/dfp/PageskinAdAgentTest.scala
@@ -166,8 +166,8 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
       true)
   }
 
-  "production DfpAgent" should "should recognise adtest targetted line items" in {
-    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/testSport/front", pressedFrontMeta, defaultEdition, noAdTestParam) should be(true)
+  "production DfpAgent" should "should recognise adtest targetted line items only if the request includes the same adtest param" in {
+    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/testSport/front", pressedFrontMeta, defaultEdition, mockedAdTestParam) should be(true)
   }
 
   "findSponsorships" should "find keyword-targeted sponsorship when keyword page has been overwritten by a pressed front" in {

--- a/common/test/common/dfp/PageskinAdAgentTest.scala
+++ b/common/test/common/dfp/PageskinAdAgentTest.scala
@@ -12,6 +12,7 @@ import org.scalatest.{FlatSpec, Matchers}
 class PageskinAdAgentTest extends FlatSpec with Matchers {
   val keywordParamSet: Set[AdTargetParam] = KeywordParam.fromItemId("sport-keyword").toSet
   val noAdTestParam: Option[String] = None
+  val mockedAdTestParam: Option[String] = Some("test-page-skin")
   val commercialProperties = CommercialProperties(
     editionBrandings = Set.empty,
     editionAdTargetings = Set(EditionAdTargeting(defaultEdition, Some(keywordParamSet))),
@@ -159,9 +160,9 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
     TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/sport-index", sportIndexFrontMeta, defaultEdition, noAdTestParam) should be(true)
   }
 
-  "non production DfpAgent" should "should recognise adtest targetted line items" in {
+  "non production DfpAgent" should "should recognise adtest targetted line items only if the request includes adtest param" in {
     NotProductionTestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/testSport/front", pressedFrontMeta,
-      defaultEdition, noAdTestParam) should be(
+      defaultEdition, mockedAdTestParam) should be(
       true)
   }
 

--- a/common/test/common/dfp/PageskinAdAgentTest.scala
+++ b/common/test/common/dfp/PageskinAdAgentTest.scala
@@ -12,7 +12,7 @@ import org.scalatest.{FlatSpec, Matchers}
 class PageskinAdAgentTest extends FlatSpec with Matchers {
   val keywordParamSet: Set[AdTargetParam] = KeywordParam.fromItemId("sport-keyword").toSet
   val noAdTestParam: Option[String] = None
-  val mockedAdTestParam: Option[String] = Some("test-page-skin")
+  val mockedAdTestParam: Option[String] = Some("6")
   val commercialProperties = CommercialProperties(
     editionBrandings = Set.empty,
     editionAdTargetings = Set(EditionAdTargeting(defaultEdition, Some(keywordParamSet))),
@@ -160,7 +160,7 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
     TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/sport-index", sportIndexFrontMeta, defaultEdition, noAdTestParam) should be(true)
   }
 
-  "non production DfpAgent" should "should recognise adtest targetted line items only if the request includes adtest param" in {
+  "non production DfpAgent" should "should recognise adtest targetted line items only if the request includes the same adtest param" in {
     NotProductionTestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/testSport/front", pressedFrontMeta,
       defaultEdition, mockedAdTestParam) should be(
       true)

--- a/common/test/model/ContentTest.scala
+++ b/common/test/model/ContentTest.scala
@@ -152,6 +152,7 @@ class ContentTest extends FlatSpec with Matchers with GuiceOneAppPerSuite with i
   val edition: Edition = mock[Edition]
   val sensitiveContentFields = Some(ContentFields(sensitive = Some(true)))
   val nonSensitiveContentFields = Some(ContentFields(sensitive = Some(true)))
+  val noAdTestParam: Option[String] = None
 
 
   when(edition.id) thenReturn "GB"
@@ -159,31 +160,31 @@ class ContentTest extends FlatSpec with Matchers with GuiceOneAppPerSuite with i
   "ContentJavascriptConfig" should "set shouldHideReaderRevenue to true for a sensitive article, published before the cutoff date, no RR flag" in {
 
     val content = Content(article.copy(webPublicationDate = dateBeforeCutoff, fields =  Some(ContentFields(sensitive = Some(true)))))
-    JavaScriptPage.getMap(SimpleContentPage(content), edition, isPreview = false).get("shouldHideReaderRevenue") should equal (Some(JsBoolean(true)))
+    JavaScriptPage.getMap(SimpleContentPage(content), edition, isPreview = false, noAdTestParam).get("shouldHideReaderRevenue") should equal (Some(JsBoolean(true)))
   }
 
   it should "set shouldHideReaderRevenue to false for a non-sensitive article, published before the cutoff date, no RR flag" in {
 
     val content =  Content(article.copy(webPublicationDate = dateBeforeCutoff, fields = Some(ContentFields(sensitive = Some(false)))))
-    JavaScriptPage.getMap(SimpleContentPage(content), edition, isPreview = false).get("shouldHideReaderRevenue") should be(Some(JsBoolean(false)))
+    JavaScriptPage.getMap(SimpleContentPage(content), edition, isPreview = false, noAdTestParam).get("shouldHideReaderRevenue") should be(Some(JsBoolean(false)))
   }
 
   it should "set shouldHideReaderRevenue to false for a sensitive article, published after the cutoff date, sHHR flag set to false" in {
 
     val content = Content(article.copy(webPublicationDate = dateAfterCutoff, fields = Some(ContentFields(sensitive = Some(true), shouldHideReaderRevenue = Some(false)))))
-    JavaScriptPage.getMap(SimpleContentPage(content), edition, isPreview = false).get("shouldHideReaderRevenue") should be(Some(JsBoolean(false)))
+    JavaScriptPage.getMap(SimpleContentPage(content), edition, isPreview = false, noAdTestParam).get("shouldHideReaderRevenue") should be(Some(JsBoolean(false)))
   }
 
   it should "set shouldHideReaderRevenue to true for a sensitive article, published after the cutoff date, sHHR flag set to true" in {
 
     val content = Content(article.copy(webPublicationDate = dateAfterCutoff, fields = Some(ContentFields(sensitive = Some(true), shouldHideReaderRevenue = Some(true)))))
-    JavaScriptPage.getMap(SimpleContentPage(content), edition, isPreview = false).get("shouldHideReaderRevenue") should be(Some(JsBoolean(true)))
+    JavaScriptPage.getMap(SimpleContentPage(content), edition, isPreview = false, noAdTestParam).get("shouldHideReaderRevenue") should be(Some(JsBoolean(true)))
   }
 
   it should "set shouldHideReaderRevenue to true for a non sensitive article, published after the cutoff date, sHHR flag set to true" in {
 
     val content =  Content(article.copy(webPublicationDate = dateAfterCutoff, fields = Some(ContentFields(sensitive = Some(false), shouldHideReaderRevenue = Some(true)))))
-    JavaScriptPage.getMap(SimpleContentPage(content), edition, isPreview =false).get("shouldHideReaderRevenue") should be(Some(JsBoolean(true)))
+    JavaScriptPage.getMap(SimpleContentPage(content), edition, isPreview =false, noAdTestParam).get("shouldHideReaderRevenue") should be(Some(JsBoolean(true)))
   }
 
   it should "set shouldHideReaderRevenue to true for any article that is Paid Content, regardless of the state of the shouldHideReaderRevenue flag in the CAPI response" in {
@@ -196,7 +197,7 @@ class ContentTest extends FlatSpec with Matchers with GuiceOneAppPerSuite with i
           tags = List(tag(s"tone/advertisement-features"))
         )
       )
-    JavaScriptPage.getMap(SimpleContentPage(content), edition, false).get("shouldHideReaderRevenue") should be(Some(JsBoolean(true)))
+    JavaScriptPage.getMap(SimpleContentPage(content), edition, false, noAdTestParam).get("shouldHideReaderRevenue") should be(Some(JsBoolean(true)))
   }
 
 

--- a/facia/app/pages/FrontHtmlPage.scala
+++ b/facia/app/pages/FrontHtmlPage.scala
@@ -25,7 +25,7 @@ object FrontHtmlPage extends HtmlPage[PressedPage] {
     val html: Html = frontBody(page)
     val edition = Edition(request)
     withJsoup(BulletCleaner(html.toString))(
-      CommercialComponentHigh(page.frontProperties.isPaidContent, page.isNetworkFront, page.metadata.hasPageSkin(edition)),
+      CommercialComponentHigh(page.frontProperties.isPaidContent, page.isNetworkFront, page.metadata.hasPageSkin(edition, request.getQueryString("adtest"))),
       CommercialMPUForFronts()
     )
   }

--- a/facia/app/pages/FrontHtmlPage.scala
+++ b/facia/app/pages/FrontHtmlPage.scala
@@ -56,7 +56,7 @@ object FrontHtmlPage extends HtmlPage[PressedPage] {
       bodyTag(classes = defaultBodyClasses)(
         tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
-        pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
+        pageSkin() when page.metadata.hasPageSkin(Edition(request), request.getQueryString("adtest")),
         guardianHeaderHtml(),
         mainContent(),
         breakingNewsDiv(),

--- a/facia/app/views/package.scala
+++ b/facia/app/views/package.scala
@@ -11,7 +11,7 @@ object FrontsCleaner {
  def apply(page: PressedPage, html: Html)(implicit request: RequestHeader, context: ApplicationContext): Html = {
     val edition = Edition(request)
     withJsoup(BulletCleaner(html.toString))(
-      CommercialComponentHigh(page.frontProperties.isPaidContent, page.isNetworkFront, page.metadata.hasPageSkin(edition)),
+      CommercialComponentHigh(page.frontProperties.isPaidContent, page.isNetworkFront, page.metadata.hasPageSkin(edition, request.getQueryString("adtest"))),
       CommercialMPUForFronts()
     )
   }


### PR DESCRIPTION
## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
