### PR TITLE
Don't load Prebid when conditions are not met

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
@@ -16,11 +16,10 @@ import { googletagPrebidEnforcement } from 'common/modules/experiments/tests/tcf
 const SOURCEPOINT_ID: string = '5f22bfd82a6b6c1afd1181a9';
 let moduleLoadResult = Promise.resolve();
 
-if (!isGoogleProxy()) {
-    moduleLoadResult = import(/* webpackChunkName: "Prebid.js" */ 'prebid.js/build/dist/prebid');
-}
-
 const loadPrebid: () => void = () => {
+    if (!isGoogleProxy()) {
+        moduleLoadResult = import(/* webpackChunkName: "Prebid.js" */ 'prebid.js/build/dist/prebid');
+    }
     moduleLoadResult.then(() => {
         if (
             dfpEnv.hbImpl.prebid &&

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
@@ -14,13 +14,8 @@ import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { googletagPrebidEnforcement } from 'common/modules/experiments/tests/tcfv2-googletag-prebid-enforcement';
 
 const SOURCEPOINT_ID: string = '5f22bfd82a6b6c1afd1181a9';
-let moduleLoadResult = Promise.resolve();
 
 const loadPrebid: () => void = () => {
-    if (!isGoogleProxy()) {
-        moduleLoadResult = import(/* webpackChunkName: "Prebid.js" */ 'prebid.js/build/dist/prebid');
-    }
-    moduleLoadResult.then(() => {
         if (
             dfpEnv.hbImpl.prebid &&
             commercialFeatures.dfpAdvertising &&
@@ -29,10 +24,11 @@ const loadPrebid: () => void = () => {
             !isGoogleProxy() &&
             !shouldIncludeOnlyA9
         ) {
-            getPageTargeting();
-            prebid.initialise(window);
+            import(/* webpackChunkName: "Prebid.js" */ 'prebid.js/build/dist/prebid').then(() => {
+                getPageTargeting();
+                prebid.initialise(window);
+            });
         }
-    })
 }
 
 const setupPrebid: () => Promise<void> = () => {
@@ -48,8 +44,9 @@ const setupPrebid: () => Promise<void> = () => {
             }
         });
     }
-    if (canRun && !isInTcfv2EnforcementVariant)
+    if (canRun && !isInTcfv2EnforcementVariant) {
         loadPrebid();
+    }
 
     return Promise.resolve();
 };


### PR DESCRIPTION
## What does this change?

For Prebid.js we have few conditions in which we want it to run. If those conditions weren't met, we were still loading the library but weren't calling the Prebid's `initialise` method.

After doing the https://github.com/guardian/frontend/pull/22856 which adds one more condition for Prebid to be loaded for TCFv2 (only when consent has been given), we realised that we can improve the mechanism of loading Prebid.js.

This PR refactors the way we import the script to be loaded when all the conditions are met.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
