### PR TITLE
Update epic image style

### DIFF
--- a/static/src/stylesheets/module/reader-revenue/_epic.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic.scss
@@ -295,30 +295,15 @@ div.contributions__secondary-button.contributions__secondary-button--epic {
 }
 
 .contributions__epic-image {
-    display: none;
-    @include mq($from: tablet) {
-        display: block;
-    }
+    margin: 12px 0 8px;
 
-    margin: 10px -5px 12px;
-    height: 150px;
-    width: calc(100% + 10px);
+    @include mq($from: tablet) {
+        margin: 10px 0;
+    }
 
     img {
         height: 100%;
         width: 100%;
         object-fit: cover;
-    }
-}
-
-.contributions__epic--with-image {
-    .contributions__title {
-        @include fs-header(5);
-        font-size: 28px;
-        line-height: 28px;
-    }
-
-    p:last-child {
-        font-weight: bold;
     }
 }


### PR DESCRIPTION
## What does this change?
Updates the styling of the image in the epic. We can set an image from the epic tool.
- remove fixed height
- allow image on mobile
- remove extra styling on headline/last paragraph (no longer required)

It's up to the user of the epic tool to set an image which conforms to the preferred aspect ratio.

#### desktop

![Screen Shot 2020-07-21 at 08 38 55](https://user-images.githubusercontent.com/1513454/88026764-3d8ff480-cb2e-11ea-9a83-bc4c34427dcb.png)

#### tablet
![Screen Shot 2020-07-21 at 08 38 40](https://user-images.githubusercontent.com/1513454/88026779-44b70280-cb2e-11ea-90ac-e10179e1e00d.png)

#### mobile
![Screen Shot 2020-07-21 at 08 38 13](https://user-images.githubusercontent.com/1513454/88026787-47195c80-cb2e-11ea-805b-c8604dae3b5b.png)

### Without ticker
![Screen Shot 2020-07-21 at 09 02 15](https://user-images.githubusercontent.com/1513454/88028899-2acaef00-cb31-11ea-9f4c-7576799ffa92.png)


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
