### PR TITLE
Reintroduce an updated AudioAtomBlockElement

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -54,7 +54,8 @@ object Sponsorship {
 
 sealed trait PageElement
 
-case class AudioAtomBlockElement(id: String, kicker: String, coverUrl: String, trackUrl: String, duration: Int, contentId: String) extends PageElement
+case class AudioAtomBlockElementAMP(id: String, kicker: String, coverUrl: String, trackUrl: String, duration: Int, contentId: String) extends PageElement
+case class AudioAtomBlockElement(amp: AudioAtomBlockElementAMP) extends PageElement
 case class AudioBlockElement(assets: Seq[AudioAsset]) extends PageElement
 case class BlockquoteBlockElement(html: String) extends PageElement
 case class ExplainerAtomBlockElement(id: String, title: String, body: String) extends PageElement
@@ -310,6 +311,10 @@ object PageElement {
               css = None,
               js = None
             ))
+
+            // Using the AudioAtomBlockElement:
+            val amp = AudioAtomBlockElementAMP(audio.id, audio.data.kicker, audio.data.coverUrl, audio.data.trackUrl, audio.data.duration, audio.data.contentId)
+            Some(AudioAtomBlockElement(amp))
           }
 
           case Some(chart: ChartAtom) => {
@@ -548,6 +553,7 @@ object PageElement {
   // Below alphabetical order (modulo two exceptions)
 
   implicit val AudioBlockElementWrites: Writes[AudioBlockElement] = Json.writes[AudioBlockElement]
+  implicit val AudioAtomBlockElementAMPWrites: Writes[AudioAtomBlockElementAMP] = Json.writes[AudioAtomBlockElementAMP]
   implicit val AudioAtomBlockElementWrites: Writes[AudioAtomBlockElement] = Json.writes[AudioAtomBlockElement]
   implicit val BlockquoteBlockElementWrites: Writes[BlockquoteBlockElement] = Json.writes[BlockquoteBlockElement]
   implicit val CalloutBlockElementWrites: Writes[CalloutBlockElement] = Json.writes[CalloutBlockElement]


### PR DESCRIPTION
## What does this change?

Reintroduce an updated `AudioAtomBlockElement`. This is the companion PR of https://github.com/guardian/dotcom-rendering/pull/1794
