### PR TITLE
Update epic reminder date to October

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-buttons.js
@@ -1,7 +1,7 @@
 // @flow
 import { paymentMethodLogosTemplate } from 'common/modules/commercial/templates/payment-method-logos-template';
 import type { ReminderFields } from 'common/modules/commercial/templates/acquisitions-epic-reminder';
-import { defaultReminderFields } from 'common/modules/commercial/templates/acquisitions-epic-control';
+import { getDefaultReminderFields } from 'common/modules/commercial/templates/acquisitions-epic-control';
 import { canShowContributionsReminderFeature } from 'common/modules/commercial/user-features';
 
 
@@ -48,10 +48,14 @@ export const epicButtonsTemplate = (
                 </a>`
         : '';
 
-    const showReminder = canShowContributionsReminderFeature();
-    const reminderCta = reminderFields ? reminderFields.reminderCTA : defaultReminderFields.reminderCTA;
+    const getReminderCta = (): ?string => {
+      const fields = reminderFields || getDefaultReminderFields();
+      return fields && fields.reminderCTA;
+    };
 
-    const reminderButton = showReminder
+    const reminderCta = canShowContributionsReminderFeature() && getReminderCta();
+
+    const reminderButton = reminderCta
         ? `<label for="epic-reminder__reveal-reminder" class="epic-reminder__prompt-label">
             <div data-cta-copy="${
                 reminderCta
@@ -61,7 +65,7 @@ export const epicButtonsTemplate = (
         </label>`
         : '';
 
-    const reminderInput = showReminder
+    const reminderInput = reminderCta
         ? `<input type="checkbox" id="epic-reminder__reveal-reminder" class="epic-reminder__reveal-reminder" />`
         : '';
 

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
@@ -15,10 +15,17 @@ const buildImage = (url: string): string =>
         <img src="${url}" alt="Image for Guardian contributions message"/>
     </div>`;
 
-export const defaultReminderFields: ReminderFields = {
+// Temporarily hard-coded while we decide on requirement
+const defaultReminderFields: ReminderFields = {
     reminderCTA: 'Remind me in October',
     reminderDate: '2020-10-14 00:00:00',
     reminderDateAsString: 'October 2020',
+};
+const defaultReminderCutoff = new Date('2020-09-14');
+
+export const getDefaultReminderFields = (): ReminderFields | null => {
+    const now = new Date();
+    return now <= defaultReminderCutoff ? defaultReminderFields : null;
 };
 
 export const acquisitionsEpicControlTemplate = ({
@@ -46,7 +53,7 @@ export const acquisitionsEpicControlTemplate = ({
     ).join(' ');
 
 
-    const reminderFields = showReminderFields || defaultReminderFields;
+    const reminderFields = showReminderFields || getDefaultReminderFields();
 
     return `<div class="contributions__epic ${extraClasses}" data-component="${componentName}" data-link-name="epic">
         <div class="${wrapperClass}">
@@ -74,7 +81,7 @@ export const acquisitionsEpicControlTemplate = ({
 
             ${footer ? buildFooter(footer) : ''}
 
-            ${canShowContributionsReminderFeature() ? acquisitionsEpicReminderTemplate(reminderFields) : ''}
+            ${canShowContributionsReminderFeature() && reminderFields ? acquisitionsEpicReminderTemplate(reminderFields) : ''}
         </div>
     </div>`;
 };

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-control.js
@@ -16,9 +16,9 @@ const buildImage = (url: string): string =>
     </div>`;
 
 export const defaultReminderFields: ReminderFields = {
-    reminderCTA: 'Remind me in September',
-    reminderDate: '2020-09-15 00:00:00',
-    reminderDateAsString: 'September 2020',
+    reminderCTA: 'Remind me in October',
+    reminderDate: '2020-10-14 00:00:00',
+    reminderDateAsString: 'October 2020',
 };
 
 export const acquisitionsEpicControlTemplate = ({


### PR DESCRIPTION
## What does this change?
We're still updating this manually for now...
Also added an automatic cut off.

Before clicking:
![Screen Shot 2020-08-19 at 10 23 06](https://user-images.githubusercontent.com/1513454/90616967-07659380-e206-11ea-8af2-f5a0e5d2b63f.png)

After submitting:
![Screen Shot 2020-08-19 at 10 22 43](https://user-images.githubusercontent.com/1513454/90616962-06ccfd00-e206-11ea-8095-6103257a0512.png)

Request:
![Screen Shot 2020-08-19 at 10 22 33](https://user-images.githubusercontent.com/1513454/90616960-06346680-e206-11ea-81d5-5dfe8706bd5e.png)

