### PR TITLE
Better detection of Spotify BlockElements

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -483,8 +483,10 @@ object PageElement {
     for {
       d <- element.audioTypeData
       html <- d.html
-      source <- d.source
-      if source == "Spotify" // We rely on the `source` field to decide whether or not this is an instance of Spotify
+      src <- getIframeSrc(html)
+      if src.contains("spotify.com") // Deciding if the source is Spotify
+                                     // Note that we cannot rely on d.source due to lack of data integrity
+                                     // Some self described Spotify elements are actually charts-datawrapper.s3.amazonaws.com
     } yield {
       SpotifyBlockElement(getEmbedUrl(d.html), getIframeHeight(html), getIframeWidth(html), d.title, d.caption)
     }


### PR DESCRIPTION
## What does this change?

Better detection of Spotify BlockElements. We stop relying on `d.source` after discovering that some self described Spotify BlockElements, in legacy contents, are actually chart iframes. 
