### PR TITLE
Update fastdom

### DIFF
--- a/docs/06-features-and-components/01-steadypage-js-utility.md
+++ b/docs/06-features-and-components/01-steadypage-js-utility.md
@@ -8,7 +8,7 @@ Before             |  After
 
 ## Fastdom
 
-**Do not use fastdom** when inserting elements with steady page. The utility uses fastdom under the hood to read and write where required. It batches the insertion of elements, so that if multiple elements are queued in the same animation frame they will be inserted in the same fastdom.write and the position scrolled once to prevent excessive page jumping.
+**Do not use fastdom** when inserting elements with steady page. The utility uses fastdom under the hood to read and write where required. It batches the insertion of elements, so that if multiple elements are queued in the same animation frame they will be inserted in the same fastdom.mutate and the position scrolled once to prevent excessive page jumping.
 
 It is not a direct replacement for fastdom as it requires the context of the element being passed in, in the form of its measurable container - the height of which must be the change of scroll position.
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "emotion": "^10.0.27",
     "emotion-server": "^10.0.5",
     "emotion-theming": "^10.0.27",
-    "fastdom": "0.8.5",
+    "fastdom": "1.0.9",
     "fence": "guardian/fence#0.2.11",
     "lodash": "^4.17.13",
     "object-fit-videos": "^1.0.3",

--- a/static/src/javascripts/bootstraps/atoms/snippet.js
+++ b/static/src/javascripts/bootstraps/atoms/snippet.js
@@ -14,7 +14,7 @@ __webpack_public_path__ = `${config.get('page.assetsPath')}javascripts/`;
 
 const updateHeight = () => {
     fastdom
-        .read(
+        .measure(
             () =>
                 document.documentElement &&
                 document.documentElement.getBoundingClientRect().height

--- a/static/src/javascripts/bootstraps/atoms/storyquestions.js
+++ b/static/src/javascripts/bootstraps/atoms/storyquestions.js
@@ -14,7 +14,7 @@ __webpack_public_path__ = `${config.get('page.assetsPath')}javascripts/`;
 
 const updateHeight = () => {
     fastdom
-        .read(
+        .measure(
             () =>
                 document.documentElement &&
                 document.documentElement.getBoundingClientRect().height

--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -173,7 +173,7 @@ const bootEnhanced = (): void => {
             }
 
             fastdom
-                .read(() => qwery('audio'))
+                .measure(() => qwery('audio'))
                 .then(els => {
                     if (els.length) {
                         require.ensure(
@@ -192,7 +192,7 @@ const bootEnhanced = (): void => {
 
             // Native video player enhancements
             fastdom
-                .read(() => qwery('video'))
+                .measure(() => qwery('video'))
                 .then(els => {
                     if (els.length) {
                         require.ensure(
@@ -336,7 +336,7 @@ const bootEnhanced = (): void => {
                 );
             }
 
-            fastdom.read(() => {
+            fastdom.measure(() => {
                 if ($('.youtube-media-atom').length > 0) {
                     require.ensure(
                         [],

--- a/static/src/javascripts/bootstraps/enhanced/media-player.js
+++ b/static/src/javascripts/bootstraps/enhanced/media-player.js
@@ -234,7 +234,7 @@ const enhanceVideo = (el: HTMLMediaElement, autoplay: boolean): any => {
 };
 
 const initPlayButtons = (root: ?HTMLElement): void => {
-    fastdom.read(() => {
+    fastdom.measure(() => {
         $('.js-video-play-button', root).each(el => {
             const $el = bonzo(el);
             bean.on(el, 'click', () => {
@@ -269,7 +269,7 @@ const initPlayButtons = (root: ?HTMLElement): void => {
 const initPlayer = (): void => {
     videojs.plugin('fullscreener', fullscreener);
 
-    fastdom.read(() => {
+    fastdom.measure(() => {
         $('.js-gu-media--enhance').each(el => {
             enhanceVideo(el, false);
         });

--- a/static/src/javascripts/bootstraps/enhanced/media-player.js
+++ b/static/src/javascripts/bootstraps/enhanced/media-player.js
@@ -204,12 +204,12 @@ const enhanceVideo = (el: HTMLMediaElement, autoplay: boolean): any => {
                             // built in vjs-user-active is buggy so using custom implementation
                             player.on('mousemove', () => {
                                 clearTimeout(mouseMoveIdle);
-                                fastdom.write(() => {
+                                fastdom.mutate(() => {
                                     player.addClass('vjs-mousemoved');
                                 });
 
                                 mouseMoveIdle = setTimeout(() => {
-                                    fastdom.write(() => {
+                                    fastdom.mutate(() => {
                                         player.removeClass('vjs-mousemoved');
                                     });
                                 }, 500);
@@ -244,7 +244,7 @@ const initPlayButtons = (root: ?HTMLElement): void => {
                 const placeholder = $('.js-video-placeholder', container);
                 const player = $('.js-video-player', container);
 
-                fastdom.write(() => {
+                fastdom.mutate(() => {
                     placeholder
                         .removeClass('media__placeholder--active')
                         .addClass('media__placeholder--hidden');
@@ -257,7 +257,7 @@ const initPlayButtons = (root: ?HTMLElement): void => {
                     enhanceVideo($('video', player).get(0), true);
                 });
             });
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 $el.removeClass('media__placeholder--hidden').addClass(
                     'media__placeholder--active'
                 );

--- a/static/src/javascripts/bootstraps/enhanced/newsletters.js
+++ b/static/src/javascripts/bootstraps/enhanced/newsletters.js
@@ -22,7 +22,7 @@ const inputs = {
 };
 
 const hideInputAndShowPreview = (el: ?Node): void => {
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         $(`.${classes.textInput}`, el).addClass('is-hidden');
         $(`.${classes.signupButton}`, el).removeClass(classes.styleSignup);
         $(`.${classes.previewButton}`, el).removeClass('is-hidden');
@@ -37,7 +37,7 @@ const validate = (form: ?HTMLFormElement): boolean => {
 
 const addSubscriptionMessage = (buttonEl: HTMLButtonElement): void => {
     const meta = $.ancestor(buttonEl, classes.wrapper);
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         $(buttonEl.form).addClass('is-hidden');
         $(`.${classes.previewButton}`, meta).addClass('is-hidden');
         $(`.${classes.signupConfirm}`, meta).removeClass('is-hidden');
@@ -107,7 +107,7 @@ const modifyFormForSignedIn = (el) => {
 const showSignupForm = (buttonEl: HTMLButtonElement): void => {
     const form = buttonEl.form;
     const meta = $.ancestor(buttonEl, 'js-newsletter-meta');
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         $(`.${classes.textInput}`, form)
             .removeClass('is-hidden')
             .focus();
@@ -119,14 +119,14 @@ const showSignupForm = (buttonEl: HTMLButtonElement): void => {
 };
 
 const updatePageForLoggedIn = (emailAddress: string, el: ?Node): void => {
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         hideInputAndShowPreview(el);
         $(`.${classes.textInput}`, el).val(emailAddress);
     });
 };
 
 const showSecondStageSignup = (buttonEl: HTMLButtonElement): void => {
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         buttonEl.setAttribute('type', 'button');
         bean.on(buttonEl, 'click', () => {
             showSignupForm(buttonEl);

--- a/static/src/javascripts/bootstraps/enhanced/sport.js
+++ b/static/src/javascripts/bootstraps/enhanced/sport.js
@@ -50,7 +50,7 @@ const cricket = (): void => {
         cricketScore.endpoint = `/sport/cricket/match/${matchDate}/${team}.json`;
 
         fastdom
-            .read(() => document.querySelector('.js-cricket-score'))
+            .measure(() => document.querySelector('.js-cricket-score'))
             .then(parentEl => {
                 cricketScore.fetch(parentEl, 'summary');
             });
@@ -81,13 +81,13 @@ const rugby = (): void => {
         // $FlowFixMe
         scoreBoard.fetched = (resp: Object): void => {
             fastdom
-                .read(() => document.querySelector('article'))
+                .measure(() => document.querySelector('article'))
                 .then(liveblog => {
                     liveblog.classList.add('content--has-scores');
                 });
 
             fastdom
-                .read(() => document.querySelector('.content--liveblog'))
+                .measure(() => document.querySelector('.content--liveblog'))
                 .then(liveblog => {
                     liveblog.classList.add('content--liveblog--rugby');
                 });

--- a/static/src/javascripts/bootstraps/enhanced/trail.js
+++ b/static/src/javascripts/bootstraps/enhanced/trail.js
@@ -165,7 +165,7 @@ const repositionComments = () => {
         fastdom
             .measure(() => $('.js-comments'))
             .then($comments =>
-                fastdom.write(() => {
+                fastdom.mutate(() => {
                     $comments.appendTo(qwery('.js-repositioned-comments'));
                     if (window.location.hash === '#comments') {
                         const top = $comments.offset().top;

--- a/static/src/javascripts/bootstraps/enhanced/trail.js
+++ b/static/src/javascripts/bootstraps/enhanced/trail.js
@@ -53,7 +53,7 @@ const insertOrProximity = (selector, insert) => {
         insert();
     } else {
         fastdom
-            .read(() => document.querySelector(selector))
+            .measure(() => document.querySelector(selector))
             .then(el => {
                 if (el) {
                     addProximityLoader(el, 1500, insert);
@@ -132,7 +132,7 @@ const initOnwardContent = () => {
             new OnwardContent(qwery('.js-onward'));
         } else if (config.get('page.tones', '') !== '') {
             fastdom
-                .read(() => Array.from(document.querySelectorAll('.js-onward')))
+                .measure(() => Array.from(document.querySelectorAll('.js-onward')))
                 .then(els => {
                     els.forEach(c => {
                         new TonalComponent().fetch(c, 'html');
@@ -151,7 +151,7 @@ const initDiscussion = () => {
         config.get('page.commentable')
     ) {
         fastdom
-            .read(() => document.querySelector('.discussion'))
+            .measure(() => document.querySelector('.discussion'))
             .then(el => {
                 if (el) {
                     new DiscussionLoader().attachTo(el);
@@ -163,7 +163,7 @@ const initDiscussion = () => {
 const repositionComments = () => {
     if (!isUserLoggedIn()) {
         fastdom
-            .read(() => $('.js-comments'))
+            .measure(() => $('.js-comments'))
             .then($comments =>
                 fastdom.write(() => {
                     $comments.appendTo(qwery('.js-repositioned-comments'));

--- a/static/src/javascripts/bootstraps/enhanced/video-player.js
+++ b/static/src/javascripts/bootstraps/enhanced/video-player.js
@@ -96,7 +96,7 @@ const bindTrackingEvents = (el: HTMLMediaElement): void => {
 };
 
 const initPlayer = (): void => {
-    fastdom.read(() => {
+    fastdom.measure(() => {
         $('.js-gu-media--enhance').each(el => {
             bindTrackingEvents(el);
             // hide download button in Chrome

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -117,7 +117,7 @@ const addScrollHandler = (): void => {
     const onScroll = (): void => {
         if (!scrollRunning) {
             scrollRunning = true;
-            fastdom.read(() => {
+            fastdom.measure(() => {
                 mediator.emitEvent('window:throttledScroll');
                 scrollRunning = false;
             });
@@ -193,7 +193,7 @@ const bootStandard = (): void => {
         Adds a global window:throttledScroll event to mediator, which throttles
         scroll events until there's a spare animationFrame.
         Callbacks of all listeners to window:throttledScroll are run in a
-        fastdom.read, meaning they can all perform DOM reads for free
+        fastdom.measure, meaning they can all perform DOM reads for free
         (after the first one that needs layout triggers it).
         However, this means it's VITAL that all writes in callbacks are
         delegated to fastdom.

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -92,7 +92,7 @@ const handleMembershipAccess = (): void => {
             const { body } = document;
 
             if (body) {
-                fastdom.write(() => body.classList.remove(requireClass));
+                fastdom.mutate(() => body.classList.remove(requireClass));
             }
         } else {
             redirect();

--- a/static/src/javascripts/lib/__mocks__/fastdom-promise.js
+++ b/static/src/javascripts/lib/__mocks__/fastdom-promise.js
@@ -1,9 +1,7 @@
 // @flow
 /* eslint-disable no-unused-vars */
 export default {
-    read: (fn: Function, ctx: ?Object): Promise<any> => Promise.resolve(fn()),
-    write: (fn: Function, ctx: ?Object): Promise<any> => Promise.resolve(fn()),
-    defer: (frame: number, fn: Function, ctx: ?Object): Promise<any> =>
-        Promise.resolve(fn()),
+    measure: (fn: Function, ctx: ?Object): Promise<any> => Promise.resolve(fn()),
+    mutate: (fn: Function, ctx: ?Object): Promise<any> => Promise.resolve(fn()),
     clear: (id: number): void => {},
 };

--- a/static/src/javascripts/lib/__mocks__/fastdom.js
+++ b/static/src/javascripts/lib/__mocks__/fastdom.js
@@ -1,8 +1,11 @@
 // @flow
+
+import promised from './fastdom-promise'
+
 /* eslint-disable no-unused-vars */
 export default {
-    read: (fn: Function, ctx: ?Object): number => fn(),
-    write: (fn: Function, ctx: ?Object): number => fn(),
-    defer: (frame: number, fn: Function, ctx: ?Object): number => fn(),
+    measure: (fn: Function, ctx: ?Object): number => fn(),
+    mutate: (fn: Function, ctx: ?Object): number => fn(),
     clear: (id: number): void => {},
+    extend: () => promised
 };

--- a/static/src/javascripts/lib/fastdom-promise.js
+++ b/static/src/javascripts/lib/fastdom-promise.js
@@ -2,6 +2,4 @@
 import fastdom from 'fastdom';
 import fastdomPromised from 'fastdom/extensions/fastdom-promised';
 
-const { measure, mutate, clear } = fastdom.extend(fastdomPromised);
-
-export default { measure, mutate, clear }
+export default fastdom.extend(fastdomPromised);

--- a/static/src/javascripts/lib/fastdom-promise.js
+++ b/static/src/javascripts/lib/fastdom-promise.js
@@ -1,26 +1,7 @@
 // @flow
 import fastdom from 'fastdom';
+import fastdomPromised from 'fastdom/extensions/fastdom-promised';
 
-const promisify = fdaction => (fn: Function, ctx: ?Object): Promise<any> =>
-    new Promise((resolve, reject) =>
-        fdaction(
-            /* this function needs to be bound to ctx - it therefore cannot
-                   be an arrow function as this will be bound with the current
-                   context and cannot be rebound.
-                */
-            function() {
-                try {
-                    resolve(fn.call(this));
-                } catch (e) {
-                    reject(e);
-                }
-            },
-            ctx
-        )
-    );
+const { measure, mutate, clear } = fastdom.extend(fastdomPromised);
 
-export default {
-    read: promisify(fastdom.read.bind(fastdom)),
-    write: promisify(fastdom.write.bind(fastdom)),
-    defer: promisify(fastdom.defer.bind(fastdom)),
-};
+export default { measure, mutate, clear }

--- a/static/src/javascripts/lib/formInlineLabels.js
+++ b/static/src/javascripts/lib/formInlineLabels.js
@@ -13,7 +13,7 @@ const updateClass = (
     const shouldUpdateClass = testFunc !== undefined ? testFunc() : true;
 
     if (shouldUpdateClass) {
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             $el[type === 'add' ? 'addClass' : 'removeClass'](cssClass);
         });
     }

--- a/static/src/javascripts/lib/proximity-loader.js
+++ b/static/src/javascripts/lib/proximity-loader.js
@@ -46,7 +46,7 @@ const addProximityLoader = (
     loadFn: () => void
 ): void => {
     // calls `loadFn` when screen is within `distanceThreshold` of `el`
-    fastdom.read(() => {
+    fastdom.measure(() => {
         const $el = bonzo(el);
         const conditionFn = () => {
             const elOffset = $el.offset();

--- a/static/src/javascripts/lib/scroller.js
+++ b/static/src/javascripts/lib/scroller.js
@@ -25,13 +25,13 @@ const scrollTo = (
     const distance = offset - from;
     const ease = createEasing(easeFn, duration);
     const scrollFn = () => {
-        fastdom.write(() => $container.scrollTop(from + ease() * distance));
+        fastdom.mutate(() => $container.scrollTop(from + ease() * distance));
     };
     const interval = setInterval(scrollFn, 15);
 
     setTimeout(() => {
         clearInterval(interval);
-        fastdom.write(() => $container.scrollTop(offset));
+        fastdom.mutate(() => $container.scrollTop(offset));
     }, duration);
 };
 

--- a/static/src/javascripts/projects/atoms/services.js
+++ b/static/src/javascripts/projects/atoms/services.js
@@ -46,7 +46,7 @@ const services: Services = {
     ophan,
     dom: {
         write: promisify(fastdom.write),
-        read: promisify(fastdom.read),
+        read: promisify(fastdom.measure),
     },
     viewport,
     consent: {

--- a/static/src/javascripts/projects/atoms/services.js
+++ b/static/src/javascripts/projects/atoms/services.js
@@ -45,7 +45,7 @@ const acastConsentState = (): Promise<boolean> => {
 const services: Services = {
     ophan,
     dom: {
-        write: promisify(fastdom.write),
+        write: promisify(fastdom.mutate),
         read: promisify(fastdom.measure),
     },
     viewport,

--- a/static/src/javascripts/projects/commercial/modules/ad-free-slot-remove.js
+++ b/static/src/javascripts/projects/commercial/modules/ad-free-slot-remove.js
@@ -43,7 +43,7 @@ const adFreeSlotRemove = once(
             '.commercial-thrasher'
         );
 
-        return fastdom.write(() => {
+        return fastdom.mutate(() => {
             if (bodyEl) {
                 if (bodyEl.classList.toString().includes('has-page-skin')) {
                     bodyEl.classList.remove('has-page-skin');

--- a/static/src/javascripts/projects/commercial/modules/article-aside-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-aside-adverts.js
@@ -51,7 +51,7 @@ export const init = (): Promise<boolean> => {
             // the sticky behaviour and conditionally adjust the slot size depending on how far down
             // the page the first immersive image appears.
             if (config.get('page.isImmersive') && $immersiveEls.length > 0) {
-                return fastdom.write(() => {
+                return fastdom.mutate(() => {
                     $adSlot.removeClass('right-sticky js-sticky-mpu is-sticky');
                     $adSlot[0].setAttribute(
                         'data-mobile',
@@ -63,7 +63,7 @@ export const init = (): Promise<boolean> => {
             // most articles are long enough to fit a DMPU. However, the occasional shorter article
             // will need the slot sizes to be adjusted, and the sticky behaviour removed.
             if (mainColHeight < minArticleHeight) {
-                return fastdom.write(() => {
+                return fastdom.mutate(() => {
                     $adSlot.removeClass('right-sticky js-sticky-mpu is-sticky');
                     $adSlot[0].setAttribute(
                         'data-mobile',

--- a/static/src/javascripts/projects/commercial/modules/article-aside-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-aside-adverts.js
@@ -36,7 +36,7 @@ export const init = (): Promise<boolean> => {
     }
 
     return fastdom
-        .read(
+        .measure(
             (): [number, number] => [
                 $mainCol.dim().height,
                 $immersiveEls.offset().top - $mainCol.offset().top,

--- a/static/src/javascripts/projects/commercial/modules/article-aside-adverts.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/article-aside-adverts.spec.js
@@ -11,7 +11,7 @@ jest.mock('common/modules/commercial/commercial-features', () => ({
     },
 }));
 
-const fastdomReadSpy = jest.spyOn(fastdom, 'read');
+const fastdomMeasureSpy = jest.spyOn(fastdom, 'measure');
 
 const sharedBeforeEach = (domSnippet: string) => () => {
     jest.resetAllMocks();
@@ -61,7 +61,7 @@ describe('Standard Article Aside Adverts', () => {
     });
 
     it('should have the correct size mappings and classes', done => {
-        fastdomReadSpy.mockReturnValue(Promise.resolve([2000, 0]));
+        fastdomMeasureSpy.mockReturnValue(Promise.resolve([2000, 0]));
         fakeMediator.once('page:defaultcommercial:right', adSlot => {
             expect(adSlot.classList).toContain('js-sticky-mpu');
             expect(adSlot.getAttribute('data-mobile')).toBe(
@@ -73,7 +73,7 @@ describe('Standard Article Aside Adverts', () => {
     });
 
     it('should mutate the ad slot in short articles', done => {
-        fastdomReadSpy.mockReturnValue(Promise.resolve([10, 0]));
+        fastdomMeasureSpy.mockReturnValue(Promise.resolve([10, 0]));
         fakeMediator.once('page:defaultcommercial:right', adSlot => {
             expect(adSlot.classList).not.toContain('js-sticky-mpu');
             expect(adSlot.getAttribute('data-mobile')).toBe(
@@ -107,7 +107,7 @@ describe('Immersive Article Aside Adverts', () => {
     });
 
     it('should remove sticky and return all slot sizes when there is enough space', done => {
-        fastdomReadSpy.mockReturnValueOnce(Promise.resolve([900001, 10000]));
+        fastdomMeasureSpy.mockReturnValueOnce(Promise.resolve([900001, 10000]));
         fakeConfig.page.isImmersive = true;
 
         fakeMediator.once('page:defaultcommercial:right', adSlot => {
@@ -125,7 +125,7 @@ describe('Immersive Article Aside Adverts', () => {
     });
 
     it('should remove sticky and return sizes that will fit when there is limited space', done => {
-        fastdomReadSpy.mockReturnValueOnce(Promise.resolve([900002, 260]));
+        fastdomMeasureSpy.mockReturnValueOnce(Promise.resolve([900002, 260]));
         fakeConfig.page.isImmersive = true;
 
         fakeMediator.once('page:defaultcommercial:right', adSlot => {
@@ -156,7 +156,7 @@ describe('Immersive Article (no immersive elements) Aside Adverts', () => {
     afterEach(sharedAfterEach);
 
     it('should have the correct size mappings and classes (leaves it untouched)', done => {
-        fastdomReadSpy.mockReturnValue(Promise.resolve([900000, 0]));
+        fastdomMeasureSpy.mockReturnValue(Promise.resolve([900000, 0]));
         fakeConfig.page.isImmersive = true;
 
         fakeMediator.once('page:defaultcommercial:right', adSlot => {

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -42,7 +42,7 @@ const insertAdAtPara = (
     });
 
     return fastdom
-        .write(() =>
+        .mutate(() =>
             ads.forEach(ad => {
                 if (para.parentNode) {
                     para.parentNode.insertBefore(ad, para);

--- a/static/src/javascripts/projects/commercial/modules/carrot-traffic-driver.js
+++ b/static/src/javascripts/projects/commercial/modules/carrot-traffic-driver.js
@@ -153,7 +153,7 @@ const insertSlot = (paras: HTMLElement[]): Promise<void> => {
     const slots = createSlots('carrot');
     const candidates = paras.slice(1);
     return fastdom
-        .write(() => {
+        .mutate(() => {
             slots.forEach(slot => {
                 if (candidates[0] && candidates[0].parentNode) {
                     candidates[0].parentNode.insertBefore(slot, candidates[0]);

--- a/static/src/javascripts/projects/commercial/modules/close-disabled-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/close-disabled-slots.js
@@ -15,7 +15,7 @@ const closeDisabledSlots = once(
         // remove the ones which should not be there
         adSlots = adSlots.filter(shouldDisableAdSlot);
 
-        return fastdom.write(() => {
+        return fastdom.mutate(() => {
             adSlots.forEach((adSlot: Element) => adSlot.remove());
         });
     }

--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.js
@@ -39,7 +39,7 @@ const insertCommentAd = (
 
     return (
         fastdom
-            .write(() => {
+            .mutate(() => {
                 $commentMainColumn.addClass('discussion__ad-wrapper');
                 if (
                     !config.get('page.isLiveBlog') &&
@@ -71,7 +71,7 @@ const maybeUpgradeSlot = (ad: Advert, $adSlot: bonzo): Advert => {
     if (!containsDMPU(ad)) {
         ad.sizes.desktop.push([300, 600], [160, 600]);
         ad.slot.defineSizeMapping([[[0, 0], ad.sizes.desktop]]);
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             $adSlot[0].setAttribute(
                 'data-desktop',
                 '1,1|2,2|300,250|300,274|fluid|300,600|160,600'

--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.js
@@ -115,7 +115,7 @@ export const initCommentAdverts = (): Promise<boolean> => {
             );
 
             fastdom
-                .read(() => $commentMainColumn.dim().height)
+                .measure(() => $commentMainColumn.dim().height)
                 .then((mainColHeight: number) => {
                     // always insert an MPU/DMPU if the user is logged in, since the
                     // containers are reordered, and comments are further from most-pop

--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.spec.js
@@ -54,7 +54,7 @@ const getBreakpoint: any = getBreakpoint_;
 const refreshAdvert: any = refreshAdvert_;
 
 const mockHeight = (height: number) => {
-    jest.spyOn(fastdom, 'read').mockReturnValue(Promise.resolve(height));
+    jest.spyOn(fastdom, 'measure').mockReturnValue(Promise.resolve(height));
 };
 
 const generateInnerHtmlWithAdSlot = () => {

--- a/static/src/javascripts/projects/commercial/modules/creatives/fabric-expandable-video-v2.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/fabric-expandable-video-v2.js
@@ -108,7 +108,7 @@ const FabricExpandableVideoV2 = (adSlot: Element, params: Object) => {
         };
 
         bean.on(adSlot, 'click', '.ad-exp__open', () => {
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 open(isClosed);
             });
         });
@@ -118,13 +118,13 @@ const FabricExpandableVideoV2 = (adSlot: Element, params: Object) => {
             'click',
             '.video-container__cta, .creative__cta',
             () => {
-                fastdom.write(() => {
+                fastdom.mutate(() => {
                     open(false);
                 });
             }
         );
 
-        return fastdom.write(() => {
+        return fastdom.mutate(() => {
             $ad.css('height', closedHeight);
             $('.ad-exp-collapse__slide', $fabricExpandableVideo).css(
                 'height',

--- a/static/src/javascripts/projects/commercial/modules/creatives/fabric-expanding-v1.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/fabric-expanding-v1.js
@@ -67,7 +67,7 @@ class FabricExpandingV1 {
         switch (this.params.backgroundImagePType) {
             case 'split':
                 scrollAmount = bottomScroll + topScroll;
-                fastdom.write(() => {
+                fastdom.mutate(() => {
                     $('.ad-exp--expand-scrolling-bg', this.adSlot).css({
                         'background-repeat': 'no-repeat',
                         'background-position': `50%${scrollAmount}%`,
@@ -76,7 +76,7 @@ class FabricExpandingV1 {
                 break;
             case 'fixed':
                 scrollAmount = -adSlotTop;
-                fastdom.write(() => {
+                fastdom.mutate(() => {
                     $('.ad-exp--expand-scrolling-bg', this.adSlot).css(
                         'background-position',
                         `50%${scrollAmount}px`
@@ -84,7 +84,7 @@ class FabricExpandingV1 {
                 });
                 break;
             case 'fixed matching fluid250':
-                fastdom.write(() => {
+                fastdom.mutate(() => {
                     $('.ad-exp--expand-scrolling-bg', this.adSlot).addClass(
                         'ad-exp--expand-scrolling-bg-fixed'
                     );
@@ -92,7 +92,7 @@ class FabricExpandingV1 {
                 break;
             case 'parallax':
                 scrollAmount = Math.ceil(adSlotTop * 0.3) + 20;
-                fastdom.write(() => {
+                fastdom.mutate(() => {
                     $('.ad-exp--expand-scrolling-bg', this.adSlot).addClass(
                         'ad-exp--expand-scrolling-bg-parallax'
                     );
@@ -121,7 +121,7 @@ class FabricExpandingV1 {
             if (!local.get(`gu.commercial.expandable.${itemIdArray[1]}`)) {
                 // expires in 1 week
                 const week = 1000 * 60 * 60 * 24 * 7;
-                fastdom.write(() => {
+                fastdom.mutate(() => {
                     local.set(
                         `gu.commercial.expandable.${itemIdArray[1]}`,
                         true,
@@ -138,7 +138,7 @@ class FabricExpandingV1 {
                     this.initialExpandCounter = true;
                 });
             } else if (this.isClosed) {
-                fastdom.write(() => {
+                fastdom.mutate(() => {
                     $('.ad-exp__open-chevron').addClass('chevron-up');
                 });
             }
@@ -265,7 +265,7 @@ class FabricExpandingV1 {
                 this.stopVideo(1000);
             }
 
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 $('.ad-exp__close-button').toggleClass('button-spin');
                 $('.ad-exp__open-chevron')
                     .removeClass('chevron-up')
@@ -288,7 +288,7 @@ class FabricExpandingV1 {
             mediator.on('window:throttledResize', this.updateBgPosition);
         }
 
-        return fastdom.write(function() {
+        return fastdom.mutate(function() {
             this.$ad = $('.ad-exp--expand', $fabricExpandingV1).css(
                 'height',
                 this.closedHeight

--- a/static/src/javascripts/projects/commercial/modules/creatives/fabric-v1.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/fabric-v1.js
@@ -75,7 +75,7 @@ class FabricV1 {
 
         if (templateOptions.scrollbg) {
             // update bg position
-            fastdom.read(this.updateBgPosition, this);
+            fastdom.measure(this.updateBgPosition, this);
             mediator.on(
                 'window:throttledScroll',
                 this.updateBgPosition.bind(this)

--- a/static/src/javascripts/projects/commercial/modules/creatives/fabric-v1.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/fabric-v1.js
@@ -99,7 +99,7 @@ class FabricV1 {
             );
         }
 
-        return fastdom.write(() => {
+        return fastdom.mutate(() => {
             this.adSlot.insertAdjacentHTML(
                 'beforeend',
                 fabricV1Tpl({
@@ -167,7 +167,7 @@ class FabricV1 {
         if (this.scrollType === 'parallax') {
             const scrollAmount =
                 Math.ceil(this.adSlot.getBoundingClientRect().top * 0.3) + 20;
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 if (this.scrollingBg) {
                     this.scrollingBg.style.backgroundPosition = `50% ${scrollAmount}%`;
                     this.scrollingBg.classList.add('ad-scrolling-bg-parallax');
@@ -179,7 +179,7 @@ class FabricV1 {
                 ((window.innerHeight - adRect.bottom + adRect.height / 2) /
                     window.innerHeight) *
                 100;
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 if (this.scrollingBg) {
                     this.scrollingBg.style.backgroundPosition = `50% ${vPos}%`;
                 }
@@ -197,7 +197,7 @@ class FabricV1 {
         ) {
             inViewB =
                 getViewport().height > this.adSlot.getBoundingClientRect().top;
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 if (this.layer2) {
                     this.layer2.classList.add(
                         `ad-scrolling-text-hide${

--- a/static/src/javascripts/projects/commercial/modules/creatives/fabric-video.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/fabric-video.js
@@ -177,7 +177,7 @@ class FabricVideo {
                     this.video.onended = this.onVideoEnded;
                 }
 
-                fastdom.read(this.onScroll, this);
+                fastdom.measure(this.onScroll, this);
 
                 return true;
             });

--- a/static/src/javascripts/projects/commercial/modules/creatives/fabric-video.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/fabric-video.js
@@ -65,7 +65,7 @@ class FabricVideo {
         this.inView = rect.top >= 0 && rect.bottom < viewportHeight;
         if (!this.isUpdating) {
             this.isUpdating = true;
-            fastdom.write(this.updateView, this);
+            fastdom.mutate(this.updateView, this);
         }
     }
 
@@ -115,7 +115,7 @@ class FabricVideo {
         const fabricVideoTpl = template(fabricVideoStr);
 
         return fastdom
-            .write(() => {
+            .mutate(() => {
                 if (this.params.Trackingpixel) {
                     addTrackingPixel(
                         this.params.Trackingpixel + this.params.cacheBuster

--- a/static/src/javascripts/projects/commercial/modules/creatives/frame.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/frame.js
@@ -46,7 +46,7 @@ class Frame {
             },
         });
 
-        return fastdom.write(() => {
+        return fastdom.mutate(() => {
             this.adSlot.insertAdjacentHTML('beforeend', frameMarkup);
 
             if (this.adSlot.lastElementChild) {

--- a/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/page-skin.js
@@ -16,7 +16,7 @@ const pageSkin = (): void => {
 
     const togglePageSkinActiveClass = (): void => {
         if (bodyEl) {
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 bodyEl.classList.toggle(
                     'has-active-pageskin',
                     isBreakpoint({ min: 'wide' })

--- a/static/src/javascripts/projects/commercial/modules/creatives/scrollable-mpu-v2.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/scrollable-mpu-v2.js
@@ -59,7 +59,7 @@ class ScrollableMpu {
     }
 
     updateBgFluid250() {
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             if (this.$scrollableImage) {
                 this.$scrollableImage.addClass(
                     'creative--scrollable-mpu-image-fixed'
@@ -71,7 +71,7 @@ class ScrollableMpu {
     updateBgParallax() {
         const scrollAmount =
             Math.ceil(this.adSlot.getBoundingClientRect().top * 0.3) + 20;
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             if (this.$scrollableImage) {
                 this.$scrollableImage
                     .addClass('creative--scrollable-mpu-image-parallax')
@@ -84,7 +84,7 @@ class ScrollableMpu {
         if (this.$scrollableMpu) {
             const position = -this.$scrollableMpu[0].getBoundingClientRect()
                 .top;
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 if (this.$scrollableImage) {
                     this.$scrollableImage.css(
                         'background-position',

--- a/static/src/javascripts/projects/commercial/modules/creatives/scrollable-mpu-v2.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/scrollable-mpu-v2.js
@@ -155,7 +155,7 @@ class ScrollableMpu {
             );
 
             // update bg position
-            fastdom.read(updateFn);
+            fastdom.measure(updateFn);
 
             mediator.on('window:throttledScroll', updateFn);
             // to be safe, also update on window resize

--- a/static/src/javascripts/projects/commercial/modules/creatives/scrollable-mpu-v2.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/scrollable-mpu-v2.spec.js
@@ -83,7 +83,7 @@ describe('Scrollable MPU', () => {
             backgroundImage: 'image',
         });
         new ScrollableMpu(adSlot, theParams).create();
-        fastdom.read(() => {
+        fastdom.measure(() => {
             expect(
                 document.querySelector(
                     '.creative--scrollable-mpu-image.creative--scrollable-mpu-image-fixed'
@@ -99,7 +99,7 @@ describe('Scrollable MPU', () => {
             backgroundImage: 'image',
         });
         new ScrollableMpu(adSlot, theParams).create();
-        fastdom.read(() => {
+        fastdom.measure(() => {
             expect(
                 document.querySelector(
                     '.creative--scrollable-mpu-image.creative--scrollable-mpu-image-parallax'

--- a/static/src/javascripts/projects/commercial/modules/dfp/apply-creative-template.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/apply-creative-template.js
@@ -58,7 +58,7 @@ const renderCreativeTemplate = (
         });
 
     const hideIframe = (): Promise<any> =>
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             iFrame.style.display = 'none';
         });
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/empty-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/empty-advert.js
@@ -18,7 +18,7 @@ const removeFromDfpEnv = advert => {
 };
 
 const emptyAdvert = (advert: Advert): void => {
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         window.googletag.destroySlots([advert.slot]);
         advert.node.remove();
         removeFromDfpEnv(advert);

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -74,7 +74,7 @@ const removeAdSlots = (): Promise<void> => {
     // Get all ad slots
     const adSlots: Array<Element> = qwery(dfpEnv.adSlotSelector);
 
-    return fastdom.write(() =>
+    return fastdom.mutate(() =>
         adSlots.forEach((adSlot: Element) => adSlot.remove())
     );
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.js
@@ -31,7 +31,7 @@ const createAdLabel = (): HTMLDivElement => {
 };
 
 export const renderAdvertLabel = (adSlotNode: HTMLElement): Promise<null> =>
-    fastdom.read(() => {
+    fastdom.measure(() => {
         if (shouldRenderLabel(adSlotNode)) {
             return fastdom.write(() => {
                 adSlotNode.prepend(createAdLabel());

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.js
@@ -33,14 +33,14 @@ const createAdLabel = (): HTMLDivElement => {
 export const renderAdvertLabel = (adSlotNode: HTMLElement): Promise<null> =>
     fastdom.measure(() => {
         if (shouldRenderLabel(adSlotNode)) {
-            return fastdom.write(() => {
+            return fastdom.mutate(() => {
                 adSlotNode.prepend(createAdLabel());
             });
         }
     });
 
 export const renderStickyAdLabel = (adSlotNode: HTMLElement): Promise<null> =>
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         const adSlotLabel = document.createElement('div');
         adSlotLabel.classList.add('ad-slot__label');
         adSlotLabel.classList.add('sticky');
@@ -51,7 +51,7 @@ export const renderStickyAdLabel = (adSlotNode: HTMLElement): Promise<null> =>
 export const renderStickyScrollForMoreLabel = (
     adSlotNode: HTMLElement
 ): Promise<null> =>
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         const scrollForMoreLabel = document.createElement('div');
         scrollForMoreLabel.classList.add('ad-slot__scroll');
         scrollForMoreLabel.innerHTML = 'Scroll for More';

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -29,7 +29,7 @@ const addClassIfHasClass = (newClassNames: Array<string>) =>
                     advert.node.classList.contains(className)
                 )
             ) {
-                return fastdom.write(() => {
+                return fastdom.mutate(() => {
                     newClassNames.forEach(className => {
                         advert.node.classList.add(className);
                     });
@@ -62,7 +62,7 @@ const addFluid = addClassIfHasClass(['ad-slot--fluid']);
 const removeStyleFromAdIframe = (advert: Advert, style: string) => {
     const adIframe: ?HTMLElement = advert.node.querySelector('iframe');
 
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         if (adIframe) {
             adIframe.style.removeProperty(style);
         }
@@ -94,7 +94,7 @@ sizeCallbacks[adSizes.mpu] = (_, advert) =>
                 stickyCommentsMpu(advert.node);
             }
         }
-        return fastdom.write(() => advert.updateExtraSlotClasses());
+        return fastdom.mutate(() => advert.updateExtraSlotClasses());
     });
 
 /**
@@ -108,7 +108,7 @@ sizeCallbacks[adSizes.halfPage] = (_, advert) =>
         if (advert.node.classList.contains('ad-slot--comments')) {
             stickyCommentsMpu(advert.node);
         }
-        return fastdom.write(() => advert.updateExtraSlotClasses());
+        return fastdom.mutate(() => advert.updateExtraSlotClasses());
     });
 
 sizeCallbacks[adSizes.skyscraper] = (_, advert) =>
@@ -119,33 +119,33 @@ sizeCallbacks[adSizes.skyscraper] = (_, advert) =>
         if (advert.node.classList.contains('ad-slot--comments')) {
             stickyCommentsMpu(advert.node);
         }
-        return fastdom.write(() =>
+        return fastdom.mutate(() =>
             advert.updateExtraSlotClasses('ad-slot--sky')
         );
     });
 
 sizeCallbacks[adSizes.video] = (_, advert) =>
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         advert.updateExtraSlotClasses('u-h');
     });
 
 sizeCallbacks[adSizes.outstreamDesktop] = (_, advert) =>
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         advert.updateExtraSlotClasses('ad-slot--outstream');
     });
 
 sizeCallbacks[adSizes.outstreamGoogleDesktop] = (_, advert) =>
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         advert.updateExtraSlotClasses('ad-slot--outstream');
     });
 
 sizeCallbacks[adSizes.outstreamMobile] = (_, advert) =>
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         advert.updateExtraSlotClasses('ad-slot--outstream');
     });
 
 sizeCallbacks[adSizes.googleCard] = (_, advert) =>
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         advert.updateExtraSlotClasses('ad-slot--gc');
     });
 
@@ -156,7 +156,7 @@ sizeCallbacks[adSizes.googleCard] = (_, advert) =>
 const outOfPageCallback = (event, advert) => {
     if (!event.slot.getOutOfPage()) {
         const parent = advert.node.parentNode;
-        return fastdom.write(() => {
+        return fastdom.mutate(() => {
             advert.node.classList.add('u-h');
             // if in a slice, add the 'no mpu' class
             if (parent.classList.contains('fc-slice__item--mpu-candidate')) {
@@ -175,7 +175,7 @@ sizeCallbacks[adSizes.empty] = outOfPageCallback;
 sizeCallbacks[adSizes.portrait] = () =>
     // remove geo most popular
     geoMostPopular.whenRendered.then(popular =>
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             if (popular && popular.elem) {
                 popular.elem.remove();
                 popular.elem = null;
@@ -194,7 +194,7 @@ const addContentClass = adSlotNode => {
     const adSlotContent = qwery('> div:not(.ad-slot__label)', adSlotNode);
 
     if (adSlotContent.length) {
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             adSlotContent[0].classList.add('ad-slot__content');
         });
     }
@@ -231,7 +231,7 @@ export const renderAdvert = (
                     return Promise.resolve(
                         sizeCallbacks[size]
                             ? sizeCallbacks[size](slotRenderEndedEvent, advert)
-                            : fastdom.write(() => {
+                            : fastdom.mutate(() => {
                                   advert.updateExtraSlotClasses();
                               })
                     );
@@ -241,7 +241,7 @@ export const renderAdvert = (
 
             const addRenderedClass = () =>
                 isRendered
-                    ? fastdom.write(() => {
+                    ? fastdom.mutate(() => {
                           advert.node.classList.add('ad-slot--rendered');
                       })
                     : Promise.resolve();

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -85,7 +85,7 @@ sizeCallbacks[adSizes.fluid] = (renderSlotEvent: any, advert: Advert) =>
  * Trigger sticky scrolling for MPUs in the right-hand article column
  */
 sizeCallbacks[adSizes.mpu] = (_, advert) =>
-    fastdom.read(() => {
+    fastdom.measure(() => {
         if (advert.node.classList.contains('js-sticky-mpu')) {
             if (advert.node.classList.contains('ad-slot--right')) {
                 stickyMpu(advert.node);
@@ -101,7 +101,7 @@ sizeCallbacks[adSizes.mpu] = (_, advert) =>
  * Resolve the stickyMpu.whenRendered promise
  */
 sizeCallbacks[adSizes.halfPage] = (_, advert) =>
-    fastdom.read(() => {
+    fastdom.measure(() => {
         if (advert.node.classList.contains('ad-slot--right')) {
             stickyMpu(advert.node);
         }
@@ -112,7 +112,7 @@ sizeCallbacks[adSizes.halfPage] = (_, advert) =>
     });
 
 sizeCallbacks[adSizes.skyscraper] = (_, advert) =>
-    fastdom.read(() => {
+    fastdom.measure(() => {
         if (advert.node.classList.contains('ad-slot--right')) {
             stickyMpu(advert.node);
         }

--- a/static/src/javascripts/projects/commercial/modules/hide-element.js
+++ b/static/src/javascripts/projects/commercial/modules/hide-element.js
@@ -2,4 +2,4 @@
 import fastdom from 'lib/fastdom-promise';
 
 export const hideElement = <T: Element>(element: T): Promise<T> =>
-    fastdom.write(() => element.classList.add('u-h'));
+    fastdom.mutate(() => element.classList.add('u-h'));

--- a/static/src/javascripts/projects/commercial/modules/high-merch.js
+++ b/static/src/javascripts/projects/commercial/modules/high-merch.js
@@ -21,7 +21,7 @@ export const init = (): Promise<void> => {
             container.appendChild(slot);
         });
 
-        return fastdom.write(() => {
+        return fastdom.mutate(() => {
             if (anchor && anchor.parentNode) {
                 anchor.parentNode.insertBefore(container, anchor);
             }

--- a/static/src/javascripts/projects/commercial/modules/hosted/about.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/about.js
@@ -33,7 +33,7 @@ const template = (): string => `
 
 export const init = () =>
     fastdom
-        .write(() => {
+        .mutate(() => {
             $(document.body).append(template());
         })
         .then(() => {
@@ -47,11 +47,11 @@ export const init = () =>
                     'click',
                     (e: Event): mixed => {
                         e.preventDefault();
-                        fastdom.write(() => overlay.classList.remove('u-h'));
+                        fastdom.mutate(() => overlay.classList.remove('u-h'));
                     }
                 );
             });
             closeBtn.addEventListener('click', () => {
-                fastdom.write(() => overlay.classList.add('u-h'));
+                fastdom.mutate(() => overlay.classList.add('u-h'));
             });
         });

--- a/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
@@ -284,7 +284,7 @@ class HostedGallery {
         const tabletSize = 740;
         const imageSize = getFrame(imgRatio);
 
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             $sizer.css('width', imageSize.width);
             $sizer.css('height', imageSize.height);
             $sizer.css('top', imageSize.topBottom);
@@ -325,7 +325,7 @@ class HostedGallery {
         galleryEl.style.msTransform = `translate(${px + offset}px,0)`;
         galleryEl.style.transform = `translate(${px +
             offset}px,0) translateZ(0)`;
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             bonzo($meta).css('opacity', offset !== 0 ? 0 : 1);
         });
     }
@@ -342,7 +342,7 @@ class HostedGallery {
         const deg = Math.ceil(fractionProgress * 360);
         const newIndex = Math.round(progress + 0.75);
         const ctaIndex: number = HostedGallery.ctaIndex() || -1;
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             this.$images.each((image, index) => {
                 const opacity = ((progress - index + 1) * 16) / 11 - 0.0625;
                 bonzo(image).css('opacity', Math.min(Math.max(opacity, 0), 1));
@@ -380,7 +380,7 @@ class HostedGallery {
         const scrollEl = this.$scrollEl;
         const length = this.$images.length;
         const scrollHeight = scrollEl[0].scrollHeight;
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             scrollEl.scrollTop(((index - 1) * scrollHeight) / length);
         });
     }
@@ -425,7 +425,7 @@ class HostedGallery {
             leftRight = `${(width - imageWidth) / 2}px`;
         }
         this.swipeContainerWidth = imageWidth;
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             $header.css('width', imageWidth);
             $footer.css('margin', `0 ${leftRight}`);
             $footer.css('width', 'auto');

--- a/static/src/javascripts/projects/commercial/modules/hosted/next-video-autoplay.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/next-video-autoplay.js
@@ -11,14 +11,14 @@ let $timer;
 let nextVideoPage;
 
 const cancelAutoplay = () => {
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         $hostedNext.addClass('hosted-slide-out');
     });
     clearInterval(nextVideoInterval);
 };
 
 const cancelAutoplayMobile = () => {
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         $hostedNext.addClass('u-h');
     });
 };
@@ -29,7 +29,7 @@ const triggerAutoplay = (getCurrentTimeFn: () => number, duration: number) => {
         const countdownLength = 10; // seconds before the end when to show the timer
 
         if (timeLeft <= countdownLength) {
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 $hostedNext.addClass('js-autoplay-start');
                 $timer.text(`${timeLeft}s`);
             });
@@ -42,7 +42,7 @@ const triggerAutoplay = (getCurrentTimeFn: () => number, duration: number) => {
 };
 
 const triggerEndSlate = () => {
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         $hostedNext.addClass('js-autoplay-start');
     });
     bean.on(document, 'click', $('.js-autoplay-cancel'), () => {

--- a/static/src/javascripts/projects/commercial/modules/hosted/next-video-autoplay.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/next-video-autoplay.spec.js
@@ -55,7 +55,7 @@ describe('Next video autoplay', () => {
 
     it('should show end slate information', done => {
         triggerEndSlate();
-        fastdom.read(() => {
+        fastdom.measure(() => {
             expect(
                 (document.querySelector(
                     '.js-hosted-next-autoplay'
@@ -68,7 +68,7 @@ describe('Next video autoplay', () => {
     it('should hide end slate information when cancel button is clicked', done => {
         addCancelListener();
         (document.querySelector('.js-autoplay-cancel'): any).click();
-        fastdom.read(() => {
+        fastdom.measure(() => {
             expect(
                 (document.querySelector(
                     '.js-hosted-next-autoplay'

--- a/static/src/javascripts/projects/commercial/modules/hosted/next-video.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/next-video.js
@@ -15,7 +15,7 @@ const loadNextVideo = (): Promise<void> => {
                 mode: 'cors',
             }
         ).then(json =>
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 let i;
                 for (i = 0; i < placeholders.length; i += 1) {
                     placeholders[i].innerHTML = json.html;

--- a/static/src/javascripts/projects/commercial/modules/hosted/onward-journey-carousel.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/onward-journey-carousel.js
@@ -19,7 +19,7 @@ class HostedCarousel {
         const pageNo = Math.min(Math.max(index, 0), this.pageCount - 1);
         this.index = pageNo;
 
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             const translate = `translate(-${pageNo}00%, 0)`;
             this.$carousel.css({
                 '-webkit-transform': translate,

--- a/static/src/javascripts/projects/commercial/modules/hosted/onward-journey-carousel.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/onward-journey-carousel.spec.js
@@ -12,21 +12,21 @@ describe('Hosted onward journey carousel', () => {
                             <span class="prev-oj-item"></span>
                             <span class="next-oj-item"></span>
                         </div>
-                    
+
                         <div class="js-carousel-pages">
                             <div class="carousel-page"></div>
                             <div class="carousel-page"></div>
                             <div class="carousel-page"></div>
                             <div class="carousel-page"></div>
                         </div>
-                    
+
                         <div>
                             <div class="js-carousel-dot highlighted"></div>
                             <div class="js-carousel-dot "></div>
                             <div class="js-carousel-dot "></div>
                             <div class="js-carousel-dot "></div>
                         </div>
-                    
+
                     </div>
                 `;
         }
@@ -47,7 +47,7 @@ describe('Hosted onward journey carousel', () => {
         expectedPage: number
     ): any => {
         (document.querySelector(`.${clickOn}`): any).click();
-        return fastdom.read(() => {
+        return fastdom.measure(() => {
             const transform = (1 - expectedPage) * 100;
 
             expect(

--- a/static/src/javascripts/projects/commercial/modules/hosted/onward-journey-carousel.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/onward-journey-carousel.spec.js
@@ -55,7 +55,7 @@ describe('Hosted onward journey carousel', () => {
                     '.js-carousel-pages'
                 ): any).getAttribute('style')
             ).toEqual(
-                `-webkit-transform: translate(${transform || '-000'}%, 0);`
+                `transform: translate(${transform || '-000'}%, 0);`
             );
 
             [1, 2, 3, 4].forEach(i => {

--- a/static/src/javascripts/projects/commercial/modules/hosted/onward.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/onward.js
@@ -45,7 +45,7 @@ export const loadOnwardComponent = (
     if (placeholders && placeholders.length) {
         fetchJson(jsonUrl, { mode: 'cors' })
             .then(json =>
-                fastdom.write(() => {
+                fastdom.mutate(() => {
                     insertHtmlFn(json, placeholders);
                 })
             )

--- a/static/src/javascripts/projects/commercial/modules/hosted/video.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/video.js
@@ -21,7 +21,7 @@ const upgradeVideoPlayerAccessibility = (player: Object): void => {
     // Set the video tech element to aria-hidden, and label the buttons in the videojs control bar.
     const playerEl = player.el();
 
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         Array.from(playerEl.querySelectorAll('.vjs-tech')).forEach(el => {
             el.setAttribute('aria-hidden', 'true');
         });

--- a/static/src/javascripts/projects/commercial/modules/liveblog-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/liveblog-adverts.js
@@ -131,7 +131,7 @@ export const init = (): Promise<void> => {
     }
 
     fastdom
-        .read(() => {
+        .measure(() => {
             WINDOWHEIGHT = getWindowHeight();
             return WINDOWHEIGHT;
         })

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.js
@@ -182,7 +182,7 @@ const setBackground = (specs: AdSpec, adSlot: HTMLElement): Promise<any> => {
 
         if (specs.scrollType === 'fixed') {
             return fastdom
-                .read(() => {
+                .measure(() => {
                     if (adSlot instanceof Element) {
                         return adSlot.getBoundingClientRect();
                     }
@@ -213,7 +213,7 @@ const setBackground = (specs: AdSpec, adSlot: HTMLElement): Promise<any> => {
         backgroundParent: HTMLElement,
         background: HTMLElement
     ) => {
-        fastdom.read(() => {
+        fastdom.measure(() => {
             const rect = adSlot.getBoundingClientRect();
             background.style.clip = `rect(${rect.top}px,100vw,${
                 rect.bottom
@@ -225,7 +225,7 @@ const setBackground = (specs: AdSpec, adSlot: HTMLElement): Promise<any> => {
         backgroundParent: HTMLElement,
         background: HTMLElement
     ) => {
-        fastdom.read(() => {
+        fastdom.measure(() => {
             // We update the style in a read batch because the DIV
             // has been promoted to its own layer and is also
             // strictly self-contained. Also, without doing that

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.js
@@ -117,7 +117,7 @@ const setBackground = (specs: AdSpec, adSlot: HTMLElement): Promise<any> => {
         }
 
         return fastdom
-            .write(() => {
+            .mutate(() => {
                 if (backgroundParent) {
                     // Create a stacking context in DCR
                     if (
@@ -188,7 +188,7 @@ const setBackground = (specs: AdSpec, adSlot: HTMLElement): Promise<any> => {
                     }
                 })
                 .then(rect =>
-                    fastdom.write(() => {
+                    fastdom.mutate(() => {
                         if (config.get('isDotcomRendering', false)) {
                             background.style.position = 'fixed';
                         }

--- a/static/src/javascripts/projects/commercial/modules/messenger/resize.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/resize.js
@@ -45,7 +45,7 @@ const resize = (
         styles.height = normalise(specs.height);
     }
 
-    return fastdom.write(() => {
+    return fastdom.mutate(() => {
         Object.assign(iframe.style, styles);
 
         if (iframeContainer) {
@@ -56,7 +56,7 @@ const resize = (
 
 // When an outstream resizes we want it to revert to its original styling
 const removeAnyOutstreamClass = (adSlot: ?HTMLElement) => {
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         if (adSlot) {
             adSlot.classList.remove('ad-slot--outstream');
         }

--- a/static/src/javascripts/projects/commercial/modules/messenger/scroll.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/scroll.js
@@ -70,7 +70,7 @@ const onScroll = (): ?Promise<any> => {
         const viewport = getViewport();
         taskQueued = true;
 
-        return fastdom.read(() => {
+        return fastdom.measure(() => {
             taskQueued = false;
 
             const iframeIds = Object.keys(iframes);
@@ -116,7 +116,7 @@ const addScrollListener = (iframe: Element, respond: any): ?Promise<any> => {
     }
 
     fastdom
-        .read(() => iframe.getBoundingClientRect())
+        .measure(() => iframe.getBoundingClientRect())
         .then(domRect => {
             sendCoordinates(iframe.id, domRect);
         });

--- a/static/src/javascripts/projects/commercial/modules/messenger/type.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/type.js
@@ -3,7 +3,7 @@ import fastdom from 'lib/fastdom-promise';
 import type { RegisterListeners } from 'commercial/modules/messenger';
 
 const setType = (type: ?string, adSlot: any) =>
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         adSlot.classList.add(`ad-slot--${type || ''}`);
     });
 const init = (register: RegisterListeners) => {

--- a/static/src/javascripts/projects/commercial/modules/messenger/viewport.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/viewport.js
@@ -8,7 +8,7 @@ let iframes = {};
 let iframeCounter = 0;
 let taskQueued = false;
 
-const lastViewportRead = () => fastdom.read(() => getViewport());
+const lastViewportRead = () => fastdom.measure(() => getViewport());
 
 const reset = (window_: WindowProxy): void => {
     w = window_ || window;

--- a/static/src/javascripts/projects/commercial/modules/mobile-sticky.js
+++ b/static/src/javascripts/projects/commercial/modules/mobile-sticky.js
@@ -33,7 +33,7 @@ export const init = (): Promise<void> => {
     if (shouldIncludeMobileSticky()) {
         const mobileStickyWrapper = createAdWrapper();
         return fastdom
-            .write(() => {
+            .mutate(() => {
                 if (document.body && mobileStickyWrapper)
                     document.body.appendChild(mobileStickyWrapper);
             })

--- a/static/src/javascripts/projects/commercial/modules/paid-containers.js
+++ b/static/src/javascripts/projects/commercial/modules/paid-containers.js
@@ -15,11 +15,11 @@ const onOpenClick = (event: EventHandler) => {
     const details = summary.parentNode;
     const label = summary.querySelector('.js-button__label');
     if (details.hasAttribute('open')) {
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             label.textContent = `More ${summary.getAttribute('data-text')}`;
         });
     } else {
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             label.textContent = 'Less';
         });
     }

--- a/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
@@ -38,7 +38,7 @@ const stickyCommentsMpu = (adSlot: HTMLElement) => {
     }
 
     fastdom
-        .read(() => referenceElement.offsetHeight - 600)
+        .measure(() => referenceElement.offsetHeight - 600)
         .then(newHeight =>
             fastdom.write(() => {
                 (adSlot.parentNode: any).style.height = `${newHeight}px`;
@@ -78,7 +78,7 @@ const stickyMpu = (adSlot: HTMLElement) => {
     }
 
     fastdom
-        .read(() => referenceElement.offsetTop + stickyPixelBoundary)
+        .measure(() => referenceElement.offsetTop + stickyPixelBoundary)
         .then(newHeight =>
             fastdom.write(() => {
                 (adSlot.parentNode: any).style.height = `${newHeight}px`;

--- a/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
@@ -40,7 +40,7 @@ const stickyCommentsMpu = (adSlot: HTMLElement) => {
     fastdom
         .measure(() => referenceElement.offsetHeight - 600)
         .then(newHeight =>
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 (adSlot.parentNode: any).style.height = `${newHeight}px`;
             })
         )
@@ -80,7 +80,7 @@ const stickyMpu = (adSlot: HTMLElement) => {
     fastdom
         .measure(() => referenceElement.offsetTop + stickyPixelBoundary)
         .then(newHeight =>
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 (adSlot.parentNode: any).style.height = `${newHeight}px`;
             })
         )

--- a/static/src/javascripts/projects/commercial/modules/sticky-mpu.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-mpu.spec.js
@@ -13,7 +13,7 @@ Object.defineProperty(HTMLElement.prototype, 'dataset', {
 });
 
 const mockHeight = (height: number) => {
-    jest.spyOn(fastdom, 'read').mockReturnValue(Promise.resolve(height));
+    jest.spyOn(fastdom, 'measure').mockReturnValue(Promise.resolve(height));
 };
 
 describe('Sticky MPU', () => {

--- a/static/src/javascripts/projects/commercial/modules/sticky-top-banner.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-top-banner.js
@@ -87,7 +87,7 @@ const onScroll = (): Promise<any> => {
 
 const update = (newHeight: number): Promise<any> =>
     fastdom
-        .read(() => {
+        .measure(() => {
             topSlotStyles = topSlotStyles || window.getComputedStyle(topSlot);
             return (
                 newHeight +
@@ -138,7 +138,7 @@ const onFirstRender = (): void => {
                 adSize1 > 0
             ) {
                 return fastdom
-                    .read(() => {
+                    .measure(() => {
                         const styles = window.getComputedStyle(topSlot);
 
                         return (
@@ -150,7 +150,7 @@ const onFirstRender = (): void => {
                     .then(resizeStickyBanner);
             }
             return fastdom
-                .read(
+                .measure(
                     () =>
                         (topSlot && topSlot.getBoundingClientRect().height) || 0
                 )
@@ -162,7 +162,7 @@ const onFirstRender = (): void => {
 
 const initState = (): Promise<any> =>
     fastdom
-        .read(() => {
+        .measure(() => {
             if (header) {
                 headerHeight = header.getBoundingClientRect().height;
             }

--- a/static/src/javascripts/projects/commercial/modules/sticky-top-banner.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-top-banner.js
@@ -29,7 +29,7 @@ const resizeStickyBanner = (newHeight: number): Promise<number> => {
         return Promise.resolve(-1);
     }
 
-    return fastdom.write(() => {
+    return fastdom.mutate(() => {
         if (stickyBanner && header) {
             const newCSSHeight = `${newHeight}px`;
             stickyBanner.classList.add('sticky-top-banner-ad');
@@ -49,7 +49,7 @@ const resizeStickyBanner = (newHeight: number): Promise<number> => {
 // them for a better experience. We only do this if the slot is in view
 // though.
 const setupAnimation = (): Promise<any> =>
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         if (stickyBanner && header) {
             if (scrollY <= headerHeight) {
                 header.classList.add('l-header--animate');
@@ -67,7 +67,7 @@ const onScroll = (): Promise<any> => {
         updateQueued = true;
 
         return fastdom
-            .write(() => {
+            .mutate(() => {
                 updateQueued = false;
                 if (stickyBanner) {
                     if (headerHeight < scrollY) {

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -56,7 +56,7 @@ const addScripts = (tags: Array<ThirdPartyTag>): void => {
     });
 
     if (hasScriptsToInsert) {
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             if (ref && ref.parentNode) {
                 ref.parentNode.insertBefore(frag, ref);
             }

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/plista-renderer.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/plista-renderer.js
@@ -20,7 +20,7 @@ const renderWidget = (widgetType: string, init: any): Promise<void> => {
     const externalTpl = template(externalContentContainerStr);
     return findAnchor()
         .then(anchorNode =>
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 $(anchorNode).after(
                     externalTpl({
                         widgetType,

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/plista.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/plista.js
@@ -64,7 +64,7 @@ const embed = function(publickey, widgetName, geo, u, categories) {
 };
 
 module.load = function() {
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         embed(config.get('page.plistaPublicApiKey'), 'innerArticle', 'au');
     });
 };

--- a/static/src/javascripts/projects/common/modules/accessibility/helpers.js
+++ b/static/src/javascripts/projects/common/modules/accessibility/helpers.js
@@ -4,7 +4,7 @@ import { isOn } from 'common/modules/accessibility/main';
 
 const shouldHideFlashingElements = (callback: ?() => {}): void => {
     if (!isOn('flashing-elements')) {
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             if (document.body) {
                 document.body.classList.add('disable-flashing-elements');
             }

--- a/static/src/javascripts/projects/common/modules/article/membership-events.js
+++ b/static/src/javascripts/projects/common/modules/article/membership-events.js
@@ -17,7 +17,7 @@ const upgradeEvent = (el: Node): void => {
         })
             .then(resp => {
                 if (resp.html) {
-                    fastdom.write(() => {
+                    fastdom.mutate(() => {
                         $(el)
                             .html(resp.html)
                             .removeClass(ELEMENT_INITIAL_CLASS)

--- a/static/src/javascripts/projects/common/modules/article/rich-links.js
+++ b/static/src/javascripts/projects/common/modules/article/rich-links.js
@@ -24,7 +24,7 @@ const hideIfPaidForAndAdFree = (el: Element): Promise<void> => {
     if (!commercialFeatures.adFree) {
         return Promise.resolve();
     }
-    return fastdom.write(() => {
+    return fastdom.mutate(() => {
         [...el.children]
             .filter(child =>
                 child.classList.toString().includes('rich-link--paidfor')
@@ -45,7 +45,7 @@ const elementIsBelowViewport = (el: Element): Promise<boolean> =>
     });
 
 const doUpgrade = (el: Element, resp: Object): Promise<void> =>
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         el.innerHTML = resp.html;
         el.classList.remove('element-rich-link--not-upgraded');
         el.classList.add('element-rich-link--upgraded');

--- a/static/src/javascripts/projects/common/modules/article/rich-links.js
+++ b/static/src/javascripts/projects/common/modules/article/rich-links.js
@@ -34,7 +34,7 @@ const hideIfPaidForAndAdFree = (el: Element): Promise<void> => {
 };
 
 const elementIsBelowViewport = (el: Element): Promise<boolean> =>
-    fastdom.read(() => {
+    fastdom.measure(() => {
         const rect = el.getBoundingClientRect();
         const height =
             window.innerHeight ||

--- a/static/src/javascripts/projects/common/modules/article/space-filler.js
+++ b/static/src/javascripts/projects/common/modules/article/space-filler.js
@@ -28,7 +28,7 @@ class SpaceFiller {
         options: ?Object
     ): Promise<any> {
         const onSpacesFound = (paragraphs: HTMLElement[]): Promise<any> =>
-            fastdom.write(() => writer(paragraphs));
+            fastdom.mutate(() => writer(paragraphs));
 
         const onNoSpacesFound = (ex: Error): boolean => {
             if (ex instanceof SpaceError) {

--- a/static/src/javascripts/projects/common/modules/article/twitter.js
+++ b/static/src/javascripts/projects/common/modules/article/twitter.js
@@ -58,7 +58,7 @@ const enhanceTweets = (): void => {
     tweetElements.forEach(element => {
         const rect = element.getBoundingClientRect();
         if (viewportHeight * 2.5 > rect.top && rect.top + rect.height > 0) {
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 element.classList.remove('js-tweet');
                 element.classList.add('twitter-tweet');
                 // We only want to render tweets once the class has been added

--- a/static/src/javascripts/projects/common/modules/atoms/quiz.js
+++ b/static/src/javascripts/projects/common/modules/atoms/quiz.js
@@ -39,7 +39,7 @@ const handleCompletion = (): void => {
 
             // if we find a message for your total show it, and exit
             if (bucketMessage) {
-                fastdom.write(() => {
+                fastdom.mutate(() => {
                     bucketMessage.style.display = 'block';
                 });
                 bean.off(document, 'click', onClick);

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -80,7 +80,7 @@ const onPlayerStateChangeEvent = (
 
     // change class according to the current state
     // TODO: Fix this so we can add poster image.
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         ['ENDED', 'PLAYING', 'PAUSED', 'BUFFERING', 'CUED'].forEach(status => {
             if (el) {
                 el.classList.toggle(
@@ -105,7 +105,7 @@ const onPlayerStateChangeEvent = (
 };
 
 const onPlayerReadyEvent = (event, handlers: Handlers, el: ?HTMLElement) => {
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         if (el) {
             el.classList.add('youtube__video-ready');
             const fcItem = $.ancestor(el, 'fc-item');

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -71,7 +71,7 @@ const iframes = [];
 document.addEventListener('focusout', () => {
     iframes.forEach(iframe => {
         fastdom
-            .read(() => {
+            .measure(() => {
                 if (document.activeElement === iframe) {
                     return $('.vjs-big-play-button', iframe.parentElement);
                 }
@@ -88,7 +88,7 @@ document.addEventListener('focusout', () => {
 
 document.addEventListener('focusin', () => {
     fastdom
-        .read(() => $('.vjs-big-play-button'))
+        .measure(() => $('.vjs-big-play-button'))
         .then(($playButton: ?bonzo) => {
             fastdom.write(() => {
                 if ($playButton) {
@@ -489,7 +489,7 @@ const getUniqueAtomId = (atomId: string): string =>
         .substr(2, 9)}`;
 
 const initYoutubePlayerForElem = (el: ?HTMLElement): void => {
-    fastdom.read(() => {
+    fastdom.measure(() => {
         if (!el) return;
 
         const iframe = el.querySelector('.youtube-media-atom__iframe');
@@ -541,7 +541,7 @@ const initYoutubePlayerForElem = (el: ?HTMLElement): void => {
 const checkElemForVideo = (elem: ?HTMLElement): void => {
     if (!elem) return;
 
-    fastdom.read(() => {
+    fastdom.measure(() => {
         $('.youtube-media-atom:not(.no-player)', elem).each(el => {
             const overlay = el.querySelector('.youtube-media-atom__overlay');
 

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -77,7 +77,7 @@ document.addEventListener('focusout', () => {
                 }
             })
             .then(($playButton: ?bonzo) => {
-                fastdom.write(() => {
+                fastdom.mutate(() => {
                     if ($playButton) {
                         $playButton.addClass('youtube-play-btn-focussed');
                     }
@@ -90,7 +90,7 @@ document.addEventListener('focusin', () => {
     fastdom
         .measure(() => $('.vjs-big-play-button'))
         .then(($playButton: ?bonzo) => {
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 if ($playButton) {
                     $playButton.removeClass('youtube-play-btn-focussed');
                 }

--- a/static/src/javascripts/projects/common/modules/commercial/adblock-ask.js
+++ b/static/src/javascripts/projects/common/modules/commercial/adblock-ask.js
@@ -29,7 +29,7 @@ export const initAdblockAsk = () => {
             .measure(() => $('.js-aside-slot-container'))
             .then(slot => {
                 if (slot) {
-                    fastdom.write(() => {
+                    fastdom.mutate(() => {
                         slot.append(askHtml);
                     });
                 }

--- a/static/src/javascripts/projects/common/modules/commercial/adblock-ask.js
+++ b/static/src/javascripts/projects/common/modules/commercial/adblock-ask.js
@@ -26,7 +26,7 @@ const canShow = () =>
 export const initAdblockAsk = () => {
     if (canShow()) {
         fastdom
-            .read(() => $('.js-aside-slot-container'))
+            .measure(() => $('.js-aside-slot-container'))
             .then(slot => {
                 if (slot) {
                     fastdom.write(() => {

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-liveblog-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-liveblog-utilities.js
@@ -119,7 +119,7 @@ const addEpicToBlocks = (
         getLiveblogEntryTimeData(el),
     ]);
 
-    return fastdom.write(() => {
+    return fastdom.mutate(() => {
         elementsWithTimeData.forEach(([el, timeData]) => {
             if (!timeData) {
                 return;

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -218,7 +218,7 @@ export const renderBanner: (BannerDataResponse) => Promise<boolean> = (response)
         .then(bannerModule => {
             const Banner = bannerModule[module.name];
 
-            return fastdom.write(() => {
+            return fastdom.mutate(() => {
                 const container = document.createElement('div');
                 container.classList.add('site-message--banner');
                 container.classList.add('remote-banner');

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -504,7 +504,7 @@ const makeEpicABTestVariant = (
 
                         emitBeginEvent(trackingCampaignId);
 
-                        return fastdom.write(() => {
+                        return fastdom.mutate(() => {
                             const targets = getTargets('.submeta');
 
                             setupClickHandling(

--- a/static/src/javascripts/projects/common/modules/commercial/epic/epic-utils.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic/epic-utils.js
@@ -78,7 +78,7 @@ const controlEpicComponent = (
 
 const insertAtSubmeta = (epic: EpicComponent): Promise<EpicComponent> =>
     fastdom
-        .read(() => document.querySelector('.submeta'))
+        .measure(() => document.querySelector('.submeta'))
         .then(element => {
             if (element && element.parentElement) {
                 element.parentElement.insertBefore(epic.html, element);

--- a/static/src/javascripts/projects/common/modules/crosswords/clues.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/clues.js
@@ -75,7 +75,7 @@ class Clues extends Component<*, *> {
             (this.props.focussed &&
                 (!prev.focussed || prev.focussed.id !== this.props.focussed.id))
         ) {
-            fastdom.read(() => {
+            fastdom.measure(() => {
                 this.scrollIntoView(this.props.focussed);
             });
         }

--- a/static/src/javascripts/projects/common/modules/crosswords/crossword.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/crossword.js
@@ -89,7 +89,7 @@ class Crossword extends Component<*, CrosswordState> {
             const stickyClueWrapperOffset = $stickyClueWrapper.offset();
             const scrollY = window.scrollY;
 
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 // Clear previous state
                 $stickyClueWrapper
                     .css('top', '')
@@ -328,7 +328,7 @@ class Crossword extends Component<*, CrosswordState> {
             fastdom.measure(() => {
                 // Our grid is a square, set the height of the grid wrapper
                 // to the width of the grid wrapper
-                fastdom.write(() => {
+                fastdom.mutate(() => {
                     this.$gridWrapper.css(
                         'height',
                         `${this.$gridWrapper.offset().width}px`

--- a/static/src/javascripts/projects/common/modules/crosswords/crossword.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/crossword.js
@@ -325,7 +325,7 @@ class Crossword extends Component<*, CrosswordState> {
                 max: 'tablet',
             })
         ) {
-            fastdom.read(() => {
+            fastdom.measure(() => {
                 // Our grid is a square, set the height of the grid wrapper
                 // to the width of the grid wrapper
                 fastdom.write(() => {

--- a/static/src/javascripts/projects/common/modules/crosswords/hidden-input.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/hidden-input.js
@@ -19,7 +19,7 @@ class HiddenInput extends Component<*, *> {
                 max: 'mobile',
             })
         ) {
-            fastdom.read(() => {
+            fastdom.measure(() => {
                 const offsets = bonzo(findDOMNode(this.input)).offset();
                 const clueHeight = document.getElementsByClassName(
                     'crossword__sticky-clue'

--- a/static/src/javascripts/projects/common/modules/crosswords/main.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/main.js
@@ -8,7 +8,7 @@ import Crossword from 'common/modules/crosswords/crossword';
 
 const initCrosswords = (): void => {
     fastdom
-        .read(() => document.getElementsByClassName('js-crossword'))
+        .measure(() => document.getElementsByClassName('js-crossword'))
         .then(elements => {
             Array.from(elements).forEach(element => {
                 const data = element.getAttribute('data-crossword-data');

--- a/static/src/javascripts/projects/common/modules/discussion/comment-count.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-count.js
@@ -28,7 +28,7 @@ const getTemplate = (
 
 const getElementsIndexedById = (context: HTMLElement): Promise<any> =>
     fastdom
-        .read(() => Array.from(context.querySelectorAll(`[${ATTRIBUTE_NAME}]`)))
+        .measure(() => Array.from(context.querySelectorAll(`[${ATTRIBUTE_NAME}]`)))
         .then(elements => {
             if (elements.length === 0) {
                 return;

--- a/static/src/javascripts/projects/common/modules/discussion/comment-count.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-count.js
@@ -81,7 +81,7 @@ const updateElement = (el: HTMLElement, count: number): Promise<void> => {
     const meta = Array.from(el.getElementsByClassName('js-item__meta'));
     const containers = meta.length ? meta : [el];
 
-    return fastdom.write(() => {
+    return fastdom.mutate(() => {
         containers.forEach(container => {
             container.insertAdjacentHTML('beforeend', html);
         });

--- a/static/src/javascripts/projects/common/modules/discussion/discussion-frontend.js
+++ b/static/src/javascripts/projects/common/modules/discussion/discussion-frontend.js
@@ -16,7 +16,7 @@ const loadDiscussionFrontend = (
         const formatted = integerCommas(value);
 
         if (formatted) {
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 element.textContent = formatted;
             });
         }

--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -498,7 +498,7 @@ class Loader extends Component {
             // If comments are hidden, lets show them
             if (commentsAreHidden) {
                 fastdom
-                    .write(() => {
+                    .mutate(() => {
                         if (this.comments) {
                             this.comments.showHiddenComments();
                         }
@@ -523,7 +523,7 @@ class Loader extends Component {
             // Scroll to toolbar and show message
             scrollToElement(qwery('.js-discussion-toolbar'), 100);
 
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 $('.js-discussion-main-comments').prepend(
                     '<div class="d-discussion__message d-discussion__message--error">The comment you requested could not be found.</div>'
                 );

--- a/static/src/javascripts/projects/common/modules/discussion/upvote.js
+++ b/static/src/javascripts/projects/common/modules/discussion/upvote.js
@@ -39,7 +39,7 @@ const showSignInTooltip = (target: Element): Promise<void> => {
 
     const links = tooltip.querySelectorAll('.js-rec-tooltip-link');
 
-    return fastdom.write(() => {
+    return fastdom.mutate(() => {
         updateReturnUrl(links, target.getAttribute('data-comment-url'));
         tooltip.removeAttribute('hidden');
         target.appendChild(tooltip);
@@ -50,19 +50,19 @@ const isOpenForRecommendations = (element: ?Element): boolean =>
     !!element && !!element.querySelector('.d-discussion--recommendations-open');
 
 const setClicked = (target: Element): Promise<void> =>
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         target.classList.remove(RECOMMENDATION_CLASS);
         target.classList.add('d-comment__recommend--clicked');
     });
 
 const unsetClicked = (target: Element): Promise<void> =>
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         target.classList.add(RECOMMENDATION_CLASS);
         target.classList.remove('d-comment__recommend--clicked');
     });
 
 const setRecommended = (target: Element): Promise<void> =>
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         target.classList.add('d-comment__recommend--recommended');
     });
 
@@ -102,7 +102,7 @@ const handle = (
 };
 
 const closeTooltip = (): Promise<void> =>
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         const tooltip = document.querySelector(`.${TOOLTIP_CLASS}`);
 
         if (tooltip) {

--- a/static/src/javascripts/projects/common/modules/discussion/user-avatars.js
+++ b/static/src/javascripts/projects/common/modules/discussion/user-avatars.js
@@ -42,7 +42,7 @@ const avatarify = (container: HTMLElement): void => {
 
 const initUserAvatars = (): Promise<void> =>
     fastdom
-        .read(() => document.getElementsByClassName('user-avatar'))
+        .measure(() => document.getElementsByClassName('user-avatar'))
         .then(avatars => {
             if (avatars) {
                 Array.from(avatars).forEach(avatarify);

--- a/static/src/javascripts/projects/common/modules/discussion/user-edit-link.js
+++ b/static/src/javascripts/projects/common/modules/discussion/user-edit-link.js
@@ -20,7 +20,7 @@ const addEditLink = (containerEl: HTMLElement): void => {
         holderEl.appendChild(linkEl);
         holderEl.classList.add('user-profile__edit-link');
 
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             containerEl.insertAdjacentElement('afterend', holderEl);
         });
     }

--- a/static/src/javascripts/projects/common/modules/discussion/user-edit-link.js
+++ b/static/src/javascripts/projects/common/modules/discussion/user-edit-link.js
@@ -28,7 +28,7 @@ const addEditLink = (containerEl: HTMLElement): void => {
 
 const initUserEditLink = (): Promise<void> =>
     fastdom
-        .read(() =>
+        .measure(() =>
             Array.from(document.getElementsByClassName('user-profile__name'))
         )
         .then(names => {

--- a/static/src/javascripts/projects/common/modules/email/email.js
+++ b/static/src/javascripts/projects/common/modules/email/email.js
@@ -63,7 +63,7 @@ const replaceContent = (isSuccess: boolean, $form: bonzo, $formHeader: ?bonzo): 
             <p class="email-sub__message__description">${submissionMessage}</p>
         </div>`;
 
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         if ($formHeader) {
             $formHeader.addClass('email-sub__header--is-hidden')
         }
@@ -99,7 +99,7 @@ const updateFormForLoggedIn = (
     el: HTMLElement
 ): void => {
     if (userFromId && userFromId.primaryEmailAddress) {
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             $('.js-email-sub__inline-label', el).addClass(
                 'email-sub__inline-label--is-hidden'
             );
@@ -136,7 +136,7 @@ const updateForm = (
         updateFormForLoggedIn(userFromId, $el);
     });
 
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         if (formDisplayNameNormalText) {
             $('.js-email-sub__display-name-normal-text', $el).text(
                 formDisplayNameNormalText
@@ -209,7 +209,7 @@ const heightSetter = ($wrapper: bonzo, reset: boolean): (() => void) => {
     };
 
     const resetHeight = () => {
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             $wrapper.css('min-height', '');
             getHeight();
             setHeight();
@@ -233,7 +233,7 @@ const setIframeHeight = (
     fastdom
         .measure(() => iFrameEl.contentWindow.document.body.clientHeight)
         .then(height =>
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 iFrameEl.height = `${height}px`;
             })
         )

--- a/static/src/javascripts/projects/common/modules/email/email.js
+++ b/static/src/javascripts/projects/common/modules/email/email.js
@@ -197,7 +197,7 @@ const heightSetter = ($wrapper: bonzo, reset: boolean): (() => void) => {
     let wrapperHeight;
 
     const getHeight = () => {
-        fastdom.read(() => {
+        fastdom.measure(() => {
             wrapperHeight = $wrapper[0].clientHeight;
         });
     };
@@ -231,7 +231,7 @@ const setIframeHeight = (
     callback: () => void
 ): (() => void) => () => {
     fastdom
-        .read(() => iFrameEl.contentWindow.document.body.clientHeight)
+        .measure(() => iFrameEl.contentWindow.document.body.clientHeight)
         .then(height =>
             fastdom.write(() => {
                 iFrameEl.height = `${height}px`;

--- a/static/src/javascripts/projects/common/modules/email/email.js
+++ b/static/src/javascripts/projects/common/modules/email/email.js
@@ -203,7 +203,7 @@ const heightSetter = ($wrapper: bonzo, reset: boolean): (() => void) => {
     };
 
     const setHeight = () => {
-        fastdom.defer(() => {
+        fastdom.mutate(() => {
             $wrapper.css('min-height', wrapperHeight);
         });
     };

--- a/static/src/javascripts/projects/common/modules/experiments/affix.js
+++ b/static/src/javascripts/projects/common/modules/experiments/affix.js
@@ -46,7 +46,7 @@ class Affix {
 
     calculateContainerPositioning(): void {
         fastdom
-            .write(() => {
+            .mutate(() => {
                 this.$container.css('top', '0');
             })
             .then(() =>
@@ -57,7 +57,7 @@ class Affix {
                 )
             )
             .then(containerTop => {
-                fastdom.write(() => {
+                fastdom.mutate(() => {
                     this.$container.css('top', `${containerTop}px`);
                 });
             });
@@ -80,7 +80,7 @@ class Affix {
 
             // Lock the affix container to the bottom marker.
             if (bottomCheck) {
-                fastdom.write(() => {
+                fastdom.mutate(() => {
                     this.$container.removeClass(affixBottomClass);
                 });
                 this.calculateContainerPositioning();
@@ -94,13 +94,13 @@ class Affix {
                     markerTopTop -
                     elHeight +
                     oldContainerStyling;
-                fastdom.write(() => {
+                fastdom.mutate(() => {
                     this.$container.css('top', `${topStyle}px`);
                     this.$container.addClass(affixBottomClass);
                 });
             }
 
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 if (affix) {
                     this.$element.addClass(affixClass);
                 } else {

--- a/static/src/javascripts/projects/common/modules/experiments/affix.js
+++ b/static/src/javascripts/projects/common/modules/experiments/affix.js
@@ -50,7 +50,7 @@ class Affix {
                 this.$container.css('top', '0');
             })
             .then(() =>
-                fastdom.read(
+                fastdom.measure(
                     () =>
                         this.$markerTop.offset().top -
                         this.$container.offset().top

--- a/static/src/javascripts/projects/common/modules/fix-secondary-column.js
+++ b/static/src/javascripts/projects/common/modules/fix-secondary-column.js
@@ -29,7 +29,7 @@ export const fixSecondaryColumn = (): void => {
             return calcShowcaseOffset(showcaseDim, mainColDim);
         })
         .then(offset =>
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 secondaryCol.style.paddingTop = `${offset}px`;
             })
         );

--- a/static/src/javascripts/projects/common/modules/fix-secondary-column.js
+++ b/static/src/javascripts/projects/common/modules/fix-secondary-column.js
@@ -23,7 +23,7 @@ export const fixSecondaryColumn = (): void => {
     }
 
     fastdom
-        .read(() => {
+        .measure(() => {
             const mainColDim = mainCol.getBoundingClientRect();
             const showcaseDim = showcase.getBoundingClientRect();
             return calcShowcaseOffset(showcaseDim, mainColDim);

--- a/static/src/javascripts/projects/common/modules/fix-secondary-column.spec.js
+++ b/static/src/javascripts/projects/common/modules/fix-secondary-column.spec.js
@@ -59,7 +59,7 @@ describe('fixSecondaryColumn when showcase element is present', () => {
     });
 
     it('should set the padding-top of the secondary column to the correct value', done => {
-        jest.spyOn(fastdom, 'read').mockReturnValue(Promise.resolve(880));
+        jest.spyOn(fastdom, 'measure').mockReturnValue(Promise.resolve(880));
 
         fastdom
             .mutate(() => {

--- a/static/src/javascripts/projects/common/modules/fix-secondary-column.spec.js
+++ b/static/src/javascripts/projects/common/modules/fix-secondary-column.spec.js
@@ -62,7 +62,7 @@ describe('fixSecondaryColumn when showcase element is present', () => {
         jest.spyOn(fastdom, 'read').mockReturnValue(Promise.resolve(880));
 
         fastdom
-            .write(() => {
+            .mutate(() => {
                 fixSecondaryColumn();
             })
             .then(() => {

--- a/static/src/javascripts/projects/common/modules/identity/ad-prefs.js
+++ b/static/src/javascripts/projects/common/modules/identity/ad-prefs.js
@@ -118,7 +118,7 @@ class AdPrefsWrapper extends Component<
 
 const enhanceAdPrefs = (): void => {
     fastdom
-        .read(() => Array.from(document.querySelectorAll(rootSelector)))
+        .measure(() => Array.from(document.querySelectorAll(rootSelector)))
         .then((wrapperEls: HTMLElement[]) => {
             wrapperEls.forEach(_ => {
                 fastdom.write(() => {

--- a/static/src/javascripts/projects/common/modules/identity/ad-prefs.js
+++ b/static/src/javascripts/projects/common/modules/identity/ad-prefs.js
@@ -121,7 +121,7 @@ const enhanceAdPrefs = (): void => {
         .measure(() => Array.from(document.querySelectorAll(rootSelector)))
         .then((wrapperEls: HTMLElement[]) => {
             wrapperEls.forEach(_ => {
-                fastdom.write(() => {
+                fastdom.mutate(() => {
                     render(
                         <AdPrefsWrapper
                             initialConsentsWithState={getAllAdConsentsWithState()}

--- a/static/src/javascripts/projects/common/modules/identity/consent-journey.js
+++ b/static/src/javascripts/projects/common/modules/identity/consent-journey.js
@@ -5,10 +5,10 @@ import fastdom from 'lib/fastdom-promise';
 import loadEnhancers from './modules/loadEnhancers';
 
 const showJourney = (journeyEl: HTMLElement): Promise<void> =>
-    fastdom.write(() => journeyEl.classList.remove('u-h'));
+    fastdom.mutate(() => journeyEl.classList.remove('u-h'));
 
 const hideLoading = (loadingEl: HTMLElement): Promise<void> =>
-    fastdom.write(() => loadingEl.remove());
+    fastdom.mutate(() => loadingEl.remove());
 
 const enhanceConsentJourney = (): void => {
     const loaders = [

--- a/static/src/javascripts/projects/common/modules/identity/consents.js
+++ b/static/src/javascripts/projects/common/modules/identity/consents.js
@@ -58,7 +58,7 @@ const buildConsentUpdatePayload = (
 };
 
 const getInputFields = (labelEl: HTMLElement): Promise<NodeList<HTMLElement>> =>
-    fastdom.read(() => labelEl.querySelectorAll('[name][value]'));
+    fastdom.measure(() => labelEl.querySelectorAll('[name][value]'));
 
 const unsubscribeFromAll = (buttonEl: HTMLButtonElement): Promise<void> => {
     buttonEl.classList.add(isLoadingClassName);
@@ -72,7 +72,7 @@ const unsubscribeFromAll = (buttonEl: HTMLButtonElement): Promise<void> => {
 
 const toggleInputsWithSelector = (className: string, checked: boolean) =>
     fastdom
-        .read(() =>
+        .measure(() =>
             Array.from(
                 document.querySelectorAll(
                     `.${className} input[type="checkbox"]`
@@ -93,7 +93,7 @@ const uncheckAllOptIns = (): Promise<void> =>
 
 const showUnsubscribeConfirmation = (): Promise<void> => {
     const fetchButton = (): Promise<HTMLButtonElement> =>
-        fastdom.read(() =>
+        fastdom.measure(() =>
             document.querySelector(`.${unsubscribeButtonClassName}`)
         );
 
@@ -204,20 +204,20 @@ const getCheckedAllStatus = (checkboxesEl: HTMLInputElement[]): boolean =>
 
 const bindCheckAllSwitch = (labelEl: HTMLElement): void => {
     const fetchElements = (): Promise<(HTMLInputElement | HTMLElement)[]> =>
-        fastdom.read(() => [
+        fastdom.measure(() => [
             labelEl.querySelector('input'),
             labelEl.querySelector('.manage-account__switch-title'),
         ]);
 
     const fetchWrappedCheckboxes = (): Promise<HTMLInputElement[]> =>
         fastdom
-            .read(() => [
+            .measure(() => [
                 labelEl.dataset.wrapper
                     ? labelEl.dataset.wrapper
                     : '.manage-account__switches',
             ])
             .then(selector =>
-                fastdom.read(() => {
+                fastdom.measure(() => {
                     const nearestWrapperEl = labelEl.closest(selector);
                     if (!nearestWrapperEl) throw new Error(ERR_MALFORMED_HTML);
                     return Array.from(

--- a/static/src/javascripts/projects/common/modules/identity/consents.js
+++ b/static/src/javascripts/projects/common/modules/identity/consents.js
@@ -100,7 +100,7 @@ const showUnsubscribeConfirmation = (): Promise<void> => {
     const updateVisibilityAndShowMessage = (
         elem: HTMLButtonElement
     ): Promise<void> =>
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             if (elem.parentElement) {
                 prependSuccessMessage(
                     UNSUBSCRIPTION_SUCCESS_MESSAGE,
@@ -248,7 +248,7 @@ const bindCheckAllSwitch = (labelEl: HTMLElement): void => {
             status ? LC_UNCHECK_ALL : LC_CHECK_ALL;
 
         const updateCheckStatus = () =>
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 checkboxEl.checked = getCheckedAllStatus(wrappedCheckboxEls);
                 titleEl.innerHTML = getTextForStatus(checkboxEl.checked);
                 labelEl.style.visibility = 'visible';
@@ -275,7 +275,7 @@ const bindCheckAllSwitch = (labelEl: HTMLElement): void => {
             );
 
             checkboxesToUpdate.forEach(wrappedCheckboxEl => {
-                fastdom.write(() => {
+                fastdom.mutate(() => {
                     wrappedCheckboxEl.checked = checkboxEl.checked;
                 });
             });

--- a/static/src/javascripts/projects/common/modules/identity/delete-account.js
+++ b/static/src/javascripts/projects/common/modules/identity/delete-account.js
@@ -9,7 +9,7 @@ const deleteLoaderElm = $('#deleteLoader')[0];
 
 const disableDeleteButton = (): void => {
     if (deleteButtonElm) {
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             deleteButtonElm.disabled = true;
         });
     }
@@ -17,7 +17,7 @@ const disableDeleteButton = (): void => {
 
 const showLoader = (): void => {
     if (deleteLoaderElm) {
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             deleteLoaderElm.classList.remove('is-hidden');
         });
     }

--- a/static/src/javascripts/projects/common/modules/identity/follow.js
+++ b/static/src/javascripts/projects/common/modules/identity/follow.js
@@ -6,7 +6,7 @@ import loadEnhancers from './modules/loadEnhancers';
 
 const bindFollow = (el): void => {
     fastdom
-        .read(() => el.querySelector('.identity-follow__button-target'))
+        .measure(() => el.querySelector('.identity-follow__button-target'))
         .then((wrapperEl: HTMLElement) => {
             fastdom.write(() => {
                 render(

--- a/static/src/javascripts/projects/common/modules/identity/follow.js
+++ b/static/src/javascripts/projects/common/modules/identity/follow.js
@@ -8,7 +8,7 @@ const bindFollow = (el): void => {
     fastdom
         .measure(() => el.querySelector('.identity-follow__button-target'))
         .then((wrapperEl: HTMLElement) => {
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 render(
                     <FollowButtonWrap
                         following

--- a/static/src/javascripts/projects/common/modules/identity/header.js
+++ b/static/src/javascripts/projects/common/modules/identity/header.js
@@ -33,7 +33,7 @@ const bindNavToggle = (buttonEl: HTMLElement): void => {
         ev.preventDefault();
 
         fastdom
-            .read(() => document.getElementById(menuElSelector))
+            .measure(() => document.getElementById(menuElSelector))
             .then((menuEl: HTMLElement) => {
                 if (!menuEl) throw new Error(ERR_UNDEFINED_MENU);
                 const watchForOutsideClick = subEv => {

--- a/static/src/javascripts/projects/common/modules/identity/header.js
+++ b/static/src/javascripts/projects/common/modules/identity/header.js
@@ -9,7 +9,7 @@ const showAccountMenu = (
     buttonEl: HTMLElement,
     menuEl: HTMLElement
 ): Promise<void> =>
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         menuEl.classList.add('is-active');
         menuEl.setAttribute('aria-hidden', 'false');
         buttonEl.setAttribute('aria-expanded', 'true');
@@ -19,7 +19,7 @@ const hideAccountMenu = (
     buttonEl: HTMLElement,
     menuEl: HTMLElement
 ): Promise<void> =>
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         menuEl.classList.remove('is-active');
         menuEl.setAttribute('aria-hidden', 'true');
         buttonEl.setAttribute('aria-expanded', 'false');

--- a/static/src/javascripts/projects/common/modules/identity/modules/button.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/button.js
@@ -3,13 +3,13 @@ import fastdom from 'lib/fastdom-promise';
 import $ from 'lib/$';
 
 export const addUpdatingState = (buttonEl: HTMLButtonElement) =>
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         buttonEl.disabled = true;
         $(buttonEl).addClass('is-updating is-updating-subscriptions');
     });
 
 export const removeUpdatingState = (buttonEl: HTMLButtonElement) =>
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         buttonEl.disabled = false;
         $(buttonEl).removeClass('is-updating is-updating-subscriptions');
     });

--- a/static/src/javascripts/projects/common/modules/identity/modules/fetchFormFields.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/fetchFormFields.js
@@ -5,7 +5,7 @@ export const getCsrfTokenFromElement = (
     originalEl: ?HTMLElement
 ): Promise<string> =>
     fastdom
-        .read(() => {
+        .measure(() => {
             if (!originalEl) return Promise.reject();
             const closestFormEl: ?Element = originalEl.closest('form');
             if (closestFormEl) {

--- a/static/src/javascripts/projects/common/modules/identity/modules/loadEnhancers.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/loadEnhancers.js
@@ -10,7 +10,7 @@ const loadEnhancers = (loaders: Array<Array<any>>): void => {
         if (typeof classname !== 'string') throw new Error('Invalid classname');
         if (typeof action !== 'function') throw new Error('Invalid action');
         return fastdom
-            .read(() => Array.from(document.querySelectorAll(classname)))
+            .measure(() => Array.from(document.querySelectorAll(classname)))
             .then(elements =>
                 elements.forEach((element: HTMLElement) => {
                     robust.catchAndLogError(classname, () => {

--- a/static/src/javascripts/projects/common/modules/identity/modules/modal.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/modal.js
@@ -13,7 +13,7 @@ const bindCloserOnce = (modalEl: HTMLElement): Promise<void[]> =>
             buttonEls
                 .filter(buttonEl => !buttonEl.dataset.closeIsBound)
                 .map(buttonEl =>
-                    fastdom.write(() => {
+                    fastdom.mutate(() => {
                         buttonEl.dataset.closeIsBound = true;
                         buttonEl.addEventListener('click', () => {
                             modalEl.classList.remove('identity-modal--active');

--- a/static/src/javascripts/projects/common/modules/identity/modules/modal.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/modal.js
@@ -6,7 +6,7 @@ const ERR_MODAL_MALFORMED = 'Modal is malformed';
 
 const bindCloserOnce = (modalEl: HTMLElement): Promise<void[]> =>
     fastdom
-        .read(() =>
+        .measure(() =>
             Array.from(modalEl.querySelectorAll('.js-identity-modal__closer'))
         )
         .then(buttonEls =>
@@ -25,7 +25,7 @@ const bindCloserOnce = (modalEl: HTMLElement): Promise<void[]> =>
 
 const getModal = (name: string): Promise<HTMLElement> =>
     fastdom
-        .read(() => {
+        .measure(() => {
             const modalEl: ?HTMLElement = document.querySelector(
                 `.identity-modal.identity-modal--${name}`
             );
@@ -36,7 +36,7 @@ const getModal = (name: string): Promise<HTMLElement> =>
 
 const getContents = (name: string): Promise<HTMLElement> =>
     getModal(name).then(modalEl =>
-        fastdom.read(() => {
+        fastdom.measure(() => {
             const contentsEl: ?HTMLElement = modalEl.querySelector(
                 `.identity-modal__content`
             );
@@ -47,14 +47,14 @@ const getContents = (name: string): Promise<HTMLElement> =>
 
 const show = (name: string): Promise<void> =>
     getModal(name).then(modalEl =>
-        fastdom.read(() => {
+        fastdom.measure(() => {
             modalEl.classList.add('identity-modal--active');
         })
     );
 
 const hide = (name: string): Promise<void> =>
     getModal(name).then(modalEl =>
-        fastdom.read(() => {
+        fastdom.measure(() => {
             modalEl.classList.remove('identity-modal--active');
         })
     );

--- a/static/src/javascripts/projects/common/modules/identity/modules/show-errors.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/show-errors.js
@@ -20,7 +20,7 @@ const renderError = (error: IdentityRenderableError): Promise<void> =>
             window.document.querySelector(`.${formErrorHolderClassName}`)
         )
         .then((errorHolderEl: HTMLElement) =>
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 const errorEl = document.createElement('div');
                 errorEl.setAttribute('role', 'alert');
                 errorEl.setAttribute('aria-live', 'polite');
@@ -53,7 +53,7 @@ const renderList = (): Promise<void> =>
             window.document.querySelector(`.${formErrorHolderClassName}`)
         )
         .then((errorHolderEl: HTMLElement) =>
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 while (errorHolderEl.firstChild) {
                     errorHolderEl.removeChild(errorHolderEl.firstChild);
                 }

--- a/static/src/javascripts/projects/common/modules/identity/modules/show-errors.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/show-errors.js
@@ -16,7 +16,7 @@ type IdentityRenderableError = {
 
 const renderError = (error: IdentityRenderableError): Promise<void> =>
     fastdom
-        .read(() =>
+        .measure(() =>
             window.document.querySelector(`.${formErrorHolderClassName}`)
         )
         .then((errorHolderEl: HTMLElement) =>
@@ -49,7 +49,7 @@ const renderError = (error: IdentityRenderableError): Promise<void> =>
 
 const renderList = (): Promise<void> =>
     fastdom
-        .read(() =>
+        .measure(() =>
             window.document.querySelector(`.${formErrorHolderClassName}`)
         )
         .then((errorHolderEl: HTMLElement) =>

--- a/static/src/javascripts/projects/common/modules/identity/modules/switch.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/switch.js
@@ -26,7 +26,7 @@ const updateDataLink = (labelEl: HTMLElement, checked): Promise<any> =>
 
 export const bindAnalyticsEventsOnce = (labelEl: HTMLElement): Promise<any> =>
     fastdom
-        .read((): ?HTMLElement => labelEl.querySelector('input'))
+        .measure((): ?HTMLElement => labelEl.querySelector('input'))
         .then((checkboxEl: HTMLInputElement) => {
             if (!labelEl.dataset.updateDataLinkBound) {
                 labelEl.addEventListener('change', () => {
@@ -40,7 +40,7 @@ export const bindAnalyticsEventsOnce = (labelEl: HTMLElement): Promise<any> =>
 export const getInfo = (labelEl: HTMLElement): Promise<any> =>
     bindAnalyticsEventsOnce(labelEl)
         .then(() =>
-            fastdom.read((): ?HTMLElement => labelEl.querySelector('input'))
+            fastdom.measure((): ?HTMLElement => labelEl.querySelector('input'))
         )
         .then((checkboxEl: HTMLInputElement) => {
             if (!labelEl.dataset.updateDataLinkBound) {
@@ -63,7 +63,7 @@ export const getInfo = (labelEl: HTMLElement): Promise<any> =>
 
 export const flip = (labelEl: HTMLElement): Promise<any> =>
     fastdom
-        .read((): ?HTMLElement => labelEl.querySelector('input'))
+        .measure((): ?HTMLElement => labelEl.querySelector('input'))
         .then((checkboxEl: HTMLInputElement) => {
             fastdom.write(() => {
                 checkboxEl.checked = !checkboxEl.checked;

--- a/static/src/javascripts/projects/common/modules/identity/modules/switch.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/switch.js
@@ -17,7 +17,7 @@ const checkboxShouldUpdate = (
 };
 
 const updateDataLink = (labelEl: HTMLElement, checked): Promise<any> =>
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         labelEl.dataset.linkName = labelEl.dataset.linkNameTemplate.replace(
             '[action]',
             checked ? 'untick' : 'tick'
@@ -65,7 +65,7 @@ export const flip = (labelEl: HTMLElement): Promise<any> =>
     fastdom
         .measure((): ?HTMLElement => labelEl.querySelector('input'))
         .then((checkboxEl: HTMLInputElement) => {
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 checkboxEl.checked = !checkboxEl.checked;
             });
         });
@@ -75,7 +75,7 @@ export const addSpinner = (
     latencyTimeout: number = 500
 ): Promise<any> =>
     fastdom
-        .write(() => {
+        .mutate(() => {
             labelEl.classList.add('is-updating');
             if (document.body) document.body.classList.add('is-updating-js');
         })
@@ -83,7 +83,7 @@ export const addSpinner = (
             labelEl.dataset.slowLoadTimeout = timeouts
                 .push(
                     setTimeout(() => {
-                        fastdom.write(() => {
+                        fastdom.mutate(() => {
                             if (document.body) {
                                 document.body.classList.add(
                                     'is-updating-cursor'
@@ -97,7 +97,7 @@ export const addSpinner = (
         });
 
 export const removeSpinner = (labelEl: HTMLElement): Promise<any> =>
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         if (document.body) document.body.classList.remove('is-updating-cursor');
         if (document.body) document.body.classList.remove('is-updating-js');
         labelEl.classList.remove('is-updating');

--- a/static/src/javascripts/projects/common/modules/identity/modules/switch.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/switch.spec.js
@@ -11,7 +11,7 @@ beforeEach(() => {
 });
 
 test('gets info', () => {
-    const el = $('.originalClassName');
+    const el = $('.originalClassName').get(0);
     getInfo(el).then(info => {
         expect(info.checked).toEqual(true);
         expect(info.name).toEqual('test-name');
@@ -25,7 +25,7 @@ test('doesnt force update with an empty data-originally-checked', () => {
             <div class="originalClassName"><input type="checkbox" checked name="test-name" /></div>
         `;
     }
-    const el = $('.originalClassName');
+    const el = $('.originalClassName').get(0);
     getInfo(el).then(info => {
         expect(info.shouldUpdate).toEqual(false);
     });
@@ -37,14 +37,14 @@ test('doesnt force update with an invalid data-originally-checked', () => {
             <div class="originalClassName" data-originally-checked="🔔"><input type="checkbox" checked name="test-name" /></div>
         `;
     }
-    const el = $('.originalClassName');
+    const el = $('.originalClassName').get(0);
     getInfo(el).then(info => {
         expect(info.shouldUpdate).toEqual(false);
     });
 });
 
 test('adds a spinner', () => {
-    const el = $('.originalClassName');
+    const el = $('.originalClassName').get(0);
     addSpinner(el).then(() => {
         expect(el.hasClass('is-updating')).toEqual(true);
         expect($(document.body).hasClass('is-updating-cursor')).toEqual(true);
@@ -56,8 +56,8 @@ test('removes a spinner', () => {
     expect(el.length).toEqual(1);
 
     if (el[0]) {
-        addSpinner(el)
-            .then(() => removeSpinner(el))
+        addSpinner(el.get(0))
+            .then(() => removeSpinner(el.get(0)))
             .then(() => {
                 expect(el[0].className).toEqual('originalClassName');
                 expect($(document.body).hasClass('is-updating-cursor')).toEqual(

--- a/static/src/javascripts/projects/common/modules/identity/upsell/upsell.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/upsell.js
@@ -47,7 +47,7 @@ const getPrefill = (el: HTMLElement): Prefill => ({
 
 const bindBlockList = (el): void => {
     fastdom
-        .read(() => getPrefill(el))
+        .measure(() => getPrefill(el))
         .then(prefill =>
             fastdom.write(() => {
                 render(

--- a/static/src/javascripts/projects/common/modules/identity/upsell/upsell.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/upsell.js
@@ -17,7 +17,7 @@ const trackInteraction = (interaction: string): void => {
 
 const bindAccountCreation = (el): void => {
     trackInteraction('set-password : display');
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         render(
             <AccountCreationCompleteConsentsFlow
                 csrfToken={el.dataset.csrf}
@@ -49,7 +49,7 @@ const bindBlockList = (el): void => {
     fastdom
         .measure(() => getPrefill(el))
         .then(prefill =>
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 render(
                     <StatefulConfirmEmailPage
                         csrfToken={prefill.csrfToken}

--- a/static/src/javascripts/projects/common/modules/identity/validation-email.js
+++ b/static/src/javascripts/projects/common/modules/identity/validation-email.js
@@ -28,7 +28,7 @@ const init = (): void => {
                                             'module:identity:validation-email:fail'
                                         );
 
-                                        fastdom.write(() => {
+                                        fastdom.mutate(() => {
                                             resendButton.innerHTML =
                                                 'An error occured, please click here to try again.';
                                         });
@@ -48,7 +48,7 @@ const init = (): void => {
                                             sentMsgEl.innerText =
                                                 'Sent. Please check your email and follow the link.';
 
-                                            fastdom.write(() => {
+                                            fastdom.mutate(() => {
                                                 resendButtonParent.replaceChild(
                                                     sentMsgEl,
                                                     resendButton
@@ -62,7 +62,7 @@ const init = (): void => {
                                         'module:identity:validation-email:fail'
                                     );
 
-                                    fastdom.write(() => {
+                                    fastdom.mutate(() => {
                                         resendButton.innerHTML =
                                             'An error occured, please click here to try again.';
                                     });

--- a/static/src/javascripts/projects/common/modules/identity/validation-email.js
+++ b/static/src/javascripts/projects/common/modules/identity/validation-email.js
@@ -8,7 +8,7 @@ import {
 
 const init = (): void => {
     fastdom
-        .read(() =>
+        .measure(() =>
             document.getElementsByClassName('js-id-send-validation-email')
         )
         .then(elems => {

--- a/static/src/javascripts/projects/common/modules/navigation/membership.js
+++ b/static/src/javascripts/projects/common/modules/navigation/membership.js
@@ -172,7 +172,7 @@ export const initMembership = (): void => {
 
     if (isPayingMember()) {
         fastdom
-            .read(() => document.getElementsByClassName('js-become-member'))
+            .measure(() => document.getElementsByClassName('js-become-member'))
             .then(becomeMemberLinks => {
                 if (becomeMemberLinks.length) {
                     becomeMemberLinks[0].setAttribute('hidden', 'hidden');
@@ -180,7 +180,7 @@ export const initMembership = (): void => {
             });
 
         fastdom
-            .read(() => document.getElementsByClassName('js-subscribe'))
+            .measure(() => document.getElementsByClassName('js-subscribe'))
             .then(subscriberLinks => {
                 if (subscriberLinks.length) {
                     subscriberLinks[0].classList.remove(

--- a/static/src/javascripts/projects/common/modules/navigation/navigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/navigation.js
@@ -17,11 +17,11 @@ const copyMegaNavMenu = (): Promise<void> => {
     let megaNav;
 
     return fastdom
-        .read(() => $('.js-mega-nav'))
+        .measure(() => $('.js-mega-nav'))
         .then(elem => {
             megaNav = elem;
 
-            return fastdom.read(() => $('.js-mega-nav-placeholder'));
+            return fastdom.measure(() => $('.js-mega-nav-placeholder'));
         })
         .then(placeholder => {
             const megaNavCopy = $.create(megaNav.html());
@@ -40,7 +40,7 @@ const copyMegaNavMenu = (): Promise<void> => {
 
 const replaceAllSectionsLink = (): Promise<void> =>
     fastdom
-        .read(() => $('.js-navigation-header .js-navigation-toggle'))
+        .measure(() => $('.js-navigation-header .js-navigation-toggle'))
         .then(elems =>
             fastdom.write(() => {
                 elems.attr('href', '#nav-allsections');
@@ -49,7 +49,7 @@ const replaceAllSectionsLink = (): Promise<void> =>
 
 const addOverflowScrollTouch = (): Promise<void> =>
     fastdom
-        .read(() => $('.navigation__scroll'))
+        .measure(() => $('.navigation__scroll'))
         .then(navScroll => {
             if (navScroll) {
                 return fastdom.write(() => {

--- a/static/src/javascripts/projects/common/modules/navigation/navigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/navigation.js
@@ -7,7 +7,7 @@ import { isIOS, getUserAgent } from 'lib/detect';
 import $ from 'lib/$';
 
 const jsEnableFooterNav = (): Promise<void> =>
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         $('.navigation-container--default')
             .removeClass('navigation-container--default')
             .addClass('navigation-container--collapsed');
@@ -31,7 +31,7 @@ const copyMegaNavMenu = (): Promise<void> => {
             );
 
             if (placeholder) {
-                return fastdom.write(() => {
+                return fastdom.mutate(() => {
                     placeholder.append(megaNavCopy);
                 });
             }
@@ -42,7 +42,7 @@ const replaceAllSectionsLink = (): Promise<void> =>
     fastdom
         .measure(() => $('.js-navigation-header .js-navigation-toggle'))
         .then(elems =>
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 elems.attr('href', '#nav-allsections');
             })
         );
@@ -52,7 +52,7 @@ const addOverflowScrollTouch = (): Promise<void> =>
         .measure(() => $('.navigation__scroll'))
         .then(navScroll => {
             if (navScroll) {
-                return fastdom.write(() => {
+                return fastdom.mutate(() => {
                     navScroll.css({
                         '-webkit-overflow-scrolling': 'touch',
                     });
@@ -66,7 +66,7 @@ const enableMegaNavToggle = (): void => {
 
         e.preventDefault();
 
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             target.toggleClass(
                 'navigation-container--expanded navigation-container--collapsed'
             );

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -147,7 +147,7 @@ const toggleMenu = (): void => {
             }
 
             return fastdom
-                .read(() => {
+                .measure(() => {
                     const docRect = body.getBoundingClientRect();
                     const rect = menuToggle.getBoundingClientRect();
                     return docRect.right - rect.right + rect.width / 2;
@@ -241,7 +241,7 @@ const toggleDropdown = (menuAndTriggerEls: MenuAndTriggerEls): void => {
     const openClass = 'dropdown-menu--open';
 
     fastdom
-        .read(() => menuAndTriggerEls)
+        .measure(() => menuAndTriggerEls)
         .then(els => {
             const { menu, trigger } = els;
 
@@ -290,7 +290,7 @@ const toggleDropdown = (menuAndTriggerEls: MenuAndTriggerEls): void => {
 
 const returnFocusToButton = (btnId: string): void => {
     fastdom
-        .read(() => document.getElementById(btnId))
+        .measure(() => document.getElementById(btnId))
         .then(btn => {
             if (btn) {
                 btn.focus();
@@ -363,7 +363,7 @@ const menuKeyHandlers = {
 };
 
 const enhanceCheckbox = (checkbox: HTMLElement): void => {
-    fastdom.read(() => {
+    fastdom.measure(() => {
         const button = document.createElement('button');
         const checkboxId = checkbox.id;
         const checkboxControls = checkbox.getAttribute('aria-controls');
@@ -467,7 +467,7 @@ const saveSearchTerm = (term: string) => local.set(SEARCH_STORAGE_KEY, term);
 
 const showMoreButton = (): void => {
     fastdom
-        .read(() => {
+        .measure(() => {
             const moreButton = document.querySelector('.js-show-more-button');
             const subnav = document.querySelector('.js-expand-subnav');
             const subnavList = document.querySelector(
@@ -508,7 +508,7 @@ const showMoreButton = (): void => {
 
 const toggleSubnavSections = (moreButton: HTMLElement): void => {
     fastdom
-        .read(() => document.querySelector('.js-expand-subnav'))
+        .measure(() => document.querySelector('.js-expand-subnav'))
         .then(subnav => {
             if (subnav) {
                 fastdom.write(() => {

--- a/static/src/javascripts/projects/common/modules/navigation/new-header.js
+++ b/static/src/javascripts/projects/common/modules/navigation/new-header.js
@@ -153,14 +153,14 @@ const toggleMenu = (): void => {
                     return docRect.right - rect.right + rect.width / 2;
                 })
                 .then(marginRight =>
-                    fastdom.write(() => {
+                    fastdom.mutate(() => {
                         menu.style.marginRight = `${marginRight}px`;
                     })
                 );
         };
         const debouncedMenuEnhancement = debounce(enhanceMenuMargin, 200);
         const removeEnhancedMenuMargin = (): Promise<void> =>
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 menu.style.marginRight = '';
             });
 
@@ -232,7 +232,7 @@ const toggleMenu = (): void => {
         }
     };
 
-    fastdom.write(update);
+    fastdom.mutate(update);
 };
 
 const toggleDropdown = (menuAndTriggerEls: MenuAndTriggerEls): void => {
@@ -253,7 +253,7 @@ const toggleDropdown = (menuAndTriggerEls: MenuAndTriggerEls): void => {
             const expandedAttr = isOpen ? 'false' : 'true';
             const hiddenAttr = isOpen ? 'true' : 'false';
 
-            return fastdom.write(() => {
+            return fastdom.mutate(() => {
                 if (trigger) {
                     trigger.setAttribute('aria-expanded', expandedAttr);
                 }
@@ -423,7 +423,7 @@ const enhanceCheckbox = (checkbox: HTMLElement): void => {
             enhanced[button.id] = true;
         };
 
-        fastdom.write(enhance);
+        fastdom.mutate(enhance);
     });
 };
 
@@ -495,7 +495,7 @@ const showMoreButton = (): void => {
 
                     // +1 to compensate for the border top on the subnav
                     if (subnavRect.top + 1 === lastChildRect.top) {
-                        fastdom.write(() => {
+                        fastdom.mutate(() => {
                             if (moreButton) {
                                 moreButton.classList.add('is-hidden');
                             }
@@ -511,7 +511,7 @@ const toggleSubnavSections = (moreButton: HTMLElement): void => {
         .measure(() => document.querySelector('.js-expand-subnav'))
         .then(subnav => {
             if (subnav) {
-                fastdom.write(() => {
+                fastdom.mutate(() => {
                     const isOpen = subnav.classList.contains(
                         'subnav--expanded'
                     );

--- a/static/src/javascripts/projects/common/modules/navigation/profile.js
+++ b/static/src/javascripts/projects/common/modules/navigation/profile.js
@@ -74,7 +74,7 @@ class Profile {
             // Run this code only if we haven't already inserted
             // the username in the header
             if (!$container.hasClass('is-signed-in')) {
-                fastdom.write(() => {
+                fastdom.mutate(() => {
                     $content.text(user.displayName);
                     $container.addClass('is-signed-in');
                     $register.hide();

--- a/static/src/javascripts/projects/common/modules/navigation/search.js
+++ b/static/src/javascripts/projects/common/modules/navigation/search.js
@@ -12,7 +12,7 @@ class Search {
 
     constructor(): void {
         fastdom
-            .read(() =>
+            .measure(() =>
                 Array.from(document.getElementsByClassName('js-search-toggle'))
             )
             .then(toggles => {
@@ -47,7 +47,7 @@ class Search {
                         });
 
                         fastdom
-                            .read(
+                            .measure(
                                 () =>
                                     document.getElementsByClassName(
                                         popupClass
@@ -154,7 +154,7 @@ class Search {
         let x;
 
         fastdom
-            .read(() => ({
+            .measure(() => ({
                 allSearchPlaceholders: Array.from(
                     document.getElementsByClassName('js-search-placeholder')
                 ),
@@ -195,7 +195,7 @@ class Search {
                     });
 
                     bean.on(searchPlaceholder, 'keydown', '.gsc-input', () => {
-                        fastdom.read(() => {
+                        fastdom.measure(() => {
                             const $autoCompleteObject = $('.gssb_c');
                             const searchFromTop = $autoCompleteObject.css(
                                 'top'

--- a/static/src/javascripts/projects/common/modules/navigation/search.js
+++ b/static/src/javascripts/projects/common/modules/navigation/search.js
@@ -37,7 +37,7 @@ class Search {
                             return;
                         }
 
-                        fastdom.write(() => {
+                        fastdom.mutate(() => {
                             toggle.setAttribute('role', 'button');
                             toggle.setAttribute(
                                 'aria-controls',
@@ -172,7 +172,7 @@ class Search {
                 // Unload any search placeholders elsewhere in the DOM
                 allSearchPlaceholders.forEach(c => {
                     if (c !== searchPlaceholder) {
-                        fastdom.write(() => {
+                        fastdom.mutate(() => {
                             c.innerHTML = '';
                         });
                     }
@@ -181,7 +181,7 @@ class Search {
                 // Load the Google search monolith, if not already present in this context.
                 // We have to re-run their script each time we do this.
                 if (!searchPlaceholder.innerHTML) {
-                    fastdom.write(() => {
+                    fastdom.mutate(() => {
                         if (searchPlaceholder) {
                             searchPlaceholder.innerHTML = `<div class="search-box" role="search">
                             <gcse:searchbox></gcse:searchbox>
@@ -202,7 +202,7 @@ class Search {
                             );
                             const windowOffset = $(window).scrollTop();
 
-                            fastdom.write(() => {
+                            fastdom.mutate(() => {
                                 $autoCompleteObject.css({
                                     top:
                                         parseInt(searchFromTop, 10) +
@@ -231,7 +231,7 @@ class Search {
                     s.src = this.gcsUrl;
                     x = document.getElementsByTagName('script')[0];
 
-                    fastdom.write(() => {
+                    fastdom.mutate(() => {
                         if (x.parentNode) {
                             x.parentNode.insertBefore(s, x);
                         }

--- a/static/src/javascripts/projects/common/modules/navigation/user-account.js
+++ b/static/src/javascripts/projects/common/modules/navigation/user-account.js
@@ -12,7 +12,7 @@ const updateCommentLink = (commentItems): void => {
                     commentItem.querySelector('.js-add-comment-activity-link')
                 )
                 .then(commentLink =>
-                    fastdom.write(() => {
+                    fastdom.mutate(() => {
                         commentItem.classList.remove('u-h');
                         commentLink.setAttribute(
                             'href',
@@ -44,7 +44,7 @@ const showMyAccountIfNecessary = (): void => {
         .then(els => {
             const { signIns, accountActionsLists, commentItems } = els;
             return fastdom
-                .write(() => {
+                .mutate(() => {
                     signIns.forEach(signIn => {
                         signIn.remove();
                     });

--- a/static/src/javascripts/projects/common/modules/navigation/user-account.js
+++ b/static/src/javascripts/projects/common/modules/navigation/user-account.js
@@ -8,7 +8,7 @@ const updateCommentLink = (commentItems): void => {
     if (user) {
         commentItems.forEach(commentItem => {
             fastdom
-                .read(() =>
+                .measure(() =>
                     commentItem.querySelector('.js-add-comment-activity-link')
                 )
                 .then(commentLink =>
@@ -30,7 +30,7 @@ const showMyAccountIfNecessary = (): void => {
     }
 
     fastdom
-        .read(() => ({
+        .measure(() => ({
             signIns: Array.from(
                 document.querySelectorAll('.js-navigation-sign-in')
             ),

--- a/static/src/javascripts/projects/common/modules/onward/breaking-news.js
+++ b/static/src/javascripts/projects/common/modules/onward/breaking-news.js
@@ -148,7 +148,7 @@ const renderAlert = (alert: Alert): bonzo => {
 
     if (closeButton) {
         bean.on(closeButton, 'click', () => {
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 $('[data-breaking-article-id]').hide();
             });
             markAlertAsDismissed(alert.id);
@@ -183,7 +183,7 @@ const show = (): Promise<boolean> => {
 
     // inject the alerts into DOM
     setTimeout(() => {
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             if (alertDelay === 0) {
                 $breakingNews.removeClass('breaking-news--fade-in');
             }

--- a/static/src/javascripts/projects/common/modules/onward/geo-most-popular.js
+++ b/static/src/javascripts/projects/common/modules/onward/geo-most-popular.js
@@ -50,7 +50,7 @@ const geoMostPopular = {
     render: once(
         (): Promise<void> => {
             fastdom
-                .read(() => {
+                .measure(() => {
                     const jsArticleBodyElement = document.querySelector(
                         '.js-article__body'
                     );

--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -415,7 +415,7 @@ const getMegaNav = (): bonzo => $('.js-global-navigation');
 
 const removeFromMegaNav = (): void => {
     getMegaNav().each(megaNav => {
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             $('.js-global-navigation__section--history', megaNav).remove();
         });
     });
@@ -453,7 +453,7 @@ const showInMegaNav = (): void => {
                             <a class="button button--small button--tag button--tertiary" href="/preferences" data-link-name="edit">edit these</a>
                         </ul>
                     </li>`;
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             getMegaNav().prepend(tagsHTML);
         });
         inMegaNav = true;

--- a/static/src/javascripts/projects/common/modules/onward/related.js
+++ b/static/src/javascripts/projects/common/modules/onward/related.js
@@ -113,7 +113,7 @@ const related = (opts: Object): void => {
 
             fetchJSON(relatedUrl, { mode: 'cors' })
                 .then(resp =>
-                    fastdom.write(() => {
+                    fastdom.mutate(() => {
                         container.innerHTML = resp.html;
                         container.classList.add('lazyloaded');
                     })

--- a/static/src/javascripts/projects/common/modules/social/pinterest.js
+++ b/static/src/javascripts/projects/common/modules/social/pinterest.js
@@ -12,7 +12,7 @@ const launchOverlay = (event: Event): void => {
         document.querySelectorAll('img:not(.gu-image):not(.responsive-img)')
     );
 
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         images.forEach(img => {
             img.setAttribute('data-pin-nopin', 'true');
         });
@@ -26,7 +26,7 @@ const initPinterest = (): void => {
         document.querySelectorAll('.social__item--pinterest')
     );
 
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         buttons.forEach(el => {
             el.addEventListener('click', launchOverlay);
         });

--- a/static/src/javascripts/projects/common/modules/social/share-count.js
+++ b/static/src/javascripts/projects/common/modules/social/share-count.js
@@ -31,7 +31,7 @@ const incrementShareCount = (amount: number): void => {
                 ? `${Math.round(displayCount / 1000)}k`
                 : displayCount;
 
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             $fullValueEls.text(formattedDisplayCount);
             $shortValueEls.text(shortDisplayCount);
         });

--- a/static/src/javascripts/projects/common/modules/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/spacefinder.js
@@ -384,7 +384,7 @@ const getMeasurements = (
           ])
         : null;
 
-    return fastdom.read(() => {
+    return fastdom.measure(() => {
         const bodyDims =
             rules.body instanceof Element && rules.body.getBoundingClientRect();
         const candidatesWithDims: SpacefinderItem[] = candidates.map(

--- a/static/src/javascripts/projects/common/modules/ui/accessibility-prefs.js
+++ b/static/src/javascripts/projects/common/modules/ui/accessibility-prefs.js
@@ -35,7 +35,7 @@ const breuer = (): void => {
 };
 
 const initAccessibilityPreferences = (): void => {
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         FILTERS.forEach(filter => {
             if (userPrefs.isOn(filter)) {
                 setFilter(filter);

--- a/static/src/javascripts/projects/common/modules/ui/autoupdate.js
+++ b/static/src/javascripts/projects/common/modules/ui/autoupdate.js
@@ -181,7 +181,7 @@ const autoUpdate = (opts?: autoUpdateOptions): void => {
     const setUpListeners = (): void => {
         bean.on(document.body, 'click', '.toast__button', () => {
             if (isLivePage) {
-                fastdom.read(() => {
+                fastdom.measure(() => {
                     scrollToElement(qwery('.blocks')[0], 300, 'easeOutQuad');
 
                     fastdom

--- a/static/src/javascripts/projects/common/modules/ui/autoupdate.js
+++ b/static/src/javascripts/projects/common/modules/ui/autoupdate.js
@@ -62,7 +62,7 @@ const autoUpdate = (opts?: autoUpdateOptions): void => {
     const isLivePage = !window.location.search.includes('?page=');
 
     const revealInjectedElements = (): void => {
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             $('.autoupdate--hidden', $liveblogBody)
                 .addClass('autoupdate--highlight')
                 .removeClass('autoupdate--hidden');
@@ -71,7 +71,7 @@ const autoUpdate = (opts?: autoUpdateOptions): void => {
     };
 
     const toastButtonRefresh = (): void => {
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             if (unreadBlocksNo > 0) {
                 const updateText =
                     unreadBlocksNo > 1 ? ' new updates' : ' new update';
@@ -92,7 +92,7 @@ const autoUpdate = (opts?: autoUpdateOptions): void => {
         const resultHtml = $.create(`<div>${newBlocks}</div>`)[0];
         let elementsToAdd;
 
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             bonzo(resultHtml.children).addClass('autoupdate--hidden');
             elementsToAdd = Array.from(resultHtml.children);
 
@@ -185,7 +185,7 @@ const autoUpdate = (opts?: autoUpdateOptions): void => {
                     scrollToElement(qwery('.blocks')[0], 300, 'easeOutQuad');
 
                     fastdom
-                        .write(() => {
+                        .mutate(() => {
                             $toastButton.addClass('loading');
                         })
                         .then(() => {
@@ -200,7 +200,7 @@ const autoUpdate = (opts?: autoUpdateOptions): void => {
         mediator.on('modules:toast__tofix:unfixed', () => {
             if (isLivePage && unreadBlocksNo > 0) {
                 fastdom
-                    .write(() => {
+                    .mutate(() => {
                         $toastButton.addClass('loading');
                     })
                     .then(() => {
@@ -232,7 +232,7 @@ const autoUpdate = (opts?: autoUpdateOptions): void => {
     initPageVisibility();
     setUpListeners();
 
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         // Enables the animations for injected blocks
         $liveblogBody.addClass('autoupdate--has-animation');
     });

--- a/static/src/javascripts/projects/common/modules/ui/dropdowns.js
+++ b/static/src/javascripts/projects/common/modules/ui/dropdowns.js
@@ -68,7 +68,7 @@ const init = (): void => {
                     }) => {
                         if (isAnimated && 'ontransitionend' in window) {
                             fastdom
-                                .write(() => {
+                                .mutate(() => {
                                     container.style.pointerEvents = 'none';
                                     if (!isActive) {
                                         container.classList.toggle(
@@ -89,7 +89,7 @@ const init = (): void => {
                                             content,
                                             'transitionend',
                                             () => {
-                                                fastdom.write(() => {
+                                                fastdom.mutate(() => {
                                                     content.style.height =
                                                         'auto';
                                                     container.style.pointerEvents =
@@ -106,7 +106,7 @@ const init = (): void => {
                                     });
                                 });
                         } else {
-                            fastdom.write(() => {
+                            fastdom.mutate(() => {
                                 container.classList.toggle('dropdown--active');
                                 updateAria(container);
                             });

--- a/static/src/javascripts/projects/common/modules/ui/dropdowns.js
+++ b/static/src/javascripts/projects/common/modules/ui/dropdowns.js
@@ -25,7 +25,7 @@ const init = (): void => {
 
         if (container) {
             fastdom
-                .read(() => {
+                .measure(() => {
                     const documentElement: ?HTMLElement =
                         document.documentElement;
                     const content = container.querySelector(`.${contentCN}`);

--- a/static/src/javascripts/projects/common/modules/ui/faux-block-link.js
+++ b/static/src/javascripts/projects/common/modules/ui/faux-block-link.js
@@ -7,7 +7,7 @@ const overlaySelector = '.u-faux-block-link__overlay';
 const hoverStateClassName = 'u-faux-block-link--hover';
 
 const showIntentToClick = (e: Event): void => {
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         if ((e.currentTarget: any).parentElement) {
             (e.currentTarget: any).parentElement.classList.add(
                 hoverStateClassName
@@ -17,7 +17,7 @@ const showIntentToClick = (e: Event): void => {
 };
 
 const removeIntentToClick = (e: Event): void => {
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         if ((e.currentTarget: any).parentElement) {
             (e.currentTarget: any).parentElement.classList.remove(
                 hoverStateClassName

--- a/static/src/javascripts/projects/common/modules/ui/full-height.js
+++ b/static/src/javascripts/projects/common/modules/ui/full-height.js
@@ -17,7 +17,7 @@ const renderBlock = (state: Object): Promise<void> =>
         .then(() => {
             if (state.isMobile) {
                 return fastdom
-                    .read(() => state.$el.height())
+                    .measure(() => state.$el.height())
                     .then(height =>
                         fastdom.write(() => {
                             state.$el.css('height', height);
@@ -36,7 +36,7 @@ const getState = (): Promise<{
     elements: Array<HTMLElement>,
     isMobile: boolean,
 }> =>
-    fastdom.read(() => {
+    fastdom.measure(() => {
         const elements = Array.from(
             document.getElementsByClassName('js-is-fixed-height')
         );

--- a/static/src/javascripts/projects/common/modules/ui/full-height.js
+++ b/static/src/javascripts/projects/common/modules/ui/full-height.js
@@ -11,7 +11,7 @@ import { getBreakpoint } from 'lib/detect';
 
 const renderBlock = (state: Object): Promise<void> =>
     fastdom
-        .write(() => {
+        .mutate(() => {
             state.$el.css('height', '');
         })
         .then(() => {
@@ -19,7 +19,7 @@ const renderBlock = (state: Object): Promise<void> =>
                 return fastdom
                     .measure(() => state.$el.height())
                     .then(height =>
-                        fastdom.write(() => {
+                        fastdom.mutate(() => {
                             state.$el.css('height', height);
                         })
                     );

--- a/static/src/javascripts/projects/common/modules/ui/last-modified.js
+++ b/static/src/javascripts/projects/common/modules/ui/last-modified.js
@@ -12,14 +12,14 @@ const lastModified = (): void => {
             const { lastModifiedElm, webPublicationDateElm } = els;
 
             if (lastModifiedElm && webPublicationDateElm) {
-                fastdom.write(() => {
+                fastdom.mutate(() => {
                     webPublicationDateElm.classList.add(
                         'content__dateline-wpd--modified'
                     );
                 });
 
                 webPublicationDateElm.addEventListener('click', () => {
-                    fastdom.write(() => {
+                    fastdom.mutate(() => {
                         lastModifiedElm.classList.toggle('u-h');
                     });
                 });

--- a/static/src/javascripts/projects/common/modules/ui/last-modified.js
+++ b/static/src/javascripts/projects/common/modules/ui/last-modified.js
@@ -4,7 +4,7 @@ import fastdom from 'lib/fastdom-promise';
 
 const lastModified = (): void => {
     fastdom
-        .read(() => ({
+        .measure(() => ({
             lastModifiedElm: document.querySelector('.js-lm'),
             webPublicationDateElm: document.querySelector('.js-wpd'),
         }))

--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -78,7 +78,7 @@ const show = (): Promise<boolean> =>
 
         addCookie(COOKIE_IMPRESSION_KEY, String(impressions + 1));
 
-        fastdom.read(() => {
+        fastdom.measure(() => {
             const $banner = $('.site-message--ios, .site-message--android');
             const bannerHeight = $banner.dim().height;
             if (window.scrollY !== 0) {

--- a/static/src/javascripts/projects/common/modules/ui/sticky.js
+++ b/static/src/javascripts/projects/common/modules/ui/sticky.js
@@ -32,14 +32,14 @@ class Sticky {
             return;
         }
 
-        fastdom.read(() => {
+        fastdom.measure(() => {
             this.offsetFromParent =
                 this.element.getBoundingClientRect().top -
                 parentElement.getBoundingClientRect().top;
         }, this);
         mediator.on('window:throttledScroll', this.updatePosition.bind(this));
         // kick off an initial position update
-        fastdom.read(this.updatePosition, this);
+        fastdom.measure(this.updatePosition, this);
     }
 
     updatePosition(): void {

--- a/static/src/javascripts/projects/common/modules/ui/sticky.js
+++ b/static/src/javascripts/projects/common/modules/ui/sticky.js
@@ -84,7 +84,7 @@ class Sticky {
         }
 
         if (css) {
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 if (stick) {
                     this.element.classList.add('is-sticky');
                 } else {

--- a/static/src/javascripts/projects/common/modules/ui/tabs.js
+++ b/static/src/javascripts/projects/common/modules/ui/tabs.js
@@ -9,7 +9,7 @@ const NAV_CLASSES = [
 ];
 
 const getTabTarget = (tab: HTMLElement): Promise<?string> =>
-    fastdom.read(() => tab.getAttribute('href'));
+    fastdom.measure(() => tab.getAttribute('href'));
 
 const hidePane = (tab: HTMLElement, pane: HTMLElement): Promise<void> => {
     const tabList: HTMLElement = (tab.parentNode: any);
@@ -42,7 +42,7 @@ const showPane = (tab: HTMLElement, pane: HTMLElement): Promise<void> => {
 
 const init = (): Promise<void> => {
     const findTabs = (): Promise<Array<HTMLElement>> =>
-        fastdom.read(() => Array.from(document.querySelectorAll('.tabs')));
+        fastdom.measure(() => Array.from(document.querySelectorAll('.tabs')));
 
     return findTabs().then(tabs => {
         tabs.forEach(tab => {

--- a/static/src/javascripts/projects/common/modules/ui/tabs.js
+++ b/static/src/javascripts/projects/common/modules/ui/tabs.js
@@ -14,7 +14,7 @@ const getTabTarget = (tab: HTMLElement): Promise<?string> =>
 const hidePane = (tab: HTMLElement, pane: HTMLElement): Promise<void> => {
     const tabList: HTMLElement = (tab.parentNode: any);
 
-    return fastdom.write(() => {
+    return fastdom.mutate(() => {
         if (tabList) {
             tabList.setAttribute('aria-selected', 'false');
             NAV_CLASSES.forEach(className =>
@@ -29,7 +29,7 @@ const hidePane = (tab: HTMLElement, pane: HTMLElement): Promise<void> => {
 const showPane = (tab: HTMLElement, pane: HTMLElement): Promise<void> => {
     const tabList: HTMLElement = (tab.parentNode: any);
 
-    return fastdom.write(() => {
+    return fastdom.mutate(() => {
         if (tabList) {
             tabList.setAttribute('aria-selected', 'true');
             NAV_CLASSES.forEach(className => tabList.classList.add(className));
@@ -58,7 +58,7 @@ const init = (): Promise<void> => {
                 return;
             }
 
-            fastdom.write(() => {
+            fastdom.mutate(() => {
                 nav.setAttribute('data-tabs-initialized', 'true');
             });
 
@@ -98,7 +98,7 @@ const init = (): Promise<void> => {
                 }
             });
 
-            return fastdom.write(() => {
+            return fastdom.mutate(() => {
                 nav.setAttribute('data-tabs-initialized', 'true');
             });
         });

--- a/static/src/javascripts/projects/common/modules/video/video-container.js
+++ b/static/src/javascripts/projects/common/modules/video/video-container.js
@@ -122,12 +122,12 @@ const reducers = {
                 );
 
                 inview.on('firstview', elem => {
-                    fastdom.write(() => {
+                    fastdom.mutate(() => {
                         const dataSrc = elem.getAttribute('data-src');
                         const src = elem.getAttribute('src');
 
                         if (dataSrc && !src) {
-                            fastdom.write(() => {
+                            fastdom.mutate(() => {
                                 elem.setAttribute('src', dataSrc);
                             });
                         }
@@ -149,7 +149,7 @@ const fetchLazyImage = (container: Element, i: number): void => {
             })
             .then(src => {
                 if (src) {
-                    fastdom.write(() => {
+                    fastdom.mutate(() => {
                         el.setAttribute('src', src);
                     });
                 }
@@ -160,7 +160,7 @@ const fetchLazyImage = (container: Element, i: number): void => {
 const update = (state: State, container: Element): Promise<number> => {
     const translateWidth = -state.videoWidth * state.position;
 
-    return fastdom.write(() => {
+    return fastdom.mutate(() => {
         const activeEl = container.querySelector(
             '.video-playlist__item--active'
         );

--- a/static/src/javascripts/projects/common/modules/video/video-container.js
+++ b/static/src/javascripts/projects/common/modules/video/video-container.js
@@ -107,7 +107,7 @@ const reducers = {
         };
         makeYouTubeNonPlayableAtSmallBreakpoint(previousState);
 
-        fastdom.read(() => {
+        fastdom.measure(() => {
             // Lazy load images on scroll for mobile
             $('.js-video-playlist-image', previousState.container).each(el => {
                 const inview = elementInView(
@@ -142,7 +142,7 @@ const reducers = {
 const fetchLazyImage = (container: Element, i: number): void => {
     $(`.js-video-playlist-image--${i}`, container).each(el => {
         fastdom
-            .read(() => {
+            .measure(() => {
                 const dataSrc = el.getAttribute('data-src');
                 const src = el.getAttribute('src');
                 return dataSrc && !src ? dataSrc : null;

--- a/static/src/javascripts/projects/facia/modules/ui/container-show-more.js
+++ b/static/src/javascripts/projects/facia/modules/ui/container-show-more.js
@@ -140,7 +140,7 @@ class Button {
     }
 
     loadShowMoreForContainer(): void {
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             this.setState(DISPLAY_STATE.loading);
         });
 
@@ -153,7 +153,7 @@ class Button {
                     dedupedShowMore = dedupShowMore(this.$container, html);
                 }
 
-                fastdom.write(() => {
+                fastdom.mutate(() => {
                     if (dedupedShowMore) {
                         this.$placeholder.replaceWith(dedupedShowMore);
                     }
@@ -164,7 +164,7 @@ class Button {
                 this.isLoaded = true;
             })
             .catch(err => {
-                fastdom.write(() => {
+                fastdom.mutate(() => {
                     this.setState(DISPLAY_STATE.hidden);
                 });
 
@@ -180,7 +180,7 @@ class Button {
     }
 
     hideErrorMessage(): void {
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             if (this.$errorMessage != null) {
                 this.$errorMessage.addClass(
                     'show-more__error-message--invisible'
@@ -202,7 +202,7 @@ class Button {
             )
         );
 
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             if (this.$errorMessage != null) {
                 this.$errorMessage.insertAfter(this.$el);
 
@@ -215,7 +215,7 @@ class Button {
 }
 
 const showMore = (button: Button): void => {
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         /**
          * Do not remove: it should retain context for the click stream module, which recurses upwards through
          * DOM nodes.
@@ -230,7 +230,7 @@ const showMore = (button: Button): void => {
 };
 
 const renderToDom = (button: Button): void => {
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         button.$container
             .addClass(HIDDEN_CLASS_NAME)
             .removeClass('js-container--fc-show-more')

--- a/static/src/javascripts/projects/facia/modules/ui/container-show-more.js
+++ b/static/src/javascripts/projects/facia/modules/ui/container-show-more.js
@@ -244,7 +244,7 @@ const renderToDom = (button: Button): void => {
 };
 
 export const init = (): void => {
-    fastdom.read(() => {
+    fastdom.measure(() => {
         const containers = qwery('.js-container--fc-show-more').map(bonzo);
         const buttons = containers
             .map(container => {

--- a/static/src/javascripts/projects/facia/modules/ui/container-toggle.js
+++ b/static/src/javascripts/projects/facia/modules/ui/container-toggle.js
@@ -59,7 +59,7 @@ export class ContainerToggle {
     setState(newState: ToggleState): void {
         this.state = newState;
 
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             // add/remove rolled class
             this.$container[
                 this.state === 'displayed' ? 'removeClass' : 'addClass'
@@ -86,7 +86,7 @@ export class ContainerToggle {
         const id = this.$container.attr('data-id');
         const $containerHeader = $('.js-container__header', this.$container[0]);
 
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             $containerHeader.append(this.$button);
             this.$container
                 .removeClass('js-container--toggle')

--- a/static/src/javascripts/projects/facia/modules/ui/container-toggle.spec.js
+++ b/static/src/javascripts/projects/facia/modules/ui/container-toggle.spec.js
@@ -57,7 +57,7 @@ describe('Container Toggle', () => {
         const toggle = new ContainerToggle(container);
         toggle.addToggle();
 
-        fastdom.defer(1, () => {
+        fastdom.mutate(() => {
             expect($container.hasClass('js-container--toggle')).toBeFalsy();
             done();
         });
@@ -67,7 +67,7 @@ describe('Container Toggle', () => {
         const toggle = new ContainerToggle(container);
         toggle.addToggle();
 
-        fastdom.defer(1, () => {
+        fastdom.mutate(() => {
             expect(
                 $container.hasClass('fc-container--will-have-toggle')
             ).toBeFalsy();
@@ -79,7 +79,7 @@ describe('Container Toggle', () => {
         const toggle = new ContainerToggle(container);
         toggle.addToggle();
 
-        fastdom.defer(1, () => {
+        fastdom.mutate(() => {
             expect(
                 $container.hasClass('fc-container--has-toggle')
             ).toBeTruthy();
@@ -91,7 +91,7 @@ describe('Container Toggle', () => {
         const toggle = new ContainerToggle(container);
         toggle.addToggle();
 
-        fastdom.defer(1, () => {
+        fastdom.mutate(() => {
             expect(
                 $('.js-container__header .fc-container__toggle', container)
                     .length
@@ -104,7 +104,7 @@ describe('Container Toggle', () => {
         const toggle = new ContainerToggle(container);
         toggle.addToggle();
 
-        fastdom.defer(1, () => {
+        fastdom.mutate(() => {
             assertState($container, 'open');
             done();
         });
@@ -114,10 +114,10 @@ describe('Container Toggle', () => {
         const toggle = new ContainerToggle(container);
         toggle.addToggle();
 
-        fastdom.defer(1, () => {
+        fastdom.mutate(() => {
             simulateClick();
 
-            fastdom.defer(1, () => {
+            fastdom.mutate(() => {
                 assertState($container, 'closed');
                 done();
             });
@@ -129,19 +129,19 @@ describe('Container Toggle', () => {
         toggle.addToggle();
 
         // click button
-        fastdom.defer(1, () => {
+        fastdom.mutate(() => {
             simulateClick();
 
             const expectedValue = {};
             expectedValue[containerId] = 'closed';
 
-            fastdom.defer(1, () => {
+            fastdom.mutate(() => {
                 expect(userPrefs.get(storageId)).toEqual(expectedValue);
 
                 // now close container
                 simulateClick();
 
-                fastdom.defer(1, () => {
+                fastdom.mutate(() => {
                     expect(userPrefs.get(storageId)).toEqual({});
 
                     done();
@@ -157,7 +157,7 @@ describe('Container Toggle', () => {
         const toggle = new ContainerToggle(container);
         toggle.addToggle();
 
-        fastdom.defer(1, () => {
+        fastdom.mutate(() => {
             assertState($container, 'closed');
             done();
         });

--- a/static/src/javascripts/projects/facia/modules/ui/lazy-load-containers.js
+++ b/static/src/javascripts/projects/facia/modules/ui/lazy-load-containers.js
@@ -41,7 +41,7 @@ export const lazyLoadContainers = (): void => {
 
                 containers = containersInRange.out;
 
-                fastdom.write(() => {
+                fastdom.mutate(() => {
                     containersInRange.in.forEach(displayContainer);
                 });
             });

--- a/static/src/javascripts/projects/facia/modules/ui/lazy-load-containers.js
+++ b/static/src/javascripts/projects/facia/modules/ui/lazy-load-containers.js
@@ -25,7 +25,7 @@ export const lazyLoadContainers = (): void => {
         if (containers.length === 0) {
             mediator.off('window:throttledScroll', lazyLoad);
         } else {
-            fastdom.read(() => {
+            fastdom.measure(() => {
                 const containersInRange = containers.reduce(
                     (result, container) => {
                         result[withinRange(container) ? 'in' : 'out'].push(

--- a/static/src/javascripts/projects/facia/modules/ui/live-blog-updates.js
+++ b/static/src/javascripts/projects/facia/modules/ui/live-blog-updates.js
@@ -75,7 +75,7 @@ const maybeAnimateBlocks = (
     immediate?: boolean
 ): Promise<boolean> =>
     fastdomPromise
-        .read(() => el.getBoundingClientRect().top)
+        .measure(() => el.getBoundingClientRect().top)
         .then(vPosition => {
             const isVisible = vPosition > 0 && vPosition < viewportHeightPx;
 
@@ -232,7 +232,7 @@ const sanitizeBlocks = (blocks: Array<Block>): Array<Block> =>
 
 const showUpdatesFromLiveBlog = (): Promise<void> =>
     fastdomPromise
-        .read(() => {
+        .measure(() => {
             const elementsById: Map<string, Array<Element>> = new Map();
 
             // For each liveblock block

--- a/static/src/javascripts/projects/facia/modules/ui/live-blog-updates.js
+++ b/static/src/javascripts/projects/facia/modules/ui/live-blog-updates.js
@@ -81,7 +81,7 @@ const maybeAnimateBlocks = (
 
             if (isVisible) {
                 timeoutPromise(immediate ? 0 : animateDelayMs).then(() =>
-                    fastdomPromise.write(() =>
+                    fastdomPromise.mutate(() =>
                         el.classList.remove(
                             'fc-item__liveblog-blocks__inner--offset'
                         )
@@ -113,7 +113,7 @@ const animateBlocks = (el: Element, container: Element): void => {
         }
     });
 
-    fastdomPromise.write(() => {
+    fastdomPromise.mutate(() => {
         container.classList.remove('fc-item__liveblog-blocks--hidden');
         container.classList.add('fc-item__liveblog-blocks--visible');
     });
@@ -123,7 +123,7 @@ const applyUpdate = (
     container: Element,
     content: Array<Element>
 ): Promise<void> =>
-    fastdomPromise.write(() => {
+    fastdomPromise.mutate(() => {
         bonzo(container)
             .empty()
             .append(content);

--- a/static/src/javascripts/projects/facia/modules/ui/snaps.js
+++ b/static/src/javascripts/projects/facia/modules/ui/snaps.js
@@ -73,7 +73,7 @@ const setSnapPoint = (el: HTMLElement, isResize: boolean): void => {
         width = el.offsetWidth;
     });
 
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         breakpoints
             .map((breakpoint, i, arr) => {
                 const isAdd =
@@ -124,7 +124,7 @@ const injectIframe = (el: HTMLElement): void => {
     snapIframes.push(iframe);
     bindIframeMsgReceiverOnce();
 
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         bonzo(el)
             .empty()
             .append(containerEl);
@@ -151,7 +151,7 @@ const fetchFragment = (el: HTMLElement, asJson: boolean = false): void => {
         })
         .then(resp => {
             $.create(resp).each(html => {
-                fastdom.write(() => {
+                fastdom.mutate(() => {
                     bonzo(el).html(html);
                 });
             });
@@ -166,7 +166,7 @@ const fetchFragment = (el: HTMLElement, asJson: boolean = false): void => {
 
 const initStandardSnap = (el: HTMLElement): void => {
     addProximityLoader(el, 1500, () => {
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             bonzo(el).addClass('facia-snap-embed');
         });
         addCss(el);

--- a/static/src/javascripts/projects/facia/modules/ui/snaps.js
+++ b/static/src/javascripts/projects/facia/modules/ui/snaps.js
@@ -69,7 +69,7 @@ const setSnapPoint = (el: HTMLElement, isResize: boolean): void => {
         },
     ];
 
-    fastdom.read(() => {
+    fastdom.measure(() => {
         width = el.offsetWidth;
     });
 

--- a/static/src/javascripts/projects/journalism/modules/audio-series-add-contributions.js
+++ b/static/src/javascripts/projects/journalism/modules/audio-series-add-contributions.js
@@ -10,7 +10,7 @@ const renderContributionsBanner = el => {
         supportContributeURL: supportContributeURL(),
     });
 
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         el.insertAdjacentHTML('afterend', banner);
     });
 };

--- a/static/src/javascripts/projects/journalism/modules/render-campaign.js
+++ b/static/src/javascripts/projects/journalism/modules/render-campaign.js
@@ -10,7 +10,7 @@ const renderCampaign = (calloutNode: HTMLElement, calloutData): void => {
     const campaignDiv = `<figure class="element element-campaign">${campaign}</figure>`;
 
     fastdom
-        .write(() => {
+        .mutate(() => {
             calloutNode.innerHTML = campaignDiv;
         })
         .then(() => {

--- a/static/src/javascripts/projects/journalism/modules/submit-form.js
+++ b/static/src/javascripts/projects/journalism/modules/submit-form.js
@@ -18,7 +18,7 @@ const enableButton = cForm => {
 
 const showConfirmation = cForm => {
     const calloutWrapper = cForm.closest('.element-campaign');
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         calloutWrapper.classList.add('success');
     });
 };
@@ -26,7 +26,7 @@ const showConfirmation = cForm => {
 const showWaiting = cForm => {
     const button = cForm.querySelector('button');
     const errorField = cForm.querySelector('.error_box');
-    fastdom.write(() => {
+    fastdom.mutate(() => {
         button.textContent = 'Sending...';
         button.disabled = true;
         errorField.innerHTML = '';
@@ -36,7 +36,7 @@ const showWaiting = cForm => {
 const showError = (cForm: HTMLElement, msg: string) => {
     const errorField = cForm.querySelector('.error_box');
     if (errorField) {
-        fastdom.write(() => {
+        fastdom.mutate(() => {
             errorField.innerHTML = `<p class="error">${msg}</p>`;
         });
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5755,9 +5755,12 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-fastdom@0.8.5:
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/fastdom/-/fastdom-0.8.5.tgz#4066d73a8a7ca9d9ee6cef103043aa1a0e2f19dd"
+fastdom@1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/fastdom/-/fastdom-1.0.9.tgz#b395fab11a3701173c02a054fe769d8f596a0a26"
+  integrity sha512-SSp4fbVzu8JkkG01NUX+0iOwe9M5PN3MGIQ84txLf4TkkJG4q30khkzumKgi4hUqO1+jX6wLHfnCPoZ6eSZ6Tg==
+  dependencies:
+    strictdom "^1.0.1"
 
 fastparse@^1.1.1:
   version "1.1.1"
@@ -11738,6 +11741,11 @@ stream-to-observable@^0.2.0:
   resolved "https://registry.yarnpkg.com/stream-to-observable/-/stream-to-observable-0.2.0.tgz#59d6ea393d87c2c0ddac10aa0d561bc6ba6f0e10"
   dependencies:
     any-observable "^0.2.0"
+
+strictdom@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/strictdom/-/strictdom-1.0.1.tgz#189de91649f73d44d59b8432efa68ef9d2659460"
+  integrity sha1-GJ3pFkn3PUTVm4Qy76aO+dJllGA=
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## What does this change?

- updates fastdom to latest version (`0.8.5` to `1.0.9`)
- uses fastdom's new native promisifying for `fastdom-promisify`
- fixes some seemingly unrelated tests that now appeared broken for me. i'm not sure how they were passing before...
  - `projects/common/modules/identity/modules/switch.spec.js`
  - `projects/commercial/modules/hosted/onward-journey-carousel.spec.js`

## Why?

was looking to move `fastdom-promisify` to libs and/or use `fastdom` as a peerDep in [commercial-core](https://github.com/guardian/commercial-core), and as i went to install it I realised the entire api had changed since we last updated it. 

we're missing out on fixes (and types) and it would be valuable to be able to declare it as an up-to-date peerDep soon

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No


