### PR TITLE
Fix for Ozone & OpenX page targeting 

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
@@ -57,8 +57,6 @@ import {
 } from '../utils';
 import { getAppNexusDirectBidParams } from './appnexus';
 
-const PAGE_TARGETING: {} = buildAppNexusTargetingObject(getPageTargeting());
-
 const isInSafeframeTestVariant = (): boolean =>
     isInVariantSynchronous(commercialPrebidSafeframe, 'variant');
 
@@ -346,7 +344,7 @@ const ozoneClientSideBidder: PrebidBidder = {
                 customData: [
                     {
                         settings: {},
-                        targeting: PAGE_TARGETING,
+                        targeting: buildAppNexusTargetingObject(getPageTargeting()),
                     },
                 ],
                 ozoneData: {}, // TODO: confirm if we need to send any


### PR DESCRIPTION
## What does this change?

After TCFv2 release a regression was found in Ozone adapter which was missing the correct page targeting params. The issue seems to arose from the time we were constructing the page targeting object as a module private variable (this seems to happen only ONCE and before the consent callback resulting in empty params) . This was not an issue for TCFv1 due to the callback been called at different times.
I have now inline the page targeting to the time we construct ozone adapter so the params are always up to date

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

### Before
<img width="1283" alt="Screenshot 2020-08-25 at 12 33 29" src="https://user-images.githubusercontent.com/51630004/91162378-aee63880-e6d4-11ea-916b-591f91e05536.png">

### After

<img width="1283" alt="Screenshot 2020-08-25 at 13 08 49" src="https://user-images.githubusercontent.com/51630004/91162387-b3125600-e6d4-11ea-8c85-2bfa3db6c397.png">


## What is the value of this and can you measure success?
Ozone adapter will receive the correct targeting params

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
