### PR TITLE
Remove hardcoded contributions-service tracking props

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -193,7 +193,7 @@ const buildEpicPayload = () => {
 const buildBannerPayload = () => {
     const page = config.get('page');
 
-    // TODO: Is there any reason we send this to the server?
+    // TODO: Review whether we need to send all of this in the payload to the server
     const tracking = {
         ophanPageId: config.get('ophan.pageViewId'),
         platformId: 'GUARDIAN_WEB',
@@ -344,9 +344,8 @@ export const fetchAndRenderEpic = (id: string) => {
                     campaignCode,
                     campaignId
                 } = meta;
-                const trackingCampaignId = `${campaignId}`;
 
-                emitBeginEvent(trackingCampaignId);
+                emitBeginEvent(campaignId);
                 setupClickHandling(abTestName, abTestVariant, componentType, campaignCode, products);
 
                 renderEpic(html, css)
@@ -359,7 +358,7 @@ export const fetchAndRenderEpic = (id: string) => {
                             abTestName,
                             abTestVariant,
                             campaignCode,
-                            trackingCampaignId,
+                            campaignId,
                             componentType,
                             products,
                             abTestVariant.showTicker,


### PR DESCRIPTION
## What does this change?

We want to start using the `contributions-service` to start serving subscriptions banners, in order to do this we have updated the `contributions-service`. The `contributions-service` was previously setup to receive tracking props in the request payloads sent to the `/epic` and `/banner` routes, these props were hardcoded and were relevant to the Epic and Contributions Banner only. 

The `contributions-service` was updated in https://github.com/guardian/contributions-service/pull/190 to no longer use these hardcoded props but to instead use props associated to the various Banner and Epic components defined in the service instead. These tracking props are now returned in the response from the the `/epic` and `/banner` routes and are fed back into the Components as props at the point they're rendered. The props can also be used in the `view` and `insert` events triggered on `frontend` and `dotcom-rendering`.

This PR makes the relevant changes to stop sending the hardcoded `ophanComponentId` to the service, and to now read the new tracking props when triggering the `view` and `insert` events.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (A similar PR is required)

## What is the value of this and can you measure success?

We can track various banners served from the `contribution-service` following this change.