### PR TITLE
Use the correct DocumentBlockElement

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -4,8 +4,8 @@ import controllers.ArticlePage
 import experiments.{ActiveExperiments, Control, DCRBubble, DotcomRendering1, DotcomRendering2, Excluded, Experiment, Participant}
 import model.PageWithStoryPackage
 import implicits.Requests._
-import model.liveblog.{BlockElement, ContentAtomBlockElement, ImageBlockElement, InstagramBlockElement, PullquoteBlockElement, RichLinkBlockElement, TableBlockElement, TextBlockElement, TweetBlockElement}
-import model.dotcomrendering.pageElements.{DocumentBlockElement, SoundcloudBlockElement, VideoVimeoBlockElement, VideoYoutubeBlockElement, VideoFacebookBlockElement}
+import model.liveblog.{BlockElement, ContentAtomBlockElement, DocumentBlockElement, ImageBlockElement, InstagramBlockElement, PullquoteBlockElement, RichLinkBlockElement, TableBlockElement, TextBlockElement, TweetBlockElement}
+import model.dotcomrendering.pageElements.{SoundcloudBlockElement, VideoVimeoBlockElement, VideoYoutubeBlockElement, VideoFacebookBlockElement}
 import play.api.mvc.RequestHeader
 import views.support.Commercial
 


### PR DESCRIPTION
## What does this change?

This fixes a bug created by the fact that in `hasOnlySupportedElements / unsupportedElement` we were matching against

```
model.dotcomrendering.pageElements.DocumentBlockElement
```

instead of matching against 

```
model.liveblog.DocumentBlockElement
```

This was only noticed by the fact that pages with `DocumentBlockElement` where still marked as unsupported despite it having been whitelisted (in fact _the other one_ had been whitelisted). 