### PR TITLE
Better email headline extraction

### DIFF
--- a/facia/app/controllers/front/FrontHeadline.scala
+++ b/facia/app/controllers/front/FrontHeadline.scala
@@ -2,6 +2,7 @@ package controllers.front
 
 import common.Logging
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
+import model.facia.PressedCollection
 import model.{Cached, PressedPage}
 import play.api.mvc.Results
 
@@ -11,12 +12,18 @@ object FrontHeadline extends Results with Logging {
     NotFound("Could not extract headline from front"),
   )
 
+  def collectionIsSuitableForHeadlineExtraction(collection: PressedCollection): Boolean = {
+    collection.curatedPlusBackfillDeduplicated.headOption match {
+      case None                 => false
+      case Some(pressedContent) => pressedContent.properties.webTitle.size > 0
+    }
+  }
+
   def renderEmailHeadline(faciaPage: PressedPage): Cached.CacheableResult = {
     val webTitle = for {
-      topCollection <- faciaPage.collections.headOption
+      topCollection <- faciaPage.collections.filter(collectionIsSuitableForHeadlineExtraction).headOption
       topCurated <- topCollection.curatedPlusBackfillDeduplicated.headOption
     } yield RevalidatableResult.Ok(topCurated.properties.webTitle)
-
     webTitle.getOrElse {
       log.warn(s"headline not found for ${faciaPage.id}")
       headlineNotFound


### PR DESCRIPTION
## What does this change?

Correct a problem by which the headline is sometimes empty because the corresponding `content.properties.webTitle` was an empty string.
