### PR TITLE
Remove the reserved email text from account deletion page

### DIFF
--- a/identity/app/views/profile/deletion/accountDeletionForm.scala.html
+++ b/identity/app/views/profile/deletion/accountDeletionForm.scala.html
@@ -35,8 +35,7 @@
         <div class="identity-section">
             <h4><a class="u-underline" href="https://www.theguardian.com/help/identity-faq">Account</a></h4>
             <p class="identity-section__text">
-                Deleting your account removes personal information from our database. Your email address becomes
-                permanently reserved and the same email address cannot be re-used to register a new account.
+                Deleting your account removes your personal information from our database.
             </p>
 
             <h4><a class="u-underline" href="https://www.theguardian.com/community-faqs">Comments</a></h4>


### PR DESCRIPTION
## What does this change?
We are no longer reserving email addresses when a user deletes their account. This updates the text a user sees on the account deletion page to reflect this change.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
<img width="1027" alt="Screenshot 2020-09-17 at 12 21 53" src="https://user-images.githubusercontent.com/33927854/93464127-94bd0600-f8e0-11ea-9ca0-b0381436052c.png">

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
