### PR TITLE
Pass submitComponentEvent prop to remote banner as a prop

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -13,7 +13,7 @@ import reportError from 'lib/report-error';
 import fastdom from 'lib/fastdom-promise';
 import config from 'lib/config';
 import { getMvtValue } from 'common/modules/analytics/mvt-cookie';
-import {submitClickEvent, submitViewEvent} from 'common/modules/commercial/acquisitions-ophan';
+import {submitClickEvent, submitViewEvent, submitComponentEvent} from 'common/modules/commercial/acquisitions-ophan';
 import fetchJson from 'lib/fetch-json';
 import { render } from 'preact-x';
 import React from 'preact-x/compat';
@@ -288,7 +288,7 @@ export const renderBanner: (BannerDataResponse) => Promise<boolean> = (response)
                 }
 
                 return render(
-                    <Banner {...module.props} />,
+                    <Banner {...module.props} submitComponentEvent={submitComponentEvent} />,
                     container
                 );
             }).then(() => {


### PR DESCRIPTION
## What does this change?

This PR passes the `submitComponentEvent` function as prop to remote Banner components as a prop. This means we can track Ophan "actions" from our Banners, such as click events.

Related PRs:

`dotcom-rendering`: https://github.com/guardian/dotcom-rendering/pull/1743
`contributions-service`: https://github.com/guardian/contributions-service/pull/196