### PR TITLE
Correct the html of the GuideAtom

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -329,12 +329,13 @@ object PageElement {
           }
 
           case Some(guide: GuideAtom) => {
+            val html = guide.data.items.map(item => s"${item.title.map( t => s"<p><strong>${t}</strong></p>" ).getOrElse("")}${item.body}").mkString("")
             Some(GuideAtomBlockElement(
               id = guide.id,
               label = guide.data.typeLabel.getOrElse("Quick Guide") ,
               title = guide.atom.title.getOrElse(""),
               img = guide.image.flatMap(ImgSrc.getAmpImageUrl),
-              html = guide.data.items.map(_.body).mkString(""),
+              html = html,
               credit = guide.credit.getOrElse("")
             ))
           }


### PR DESCRIPTION
## What does this change?

Update the html of the GuideAtom passed to DCR

Before:

![Before](https://user-images.githubusercontent.com/6035518/89903684-dc64b980-dbdf-11ea-9c09-4d2389a8344a.png)

After:

![After](https://user-images.githubusercontent.com/6035518/89903702-e1c20400-dbdf-11ea-9238-ad3c37db8f26.png)

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No

