### PR TITLE
Upgrade Prebid to 3.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ophan-tracker-js": "1.3.20",
     "preact": "^8.2.9",
     "preact-compat": "^3.18.4",
-    "prebid.js": "https://github.com/guardian/Prebid.js#d6fd59",
+    "prebid.js": "https://github.com/guardian/Prebid.js#009f49",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ophan-tracker-js": "1.3.20",
     "preact": "^8.2.9",
     "preact-compat": "^3.18.4",
-    "prebid.js": "https://github.com/guardian/Prebid.js#009f49",
+    "prebid.js": "https://github.com/guardian/Prebid.js#681fbb",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8832,9 +8832,9 @@ preact@^8.2.9:
   version "8.2.9"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.9.tgz#813ba9dd45e5d97c5ea0d6c86d375b3be711cc40"
 
-"prebid.js@https://github.com/guardian/Prebid.js#009f49":
+"prebid.js@https://github.com/guardian/Prebid.js#681fbb":
   version "3.26.0"
-  resolved "https://github.com/guardian/Prebid.js#009f490236350b05ef3cdbc0c700ed30594a53d4"
+  resolved "https://github.com/guardian/Prebid.js#681fbb0bf6b6a0cce186b362655655357a7b13c3"
   dependencies:
     babel-plugin-transform-object-assign "^6.22.0"
     core-js "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1535,7 +1535,7 @@ abab@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"
 
-abab@^2.0.2:
+abab@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.3.tgz#623e2075e02eb2d3f2475e49f99c91846467907a"
   integrity sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==
@@ -3238,6 +3238,11 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
+core-js-pure@^3.6.5:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.5.tgz#c79e75f5e38dbc85a662d91eea52b8256d53b813"
+  integrity sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
+
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
@@ -3246,10 +3251,6 @@ core-js@^2.4.0, core-js@^2.5.0:
   version "2.6.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
 
-core-js@^2.4.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.1.tgz#87416ae817de957a3f249b3b5ca475d4aaed6042"
-
 core-js@^2.5.3:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
@@ -3257,6 +3258,11 @@ core-js@^2.5.3:
 core-js@^2.5.7:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
+
+core-js@^3.0.0:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
+  integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -5141,10 +5147,10 @@ fstream@^1.0.0, fstream@^1.0.2, fstream@~1.0.10:
     mkdirp ">=0.5 0"
     rimraf "2"
 
-fun-hooks@^0.9.8:
-  version "0.9.8"
-  resolved "https://registry.yarnpkg.com/fun-hooks/-/fun-hooks-0.9.8.tgz#7103beb4a5011697343eabe7b2f92769789087ca"
-  integrity sha512-FZUHodONJBOCCETXnHTSvqnz+pLZiN2ZqbOZsjXIqJRI8AbvTqOJzDTEeMfPzFf8rPuSZnD5EPcbl7yZsEQ/NA==
+fun-hooks@^0.9.9:
+  version "0.9.9"
+  resolved "https://registry.yarnpkg.com/fun-hooks/-/fun-hooks-0.9.9.tgz#225481b58d8f805db0704e06f78cd76942ae1c45"
+  integrity sha512-821UhoYfO9Sg01wAl/QsDRB088BW0aeOqzC1PXLxSlB+kaUVbK+Vp6wMDHU5huZZopYxmMmv5jDkEYqDpK3hqg==
   dependencies:
     typescript-tuple "^2.2.1"
 
@@ -7106,16 +7112,15 @@ listr@^0.12.0:
     stream-to-observable "^0.1.0"
     strip-ansi "^3.0.1"
 
-live-connect-js@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/live-connect-js/-/live-connect-js-1.1.1.tgz#f09e184f500a792645a15f451b17d0e8187f01f4"
-  integrity sha512-PsYiZ6R6ecBQgcg3BWvzGf2TNOqpNFK1lUyfYAUEZ+DPwPciKNRM3CQIDtytVvR9vsH7nhotMaU3bBgb7iuPfQ==
+live-connect-js@1.1.10:
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/live-connect-js/-/live-connect-js-1.1.10.tgz#8839495cd4b9c3ea6b89229795319452eb3f1830"
+  integrity sha512-G/LJKN3b21DZILCQRyataC/znLvJRyogtu7mAkKlkhP9B9UJ8bcOL7ihW/clD2PsT4hVUkeabHhUGsPCmhsjFw==
   dependencies:
     "@kiosked/ulid" "^3.0.0"
-    abab "^2.0.2"
+    abab "^2.0.3"
     browser-cookies "^1.2.0"
     tiny-hashes "1.0.1"
-    tiny-uuid4 "^1.0.1"
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -8827,22 +8832,23 @@ preact@^8.2.9:
   version "8.2.9"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.9.tgz#813ba9dd45e5d97c5ea0d6c86d375b3be711cc40"
 
-"prebid.js@https://github.com/guardian/Prebid.js#d6fd59":
-  version "3.16.0"
-  resolved "https://github.com/guardian/Prebid.js#d6fd597cfbe1fbc59b35a0fd74487cb0e1a7624e"
+"prebid.js@https://github.com/guardian/Prebid.js#009f49":
+  version "3.26.0"
+  resolved "https://github.com/guardian/Prebid.js#009f490236350b05ef3cdbc0c700ed30594a53d4"
   dependencies:
     babel-plugin-transform-object-assign "^6.22.0"
-    core-js "^2.4.1"
+    core-js "^3.0.0"
+    core-js-pure "^3.6.5"
     criteo-direct-rsa-validate "^1.1.0"
     crypto-js "^3.3.0"
     deep-equal "^1.0.1"
     dlv "1.1.3"
     dset "2.0.1"
     express "^4.15.4"
-    fun-hooks "^0.9.8"
+    fun-hooks "^0.9.9"
     jsencrypt "^3.0.0-rc.1"
     just-clone "^1.0.2"
-    live-connect-js "1.1.1"
+    live-connect-js "1.1.10"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -10691,11 +10697,6 @@ tiny-hashes@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tiny-hashes/-/tiny-hashes-1.0.1.tgz#ddbe9060312ddb4efe0a174bb3a27e1331c425a1"
   integrity sha512-knIN5zj4fl7kW4EBU5sLP20DWUvi/rVouvJezV0UAym2DkQaqm365Nyc8F3QEiOvunNDMxR8UhcXd1d5g+Wg1g==
-
-tiny-uuid4@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/tiny-uuid4/-/tiny-uuid4-1.0.1.tgz#bd44e9dd5f5fbd1768d6d1fbf3020c886a1b7766"
-  integrity sha1-vUTp3V9fvRdo1tH78wIMiGobd2Y=
 
 tmp@^0.0.31:
   version "0.0.31"


### PR DESCRIPTION
## What does this change?

This upgrades Prebid.js to 3.26.0.

You can read more about the change [in the PR on our fork of Prebid.](https://github.com/guardian/Prebid.js/pull/108)

I currently have to test the on CODE.

### Tested

- [ ] Locally
- [x] On CODE (optional)

@guardian/commercial-dev 