### PR TITLE
Add timeline to ArticlePicker

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -53,7 +53,7 @@ object ArticlePageChecks {
       case ContentAtomBlockElement(_, atomtype) => {
         // ContentAtomBlockElement was expanded to include atomtype.
         // To support an atom type, just add it to supportedAtomTypes
-        val supportedAtomTypes = List("explainer", "interactive", "qanda", "guide")
+        val supportedAtomTypes = List("explainer", "interactive", "qanda", "guide", "timeline")
         !supportedAtomTypes.contains(atomtype)
       }
       case _ => true


### PR DESCRIPTION
## What does this change?
This adds timelines to the list of allowed atoms from atoms-rendering.

![Screenshot 2020-08-14 at 14 53 19](https://user-images.githubusercontent.com/35331926/90410949-f0f2f700-e0a2-11ea-88bf-434bb98744ce.png)

![Screenshot 2020-08-14 at 14 53 54](https://user-images.githubusercontent.com/35331926/90410964-f4867e00-e0a2-11ea-9b9a-0752caa1625f.png)




