### PR TITLE
Apply Acast (audio ads) client-side to respect consent

### DIFF
--- a/applications/app/views/fragments/audioBody.scala.html
+++ b/applications/app/views/fragments/audioBody.scala.html
@@ -42,7 +42,7 @@
                 data-component="main audio"
                 id="audio-component-container"
                 data-media-id="@audio.elements.mainAudio.map(_.properties.id)"
-                data-source="@audio.downloadUrl.map(Audio.acastUrl(_, isAdFree))"
+                data-source="@audio.downloadUrl"
                 data-download-url="@audio.downloadUrl.getOrElse("#")"
                 data-duration="@audio.duration"
                 >

--- a/applications/test/MediaControllerTest.scala
+++ b/applications/test/MediaControllerTest.scala
@@ -96,30 +96,4 @@ import scala.util.matching.Regex
     status(result) should be(200)
   }
 
-  it should "render audio with an acast URL" in {
-    val fakeRequest = TestRequest(audioUrl)
-    val result = mediaController.render(audioUrl)(fakeRequest)
-
-    status(result) should be(200)
-
-    val html = Jsoup.parse(contentAsString(result))
-    val audioEl = html.getElementsByClass("podcast__player")
-
-    audioEl.attr("data-source") should startWith("https://flex.acast.com/audio.guim.co.uk")
-    audioEl.attr("data-download-url") should startWith("https://audio.guim.co.uk")
-  }
-
-  it should "NOT render audio with an acast URL for ad-free requests" in {
-    val fakeRequest = TestRequest(audioUrl).withHeaders("X-GU-Commercial-Ad-Free" -> "true")
-    val result = mediaController.render(audioUrl)(fakeRequest)
-
-    status(result) should be(200)
-
-    val html = Jsoup.parse(contentAsString(result))
-    val audioEl = html.getElementsByClass("podcast__player")
-
-    audioEl.attr("data-source") should startWith("https://audio.guim.co.uk")
-    audioEl.attr("data-download-url") should startWith("https://audio.guim.co.uk")
-  }
-
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -409,7 +409,7 @@ trait FeatureSwitches {
     owners = Seq(Owner.withName("journalism team")),
     safeState = On,
     sellByDate = never,
-    exposeClientSide = false,
+    exposeClientSide = true,
   )
 
   // Simple & Coherent

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -636,12 +636,6 @@ object Audio {
 
     Audio(contentOverrides)
   }
-
-  def acastUrl(player: AudioPlayer, url: String, isAdFree: Boolean): String =
-    if (player.audio.tags.isPodcast) acastUrl(url, isAdFree) else url
-  def acastUrl(url: String, isAdFree: Boolean): String =
-    if (!isAdFree && conf.switches.Switches.Acast.isSwitchedOn) "https://flex.acast.com/" + url.replace("https://", "")
-    else url
 }
 
 final case class Audio(override val content: Content) extends ContentType {

--- a/common/app/views/fragments/media/audio.scala.html
+++ b/common/app/views/fragments/media/audio.scala.html
@@ -8,7 +8,7 @@
         data-auto-play="@player.autoPlay" preload="none">
 
         @player.audioElement.audio.encodings.map { encoding =>
-            <source src="@model.Audio.acastUrl(player, encoding.url, isAdFree)" type="@encoding.format" />
+            <source src="@encoding.url" type="@encoding.format" />
         }
     </audio>
     @player.audio match {
@@ -48,7 +48,7 @@
                 @audio.downloadUrl.map { downloadUrl =>
                     <li class="podcast-meta__item podcast-meta__item--download">
                         <a class="podcast-meta__item__link pseudo-icon"
-                        href="@model.Audio.acastUrl(player, downloadUrl, isAdFree)"
+                        href="@downloadUrl"
                         data-link-name="@trackingCode("download")">Download</a>
                     </li>
                 }


### PR DESCRIPTION
## What does this change?

Apply Acast (audio ads) client-side so that we can respect consent.

The specific conditions to use Acast are:

* is a podcast
* user is not ad-free
* user has consented to Acast
* Acast switch is on

Note, audio atoms have a separate rendering flow; this change only affects audio pages.

## Does this change need to be reproduced in dotcom-rendering ?

(Only once audio pages are migrated which is not anytime soon.)

## What is the value of this and can you measure success?

Required to respect consent here.