### PR TITLE
Remote 500 Render Issue

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -35,7 +35,9 @@ class ArticleController(
 
   private def isSupported(c: ApiContent) = c.isArticle || c.isLiveBlog || c.isSudoku
   override def canRender(i: ItemResponse): Boolean = i.content.exists(isSupported)
-  override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = mapModel(path, Canonical)((article, blocks) => render(path, article, blocks))
+  // Replace Canonical with ArticleBlocks
+  //override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = mapModel(path, Canonical)((article, blocks) => render(path, article, blocks))
+  override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = mapModel(path, ArticleBlocks)((article, blocks) => render(path, article, blocks))
 
   def renderJson(path: String): Action[AnyContent] = {
     Action.async { implicit request =>

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -36,8 +36,8 @@ class ArticleController(
   private def isSupported(c: ApiContent) = c.isArticle || c.isLiveBlog || c.isSudoku
   override def canRender(i: ItemResponse): Boolean = i.content.exists(isSupported)
   // Replace Canonical with ArticleBlocks
-  //override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = mapModel(path, Canonical)((article, blocks) => render(path, article, blocks))
-  override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = mapModel(path, ArticleBlocks)((article, blocks) => render(path, article, blocks))
+  override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = mapModel(path, Canonical)((article, blocks) => render(path, article, blocks))
+  //override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = mapModel(path, ArticleBlocks)((article, blocks) => render(path, article, blocks))
 
   def renderJson(path: String): Action[AnyContent] = {
     Action.async { implicit request =>


### PR DESCRIPTION
## What does this change?

Currently, DCR will get 500 errors for certain pages like:

https://www.theguardian.com/theobserver/2014/aug/31/profile-clare-smyth-gordon-ramsay-chef-perfect-ten?dcr

This has been traced to the ArticleController in the article app, specifically renderItem:

`override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = mapModel(path, **Canonical**)((article, blocks) => render(path, article, blocks))
`
The Canonical reference will cause some pages to fail rendering. Changing this to ArticleBlocks fixes the issue

`override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = mapModel(path, **ArticleBlocks**)((article, blocks) => render(path, article, blocks))
`

****However**, it seems to cause test failure issues further down the line and ultimately a build failure.**

## It will fail when built using ArticleBlocks

The results below are from running article locally, using the original Canonical form first, then the ArticleBlocks form.

As seen in the results, ArticleBlocks fixes the 500 error locally (but will cause a build fail).

## Canonical (Original State)

**Renders in DCR:**

theobserver/she-said/2014/apr/17/unisex-changing-rooms-are-depriving-me-of-getting-naked-with-my-fellow-women
theguardian/from-the-archive-blog/2012/feb/17/charlie-chaplin-1952-communist

**Remote Render Error:**

theobserver/2014/aug/31/profile-clare-smyth-gordon-ramsay-chef-perfect-ten
theguardian/2003/jul/26/features.jobsmoney7
theguardian/2012/aug/24/good-to-meet-you-zubair-limbada


**Won’t Render DCR (Potentially Unsupported Elements):**

theobserver/2009/may/17/magazine
theobserver/2015/nov/01/news/uknews
theobserver/gallery/2013/sep/14/the-10-best-fonts
theguardian/2015/nov/04/g2/features
theguardian/2015/nov/03/mainsection
theguardian/gallery/2009/apr/01/prince-harry-william-monarchy

## ArticleBlocks (Replaces Canonical)

**Renders in DCR:**
theobserver/2014/aug/31/profile-clare-smyth-gordon-ramsay-chef-perfect-ten
theobserver/she-said/2014/apr/17/unisex-changing-rooms-are-depriving-me-of-getting-naked-with-my-fellow-women
theguardian/2012/aug/24/good-to-meet-you-zubair-limbada
theguardian/2003/jul/26/features.jobsmoney7
theguardian/from-the-archive-blog/2012/feb/17/charlie-chaplin-1952-communist


**Won’t Render DCR (Potentially Unsupported Elements):**
theobserver/2009/may/17/magazine
theobserver/2015/nov/01/news/uknews
theobserver/gallery/2013/sep/14/the-10-best-fonts
theguardian/2015/nov/03/mainsection
theguardian/2015/nov/04/g2/features
theguardian/gallery/2009/apr/01/prince-harry-william-monarchy


## Build Failure Info

The failure comes from `test.PreviewTestSuite: test.PreviewTestSuite.test` with the error `PreviewServerTest.Preview Server should be able to serve an article`

For full fail details see here:
https://teamcity.gutools.co.uk/viewLog.html?buildId=548664&buildTypeId=dotcom_master