### PR TITLE
TCFv2 0% Server-side Test

### DIFF
--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -50,7 +50,6 @@ class DevParametersHttpRequestHandler(
     "timestamp", //used to get specific builds for inteactive serviceworkers
     "pbjs_debug", // set to `true` to enable prebid debugging,
     "amzn_debug_mode", // set to `1` to enable A9 debugging
-    "_sp_env" // set to `stage` to enable SourcePoint staging
   )
 
   val commercialParams = Seq(

--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -48,8 +48,9 @@ class DevParametersHttpRequestHandler(
     "heatmap", // used by ophan javascript to enable the heatmap
     "format", // used to determine whether HTML should be served in email-friendly format or not
     "timestamp", //used to get specific builds for inteactive serviceworkers
-    "pbjs_debug", // set to true to enable prebid debugging,
-    "amzn_debug_mode" // set to 1 to enable A9 debugging
+    "pbjs_debug", // set to `true` to enable prebid debugging,
+    "amzn_debug_mode", // set to `1` to enable A9 debugging
+    "_sp_env" // set to `stage` to enable SourcePoint staging
   )
 
   val commercialParams = Seq(

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -3,6 +3,8 @@ package experiments
 import conf.switches.{Owner, SwitchGroup}
 import experiments.ParticipationGroups._
 import org.joda.time.LocalDate
+import conf.switches.Owner.group
+import conf.switches.SwitchGroup.Commercial
 
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
@@ -52,7 +54,7 @@ object DCRBubble extends Experiment(
 object UseTCFv2 extends Experiment(
   name = "use-tcfv2",
   description = "Use TCFv2 CMP",
-  owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
+  owners = group(Commercial),
   sellByDate = new LocalDate(2020, 8, 24),
   participationGroup = Perc0A
 )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -47,3 +47,11 @@ object DCRBubble extends Experiment(
   sellByDate = new LocalDate(2020, 12, 1),
   participationGroup = Perc0B // Also see ArticlePicker.scala - our main filter mechanism is by page features
 )
+
+object TCFv2 extends Experiment(
+  name = "use-tcfv2",
+  description = "Use TCFv2 CMP",
+  owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
+  sellByDate = new LocalDate(2020, 8, 24),
+  participationGroup = Perc0A 
+)

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -9,7 +9,8 @@ object ActiveExperiments extends ExperimentsDefinition {
     OldTLSSupportDeprecation,
     DotcomRendering1,
     DotcomRendering2,
-    DCRBubble
+    DCRBubble,
+    TCFv2
   )
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -53,5 +54,5 @@ object TCFv2 extends Experiment(
   description = "Use TCFv2 CMP",
   owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),
   sellByDate = new LocalDate(2020, 8, 24),
-  participationGroup = Perc0A 
+  participationGroup = Perc0A
 )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -10,7 +10,7 @@ object ActiveExperiments extends ExperimentsDefinition {
     DotcomRendering1,
     DotcomRendering2,
     DCRBubble,
-    TCFv2
+    UseTCFv2
   )
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -49,7 +49,7 @@ object DCRBubble extends Experiment(
   participationGroup = Perc0B // Also see ArticlePicker.scala - our main filter mechanism is by page features
 )
 
-object TCFv2 extends Experiment(
+object UseTCFv2 extends Experiment(
   name = "use-tcfv2",
   description = "Use TCFv2 CMP",
   owners = Seq(Owner.withEmail("commercial.dev@guardian.co.uk")),

--- a/package.json
+++ b/package.json
@@ -171,10 +171,7 @@
       "<rootDir>/dev/jest.setupTestFrameworkScriptFile.js"
     ],
     "testEnvironment": "jest-environment-jsdom-global",
-    "testURL": "http://testurl.theguardian.com",
-    "transformIgnorePatterns": [
-      "<rootDir>/(node_modules)/"
-    ]
+    "testURL": "http://testurl.theguardian.com"
   },
   "scripts": {
     "postinstall": "./tools/sync-githooks.js",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@emotion/styled": "^10.0.27",
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/automat-client": "^0.2.16",
-    "@guardian/consent-management-platform": "4.0.0-2",
+    "@guardian/consent-management-platform": "4.0.0-3",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/shimport": "^1.0.2",
     "@guardian/src-button": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@emotion/styled": "^10.0.27",
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/automat-client": "^0.2.16",
-    "@guardian/consent-management-platform": "4.0.0-4",
+    "@guardian/consent-management-platform": "4.0.0-5",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/shimport": "^1.0.2",
     "@guardian/src-button": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@emotion/styled": "^10.0.27",
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/automat-client": "^0.2.16",
-    "@guardian/consent-management-platform": "4.0.0-3",
+    "@guardian/consent-management-platform": "4.0.0-4",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/shimport": "^1.0.2",
     "@guardian/src-button": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@emotion/styled": "^10.0.27",
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/automat-client": "^0.2.16",
-    "@guardian/consent-management-platform": "4.0.0-1",
+    "@guardian/consent-management-platform": "4.0.0-2",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/shimport": "^1.0.2",
     "@guardian/src-button": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@emotion/styled": "^10.0.27",
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/automat-client": "^0.2.16",
-    "@guardian/consent-management-platform": "3.4.5",
+    "@guardian/consent-management-platform": "4.0.0-0",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/shimport": "^1.0.2",
     "@guardian/src-button": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@emotion/styled": "^10.0.27",
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/automat-client": "^0.2.16",
-    "@guardian/consent-management-platform": "3.4.5",
+    "@guardian/consent-management-platform": "4.0.0-1",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/shimport": "^1.0.2",
     "@guardian/src-button": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -171,7 +171,10 @@
       "<rootDir>/dev/jest.setupTestFrameworkScriptFile.js"
     ],
     "testEnvironment": "jest-environment-jsdom-global",
-    "testURL": "http://testurl.theguardian.com"
+    "testURL": "http://testurl.theguardian.com",
+    "transformIgnorePatterns": [
+      "<rootDir>/(node_modules)/"
+    ]
   },
   "scripts": {
     "postinstall": "./tools/sync-githooks.js",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@emotion/styled": "^10.0.27",
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/automat-client": "^0.2.16",
-    "@guardian/consent-management-platform": "4.0.0-0",
+    "@guardian/consent-management-platform": "4.0.0-1",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/shimport": "^1.0.2",
     "@guardian/src-button": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@emotion/styled": "^10.0.27",
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/automat-client": "^0.2.16",
-    "@guardian/consent-management-platform": "4.0.0-1",
+    "@guardian/consent-management-platform": "4.0.0-0",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/shimport": "^1.0.2",
     "@guardian/src-button": "^0.16.1",

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -34,6 +34,11 @@ const go = () => {
         bootStandard();
 
         // Start CMP
+        console.log('[CMP—TCFv2]', {
+            isInTcfv2Test: isInTcfv2Test(),
+            isCcpaApplicable: isCcpaApplicable(),
+            isInUsa: isInUsa(),
+        });
         if (isCcpaApplicable()) {
             oldCmp.init({ useCcpa: true });
         } else if (isInTcfv2Test()) {

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -11,7 +11,9 @@ import { captureOphanInfo } from 'lib/capture-ophan-info';
 import reportError from 'lib/report-error';
 import 'projects/commercial/modules/cmp/stub';
 import { isCcpaApplicable } from 'commercial/modules/cmp/ccpa-cmp';
-import { init } from '@guardian/consent-management-platform';
+import { isInUsa } from 'projects/common/modules/commercial/geo-utils.js';
+import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
+import { cmp, oldCmp } from '@guardian/consent-management-platform';
 
 // Let webpack know where to get files from
 // __webpack_public_path__ is a special webpack variable
@@ -33,7 +35,9 @@ const go = () => {
 
         // Start CMP
         if (isCcpaApplicable()) {
-            init({ useCcpa: true });
+            oldCmp.init({ useCcpa: true });
+        } else if (isInTcfv2Test()) {
+            cmp.init({ isInUsa: isInUsa() });
         }
 
         // 2. once standard is done, next is commercial

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -34,14 +34,12 @@ const go = () => {
         bootStandard();
 
         // Start CMP
-        console.log('[CMP—TCFv2]', {
-            isInTcfv2Test: isInTcfv2Test(),
-            isCcpaApplicable: isCcpaApplicable(),
-            isInUsa: isInUsa(),
-        });
         if (isCcpaApplicable()) {
             oldCmp.init({ useCcpa: true });
-        } else if (isInTcfv2Test()) {
+        } else if (
+            isInTcfv2Test() &&
+            window.location.search.includes('_sp_env=stage') // TODO: enable live Sourcepoint campaign
+        ) {
             cmp.init({ isInUsa: isInUsa() });
         }
 

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -36,10 +36,7 @@ const go = () => {
         // Start CMP
         if (isCcpaApplicable()) {
             oldCmp.init({ useCcpa: true });
-        } else if (
-            isInTcfv2Test() &&
-            window.location.search.includes('_sp_env=stage') // TODO: enable live Sourcepoint campaign
-        ) {
+        } else if (isInTcfv2Test()) {
             cmp.init({ isInUsa: isInUsa() });
         }
 

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -38,6 +38,8 @@ const go = () => {
             oldCmp.init({ useCcpa: true });
         } else if (isInTcfv2Test()) {
             cmp.init({ isInUsa: isInUsa() });
+        } else {
+            // do nothing, TCFv1 CMP auto initialises
         }
 
         // 2. once standard is done, next is commercial

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -12,8 +12,8 @@ import reportError from 'lib/report-error';
 import 'projects/commercial/modules/cmp/stub';
 import { isCcpaApplicable } from 'commercial/modules/cmp/ccpa-cmp';
 import { isInUsa } from 'projects/common/modules/commercial/geo-utils.js';
-import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
 import { cmp, oldCmp } from '@guardian/consent-management-platform';
+import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
 
 // Let webpack know where to get files from
 // __webpack_public_path__ is a special webpack variable

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -11,7 +11,9 @@ import { captureOphanInfo } from 'lib/capture-ophan-info';
 import reportError from 'lib/report-error';
 import 'projects/commercial/modules/cmp/stub';
 import { isCcpaApplicable } from 'commercial/modules/cmp/ccpa-cmp';
-import { init } from '@guardian/consent-management-platform';
+import { isInUsa } from 'projects/common/modules/commercial/geo-utils.js';
+import { cmp, oldCmp } from '@guardian/consent-management-platform';
+import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
 
 // Let webpack know where to get files from
 // __webpack_public_path__ is a special webpack variable
@@ -33,7 +35,9 @@ const go = () => {
 
         // Start CMP
         if (isCcpaApplicable()) {
-            init({ useCcpa: true });
+            oldCmp.init({ useCcpa: true });
+        } else if (isInTcfv2Test()) {
+            cmp.init({ isInUsa: isInUsa() });
         }
 
         // 2. once standard is done, next is commercial

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -34,11 +34,6 @@ const go = () => {
         bootStandard();
 
         // Start CMP
-        console.log('[CMP—TCFv2]', {
-            isInTcfv2Test: isInTcfv2Test(),
-            isCcpaApplicable: isCcpaApplicable(),
-            isInUsa: isInUsa(),
-        });
         if (isCcpaApplicable()) {
             oldCmp.init({ useCcpa: true });
         } else if (isInTcfv2Test()) {

--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
@@ -245,10 +245,10 @@ class CmpService {
 
     receiveMessage = ({ data, origin, source }: MessageEvent): void => {
         if (data instanceof Object) {
-            const { __cmpCall: cmpSource }: MessageData = data;
-            if (cmpSource) {
+            const { __cmpCall: cmp }: MessageData = data;
+            if (cmp) {
                 log.info(`Message from: ${origin}`);
-                const { callId, command, parameter } = cmpSource;
+                const { callId, command, parameter } = cmp;
                 if (source && source.postMessage) {
                     this.processCommand(command, parameter, returnValue =>
                         source.postMessage(

--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
@@ -1,21 +1,15 @@
 // @flow strict
 
+import { cmp, oldCmp } from '@guardian/consent-management-platform';
+
 import config from 'lib/config';
 import { getCookie } from 'lib/cookies';
 import { getUrlVars } from 'lib/url';
 import fetchJSON from 'lib/fetch-json';
-import { onIabConsentNotification } from '@guardian/consent-management-platform';
 import { isCcpaApplicable } from 'commercial/modules/cmp/ccpa-cmp';
 import { log } from './log';
 import { CmpStore } from './store';
 import { encodeVendorConsentData } from './cookie';
-
-import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
-import { cmp, oldCmp } from '@guardian/consent-management-platform';
-
-const onIabConsentNotification = isInTcfv2Test()
-    ? cmp.onConsentChange
-    : oldCmp.onIabConsentNotification;
 
 // Avoid Flow and eslint to complain about this import not being available
 // in a fresh checkout.
@@ -39,6 +33,10 @@ import type {
     VendorConsentResponse,
 } from './types';
 import { isInTcfv2Test } from './tcfv2-test';
+
+const onIabConsentNotification = isInTcfv2Test()
+    ? cmp.onConsentChange
+    : oldCmp.onIabConsentNotification;
 
 type MessageData = {
     __cmpCall: ?{
@@ -252,10 +250,10 @@ class CmpService {
 
     receiveMessage = ({ data, origin, source }: MessageEvent): void => {
         if (data instanceof Object) {
-            const { __cmpCall: cmp }: MessageData = data;
-            if (cmp) {
+            const { __cmpCall: cmpSource }: MessageData = data;
+            if (cmpSource) {
                 log.info(`Message from: ${origin}`);
-                const { callId, command, parameter } = cmp;
+                const { callId, command, parameter } = cmpSource;
                 if (source && source.postMessage) {
                     this.processCommand(command, parameter, returnValue =>
                         source.postMessage(
@@ -288,7 +286,7 @@ class CmpService {
 export const init = (): void => {
     // Only run our CmpService if prepareCmp has added the CMP stub
     if (window[CMP_GLOBAL_NAME] && !isCcpaApplicable() && !isInTcfv2Test()) {
-        let cmp: ?CmpService;
+        let cmpService: ?CmpService;
         // Pull queued commands from the CMP stub
         const { commandQueue = [] } = window[CMP_GLOBAL_NAME] || {};
 
@@ -302,27 +300,27 @@ export const init = (): void => {
             // Initialize the store with all of our consent data
             const store = generateStore();
             /**
-             * If instance of cmp exists get it's eventListeners
+             * If instance of cmpService exists get it's eventListeners
              * as we'll need to add them to the new instance of cmp.
              */
-            const eventListeners = cmp ? cmp.eventListeners : {};
+            const eventListeners = cmpService ? cmpService.eventListeners : {};
 
             // Create new instance of CmpService and assign to cmp
-            cmp = new CmpService(store, eventListeners);
+            cmpService = new CmpService(store, eventListeners);
 
             // Set window[CMP_GLOBAL_NAME] to new `cmp.processCommand`
-            window[CMP_GLOBAL_NAME] = cmp.processCommand;
+            window[CMP_GLOBAL_NAME] = cmpService.processCommand;
         });
 
         // Just required when we first initialise cmp on page load
-        if (cmp) {
-            cmp.commandQueue = commandQueue;
-            cmp.isLoaded = true;
-            cmp.notify('isLoaded');
+        if (cmpService) {
+            cmpService.commandQueue = commandQueue;
+            cmpService.isLoaded = true;
+            cmpService.notify('isLoaded');
             // Execute any previously queued command
-            cmp.processCommandQueue();
-            cmp.cmpReady = true;
-            cmp.notify('cmpReady');
+            cmpService.processCommandQueue();
+            cmpService.cmpReady = true;
+            cmpService.notify('cmpReady');
         }
     }
 };

--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
@@ -295,12 +295,12 @@ export const init = (): void => {
             // Initialize the store with all of our consent data
             const store = generateStore();
             /**
-             * If instance of cmpService exists get it's eventListeners
+             * If instance of cmp exists get it's eventListeners
              * as we'll need to add them to the new instance of cmp.
              */
             const eventListeners = cmp ? cmp.eventListeners : {};
 
-            // Create new instance of cmp and assign to cmp
+            // Create new instance of cmpService and assign to cmp
             cmp = new CmpService(store, eventListeners);
 
             // Set window[CMP_GLOBAL_NAME] to new `cmp.processCommand`

--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
@@ -300,7 +300,7 @@ export const init = (): void => {
              */
             const eventListeners = cmp ? cmp.eventListeners : {};
 
-            // Create new instance of cmpService and assign to cmp
+            // Create new instance of CmpService and assign to cmp
             cmp = new CmpService(store, eventListeners);
 
             // Set window[CMP_GLOBAL_NAME] to new `cmp.processCommand`
@@ -320,4 +320,4 @@ export const init = (): void => {
     }
 };
 
-export const _ = { oldCmp, CmpService, readConsentCookie };
+export const _ = { CmpService, readConsentCookie };

--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
@@ -1,6 +1,6 @@
 // @flow strict
 
-import { cmp, oldCmp } from '@guardian/consent-management-platform';
+import { onConsentChange, oldCmp } from '@guardian/consent-management-platform';
 
 import config from 'lib/config';
 import { getCookie } from 'lib/cookies';
@@ -35,7 +35,7 @@ import type {
 import { isInTcfv2Test } from './tcfv2-test';
 
 const onIabConsentNotification = isInTcfv2Test()
-    ? cmp.onConsentChange
+    ? onConsentChange
     : oldCmp.onIabConsentNotification;
 
 type MessageData = {

--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
@@ -32,11 +32,7 @@ import type {
     VendorList,
     VendorConsentResponse,
 } from './types';
-import { isInTcfv2Test } from './tcfv2-test';
-
-const onIabConsentNotification = isInTcfv2Test()
-    ? onConsentChange
-    : oldCmp.onIabConsentNotification;
+import { isInTcfv2Test } from './tcfv2-test'
 
 type MessageData = {
     __cmpCall: ?{
@@ -296,7 +292,7 @@ export const init = (): void => {
          * state. If consent state updates via the UI the callback will be triggered
          * again which will update cmp with the new consent state.
          */
-        onIabConsentNotification(() => {
+        oldCmp.onIabConsentNotification(() => {
             // Initialize the store with all of our consent data
             const store = generateStore();
             /**

--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
@@ -1,11 +1,10 @@
 // @flow strict
 
-import { oldCmp } from '@guardian/consent-management-platform';
-
 import config from 'lib/config';
 import { getCookie } from 'lib/cookies';
 import { getUrlVars } from 'lib/url';
 import fetchJSON from 'lib/fetch-json';
+import { oldCmp } from '@guardian/consent-management-platform';
 import { isCcpaApplicable } from 'commercial/modules/cmp/ccpa-cmp';
 import { log } from './log';
 import { CmpStore } from './store';

--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
@@ -325,4 +325,4 @@ export const init = (): void => {
     }
 };
 
-export const _ = { CmpService, readConsentCookie };
+export const _ = { oldCmp, onConsentChange, CmpService, readConsentCookie };

--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.js
@@ -10,6 +10,13 @@ import { log } from './log';
 import { CmpStore } from './store';
 import { encodeVendorConsentData } from './cookie';
 
+import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
+import { cmp, oldCmp } from '@guardian/consent-management-platform';
+
+const onIabConsentNotification = isInTcfv2Test()
+    ? cmp.onConsentChange
+    : oldCmp.onIabConsentNotification;
+
 // Avoid Flow and eslint to complain about this import not being available
 // in a fresh checkout.
 // See tools/tools/__tasks__/compile/data/aib_cmp.js to understand
@@ -31,6 +38,7 @@ import type {
     VendorList,
     VendorConsentResponse,
 } from './types';
+import { isInTcfv2Test } from './tcfv2-test';
 
 type MessageData = {
     __cmpCall: ?{
@@ -279,7 +287,7 @@ class CmpService {
 
 export const init = (): void => {
     // Only run our CmpService if prepareCmp has added the CMP stub
-    if (window[CMP_GLOBAL_NAME] && !isCcpaApplicable()) {
+    if (window[CMP_GLOBAL_NAME] && !isCcpaApplicable() && !isInTcfv2Test()) {
         let cmp: ?CmpService;
         // Pull queued commands from the CMP stub
         const { commandQueue = [] } = window[CMP_GLOBAL_NAME] || {};

--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.spec.js
@@ -25,6 +25,19 @@ jest.mock('commercial/modules/cmp/log', () => ({
     },
 }));
 
+jest.mock('@guardian/consent-management-platform', () => ({
+    oldCmp: {
+        onIabConsentNotification: jest.fn(),
+        onGuConsentNotification: jest.fn(),
+    },
+    onConsentChange: jest.fn(),
+}));
+
+// Force TCFv1
+jest.mock('commercial/modules/cmp/tcfv2-test', () => ({
+    isInTcfv2Test: jest.fn().mockReturnValue(false),
+}));
+
 const shortVendorList = {
     version: 1,
     purposeIDs: [1, 2, 3, 4],

--- a/static/src/javascripts/projects/commercial/modules/cmp/cmp.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/cmp.spec.js
@@ -8,6 +8,9 @@ jest.mock('projects/commercial/modules/cmp/ccpa-cmp', () => ({
     isCcpaApplicable: () => false,
 }));
 
+// TODO: Investigate why we need to mock the CMP
+jest.mock('@guardian/consent-management-platform', () => ({}));
+
 jest.mock('lib/raven');
 jest.mock('lib/fetch-json', () => jest.fn());
 const fetchJsonMock: JestMockFn<*, *> = (fetchJson: any);
@@ -23,19 +26,6 @@ jest.mock('commercial/modules/cmp/log', () => ({
         warn: jest.fn(),
         info: jest.fn(),
     },
-}));
-
-jest.mock('@guardian/consent-management-platform', () => ({
-    oldCmp: {
-        onIabConsentNotification: jest.fn(),
-        onGuConsentNotification: jest.fn(),
-    },
-    onConsentChange: jest.fn(),
-}));
-
-// Force TCFv1
-jest.mock('commercial/modules/cmp/tcfv2-test', () => ({
-    isInTcfv2Test: jest.fn().mockReturnValue(false),
 }));
 
 const shortVendorList = {

--- a/static/src/javascripts/projects/commercial/modules/cmp/tcfv2-test.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/tcfv2-test.js
@@ -5,13 +5,23 @@ import config from 'lib/config';
 
 let isInTest;
 
-const isInServerSideTest = (): boolean => 
+const isInServerSideTest = (): boolean =>
     config.get('tests.useTcfv2Variant') === 'variant';
 
 export const isInTcfv2Test = (): boolean => {
+    return true; // TODO: Remove!
+
     if (typeof isInTest === 'undefined') {
+        console.log(
+            '[CMP—TCFv2]',
+            'isInUsa',
+            isInUsa(),
+            '—',
+            'isInServerSideTest',
+            isInServerSideTest()
+        );
         isInTest = !isInUsa() && isInServerSideTest();
     }
-    
+
     return isInTest;
 };

--- a/static/src/javascripts/projects/commercial/modules/cmp/tcfv2-test.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/tcfv2-test.js
@@ -9,8 +9,6 @@ const isInServerSideTest = (): boolean =>
     config.get('tests.useTcfv2Variant') === 'variant';
 
 export const isInTcfv2Test = (): boolean => {
-    return true; // TODO: Remove!
-
     if (typeof isInTest === 'undefined') {
         console.log(
             '[CMP—TCFv2]',
@@ -20,7 +18,8 @@ export const isInTcfv2Test = (): boolean => {
             'isInServerSideTest',
             isInServerSideTest()
         );
-        isInTest = !isInUsa() && isInServerSideTest();
+        // TODO REMOVE true which is used for testing
+        isInTest = true || (!isInUsa() && isInServerSideTest());
     }
 
     return isInTest;

--- a/static/src/javascripts/projects/commercial/modules/cmp/tcfv2-test.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/tcfv2-test.js
@@ -1,0 +1,17 @@
+// @flow
+
+import { isInUsa } from 'common/modules/commercial/geo-utils';
+import config from 'lib/config';
+
+let isInTest;
+
+const isInServerSideTest = (): boolean => 
+    config.get('tests.useTcfv2Variant') === 'variant';
+
+export const isInTcfv2Test = (): boolean => {
+    if (typeof isInTest === 'undefined') {
+        isInTest = !isInUsa() && isInServerSideTest();
+    }
+    
+    return isInTest;
+};

--- a/static/src/javascripts/projects/commercial/modules/cmp/tcfv2-test.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/tcfv2-test.js
@@ -10,16 +10,7 @@ const isInServerSideTest = (): boolean =>
 
 export const isInTcfv2Test = (): boolean => {
     if (typeof isInTest === 'undefined') {
-        console.log(
-            '[CMP—TCFv2]',
-            'isInUsa',
-            isInUsa(),
-            '—',
-            'isInServerSideTest',
-            isInServerSideTest()
-        );
-        // TODO REMOVE true which is used for testing
-        isInTest = true || (!isInUsa() && isInServerSideTest());
+        isInTest = !isInUsa() && isInServerSideTest();
     }
 
     return isInTest;

--- a/static/src/javascripts/projects/commercial/modules/comscore.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.js
@@ -4,13 +4,7 @@ import config from 'lib/config';
 import { loadScript } from 'lib/load-script';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 
-import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
-
-const onGuConsentNotification = isInTcfv2Test()
-    ? () => {
-          console.warn('[CMP—TCFv2] this method is deprecated');
-      }
-    : oldCmp.onGuConsentNotification;
+const onGuConsentNotification = oldCmp.onGuConsentNotification;
 
 type comscoreGlobals = {
     c1: string,

--- a/static/src/javascripts/projects/commercial/modules/comscore.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.js
@@ -1,20 +1,8 @@
 // @flow strict
-import { oldCmp, onConsentChange } from '@guardian/consent-management-platform';
+import { oldCmp } from '@guardian/consent-management-platform';
 import config from 'lib/config';
 import { loadScript } from 'lib/load-script';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
-import { isInTcfv2Test } from './cmp/tcfv2-test';
-
-// TODO: Remove oldCmp.onGuConsentNotification and justuse onConsentChange when tcfv2 is released
-const onGuConsentNotification = isInTcfv2Test()
-    ? (fake, callback) => {
-          onConsentChange(callback);
-          console.warn(
-              'the onGuConsentNotification method is deprecated',
-              fake
-          );
-      }
-    : oldCmp.onGuConsentNotification;
 
 type comscoreGlobals = {
     c1: string,
@@ -64,7 +52,7 @@ const initOnConsent = (state: boolean | null) => {
 
 export const init = (): Promise<void> => {
     if (commercialFeatures.comscore) {
-        onGuConsentNotification('performance', initOnConsent);
+        oldCmp.onGuConsentNotification('performance', initOnConsent);
     }
 
     return Promise.resolve();

--- a/static/src/javascripts/projects/commercial/modules/comscore.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.js
@@ -6,8 +6,12 @@ import { commercialFeatures } from 'common/modules/commercial/commercial-feature
 import { isInTcfv2Test } from './cmp/tcfv2-test';
 
 const onGuConsentNotification = isInTcfv2Test()
-    ? () => {
-          console.warn('the onGuConsentNotification method is deprecated');
+    ? (fake, args) => {
+          console.warn(
+              'the onGuConsentNotification method is deprecated',
+              fake,
+              args
+          );
       }
     : oldCmp.onGuConsentNotification;
 

--- a/static/src/javascripts/projects/commercial/modules/comscore.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.js
@@ -1,16 +1,17 @@
 // @flow strict
-import { oldCmp } from '@guardian/consent-management-platform';
+import { oldCmp, onConsentChange } from '@guardian/consent-management-platform';
 import config from 'lib/config';
 import { loadScript } from 'lib/load-script';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { isInTcfv2Test } from './cmp/tcfv2-test';
 
+// TODO: Remove oldCmp.onGuConsentNotification and justuse onConsentChange when tcfv2 is released
 const onGuConsentNotification = isInTcfv2Test()
-    ? (fake, args) => {
+    ? (fake, callback) => {
+          onConsentChange(callback);
           console.warn(
               'the onGuConsentNotification method is deprecated',
-              fake,
-              args
+              fake
           );
       }
     : oldCmp.onGuConsentNotification;

--- a/static/src/javascripts/projects/commercial/modules/comscore.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.js
@@ -4,6 +4,14 @@ import config from 'lib/config';
 import { loadScript } from 'lib/load-script';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 
+import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
+
+const onGuConsentNotification = isInTcfv2Test()
+    ? () => {
+          console.warn('[CMP—TCFv2] this method is deprecated');
+      }
+    : oldCmp.onGuConsentNotification;
+
 type comscoreGlobals = {
     c1: string,
     c2: string,
@@ -52,7 +60,7 @@ const initOnConsent = (state: boolean | null) => {
 
 export const init = (): Promise<void> => {
     if (commercialFeatures.comscore) {
-        oldCmp.onGuConsentNotification('performance', initOnConsent);
+        onGuConsentNotification('performance', initOnConsent);
     }
 
     return Promise.resolve();

--- a/static/src/javascripts/projects/commercial/modules/comscore.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.js
@@ -1,8 +1,16 @@
 // @flow strict
-import { onGuConsentNotification } from '@guardian/consent-management-platform';
+import { oldCmp } from '@guardian/consent-management-platform';
 import config from 'lib/config';
 import { loadScript } from 'lib/load-script';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
+
+import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
+
+const onGuConsentNotification = isInTcfv2Test()
+    ? () => {
+          console.warn('[CMP—TCFv2] this method is deprecated');
+      }
+    : oldCmp.onGuConsentNotification;
 
 type comscoreGlobals = {
     c1: string,

--- a/static/src/javascripts/projects/commercial/modules/comscore.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.js
@@ -3,8 +3,13 @@ import { oldCmp } from '@guardian/consent-management-platform';
 import config from 'lib/config';
 import { loadScript } from 'lib/load-script';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
+import { isInTcfv2Test } from './cmp/tcfv2-test';
 
-const onGuConsentNotification = oldCmp.onGuConsentNotification;
+const onGuConsentNotification = isInTcfv2Test()
+    ? () => {
+          console.warn('the onGuConsentNotification method is deprecated');
+      }
+    : oldCmp.onGuConsentNotification;
 
 type comscoreGlobals = {
     c1: string,

--- a/static/src/javascripts/projects/commercial/modules/comscore.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { onGuConsentNotification } from '@guardian/consent-management-platform';
+import { oldCmp } from '@guardian/consent-management-platform';
 import config from 'lib/config';
 import { loadScript } from 'lib/load-script';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
@@ -52,7 +52,7 @@ const initOnConsent = (state: boolean | null) => {
 
 export const init = (): Promise<void> => {
     if (commercialFeatures.comscore) {
-        onGuConsentNotification('performance', initOnConsent);
+        oldCmp.onGuConsentNotification('performance', initOnConsent);
     }
 
     return Promise.resolve();

--- a/static/src/javascripts/projects/commercial/modules/comscore.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.spec.js
@@ -1,14 +1,22 @@
 // @flow
-import { onGuConsentNotification as onGuConsentNotification_ } from '@guardian/consent-management-platform';
 import { loadScript } from 'lib/load-script';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
+import { oldCmp } from '@guardian/consent-management-platform';
 import { init, _ } from './comscore';
 
-const onGuConsentNotification: any = onGuConsentNotification_;
-
 jest.mock('@guardian/consent-management-platform', () => ({
-    onGuConsentNotification: jest.fn(),
+    oldCmp: {
+        onGuConsentNotification: jest.fn(),
+        onIabConsentNotification: jest.fn(),
+    },
+    onConsentChange: jest.fn(),
 }));
+
+// Force TCFv1
+jest.mock('commercial/modules/cmp/tcfv2-test', () => ({
+    isInTcfv2Test: jest.fn().mockReturnValue(false),
+}));
+const onGuConsentNotification = oldCmp.onGuConsentNotification;
 
 jest.mock('lib/load-script', () => ({
     loadScript: jest.fn(() => Promise.resolve()),

--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
@@ -9,7 +9,9 @@ import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { loadAdvert } from 'commercial/modules/dfp/load-advert';
 import { fillAdvertSlots as fillAdvertSlots_ } from 'commercial/modules/dfp/fill-advert-slots';
-import { onIabConsentNotification as onIabConsentNotification_ } from '@guardian/consent-management-platform';
+import { oldCmp as oldCmp_ } from '@guardian/consent-management-platform';
+
+const oldCmp: any = oldCmp_;
 
 // $FlowFixMe property requireActual is actually not missing Flow.
 const { fillAdvertSlots: actualFillAdvertSlots } = jest.requireActual(
@@ -18,10 +20,14 @@ const { fillAdvertSlots: actualFillAdvertSlots } = jest.requireActual(
 
 const getBreakpoint: any = getBreakpoint_;
 const fillAdvertSlots: any = fillAdvertSlots_;
-const onIabConsentNotification: any = onIabConsentNotification_;
 
 jest.mock('commercial/modules/dfp/fill-advert-slots', () => ({
     fillAdvertSlots: jest.fn(),
+}));
+jest.mock('commercial/modules/cmp/tcfv2-test', () => ({
+    isInTcfv2Test: jest
+        .fn()
+        .mockImplementation(() => false),
 }));
 jest.mock('lib/raven');
 jest.mock('common/modules/identity/api', () => ({
@@ -93,7 +99,10 @@ jest.mock('commercial/modules/dfp/load-advert', () => ({
     loadAdvert: jest.fn(),
 }));
 jest.mock('@guardian/consent-management-platform', () => ({
-    onIabConsentNotification: jest.fn(),
+    oldCmp: {
+        onIabConsentNotification: jest.fn()
+    },
+    onConsentChange: jest.fn()
 }));
 
 let $style;
@@ -450,7 +459,7 @@ describe('DFP', () => {
 
     describe('NPA flag is set correctly', () => {
         it('when full TCF consent was given', () => {
-            onIabConsentNotification.mockImplementation(callback =>
+            oldCmp.onIabConsentNotification.mockImplementation(callback =>
                 callback(tcfWithConsent)
             );
             prepareGoogletag().then(() => {
@@ -460,7 +469,7 @@ describe('DFP', () => {
             });
         });
         it('when no TCF consent preferences were specified', () => {
-            onIabConsentNotification.mockImplementation(callback =>
+            oldCmp.onIabConsentNotification.mockImplementation(callback =>
                 callback(tcfNullConsent)
             );
             prepareGoogletag().then(() => {
@@ -470,7 +479,7 @@ describe('DFP', () => {
             });
         });
         it('when full TCF consent was denied', () => {
-            onIabConsentNotification.mockImplementation(callback =>
+            oldCmp.onIabConsentNotification.mockImplementation(callback =>
                 callback(tcfWithoutConsent)
             );
             prepareGoogletag().then(() => {
@@ -480,7 +489,7 @@ describe('DFP', () => {
             });
         });
         it('when only partial TCF consent was given', () => {
-            onIabConsentNotification.mockImplementation(callback =>
+            oldCmp.onIabConsentNotification.mockImplementation(callback =>
                 callback(tcfMixedConsent)
             );
             prepareGoogletag().then(() => {
@@ -492,7 +501,7 @@ describe('DFP', () => {
     });
     describe('restrictDataProcessing flag is set correctly', () => {
         it('when CCPA consent was given', () => {
-            onIabConsentNotification.mockImplementation(callback =>
+            oldCmp.onIabConsentNotification.mockImplementation(callback =>
                 callback(ccpaWithConsent)
             );
             prepareGoogletag().then(() => {
@@ -504,7 +513,7 @@ describe('DFP', () => {
             });
         });
         it('when CCPA consent was denied', () => {
-            onIabConsentNotification.mockImplementation(callback =>
+            oldCmp.onIabConsentNotification.mockImplementation(callback =>
                 callback(ccpaWithoutConsent)
             );
             prepareGoogletag().then(() => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -8,7 +8,6 @@ import raven from 'lib/raven';
 import sha1 from 'lib/sha1';
 import { session } from 'lib/storage';
 import { getPageTargeting } from 'common/modules/commercial/build-page-targeting';
-import { onIabConsentNotification } from '@guardian/consent-management-platform';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { adFreeSlotRemove } from 'commercial/modules/ad-free-slot-remove';
 import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
@@ -31,8 +30,8 @@ import { init as scroll } from 'commercial/modules/messenger/scroll';
 import { init as type } from 'commercial/modules/messenger/type';
 import { init as viewport } from 'commercial/modules/messenger/viewport';
 
-import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
 import { cmp, oldCmp } from '@guardian/consent-management-platform';
+import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
 
 const onIabConsentNotification = isInTcfv2Test()
     ? cmp.onConsentChange

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -31,6 +31,13 @@ import { init as scroll } from 'commercial/modules/messenger/scroll';
 import { init as type } from 'commercial/modules/messenger/type';
 import { init as viewport } from 'commercial/modules/messenger/viewport';
 
+import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
+import { cmp, oldCmp } from '@guardian/consent-management-platform';
+
+const onIabConsentNotification = isInTcfv2Test()
+    ? cmp.onConsentChange
+    : oldCmp.onIabConsentNotification;
+
 initMessenger(
     type,
     getStyles,

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -8,7 +8,6 @@ import raven from 'lib/raven';
 import sha1 from 'lib/sha1';
 import { session } from 'lib/storage';
 import { getPageTargeting } from 'common/modules/commercial/build-page-targeting';
-import { onIabConsentNotification } from '@guardian/consent-management-platform';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { adFreeSlotRemove } from 'commercial/modules/ad-free-slot-remove';
 import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
@@ -30,6 +29,13 @@ import { init as resize } from 'commercial/modules/messenger/resize';
 import { init as scroll } from 'commercial/modules/messenger/scroll';
 import { init as type } from 'commercial/modules/messenger/type';
 import { init as viewport } from 'commercial/modules/messenger/viewport';
+
+import { cmp, oldCmp } from '@guardian/consent-management-platform';
+import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
+
+const onIabConsentNotification = isInTcfv2Test()
+    ? cmp.onConsentChange
+    : oldCmp.onIabConsentNotification;
 
 initMessenger(
     type,

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -33,7 +33,7 @@ import { init as viewport } from 'commercial/modules/messenger/viewport';
 import { onConsentChange, oldCmp } from '@guardian/consent-management-platform';
 import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
 
-const onIabConsentNotification = isInTcfv2Test()
+const onCMPConsentNotification = isInTcfv2Test()
     ? onConsentChange
     : oldCmp.onIabConsentNotification;
 
@@ -108,7 +108,7 @@ export const init = (): Promise<void> => {
             }
         );
 
-        onIabConsentNotification(state => {
+        onCMPConsentNotification(state => {
             // typeof state === 'boolean' means CCPA mode is on
             if (typeof state === 'boolean') {
                 window.googletag.cmd.push(() => {
@@ -117,7 +117,14 @@ export const init = (): Promise<void> => {
                     });
                 });
             } else {
-                const npaFlag = Object.values(state).includes(false);
+                let npaFlag: boolean;
+                if (typeof state.tcfv2 !== 'undefined') {
+                    // TCFv2 mode,
+                    npaFlag = Object.values(state.tcfv2).every(Boolean);
+                } else {
+                    // TCFv1 mode
+                    npaFlag = Object.values(state).includes(false);
+                }
                 window.googletag.cmd.push(() => {
                     window.googletag
                         .pubads()

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -30,11 +30,11 @@ import { init as scroll } from 'commercial/modules/messenger/scroll';
 import { init as type } from 'commercial/modules/messenger/type';
 import { init as viewport } from 'commercial/modules/messenger/viewport';
 
-import { cmp, oldCmp } from '@guardian/consent-management-platform';
+import { onConsentChange, oldCmp } from '@guardian/consent-management-platform';
 import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
 
 const onIabConsentNotification = isInTcfv2Test()
-    ? cmp.onConsentChange
+    ? onConsentChange
     : oldCmp.onIabConsentNotification;
 
 initMessenger(

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
@@ -7,7 +7,7 @@ import { isInAuOrNz } from 'common/modules/commercial/geo-utils';
 import { onConsentChange, oldCmp } from '@guardian/consent-management-platform';
 import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
 
-const onIabConsentNotification = isInTcfv2Test()
+const onCMPConsentNotification = isInTcfv2Test()
     ? onConsentChange
     : oldCmp.onIabConsentNotification;
 
@@ -34,13 +34,19 @@ const initialise = (): void => {
 };
 
 const setupRedplanet: () => Promise<void> = () => {
-    onIabConsentNotification(state => {
+    onCMPConsentNotification(state => {
         // typeof state === 'boolean' means CCPA mode is on
         // CCPA only runs in the US and Redplanet only runs in Australia
         // so this should never happen
         if (typeof state !== 'boolean') {
-            const canRun =
-                state[1] && state[2] && state[3] && state[4] && state[5];
+            let canRun: boolean;
+            if (typeof state.tcfv2 !== 'undefined') {
+                // TCFv2 mode,
+                canRun = Object.values(state.tcfv2).every(Boolean);
+            } else {
+                // TCFv1 mode
+                canRun = state[1] && state[2] && state[3] && state[4] && state[5];
+            }
 
             if (!initialised && canRun) {
                 initialised = true;

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
@@ -2,8 +2,14 @@
 
 import config from 'lib/config';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
-import { onIabConsentNotification } from '@guardian/consent-management-platform';
 import { isInAuOrNz } from 'common/modules/commercial/geo-utils';
+
+import { cmp, oldCmp } from '@guardian/consent-management-platform';
+import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
+
+const onIabConsentNotification = isInTcfv2Test()
+    ? cmp.onConsentChange
+    : oldCmp.onIabConsentNotification;
 
 let initialised = false;
 
@@ -49,10 +55,7 @@ const setupRedplanet: () => Promise<void> = () => {
 };
 
 export const init = (): Promise<void> => {
-    if (
-        commercialFeatures.launchpad &&
-        isInAuOrNz()
-    ) {
+    if (commercialFeatures.launchpad && isInAuOrNz()) {
         return setupRedplanet();
     }
     return Promise.resolve();

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
@@ -5,6 +5,13 @@ import { commercialFeatures } from 'common/modules/commercial/commercial-feature
 import { onIabConsentNotification } from '@guardian/consent-management-platform';
 import { isInAuOrNz } from 'common/modules/commercial/geo-utils';
 
+import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
+import { cmp, oldCmp } from '@guardian/consent-management-platform';
+
+const onIabConsentNotification = isInTcfv2Test()
+    ? cmp.onConsentChange
+    : oldCmp.onIabConsentNotification;
+
 let initialised = false;
 
 const initialise = (): void => {
@@ -49,10 +56,7 @@ const setupRedplanet: () => Promise<void> = () => {
 };
 
 export const init = (): Promise<void> => {
-    if (
-        commercialFeatures.launchpad &&
-        isInAuOrNz()
-    ) {
+    if (commercialFeatures.launchpad && isInAuOrNz()) {
         return setupRedplanet();
     }
     return Promise.resolve();

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
@@ -4,11 +4,11 @@ import config from 'lib/config';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { isInAuOrNz } from 'common/modules/commercial/geo-utils';
 
-import { cmp, oldCmp } from '@guardian/consent-management-platform';
+import { onConsentChange, oldCmp } from '@guardian/consent-management-platform';
 import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
 
 const onIabConsentNotification = isInTcfv2Test()
-    ? cmp.onConsentChange
+    ? onConsentChange
     : oldCmp.onIabConsentNotification;
 
 let initialised = false;

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
@@ -2,11 +2,10 @@
 
 import config from 'lib/config';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
-import { onIabConsentNotification } from '@guardian/consent-management-platform';
 import { isInAuOrNz } from 'common/modules/commercial/geo-utils';
 
-import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
 import { cmp, oldCmp } from '@guardian/consent-management-platform';
+import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
 
 const onIabConsentNotification = isInTcfv2Test()
     ? cmp.onConsentChange

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
@@ -10,11 +10,11 @@ import type {
     HeaderBiddingSlot,
 } from 'commercial/modules/header-bidding/types';
 
-import { cmp, oldCmp } from '@guardian/consent-management-platform';
+import { onConsentChange, oldCmp } from '@guardian/consent-management-platform';
 import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
 
 const onIabConsentNotification = isInTcfv2Test()
-    ? cmp.onConsentChange
+    ? onConsentChange
     : oldCmp.onIabConsentNotification;
 
 class A9AdUnit {

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
@@ -11,6 +11,13 @@ import type {
 } from 'commercial/modules/header-bidding/types';
 import { onIabConsentNotification } from '@guardian/consent-management-platform';
 
+import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
+import { cmp, oldCmp } from '@guardian/consent-management-platform';
+
+const onIabConsentNotification = isInTcfv2Test()
+    ? cmp.onConsentChange
+    : oldCmp.onIabConsentNotification;
+
 class A9AdUnit {
     slotID: ?string;
     slotName: ?string;

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
@@ -13,7 +13,7 @@ import type {
 import { onConsentChange, oldCmp } from '@guardian/consent-management-platform';
 import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
 
-const onIabConsentNotification = isInTcfv2Test()
+const onCMPConsentNotification = isInTcfv2Test()
     ? onConsentChange
     : oldCmp.onIabConsentNotification;
 
@@ -39,12 +39,18 @@ let requestQueue: Promise<void> = Promise.resolve();
 const bidderTimeout: number = 1500;
 
 const initialise = (): void => {
-    onIabConsentNotification(state => {
-        // typeof state === 'boolean' means CCPA mode is on
-        const canRun =
-            typeof state === 'boolean'
-                ? !state
-                : state[1] && state[2] && state[3] && state[4] && state[5];
+    onCMPConsentNotification(state => {
+        let canRun: boolean;
+        if (typeof state === 'boolean') {
+            // CCPA mode
+            canRun = !state;
+        } else if (typeof state.tcfv2 !== 'undefined') {
+            // TCFv2 mode,
+            canRun = Object.values(state.tcfv2).every(Boolean);
+        } else {
+            // TCFv1 mode
+            canRun = state[1] && state[2] && state[3] && state[4] && state[5];
+        }
 
         if (!initialised && canRun) {
             initialised = true;

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
@@ -9,7 +9,13 @@ import type {
     HeaderBiddingSize,
     HeaderBiddingSlot,
 } from 'commercial/modules/header-bidding/types';
-import { onIabConsentNotification } from '@guardian/consent-management-platform';
+
+import { cmp, oldCmp } from '@guardian/consent-management-platform';
+import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
+
+const onIabConsentNotification = isInTcfv2Test()
+    ? cmp.onConsentChange
+    : oldCmp.onIabConsentNotification;
 
 class A9AdUnit {
     slotID: ?string;

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
@@ -9,10 +9,9 @@ import type {
     HeaderBiddingSize,
     HeaderBiddingSlot,
 } from 'commercial/modules/header-bidding/types';
-import { onIabConsentNotification } from '@guardian/consent-management-platform';
 
-import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
 import { cmp, oldCmp } from '@guardian/consent-management-platform';
+import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
 
 const onIabConsentNotification = isInTcfv2Test()
     ? cmp.onConsentChange

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.spec.js
@@ -6,9 +6,7 @@ import {
     oldCmp as oldCmp_ } from '@guardian/consent-management-platform';
 import { isInTcfv2Test as isInTcfv2Test_ } from 'commercial/modules/cmp/tcfv2-test';
 
-const onConsentChange: any = onConsentChange_;
 const oldCmp: any = oldCmp_;
-const isInTcfv2Test: any = isInTcfv2Test_;
 
 const TcfWithConsentMock = (callback): void =>
     callback({ '1': true, '2': true, '3': true, '4': true, '5': true });

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.spec.js
@@ -2,9 +2,7 @@
 
 import a9, { _ } from 'commercial/modules/header-bidding/a9/a9';
 import {
-    onConsentChange as onConsentChange_,
     oldCmp as oldCmp_ } from '@guardian/consent-management-platform';
-import { isInTcfv2Test as isInTcfv2Test_ } from 'commercial/modules/cmp/tcfv2-test';
 
 const oldCmp: any = oldCmp_;
 

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.spec.js
@@ -1,9 +1,14 @@
 // @flow
 
 import a9, { _ } from 'commercial/modules/header-bidding/a9/a9';
-import { onIabConsentNotification as onIabConsentNotification_ } from '@guardian/consent-management-platform';
+import {
+    onConsentChange as onConsentChange_,
+    oldCmp as oldCmp_ } from '@guardian/consent-management-platform';
+import { isInTcfv2Test as isInTcfv2Test_ } from 'commercial/modules/cmp/tcfv2-test';
 
-const onIabConsentNotification: any = onIabConsentNotification_;
+const onConsentChange: any = onConsentChange_;
+const oldCmp: any = oldCmp_;
+const isInTcfv2Test: any = isInTcfv2Test_;
 
 const TcfWithConsentMock = (callback): void =>
     callback({ '1': true, '2': true, '3': true, '4': true, '5': true });
@@ -15,6 +20,12 @@ jest.mock('commercial/modules/dfp/Advert', () =>
     jest.fn().mockImplementation(() => ({ advert: jest.fn() }))
 );
 
+jest.mock('commercial/modules/cmp/tcfv2-test', () => ({
+    isInTcfv2Test: jest
+        .fn()
+        .mockImplementation(() => false),
+}));
+
 jest.mock('commercial/modules/header-bidding/slot-config', () => ({
     slots: jest
         .fn()
@@ -24,7 +35,10 @@ jest.mock('commercial/modules/header-bidding/slot-config', () => ({
 }));
 
 jest.mock('@guardian/consent-management-platform', () => ({
-    onIabConsentNotification: jest.fn(),
+    oldCmp: {
+        onIabConsentNotification: jest.fn()
+    },
+    onConsentChange: jest.fn()
 }));
 
 beforeEach(async () => {
@@ -43,14 +57,14 @@ afterAll(() => {
 
 describe('initialise', () => {
     it('should generate initialise A9 library when TCF consent has been given', () => {
-        onIabConsentNotification.mockImplementation(TcfWithConsentMock);
+        oldCmp.onIabConsentNotification.mockImplementation(TcfWithConsentMock);
         a9.initialise();
         expect(window.apstag).toBeDefined();
         expect(window.apstag.init).toHaveBeenCalled();
     });
 
     it('should generate initialise A9 library when CCPA consent has been given', () => {
-        onIabConsentNotification.mockImplementation(CcpaWithConsentMock);
+        oldCmp.onIabConsentNotification.mockImplementation(CcpaWithConsentMock);
         a9.initialise();
         expect(window.apstag).toBeDefined();
         expect(window.apstag.init).toHaveBeenCalled();

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.spec.js
@@ -1,8 +1,7 @@
 // @flow
 
 import a9, { _ } from 'commercial/modules/header-bidding/a9/a9';
-import {
-    oldCmp as oldCmp_ } from '@guardian/consent-management-platform';
+import { oldCmp as oldCmp_ } from '@guardian/consent-management-platform';
 
 const oldCmp: any = oldCmp_;
 

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -23,8 +23,12 @@ const onIabConsentNotification = isInTcfv2Test()
     : oldCmp.onIabConsentNotification;
 
 const onGuConsentNotification = isInTcfv2Test()
-    ? () => {
-          console.warn('the onGuConsentNotification method is deprecated');
+    ? (fake, args) => {
+          console.warn(
+              'the onGuConsentNotification method is deprecated',
+              fake,
+              args
+          );
       }
     : oldCmp.onGuConsentNotification;
 

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -14,10 +14,15 @@ import { permutive } from 'commercial/modules/third-party-tags/permutive';
 import { init as initPlistaRenderer } from 'commercial/modules/third-party-tags/plista-renderer';
 import { twitterUwt } from 'commercial/modules/third-party-tags/twitter-uwt';
 import { connatix } from 'commercial/modules/third-party-tags/connatix';
-import {
-    onIabConsentNotification,
-    onGuConsentNotification,
-} from '@guardian/consent-management-platform';
+
+import { cmp, oldCmp } from '@guardian/consent-management-platform';
+import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
+
+const onIabConsentNotification = isInTcfv2Test()
+    ? cmp.onConsentChange
+    : oldCmp.onIabConsentNotification;
+
+const onGuConsentNotification = oldCmp.onGuConsentNotification;
 
 let advertisingScriptsInserted: boolean = false;
 let performanceScriptsInserted: boolean = false;

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -22,7 +22,11 @@ const onIabConsentNotification = isInTcfv2Test()
     ? onConsentChange
     : oldCmp.onIabConsentNotification;
 
-const onGuConsentNotification = oldCmp.onGuConsentNotification;
+const onGuConsentNotification = isInTcfv2Test()
+    ? () => {
+          console.warn('the onGuConsentNotification method is deprecated');
+      }
+    : oldCmp.onGuConsentNotification;
 
 let advertisingScriptsInserted: boolean = false;
 let performanceScriptsInserted: boolean = false;

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -22,17 +22,6 @@ const onCMPConsentNotification = isInTcfv2Test()
     ? onConsentChange
     : oldCmp.onIabConsentNotification;
 
-// TODO: Remove oldCmp.onGuConsentNotification and justuse onConsentChange when tcfv2 is released
-const onGuConsentNotification = isInTcfv2Test()
-    ? (fake, callback) => {
-        onConsentChange(callback);
-        console.warn(
-            'the onGuConsentNotification method is deprecated',
-            fake
-        );
-    }
-    : oldCmp.onGuConsentNotification;
-
 let advertisingScriptsInserted: boolean = false;
 let performanceScriptsInserted: boolean = false;
 
@@ -74,7 +63,7 @@ const insertScripts = (
     advertisingServices: Array<ThirdPartyTag>,
     performanceServices: Array<ThirdPartyTag>
 ): void => {
-    onGuConsentNotification('performance', state => {
+    oldCmp.onGuConsentNotification('performance', state => {
         if (!performanceScriptsInserted && state) {
             addScripts(performanceServices);
             performanceScriptsInserted = true;

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -22,11 +22,7 @@ const onIabConsentNotification = isInTcfv2Test()
     ? onConsentChange
     : oldCmp.onIabConsentNotification;
 
-const onGuConsentNotification = isInTcfv2Test()
-    ? () => {
-          console.warn('[CMP—TCFv2] this method is deprecated');
-      }
-    : oldCmp.onGuConsentNotification;
+const onGuConsentNotification = oldCmp.onGuConsentNotification;
 
 let advertisingScriptsInserted: boolean = false;
 let performanceScriptsInserted: boolean = false;

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -22,14 +22,15 @@ const onIabConsentNotification = isInTcfv2Test()
     ? onConsentChange
     : oldCmp.onIabConsentNotification;
 
+// TODO: Remove oldCmp.onGuConsentNotification and justuse onConsentChange when tcfv2 is released
 const onGuConsentNotification = isInTcfv2Test()
-    ? (fake, args) => {
-          console.warn(
-              'the onGuConsentNotification method is deprecated',
-              fake,
-              args
-          );
-      }
+    ? (fake, callback) => {
+        onConsentChange(callback);
+        console.warn(
+            'the onGuConsentNotification method is deprecated',
+            fake
+        );
+    }
     : oldCmp.onGuConsentNotification;
 
 let advertisingScriptsInserted: boolean = false;

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -14,6 +14,7 @@ import { permutive } from 'commercial/modules/third-party-tags/permutive';
 import { init as initPlistaRenderer } from 'commercial/modules/third-party-tags/plista-renderer';
 import { twitterUwt } from 'commercial/modules/third-party-tags/twitter-uwt';
 import { connatix } from 'commercial/modules/third-party-tags/connatix';
+
 import { cmp, oldCmp } from '@guardian/consent-management-platform';
 import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
 

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -15,14 +15,18 @@ import { init as initPlistaRenderer } from 'commercial/modules/third-party-tags/
 import { twitterUwt } from 'commercial/modules/third-party-tags/twitter-uwt';
 import { connatix } from 'commercial/modules/third-party-tags/connatix';
 
-import { cmp, oldCmp } from '@guardian/consent-management-platform';
+import { onConsentChange, oldCmp } from '@guardian/consent-management-platform';
 import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
 
 const onIabConsentNotification = isInTcfv2Test()
-    ? cmp.onConsentChange
+    ? onConsentChange
     : oldCmp.onIabConsentNotification;
 
-const onGuConsentNotification = oldCmp.onGuConsentNotification;
+const onGuConsentNotification = isInTcfv2Test()
+    ? () => {
+          console.warn('[CMP—TCFv2] this method is deprecated');
+      }
+    : oldCmp.onGuConsentNotification;
 
 let advertisingScriptsInserted: boolean = false;
 let performanceScriptsInserted: boolean = false;

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -14,10 +14,14 @@ import { permutive } from 'commercial/modules/third-party-tags/permutive';
 import { init as initPlistaRenderer } from 'commercial/modules/third-party-tags/plista-renderer';
 import { twitterUwt } from 'commercial/modules/third-party-tags/twitter-uwt';
 import { connatix } from 'commercial/modules/third-party-tags/connatix';
-import {
-    onIabConsentNotification,
-    onGuConsentNotification,
-} from '@guardian/consent-management-platform';
+import { cmp, oldCmp } from '@guardian/consent-management-platform';
+import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
+
+const onIabConsentNotification = isInTcfv2Test()
+    ? cmp.onConsentChange
+    : oldCmp.onIabConsentNotification;
+
+const onGuConsentNotification = oldCmp.onGuConsentNotification;
 
 let advertisingScriptsInserted: boolean = false;
 let performanceScriptsInserted: boolean = false;

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -18,7 +18,7 @@ import { connatix } from 'commercial/modules/third-party-tags/connatix';
 import { onConsentChange, oldCmp } from '@guardian/consent-management-platform';
 import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
 
-const onIabConsentNotification = isInTcfv2Test()
+const onCMPConsentNotification = isInTcfv2Test()
     ? onConsentChange
     : oldCmp.onIabConsentNotification;
 
@@ -81,12 +81,18 @@ const insertScripts = (
         }
     });
 
-    onIabConsentNotification(state => {
-        // typeof state === 'boolean' means CCPA mode is on
-        const canRun =
-            typeof state === 'boolean'
-                ? !state
-                : state[1] && state[2] && state[3] && state[4] && state[5];
+    onCMPConsentNotification(state => {
+        let canRun: boolean;
+        if (typeof state === 'boolean') {
+            // CCPA mode
+            canRun = !state;
+        } else if (typeof state.tcfv2 !== 'undefined') {
+            // TCFv2 mode,
+            canRun = Object.values(state.tcfv2).every(Boolean);
+        } else {
+            // TCFv1 mode
+            canRun = state[1] && state[2] && state[3] && state[4] && state[5];
+        }
 
         if (!advertisingScriptsInserted && canRun) {
             addScripts(advertisingServices);

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
@@ -1,6 +1,5 @@
 // @flow
-import { onConsentChange, oldCmp } from '@guardian/consent-management-platform';
-import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
+import { oldCmp } from '@guardian/consent-management-platform';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { init, _ } from './third-party-tags';
 

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
@@ -1,21 +1,27 @@
 // @flow
-import {
-    onIabConsentNotification as onIabConsentNotification_,
-    onGuConsentNotification as onGuConsentNotification_,
-} from '@guardian/consent-management-platform';
+import { onConsentChange, oldCmp } from '@guardian/consent-management-platform';
+import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { init, _ } from './third-party-tags';
-
-const onIabConsentNotification: any = onIabConsentNotification_;
-const onGuConsentNotification: any = onGuConsentNotification_;
 
 const { insertScripts, loadOther } = _;
 
 jest.mock('lib/raven');
+
 jest.mock('@guardian/consent-management-platform', () => ({
-    onIabConsentNotification: jest.fn(),
-    onGuConsentNotification: jest.fn(),
+    oldCmp: {
+        onIabConsentNotification: jest.fn(),
+        onGuConsentNotification: jest.fn(),
+    },
+    onConsentChange: jest.fn(),
 }));
+
+// Force TCFv1
+jest.mock('commercial/modules/cmp/tcfv2-test', () => ({
+    isInTcfv2Test: jest.fn().mockReturnValue(false),
+}));
+const onIabConsentNotification = oldCmp.onIabConsentNotification;
+const onGuConsentNotification = oldCmp.onGuConsentNotification;
 
 beforeEach(() => {
     const firstScript = document.createElement('script');

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -14,7 +14,7 @@ import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
 
 import { getPermutivePFPSegments } from '../commercial/permutive';
 
-const onIabConsentNotification = isInTcfv2Test()
+const onCMPConsentNotification = isInTcfv2Test()
     ? onConsentChange
     : oldCmp.onIabConsentNotification;
 
@@ -54,12 +54,13 @@ interface AdsConfig {
 
 let tcfState = null;
 let ccpaState = null;
-onIabConsentNotification(state => {
+onCMPConsentNotification(state => {
     // typeof state === 'boolean' means CCPA mode is on
     if (typeof state === 'boolean') {
         ccpaState = state;
     } else {
-        tcfState = state[1] && state[2] && state[3] && state[4] && state[5];
+        tcfState = state.tcfv2 ? Object.values(state.tcfv2).every(Boolean) :
+            state[1] && state[2] && state[3] && state[4] && state[5];
     }
 });
 

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -6,13 +6,13 @@ import { loadScript } from 'lib/load-script';
 import { constructQuery } from 'lib/url';
 import { getPageTargeting } from 'common/modules/commercial/build-page-targeting';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
-import { onIabConsentNotification } from '@guardian/consent-management-platform';
 import $ from 'lib/$';
 import { buildPfpEvent } from 'common/modules/video/ga-helper';
-import { getPermutivePFPSegments } from '../commercial/permutive';
 
-import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
 import { cmp, oldCmp } from '@guardian/consent-management-platform';
+import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
+
+import { getPermutivePFPSegments } from '../commercial/permutive';
 
 const onIabConsentNotification = isInTcfv2Test()
     ? cmp.onConsentChange

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -6,10 +6,17 @@ import { loadScript } from 'lib/load-script';
 import { constructQuery } from 'lib/url';
 import { getPageTargeting } from 'common/modules/commercial/build-page-targeting';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
-import { onIabConsentNotification } from '@guardian/consent-management-platform';
 import $ from 'lib/$';
 import { buildPfpEvent } from 'common/modules/video/ga-helper';
+
+import { cmp, oldCmp } from '@guardian/consent-management-platform';
+import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
+
 import { getPermutivePFPSegments } from '../commercial/permutive';
+
+const onIabConsentNotification = isInTcfv2Test()
+    ? cmp.onConsentChange
+    : oldCmp.onIabConsentNotification;
 
 const scriptSrc = 'https://www.youtube.com/iframe_api';
 const promise = new Promise(resolve => {

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -11,6 +11,13 @@ import $ from 'lib/$';
 import { buildPfpEvent } from 'common/modules/video/ga-helper';
 import { getPermutivePFPSegments } from '../commercial/permutive';
 
+import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
+import { cmp, oldCmp } from '@guardian/consent-management-platform';
+
+const onIabConsentNotification = isInTcfv2Test()
+    ? cmp.onConsentChange
+    : oldCmp.onIabConsentNotification;
+
 const scriptSrc = 'https://www.youtube.com/iframe_api';
 const promise = new Promise(resolve => {
     if (window.YT && window.YT.Player) {

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -9,13 +9,13 @@ import { commercialFeatures } from 'common/modules/commercial/commercial-feature
 import $ from 'lib/$';
 import { buildPfpEvent } from 'common/modules/video/ga-helper';
 
-import { cmp, oldCmp } from '@guardian/consent-management-platform';
+import { onConsentChange, oldCmp } from '@guardian/consent-management-platform';
 import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
 
 import { getPermutivePFPSegments } from '../commercial/permutive';
 
 const onIabConsentNotification = isInTcfv2Test()
-    ? cmp.onConsentChange
+    ? onConsentChange
     : oldCmp.onIabConsentNotification;
 
 const scriptSrc = 'https://www.youtube.com/iframe_api';

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -8,7 +8,6 @@ import { getPageTargeting } from 'common/modules/commercial/build-page-targeting
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import $ from 'lib/$';
 import { buildPfpEvent } from 'common/modules/video/ga-helper';
-
 import { onConsentChange, oldCmp } from '@guardian/consent-management-platform';
 import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
 

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.js
@@ -17,6 +17,7 @@ jest.mock('lib/config', () => ({
         if (key === 'isDotcomRendering') {
             return false;
         }
+        if (key === 'page.edition') return 'UK';
         throw new Error(
             `Unexpected config lookup '${key}', check the mock is still correct`
         );
@@ -24,7 +25,16 @@ jest.mock('lib/config', () => ({
 }));
 
 jest.mock('@guardian/consent-management-platform', () => ({
-    onIabConsentNotification: jest.fn(callback => callback({ '1': true })),
+    oldCmp: {
+        onIabConsentNotification: jest.fn(),
+        onGuConsentNotification: jest.fn(),
+    },
+    onConsentChange: jest.fn(),
+}));
+
+// Force TCFv1
+jest.mock('commercial/modules/cmp/tcfv2-test', () => ({
+    isInTcfv2Test: jest.fn().mockReturnValue(false),
 }));
 
 jest.mock('common/modules/commercial/commercial-features', () => ({

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.js
@@ -17,7 +17,6 @@ jest.mock('lib/config', () => ({
         if (key === 'isDotcomRendering') {
             return false;
         }
-        if (key === 'page.edition') return 'UK';
         throw new Error(
             `Unexpected config lookup '${key}', check the mock is still correct`
         );
@@ -26,10 +25,8 @@ jest.mock('lib/config', () => ({
 
 jest.mock('@guardian/consent-management-platform', () => ({
     oldCmp: {
-        onIabConsentNotification: jest.fn(),
-        onGuConsentNotification: jest.fn(),
+        onIabConsentNotification: jest.fn(callback => callback({ '1': true })),
     },
-    onConsentChange: jest.fn(),
 }));
 
 // Force TCFv1

--- a/static/src/javascripts/projects/common/modules/cmp-ui/index.js
+++ b/static/src/javascripts/projects/common/modules/cmp-ui/index.js
@@ -2,8 +2,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import reportError from 'lib/report-error';
-import { ConsentManagementPlatform } from '@guardian/consent-management-platform/dist/ConsentManagementPlatform';
-import { setErrorHandler } from '@guardian/consent-management-platform';
+import { oldCmp } from '@guardian/consent-management-platform';
+
+const ConsentManagementPlatform = oldCmp.ConsentManagementPlatform;
+const setErrorHandler = oldCmp.setErrorHandler;
 
 export const init = (forceModal: boolean) => {
     const container = document.createElement('div');

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -21,6 +21,13 @@ import once from 'lodash/once';
 import pick from 'lodash/pick';
 import pickBy from 'lodash/pickBy';
 
+import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
+import { cmp, oldCmp } from '@guardian/consent-management-platform';
+
+const onIabConsentNotification = isInTcfv2Test()
+    ? cmp.onConsentChange
+    : oldCmp.onIabConsentNotification;
+
 type PageTargeting = {
     sens: string,
     url: string,
@@ -254,9 +261,9 @@ const buildPageTargetting = (
                 config.get('page.dcrCouldRender', false)
                     ? 't'
                     : 'f',
-                       // Indicates whether the page is DCR eligible. This happens when the page
-                       // was DCR eligible and was actually rendered by DCR or
-                       // was DCR eligible but rendered by frontend for a user not in the DotcomRendering experiment
+            // Indicates whether the page is DCR eligible. This happens when the page
+            // was DCR eligible and was actually rendered by DCR or
+            // was DCR eligible but rendered by frontend for a user not in the DotcomRendering experiment
             inskin: inskinTargetting(),
             urlkw: getUrlKeywords(page.pageId),
             rdp: getRdpValue(ccpaState),

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -12,7 +12,6 @@ import { getUrlVars } from 'lib/url';
 import { getPermutiveSegments } from 'common/modules/commercial/permutive';
 import { isUserLoggedIn } from 'common/modules/identity/api';
 import { getUserSegments } from 'common/modules/commercial/user-ad-targeting';
-import { onIabConsentNotification } from '@guardian/consent-management-platform';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { getSynchronousParticipations } from 'common/modules/experiments/ab';
 import { removeFalseyValues } from 'commercial/modules/header-bidding/utils';
@@ -20,6 +19,13 @@ import flattenDeep from 'lodash/flattenDeep';
 import once from 'lodash/once';
 import pick from 'lodash/pick';
 import pickBy from 'lodash/pickBy';
+
+import { cmp, oldCmp } from '@guardian/consent-management-platform';
+import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
+
+const onIabConsentNotification = isInTcfv2Test()
+    ? cmp.onConsentChange
+    : oldCmp.onIabConsentNotification;
 
 type PageTargeting = {
     sens: string,
@@ -254,9 +260,9 @@ const buildPageTargetting = (
                 config.get('page.dcrCouldRender', false)
                     ? 't'
                     : 'f',
-                       // Indicates whether the page is DCR eligible. This happens when the page
-                       // was DCR eligible and was actually rendered by DCR or
-                       // was DCR eligible but rendered by frontend for a user not in the DotcomRendering experiment
+            // Indicates whether the page is DCR eligible. This happens when the page
+            // was DCR eligible and was actually rendered by DCR or
+            // was DCR eligible but rendered by frontend for a user not in the DotcomRendering experiment
             inskin: inskinTargetting(),
             urlkw: getUrlKeywords(page.pageId),
             rdp: getRdpValue(ccpaState),

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -12,7 +12,6 @@ import { getUrlVars } from 'lib/url';
 import { getPermutiveSegments } from 'common/modules/commercial/permutive';
 import { isUserLoggedIn } from 'common/modules/identity/api';
 import { getUserSegments } from 'common/modules/commercial/user-ad-targeting';
-import { onIabConsentNotification } from '@guardian/consent-management-platform';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { getSynchronousParticipations } from 'common/modules/experiments/ab';
 import { removeFalseyValues } from 'commercial/modules/header-bidding/utils';
@@ -21,8 +20,8 @@ import once from 'lodash/once';
 import pick from 'lodash/pick';
 import pickBy from 'lodash/pickBy';
 
-import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
 import { cmp, oldCmp } from '@guardian/consent-management-platform';
+import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
 
 const onIabConsentNotification = isInTcfv2Test()
     ? cmp.onConsentChange

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -20,11 +20,11 @@ import once from 'lodash/once';
 import pick from 'lodash/pick';
 import pickBy from 'lodash/pickBy';
 
-import { cmp, oldCmp } from '@guardian/consent-management-platform';
+import { oldCmp, onConsentChange } from '@guardian/consent-management-platform';
 import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
 
 const onIabConsentNotification = isInTcfv2Test()
-    ? cmp.onConsentChange
+    ? onConsentChange
     : oldCmp.onIabConsentNotification;
 
 type PageTargeting = {

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -16,8 +16,7 @@ import { getSync as getSync_ } from 'lib/geolocation';
 import { isUserLoggedIn as isUserLoggedIn_ } from 'common/modules/identity/api';
 import { getUserSegments as getUserSegments_ } from 'common/modules/commercial/user-ad-targeting';
 import { getSynchronousParticipations as getSynchronousParticipations_ } from 'common/modules/experiments/ab';
-import {
-    oldCmp as oldCmp_ } from '@guardian/consent-management-platform';
+import { oldCmp as oldCmp_ } from '@guardian/consent-management-platform';
 
 const oldCmp: any = oldCmp_;
 const getCookie: any = getCookie_;
@@ -34,9 +33,7 @@ jest.mock('lib/cookies', () => ({
     getCookie: jest.fn(),
 }));
 jest.mock('commercial/modules/cmp/tcfv2-test', () => ({
-    isInTcfv2Test: jest
-        .fn()
-        .mockImplementation(() => false),
+    isInTcfv2Test: jest.fn().mockImplementation(() => false),
 }));
 jest.mock('lib/detect', () => ({
     getViewport: jest.fn(),
@@ -62,9 +59,9 @@ jest.mock('common/modules/commercial/commercial-features', () => ({
 }));
 jest.mock('@guardian/consent-management-platform', () => ({
     oldCmp: {
-        onIabConsentNotification: jest.fn()
+        onIabConsentNotification: jest.fn(),
     },
-    onConsentChange: jest.fn()
+    onConsentChange: jest.fn(),
 }));
 
 const tcfWithConsentMock = (callback): void =>
@@ -175,7 +172,9 @@ describe('Build Page Targeting', () => {
         expect(getPageTargeting().pa).toBe('t');
 
         _.resetPageTargeting();
-        oldCmp.onIabConsentNotification.mockImplementation(tcfWithoutConsentMock);
+        oldCmp.onIabConsentNotification.mockImplementation(
+            tcfWithoutConsentMock
+        );
         expect(getPageTargeting().pa).toBe('f');
 
         _.resetPageTargeting();
@@ -191,7 +190,9 @@ describe('Build Page Targeting', () => {
         expect(getPageTargeting().pa).toBe('t');
 
         _.resetPageTargeting();
-        oldCmp.onIabConsentNotification.mockImplementation(ccpaWithoutConsentMock);
+        oldCmp.onIabConsentNotification.mockImplementation(
+            ccpaWithoutConsentMock
+        );
         expect(getPageTargeting().pa).toBe('f');
     });
 
@@ -200,7 +201,9 @@ describe('Build Page Targeting', () => {
         expect(getPageTargeting().rdp).toBe('na');
 
         _.resetPageTargeting();
-        oldCmp.onIabConsentNotification.mockImplementation(tcfWithoutConsentMock);
+        oldCmp.onIabConsentNotification.mockImplementation(
+            tcfWithoutConsentMock
+        );
         expect(getPageTargeting().rdp).toBe('na');
 
         _.resetPageTargeting();
@@ -216,7 +219,9 @@ describe('Build Page Targeting', () => {
         expect(getPageTargeting().rdp).toBe('f');
 
         _.resetPageTargeting();
-        oldCmp.onIabConsentNotification.mockImplementation(ccpaWithoutConsentMock);
+        oldCmp.onIabConsentNotification.mockImplementation(
+            ccpaWithoutConsentMock
+        );
         expect(getPageTargeting().rdp).toBe('t');
     });
 

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -16,8 +16,10 @@ import { getSync as getSync_ } from 'lib/geolocation';
 import { isUserLoggedIn as isUserLoggedIn_ } from 'common/modules/identity/api';
 import { getUserSegments as getUserSegments_ } from 'common/modules/commercial/user-ad-targeting';
 import { getSynchronousParticipations as getSynchronousParticipations_ } from 'common/modules/experiments/ab';
-import { onIabConsentNotification as onIabConsentNotification_ } from '@guardian/consent-management-platform';
+import {
+    oldCmp as oldCmp_ } from '@guardian/consent-management-platform';
 
+const oldCmp: any = oldCmp_;
 const getCookie: any = getCookie_;
 const getUserSegments: any = getUserSegments_;
 const getSynchronousParticipations: any = getSynchronousParticipations_;
@@ -25,12 +27,16 @@ const getReferrer: any = getReferrer_;
 const getBreakpoint: any = getBreakpoint_;
 const isUserLoggedIn: any = isUserLoggedIn_;
 const getSync: any = getSync_;
-const onIabConsentNotification: any = onIabConsentNotification_;
 
 jest.mock('lib/storage');
 jest.mock('lib/config');
 jest.mock('lib/cookies', () => ({
     getCookie: jest.fn(),
+}));
+jest.mock('commercial/modules/cmp/tcfv2-test', () => ({
+    isInTcfv2Test: jest
+        .fn()
+        .mockImplementation(() => false),
 }));
 jest.mock('lib/detect', () => ({
     getViewport: jest.fn(),
@@ -55,7 +61,10 @@ jest.mock('common/modules/commercial/commercial-features', () => ({
     commercialFeatures() {},
 }));
 jest.mock('@guardian/consent-management-platform', () => ({
-    onIabConsentNotification: jest.fn(),
+    oldCmp: {
+        onIabConsentNotification: jest.fn()
+    },
+    onConsentChange: jest.fn()
 }));
 
 const tcfWithConsentMock = (callback): void =>
@@ -108,7 +117,7 @@ describe('Build Page Targeting', () => {
         // Reset mocking to default values.
         getCookie.mockReturnValue('ng101');
         _.resetPageTargeting();
-        onIabConsentNotification.mockImplementation(tcfNullConsentMock);
+        oldCmp.onIabConsentNotification.mockImplementation(tcfNullConsentMock);
 
         getBreakpoint.mockReturnValue('mobile');
         getReferrer.mockReturnValue('');
@@ -162,52 +171,52 @@ describe('Build Page Targeting', () => {
     });
 
     it('should set correct personalized ad (pa) param', () => {
-        onIabConsentNotification.mockImplementation(tcfWithConsentMock);
+        oldCmp.onIabConsentNotification.mockImplementation(tcfWithConsentMock);
         expect(getPageTargeting().pa).toBe('t');
 
         _.resetPageTargeting();
-        onIabConsentNotification.mockImplementation(tcfWithoutConsentMock);
+        oldCmp.onIabConsentNotification.mockImplementation(tcfWithoutConsentMock);
         expect(getPageTargeting().pa).toBe('f');
 
         _.resetPageTargeting();
-        onIabConsentNotification.mockImplementation(tcfNullConsentMock);
+        oldCmp.onIabConsentNotification.mockImplementation(tcfNullConsentMock);
         expect(getPageTargeting().pa).toBe('f');
 
         _.resetPageTargeting();
-        onIabConsentNotification.mockImplementation(tcfMixedConsentMock);
+        oldCmp.onIabConsentNotification.mockImplementation(tcfMixedConsentMock);
         expect(getPageTargeting().pa).toBe('f');
 
         _.resetPageTargeting();
-        onIabConsentNotification.mockImplementation(ccpaWithConsentMock);
+        oldCmp.onIabConsentNotification.mockImplementation(ccpaWithConsentMock);
         expect(getPageTargeting().pa).toBe('t');
 
         _.resetPageTargeting();
-        onIabConsentNotification.mockImplementation(ccpaWithoutConsentMock);
+        oldCmp.onIabConsentNotification.mockImplementation(ccpaWithoutConsentMock);
         expect(getPageTargeting().pa).toBe('f');
     });
 
     it('Should correctly set the RDP flag (rdp) param', () => {
-        onIabConsentNotification.mockImplementation(tcfWithConsentMock);
+        oldCmp.onIabConsentNotification.mockImplementation(tcfWithConsentMock);
         expect(getPageTargeting().rdp).toBe('na');
 
         _.resetPageTargeting();
-        onIabConsentNotification.mockImplementation(tcfWithoutConsentMock);
+        oldCmp.onIabConsentNotification.mockImplementation(tcfWithoutConsentMock);
         expect(getPageTargeting().rdp).toBe('na');
 
         _.resetPageTargeting();
-        onIabConsentNotification.mockImplementation(tcfNullConsentMock);
+        oldCmp.onIabConsentNotification.mockImplementation(tcfNullConsentMock);
         expect(getPageTargeting().rdp).toBe('na');
 
         _.resetPageTargeting();
-        onIabConsentNotification.mockImplementation(tcfMixedConsentMock);
+        oldCmp.onIabConsentNotification.mockImplementation(tcfMixedConsentMock);
         expect(getPageTargeting().rdp).toBe('na');
 
         _.resetPageTargeting();
-        onIabConsentNotification.mockImplementation(ccpaWithConsentMock);
+        oldCmp.onIabConsentNotification.mockImplementation(ccpaWithConsentMock);
         expect(getPageTargeting().rdp).toBe('f');
 
         _.resetPageTargeting();
-        onIabConsentNotification.mockImplementation(ccpaWithoutConsentMock);
+        oldCmp.onIabConsentNotification.mockImplementation(ccpaWithoutConsentMock);
         expect(getPageTargeting().rdp).toBe('t');
     });
 

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -1,10 +1,6 @@
 // @flow
 import config from 'lib/config';
-import {
-    shouldShow,
-    checkWillShowUi,
-    showPrivacyManager,
-} from '@guardian/consent-management-platform';
+import { oldCmp } from '@guardian/consent-management-platform';
 import { isCcpaApplicable } from 'commercial/modules/cmp/ccpa-cmp';
 import raven from 'lib/raven';
 
@@ -26,7 +22,7 @@ export const show = (forceModal: ?boolean): Promise<boolean> => {
                     () => {
                         if (isCcpaApplicable()) {
                             if (forceModal) {
-                                showPrivacyManager();
+                                oldCmp.showPrivacyManager();
                             }
                         } else {
                             require('common/modules/cmp-ui').init(!!forceModal);
@@ -85,10 +81,10 @@ export const consentManagementPlatformUi = {
     id: 'cmpUi',
     canShow: (): Promise<boolean> => {
         if (isCcpaApplicable()) {
-            return checkWillShowUi();
+            return oldCmp.checkWillShowUi();
         }
         return Promise.resolve(
-            config.get('switches.cmpUi', true) && shouldShow()
+            config.get('switches.cmpUi', true) && oldCmp.shouldShow()
         );
     },
     show,

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -3,7 +3,7 @@ import config from 'lib/config';
 import { cmp, oldCmp } from '@guardian/consent-management-platform';
 import { isCcpaApplicable } from 'commercial/modules/cmp/ccpa-cmp';
 import raven from 'lib/raven';
-import { isInTcfv2Test } from "commercial/modules/cmp/tcfv2-test";
+import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
 
 let initUi;
 

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -1,8 +1,9 @@
 // @flow
 import config from 'lib/config';
-import { oldCmp } from '@guardian/consent-management-platform';
+import { cmp, oldCmp } from '@guardian/consent-management-platform';
 import { isCcpaApplicable } from 'commercial/modules/cmp/ccpa-cmp';
 import raven from 'lib/raven';
+import { isInTcfv2Test } from "commercial/modules/cmp/tcfv2-test";
 
 let initUi;
 
@@ -23,6 +24,10 @@ export const show = (forceModal: ?boolean): Promise<boolean> => {
                         if (isCcpaApplicable()) {
                             if (forceModal) {
                                 oldCmp.showPrivacyManager();
+                            }
+                        } else if (isInTcfv2Test()) {
+                            if (forceModal) {
+                                cmp.showPrivacyManager();
                             }
                         } else {
                             require('common/modules/cmp-ui').init(!!forceModal);
@@ -82,6 +87,9 @@ export const consentManagementPlatformUi = {
     canShow: (): Promise<boolean> => {
         if (isCcpaApplicable()) {
             return oldCmp.checkWillShowUi();
+        }
+        if (isInTcfv2Test()) {
+            return cmp.willShowPrivacyMessage();
         }
         return Promise.resolve(
             config.get('switches.cmpUi', true) && oldCmp.shouldShow()

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.spec.js
@@ -1,8 +1,6 @@
 // @flow
 import { isCcpaApplicable as isCcpaApplicable_ } from 'commercial/modules/cmp/ccpa-cmp';
-import {
-    shouldShow,
-    checkWillShowUi,
+import { oldCmp,
 } from '@guardian/consent-management-platform';
 import config from 'lib/config';
 import { consentManagementPlatformUi } from './cmp-ui';
@@ -10,8 +8,11 @@ import { consentManagementPlatformUi } from './cmp-ui';
 jest.mock('lib/raven');
 
 jest.mock('@guardian/consent-management-platform', () => ({
-    shouldShow: jest.fn(),
-    checkWillShowUi: jest.fn(),
+    oldCmp: {
+        shouldShow: jest.fn(),
+        checkWillShowUi: jest.fn(),
+    },
+    onConsentChange: jest.fn()
 }));
 
 jest.mock('lib/report-error', () => jest.fn());
@@ -19,6 +20,12 @@ jest.mock('lib/report-error', () => jest.fn());
 const isCcpaApplicable: any = isCcpaApplicable_;
 jest.mock('projects/commercial/modules/cmp/ccpa-cmp', () => ({
     isCcpaApplicable: jest.fn(),
+}));
+
+jest.mock('commercial/modules/cmp/tcfv2-test', () => ({
+    isInTcfv2Test: jest
+        .fn()
+        .mockImplementation(() => false),
 }));
 
 describe('cmp-ui', () => {
@@ -29,14 +36,14 @@ describe('cmp-ui', () => {
     describe('consentManagementPlatformUi', () => {
         describe('canShow', () => {
             it('return true if shouldShow returns true', () => {
-                shouldShow.mockReturnValue(true);
+                oldCmp.shouldShow.mockReturnValue(true);
 
                 return consentManagementPlatformUi.canShow().then(show => {
                     expect(show).toBe(true);
                 });
             });
             it('return false if shouldShow returns false', () => {
-                shouldShow.mockReturnValue(false);
+                oldCmp.shouldShow.mockReturnValue(false);
 
                 return consentManagementPlatformUi.canShow().then(show => {
                     expect(show).toBe(false);
@@ -52,11 +59,11 @@ describe('cmp-ui', () => {
 
             it('returns checkWillShowUi if user is in CCPA variant', () => {
                 config.set('switches.cmpUi', true);
-                checkWillShowUi.mockReturnValue(Promise.resolve(true));
+                oldCmp.checkWillShowUi.mockReturnValue(Promise.resolve(true));
                 isCcpaApplicable.mockReturnValue(true);
 
                 return consentManagementPlatformUi.canShow().then(show => {
-                    expect(checkWillShowUi).toHaveBeenCalledTimes(1);
+                    expect(oldCmp.checkWillShowUi).toHaveBeenCalledTimes(1);
                     expect(show).toBe(true);
                 });
             });

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.spec.js
@@ -1,7 +1,6 @@
 // @flow
 import { isCcpaApplicable as isCcpaApplicable_ } from 'commercial/modules/cmp/ccpa-cmp';
-import { oldCmp,
-} from '@guardian/consent-management-platform';
+import { oldCmp } from '@guardian/consent-management-platform';
 import config from 'lib/config';
 import { consentManagementPlatformUi } from './cmp-ui';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1150,10 +1150,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.16.tgz#3ef47e7f49e633aea51c67f061d8d313a26fa9bc"
   integrity sha512-SgNU2bgiyQaXNfqanx4SDmxqAhXW6QBCTk4tRnCgV9Ht6noRl7UsDfx4I0u+M4H3TRnK4I/i2mmlJBtnuwhxEg==
 
-"@guardian/consent-management-platform@4.0.0-0":
-  version "4.0.0-0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.0-0.tgz#22e5522a02da8946675bd2805cf7c1e50274402b"
-  integrity sha512-E3QVyG1KyIQQ5+PDGaGetVfS4LIk1XNDMzUv3DDsGxd3Xa1HVoOw5uf5qCxlHN45+TI0f6NGNx85/H/y2n6yGA==
+"@guardian/consent-management-platform@4.0.0-1":
+  version "4.0.0-1"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.0-1.tgz#0368024793920e4e99f1a7352abffbf89cebccb9"
+  integrity sha512-eT1H133qrBhgkMKEl2Nze/JTXLLnNOgDhLvXevi+6EIwXCkUtLLbwebe3py6GEsMOajSTZDYnmL7XunMlnxRNA==
   dependencies:
     "@guardian/old-cmp" "npm:@guardian/consent-management-platform@^3.4.8"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1150,10 +1150,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.16.tgz#3ef47e7f49e633aea51c67f061d8d313a26fa9bc"
   integrity sha512-SgNU2bgiyQaXNfqanx4SDmxqAhXW6QBCTk4tRnCgV9Ht6noRl7UsDfx4I0u+M4H3TRnK4I/i2mmlJBtnuwhxEg==
 
-"@guardian/consent-management-platform@4.0.0-4":
-  version "4.0.0-4"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.0-4.tgz#cf8dfbf3dad49ae1b2bf8d30e46a4cf8687d7bca"
-  integrity sha512-jQ55GxNbn4rNNVRdKIBUOSQkVtWiFk5H2YKfuzHbDF7MWflgaxXUs5kpUEccG0sV/lXviRoeFo9K2VNnZPPNog==
+"@guardian/consent-management-platform@4.0.0-5":
+  version "4.0.0-5"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.0-5.tgz#2980e4794754c3a297ea172cfe11712b08b5f54c"
+  integrity sha512-yhcSVOQ8ULHSNHe88RXemvKxzFG5uMmv0Qul3GU9S5KUsrq/KdPFnnbdt72H+dH9l2AtffxX2oJ42TZcSAriJw==
   dependencies:
     "@guardian/old-cmp" "npm:@guardian/consent-management-platform@^3.4.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1150,10 +1150,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.16.tgz#3ef47e7f49e633aea51c67f061d8d313a26fa9bc"
   integrity sha512-SgNU2bgiyQaXNfqanx4SDmxqAhXW6QBCTk4tRnCgV9Ht6noRl7UsDfx4I0u+M4H3TRnK4I/i2mmlJBtnuwhxEg==
 
-"@guardian/consent-management-platform@4.0.0-3":
-  version "4.0.0-3"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.0-3.tgz#b0d0a465199639bc1253cac6dbce94fc2f006e85"
-  integrity sha512-5hCMHI35yE3HM3P+O2mO/f4WwobP3f88vbe/WEb43Snx1ymCntlVi43rNxrCEKdGJUuzmlSZvsvscG2tDVE5fw==
+"@guardian/consent-management-platform@4.0.0-4":
+  version "4.0.0-4"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.0-4.tgz#cf8dfbf3dad49ae1b2bf8d30e46a4cf8687d7bca"
+  integrity sha512-jQ55GxNbn4rNNVRdKIBUOSQkVtWiFk5H2YKfuzHbDF7MWflgaxXUs5kpUEccG0sV/lXviRoeFo9K2VNnZPPNog==
   dependencies:
     "@guardian/old-cmp" "npm:@guardian/consent-management-platform@^3.4.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1150,12 +1150,12 @@
   resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.16.tgz#3ef47e7f49e633aea51c67f061d8d313a26fa9bc"
   integrity sha512-SgNU2bgiyQaXNfqanx4SDmxqAhXW6QBCTk4tRnCgV9Ht6noRl7UsDfx4I0u+M4H3TRnK4I/i2mmlJBtnuwhxEg==
 
-"@guardian/consent-management-platform@4.0.0-1":
-  version "4.0.0-1"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.0-1.tgz#0368024793920e4e99f1a7352abffbf89cebccb9"
-  integrity sha512-eT1H133qrBhgkMKEl2Nze/JTXLLnNOgDhLvXevi+6EIwXCkUtLLbwebe3py6GEsMOajSTZDYnmL7XunMlnxRNA==
+"@guardian/consent-management-platform@4.0.0-2":
+  version "4.0.0-2"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.0-2.tgz#ad055a1f7470f440863d049b36a27bb41ed5d990"
+  integrity sha512-FCgl/6MgH7NU+Qg950DjF+avisQunZK9Rs0ZMIzcFzXT8QO3SJn9H4n1y4Y0RqUGe4V40n+5KmcgCfGAkwsBmA==
   dependencies:
-    "@guardian/old-cmp" "npm:@guardian/consent-management-platform@^3.4.8"
+    "@guardian/old-cmp" "npm:@guardian/consent-management-platform@^3.4.9"
 
 "@guardian/dotcom-rendering@git://github.com/guardian/dotcom-rendering.git#version-1-alpha":
   version "0.1.0-alpha"
@@ -1169,10 +1169,10 @@
     inquirer "^5.2.0"
     pretty-bytes "^4.0.2"
 
-"@guardian/old-cmp@npm:@guardian/consent-management-platform@^3.4.8":
-  version "3.4.8"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-3.4.8.tgz#01c8e9894a93ec581024f59d53038ffd915ddc8c"
-  integrity sha512-NZHnq4ayk+tERo72aaTIGJE0uOV/zXFXJUYw2y9M2KKgwqSMQ5ht82jmsLeuEmgVg79EYjKgPWIXU8KeWFShNQ==
+"@guardian/old-cmp@npm:@guardian/consent-management-platform@^3.4.9":
+  version "3.4.9"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-3.4.9.tgz#6bd6108e12cb122c4a1fcba4ae657f4d0b67ad0b"
+  integrity sha512-9TRCahVCILDvD78xQpADaZMqqUZM1opsBXKPasVdEt3hnRyMwVB+l68DpydIEK8DZE9S2jxbuqtOEKrci/qMsw==
   dependencies:
     consent-string "1.5.2"
     js-cookie "2.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1150,14 +1150,12 @@
   resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.16.tgz#3ef47e7f49e633aea51c67f061d8d313a26fa9bc"
   integrity sha512-SgNU2bgiyQaXNfqanx4SDmxqAhXW6QBCTk4tRnCgV9Ht6noRl7UsDfx4I0u+M4H3TRnK4I/i2mmlJBtnuwhxEg==
 
-"@guardian/consent-management-platform@3.4.5":
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-3.4.5.tgz#6d26f70b76d0ddd4ed1090433c992d61ccfbb9c7"
-  integrity sha512-aQvZ7aWrTAnda8FoWWoH9PTGRJQc4CQ7aO7oqkGgx0C3MJKayzLYe1Gsa3jlB5fuh4b8Nrw71PQ9HFglPmjEaw==
+"@guardian/consent-management-platform@4.0.0-0":
+  version "4.0.0-0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.0-0.tgz#22e5522a02da8946675bd2805cf7c1e50274402b"
+  integrity sha512-E3QVyG1KyIQQ5+PDGaGetVfS4LIk1XNDMzUv3DDsGxd3Xa1HVoOw5uf5qCxlHN45+TI0f6NGNx85/H/y2n6yGA==
   dependencies:
-    consent-string "1.5.2"
-    js-cookie "2.2.1"
-    whatwg-fetch "3.0.0"
+    "@guardian/old-cmp" "npm:@guardian/consent-management-platform@^3.4.8"
 
 "@guardian/dotcom-rendering@git://github.com/guardian/dotcom-rendering.git#version-1-alpha":
   version "0.1.0-alpha"
@@ -1170,6 +1168,15 @@
     filesizegzip "^2.0.0"
     inquirer "^5.2.0"
     pretty-bytes "^4.0.2"
+
+"@guardian/old-cmp@npm:@guardian/consent-management-platform@^3.4.8":
+  version "3.4.8"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-3.4.8.tgz#01c8e9894a93ec581024f59d53038ffd915ddc8c"
+  integrity sha512-NZHnq4ayk+tERo72aaTIGJE0uOV/zXFXJUYw2y9M2KKgwqSMQ5ht82jmsLeuEmgVg79EYjKgPWIXU8KeWFShNQ==
+  dependencies:
+    consent-string "1.5.2"
+    js-cookie "2.2.1"
+    whatwg-fetch "3.0.0"
 
 "@guardian/shimport@^1.0.2":
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1150,10 +1150,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.16.tgz#3ef47e7f49e633aea51c67f061d8d313a26fa9bc"
   integrity sha512-SgNU2bgiyQaXNfqanx4SDmxqAhXW6QBCTk4tRnCgV9Ht6noRl7UsDfx4I0u+M4H3TRnK4I/i2mmlJBtnuwhxEg==
 
-"@guardian/consent-management-platform@4.0.0-2":
-  version "4.0.0-2"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.0-2.tgz#ad055a1f7470f440863d049b36a27bb41ed5d990"
-  integrity sha512-FCgl/6MgH7NU+Qg950DjF+avisQunZK9Rs0ZMIzcFzXT8QO3SJn9H4n1y4Y0RqUGe4V40n+5KmcgCfGAkwsBmA==
+"@guardian/consent-management-platform@4.0.0-3":
+  version "4.0.0-3"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.0-3.tgz#b0d0a465199639bc1253cac6dbce94fc2f006e85"
+  integrity sha512-5hCMHI35yE3HM3P+O2mO/f4WwobP3f88vbe/WEb43Snx1ymCntlVi43rNxrCEKdGJUuzmlSZvsvscG2tDVE5fw==
   dependencies:
     "@guardian/old-cmp" "npm:@guardian/consent-management-platform@^3.4.9"
 


### PR DESCRIPTION
## What does this change?

Implements TCFv2 0% test in frontend.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No, **not yet**
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

The CMP is working properly, and the AB test is running smoothly.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
