### PR TITLE
Remove numbered list articles from the picker

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -92,6 +92,8 @@ object ArticlePageChecks {
     "artanddesign/series/guardian-print-shop"
   )
 
+  def isNotNumberedList(page: PageWithStoryPackage): Boolean = ! page.item.isNumberedList
+
   def isNotPhotoEssay(page: PageWithStoryPackage): Boolean = ! page.item.isPhotoEssay
 
   def isNotLiveBlog(page:PageWithStoryPackage): Boolean = ! page.item.isLiveBlog
@@ -158,6 +160,7 @@ object ArticlePicker {
       ("isNotPaidContent", ArticlePageChecks.isNotPaidContent(page)),
       ("isSupportedTone", ArticlePageChecks.isSupportedTone(page)),
       ("isNotInBlockList", ArticlePageChecks.isNotInBlockList(page))
+      ("isNotNumberedList", ArticlePageChecks.isNotNumberedList(page)),
     )
   }
 

--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -159,8 +159,8 @@ object ArticlePicker {
       ("isNotAMP", ArticlePageChecks.isNotAMP(request)),
       ("isNotPaidContent", ArticlePageChecks.isNotPaidContent(page)),
       ("isSupportedTone", ArticlePageChecks.isSupportedTone(page)),
-      ("isNotInBlockList", ArticlePageChecks.isNotInBlockList(page))
-      ("isNotNumberedList", ArticlePageChecks.isNotNumberedList(page)),
+      ("isNotInBlockList", ArticlePageChecks.isNotInBlockList(page)),
+      ("isNotNumberedList", ArticlePageChecks.isNotNumberedList(page))
     )
   }
 


### PR DESCRIPTION
## What does this change?
Until we do the work to render numbered list articles, we should exclude them from DCR.

