### PR TITLE
Ensure secure link for GuVideoBlockElement

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -421,6 +421,8 @@ object PageElement {
 
       case Video =>
         if (element.assets.nonEmpty) {
+          println(element.videoTypeData.flatMap(_.html).getOrElse(""))
+          val html = ensureSecureLinkInHTMLFragment(element.videoTypeData.flatMap(_.html).getOrElse(""))
           List(
             GuVideoBlockElement(
               element.assets.map(VideoAsset.make),
@@ -430,7 +432,7 @@ object PageElement {
               element.videoTypeData.flatMap(_.caption).getOrElse(""),
               element.videoTypeData.flatMap(_.url).getOrElse(""),
               element.videoTypeData.flatMap(_.originalUrl).getOrElse(""),
-              element.videoTypeData.flatMap(_.html).getOrElse(""),
+              html,
               element.videoTypeData.flatMap(_.source).getOrElse(""),
               Role(element.videoTypeData.flatMap(_.role)),
             ),
@@ -662,6 +664,10 @@ object PageElement {
       case Form                      => List(FormBlockElement(None))
       case EnumUnknownElementType(f) => List(UnknownBlockElement(None))
     }
+  }
+
+  private[this] def ensureSecureLinkInHTMLFragment(html: String): String = {
+    html.replaceAll("http:", "https:")
   }
 
   private[this] def getIframeSrc(html: String): Option[String] = {


### PR DESCRIPTION
## What does this change?

Ensures that `GuVideoBlockElement` sent to DCR uses secure links. This is a quick fix for handling an old video that was reused today. (Refactoring might follow).

BEFORE:
```
<video data-media-id="gu-video-457132757" class="gu-video" controls="controls" poster="http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2015/6/11/1434025823959/KP_270483_crop_640x360.jpg"> 
<source src="http://cdn.theguardian.tv/mainwebsite/2015/06/11/150611spacediary_desk.mp4"/>
<source src="http://cdn.theguardian.tv/3gp/small/2015/06/11/150611spacediary_small.3gp"/>
<source src="http://cdn.theguardian.tv/HLS/2015/06/11/150611spacediary.m3u8"/>
<source src="http://cdn.theguardian.tv/3gp/large/2015/06/11/150611spacediary_large.3gp"/>
<source src="http://cdn.theguardian.tv/webM/2015/06/11/150611spacediary_synd_768k_vp8.webm"/>
</video>
```


AFTER:

<img width="1252" alt="Screenshot 2020-09-02 at 14 51 02" src="https://user-images.githubusercontent.com/6035518/91992236-cd2ee280-ed2b-11ea-9ce3-d608113e37f8.png">
