### PR TITLE
Identity | Sign In Gate | Remove full width background

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/main-variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/main-variant.js
@@ -54,7 +54,6 @@ const htmlTemplate: ({
             <a class="signin-gate__link--var signin-gate__signin--var js-signin-gate__sign-in signin-gate__link-no-ptm signin-gate__center-424" href="${signInUrl}">Sign in</a>
         </div>
         <div class="signin-gate__faqlinks--var signin-gate__margin-top--var">
-            <div class="signin-gate__faqlinks--fullwidth--var"></div>
             <div class="signin-gate__buttons">
                 <a class="signin-gate__link--var js-signin-gate__why" href="${guUrl}/membership/2019/dec/20/signing-in-to-the-guardian">Why register & how does it help?</a>
             </div>
@@ -86,12 +85,6 @@ export const designShow: ({
         handler: ({ articleBody, shadowArticleBody }) => {
             // fix the border on the faqlinks
             gateBorderFix();
-
-            addCSSOnOpinion({
-                element: shadowArticleBody,
-                selector: '.signin-gate__faqlinks--fullwidth--var',
-                css: 'signin-gate__faqlinks--fullwidth--var--comment',
-            });
 
             addCSSOnOpinion({
                 element: shadowArticleBody,

--- a/static/src/stylesheets/module/identity/_sign-in-gate.scss
+++ b/static/src/stylesheets/module/identity/_sign-in-gate.scss
@@ -316,46 +316,14 @@
 }
 
 .signin-gate__faqlinks--var {
-    background-color: $brightness-97;
     padding-bottom: $gs-baseline * 3;
     padding-top: $gs-baseline * 1;
     position: relative;
 }
 .signin-gate__faqlinks--var--comment {
-    background-color: $brightness-100;
     padding-bottom: $gs-baseline * 3;
     padding-top: $gs-baseline * 1;
     position: relative;
-}
-
-.signin-gate__faqlinks--fullwidth--var {
-    background-color: $brightness-97;
-}
-
-.signin-gate__faqlinks--fullwidth--var:before {
-    content: '';
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: -9999px;
-    right: 0;
-    border-left: 9999px solid $brightness-97;
-    box-shadow: 9999px 0 0 $brightness-97;
-}
-
-.signin-gate__faqlinks--fullwidth--var--comment {
-    background-color: $brightness-100;
-}
-
-.signin-gate__faqlinks--fullwidth--var--comment:before {
-    content: '';
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: -9999px;
-    right: 0;
-    border-left: 9999px solid $brightness-100;
-    box-shadow: 9999px 0 0 $brightness-100;
 }
 
 .signin-gate__content-main-column__border-fix:before {


### PR DESCRIPTION
## What does this change?
- Remove the full width background colour from the sign in gate main design as it obstructed the link text

## Screenshots
Opinion:
![localhost_9000_commentisfree_2020_jan_17_a-and-e-wait-times-nhs-investment-review](https://user-images.githubusercontent.com/13315440/92133764-ad1d2300-ee00-11ea-9df5-7baa3bba68ff.png)

Article:
![localhost_9000_science_grrlscientist_2012_aug_07_3](https://user-images.githubusercontent.com/13315440/92133782-b3130400-ee00-11ea-837b-412f5fa2fb53.png)

### Tested

- [X] Locally
- [ ] On CODE (optional)
