### PR TITLE
Add Chart Atom to allow list

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -65,7 +65,7 @@ object ArticlePageChecks {
         case ContentAtomBlockElement(_, atomtype) => {
           // ContentAtomBlockElement was expanded to include atomtype.
           // To support an atom type, just add it to supportedAtomTypes
-          val supportedAtomTypes = List("explainer", "interactive", "qanda", "guide", "timeline", "profile")
+          val supportedAtomTypes = List("explainer", "interactive", "qanda", "guide", "timeline", "profile", "chart")
           !supportedAtomTypes.contains(atomtype)
         }
         case _ => true


### PR DESCRIPTION
## What does this change?
This adds the chart atom from atoms-rendering to the article allow-list.

## Screenshots
![image](https://user-images.githubusercontent.com/35331926/92478046-7d439600-f1d9-11ea-8ee2-1d51eb08c3b1.png)
![image](https://user-images.githubusercontent.com/35331926/92478061-86346780-f1d9-11ea-8c1d-a2d406a1bdc1.png)

### Tested

- [X] Locally
- [ ] On CODE (optional)
