### PR TITLE
Enabling match reports in the article picker for DCR to render

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -122,6 +122,7 @@ object ArticlePageChecks {
       "tone/interview",
       "tone/letters",
       "tone/livereview",
+      "tone/matchreports",
       "tone/news",
       "tone/obituaries",
       "tone/performances",


### PR DESCRIPTION
## What does this change?
Adds the match report tone to the allowed list of tags for rendering in DCR. 

Awaiting release of https://github.com/guardian/dotcom-rendering/pull/1820