### PR TITLE
Add Redplanet behind Sourcepoint consent

### DIFF
--- a/static/src/javascripts/bootstraps/commercial.dcr.js
+++ b/static/src/javascripts/bootstraps/commercial.dcr.js
@@ -47,7 +47,7 @@ if (!commercialFeatures.adFree) {
         // Permutive init code must run before google tag enableServices()
         // The permutive lib however is loaded async with the third party tags
         ['cm-prepare-googletag', () => initPermutive().then(prepareGoogletag)],
-        ['cm-redplanet', () => initRedplanet()],
+        ['cm-redplanet', initRedplanet],
         ['cm-prepare-adverification', prepareAdVerification],
         ['cm-mobileSticky', initMobileSticky],
         ['cm-highMerch', initHighMerch],

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -46,7 +46,7 @@ if (!commercialFeatures.adFree) {
         // Permutive init code must run before google tag enableServices()
         // The permutive lib however is loaded async with the third party tags
         ['cm-prepare-googletag', () => initPermutive().then(prepareGoogletag)],
-        ['cm-redplanet', () => initRedplanet()],
+        ['cm-redplanet', initRedplanet],
         ['cm-prepare-adverification', prepareAdVerification],
         ['cm-mobileSticky', initMobileSticky],
         ['cm-highMerch', initHighMerch],

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
@@ -36,31 +36,31 @@ const setupRedplanet: () => Promise<void> = () => {
     onCMPConsentNotification(state => {
         // CCPA only runs in the US and Redplanet only runs in Australia
         // so this should never happen
-        if (!state.ccpa) {
-            // not CCPA mode
-            let canRun: boolean;
-            if (state.tcfv2) {
-                // TCFv2 mode
-                if (
-                    typeof state.tcfv2.customVendors[SOURCEPOINT_ID] !== 'undefined'
-                ) {
-                    canRun = state.tcfv2.customVendors[SOURCEPOINT_ID];
-                } else {
-                    canRun = Object.values(state.tcfv2.consents).every(Boolean);
-                }
+        if (state.ccpa) {
+            throw new Error(`Error running Redplanet with CCPA (US CMP) present. It should only run in Australia on TCF mode`);
+        }
+        let canRun: boolean;
+        if (state.tcfv2) {
+            // TCFv2 mode
+            if (
+                typeof state.tcfv2.customVendors[SOURCEPOINT_ID] !== 'undefined'
+            ) {
+                canRun = state.tcfv2.customVendors[SOURCEPOINT_ID];
             } else {
-                // TCFv1 mode
-                canRun =
-                    state[1] && state[2] && state[3] && state[4] && state[5];
+                canRun = Object.values(state.tcfv2.consents).every(Boolean);
             }
+        } else {
+            // TCFv1 mode
+            canRun =
+                state[1] && state[2] && state[3] && state[4] && state[5];
+        }
 
-            if (!initialised && canRun) {
-                initialised = true;
-                return import('lib/launchpad.js').then(() => {
-                    initialise();
-                    return Promise.resolve();
-                });
-            }
+        if (!initialised && canRun) {
+            initialised = true;
+            return import('lib/launchpad.js').then(() => {
+                initialise();
+                return Promise.resolve();
+            });
         }
     });
     return Promise.resolve();

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.spec.js
@@ -147,7 +147,7 @@ describe('init', () => {
         expect(window.launchpad).toBeCalled();
     });
 
-    it('should not initialise redplanet initialise when TCFv2 consent has not been given', async () => {
+    it('should not initialise redplanet when TCFv2 consent has not been given', async () => {
         commercialFeatures.launchpad = true;
         isInAuOrNz.mockReturnValue(true);
         shouldUseSourcepointCmp.mockImplementation(() => true);

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.spec.js
@@ -79,6 +79,9 @@ jest.mock('common/modules/experiments/ab', () => ({
     isInVariantSynchronous: jest.fn(),
 }));
 
+const CcpaWithConsentMock = (callback): void =>
+    callback({ ccpa: { doNotSell: false } });
+
 window.launchpad = jest.fn().mockImplementationOnce(() => jest.fn());
 
 describe('init', () => {
@@ -154,6 +157,14 @@ describe('init', () => {
         onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
         await init();
         expect(window.launchpad).not.toBeCalled();
+    });
+
+    it('should throw an error when on CCPA mode', async () => {
+        commercialFeatures.launchpad = true;
+        isInAuOrNz.mockReturnValue(true);
+        shouldUseSourcepointCmp.mockImplementation(() => true);
+        onConsentChange.mockImplementation(CcpaWithConsentMock);
+        expect(await init).toThrow(`Error running Redplanet with CCPA (US CMP) present. It should only run in Australia on TCF mode`);
     });
 
     it('should not initialise redplanet when launchpad conditions are false', async () => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.spec.js
@@ -2,10 +2,12 @@
 
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import {
-    oldCmp as oldCmp_ } from '@guardian/consent-management-platform';
+    oldCmp as oldCmp_,
+    onConsentChange as onConsentChange_, } from '@guardian/consent-management-platform';
 import { isInAuOrNz as isInAuOrNz_ } from 'common/modules/commercial/geo-utils';
 import config from 'lib/config';
-import { init } from './redplanet';
+import { shouldUseSourcepointCmp as shouldUseSourcepointCmp_ } from 'commercial/modules/cmp/sourcepoint';
+import { init, resetModule } from './redplanet';
 
 const oldCmp: any = oldCmp_;
 const isInAuOrNz: any = isInAuOrNz_;
@@ -15,9 +17,25 @@ const trueConsentMock = (callback): void =>
 const falseConsentMock = (callback): void =>
     callback({ '1': true, '2': true, '3': true, '4': true, '5': false });
 
+const tcfv2WithConsentMock = (callback): void =>
+    callback({
+        tcfv2: { customVendors: { '5f199c302425a33f3f090f51': true } },
+    });
+
+const tcfv2WithoutConsentMock = (callback): void =>
+    callback({
+        tcfv2: { customVendors: { '5f199c302425a33f3f090f51': false } },
+    });
+
+const shouldUseSourcepointCmp: any = shouldUseSourcepointCmp_;
+const onConsentChange: any = onConsentChange_;
 
 jest.mock('common/modules/commercial/commercial-features', () => ({
     commercialFeatures: {},
+}));
+
+jest.mock('commercial/modules/cmp/sourcepoint', () => ({
+    shouldUseSourcepointCmp: jest.fn(),
 }));
 
 jest.mock('commercial/modules/cmp/tcfv2-test', () => ({
@@ -66,6 +84,7 @@ window.launchpad = jest.fn().mockImplementationOnce(() => jest.fn());
 describe('init', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        resetModule();
     });
 
     afterAll(() => {
@@ -115,6 +134,24 @@ describe('init', () => {
         commercialFeatures.launchpad = true;
         isInAuOrNz.mockReturnValue(true);
         oldCmp.onIabConsentNotification.mockImplementation(falseConsentMock);
+        await init();
+        expect(window.launchpad).not.toBeCalled();
+    });
+
+    it('should initialise redplanet  when TCFv2 consent has been given', async () => {
+        commercialFeatures.launchpad = true;
+        isInAuOrNz.mockReturnValue(true);
+        shouldUseSourcepointCmp.mockImplementation(() => true);
+        onConsentChange.mockImplementation(tcfv2WithConsentMock);
+        await init();
+        expect(window.launchpad).toBeCalled();
+    });
+
+    it('should not initialise redplanet initialise when TCFv2 consent has not been given', async () => {
+        commercialFeatures.launchpad = true;
+        isInAuOrNz.mockReturnValue(true);
+        shouldUseSourcepointCmp.mockImplementation(() => true);
+        onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
         await init();
         expect(window.launchpad).not.toBeCalled();
     });


### PR DESCRIPTION
## What does this change?

Uses the specific Redplanet sourcepoint id to add Redplanet behind Sourcepoint consent
