### PR TITLE
Fix tcfv2 consent targeting param

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -21,6 +21,7 @@ import flattenDeep from 'lodash/flattenDeep';
 import once from 'lodash/once';
 import pick from 'lodash/pick';
 import pickBy from 'lodash/pickBy';
+import { isInTcfv2Test } from 'commercial/modules/cmp/tcfv2-test';
 
 type PageTargeting = {
     sens: string,
@@ -220,7 +221,7 @@ const getRdpValue = (ccpaState: boolean | null): string => {
 };
 
 const getTcfv2ConsentValue = (tcfv2State: boolean | null): string => {
-    if (shouldUseSourcepointCmp() && tcfv2State !== null) {
+    if (isInTcfv2Test() && tcfv2State !== null) {
         return tcfv2State ? 't' : 'f';
     }
     return 'na';

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -271,6 +271,14 @@ describe('Build Page Targeting', () => {
 
         expect(getPageTargeting().consent_tcfv2).toBe('f');
         expect(getPageTargeting().cmp_interaction).toBe('useractioncomplete');
+
+        _.resetPageTargeting();
+        shouldUseSourcepointCmp.mockImplementation(() => true);
+        onConsentChange.mockImplementation(tcfWithConsentMock);
+        isInTcfv2Test.mockReturnValue(false);
+
+        expect(getPageTargeting().consent_tcfv2).toBe('na');
+        expect(getPageTargeting().cmp_interaction).toBe('na');
     });
 
     it('should set correct edition param', () => {


### PR DESCRIPTION
## What does this change?

Fixes an issue in which we were passing t/f to consent_tcfv2 when in US

