### PR TITLE
Add tag links to DCR

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -434,17 +434,19 @@ object DotcomponentsDataModel {
   }
 
   private def blockElementsToPageElements(capiElems: Seq[ClientBlockElement], request: RequestHeader, article: Article, affiliateLinks: Boolean, isMainBlock: Boolean, isImmersive: Boolean, campaigns: Option[JsValue], calloutsUrl: Option[String]): List[PageElement] = {
-    val atoms: Iterable[Atom] = article.content.atoms.map(_.all).getOrElse(Seq())
+    val edition = Edition.apply(request)
+
     val elems = capiElems.toList.flatMap(el => PageElement.make(
       element = el,
-      addAffiliateLinks = affiliateLinks,
       pageUrl = request.uri,
-      atoms = atoms,
+      article = article,
+      addAffiliateLinks = affiliateLinks,
       isMainBlock,
-      isImmersive,
       campaigns,
-      calloutsUrl
+      calloutsUrl,
+      edition
     )).filter(PageElement.isSupported)
+
     addDisclaimer(elems, capiElems, affiliateLinks)
   }
 

--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -58,7 +58,7 @@ object BodyProcessor {
       R2VideoCleaner,
       PictureCleaner(article),
       DropCaps(article.tags.isComment || article.tags.isFeature, article.isImmersive),
-      TagLinker(article),
+      TagLinker(article.tags, article.content.showInRelated),
       ImmersiveHeaders(article.isImmersive),
       FigCaptionCleaner,
       RichLinkCleaner(),

--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -24,7 +24,7 @@ trait LinkTo extends Logging {
   def apply(html: Html)(implicit request: RequestHeader): String = this(html.toString(), Edition(request))
   def apply(link: String)(implicit request: RequestHeader): String = this(link, Edition(request))
 
-  def apply(url: String, edition: Edition)(implicit request: RequestHeader): String =
+  def apply(url: String, edition: Edition): String =
     processUrl(url.trim, edition).url
 
   def apply(trail: Trail)(implicit request: RequestHeader): Option[String] = Option(apply(trail.metadata.url))

--- a/common/app/model/dotcomrendering/pageElements/Cleaners.scala
+++ b/common/app/model/dotcomrendering/pageElements/Cleaners.scala
@@ -1,0 +1,32 @@
+package model.dotcomrendering.pageElements
+
+import common.Edition
+import org.jsoup.Jsoup
+import views.support.{AffiliateLinksCleaner, TagLinker}
+import conf.Configuration.{affiliateLinks => affiliateLinksConfig}
+import model.Tags
+
+object Cleaners {
+
+  def affiliateLinks(pageUrl: String)(el: TextBlockElement): TextBlockElement = {
+    val doc = Jsoup.parseBodyFragment(el.html)
+    val links = AffiliateLinksCleaner.getAffiliateableLinks(doc)
+    links.foreach(el => {
+      val id = affiliateLinksConfig.skimlinksId
+      el.attr("href", AffiliateLinksCleaner.linkToSkimLink(el.attr("href"), pageUrl, id))
+    })
+
+    if (links.nonEmpty) {
+      TextBlockElement(doc.body().html())
+    } else {
+      el
+    }
+  }
+
+  def tagLinks(tags: Tags, showInRelated: Boolean, edition: Edition)(el: TextBlockElement): TextBlockElement = {
+    val cleaner = TagLinker(tags, showInRelated)(edition)
+    val doc = Jsoup.parseBodyFragment(el.html)
+    val withLinks = cleaner.clean(doc)
+    TextBlockElement(withLinks.body().html())
+  }
+}

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -208,7 +208,8 @@ object PageElement {
           BlockquoteBlockElement(blockquote)
         case (_, para) =>
           val tagLinks = Cleaners.tagLinks(article.tags, article.content.showInRelated, edition) _
-          val transforms = if (addAffiliateLinks) Cleaners.affiliateLinks(pageUrl) _ andThen tagLinks else tagLinks
+          val affiliateLinks = Cleaners.affiliateLinks(pageUrl) _
+          val transforms = if (addAffiliateLinks) affiliateLinks andThen tagLinks else tagLinks
           transforms(TextBlockElement(para))
         }
       }

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -1,17 +1,18 @@
 package model.dotcomrendering.pageElements
 
-import java.net.{URLEncoder}
+import java.net.URLEncoder
 
 import com.gu.contentapi.client.model.v1.ElementType.{Map => _, _}
 import com.gu.contentapi.client.model.v1.{ElementType, SponsorshipType, BlockElement => ApiBlockElement, Sponsorship => ApiSponsorship}
+import common.Edition
 import conf.Configuration
-import layout.ContentWidths.{DotcomRenderingImageRoleWidthByBreakpointMapping}
+import layout.ContentWidths.DotcomRenderingImageRoleWidthByBreakpointMapping
 import model.content._
-import model.{AudioAsset, ImageAsset, ImageMedia, VideoAsset}
+import model.{Article, AudioAsset, ImageAsset, ImageMedia, VideoAsset}
 import org.jsoup.Jsoup
 import play.api.libs.json._
 import views.support.cleaner.SoundcloudHelper
-import views.support.{AffiliateLinksCleaner, ImgSrc, SrcSet}
+import views.support.{ImgSrc, SrcSet}
 
 import scala.collection.JavaConverters._
 
@@ -175,7 +176,20 @@ object PageElement {
     }
   }
 
-  def make(element: ApiBlockElement, addAffiliateLinks: Boolean, pageUrl: String, atoms: Iterable[Atom], isMainBlock: Boolean, isImmersive: Boolean, campaigns: Option[JsValue], calloutsUrl: Option[String]): List[PageElement] = {
+  def make(
+    element: ApiBlockElement,
+    pageUrl: String,
+    article: Article,
+    addAffiliateLinks: Boolean,
+    isMainBlock: Boolean,
+    campaigns: Option[JsValue],
+    calloutsUrl: Option[String],
+    edition: Edition
+  ): List[PageElement] = {
+
+    val atoms = article.content.atoms.map(_.all).getOrElse(Seq())
+    val isImmersive = article.isImmersive
+
     def extractAtom: Option[Atom] = for {
       contentAtom <- element.contentAtomTypeData
       atom <- atoms.find(_.id == contentAtom.atomId)
@@ -186,12 +200,16 @@ object PageElement {
       case Text => for {
         block <- element.textTypeData.toList
         text <- block.html.toList
-        element <- Cleaner.split(text)
+        element <- HTML.tags(text)
       } yield { element match {
-        case ("h2", heading) => SubheadingBlockElement(heading)
-        case ("blockquote", blockquote) => BlockquoteBlockElement(blockquote)
-        case (_ , para) if (addAffiliateLinks) => AffiliateLinksCleaner.replaceLinksInElement(para, pageUrl = pageUrl, contentType = "article")
-        case (_, para) => TextBlockElement(para)
+        case ("h2", heading) =>
+          SubheadingBlockElement(heading)
+        case ("blockquote", blockquote) =>
+          BlockquoteBlockElement(blockquote)
+        case (_, para) =>
+          val tagLinks = Cleaners.tagLinks(article.tags, article.content.showInRelated, edition) _
+          val transforms = if (addAffiliateLinks) Cleaners.affiliateLinks(pageUrl) _ andThen tagLinks else tagLinks
+          transforms(TextBlockElement(para))
         }
       }
 
@@ -638,8 +656,8 @@ object PageElement {
 // Misc.
 // ------------------------------------------------------
 
-object Cleaner{
-  def split(html: String):List[(String, String)] = {
+object HTML {
+  def tags(html: String): List[(String, String)] = {
     Jsoup
       .parseBodyFragment(html)
       .body()

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -13,7 +13,6 @@ import layout.ContentWidths
 import layout.ContentWidths._
 import model._
 import model.content._
-import model.dotcomrendering.pageElements.{PageElement, TextBlockElement}
 import navigation.ReaderRevenueSite
 import org.joda.time.DateTime
 import org.jsoup.Jsoup
@@ -862,19 +861,6 @@ object AffiliateLinksCleaner {
     val shouldAppendDisclaimer = appendDisclaimer.getOrElse(linksToReplace.nonEmpty)
     if (shouldAppendDisclaimer) insertAffiliateDisclaimer(html, contentType)
     else html
-  }
-
-  def replaceLinksInElement(html: String, pageUrl: String, contentType: String): TextBlockElement
-  = {
-    val doc = Jsoup.parseBodyFragment(html)
-    val linksToReplace: mutable.Seq[Element] = getAffiliateableLinks(doc)
-    linksToReplace.foreach{el => el.attr("href", linkToSkimLink(el.attr("href"), pageUrl, skimlinksId))}
-
-    if (linksToReplace.nonEmpty) {
-        TextBlockElement(doc.body().html())
-    } else {
-        TextBlockElement(html)
-    }
   }
 
   def isAffiliatable(element: Element): Boolean =

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -331,7 +331,7 @@ class TweetCleaner(content: Content) extends HtmlCleaner {
   }
 }
 
-case class TagLinker(article: Article)(implicit val edition: Edition, implicit val request: RequestHeader) extends HtmlCleaner{
+case class TagLinker(tags: Tags, showInRelated: Boolean)(implicit val edition: Edition) extends HtmlCleaner{
 
   private val group1 = "$1"
   private val group2 = "$2"
@@ -348,7 +348,7 @@ case class TagLinker(article: Article)(implicit val edition: Edition, implicit v
 
   def clean(doc: Document): Document = {
 
-    if (article.content.showInRelated) {
+    if (showInRelated) {
 
       // Get all paragraphs which are not contained in a pullquote or in an instagram caption
       val paragraphs = doc.getElementsByTag("p").asScala.filterNot( p =>
@@ -361,7 +361,7 @@ case class TagLinker(article: Article)(implicit val edition: Edition, implicit v
 
       // order by length of name so we do not make simple match errors
       // e.g 'Northern Ireland' & 'Ireland'
-      article.tags.keywords.filterNot(_.isSectionTag).sortBy(_.name.length).reverse.foreach { keyword =>
+      tags.keywords.filterNot(_.isSectionTag).sortBy(_.name.length).reverse.foreach { keyword =>
 
         // don't link again in paragraphs that already have links
         val unlinkedParas = paragraphs.filterNot(_.html.contains("<a"))

--- a/common/test/common/TagLinkerTest.scala
+++ b/common/test/common/TagLinkerTest.scala
@@ -1,14 +1,9 @@
 package common
 
-import java.time.ZoneOffset
-
-import com.gu.contentapi.client.model.v1.{ContentFields, TagType, Content => ApiContent, Tag => ApiTag}
-import com.gu.contentapi.client.utils.CapiModelEnrichment.RichOffsetDateTime
+import com.gu.contentapi.client.model.v1.{TagType, Tag => ApiTag }
 import common.editions.Uk
 import conf.Configuration
-import implicits.Dates.jodaToJavaInstant
-import model.{Article, Content}
-import org.joda.time.DateTime
+import model.{Tag, TagProperties, Tags}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.{FlatSpec, Matchers}
@@ -27,95 +22,78 @@ class TagLinkerTest extends FlatSpec with Matchers with GuiceOneAppPerSuite {
     val firstPara = d.select("p").asScala.head.html
   }
 
+  val tagLinker = TagLinker(Tags(List(tag("sport/cycling", "Cycling"))), true)
+
   "TagLinker" should "link tag at the start of the paragraph" in {
-    val cleaned = TagLinker(article(tag("sport/cycling", "Cycling"))).clean(souped("""<p>Cycling is an awesome sport.</p>"""))
+    val cleaned = tagLinker.clean(souped("""<p>Cycling is an awesome sport.</p>"""))
     cleaned.firstPara should be (s"""<a href="${Configuration.site.host}/sport/cycling" data-link-name="auto-linked-tag" data-component="auto-linked-tag" class="u-underline">Cycling</a> is an awesome sport.""")
   }
 
   it should "link tag in the middle of the paragraph" in {
-    val cleaned = TagLinker(article(tag("sport/cycling", "Cycling"))).clean(souped("""<p>After the change in law, Cycling is an awesome sport.</p>"""))
+    val cleaned = tagLinker.clean(souped("""<p>After the change in law, Cycling is an awesome sport.</p>"""))
     cleaned.firstPara should be (s"""After the change in law, <a href="${Configuration.site.host}/sport/cycling" data-link-name="auto-linked-tag" data-component="auto-linked-tag" class="u-underline">Cycling</a> is an awesome sport.""")
   }
 
   it should "link tag at the end of the paragraph" in {
-    val cleaned = TagLinker(article(tag("sport/cycling", "Cycling"))).clean(souped("""<p>After all that Cycling.</p>"""))
+    val cleaned = tagLinker.clean(souped("""<p>After all that Cycling.</p>"""))
     cleaned.firstPara should be (s"""After all that <a href="${Configuration.site.host}/sport/cycling" data-link-name="auto-linked-tag" data-component="auto-linked-tag" class="u-underline">Cycling</a>.""")
   }
 
   it should "link if followed by a comma" in {
-    val cleaned = TagLinker(article(tag("sport/cycling", "Cycling"))).clean(souped("""<p>Show up to Cycling, it won't hurt.</p>"""))
+    val cleaned = tagLinker.clean(souped("""<p>Show up to Cycling, it won't hurt.</p>"""))
     cleaned.firstPara should be (s"""Show up to <a href="${Configuration.site.host}/sport/cycling" data-link-name="auto-linked-tag" data-component="auto-linked-tag" class="u-underline">Cycling</a>, it won't hurt.""")
   }
 
   it should "link if followed by a question mark" in {
-    val cleaned = TagLinker(article(tag("sport/cycling", "Cycling"))).clean(souped("""<p>Who knows about Cycling?</p>"""))
+    val cleaned = tagLinker.clean(souped("""<p>Who knows about Cycling?</p>"""))
     cleaned.firstPara should be (s"""Who knows about <a href="${Configuration.site.host}/sport/cycling" data-link-name="auto-linked-tag" data-component="auto-linked-tag" class="u-underline">Cycling</a>?""")
   }
 
   it should "not link as part of another word" in {
-    val cleaned = TagLinker(article(tag("sport/cycling", "Cycling"))).clean(souped("""<p>Who knows what Anti-Cycling-Patterns are?.</p>"""))
+    val cleaned = tagLinker.clean(souped("""<p>Who knows what Anti-Cycling-Patterns are?.</p>"""))
     cleaned.firstPara should be ("""Who knows what Anti-Cycling-Patterns are?.""")
   }
 
   it should "not link as start of another word" in {
-    val cleaned = TagLinker(article(tag("sport/cycling", "Cycling"))).clean(souped("""<p>Who knows what Cycling-Patterns are?.</p>"""))
+    val cleaned = tagLinker.clean(souped("""<p>Who knows what Cycling-Patterns are?.</p>"""))
     cleaned.firstPara should be ("""Who knows what Cycling-Patterns are?.""")
   }
 
   it should "not link as end of another word" in {
-    val cleaned = TagLinker(article(tag("sport/cycling", "Cycling"))).clean(souped("""<p>Who knows what Anti-Cycling is?.</p>"""))
+    val cleaned = tagLinker.clean(souped("""<p>Who knows what Anti-Cycling is?.</p>"""))
     cleaned.firstPara should be ("""Who knows what Anti-Cycling is?.""")
   }
 
   it should "escape the tag name" in {
-    val cleaned = TagLinker(article(tag("sport/cycling", "Cycling?."))).clean(souped(
+    val cleaned = TagLinker(Tags(List(tag("sport/cycling", "Cycling?."))), true).clean(souped(
       """<p>Help with the Cycling?.</p>"""))
     cleaned.firstPara should be (s"""Help with the <a href="${Configuration.site.host}/sport/cycling" data-link-name="auto-linked-tag" data-component="auto-linked-tag" class="u-underline">Cycling?.</a>""")
   }
 
   it should "not link tags in an article pullquote" in {
-    val cleaned = TagLinker(article(tag("sport/cycling", "Cycling"))).clean(souped("""<aside class="element-pullquote"><p>Cycling is an awesome sport.</p></aside>"""))
+    val cleaned = tagLinker.clean(souped("""<aside class="element-pullquote"><p>Cycling is an awesome sport.</p></aside>"""))
     cleaned.firstPara should be ("""Cycling is an awesome sport.""")
   }
 
   it should "not link tags in articles that should be excluded from related content" in {
-    val cleaned = TagLinker(sensitiveArticle(tag("sport/cycling", "Cycling"))).clean(souped("""<p>Cycling is an awesome sport.</p>"""))
+    val cleaned = TagLinker(Tags(List(tag("sport/cycling", "Cycling"))), false).clean(souped("""<p>Cycling is an awesome sport.</p>"""))
     cleaned.firstPara should be ("""Cycling is an awesome sport.""")
   }
 
   it should "not blow up if there are 'regex' characters in the tag names" in {
-    val cleaned = TagLinker(article(tag("music/asap-rocky", "A$AP Rocky"))).clean(souped("""<p>such as Harlem rapper A$AP Rocky</p>"""))
+    val cleaned = TagLinker(Tags(List(tag("music/asap-rocky", "A$AP Rocky"))), true).clean(souped("""<p>such as Harlem rapper A$AP Rocky</p>"""))
     cleaned.firstPara should be ("such as Harlem rapper A$AP Rocky")
   }
 
-  private def tag(id: String, name: String) = ApiTag(id, TagType.Keyword, webTitle = name, webUrl = "does not matter",
-    apiUrl = "does not matter", sectionId = Some("does not matter"))
+  private[this] def tag(id: String, name: String): Tag = {
+    val apiTag = ApiTag(id, TagType.Keyword, webTitle = name, webUrl = "does not matter",
+      apiUrl = "does not matter", sectionId = Some("does not matter"))
 
-  private def sensitiveArticle(tags: ApiTag*) = {
-    val contentApiItem = contentApi(tags.toList).copy(fields = Some(ContentFields(showInRelatedContent = Some(false))))
-
-    val content = Content.make(contentApiItem)
-    Article.make(content)
-  }
-
-  private def contentApi(tags: List[ApiTag]) = ApiContent(
-      id = "foo/2012/jan/07/bar",
-      sectionId = None,
-      sectionName = None,
-      webPublicationDate = Some((jodaToJavaInstant(new DateTime()).atOffset(ZoneOffset.UTC)).toCapiDateTime),
-      webTitle = "Some article",
-      webUrl = "http://www.guardian.co.uk/foo/2012/jan/07/bar",
-      apiUrl = "http://content.guardianapis.com/foo/2012/jan/07/bar",
-      elements = None,
-      tags = tags,
-      fields = Some(ContentFields(showInRelatedContent = Some(true)))
-  )
-
-  private def article(tags: ApiTag*) = {
-    val contentApiItem = contentApi(tags.toList)
-
-    val content = Content.make(contentApiItem)
-    Article.make(content)
+    Tag(
+      properties = TagProperties.make(apiTag),
+      pagination = None,
+      richLinkId = None
+    )
   }
 
   private def souped(s: String) = Jsoup.parseBodyFragment(s)


### PR DESCRIPTION
Note, normally we do not show tag links for paras which follow a pullquote or Instagram caption. Replicating this is tricky in
the elements model so this has been dropped.

## What does this change?

Adds tag links to DCR.

## Screenshots

![Screenshot 2020-08-18 at 17 13 39](https://user-images.githubusercontent.com/858402/90538679-c7a39b00-e176-11ea-9a6f-db772e150e2a.png)

## What is the value of this and can you measure success?

SEO - not directly measurable.