### PR TITLE
Create privacy switches

### DIFF
--- a/common/app/conf/switches/PrivacySwitches.scala
+++ b/common/app/conf/switches/PrivacySwitches.scala
@@ -3,7 +3,6 @@ package conf.switches
 import conf.switches.Expiry.never
 import conf.switches.Owner.group
 import conf.switches.SwitchGroup.{Privacy}
-import org.joda.time.LocalDate
 
 trait PrivacySwitches {
 

--- a/common/app/conf/switches/PrivacySwitches.scala
+++ b/common/app/conf/switches/PrivacySwitches.scala
@@ -1,0 +1,39 @@
+package conf.switches
+
+import conf.switches.Expiry.never
+import conf.switches.Owner.group
+import conf.switches.SwitchGroup.{Privacy}
+import org.joda.time.LocalDate
+
+trait PrivacySwitches {
+
+  val Cmp = Switch(
+    SwitchGroup.Privacy,
+    "consent-management",
+    "Enable consent management. Individual frameworks will also need to be switched on.",
+    owners = group(Commercial),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
+  val TCFv2 = Switch(
+    SwitchGroup.Privacy,
+    "framework-tcfv2",
+    "Enable the TCFv2 framework (if consent-management is on).",
+    owners = group(Commercial),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
+  val CCPA = Switch(
+    SwitchGroup.Privacy,
+    "framework-ccpa",
+    "Enable the CCPA framework (if consent-management is on).",
+    owners = group(Commercial),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+}

--- a/common/app/conf/switches/PrivacySwitches.scala
+++ b/common/app/conf/switches/PrivacySwitches.scala
@@ -2,7 +2,7 @@ package conf.switches
 
 import conf.switches.Expiry.never
 import conf.switches.Owner.group
-import conf.switches.SwitchGroup.{Privacy}
+import conf.switches.SwitchGroup.{Privacy,Commercial}
 
 trait PrivacySwitches {
 

--- a/common/app/conf/switches/Switches.scala
+++ b/common/app/conf/switches/Switches.scala
@@ -34,6 +34,7 @@ object SwitchGroup {
   val ServerSideExperiments = SwitchGroup("Server-side Experiments")
   val Membership = SwitchGroup("Membership")
   val Journalism = SwitchGroup("Journalism")
+  val Privacy = SwitchGroup("Privacy")
 }
 
 
@@ -156,6 +157,7 @@ with ServerSideExperimentSwitches
 with FaciaSwitches
 with ABTestSwitches
 with CommercialSwitches
+with PrivacySwitches
 with PrebidSwitches
 with DiscussionSwitches
 with PerformanceSwitches


### PR DESCRIPTION
## What does this change?

- adds a `Privacy` section to the switchboard
- adds 3 CMP-related switches to the new section

this paves the way to removing all the other cmp/tcf/ccpa-related switches already on there in commercial and feature sections.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

