### PR TITLE
Exit SBT script on mismatching Java Version

### DIFF
--- a/sbt
+++ b/sbt
@@ -13,8 +13,6 @@ JAVA_VERSION=$(sbt 'eval sys.props("java.version")' \
 | egrep -o ".{5}" \
 | head -1)
 
-echo "JAVA_VERSION=$JAVA_VERSION"
-
 if [ "$JAVA_VERSION" != "1.8.0" ]; then
     echo "SBT is not using Java 8. Have you set JAVA_HOME in your profile?"
     exit 1

--- a/sbt
+++ b/sbt
@@ -6,6 +6,20 @@ if [ -f "~/.sbtconfig" ]; then
   . ~/.sbtconfig
 fi
 
+JAVA_VERSION=$(sbt 'eval sys.props("java.version")' \
+| egrep -o "(ans: String = )(.+)" \
+| egrep -o "\S+" \
+| tail -1 \
+| egrep -o ".{5}" \
+| head -1)
+
+echo "JAVA_VERSION=$JAVA_VERSION"
+
+if [ "$JAVA_VERSION" != "1.8.0" ]; then
+    echo "SBT is not using Java 8. Have you set JAVA_HOME in your profile?"
+    exit 1
+fi
+
 # Debug option
 DEBUG_PARAMS=""
 for arg in "$@"


### PR DESCRIPTION
## What does this change?

@sihil has collated a number of issues which can be traced back to SBT using Homebrew’s Java.

As the SBT script is already quite verbose, I think it’s better to prevent running it entirely if the Java version is incorrect.

> tl;dr: add an "export JAVA_HOME=$(/usr/libexec/java_home)" to your ~/.bash_profile or equivalent to avoid JDK version issues; and make sure you're not using AdoptOpenJDK 1.8.0_242.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

![image](https://user-images.githubusercontent.com/76776/94444253-0b3deb80-019e-11eb-8476-b4e004571e0d.png)

## What is the value of this and can you measure success?

Problems running frontend will be understood quicker.

## Checklist

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
