### PR TITLE
Expand remote epic variants test to 20%

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -152,7 +152,7 @@ trait ABTestSwitches {
     "Serve epics from remote service for subset of audience",
     owners = Seq(Owner.withGithub("nicl")),
     safeState = Off,
-    sellByDate = new LocalDate(2020, 8, 24),
+    sellByDate = new LocalDate(2020, 9, 8),
     exposeClientSide = true,
   )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/remote-epic-variants.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/remote-epic-variants.js
@@ -1,8 +1,6 @@
 // @flow
 
 import { fetchAndRenderEpic } from "common/modules/commercial/contributions-service";
-import { getSync as geolocationGetSync } from 'lib/geolocation';
-import config from 'lib/config';
 
 const id = 'RemoteEpicVariants';
 
@@ -15,7 +13,7 @@ const remoteVariant: Variant = {
 export const remoteEpicVariants: Runnable<AcquisitionsABTest> = {
     id,
     start: '2020-05-01',
-    expiry: '2020-09-06',
+    expiry: '2020-09-08',
     author: "Nicolas Long",
     description: "Pseudo-test to use remote service for % of contribution epics. Expected to run as highest priority test; the canRun will then narrow the audience.",
     audience: 1,
@@ -23,15 +21,7 @@ export const remoteEpicVariants: Runnable<AcquisitionsABTest> = {
     successMeasure: "Revenue/impressions equivalent to local variants",
     audienceCriteria: "All",
     variants: [remoteVariant],
-    canRun: () => {
-        // Delay geolocation due to known race condition
-        // https://github.com/guardian/frontend/pull/22322
-        const geolocation = geolocationGetSync();
-        return config.get("switches.abRemoteEpicVariants") && geolocation !== 'AU' && Math.random() < 0.01// set test % here
-    }
-
-    ,
-
+    canRun: () =>  Math.random() < 0.2, // set test % here
     variantToRun: remoteVariant,
     showForSensitive: true, // there is special targeting logic around this so we don't set to false here
 


### PR DESCRIPTION
## What does this change?

Expand remote epic variants test to 20%.

Australia is also no longer excluded - as the Australia moment has ended.

Lastly, the switch expiry has also been updated to align with the client side definition.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

To validate the remote epic across all variants.
