### PR TITLE
Revert Ozone fix to check if there's an impact on pageskins

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
@@ -59,6 +59,8 @@ import {
 } from '../utils';
 import { getAppNexusDirectBidParams } from './appnexus';
 
+const PAGE_TARGETING: {} = buildAppNexusTargetingObject(getPageTargeting());
+
 const isInSafeframeTestVariant = (): boolean =>
     isInVariantSynchronous(commercialPrebidSafeframe, 'variant');
 
@@ -301,7 +303,7 @@ const getOzoneTargeting = (): { } => {
             'lotamePid': lotameData.ozoneLotameProfileId,
         }
     }
-    return appNexusTargetingObject;
+    return PAGE_TARGETING;
 };
 
 // Is pbtest being used?


### PR DESCRIPTION
## What does this change?

Page skins have stopped working around 11am which coincides with the time this PR was introduced: https://github.com/guardian/frontend/pull/22930

Although there is no obvious link to pageskins, let's try to revert the change to see if it impacts it 
