### PR TITLE
Enable older guardian video in the article picker

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -53,6 +53,7 @@ object ArticlePageChecks {
       blockElement match {
         case _: AudioBlockElement     => false
         case _: DocumentBlockElement  => false
+        case _: GuVideoBlockElement  => false
         case _: ImageBlockElement     => false
         case _: InstagramBlockElement => false
         case _: PullquoteBlockElement => false


### PR DESCRIPTION
## What does this change?
Adds the support for older guardian video within DCR articles.

## Can you measure success?
Should bump up DCRcouldrender %