### PR TITLE
[hotfix] Update CMP package

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@emotion/styled": "^10.0.27",
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/automat-client": "^0.2.16",
-    "@guardian/consent-management-platform": "4.0.0-6",
+    "@guardian/consent-management-platform": "4.0.0-7",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/shimport": "^1.0.2",
     "@guardian/src-button": "^0.16.1",

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -120,7 +120,9 @@ export const init = (): Promise<void> => {
                 let npaFlag: boolean;
                 if (typeof state.tcfv2 !== 'undefined') {
                     // TCFv2 mode,
-                    npaFlag = Object.keys(state.tcfv2.tcfData).length === 0 || Object.values(state.tcfv2.tcfData).includes(false);
+                    npaFlag =
+                        Object.keys(state.tcfv2.consents).length === 0 ||
+                        Object.values(state.tcfv2.consents).includes(false);
                 } else {
                     // TCFv1 mode
                     npaFlag = Object.values(state).includes(false);

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
@@ -42,10 +42,11 @@ const setupRedplanet: () => Promise<void> = () => {
             let canRun: boolean;
             if (typeof state.tcfv2 !== 'undefined') {
                 // TCFv2 mode,
-                canRun = Object.values(state.tcfv2.tcfData).every(Boolean);
+                canRun = Object.values(state.tcfv2.consents).every(Boolean);
             } else {
                 // TCFv1 mode
-                canRun = state[1] && state[2] && state[3] && state[4] && state[5];
+                canRun =
+                    state[1] && state[2] && state[3] && state[4] && state[5];
             }
 
             if (!initialised && canRun) {

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
@@ -46,10 +46,12 @@ const initialise = (): void => {
             canRun = !state;
         } else if (typeof state.tcfv2 !== 'undefined') {
             // TCFv2 mode,
-            if (typeof state.tcfv2.customVendors.grants[SOURCEPOINT_ID] !== 'undefined') {
-                canRun = state.tcfv2.customVendors.grants[SOURCEPOINT_ID].vendorGrant;
+            if (
+                typeof state.tcfv2.customVendors[SOURCEPOINT_ID] !== 'undefined'
+            ) {
+                canRun = state.tcfv2.customVendors[SOURCEPOINT_ID];
             } else {
-                canRun = Object.values(state.tcfv2.tcfData).every(Boolean);
+                canRun = Object.values(state.tcfv2.consents).every(Boolean);
             }
         } else {
             // TCFv1 mode

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.spec.js
@@ -1,8 +1,11 @@
 // @flow
 
 import a9, { _ } from 'commercial/modules/header-bidding/a9/a9';
-import { oldCmp as oldCmp_, onConsentChange as onConsentChange_ } from '@guardian/consent-management-platform';
-import { isInTcfv2Test as isInTcfv2Test_} from 'commercial/modules/cmp/tcfv2-test';
+import {
+    oldCmp as oldCmp_,
+    onConsentChange as onConsentChange_,
+} from '@guardian/consent-management-platform';
+import { isInTcfv2Test as isInTcfv2Test_ } from 'commercial/modules/cmp/tcfv2-test';
 
 const oldCmp: any = oldCmp_;
 const isInTcfv2Test: any = isInTcfv2Test_;
@@ -12,7 +15,9 @@ const TcfWithConsentMock = (callback): void =>
     callback({ '1': true, '2': true, '3': true, '4': true, '5': true });
 
 const tcfv2WithConsentMock = (callback): void =>
-    callback({ tcfv2 : { customVendors: { grants: { '5edf9a821dc4e95986b66df4': { vendorGrant: true }}}}});
+    callback({
+        tcfv2: { customVendors: { '5edf9a821dc4e95986b66df4': true } },
+    });
 
 const CcpaWithConsentMock = (callback): void => callback(false);
 
@@ -22,8 +27,7 @@ jest.mock('commercial/modules/dfp/Advert', () =>
 );
 
 jest.mock('commercial/modules/cmp/tcfv2-test', () => ({
-    isInTcfv2Test: jest
-        .fn(),
+    isInTcfv2Test: jest.fn(),
 }));
 
 jest.mock('commercial/modules/header-bidding/slot-config', () => ({
@@ -36,9 +40,9 @@ jest.mock('commercial/modules/header-bidding/slot-config', () => ({
 
 jest.mock('@guardian/consent-management-platform', () => ({
     oldCmp: {
-        onIabConsentNotification: jest.fn()
+        onIabConsentNotification: jest.fn(),
     },
-    onConsentChange: jest.fn()
+    onConsentChange: jest.fn(),
 }));
 
 beforeEach(async () => {

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -76,13 +76,14 @@ const insertScripts = (
             if (!state) consentedAdvertisingServices = [...advertisingServices];
         } else if (typeof state.tcfv2 !== 'undefined') {
             // TCFv2 mode,
-            consentedAdvertisingServices = advertisingServices.filter(script => {
-                if (typeof script.sourcepointId !== 'undefined' &&
-                    typeof state.tcfv2.customVendors.grants[script.sourcepointId] !== 'undefined') {
-                    return state.tcfv2.customVendors.grants[script.sourcepointId].vendorGrant;
+            consentedAdvertisingServices = advertisingServices.filter(
+                script => {
+                    if (typeof script.sourcepointId !== 'undefined') {
+                        return state.tcfv2.customVendors[script.sourcepointId];
+                    }
+                    return Object.values(state.tcfv2.consents).every(Boolean);
                 }
-                return Object.values(state.tcfv2.tcfData).every(Boolean);
-            });
+            );
         } else if (state[1] && state[2] && state[3] && state[4] && state[5]) {
             // TCFv1 mode
             consentedAdvertisingServices = [...advertisingServices];

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
@@ -1,5 +1,8 @@
 // @flow
-import { oldCmp, onConsentChange as onConsentChange_ } from '@guardian/consent-management-platform';
+import {
+    oldCmp,
+    onConsentChange as onConsentChange_,
+} from '@guardian/consent-management-platform';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { isInTcfv2Test as isInTcfv2Test_ } from 'commercial/modules/cmp/tcfv2-test';
 import { init, _ } from './third-party-tags';
@@ -26,9 +29,9 @@ const onIabConsentNotification = oldCmp.onIabConsentNotification;
 const onGuConsentNotification = oldCmp.onGuConsentNotification;
 
 const tcfv2WithConsentMock = (callback): void =>
-    callback({ tcfv2 : { customVendors: { grants: { '1': { vendorGrant: true }, '2': { vendorGrant: false }}}}});
+    callback({ tcfv2: { customVendors: { '1': true, '2': false } } });
 const tcfv2WithoutConsentMock = (callback): void =>
-    callback({ tcfv2 : { customVendors: { grants: { '1': { vendorGrant: false }, '2': { vendorGrant: false }}}}});
+    callback({ tcfv2: { customVendors: { '1': false, '2': false } } });
 
 beforeEach(() => {
     const firstScript = document.createElement('script');
@@ -182,10 +185,7 @@ describe('third party tags', () => {
             _.reset();
             isInTcfv2Test.mockImplementation(() => true);
             onConsentChange.mockImplementation(tcfv2WithConsentMock);
-            insertScripts(
-                [fakeThirdPartyAdvertisingTag],
-                []
-            );
+            insertScripts([fakeThirdPartyAdvertisingTag], []);
             expect(document.scripts.length).toBe(2);
         });
 
@@ -193,10 +193,7 @@ describe('third party tags', () => {
             _.reset();
             isInTcfv2Test.mockImplementation(() => true);
             onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
-            insertScripts(
-                [fakeThirdPartyAdvertisingTag],
-                []
-            );
+            insertScripts([fakeThirdPartyAdvertisingTag], []);
             expect(document.scripts.length).toBe(1);
         });
     });

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -58,8 +58,9 @@ onCMPConsentNotification(state => {
     if (typeof state === 'boolean') {
         ccpaState = state;
     } else {
-        tcfState = state.tcfv2 ? Object.values(state.tcfv2.tcfData).every(Boolean) :
-            state[1] && state[2] && state[3] && state[4] && state[5];
+        tcfState = state.tcfv2
+            ? Object.values(state.tcfv2.consents).every(Boolean)
+            : state[1] && state[2] && state[3] && state[4] && state[5];
     }
 });
 

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -299,7 +299,7 @@ const getPageTargeting = (): { [key: string]: mixed } => {
             canRun = !state;
         } else if (typeof state.tcfv2 !== 'undefined') {
             // TCFv2 mode,
-            canRun = Object.values(state.tcfv2.tcfData).every(Boolean);
+            canRun = Object.values(state.tcfv2.consents).every(Boolean);
         } else {
             // TCFv1 mode
             canRun = state[1] && state[2] && state[3] && state[4] && state[5];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1150,10 +1150,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/automat-client/-/automat-client-0.2.16.tgz#3ef47e7f49e633aea51c67f061d8d313a26fa9bc"
   integrity sha512-SgNU2bgiyQaXNfqanx4SDmxqAhXW6QBCTk4tRnCgV9Ht6noRl7UsDfx4I0u+M4H3TRnK4I/i2mmlJBtnuwhxEg==
 
-"@guardian/consent-management-platform@4.0.0-6":
-  version "4.0.0-6"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.0-6.tgz#ad8959e7a6dcbb98cb0678adf879a2739265b35c"
-  integrity sha512-k6k+wuUfYsGlwRq/24Y86krT1a4xXzKvdB4uC2UurTdxCWQ8wkL2G2ETZQFE9ouIRCjppeh3AgW9aec1SP0RBA==
+"@guardian/consent-management-platform@4.0.0-7":
+  version "4.0.0-7"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.0-7.tgz#facabcd8b9a62ea39c2a104d0080c790e473828a"
+  integrity sha512-Qi1J/uN6HfhDgluV5yexX49dKHgShtqbeMZ/UdZna5XFoS1ZPvRlRtycK02B6cBurO7auJH9kiwrCO9caZub4Q==
   dependencies:
     "@guardian/old-cmp" "npm:@guardian/consent-management-platform@^3.4.9"
 


### PR DESCRIPTION
## What does this change?

Exposes the `oldCmp.showPrivacyManager` for CCPA:

https://github.com/guardian/consent-management-platform/commit/c24c4efb2237cea481887d4fdd284fb12d9d1874

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
