### PR TITLE
Braze Banner -> 0.0.7 - support for DigitalSubscriberAppBanner and Braze click analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.7",
     "@guardian/consent-management-platform": "4.3.0",
-    "@guardian/braze-components": "^0.0.6",
+    "@guardian/braze-components": "^0.0.7",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/shimport": "^1.0.2",
     "@guardian/src-button": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.7",
     "@guardian/consent-management-platform": "4.3.0",
-    "@guardian/braze-components": "^0.0.5",
+    "@guardian/braze-components": "^0.0.6",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/shimport": "^1.0.2",
     "@guardian/src-button": "^0.16.1",

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -112,14 +112,18 @@ const show = (): Promise<boolean> => import(
 
         mountDynamic(
             container,
-            module.ExampleComponent,
+            module.DigitalSubscriberAppBanner,
             {
-                message: messageConfig.extras["test-key"],
                 onButtonClick: () => {
                     if (appboy) {
-                        appboy.logInAppMessageClick(messageConfig);
+                        const thisButton = new appboy.InAppMessageButton(null,null,null,null,null,null,parseInt(buttonId))
+                        appboy.logInAppMessageButtonClick(
+                            thisButton, messageConfig
+                        );
                     }
                 },
+                header: messageConfig.extras["header"],
+                body: messageConfig.extras["body"],
             },
             true,
         );

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -43,7 +43,17 @@ type InAppMessage = {
     },
 };
 
-type InAppMessageButton = any;
+type ClickAction = "NEWS_FEED" | "URI" | "NONE"
+
+type InAppMessageButton = (
+    text?: string | null,
+    backgroundColor?: number| null,
+    textColor?: number | null,
+    borderColor?: number | null,
+    clickAction?: ClickAction | null,
+    uri?: string | null,
+    id: number) => void;
+
 type InAppMessageCallback = (InAppMessage) => void;
 
 type AppBoy = {
@@ -53,7 +63,7 @@ type AppBoy = {
     openSession: () => void,
     logInAppMessageButtonClick: (InAppMessageButton, InAppMessage) => void,
     logInAppMessageImpression: (InAppMessage) => void,
-    InAppMessageButton: InAppMessageButton,
+    InAppMessageButton: (null, null, null, null, null, null, number) => any,
 };
 
 let messageConfig: InAppMessage;

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -124,8 +124,8 @@ const show = (): Promise<boolean> => import(
                         );
                     }
                 },
-                header: messageConfig.extras["header"],
-                body: messageConfig.extras["body"],
+                header: messageConfig.extras.header,
+                body: messageConfig.extras.body,
             },
             true,
         );

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -43,7 +43,7 @@ type InAppMessage = {
     },
 };
 
-type InAppMessageButton = [null, null, null, null, null, null, string]
+type InAppMessageButton = (null, null, null, null, null, null, string);
 type InAppMessageCallback = (InAppMessage) => void;
 
 type AppBoy = {

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -45,7 +45,7 @@ type InAppMessage = {
 
 type ClickAction = "NEWS_FEED" | "URI" | "NONE"
 
-type InAppMessageButton = (
+type InAppMessageButtonObject = (
     text?: string | null,
     backgroundColor?: number| null,
     textColor?: number | null,
@@ -61,9 +61,9 @@ type AppBoy = {
     subscribeToInAppMessage: (InAppMessageCallback) => {},
     changeUser: (string) => void,
     openSession: () => void,
-    logInAppMessageButtonClick: (InAppMessageButton, InAppMessage) => void,
+    logInAppMessageButtonClick: (InAppMessageButtonObject, InAppMessage) => void,
     logInAppMessageImpression: (InAppMessage) => void,
-    InAppMessageButton: (null, null, null, null, null, null, number) => any,
+    InAppMessageButton: (null, null, null, null, null, null, number) => InAppMessageButtonObject,
 };
 
 let messageConfig: InAppMessage;

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -45,14 +45,15 @@ type InAppMessage = {
 
 type ClickAction = "NEWS_FEED" | "URI" | "NONE"
 
-type InAppMessageButtonObject = (
-    text?: string,
+type InAppMessageButtonInstance = {
+    text: string,
     backgroundColor?: number,
     textColor?: number,
     borderColor?: number,
     clickAction?: ClickAction,
     uri?: string,
-    id: number) => void;
+    id?: number
+}
 
 type InAppMessageCallback = (InAppMessage) => void;
 
@@ -61,9 +62,9 @@ type AppBoy = {
     subscribeToInAppMessage: (InAppMessageCallback) => {},
     changeUser: (string) => void,
     openSession: () => void,
-    logInAppMessageButtonClick: (InAppMessageButtonObject, InAppMessage) => void,
+    logInAppMessageButtonClick: (InAppMessageButtonInstance, InAppMessage) => void,
     logInAppMessageImpression: (InAppMessage) => void,
-    InAppMessageButton: (null, null, null, null, null, null, number) => InAppMessageButtonObject,
+    InAppMessageButton: (string, ?number, ?number, ?number, ?ClickAction, ?string, ?number) => InAppMessageButtonInstance,
 };
 
 let messageConfig: InAppMessage;
@@ -128,7 +129,7 @@ const show = (): Promise<boolean> => import(
             {
                 onButtonClick: (buttonId: number) => {
                     if (appboy) {
-                        const thisButton = new appboy.InAppMessageButton(null,null,null,null,null,null,buttonId)
+                        const thisButton = new appboy.InAppMessageButton(`Button ${buttonId}`,null,null,null,null,null,buttonId)
                         appboy.logInAppMessageButtonClick(
                             thisButton, messageConfig
                         );

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -46,12 +46,12 @@ type InAppMessage = {
 type ClickAction = "NEWS_FEED" | "URI" | "NONE"
 
 type InAppMessageButtonObject = (
-    text?: string | null,
-    backgroundColor?: number| null,
-    textColor?: number | null,
-    borderColor?: number | null,
-    clickAction?: ClickAction | null,
-    uri?: string | null,
+    text?: string,
+    backgroundColor?: number,
+    textColor?: number,
+    borderColor?: number,
+    clickAction?: ClickAction,
+    uri?: string,
     id: number) => void;
 
 type InAppMessageCallback = (InAppMessage) => void;

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -51,8 +51,8 @@ type AppBoy = {
     subscribeToInAppMessage: (InAppMessageCallback) => {},
     changeUser: (string) => void,
     openSession: () => void,
-    logInAppMessageClick: (InAppMessage) => void,
     logInAppMessageButtonClick: (InAppMessageButton, InAppMessage) => void,
+    logInAppMessageImpression: (InAppMessage) => void,
     InAppMessageButton: InAppMessageButton,
 };
 

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -43,7 +43,7 @@ type InAppMessage = {
     },
 };
 
-type InAppMessageButton = (null, null, null, null, null, null, string);
+type InAppMessageButton = any;
 type InAppMessageCallback = (InAppMessage) => void;
 
 type AppBoy = {
@@ -51,9 +51,9 @@ type AppBoy = {
     subscribeToInAppMessage: (InAppMessageCallback) => {},
     changeUser: (string) => void,
     openSession: () => void,
-    logInAppMessageClick: (InAppMessage) => void;
-    logInAppMessageImpression: (InAppMessage) => void;
-    InAppMessageButton: InAppMessageButton
+    logInAppMessageClick: (InAppMessage) => void,
+    logInAppMessageButtonClick: (InAppMessageButton, InAppMessage) => void,
+    InAppMessageButton: InAppMessageButton,
 };
 
 let messageConfig: InAppMessage;
@@ -116,9 +116,9 @@ const show = (): Promise<boolean> => import(
             container,
             module.DigitalSubscriberAppBanner,
             {
-                onButtonClick: () => {
+                onButtonClick: (buttonId: number) => {
                     if (appboy) {
-                        const thisButton = new appboy.InAppMessageButton(null,null,null,null,null,null,parseInt(buttonId))
+                        const thisButton = new appboy.InAppMessageButton(null,null,null,null,null,null,buttonId)
                         appboy.logInAppMessageButtonClick(
                             thisButton, messageConfig
                         );

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -43,6 +43,7 @@ type InAppMessage = {
     },
 };
 
+type InAppMessageButton = [null, null, null, null, null, null, string]
 type InAppMessageCallback = (InAppMessage) => void;
 
 type AppBoy = {
@@ -52,6 +53,7 @@ type AppBoy = {
     openSession: () => void,
     logInAppMessageClick: (InAppMessage) => void;
     logInAppMessageImpression: (InAppMessage) => void;
+    InAppMessageButton: InAppMessageButton
 };
 
 let messageConfig: InAppMessage;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1168,13 +1168,15 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/braze-components@^0.0.5":
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-0.0.5.tgz#abd9eaaf17feb59dc749b4b616cac80325115df0"
-  integrity sha512-jVO/TAmCKBtxb9yvAVguJ2edE+OLdcUPlk+VN2TsoVR6HqOqzlt1Mmo1WSautU1mO3km4LfIba9mUV49t9eBHw==
+"@guardian/braze-components@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-0.0.6.tgz#ca6a1d5806dc92ca4e34554b65ac11ac716167ef"
+  integrity sha512-xGEFlYHkKivW/Ge7H4HA+a/FSVfEpfQEhp+Jw9HgiPjcTVaqt5NP6RunYFq/HvAHmyN0+VBikrYi3bLsqjM50Q==
   dependencies:
     "@guardian/src-button" "^2.1.0"
     "@guardian/src-foundations" "^2.1.0"
+    "@guardian/src-grid" "^2.2.0"
+    "@guardian/src-icons" "^2.2.0"
 
 "@guardian/consent-management-platform@4.3.0":
   version "4.3.0"
@@ -1241,6 +1243,18 @@
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-2.1.0.tgz#7d4abd30c7cca6df02cd61b125e43f18ac9b801f"
   integrity sha512-1ELb3CtDEhkhUWcv2zVwFqonokYg7pbizQqYMmRfNnHIzNp3+aJl48BHMRTd9Nqqcx+As9syUXPs09CeaAOMfg==
 
+"@guardian/src-foundations@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-2.3.0.tgz#3bd6b3f455f832b4ae01ed62ae91d0e429c52310"
+  integrity sha512-HUGEcA/+mvP9S6vvQjmB1rrt0jVVTuuYhoeuZnYY2UE6u0wz36Zk8VTmTj14yUcxDPbE0gmU4iPNrqAKQ2Ar8Q==
+
+"@guardian/src-grid@^2.2.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-grid/-/src-grid-2.3.0.tgz#56e1cc2e7340602017059d363dab9fd42615ea28"
+  integrity sha512-1WRJm1FHiWTrbL4oqnRM0vJSb3Hs4fvxSW7jvvz6lUBafZS2w8+1YTuh8v40VUhU6UL2d6LIeG72rmpBYdM58w==
+  dependencies:
+    "@guardian/src-helpers" "^2.3.0"
+
 "@guardian/src-helpers@^0.16.1":
   version "0.16.1"
   resolved "https://registry.yarnpkg.com/@guardian/src-helpers/-/src-helpers-0.16.1.tgz#cf1e5e6a2c36bb1d91c9785cbfe7f48b735644aa"
@@ -1254,6 +1268,18 @@
   integrity sha512-M3ShTyoYHcH6tyGsGEp7KgXaJbIpvzmFB9AVvzjs/Ozn9a1ii1F4/FBEBJAlDwijgrnUtASeSZ73ncSkvofdiw==
   dependencies:
     "@guardian/src-foundations" "^2.1.0"
+
+"@guardian/src-helpers@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-helpers/-/src-helpers-2.3.0.tgz#3af8b3c04ffcbb3ce1964d9a9d6694015b265991"
+  integrity sha512-wKSdzYq9Vuf/jDmcKuJ6VmV0ZIi384fXPeNwGrM4dv6utiE7Jv+fP/NYq+5Inirkcn3k/MO+3LY5uI0pTdAnsA==
+  dependencies:
+    "@guardian/src-foundations" "^2.3.0"
+
+"@guardian/src-icons@^2.2.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-icons/-/src-icons-2.3.0.tgz#6fb09b37616ebd075ed1ab7a3363412e2f852b9e"
+  integrity sha512-V/qgRZ+bRIkbyhLF45DY8hSiOwyHIxdkNQ6mq0HMxlGkdqg3MPEfrOHes17VQTPT6NJxwD5S2qHcEKxTs7XDIA==
 
 "@guardian/src-svgs@^0.16.1":
   version "0.16.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1168,10 +1168,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/braze-components@^0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-0.0.6.tgz#ca6a1d5806dc92ca4e34554b65ac11ac716167ef"
-  integrity sha512-xGEFlYHkKivW/Ge7H4HA+a/FSVfEpfQEhp+Jw9HgiPjcTVaqt5NP6RunYFq/HvAHmyN0+VBikrYi3bLsqjM50Q==
+"@guardian/braze-components@^0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-0.0.7.tgz#06d6301b13a4b5393bf71e61a1c8078525369fbf"
+  integrity sha512-ZlXQe5EuPnv+hsEJIEVAbHTSxqBx8yPd9JmCw8ndvYGE8z04H+ZTzTbK26PwpLWiYGSKBmdRvtRqy/qO5A2l6g==
   dependencies:
     "@guardian/src-button" "^2.1.0"
     "@guardian/src-foundations" "^2.1.0"


### PR DESCRIPTION
## What does this change?
We have moved to the new Braze Banner component module in npm. This banner pulls 'header' and 'body' copy from a Braze campaign, and renders it on The Guardian Website.

Buttons clicks are logged in Braze for either 'Button 1' (with a buttonId of 0) or 'Button 2' (with a buttonId of '1') - this is set in the banner in the braze-components [repo](https://github.com/guardian/braze-components). This happens via the logInAppMessageButtonClick method, which requires 6 preceding arguments in addition to the buttonId, none of which are necessary for our purposes. 

The new banner component takes new props, so these have been updated from those required by the previous 'ExampleComponent' (which is not present in the new version of braze-banner in npm).

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes (PR [here](https://github.com/guardian/dotcom-rendering/pull/1910))

We will create a new PR to replicate this functionality in DCR.

## Screenshots
![image](https://user-images.githubusercontent.com/34686302/92753765-1b726000-f382-11ea-9248-4988a03c2214.png)

## What is the value of this and can you measure success?

The banner is a better representation of the final banner required by Marketing, and also passes click analytics to Braze (this has been tested in the Braze interface).

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [X] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
