### PR TITLE
Add QuizAtomBlockElement to support passing Quiz data to DCR

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -206,10 +206,17 @@ case class ProfileAtomBlockElement(
     items: List[ProfileAtomBlockElementItem],
     credit: String,
 ) extends PageElement
-
 case class PullquoteBlockElement(html: Option[String], role: Role, attribution: Option[String]) extends PageElement
 case class QABlockElement(id: String, title: String, img: Option[String], html: String, credit: String)
     extends PageElement
+case class QuizAtomAnswer(id: String, text: String, revealText: Option[String], isCorrect: Boolean)
+case class QuizAtomQuestion(id: String, text: String, answers: Seq[QuizAtomAnswer], imageUrl: Option[String])
+object QuizAtomBlockElement {
+  implicit val QuizAtomAnswerWrites: Writes[QuizAtomAnswer] = Json.writes[QuizAtomAnswer]
+  implicit val QuizAtomQuestionWrites: Writes[QuizAtomQuestion] = Json.writes[QuizAtomQuestion]
+  implicit val QuizAtomBlockElementWrites: Writes[QuizAtomBlockElement] = Json.writes[QuizAtomBlockElement]
+}
+case class QuizAtomBlockElement(id: String, questions: Seq[QuizAtomQuestion]) extends PageElement
 case class RichLinkBlockElement(
     url: Option[String],
     text: Option[String],
@@ -309,6 +316,7 @@ object PageElement {
       case _: ProfileAtomBlockElement     => true
       case _: PullquoteBlockElement       => true
       case _: QABlockElement              => true
+      case _: QuizAtomBlockElement        => true
       case _: RichLinkBlockElement        => true
       case _: SoundcloudBlockElement      => true
       case _: SpotifyBlockElement         => true
@@ -670,6 +678,27 @@ object PageElement {
               ),
             )
           }
+          case Some(quizAtom: QuizAtom) =>
+            Some(
+              QuizAtomBlockElement(
+                id = quizAtom.id,
+                questions = quizAtom.content.questions.map { q =>
+                  QuizAtomQuestion(
+                    id = q.id,
+                    text = q.text,
+                    answers = q.answers.map(a =>
+                      QuizAtomAnswer(
+                        id = a.id,
+                        text = a.text,
+                        revealText = a.revealText,
+                        isCorrect = a.weight == 1,
+                      ),
+                    ),
+                    imageUrl = q.imageMedia.flatMap(i => ImgSrc.getAmpImageUrl(i.imageMedia)),
+                  )
+                },
+              ),
+            )
 
           // Here we capture all the atom types which are not yet supported.
           // ContentAtomBlockElement is mapped to null in the DCR source code.


### PR DESCRIPTION
## What does this change?

Here we add a `QuizAtomBlockElement` and use this to determine the JSON to be passed to DCR for rendering Quiz atoms.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
Running frontend locally, we now produce the following JSON when we call [http://localhost:9000/football/that-1980s-sports-blog/2020/jun/12/sports-quiz-football-in-the-1980s.json?dcr](http://localhost:9000/football/that-1980s-sports-blog/2020/jun/12/sports-quiz-football-in-the-1980s.json?dcr):

![image](https://user-images.githubusercontent.com/9820960/91165704-0a122e00-e6c9-11ea-90d1-8392c04b0d5b.png)

Rendering a quiz atom using this JSON from a story in [atoms-rendering](https://github.com/guardian/atoms-rendering), we can see that this allows us to reproduce the majority of the functionality of [the quiz](https://www.theguardian.com/football/that-1980s-sports-blog/2020/jun/12/sports-quiz-football-in-the-1980s):

![image](https://user-images.githubusercontent.com/9820960/91165895-6b3a0180-e6c9-11ea-8df9-9456f89b9738.png)

We may need to add to this, I haven't yet implemented the submit behaviour on quiz atoms, but it's useful to have some of this implemented all the same.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
