### PR TITLE
Switch off article count opt-out tests

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -474,16 +474,6 @@ trait FeatureSwitches {
     exposeClientSide = true
   )
 
-  val articlesViewedOptOut = Switch(
-    SwitchGroup.Feature,
-    "show-articles-viewed-opt-out",
-    "This toggles the articles viewed count opt out in the epic",
-    owners = Seq(Owner.withGithub("tomrf1")),
-    safeState = Off,
-    sellByDate = new LocalDate(2021, 6, 15),
-    exposeClientSide = true
-  )
-
   val discountCodeLinks = Switch(
     SwitchGroup.Feature,
     "discount-code-site-links",

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -33,7 +33,7 @@ import { epicButtonsTemplate } from 'common/modules/commercial/templates/acquisi
 import { acquisitionsEpicControlTemplate } from 'common/modules/commercial/templates/acquisitions-epic-control';
 import { epicLiveBlogTemplate } from 'common/modules/commercial/templates/acquisitions-epic-liveblog';
 import { epicArticlesViewedOptOutTemplate } from 'common/modules/commercial/templates/epic-articles-viewed-opt-out-template';
-import { optOutEnabled, userIsInArticlesViewedOptOutTest, setupArticlesViewedOptOut, onEpicViewed } from 'common/modules/commercial/epic-articles-viewed-opt-out';
+import { setupArticlesViewedOptOut, onEpicViewed } from 'common/modules/commercial/epic-articles-viewed-opt-out';
 import {
     shouldHideSupportMessaging,
     isPostAskPauseOneOffContributor,
@@ -93,14 +93,9 @@ const replaceCountryName = (text: string, countryName: ?string): string =>
 const replaceArticlesViewed = (text: string, count: ?number): string => {
     if (count) {
         const countValue = count;   // Flow gets confused about the value in count if we don't reassign to another const
-        // A/B test the opt-out feature if the switch is enabled
-        if (optOutEnabled() && userIsInArticlesViewedOptOutTest()) {
-            return text.replace(/%%ARTICLE_COUNT%%( \w+)?/g, (match, nextWord) =>
-                epicArticlesViewedOptOutTemplate(countValue, nextWord)
-            );
-        }
-
-        return text.replace(/%%ARTICLE_COUNT%%/g, `<span class="epic-article-count__normal">${count.toString()}</span>`)
+        return text.replace(/%%ARTICLE_COUNT%%( \w+)?/g, (match, nextWord) =>
+            epicArticlesViewedOptOutTemplate(countValue, nextWord)
+        );
     }
     return text;
 };

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.spec.js
@@ -92,11 +92,6 @@ describe('replaceArticlesViewed', () => {
         expect(replaceArticlesViewed(text, 5)).toBe(text)
     });
 
-    it('should replace the template with just the count', () => {
-        const text = 'You have read %%ARTICLE_COUNT%% articles.';
-        expect(replaceArticlesViewed(text, 5)).toBe('You have read <span class="epic-article-count__normal">5</span> articles.')
-    });
-
     it('should replace the template with opt-out feature html', () => {
         config.set('switches.showArticlesViewedOptOut', true);
         getCookie.mockReturnValue(1);   // mvt values in the lower half of the range are in the variant

--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-articles-viewed-opt-out.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-articles-viewed-opt-out.js
@@ -4,7 +4,6 @@ import {
     getLocalCurrencySymbol,
     getSync as geolocationGetSync,
 } from 'lib/geolocation';
-import config from "lib/config";
 import { getCookie } from "lib/cookies";
 import { ARTICLES_VIEWED_OPT_OUT_COOKIE } from "common/modules/commercial/user-features";
 import { getArticleViewCountForWeeks } from 'common/modules/onward/history';
@@ -19,7 +18,6 @@ const geolocation = geolocationGetSync();
 const leadSentence = 'We chose a different approach. Will you support it?'
 const articlesRead = articlesReadTooltipMarkup(articleViewCount)
 const variantMessageText = `With news under threat, just when we need it most, the Guardian’s quality, fact-checked news and measured explanation has never mattered more. Our editorial independence is vital. We believe every one of us deserves to read honest reporting – that’s why we remain with you, open to all. And you’re visiting in your millions. You’ve read more than ${articlesRead} in the last six months. But at this crucial moment, advertising revenue is plummeting. We need you to help fill the gap. Every contribution, however big or small, is valuable – in times of crisis and beyond.`
-const controlMessageText = `With news under threat, just when we need it most, the Guardian’s quality, fact-checked news and measured explanation has never mattered more. Our editorial independence is vital. We believe every one of us deserves to read honest reporting – that’s why we remain with you, open to all. And you’re visiting in your millions. You’ve read more than ${articleViewCount.toString()} articles in the last six months. But at this crucial moment, advertising revenue is plummeting. We need you to help fill the gap. Every contribution, however big or small, is valuable – in times of crisis and beyond.`
 const ctaText = `<span class="engagement-banner__highlight"> Support The Guardian from as little as ${getLocalCurrencySymbol(geolocation)}1.</span>`;
 
 export const contributionsBannerArticlesViewedOptOut: AcquisitionsABTest = {
@@ -35,26 +33,15 @@ export const contributionsBannerArticlesViewedOptOut: AcquisitionsABTest = {
     audienceCriteria: 'All',
     idealOutcome: 'variant design performs at least as well as control',
     canRun: () => {
-        const bannerOptOutEnabled = config.get('switches.showArticlesViewedOptOut')
-        const minimumNumberOfArticlesViewed = articleViewCount >= minArticleViews
-        const optOutCookieNotSet = !getCookie(ARTICLES_VIEWED_OPT_OUT_COOKIE.name)
+        const minimumNumberOfArticlesViewed = articleViewCount >= minArticleViews;
+        const optOutCookieNotSet = !getCookie(ARTICLES_VIEWED_OPT_OUT_COOKIE.name);
 
-        return (bannerOptOutEnabled && minimumNumberOfArticlesViewed && optOutCookieNotSet)
+        return (minimumNumberOfArticlesViewed && optOutCookieNotSet)
     },
     showForSensitive: true,
     componentType: 'ACQUISITIONS_ENGAGEMENT_BANNER',
     geolocation,
     variants: [
-        {
-            id: 'control',
-            test: (): void => {},
-            engagementBannerParams: {
-                leadSentence,
-                messageText: controlMessageText,
-                ctaText,
-                template: acquisitionsBannerControlTemplate
-            }
-        },
         {
             id: 'variant',
             test: (): void => {},


### PR DESCRIPTION
## What does this change?
We have been running two A/B tests for an opt-out feature on the article count in contributions messages:
1. on the epic
2. on the banner

It hasn't hurt acquisitions so we're rolling out to 100% of the audience.

In the case of the epic, this change just removes the logic that splits the audience in half.
In the case of the banner, the hardcoded 'test' will still exist and we'll just have a single control variant. This is because we don't yet have support for article count in the banner via tooling.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
