### PR TITLE
Fix ads covering immersive content

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -191,7 +191,7 @@
 }
 
 .content--immersive-article {
-    .ad-slot--inline {
+    .ad-slot--offset-right {
         clear: both;
     }
 }

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -190,6 +190,12 @@
     }
 }
 
+.content--immersive-article {
+    .ad-slot--inline {
+        clear: both;
+    }
+}
+
 .ad-slot--liveblog-inline,
 
 .ad-slot--container-inline,


### PR DESCRIPTION
## What does this change?

Fixes an issue with inline ads covering supporting immersive content—floating images in the following example.

https://www.theguardian.com/us-news/2020/sep/21/climate-takeover-meet-first-time-voters-guest-editing-guardian-us

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

![image](https://user-images.githubusercontent.com/76776/94020138-7c4e5f00-fdaa-11ea-8bb4-01b79998d92e.png)

![image](https://user-images.githubusercontent.com/76776/94020163-83756d00-fdaa-11ea-8a92-8914602673cb.png)

## What is the value of this and can you measure success?

We should not have ads covering supporting images.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [X] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
