### PR TITLE
Fix crossword card images

### DIFF
--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -1,3 +1,4 @@
+@import views.support.ImgSrc
 @(item: layout.ContentCard, containerIndex: Int, index: Int, visibilityDataAttribute: String, isFirstContainer: Boolean, isList: Boolean)(implicit request: RequestHeader)
 
 @import layout.{FaciaWidths, FrontendLatestSnap}
@@ -129,8 +130,7 @@ data-test-id="facia-card"
             case Some(svg@CrosswordSvg(_)) => {
                 <div class="fc-item__media-wrapper">
                     <div class="fc-item__image-container u-responsive-ratio inlined-image">
-                        <object type="image/svg+xml" data="@svg.imageUrl" class="responsive-img" alt=""
-                        role="presentation" data-crossword-id="@svg.persistenceId" ></object>
+                        <img class="responsive-img" src="@svg.imageUrl" data-crossword-id="@svg.persistenceId" alt="">
                     </div>
                 </div>
             }

--- a/common/app/views/fragments/items/facia_cards/dynamoContentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/dynamoContentCard.scala.html
@@ -140,8 +140,7 @@ data-test-id="facia-card"
             case Some(svg@CrosswordSvg(_)) => {
                 <div class="fc-item__media-wrapper">
                     <div class="fc-item__image-container u-responsive-ratio inlined-image">
-                        <object type="image/svg+xml" data="@svg.imageUrl" class="responsive-img" alt=""
-                        role="presentation" data-crossword-id="@svg.persistenceId" ></object>
+                        <img class="responsive-img" src="@svg.imageUrl" data-crossword-id="@svg.persistenceId" alt="">
                     </div>
                 </div>
             }


### PR DESCRIPTION
## What does this change?

We now prohibit `object-src` in our Content Security Policy.

As a result, we need to load crossword SVGs differently.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

![Screenshot 2020-07-13 at 12 16 02](https://user-images.githubusercontent.com/858402/87298921-fc329000-c502-11ea-98e2-924466a84815.png)

(at the moment the image doesn't load on PROD)

## What is the value of this and can you measure success?

A bug fix.

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)
