### PR TITLE
Update style of button linking to Aus moment map

### DIFF
--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -40,7 +40,7 @@
                             @if(ausMomentEnabled) {
                                 <div class="cta-bar__text hide-until-tablet js-aus-moment-header-supporter">
                                     <div class="cta-bar__heading">
-                                        Welcome back
+                                        Thank you
                                     </div>
                                     <div class="cta-bar__subheading">
                                         We're funded by <span class="cta-bar__aus-moment-count"></span>

--- a/static/src/stylesheets/layout/nav/_cta-bar.scss
+++ b/static/src/stylesheets/layout/nav/_cta-bar.scss
@@ -68,16 +68,14 @@
 }
 
 .new-header__cta-bar-aus-moment .cta-bar__aus-map-cta {
-    color: $brightness-100;
-    border-radius: 18px;
-    border: 1px solid $brightness-100;
-    background: none;
+    color: $brand-main;
+    background-color: #C1D8FC;
     margin-top: 5px;
 
     &:hover,
     &:focus {
-        color: $brightness-100;
-        background-color: $brand-dark;
+        color: $brand-main;
+        background-color: #B1C9F3;
     }
 }
 

--- a/static/src/stylesheets/layout/nav/_cta-bar.scss
+++ b/static/src/stylesheets/layout/nav/_cta-bar.scss
@@ -68,14 +68,14 @@
 }
 
 .new-header__cta-bar-aus-moment .cta-bar__aus-map-cta {
-    color: $brand-main;
-    background-color: #C1D8FC;
+    color: $brightness-100;
+    background-color: #2c4c86;
     margin-top: 5px;
 
     &:hover,
     &:focus {
-        color: $brand-main;
-        background-color: #B1C9F3;
+        color: $brightness-100;
+        background-color: #55698e;
     }
 }
 


### PR DESCRIPTION
Follow up to https://github.com/guardian/frontend/pull/22793

1. Header now says "Thank you"
2. Button design has changed to:
![Screen Shot 2020-07-13 at 13 39 24](https://user-images.githubusercontent.com/1513454/87305432-67359400-c50e-11ea-84e4-25725022ab16.png)

Hover state:
![Screen Shot 2020-07-13 at 13 39 29](https://user-images.githubusercontent.com/1513454/87305435-6866c100-c50e-11ea-9c0a-5a327658ad68.png)
