### PR TITLE
Fix colours on aus moment map cta in the header

### DIFF
--- a/static/src/stylesheets/layout/nav/_cta-bar.scss
+++ b/static/src/stylesheets/layout/nav/_cta-bar.scss
@@ -74,6 +74,7 @@
 
     &:hover,
     &:focus {
+        color: $brightness-100;
         background-color: #2c4c86;
     }
 }

--- a/static/src/stylesheets/layout/nav/_cta-bar.scss
+++ b/static/src/stylesheets/layout/nav/_cta-bar.scss
@@ -69,13 +69,12 @@
 
 .new-header__cta-bar-aus-moment .cta-bar__aus-map-cta {
     color: $brightness-100;
-    background-color: #2c4c86;
+    background-color: #55698e;
     margin-top: 5px;
 
     &:hover,
     &:focus {
-        color: $brightness-100;
-        background-color: #55698e;
+        background-color: #2c4c86;
     }
 }
 


### PR DESCRIPTION
to be consistent with the Design System colours
https://github.com/guardian/dotcom-rendering/pull/1723

normal:
<img width="400" alt="Screen Shot 2020-07-13 at 16 10 26" src="https://user-images.githubusercontent.com/1513454/87321311-ff8a4380-c523-11ea-9cc7-e66d436215e3.png">

hover:
<img width="400" alt="Screen Shot 2020-07-13 at 16 14 12" src="https://user-images.githubusercontent.com/1513454/87321303-fdc08000-c523-11ea-8368-74895acd4302.png">
