### PR TITLE
Temporary meta timestamp formatting

### DIFF
--- a/common/app/model/DatesAndTimes.scala
+++ b/common/app/model/DatesAndTimes.scala
@@ -35,11 +35,18 @@ object ArticleDateTimes {
     val lastUpdatedDisplay = GUDateTimeFormatNew.formatTimeForDisplay(lastUpdatedDateTime, request)
 
     val primaryDateLine = GUDateTimeFormatNew.formatDateTimeForDisplay(articleDateTimes.webPublicationDate, request)
-    val secondaryDateLine =
+    /* val secondaryDateLine =
       if (articleDateTimes.hasBeenModified && (articleDateTimes.webPublicationDate != articleDateTimes.firstPublicationDate) ) {
         GUDateTimeFormatNew.formatDateTimeForDisplay(articleDateTimes.lastModificationDate, request)
       } else {
         GUDateTimeFormatNew.formatDateTimeForDisplay(articleDateTimes.lastModificationDate, request)
+      } */
+
+    val secondaryDateLine =
+      if (articleDateTimes.hasBeenModified && (articleDateTimes.webPublicationDate != articleDateTimes.firstPublicationDate.getOrElse("")) ) {
+        "First published on " + GUDateTimeFormatNew.formatDateTimeForDisplay(articleDateTimes.firstPublicationDate.getOrElse(articleDateTimes.webPublicationDate), request)
+      } else {
+        "Last modified on " + GUDateTimeFormatNew.formatDateTimeForDisplay(articleDateTimes.lastModificationDate, request)
       }
 
     DisplayedDateTimesDCR(

--- a/common/app/model/DatesAndTimes.scala
+++ b/common/app/model/DatesAndTimes.scala
@@ -35,12 +35,6 @@ object ArticleDateTimes {
     val lastUpdatedDisplay = GUDateTimeFormatNew.formatTimeForDisplay(lastUpdatedDateTime, request)
 
     val primaryDateLine = GUDateTimeFormatNew.formatDateTimeForDisplay(articleDateTimes.webPublicationDate, request)
-    /* val secondaryDateLine =
-      if (articleDateTimes.hasBeenModified && (articleDateTimes.webPublicationDate != articleDateTimes.firstPublicationDate) ) {
-        GUDateTimeFormatNew.formatDateTimeForDisplay(articleDateTimes.lastModificationDate, request)
-      } else {
-        GUDateTimeFormatNew.formatDateTimeForDisplay(articleDateTimes.lastModificationDate, request)
-      } */
 
     val secondaryDateLine =
       if (articleDateTimes.hasBeenModified && (articleDateTimes.webPublicationDate != articleDateTimes.firstPublicationDate.getOrElse("")) ) {


### PR DESCRIPTION
## What does this change?
This is meant as a temporary fix for primary and secondary meta timestamps used in DCR. The current implementation decides whether the secondary date is 'First published on' or 'Last modified on' and prepends to the string.

![Screenshot 2020-08-21 at 11 57 16](https://user-images.githubusercontent.com/35331926/90883687-387cca00-e3a6-11ea-8ef3-f89f614485e4.png)
![Screenshot 2020-08-21 at 11 57 25](https://user-images.githubusercontent.com/35331926/90883694-3b77ba80-e3a6-11ea-8b54-7831c2b8942c.png)
![Screenshot 2020-08-21 at 11 57 37](https://user-images.githubusercontent.com/35331926/90883700-3dda1480-e3a6-11ea-8bca-2d684966ae88.png)
