### PR TITLE
Identity | Update Identity library to add new newsletter

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.221"
+  val identityLibVersion = "3.225"
   val awsVersion = "1.11.240"
   val capiVersion = "17.1"
   val faciaVersion = "3.0.20"


### PR DESCRIPTION
## What does this change?

Bump Identity library to `3.225` to add the new `Design Review` newsletter.

Identity PR: https://github.com/guardian/identity/pull/1813