### PR TITLE
Change newsletter signup footer text

### DIFF
--- a/common/app/views/emailFragment.scala.html
+++ b/common/app/views/emailFragment.scala.html
@@ -1,5 +1,10 @@
 @(page: model.Page, emailType: String, listName: String)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @emailEmbed(page) {
-    @fragments.email.signup.emailSignUp(emailType, listName, "Sign up to our daily email")
+    @fragments.email.signup.emailSignUp(
+        emailType,
+        listName,
+        "Sign up for the Guardian Today email",
+        "All the day’s headlines and highlights from the Guardian, direct to you every morning"
+    )
 }

--- a/common/app/views/fragments/email/signup/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/emailSignUp.scala.html
@@ -34,7 +34,7 @@
 @wrapperClass = @{ "email-sub js-email-sub" + " email-sub--" + componentClass + " js-email-sub--" + componentClass }
 @wrapperToneClass = @{ if (componentClass == "plaintone") "email-sub--tone-" + listNamesTones.getOrElse(listName, "news") }
 @formClass = @{ "email-sub__form js-email-sub__form" + " email-sub__form--" + componentClass }
-@headerClass = @{"email-sub__header" + " email-sub__header--" + componentClass }
+@headerClass = @{"email-sub__header js-email-sub__header" + " email-sub__header--" + componentClass + " js-email-sub__header--" + componentClass }
 
 
 @form = {

--- a/static/src/stylesheets/module/email-signup/_form.scss
+++ b/static/src/stylesheets/module/email-signup/_form.scss
@@ -215,7 +215,6 @@
         &:not(.email-sub__submit-button--solo) {
             position: absolute;
             right: 0;
-            top: 34px;
         }
 
         & svg {

--- a/static/src/stylesheets/module/email-signup/_header.scss
+++ b/static/src/stylesheets/module/email-signup/_header.scss
@@ -54,6 +54,10 @@
         color: $brightness-100;
         margin: ($gs-baseline / 2) 0;
     }
+
+    .email-sub__description {
+        @include fs-textSans(3);
+    }
 }
 
 // PLAIN MODS

--- a/static/src/stylesheets/module/email-signup/_header.scss
+++ b/static/src/stylesheets/module/email-signup/_header.scss
@@ -48,6 +48,8 @@
 
 // FOOTER MODS
 .email-sub__header--footer {
+    margin: 5px 0;
+
     .email-sub__heading {
         @include fs-textSans(5);
         font-weight: 700;
@@ -58,6 +60,10 @@
     .email-sub__description {
         @include fs-textSans(3);
     }
+}
+
+.email-sub__header--is-hidden {
+    display: none;
 }
 
 // PLAIN MODS


### PR DESCRIPTION
## What does this change?
- Updates newsletter sign up "context text" in the footer (the text shown prior to sign up)
- Removes the context text and displays confirmation following for submission.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)
Will update the iframe and CSS on DCR, as well as any relevant javascript

## Screenshots
### Before submission
![image](https://user-images.githubusercontent.com/9122944/93775295-25198480-fc1a-11ea-93e8-60f098f91481.png)

### After submission
![image](https://user-images.githubusercontent.com/9122944/93775258-16cb6880-fc1a-11ea-9d64-39d21e1e2ae9.png)

## What is the value of this and can you measure success?
Part of Newsletter discoverability OKR.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
