### PR TITLE
Update twitter universal tag

### DIFF
--- a/static/src/javascripts/__flow__/types/global.js
+++ b/static/src/javascripts/__flow__/types/global.js
@@ -28,7 +28,7 @@ declare type TagAtrribute = {
 
 declare type ThirdPartyTag = {
     shouldRun: boolean,
-    url: string,
+    url?: string,
     sourcepointId?: string,
     onLoad?: () => any,
     beforeLoad?: () => any,
@@ -36,6 +36,7 @@ declare type ThirdPartyTag = {
     attrs?: Array<TagAtrribute>,
     async?: boolean,
     loaded?: boolean,
+    insertBody?: any,
 };
 
 declare var jsdom: {

--- a/static/src/javascripts/__flow__/types/global.js
+++ b/static/src/javascripts/__flow__/types/global.js
@@ -36,7 +36,7 @@ declare type ThirdPartyTag = {
     attrs?: Array<TagAtrribute>,
     async?: boolean,
     loaded?: boolean,
-    insertBody?: any,
+    insertSnippet?: any,
 };
 
 declare var jsdom: {

--- a/static/src/javascripts/__flow__/types/global.js
+++ b/static/src/javascripts/__flow__/types/global.js
@@ -36,7 +36,7 @@ declare type ThirdPartyTag = {
     attrs?: Array<TagAtrribute>,
     async?: boolean,
     loaded?: boolean,
-    insertSnippet?: any,
+    insertSnippet?: () => any,
 };
 
 declare var jsdom: {

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -31,8 +31,8 @@ const addScripts = (tags: Array<ThirdPartyTag>): void => {
         if (tag.useImage === true && typeof tag.url !== "undefined") {
             new Image().src = tag.url;
         }
-        if (tag.insertBody) {
-            tag.insertBody();
+        if (tag.insertSnippet) {
+            tag.insertSnippet();
         } else {
             hasScriptsToInsert = true;
             const script = document.createElement('script');

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -28,12 +28,17 @@ const addScripts = (tags: Array<ThirdPartyTag>): void => {
         if (tag.beforeLoad) {
             tag.beforeLoad();
         }
-        if (tag.useImage === true) {
+        if (tag.useImage === true && typeof tag.url !== "undefined") {
             new Image().src = tag.url;
+        }
+        if (tag.insertBody) {
+            tag.insertBody();
         } else {
             hasScriptsToInsert = true;
             const script = document.createElement('script');
-            script.src = tag.url;
+            if (typeof tag.url !== "undefined") {
+                script.src = tag.url;
+            }
             script.onload = tag.onLoad;
             if (tag.async === true) {
                 script.setAttribute('async', '');

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-uwt.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-uwt.js
@@ -1,18 +1,23 @@
 // @flow strict
 import config from 'lib/config';
 
-const onLoad = () => {
-    // Insert Twitter Pixel ID and Standard Event data below
-    if (window.twq) {
-        window.twq('init', 'nyl43');
-        window.twq('track', 'PageView');
-    }
+const insertBody = () => {
+    // Twitter universal website tag code -->
+    /*eslint-disable */
+    // $FlowFixMe
+        !function(e,t,n,s,u,a){e.twq||(s=e.twq=function(){s.exe?s.exe(...arguments):s.queue.push(arguments);
+    },s.version='1.1',s.queue=[],u=t.createElement(n),u.async=!0,u.src='//static.ads-twitter.com/uwt.js',
+        a=t.getElementsByTagName(n)[0],a.parentNode.insertBefore(u,a))}(window,document,'script');
+        // Insert Twitter Pixel ID and Standard Event data below
+        // $FlowFixMe
+        twq('init','nyl43');
+        twq('track','PageView');
+    /* eslint-enable */
 };
 
 // Twitter universal website tag code
 export const twitterUwt: () => ThirdPartyTag = () => ({
     shouldRun: config.get('switches.twitterUwt', false),
-    url: '//static.ads-twitter.com/uwt.js',
     sourcepointId: '5e71760b69966540e4554f01',
-    onLoad,
+    insertBody,
 });

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-uwt.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-uwt.js
@@ -2,7 +2,8 @@
 import config from 'lib/config';
 
 const insertSnippet = () => {
-    // Twitter universal website tag code -->
+    // Twitter universal website tag code
+    // How to set up conversion tracking: https://business.twitter.com/en/help/campaign-measurement-and-analytics/conversion-tracking-for-websites.html
     /*eslint-disable */
     // $FlowFixMe
         !function(e,t,n,s,u,a){e.twq||(s=e.twq=function(){s.exe?s.exe(...arguments):s.queue.push(arguments);

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-uwt.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-uwt.js
@@ -1,7 +1,7 @@
 // @flow strict
 import config from 'lib/config';
 
-const insertBody = () => {
+const insertSnippet = () => {
     // Twitter universal website tag code -->
     /*eslint-disable */
     // $FlowFixMe
@@ -19,5 +19,5 @@ const insertBody = () => {
 export const twitterUwt: () => ThirdPartyTag = () => ({
     shouldRun: config.get('switches.twitterUwt', false),
     sourcepointId: '5e71760b69966540e4554f01',
-    insertBody,
+    insertSnippet,
 });

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-uwt.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-uwt.spec.js
@@ -20,7 +20,7 @@ describe('twitterUwt', () => {
         expect(sourcepointId).toBe('5e71760b69966540e4554f01');
     });
 
-    it('should have insert body function', () => {
+    it('should have insertSnippet function', () => {
         config.set('switches.twitterUwt', true);
         const { insertSnippet  } = twitterUwt();
 

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-uwt.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-uwt.spec.js
@@ -22,8 +22,8 @@ describe('twitterUwt', () => {
 
     it('should have insert body function', () => {
         config.set('switches.twitterUwt', true);
-        const { insertBody  } = twitterUwt();
+        const { insertSnippet  } = twitterUwt();
 
-        expect(insertBody).toBeDefined();
+        expect(insertSnippet).toBeDefined();
     });
 });

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-uwt.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-uwt.spec.js
@@ -5,20 +5,25 @@ import config from 'lib/config';
 describe('twitterUwt', () => {
     it('shouldRun to be true if ad the switch is on', () => {
         config.set('switches.twitterUwt', true);
-        const { shouldRun, url, onLoad } = twitterUwt();
+        const { shouldRun, url } = twitterUwt();
 
         expect(shouldRun).toEqual(true);
-        expect(url).toEqual('//static.ads-twitter.com/uwt.js');
-        expect(onLoad).toBeDefined();
+        expect(url).toBeUndefined();
     });
 
     it('shouldRun to be false if the switch is off', () => {
         config.set('switches.twitterUwt', false);
-        const { shouldRun, url, onLoad, sourcepointId } = twitterUwt();
+        const { shouldRun, url, sourcepointId } = twitterUwt();
 
         expect(shouldRun).toEqual(false);
-        expect(url).toEqual('//static.ads-twitter.com/uwt.js');
-        expect(onLoad).toBeDefined();
+        expect(url).toBeUndefined();
         expect(sourcepointId).toBe('5e71760b69966540e4554f01');
+    });
+
+    it('should have insert body function', () => {
+        config.set('switches.twitterUwt', true);
+        const { insertBody  } = twitterUwt();
+
+        expect(insertBody).toBeDefined();
     });
 });


### PR DESCRIPTION
## What does this change?

We have been using an old twitter tag which wasn't working. This PR refactors the third-party-tags module to allow the addition of scripts tag as a snippet rather that a URL.
Twitter pixel need to be added as is to the page rather than a script tag with a URL

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

### Before

<img width="1052" alt="Screenshot 2020-08-28 at 13 09 31" src="https://user-images.githubusercontent.com/51630004/91549812-32e82c80-e930-11ea-8923-59dc0313ae71.png">


### After

<img width="1052" alt="Screenshot 2020-08-28 at 13 09 10" src="https://user-images.githubusercontent.com/51630004/91549820-37ace080-e930-11ea-94a3-c5d9dfe429ff.png">


## What is the value of this and can you measure success?
Twitter integration will start working again

### Tested

- [x] Locally
- [ ] On CODE (optional)

