### PR TITLE
Add tcfv2 build page targeting params

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -309,8 +309,8 @@ const getPageTargeting = (): { [key: string]: mixed } => {
             canRun = !state;
         } else if (typeof state.tcfv2 !== 'undefined') {
             // TCFv2 mode,
-            canRun = state.tcfv2.tcfData ? Object.keys(state.tcfv2.tcfData).length > 0 &&
-                Object.values(state.tcfv2.tcfData).every(Boolean): false;
+            canRun = state.tcfv2.consents ? Object.keys(state.tcfv2.consents).length > 0 &&
+                Object.values(state.tcfv2.consents).every(Boolean): false;
         } else {
             // TCFv1 mode
             canRun = state[1] && state[2] && state[3] && state[4] && state[5];

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -81,11 +81,11 @@ const ccpaWithConsentMock = (callback): void => callback(false);
 const ccpaWithoutConsentMock = (callback): void => callback(true);
 
 const tcfv2WithConsentMock = (callback): void =>
-    callback({ tcfv2 : { tcfData: {  '1':  true , '2': true }, eventStatus: 'useractioncomplete'}});
+    callback({ tcfv2 : { consents: {  '1':  true , '2': true }, eventStatus: 'useractioncomplete'}});
 const tcfv2WithoutConsentMock = (callback): void =>
-    callback({ tcfv2 : { tcfData: { }, eventStatus: 'cmpuishown' }});
+    callback({ tcfv2 : { consents: { }, eventStatus: 'cmpuishown' }});
 const tcfv2MixedConsentMock = (callback): void =>
-    callback({ tcfv2 : { tcfData: {  '1':  true , '2': false }, eventStatus: 'useractioncomplete'}});
+    callback({ tcfv2 : { consents: {  '1':  true , '2': false }, eventStatus: 'useractioncomplete'}});
 
 
 describe('Build Page Targeting', () => {

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -85,7 +85,7 @@ const tcfv2WithConsentMock = (callback): void =>
 const tcfv2WithoutConsentMock = (callback): void =>
     callback({ tcfv2 : { consents: { }, eventStatus: 'cmpuishown' }});
 const tcfv2MixedConsentMock = (callback): void =>
-    callback({ tcfv2 : { consents: {  '1':  true , '2': false }, eventStatus: 'useractioncomplete'}});
+    callback({ tcfv2 : { consents: {  '1':  false , '2': true }, eventStatus: 'useractioncomplete'}});
 
 
 describe('Build Page Targeting', () => {


### PR DESCRIPTION
## What does this change?
Adds tcfv2 build page targeting params

- Keyname = _consent_tcfV2_ (‘t’, ‘f’, ‘na’)

- Keyname = _cmp_interaction_ 

- **Values**  for cmp_interaction can be: 
- '_tcloaded_', (CMP loaded and prepared)
- '_cmpuishown_', (CMP UI shown)
-  ‘_useractioncomplete_’ (User confirmed or reconfirmed choices)
- ‘_na_’ (not in tcfv2 mode)


