### PR TITLE
Update Aus header

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -484,16 +484,6 @@ trait FeatureSwitches {
     exposeClientSide = true
   )
 
-  val ausMoment2020Header = Switch(
-    SwitchGroup.Feature,
-    "aus-moment-2020-header",
-    "Enables the Aus moment special header",
-    owners = Seq(Owner.withGithub("tomrf1")),
-    safeState = Off,
-    sellByDate = new LocalDate(2020, 8, 3),
-    exposeClientSide = true
-  )
-
   val remoteBanner = Switch(
     SwitchGroup.Feature,
     "remote-banner",

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -47,7 +47,7 @@
                                             editionId
                                         }"
                                         href="https://support.theguardian.com/aus-2020-map?INTCMP=Aus_moment_2020_frontend_header">
-                                            Hear from our supporters
+                                            Hear from other supporters
                                             @fragments.inlineSvg("arrow-right", "icon")
                                         </a>
                                     </div>

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -5,7 +5,7 @@
 @import navigation.NavMenu
 @import navigation.UrlHelpers.{getJobUrl, Header, getReaderRevenueUrl}
 @import navigation.ReaderRevenueSite.{Support, SupportSubscribe, SupportContribute}
-@import conf.switches.Switches.{ IdentityProfileNavigationSwitch, SearchSwitch, UsHeaderAndFooterSubscribeLinkSwitch, ausMoment2020Header }
+@import conf.switches.Switches.{ IdentityProfileNavigationSwitch, SearchSwitch, UsHeaderAndFooterSubscribeLinkSwitch }
 
 @defining(NavMenu(page, Edition(request))) { navMenu: NavMenu =>
     <header class="@RenderClasses(Map(
@@ -32,20 +32,15 @@
             </a>
 
             @defining(Edition(request).id.toLowerCase()) { editionId =>
-                @defining(editionId == "au" && ausMoment2020Header.isSwitchedOn) { ausMomentEnabled =>
-                    <div class="@{
-                        if(ausMomentEnabled) "new-header__cta-bar-aus-moment" else "new-header__cta-bar"
-                    } hide-until-mobile">
-                        @if(!page.metadata.hasSlimHeader) {
-                            @if(ausMomentEnabled) {
-                                <div class="cta-bar__text hide-until-tablet js-aus-moment-header-supporter">
+                @defining(editionId == "au") { ausEdition =>
+                    @if(ausEdition) {
+                        <div class="new-header__cta-bar-aus-moment hide-until-mobile">
+                            @if(!page.metadata.hasSlimHeader) {
+                                <div class="cta-bar__text-aus-supporter hide-until-tablet">
                                     <div class="cta-bar__heading">
                                         Thank you
                                     </div>
                                     <div class="cta-bar__subheading">
-                                        We're funded by <span class="cta-bar__aus-moment-count"></span>
-                                        readers across Australia.
-                                        <br/>
                                         <a class="cta-bar__cta cta-bar__aus-map-cta hide-until-tablet"
                                         data-link-name="nav2 : aus-map-cta"
                                         data-edition="@{
@@ -57,26 +52,19 @@
                                         </a>
                                     </div>
                                 </div>
-
-                                <div class="cta-bar__text hide-until-tablet js-aus-moment-header-non-supporter">
-                                    <div class="cta-bar__heading">
-                                        Support The Guardian
-                                    </div>
-                                    <div class="cta-bar__subheading">
-                                        We're funded by <span class="cta-bar__aus-moment-count"></span>
-                                        readers across Australia
-                                    </div>
-                                </div>
-                            } else {
-                                <div class="cta-bar__text hide-until-tablet">
-                                    <div class="cta-bar__heading">
-                                        Support The Guardian
-                                    </div>
-                                    <div class="cta-bar__subheading">
-                                        Available for everyone, funded by readers
-                                    </div>
-                                </div>
                             }
+                        </div>
+                    }
+                    <div class="new-header__cta-bar hide-until-mobile">
+                        @if(!page.metadata.hasSlimHeader) {
+                            <div class="cta-bar__text hide-until-tablet">
+                                <div class="cta-bar__heading">
+                                    Support The Guardian
+                                </div>
+                                <div class="cta-bar__subheading">
+                                    Available for everyone, funded by readers
+                                </div>
+                            </div>
                         }
 
                         <a class="cta-bar__cta hide-until-tablet js-change-become-member-link js-acquisition-link"

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -1,9 +1,6 @@
 // @flow
 import { addReferrerData } from 'common/modules/commercial/acquisitions-ophan';
 import { addCountryGroupToSupportLink } from 'common/modules/commercial/support-utilities';
-import fetchJSON from 'lib/fetch-json';
-import { getCookie, addForMinutes as addCookie } from 'lib/cookies';
-import config from "lib/config";
 
 // Currently the only acquisition components on the site are
 // from the Mother Load campaign and the Wide Brown Land campaign.
@@ -114,52 +111,7 @@ const addReferrerDataToAcquisitionLinksInInteractiveIframes = (): void => {
     });
 };
 
-const AUS_MOMENT_SUPPORTER_COUNT_COOKIE_NAME = 'gu_aus_moment_supporter_count';
-
-const setupAusMomentHeader = () => {
-    const ausHeading = document.querySelector('.new-header__cta-bar-aus-moment');
-    if (ausHeading) {
-
-        const countElements = ausHeading.getElementsByClassName('cta-bar__aus-moment-count');
-        if (countElements) {
-
-            const insertCount = (totalRaw: string) => {
-                const total = parseInt(totalRaw, 10);
-
-                if (!Number.isNaN(Number(total))) {
-                    for (let i = 0; i < countElements.length; i+=1) {
-                        const element = countElements.item(i);
-                        if (element) {
-                            element.innerHTML = `${total.toLocaleString()} `
-                        }
-                    }
-                }
-            };
-
-            const cookieValue = getCookie(AUS_MOMENT_SUPPORTER_COUNT_COOKIE_NAME);
-            if (cookieValue) {
-                insertCount(cookieValue);
-            } else {
-                fetchJSON('https://support.theguardian.com/supporters-ticker.json', {
-                    mode: 'cors',
-                }).then(data => {
-                    const total = data.total;
-
-                    if (total) {
-                        addCookie(AUS_MOMENT_SUPPORTER_COUNT_COOKIE_NAME, total, 60);
-                        insertCount(total)
-                    }
-                })
-            }
-        }
-    }
-};
-
 export const init = (): void => {
     addReferrerDataToAcquisitionLinksInInteractiveIframes();
     enrichAcquisitionLinksOnPage();
-
-    if (config.get('switches.ausMoment2020Header')) {
-        setupAusMomentHeader();
-    }
 };

--- a/static/src/stylesheets/layout/nav/_cta-bar.scss
+++ b/static/src/stylesheets/layout/nav/_cta-bar.scss
@@ -5,6 +5,15 @@
     }
 }
 
+.new-header__cta-bar-aus-moment {
+    display: none;
+
+    .hide-support-messaging &,
+    .is-recent-contributor & {
+        display: block;
+    }
+}
+
 .new-header__cta-bar, .new-header__cta-bar-aus-moment {
     position: absolute;
     top: 30px;
@@ -41,32 +50,6 @@
     }
 }
 
-.new-header__cta-bar-aus-moment {
-    .js-aus-moment-header-supporter {
-        display: none;
-    }
-}
-
-.new-header__cta-bar-aus-moment {
-    .hide-support-messaging &,
-    .is-recent-contributor & {
-        .js-aus-moment-header-non-supporter {
-            display: none;
-        }
-        .js-aus-moment-header-supporter {
-            display: block;
-        }
-
-        .cta-bar__cta {
-            display: none;
-        }
-
-        .cta-bar__aus-map-cta {
-            display: block;
-        }
-    }
-}
-
 .new-header__cta-bar-aus-moment .cta-bar__aus-map-cta {
     color: $brightness-100;
     background-color: #55698e;
@@ -79,12 +62,7 @@
     }
 }
 
-.cta-bar__aus-moment-count {
-    color: $highlight-main;
-    font-weight: 700;
-}
-
-.cta-bar__text {
+.cta-bar__text, .cta-bar__text-aus-supporter {
     display: block;
     margin: ($gs-baseline / 4) 0 9px;
 


### PR DESCRIPTION
## What does this change?
We have been showing a special header to AU users.
Now that the 'moment' is over, we will remove it for non-supporters, and modify it for supporters.
This is now a permanent feature so I've removed the switch.

- Non-supporters: back to the standard header (seen by all regions)
![Screen Shot 2020-07-27 at 14 23 31](https://user-images.githubusercontent.com/1513454/88547653-f023f380-d015-11ea-9b4f-6fc31a660984.png)
![Screen Shot 2020-07-27 at 14 23 52](https://user-images.githubusercontent.com/1513454/88547660-f1edb700-d015-11ea-99c2-e98680f05dc8.png)

- Supporters: still have a special header (on desktop), but we've removed the line with the ticker value:
![Screen Shot 2020-07-27 at 14 24 40](https://user-images.githubusercontent.com/1513454/88547672-f4e8a780-d015-11ea-96ae-dc6a4a997889.png)
![Screen Shot 2020-07-27 at 14 24 24](https://user-images.githubusercontent.com/1513454/88547669-f4501100-d015-11ea-9833-cc3491870969.png)

