### PR TITLE
Don't show the Braze banner on GLabs paid content pages

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -65,6 +65,20 @@ type AppBoy = {
     InAppMessageButton: (string, ?number, ?number, ?number, ?ClickAction, ?string, ?number) => InAppMessageButtonInstance,
 };
 
+type PreCheckArgs = {
+    brazeSwitch: boolean,
+    apiKey?: string,
+    isDigiSubscriber: boolean,
+    pageConfig: { [string]: any },
+};
+
+const canShowPreChecks = ({
+    brazeSwitch,
+    apiKey,
+    isDigiSubscriber,
+    pageConfig,
+}: PreCheckArgs) => Boolean(brazeSwitch && apiKey && isDigiSubscriber && !pageConfig.isPaidContent);
+
 let messageConfig: InAppMessage;
 let appboy: ?AppBoy;
 
@@ -72,11 +86,12 @@ const canShow = async (): Promise<boolean> => {
     const brazeSwitch = config.get('switches.brazeSwitch');
     const apiKey = config.get('page.brazeApiKey');
 
-    if (!(brazeSwitch && apiKey)) {
-        return false;
-    }
-
-    if (!isDigitalSubscriber()) {
+    if (!canShowPreChecks({
+        brazeSwitch,
+        apiKey,
+        isDigiSubscriber: isDigitalSubscriber(),
+        pageConfig: config.get('page'),
+    })) {
         return false;
     }
 
@@ -175,4 +190,5 @@ export {
     brazeBanner,
     brazeVendorId,
     hasRequiredConsents,
+    canShowPreChecks,
 }

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.spec.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {brazeVendorId, hasRequiredConsents} from "./brazeBanner";
+import {brazeVendorId, canShowPreChecks, hasRequiredConsents} from "./brazeBanner";
 
 jest.mock('lib/raven');
 
@@ -13,6 +13,74 @@ jest.mock('@guardian/consent-management-platform', () => ({
 
 afterEach(() => {
     mockOnConsentChangeResult = undefined;
+});
+
+describe('canShowPreChecks', () => {
+    describe('when the switch is off', () => {
+        it('returns false', () => {
+            const result = canShowPreChecks({
+                brazeSwitch: false,
+                apiKey: 'abcde',
+                isDigiSubscriber: true,
+                pageConfig: {isPaidContent: false},
+            })
+
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('when the api key is empty', () => {
+        it('returns false', () => {
+            const result = canShowPreChecks({
+                brazeSwitch: true,
+                apiKey: '',
+                isDigiSubscriber: true,
+                pageConfig: {isPaidContent: false},
+            })
+
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('when not a digital subscriber', () => {
+        it('returns false', () => {
+            const result = canShowPreChecks({
+                brazeSwitch: true,
+                apiKey: 'abcde',
+                isDigiSubscriber: false,
+                pageConfig: {isPaidContent: false},
+            })
+
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('when viewing paid content', () => {
+        it('returns false', () => {
+            const result = canShowPreChecks({
+                brazeSwitch: true,
+                apiKey: 'abcde',
+                isDigiSubscriber: true,
+                pageConfig: {isPaidContent: true},
+            })
+
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('when all checks pass', () => {
+        it('returns true', () => {
+            const result = canShowPreChecks({
+                brazeSwitch: true,
+                apiKey: 'abcde',
+                isDigiSubscriber: true,
+                pageConfig: {isPaidContent: false},
+            })
+
+            expect(result).toBe(true);
+
+        })
+    })
 });
 
 describe('hasRequiredConsents', () => {


### PR DESCRIPTION
## What does this change?

We shouldn't show the banner on GLabs paid content pages.

This PR contains 2 distinct commits:

1. Refactor the `canShow` logic a bit to make more use of async/await. I think this makes it more readable (and is closer to DCR's implementation).
2. Stop the banner from rendering on GLabs paid content pages.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation) PR to follow

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [x] Yes (please give details) We'll no longer show the braze banner on these pages (the feature hasn't been enabled yet, so in reality this hasn't ever been the case).

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
