### PR TITLE
Add tcfv2 params to pfp youtube player

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.7",
     "@guardian/braze-components": "0.0.11",
-    "@guardian/consent-management-platform": "6.1.2-0",
+    "@guardian/consent-management-platform": "6.2.0",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/shimport": "^1.0.2",
     "@guardian/src-button": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.7",
     "@guardian/braze-components": "0.0.11",
-    "@guardian/consent-management-platform": "6.1.0",
+    "@guardian/consent-management-platform": "6.1.2-0",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/shimport": "^1.0.2",
     "@guardian/src-button": "^0.16.1",

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -59,7 +59,7 @@ onConsentChange(state => {
         tcfData = state.tcfv2;
         tcfState = tcfData
             ? Object.values(tcfData.consents).every(Boolean)
-            : state[1] && state[2] && state[3] && state[4] && state[5];
+            : false
     }
 });
 

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -40,6 +40,9 @@ interface AdsConfig {
     adTagParameters?: {
         iu: any,
         cust_params: string,
+        cmpGdpr: number,
+        cmpVcd: string,
+        cmpGvcd: string,
     };
     disableAds?: boolean;
     nonPersonalizedAd?: boolean;
@@ -48,12 +51,14 @@ interface AdsConfig {
 
 let tcfState = null;
 let ccpaState = null;
+let tcfData = {};
 onConsentChange(state => {
     if (state.ccpa) {
         ccpaState = state.doNotSell;
     } else {
-        tcfState = state.tcfv2
-            ? Object.values(state.tcfv2.consents).every(Boolean)
+        tcfData = state.tcfv2;
+        tcfState = tcfData
+            ? Object.values(tcfData.consents).every(Boolean)
             : state[1] && state[2] && state[3] && state[4] && state[5];
     }
 });
@@ -134,6 +139,9 @@ const createAdsConfig = (
         adTagParameters: {
             iu: config.get('page.adUnit'),
             cust_params: encodeURIComponent(constructQuery(custParams)),
+            cmpGdpr: tcfData.gdprApplies ? 1 : 0,
+            cmpVcd: tcfData.tcString,
+            cmpGvcd: tcfData.addtlConsent,
         },
     };
 

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.js
@@ -105,14 +105,18 @@ describe('create ads config', () => {
         }
     });
 
-    it('in non ad-free includes url-escaped targeting params', () => {
+    it('in non ad-free includes url-escaped and tcfv2 targeting params', () => {
         const result = youtubePlayer.createAdsConfig(false, null, null);
-
+        const expectedAdTargetingParams =  {
+            "cmpGdpr": 1,
+            "cmpGvcd": "testaddtlConsent",
+            "cmpVcd": "testTcString",
+            "cust_params": "key%3Dvalue%26permutive%3D42",
+            "iu": "adunit"
+        };
         expect(result.adTagParameters).toBeDefined();
         if (result.adTagParameters) {
-            expect(result.adTagParameters.cust_params).toEqual(
-                'key%3Dvalue%26permutive%3D42'
-            );
+            expect(result.adTagParameters).toEqual(expectedAdTargetingParams);
         }
     });
 });

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.js
@@ -25,7 +25,7 @@ jest.mock('lib/config', () => ({
 
 jest.mock('@guardian/consent-management-platform', () => ({
     onConsentChange: jest.fn(callback =>
-        callback({ tcfv2: { consents: { '1': true } } })
+        callback({ tcfv2: { consents: { '1': true }, gdprApplies: true, tcString:"testTcString", addtlConsent: "testaddtlConsent" } })
     ),
 }));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1753,10 +1753,10 @@
     "@guardian/src-icons" "^2.2.0"
     emotion-theming "^10.0.19"
 
-"@guardian/consent-management-platform@6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.1.0.tgz#0de83ca15d37a60bd79f2e95046ca68d8cc5141d"
-  integrity sha512-EVRoGDSk78UK9+0ILHkkubWjLdBvNrvmObwNfbrYxXnfOtyszGuy+mfhtGtLAXUKf85w+7nXnY/hKRmz4MfyeQ==
+"@guardian/consent-management-platform@6.1.2-0":
+  version "6.1.2-0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.1.2-0.tgz#e043a117df6721dd6a6bc897c180243942a706e0"
+  integrity sha512-Ab544gJcsVCiprznB8Ltd6kNcl8lVmGd+CEoci5ZArSESi9V4HB/5CmwHyZUOeZ8/WwYBF0qMU/kkfINWdyljA==
 
 "@guardian/dotcom-rendering@git://github.com/guardian/dotcom-rendering.git#version-1-alpha":
   version "0.1.0-alpha"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1753,10 +1753,10 @@
     "@guardian/src-icons" "^2.2.0"
     emotion-theming "^10.0.19"
 
-"@guardian/consent-management-platform@6.1.2-0":
-  version "6.1.2-0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.1.2-0.tgz#e043a117df6721dd6a6bc897c180243942a706e0"
-  integrity sha512-Ab544gJcsVCiprznB8Ltd6kNcl8lVmGd+CEoci5ZArSESi9V4HB/5CmwHyZUOeZ8/WwYBF0qMU/kkfINWdyljA==
+"@guardian/consent-management-platform@6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.2.0.tgz#85f7ffa30318fc190be1d664945da0b30076a592"
+  integrity sha512-vlA3wjRnOBtCvDXNh6BCMliR/UZ5k9aLzN7opWvZVWe1j7/c3709B148AOEhWpn5PbZk8gd/Y1XVfQUn0USrrQ==
 
 "@guardian/dotcom-rendering@git://github.com/guardian/dotcom-rendering.git#version-1-alpha":
   version "0.1.0-alpha"


### PR DESCRIPTION
## What does this change?
Youtube Pfp needs some more data to pass for tcfv2 purposes
https://developers.google.com/youtube/pfp/web/iframe_embed_config_api#ad_serving_controls
In particular they need

addtlConsent,
gdprApplies,
tcString

Relies on https://github.com/guardian/consent-management-platform/pull/294


### Tested

- [x] Locally
- [ ] On CODE (optional)

