### PR TITLE
Identity | Sign In Gate | Remove gateBorderFix

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
@@ -389,17 +389,6 @@ export const addOverlayVariantCSS: ({
     }
 };
 
-// helper method to fix the border on the faqlinks bg colour
-export const gateBorderFix = () => {
-    const contentMainColumn = document.querySelector('.js-content-main-column');
-
-    if (contentMainColumn) {
-        contentMainColumn.classList.add(
-            'signin-gate__content-main-column__border-fix'
-        );
-    }
-};
-
 // helper method which first shows the gate based on the template supplied, adds any
 // handlers, e.g. click events etc. defined in the handler parameter function
 export const showGate: ({

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/main-variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/main-variant.js
@@ -10,7 +10,6 @@ import {
     showPrivacySettingsCMPModule,
     addOverlayVariantCSS,
     setGatePageTargeting,
-    gateBorderFix,
     addCSSOnOpinion,
     incrementUserDismissedGateCount
 } from '../../helper';
@@ -84,9 +83,6 @@ export const designShow: ({
             guUrl,
         }),
         handler: ({ articleBody, shadowArticleBody }) => {
-            // fix the border on the faqlinks
-            gateBorderFix();
-
             addCSSOnOpinion({
                 element: shadowArticleBody,
                 selector: '.signin-gate__faqlinks--var',

--- a/static/src/stylesheets/module/identity/_sign-in-gate.scss
+++ b/static/src/stylesheets/module/identity/_sign-in-gate.scss
@@ -326,10 +326,6 @@
     position: relative;
 }
 
-.signin-gate__content-main-column__border-fix:before {
-    z-index: 1;
-}
-
 // VARIANT DESIGN - article gradient overlay changes // vii-variant
 
 .signin-gate__content--var {


### PR DESCRIPTION
## What does this change?
- Remove `gateBorderFix` method
- Remove `.signin-gate__content-main-column__border-fix:before`  CSS class

In #22790 we added this method and class in to fix an issue with the full width background colour on the FAQ links on the Sign In Gate. However in #22967 the background colour was removed, although the fix had not been removed.

@mxdvl [noted](https://github.com/guardian/frontend/pull/22790#issuecomment-704240250) that this code caused some issues with aside/pull quotes when the gate was dismissed. So this PR removes the code causing that issue as it's no longer needed.

## Screenshots
Broken:
![image](https://user-images.githubusercontent.com/76776/95202336-1960bd00-07d9-11eb-9152-09491f065ae0.png)

Fixed:
![wavebox_RZNLi9ClOB](https://user-images.githubusercontent.com/13315440/95206357-832f9580-07de-11eb-8fd1-5724e60afff6.png)

### Tested

- [x] Locally
- [x] On CODE (optional)
