### PR TITLE
Only show share count greater than 0

### DIFF
--- a/static/src/javascripts/projects/common/modules/social/share-count.js
+++ b/static/src/javascripts/projects/common/modules/social/share-count.js
@@ -72,8 +72,10 @@ const fetch = (): void => {
     }).then(res => {
         const count = res.share_count || 0;
         counts.facebook = count;
-        addToShareCount(count);
-        updateTooltip();
+        if (count > 0) {
+            addToShareCount(count);
+            updateTooltip();
+        }
     });
 };
 


### PR DESCRIPTION
## What does this change?

Quick fix, following a discussion with Editorial, it was decided that a 0 value share count is not particularly useful to readers and is sometimes shown when the upstream APIs fail to return correctly so we will not show the share count if it is 0

![image](https://user-images.githubusercontent.com/638051/88385370-1ba0a700-cda6-11ea-9c0d-a1109866d301.png)

vs 

![image](https://user-images.githubusercontent.com/638051/88385269-f01dbc80-cda5-11ea-9c2c-3dde111f8fdd.png)


## Does this change need to be reproduced in dotcom-rendering ?

- [X] Yes
