### PR TITLE
Update local identity instructions

### DIFF
--- a/identity/README.md
+++ b/identity/README.md
@@ -4,39 +4,46 @@ This sub-project handles the Guardian profile functionality.
 
 ## Running Identity locally
 
-Identity runs securely on a separate subdomain. As such it isn't part
-of the dev-build application. The project should be run alongside
-dev-build if required.
+Identity runs securely on a separate subdomain. As such it isn't part of the
+dev-build application. The project should be run alongside dev-build if
+required.
 
-The `/nginx` dir contains instructions scripts and configuration for getting nginx setup. Make sure you run `./setup.sh` to have nginx properly configured.
+The [`nginx` README] contains instructions for getting nginx setup. Make sure
+you follow those instructions first.
 
- After following these
-instructions, you'll need to run Identity on port 9009 (it doesn't run
-on the default port, 9000 because that would clash with the rest of
-the application). You can do this by passing the port as an argument
-to the run command or by using the idrun command, which adds the port
-argument for you.
+Now to run the identity app:
 
-So to go into the Identity project:
+```
+$ ./sbt
+project identity
+run
+```
 
-  `./sbt` and `project identity`
+By default the app will listen on port 9009 (it doesn't run on the default
+port, 9000 because that would clash with the rest of the application)
 
-and then the following commands are equivalent:
+[`nginx` README]: ../nginx/README.md
 
-  `run` or `run 9009`
+## Running Identity Frontend locally
 
-The former is encouraged, in case we ever need to change the port.
+In order to have a fully functioning dev environment with working login etc
+you'll need to also run the [Identity Frontend] project locally.
 
-So the required steps are:
+First follow the [nginx instructions] in the [identity-platform repo].
 
-* configure and run nginx (see `/nginx`)
-* run the Identity subproject on port 9009
+Now follow the instructions for [running identity-frontend locally].
 
-With these in place, you'll be able to browse Identity on
+[Identity Frontend]: https://github.com/guardian/identity-frontend
+[nginx instructions]: https://github.com/guardian/identity-platform/tree/master/nginx
+[identity-platform repo]: https://github.com/guardian/identity-platform
+[running identity-frontend locally]: https://github.com/guardian/identity-frontend#running
 
-  https://profile.thegulocal.com/
+With both these in place, you'll be able to browse Identity on
+https://profile.thegulocal.com/ and login on https://m.thegulocal.com.
 
 ## Configuration of local Identity API
+
+By default local Identity will use the CODE Identity API.
 
 The Identity site can be configured to use the local Identity API with the
 following properties in `~/.gu/frontend.conf`.
@@ -48,3 +55,14 @@ devOverrides {
   id.apiClientToken=frontend-dev-client-token
 }
 ```
+
+You can configure [identity-frontend in the same way].
+
+[identity-frontend in the same way]: https://github.com/guardian/identity-frontend#running-against-dev-identity-api
+
+### Proxying local Identity API requests to CODE
+
+You can also use `idapi-code-proxy.thegulocal.com` locally to proxy requests to
+CODE. This is necessary if you want requests to CODE identity API to work from
+the browser (running on the same domain as `m.thegulocal.com` means Cookies
+will be sent correctly).

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -2,14 +2,15 @@
 
 ## Install dependencies
 
-### Mac
+### Mac (via Homebrew)
 
-[Install Homebrew](http://brew.sh/#install).
+First [install Homebrew](http://brew.sh/#install).
+
+Then:
 
 ```
-$ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-
-$ brew bundle
+$ cd nginx
+$ brew bundle # install deps from the Brewfile
 ```
 
 ### Other operating systems
@@ -22,7 +23,7 @@ You need to install:
 ## Configure Nginx with SSL
 
 1. Run `nginx/setup.sh`
-1. To setup Dotcom Identity Frontend follow the [identity-platform README](https://github.com/guardian/identity-platform)
+1. To setup Identity follow the [Identity README](../identity/README.md)
 
 ## Access the Site
 


### PR DESCRIPTION
## What does this change?

Updates the instructions for running identity locally. Following the existing instructions didn't _quite_ get me to the point where identity was fully working locally (including being able to login).