### PR TITLE
Refactor contributions service in preparation for subs banners

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -504,4 +504,13 @@ trait FeatureSwitches {
     exposeClientSide = true
   )
 
+  val remoteSubscriptionsBanner = Switch(
+    SwitchGroup.Feature,
+    "remote-subscriptions-banner",
+    "Enables the subscriptions banner fetched from contributions-service",
+    owners = Seq(Owner.withGithub("GHaberis")),
+    safeState = Off,
+    sellByDate = new LocalDate(2021, 8, 3),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -206,8 +206,12 @@ const buildBannerPayload = () => {
         isPaidContent: page.isPaidContent,
         showSupportMessaging: !shouldHideSupportMessaging(),
         engagementBannerLastClosedAt: userPrefs.get('engagementBannerLastClosedAt') || undefined,
+        subscriptionBannerLastClosedAt: userPrefs.get('subscriptionBannerLastClosedAt') || undefined,
         mvtId: getMvtValue(),
         countryCode: geolocationGetSync(),
+        switches: {
+            remoteSubscriptionsBanner: config.get('switches.remoteSubscriptionsBanner', false)
+        }
     };
 
     return {

--- a/static/src/javascripts/projects/common/modules/commercial/reader-revenue-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/reader-revenue-banner.js
@@ -13,7 +13,7 @@ let data: ?BannerDataResponse = null;
 const show = () => data ? renderBanner(data) : Promise.resolve(false);
 
 const canShow = (): Promise<boolean> => {
-    if (!config.get('switches.remoteBanner')) {
+    if (!config.get('switches.remoteBanner', false)) {
         return Promise.resolve(false);
     }
 

--- a/static/src/javascripts/projects/common/modules/commercial/reader-revenue-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/reader-revenue-banner.js
@@ -3,7 +3,6 @@
 import type { Banner } from 'common/modules/ui/bannerPicker';
 import { fetchBannerData, renderBanner, type BannerDataResponse } from 'common/modules/commercial/contributions-service';
 import config from "lib/config";
-import { getSync as geolocationGetSync } from 'lib/geolocation';
 import reportError from "lib/report-error";
 
 
@@ -14,11 +13,7 @@ let data: ?BannerDataResponse = null;
 const show = () => data ? renderBanner(data) : Promise.resolve(false);
 
 const canShow = (): Promise<boolean> => {
-    const countryCode = geolocationGetSync();
-    const forceBanner = window.location.search.includes('force-remote-banner=true');
-    const enabled = (config.get('switches.remoteBanner') && countryCode === 'AU') || forceBanner;
-
-    if (!enabled) {
+    if (!config.get('switches.remoteBanner')) {
         return Promise.resolve(false);
     }
 

--- a/static/src/javascripts/projects/common/modules/commercial/reader-revenue-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/reader-revenue-banner.js
@@ -3,6 +3,7 @@
 import type { Banner } from 'common/modules/ui/bannerPicker';
 import { fetchBannerData, renderBanner, type BannerDataResponse } from 'common/modules/commercial/contributions-service';
 import config from "lib/config";
+import { getSync as geolocationGetSync } from 'lib/geolocation';
 import reportError from "lib/report-error";
 
 
@@ -13,7 +14,11 @@ let data: ?BannerDataResponse = null;
 const show = () => data ? renderBanner(data) : Promise.resolve(false);
 
 const canShow = (): Promise<boolean> => {
-    if (!config.get('switches.remoteBanner', false)) {
+    const countryCode = geolocationGetSync();
+    const forceBanner = window.location.search.includes('force-remote-banner=true');
+    const enabled = (config.get('switches.remoteBanner') && countryCode === 'AU') || forceBanner;
+
+    if (!enabled) {
         return Promise.resolve(false);
     }
 

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.js
@@ -26,9 +26,11 @@ import type { BannerTracking } from './subscription-banner-tracking';
 const MESSAGE_CODE = 'subscription-banner';
 const SUBSCRIPTION_BANNER_CLOSED_KEY = 'subscriptionBannerLastClosedAt';
 
+const remoteSubscriptionsBannerSwitchIsOn = config.get('switches.remoteBanner', false) && config.get('switches.remoteSubscriptionsBanner', false)
+
 const subscriptionBannerSwitchIsOn: boolean = config.get(
     'switches.subscriptionBanner'
-) && !config.get('switches.remoteBanner', false) && !config.get('switches.remoteSubscriptionsBanner', false);
+) && !remoteSubscriptionsBannerSwitchIsOn;
 
 const pageviews: number = local.get('gu.alreadyVisited');
 

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.js
@@ -28,7 +28,8 @@ const SUBSCRIPTION_BANNER_CLOSED_KEY = 'subscriptionBannerLastClosedAt';
 
 const subscriptionBannerSwitchIsOn: boolean = config.get(
     'switches.subscriptionBanner'
-);
+) && !config.get('switches.remoteBanner', false) && !config.get('switches.remoteSubscriptionsBanner', false);
+
 const pageviews: number = local.get('gu.alreadyVisited');
 
 const currentRegion: ReaderRevenueRegion = getReaderRevenueRegion(
@@ -191,11 +192,11 @@ const canShow: () => Promise<boolean> = async () => {
     );
 
     const can = Promise.resolve(
+            subscriptionBannerSwitchIsOn &&
             pageviews >= 4 &&
             !hasAcknowledgedSinceLastRedeploy &&
             !shouldHideSupportMessaging() &&
             !pageShouldHideReaderRevenue() &&
-            subscriptionBannerSwitchIsOn &&
             !pageIsIdentity()
     );
 


### PR DESCRIPTION
## What does this change?

This PR prepares frontend for the introduction of subscriptions banners to the contributions service. Changes to do this:

- Add a new `remoteSubscriptionsBanner` switch. By default this is OFF. 
- I've updated the old `frontend` rendered `subscription-banner.js` to check this new `remoteSubscriptionsBanner` switch. If the `remoteSubscriptionsBanner` is ON the `canShow` for this old banner will resolve with `false`.
- I've updated the `targeting` object in `contributions-service.js` to include a new property `switches: {}`. We'll interrogate this object on the service to see whether individual banners have been turned on/off. This means we can release the code on the service for the subscriptions banners and whilst this switch is OFF they'll never be selected, we can then use this switch to turn the old subscriptions banner off and the new one on.
- I've also included a new property `subscriptionBannerLastClosedAt` in the `targeting` object in `contributions-service.js`.
- ~~I've updated `reader-revenue-banner.js` to remove the conditional `countryCode === 'AU'`, this is only relevant to the Australia Moment Banner, and we have the same conditional check on the `contributions-service` so the `AusMomentContributionsBanner` should never be selected unless in Australia.~~ (I've temporarily restored this AU restriction so not to increase load to the service)

## Does this change need to be reproduced in dotcom-rendering ?

- [x] Yes

## What is the value of this and can you measure success?

- Sends extra info required to select the subscriptions banners
- Allows us to quickly turn off the old subscriptions banner and start using new service with the `remoteSubscriptionsBanner` switch.