### PR TITLE
Identity / Add Sign In Gate Dismiss Window Test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -116,6 +116,16 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+   Switch(
+    ABTests,
+    "ab-sign-in-gate-dismiss-window",
+    "Show sign in gate to users on 3rd article view, then don't reshow (control), reshow next article (variant 1), reshow next day (variant 2)",
+    owners = Seq(Owner.withGithub("vlbee")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 12, 1),
+    exposeClientSide = true
+  )
+
   Switch(
     ABTests,
     "ab-sign-in-gate-main-control",

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -10,8 +10,9 @@ import { pangaeaAdapterTest } from 'common/modules/experiments/tests/commercial-
 import { connatixTest } from 'common/modules/experiments/tests/connatix-ab-test';
 import { remoteEpicVariants } from 'common/modules/experiments/tests/remote-epic-variants';
 import { signInGatePatientia } from 'common/modules/experiments/tests/sign-in-gate-patientia';
-import { signInGateMainVariant } from "common/modules/experiments/tests/sign-in-gate-main-variant";
-import { signInGateMainControl } from "common/modules/experiments/tests/sign-in-gate-main-control";
+import { signInGateMainVariant } from 'common/modules/experiments/tests/sign-in-gate-main-variant';
+import { signInGateMainControl } from 'common/modules/experiments/tests/sign-in-gate-main-control';
+import { signInGateDismissWindow } from 'common/modules/experiments/tests/sign-in-gate-dismiss-window';
 import { contributionsCovidBannerRoundTwo } from 'common/modules/experiments/tests/contribs-banner-covid-round-two';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
@@ -23,6 +24,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     signInGatePatientia,
     signInGateMainVariant,
     signInGateMainControl,
+    signInGateDismissWindow,
 ];
 
 export const priorityEpicTest: AcquisitionsABTest = remoteEpicVariants;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-dismiss-window.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-dismiss-window.js
@@ -1,0 +1,35 @@
+// @flow
+export const signInGateDismissWindow: ABTest = {
+    id: 'SignInGateDismissWindow',
+    start: '2020-08-12',
+    expiry: '2020-12-01',
+    author: 'vlbee',
+    description:
+        'Dismiss Window sign in gate test on 3nd article view of simple article templates, with higher priority over banners and epic',
+    audience: 0.025,
+    audienceOffset: 0.875,
+    successMeasure:
+        'More users who previously dismissed the gate sign in or create a Guardian account',
+    audienceCriteria:
+        '3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics. Control group will no longer see gate after first dismissal, Variant 1 will see gate on every article after first dimissal, Variant 2 will see gate again after 24hrs first dimissal in same session',
+    ophanComponentId: 'dismiss_window_test',
+    dataLinkNames: 'SignInGateDismissWindow',
+    idealOutcome:
+        'Conversion to sign in is higher with increased gate impressions after initial dismissal, with no sustained negative impact to engagement levels or supporter acquisition',
+    showForSensitive: false,
+    canRun: () => true,
+    variants: [
+        {
+            id: 'dismiss-window-control',
+            test: (): void => {},
+        },
+        {
+            id: 'dismiss-window-variant-1-article',
+            test: (): void => {},
+        },
+        {
+            id: 'dismiss-window-variant-2-day',
+            test: (): void => {},
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-control.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-control.js
@@ -10,7 +10,7 @@ export const signInGateMainControl: ABTest = {
     author: 'Mahesh Makani',
     description:
         'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Control Audience.',
-    audience: 0.09,
+    audience: 0.0999,
     audienceOffset: 0.9,
     successMeasure: 'N/A - User does not see gate, only to compare to variant.',
     audienceCriteria:

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
@@ -10,7 +10,7 @@ export const signInGateMainVariant: ABTest = {
     author: 'Mahesh Makani',
     description:
         'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Main/Variant Audience.',
-    audience: 0.9,
+    audience: 0.875,
     audienceOffset: 0.0,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
@@ -10,7 +10,7 @@ import {
 import { isUserLoggedIn } from 'common/modules/identity/api';
 import { show as showCMPModule } from 'common/modules/ui/cmp-ui';
 import { submitClickEventTracking } from './component-event-tracking';
-import type { CurrentABTest, GateStatus } from './types';
+import type { CurrentABTest, GateStatus, DismissalWindow } from './types';
 
 // Helper for setGatePageTargeting function
 const setGoogleTargeting = (canShow: GateStatus): void => {
@@ -49,6 +49,26 @@ export const getVariant: ABTest => string = test => {
     return currentTest ? currentTest.variantToRun.id : '';
 };
 
+// set in user preferences that the user has dismissed the gate, set the value to the current ISO date string
+// name is optional, but can be used to differentiate between multiple sign in gate tests
+export const setUserDismissedGate: ({
+    name?: string,
+    variant: string,
+    componentName: string,
+}) => void = ({ name = '', variant, componentName }) => {
+    const prefs = userPrefs.get(componentName) || {};
+    prefs[`${name ? `${name}-` : ''}${variant}`] = new Date().toISOString();
+    userPrefs.set(componentName, prefs);
+};
+
+// delete from user preferences that the user has previously dismissed the gate
+// name is optional, but can be used to differentiate between multiple sign in gate tests
+export const unsetUserDismissedGate: ({
+    componentName: string,
+}) => void = ({ componentName }) => {
+    userPrefs.remove(componentName);
+};
+
 // check if the user has dismissed the gate by checking the user preferences,
 // name is optional, but can be used to differentiate between multiple sign in gate tests
 export const hasUserDismissedGate: ({
@@ -59,6 +79,36 @@ export const hasUserDismissedGate: ({
     const prefs = userPrefs.get(componentName) || {};
 
     return !!prefs[`${name ? `${name}-` : ''}${variant}`];
+};
+
+// check if the user has dismissed the gate within a given timeframe
+export const hasUserDismissedGateInWindow: ({
+    window: DismissalWindow,
+    name?: string,
+    variant: string,
+    componentName: string,
+}) => boolean = ({ window, name = '', componentName, variant }) => {
+    const prefs = userPrefs.get(componentName) || {};
+    if (!prefs[`${name ? `${name}-` : ''}${variant}`]) {
+        return false;
+    }
+
+    const dismissalTZ = Date.parse(
+        prefs[`${name ? `${name}-` : ''}${variant}`]
+    );
+
+    const dismissalWindows = {
+        day: 24,
+        dev: 0.05, // 3 min for testing
+    };
+    const hours = (Date.now() - dismissalTZ) / 36e5; //  36e5 is the scientific notation for 60*60*1000, which converts the milliseconds difference into hours.
+
+    if (hours >= dismissalWindows[window]) {
+        unsetUserDismissedGate({ componentName }); // clears the dismissal
+        return false;
+    }
+
+    return true;
 };
 
 // Dynamically sets the gate custom parameter for Google ad request page targeting
@@ -73,18 +123,6 @@ export const setGatePageTargeting = (
     } else {
         setGoogleTargeting(canShowCheck);
     }
-};
-
-// set in user preferences that the user has dismissed the gate, set the value to the current ISO date string
-// name is optional, but can be used to differentiate between multiple sign in gate tests
-export const setUserDismissedGate: ({
-    name?: string,
-    variant: string,
-    componentName: string,
-}) => void = ({ name = '', variant, componentName }) => {
-    const prefs = userPrefs.get(componentName) || {};
-    prefs[`${name ? `${name}-` : ''}${variant}`] = new Date().toISOString();
-    userPrefs.set(componentName, prefs);
 };
 
 // use the dailyArticleCount from the local storage to see how many articles the user has viewed in a day
@@ -215,7 +253,7 @@ export const showPrivacySettingsCMPModule: () => void = () => {
 export const addCSSOnOpinion: ({
     element: HTMLElement,
     selector: string,
-    css: string
+    css: string,
 }) => void = ({ element, selector, css }) => {
     if (config.get(`page.tones`) === 'Comment') {
         const selection = element.querySelector(selector);
@@ -223,7 +261,7 @@ export const addCSSOnOpinion: ({
             selection.classList.add(css);
         }
     }
-}
+};
 
 // add the background color if the page the user is on is the opinion section
 export const addOpinionBgColour: ({
@@ -311,9 +349,11 @@ export const gateBorderFix = () => {
     const contentMainColumn = document.querySelector('.js-content-main-column');
 
     if (contentMainColumn) {
-        contentMainColumn.classList.add('signin-gate__content-main-column__border-fix');
+        contentMainColumn.classList.add(
+            'signin-gate__content-main-column__border-fix'
+        );
     }
-}
+};
 
 // helper method which first shows the gate based on the template supplied, adds any
 // handlers, e.g. click events etc. defined in the handler parameter function

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.spec.js
@@ -1,0 +1,84 @@
+// @flow
+import { hasUserDismissedGateInWindow } from './helper';
+
+jest.mock('bean', () => ({
+    record: jest.fn(),
+}));
+
+jest.mock('common/modules/user-prefs', () => ({
+    get: jest.fn(() => undefined),
+    remove: jest.fn(),
+}));
+
+jest.mock('lib/storage', () => ({
+    local: {
+        get: jest.fn(() => [{ count: 2, day: 1 }]),
+    },
+}));
+
+jest.mock('lib/config', () => ({
+    get: jest.fn(() => false),
+}));
+
+jest.mock('common/modules/experiments/ab', () => ({
+    isInABTestSynchronous: jest.fn(() => true),
+    getAsyncTestsToRun: jest.fn(() => Promise.resolve([])),
+    getSynchronousTestsToRun: jest.fn(() => [
+        {
+            id: 'SignInGatePatientia', // Update for each new test
+            dataLinkNames: 'SignInGatePatientia', // Update for each new test
+            variantToRun: {
+                id: 'patientia-variant-1', // Update for each new test
+            },
+            ophanComponentId: 'patientia_test',
+        },
+    ]),
+}));
+
+jest.mock('common/modules/identity/api', () => ({
+    isUserLoggedIn: jest.fn(() => false),
+}));
+
+jest.mock('common/modules/ui/cmp-ui', () => ({
+    get: jest.fn(() => undefined),
+}));
+
+jest.mock('./component-event-tracking', () => ({
+    get: jest.fn(() => undefined),
+}));
+
+const fakeUserPrefs: any = require('common/modules/user-prefs');
+
+describe('Sign In Gate Helper functions', () => {
+    describe('hasUserDismissedGateInWindow', () => {
+        const moreThanADayAgo = new Date();
+        moreThanADayAgo.setHours(moreThanADayAgo.getHours() - 26);
+        const lessThanADayAgo = new Date();
+        lessThanADayAgo.setHours(lessThanADayAgo.getHours() - 14);
+
+        const test = {
+            window: 'day',
+            name: 'SignInGatePatientia',
+            variant: 'patientia-variant-1',
+            componentName: 'sign-in-gate',
+        };
+
+        it('should return true if timestamp is less than specified window', () => {
+            fakeUserPrefs.get.mockReturnValueOnce({
+                'SignInGatePatientia-patientia-variant-1': lessThanADayAgo.toISOString(),
+            });
+
+            expect(hasUserDismissedGateInWindow(test)).toBe(true);
+            expect(fakeUserPrefs.remove).toHaveBeenCalledTimes(0);
+        });
+
+        it('should clear local storage prefs and return false if timestamp from prefs is more than specified window', () => {
+            fakeUserPrefs.get.mockReturnValueOnce({
+                'SignInGatePatientia-patientia-variant-1': moreThanADayAgo.toISOString(),
+            });
+
+            expect(hasUserDismissedGateInWindow(test)).toBe(false);
+            expect(fakeUserPrefs.remove).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
@@ -6,6 +6,7 @@ import type { Banner } from 'common/modules/ui/bannerPicker';
 import { signInGatePatientia } from 'common/modules/experiments/tests/sign-in-gate-patientia';
 import { signInGateMainVariant } from 'common/modules/experiments/tests/sign-in-gate-main-variant';
 import { signInGateMainControl } from 'common/modules/experiments/tests/sign-in-gate-main-control';
+import { signInGateDismissWindow } from 'common/modules/experiments/tests/sign-in-gate-dismiss-window';
 import { submitViewEventTracking } from './component-event-tracking';
 import { getVariant, isInTest, getTestforMultiTest } from './helper';
 import { withComponentId, componentName } from './component';
@@ -17,7 +18,12 @@ import type {
 } from './types';
 
 // if using multiple tests, then add them all in this array. (all the variant names in each test in the array must be unique)
-const tests = [signInGatePatientia, signInGateMainVariant, signInGateMainControl];
+const tests = [
+    signInGatePatientia,
+    signInGateMainVariant,
+    signInGateMainControl,
+    signInGateDismissWindow,
+];
 
 const canShow: () => Promise<boolean> = () =>
     new Promise(resolve => {

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
@@ -90,8 +90,9 @@ describe('Sign in gate test', () => {
 
     describe('canShow returns false', () => {
         it('should return false if not in correct test', () => {
-            // mock twice as we have 2 tests
+            // mock for each sign in gate test we have in experiments/tests
             fakeIsInABTestSynchronous
+                .mockReturnValueOnce(false)
                 .mockReturnValueOnce(false)
                 .mockReturnValueOnce(false)
                 .mockReturnValueOnce(false);

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/types.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/types.js
@@ -15,6 +15,7 @@ export type ComponentEventParams = {
     visitId?: string,
 };
 
+export type DismissalWindow = 'day' | 'dev';
 export type GateStatus = boolean | 'dismissed' | 'signed in';
 
 export type SignInGateVariant = {

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/dismiss-window/control.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/dismiss-window/control.js
@@ -1,0 +1,56 @@
+// @flow
+import type { CurrentABTest, SignInGateVariant } from '../../types';
+import { componentName } from '../../component';
+import {
+    hasUserDismissedGate,
+    isNPageOrHigherPageView,
+    isLoggedIn,
+    isInvalidArticleType,
+    isInvalidSection,
+    isIOS9,
+    setGatePageTargeting,
+} from '../../helper';
+
+// pull in the show method from the design folder, which has the html template and and click handlers etc.
+import { designShow } from '../design/main-variant';
+
+// define the variant name here
+const variant = 'dismiss-window-control'; // never reshow the gate once a user has dimissed it
+
+// method which returns a boolean determining if this variant can be shown on the current pageview
+const canShow: (name?: string) => boolean = (name = '') => {
+    const isGateDismissed = hasUserDismissedGate({
+        name,
+        variant,
+        componentName,
+    });
+
+    const canShowCheck =
+        !isGateDismissed &&
+        isNPageOrHigherPageView(3) &&
+        !isLoggedIn() &&
+        !isInvalidArticleType() &&
+        !isInvalidSection() &&
+        !isIOS9();
+
+    setGatePageTargeting(isGateDismissed, canShowCheck);
+    return canShowCheck;
+};
+
+// method which runs if the canShow method returns true, used to display the gate and logic associated with it
+// it returns a boolean, since the sign in gate is based on a `Banner` type who's show method returns a Promise<boolean>
+// in our case it returns true if the design ran successfully, and false if there were any problems encountered
+const show: ({
+    abTest: CurrentABTest,
+    guUrl: string,
+    signInUrl: string,
+    ophanComponentId: string,
+}) => boolean = ({ abTest, guUrl, signInUrl, ophanComponentId }) =>
+    designShow({ abTest, guUrl, signInUrl, ophanComponentId });
+
+// export the variant as a SignInGateVariant type
+export const signInGateVariant: SignInGateVariant = {
+    name: variant,
+    canShow,
+    show,
+};

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/dismiss-window/variant-1-article.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/dismiss-window/variant-1-article.js
@@ -1,0 +1,55 @@
+// @flow
+import type { CurrentABTest, SignInGateVariant } from '../../types';
+import { componentName } from '../../component';
+import {
+    isLoggedIn,
+    isNPageOrHigherPageView,
+    isInvalidArticleType,
+    isInvalidSection,
+    isIOS9,
+    setGatePageTargeting,
+    unsetUserDismissedGate,
+} from '../../helper';
+
+// pull in the show method from the design folder, which has the html template and and click handlers etc.
+import { designShow } from '../design/main-variant';
+
+// define the variant name here
+const variant = 'dismiss-window-variant-1-article'; // reshow the gate on every article, regardless if user has previously dismissed gate
+
+// method which returns a boolean determining if this variant can be shown on the current pageview
+const canShow: () => boolean = () => {
+    // clears any previous dismissal from gu.prefs.signin-gate
+    unsetUserDismissedGate({
+        componentName,
+    });
+
+    const canShowCheck =
+        isNPageOrHigherPageView(3) &&
+        !isLoggedIn() &&
+        !isInvalidArticleType() &&
+        !isInvalidSection() &&
+        !isIOS9();
+
+    // as we always show the gate irrespective of previous user dismissal, hardcode a "false" here
+    setGatePageTargeting(false, canShowCheck);
+    return canShowCheck;
+};
+
+// method which runs if the canShow method returns true, used to display the gate and logic associated with it
+// it returns a boolean, since the sign in gate is based on a `Banner` type who's show method returns a Promise<boolean>
+// in our case it returns true if the design ran successfully, and false if there were any problems encountered
+const show: ({
+    abTest: CurrentABTest,
+    guUrl: string,
+    signInUrl: string,
+    ophanComponentId: string,
+}) => boolean = ({ abTest, guUrl, signInUrl, ophanComponentId }) =>
+    designShow({ abTest, guUrl, signInUrl, ophanComponentId });
+
+// export the variant as a SignInGateVariant type
+export const signInGateVariant: SignInGateVariant = {
+    name: variant,
+    canShow,
+    show,
+};

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/dismiss-window/variant-2-day.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/dismiss-window/variant-2-day.js
@@ -1,0 +1,57 @@
+// @flow
+import type { CurrentABTest, SignInGateVariant } from '../../types';
+import { componentName } from '../../component';
+import {
+    hasUserDismissedGateInWindow,
+    isNPageOrHigherPageView,
+    isLoggedIn,
+    isInvalidArticleType,
+    isInvalidSection,
+    isIOS9,
+    setGatePageTargeting,
+} from '../../helper';
+
+// pull in the show method from the design folder, which has the html template and and click handlers etc.
+import { designShow } from '../design/main-variant';
+
+// define the variant name here
+const variant = 'dismiss-window-variant-2-day'; // reshow the gate 24 hrs (1 day) after last dismissal timestamp
+
+// method which returns a boolean determining if this variant can be shown on the current pageview
+const canShow: (name?: string) => boolean = (name = '') => {
+    const isGateDismissed = hasUserDismissedGateInWindow({
+        window: 'day',
+        name,
+        variant,
+        componentName,
+    });
+
+    const canShowCheck =
+        !isGateDismissed &&
+        isNPageOrHigherPageView(3) &&
+        !isLoggedIn() &&
+        !isInvalidArticleType() &&
+        !isInvalidSection() &&
+        !isIOS9();
+
+    setGatePageTargeting(isGateDismissed, canShowCheck);
+    return canShowCheck;
+};
+
+// method which runs if the canShow method returns true, used to display the gate and logic associated with it
+// it returns a boolean, since the sign in gate is based on a `Banner` type who's show method returns a Promise<boolean>
+// in our case it returns true if the design ran successfully, and false if there were any problems encountered
+const show: ({
+    abTest: CurrentABTest,
+    guUrl: string,
+    signInUrl: string,
+    ophanComponentId: string,
+}) => boolean = ({ abTest, guUrl, signInUrl, ophanComponentId }) =>
+    designShow({ abTest, guUrl, signInUrl, ophanComponentId });
+
+// export the variant as a SignInGateVariant type
+export const signInGateVariant: SignInGateVariant = {
+    name: variant,
+    canShow,
+    show,
+};

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/index.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/index.js
@@ -6,6 +6,9 @@ import { signInGateVariant as patientiaControl } from './patientia/control';
 import { signInGateVariant as patientiaVariant } from './patientia/variant';
 import { signInGateVariant as mainVariant } from './main/variant';
 import { signInGateVariant as mainControl } from './main/control';
+import { signInGateVariant as dismissWindowControl } from './dismiss-window/control';
+import { signInGateVariant as dismissWindowVariant1Article } from './dismiss-window/variant-1-article';
+import { signInGateVariant as dismissWindowVariant2Day } from './dismiss-window/variant-2-day';
 
 // to add a variant, first import the variant in the SignInGateVariant type, and then add to this exported array
 export const variants: Array<SignInGateVariant> = [
@@ -14,4 +17,7 @@ export const variants: Array<SignInGateVariant> = [
     patientiaVariant,
     mainVariant,
     mainControl,
+    dismissWindowControl,
+    dismissWindowVariant1Article,
+    dismissWindowVariant2Day,
 ];


### PR DESCRIPTION
## What does this change?
Adds the Dismiss Window Test for the Sign In Gate

- Show sign in gate to users on 3rd article view, then don't reshow (control)
- reshow next article (variant 1) - 
- reshow next day (variant 2)

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [x] On CODE (optional)
