### PR TITLE
Fix repeated word 'articles' in banner copy

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-articles-viewed-opt-out.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/contribs-banner-articles-viewed-opt-out.js
@@ -17,7 +17,7 @@ const articleViewCount = getArticleViewCountForWeeks(articleCountWeeks);
 const geolocation = geolocationGetSync();
 const leadSentence = 'We chose a different approach. Will you support it?'
 const articlesRead = articlesReadTooltipMarkup(articleViewCount)
-const variantMessageText = `We believe every one of us deserves to read quality, independent, fact-checked news and measured explanation – that’s why we keep Guardian journalism open to all. Our editorial independence has never been so vital. No one sets our agenda, or edits our editor, so we can keep providing independent reporting each and every day. You’ve read more than ${articlesRead} articles in the last year. No matter how unpredictable the future feels, we will remain with you. Every contribution, however big or small, makes our work possible – in times of crisis and beyond.`
+const variantMessageText = `We believe every one of us deserves to read quality, independent, fact-checked news and measured explanation – that’s why we keep Guardian journalism open to all. Our editorial independence has never been so vital. No one sets our agenda, or edits our editor, so we can keep providing independent reporting each and every day. You’ve read more than ${articlesRead} in the last year. No matter how unpredictable the future feels, we will remain with you. Every contribution, however big or small, makes our work possible – in times of crisis and beyond.`
 const ctaText = `<span class="engagement-banner__highlight"> Support the Guardian today from as little as ${getLocalCurrencySymbol(geolocation)}1.</span>`;
 
 export const contributionsBannerArticlesViewedOptOut: AcquisitionsABTest = {


### PR DESCRIPTION
## What does this change?
Fix repeated word 'articles' in banner copy.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
Before: 
![Screen Shot 2020-09-04 at 15 04 26](https://user-images.githubusercontent.com/1515970/92360325-86067000-f0e4-11ea-87d3-a83cbdaf86cd.png)

## What is the value of this and can you measure success?
Due to this typo, we have had to turn off article count banner via the feature switch. The Article count banner makes more money than the non-article count one as it appeals to a different audience.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/master/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
