### PR TITLE
Pass component event parameters for all signin referrers

### DIFF
--- a/common/app/navigation/AuthenticationComponentEvent.scala
+++ b/common/app/navigation/AuthenticationComponentEvent.scala
@@ -14,12 +14,11 @@ object AuthenticationComponentEvent {
   case object SigninFromPasswordResetConfirmation extends ComponentEventId("signin_from_password_reset_confirmation")
 
   def createAuthenticationComponentEventParams(componentEventId: ComponentEventId): String = createAuthenticationComponentEventTuple(componentEventId) match {
-    case (key, value) => s"$key=$value"
+    case (key, value) => s"$key=${URLEncoder.encode(value, "UTF-8")}"
   }
 
   def createAuthenticationComponentEventTuple(componentEventId: ComponentEventId): (String, String) = {
     val eventParams = s"componentType=IDENTITY_AUTHENTICATION&componentId=${componentEventId.id}"
-    val encodedParams = URLEncoder.encode(eventParams, "UTF-8")
-    "componentEventParams" -> encodedParams
+    "componentEventParams" -> eventParams
   }
 }

--- a/common/app/navigation/AuthenticationComponentEvent.scala
+++ b/common/app/navigation/AuthenticationComponentEvent.scala
@@ -1,0 +1,25 @@
+package navigation
+
+import java.net.URLEncoder
+
+
+object AuthenticationComponentEvent {
+  sealed abstract class ComponentEventId(val id: String)
+  case object SigninHeaderId extends ComponentEventId("guardian_signin_header")
+  case object SigninToReply extends ComponentEventId("signin_to_reply_comment")
+  case object SigninToRecommend extends ComponentEventId("signin_to_recommend_comment")
+  case object RegisterToRecommend extends ComponentEventId("register_to_recommend_comment")
+  case object SigninRedirect extends ComponentEventId("signin_redirect_for_action")
+  case object SigninFromFormStack extends ComponentEventId("signin_from_formstack")
+  case object SigninFromPasswordResetConfirmation extends ComponentEventId("signin_from_password_reset_confirmation")
+
+  def createAuthenticationComponentEventParams(componentEventId: ComponentEventId): String = createAuthenticationComponentEventTuple(componentEventId) match {
+    case (key, value) => s"$key=$value"
+  }
+
+  def createAuthenticationComponentEventTuple(componentEventId: ComponentEventId): (String, String) = {
+    val eventParams = s"componentType=IDENTITY_AUTHENTICATION&componentId=${componentEventId.id}"
+    val encodedParams = URLEncoder.encode(eventParams, "UTF-8")
+    "componentEventParams" -> encodedParams
+  }
+}

--- a/common/app/navigation/AuthenticationComponentEvent.scala
+++ b/common/app/navigation/AuthenticationComponentEvent.scala
@@ -18,7 +18,7 @@ object AuthenticationComponentEvent {
   }
 
   def createAuthenticationComponentEventTuple(componentEventId: ComponentEventId): (String, String) = {
-    val eventParams = s"componentType=IDENTITY_AUTHENTICATION&componentId=${componentEventId.id}"
+    val eventParams = s"componentType=identityauthentication&componentId=${componentEventId.id}"
     "componentEventParams" -> eventParams
   }
 }

--- a/common/app/views/fragments/nav/userAccountDropdown.scala.html
+++ b/common/app/views/fragments/nav/userAccountDropdown.scala.html
@@ -1,6 +1,7 @@
 @()(implicit request: RequestHeader)
 
 @import conf.Configuration
+@import navigation.AuthenticationComponentEvent._
 @import views.support.DropdownMenus.accountDropdownMenu
 
 <div class="new-header__user-account-container">
@@ -8,12 +9,12 @@
 
     <a class="top-bar__item js-navigation-sign-in my-account"
         data-link-name="nav2 : topbar : signin"
-        href="@Configuration.id.url/signin?INTCMP=DOTCOM_NEWHEADER_SIGNIN">
+        href="@Configuration.id.url/signin?INTCMP=DOTCOM_NEWHEADER_SIGNIN&@createAuthenticationComponentEventParams(SigninHeaderId)">
         @fragments.inlineSvg("profile", "icon", List("top-bar__item__icon"))
         Sign in
     </a>
 
-    <input 
+    <input
         type="checkbox"
         id="my-account-toggle"
         aria-controls="my-account-dropdown"
@@ -24,7 +25,7 @@
 
     <label class="top-bar__item popup__toggle js-navigation-account-actions js-user-account-trigger is-hidden"
         for="my-account-toggle"
-        data-link-name="nav2 : topbar: my account"        
+        data-link-name="nav2 : topbar: my account"
         tabindex="0">
             @fragments.inlineSvg("profile", "icon", List("top-bar__item__icon"))
             My account

--- a/common/test/navigation/AuthenticationComponentEventTest.scala
+++ b/common/test/navigation/AuthenticationComponentEventTest.scala
@@ -1,0 +1,16 @@
+package navigation
+
+import org.scalatest.{FlatSpec, Matchers}
+import AuthenticationComponentEvent._
+
+class AuthenticationComponentEventTest extends FlatSpec with Matchers {
+
+  "createAuthenticationComponentEventTuple" should "create a component event tuple with the parameters passed" in {
+    createAuthenticationComponentEventTuple(SigninHeaderId) shouldBe "componentEventParams" -> "componentType%3DIDENTITY_AUTHENTICATION%26componentId%3Dguardian_signin_header"
+  }
+
+  "createAuthenticationComponentEventParams" should "create component event parameters with the parameters passed" in {
+    createAuthenticationComponentEventParams(SigninHeaderId) shouldBe "componentEventParams=componentType%3DIDENTITY_AUTHENTICATION%26componentId%3Dguardian_signin_header"
+  }
+
+}

--- a/common/test/navigation/AuthenticationComponentEventTest.scala
+++ b/common/test/navigation/AuthenticationComponentEventTest.scala
@@ -6,11 +6,11 @@ import AuthenticationComponentEvent._
 class AuthenticationComponentEventTest extends FlatSpec with Matchers {
 
   "createAuthenticationComponentEventTuple" should "create a component event tuple with the parameters passed" in {
-    createAuthenticationComponentEventTuple(SigninHeaderId) shouldBe "componentEventParams" -> "componentType=IDENTITY_AUTHENTICATION&componentId=guardian_signin_header"
+    createAuthenticationComponentEventTuple(SigninHeaderId) shouldBe "componentEventParams" -> "componentType=identityauthentication&componentId=guardian_signin_header"
   }
 
   "createAuthenticationComponentEventParams" should "create component event parameters with the parameters passed" in {
-    createAuthenticationComponentEventParams(SigninHeaderId) shouldBe "componentEventParams=componentType%3DIDENTITY_AUTHENTICATION%26componentId%3Dguardian_signin_header"
+    createAuthenticationComponentEventParams(SigninHeaderId) shouldBe "componentEventParams=componentType%3Didentityauthentication%26componentId%3Dguardian_signin_header"
   }
 
 }

--- a/common/test/navigation/AuthenticationComponentEventTest.scala
+++ b/common/test/navigation/AuthenticationComponentEventTest.scala
@@ -6,7 +6,7 @@ import AuthenticationComponentEvent._
 class AuthenticationComponentEventTest extends FlatSpec with Matchers {
 
   "createAuthenticationComponentEventTuple" should "create a component event tuple with the parameters passed" in {
-    createAuthenticationComponentEventTuple(SigninHeaderId) shouldBe "componentEventParams" -> "componentType%3DIDENTITY_AUTHENTICATION%26componentId%3Dguardian_signin_header"
+    createAuthenticationComponentEventTuple(SigninHeaderId) shouldBe "componentEventParams" -> "componentType=IDENTITY_AUTHENTICATION&componentId=guardian_signin_header"
   }
 
   "createAuthenticationComponentEventParams" should "create component event parameters with the parameters passed" in {

--- a/discussion/app/views/fragments/comment.scala.html
+++ b/discussion/app/views/fragments/comment.scala.html
@@ -5,6 +5,7 @@
 @import views.support.{GuDateFormatLegacy, RenderClasses}
 @import views.support.`package`.withJsoup
 @import views.support.{BulletCleaner, InBodyLinkCleaner}
+@import navigation.AuthenticationComponentEvent._
 
 @(comment: Comment, isClosedForRecommendation: Boolean = true, isResponse: Boolean = false)(implicit request: RequestHeader)
 
@@ -108,7 +109,7 @@
                 </div>
                 @if(!comment.isBlocked){
                     <div class="d-comment__actions d-comment__actions--left modern-visible">
-                        <a class="d-comment__action d-comment__action--reply" href="https://profile.theguardian.com/signin?returnUrl=@comment.webUrl"
+                        <a class="d-comment__action d-comment__action--reply" href="https://profile.theguardian.com/signin?returnUrl=@comment.webUrl&@createAuthenticationComponentEventParams(SigninToReply)"
                                 data-link-name="reply to comment" data-comment-id="@comment.id" role="button">
                             @fragments.inlineSvg("reply", "icon", List("blue"))
                             Reply

--- a/discussion/app/views/fragments/recommendationTooltip.scala.html
+++ b/discussion/app/views/fragments/recommendationTooltip.scala.html
@@ -1,4 +1,5 @@
 @import conf.Configuration
+@import navigation.AuthenticationComponentEvent._
 
 <div hidden class="tooltip-box tooltip-box--neutral tooltip-box--width4 js-rec-tooltip">
     <button
@@ -12,12 +13,12 @@
     <p class="tooltip-box__p">
         <a
             class="js-rec-tooltip-link"
-            href="@Configuration.id.url/signin?INTCMP=DOTCOM_COMMENTS_SIGNIN_RECOMM"
+            href="@Configuration.id.url/signin?INTCMP=DOTCOM_COMMENTS_SIGNIN_RECOMM&@createAuthenticationComponentEventParams(SigninToRecommend)"
         >Sign in</a>
         or
         <a
             class="js-rec-tooltip-link"
-            href="@Configuration.id.url/register?INTCMP=DOTCOM_COMMENTS_REG_RECOMM"
+            href="@Configuration.id.url/register?INTCMP=DOTCOM_COMMENTS_REG_RECOMM&@createAuthenticationComponentEventParams(RegisterToRecommend)"
         >create your Guardian account</a>
         to recommend a comment
     </p>

--- a/identity/app/actions/AuthenticatedActions.scala
+++ b/identity/app/actions/AuthenticatedActions.scala
@@ -7,6 +7,8 @@ import play.api.mvc._
 import services._
 import utils.Logging
 import scala.concurrent.{ExecutionContext, Future}
+import navigation.AuthenticationComponentEvent._
+
 
 object AuthenticatedActions {
   type AuthRequest[A] = AuthenticatedRequest[A, AuthenticatedUser]
@@ -29,7 +31,7 @@ class AuthenticatedActions(
 
     val params = List("returnUrl" -> returnUrl) ++
       List("INTCMP", "email", "CMP", "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content","clientId","encryptedEmail","autoSignInToken") //only forward these if they exist in original query string
-        .flatMap(name => request.getQueryString(name).map(value => name -> value))
+        .flatMap(name => request.getQueryString(name).map(value => name -> value)) :+ createAuthenticationComponentEventTuple(SigninRedirect)
 
     val redirectUrlWithParams = identityUrlBuilder.appendQueryParams(path, params)
 

--- a/identity/app/views/formstack/formstackFormComposer.scala.html
+++ b/identity/app/views/formstack/formstackFormComposer.scala.html
@@ -1,3 +1,5 @@
+@import navigation.AuthenticationComponentEvent._
+
 @(page: model.Page, formstackForm: _root_.formstack.FormstackForm)(implicit request: RequestHeader)
 
 <!DOCTYPE html>
@@ -393,7 +395,7 @@ a {
                 if (user) {
                     return user;
                 } else {
-                    window.location.href = '/signin?returnUrl=' + document.location.href;
+                    window.location.href = '/signin?returnUrl=' + document.location.href + '&@createAuthenticationComponentEventParams(SigninFromFormStack)';
                 }
             };
 

--- a/identity/app/views/password/passwordResetConfirmation.scala.html
+++ b/identity/app/views/password/passwordResetConfirmation.scala.html
@@ -4,6 +4,8 @@
 @import views.html.fragments.registrationFooter
 
 @import model.ReturnJourney
+@import navigation.AuthenticationComponentEvent._
+
 @(page: Page, idRequest: IdentityRequest, idUrlBuilder: IdentityUrlBuilder, userIsLoggedIn: Boolean, returnUrl: Option[String], returnJourney: ReturnJourney.Journey)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 
@@ -18,7 +20,7 @@
         <div class="identity-forms-message__body">
             @if(!userIsLoggedIn){
                 <p>
-                    <a class="u-underline" href="@idUrlBuilder.buildUrl("/signin", idRequest)" data-link-name="Sign in after reset">Sign in to your account</a>.
+                    <a class="u-underline" href="@idUrlBuilder.buildUrl("/signin", idRequest, createAuthenticationComponentEventTuple(SigninFromPasswordResetConfirmation))" data-link-name="Sign in after reset">Sign in to your account</a>.
                 </p>
             }else{
 

--- a/identity/test/actions/AuthenticatedActionsTest.scala
+++ b/identity/test/actions/AuthenticatedActionsTest.scala
@@ -24,7 +24,7 @@ import scala.concurrent.Future
 class AuthenticatedActionsTest extends WordSpecLike with MockitoSugar with ScalaFutures with Matchers with WithTestIdConfig with WithTestExecutionContext {
 
   trait TestFixture {
-    val expectedEventParameters = "componentEventParams=componentType%3DIDENTITY_AUTHENTICATION%26componentId%3Dsignin_redirect_for_action"
+    val expectedEventParameters = "componentEventParams=componentType%3Didentityauthentication%26componentId%3Dsignin_redirect_for_action"
 
     val authService = mock[AuthenticationService]
     val client: IdApiClient = mock[IdApiClient]

--- a/identity/test/actions/AuthenticatedActionsTest.scala
+++ b/identity/test/actions/AuthenticatedActionsTest.scala
@@ -24,6 +24,8 @@ import scala.concurrent.Future
 class AuthenticatedActionsTest extends WordSpecLike with MockitoSugar with ScalaFutures with Matchers with WithTestIdConfig with WithTestExecutionContext {
 
   trait TestFixture {
+    val expectedEventParameters = "componentEventParams=componentType%3DIDENTITY_AUTHENTICATION%26componentId%3Dsignin_redirect_for_action"
+
     val authService = mock[AuthenticationService]
     val client: IdApiClient = mock[IdApiClient]
     val idRequestParser: IdRequestParser = mock[IdRequestParser]
@@ -51,7 +53,7 @@ class AuthenticatedActionsTest extends WordSpecLike with MockitoSugar with Scala
       when(authService.fullyAuthenticatedUser(any[RequestHeader])).thenReturn(Some(notRecentlyAuthedUser))
 
       val result = actions.consentAuthWithIdapiUserWithEmailValidation.apply(failTest)(request)
-      val expectedLocation = s"/reauthenticate?returnUrl=${URLEncoder.encode(originalUrl, "utf-8")}"
+      val expectedLocation = s"/reauthenticate?returnUrl=${URLEncoder.encode(originalUrl, "utf-8")}&$expectedEventParameters"
       whenReady(result) { res =>
         res.header.status shouldBe 303
         res.header.headers should contain("Location" -> expectedLocation)
@@ -89,7 +91,7 @@ class AuthenticatedActionsTest extends WordSpecLike with MockitoSugar with Scala
       when(authService.consentCookieAuthenticatedUser(any[RequestHeader])).thenReturn(None)
 
       val result = actions.consentAuthWithIdapiUserWithEmailValidation.apply(failTest)(request)
-      val expectedLocation = s"/signin?returnUrl=${URLEncoder.encode(originalUrl, "utf-8")}"
+      val expectedLocation = s"/signin?returnUrl=${URLEncoder.encode(originalUrl, "utf-8")}&$expectedEventParameters"
       whenReady(result) { res =>
         res.header.status shouldBe 303
         res.header.headers should contain("Location" -> expectedLocation)
@@ -140,7 +142,7 @@ class AuthenticatedActionsTest extends WordSpecLike with MockitoSugar with Scala
       when(authService.consentCookieAuthenticatedUser(any[RequestHeader])).thenReturn(None)
 
       val result = actions.consentAuthWithIdapiUserWithEmailValidation.apply(failTest)(request)
-      val expectedLocation = s"/reauthenticate?returnUrl=${URLEncoder.encode(originalUrl, "utf-8")}"
+      val expectedLocation = s"/reauthenticate?returnUrl=${URLEncoder.encode(originalUrl, "utf-8")}&$expectedEventParameters"
       whenReady(result) { res =>
         res.header.status shouldBe 303
         res.header.headers should contain("Location" -> expectedLocation)

--- a/static/src/javascripts/projects/common/modules/identity/api.js
+++ b/static/src/javascripts/projects/common/modules/identity/api.js
@@ -11,6 +11,7 @@ import { getUrlVars } from 'lib/url';
 import fetch from 'lib/fetch-json';
 import qs from 'qs';
 import reqwest from 'reqwest';
+import { createAuthenticationComponentEventParams } from "common/modules/identity/auth-component-event-params";
 
 let userFromCookieCache = null;
 
@@ -165,7 +166,7 @@ export const redirectTo = (url: string): void => {
     window.location.assign(url);
 };
 
-export const getUserOrSignIn = (paramUrl: ?string): ?Object => {
+export const getUserOrSignIn = (componentId: string, paramUrl: ?string): ?Object => {
     let returnUrl = paramUrl;
 
     if (isUserLoggedIn()) {
@@ -173,7 +174,12 @@ export const getUserOrSignIn = (paramUrl: ?string): ?Object => {
     }
 
     returnUrl = encodeURIComponent(returnUrl || document.location.href);
-    const url = `${getUrl() || ''}/signin?returnUrl=${returnUrl}`;
+    let url = `${getUrl() || ''}/signin?returnUrl=${returnUrl}`;
+
+    if (componentId) {
+        url += `&${createAuthenticationComponentEventParams(componentId)}`
+    }
+
     redirectTo(url);
 };
 

--- a/static/src/javascripts/projects/common/modules/identity/api.js
+++ b/static/src/javascripts/projects/common/modules/identity/api.js
@@ -11,7 +11,8 @@ import { getUrlVars } from 'lib/url';
 import fetch from 'lib/fetch-json';
 import qs from 'qs';
 import reqwest from 'reqwest';
-import { createAuthenticationComponentEventParams } from "common/modules/identity/auth-component-event-params";
+import { createAuthenticationComponentEvent, createAuthenticationComponentEventParams } from "common/modules/identity/auth-component-event-params";
+import type { AuthenticationComponentId } from "common/modules/identity/auth-component-event-params";
 
 let userFromCookieCache = null;
 
@@ -166,7 +167,7 @@ export const redirectTo = (url: string): void => {
     window.location.assign(url);
 };
 
-export const getUserOrSignIn = (componentId: string, paramUrl: ?string): ?Object => {
+export const getUserOrSignIn = (componentId: AuthenticationComponentId, paramUrl: ?string): ?Object => {
     let returnUrl = paramUrl;
 
     if (isUserLoggedIn()) {
@@ -316,14 +317,24 @@ export const setConsent = (consents: SettableConsent[]): Promise<void> =>
     });
 export const ajaxSignIn = (credentials: PasswordCredential) => {
     const url = `${profileRoot || ''}/actions/auth/ajax`;
+    const body: Object = {
+        email: credentials.id,
+        password: credentials.password,
+    };
+
+    if (
+        window.guardian &&
+        window.guardian.ophan &&
+        window.guardian.ophan.viewId
+    ) {
+        body.componentEventParams = createAuthenticationComponentEvent('guardian_smartlock', window.guardian.ophan.viewId);
+    }
+
     return fetch(url, {
         mode: 'cors',
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: qs.stringify({
-            email: credentials.id,
-            password: credentials.password,
-        }),
+        body: qs.stringify(body),
         credentials: 'include',
     });
 };

--- a/static/src/javascripts/projects/common/modules/identity/api.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/api.spec.js
@@ -119,19 +119,19 @@ describe('Identity API', () => {
         window.location.assign(returnUrl);
 
         getCookieStub.mockImplementationOnce(() => null);
-        getUserOrSignIn('some-component-id');
+        getUserOrSignIn('email_sign_in_banner');
 
         expect(window.location.href).toBe(
             `${config.page.idUrl}/signin?returnUrl=${encodeURIComponent(
                 returnUrl
-            )}&componentEventParams=componentType%3DIDENTITY_AUTHENTICATION%26componentId%3Dsome-component-id`
+            )}&componentEventParams=componentType%3DIDENTITY_AUTHENTICATION%26componentId%3Demail_sign_in_banner`
         );
 
         window.location.assign(origHref);
     });
 
     it('should not redirect to sign in when user is already signed in', () => {
-        const user = getUserOrSignIn('some-component-id');
+        const user = getUserOrSignIn('email_sign_in_banner');
         const displayName = user && user.displayName;
 
         expect(displayName).toBe('Amélie Jôse');
@@ -142,12 +142,12 @@ describe('Identity API', () => {
         const returnUrl = 'http://www.theguardian.com/foo';
 
         getCookieStub.mockImplementationOnce(() => null);
-        getUserOrSignIn('some-component-id', returnUrl);
+        getUserOrSignIn('email_sign_in_banner', returnUrl);
 
         expect(window.location.href).toBe(
             `${config.page.idUrl}/signin?returnUrl=${encodeURIComponent(
                 returnUrl
-            )}&componentEventParams=componentType%3DIDENTITY_AUTHENTICATION%26componentId%3Dsome-component-id`
+            )}&componentEventParams=componentType%3DIDENTITY_AUTHENTICATION%26componentId%3Demail_sign_in_banner`
         );
 
         window.location.assign(origHref);

--- a/static/src/javascripts/projects/common/modules/identity/api.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/api.spec.js
@@ -119,19 +119,19 @@ describe('Identity API', () => {
         window.location.assign(returnUrl);
 
         getCookieStub.mockImplementationOnce(() => null);
-        getUserOrSignIn();
+        getUserOrSignIn('some-component-id');
 
         expect(window.location.href).toBe(
             `${config.page.idUrl}/signin?returnUrl=${encodeURIComponent(
                 returnUrl
-            )}`
+            )}&componentEventParams=componentType%3DIDENTITY_AUTHENTICATION%26componentId%3Dsome-component-id`
         );
 
         window.location.assign(origHref);
     });
 
     it('should not redirect to sign in when user is already signed in', () => {
-        const user = getUserOrSignIn();
+        const user = getUserOrSignIn('some-component-id');
         const displayName = user && user.displayName;
 
         expect(displayName).toBe('Amélie Jôse');
@@ -142,12 +142,12 @@ describe('Identity API', () => {
         const returnUrl = 'http://www.theguardian.com/foo';
 
         getCookieStub.mockImplementationOnce(() => null);
-        getUserOrSignIn(returnUrl);
+        getUserOrSignIn('some-component-id', returnUrl);
 
         expect(window.location.href).toBe(
             `${config.page.idUrl}/signin?returnUrl=${encodeURIComponent(
                 returnUrl
-            )}`
+            )}&componentEventParams=componentType%3DIDENTITY_AUTHENTICATION%26componentId%3Dsome-component-id`
         );
 
         window.location.assign(origHref);

--- a/static/src/javascripts/projects/common/modules/identity/api.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/api.spec.js
@@ -124,7 +124,7 @@ describe('Identity API', () => {
         expect(window.location.href).toBe(
             `${config.page.idUrl}/signin?returnUrl=${encodeURIComponent(
                 returnUrl
-            )}&componentEventParams=componentType%3DIDENTITY_AUTHENTICATION%26componentId%3Demail_sign_in_banner`
+            )}&componentEventParams=componentType%3Didentityauthentication%26componentId%3Demail_sign_in_banner`
         );
 
         window.location.assign(origHref);
@@ -147,7 +147,7 @@ describe('Identity API', () => {
         expect(window.location.href).toBe(
             `${config.page.idUrl}/signin?returnUrl=${encodeURIComponent(
                 returnUrl
-            )}&componentEventParams=componentType%3DIDENTITY_AUTHENTICATION%26componentId%3Demail_sign_in_banner`
+            )}&componentEventParams=componentType%3Didentityauthentication%26componentId%3Demail_sign_in_banner`
         );
 
         window.location.assign(origHref);

--- a/static/src/javascripts/projects/common/modules/identity/auth-component-event-params.js
+++ b/static/src/javascripts/projects/common/modules/identity/auth-component-event-params.js
@@ -1,0 +1,11 @@
+// @flow
+import {constructQuery} from "../../../../lib/url";
+
+export const createAuthenticationComponentEventParams = (componentId: string) =>
+    `componentEventParams=${encodeURIComponent(
+        constructQuery({
+            componentType: 'IDENTITY_AUTHENTICATION',
+            componentId
+        })
+    )}`;
+

--- a/static/src/javascripts/projects/common/modules/identity/auth-component-event-params.js
+++ b/static/src/javascripts/projects/common/modules/identity/auth-component-event-params.js
@@ -13,7 +13,7 @@ export const createAuthenticationComponentEvent = (componentId: AuthenticationCo
         params.viewId = pageViewId;
     }
 
-    return encodeURIComponent(constructQuery(params));
+    return constructQuery(params);
 };
 
-export const createAuthenticationComponentEventParams = (componentId: AuthenticationComponentId, pageViewId?: string) => `componentEventParams=${createAuthenticationComponentEvent(componentId, pageViewId)}`;
+export const createAuthenticationComponentEventParams = (componentId: AuthenticationComponentId, pageViewId?: string) => `componentEventParams=${encodeURIComponent(createAuthenticationComponentEvent(componentId, pageViewId))}`;

--- a/static/src/javascripts/projects/common/modules/identity/auth-component-event-params.js
+++ b/static/src/javascripts/projects/common/modules/identity/auth-component-event-params.js
@@ -1,11 +1,19 @@
 // @flow
 import {constructQuery} from "../../../../lib/url";
 
-export const createAuthenticationComponentEventParams = (componentId: string) =>
-    `componentEventParams=${encodeURIComponent(
-        constructQuery({
-            componentType: 'IDENTITY_AUTHENTICATION',
-            componentId
-        })
-    )}`;
+export type AuthenticationComponentId = 'email_sign_in_banner' | 'subscription_sign_in_banner' | 'guardian_smartlock' | 'signin_from_formstack'
 
+export const createAuthenticationComponentEvent = (componentId: AuthenticationComponentId, pageViewId?: string) => {
+    const params: Object = {
+        componentType: 'IDENTITY_AUTHENTICATION',
+        componentId,
+    };
+
+    if (pageViewId) {
+        params.viewId = pageViewId;
+    }
+
+    return encodeURIComponent(constructQuery(params));
+};
+
+export const createAuthenticationComponentEventParams = (componentId: AuthenticationComponentId, pageViewId?: string) => `componentEventParams=${createAuthenticationComponentEvent(componentId, pageViewId)}`;

--- a/static/src/javascripts/projects/common/modules/identity/auth-component-event-params.js
+++ b/static/src/javascripts/projects/common/modules/identity/auth-component-event-params.js
@@ -5,7 +5,7 @@ export type AuthenticationComponentId = 'email_sign_in_banner' | 'subscription_s
 
 export const createAuthenticationComponentEvent = (componentId: AuthenticationComponentId, pageViewId?: string) => {
     const params: Object = {
-        componentType: 'IDENTITY_AUTHENTICATION',
+        componentType: 'identityauthentication',
         componentId,
     };
 

--- a/static/src/javascripts/projects/common/modules/identity/auth-component-event-params.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/auth-component-event-params.spec.js
@@ -1,0 +1,9 @@
+// @flow
+
+import { createAuthenticationComponentEventParams } from "common/modules/identity/auth-component-event-params";
+
+describe('createAuthenticationComponentEventParams', () => {
+    it('should create component event params using the component ID passed', () => {
+        expect(createAuthenticationComponentEventParams('some-component-id')).toBe('componentEventParams=componentType%3DIDENTITY_AUTHENTICATION%26componentId%3Dsome-component-id')
+    })
+});

--- a/static/src/javascripts/projects/common/modules/identity/auth-component-event-params.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/auth-component-event-params.spec.js
@@ -4,6 +4,6 @@ import { createAuthenticationComponentEventParams } from "common/modules/identit
 
 describe('createAuthenticationComponentEventParams', () => {
     it('should create component event params using the component ID passed', () => {
-        expect(createAuthenticationComponentEventParams('some-component-id')).toBe('componentEventParams=componentType%3DIDENTITY_AUTHENTICATION%26componentId%3Dsome-component-id')
+        expect(createAuthenticationComponentEventParams('email_sign_in_banner')).toBe('componentEventParams=componentType%3DIDENTITY_AUTHENTICATION%26componentId%3Demail_sign_in_banner')
     })
 });

--- a/static/src/javascripts/projects/common/modules/identity/auth-component-event-params.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/auth-component-event-params.spec.js
@@ -4,6 +4,6 @@ import { createAuthenticationComponentEventParams } from "common/modules/identit
 
 describe('createAuthenticationComponentEventParams', () => {
     it('should create component event params using the component ID passed', () => {
-        expect(createAuthenticationComponentEventParams('email_sign_in_banner')).toBe('componentEventParams=componentType%3DIDENTITY_AUTHENTICATION%26componentId%3Demail_sign_in_banner')
+        expect(createAuthenticationComponentEventParams('email_sign_in_banner')).toBe('componentEventParams=componentType%3Didentityauthentication%26componentId%3Demail_sign_in_banner')
     })
 });

--- a/static/src/javascripts/projects/common/modules/identity/email-sign-in-banner/index.js
+++ b/static/src/javascripts/projects/common/modules/identity/email-sign-in-banner/index.js
@@ -15,7 +15,7 @@ const userPrefsStoreKey = 'emailbanner.referrerEmail';
 
 const emailPrefsLink = `https://${config.get('page.host')}/email-newsletters`;
 
-const signInLink = `${config.get('page.idUrl')}/signin?returnUrl=${config.get(emailPrefsLink)}&${createAuthenticationComponentEventParams('email-sign-in-banner')}`;
+const signInLink = `${config.get('page.idUrl')}/signin?returnUrl=${config.get(emailPrefsLink)}&${createAuthenticationComponentEventParams('email_sign_in_banner')}`;
 
 const isSecondEmailPageview = (): boolean => {
     const prefs = userPrefs.get(userPrefsStoreKey) || {};

--- a/static/src/javascripts/projects/common/modules/identity/email-sign-in-banner/index.js
+++ b/static/src/javascripts/projects/common/modules/identity/email-sign-in-banner/index.js
@@ -6,6 +6,7 @@ import ophan from 'ophan/ng';
 import config from 'lib/config';
 import userPrefs from 'common/modules/user-prefs';
 import type { Banner } from 'common/modules/ui/bannerPicker';
+import {createAuthenticationComponentEventParams} from "common/modules/identity/auth-component-event-params";
 import { make as makeTemplate, messageCode } from './template';
 import { getEmailCampaignFromUrl, getEmailCampaignFromUtm } from './campaigns';
 
@@ -14,9 +15,7 @@ const userPrefsStoreKey = 'emailbanner.referrerEmail';
 
 const emailPrefsLink = `https://${config.get('page.host')}/email-newsletters`;
 
-const signInLink = `${config.get('page.idUrl')}/signin?returnUrl=${config.get(
-    emailPrefsLink
-)}`;
+const signInLink = `${config.get('page.idUrl')}/signin?returnUrl=${config.get(emailPrefsLink)}&${createAuthenticationComponentEventParams('email-sign-in-banner')}`;
 
 const isSecondEmailPageview = (): boolean => {
     const prefs = userPrefs.get(userPrefsStoreKey) || {};

--- a/static/src/javascripts/projects/common/modules/identity/formstack-iframe-embed.js
+++ b/static/src/javascripts/projects/common/modules/identity/formstack-iframe-embed.js
@@ -125,7 +125,7 @@ class FormstackEmbedIframe {
 
     init(): void {
         // User object required to populate fields
-        const user = getUserOrSignIn();
+        const user = getUserOrSignIn('signin_from_formstack');
 
         if (!user) {
             return;

--- a/static/src/javascripts/projects/common/modules/identity/formstack.js
+++ b/static/src/javascripts/projects/common/modules/identity/formstack.js
@@ -71,7 +71,7 @@ class Formstack {
 
     init(): void {
         // User object required to populate fields
-        let user = getUserOrSignIn();
+        let user = getUserOrSignIn('signin_from_formstack');
 
         if (!user) {
             user = {};

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-tracking.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-tracking.js
@@ -42,7 +42,7 @@ const createTracking = (
     const isGuardianWeeklyRegion = (region === 'australia' || region === 'rest-of-world');
 
     const guardianWeeklyTracking = {
-        signInUrl: `${signinHostname}/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_gWeekly&CMP_TU=mrtn&CMP_BUNIT=subs&${createAuthenticationComponentEventParams('subscription-sign-in-banner')}`,
+        signInUrl: `${signinHostname}/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_gWeekly&CMP_TU=mrtn&CMP_BUNIT=subs&${createAuthenticationComponentEventParams('subscription_sign_in_banner')}`,
         subscriptionUrl: addTrackingCodesToUrl({
             base: `${subscriptionHostname}/subscribe/weekly`,
             componentType: COMPONENT_TYPE,
@@ -58,7 +58,7 @@ const createTracking = (
 
 export const bannerTracking = (region: ReaderRevenueRegion) => {
     const defaultTracking = {
-        signInUrl: `${signinHostname}/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_Existing&CMP_TU=mrtn&CMP_BUNIT=subs&${createAuthenticationComponentEventParams('subscription-sign-in-banner')}`,
+        signInUrl: `${signinHostname}/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_Existing&CMP_TU=mrtn&CMP_BUNIT=subs&${createAuthenticationComponentEventParams('subscription_sign_in_banner')}`,
         gaTracking: () => trackNonClickInteraction(DISPLAY_EVENT_KEY),
         subscriptionUrl: addTrackingCodesToUrl({
             base: `${subscriptionHostname}/subscribe/digital`,

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-tracking.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner-tracking.js
@@ -9,6 +9,7 @@ import { trackNonClickInteraction } from 'common/modules/analytics/google';
 
 // types
 import type { ReaderRevenueRegion } from 'common/modules/commercial/contributions-utilities';
+import {createAuthenticationComponentEventParams} from "common/modules/identity/auth-component-event-params";
 
 export type BannerTracking = {
     signInUrl: string,
@@ -41,7 +42,7 @@ const createTracking = (
     const isGuardianWeeklyRegion = (region === 'australia' || region === 'rest-of-world');
 
     const guardianWeeklyTracking = {
-        signInUrl: `${signinHostname}/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_gWeekly&CMP_TU=mrtn&CMP_BUNIT=subs`,
+        signInUrl: `${signinHostname}/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_gWeekly&CMP_TU=mrtn&CMP_BUNIT=subs&${createAuthenticationComponentEventParams('subscription-sign-in-banner')}`,
         subscriptionUrl: addTrackingCodesToUrl({
             base: `${subscriptionHostname}/subscribe/weekly`,
             componentType: COMPONENT_TYPE,
@@ -57,7 +58,7 @@ const createTracking = (
 
 export const bannerTracking = (region: ReaderRevenueRegion) => {
     const defaultTracking = {
-        signInUrl: `${signinHostname}/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_Existing&CMP_TU=mrtn&CMP_BUNIT=subs`,
+        signInUrl: `${signinHostname}/signin?utm_source=gdnwb&utm_medium=banner&utm_campaign=SubsBanner_Existing&CMP_TU=mrtn&CMP_BUNIT=subs&${createAuthenticationComponentEventParams('subscription-sign-in-banner')}`,
         gaTracking: () => trackNonClickInteraction(DISPLAY_EVENT_KEY),
         subscriptionUrl: addTrackingCodesToUrl({
             base: `${subscriptionHostname}/subscribe/digital`,


### PR DESCRIPTION
## What does this change?

- Pass component event parameters for all signin referrers. These parameters get propagated from /signin to IDAPI which sends the component events on behalf of the user. IDAPI sends the component event to Ophan using the /signin page view ID and the new SC_GU_U cookie. This means the pageview entry has session information associated.
- Send component event parameters for navigator.credentials auto signin (smartlock). We also send the pageview ID as a component event here because the user does not go through the signin page.


## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes (please indicate your plans for DCR Implementation)

We need to implement the same thing in DCR

## What is the value of this and can you measure success?

Data analysts will be able to track the different signin mechanisms users are using the authenticate with the Guardian.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
