### PR TITLE
Remove Acast (audio ads)

### DIFF
--- a/applications/app/views/fragments/audioBody.scala.html
+++ b/applications/app/views/fragments/audioBody.scala.html
@@ -11,7 +11,7 @@
 
 @seriesId() = {@audio.tags.tags.find(_.properties.podcast.nonEmpty).map(s => s.id.substring(s.id.lastIndexOf("/") + 1))}
 
-@defining(isPaidContent(page), isAdFree(request)) { case (isPaidContent, isAdFree) =>
+@defining(isPaidContent(page)) { case isPaidContent =>
 
 <div class="@RenderClasses(Map(
     "l-side-margins--media" ->  !isPaidContent,
@@ -42,7 +42,7 @@
                 data-component="main audio"
                 id="audio-component-container"
                 data-media-id="@audio.elements.mainAudio.map(_.properties.id)"
-                data-source="@audio.downloadUrl.map(Audio.acastUrl(_, isAdFree))"
+                data-source="@audio.downloadUrl"
                 data-download-url="@audio.downloadUrl.getOrElse("#")"
                 data-duration="@audio.duration"
                 >

--- a/applications/test/MediaControllerTest.scala
+++ b/applications/test/MediaControllerTest.scala
@@ -95,31 +95,4 @@ import scala.util.matching.Regex
     val result = mediaController.render(audioUrl)(TestRequest(audioUrl))
     status(result) should be(200)
   }
-
-  it should "render audio with an acast URL" in {
-    val fakeRequest = TestRequest(audioUrl)
-    val result = mediaController.render(audioUrl)(fakeRequest)
-
-    status(result) should be(200)
-
-    val html = Jsoup.parse(contentAsString(result))
-    val audioEl = html.getElementsByClass("podcast__player")
-
-    audioEl.attr("data-source") should startWith("https://flex.acast.com/audio.guim.co.uk")
-    audioEl.attr("data-download-url") should startWith("https://audio.guim.co.uk")
-  }
-
-  it should "NOT render audio with an acast URL for ad-free requests" in {
-    val fakeRequest = TestRequest(audioUrl).withHeaders("X-GU-Commercial-Ad-Free" -> "true")
-    val result = mediaController.render(audioUrl)(fakeRequest)
-
-    status(result) should be(200)
-
-    val html = Jsoup.parse(contentAsString(result))
-    val audioEl = html.getElementsByClass("podcast__player")
-
-    audioEl.attr("data-source") should startWith("https://audio.guim.co.uk")
-    audioEl.attr("data-download-url") should startWith("https://audio.guim.co.uk")
-  }
-
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -402,16 +402,6 @@ trait FeatureSwitches {
     exposeClientSide = true,
   )
 
-  val Acast = Switch(
-    SwitchGroup.Feature,
-    "acast",
-    "When ON, requests to audio files will be routed to Acast if advertising is enabled",
-    owners = Seq(Owner.withName("journalism team")),
-    safeState = On,
-    sellByDate = never,
-    exposeClientSide = false,
-  )
-
   // Simple & Coherent
   val ScAdFreeBanner = Switch(
     SwitchGroup.Feature,

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -636,12 +636,6 @@ object Audio {
 
     Audio(contentOverrides)
   }
-
-  def acastUrl(player: AudioPlayer, url: String, isAdFree: Boolean): String =
-    if (player.audio.tags.isPodcast) acastUrl(url, isAdFree) else url
-  def acastUrl(url: String, isAdFree: Boolean): String =
-    if (!isAdFree && conf.switches.Switches.Acast.isSwitchedOn) "https://flex.acast.com/" + url.replace("https://", "")
-    else url
 }
 
 final case class Audio(override val content: Content) extends ContentType {

--- a/common/app/model/content/Atoms.scala
+++ b/common/app/model/content/Atoms.scala
@@ -39,8 +39,8 @@ final case class Atoms(
 
 object Atoms extends common.Logging {
 
-  def articleConfig(isAdFree: Boolean = false, useAcast: Boolean = false): ArticleConfiguration = {
-    val audioSettings = AudioSettings(externalAdvertising = !isAdFree && useAcast)
+  def articleConfig(isAdFree: Boolean = false): ArticleConfiguration = {
+    val audioSettings = AudioSettings(externalAdvertising = false)
     val artConf = ArticleConfiguration(
       ajaxUrl = Configuration.ajax.url,
       audioSettings = audioSettings,

--- a/common/app/views/fragments/atoms/audio.scala.html
+++ b/common/app/views/fragments/atoms/audio.scala.html
@@ -8,7 +8,6 @@ This code is experimental and was introduced on May 2020 as a way to demonstrate
 showing atoms from first principles. It should not be considered ready for wide use because
 the atom is showing fine but there are some missing bits in the HTML template.
 *@
-
 @(atomId:String, html: Html, css: Option[String], js: Option[String])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 <!DOCTYPE html>

--- a/common/app/views/fragments/media/audio.scala.html
+++ b/common/app/views/fragments/media/audio.scala.html
@@ -8,7 +8,7 @@
         data-auto-play="@player.autoPlay" preload="none">
 
         @player.audioElement.audio.encodings.map { encoding =>
-            <source src="@model.Audio.acastUrl(player, encoding.url, isAdFree)" type="@encoding.format" />
+            <source src="@encoding.url" type="@encoding.format" />
         }
     </audio>
     @player.audio match {
@@ -48,7 +48,7 @@
                 @audio.downloadUrl.map { downloadUrl =>
                     <li class="podcast-meta__item podcast-meta__item--download">
                         <a class="podcast-meta__item__link pseudo-icon"
-                        href="@model.Audio.acastUrl(player, downloadUrl, isAdFree)"
+                        href="@downloadUrl"
                         data-link-name="@trackingCode("download")">Download</a>
                     </li>
                 }

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -710,7 +710,7 @@ case class AtomsCleaner(
     if (UseAtomsSwitch.isSwitchedOn) {
 
       val articleConfig: ArticleConfiguration =
-        Atoms.articleConfig(isAdFree(request), Switches.Acast.isSwitchedOn)
+        Atoms.articleConfig(isAdFree(request))
 
       for {
         atomContainer <- document.getElementsByClass("element-atom").asScala


### PR DESCRIPTION
#22298  What does this change?

Managing consent is difficult for podcasts (as we render them server-side). So we are simply removing all ads on these.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)