### PR TITLE
Show signin gate 5 times after the first dismissal if user does not signin

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -71,7 +71,7 @@ trait ABTestSwitches {
     "ab-sign-in-gate-main-control",
     "Control audience for the sign in gate to 9% audience. Will never see the sign in gate.",
     owners = Seq(Owner.withGithub("coldlink")),
-    safeState = On,
+    safeState = Off,
     sellByDate = new LocalDate(2020, 12, 1),
     exposeClientSide = true,
   )
@@ -81,7 +81,7 @@ trait ABTestSwitches {
     "ab-sign-in-gate-main-variant",
     "Show sign in gate to 90% of users on 3rd article view, variant/full audience",
     owners = Seq(Owner.withGithub("coldlink")),
-    safeState = On,
+    safeState = Off,
     sellByDate = new LocalDate(2020, 12, 1),
     exposeClientSide = true,
   )

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -71,7 +71,7 @@ trait ABTestSwitches {
     "ab-sign-in-gate-main-control",
     "Control audience for the sign in gate to 9% audience. Will never see the sign in gate.",
     owners = Seq(Owner.withGithub("coldlink")),
-    safeState = Off,
+    safeState = On,
     sellByDate = new LocalDate(2020, 12, 1),
     exposeClientSide = true,
   )
@@ -81,7 +81,7 @@ trait ABTestSwitches {
     "ab-sign-in-gate-main-variant",
     "Show sign in gate to 90% of users on 3rd article view, variant/full audience",
     owners = Seq(Owner.withGithub("coldlink")),
-    safeState = Off,
+    safeState = On,
     sellByDate = new LocalDate(2020, 12, 1),
     exposeClientSide = true,
   )

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-control.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-control.js
@@ -15,7 +15,7 @@ export const signInGateMainControl: ABTest = {
     successMeasure: 'N/A - User does not see gate, only to compare to variant.',
     audienceCriteria:
         '3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
-    ophanComponentId: 'main_control_1',
+    ophanComponentId: 'main_control_2',
     dataLinkNames: 'SignInGateMain',
     idealOutcome:
         'Increase the number of users signed in whilst running at a reasonable scale',
@@ -23,7 +23,7 @@ export const signInGateMainControl: ABTest = {
     canRun: () => true,
     variants: [
         {
-            id: 'main-control-1',
+            id: 'main-control-2',
             test: (): void => {},
         },
     ],

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
@@ -15,7 +15,7 @@ export const signInGateMainVariant: ABTest = {
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:
         '3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
-    ophanComponentId: 'main_variant_1',
+    ophanComponentId: 'main_variant_2',
     dataLinkNames: 'SignInGateMain',
     idealOutcome:
         'Increase the number of users signed in whilst running at a reasonable scale',
@@ -23,7 +23,7 @@ export const signInGateMainVariant: ABTest = {
     canRun: () => true,
     variants: [
         {
-            id: 'main-variant-1',
+            id: 'main-variant-2',
             test: (): void => {},
         },
     ],

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
@@ -23,6 +23,27 @@ const setGoogleTargeting = (canShow: GateStatus): void => {
     }
 };
 
+// We use this key for storing the gate dismissed count against
+const localStorageDismissedCountKey = (variant: string, name: string): string => `gate-dismissed-count-${name}-${variant}`;
+
+const retrieveDismissedCount = (
+    variant: string,
+    name: string,
+    componentName: string
+): number => {
+    try {
+        const prefs = userPrefs.get(componentName) || {};
+        const dismissed: any = prefs[localStorageDismissedCountKey(variant, name)];
+
+        if (Number.isFinite(dismissed)) {
+            return dismissed;
+        }
+        return 0;
+    } catch (error) {
+        return 0;
+    }
+};
+
 // wrapper over isLoggedIn
 export const isLoggedIn = isUserLoggedIn;
 
@@ -111,38 +132,13 @@ export const hasUserDismissedGateInWindow: ({
     return true;
 };
 
-// We use this key for storing the gate dismissed count against
-const localStorageDismissedCountKey = (variant: string, name: string): string => {
-    return `gate-dismissed-count-${name}-${variant}`;
-};
-
-const retrieveDismissedCount = (
-    variant: string,
-    name: string,
-    componentName: string
-): number => {
-    try {
-        const prefs = userPrefs.get(componentName) || {};
-        const dismissed: any = prefs[localStorageDismissedCountKey(variant, name)];
-
-        if (Number.isFinite(dismissed)) {
-            return dismissed;
-        }
-        return 0;
-    } catch (error) {
-        return 0;
-    }
-};
-
 // Test whether the user has dismissed the gate variant more than `count` times
 export const hasUserDismissedGateMoreThanCount = (
     variant: string,
     name: string,
     componentName: string,
     count: number
-): boolean => {
-    return retrieveDismissedCount(variant, name, componentName) > count;
-};
+): boolean => retrieveDismissedCount(variant, name, componentName) > count;
 
 // Increment the number of times a user has dismissed this gate variant
 export const incrementUserDismissedGateCount = (
@@ -152,7 +148,7 @@ export const incrementUserDismissedGateCount = (
 ): void => {
     try {
         const prefs = userPrefs.get(componentName) || {};
-        prefs[localStorageDismissedCountKey(variant, name)] = retrieveDismissedCount(variant, name) + 1;
+        prefs[localStorageDismissedCountKey(variant, name)] = retrieveDismissedCount(variant, name, componentName) + 1;
         userPrefs.set(componentName, prefs);
     } catch (error) {
         // localstorage isn't available so show the gate

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
@@ -111,6 +111,54 @@ export const hasUserDismissedGateInWindow: ({
     return true;
 };
 
+// We use this key for storing the gate dismissed count against
+const localStorageDismissedCountKey = (variant: string, name: string): string => {
+    return `gate-dismissed-count-${name}-${variant}`;
+};
+
+const retrieveDismissedCount = (
+    variant: string,
+    name: string,
+    componentName: string
+): number => {
+    try {
+        const prefs = userPrefs.get(componentName) || {};
+        const dismissed: any = prefs[localStorageDismissedCountKey(variant, name)];
+
+        if (Number.isFinite(dismissed)) {
+            return dismissed;
+        }
+        return 0;
+    } catch (error) {
+        return 0;
+    }
+};
+
+// Test whether the user has dismissed the gate variant more than `count` times
+export const hasUserDismissedGateMoreThanCount = (
+    variant: string,
+    name: string,
+    componentName: string,
+    count: number
+): boolean => {
+    return retrieveDismissedCount(variant, name, componentName) > count;
+};
+
+// Increment the number of times a user has dismissed this gate variant
+export const incrementUserDismissedGateCount = (
+    variant: string,
+    name: string,
+    componentName: string
+): void => {
+    try {
+        const prefs = userPrefs.get(componentName) || {};
+        prefs[localStorageDismissedCountKey(variant, name)] = retrieveDismissedCount(variant, name) + 1;
+        userPrefs.set(componentName, prefs);
+    } catch (error) {
+        // localstorage isn't available so show the gate
+    }
+};
+
 // Dynamically sets the gate custom parameter for Google ad request page targeting
 export const setGatePageTargeting = (
     isGateDismissed: boolean,

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import { hasUserDismissedGateInWindow } from './helper';
+import { hasUserDismissedGateInWindow, hasUserDismissedGateMoreThanCount, incrementUserDismissedGateCount } from './helper';
 
 jest.mock('bean', () => ({
     record: jest.fn(),
@@ -7,6 +7,7 @@ jest.mock('bean', () => ({
 
 jest.mock('common/modules/user-prefs', () => ({
     get: jest.fn(() => undefined),
+    set: jest.fn(() => undefined),
     remove: jest.fn(),
 }));
 
@@ -84,5 +85,43 @@ describe('Sign In Gate Helper functions', () => {
             expect(hasUserDismissedGateInWindow(test)).toBe(false);
             expect(fakeUserPrefs.remove).toHaveBeenCalledTimes(1);
         });
+    });
+
+    describe('hasUserDismissedGateMoreThanCount', () => {
+        let userPrefs = {};
+
+        beforeEach(() => {
+            userPrefs = {};
+            fakeUserPrefs.get.mockImplementation((k) => userPrefs[k]);
+            fakeUserPrefs.set.mockImplementation((k, v) => {
+                userPrefs[k] = v
+            });
+        });
+
+        afterEach(() => {
+            fakeUserPrefs.get.mockRestore();
+            fakeUserPrefs.set.mockRestore();
+        });
+
+        it('should depend on the counter incremented by incrementUserDismissedGateCount', () => {
+            expect(hasUserDismissedGateMoreThanCount('variant-1', 'test-1', 'sign-in-gate', 0)).toBe(false);
+
+            incrementUserDismissedGateCount('variant-1', 'test-1', 'sign-in-gate');
+            expect(hasUserDismissedGateMoreThanCount('variant-1', 'test-1','sign-in-gate', 0)).toBe(true);
+            expect(hasUserDismissedGateMoreThanCount('variant-1', 'test-1', 'sign-in-gate',1)).toBe(false);
+
+            incrementUserDismissedGateCount('variant-1', 'test-1', 'sign-in-gate');
+            expect(hasUserDismissedGateMoreThanCount('variant-1', 'test-1', 'sign-in-gate', 1)).toBe(true);
+            expect(hasUserDismissedGateMoreThanCount('variant-1', 'test-1', 'sign-in-gate', 2)).toBe(false);
+
+            expect(hasUserDismissedGateMoreThanCount('variant-2', 'test-1', 'sign-in-gate', 0)).toBe(false);
+        });
+
+        it('should not be affected by incrementing other variants or tests', () => {
+            incrementUserDismissedGateCount('variant-1', 'test-1', 'sign-in-gate');
+            expect(hasUserDismissedGateMoreThanCount('variant-2', 'test-1', 'sign-in-gate', 0)).toBe(false);
+            expect(hasUserDismissedGateMoreThanCount('variant-1', 'test-2', 'sign-in-gate', 0)).toBe(false);
+        });
+
     });
 });

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/main-variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/main-variant.js
@@ -13,6 +13,7 @@ import {
     gateBorderFix,
     addCSSOnOpinion
 } from '../../helper';
+import { incrementUserDismissedGateCount } from "common/modules/identity/sign-in-gate/helper";
 
 // add the html template as the return of the function below
 // signInUrl - parameter which holds the link to the sign in/register page with the tracking parameters added
@@ -136,6 +137,13 @@ export const designShow: ({
                         name: abTest.name,
                         variant: abTest.variant,
                     });
+
+                    // increment gate dismissed count
+                    incrementUserDismissedGateCount(
+                        abTest.variant,
+                        abTest.name,
+                        componentName,
+                    );
                 },
             });
 

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/main-variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/main-variant.js
@@ -11,9 +11,9 @@ import {
     addOverlayVariantCSS,
     setGatePageTargeting,
     gateBorderFix,
-    addCSSOnOpinion
+    addCSSOnOpinion,
+    incrementUserDismissedGateCount
 } from '../../helper';
-import { incrementUserDismissedGateCount } from "common/modules/identity/sign-in-gate/helper";
 
 // add the html template as the return of the function below
 // signInUrl - parameter which holds the link to the sign in/register page with the tracking parameters added

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/main/control.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/main/control.js
@@ -12,7 +12,7 @@ import {
 } from '../../helper';
 
 // define the variant name here
-const variant = 'main-control-1';
+const variant = 'main-control-2';
 
 // method which returns a boolean determining if this variant can be shown on the current pageview
 const canShow: (name?: string) => boolean = (name = '') => {

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/main/variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/main/variant.js
@@ -8,11 +8,11 @@ import {
     isInvalidSection,
     isIOS9,
     setGatePageTargeting,
+    hasUserDismissedGateMoreThanCount
 } from '../../helper';
 
 // pull in the show method from the design folder, which has the html template and and click handlers etc.
 import { designShow } from '../design/main-variant';
-import { hasUserDismissedGateMoreThanCount } from "common/modules/identity/sign-in-gate/helper";
 
 // define the variant name here
 const variant = 'main-variant-2';

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/main/variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/main/variant.js
@@ -2,7 +2,6 @@
 import type { CurrentABTest, SignInGateVariant } from '../../types';
 import { componentName } from '../../component';
 import {
-    hasUserDismissedGate,
     isNPageOrHigherPageView,
     isLoggedIn,
     isInvalidArticleType,
@@ -13,17 +12,19 @@ import {
 
 // pull in the show method from the design folder, which has the html template and and click handlers etc.
 import { designShow } from '../design/main-variant';
+import { hasUserDismissedGateMoreThanCount } from "common/modules/identity/sign-in-gate/helper";
 
 // define the variant name here
-const variant = 'main-variant-1';
+const variant = 'main-variant-2';
 
 // method which returns a boolean determining if this variant can be shown on the current pageview
 const canShow: (name?: string) => boolean = (name = '') => {
-    const isGateDismissed = hasUserDismissedGate({
-        name,
+    const isGateDismissed = hasUserDismissedGateMoreThanCount(
         variant,
+        name,
         componentName,
-    });
+        5
+    );
     const canShowCheck =
         !isGateDismissed &&
         isNPageOrHigherPageView(3) &&


### PR DESCRIPTION
## What does this change?

Show signin gate 5 times after the first dismissal if user does not signin or register.
See https://trello.com/c/Xp9mwQGy/2471-goal-update-dismiss-rules-to-display-the-sign-in-gate-on-every-eligible-article-after-dismissing-t

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes (please indicate your plans for DCR Implementation)
https://github.com/guardian/dotcom-rendering/pull/1954

## Screenshots

## What is the value of this and can you measure success?

Increase number of users registering / signing in. Data shows that a large percentage of users signin after 5 gate viewings.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
