### PR TITLE
Sample core vitals to 5%

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/google.js
+++ b/static/src/javascripts/projects/common/modules/analytics/google.js
@@ -173,13 +173,21 @@ const sendCoreVital = ({ name, delta, id }: coreVitalsArgs): void => {
 // Supported only in Chromium but npm module tested in all our supported browsers
 // https://www.npmjs.com/package/web-vitals#browser-support
 
-// CLS and LCP are captured when the page lifecycle changes to 'hidden'.
-// https://developers.google.com/web/updates/2018/07/page-lifecycle-api#advice-hidden
-getCLS(sendCoreVital); // https://github.com/GoogleChrome/web-vitals#getcls (This is actually DCLS, as doesn't track CLS in iframes, see https://github.com/WICG/layout-instability#cumulative-scores)
-getLCP(sendCoreVital); // https://github.com/GoogleChrome/web-vitals#getlcp
+// Only send for roughly 5% of users
+// We want all or nothing on the corevitals so that they can be easily compared for a single pageview
+// so we do this here rather than in the sendCoreVital function
+const randomPerc = Math.random() * 100;
+const coreVitalsSampleRate = 5;
 
-// FID is captured when a user interacts with the page
-getFID(sendCoreVital); // https://github.com/GoogleChrome/web-vitals#getfid
+if (coreVitalsSampleRate >= randomPerc) {
+    // CLS and LCP are captured when the page lifecycle changes to 'hidden'.
+    // https://developers.google.com/web/updates/2018/07/page-lifecycle-api#advice-hidden
+    getCLS(sendCoreVital); // https://github.com/GoogleChrome/web-vitals#getcls (This is actually DCLS, as doesn't track CLS in iframes, see https://github.com/WICG/layout-instability#cumulative-scores)
+    getLCP(sendCoreVital); // https://github.com/GoogleChrome/web-vitals#getlcp
+
+    // FID is captured when a user interacts with the page
+    getFID(sendCoreVital); // https://github.com/GoogleChrome/web-vitals#getfid
+}
 
 export {
     trackNonClickInteraction,

--- a/static/src/javascripts/projects/common/modules/analytics/google.js
+++ b/static/src/javascripts/projects/common/modules/analytics/google.js
@@ -179,7 +179,7 @@ const sendCoreVital = ({ name, delta, id }: coreVitalsArgs): void => {
 const randomPerc = Math.random() * 100;
 const coreVitalsSampleRate = 5;
 
-if (coreVitalsSampleRate >= randomPerc) {
+if (randomPerc <= coreVitalsSampleRate) {
     // CLS and LCP are captured when the page lifecycle changes to 'hidden'.
     // https://developers.google.com/web/updates/2018/07/page-lifecycle-api#advice-hidden
     getCLS(sendCoreVital); // https://github.com/GoogleChrome/web-vitals#getcls (This is actually DCLS, as doesn't track CLS in iframes, see https://github.com/WICG/layout-instability#cumulative-scores)


### PR DESCRIPTION
## What does this change?

Samples the core vitals event down to 5% of users. This is required because we don't use `siteSpeed` metrics.

### Before

Would send on 100% of pageviews.

### After

Will send on 5% of page views.

## Why?

💲 💲 
