### PR TITLE
Add tracking to Epic secondary CTA

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
@@ -101,28 +101,35 @@ export const addReferrerData = (acquisitionData: {}): {} =>
         referrerUrl: window.location.href.split('?')[0],
     });
 
+// Adds acquisition tracking codes if it is a support url
 export const addTrackingCodesToUrl = ({
     base,
     componentType,
     componentId,
     campaignCode,
     abTest,
-}: AcquisitionLinkParams) => {
-    const acquisitionData = addReferrerData({
-        source: 'GUARDIAN_WEB',
-        componentId,
-        componentType,
-        campaignCode,
-        abTest,
-    });
+}: AcquisitionLinkParams): string => {
+    const isSupportUrl = base.search(/(support.theguardian.com)(\/[a-z]*)?\/(contribute|subscribe)/) >= 0;
 
-    const params = {
-        REFPVID: config.get('ophan.pageViewId') || 'not_found',
-        INTCMP: campaignCode,
-        acquisitionData: JSON.stringify(acquisitionData),
-    };
+    if (isSupportUrl) {
+        const acquisitionData = addReferrerData({
+            source: 'GUARDIAN_WEB',
+            componentId,
+            componentType,
+            campaignCode,
+            abTest,
+        });
 
-    return `${base}${base.includes('?') ? '&' : '?'}${constructURLQuery(
-        params
-    )}`;
+        const params = {
+            REFPVID: config.get('ophan.pageViewId') || 'not_found',
+            INTCMP: campaignCode,
+            acquisitionData: JSON.stringify(acquisitionData),
+        };
+
+        return `${base}${base.includes('?') ? '&' : '?'}${constructURLQuery(
+            params
+        )}`;
+    }
+
+    return base;
 };

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -378,6 +378,20 @@ const makeEpicABTestVariant = (
         initVariant.id
     );
 
+    const addTrackingToCta = (cta: EpicCta): EpicCta => ({
+        url: addTrackingCodesToUrl({
+            base: addCountryGroupToSupportLink(cta.url),
+            componentType: parentTest.componentType,
+            componentId,
+            campaignCode,
+            abTest: {
+                name: parentTest.id,
+                variant: initVariant.id,
+            },
+        }),
+        ctaText: cta.ctaText,
+    });
+
     return {
         id: initVariant.id,
         componentName: `mem_acquisition_${trackingCampaignId}_${
@@ -399,7 +413,7 @@ const makeEpicABTestVariant = (
         template: initVariant.template || parentTemplate,
         buttonTemplate: initVariant.buttonTemplate,
         ctaText: initVariant.ctaText,
-        secondaryCta: initVariant.secondaryCta,
+        secondaryCta: initVariant.secondaryCta && addTrackingToCta(initVariant.secondaryCta),
         copy: initVariant.copy,
         classNames: initVariant.classNames || [],
         showTicker: initVariant.showTicker || false,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -378,7 +378,7 @@ const makeEpicABTestVariant = (
         initVariant.id
     );
 
-    const addTrackingToCta = (cta: EpicCta): EpicCta => ({
+    const addTrackingAndCountryGroupToCta = (cta: EpicCta): EpicCta => ({
         url: addTrackingCodesToUrl({
             base: addCountryGroupToSupportLink(cta.url),
             componentType: parentTest.componentType,
@@ -413,7 +413,7 @@ const makeEpicABTestVariant = (
         template: initVariant.template || parentTemplate,
         buttonTemplate: initVariant.buttonTemplate,
         ctaText: initVariant.ctaText,
-        secondaryCta: initVariant.secondaryCta && addTrackingToCta(initVariant.secondaryCta),
+        secondaryCta: initVariant.secondaryCta && addTrackingAndCountryGroupToCta(initVariant.secondaryCta),
         copy: initVariant.copy,
         classNames: initVariant.classNames || [],
         showTicker: initVariant.showTicker || false,

--- a/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-engagement-banner.spec.js
@@ -56,7 +56,7 @@ jest.mock(
         getControlEngagementBannerParams: jest.fn(() =>
             Promise.resolve({
                 products: ['CONTRIBUTION'],
-                linkUrl: 'fake-link-url',
+                linkUrl: 'https://support.theguardian.com/contribute',
             })
         ),
     })
@@ -200,7 +200,7 @@ describe('Membership engagement banner', () => {
                 Promise.resolve({
                     products: ['CONTRIBUTION'],
                     campaignCode: 'fake-campaign-code',
-                    linkUrl: 'fake-link-url',
+                    linkUrl: 'https://support.theguardian.com/contribute',
                 })
             );
             emitSpy = jest.spyOn(fakeMediator, 'emit');
@@ -252,7 +252,7 @@ describe('Membership engagement banner', () => {
         beforeEach(() => {
             getControlEngagementBannerParams.mockImplementationOnce(() =>
                 Promise.resolve({
-                    linkUrl: 'fake-link-url',
+                    linkUrl: 'https://support.theguardian.com/contribute',
                 })
             );
         });
@@ -281,7 +281,7 @@ describe('Membership engagement banner', () => {
             getControlEngagementBannerParams.mockImplementationOnce(() =>
                 Promise.resolve({
                     messageText: 'fake-message-text',
-                    linkUrl: 'fake-link-url',
+                    linkUrl: 'https://support.theguardian.com/contribute',
                     buttonCaption: 'fake-button-caption',
                 })
             );
@@ -314,7 +314,7 @@ describe('Membership engagement banner', () => {
                 .show()
                 .then(() =>
                     expect(FakeMessage.prototype.show.mock.calls[0][0]).toMatch(
-                        /fake-link-url\?fake-query-parameters/
+                        /https:\/\/support\.theguardian\.com\/contribute\?fake-query-parameters/
                     )
                 ));
 


### PR DESCRIPTION
## What does this change?
We allow a secondary CTA in the epic.
For the primary CTA we automatically add tracking params for use by support.theguardian.com.
We do not do this for the secondary CTA because it has always been used for linking to articles on theguardian.com.

However, we are now testing linking to /subscribe and /contribute in the epic, and so it is necessary for the secondary CTA to have tracking params _only if_ it is linking to /contribute or /subscribe

PR for DCR (contributions-service): https://github.com/guardian/contributions-service/pull/202

### E.g. linking to article (no tracking is added):
![Screen Shot 2020-07-28 at 10 03 19](https://user-images.githubusercontent.com/1513454/88644288-b1944480-d0ba-11ea-86ba-620d2d78907a.png)


### E.g. linking to /subscribe (tracking is added):
![Screen Shot 2020-07-28 at 09 58 09](https://user-images.githubusercontent.com/1513454/88644309-b5c06200-d0ba-11ea-9dee-a3d10628e312.png)

