### PR TITLE
Update README about change of default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,22 @@ The Guardian website frontend.
 
 Frontend is [a set of Play Framework 2 Scala applications](docs/02-architecture/01-applications-architecture.md). It is built in two parts, using `make` for the client side asset build and SBT for the Play Framework backend.
 
+# Moving to main
+
+The `master` branch in the frontend repository has now been renamed to `main`. If you work with this repository, there are two things you need to do!
+
+First, you need to make some changes to your local repository. We recommend you run the following sequence of commands, which will rename your master branch to main and set main as your default branch.
+
+```
+git fetch --all
+git remote set-head origin -a
+git branch master --set-upstream-to origin/main
+git branch -m master main
+```
+
+
+Second, you’ll need to rebase or merge from main on any branch you’ve started working on before the rename. This is because frontend has a pre-push git hook that is hardcoded to look for `origin/master`. This has been patched in main, so you’ll need to integrate that change into your branch to be able to push to github.
+
 # Documentation
 
 **[All documentation notes and useful items can be found in the `docs` folder](docs).**


### PR DESCRIPTION
## What does this change?

Update the README, with instructions to move the default branch from `master` to `main`. 
