### PR TITLE
E-mail signup footer text update

### DIFF
--- a/common/app/views/emailFragment.scala.html
+++ b/common/app/views/emailFragment.scala.html
@@ -1,5 +1,5 @@
 @(page: model.Page, emailType: String, listName: String)(implicit request: RequestHeader, context: model.ApplicationContext)
 
-@emailEmbed(page){
+@emailEmbed(page) {
     @fragments.email.signup.emailSignUp(emailType, listName, "Sign up to our daily email")
 }

--- a/common/app/views/fragments/email/signup/emailIframe.scala.html
+++ b/common/app/views/fragments/email/signup/emailIframe.scala.html
@@ -2,4 +2,4 @@
     campaignCode: String,
     formType: String = "footer")
 
-<iframe title="Guardian Email Sign-up Form" src="@{"/email/form/" + formType + "/" + listName}" scrolling="no" seamless id="@{formType + "__email-form"}" frameborder="0" class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe" data-form-success-desc="We will send you our picks of the most important headlines tomorrow morning."></iframe>
+<iframe title="Guardian Email Sign-up Form" src="@{"/email/form/" + formType + "/" + listName}" scrolling="no" seamless id="@{formType + "__email-form"}" frameborder="0" class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe" data-form-success-desc="Open up the email and click the verify button to confirm your email address.\nYou'll then start receiving the daily email."></iframe>

--- a/common/app/views/fragments/email/signup/emailIframe.scala.html
+++ b/common/app/views/fragments/email/signup/emailIframe.scala.html
@@ -2,4 +2,4 @@
     campaignCode: String,
     formType: String = "footer")
 
-<iframe title="Guardian Email Sign-up Form" src="@{"/email/form/" + formType + "/" + listName}" scrolling="no" seamless id="@{formType + "__email-form"}" frameborder="0" class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe" data-form-success-desc="Open up the email and click the verify button to confirm your email address.\nYou'll then start receiving the daily email."></iframe>
+<iframe title="Guardian Email Sign-up Form" src="@{"/email/form/" + formType + "/" + listName}" scrolling="no" seamless id="@{formType + "__email-form"}" frameborder="0" class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe" data-form-success-desc="Open up the email and click the verify button to confirm your email address.<br/><br/>You'll then start receiving the daily email."></iframe>

--- a/common/app/views/fragments/email/signup/emailIframe.scala.html
+++ b/common/app/views/fragments/email/signup/emailIframe.scala.html
@@ -2,4 +2,11 @@
     campaignCode: String,
     formType: String = "footer")
 
-<iframe title="Guardian Email Sign-up Form" src="@{"/email/form/" + formType + "/" + listName}" scrolling="no" seamless id="@{formType + "__email-form"}" frameborder="0" class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe" data-form-success-desc="Open up the email and click the verify button to confirm your email address.<br/><br/>You'll then start receiving the daily email."></iframe>
+<iframe
+    title="Guardian Email Sign-up Form"
+    src="@{"/email/form/" + formType + "/" + listName}"
+    scrolling="no" seamless
+    id="@{formType + "__email-form"}" frameborder="0"
+    class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe"
+    data-form-success-headline="We've sent you an email!"
+    data-form-success-desc="Open up the email and click the verify button to confirm your email address.<br/><br/>You'll then start receiving the daily email."></iframe>

--- a/common/app/views/fragments/email/signup/subscriptionResult.scala.html
+++ b/common/app/views/fragments/email/signup/subscriptionResult.scala.html
@@ -7,7 +7,7 @@
         @result match {
             case Subscribed => {
                 @fragments.inlineSvg("mail", "icon")
-                <h3 class="email-sub__message__headline">Please check your emails to confirm your subscription!</h3>
+                <h3 class="email-sub__message__headline">We've sent you an email!</h3>
             }
 
             case InvalidEmail => {

--- a/common/app/views/fragments/email/signup/subscriptionResult.scala.html
+++ b/common/app/views/fragments/email/signup/subscriptionResult.scala.html
@@ -7,7 +7,7 @@
         @result match {
             case Subscribed => {
                 @fragments.inlineSvg("mail", "icon")
-                <h3 class="email-sub__message__headline">We've sent you an email!</h3>
+                <h3 class="email-sub__message__headline">Please check your emails to confirm your subscription!</h3>
             }
 
             case InvalidEmail => {

--- a/static/src/stylesheets/module/email-signup/_form.scss
+++ b/static/src/stylesheets/module/email-signup/_form.scss
@@ -195,7 +195,7 @@
 // FOOTER MODS
 .footer__email-container .email-sub__iframe {
     max-width: gs-span(4);
-    min-height: 90px;
+    min-height: 9rem;
     margin: 0 0 $gs-baseline;
 }
 

--- a/static/src/stylesheets/module/email-signup/_form.scss
+++ b/static/src/stylesheets/module/email-signup/_form.scss
@@ -195,7 +195,7 @@
 // FOOTER MODS
 .footer__email-container .email-sub__iframe {
     max-width: gs-span(4);
-    min-height: 9rem;
+    min-height: 150px;
     margin: 0 0 $gs-baseline;
 }
 

--- a/static/src/stylesheets/module/email-signup/_form.scss
+++ b/static/src/stylesheets/module/email-signup/_form.scss
@@ -155,7 +155,6 @@
 .email-sub__message__headline,
 .email-sub__message__description {
     @include fs-textSans(3);
-    color: #000000;
 }
 
 .email-sub__message__headline {


### PR DESCRIPTION
## What does this change?
Updates foot text and changes the `min-height` to reflect this new text.

I've use two line break elements back to back as this seems to be the best way to force a line gap without changing how we render the success description outside of the footer.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
### After (Desktop)
![image](https://user-images.githubusercontent.com/9122944/93487633-639efe80-f8fd-11ea-8139-819bb26be411.png)

### After (Mobile)
![image](https://user-images.githubusercontent.com/9122944/93487740-79142880-f8fd-11ea-8b67-255e8a7ea121.png)

## What is the value of this and can you measure success?

Fixes text as per [Trello card request][(https://trello.com/c/wONaaqpt/162-fix-the-footer-newsletter-guest-sign-up), improving the legibility of the text and adding more clarity around what to do after sign up.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
