### PR TITLE
ignore metals files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ static/vendor/data/cmp_vendorlist.json
 .sbt
 .sbt.*
 .metals
+.bloop
+/project
 
 log
 logs

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ static/vendor/data/cmp_vendorlist.json
 .node-version
 .sbt
 .sbt.*
+
+# metal vscode extension
 .metals
 .bloop
 /project/metals.sbt

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,8 @@ static/vendor/data/cmp_vendorlist.json
 .sbt.*
 .metals
 .bloop
-/project
+/project/metals.sbt
+/project/project
 
 log
 logs


### PR DESCRIPTION
## What does this change?

ignores files created for use by the [vscode metals extension](https://scalameta.org/metals/docs/editors/vscode.html)