### PR TITLE
Re-init article body ads on custom event 

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -272,8 +272,8 @@ const doInit = (): Promise<boolean> => {
 export const init = (): Promise<boolean> => {
     // Also init when the main article is redisplayed
     // For instance by the signin gate.
-    mediator.on('page:article:redisplayed', () => {
-        doInit();
-    });
+    mediator.on('page:article:redisplayed', doInit);
+    // DCR doesn't have mediator, so listen for CustomEvent
+    document.addEventListener('dcr:page:article:redisplayed', doInit);
     return doInit();
 };


### PR DESCRIPTION
# What does this change?

updates article body ads to also re-init on a custom event, not just a `mediator` event

## Does this change need to be reproduced in dotcom-rendering ?

- [x] Yes (please indicate your plans for DCR Implementation)

to trigger this on DCR you need to dispatch [a custom event](https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Creating_and_triggering_events) with the type of `'dcr:page:article:redisplayed'`, e.g.

```js
document.dispatchEvent(
    new CustomEvent('dcr:page:article:redisplayed')
);
```

## What is the value of this and can you measure success?

enable sign in gate to reload ads on DCR when it's dismissed

cc @coldlink @dominickendrick 