### PR TITLE
Use full hostname for lightbox and selection sharing

### DIFF
--- a/static/src/javascripts/projects/common/modules/gallery/lightbox.js
+++ b/static/src/javascripts/projects/common/modules/gallery/lightbox.js
@@ -169,7 +169,7 @@ class GalleryLightbox {
     }
 
     generateImgHTML(img: Object, i: number): string {
-        const blockShortUrl = config.get('page.shortUrl');
+        const blockShortUrl = config.get('page.host') + config.get('page.shortUrlId');
         const urlPrefix = img.src.startsWith('//') ? 'http:' : '';
         const shareItems: Array<{
             text: string,
@@ -211,7 +211,6 @@ class GalleryLightbox {
             index: i,
             caption: img.caption,
             credit: img.displayCredit ? img.credit : '',
-            blockShortUrl,
             shareButtons: shareItems
                 .map(s => template(shareButtonTpl)(s))
                 .join(''),

--- a/static/src/javascripts/projects/common/modules/ui/selection-sharing.js
+++ b/static/src/javascripts/projects/common/modules/ui/selection-sharing.js
@@ -104,13 +104,13 @@ const updateSelection = (): void => {
         }
 
         const twitterText = encodeURIComponent(twitterMessage);
-        const twitterShortUrl = `${config.get('page.shortUrl')}/stw`;
+        const twitterShortUrl = `${config.get('page.host')}${config.get('page.shortUrlId')}/stw`;
         const twitterUrl = encodeURI(twitterShortUrl);
-        const twitterHref = `https://twitter.com/intent/tweet?text=%E2%80%9C${twitterText}%E2%80%9D&url=${twitterUrl}`;
+        const twitterHref = `https://twitter.com/intent/tweet?text=%E2%80%9C${twitterText}%E2%80%9D&url=${encodeURI(twitterUrl)}`;
 
         const emailSubject = encodeURI(config.get('page.webTitle'));
         const emailSelection = encodeURI(range.toString());
-        const emailShortUrl = `${config.get('page.shortUrl')}/sbl`;
+        const emailShortUrl = `${config.get('page.host')}${config.get('page.shortUrlId')}/sbl`;
         const emailUrl = encodeURI(emailShortUrl);
         const emailHref = `mailto:?subject=${emailSubject}&body=%E2%80%9C${emailSelection}%E2%80%9D ${emailUrl}`;
 


### PR DESCRIPTION
## What does this change?
Uses theguardian.com rather than gu.com for share links on gallery lightbox and article "selection shares". This way there is no unnecessary extra redirect, and we remove another use of gu.com.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
