### PR TITLE
Log Braze banner impressions with Ophan

### DIFF
--- a/static/src/javascripts/__flow__/types/ophan.js
+++ b/static/src/javascripts/__flow__/types/ophan.js
@@ -54,7 +54,8 @@ declare type OphanComponentType =
     | 'ACQUISITIONS_EDITORIAL_LINK'
     | 'ACQUISITIONS_SUBSCRIPTIONS_BANNER'
     | 'ACQUISITIONS_OTHER'
-    | 'SIGN_IN_GATE';
+    | 'SIGN_IN_GATE'
+    | 'RETENTION_ENGAGEMENT_BANNER';
 
 declare type OphanComponent = {
     componentType: OphanComponentType,

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -5,6 +5,7 @@ import config from 'lib/config';
 import reportError from 'lib/report-error';
 import {onConsentChange} from '@guardian/consent-management-platform';
 import {mountDynamic} from "@guardian/automat-modules";
+import {submitViewEvent} from 'common/modules/commercial/acquisitions-ophan';
 
 import {getUserFromApi} from '../../common/modules/identity/api';
 import {isDigitalSubscriber} from "../../common/modules/commercial/user-features";
@@ -170,6 +171,14 @@ const show = (): Promise<boolean> => import(
             // Log the impression with Braze
             appboy.logInAppMessageImpression(messageConfig);
         }
+
+        // Log the impression with Ophan
+        submitViewEvent({
+            component: {
+                componentType: 'RETENTION_ENGAGEMENT_BANNER',
+                id: messageConfig.extras.componentName,
+            },
+        });
 
         return true;
     })

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.spec.js
@@ -3,6 +3,7 @@
 import {brazeVendorId, canShowPreChecks, hasRequiredConsents} from "./brazeBanner";
 
 jest.mock('lib/raven');
+jest.mock('ophan/ng', () => null);
 
 let mockOnConsentChangeResult;
 jest.mock('@guardian/consent-management-platform', () => ({


### PR DESCRIPTION
## What does this change?

Start sending Braze banner view events to Ophan.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation) guardian/dotcom-rendering#1944

## What is the value of this and can you measure success?

To get an accurate idea of how often we're showing the banner, which is useful feedback to understand how the campaign is performing (and whether it's configured correctly).

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
