### PR TITLE
Add tag links to DCR

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -12,7 +12,7 @@ import conf.Configuration.affiliateLinks
 import conf.switches.Switches
 import conf.{Configuration, Static}
 import model.content.Atom
-import model.dotcomrendering.pageElements.{DisclaimerBlockElement, PageElement}
+import model.dotcomrendering.pageElements.{Cleaners, DisclaimerBlockElement, PageElement}
 import model.{
   Article,
   ArticleDateTimes,
@@ -462,7 +462,10 @@ object DotcomponentsDataModel {
       campaigns: Option[JsValue],
       calloutsUrl: Option[String],
   ): List[PageElement] = {
+
     val atoms: Iterable[Atom] = article.content.atoms.map(_.all).getOrElse(Seq())
+    val edition = Edition.apply(request)
+
     val elems = capiElems.toList
       .flatMap(el =>
         PageElement.make(
@@ -477,7 +480,9 @@ object DotcomponentsDataModel {
         ),
       )
       .filter(PageElement.isSupported)
-    addDisclaimer(elems, capiElems, affiliateLinks)
+
+    val withTagLinks = Cleaners.tagLinks(elems, article.content.tags, article.content.showInRelated, edition)
+    addDisclaimer(withTagLinks, capiElems, affiliateLinks)
   }
 
   private def toBlock(

--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -24,7 +24,7 @@ trait LinkTo extends Logging {
   def apply(html: Html)(implicit request: RequestHeader): String = this(html.toString(), Edition(request))
   def apply(link: String)(implicit request: RequestHeader): String = this(link, Edition(request))
 
-  def apply(url: String, edition: Edition)(implicit request: RequestHeader): String =
+  def apply(url: String, edition: Edition): String =
     processUrl(url.trim, edition).url
 
   def apply(trail: Trail)(implicit request: RequestHeader): Option[String] = Option(apply(trail.metadata.url))

--- a/common/app/model/dotcomrendering/pageElements/Cleaners.scala
+++ b/common/app/model/dotcomrendering/pageElements/Cleaners.scala
@@ -1,0 +1,79 @@
+package model.dotcomrendering.pageElements
+
+import common.{Edition, LinkTo}
+import conf.Configuration.{affiliateLinks => affiliateLinksConfig}
+import model.{Tag, Tags}
+import org.jsoup.Jsoup
+import views.support.AffiliateLinksCleaner
+
+import scala.util.matching.Regex
+import scala.util.matching.Regex.Match
+
+object Cleaners {
+
+  def affiliateLinks(pageUrl: String)(el: TextBlockElement): TextBlockElement = {
+    val doc = Jsoup.parseBodyFragment(el.html)
+    val links = AffiliateLinksCleaner.getAffiliateableLinks(doc)
+    links.foreach(el => {
+      val id = affiliateLinksConfig.skimlinksId
+      el.attr("href", AffiliateLinksCleaner.linkToSkimLink(el.attr("href"), pageUrl, id))
+    })
+
+    if (links.nonEmpty) {
+      TextBlockElement(doc.body().html())
+    } else {
+      el
+    }
+  }
+
+  def tagLinks(els: List[PageElement], tags: Tags, showInRelated: Boolean, edition: Edition): List[PageElement] = {
+    var terms = Set[String]()
+
+    els.map({
+      case el: TextBlockElement =>
+        val (updatedEl, updatedTerms) = TagLinker.addLink(tags, showInRelated, el, terms, edition)
+        terms = updatedTerms
+        updatedEl
+      case other => other
+    })
+  }
+}
+
+object TagLinker {
+
+  def link(tag: Tag, edition: Edition): String = {
+    val href = LinkTo(tag.metadata.url, edition)
+
+    s"""<a href=$href data-component="auto-linked-tag">${tag.name}</a>"""
+  }
+
+  def keywordRegex(tagName: String): Regex = {
+    // whitespace or start of line, then tag name, then whitespace, comma, end of line, full stop or question mark.
+    s"""( |^)($tagName)([ ,$$.?])""".r("start", "tag", "end")
+  }
+
+  def addLink(
+      tags: Tags,
+      showInRelated: Boolean,
+      el: TextBlockElement,
+      terms: Set[String],
+      edition: Edition,
+  ): (TextBlockElement, Set[String]) = {
+
+    val containsLink = el.html.contains("<a")
+
+    if (showInRelated && !containsLink) {
+      val keywords =
+        tags.keywords.filterNot(_.isSectionTag).sortBy(_.name.length).filterNot(tag => terms.contains(tag.name))
+      val keyword = keywords.find(tag => el.html.contains(tag.name))
+
+      keyword.map(tag => {
+        def mapper(tag: Tag)(m: Match) = Some(m.group("start") + link(tag, edition) + m.group("end"))
+        val updatedHtml = keywordRegex(tag.name).replaceSomeIn(el.html, mapper(tag))
+        (TextBlockElement(updatedHtml), terms + tag.name)
+      }) getOrElse (el, terms)
+    } else {
+      (el, terms)
+    }
+  }
+}

--- a/common/app/model/dotcomrendering/pageElements/Cleaners.scala
+++ b/common/app/model/dotcomrendering/pageElements/Cleaners.scala
@@ -64,7 +64,7 @@ object TagLinker {
 
     if (showInRelated && !containsLink) {
       val keywords =
-        tags.keywords.filterNot(_.isSectionTag).sortBy(_.name.length).filterNot(tag => terms.contains(tag.name))
+        tags.keywords.filterNot(_.isSectionTag).sortBy(_.name.length).reverse.filterNot(tag => terms.contains(tag.name))
       val keyword = keywords.find(tag => el.html.contains(tag.name))
 
       keyword.map(tag => {

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -326,11 +326,10 @@ object PageElement {
           element <- Cleaner.split(text)
         } yield {
           element match {
-            case ("h2", heading)            => SubheadingBlockElement(heading)
-            case ("blockquote", blockquote) => BlockquoteBlockElement(blockquote)
-            case (_, para) if (addAffiliateLinks) =>
-              AffiliateLinksCleaner.replaceLinksInElement(para, pageUrl = pageUrl, contentType = "article")
-            case (_, para) => TextBlockElement(para)
+            case ("h2", heading)                  => SubheadingBlockElement(heading)
+            case ("blockquote", blockquote)       => BlockquoteBlockElement(blockquote)
+            case (_, para) if (addAffiliateLinks) => Cleaners.affiliateLinks(pageUrl)(TextBlockElement(para))
+            case (_, para)                        => TextBlockElement(para)
           }
         }
 

--- a/common/test/model/dotcomrendering/pageElements/CleanersTest.scala
+++ b/common/test/model/dotcomrendering/pageElements/CleanersTest.scala
@@ -1,0 +1,144 @@
+package model
+
+import com.gu.contentapi.client.model.v1.TagType.Keyword
+import com.gu.contentapi.client.model.v1.{Tag => ApiTag}
+import common.editions
+import conf.Configuration
+import model.dotcomrendering.pageElements.{Cleaners, TagLinker, TextBlockElement}
+import org.scalatest.{FlatSpec, Matchers}
+
+class CleanersTest extends FlatSpec with Matchers {
+
+  val host = Configuration.site.host
+
+  "TagLinker" should "match tags in a para" in {
+    val examples = List(
+      "the Champions League is great!" -> Some("Champions League"),
+      "What do you think about the Champions League?" -> Some("Champions League"),
+      "What do you think about the Champions?" -> None,
+    )
+
+    val re = TagLinker.keywordRegex("Champions League")
+
+    examples.foreach({
+      case (example, want) =>
+        val got = re.findFirstMatchIn(example).map(_.group("tag"))
+        got shouldBe want
+    })
+  }
+
+  "Add link" should "link tags in a text block element and return linked terms" in {
+    val examples = List(
+      TextBlockElement("the Champions League is great!") ->
+        (TextBlockElement(
+          s"""the <a href=${host}/championsleague data-component="auto-linked-tag">Champions League</a> is great!""",
+        ), Set("Champions League")),
+      TextBlockElement("What do you think about the Champions?") ->
+        (TextBlockElement("What do you think about the Champions?"), Set.empty),
+    )
+
+    val tag = Tag(
+      TagProperties.make(
+        ApiTag(
+          id = "championsleague",
+          `type` = Keyword,
+          sectionId = Some("football"),
+          webTitle = "Champions League",
+          webUrl = "/football/championsleague",
+          apiUrl = "example",
+        ),
+      ),
+      None,
+      None,
+    )
+
+    examples.foreach({
+      case (example, want) =>
+        val got = TagLinker.addLink(
+          tags = Tags(List(tag)),
+          showInRelated = true,
+          el = example,
+          terms = Set.empty,
+          edition = editions.Uk,
+        )
+
+        got shouldBe want
+    })
+  }
+
+  "tagLinks" should "link only first occurrence of a tag" in {
+    val elements = List(
+      TextBlockElement("Champions League first"),
+      TextBlockElement("Champions League repeat"),
+    )
+
+    val want = List(
+      TextBlockElement(
+        s"""<a href=${host}/championsleague data-component="auto-linked-tag">Champions League</a> first""",
+      ),
+      TextBlockElement("Champions League repeat"),
+    )
+
+    val tag = Tag(
+      TagProperties.make(
+        ApiTag(
+          id = "championsleague",
+          `type` = Keyword,
+          sectionId = Some("football"),
+          webTitle = "Champions League",
+          webUrl = "/football/championsleague",
+          apiUrl = "example",
+        ),
+      ),
+      None,
+      None,
+    )
+
+    val got = Cleaners.tagLinks(
+      els = elements,
+      tags = Tags(List(tag)),
+      showInRelated = true,
+      edition = editions.Uk,
+    )
+
+    got shouldBe want
+  }
+
+  "tagLinks" should "ignore paragraphs that already contain links" in {
+    val elements = List(
+      TextBlockElement("""Champions League tables <a href="example.com/checkitoutfoo">here</a>"""),
+      TextBlockElement("Champions League repeat"),
+    )
+
+    val want = List(
+      TextBlockElement("""Champions League tables <a href="example.com/checkitoutfoo">here</a>"""),
+      TextBlockElement(
+        s"""<a href=${host}/championsleague data-component="auto-linked-tag">Champions League</a> repeat""",
+      ),
+    )
+
+    val tag = Tag(
+      TagProperties.make(
+        ApiTag(
+          id = "championsleague",
+          `type` = Keyword,
+          sectionId = Some("football"),
+          webTitle = "Champions League",
+          webUrl = "/football/championsleague",
+          apiUrl = "example",
+        ),
+      ),
+      None,
+      None,
+    )
+
+    val got = Cleaners.tagLinks(
+      els = elements,
+      tags = Tags(List(tag)),
+      showInRelated = true,
+      edition = editions.Uk,
+    )
+
+    got shouldBe want
+  }
+}


### PR DESCRIPTION
## What does this change?

Adds tag links to DCR.

Note, attempt number 1 (https://github.com/guardian/frontend/pull/22906) failed because I hadn't realised there is state involved - specifically, if a tag has already been linked in a previous paragraph, don't link in further ones. The existing code didn't work so well with the `List[PageElement]` newer datastructure here so I've heavily modified it.

Tested locally with this article, which is a good test case: https://www.theguardian.com/politics/2020/aug/19/met-close-inquiry-into-alex-salmond-with-no-further-action?dcr=false as it has many tag links, some of which repeat.

