### PR TITLE
CMP Third Party tags fix

### DIFF
--- a/static/src/javascripts/__flow__/types/global.js
+++ b/static/src/javascripts/__flow__/types/global.js
@@ -34,6 +34,7 @@ declare type ThirdPartyTag = {
     useImage?: boolean,
     attrs?: Array<TagAtrribute>,
     async?: boolean,
+    loaded?: boolean,
 };
 
 declare var jsdom: {

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -17,15 +17,12 @@ import { twitterUwt } from 'commercial/modules/third-party-tags/twitter-uwt';
 import { connatix } from 'commercial/modules/third-party-tags/connatix';
 import { lotame } from 'commercial/modules/third-party-tags/lotame';
 
-let advertisingScriptsInserted: boolean = false;
-let performanceScriptsInserted: boolean = false;
-
 const addScripts = (tags: Array<ThirdPartyTag>): void => {
     const ref = document.scripts[0];
     const frag = document.createDocumentFragment();
     let hasScriptsToInsert = false;
 
-    tags.forEach(tag => {
+    tags.filter(t => !t.loaded).forEach(tag => {
         if (tag.useImage === true) {
             new Image().src = tag.url;
         } else {
@@ -43,6 +40,7 @@ const addScripts = (tags: Array<ThirdPartyTag>): void => {
             }
             frag.appendChild(script);
         }
+        tag.loaded = true;
     });
 
     if (hasScriptsToInsert) {
@@ -59,9 +57,8 @@ const insertScripts = (
     performanceServices: Array<ThirdPartyTag>
 ): void => {
     oldCmp.onGuConsentNotification('performance', state => {
-        if (!performanceScriptsInserted && state) {
+        if (state) {
             addScripts(performanceServices);
-            performanceScriptsInserted = true;
         }
     });
 
@@ -97,11 +94,9 @@ const insertScripts = (
         }
 
         if (
-            !advertisingScriptsInserted &&
             consentedAdvertisingServices.length > 0
         ) {
             addScripts(consentedAdvertisingServices);
-            advertisingScriptsInserted = true;
         }
     });
 };
@@ -150,8 +145,4 @@ export { init };
 export const _ = {
     insertScripts,
     loadOther,
-    reset: () => {
-        advertisingScriptsInserted = false;
-        performanceScriptsInserted = false;
-    },
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -22,7 +22,10 @@ const addScripts = (tags: Array<ThirdPartyTag>): void => {
     const frag = document.createDocumentFragment();
     let hasScriptsToInsert = false;
 
-    tags.filter(t => !t.loaded).forEach(tag => {
+    tags.forEach(tag => {
+        if (tag.loaded === true) {
+            return;
+        }
         if (tag.useImage === true) {
             new Image().src = tag.url;
         } else {

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
@@ -217,14 +217,17 @@ describe('third party tags', () => {
         });
 
         it('should not add already loaded tags ', () => {
-            fakeThirdPartyAdvertisingTag.loaded = true;
             shouldUseSourcepointCmp.mockImplementation(() => true);
             onConsentChange.mockImplementation(tcfv2WithConsentMock);
             insertScripts(
                 [fakeThirdPartyAdvertisingTag, fakeThirdPartyAdvertisingTag2],
                 []
             );
-            expect(document.scripts.length).toBe(1);
+            insertScripts(
+                [fakeThirdPartyAdvertisingTag, fakeThirdPartyAdvertisingTag2],
+                []
+            );
+            expect(document.scripts.length).toBe(2);
         });
 
         it('should not add scripts to the document when TCFv2 consent has not been given', () => {

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
@@ -41,11 +41,11 @@ const tcfv2WithConsentMock = (callback): void =>
                 '7': true,
                 '8': true,
             },
-            vendorConsents: { '100': true, '200': false },
+            vendorConsents: { '100': true, '200': false, '300': false },
         },
     });
 const tcfv2WithoutConsentMock = (callback): void =>
-    callback({ tcfv2: { vendorConsents: { '100': false, '200': false } } });
+    callback({ tcfv2: { vendorConsents: { '100': false, '200': false, '300': false } } });
 
 beforeEach(() => {
     const firstScript = document.createElement('script');
@@ -114,20 +114,33 @@ describe('third party tags', () => {
     });
 
     describe('insertScripts', () => {
-        const fakeThirdPartyAdvertisingTag: ThirdPartyTag = {
+        let fakeThirdPartyAdvertisingTag: ThirdPartyTag = {
             shouldRun: true,
             url: '//fakeThirdPartyAdvertisingTag.js',
             onLoad: jest.fn(),
             sourcepointId: '100',
         };
-        const fakeThirdPartyPerformanceTag: ThirdPartyTag = {
+        let fakeThirdPartyAdvertisingTag2: ThirdPartyTag = {
+            shouldRun: true,
+            url: '//fakeThirdPartyAdvertisingTag2.js',
+            onLoad: jest.fn(),
+            sourcepointId: '300',
+        };
+        let fakeThirdPartyPerformanceTag: ThirdPartyTag = {
             shouldRun: true,
             url: '//fakeThirdPartyPerformanceTag.js',
             onLoad: jest.fn(),
             sourcepointId: '200',
         };
+
+        beforeEach(() => {
+            fakeThirdPartyAdvertisingTag.loaded = undefined;
+            fakeThirdPartyAdvertisingTag2.loaded = undefined;
+            fakeThirdPartyPerformanceTag.loaded = undefined;
+        });
+
+
         it('should add scripts to the document when TCF consent has been given', () => {
-            _.reset();
             onIabConsentNotification.mockImplementation(callback =>
                 callback({
                     '1': true,
@@ -147,7 +160,6 @@ describe('third party tags', () => {
             expect(document.scripts.length).toBe(3);
         });
         it('should not add scripts to the document when TCF consent has not been given', () => {
-            _.reset();
             onIabConsentNotification.mockImplementation(callback =>
                 callback({
                     '1': false,
@@ -167,7 +179,6 @@ describe('third party tags', () => {
             expect(document.scripts.length).toBe(1);
         });
         it('should add scripts to the document when CCPA consent has been given', () => {
-            _.reset();
             shouldUseSourcepointCmp.mockImplementation(() => true);
             onConsentChange.mockImplementation(callback =>
                 callback({ ccpa: { doNotSell: false } })
@@ -182,7 +193,6 @@ describe('third party tags', () => {
             expect(document.scripts.length).toBe(3);
         });
         it('should not add scripts to the document when CCPA consent has not been given', () => {
-            _.reset();
             shouldUseSourcepointCmp.mockImplementation(() => true);
             onConsentChange.mockImplementation(callback =>
                 callback({ ccpa: { doNotSell: true } })
@@ -198,22 +208,31 @@ describe('third party tags', () => {
         });
 
         it('should only add consented custom vendors to the document for TCFv2', () => {
-            _.reset();
             shouldUseSourcepointCmp.mockImplementation(() => true);
             onConsentChange.mockImplementation(tcfv2WithConsentMock);
             insertScripts(
-                [fakeThirdPartyAdvertisingTag, fakeThirdPartyPerformanceTag],
+                [fakeThirdPartyAdvertisingTag, fakeThirdPartyAdvertisingTag2],
                 []
             );
             expect(document.scripts.length).toBe(2);
         });
 
+        it('should not add already loaded tags ', () => {
+            fakeThirdPartyAdvertisingTag.loaded = true;
+            shouldUseSourcepointCmp.mockImplementation(() => true);
+            onConsentChange.mockImplementation(tcfv2WithConsentMock);
+            insertScripts(
+                [fakeThirdPartyAdvertisingTag, fakeThirdPartyAdvertisingTag2],
+                []
+            );
+            expect(document.scripts.length).toBe(1);
+        });
+
         it('should not add scripts to the document when TCFv2 consent has not been given', () => {
-            _.reset();
             shouldUseSourcepointCmp.mockImplementation(() => true);
             onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
             insertScripts(
-                [fakeThirdPartyAdvertisingTag, fakeThirdPartyPerformanceTag],
+                [fakeThirdPartyAdvertisingTag, fakeThirdPartyAdvertisingTag2],
                 []
             );
             expect(document.scripts.length).toBe(1);

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
@@ -114,19 +114,19 @@ describe('third party tags', () => {
     });
 
     describe('insertScripts', () => {
-        let fakeThirdPartyAdvertisingTag: ThirdPartyTag = {
+        const fakeThirdPartyAdvertisingTag: ThirdPartyTag = {
             shouldRun: true,
             url: '//fakeThirdPartyAdvertisingTag.js',
             onLoad: jest.fn(),
             sourcepointId: '100',
         };
-        let fakeThirdPartyAdvertisingTag2: ThirdPartyTag = {
+        const fakeThirdPartyAdvertisingTag2: ThirdPartyTag = {
             shouldRun: true,
             url: '//fakeThirdPartyAdvertisingTag2.js',
             onLoad: jest.fn(),
             sourcepointId: '300',
         };
-        let fakeThirdPartyPerformanceTag: ThirdPartyTag = {
+        const fakeThirdPartyPerformanceTag: ThirdPartyTag = {
             shouldRun: true,
             url: '//fakeThirdPartyPerformanceTag.js',
             onLoad: jest.fn(),
@@ -138,7 +138,6 @@ describe('third party tags', () => {
             fakeThirdPartyAdvertisingTag2.loaded = undefined;
             fakeThirdPartyPerformanceTag.loaded = undefined;
         });
-
 
         it('should add scripts to the document when TCF consent has been given', () => {
             onIabConsentNotification.mockImplementation(callback =>


### PR DESCRIPTION
## What does this change?
This PR changes the logic of how we decide to insert the third party tags. Previously we were deciding on the whole array  of TPT (`advertisingScriptsInserted` or `performanceScriptsInserted`) if they have been inserted or not and only if they haven't been inserted we were adding them all. This was causing issues for TCFv2 since the first callback which just shows the banner and contains very few third party tags will mark them as inserted, and the second time when user actually interacts with the banner will not insert the new subset of third party tags until a reload has happened.

Now we are checking individual tags if they have been loaded or not as each time a user changes their consent it could involve a different subset of third party tags to run. 


## What is the value of this and can you measure success?
When the CMP callback is invoked, the correct consented third parties will run immediately without a reload to be needed


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
