### PR TITLE
Identity | Sign In Gate | Exclude gnm-archive from sign in gate

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
@@ -188,6 +188,7 @@ export const isInvalidSection = (include: Array<string> = []): boolean => {
         'membership',
         'help',
         'guardian-live-australia',
+        'gnm-archive',
     ];
 
     return invalidSections


### PR DESCRIPTION
## What does this change?
- Add `gnm-archive` to excluded list of sections as we don't wait it to show up on https://www.theguardian.com/gnm-archive/2020/aug/10/could-you-help-with-the-archives-shorthand-transcription-project