### PR TITLE
Increase newsletter tracking granularity

### DIFF
--- a/identity/app/views/fragments/form/switch.scala.html
+++ b/identity/app/views/fragments/form/switch.scala.html
@@ -11,7 +11,8 @@
     footer: Option[Html] = None,
     highlighted: Boolean = false,
     skin: Option[String] = None,
-    boldTitle: Boolean = true
+    boldTitle: Boolean = true,
+    newsletterIdentityName: Option[String] = None
 )(implicit handler: views.html.helper.FieldConstructor, messages: play.api.i18n.Messages)
 
 
@@ -23,8 +24,9 @@
         (s"manage-account__switch--${skin.getOrElse("")}", skin.isDefined)
     )
 }
+@linkName = @{newsletterIdentityName.getOrElse(title)}
 
-<label class="@views.support.RenderClasses(classes)" data-originally-checked="@field.value" data-link-name-template="mma switch : @title : [action]">
+<label class="@views.support.RenderClasses(classes)" data-originally-checked="@field.value" data-link-name-template="mma switch : @linkName : [action]">
     <div class="manage-account__switch-content">
         @fragments.form.checkbox(field, Checkbox(field).args:_*)
         <div class="manage-account__switch-checkbox"></div>

--- a/identity/app/views/fragments/newsletterSwitch.scala.html
+++ b/identity/app/views/fragments/newsletterSwitch.scala.html
@@ -56,5 +56,6 @@
     field = newsletterField,
     extraFields = Nil,
     footer = Some(buildFooter(newsletter)),
-    skin = skin
+    skin = skin,
+    newsletterIdentityName = Some(newsletter.identityName)
 )(nonInputFields, messages)


### PR DESCRIPTION
## What does this change?

In order to properly track the newsletter sign ups at a more granular level, we need to use the `identityName` for the `data-link-name`. To do this and to maintain current functionality I've added a new optional field to the checkboxes used such that a newsletter will use the `identityName` whilst consents and sms will use the existing `name` field.


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally

![image](https://user-images.githubusercontent.com/9122944/87428694-aaf5cf80-c5da-11ea-8038-4c3f4cd446e8.png)


- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
