### PR TITLE
Fix key values for Ozone and OpenX without breaking pageskins

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
@@ -59,7 +59,8 @@ import {
 } from '../utils';
 import { getAppNexusDirectBidParams } from './appnexus';
 
-const PAGE_TARGETING: {} = buildAppNexusTargetingObject(getPageTargeting());
+//The below line is needed for page skins to show
+getPageTargeting();
 
 const isInSafeframeTestVariant = (): boolean =>
     isInVariantSynchronous(commercialPrebidSafeframe, 'variant');
@@ -303,7 +304,7 @@ const getOzoneTargeting = (): { } => {
             'lotamePid': lotameData.ozoneLotameProfileId,
         }
     }
-    return PAGE_TARGETING;
+    return appNexusTargetingObject;
 };
 
 // Is pbtest being used?

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
@@ -59,7 +59,7 @@ import {
 } from '../utils';
 import { getAppNexusDirectBidParams } from './appnexus';
 
-//The below line is needed for page skins to show
+// The below line is needed for page skins to show
 getPageTargeting();
 
 const isInSafeframeTestVariant = (): boolean =>


### PR DESCRIPTION
## What does this change?
Page skins have stopped working after this fix : https://github.com/guardian/frontend/pull/22930
This is an attempt to Fix key values for Ozone and OpenX without breaking pageskins
