### PR TITLE
Stop including interactive snaps in emails [v2]

### DIFF
--- a/common/app/layout/CollectionEmail.scala
+++ b/common/app/layout/CollectionEmail.scala
@@ -35,7 +35,16 @@ object EmailContentContainer {
 
   private def pressedCollectionToContentContainer(pressedCollection: PressedCollection): EmailContentContainer = {
     val cards = pressedCollection.curatedPlusBackfillDeduplicated.flatMap(contentCard(_, pressedCollection.config))
-    fromCollectionAndCards(pressedCollection, cards)
+
+    /*
+        date: 03rd September 2020
+        author: Pascal
+        message: emailcards was introduced, as a subset of cards, to avoid interactive snaps in
+        emails (original request from Celine). `c.snapStuff.isDefined` seems to be the right way to do it.
+     */
+    val emailcards = cards.filterNot(c => c.snapStuff.isDefined)
+
+    fromCollectionAndCards(pressedCollection, emailcards)
   }
 
   def storiesCount(collectionConfig: CollectionConfig): Int =

--- a/common/app/layout/CollectionEmail.scala
+++ b/common/app/layout/CollectionEmail.scala
@@ -40,9 +40,10 @@ object EmailContentContainer {
         date: 03rd September 2020
         author: Pascal
         message: emailcards was introduced, as a subset of cards, to avoid interactive snaps in
-        emails (original request from Celine). `c.snapStuff.isDefined` seems to be the right way to do it.
+        emails (original request from Celine)
      */
-    val emailcards = cards.filterNot(c => c.snapStuff.isDefined)
+    val emailcards =
+      cards.filterNot(c => c.properties.fold(false)(p => p.embedType.fold(false)(_ == "interactive")))
 
     fromCollectionAndCards(pressedCollection, emailcards)
   }

--- a/common/app/layout/CollectionEmail.scala
+++ b/common/app/layout/CollectionEmail.scala
@@ -43,7 +43,7 @@ object EmailContentContainer {
         emails (original request from Celine)
      */
     val emailcards =
-      cards.filterNot(c => c.properties.fold(false)(p => p.embedType.fold(false)(_ == "interactive")))
+      cards.filterNot(_.properties.fold(false)(_.embedType.fold(false)(_ == "interactive")))
 
     fromCollectionAndCards(pressedCollection, emailcards)
   }


### PR DESCRIPTION
## What does this change?

Stop including interactive snaps in emails. Redo of this one ( https://github.com/guardian/frontend/pull/22965 ) which was too aggressive. 
