### PR TITLE
Add core-vitals reporting to Frontend GA

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "@emotion/core": "^10.0.27",
     "@emotion/styled": "^10.0.27",
     "@guardian/atom-renderer": "1.1.6",
-    "@guardian/consent-management-platform": "4.0.0-9",
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.7",
+    "@guardian/consent-management-platform": "4.0.0-9",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/shimport": "^1.0.2",
     "@guardian/src-button": "^0.16.1",
@@ -54,6 +54,7 @@
     "videojs-ima": "googleads/videojs-ima#0.3.0",
     "videojs-persistvolume": "guardian/videojs-persistvolume#0.1.4",
     "videojs-playlist": "guardian/videojs-playlist#0.1.4",
+    "web-vitals": "^0.2.4",
     "webshot": "^0.18.0",
     "wolfy87-eventemitter": "~5.2.4"
   },

--- a/static/src/javascripts/projects/common/modules/analytics/google.js
+++ b/static/src/javascripts/projects/common/modules/analytics/google.js
@@ -1,5 +1,6 @@
 // @flow
 
+import { getCLS, getFID, getLCP } from 'web-vitals';
 import config from 'lib/config';
 import mediator from 'lib/mediator';
 
@@ -134,6 +135,51 @@ const trackPerformance = (
         }
     }
 };
+
+// This matches DCR implementation
+type coreVitalsArgs = {
+    name: string;
+    delta: number;
+    id: string;
+};
+// https://www.npmjs.com/package/web-vitals#using-analyticsjs
+const sendCoreVital = ({ name, delta, id }: coreVitalsArgs): void => {
+    const { ga } = window;
+
+    if (!ga) {
+        return;
+    }
+
+
+    ga(send, 'event', {
+        eventCategory: 'Web Vitals',
+        eventAction: name,
+        // Google Analytics metrics must be integers, so the value is rounded.
+        // For CLS the value is first multiplied by 1000 for greater precision
+        // (note: increase the multiplier for greater precision if needed).
+        eventValue: Math.round(name === 'CLS' ? delta * 1000 : delta),
+        // The `id` value will be unique to the current page load. When sending
+        // multiple values from the same page (e.g. for CLS), Google Analytics can
+        // compute a total by grouping on this ID (note: requires `eventLabel` to
+        // be a dimension in your report).
+        eventLabel: id,
+        // Use a non-interaction event to avoid affecting bounce rate.
+        nonInteraction: true,
+    });
+};
+
+// //////////////////////
+// Core Vitals Reporting
+// Supported only in Chromium but npm module tested in all our supported browsers
+// https://www.npmjs.com/package/web-vitals#browser-support
+
+// CLS and LCP are captured when the page lifecycle changes to 'hidden'.
+// https://developers.google.com/web/updates/2018/07/page-lifecycle-api#advice-hidden
+getCLS(sendCoreVital); // https://github.com/GoogleChrome/web-vitals#getcls (This is actually DCLS, as doesn't track CLS in iframes, see https://github.com/WICG/layout-instability#cumulative-scores)
+getLCP(sendCoreVital); // https://github.com/GoogleChrome/web-vitals#getlcp
+
+// FID is captured when a user interacts with the page
+getFID(sendCoreVital); // https://github.com/GoogleChrome/web-vitals#getfid
 
 export {
     trackNonClickInteraction,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11318,6 +11318,11 @@ wcwidth@^1.0.0:
   dependencies:
     defaults "^1.0.3"
 
+web-vitals@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-0.2.4.tgz#ec3df43c834a207fd7cdefd732b2987896e08511"
+  integrity sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg==
+
 webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"


### PR DESCRIPTION
## What does this change?

As Per DCR: https://github.com/guardian/dotcom-rendering/pull/1793

## What does this change?

Implements the official [GoogleChrome web-vitals](https://github.com/GoogleChrome/web-vitals) metrics module reporting the results to Google Analytics.

The library is small (with easy to read code) and well tested, it makes more sense than implementing these ourselves. Reporting to GA is simple and matches how we were previously reporting LCP.

We are reporting:

- *Largest Contentful Paint* when page lifecycle becomes 'hidden'
- *Cumulative Layout Shift* when page lifecycle becomes 'hidden'
- *First Input Delay* on a user interaction

I am limiting the data to these three for now to avoid sending many more events to GA. We may want to expand on this in the future, this library in particular also tracks FCP and TTFB which are not automatically tracked by GA.

## Why?

Tracking core vitals at RUM is required to allow us to measure pages that are damaging to user experience and web performance. We can see Core Vitals at a RUM level using the CrUX report which feeds into the Google Search Console but capturing the data ourselves here (and later, maybe, Ophan) means we can better segment the data to pages, sections and platforms.

Be aware: the data is only available for Chromium browsers.