### PR TITLE
Add browserId to Sourcepoint pubData

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.7",
-    "@guardian/consent-management-platform": "4.0.0-10",
+    "@guardian/consent-management-platform": "4.0.0-13",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/shimport": "^1.0.2",
     "@guardian/src-button": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.7",
-    "@guardian/consent-management-platform": "4.0.0-9",
+    "@guardian/consent-management-platform": "4.0.0-10",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/shimport": "^1.0.2",
     "@guardian/src-button": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.7",
-    "@guardian/consent-management-platform": "4.0.0-14",
+    "@guardian/consent-management-platform": "4.0.0-beta.0",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/shimport": "^1.0.2",
     "@guardian/src-button": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.7",
-    "@guardian/consent-management-platform": "4.0.0-13",
+    "@guardian/consent-management-platform": "4.0.0-14",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/shimport": "^1.0.2",
     "@guardian/src-button": "^0.16.1",

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -35,7 +35,11 @@ const go = () => {
         // Start CMP
         if (shouldUseSourcepointCmp()) {
             // CCPA and TCFv2
-            cmp.init({ pubData: config.get('guardian.config.ophan.browserId'), isInUsa: isInUsa() });
+            const browserId: string | void = config.get('guardian.config.ophan.browserId');
+            const pubData: { browserId?: string } | void = browserId
+                ? { browserId }
+                : undefined;
+            cmp.init({ pubData, isInUsa: isInUsa() });
         } else {
             // do nothing, TCFv1 CMP auto initialises
         }

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -35,7 +35,7 @@ const go = () => {
         // Start CMP
         if (shouldUseSourcepointCmp()) {
             // CCPA and TCFv2
-            cmp.init({ isInUsa: isInUsa() });
+            cmp.init({ pubData: config.get('guardian.config.ophan.browserId'), isInUsa: isInUsa() });
         } else {
             // do nothing, TCFv1 CMP auto initialises
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1163,10 +1163,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/consent-management-platform@4.0.0-10":
-  version "4.0.0-10"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.0-10.tgz#d34fafcd8c4dfd2fe301df3fbb283fa8007ad0d3"
-  integrity sha512-YwQVc1vNzA0YmXzbwQmW8MJmXKVkWR/clPTeV/eyaiK54d8ryydtEeFj3WU/3qTZapLy8x1mNAtfcaWeh078VA==
+"@guardian/consent-management-platform@4.0.0-14":
+  version "4.0.0-14"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.0-14.tgz#ee02f74ec22f0d7e6426ee5c0c0e96b884e4217d"
+  integrity sha512-4wtGYIsdtma+wT91rrqF7tvqPq4VqkdWQNOU2yNbxSsJwbGejo22Z0l+BkHyYIdXR76pNb/8zVTFR5HFREZYnQ==
   dependencies:
     "@guardian/old-cmp" "npm:@guardian/consent-management-platform@^3.4.10"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1163,10 +1163,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/consent-management-platform@4.0.0-14":
-  version "4.0.0-14"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.0-14.tgz#ee02f74ec22f0d7e6426ee5c0c0e96b884e4217d"
-  integrity sha512-4wtGYIsdtma+wT91rrqF7tvqPq4VqkdWQNOU2yNbxSsJwbGejo22Z0l+BkHyYIdXR76pNb/8zVTFR5HFREZYnQ==
+"@guardian/consent-management-platform@4.0.0-beta.0":
+  version "4.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.0-beta.0.tgz#d09d9ce569aa08b85ad97a342e95b8916f7b2fe7"
+  integrity sha512-2dwfDyewIv7c3/c3F5t6MX0fd7O+OCP3kcXZ6WZXwPaDs3aFomHwgTKDIXMf0ZFGOlTCItHVopL6xPOMMDXJeA==
   dependencies:
     "@guardian/old-cmp" "npm:@guardian/consent-management-platform@^3.4.10"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1163,12 +1163,12 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/consent-management-platform@4.0.0-9":
-  version "4.0.0-9"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.0-9.tgz#9335485e5b98c7771498dee2bb892a5f94e27b19"
-  integrity sha512-JL2LpgbUcYz488kBAmCAAn0t8NtmT8s4LDXd2sVvRhZAThG4evGyJDD1fI9FhBmwvhAukRaet2SPr52hxt7zUQ==
+"@guardian/consent-management-platform@4.0.0-10":
+  version "4.0.0-10"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.0-10.tgz#d34fafcd8c4dfd2fe301df3fbb283fa8007ad0d3"
+  integrity sha512-YwQVc1vNzA0YmXzbwQmW8MJmXKVkWR/clPTeV/eyaiK54d8ryydtEeFj3WU/3qTZapLy8x1mNAtfcaWeh078VA==
   dependencies:
-    "@guardian/old-cmp" "npm:@guardian/consent-management-platform@^3.4.9"
+    "@guardian/old-cmp" "npm:@guardian/consent-management-platform@^3.4.10"
 
 "@guardian/dotcom-rendering@git://github.com/guardian/dotcom-rendering.git#version-1-alpha":
   version "0.1.0-alpha"
@@ -1182,10 +1182,10 @@
     inquirer "^5.2.0"
     pretty-bytes "^4.0.2"
 
-"@guardian/old-cmp@npm:@guardian/consent-management-platform@^3.4.9":
-  version "3.4.9"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-3.4.9.tgz#6bd6108e12cb122c4a1fcba4ae657f4d0b67ad0b"
-  integrity sha512-9TRCahVCILDvD78xQpADaZMqqUZM1opsBXKPasVdEt3hnRyMwVB+l68DpydIEK8DZE9S2jxbuqtOEKrci/qMsw==
+"@guardian/old-cmp@npm:@guardian/consent-management-platform@^3.4.10":
+  version "3.4.10"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-3.4.10.tgz#604e71d27c6bfa4664c83c55578a8aa73ff09d82"
+  integrity sha512-P3dTf9EqYhpH7JQ+Bg9MNoIQ08U4yD5j+s5epO9mNTaIBiX1BeOF3RcI3KNj/dBxSggaut0rBdQ82GN54Bg4jA==
   dependencies:
     consent-string "1.5.2"
     js-cookie "2.2.1"


### PR DESCRIPTION
## What does this change?

This updates the `consent-management-platform` version to an inital `beta` release which accepts `pubData`.

This adds `browserId` via the `pubData` object upon initialisation of the CMP. This allows us to track consent on a per browser/user basis and will then be used for reporting.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

A smiliar PR will appear for DCR.

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->

@guardian/commercial-dev 