### PR TITLE
Bump Ophan Tracker JS to trim huge component names

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "fence": "guardian/fence#0.2.11",
     "lodash": "^4.17.13",
     "object-fit-videos": "^1.0.3",
-    "ophan-tracker-js": "1.3.21",
+    "ophan-tracker-js": "1.3.22",
     "preact": "^8.2.9",
     "preact-compat": "^3.18.4",
     "prebid.js": "https://github.com/guardian/Prebid.js#681fbb",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8223,10 +8223,10 @@ openurl@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/openurl/-/openurl-1.1.1.tgz#3875b4b0ef7a52c156f0db41d4609dbb0f94b387"
 
-ophan-tracker-js@1.3.21:
-  version "1.3.21"
-  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.21.tgz#b81463c1b96249e32f28ff42aa433ed00f143cc0"
-  integrity sha512-hroyMjdQbx3ywDJmYsCpY2Qcff1aYmH5M0wZSi56smSPUHP0SziRaMJx34G9rEKR8UL6EBUO6KIHSYyKcto5hg==
+ophan-tracker-js@1.3.22:
+  version "1.3.22"
+  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.22.tgz#1ce0ce5066ff8230edc97c2105f9b52b95c1efb4"
+  integrity sha512-UNTMjo/cEyHy7BfsrAs250Q7ujElYd6RqmAIb/+aoAT9oduHZ2giJ9nJMcd5qC83U4EP8adh9gcY+dGgJsEEBQ==
 
 opn@5.3.0:
   version "5.3.0"


### PR DESCRIPTION
## What does this change?

With [this PR](https://github.com/guardian/ophan/pull/3903) in the Ophan repo, we update OPhan tracker JS to truncate `renderedComponent` names to a maximum length of 50 characters, to keep requests to ophan.theguardian.com shorter than the 2,000 character URL-length limit enforced by Akka HTTP.

The updated Ophan Tracker JS library has been [published on NPM](https://www.npmjs.com/package/ophan-tracker-js/v/1.3.22.). 

## Does this change need to be reproduced in dotcom-rendering ?

This will be necessary anywhere that a Guardian Labs component might be rendered on a page (because they are sending `renderedComponent` names of ~200 characters each). 

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation) - we will open a PR against https://github.com/guardian/dotcom-rendering

## Screenshots

## What is the value of this and can you measure success?
This fixes issue https://github.com/guardian/ophan/issues/3786 and will improve user experience, as users will be transmitting less data to Ophan. 

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
