### PR TITLE
Track (remote) subscriptions banner view event in GA

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -14,6 +14,7 @@ import fastdom from 'lib/fastdom-promise';
 import config from 'lib/config';
 import { getMvtValue } from 'common/modules/analytics/mvt-cookie';
 import {submitViewEvent, submitComponentEvent} from 'common/modules/commercial/acquisitions-ophan';
+import { trackNonClickInteraction } from 'common/modules/analytics/google';
 import fetchJson from 'lib/fetch-json';
 import { mountDynamic } from "@guardian/automat-modules";
 import { getCookie } from 'lib/cookies';
@@ -240,6 +241,11 @@ export const renderBanner: (BannerDataResponse) => Promise<boolean> = (response)
                         variant: abTestVariant,
                     }
                 });
+
+                // track banner view event in Google Analytics for subscriptions banner
+                if (componentType === 'ACQUISITIONS_SUBSCRIPTIONS_BANNER') {
+                    trackNonClickInteraction('subscription-banner : display')
+                }
 
                 return true
             });


### PR DESCRIPTION
## What does this change?

This PR adds a tracking call to Google Analytics (GA) that's fired when a subscriptions banner served from the remote `contributions-service` has been seen. This event is currently recorded in GA for subscriptions banners that are NOT served from the remote `contributions-service`, so we're just making sure we retain this data, as requested by the stakeholder.

**dotcom-rendering equivalent PR:** https://github.com/guardian/dotcom-rendering/pull/1759