### PR TITLE
Bump @guardian/braze-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@guardian/atom-renderer": "1.1.6",
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.7",
-    "@guardian/braze-components": "0.0.9",
+    "@guardian/braze-components": "0.0.10",
     "@guardian/consent-management-platform": "6.0.0",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/shimport": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1742,10 +1742,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/braze-components@0.0.9":
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-0.0.9.tgz#df4293febbfb04f155ea23aa7726c25971659db3"
-  integrity sha512-HNhKoTTjrNWFdMQEtGrZsfr/INeX4Y2mt03GzHnZ7DSXrDBBHVfQYhgn72ye50tMcdXMzzjIbMTJ1MCnLcL5XA==
+"@guardian/braze-components@0.0.10":
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-0.0.10.tgz#a5e49f06a2ec81ad7f3c4bf2f81ebe6b39ab1dee"
+  integrity sha512-1vwhZpg9wSY0oCGERcblz3QcOvtguUSSpexJdmwB4HoO+sDVcVXkNeaceDzRQdlnGO89JxpGiSOuIBzpssBJWg==
   dependencies:
     "@guardian/src-button" "^2.1.0"
     "@guardian/src-foundations" "^2.1.0"


### PR DESCRIPTION
##  What does this change?

Updates to a new version of @guardian/braze-components which publishes esm and cjs. The linter was failing previously when we were only publishing esm and this seems to fix things.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation) PR to follow

## Screenshots

<img width="1552" alt="Screenshot 2020-09-24 at 12 39 56" src="https://user-images.githubusercontent.com/379839/94140386-1540b100-fe63-11ea-961f-d307b19cff22.png">

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
