### PR TITLE
Stop including interactive snaps in emails

### DIFF
--- a/common/app/layout/CollectionEmail.scala
+++ b/common/app/layout/CollectionEmail.scala
@@ -34,8 +34,18 @@ object EmailContentContainer {
   }
 
   private def pressedCollectionToContentContainer(pressedCollection: PressedCollection): EmailContentContainer = {
-    val cards = pressedCollection.curatedPlusBackfillDeduplicated.flatMap(contentCard(_, pressedCollection.config))
-    fromCollectionAndCards(pressedCollection, cards)
+    val cards =
+      pressedCollection.curatedPlusBackfillDeduplicated.flatMap(contentCard(_, pressedCollection.config))
+
+    /*
+        date: 03rd September 2020
+        author: Pascal
+        message: emailcards was introduced, as a subset of cards, to avoid interactive snaps in
+        emails (original request from Celine). `c.snapStuff.isDefined` seems to be the right way to do it.
+     */
+    val emailcards = cards.filterNot(c => c.snapStuff.isDefined)
+
+    fromCollectionAndCards(pressedCollection, emailcards)
   }
 
   def storiesCount(collectionConfig: CollectionConfig): Int =

--- a/common/app/layout/CollectionEmail.scala
+++ b/common/app/layout/CollectionEmail.scala
@@ -34,8 +34,7 @@ object EmailContentContainer {
   }
 
   private def pressedCollectionToContentContainer(pressedCollection: PressedCollection): EmailContentContainer = {
-    val cards =
-      pressedCollection.curatedPlusBackfillDeduplicated.flatMap(contentCard(_, pressedCollection.config))
+    val cards = pressedCollection.curatedPlusBackfillDeduplicated.flatMap(contentCard(_, pressedCollection.config))
 
     /*
         date: 03rd September 2020


### PR DESCRIPTION
## What does this change?

To avoid interactive snaps in emails (original request from Celine). `c.snapStuff.isDefined` seems to be the right way to do it.

CODE:

<img width="1253" alt="Screenshot 2020-09-03 at 15 10 02" src="https://user-images.githubusercontent.com/6035518/92126512-2ebc8300-edf8-11ea-82ab-779a3e1e2aca.png">


BEFORE:

<img width="1010" alt="Screenshot 2020-09-03 at 15 10 09" src="https://user-images.githubusercontent.com/6035518/92126508-2cf2bf80-edf8-11ea-93bf-1867027e5702.png">


AFTER:

<img width="1003" alt="Screenshot 2020-09-03 at 15 10 20" src="https://user-images.githubusercontent.com/6035518/92126389-06348900-edf8-11ea-81dd-cd83551c9977.png">