### PR TITLE
Set authentication cookies on validate email

### DIFF
--- a/identity/app/idapiclient/IdApiClient.scala
+++ b/identity/app/idapiclient/IdApiClient.scala
@@ -11,7 +11,7 @@ import net.liftweb.json.compactRender
 import net.liftweb.json.JsonAST.JObject
 import net.liftweb.json.Serialization.write
 import utils.SafeLogging
-import idapiclient.requests.{DeletionBody, PasswordUpdate, TokenPassword, AutoSignInToken}
+import idapiclient.requests.{AutoSignInToken, DeletionBody, PasswordUpdate, TokenPassword}
 import org.slf4j.LoggerFactory
 import play.api.libs.ws.WSClient
 
@@ -136,8 +136,8 @@ class IdApiClient(
     delete(urlJoin("useremails", userId, "subscriptions"), Some(auth), Some(trackingParameters), Some(write(emailList))) map extractUnit
   }
 
-  def validateEmail(token: String, trackingParameters: TrackingData): Future[Response[Unit]] =
-    post(urlJoin("user","validate-email", token), trackingParameters = Some(trackingParameters)) map extractUnit
+  def validateEmail(token: String, trackingParameters: TrackingData): Future[Response[CookiesResponse]] =
+    post(urlJoin("user","validate-email", token), trackingParameters = Some(trackingParameters)) map extract[CookiesResponse](jsonField("cookies"))
 
   def setPasswordGuest(password: String, token: String): Future[Response[CookiesResponse]] = {
     val body: JObject = "password" -> password


### PR DESCRIPTION
## What does this change?

The IDAPI validate email endpoint now returns session cookies. Set those cookies on the successful redirect for the user. 

The plan is to prevent password signin for users who have not validated their email address. This makes it a bit easier for users to start using the Guardian after signing up and validating their email.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
