### PR TITLE
Adds a JSON endpoint for Facia containers

### DIFF
--- a/common/app/model/pressedContent.scala
+++ b/common/app/model/pressedContent.scala
@@ -6,7 +6,7 @@ import com.gu.contentapi.client.utils.DesignType
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichContent
 import com.gu.facia.api.utils.FaciaContentUtils
 import com.gu.facia.api.{models => fapi, utils => fapiutils}
-import com.gu.facia.client.models.{Backfill, CollectionConfigJson, Metadata, CollectionPlatform}
+import com.gu.facia.client.models.{Backfill, CollectionConfigJson, CollectionPlatform, Metadata}
 import common.{Edition, HTML}
 import common.commercial.EditionBranding
 import model.content.{Atoms, MediaAtom}
@@ -26,6 +26,7 @@ import model.{
   VideoElement,
 }
 import org.joda.time.DateTime
+import views.support.ContentOldAgeDescriber
 
 sealed trait PressedContent {
   def properties: PressedProperties
@@ -46,6 +47,14 @@ sealed trait PressedContent {
       editionBranding <- brandings find (_.edition == edition)
       branding <- editionBranding.branding
     } yield branding
+
+  // For DCR
+  def ageWarning: Option[String] = {
+    properties.maybeContent
+      .filter(c => c.tags.tags.exists(_.id == "tone/news"))
+      .map(ContentOldAgeDescriber.apply)
+      .filterNot(_ == "")
+  }
 }
 
 object PressedContent {

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -66,6 +66,22 @@ trait FaciaController
 
   def renderContainerJson(id: String): Action[AnyContent] = renderContainer(id, false)
 
+  def renderContainerDataJson(id: String): Action[AnyContent] =
+    Action.async { implicit request =>
+      getPressedCollection(id).map {
+        case Some(collection) =>
+          val onwardItems = OnwardItem.fromCollection(collection)
+
+          Cached(CacheTime.Facia) {
+            JsonComponent(onwardItems)
+          }
+        case None =>
+          Cached(CacheTime.NotFound)(
+            WithoutRevalidationResult(NotFound(s"collection id $id does not exist")),
+          )
+      }
+    }
+
   def renderSomeFrontContainersMf2(
       count: Int,
       offset: Int,

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -70,7 +70,7 @@ trait FaciaController
     Action.async { implicit request =>
       getPressedCollection(id).map {
         case Some(collection) =>
-          val onwardItems = OnwardItem.fromCollection(collection)
+          val onwardItems = OnwardCollection.fromCollection(collection)
 
           Cached(CacheTime.Facia) {
             JsonComponent(onwardItems)

--- a/facia/app/model/OnwardItem.scala
+++ b/facia/app/model/OnwardItem.scala
@@ -1,0 +1,68 @@
+package model
+
+import com.github.nscala_time.time.Imports.DateTimeZone
+import common.{Edition, LinkTo}
+import model.facia.PressedCollection
+import model.pressed.PressedContent
+import play.api.libs.json.Json
+import views.support.{ImgSrc, RemoveOuterParaHtml}
+import implicits.FaciaContentFrontendHelpers._
+import play.api.mvc.RequestHeader
+
+// Temporarily copied from onward for the headlines test. We should move this/refactor if the test is successful.
+case class OnwardItem(
+    url: String,
+    linkText: String,
+    showByline: Boolean,
+    byline: Option[String],
+    image: Option[String],
+    ageWarning: Option[String],
+    isLiveBlog: Boolean,
+    pillar: String,
+    designType: String,
+    webPublicationDate: String,
+    headline: String,
+    mediaType: Option[String],
+    shortUrl: String,
+    kickerText: Option[String],
+    starRating: Option[Int],
+)
+
+object OnwardItem {
+
+  implicit def writes = Json.writes[OnwardItem]
+
+  private[this] def asOnwardItem(content: PressedContent, edition: Edition): OnwardItem = {
+    // a DCR hack that we should standardise
+    def pillarToString(pillar: Pillar): String = {
+      pillar.toString.toLowerCase() match {
+        case "arts" => "culture"
+        case other  => other
+      }
+    }
+
+    OnwardItem(
+      url = LinkTo(content.header.url, edition),
+      linkText = RemoveOuterParaHtml(content.properties.linkText.getOrElse(content.header.headline)).body,
+      showByline = content.properties.showByline,
+      byline = content.properties.byline,
+      image = content.trailPicture.flatMap(ImgSrc.getFallbackUrl),
+      ageWarning = content.ageWarning,
+      isLiveBlog = content.properties.isLiveBlog,
+      pillar = content.maybePillar.map(pillarToString).getOrElse("news"),
+      designType = content.properties.maybeContent.map(_.metadata.designType).getOrElse(Article).toString,
+      webPublicationDate = content.webPublicationDate.withZone(DateTimeZone.UTC).toString,
+      headline = content.header.headline,
+      mediaType = content.card.mediaType.map(_.toString()),
+      shortUrl = content.card.shortUrl,
+      kickerText = content.header.kicker.flatMap(_.properties.kickerText),
+      starRating = content.card.starRating,
+    ),
+  }
+
+  def fromCollection(collection: PressedCollection)(implicit request: RequestHeader): List[OnwardItem] = {
+    collection.curatedPlusBackfillDeduplicated
+      .take(10)
+      .map(pressed => asOnwardItem(pressed, Edition(request)))
+  }
+}

--- a/facia/app/model/OnwardItem.scala
+++ b/facia/app/model/OnwardItem.scala
@@ -32,7 +32,7 @@ object OnwardItem {
 
   implicit def writes = Json.writes[OnwardItem]
 
-  private[this] def asOnwardItem(content: PressedContent, edition: Edition): OnwardItem = {
+  def asOnwardItem(content: PressedContent, edition: Edition): OnwardItem = {
     // a DCR hack that we should standardise
     def pillarToString(pillar: Pillar): String = {
       pillar.toString.toLowerCase() match {
@@ -57,12 +57,29 @@ object OnwardItem {
       shortUrl = content.card.shortUrl,
       kickerText = content.header.kicker.flatMap(_.properties.kickerText),
       starRating = content.card.starRating,
-    ),
+    )
   }
+}
 
-  def fromCollection(collection: PressedCollection)(implicit request: RequestHeader): List[OnwardItem] = {
-    collection.curatedPlusBackfillDeduplicated
+case class OnwardCollection(
+    displayName: String,
+    heading: String,
+    trails: List[OnwardItem],
+)
+
+object OnwardCollection {
+
+  implicit def writes = Json.writes[OnwardCollection]
+
+  def fromCollection(collection: PressedCollection)(implicit request: RequestHeader): OnwardCollection = {
+    val trails = collection.curatedPlusBackfillDeduplicated
       .take(10)
-      .map(pressed => asOnwardItem(pressed, Edition(request)))
+      .map(pressed => OnwardItem.asOnwardItem(pressed, Edition(request)))
+
+    OnwardCollection(
+      displayName = collection.displayName,
+      heading = collection.displayName,
+      trails = trails,
+    )
   }
 }

--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -25,7 +25,8 @@ GET        /container/count/:count/offset/:offset/section/:section/edition/:edit
 #Facia Press
 GET        /collection/*id/rss                                                      controllers.FaciaController.renderCollectionRss(id)
 GET        /container/use-layout/*id.json                                           controllers.FaciaController.renderContainerJsonWithFrontsLayout(id)
-GET        /container/*id.json                                                      controllers.FaciaController.renderContainerJson(id)
+GET        /container/data/*id.json                                                 controllers.FaciaController.renderContainerDataJson(id)
+GET        /container/*id.json                                                     controllers.FaciaController.renderContainerJson(id)
 GET        /most-relevant-container/*path.json                                      controllers.FaciaController.renderMostRelevantContainerJson(path)
 
 # Editionalised pages

--- a/onward/app/models/OnwardCollection.scala
+++ b/onward/app/models/OnwardCollection.scala
@@ -133,12 +133,6 @@ object OnwardCollection {
   implicit val onwardCollectionResponseForDRCv2Writes = Json.writes[OnwardCollectionForDCRv2]
 
   def trailsToItems(trails: Seq[PressedContent])(implicit request: RequestHeader): Seq[OnwardItem] = {
-    def ageWarning(content: PressedContent): Option[String] = {
-      content.properties.maybeContent
-        .filter(c => c.tags.tags.exists(_.id == "tone/news"))
-        .map(ContentOldAgeDescriber.apply)
-        .filterNot(_ == "")
-    }
     trails
       .take(10)
       .map(content =>
@@ -148,7 +142,7 @@ object OnwardCollection {
           showByline = content.properties.showByline,
           byline = content.properties.byline,
           image = content.trailPicture.flatMap(ImgSrc.getFallbackUrl),
-          ageWarning = ageWarning(content),
+          ageWarning = content.ageWarning,
           isLiveBlog = content.properties.isLiveBlog,
           pillar = determinePillar(content.maybePillar),
           designType = content.properties.maybeContent.map(_.metadata.designType).getOrElse(Article).toString,


### PR DESCRIPTION
## What does this change?

    GET /container/data/{containerID}.json

This is for some upcoming onwards tests we'd like to do in DCR. As
a result, some of the code is simply duplicated from Onwards for
now. If successful, we should consolidate this code and decide where
best to locate it.

## Screenshots

![Screenshot 2020-09-10 at 16 14 15](https://user-images.githubusercontent.com/858402/92752285-b5d1a400-f380-11ea-8778-3f77e75ff406.png)

## What is the value of this and can you measure success?

(Enables an upcoming onwards test in DCR.)