### PR TITLE
Add missing title to AudioAtomBlockElement

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -62,6 +62,7 @@ sealed trait PageElement
 case class AudioAtomBlockElement(
     id: String,
     kicker: String,
+    title: Option[String],
     coverUrl: String,
     trackUrl: String,
     duration: Int,
@@ -554,12 +555,13 @@ object PageElement {
             // Using the AudioAtomBlockElement:
             Some(
               AudioAtomBlockElement(
-                audio.id,
-                audio.data.kicker,
-                audio.data.coverUrl,
-                audio.data.trackUrl,
-                audio.data.duration,
-                audio.data.contentId,
+                id = audio.id,
+                kicker = audio.data.kicker,
+                title = audio.atom.title,
+                coverUrl = audio.data.coverUrl,
+                trackUrl = audio.data.trackUrl,
+                duration = audio.data.duration,
+                contentId = audio.data.contentId,
               ),
             )
           }


### PR DESCRIPTION
## What does this change?

Add missing title to AudioAtomBlockElement.

RENDERED ATOM:

![Screenshot 2020-09-08 at 13 05 21](https://user-images.githubusercontent.com/6035518/92474620-0eb00980-f1d4-11ea-8144-3df538c47928.png)

DCR DATA BEFORE:

![Before](https://user-images.githubusercontent.com/6035518/92474515-e0322e80-f1d3-11ea-9a12-86373056e1fd.png)

DCR DATA  AFTER:

![after](https://user-images.githubusercontent.com/6035518/92474527-e58f7900-f1d3-11ea-8ba2-c06161d25b63.png)


