### PR TITLE
cmp get consent refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.7",
     "@guardian/braze-components": "0.0.11",
-    "@guardian/consent-management-platform": "6.0.0",
+    "@guardian/consent-management-platform": "6.1.0",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/shimport": "^1.0.2",
     "@guardian/src-button": "^0.16.1",

--- a/static/src/javascripts/__flow__/types/global.js
+++ b/static/src/javascripts/__flow__/types/global.js
@@ -29,7 +29,7 @@ declare type TagAtrribute = {
 declare type ThirdPartyTag = {
     shouldRun: boolean,
     url?: string,
-    sourcepointId?: string,
+    name?: string,
     onLoad?: () => any,
     beforeLoad?: () => any,
     useImage?: boolean,

--- a/static/src/javascripts/projects/commercial/modules/comscore.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { onConsentChange } from '@guardian/consent-management-platform';
+import { onConsentChange, getConsentFor } from '@guardian/consent-management-platform';
 import config from 'lib/config';
 import { loadScript } from 'lib/load-script';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
@@ -14,7 +14,6 @@ type comscoreGlobals = {
 const comscoreSrc = '//sb.scorecardresearch.com/cs/6035250/beacon.js';
 const comscoreC1 = '2';
 const comscoreC2 = '6035250';
-const SOURCEPOINT_ID: string = '5efefe25b8e05c06542b2a77';
 
 let initialised = false;
 
@@ -55,7 +54,7 @@ export const init = (): Promise<void> => {
     if (commercialFeatures.comscore) {
         onConsentChange(state => {
             const canRunTcfv2 =
-                state.tcfv2 && state.tcfv2.vendorConsents[SOURCEPOINT_ID];
+                state.tcfv2 && getConsentFor('comscore', state);
             const canRunCcpa = !!state.ccpa; // always runs in CCPA
             if (canRunTcfv2 || canRunCcpa) initOnConsent(true);
         });
@@ -73,5 +72,4 @@ export const _ = {
     comscoreSrc,
     comscoreC1,
     comscoreC2,
-    SOURCEPOINT_ID,
 };

--- a/static/src/javascripts/projects/commercial/modules/comscore.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.spec.js
@@ -1,20 +1,23 @@
 // @flow
 import { loadScript } from 'lib/load-script';
-import { onConsentChange as onConsentChange_ } from '@guardian/consent-management-platform';
+import { onConsentChange as onConsentChange_, getConsentFor as getConsentFor_ } from '@guardian/consent-management-platform';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { init, _ } from './comscore';
 
 jest.mock('@guardian/consent-management-platform', () => ({
     onConsentChange: jest.fn(),
+    getConsentFor: jest.fn()
 }));
 
 const onConsentChange: any = onConsentChange_;
+const getConsentFor: any = getConsentFor_;
+const SOURCEPOINT_ID = '5efefe25b8e05c06542b2a77';
 
 const tcfv2WithConsentMock = (callback): void =>
     callback({
         tcfv2: {
             vendorConsents: {
-                [_.SOURCEPOINT_ID]: true,
+                [SOURCEPOINT_ID]: true,
             },
         },
     });
@@ -22,7 +25,7 @@ const tcfv2WithoutConsentMock = (callback): void =>
     callback({
         tcfv2: {
             vendorConsents: {
-                [_.SOURCEPOINT_ID]: false,
+                [SOURCEPOINT_ID]: false,
             },
         },
     });
@@ -72,12 +75,14 @@ describe('comscore init', () => {
 
         it('TCFv2 with consent: runs', () => {
             onConsentChange.mockImplementation(tcfv2WithConsentMock);
+            getConsentFor.mockImplementation(true);
             init();
             expect(loadScript).toBeCalled();
         });
 
         it('TCFv2 without consent: does not run', () => {
             onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
+            getConsentFor.mockImplementation(false);
             init();
             expect(loadScript).not.toBeCalled();
         });

--- a/static/src/javascripts/projects/commercial/modules/comscore.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.spec.js
@@ -75,14 +75,14 @@ describe('comscore init', () => {
 
         it('TCFv2 with consent: runs', () => {
             onConsentChange.mockImplementation(tcfv2WithConsentMock);
-            getConsentFor.mockImplementation(true);
+            getConsentFor.mockReturnValue(true);
             init();
             expect(loadScript).toBeCalled();
         });
 
         it('TCFv2 without consent: does not run', () => {
             onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
-            getConsentFor.mockImplementation(false);
+            getConsentFor.mockReturnValue(false);
             init();
             expect(loadScript).not.toBeCalled();
         });

--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
@@ -9,9 +9,10 @@ import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { loadAdvert } from 'commercial/modules/dfp/load-advert';
 import { fillAdvertSlots as fillAdvertSlots_ } from 'commercial/modules/dfp/fill-advert-slots';
-import { onConsentChange as onConsentChange_ } from '@guardian/consent-management-platform';
+import { onConsentChange as onConsentChange_ , getConsentFor as getConsentFor_} from '@guardian/consent-management-platform';
 
 const onConsentChange: any = onConsentChange_;
+const getConsentFor: any = getConsentFor_;
 
 // $FlowFixMe property requireActual is actually not missing Flow.
 const { fillAdvertSlots: actualFillAdvertSlots } = jest.requireActual(
@@ -95,6 +96,7 @@ jest.mock('commercial/modules/dfp/load-advert', () => ({
 }));
 jest.mock('@guardian/consent-management-platform', () => ({
     onConsentChange: jest.fn(),
+    getConsentFor: jest.fn()
 }));
 
 let $style;
@@ -473,6 +475,7 @@ describe('DFP', () => {
             onConsentChange.mockImplementation(callback =>
                 callback(tcfv2WithConsent)
             );
+            getConsentFor.mockReturnValue(true);
             prepareGoogletag().then(() => {
                 expect(
                     window.googletag.pubads().setTargeting
@@ -486,6 +489,7 @@ describe('DFP', () => {
             onConsentChange.mockImplementation(callback =>
                 callback(tcfv2WithConsent)
             );
+            getConsentFor.mockReturnValue(true);
             prepareGoogletag().then(() => {
                 expect(
                     window.googletag.pubads().setRequestNonPersonalizedAds
@@ -496,6 +500,7 @@ describe('DFP', () => {
             onConsentChange.mockImplementation(callback =>
                 callback(tcfv2NullConsent)
             );
+            getConsentFor.mockReturnValue(true);
             prepareGoogletag().then(() => {
                 expect(
                     window.googletag.pubads().setRequestNonPersonalizedAds
@@ -506,6 +511,7 @@ describe('DFP', () => {
             onConsentChange.mockImplementation(callback =>
                 callback(tcfv2WithoutConsent)
             );
+            getConsentFor.mockReturnValue(false);
             prepareGoogletag().then(() => {
                 expect(
                     window.googletag.pubads().setRequestNonPersonalizedAds
@@ -516,6 +522,7 @@ describe('DFP', () => {
             onConsentChange.mockImplementation(callback =>
                 callback(tcfv2MixedConsent)
             );
+            getConsentFor.mockReturnValue(false);
             prepareGoogletag().then(() => {
                 expect(
                     window.googletag.pubads().setRequestNonPersonalizedAds
@@ -528,6 +535,7 @@ describe('DFP', () => {
             onConsentChange.mockImplementation(callback =>
                 callback(ccpaWithConsent)
             );
+            getConsentFor.mockReturnValue(true);
             prepareGoogletag().then(() => {
                 expect(
                     window.googletag.pubads().setPrivacySettings
@@ -540,6 +548,7 @@ describe('DFP', () => {
             onConsentChange.mockImplementation(callback =>
                 callback(ccpaWithoutConsent)
             );
+            getConsentFor.mockReturnValue(false);
             prepareGoogletag().then(() => {
                 expect(
                     window.googletag.pubads().setPrivacySettings

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -119,9 +119,6 @@ export const init = (): Promise<void> => {
                         Object.keys(state.tcfv2.consents).length === 0 ||
                         Object.values(state.tcfv2.consents).includes(false);
                     canRun = getConsentFor('googletag', state);
-                } else {
-                    // TCFv1 mode
-                    npaFlag = Object.values(state).includes(false);
                 }
                 window.googletag.cmd.push(() => {
                     window.googletag

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -7,7 +7,7 @@ import { loadScript } from 'lib/load-script';
 import raven from 'lib/raven';
 import sha1 from 'lib/sha1';
 import { session } from 'lib/storage';
-import { onConsentChange } from '@guardian/consent-management-platform';
+import { onConsentChange, getConsentFor } from '@guardian/consent-management-platform';
 import { getPageTargeting } from 'common/modules/commercial/build-page-targeting';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { adFreeSlotRemove } from 'commercial/modules/ad-free-slot-remove';
@@ -43,8 +43,6 @@ initMessenger(
     background,
     disableRefresh
 );
-
-const SOURCEPOINT_ID: string = '5f1aada6b8e05c306c0597d7';
 
 const setDfpListeners = (): void => {
     const pubads = window.googletag.pubads();
@@ -120,7 +118,7 @@ export const init = (): Promise<void> => {
                     npaFlag =
                         Object.keys(state.tcfv2.consents).length === 0 ||
                         Object.values(state.tcfv2.consents).includes(false);
-                    canRun = state.tcfv2.vendorConsents[SOURCEPOINT_ID];
+                    canRun = getConsentFor('googletag', state);
                 } else {
                     // TCFv1 mode
                     npaFlag = Object.values(state).includes(false);

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
@@ -1,7 +1,7 @@
 // @flow
 
 import config from 'lib/config';
-import { onConsentChange } from '@guardian/consent-management-platform';
+import { onConsentChange, getConsentFor } from '@guardian/consent-management-platform';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { getPageTargeting } from 'common/modules/commercial/build-page-targeting';
 import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
@@ -9,8 +9,6 @@ import once from 'lodash/once';
 import prebid from 'commercial/modules/header-bidding/prebid/prebid';
 import { isGoogleProxy } from 'lib/detect';
 import { shouldIncludeOnlyA9 } from 'commercial/modules/header-bidding/utils';
-
-const SOURCEPOINT_ID: string = '5f22bfd82a6b6c1afd1181a9';
 
 const loadPrebid: () => void = () => {
     if (
@@ -34,7 +32,7 @@ const setupPrebid: () => Promise<void> = () => {
     onConsentChange(state => {
         // Only TCFv2 mode can prevent running Prebid
         const canRun: boolean = state.tcfv2
-            ? state.tcfv2.vendorConsents[SOURCEPOINT_ID]
+            ? getConsentFor('prebid', state)
             : true;
         if (canRun) {
             loadPrebid();

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.js
@@ -3,13 +3,14 @@
 import config from 'lib/config';
 import { isGoogleProxy } from 'lib/detect';
 import prebid from 'commercial/modules/header-bidding/prebid/prebid';
-import { onConsentChange as onConsentChange_ } from '@guardian/consent-management-platform';
+import { onConsentChange as onConsentChange_, getConsentFor as getConsentFor_ } from '@guardian/consent-management-platform';
 import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { _ } from './prepare-prebid';
 
 const { setupPrebid } = _;
 const onConsentChange: any = onConsentChange_;
+const getConsentFor: any = getConsentFor_;
 
 jest.mock('common/modules/commercial/commercial-features', () => ({
     commercialFeatures: {},
@@ -37,6 +38,7 @@ jest.mock('commercial/modules/header-bidding/utils', () => ({
 
 jest.mock('@guardian/consent-management-platform', () => ({
     onConsentChange: jest.fn(),
+    getConsentFor: jest.fn()
 }));
 
 const tcfv2WithConsentMock = (callback): void =>
@@ -73,6 +75,7 @@ describe('init', () => {
         commercialFeatures.dfpAdvertising = true;
         commercialFeatures.adFree = false;
         onConsentChange.mockImplementation(tcfv2WithConsentMock);
+        getConsentFor.mockReturnValue(true);
         await setupPrebid();
         expect(prebid.initialise).toBeCalled();
     });
@@ -132,6 +135,7 @@ describe('init', () => {
         commercialFeatures.dfpAdvertising = true;
         commercialFeatures.adFree = false;
         onConsentChange.mockImplementation(tcfv2WithConsentMock);
+        getConsentFor.mockReturnValue(true);
         await setupPrebid();
         expect(prebid.initialise).toBeCalled();
     });
@@ -141,6 +145,7 @@ describe('init', () => {
         commercialFeatures.dfpAdvertising = true;
         commercialFeatures.adFree = false;
         onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
+        getConsentFor.mockReturnValue(false);
         await setupPrebid();
         expect(prebid.initialise).not.toBeCalled();
     });

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
@@ -1,12 +1,11 @@
 // @flow strict
 
 import config from 'lib/config';
-import { onConsentChange } from '@guardian/consent-management-platform';
+import { onConsentChange, getConsentFor } from '@guardian/consent-management-platform';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { isInAuOrNz } from 'common/modules/commercial/geo-utils';
 
 let initialised = false;
-const SOURCEPOINT_ID: string = '5f199c302425a33f3f090f51';
 
 const initialise = (): void => {
     // Initialise Launchpad Tracker
@@ -39,16 +38,7 @@ const setupRedplanet: () => Promise<void> = () => {
         }
         let canRun: boolean;
         if (state.tcfv2) {
-            // TCFv2 mode
-            if (
-                typeof state.tcfv2.vendorConsents !== 'undefined' &&
-                typeof state.tcfv2.vendorConsents[SOURCEPOINT_ID] !==
-                    'undefined'
-            ) {
-                canRun = state.tcfv2.vendorConsents[SOURCEPOINT_ID];
-            } else {
-                canRun = Object.values(state.tcfv2.consents).every(Boolean);
-            }
+            canRun = getConsentFor('redplanet', state);
         } else {
             // TCFv1 mode
             canRun = state[1] && state[2] && state[3] && state[4] && state[5];

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
@@ -36,13 +36,7 @@ const setupRedplanet: () => Promise<void> = () => {
                 `Error running Redplanet with CCPA (US CMP) present. It should only run in Australia on TCFv2 mode`
             );
         }
-        let canRun: boolean;
-        if (state.tcfv2) {
-            canRun = getConsentFor('redplanet', state);
-        } else {
-            // TCFv1 mode
-            canRun = state[1] && state[2] && state[3] && state[4] && state[5];
-        }
+        let canRun: boolean = getConsentFor('redplanet', state);
 
         if (!initialised && canRun) {
             initialised = true;

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
@@ -36,7 +36,7 @@ const setupRedplanet: () => Promise<void> = () => {
                 `Error running Redplanet with CCPA (US CMP) present. It should only run in Australia on TCFv2 mode`
             );
         }
-        let canRun: boolean = getConsentFor('redplanet', state);
+        const canRun: boolean = getConsentFor('redplanet', state);
 
         if (!initialised && canRun) {
             initialised = true;

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.spec.js
@@ -1,7 +1,10 @@
 // @flow
 
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
-import { onConsentChange as onConsentChange_ } from '@guardian/consent-management-platform';
+import {
+    getConsentFor as getConsentFor_,
+    onConsentChange as onConsentChange_
+} from '@guardian/consent-management-platform';
 import { isInAuOrNz as isInAuOrNz_ } from 'common/modules/commercial/geo-utils';
 import config from 'lib/config';
 import { init, resetModule } from './redplanet';
@@ -50,6 +53,7 @@ jest.mock('lib/load-script', () => ({
 
 jest.mock('@guardian/consent-management-platform', () => ({
     onConsentChange: jest.fn(),
+    getConsentFor: jest.fn()
 }));
 
 jest.mock('common/modules/experiments/ab', () => ({
@@ -58,6 +62,8 @@ jest.mock('common/modules/experiments/ab', () => ({
 
 const CcpaWithConsentMock = (callback): void =>
     callback({ ccpa: { doNotSell: false } });
+
+const getConsentFor: any = getConsentFor_;
 
 window.launchpad = jest.fn().mockImplementationOnce(() => jest.fn());
 
@@ -79,6 +85,7 @@ describe('init', () => {
         config.set('page.sectionName', 'Politics');
         config.set('page.contentType', 'Article');
         onConsentChange.mockImplementation(tcfv2WithConsentMock);
+        getConsentFor.mockReturnValue(true);
 
         await init();
 
@@ -114,6 +121,7 @@ describe('init', () => {
         commercialFeatures.launchpad = true;
         isInAuOrNz.mockReturnValue(true);
         onConsentChange.mockImplementation(tcfv2WithConsentMock);
+        getConsentFor.mockReturnValue(true);
         await init();
         expect(window.launchpad).toBeCalled();
     });
@@ -122,6 +130,7 @@ describe('init', () => {
         commercialFeatures.launchpad = true;
         isInAuOrNz.mockReturnValue(true);
         onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
+        getConsentFor.mockReturnValue(false);
         await init();
         expect(window.launchpad).not.toBeCalled();
     });
@@ -130,6 +139,7 @@ describe('init', () => {
         commercialFeatures.launchpad = true;
         isInAuOrNz.mockReturnValue(true);
         onConsentChange.mockImplementation(CcpaWithConsentMock);
+        getConsentFor.mockReturnValue(true);
         expect(await init).toThrow(
             `Error running Redplanet with CCPA (US CMP) present. It should only run in Australia on TCFv2 mode`
         );
@@ -139,6 +149,7 @@ describe('init', () => {
         commercialFeatures.launchpad = false;
         isInAuOrNz.mockReturnValue(true);
         onConsentChange.mockImplementation(tcfv2WithConsentMock);
+        getConsentFor.mockReturnValue(true);
         await init();
         expect(window.launchpad).not.toBeCalled();
     });
@@ -147,6 +158,7 @@ describe('init', () => {
         commercialFeatures.launchpad = true;
         isInAuOrNz.mockReturnValue(false);
         onConsentChange.mockImplementation(tcfv2WithConsentMock);
+        getConsentFor.mockReturnValue(true);
         await init();
         expect(window.launchpad).not.toBeCalled();
     });

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
@@ -35,17 +35,7 @@ const bidderTimeout: number = 1500;
 
 const initialise = (): void => {
     onConsentChange(state => {
-        let canRun: boolean;
-        if (state.ccpa) {
-            // CCPA mode
-            canRun = !state.doNotSell;
-        } else if (state.tcfv2) {
-            // TCFv2 mode
-            canRun = getConsentFor('a9', state);
-        } else {
-            // TCFv1 mode
-            canRun = state[1] && state[2] && state[3] && state[4] && state[5];
-        }
+        let canRun: boolean = getConsentFor('a9', state);
 
         if (!initialised && canRun) {
             initialised = true;

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
@@ -35,7 +35,7 @@ const bidderTimeout: number = 1500;
 
 const initialise = (): void => {
     onConsentChange(state => {
-        let canRun: boolean = getConsentFor('a9', state);
+        const canRun: boolean = getConsentFor('a9', state);
 
         if (!initialised && canRun) {
             initialised = true;

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
@@ -1,7 +1,7 @@
 // @flow strict
 
 import config from 'lib/config';
-import { onConsentChange } from '@guardian/consent-management-platform';
+import { onConsentChange, getConsentFor } from '@guardian/consent-management-platform';
 
 import { Advert } from 'commercial/modules/dfp/Advert';
 import { getHeaderBiddingAdSlots } from 'commercial/modules/header-bidding/slot-config';
@@ -32,7 +32,6 @@ let initialised: boolean = false;
 let requestQueue: Promise<void> = Promise.resolve();
 
 const bidderTimeout: number = 1500;
-const SOURCEPOINT_ID: string = '5edf9a821dc4e95986b66df4';
 
 const initialise = (): void => {
     onConsentChange(state => {
@@ -42,15 +41,7 @@ const initialise = (): void => {
             canRun = !state.doNotSell;
         } else if (state.tcfv2) {
             // TCFv2 mode
-            if (
-                typeof state.tcfv2.vendorConsents !== 'undefined' &&
-                typeof state.tcfv2.vendorConsents[SOURCEPOINT_ID] !==
-                    'undefined'
-            ) {
-                canRun = state.tcfv2.vendorConsents[SOURCEPOINT_ID];
-            } else {
-                canRun = Object.values(state.tcfv2.consents).every(Boolean);
-            }
+            canRun = getConsentFor('a9', state);
         } else {
             // TCFv1 mode
             canRun = state[1] && state[2] && state[3] && state[4] && state[5];

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.spec.js
@@ -1,7 +1,7 @@
 // @flow
 
 import a9, { _ } from 'commercial/modules/header-bidding/a9/a9';
-import { onConsentChange as onConsentChange_ } from '@guardian/consent-management-platform';
+import { onConsentChange as onConsentChange_ , getConsentFor as getConsentFor_ } from '@guardian/consent-management-platform';
 
 const onConsentChange: any = onConsentChange_;
 
@@ -12,6 +12,8 @@ const tcfv2WithConsentMock = (callback): void =>
 
 const CcpaWithConsentMock = (callback): void =>
     callback({ ccpa: { doNotSell: false } });
+
+const getConsentFor: any = getConsentFor_;
 
 jest.mock('lib/raven');
 jest.mock('commercial/modules/dfp/Advert', () =>
@@ -28,6 +30,7 @@ jest.mock('commercial/modules/header-bidding/slot-config', () => ({
 
 jest.mock('@guardian/consent-management-platform', () => ({
     onConsentChange: jest.fn(),
+    getConsentFor: jest.fn()
 }));
 
 beforeEach(async () => {
@@ -47,6 +50,7 @@ afterAll(() => {
 describe('initialise', () => {
     it('should generate initialise A9 library when TCFv2 consent has been given', () => {
         onConsentChange.mockImplementation(tcfv2WithConsentMock);
+        getConsentFor.mockReturnValue(true);
         a9.initialise();
         expect(window.apstag).toBeDefined();
         expect(window.apstag.init).toHaveBeenCalled();
@@ -54,6 +58,7 @@ describe('initialise', () => {
 
     it('should generate initialise A9 library when CCPA consent has been given', () => {
         onConsentChange.mockImplementation(CcpaWithConsentMock);
+        getConsentFor.mockReturnValue(true);
         a9.initialise();
         expect(window.apstag).toBeDefined();
         expect(window.apstag.init).toHaveBeenCalled();

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -65,7 +65,8 @@ const insertScripts = (
     advertisingServices: Array<ThirdPartyTag>,
     performanceServices: Array<ThirdPartyTag> // performanceServices always run
 ): void => {
-    addScripts(performanceServices);onConsentChange(state => {
+    addScripts(performanceServices);
+    onConsentChange(state => {
         const consentedAdvertisingServices = advertisingServices.filter(
             script => getConsentFor(script.name, state)
         );

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -2,7 +2,7 @@
 /* A regionalised container for all the commercial tags. */
 
 import fastdom from 'lib/fastdom-promise';
-import { onConsentChange } from '@guardian/consent-management-platform';
+import { onConsentChange, getConsentFor } from '@guardian/consent-management-platform';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { imrWorldwide } from 'commercial/modules/third-party-tags/imr-worldwide';
 import { imrWorldwideLegacy } from 'commercial/modules/third-party-tags/imr-worldwide-legacy';
@@ -76,18 +76,7 @@ const insertScripts = (
         } else if (state.tcfv2) {
             // TCFv2 mode,
             consentedAdvertisingServices = advertisingServices.filter(
-                script => {
-                    if (
-                        typeof script.sourcepointId !== 'undefined' &&
-                        typeof state.tcfv2.vendorConsents !== 'undefined' &&
-                        typeof state.tcfv2.vendorConsents[
-                            script.sourcepointId
-                        ] !== 'undefined'
-                    ) {
-                        return state.tcfv2.vendorConsents[script.sourcepointId];
-                    }
-                    return Object.values(state.tcfv2.consents).every(Boolean);
-                }
+                script => getConsentFor(script.name, state)
             );
         } else if (state[1] && state[2] && state[3] && state[4] && state[5]) {
             // TCFv1 mode

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -65,23 +65,10 @@ const insertScripts = (
     advertisingServices: Array<ThirdPartyTag>,
     performanceServices: Array<ThirdPartyTag> // performanceServices always run
 ): void => {
-    addScripts(performanceServices);
-
-    onConsentChange(state => {
-        let consentedAdvertisingServices = [];
-        if (state.ccpa) {
-            // CCPA mode
-            if (!state.ccpa.doNotSell)
-                consentedAdvertisingServices = [...advertisingServices];
-        } else if (state.tcfv2) {
-            // TCFv2 mode,
-            consentedAdvertisingServices = advertisingServices.filter(
-                script => getConsentFor(script.name, state)
-            );
-        } else if (state[1] && state[2] && state[3] && state[4] && state[5]) {
-            // TCFv1 mode
-            consentedAdvertisingServices = [...advertisingServices];
-        }
+    addScripts(performanceServices);onConsentChange(state => {
+        const consentedAdvertisingServices = advertisingServices.filter(
+            script => getConsentFor(script.name, state)
+        );
 
         if (consentedAdvertisingServices.length > 0) {
             addScripts(consentedAdvertisingServices);

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
@@ -1,5 +1,8 @@
 // @flow
-import { onConsentChange as onConsentChange_ } from '@guardian/consent-management-platform';
+import {
+    getConsentFor as getConsentFor_,
+    onConsentChange as onConsentChange_
+} from '@guardian/consent-management-platform';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { init, _ } from './third-party-tags';
 
@@ -9,9 +12,11 @@ jest.mock('lib/raven');
 
 jest.mock('@guardian/consent-management-platform', () => ({
     onConsentChange: jest.fn(),
+    getConsentFor: jest.fn()
 }));
 
 const onConsentChange: any = onConsentChange_;
+const getConsentFor: any = getConsentFor_;
 
 const tcfv2AllConsentMock = (callback): void =>
     callback({
@@ -141,19 +146,19 @@ describe('third party tags', () => {
             shouldRun: true,
             url: '//fakeThirdPartyAdvertisingTag.js',
             onLoad: jest.fn(),
-            sourcepointId: '100',
+            name: 'permutive',
         };
         const fakeThirdPartyAdvertisingTag2: ThirdPartyTag = {
             shouldRun: true,
             url: '//fakeThirdPartyAdvertisingTag2.js',
             onLoad: jest.fn(),
-            sourcepointId: '300',
+            name: 'lotame',
         };
         const fakeThirdPartyPerformanceTag: ThirdPartyTag = {
             shouldRun: true,
             url: '//fakeThirdPartyPerformanceTag.js',
             onLoad: jest.fn(),
-            sourcepointId: '200',
+            name: 'twitter',
         };
 
         beforeEach(() => {
@@ -162,16 +167,19 @@ describe('third party tags', () => {
             fakeThirdPartyPerformanceTag.loaded = undefined;
         });
 
-        it('should add scripts to the document when TCFv2 consent has been given', () => {
+        it.only('should add scripts to the document when TCFv2 consent has been given', () => {
             onConsentChange.mockImplementation(tcfv2AllConsentMock);
+            getConsentFor.mockReturnValue(true);
             insertScripts(
                 [fakeThirdPartyAdvertisingTag],
                 [fakeThirdPartyPerformanceTag]
             );
             expect(document.scripts.length).toBe(3);
         });
+
         it('should only add performance scripts to the document when TCFv2 consent has not been given', () => {
             onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
+            getConsentFor.mockReturnValue(false);
             insertScripts(
                 [fakeThirdPartyAdvertisingTag],
                 [fakeThirdPartyPerformanceTag]
@@ -182,6 +190,7 @@ describe('third party tags', () => {
             onConsentChange.mockImplementation(callback =>
                 callback({ ccpa: { doNotSell: false } })
             );
+            getConsentFor.mockReturnValue(true);
             insertScripts(
                 [fakeThirdPartyAdvertisingTag],
                 [fakeThirdPartyPerformanceTag]
@@ -192,6 +201,7 @@ describe('third party tags', () => {
             onConsentChange.mockImplementation(callback =>
                 callback({ ccpa: { doNotSell: true } })
             );
+            getConsentFor.mockReturnValue(false);
             insertScripts(
                 [fakeThirdPartyAdvertisingTag],
                 [fakeThirdPartyPerformanceTag]
@@ -201,6 +211,7 @@ describe('third party tags', () => {
 
         it('should only add consented custom vendors to the document for TCFv2', () => {
             onConsentChange.mockImplementation(tcfv2WithConsentMock);
+            getConsentFor.mockReturnValue(true);
             insertScripts(
                 [fakeThirdPartyAdvertisingTag, fakeThirdPartyAdvertisingTag2],
                 []
@@ -210,6 +221,7 @@ describe('third party tags', () => {
 
         it('should not add already loaded tags ', () => {
             onConsentChange.mockImplementation(tcfv2WithConsentMock);
+            getConsentFor.mockReturnValue(true);
             insertScripts(
                 [fakeThirdPartyAdvertisingTag, fakeThirdPartyAdvertisingTag2],
                 []
@@ -223,6 +235,7 @@ describe('third party tags', () => {
 
         it('should not add scripts to the document when TCFv2 consent has not been given', () => {
             onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
+            getConsentFor.mockReturnValue(false);
             insertScripts(
                 [fakeThirdPartyAdvertisingTag, fakeThirdPartyAdvertisingTag2],
                 []

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
@@ -211,7 +211,8 @@ describe('third party tags', () => {
 
         it('should only add consented custom vendors to the document for TCFv2', () => {
             onConsentChange.mockImplementation(tcfv2WithConsentMock);
-            getConsentFor.mockReturnValue(true);
+            getConsentFor.mockReturnValueOnce(true);
+            getConsentFor.mockReturnValueOnce(false);
             insertScripts(
                 [fakeThirdPartyAdvertisingTag, fakeThirdPartyAdvertisingTag2],
                 []
@@ -221,7 +222,10 @@ describe('third party tags', () => {
 
         it('should not add already loaded tags ', () => {
             onConsentChange.mockImplementation(tcfv2WithConsentMock);
-            getConsentFor.mockReturnValue(true);
+            getConsentFor.mockReturnValueOnce(true);
+            getConsentFor.mockReturnValueOnce(false);
+            getConsentFor.mockReturnValueOnce(true);
+            getConsentFor.mockReturnValueOnce(false);
             insertScripts(
                 [fakeThirdPartyAdvertisingTag, fakeThirdPartyAdvertisingTag2],
                 []

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
@@ -167,7 +167,7 @@ describe('third party tags', () => {
             fakeThirdPartyPerformanceTag.loaded = undefined;
         });
 
-        it.only('should add scripts to the document when TCFv2 consent has been given', () => {
+        it('should add scripts to the document when TCFv2 consent has been given', () => {
             onConsentChange.mockImplementation(tcfv2AllConsentMock);
             getConsentFor.mockReturnValue(true);
             insertScripts(

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/facebook-pixel.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/facebook-pixel.js
@@ -6,6 +6,6 @@ export const fbPixel: () => ThirdPartyTag = () => ({
     url: `https://www.facebook.com/tr?id=${config.get(
         'libs.facebookAccountId'
     )}&ev=PageView&noscript=1`,
-    sourcepointId: '5e7e1298b8e05c54a85c52d2',
+    name: 'fb',
     useImage: true,
 });

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/facebook-pixel.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/facebook-pixel.spec.js
@@ -36,8 +36,8 @@ describe('Facebook tracking pixel', () => {
         expect(result.url).toBe(
             'https://www.facebook.com/tr?id=test-account-id&ev=PageView&noscript=1'
         );
-        expect(result.sourcepointId).toBe(
-            '5e7e1298b8e05c54a85c52d2'
+        expect(result.name).toBe(
+            'fb'
         );
     });
 

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/ias.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/ias.js
@@ -4,5 +4,5 @@ import config from 'lib/config';
 export const ias: ThirdPartyTag = {
     shouldRun: config.get('switches.iasAdTargeting', false),
     url: '//cdn.adsafeprotected.com/iasPET.1.js',
-    sourcepointId: '5e7ced57b8e05c485246ccf3',
+    name: 'ias',
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/inizio.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/inizio.js
@@ -30,6 +30,6 @@ export const inizio: ThirdPartyTag = {
     shouldRun: config.get('switches.inizio', false),
     url:
         '//cdn.brandmetrics.com/survey/script/e96d04c832084488a841a06b49b8fb2d.js',
-    sourcepointId: '5e37fc3e56a5e6615502f9c9',
+    name: 'inizio',
     onLoad,
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/lotame.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/lotame.js
@@ -50,5 +50,5 @@ export const lotame: () => ThirdPartyTag = () => ({
         config.get('switches.lotame', false) && !(isInUsOrCa() || isInAuOrNz()),
     url: '//tags.crwdcntrl.net/lt/c/12666/lt.min.js',
     beforeLoad,
-    sourcepointId: '5ed6aeb1b8e05c241a63c71f',
+    name: 'lotame',
 });

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/lotame.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/lotame.spec.js
@@ -16,11 +16,11 @@ describe('Lotame', () => {
     });
 
     it('should exist', () => {
-        const { shouldRun, url, sourcepointId } = lotame();
+        const { shouldRun, url, name } = lotame();
 
         expect(shouldRun).toEqual(true);
         expect(url).toEqual(expect.stringContaining('crwdcntrl'));
-        expect(sourcepointId).toBe('5ed6aeb1b8e05c241a63c71f');
+        expect(name).toBe('lotame');
     });
 
     it('shouldRun to be true if ad the switch is on', () => {

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/permutive.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/permutive.js
@@ -4,5 +4,5 @@ import config from 'lib/config';
 export const permutive: ThirdPartyTag = {
     shouldRun: config.get('switches.permutive', false),
     url: '//cdn.permutive.com/d6691a17-6fdb-4d26-85d6-b3dd27f55f08-web.js',
-    sourcepointId: '5eff0d77969bfa03746427eb',
+    name: 'permutive'
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/remarketing.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/remarketing.js
@@ -13,5 +13,5 @@ export const remarketing: () => ThirdPartyTag = () => ({
     shouldRun: config.get('switches.remarketing', false),
     url: '//www.googleadservices.com/pagead/conversion_async.js',
     onLoad,
-    sourcepointId: '5ed0eb688a76503f1016578f',
+    name: 'remarketing',
 });

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/remarketing.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/remarketing.spec.js
@@ -11,15 +11,15 @@ describe('Remarketing', () => {
     });
 
     it('should exist', () => {
-        const { shouldRun, url, onLoad, sourcepointId } = remarketing();
+        const { shouldRun, url, onLoad, name } = remarketing();
 
         expect(shouldRun).toEqual(true);
         expect(url).toEqual(
             expect.stringContaining('www.googleadservices.com')
         );
         expect(onLoad).toBeDefined();
-        expect(sourcepointId).toBe(
-            '5ed0eb688a76503f1016578f'
+        expect(name).toBe(
+            'remarketing'
         );
     });
 

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-uwt.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-uwt.js
@@ -19,6 +19,6 @@ const insertSnippet = () => {
 // Twitter universal website tag code
 export const twitterUwt: () => ThirdPartyTag = () => ({
     shouldRun: config.get('switches.twitterUwt', false),
-    sourcepointId: '5e71760b69966540e4554f01',
+    name: 'twitter',
     insertSnippet,
 });

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-uwt.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/twitter-uwt.spec.js
@@ -13,11 +13,11 @@ describe('twitterUwt', () => {
 
     it('shouldRun to be false if the switch is off', () => {
         config.set('switches.twitterUwt', false);
-        const { shouldRun, url, sourcepointId } = twitterUwt();
+        const { shouldRun, url, name } = twitterUwt();
 
         expect(shouldRun).toEqual(false);
         expect(url).toBeUndefined();
-        expect(sourcepointId).toBe('5e71760b69966540e4554f01');
+        expect(name).toBe('twitter');
     });
 
     it('should have insertSnippet function', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1753,10 +1753,10 @@
     "@guardian/src-icons" "^2.2.0"
     emotion-theming "^10.0.19"
 
-"@guardian/consent-management-platform@6.2.0-0":
-  version "6.2.0-0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.2.0-0.tgz#3a7586c3270786b1e4517d843cd006cd7167146b"
-  integrity sha512-s1eepEwBS2ijPjxZc9SCXrTMT237aZe4v6UmV0LUuWIb2K/jXpAzpUu7lJG3UwP1U8O+kBIDIUSfj9f8M+AcZg==
+"@guardian/consent-management-platform@6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.1.0.tgz#0de83ca15d37a60bd79f2e95046ca68d8cc5141d"
+  integrity sha512-EVRoGDSk78UK9+0ILHkkubWjLdBvNrvmObwNfbrYxXnfOtyszGuy+mfhtGtLAXUKf85w+7nXnY/hKRmz4MfyeQ==
 
 "@guardian/dotcom-rendering@git://github.com/guardian/dotcom-rendering.git#version-1-alpha":
   version "0.1.0-alpha"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1753,10 +1753,10 @@
     "@guardian/src-icons" "^2.2.0"
     emotion-theming "^10.0.19"
 
-"@guardian/consent-management-platform@6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.0.0.tgz#81eea5a8a965f1d94b8271ba946a2e59697487ec"
-  integrity sha512-ruroeF+lEcNQlRwUljd/PgWXDjriqlPJp5V9C1511ss5ItawFIJANm5ubJKidlMMpANcalqPudQuDnpCweHd6w==
+"@guardian/consent-management-platform@6.2.0-0":
+  version "6.2.0-0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.2.0-0.tgz#3a7586c3270786b1e4517d843cd006cd7167146b"
+  integrity sha512-s1eepEwBS2ijPjxZc9SCXrTMT237aZe4v6UmV0LUuWIb2K/jXpAzpUu7lJG3UwP1U8O+kBIDIUSfj9f8M+AcZg==
 
 "@guardian/dotcom-rendering@git://github.com/guardian/dotcom-rendering.git#version-1-alpha":
   version "0.1.0-alpha"


### PR DESCRIPTION
## What does this change?
Refactor to use getConsentFor module from cmp https://github.com/guardian/consent-management-platform/pull/276

Pending

- [x] fix tests
- [x] wait for ES2020 PR to get merged https://github.com/guardian/frontend/pull/23011
- [x] wait for cmp PR to get merged https://github.com/guardian/consent-management-platform/pull/276
- [x] test end to end