### PR TITLE
[CMP] Further CMP Cleanup

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -56,7 +56,7 @@ import ophan from 'ophan/ng';
 import { adFreeBanner } from 'common/modules/commercial/ad-free-banner';
 import { init as initReaderRevenueDevUtils } from 'common/modules/commercial/reader-revenue-dev-utils';
 import {
-    consentManagementPlatformUi,
+    cmpBannerCandidate,
     addPrivacySettingsLink,
 } from 'common/modules/ui/cmp-ui';
 import { signInGate } from 'common/modules/identity/sign-in-gate';
@@ -305,7 +305,7 @@ const initialiseEmail = (): void => {
 const initialiseBanner = (): void => {
     // ordered by priority
     const bannerList = [
-        consentManagementPlatformUi,
+        cmpBannerCandidate,
         breakingNews,
         signInGate,
         membershipBanner,

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -2,6 +2,7 @@
 import config from 'lib/config';
 import { cmp } from '@guardian/consent-management-platform';
 import { getPrivacyFramework } from 'lib/getPrivacyFramework';
+import type { Banner } from 'common/modules/ui/bannerPicker';
 
 export const addPrivacySettingsLink = (): void => {
     if (!config.get('switches.cmpUi', true)) {
@@ -42,7 +43,7 @@ export const addPrivacySettingsLink = (): void => {
     }
 };
 
-export const consentManagementPlatformUi = {
+export const consentManagementPlatformUi: Banner = {
     id: 'cmpUi',
     canShow: (): Promise<boolean> => {
         if (!config.get('switches.cmp', true)) return Promise.resolve(false);

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -47,7 +47,7 @@ export const cmpBannerCandidate: Banner = {
     id: 'cmpUi',
     canShow: (): Promise<boolean> => {
         if (!config.get('switches.cmp', true)) return Promise.resolve(false);
-        return Promise.resolve(cmp.willShowPrivacyMessage());
+        return cmp.willShowPrivacyMessage();
     },
     // Remote banner is injected first: show() always resolves to `true`
     show: (): Promise<boolean> => Promise.resolve(true),

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -43,7 +43,7 @@ export const addPrivacySettingsLink = (): void => {
     }
 };
 
-export const consentManagementPlatformUi: Banner = {
+export const cmpBannerCandidate: Banner = {
     id: 'cmpUi',
     canShow: (): Promise<boolean> => {
         if (!config.get('switches.cmp', true)) return Promise.resolve(false);

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.spec.js
@@ -1,7 +1,7 @@
 // @flow
 import config from 'lib/config';
 import { cmp } from '@guardian/consent-management-platform';
-import { cmpBannerCandidate as consentManagementPlatformUi } from './cmp-ui';
+import { cmpBannerCandidate } from './cmp-ui';
 
 jest.mock('lib/raven');
 
@@ -19,32 +19,32 @@ describe('cmp-ui', () => {
         jest.resetAllMocks();
     });
 
-    describe('consentManagementPlatformUi', () => {
+    describe('cmpBannerCandidate', () => {
         describe('canShow', () => {
             it('return true if cmp.willShowPrivacyMessage() returns true', () => {
                 cmp.willShowPrivacyMessage.mockImplementation(() => true);
 
-                return consentManagementPlatformUi.canShow().then(show => {
+                return cmpBannerCandidate.canShow().then(show => {
                     expect(show).toBe(true);
                 });
             });
             it('return false if cmp.willShowPrivacyMessage() returns false', () => {
                 cmp.willShowPrivacyMessage.mockImplementation(() => false);
 
-                return consentManagementPlatformUi.canShow().then(show => {
+                return cmpBannerCandidate.canShow().then(show => {
                     expect(show).toBe(false);
                 });
             });
 
             it('returns willShowPrivacyMessage if using Sourcepoint CMP', () =>
-                consentManagementPlatformUi.canShow().then(() => {
+                cmpBannerCandidate.canShow().then(() => {
                     expect(cmp.willShowPrivacyMessage).toHaveBeenCalledTimes(1);
                 }));
 
             it('return false if CMP switch is off', () => {
                 config.set('switches.cmp', false);
 
-                return consentManagementPlatformUi.canShow().then(show => {
+                return cmpBannerCandidate.canShow().then(show => {
                     expect(show).toBe(false);
                 });
             });

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.spec.js
@@ -21,26 +21,21 @@ describe('cmp-ui', () => {
 
     describe('cmpBannerCandidate', () => {
         describe('canShow', () => {
-            it('return true if cmp.willShowPrivacyMessage() returns true', () => {
-                cmp.willShowPrivacyMessage.mockImplementation(() => true);
+            it('return true if cmp.willShowPrivacyMessage() resolves to true', () => {
+                cmp.willShowPrivacyMessage.mockResolvedValue(true);
 
                 return cmpBannerCandidate.canShow().then(show => {
+                    expect(cmp.willShowPrivacyMessage).toHaveBeenCalledTimes(1);
                     expect(show).toBe(true);
                 });
             });
-            it('return false if cmp.willShowPrivacyMessage() returns false', () => {
-                cmp.willShowPrivacyMessage.mockImplementation(() => false);
+            it('return false if cmp.willShowPrivacyMessage() resolves to false', () => {
+                cmp.willShowPrivacyMessage.mockResolvedValue(false);
 
                 return cmpBannerCandidate.canShow().then(show => {
                     expect(show).toBe(false);
                 });
             });
-
-            it('returns willShowPrivacyMessage if using Sourcepoint CMP', () =>
-                cmpBannerCandidate.canShow().then(() => {
-                    expect(cmp.willShowPrivacyMessage).toHaveBeenCalledTimes(1);
-                }));
-
             it('return false if CMP switch is off', () => {
                 config.set('switches.cmp', false);
 

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.spec.js
@@ -1,7 +1,7 @@
 // @flow
 import config from 'lib/config';
 import { cmp } from '@guardian/consent-management-platform';
-import { consentManagementPlatformUi } from './cmp-ui';
+import { cmpBannerCandidate as consentManagementPlatformUi } from './cmp-ui';
 
 jest.mock('lib/raven');
 


### PR DESCRIPTION
## What does this change?

Some clean-up of the CMP UI following #22920 .

- Rename CMP banner: `consentManagementPlatformUi` &rarr; `cmpBannerCandidate` 
d0ed21b...b9418a9
- Force its type to `Banner` d0ed21b
- Update tests to resolve a `Promise` rather than return a `boolean` f884863

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?

Clearer code, better tests, more enforced types.

## Checklist

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
