### PR TITLE
[CMP] Remove unused switches from Commercial

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -17,46 +17,6 @@ trait CommercialSwitches {
     exposeClientSide = true,
   )
 
-  val CmpUi = Switch(
-    SwitchGroup.Feature,
-    "cmp-ui",
-    "If this switch is off, the CMP UI will be completely unavailable to users.",
-    owners = group(Commercial),
-    safeState = On,
-    sellByDate = never,
-    exposeClientSide = true,
-  )
-
-  val CcpaCmpUi = Switch(
-    SwitchGroup.Feature,
-    "ccpa-cmp-ui",
-    "If this switch is on, the CCPA CMP UI will be available to users in the USA.",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true,
-  )
-
-  val TCFv2DCR = Switch(
-    SwitchGroup.Feature,
-    "tcfv2-dcr",
-    "If this switch is on, the TCF v2 CMP UI will be shown to users outside the USA on DCR.",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true,
-  )
-
-  val TCFv2Frontend = Switch(
-    SwitchGroup.Feature,
-    "tcfv2-frontend",
-    "If this switch is on, the TCF v2 CMP UI will be available to users outside the USA on frontend.",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true,
-  )
-
   val CarrotTrafficDriverSwitch = Switch(
     Commercial,
     "carrot-traffic-driver",
@@ -367,16 +327,6 @@ trait CommercialSwitches {
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false,
-  )
-
-  val enableConsentManagementService: Switch = Switch(
-    group = Commercial,
-    name = "enable-consent-management-service",
-    description = "Enable our CMP service to run on each page, so that vendors can query the consent status.",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true,
   )
 
   val facebookTrackingPixel: Switch = Switch(

--- a/common/app/conf/switches/PrivacySwitches.scala
+++ b/common/app/conf/switches/PrivacySwitches.scala
@@ -9,27 +9,7 @@ trait PrivacySwitches {
   val Cmp = Switch(
     SwitchGroup.Privacy,
     "consent-management",
-    "Enable consent management. Individual frameworks will also need to be switched on.",
-    owners = group(Commercial),
-    safeState = On,
-    sellByDate = never,
-    exposeClientSide = true,
-  )
-
-  val TCFv2 = Switch(
-    SwitchGroup.Privacy,
-    "framework-tcfv2",
-    "Enable the TCFv2 framework (if consent-management is on).",
-    owners = group(Commercial),
-    safeState = On,
-    sellByDate = never,
-    exposeClientSide = true,
-  )
-
-  val CCPA = Switch(
-    SwitchGroup.Privacy,
-    "framework-ccpa",
-    "Enable the CCPA framework (if consent-management is on).",
+    "Enable consent management.",
     owners = group(Commercial),
     safeState = On,
     sellByDate = never,

--- a/common/app/views/fragments/inlineJSNonBlocking.scala.html
+++ b/common/app/views/fragments/inlineJSNonBlocking.scala.html
@@ -1,5 +1,5 @@
 @import common.InlineJs
-@import conf.switches.Switches.{IdentityProfileNavigationSwitch, enableConsentManagementService, LotameSwitch}
+@import conf.switches.Switches.{IdentityProfileNavigationSwitch, Cmp, LotameSwitch}
 @import conf.Configuration
 @import model.Page
 @import templates.inlineJS.nonBlocking.js._


### PR DESCRIPTION
## What does this change?

Removes switches that are not used. The Privacy group is where the relevant ones are found, since #22901.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

![image](https://user-images.githubusercontent.com/76776/92009659-bc3c9c00-ed40-11ea-80ce-afb23d57e96f.png)

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
