### PR TITLE
Restrict affiliate links to older content

### DIFF
--- a/applications/app/views/package.scala
+++ b/applications/app/views/package.scala
@@ -39,7 +39,8 @@ object GalleryCaptionCleaners {
         page.gallery.content.fields.showAffiliateLinks,
         "gallery",
         appendDisclaimer = Some(isFirstRow && page.item.lightbox.containsAffiliateableLinks),
-        tags = page.gallery.content.tags.tags.map(_.id)))
+        tags = page.gallery.content.tags.tags.map(_.id),
+        page.gallery.content.fields.firstPublicationDate))
 
     val cleanedHtml = cleaners.foldLeft(Jsoup.parseBodyFragment(caption)) { case (html, cleaner) => cleaner.clean(html) }
     cleanedHtml.outputSettings().prettyPrint(false)

--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -512,7 +512,8 @@ object DotcomponentsDataModel {
       supportedSections = affiliateLinks.affiliateLinkSections,
       defaultOffTags = affiliateLinks.defaultOffTags,
       alwaysOffTags = affiliateLinks.alwaysOffTags,
-      tagPaths = article.content.tags.tags.map(_.id)
+      tagPaths = article.content.tags.tags.map(_.id),
+      firstPublishedDate = article.content.fields.firstPublicationDate
     )
 
     val bodyBlocksRaw = page match {

--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -77,10 +77,10 @@ object BodyProcessor {
       MinuteCleaner(article),
       GarnettQuoteCleaner,
       AffiliateLinksCleaner(
-        request.uri,
-        article.content.metadata.sectionId,
-        article.content.fields.showAffiliateLinks,
-        "article",
+        pageUrl = request.uri,
+        sectionId = article.content.metadata.sectionId,
+        showAffiliateLinks = article.content.fields.showAffiliateLinks,
+        contentType = "article",
         tags = article.content.tags.tags.map(_.id),
         publishedDate = article.content.fields.firstPublicationDate)
     ) ++

--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -76,7 +76,13 @@ object BodyProcessor {
       TimestampCleaner(article),
       MinuteCleaner(article),
       GarnettQuoteCleaner,
-      AffiliateLinksCleaner(request.uri, article.content.metadata.sectionId, article.content.fields.showAffiliateLinks, "article", tags = article.content.tags.tags.map(_.id))
+      AffiliateLinksCleaner(
+        request.uri,
+        article.content.metadata.sectionId,
+        article.content.fields.showAffiliateLinks,
+        "article",
+        tags = article.content.tags.tags.map(_.id),
+        publishedDate = article.content.fields.firstPublicationDate)
     ) ++
       ListIf(true)(VideoEmbedCleaner(article))
   }

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -904,7 +904,7 @@ object AffiliateLinksCleaner {
     tagPaths: List[String],
     firstPublishedDate: Option[DateTime]
   ): Boolean = {
-    val publishedCutOffDate = new DateTime(2020, 7, 15, 0, 0)
+    val publishedCutOffDate = new DateTime(2020, 7, 14, 0, 0)
 
     // Never include affiliate links if it is tagged with an always off tag, or if it was published before our cut off
     // date. The cut off date is to avoid needing consent, although this is not intended to be permanent

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -15,6 +15,7 @@ import model._
 import model.content._
 import model.dotcomrendering.pageElements.{PageElement, TextBlockElement}
 import navigation.ReaderRevenueSite
+import org.joda.time.DateTime
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element, TextNode}
 import play.api.mvc.RequestHeader
@@ -836,11 +837,12 @@ case class AffiliateLinksCleaner(
                                   showAffiliateLinks: Option[Boolean],
                                   contentType: String,
                                   appendDisclaimer: Option[Boolean] = None,
-                                  tags: List[String]) extends HtmlCleaner with Logging {
+                                  tags: List[String],
+                                  publishedDate: Option[DateTime]) extends HtmlCleaner with Logging {
 
   override def clean(document: Document): Document = {
     if (AffiliateLinks.isSwitchedOn && AffiliateLinksCleaner.shouldAddAffiliateLinks(AffiliateLinks.isSwitchedOn,
-      sectionId, showAffiliateLinks, affiliateLinkSections, defaultOffTags, alwaysOffTags, tags)) {
+      sectionId, showAffiliateLinks, affiliateLinkSections, defaultOffTags, alwaysOffTags, tags, publishedDate)) {
       AffiliateLinksCleaner.replaceLinksInHtml(document, pageUrl, appendDisclaimer, contentType, skimlinksId)
     } else document
   }
@@ -899,9 +901,14 @@ object AffiliateLinksCleaner {
     supportedSections: Set[String],
     defaultOffTags: Set[String],
     alwaysOffTags: Set[String],
-    tagPaths: List[String]
+    tagPaths: List[String],
+    firstPublishedDate: Option[DateTime]
   ): Boolean = {
-    if (!contentHasAlwaysOffTag(tagPaths, alwaysOffTags)) {
+    val publishedCutOffDate = new DateTime(2020, 7, 15, 0, 0)
+
+    // Never include affiliate links if it is tagged with an always off tag, or if it was published before our cut off
+    // date. The cut off date is to avoid needing consent, although this is not intended to be permanent
+    if (!contentHasAlwaysOffTag(tagPaths, alwaysOffTags) && firstPublishedDate.exists(_.isBefore(publishedCutOffDate))) {
       if (showAffiliateLinks.isDefined) {
         showAffiliateLinks.contains(true)
       } else {

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -904,7 +904,7 @@ object AffiliateLinksCleaner {
     tagPaths: List[String],
     firstPublishedDate: Option[DateTime]
   ): Boolean = {
-    val publishedCutOffDate = new DateTime(2020, 7, 14, 0, 0)
+    val publishedCutOffDate = new DateTime(2020, 8, 14, 0, 0)
 
     // Never include affiliate links if it is tagged with an always off tag, or if it was published before our cut off
     // date. The cut off date is to avoid needing consent, although this is not intended to be permanent

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -907,7 +907,7 @@ object AffiliateLinksCleaner {
     val publishedCutOffDate = new DateTime(2020, 8, 14, 0, 0)
 
     // Never include affiliate links if it is tagged with an always off tag, or if it was published before our cut off
-    // date. The cut off date is to avoid needing consent, although this is not intended to be permanent
+    // date. The cut off date is temporary while we are working on improving the compliance of affiliate links
     if (!contentHasAlwaysOffTag(tagPaths, alwaysOffTags) && firstPublishedDate.exists(_.isBefore(publishedCutOffDate))) {
       if (showAffiliateLinks.isDefined) {
         showAffiliateLinks.contains(true)

--- a/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
+++ b/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
@@ -13,8 +13,8 @@ class AffiliateLinksCleanerTest extends FlatSpec with Matchers {
 
   "shouldAddAffiliateLinks" should "correctly determine when to add affiliate links" in {
     val supportedSections = Set("film", "books", "fashion")
-    val oldPublishedDate = Some(new DateTime(2020, 7, 13, 0, 0))
-    val newPublishedDate = Some(new DateTime(2020, 7, 15, 0, 0))
+    val oldPublishedDate = Some(new DateTime(2020, 8, 13, 0, 0))
+    val newPublishedDate = Some(new DateTime(2020, 8, 15, 0, 0))
 
     shouldAddAffiliateLinks(switchedOn = false, "film", None, supportedSections, Set.empty, Set.empty, List.empty, oldPublishedDate) should be (false)
     shouldAddAffiliateLinks(switchedOn = true, "film", None, supportedSections, Set.empty, Set.empty, List.empty, oldPublishedDate) should be (true)

--- a/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
+++ b/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
@@ -1,4 +1,5 @@
 package views.support.cleaner
+import org.joda.time.DateTime
 import org.scalatest.{FlatSpec, Matchers}
 import views.support.AffiliateLinksCleaner._
 
@@ -12,14 +13,18 @@ class AffiliateLinksCleanerTest extends FlatSpec with Matchers {
 
   "shouldAddAffiliateLinks" should "correctly determine when to add affiliate links" in {
     val supportedSections = Set("film", "books", "fashion")
-    shouldAddAffiliateLinks(switchedOn = false, "film", None, supportedSections, Set.empty, Set.empty, List.empty ) should be (false)
-    shouldAddAffiliateLinks(switchedOn = true, "film", None, supportedSections, Set.empty, Set.empty, List.empty) should be (true)
-    shouldAddAffiliateLinks(switchedOn = true, "film", Some(false), supportedSections, Set.empty, Set.empty, List.empty) should be (false)
-    shouldAddAffiliateLinks(switchedOn = true, "news", Some(true), supportedSections, Set.empty, Set.empty, List.empty) should be (true)
-    shouldAddAffiliateLinks(switchedOn = true, "news", None, supportedSections, Set("bereavement"), Set.empty, List("bereavement")) should be (false)
-    shouldAddAffiliateLinks(switchedOn = true, "news", None, supportedSections, Set("bereavement"), Set.empty, List("tech")) should be (false)
-    shouldAddAffiliateLinks(switchedOn = true, "fashion", None, supportedSections, Set("bereavement"), Set.empty, List("tech")) should be (true)
-    shouldAddAffiliateLinks(switchedOn = true, "fashion", Some(true), supportedSections, Set.empty, Set("bereavement"), List("bereavement")) should be (false)
-    shouldAddAffiliateLinks(switchedOn = true, "fashion", Some(true), supportedSections, Set.empty, Set("bereavement"), List("tech")) should be (true)
+    val oldPublishedDate = Some(new DateTime(2020, 7, 14, 0, 0))
+    val newPublishedDate = Some(new DateTime(2020, 7, 15, 0, 0))
+
+    shouldAddAffiliateLinks(switchedOn = false, "film", None, supportedSections, Set.empty, Set.empty, List.empty, oldPublishedDate) should be (false)
+    shouldAddAffiliateLinks(switchedOn = true, "film", None, supportedSections, Set.empty, Set.empty, List.empty, oldPublishedDate) should be (true)
+    shouldAddAffiliateLinks(switchedOn = true, "film", Some(false), supportedSections, Set.empty, Set.empty, List.empty, oldPublishedDate) should be (false)
+    shouldAddAffiliateLinks(switchedOn = true, "news", Some(true), supportedSections, Set.empty, Set.empty, List.empty, oldPublishedDate) should be (true)
+    shouldAddAffiliateLinks(switchedOn = true, "news", None, supportedSections, Set("bereavement"), Set.empty, List("bereavement"), oldPublishedDate) should be (false)
+    shouldAddAffiliateLinks(switchedOn = true, "news", None, supportedSections, Set("bereavement"), Set.empty, List("tech"), oldPublishedDate) should be (false)
+    shouldAddAffiliateLinks(switchedOn = true, "fashion", None, supportedSections, Set("bereavement"), Set.empty, List("tech"), oldPublishedDate) should be (true)
+    shouldAddAffiliateLinks(switchedOn = true, "fashion", Some(true), supportedSections, Set.empty, Set("bereavement"), List("bereavement"), oldPublishedDate) should be (false)
+    shouldAddAffiliateLinks(switchedOn = true, "fashion", Some(true), supportedSections, Set.empty, Set("bereavement"), List("tech"), oldPublishedDate) should be (true)
+    shouldAddAffiliateLinks(switchedOn = true, "fashion", Some(true), supportedSections, Set.empty, Set("bereavement"), List("tech"), newPublishedDate) should be (false)
   }
 }

--- a/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
+++ b/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
@@ -13,7 +13,7 @@ class AffiliateLinksCleanerTest extends FlatSpec with Matchers {
 
   "shouldAddAffiliateLinks" should "correctly determine when to add affiliate links" in {
     val supportedSections = Set("film", "books", "fashion")
-    val oldPublishedDate = Some(new DateTime(2020, 7, 14, 0, 0))
+    val oldPublishedDate = Some(new DateTime(2020, 7, 13, 0, 0))
     val newPublishedDate = Some(new DateTime(2020, 7, 15, 0, 0))
 
     shouldAddAffiliateLinks(switchedOn = false, "film", None, supportedSections, Set.empty, Set.empty, List.empty, oldPublishedDate) should be (false)


### PR DESCRIPTION
## What does this change?
Removes affiliate links from any content with a first published date from Friday August 14th onwards. We're doing this in the short term while we improve the compliance of affiliate links. This will only be temporary.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No (already part of this)
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
N/
N/A

## What is the value of this and can you measure success?
Better compliance with regulatory requirements

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
