### PR TITLE
Add Youtube override image if Main Element

### DIFF
--- a/article/app/model/dotcomponents/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomponents/DotcomponentsDataModel.scala
@@ -477,6 +477,7 @@ object DotcomponentsDataModel {
           isImmersive,
           campaigns,
           calloutsUrl,
+          article.elements.thumbnail,
         ),
       )
       .filter(PageElement.isSupported)

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -3,7 +3,12 @@ package model.dotcomrendering.pageElements
 import java.net.URLEncoder
 
 import com.gu.contentapi.client.model.v1.ElementType.{Map => _, _}
-import com.gu.contentapi.client.model.v1.{ElementType, SponsorshipType, BlockElement => ApiBlockElement, Sponsorship => ApiSponsorship}
+import com.gu.contentapi.client.model.v1.{
+  ElementType,
+  SponsorshipType,
+  BlockElement => ApiBlockElement,
+  Sponsorship => ApiSponsorship,
+}
 import conf.Configuration
 import layout.ContentWidths.DotcomRenderingImageRoleWidthByBreakpointMapping
 import model.content._
@@ -264,8 +269,13 @@ case class VideoYoutubeBlockElement(
 ) extends PageElement
 case class VineBlockElement(html: Option[String]) extends PageElement
 case class WitnessBlockElement(html: Option[String]) extends PageElement
-case class YoutubeBlockElement(id: String, assetId: String, channelId: Option[String], mediaTitle: String, overrideImage: Option[String])
-    extends PageElement
+case class YoutubeBlockElement(
+    id: String,
+    assetId: String,
+    channelId: Option[String],
+    mediaTitle: String,
+    overrideImage: Option[String],
+) extends PageElement
 
 // Intended for unstructured html that we can't model, typically rejected by consumers
 case class HTMLFallbackBlockElement(html: String) extends PageElement
@@ -328,7 +338,7 @@ object PageElement {
       isImmersive: Boolean,
       campaigns: Option[JsValue],
       calloutsUrl: Option[String],
-      overrideImage: Option[ImageElement]
+      overrideImage: Option[ImageElement],
   ): List[PageElement] = {
     def extractAtom: Option[Atom] =
       for {
@@ -621,7 +631,7 @@ object PageElement {
                     assetId = asset.id, // Youtube ID
                     channelId = mediaAtom.channelId, // Channel ID
                     mediaTitle = mediaAtom.title, // Caption
-                    overrideImage = if(isMainBlock)imageOverride else None,
+                    overrideImage = if (isMainBlock) imageOverride else None,
                   )
                 })
               }


### PR DESCRIPTION
## What does this change?

If a Youtube video is inside a Main Element it will be provided with the overriding thumbnail image for that article which can be placed on top of the video in DCR

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes (please indicate your plans for DCR Implementation)

Currently working on the implementation on DCR and atoms-rendering at the moment.

## Screenshots

<img width="1057" alt="Screenshot 2020-09-17 at 09 36 41" src="https://user-images.githubusercontent.com/35331926/93446845-9a5b2180-f8c9-11ea-9104-3eef8c164c5a.png">

