### PR TITLE
Use remote contributions banner

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -44,7 +44,6 @@ import { smartAppBanner } from 'common/modules/ui/smartAppBanner';
 import { init as initTabs } from 'common/modules/ui/tabs';
 import { Toggles } from 'common/modules/ui/toggles';
 import { initPinterest } from 'common/modules/social/pinterest';
-import { membershipEngagementBanner } from 'common/modules/commercial/membership-engagement-banner';
 import { subscriptionBanner } from 'common/modules/ui/subscription-banners/subscription-banner';
 import { initEmail } from 'common/modules/email/email';
 import { init as initIdentity } from 'bootstraps/enhanced/identity-common';
@@ -309,7 +308,6 @@ const initialiseBanner = (): void => {
         breakingNews,
         signInGate,
         membershipBanner,
-        membershipEngagementBanner,
         readerRevenueBanner,
         subscriptionBanner,
         smartAppBanner,

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -143,7 +143,8 @@ const buildBannerPayload = () => {
         countryCode: geolocationGetSync(),
         switches: {
             remoteSubscriptionsBanner: config.get('switches.remoteSubscriptionsBanner', false)
-        }
+        },
+        weeklyArticleHistory: getWeeklyArticleHistory(),
     };
 
     return {


### PR DESCRIPTION
DCR is already fetching contributions banner from the support-dotcom-components service.
We can now use this for frontend as well.

![Screen Shot 2020-09-10 at 08 52 42](https://user-images.githubusercontent.com/1513454/92709057-83a74e80-f34e-11ea-886f-97f6beb63ee1.png)


https://github.com/guardian/support-dotcom-components/pull/226