### PR TITLE
Bt/update account deletion text

### DIFF
--- a/identity/app/views/profile/deletion/accountDeletionForm.scala.html
+++ b/identity/app/views/profile/deletion/accountDeletionForm.scala.html
@@ -35,7 +35,8 @@
         <div class="identity-section">
             <h4><a class="u-underline" href="https://www.theguardian.com/help/identity-faq">Account</a></h4>
             <p class="identity-section__text">
-                If you delete your account you will still be able to create a new one with the same email address.
+                Deleting your account removes personal information from our database. Your email address becomes
+                permanently reserved and the same email address cannot be re-used to register a new account.
             </p>
 
             <h4><a class="u-underline" href="https://www.theguardian.com/community-faqs">Comments</a></h4>

--- a/identity/app/views/profile/deletion/accountDeletionForm.scala.html
+++ b/identity/app/views/profile/deletion/accountDeletionForm.scala.html
@@ -35,8 +35,7 @@
         <div class="identity-section">
             <h4><a class="u-underline" href="https://www.theguardian.com/help/identity-faq">Account</a></h4>
             <p class="identity-section__text">
-                Deleting your account removes personal information from our database. Your email address becomes
-                permanently reserved and the same email address cannot be re-used to register a new account.
+                If you delete your account you will still be able to create a new one with the same email address.
             </p>
 
             <h4><a class="u-underline" href="https://www.theguardian.com/community-faqs">Comments</a></h4>
@@ -46,6 +45,10 @@
                 be removed please contact the <a class="u-underline" href="mailto:moderation@@theguardian.com">Moderation Team</a>.
                 Please note that requests are considered on a case-by-case basis and your comments will not be
                 automatically deleted.
+            </p>
+            <p class="identity-section__text">
+                If you have previously been banned, watched or premoderated due to inappropriate commenting behaviour,
+                these restrictions will still be in place if you create a new account with the same email address.
             </p>
 
             <h4><a class="u-underline" href="https://membership.theguardian.com/help">Membership</a></h4>


### PR DESCRIPTION
## What does this change?

This adds a paragraph to the profile.theguardian.com/delete page informing users that if have been previously banned, watched or premoderated due to inappropriate commenting behaviour, these restrictions will still be in place if they create a new account with the same email address.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
