### PR TITLE
Add TCFv2 server side test

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -47,3 +47,11 @@ object DCRBubble extends Experiment(
   sellByDate = new LocalDate(2020, 12, 1),
   participationGroup = Perc0B // Also see ArticlePicker.scala - our main filter mechanism is by page features
 )
+
+object TCFv2 extends Experiment(
+  name = "use-tcfv2",
+  description = "Use TCFv2 CMP",
+  owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
+  sellByDate = new LocalDate(2020, 8, 24),
+  participationGroup = Perc0A 
+)

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -9,7 +9,8 @@ object ActiveExperiments extends ExperimentsDefinition {
     OldTLSSupportDeprecation,
     DotcomRendering1,
     DotcomRendering2,
-    DCRBubble
+    DCRBubble,
+    TCFv2
   )
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -53,5 +54,5 @@ object TCFv2 extends Experiment(
   description = "Use TCFv2 CMP",
   owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
   sellByDate = new LocalDate(2020, 8, 24),
-  participationGroup = Perc0A 
+  participationGroup = Perc0A
 )

--- a/static/src/javascripts/projects/commercial/modules/cmp/tcfv2-test.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/tcfv2-test.js
@@ -1,0 +1,17 @@
+// @flow
+
+import { isInUsa } from 'common/modules/commercial/geo-utils';
+import config from 'lib/config';
+
+let isInTest;
+
+const isInServerSideTest = (): boolean => 
+    config.get('tests.useTcfv2Variant') === 'variant';
+
+export const isInTcfv2Test = (): boolean => {
+    if (typeof isInTest === 'undefined') {
+        isInTest = !isInUsa() && isInServerSideTest();
+    }
+    
+    return isInTest;
+};


### PR DESCRIPTION
## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
