### PR TITLE
Use newer atom-renderer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@braze/web-sdk-core": "^3.0.0",
     "@emotion/core": "^10.0.27",
     "@emotion/styled": "^10.0.27",
-    "@guardian/atom-renderer": "1.1.6",
+    "@guardian/atom-renderer": "1.2.1",
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.7",
     "@guardian/braze-components": "0.0.11",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -72,7 +72,7 @@ object Dependencies {
   val playJsonExtensions = "ai.x" %% "play-json-extensions" % playJsonExtensionsVersion
   val playJsonJoda = "com.typesafe.play" %% "play-json-joda" % playJsonVersion
   val playIteratees = "com.typesafe.play" %% "play-iteratees" % "2.6.1"
-  val atomRenderer = "com.gu" %% "atom-renderer" % "1.1.6"
+  val atomRenderer = "com.gu" %% "atom-renderer" % "1.2.0"
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.9"
   val capiAws = "com.gu" %% "content-api-client-aws" % "0.5"
   val okhttp = "com.squareup.okhttp3" % "okhttp" % "3.10.0"

--- a/static/src/javascripts/projects/atoms/services.js
+++ b/static/src/javascripts/projects/atoms/services.js
@@ -5,6 +5,11 @@
 
 import ophan from 'ophan/ng';
 import fastdom from 'fastdom';
+import { isAdFreeUser } from 'common/modules/commercial/user-features';
+import {
+    onConsentChange,
+    getConsentFor,
+} from '@guardian/consent-management-platform';
 import { viewport } from './services/viewport';
 
 // Need to pass in the API to native services, something that looks
@@ -26,6 +31,17 @@ const promisify = (fdaction: FastdomAction) => (
         });
     });
 
+const acastConsentState = (): Promise<boolean> => {
+    const p = new Promise(resolve => {
+        onConsentChange(state => {
+            const consented = getConsentFor('acast', state);
+            resolve(consented);
+        });
+    });
+
+    return p;
+};
+
 const services: Services = {
     ophan,
     dom: {
@@ -33,6 +49,12 @@ const services: Services = {
         read: promisify(fastdom.read),
     },
     viewport,
+    consent: {
+        acast: acastConsentState(),
+    },
+    commercial: {
+        isAdFree: isAdFreeUser(),
+    },
 };
 
 export { services };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1705,10 +1705,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@guardian/atom-renderer@1.1.6":
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/@guardian/atom-renderer/-/atom-renderer-1.1.6.tgz#e5bfc53d48dc3d49191903c133484cbfd3a142b6"
-  integrity sha512-l206iwL+8TcUHwozpw5phTBNVp0jFqk/azAcZ+YxwP3MEqE68XcR/SuP9FybKcAomeOd7xM6TzX1031Ci3LHCw==
+"@guardian/atom-renderer@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@guardian/atom-renderer/-/atom-renderer-1.2.1.tgz#b908676560d66154f3d812eff0643db3d6e4732c"
+  integrity sha512-tx3CKQknhWOtxCeAqvTHAYFwsVt3cfGiAIwU3oKbqq9cx4DkfN3aXqodfESkbb22qUEH+dEKxSvUG6VYiLcCYw==
   dependencies:
     "@babel/preset-env" "^7.3.1"
     "@babel/preset-flow" "^7.0.0"


### PR DESCRIPTION
## What does this change?

Updates atom-renderer version to latest version which only wraps audio atoms with Acast if consent has been given.

## Does this change need to be reproduced in dotcom-rendering ?

(Yes - the plan is to update the `atoms-rendering` library accordingly.)

## What is the value of this and can you measure success?

Respect Acast consent.

## Checklist

### Tested

The atom-renderer library doesn't work locally for some reason even on main, so plan is to test on CODE.

- [ ] Locally
- [ ] On CODE (TODO)

