### PR TITLE
Dynamo should avoid adding palette tags not Dynamic

### DIFF
--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -1,8 +1,16 @@
 package views.support
 
-import com.gu.facia.client.models.{BreakingPalette, EventAltPalette, EventPalette, InvestigationPalette, LongRunningPalette, Metadata, SombrePalette}
+import com.gu.facia.client.models.{
+  BreakingPalette,
+  EventAltPalette,
+  EventPalette,
+  InvestigationPalette,
+  LongRunningPalette,
+  Metadata,
+  SombrePalette,
+}
 import layout._
-import layout.slices.{Container, Dynamic, DynamicPackage, DynamicSlowMPU}
+import layout.slices._
 import model.ContentDesignType.RichContentDesignType
 import model.Pillar.RichPillar
 import model.pressed.{Audio, Gallery, SpecialReport, Video}
@@ -161,8 +169,9 @@ object GetClasses {
 
   def paletteClasses(container: Container, metadata: Seq[Metadata]): Option[Seq[String]] = {
     container match {
-      case Dynamic(DynamicPackage) => None
-      case _ => primaryPaletteClass(metadata).map(Seq(_, "fc-container--has-palette"))
+      case Fixed(_) | Dynamic(DynamicSlow) | Dynamic(DynamicFast) | Dynamic(DynamicSlowMPU(_, _)) =>
+        primaryPaletteClass(metadata).map(Seq(_, "fc-container--has-palette"))
+      case _ => None
     }
   }
 

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -1,22 +1,13 @@
 package views.support
 
+import com.gu.facia.client.models.{BreakingPalette, EventAltPalette, EventPalette, InvestigationPalette, LongRunningPalette, Metadata, SombrePalette}
 import layout._
-import model.pressed.{Audio, Gallery, SpecialReport, Video}
-import slices.{Container, Dynamic, DynamicSlowMPU, Fixed}
-import play.api.mvc.RequestHeader
-import model.Pillar.RichPillar
+import layout.slices.{Container, Dynamic, DynamicPackage, DynamicSlowMPU}
 import model.ContentDesignType.RichContentDesignType
+import model.Pillar.RichPillar
+import model.pressed.{Audio, Gallery, SpecialReport, Video}
+import play.api.mvc.RequestHeader
 import views.support.Commercial.isAdFree
-import com.gu.facia.client.models.{
-  BreakingPalette,
-  EventAltPalette,
-  EventPalette,
-  InvestigationPalette,
-  LongRunningPalette,
-  Metadata,
-  SombrePalette,
-}
-import views.support.GetClasses.primaryPaletteClass
 
 object GetClasses {
   def forHtmlBlob(item: HtmlBlob): String = {
@@ -170,8 +161,8 @@ object GetClasses {
 
   def paletteClasses(container: Container, metadata: Seq[Metadata]): Option[Seq[String]] = {
     container match {
-      case Fixed(_) => primaryPaletteClass(metadata).map(Seq(_, "fc-container--has-palette"))
-      case _        => None
+      case Dynamic(DynamicPackage) => None
+      case _ => primaryPaletteClass(metadata).map(Seq(_, "fc-container--has-palette"))
     }
   }
 


### PR DESCRIPTION
## What does this change?
Our definition of Dynamo got a bit lost in translation and we equated it to Dynamic, whereas actually we should only avoid adding palette tags to DynamicPackage aka dynamic/package.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
