### PR TITLE
Use light colour for news kickers and bylines in Dynamo

### DIFF
--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -778,6 +778,7 @@ $block-height: 58px; // Note: duplicated from _item.scss
     @include pillar-override(arts, $culture-bright, $culture-dark);
     @include pillar-override(sport, $sport-bright, $sport-bright);
     @include pillar-override(opinion, $opinion-bright, $opinion-bright);
-    @include pillar-override(news, $news-bright, $news-bright);
+    @include pillar-override(news, #f5998c, $news-bright);
+
     @include pillar-override(special-report, $highlight-main, $highlight-dark);
 }


### PR DESCRIPTION
## What does this change?

Uses the new palette colour to match longRunningPalette style

### Before

![image](https://user-images.githubusercontent.com/638051/93890072-da633f80-fce1-11ea-9979-e6f47e3e24c6.png)

### After

![image](https://user-images.githubusercontent.com/638051/93890110-e4853e00-fce1-11ea-9b6b-b448bc1b1d89.png)
