### PR TITLE
Use image resizer for podcast covers

### DIFF
--- a/applications/app/views/fragments/audioBody.scala.html
+++ b/applications/app/views/fragments/audioBody.scala.html
@@ -5,6 +5,8 @@
 @import views.support.TrailCssClasses.toneClass
 @import views.support.{RenderClasses}
 
+@import views.support.ImgSrc
+@import views.support.ImageProfile
 @(page: MediaPage, audio: Audio)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @trackingCode(target: String) = {@if(page.media.tags.isPodcast){podcast:subscribe:}@target:@page.media.metadata.webTitle}
@@ -53,7 +55,7 @@
             ; image <- podcast.image
             ) {
                 <div class="podcast__cover">
-                    <a href="@LinkTo {/@series.id}"><img src="@image" class="podcast__cover-image" alt></a>
+                    <a href="@LinkTo {/@series.id}"><img src="@ImgSrc(image, ImageProfile(width = Some(220)))" class="podcast__cover-image" alt></a>
                 </div>
             }
 

--- a/applications/app/views/fragments/audioBody.scala.html
+++ b/applications/app/views/fragments/audioBody.scala.html
@@ -55,7 +55,7 @@
             ; image <- podcast.image
             ) {
                 <div class="podcast__cover">
-                    <a href="@LinkTo {/@series.id}"><img src="@ImgSrc(image, ImageProfile(width = Some(220)))" class="podcast__cover-image" alt></a>
+                    <a href="@LinkTo {/@series.id}"><img src="@ImgSrc(image, ImageProfile(width = Some(440)))" class="podcast__cover-image" alt></a>
                 </div>
             }
 


### PR DESCRIPTION
## What does this change?

Uses the image resizer for podcast cover images on podcast articles

## Does this change need to be reproduced in dotcom-rendering ?

This will need to be reproduced when podcasts are implemented on DCR

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

## Screenshots
![Screen Shot 2020-08-05 at 17 30 08](https://user-images.githubusercontent.com/2619836/89439024-7ee4ee80-d741-11ea-880f-fe7be9ae0e97.png)

(changes the Orange "Full Story" image)

## What is the value of this and can you measure success?

Smaller images: less bandwidth, happier users.  For example, Full Story Australia news podcast logo (https://www.theguardian.com/australia-news/audio/2020/aug/05/how-covid-19-laid-bare-the-cracks-in-australias-aged-care-system) is currently **6.3MB**, after this change it is **7.5kB**

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
