### PR TITLE
Add make sbt command

### DIFF
--- a/docs/01-start-here/01-installation-steps.md
+++ b/docs/01-start-here/01-installation-steps.md
@@ -150,10 +150,12 @@ $ make watch
 As a convenience, this command will also watch for changes to client side code and
 automatically inject changes into the browser without requiring a browser refresh.
 
-In another console, run the supplied bash script [sbt]. The dot and slash are important in this command.
+In another console, run the supplied bash script [sbt].
+You can use the following command to call the bash script. Alternatively, make
+sure you include dot and slash if executing the script directly.
 
 ```bash
-$ ./sbt
+$ make sbt
 ```
 
 Wait for SBT to be up and running. This may take 15 mins or so to start the first time - you'll know

--- a/makefile
+++ b/makefile
@@ -11,6 +11,8 @@ help:
 list: # PRIVATE
 	@node tools/messages.js describeMakefile --all
 
+# Add phony targets
+.PHONY: sbt
 
 
 # *********************** SETUP ***********************
@@ -41,6 +43,9 @@ check-node-env: # PRIVATE
 # Uses port 3000 insead of 9000.
 watch: compile-watch
 	@./dev/watch.js
+
+sbt: # PRIVATE
+	./sbt
 
 # *********************** ASSETS ***********************
 


### PR DESCRIPTION
## What does this change?

Allow to run all development tools from the Makefile/`make` command.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

![image](https://user-images.githubusercontent.com/76776/93746319-cee21c80-fbec-11ea-8c0d-e5a83ffa54c9.png)


## What is the value of this and can you measure success?

Clarifies potential confusion with the `sbt` _command_ and the `./sbt` _script._

## Checklist

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
