### PR TITLE
Git ignore nginx/Brewfile.lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ target
 /*/bin/
 dist
 
+nginx/Brewfile.lock.json
+
 RUNNING_PID
 
 *.sublime-*


### PR DESCRIPTION
## What does this change?

This file is generated when installing dependencies from the Brewfile. Git ignore rather than commit the file, because this lockfile doesn't guarantee the exact versions of dependencies like e.g. `yarn.lock`. Instead it gives status information from the last successful `brew bundle`, so committing doesn't seem useful.