### PR TITLE
Make alreadyVisited local storage format match DCR

### DIFF
--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -230,7 +230,7 @@ const bootStandard = (): void => {
     // set local storage: gu.alreadyVisited
     if (window.guardian.isEnhanced) {
         const key = 'gu.alreadyVisited';
-        const alreadyVisited = storage.getRaw(key) || 0;
+        const alreadyVisited = parseInt(storage.getRaw(key)) || 0;
         storage.setRaw(key, alreadyVisited + 1);
     }
 

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -230,8 +230,8 @@ const bootStandard = (): void => {
     // set local storage: gu.alreadyVisited
     if (window.guardian.isEnhanced) {
         const key = 'gu.alreadyVisited';
-        const alreadyVisited = storage.get(key) || 0;
-        storage.set(key, alreadyVisited + 1);
+        const alreadyVisited = storage.getRaw(key) || 0;
+        storage.setRaw(key, alreadyVisited + 1);
     }
 
     if (

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -230,7 +230,7 @@ const bootStandard = (): void => {
     // set local storage: gu.alreadyVisited
     if (window.guardian.isEnhanced) {
         const key = 'gu.alreadyVisited';
-        const alreadyVisited = parseInt(storage.getRaw(key)) || 0;
+        const alreadyVisited = parseInt(storage.getRaw(key), 10) || 0;
         storage.setRaw(key, alreadyVisited + 1);
     }
 

--- a/static/src/javascripts/lib/storage.js
+++ b/static/src/javascripts/lib/storage.js
@@ -79,6 +79,17 @@ class Storage {
         );
     }
 
+    setRaw(key: string, value: any): any {
+        if (!this.available) {
+            return;
+        }
+
+        return this.storage.setItem(
+            key,
+            value,
+        );
+    }
+
     setIfNotExists(key: string, value: any, options: Object = {}): any {
         if (!this.available) {
             return;

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -110,7 +110,7 @@ const abParam = (): Array<string> => {
 };
 
 const getVisitedValue = (): string => {
-    const visitCount: number = parseInt(local.getRaw('gu.alreadyVisited')) || 0;
+    const visitCount: number = parseInt(local.getRaw('gu.alreadyVisited'), 10) || 0;
 
     if (visitCount <= 5) {
         return visitCount.toString();

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -110,7 +110,7 @@ const abParam = (): Array<string> => {
 };
 
 const getVisitedValue = (): string => {
-    const visitCount: number = local.getRaw('gu.alreadyVisited') || 0;
+    const visitCount: number = parseInt(local.getRaw('gu.alreadyVisited')) || 0;
 
     if (visitCount <= 5) {
         return visitCount.toString();

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -110,7 +110,7 @@ const abParam = (): Array<string> => {
 };
 
 const getVisitedValue = (): string => {
-    const visitCount: number = local.get('gu.alreadyVisited') || 0;
+    const visitCount: number = local.getRaw('gu.alreadyVisited') || 0;
 
     if (visitCount <= 5) {
         return visitCount.toString();

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -28,7 +28,6 @@ const isUserLoggedIn: any = isUserLoggedIn_;
 const getSync: any = getSync_;
 const getPrivacyFramework: any = getPrivacyFramework_;
 
-jest.mock('lib/storage');
 jest.mock('lib/config');
 jest.mock('lib/cookies', () => ({
     getCookie: jest.fn(),

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -153,7 +153,7 @@ describe('Build Page Targeting', () => {
             },
         });
 
-        local.set('gu.alreadyVisited', 0);
+        local.setRaw('gu.alreadyVisited', 0);
 
         getSync.mockReturnValue('US');
         getPrivacyFramework.mockReturnValue({ ccpa: true });
@@ -378,17 +378,17 @@ describe('Build Page Targeting', () => {
 
     describe('Already visited frequency', () => {
         it('can pass a value of five or less', () => {
-            local.set('gu.alreadyVisited', 5);
+            local.setRaw('gu.alreadyVisited', 5);
             expect(getPageTargeting().fr).toEqual('5');
         });
 
         it('between five and thirty, includes it in a bucket in the form "x-y"', () => {
-            local.set('gu.alreadyVisited', 18);
+            local.setRaw('gu.alreadyVisited', 18);
             expect(getPageTargeting().fr).toEqual('16-19');
         });
 
         it('over thirty, includes it in the bucket "30plus"', () => {
-            local.set('gu.alreadyVisited', 300);
+            local.setRaw('gu.alreadyVisited', 300);
             expect(getPageTargeting().fr).toEqual('30plus');
         });
 

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -85,7 +85,7 @@ const getReaderRevenueRegion = (geolocation: string): ReaderRevenueRegion => {
     }
 };
 
-const getVisitCount = (): number => local.get('gu.alreadyVisited') || 0;
+const getVisitCount = (): number => local.getRaw('gu.alreadyVisited') || 0;
 
 const replaceCountryName = (text: string, countryName: ?string): string =>
     countryName ? text.replace(/%%COUNTRY_NAME%%/g, countryName) : text;

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -85,7 +85,7 @@ const getReaderRevenueRegion = (geolocation: string): ReaderRevenueRegion => {
     }
 };
 
-const getVisitCount = (): number => local.getRaw('gu.alreadyVisited') || 0;
+const getVisitCount = (): number => parseInt(local.getRaw('gu.alreadyVisited')) || 0;
 
 const replaceCountryName = (text: string, countryName: ?string): string =>
     countryName ? text.replace(/%%COUNTRY_NAME%%/g, countryName) : text;

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -85,7 +85,7 @@ const getReaderRevenueRegion = (geolocation: string): ReaderRevenueRegion => {
     }
 };
 
-const getVisitCount = (): number => parseInt(local.getRaw('gu.alreadyVisited')) || 0;
+const getVisitCount = (): number => parseInt(local.getRaw('gu.alreadyVisited'), 10) || 0;
 
 const replaceCountryName = (text: string, countryName: ?string): string =>
     countryName ? text.replace(/%%COUNTRY_NAME%%/g, countryName) : text;

--- a/static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js
+++ b/static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js
@@ -91,7 +91,7 @@ const showMeTheBanner = (asExistingSupporter: boolean = false): void => {
     clearBannerHistory();
 
     // The banner only displays after a certain number of pageviews. So let's get there quick!
-    local.set('gu.alreadyVisited', minArticlesBeforeShowingBanner + 1);
+    local.setRaw('gu.alreadyVisited', minArticlesBeforeShowingBanner + 1);
     clearCommonReaderRevenueStateAndReload(asExistingSupporter);
 };
 

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.js
@@ -32,7 +32,7 @@ const subscriptionBannerSwitchIsOn: boolean = config.get(
     'switches.subscriptionBanner'
 ) && !remoteSubscriptionsBannerSwitchIsOn;
 
-const pageviews: number = parseInt(local.getRaw('gu.alreadyVisited')) || 0;
+const pageviews: number = parseInt(local.getRaw('gu.alreadyVisited'), 10) || 0;
 
 const currentRegion: ReaderRevenueRegion = getReaderRevenueRegion(
     geolocationGetSync()

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.js
@@ -32,7 +32,7 @@ const subscriptionBannerSwitchIsOn: boolean = config.get(
     'switches.subscriptionBanner'
 ) && !remoteSubscriptionsBannerSwitchIsOn;
 
-const pageviews: number = local.get('gu.alreadyVisited');
+const pageviews: number = local.getRaw('gu.alreadyVisited');
 
 const currentRegion: ReaderRevenueRegion = getReaderRevenueRegion(
     geolocationGetSync()

--- a/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/subscription-banners/subscription-banner.js
@@ -32,7 +32,7 @@ const subscriptionBannerSwitchIsOn: boolean = config.get(
     'switches.subscriptionBanner'
 ) && !remoteSubscriptionsBannerSwitchIsOn;
 
-const pageviews: number = local.getRaw('gu.alreadyVisited');
+const pageviews: number = parseInt(local.getRaw('gu.alreadyVisited')) || 0;
 
 const currentRegion: ReaderRevenueRegion = getReaderRevenueRegion(
     geolocationGetSync()


### PR DESCRIPTION
Currently we store this counter as a json object in frontend, but just as a number in DCR.
This means it gets reset any time you move from one to the other.

After the fix:

### frontend:
![Screen Shot 2020-10-05 at 10 31 58](https://user-images.githubusercontent.com/1513454/95063317-19d45780-06f6-11eb-9072-3308734aa775.png)

### dcr:
![Screen Shot 2020-10-05 at 10 33 48](https://user-images.githubusercontent.com/1513454/95063473-47210580-06f6-11eb-86d1-ad6d6e00728b.png)
