### PR TITLE
Update initialisation of CMP to take bwid directly

### DIFF
--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -12,6 +12,7 @@ import reportError from 'lib/report-error';
 import { cmp } from '@guardian/consent-management-platform';
 import { isInUsa } from 'projects/common/modules/commercial/geo-utils.js';
 import { shouldUseSourcepointCmp } from 'commercial/modules/cmp/sourcepoint';
+import { getCookie } from 'lib/cookies';
 import 'projects/commercial/modules/cmp/stub';
 
 // Let webpack know where to get files from
@@ -35,7 +36,7 @@ const go = () => {
         // Start CMP
         if (shouldUseSourcepointCmp()) {
             // CCPA and TCFv2
-            const browserId: string | void = config.get('guardian.config.ophan.browserId');
+            const browserId: ?string = getCookie('bwid');
             const pubData: { browserId?: string } | void = browserId
                 ? { browserId }
                 : undefined;


### PR DESCRIPTION
## What does this change?

This updates the initialisation of the CMP via the init function to take the browserId directly from the `bwid` cookie; it seems that the code to update the `guardian.config.ophan.browserId` happens in the non-blocking part of the code at the very end of the page, meaning that the initialisation seems to happen before the setting of the value.

You can see the code to set the `guradian.config.ophan.browserId` here:

https://github.com/guardian/frontend/blob/master/common/app/templates/inlineJS/nonBlocking/ophanConfig.scala.js

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->

@guardian/commercial-dev 