### PR TITLE
Bump CMP

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.7",
-    "@guardian/consent-management-platform": "4.0.1",
+    "@guardian/consent-management-platform": "4.0.2",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/shimport": "^1.0.2",
     "@guardian/src-button": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.7",
-    "@guardian/consent-management-platform": "4.0.1-3",
+    "@guardian/consent-management-platform": "4.0.1",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/shimport": "^1.0.2",
     "@guardian/src-button": "^0.16.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1163,10 +1163,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/consent-management-platform@4.0.1-3":
-  version "4.0.1-3"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.1-3.tgz#3c29aea3d2f9551bb1a42a784d5ae46f97a9ae6c"
-  integrity sha512-QSSVZO/gAclMKNfmaDVJwnZuRmmL9O7uqu1F+aueJ8OGc3BxbYuKQmThbxFo5MG4y3teG65ZFo8S26EZimzhcQ==
+"@guardian/consent-management-platform@4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.1.tgz#49d9f714367c16aa23bb9cf45c4d1eac4c01bb72"
+  integrity sha512-8t/Pizc8NUqKj7TUxQI1YRFAClBsPBQvT915gjvAP+flTpgQUJN2cwnnJqypvJeWH0LF8WhO7B3zhq2ADK/YeQ==
   dependencies:
     "@guardian/old-cmp" "npm:@guardian/consent-management-platform@^3.4.10"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1163,10 +1163,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/consent-management-platform@4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.1.tgz#49d9f714367c16aa23bb9cf45c4d1eac4c01bb72"
-  integrity sha512-8t/Pizc8NUqKj7TUxQI1YRFAClBsPBQvT915gjvAP+flTpgQUJN2cwnnJqypvJeWH0LF8WhO7B3zhq2ADK/YeQ==
+"@guardian/consent-management-platform@4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-4.0.2.tgz#a8ec4315e68e15902bac0d3bcd99675b546ed353"
+  integrity sha512-FhdhgzJ2+6Jpzo+QjLQUEXOxDK70D9DIfSvf5JTdX8yqAj0fptqPTPayBujqdLT5wYRUmqFN07kg76verh1CXg==
   dependencies:
     "@guardian/old-cmp" "npm:@guardian/consent-management-platform@^3.4.10"
 


### PR DESCRIPTION
## What does this change?

bumps CMP to same version as DCR

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes https://github.com/guardian/dotcom-rendering/pull/1833

## Why?

it might fix ads in the US...

