### PR TITLE
Create TCFv2 switches

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -37,10 +37,20 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
-  val TCFv2CmpUi = Switch(
+  val TCFv2DCR = Switch(
     SwitchGroup.Feature,
-    "tcfv2-cmp-ui",
-    "If this switch is on, the TCF v2 CMP UI will be available to users outside the USA.",
+    "tcfv2-dcr",
+    "If this switch is on, the TCF v2 CMP UI will be shown to users outside the USA on DCR.",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
+  val TCFv2Frontend = Switch(
+    SwitchGroup.Feature,
+    "tcfv2-frontend",
+    "If this switch is on, the TCF v2 CMP UI will be available to users outside the USA on frontend.",
     owners = group(Commercial),
     safeState = Off,
     sellByDate = never,

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -37,6 +37,16 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
+  val TCFv2CmpUi = Switch(
+    SwitchGroup.Feature,
+    "tcfv2-cmp-ui",
+    "If this switch is on, the TCF v2 CMP UI will be available to users outside the USA.",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
   val CarrotTrafficDriverSwitch = Switch(
     Commercial,
     "carrot-traffic-driver",


### PR DESCRIPTION
## What does this change?

creates 2 switches we can use to roll out TCF v2 to 100% of users

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

