### PR TITLE
Temporarily disable DCR support for GuVideoBlockElement (again)

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -53,7 +53,7 @@ object ArticlePageChecks {
       blockElement match {
         case _: AudioBlockElement     => false
         case _: DocumentBlockElement  => false
-        case _: GuVideoBlockElement   => false
+        case _: GuVideoBlockElement   => true
         case _: ImageBlockElement     => false
         case _: InstagramBlockElement => false
         case _: PullquoteBlockElement => false

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -286,7 +286,7 @@ object PageElement {
       case _: ExplainerAtomBlockElement   => true
       case _: GenericAtomBlockElement     => true
       case _: GuideAtomBlockElement       => true
-      case _: GuVideoBlockElement         => false
+      case _: GuVideoBlockElement         => true
       case _: ImageBlockElement           => true
       case _: InstagramBlockElement       => true
       case _: InteractiveAtomBlockElement => true


### PR DESCRIPTION
## What does this change?

Temporarily disable DCR support for GuVideoBlockElement (using the HTML field is not good, as old videos carry unsecured links). Correct: https://github.com/guardian/frontend/pull/22961


