### PR TITLE
Check Custom Vendors

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@emotion/core": "^10.0.27",
     "@emotion/styled": "^10.0.27",
     "@guardian/atom-renderer": "1.1.6",
-    "@guardian/consent-management-platform": "4.0.0-8",
+    "@guardian/consent-management-platform": "4.0.0-9",
     "@guardian/automat-contributions": "^0.3.5",
     "@guardian/automat-modules": "^0.3.3",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
@@ -37,12 +37,15 @@ const setupRedplanet: () => Promise<void> = () => {
         // CCPA only runs in the US and Redplanet only runs in Australia
         // so this should never happen
         if (state.ccpa) {
-            throw new Error(`Error running Redplanet with CCPA (US CMP) present. It should only run in Australia on TCF mode`);
+            throw new Error(
+                `Error running Redplanet with CCPA (US CMP) present. It should only run in Australia on TCF mode`
+            );
         }
         let canRun: boolean;
         if (state.tcfv2) {
             // TCFv2 mode
             if (
+                typeof state.tcfv2.customVendors !== 'undefined' &&
                 typeof state.tcfv2.customVendors[SOURCEPOINT_ID] !== 'undefined'
             ) {
                 canRun = state.tcfv2.customVendors[SOURCEPOINT_ID];
@@ -51,8 +54,7 @@ const setupRedplanet: () => Promise<void> = () => {
             }
         } else {
             // TCFv1 mode
-            canRun =
-                state[1] && state[2] && state[3] && state[4] && state[5];
+            canRun = state[1] && state[2] && state[3] && state[4] && state[5];
         }
 
         if (!initialised && canRun) {

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
@@ -45,10 +45,11 @@ const setupRedplanet: () => Promise<void> = () => {
         if (state.tcfv2) {
             // TCFv2 mode
             if (
-                typeof state.tcfv2.customVendors !== 'undefined' &&
-                typeof state.tcfv2.customVendors[SOURCEPOINT_ID] !== 'undefined'
+                typeof state.tcfv2.vendorConsents !== 'undefined' &&
+                typeof state.tcfv2.vendorConsents[SOURCEPOINT_ID] !==
+                    'undefined'
             ) {
-                canRun = state.tcfv2.customVendors[SOURCEPOINT_ID];
+                canRun = state.tcfv2.vendorConsents[SOURCEPOINT_ID];
             } else {
                 canRun = Object.values(state.tcfv2.consents).every(Boolean);
             }

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.spec.js
@@ -3,7 +3,8 @@
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import {
     oldCmp as oldCmp_,
-    onConsentChange as onConsentChange_, } from '@guardian/consent-management-platform';
+    onConsentChange as onConsentChange_,
+} from '@guardian/consent-management-platform';
 import { isInAuOrNz as isInAuOrNz_ } from 'common/modules/commercial/geo-utils';
 import config from 'lib/config';
 import { shouldUseSourcepointCmp as shouldUseSourcepointCmp_ } from 'commercial/modules/cmp/sourcepoint';
@@ -19,12 +20,12 @@ const falseConsentMock = (callback): void =>
 
 const tcfv2WithConsentMock = (callback): void =>
     callback({
-        tcfv2: { customVendors: { '5f199c302425a33f3f090f51': true } },
+        tcfv2: { vendorConsents: { '5f199c302425a33f3f090f51': true } },
     });
 
 const tcfv2WithoutConsentMock = (callback): void =>
     callback({
-        tcfv2: { customVendors: { '5f199c302425a33f3f090f51': false } },
+        tcfv2: { vendorConsents: { '5f199c302425a33f3f090f51': false } },
     });
 
 const shouldUseSourcepointCmp: any = shouldUseSourcepointCmp_;
@@ -39,9 +40,7 @@ jest.mock('commercial/modules/cmp/sourcepoint', () => ({
 }));
 
 jest.mock('commercial/modules/cmp/tcfv2-test', () => ({
-    isInTcfv2Test: jest
-        .fn()
-        .mockImplementation(() => false),
+    isInTcfv2Test: jest.fn().mockImplementation(() => false),
 }));
 
 jest.mock('commercial/modules/dfp/Advert', () =>
@@ -70,9 +69,9 @@ jest.mock('lib/load-script', () => ({
 
 jest.mock('@guardian/consent-management-platform', () => ({
     oldCmp: {
-        onIabConsentNotification: jest.fn()
+        onIabConsentNotification: jest.fn(),
     },
-    onConsentChange: jest.fn()
+    onConsentChange: jest.fn(),
 }));
 
 jest.mock('common/modules/experiments/ab', () => ({
@@ -164,7 +163,9 @@ describe('init', () => {
         isInAuOrNz.mockReturnValue(true);
         shouldUseSourcepointCmp.mockImplementation(() => true);
         onConsentChange.mockImplementation(CcpaWithConsentMock);
-        expect(await init).toThrow(`Error running Redplanet with CCPA (US CMP) present. It should only run in Australia on TCF mode`);
+        expect(await init).toThrow(
+            `Error running Redplanet with CCPA (US CMP) present. It should only run in Australia on TCF mode`
+        );
     });
 
     it('should not initialise redplanet when launchpad conditions are false', async () => {

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
@@ -48,6 +48,7 @@ const initialise = (): void => {
         } else if (state.tcfv2) {
             // TCFv2 mode
             if (
+                typeof state.tcfv2.customVendors !== 'undefined' &&
                 typeof state.tcfv2.customVendors[SOURCEPOINT_ID] !== 'undefined'
             ) {
                 canRun = state.tcfv2.customVendors[SOURCEPOINT_ID];

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
@@ -48,10 +48,11 @@ const initialise = (): void => {
         } else if (state.tcfv2) {
             // TCFv2 mode
             if (
-                typeof state.tcfv2.customVendors !== 'undefined' &&
-                typeof state.tcfv2.customVendors[SOURCEPOINT_ID] !== 'undefined'
+                typeof state.tcfv2.vendorConsents !== 'undefined' &&
+                typeof state.tcfv2.vendorConsents[SOURCEPOINT_ID] !==
+                    'undefined'
             ) {
-                canRun = state.tcfv2.customVendors[SOURCEPOINT_ID];
+                canRun = state.tcfv2.vendorConsents[SOURCEPOINT_ID];
             } else {
                 canRun = Object.values(state.tcfv2.consents).every(Boolean);
             }

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.spec.js
@@ -16,7 +16,7 @@ const TcfWithConsentMock = (callback): void =>
 
 const tcfv2WithConsentMock = (callback): void =>
     callback({
-        tcfv2: { customVendors: { '5edf9a821dc4e95986b66df4': true } },
+        tcfv2: { vendorConsents: { '5edf9a821dc4e95986b66df4': true } },
     });
 
 const CcpaWithConsentMock = (callback): void =>

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -78,7 +78,10 @@ const insertScripts = (
             // TCFv2 mode,
             consentedAdvertisingServices = advertisingServices.filter(
                 script => {
-                    if (typeof script.sourcepointId !== 'undefined') {
+                    if (
+                        typeof script.sourcepointId !== 'undefined' &&
+                        typeof state.tcfv2.customVendors !== 'undefined'
+                    ) {
                         return state.tcfv2.customVendors[script.sourcepointId];
                     }
                     return Object.values(state.tcfv2.consents).every(Boolean);

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -80,9 +80,9 @@ const insertScripts = (
                 script => {
                     if (
                         typeof script.sourcepointId !== 'undefined' &&
-                        typeof state.tcfv2.customVendors !== 'undefined'
+                        typeof state.tcfv2.vendorConsents !== 'undefined'
                     ) {
-                        return state.tcfv2.customVendors[script.sourcepointId];
+                        return state.tcfv2.vendorConsents[script.sourcepointId];
                     }
                     return Object.values(state.tcfv2.consents).every(Boolean);
                 }

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
@@ -41,11 +41,11 @@ const tcfv2WithConsentMock = (callback): void =>
                 '7': true,
                 '8': true,
             },
-            customVendors: { '100': true, '200': false },
+            vendorConsents: { '100': true, '200': false },
         },
     });
 const tcfv2WithoutConsentMock = (callback): void =>
-    callback({ tcfv2: { customVendors: { '100': false, '200': false } } });
+    callback({ tcfv2: { vendorConsents: { '100': false, '200': false } } });
 
 beforeEach(() => {
     const firstScript = document.createElement('script');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1163,10 +1163,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/consent-management-platform@4.0.0-8":
-  version "4.0.0-8"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.0-8.tgz#0ed90fa437d23662285155ec4e8577eb99ccb103"
-  integrity sha512-LxvxDpuWSewwvn86lnLoCq+GDOuZOMU9nuZepdanuoRdnmRmsc6wZU8xfjl1OrZ+fcT0fapQAXzqViQ41bS7dA==
+"@guardian/consent-management-platform@4.0.0-9":
+  version "4.0.0-9"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.0-9.tgz#9335485e5b98c7771498dee2bb892a5f94e27b19"
+  integrity sha512-JL2LpgbUcYz488kBAmCAAn0t8NtmT8s4LDXd2sVvRhZAThG4evGyJDD1fI9FhBmwvhAukRaet2SPr52hxt7zUQ==
   dependencies:
     "@guardian/old-cmp" "npm:@guardian/consent-management-platform@^3.4.9"
 


### PR DESCRIPTION
## What does this change?

This PR fixes a an bug when trying to determine if a third-party script can run.
When checking for an ID in `state.tcfv2.customVendors`, we need first to make sure that the object exists.

Co-Authored-By: Ioanna Kyprianou <51630004+ioanna0@users.noreply.github.com>

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

n/a

## What is the value of this and can you measure success?

Less errors, more robust code.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [X] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
