### PR TITLE
Add 100% for sourcepoint CMP

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/cmp/sourcepoint.js
+++ b/static/src/javascripts/projects/commercial/modules/cmp/sourcepoint.js
@@ -7,9 +7,9 @@ import { isInTcfv2Test } from './tcfv2-test';
 let useSourcepointCmp;
 
 export const shouldUseSourcepointCmp = (): boolean => {
-    useSourcepointCmp =
-        (isInUsa() && config.get('switches.ccpaCmpUi', false)) ||
-        isInTcfv2Test();
+    useSourcepointCmp = isInUsa()
+        ? config.get('switches.ccpaCmpUi', false)
+        : isInTcfv2Test() || config.get('switches.tcfv2Frontend', false);
 
     return useSourcepointCmp;
 };


### PR DESCRIPTION
## What does this change?

add switch check as further condition for using new CMP

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes https://github.com/guardian/dotcom-rendering/pull/1797

## Screenshots

## What is the value of this and can you measure success?

can switch TCFv2 on

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
