### PR TITLE
 TCFv2 Enforcement for googletag and prebid  based on Sourcepoint ID

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -146,4 +146,13 @@ trait ABTestSwitches {
     exposeClientSide = true,
   )
 
+  Switch(
+    ABTests,
+    "ab-tcfv2-googletag-prebid-enforcement",
+    "Put googletag and prebid behind TCFv2 Sourcepoint enforcement",
+    owners = Seq(Owner.withGithub("ioanna0")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 9, 30),
+    exposeClientSide = true,
+  )
 }

--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
@@ -276,7 +276,7 @@ describe('DFP', () => {
     it('hides all ad slots when all DFP advertising is disabled', () => {
         commercialFeatures.dfpAdvertising = false;
 
-        return prepareGoogletag().then(() => {
+        prepareGoogletag().then(() => {
             const remainingAdSlots = document.querySelectorAll('.js-ad-slot');
             expect(remainingAdSlots.length).toBe(0);
         });
@@ -459,7 +459,7 @@ describe('DFP', () => {
             oldCmp.onIabConsentNotification.mockImplementation(callback =>
                 callback(tcfWithConsent)
             );
-            return prepareGoogletag().then(() => {
+            prepareGoogletag().then(() => {
                 expect(
                     window.googletag.pubads().setTargeting
                 ).toHaveBeenCalledWith('k', ['korea', 'ukraine']);
@@ -472,7 +472,7 @@ describe('DFP', () => {
             oldCmp.onIabConsentNotification.mockImplementation(callback =>
                 callback(tcfWithConsent)
             );
-            return prepareGoogletag().then(() => {
+            prepareGoogletag().then(() => {
                 expect(
                     window.googletag.pubads().setRequestNonPersonalizedAds
                 ).toHaveBeenCalledWith(0);
@@ -482,7 +482,7 @@ describe('DFP', () => {
             oldCmp.onIabConsentNotification.mockImplementation(callback =>
                 callback(tcfNullConsent)
             );
-            return prepareGoogletag().then(() => {
+            prepareGoogletag().then(() => {
                 expect(
                     window.googletag.pubads().setRequestNonPersonalizedAds
                 ).toHaveBeenCalledWith(0);
@@ -492,7 +492,7 @@ describe('DFP', () => {
             oldCmp.onIabConsentNotification.mockImplementation(callback =>
                 callback(tcfWithoutConsent)
             );
-            return prepareGoogletag().then(() => {
+            prepareGoogletag().then(() => {
                 expect(
                     window.googletag.pubads().setRequestNonPersonalizedAds
                 ).toHaveBeenCalledWith(1);
@@ -502,7 +502,7 @@ describe('DFP', () => {
             oldCmp.onIabConsentNotification.mockImplementation(callback =>
                 callback(tcfMixedConsent)
             );
-            return prepareGoogletag().then(() => {
+            prepareGoogletag().then(() => {
                 expect(
                     window.googletag.pubads().setRequestNonPersonalizedAds
                 ).toHaveBeenCalledWith(1);
@@ -515,7 +515,7 @@ describe('DFP', () => {
             onConsentChange.mockImplementation(callback =>
                 callback(ccpaWithConsent)
             );
-            return prepareGoogletag().then(() => {
+            prepareGoogletag().then(() => {
                 expect(
                     window.googletag.pubads().setPrivacySettings
                 ).toHaveBeenCalledWith({
@@ -528,7 +528,7 @@ describe('DFP', () => {
             onConsentChange.mockImplementation(callback =>
                 callback(ccpaWithoutConsent)
             );
-            return prepareGoogletag().then(() => {
+            prepareGoogletag().then(() => {
                 expect(
                     window.googletag.pubads().setPrivacySettings
                 ).toHaveBeenCalledWith({

--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
@@ -276,7 +276,7 @@ describe('DFP', () => {
     it('hides all ad slots when all DFP advertising is disabled', () => {
         commercialFeatures.dfpAdvertising = false;
 
-        prepareGoogletag().then(() => {
+        return prepareGoogletag().then(() => {
             const remainingAdSlots = document.querySelectorAll('.js-ad-slot');
             expect(remainingAdSlots.length).toBe(0);
         });

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -128,7 +128,16 @@ export const init = (): Promise<void> => {
                     npaFlag =
                         Object.keys(state.tcfv2.consents).length === 0 ||
                         Object.values(state.tcfv2.consents).includes(false);
-                    canRun = isInTcfv2EnforcementVariant ? state.tcfv2.vendorConsents[SOURCEPOINT_ID] : true;
+                    canRun = state.tcfv2.vendorConsents[SOURCEPOINT_ID];
+                    if (canRun && isInTcfv2EnforcementVariant) {
+                        loadScript(
+                            config.get(
+                                'libs.googletag',
+                                '//www.googletagservices.com/tag/js/gpt.js'
+                            ),
+                            { async: false }
+                        );
+                    }
                 } else {
                     // TCFv1 mode
                     npaFlag = Object.values(state).includes(false);

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -31,6 +31,8 @@ import { init as resize } from 'commercial/modules/messenger/resize';
 import { init as scroll } from 'commercial/modules/messenger/scroll';
 import { init as type } from 'commercial/modules/messenger/type';
 import { init as viewport } from 'commercial/modules/messenger/viewport';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { googletagPrebidEnforcement } from 'common/modules/experiments/tests/tcfv2-googletag-prebid-enforcement';
 
 initMessenger(
     type,
@@ -109,8 +111,9 @@ export const init = (): Promise<void> => {
             ? onConsentChange
             : oldCmp.onIabConsentNotification;
 
+        const isInTcfv2EnforcementVariant = isInVariantSynchronous(googletagPrebidEnforcement, 'variant')
+        let canRun: boolean = true;
         onCMPConsentNotification(state => {
-            let canRun: boolean = true;
             if (state.ccpa) {
                 // CCPA mode
                 window.googletag.cmd.push(() => {
@@ -126,7 +129,7 @@ export const init = (): Promise<void> => {
                         Object.keys(state.tcfv2.consents).length === 0 ||
                         Object.values(state.tcfv2.consents).includes(false);
                     canRun = state.tcfv2.vendorConsents[SOURCEPOINT_ID];
-                    if (canRun) {
+                    if (canRun && isInTcfv2EnforcementVariant) {
                         loadScript(
                             config.get(
                                 'libs.googletag',
@@ -151,6 +154,15 @@ export const init = (): Promise<void> => {
         // Prebid will already be loaded, and window.googletag is stubbed in `commercial.js`.
         // TODO: what if Prebid is also behind consent?
         // Just load googletag. Prebid will already be loaded, and googletag is already added to the window by Prebid.
+        if (canRun && !isInTcfv2EnforcementVariant) {
+            loadScript(
+                config.get(
+                    'libs.googletag',
+                    '//www.googletagservices.com/tag/js/gpt.js'
+                ),
+                { async: false }
+            );
+        }
         return Promise.resolve();
     };
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -128,16 +128,7 @@ export const init = (): Promise<void> => {
                     npaFlag =
                         Object.keys(state.tcfv2.consents).length === 0 ||
                         Object.values(state.tcfv2.consents).includes(false);
-                    canRun = state.tcfv2.vendorConsents[SOURCEPOINT_ID];
-                    if (canRun && isInTcfv2EnforcementVariant) {
-                        loadScript(
-                            config.get(
-                                'libs.googletag',
-                                '//www.googletagservices.com/tag/js/gpt.js'
-                            ),
-                            { async: false }
-                        );
-                    }
+                    canRun = isInTcfv2EnforcementVariant ? state.tcfv2.vendorConsents[SOURCEPOINT_ID] : true;
                 } else {
                     // TCFv1 mode
                     npaFlag = Object.values(state).includes(false);

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -45,6 +45,8 @@ initMessenger(
     disableRefresh
 );
 
+const SOURCEPOINT_ID: string = '5f1aada6b8e05c306c0597d7';
+
 const setDfpListeners = (): void => {
     const pubads = window.googletag.pubads();
     pubads.addEventListener('slotRenderEnded', raven.wrap(onSlotRender));
@@ -123,7 +125,16 @@ export const init = (): Promise<void> => {
                     npaFlag =
                         Object.keys(state.tcfv2.consents).length === 0 ||
                         Object.values(state.tcfv2.consents).includes(false);
-                    canRun = state.tcfv2.consents['1']; // Store and/or access information on a device
+                    canRun = state.tcfv2.vendorConsents[SOURCEPOINT_ID];
+                    if (canRun) {
+                        loadScript(
+                            config.get(
+                                'libs.googletag',
+                                '//www.googletagservices.com/tag/js/gpt.js'
+                            ),
+                            { async: false }
+                        );
+                    }
                 } else {
                     // TCFv1 mode
                     npaFlag = Object.values(state).includes(false);
@@ -135,21 +146,11 @@ export const init = (): Promise<void> => {
                         .setRequestNonPersonalizedAds(npaFlag ? 1 : 0);
                 });
             }
-
-            // Load googletag if TCFv2 purpose 1 consent is not `false`.
-            // Prebid will already be loaded, and window.googletag is stubbed in `commercial.js`.
-            // TODO: what if Prebid is also behind consent?
-            if (canRun) {
-                return loadScript(
-                    config.get(
-                        'libs.googletag',
-                        '//www.googletagservices.com/tag/js/gpt.js'
-                    ),
-                    { async: false }
-                );
-            }
-            // return Promise.resolve();
         });
+
+        // Prebid will already be loaded, and window.googletag is stubbed in `commercial.js`.
+        // TODO: what if Prebid is also behind consent?
+        // Just load googletag. Prebid will already be loaded, and googletag is already added to the window by Prebid.
         return Promise.resolve();
     };
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -141,7 +141,6 @@ export const init = (): Promise<void> => {
                 } else {
                     // TCFv1 mode
                     npaFlag = Object.values(state).includes(false);
-                    // TODO: decide if purpose 1 should apply to TCFv1
                 }
                 window.googletag.cmd.push(() => {
                     window.googletag
@@ -152,7 +151,6 @@ export const init = (): Promise<void> => {
         });
 
         // Prebid will already be loaded, and window.googletag is stubbed in `commercial.js`.
-        // TODO: what if Prebid is also behind consent?
         // Just load googletag. Prebid will already be loaded, and googletag is already added to the window by Prebid.
         if (canRun && !isInTcfv2EnforcementVariant) {
             loadScript(

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
@@ -11,6 +11,7 @@ import prebid from 'commercial/modules/header-bidding/prebid/prebid';
 import { isGoogleProxy } from 'lib/detect';
 import { shouldIncludeOnlyA9 } from 'commercial/modules/header-bidding/utils';
 
+const SOURCEPOINT_ID: string = '5f22bfd82a6b6c1afd1181a9';
 let moduleLoadResult = Promise.resolve();
 
 if (!isGoogleProxy()) {
@@ -22,7 +23,7 @@ const setupPrebid: () => Promise<void> = () => {
     if (shouldUseSourcepointCmp()) {
         onConsentChange(state => {
             // Only TCFv2 mode can prevent running Prebid
-            if (state.tcfv2) canRun = state.tcfv2.consents['1']; // Store and/or access information on a device
+            if (state.tcfv2) canRun = state.tcfv2.vendorConsents[SOURCEPOINT_ID];
         });
     }
     if (canRun)

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.js
@@ -147,6 +147,19 @@ describe('init', () => {
         expect(prebid.initialise).toBeCalled();
     });
 
+    it('should not initialise Prebid if TCFv2 consent with correct Sourcepoint Id is false but not in variant', async () => {
+        dfpEnv.hbImpl = { prebid: true, a9: false };
+        commercialFeatures.dfpAdvertising = true;
+        commercialFeatures.adFree = false;
+        isInVariantSynchronous.mockImplementation(
+            (testId, variantId) => variantId === 'notintest'
+        );
+        shouldUseSourcepointCmp.mockImplementation(() => true);
+        onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
+        await setupPrebid();
+        expect(prebid.initialise).not.toBeCalled();
+    });
+
     it('should not initialise Prebid if TCFv2 with correct Sourcepoint Id is false', async () => {
         dfpEnv.hbImpl = { prebid: true, a9: false };
         commercialFeatures.dfpAdvertising = true;

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.js
@@ -160,16 +160,6 @@ describe('init', () => {
         expect(prebid.initialise).not.toBeCalled();
     });
 
-    it('should not initialise Prebid if TCFv2 with correct Sourcepoint Id is false', async () => {
-        dfpEnv.hbImpl = { prebid: true, a9: false };
-        commercialFeatures.dfpAdvertising = true;
-        commercialFeatures.adFree = false;
-        shouldUseSourcepointCmp.mockImplementation(() => true);
-        onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
-        await setupPrebid();
-        expect(prebid.initialise).not.toBeCalled();
-    });
-
     it('isGoogleWebPreview should return false with no navigator or useragent', () => {
         expect(isGoogleProxy()).toBe(false);
     });

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.js
@@ -6,15 +6,21 @@ import prebid from 'commercial/modules/header-bidding/prebid/prebid';
 import { shouldUseSourcepointCmp as shouldUseSourcepointCmp_ } from 'commercial/modules/cmp/sourcepoint';
 import { onConsentChange as onConsentChange_ } from '@guardian/consent-management-platform';
 import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
+import { isInVariantSynchronous as isInVariantSynchronous_ } from 'common/modules/experiments/ab';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { _ } from './prepare-prebid';
 
 const { setupPrebid } = _;
 const onConsentChange: any = onConsentChange_;
 const shouldUseSourcepointCmp: any = shouldUseSourcepointCmp_;
+const isInVariantSynchronous: any = isInVariantSynchronous_;
 
 jest.mock('common/modules/commercial/commercial-features', () => ({
     commercialFeatures: {},
+}));
+
+jest.mock('common/modules/experiments/ab', () => ({
+    isInVariantSynchronous: jest.fn(),
 }));
 
 jest.mock('commercial/modules/header-bidding/prebid/prebid', () => ({
@@ -128,10 +134,13 @@ describe('init', () => {
         await setupPrebid();
         expect(prebid.initialise).toBeCalled();
     });
-    it('should initialise Prebid if TCFv2 consent with correct Sourcepoint Id is true', async () => {
+    it('should initialise Prebid if TCFv2 consent with correct Sourcepoint Id is true in variant', async () => {
         dfpEnv.hbImpl = { prebid: true, a9: false };
         commercialFeatures.dfpAdvertising = true;
         commercialFeatures.adFree = false;
+        isInVariantSynchronous.mockImplementation(
+            (testId, variantId) => variantId === 'variant'
+        );
         shouldUseSourcepointCmp.mockImplementation(() => true);
         onConsentChange.mockImplementation(tcfv2WithConsentMock);
         await setupPrebid();

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.js
@@ -46,10 +46,10 @@ jest.mock('@guardian/consent-management-platform', () => ({
 }));
 
 const tcfv2WithConsentMock = (callback): void =>
-    callback({ tcfv2: { consents: { '1': true } } });
+    callback({ tcfv2: { vendorConsents: { '5f22bfd82a6b6c1afd1181a9': true } }});
 
 const tcfv2WithoutConsentMock = (callback): void =>
-    callback({ tcfv2: { consents: { '1': false } } });
+    callback({ tcfv2: { vendorConsents: { '5f22bfd82a6b6c1afd1181a9': false } }});
 
 const fakeUserAgent = (userAgent: string): void => {
     const userAgentObject = {};
@@ -128,7 +128,7 @@ describe('init', () => {
         await setupPrebid();
         expect(prebid.initialise).toBeCalled();
     });
-    it('should initialise Prebid if TCFv2 purpose 1 consent is given', async () => {
+    it('should initialise Prebid if TCFv2 consent with correct Sourcepoint Id is true', async () => {
         dfpEnv.hbImpl = { prebid: true, a9: false };
         commercialFeatures.dfpAdvertising = true;
         commercialFeatures.adFree = false;
@@ -138,7 +138,7 @@ describe('init', () => {
         expect(prebid.initialise).toBeCalled();
     });
 
-    it('should not initialise Prebid if TCFv2 purpose 1 consent is not given', async () => {
+    it('should not initialise Prebid if TCFv2 with correct Sourcepoint Id is false', async () => {
         dfpEnv.hbImpl = { prebid: true, a9: false };
         commercialFeatures.dfpAdvertising = true;
         commercialFeatures.adFree = false;

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -13,6 +13,7 @@ import { signInGatePatientia } from 'common/modules/experiments/tests/sign-in-ga
 import { signInGateMainVariant } from "common/modules/experiments/tests/sign-in-gate-main-variant";
 import { signInGateMainControl } from "common/modules/experiments/tests/sign-in-gate-main-control";
 import { contributionsCovidBannerRoundTwo } from 'common/modules/experiments/tests/contribs-banner-covid-round-two';
+import { googletagPrebidEnforcement } from 'common/modules/experiments/tests/tcfv2-googletag-prebid-enforcement';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
@@ -23,6 +24,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     signInGatePatientia,
     signInGateMainVariant,
     signInGateMainControl,
+    googletagPrebidEnforcement,
 ];
 
 export const priorityEpicTest: AcquisitionsABTest = remoteEpicVariants;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/tcfv2-googletag-prebid-enforcement.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/tcfv2-googletag-prebid-enforcement.js
@@ -1,0 +1,28 @@
+// @flow strict
+
+export const googletagPrebidEnforcement: ABTest = {
+    id: 'Tcfv2GoogletagPrebidEnforcement',
+    start: '2020-08-04',
+    expiry: '2020-09-30',
+    author: 'Ioanna Kyprianou',
+    description: 'This is to test adding googletag and prebid behind TCFv2 Sourcepoint enforcement',
+    audience: 0.0,
+    audienceOffset: 0.0,
+    successMeasure: 'We don\'t break the site',
+    audienceCriteria: 'n/a',
+    dataLinkNames: 'n/a',
+    idealOutcome: 'We don\'t break the site',
+    showForSensitive: false,
+    canRun: () => true,
+    variants: [
+        {
+            id: 'control',
+            test: (): void => {},
+        },
+        {
+            id: 'variant',
+            test: (): void => {},
+        },
+    ],
+};
+


### PR DESCRIPTION
## What does this change?

Using the TCFv2 framework, we want to set googletag and prebid behind Sourcepoint enforcement.  

This PR disables googletag and prebid.js if the consent no consent has been given.

Also creates this logic behind a 0% AB test for testing purposes. Test param: `#ab-Tcfv2GoogletagPrebidEnforcement=variant`

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
