### PR TITLE
Extend switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -142,7 +142,7 @@ trait ABTestSwitches {
     "Serve epics from remote service for subset of audience",
     owners = Seq(Owner.withGithub("nicl")),
     safeState = Off,
-    sellByDate = new LocalDate(2020, 7, 21),
+    sellByDate = new LocalDate(2020, 8, 24),
     exposeClientSide = true,
   )
 


### PR DESCRIPTION
Extends expired switch. We still plan to run this test soon.