### PR TITLE
Redirect AMP errors to canonical URL

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -108,7 +108,7 @@ class ArticleController(
       case EmailFormat                        => Future.successful(common.renderEmail(ArticleEmailHtmlPage.html(article), article))
       case HtmlFormat if tier == RemoteRender => remoteRenderer.getArticle(ws, path, article, blocks, pageType)
       case HtmlFormat                         => Future.successful(common.renderHtml(ArticleHtmlPage.html(article), article))
-      case AmpFormat if isAmpSupported        => remoteRenderer.getAMPArticle(ws, path, article, blocks, pageType)
+      case AmpFormat if isAmpSupported        => remoteRenderer.getAMPArticle(ws, article, blocks, pageType)
       case AmpFormat                          => Future.successful(common.renderHtml(ArticleHtmlPage.html(article), article))
     }
   }

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -64,7 +64,7 @@ class LiveBlogController(
               case (blog: LiveBlogPage, HtmlFormat) =>
                 Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
               case (blog: LiveBlogPage, AmpFormat) if isAmpSupported =>
-                remoteRenderer.getAMPArticle(ws, path, page, blocks, pageType)
+                remoteRenderer.getAMPArticle(ws, blog, blocks, pageType)
               case (blog: LiveBlogPage, AmpFormat) =>
                 Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
               case _ => Future.successful(NotFound)

--- a/article/app/renderers/RemoteRenderer.scala
+++ b/article/app/renderers/RemoteRenderer.scala
@@ -2,14 +2,14 @@ package renderers
 
 import akka.actor.ActorSystem
 import com.gu.contentapi.client.model.v1.Blocks
-import common.Logging
+import common.{LinkTo, Logging}
 import concurrent.CircuitBreakerRegistry
 import conf.Configuration
 import conf.switches.Switches.CircuitBreakerSwitch
 import model.Cached.RevalidatableResult
 import model.dotcomponents.{DCRDataModel, DotcomponentsDataModel}
-import model.{Cached, PageWithStoryPackage, NoCache}
-import play.api.libs.ws.WSClient
+import model.{Cached, NoCache, PageWithStoryPackage}
+import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc.{RequestHeader, Result}
 import play.twirl.api.Html
 
@@ -31,49 +31,54 @@ class RemoteRenderer extends Logging {
   private[this] def get(
       ws: WSClient,
       payload: String,
-      article: PageWithStoryPackage,
       endpoint: String,
+      handler: WSResponse => Result,
   )(implicit request: RequestHeader): Future[Result] = {
 
-    def get(): Future[Result] = {
-
+    def getRecover(): Future[Result] = {
       ws.url(endpoint)
         .withRequestTimeout(Configuration.rendering.timeout)
         .addHttpHeaders("Content-Type" -> "application/json")
         .post(payload)
-        .map(response => {
-          response.status match {
-            case 200 =>
-              Cached(article)(RevalidatableResult.Ok(Html(response.body)))
-                .withHeaders("X-GU-Dotcomponents" -> "true")
-            case 400 =>
-              // if DCR returns a 400 it's because *we* failed, so frontend should return a 500
-              NoCache(play.api.mvc.Results.InternalServerError("Remote renderer validation error (400)"))
-                .withHeaders("X-GU-Dotcomponents" -> "true")
-            case _ =>
-              NoCache(play.api.mvc.Results.InternalServerError("Remote renderer error (500)"))
-                .withHeaders("X-GU-Dotcomponents" -> "true")
-          }
-        })
+        .map(handler)
     }
 
     if (CircuitBreakerSwitch.isSwitchedOn) {
-      circuitBreaker.withCircuitBreaker(get())
+      circuitBreaker.withCircuitBreaker(getRecover())
     } else {
-      get()
+      getRecover()
     }
   }
 
   def getAMPArticle(
       ws: WSClient,
-      payload: String,
       page: PageWithStoryPackage,
       blocks: Blocks,
       pageType: PageType,
   )(implicit request: RequestHeader): Future[Result] = {
     val dataModel = DotcomponentsDataModel.fromArticle(page, request, blocks, pageType)
     val json = DCRDataModel.toJson(dataModel)
-    get(ws, json, page, Configuration.rendering.AMPArticleEndpoint)
+
+    def handler(response: WSResponse): Result = {
+      response.status match {
+        case 200 =>
+          Cached(page)(RevalidatableResult.Ok(Html(response.body)))
+            .withHeaders("X-GU-Dotcomponents" -> "true")
+        case 400 =>
+          // if DCR returns a 400 it's because *we* failed, so frontend should return a 500
+          NoCache(play.api.mvc.Results.InternalServerError("Remote renderer validation error (400)"))
+            .withHeaders("X-GU-Dotcomponents" -> "true")
+        case _ =>
+          // Ensure AMP doesn't cache error responses by redirecting them to non-AMP
+          NoCache(
+            play.api.mvc.Results
+              .TemporaryRedirect(LinkTo(page.metadata.url))
+              .withHeaders("X-GU-Dotcomponents" -> "true"),
+          )
+      }
+    }
+
+    get(ws, json, Configuration.rendering.AMPArticleEndpoint, handler)
   }
 
   def getArticle(
@@ -85,7 +90,26 @@ class RemoteRenderer extends Logging {
   )(implicit request: RequestHeader): Future[Result] = {
     val dataModel = DotcomponentsDataModel.fromArticle(page, request, blocks, pageType)
     val json = DCRDataModel.toJson(dataModel)
-    get(ws, json, page, Configuration.rendering.renderingEndpoint)
+
+    def handler(response: WSResponse): Result = {
+      response.status match {
+        case 200 =>
+          Cached(page)(RevalidatableResult.Ok(Html(response.body)))
+            .withHeaders("X-GU-Dotcomponents" -> "true")
+        case 400 =>
+          // if DCR returns a 400 it's because *we* failed, so frontend should return a 500
+          NoCache(play.api.mvc.Results.InternalServerError("Remote renderer validation error (400)"))
+            .withHeaders("X-GU-Dotcomponents" -> "true")
+        case _ =>
+          NoCache(
+            play.api.mvc.Results
+              .InternalServerError("Remote renderer error (500)")
+              .withHeaders("X-GU-Dotcomponents" -> "true"),
+          )
+      }
+    }
+
+    get(ws, json, Configuration.rendering.renderingEndpoint, handler)
   }
 }
 


### PR DESCRIPTION
## What does this change?

Redirect AMP errors to main version rather than returning an error.

cc @rcrphillips 
