### PR TITLE
[CMP] Update Comscore in CCPA

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/comscore.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.js
@@ -56,7 +56,7 @@ export const init = (): Promise<void> => {
         onConsentChange(state => {
             const canRunTcfv2 =
                 state.tcfv2 && state.tcfv2.vendorConsents[SOURCEPOINT_ID];
-            const canRunCcpa = state.ccpa && !state.ccpa.doNotSell;
+            const canRunCcpa = !!state.ccpa; // always runs in CCPA
             if (canRunTcfv2 || canRunCcpa) initOnConsent(true);
         });
     }

--- a/static/src/javascripts/projects/commercial/modules/comscore.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.js
@@ -67,6 +67,9 @@ export const init = (): Promise<void> => {
 export const _ = {
     getGlobals,
     initOnConsent,
+    resetInit: () => {
+        initialised = false;
+    },
     comscoreSrc,
     comscoreC1,
     comscoreC2,

--- a/static/src/javascripts/projects/commercial/modules/comscore.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.js
@@ -70,4 +70,5 @@ export const _ = {
     comscoreSrc,
     comscoreC1,
     comscoreC2,
+    SOURCEPOINT_ID,
 };

--- a/static/src/javascripts/projects/commercial/modules/comscore.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.spec.js
@@ -9,7 +9,6 @@ jest.mock('@guardian/consent-management-platform', () => ({
 }));
 
 const onConsentChange: any = onConsentChange_;
-const spyConsent = jest.spyOn(_, 'initOnConsent');
 
 const tcfv2WithConsentMock = (callback): void =>
     callback({
@@ -65,32 +64,33 @@ describe('comscore init', () => {
         expect(onConsentChange).toBeCalled();
     });
 
-    describe.skip('Framework consent: running on consent', () => {
+    describe('Framework consent: running on consent', () => {
         beforeEach(() => {
             jest.resetAllMocks();
+            _.resetInit();
         });
 
         it('TCFv2 with consent: runs', () => {
             onConsentChange.mockImplementation(tcfv2WithConsentMock);
             init();
-            expect(spyConsent).toBeCalledWith(true);
+            expect(loadScript).toBeCalled();
         });
 
         it('TCFv2 without consent: does not run', () => {
             onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
             init();
-            expect(spyConsent).not.toBeCalled();
+            expect(loadScript).not.toBeCalled();
         });
         it('CCPA with consent: runs', () => {
             onConsentChange.mockImplementation(ccpaWithConsentMock);
             init();
-            expect(spyConsent).toBeCalledWith(true);
+            expect(loadScript).toBeCalled();
         });
 
         it('CCPA without consent: runs', () => {
             onConsentChange.mockImplementation(ccpaWithoutConsentMock);
             init();
-            expect(spyConsent).toBeCalledWith(true);
+            expect(loadScript).toBeCalled();
         });
     });
 });

--- a/static/src/javascripts/projects/commercial/modules/comscore.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.spec.js
@@ -9,6 +9,36 @@ jest.mock('@guardian/consent-management-platform', () => ({
 }));
 
 const onConsentChange: any = onConsentChange_;
+const spyConsent = jest.spyOn(_, 'initOnConsent');
+
+const tcfv2WithConsentMock = (callback): void =>
+    callback({
+        tcfv2: {
+            vendorConsents: {
+                [_.SOURCEPOINT_ID]: true,
+            },
+        },
+    });
+const tcfv2WithoutConsentMock = (callback): void =>
+    callback({
+        tcfv2: {
+            vendorConsents: {
+                [_.SOURCEPOINT_ID]: false,
+            },
+        },
+    });
+const ccpaWithConsentMock = (callback): void =>
+    callback({
+        ccpa: {
+            doNotSell: false,
+        },
+    });
+const ccpaWithoutConsentMock = (callback): void =>
+    callback({
+        ccpa: {
+            doNotSell: true,
+        },
+    });
 
 jest.mock('lib/load-script', () => ({
     loadScript: jest.fn(() => Promise.resolve()),
@@ -33,6 +63,35 @@ describe('comscore init', () => {
         init();
 
         expect(onConsentChange).toBeCalled();
+    });
+
+    describe.skip('Framework consent: running on consent', () => {
+        beforeEach(() => {
+            jest.resetAllMocks();
+        });
+
+        it('TCFv2 with consent: runs', () => {
+            onConsentChange.mockImplementation(tcfv2WithConsentMock);
+            init();
+            expect(spyConsent).toBeCalledWith(true);
+        });
+
+        it('TCFv2 without consent: does not run', () => {
+            onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
+            init();
+            expect(spyConsent).not.toBeCalled();
+        });
+        it('CCPA with consent: runs', () => {
+            onConsentChange.mockImplementation(ccpaWithConsentMock);
+            init();
+            expect(spyConsent).toBeCalledWith(true);
+        });
+
+        it('CCPA without consent: runs', () => {
+            onConsentChange.mockImplementation(ccpaWithoutConsentMock);
+            init();
+            expect(spyConsent).toBeCalledWith(true);
+        });
     });
 });
 


### PR DESCRIPTION
## What does this change?

Comscore should always be loaded in the CCPA framework.

- [x] add unit tests

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes (part of the commercial bundle)

## What is the value of this and can you measure success?

Comescore should run in the whether `state.ccpa.doNotSell` is `true` or `false`.
User consent should still be given for it to run in the TCFv2 framework

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
