### PR TITLE
Added Ophan click tracking for Braze Banner

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@guardian/atom-renderer": "1.2.1",
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.7",
-    "@guardian/braze-components": "0.0.11",
+    "@guardian/braze-components": "0.0.12",
     "@guardian/commercial-core": "^0.6.0",
     "@guardian/consent-management-platform": "6.2.0",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -5,7 +5,7 @@ import config from 'lib/config';
 import reportError from 'lib/report-error';
 import {onConsentChange} from '@guardian/consent-management-platform';
 import {mountDynamic} from "@guardian/automat-modules";
-import {submitViewEvent} from 'common/modules/commercial/acquisitions-ophan';
+import {submitViewEvent, submitClickEvent} from 'common/modules/commercial/acquisitions-ophan';
 
 import {getUserFromApi} from '../../common/modules/identity/api';
 import {isDigitalSubscriber} from "../../common/modules/commercial/user-features";
@@ -160,6 +160,16 @@ const show = (): Promise<boolean> => import(
                         appboy.logInAppMessageButtonClick(
                             thisButton, messageConfig
                         );
+                        // Log the click with Ophan
+                        submitClickEvent({
+                            component: {
+                                componentType: 'BRAZE_BANNER',
+                                id: messageConfig.extras.componentName,
+                                // Braze displays button id from 1, but internal representation is numbered from 0
+                                // This means that the Button ID in Braze and Ophan will be the same
+                                value: (buttonId + 1).toString(10),
+                            },
+                        });
                     }
                 },
                 brazeMessageProps: messageConfig.extras,

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -5,7 +5,7 @@ import config from 'lib/config';
 import reportError from 'lib/report-error';
 import {onConsentChange} from '@guardian/consent-management-platform';
 import {mountDynamic} from "@guardian/automat-modules";
-import {submitViewEvent, submitClickEvent} from 'common/modules/commercial/acquisitions-ophan';
+import {submitViewEvent, submitComponentEvent} from 'common/modules/commercial/acquisitions-ophan';
 
 import {getUserFromApi} from '../../common/modules/identity/api';
 import {isDigitalSubscriber} from "../../common/modules/commercial/user-features";
@@ -154,24 +154,15 @@ const show = (): Promise<boolean> => import(
             module.BrazeMessage,
             {
                 componentName: messageConfig.extras.componentName,
-                onButtonClick: (buttonId: number) => {
+                logButtonClickWithBraze: (buttonId: number) => {
                     if (appboy) {
                         const thisButton = new appboy.InAppMessageButton(`Button ${buttonId}`,null,null,null,null,null,buttonId)
                         appboy.logInAppMessageButtonClick(
                             thisButton, messageConfig
                         );
-                        // Log the click with Ophan
-                        submitClickEvent({
-                            component: {
-                                componentType: 'BRAZE_BANNER',
-                                id: messageConfig.extras.componentName,
-                                // Braze displays button id from 1, but internal representation is numbered from 0
-                                // This means that the Button ID in Braze and Ophan will be the same
-                                value: (buttonId + 1).toString(10),
-                            },
-                        });
                     }
                 },
+                submitComponentEvent,
                 brazeMessageProps: messageConfig.extras,
             },
             true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1742,10 +1742,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/braze-components@0.0.11":
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-0.0.11.tgz#93bc757be9b273fb3d305e9f0321862696a7aee4"
-  integrity sha512-mkBliGKiqHN4jm3N/Jy+JVNfmZESvNT9lO4pwiMvjiy9TaN/yW9ZWRVelsXHw05qcqlQsuiRp/B85htxz3Tk+Q==
+"@guardian/braze-components@0.0.12":
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-0.0.12.tgz#38de36010113e07e41238aa5c27b8bcf50a9bfff"
+  integrity sha512-ooouk1mrVP+RMHu4mVRfgFaxjL794MdLpmgCyC4gTuDzyIh4VOliJxrffOqr0RQiJPPiOqyyC/gG+386amf1Pw==
   dependencies:
     "@guardian/src-button" "^2.1.0"
     "@guardian/src-foundations" "^2.1.0"


### PR DESCRIPTION
## What does this change?
Adds Ophan click tracking to Braze Banner.

Branches from `tw-braze-banner-ophan-events`

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes (DCR PR to follow)

## Screenshots

## What is the value of this and can you measure success?
Ophan click events for Braze Banner

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
