### PR TITLE
Node bump: single “v” in version number

### DIFF
--- a/git-hooks/post-merge
+++ b/git-hooks/post-merge
@@ -15,7 +15,7 @@ execa
 
             console.log(
                 `${chalk.red(
-                    `Frontend now requires Node v${nvmrcVersion}. Switch to the latest version using \`nvm install\` or download from nodejs.org. Then run \`make reinstall\`.`
+                    `Frontend now requires Node ${nvmrcVersion}. Switch to the latest version using \`nvm install\` or download from nodejs.org. Then run \`make reinstall\`.`
                 )}`
             );
         } else if (changedFiles.includes('yarn.lock')) {


### PR DESCRIPTION
## What does this change?

Follow up on #22950 with a cosmetic fix.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

![image](https://user-images.githubusercontent.com/76776/92007660-230c8600-ed3e-11ea-9479-230b7f67516a.png)

## What is the value of this and can you measure success?

The offending double “v” `Frontend now requires Node vv10.22.0` is now gone.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
