### PR TITLE
Passing required fields to build SpotifyBlockElement iframe on DCR

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -38,7 +38,7 @@ object ArticlePageChecks {
     def unsupportedElement(blockElement: BlockElement) = blockElement match {
       case _: AudioBlockElement => {
         val e = blockElement.asInstanceOf[AudioBlockElement].element
-        val resolve = model.dotcomrendering.pageElements.PageElement.audiIsDCRSupported(e)
+        val resolve = model.dotcomrendering.pageElements.PageElement.audioIsDCRSupported(e)
         !resolve
       }
       case _: DocumentBlockElement => false

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -447,7 +447,7 @@ object PageElement {
     doc.getElementsByTag("iframe").asScala.headOption.map(_.attr("width").toInt)
   }
 
-    private[this] def getIframeHeight(html: String): Option[Int] = {
+  private[this] def getIframeHeight(html: String): Option[Int] = {
     val doc = Jsoup.parseBodyFragment(html)
     doc.getElementsByTag("iframe").asScala.headOption.map(_.attr("height").toInt)
   }


### PR DESCRIPTION
## What does this change?

Update the backend `SpotifyBlockElement`, to allow for a DCR generated iframe, instead of the CAPI precompiled HTML.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes: https://github.com/guardian/dotcom-rendering/pull/1802 
