### PR TITLE
[CMP] Fix modal displaying on load

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -48,8 +48,6 @@ export const consentManagementPlatformUi = {
         if (!config.get('switches.cmp', true)) return Promise.resolve(false);
         return Promise.resolve(cmp.willShowPrivacyMessage());
     },
-    show: (): Promise<boolean> => {
-        cmp.showPrivacyManager();
-        return Promise.resolve(true);
-    },
+    // Remote banner is injected first: show() always resolves to `true`
+    show: (): Promise<boolean> => Promise.resolve(true),
 };


### PR DESCRIPTION
## What does this change?

A recent change in #22920 triggered the CMP modal for new users on top of the banner. This fixes that.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

The CMP banner is fired, but not the modal.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
