### PR TITLE
Force the Braze banner via the query string

### DIFF
--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -48,6 +48,7 @@ class DevParametersHttpRequestHandler(
     "timestamp", //used to get specific builds for inteactive serviceworkers
     "pbjs_debug", // set to `true` to enable prebid debugging,
     "amzn_debug_mode", // set to `1` to enable A9 debugging
+    "force-braze-message", // JSON encoded representation of "extras" data from Braze
   )
 
   val commercialParams = Seq(


### PR DESCRIPTION
## What does this change?

This PR adds support for forcing the braze banner via a query string arg, `force-braze-banner`. The value should be a JSON encoded representation of the key value pairs supplied to us by Braze, which configure the message. E.g.

```js
{
  componentName: "DigitalSubscriberAppBanner",
  header: "Hello",
  body: "Some body text",
}
```

Example URL:

https://theguardian.com/sport/2019/jul/28/tour-de-france-key-moments-egan-bernal-yellow-jersey?force-braze-message={"componentName":"DigitalSubscriberAppBanner","header":"Well%20hello","body":"Something%20something%20this%20is%20a%20forced%20banner"}

This doesn't guarantee that you'll see the banner (another higher priority banner could get the slot) but it simulates Braze giving us a message to show. If you do see another banner it usually works to dismiss it and refresh the page until you see the Braze banner.

Note that this PR is based on top of #23043. When that PR is merged I'll rebase this one and update the base branch.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation) guardian/dotcom-rendering#1959

## Screenshots

<img width="1552" alt="Screenshot 2020-10-02 at 11 50 15" src="https://user-images.githubusercontent.com/379839/94916689-1303d580-04a7-11eb-87fb-7426abcab165.png">

## What is the value of this and can you measure success?

Easier testing/previewing Braze message in context.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
