### PR TITLE
Copy refresh for digital subscriptions banner

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-template.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-template.js
@@ -16,14 +16,11 @@ const subscriptionBannerTemplate = (
 <div id="js-site-message--subscription-banner" class="site-message--subscription-banner">
     <div class="site-message--subscription-banner__inner">
         <h3 class="site-message--subscription-banner__title">
-            <span class="site-message--subscription-banner__no-wrap">The world is changing by the minute.</span>
-            <span class="site-message--subscription-banner__no-wrap">Keep up with a digital subscription.</span>
+            <span class="site-message--subscription-banner__no-wrap">Our reporting. Your pace.</span>
         </h3>
 
         <div class="site-message--subscription-banner__description">
-            <p>Two Guardian apps, with you every day. <b>The Daily</b>,
-            joining you in the morning to share politics, culture, food and opinion.
-            <b>Live</b>, constantly by your side, keeping you connected with the outside world.</p>
+            <p>Tired of being always on? Our Daily edition comes to you just once a day. If a story breaks, you can still catch it with Premium access to our Live app. All with no ads. It's up to you.</p>
         </div>
 
         <div class="site-message--subscription-banner__cta-container">


### PR DESCRIPTION
## What does this change?

Copy refresh for digital subscriptions banner


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No, although we should reflect these changes in the `contributions-service`.

## Screenshots

<img width="397" alt="Screenshot 2020-07-16 at 12 46 48" src="https://user-images.githubusercontent.com/1590704/87772693-fd70ff00-c819-11ea-98f9-85c2bb18877f.png">

<img width="1580" alt="Screenshot 2020-07-16 at 12 46 12" src="https://user-images.githubusercontent.com/1590704/87772703-01048600-c81a-11ea-9508-0452b42d2a38.png">

<img width="460" alt="Screenshot 2020-07-16 at 12 47 07" src="https://user-images.githubusercontent.com/1590704/87772726-08c42a80-c81a-11ea-865f-f3669a2d72d5.png">

