### PR TITLE
secureVideoHtmlUrls for GuVideoBlockElement

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -53,7 +53,7 @@ object ArticlePageChecks {
       blockElement match {
         case _: AudioBlockElement     => false
         case _: DocumentBlockElement  => false
-        case _: GuVideoBlockElement   => true
+        case _: GuVideoBlockElement   => false
         case _: ImageBlockElement     => false
         case _: InstagramBlockElement => false
         case _: PullquoteBlockElement => false

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -426,7 +426,29 @@ object PageElement {
 
       case Audio => audioToPageElement(element).toList
 
-      case Video =>
+      case Video => {
+        def enhanceHTML(html: String): String = {
+          /*
+            Date: 04th September 2020
+            author: Pascal
+
+            Enhance HTML process cases such as
+
+            <video data-media-id=\"gu-video-457132757\" class=\"gu-video\" controls=\"controls\" poster=\"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2015/6/11/1434025823959/KP_270483_crop_640x360.jpg\">
+              <source src=\"http://cdn.theguardian.tv/mainwebsite/2015/06/11/150611spacediary_desk.mp4\"/>
+              <source src=\"http://cdn.theguardian.tv/3gp/small/2015/06/11/150611spacediary_small.3gp\"/>
+              <source src=\"http://cdn.theguardian.tv/HLS/2015/06/11/150611spacediary.m3u8\"/>
+              <source src=\"http://cdn.theguardian.tv/3gp/large/2015/06/11/150611spacediary_large.3gp\"/>
+              <source src=\"http://cdn.theguardian.tv/webM/2015/06/11/150611spacediary_synd_768k_vp8.webm\"/>
+            </video>
+
+            Originally found at https://www.theguardian.com/books/2020/sep/02/top-10-books-about-space-travel-samantha-cristoforetti?dcr=false
+
+            by replacing http://cdn.theguardian.tv by https://cdn.theguardian.tv
+           */
+
+          html.replaceAll("http://cdn.theguardian.tv", "https://cdn.theguardian.tv")
+        }
         if (element.assets.nonEmpty) {
           List(
             GuVideoBlockElement(
@@ -437,12 +459,13 @@ object PageElement {
               element.videoTypeData.flatMap(_.caption).getOrElse(""),
               element.videoTypeData.flatMap(_.url).getOrElse(""),
               element.videoTypeData.flatMap(_.originalUrl).getOrElse(""),
-              element.videoTypeData.flatMap(_.html).getOrElse(""),
+              enhanceHTML(element.videoTypeData.flatMap(_.html).getOrElse("")),
               element.videoTypeData.flatMap(_.source).getOrElse(""),
               Role(element.videoTypeData.flatMap(_.role)),
             ),
           )
         } else videoToPageElement(element).toList
+      }
 
       case Membership =>
         element.membershipTypeData

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -469,8 +469,8 @@ object PageElement {
 
           element.assets.toList
             .foldLeft(html) { (h, asset) =>
-              val link = asset.file.getOrElse("")
-              h.replaceAll(link, link.replace("http:", "https:"))
+              val url = asset.file.getOrElse("")
+              h.replaceAll(url, url.replace("http:", "https:"))
             }
         }
         if (element.assets.nonEmpty) {

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -467,14 +467,11 @@ object PageElement {
 
            */
 
-          var enhanceHTML = html
           element.assets.toList
-            .filter(x => x.mimeType.fold(false)(s => s.startsWith("video")))
-            .foreach { asset =>
+            .foldLeft(html) { (h, asset) =>
               val link = asset.file.getOrElse("")
-              enhanceHTML = enhanceHTML.replaceAll(link, link.replace("http:", "https:"))
+              h.replaceAll(link, link.replace("http:", "https:"))
             }
-          enhanceHTML
         }
         if (element.assets.nonEmpty) {
           List(

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -427,7 +427,7 @@ object PageElement {
       case Audio => audioToPageElement(element).toList
 
       case Video => {
-        def enhanceHTML(html: String): String = {
+        def secureVideoHtmlUrls(html: String, element: ApiBlockElement): String = {
           /*
             Date: 04th September 2020
             author: Pascal
@@ -444,10 +444,37 @@ object PageElement {
 
             Originally found at https://www.theguardian.com/books/2020/sep/02/top-10-books-about-space-travel-samantha-cristoforetti?dcr=false
 
-            by replacing http://cdn.theguardian.tv by https://cdn.theguardian.tv
+            We need to replace the links by secure links.
+
+            There are three ways to do this
+
+              1. Replace "http:" by "https:" in the HTML string; but that's a bit dangerous.
+
+              2. Replace "http://cdn.theguardian.tv" by "https://cdn.theguardian.tv"; but that's limiting
+
+              3. Replace all the unsecured links by the secure ones. This is perfect but the problem is to list the (unsecured) links
+                 To achieve that we capitalise on the fact that the links are listed in element.assets
+
+            The outcome is
+
+            <video data-media-id=\"gu-video-457132757\" class=\"gu-video\" controls=\"controls\" poster=\"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2015/6/11/1434025823959/KP_270483_crop_640x360.jpg\">
+              <source src=\"https://cdn.theguardian.tv/mainwebsite/2015/06/11/150611spacediary_desk.mp4\"/>
+              <source src=\"https://cdn.theguardian.tv/3gp/small/2015/06/11/150611spacediary_small.3gp\"/>
+              <source src=\"https://cdn.theguardian.tv/HLS/2015/06/11/150611spacediary.m3u8\"/>
+              <source src=\"https://cdn.theguardian.tv/3gp/large/2015/06/11/150611spacediary_large.3gp\"/>
+              <source src=\"https://cdn.theguardian.tv/webM/2015/06/11/150611spacediary_synd_768k_vp8.webm\"/>
+            </video>
+
            */
 
-          html.replaceAll("http://cdn.theguardian.tv", "https://cdn.theguardian.tv")
+          var enhanceHTML = html
+          element.assets.toList
+            .filter(x => x.mimeType.fold(false)(s => s.startsWith("video")))
+            .foreach { asset =>
+              val link = asset.file.getOrElse("")
+              enhanceHTML = enhanceHTML.replaceAll(link, link.replace("http:", "https:"))
+            }
+          enhanceHTML
         }
         if (element.assets.nonEmpty) {
           List(
@@ -459,7 +486,7 @@ object PageElement {
               element.videoTypeData.flatMap(_.caption).getOrElse(""),
               element.videoTypeData.flatMap(_.url).getOrElse(""),
               element.videoTypeData.flatMap(_.originalUrl).getOrElse(""),
-              enhanceHTML(element.videoTypeData.flatMap(_.html).getOrElse("")),
+              secureVideoHtmlUrls(element.videoTypeData.flatMap(_.html).getOrElse(""), element),
               element.videoTypeData.flatMap(_.source).getOrElse(""),
               Role(element.videoTypeData.flatMap(_.role)),
             ),

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -432,7 +432,7 @@ object PageElement {
             Date: 04th September 2020
             author: Pascal
 
-            Enhance HTML process cases such as
+            Enhance HTML to process cases such as
 
             <video data-media-id=\"gu-video-457132757\" class=\"gu-video\" controls=\"controls\" poster=\"http://static.guim.co.uk/sys-images/Guardian/Pix/audio/video/2015/6/11/1434025823959/KP_270483_crop_640x360.jpg\">
               <source src=\"http://cdn.theguardian.tv/mainwebsite/2015/06/11/150611spacediary_desk.mp4\"/>


### PR DESCRIPTION
## What does this change?

`secureVideoHtmlUrls` for `GuVideoBlockElement`. This change was due since this: https://github.com/guardian/frontend/pull/22961 (after the original: https://github.com/guardian/frontend/pull/22951)