### PR TITLE
Clear AudioBlockElement/SoundcloudBlockElement for DCR experiment

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -39,8 +39,8 @@ object ArticlePageChecks {
     def unsupportedElement(blockElement: BlockElement) = blockElement match {
       case _: AudioBlockElement => {
         val e = blockElement.asInstanceOf[AudioBlockElement].element
-        val resolve = model.dotcomrendering.pageElements.PageElement.liveBlogAudioBlockElementResolvesToPageElementSoundcloudBlockElement(e)
-        false
+        val resolve = model.dotcomrendering.pageElements.PageElement.audiIsDCRSupported(e)
+        !resolve
       }
       case _: DocumentBlockElement => false
       case _: ImageBlockElement => false

--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -2,10 +2,10 @@ package services.dotcomponents
 
 import controllers.ArticlePage
 import experiments.{ActiveExperiments, Control, DCRBubble, DotcomRendering1, DotcomRendering2, Excluded, Experiment, Participant}
-import model.PageWithStoryPackage
+import model.{AudioAsset, PageWithStoryPackage}
 import implicits.Requests._
-import model.liveblog.{BlockElement, ContentAtomBlockElement, DocumentBlockElement, ImageBlockElement, InstagramBlockElement, PullquoteBlockElement, RichLinkBlockElement, TableBlockElement, TextBlockElement, TweetBlockElement}
-import model.dotcomrendering.pageElements.{SoundcloudBlockElement, VideoVimeoBlockElement, VideoYoutubeBlockElement, VideoFacebookBlockElement}
+import model.liveblog.{AudioBlockElement, BlockElement, ContentAtomBlockElement, DocumentBlockElement, ImageBlockElement, InstagramBlockElement, PullquoteBlockElement, RichLinkBlockElement, TableBlockElement, TextBlockElement, TweetBlockElement}
+import model.dotcomrendering.pageElements.{SoundcloudBlockElement, VideoFacebookBlockElement, VideoVimeoBlockElement, VideoYoutubeBlockElement}
 import play.api.mvc.RequestHeader
 import views.support.Commercial
 
@@ -37,7 +37,11 @@ object ArticlePageChecks {
     // See: https://github.com/guardian/dotcom-rendering/blob/master/packages/frontend/web/components/lib/ArticleRenderer.tsx
 
     def unsupportedElement(blockElement: BlockElement) = blockElement match {
-
+      case _: AudioBlockElement => {
+        val e = blockElement.asInstanceOf[AudioBlockElement].element
+        val resolve = model.dotcomrendering.pageElements.PageElement.liveBlogAudioBlockElementResolvesToPageElementSoundcloudBlockElement(e)
+        false
+      }
       case _: DocumentBlockElement => false
       case _: ImageBlockElement => false
       case _: InstagramBlockElement => false

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -446,6 +446,21 @@ object PageElement {
     }
   }
 
+  def liveBlogAudioBlockElementResolvesToPageElementSoundcloudBlockElement(element: ApiBlockElement): Boolean = {
+    /*
+      date: July 20th 2020
+      author: Pascal
+      This function was introduced to be able to know from the article picker whether or not
+      an AudioBlockElement given to the article picker's function "hasOnlySupportedElements" would
+      resolve to a SoundcloudBlockElement (which we currently support in DCR) or an AudioBlockElement
+      (which DCR doesn't yet support).
+     */
+    audioToPageElement(element: ApiBlockElement) match {
+      case Some(_: SoundcloudBlockElement) => true
+      case _ => false
+    }
+  }
+
   private def audioToPageElement(element: ApiBlockElement) = {
     for {
       d <- element.audioTypeData

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -446,14 +446,17 @@ object PageElement {
     }
   }
 
-  def liveBlogAudioBlockElementResolvesToPageElementSoundcloudBlockElement(element: ApiBlockElement): Boolean = {
+  def audiIsDCRSupported(element: ApiBlockElement): Boolean = {
     /*
-      date: July 20th 2020
+      date: July 21th 2020
       author: Pascal
+
       This function was introduced to be able to know from the article picker whether or not
       an AudioBlockElement given to the article picker's function "hasOnlySupportedElements" would
       resolve to a SoundcloudBlockElement (which we currently support in DCR) or an AudioBlockElement
       (which DCR doesn't yet support).
+
+      See: 783a70d0-f6f2-43ab-a302-f4a12ba03aa0
      */
     audioToPageElement(element: ApiBlockElement) match {
       case Some(_: SoundcloudBlockElement) => true

--- a/common/app/model/liveblog/BlockElement.scala
+++ b/common/app/model/liveblog/BlockElement.scala
@@ -27,6 +27,8 @@ case class AudioBlockElement(element: ApiBlockElement, assets: Seq[AudioAsset]) 
   the article picker will not need to segregate between variations of the AudioBlockElement. At this point
   the AudioBlockElement can lose the element attribute.
 
+  mark: 783a70d0-f6f2-43ab-a302-f4a12ba03aa0
+
  */
 
 case class GuVideoBlockElement(assets: Seq[VideoAsset], imageMedia: ImageMedia, data: Map[String, String]) extends BlockElement

--- a/common/app/model/liveblog/BlockElement.scala
+++ b/common/app/model/liveblog/BlockElement.scala
@@ -10,7 +10,7 @@ case class TextBlockElement(html: Option[String]) extends BlockElement
 case class TweetBlockElement(html: Option[String]) extends BlockElement
 case class PullquoteBlockElement(html: Option[String]) extends BlockElement
 case class ImageBlockElement(media: ImageMedia, data: Map[String, String], displayCredit: Option[Boolean]) extends BlockElement
-case class AudioBlockElement(assets: Seq[AudioAsset]) extends BlockElement
+case class AudioBlockElement(element: ApiBlockElement, assets: Seq[AudioAsset]) extends BlockElement
 case class GuVideoBlockElement(assets: Seq[VideoAsset], imageMedia: ImageMedia, data: Map[String, String]) extends BlockElement
 case class VideoBlockElement(data: Map[String, String]) extends BlockElement
 case class EmbedBlockElement(html: Option[String], safe: Option[Boolean], alt: Option[String]) extends BlockElement
@@ -89,7 +89,7 @@ object BlockElement {
         element.imageTypeData.flatMap(_.displayCredit)
       ))
 
-      case Audio => Some(AudioBlockElement(element.assets.map(AudioAsset.make)))
+      case Audio => Some(AudioBlockElement(element, element.assets.map(AudioAsset.make)))
 
       case Video =>
         if (element.assets.nonEmpty) {
@@ -156,7 +156,11 @@ object BlockElement {
 
   implicit val textBlockElementWrites: Writes[TextBlockElement] = Json.writes[TextBlockElement]
   implicit val ImageBlockElementWrites: Writes[ImageBlockElement] = Json.writes[ImageBlockElement]
-  implicit val AudioBlockElementWrites: Writes[AudioBlockElement] = Json.writes[AudioBlockElement]
+  implicit val AudioBlockElementWrites: Writes[AudioBlockElement] = new Writes[AudioBlockElement] {
+    def writes(audio: AudioBlockElement): JsObject = Json.obj(
+      "assets" -> audio.assets
+    )
+  }
   implicit val GuVideoBlockElementWrites: Writes[GuVideoBlockElement] = Json.writes[GuVideoBlockElement]
   implicit val VideoBlockElementWrites: Writes[VideoBlockElement] = Json.writes[VideoBlockElement]
   implicit val TweetBlockElementWrites: Writes[TweetBlockElement] = Json.writes[TweetBlockElement]


### PR DESCRIPTION
## What does this change?

Clear `(liveblog.)AudioBlockElement` for DCR experiment. Note that `(liveblog.)AudioBlockElement` is transformed either to `SoundcloudBlockElement` or `(PageElement.)AudioBlockElement`, and only `SoundcloudBlockElement` is being cleared.

This is the second PR after: https://github.com/guardian/frontend/pull/22823
