### PR TITLE
Transpile all @guardian npm packages

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -93,9 +93,7 @@ module.exports = {
         rules: [
             {
                 test: /(\.js)|(\.mjs)$/,
-                // TODO: @guardian/dotcom-rendering is not properly published or pre-transpiled, so we have to
-                // transpile it as part of the frontend build step for now
-                exclude: /(node_modules\/(?!(@guardian\/dotcom-rendering)|(dynamic-import-polyfill))|vendor\/)/,
+                exclude: /(node_modules\/(?!(@guardian\/)|(dynamic-import-polyfill))|vendor\/)/,
                 loader: 'babel-loader',
             },
             {


### PR DESCRIPTION
## What does this change?

Enables transpiling of all `@guardian` npm packages. Ensuring that the platforms transpile means we can safely target ES2020 in @guardian NPM packages.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation) guardian/dotcom-rendering#1921

## Checklist

### Tested

- [ ] Locally
- [ ] On CODE (optional)
