### PR TITLE
Replace old shady pie with new MPU image

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/adblock-ask.js
+++ b/static/src/javascripts/projects/common/modules/commercial/adblock-ask.js
@@ -13,7 +13,7 @@ const supportUrl = `${supportSubscribeDigitalURL()}?acquisitionData=%7B%22compon
 const askHtml = `
 <div class="contributions__adblock">
     <a href="${supportUrl}">
-        <img src="https://media.guim.co.uk/3edc720c6210f873c7e75df4c46bea75615401d8/0_0_300_250/300.jpg" alt="" />
+        <img src="https://uploads.guim.co.uk/2020/10/02/Digisubs_MPU_c1_my_opt.png" alt="" />
     </a>
 </div>
 `;

--- a/static/src/javascripts/projects/common/modules/commercial/adblock-ask.js
+++ b/static/src/javascripts/projects/common/modules/commercial/adblock-ask.js
@@ -12,20 +12,9 @@ const supportUrl = `${supportSubscribeDigitalURL()}?acquisitionData=%7B%22compon
 
 const askHtml = `
 <div class="contributions__adblock">
-    <div class="contributions__adblock-content">
-        <div class="contributions__adblock-header">
-            <h2>
-                Read The<br>
-                Guardian without<br>
-                interruption on all<br>
-                your devices
-            </h2>
-        </div>
-        <a class="contributions__adblock-button" href="${supportUrl}">
-            <span class="component-button__content">Subscribe now</span>
-        </a>
-        <img src="https://media.guim.co.uk/b437f809d9fa4c72336ccbead1730b6bb0965239/0_0_432_503/432.png" class="contributions__adblock-image" alt="" />
-    </div>
+    <a href="${supportUrl}">
+        <img src="https://media.guim.co.uk/3edc720c6210f873c7e75df4c46bea75615401d8/0_0_300_250/300.jpg" alt="" />
+    </a>
 </div>
 `;
 

--- a/static/src/stylesheets/module/reader-revenue/_epic.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic.scss
@@ -233,65 +233,12 @@ div.contributions__secondary-button.contributions__secondary-button--epic {
     top: 6px;
     padding-top: $gs-baseline/2;
     width: 93%;
-    background-color: $highlight-main;
-
-    .contributions__adblock-header {
-        padding-left: 10px;
-        padding-top: 3px;
-
-        h2 {
-            @include fs-headline(6);
-            font-weight: 700;
-            font-size: 28px;
-            line-height: 30px;
-        }
-    }
-
-    .contributions__adblock-sub {
-        @include fs-headline(2);
-        padding: 12px 0 10px 10px;
-    }
-
-    .contributions__adblock-button {
-        margin: 25px 0 78px 10px;
-        background-color: $brightness-7 !important;
-        color: $brightness-100 !important;
-        font-size: 16px;
-        line-height: 22px;
-        font-family: $f-sans-serif-text;
-        display: inline-flex;
-        align-items: center;
-        text-decoration: none;
-        font-weight: bold;
-        height: 42px;
-        min-height: 42px;
-        padding: 0 21px;
-        border-radius: 21px;
-        box-sizing: border-box;
-        cursor: pointer;
-        transition: .3s ease-in-out;
-        justify-content: space-between;
-        position: relative;
-
-        &:hover, &:focus {
-            background-color: $highlight-dark;
-            svg {
-                transform: translateX(20%);
-            }
-        }
-
-        span {
-            flex: 0 0 auto;
-            display: block;
-        }
-    }
 
     .contributions__adblock-image {
-        height: 150px;
+        height: 100%;
         position: absolute;
         bottom: 0;
-        right: 0;
-    }
+     }
 }
 
 .contributions__epic-image {


### PR DESCRIPTION
## What does this change?

Replaces the adblock fallback 'shady pie' with a new MPU image.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

![Screenshot 2020-10-01 at 13 00 23](https://user-images.githubusercontent.com/29146931/94819696-77fff280-03f7-11eb-94c2-3922567dbff9.png)

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
