### PR TITLE
Use generic BrazeMessage component

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.7",
-    "@guardian/braze-components": "^0.0.7",
+    "@guardian/braze-components": "0.0.9",
     "@guardian/consent-management-platform": "6.0.0",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/shimport": "^1.0.2",

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -150,8 +150,9 @@ const show = (): Promise<boolean> => import(
 
         mountDynamic(
             container,
-            module.DigitalSubscriberAppBanner,
+            module.BrazeMessage,
             {
+                componentName: messageConfig.extras.componentName,
                 onButtonClick: (buttonId: number) => {
                     if (appboy) {
                         const thisButton = new appboy.InAppMessageButton(`Button ${buttonId}`,null,null,null,null,null,buttonId)
@@ -160,8 +161,7 @@ const show = (): Promise<boolean> => import(
                         );
                     }
                 },
-                header: messageConfig.extras.header,
-                body: messageConfig.extras.body,
+                brazeMessageProps: messageConfig.extras,
             },
             true,
         );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1742,15 +1742,16 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/braze-components@^0.0.7":
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-0.0.7.tgz#06d6301b13a4b5393bf71e61a1c8078525369fbf"
-  integrity sha512-ZlXQe5EuPnv+hsEJIEVAbHTSxqBx8yPd9JmCw8ndvYGE8z04H+ZTzTbK26PwpLWiYGSKBmdRvtRqy/qO5A2l6g==
+"@guardian/braze-components@0.0.9":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-0.0.9.tgz#df4293febbfb04f155ea23aa7726c25971659db3"
+  integrity sha512-HNhKoTTjrNWFdMQEtGrZsfr/INeX4Y2mt03GzHnZ7DSXrDBBHVfQYhgn72ye50tMcdXMzzjIbMTJ1MCnLcL5XA==
   dependencies:
     "@guardian/src-button" "^2.1.0"
     "@guardian/src-foundations" "^2.1.0"
     "@guardian/src-grid" "^2.2.0"
     "@guardian/src-icons" "^2.2.0"
+    emotion-theming "^10.0.19"
 
 "@guardian/consent-management-platform@6.0.0":
   version "6.0.0"
@@ -4896,7 +4897,7 @@ emotion-server@^10.0.5:
   dependencies:
     create-emotion-server "10.0.27"
 
-emotion-theming@^10.0.27:
+emotion-theming@^10.0.19, emotion-theming@^10.0.27:
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/emotion-theming/-/emotion-theming-10.0.27.tgz#1887baaec15199862c89b1b984b79806f2b9ab10"
   integrity sha512-MlF1yu/gYh8u+sLUqA0YuA9JX0P4Hb69WlKc/9OLo+WCXuX6sy/KoIa+qJimgmr2dWqnypYKYPX37esjDBbhdw==


### PR DESCRIPTION
## What does this change?

This updates `brazeBanner.js` to use the new `BrazeMessage` component introduced in guardian/braze-components#9. This expects the component name as a prop, which we get from Braze, giving us flexibility to control the ultimately rendered component from Braze. Thread through all other extras, so we don’t need to make changes on the platform to support other props.

We'll wait for the above PR to be merged and a new version released to NPM before marking this as ready to merge.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation) PR to follow

## Screenshots

No visible change for the user, but to prove this works here it is locally:

<img width="1552" alt="Screenshot 2020-09-22 at 18 00 14" src="https://user-images.githubusercontent.com/379839/93914609-af3b1900-fcfe-11ea-9ce5-c9bf63a153d4.png">

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
