### PR TITLE
Fix failure to render video embeds without captions in DCR

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -102,10 +102,10 @@ case class TextBlockElement(html: String) extends PageElement
 case class TimelineBlockElement(id: String, title: String, description: Option[String], events: Seq[TimelineEvent]) extends PageElement
 case class TweetBlockElement(html: String, url: String, id: String, hasMedia: Boolean, role: Role) extends PageElement
 case class UnknownBlockElement(html: Option[String]) extends PageElement
-case class VideoBlockElement(caption: String, url: String, originalUrl: String, height: Int, width: Int, role: Role) extends PageElement
-case class VideoFacebookBlockElement(caption: String, url: String, originalUrl: String, embedUrl: Option[String], height: Int, width: Int, role: Role) extends PageElement
-case class VideoVimeoBlockElement(caption: String, url: String, originalUrl: String, embedUrl: Option[String], height: Int, width: Int, role: Role) extends PageElement
-case class VideoYoutubeBlockElement(caption: String, url: String, originalUrl: String, embedUrl: Option[String], height: Int, width: Int, role: Role) extends PageElement
+case class VideoBlockElement(caption: Option[String], url: String, originalUrl: String, height: Int, width: Int, role: Role) extends PageElement
+case class VideoFacebookBlockElement(caption: Option[String], url: String, originalUrl: String, embedUrl: Option[String], height: Int, width: Int, role: Role) extends PageElement
+case class VideoVimeoBlockElement(caption: Option[String], url: String, originalUrl: String, embedUrl: Option[String], height: Int, width: Int, role: Role) extends PageElement
+case class VideoYoutubeBlockElement(caption: Option[String], url: String, originalUrl: String, embedUrl: Option[String], height: Int, width: Int, role: Role) extends PageElement
 case class VineBlockElement(html: Option[String]) extends PageElement
 case class WitnessBlockElement(html: Option[String]) extends PageElement
 case class YoutubeBlockElement(id: String, assetId: String, channelId: Option[String], mediaTitle: String) extends PageElement
@@ -508,7 +508,7 @@ object PageElement {
     for {
       data <- element.videoTypeData
       source <- data.source
-      caption <- data.caption
+      caption = data.caption
       originalUrl <- data.originalUrl
       height <- data.height
       width <- data.width


### PR DESCRIPTION
This fixes an issue where the Youtube embed does not show in [the DCR version of this article](https://www.theguardian.com/games/2020/jun/12/playstation-5-video-games-console-not-dead-ps5?dcr), whereas [for frontend rendered articles it does](https://www.theguardian.com/games/2020/jun/12/playstation-5-video-games-console-not-dead-ps5?dcr=false).

## What does this change?
The broken example above does not have a caption, which currently means we would not return the `PageElement` for the embed. Here we make the caption optional, and return a `PageElement` for video embeds when the caption is `None`.

DCR is currently configured to handle optional captions (see [here](https://github.com/guardian/dotcom-rendering/blob/master/src/web/components/elements/YoutubeEmbedBlockComponent.tsx#L13) for Youtube (web), [here](https://github.com/guardian/dotcom-rendering/blob/master/src/lib/content.d.ts#L293) for Youtube (AMP), [here](https://github.com/guardian/dotcom-rendering/blob/master/src/web/components/elements/VideoFacebookBlockComponent.tsx#L13) for Facebook (web), [here](https://github.com/guardian/dotcom-rendering/blob/master/src/web/components/elements/VimeoBlockComponent.tsx#L23) for Vimeo (web). This means changes do not need to be made in dotcom-rendering for videos to render once this is merged.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
Running DCR locally pointing at this version of frontend we can see the embed renders on web:

![image](https://user-images.githubusercontent.com/9820960/88563220-a34a1800-d029-11ea-8e6d-99006dd3d78d.png)

The embed now also renders on AMP:

![image](https://user-images.githubusercontent.com/9820960/88563345-cd033f00-d029-11ea-99c6-e84ac5c1fa85.png)

An outstanding difference is that the social share buttons don't appear below the video for the DCR rendered versions, but [since this is true for videos we currently render through DCR](https://www.theguardian.com/music/2020/jun/17/madonna-where-to-start-in-her-back-catalogue?dcr) I think this is a separate issue.

## Checklist

### Does this affect other platforms?

- [x] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
