### PR TITLE
Fix liveblog epic tracking

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-liveblog-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-liveblog-utilities.js
@@ -4,6 +4,8 @@ import $ from 'lib/$';
 import mediator from 'lib/mediator';
 import { elementInView } from 'lib/element-inview';
 import fastdom from 'lib/fastdom-promise';
+import {submitInsertEvent, submitViewEvent} from "common/modules/commercial/acquisitions-ophan";
+import type {ComponentEventWithoutAction} from "common/modules/commercial/acquisitions-ophan";
 
 let isAutoUpdateHandlerBound = false;
 const INSERT_EPIC_AFTER_CLASS = 'js-insert-epic-after';
@@ -15,6 +17,18 @@ type TimeData = {
     date: string,
     time: string,
 };
+
+const buildComponentEventWithoutAction = (variant: EpicVariant, parentTest: EpicABTest): ComponentEventWithoutAction => ({
+    component: {
+        componentType: parentTest.componentType,
+        campaignCode: variant.campaignCode,
+        id: variant.campaignCode,
+    },
+    abTest: {
+        name: parentTest.id,
+        variant: variant.id,
+    },
+});
 
 const getLiveblogEntryTimeData = (el: Element): ?TimeData => {
     const timeEl = el.querySelector('time');
@@ -91,10 +105,7 @@ const setupViewTracking = (
 
     inView.on('firstview', () => {
         logView(variant.id);
-        mediator.emit(parentTest.viewEvent, {
-            componentType: parentTest.componentType,
-            campaignCode: variant.campaignCode,
-        });
+        submitViewEvent(buildComponentEventWithoutAction(variant, parentTest));
     });
 };
 
@@ -116,7 +127,9 @@ const addEpicToBlocks = (
 
             const $epic = $.create(epicHtml);
             $epic.insertAfter(el);
-            mediator.emit(parentTest.insertEvent);
+
+            submitInsertEvent(buildComponentEventWithoutAction(variant, parentTest));
+
             $(el).removeClass(INSERT_EPIC_AFTER_CLASS);
             setEpicLiveblogEntryTimeData($epic[0], timeData);
             setupViewTracking(el, variant, parentTest);


### PR DESCRIPTION
## What does this change?
Liveblog epic tracking has been broken since [this PR](https://github.com/guardian/frontend/pull/22552) changed how epic tracking works.
It should send `componentEvent`s to ophan for INSERT and VIEW.

From the network tab:
![Screen Shot 2020-07-16 at 08 52 06](https://user-images.githubusercontent.com/1513454/87643898-5c177980-c743-11ea-9499-77182f76e968.png)
![Screen Shot 2020-07-16 at 08 52 25](https://user-images.githubusercontent.com/1513454/87643900-5d48a680-c743-11ea-9a06-415322930f86.png)


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
