### PR TITLE
Attempt to fix hover on feature stories in dynamo

### DIFF
--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -213,13 +213,13 @@ $block-height: 58px; // Note: duplicated from _item.scss
             .fc-item__headline {
                 color: #ffffff;
             }
-        }
 
-        &:hover {
-            background-color: darken($story-package-card-colour, 5%);
-
-            .fc-trail__count--commentcount {
+            &:hover {
                 background-color: darken($story-package-card-colour, 5%);
+
+                .fc-trail__count--commentcount {
+                    background-color: darken($story-package-card-colour, 5%);
+                }
             }
         }
 


### PR DESCRIPTION
## What does this change?
Scopes the darker hover on dynamo containers to not happen when the story is `feature` in order to fix an issue reported by fronts editors.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
Before
![image](https://user-images.githubusercontent.com/8754692/91853193-bfa92800-ec59-11ea-9c13-4686ba8a42ad.png)

After
![image](https://user-images.githubusercontent.com/8754692/91853214-c8016300-ec59-11ea-8d66-d9b181cc28c5.png)


## What is the value of this and can you measure success?
Fixes a visual bug that comes up semi-often at the moment.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
