### PR TITLE
Add a class to apply palette styling on fronts containers

### DIFF
--- a/common/app/layout/FaciaContainer.scala
+++ b/common/app/layout/FaciaContainer.scala
@@ -5,7 +5,7 @@ import model.pressed.{CollectionConfig, PressedContent}
 import org.joda.time.DateTime
 import services.CollectionConfigWithId
 import slices.{MostPopular, _}
-import views.support.GetClasses.paletteClass
+import views.support.GetClasses.paletteClasses
 
 case class FaciaContainer(
     index: Int,
@@ -166,9 +166,7 @@ object FaciaContainer {
         case _            => ContainerCommercialOptions(omitMPU = false, adFree = adFree)
       },
       config.config.description.map(DescriptionMetaHeader),
-      customClasses = config.config.metadata
-        .flatMap(paletteClass(container, _))
-        .map(Seq(_, "fc-container--has-palette")),
+      customClasses = config.config.metadata.flatMap(paletteClasses(container, _)),
       hideToggle = false,
       showTimestamps = false,
       None,

--- a/common/app/layout/FaciaContainer.scala
+++ b/common/app/layout/FaciaContainer.scala
@@ -5,6 +5,7 @@ import model.pressed.{CollectionConfig, PressedContent}
 import org.joda.time.DateTime
 import services.CollectionConfigWithId
 import slices.{MostPopular, _}
+import views.support.GetClasses.paletteClass
 
 case class FaciaContainer(
     index: Int,
@@ -165,7 +166,7 @@ object FaciaContainer {
         case _            => ContainerCommercialOptions(omitMPU = false, adFree = adFree)
       },
       config.config.description.map(DescriptionMetaHeader),
-      None,
+      customClasses = config.config.metadata.flatMap(paletteClass(container, _)).map(Seq(_)),
       hideToggle = false,
       showTimestamps = false,
       None,

--- a/common/app/layout/FaciaContainer.scala
+++ b/common/app/layout/FaciaContainer.scala
@@ -166,7 +166,9 @@ object FaciaContainer {
         case _            => ContainerCommercialOptions(omitMPU = false, adFree = adFree)
       },
       config.config.description.map(DescriptionMetaHeader),
-      customClasses = config.config.metadata.flatMap(paletteClass(container, _)).map(Seq(_)),
+      customClasses = config.config.metadata
+        .flatMap(paletteClass(container, _))
+        .map(Seq(_, "fc-container--has-palette")),
       hideToggle = false,
       showTimestamps = false,
       None,

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -168,11 +168,12 @@ object GetClasses {
       ) collect { case (kls, true) => kls }: _*,
     )
 
-  def paletteClass(container: Container, metadata: Seq[Metadata]): Option[String] =
+  def paletteClasses(container: Container, metadata: Seq[Metadata]): Option[Seq[String]] = {
     container match {
-      case Fixed(_) => primaryPaletteClass(metadata)
+      case Fixed(_) => primaryPaletteClass(metadata).map(Seq(_, "fc-container--has-palette"))
       case _        => None
     }
+  }
 
   private val paletteClassesByMetadataTag: Map[Metadata, String] = Map(
     LongRunningPalette -> "fc-container--long-running-palette",
@@ -183,12 +184,12 @@ object GetClasses {
     EventAltPalette -> "fc-container--event-alt-palette",
   )
 
-  private def primaryPaletteClass(metadata: Seq[Metadata]): Option[String] = {
-    primaryPaletteTag(metadata).map(tag => paletteClassesByMetadataTag(tag))
-  }
-
   private def primaryPaletteTag(metadata: Seq[Metadata]): Option[Metadata] = {
     val paletteMetadataTags = paletteClassesByMetadataTag.keySet
     metadata.find(tag => paletteMetadataTags.contains(tag))
+  }
+
+  private def primaryPaletteClass(metadata: Seq[Metadata]): Option[String] = {
+    primaryPaletteTag(metadata).map(tag => paletteClassesByMetadataTag(tag))
   }
 }

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -1,12 +1,22 @@
 package views.support
 
 import layout._
-import model.pressed.{Audio, Gallery, Video, SpecialReport}
-import slices.{Dynamic, DynamicSlowMPU}
+import model.pressed.{Audio, Gallery, SpecialReport, Video}
+import slices.{Container, Dynamic, DynamicSlowMPU, Fixed}
 import play.api.mvc.RequestHeader
 import model.Pillar.RichPillar
 import model.ContentDesignType.RichContentDesignType
 import views.support.Commercial.isAdFree
+import com.gu.facia.client.models.{
+  BreakingPalette,
+  EventAltPalette,
+  EventPalette,
+  InvestigationPalette,
+  LongRunningPalette,
+  Metadata,
+  SombrePalette,
+}
+import views.support.GetClasses.primaryPaletteClass
 
 object GetClasses {
   def forHtmlBlob(item: HtmlBlob): String = {
@@ -157,4 +167,28 @@ object GetClasses {
         "fc-container--video-no-fill-sides" -> frontId.contains("video"),
       ) collect { case (kls, true) => kls }: _*,
     )
+
+  def paletteClass(container: Container, metadata: Seq[Metadata]): Option[String] =
+    container match {
+      case Fixed(_) => primaryPaletteClass(metadata)
+      case _        => None
+    }
+
+  private val paletteClassesByMetadataTag: Map[Metadata, String] = Map(
+    LongRunningPalette -> "fc-container--long-running-palette",
+    SombrePalette -> "fc-container--sombre-palette",
+    InvestigationPalette -> "fc-container--investigation-palette",
+    BreakingPalette -> "fc-container--breaking-palette",
+    EventPalette -> "fc-container--event-palette",
+    EventAltPalette -> "fc-container--event-alt-palette",
+  )
+
+  private def primaryPaletteClass(metadata: Seq[Metadata]): Option[String] = {
+    primaryPaletteTag(metadata).map(tag => paletteClassesByMetadataTag(tag))
+  }
+
+  private def primaryPaletteTag(metadata: Seq[Metadata]): Option[Metadata] = {
+    val paletteMetadataTags = paletteClassesByMetadataTag.keySet
+    metadata.find(tag => paletteMetadataTags.contains(tag))
+  }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,13 +6,13 @@ object Dependencies {
   val identityLibVersion = "3.226"
   val awsVersion = "1.11.240"
   val capiVersion = "17.1"
-  val faciaVersion = "3.0.20"
+  val faciaVersion = "3.2.0"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"
   val playJsonVersion = "2.6.3"
   val playJsonExtensionsVersion = "0.10.0"
-  val guBox = "com.gu" %% "box" %  "0.1.0"
+  val guBox = "com.gu" %% "box" % "0.1.0"
   val akkaContrib = "com.typesafe.akka" %% "akka-contrib" % "2.5.6"
   val apacheCommonsMath3 = "org.apache.commons" % "commons-math3" % "3.6.1"
   val awsCore = "com.amazonaws" % "aws-java-sdk-core" % awsVersion
@@ -76,14 +76,14 @@ object Dependencies {
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.9"
   val capiAws = "com.gu" %% "content-api-client-aws" % "0.5"
   val okhttp = "com.squareup.okhttp3" % "okhttp" % "3.10.0"
-  val jsonSchema = "com.eclipsesource"  %% "play-json-schema-validator" % "0.9.5-M4"
+  val jsonSchema = "com.eclipsesource" %% "play-json-schema-validator" % "0.9.5-M4"
 
   // sbt-native-packager does not seem respect the latestRevision conflict manager when building the
   // classpath in the executable shell file for the service. The classpath output is different to the
   // dependencies indicated by the dependency tree plugin. Specifying jackson versions manually seems
   // to be the only way of making sbt-native-packager build a classpath with consistent jackson versions.
   val jacksonVersion = "2.11.0"
-  val jacksonDataFormat = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor"  % jacksonVersion
+  val jacksonDataFormat = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion
   val jacksonCore = "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion
   val jacksonDataType = "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion
   val jacksonDataTypeJdk8 = "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion


### PR DESCRIPTION
This adds two `customClass`s to the `<section>` tag of a fronts container if:
- The container is of type `Fixed(_)`
- At least one of the following metadata tags is present on the [`CollectionConfig`](https://github.com/guardian/facia-scala-client/blob/master/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala) data we get from FAPI ([these tags may be added through the fronts tool](https://github.com/guardian/facia-scala-client/pull/241)):
`LongRunningPalette`
`SombrePalette`
`InvestigationPalette`
`BreakingPalette`
`EventPalette`
`EventAltPalette`

The class `"fc-container--has-palette"` is always added if the above is true, along with **one*** of the following classes:
`"fc-container--long-running-palette"`, 
`"fc-container--sombre-palette"`, 
`"fc-container--investigation-palette"`, 
`"fc-container--breaking-palette"`, 
`"fc-container--event-palette"`, 
`"fc-container--event-alt-palette"`

This will allow custom styling to be applied for special containers, e.g. for the US election.

\* if more than one palette Metadata tag is present, the first matching tag is selected

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No, DCR doesn't support fronts (yet...)
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
![paletteTags](https://user-images.githubusercontent.com/9820960/94032368-d275cf00-fdb7-11ea-8510-53543a70abf5.png)


## Checklist

### Does this affect other platforms?

- [x] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
