### PR TITLE
Set up new design templates and styles

### DIFF
--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -45,7 +45,7 @@
                         <input class="newsletter-card__text-input u-h"
                           type="text"
                           name="name"
-                          autocomplete="nope"/>
+                          autocomplete="off"/>
                         <input class="newsletter-card__text-input js-newsletter-card__text-input"
                           type="email"
                           name="email"

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -61,6 +61,6 @@ object NewsletterEmbedDesign
       name = "new-newsletter-embed-designs",
       description = "New newsletter signup embeds for discoverability OKR",
       owners = Seq(Owner.withGithub("buck06191")),
-      sellByDate = new LocalDate(2020, 11, 1),
+      sellByDate = new LocalDate(2020, 11, 2),
       participationGroup = Perc0C,
     )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -12,6 +12,7 @@ object ActiveExperiments extends ExperimentsDefinition {
     DotcomRendering,
     DCRBubble,
     NGInteractiveDCR,
+    NewsletterEmbedDesign,
   )
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -53,4 +54,13 @@ object NGInteractiveDCR
       owners = Seq(Owner.withGithub("shtukas")),
       sellByDate = new LocalDate(2021, 6, 1),
       participationGroup = Perc0B,
+    )
+
+object NewsletterEmbedDesign
+    extends Experiment(
+      name = "new-newsletter-embed-designs",
+      description = "New newsletter signup embeds for discoverability OKR",
+      owners = Seq(Owner.withGithub("buck06191")),
+      sellByDate = new LocalDate(2020, 11, 1),
+      participationGroup = Perc0C,
     )

--- a/common/app/views/emailEmbed.scala.html
+++ b/common/app/views/emailEmbed.scala.html
@@ -35,4 +35,8 @@
     <body>
         @body
     </body>
+    <script src="https://interactive.guim.co.uk/libs/iframe-messenger/iframeMessenger.js"></script>
+    <script>
+        iframeMessenger.enableAutoResize();
+    </script>
 </html>

--- a/common/app/views/emailFragment.scala.html
+++ b/common/app/views/emailFragment.scala.html
@@ -2,8 +2,10 @@
 @import experiments.{ActiveExperiments, NewsletterEmbedDesign}
 @(page: model.Page, emailType: String, listName: String, emailEmbedData: EmailEmbed)(implicit request: RequestHeader, context: model.ApplicationContext)
 
+@electionNewsletters = @{List("minute-us", "us-morning-newsletter", "today-us", "green-light")}
+
 @emailEmbed(page) {
-    @if(ActiveExperiments.isParticipating(NewsletterEmbedDesign)){
+    @if(ActiveExperiments.isParticipating(NewsletterEmbedDesign) && electionNewsletters.contains(listName)){
         @fragments.email.signup.emailSignUpNewDesign(
             emailType,
             listName,

--- a/common/app/views/emailFragment.scala.html
+++ b/common/app/views/emailFragment.scala.html
@@ -2,7 +2,7 @@
 @(page: model.Page, emailType: String, listName: String, emailEmbedData: EmailEmbed)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @emailEmbed(page) {
-    @fragments.email.signup.emailSignUp(
+    @fragments.email.signup.emailSignUpNewDesign(
         emailType,
         listName,
         emailEmbedData

--- a/common/app/views/emailFragment.scala.html
+++ b/common/app/views/emailFragment.scala.html
@@ -1,10 +1,20 @@
 @import com.gu.identity.model.EmailEmbed
+@import experiments.{ActiveExperiments, NewsletterEmbedDesign}
 @(page: model.Page, emailType: String, listName: String, emailEmbedData: EmailEmbed)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @emailEmbed(page) {
-    @fragments.email.signup.emailSignUpNewDesign(
-        emailType,
-        listName,
-        emailEmbedData
-    )
+    @if(ActiveExperiments.isParticipating(NewsletterEmbedDesign)){
+        @fragments.email.signup.emailSignUpNewDesign(
+            emailType,
+            listName,
+            emailEmbedData
+        )
+    } else {
+      @fragments.email.signup.emailSignUp(
+          emailType,
+          listName,
+          emailEmbedData
+        )
+    }
+
 }

--- a/common/app/views/fragments/email/signup/emailIframe.scala.html
+++ b/common/app/views/fragments/email/signup/emailIframe.scala.html
@@ -7,6 +7,6 @@
     src="@{"/email/form/" + formType + "/" + listName}"
     scrolling="no" seamless
     id="@{formType + "__email-form"}" frameborder="0"
-    class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe"
+    class="iframed--overflow-hidden email-sub__iframe"
 ></iframe>
 

--- a/common/app/views/fragments/email/signup/emailSignUpNewDesign.scala.html
+++ b/common/app/views/fragments/email/signup/emailSignUpNewDesign.scala.html
@@ -1,0 +1,83 @@
+@import com.gu.identity.model.EmailEmbed
+@(  componentClass: String,
+    listName:String,
+    emailEmbedData: EmailEmbed)(implicit request: RequestHeader)
+
+@import common.LinkTo
+
+
+@formId = @{ componentClass + "-newsletter-embed-form" }
+@dummyInputId = @{ componentClass + "-email-sub-input-name" }
+
+@wrapperClass = @{ "newsletter-embed" + " newsletter-embed--" + componentClass  }
+@formClass = @{ "newsletter-embed__form" + " newsletter-embed__form--" + componentClass }
+
+@imageAltText = @{s"${emailEmbedData.name} profile image"}
+
+
+@form = {
+    <form action="@LinkTo(s"/email/$listName")" method="post" id="@formId" class="@formClass" data-email-form-type="@componentClass" data-email-list-name="@listName">
+        @helper.CSRF.formField
+
+        <div class="newsletter-embed__form-wrapper">
+            <label for="newsletter-embed__input">
+                <span>Enter your email address</span>
+            </label>
+
+            <input
+            class="newsletter-embed__input"
+            type="email"
+            name="email"
+            id="newsletter-embed__input"
+            required />
+            <input
+            class="email-sub__text-input u-h"
+            autocomplete="nope"
+            type="text"
+            name="name"
+            id="@dummyInputId"
+            placeholder="Name" />
+            <input class="email-sub__listname-input" type="hidden" name="listName" value="@listName" />
+
+
+            <button
+            type="submit"
+            class="newsletter-embed__submit-button"
+            data-component="email-signup-button @componentClass-@listName--newDesign"
+            data-link-name="@componentClass | @listName">
+                Sign up
+            </button>
+            <a class="newsletter-embed__privacy-policy" href="#privacy-policy">
+                Read our privacy policy here
+            </a>
+        </div>
+    </form>
+}
+
+
+<div class="@wrapperClass" style="background-color: @emailEmbedData.hexCode">
+    @if(emailEmbedData.imageUrl.nonEmpty){
+        <aside class="newsletter-embed__image">
+            <img
+            src="@emailEmbedData.imageUrl"
+            alt="@imageAltText"/>
+        </aside>
+    }
+    <div class="newsletter-embed__body">
+        <section class="newsletter-embed__summary">
+            <h2 class="newsletter-embed__headline">
+                @{emailEmbedData.title}
+            </h2>
+            <p class="newsletter-embed__description">
+                @{emailEmbedData.description}
+            </p>
+        </section>
+        <section class="newsletter-embed__signup">
+            @form
+        </section>
+</div>
+
+<script>
+    trackClickEvent(document.getElementById("email-embed-signup-button"))
+</script>
+

--- a/common/app/views/fragments/email/signup/emailSignUpNewDesign.scala.html
+++ b/common/app/views/fragments/email/signup/emailSignUpNewDesign.scala.html
@@ -65,9 +65,11 @@
     }
     <div class="newsletter-embed__body">
         <section class="newsletter-embed__summary">
+          <div class="newsletter-embed__headline-wrapper">
             <h2 class="newsletter-embed__headline">
                 @{emailEmbedData.title}
             </h2>
+          </div>
             <p class="newsletter-embed__description">
                 @{emailEmbedData.description}
             </p>

--- a/common/app/views/fragments/email/signup/emailSignUpNewDesign.scala.html
+++ b/common/app/views/fragments/email/signup/emailSignUpNewDesign.scala.html
@@ -32,7 +32,7 @@
             required />
             <input
             class="email-sub__text-input u-h"
-            autocomplete="nope"
+            autocomplete="off"
             type="text"
             name="name"
             id="@dummyInputId"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.231-SNAPSHOT"
+  val identityLibVersion = "3.231"
   val awsVersion = "1.11.240"
   val capiVersion = "17.2"
   val faciaVersion = "3.2.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.231"
+  val identityLibVersion = "3.232"
   val awsVersion = "1.11.240"
   val capiVersion = "17.2"
   val faciaVersion = "3.2.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.230"
+  val identityLibVersion = "3.231-SNAPSHOT"
   val awsVersion = "1.11.240"
   val capiVersion = "17.2"
   val faciaVersion = "3.2.0"

--- a/static/src/javascripts/bootstraps/standard/emailEmbeds.js
+++ b/static/src/javascripts/bootstraps/standard/emailEmbeds.js
@@ -1,0 +1,33 @@
+// @flow
+
+import config from 'lib/config';
+
+const initEmbedResize = () => {
+    const iframes: HTMLIFrameElement[] = ([
+        ...document.querySelectorAll('.element-embed > .email-sub__iframe'),
+    ]: any);
+
+    window.addEventListener('message', event => {
+        const iframe: ?HTMLIFrameElement = iframes.find(i => {
+            try {
+                return i.src === event.source.location.href;
+            } catch (e) {
+                return false;
+            }
+        });
+        if (iframe) {
+            try {
+                const message = JSON.parse(event.data);
+                switch (message.type) {
+                    case 'set-height':
+                        iframe.height = message.value;
+                        break;
+                    default:
+                }
+                // eslint-disable-next-line no-empty
+            } catch (e) {
+            }
+        }
+    });
+};
+export { initEmbedResize };

--- a/static/src/javascripts/bootstraps/standard/emailEmbeds.js
+++ b/static/src/javascripts/bootstraps/standard/emailEmbeds.js
@@ -1,26 +1,26 @@
 // @flow
 
-import config from 'lib/config';
-
 const initEmbedResize = () => {
-    const iframes: HTMLIFrameElement[] = ([
+    const allIframes: HTMLIFrameElement[] = ([
         ...document.querySelectorAll('.element-embed > .email-sub__iframe'),
     ]: any);
 
     window.addEventListener('message', event => {
-        const iframe: ?HTMLIFrameElement = iframes.find(i => {
+        const iframes: HTMLIFrameElement[] = allIframes.filter(i => {
             try {
                 return i.src === event.source.location.href;
             } catch (e) {
                 return false;
             }
         });
-        if (iframe) {
+        if (iframes.length !== 0) {
             try {
                 const message = JSON.parse(event.data);
                 switch (message.type) {
                     case 'set-height':
-                        iframe.height = message.value;
+                        iframes.forEach( iframe => {
+                            iframe.height = message.value;
+                        })
                         break;
                     default:
                 }

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -39,6 +39,7 @@ import { trackPerformance } from 'common/modules/analytics/google';
 import debounce from 'lodash/debounce';
 import ophan from 'ophan/ng';
 import { initAtoms } from './atoms';
+import { initEmbedResize } from "./emailEmbeds";
 
 const setAdTestCookie = (): void => {
     const queryParams = getUrlVars();
@@ -271,6 +272,8 @@ const bootStandard = (): void => {
     }
 
     initAtoms();
+
+    initEmbedResize();
 
     showHiringMessage();
 

--- a/static/src/stylesheets/module/email-signup/_form.scss
+++ b/static/src/stylesheets/module/email-signup/_form.scss
@@ -13,6 +13,7 @@
     // adjustments, off grid, based on element font-size
     width: calc(100% + #{$rounded-adjustment});
     margin-left: -#{$rounded-adjustment / 2};
+    min-height: 260px; // TODO: remove and replace with javascript
 }
 
 .email-sub__form {

--- a/static/src/stylesheets/module/email-signup/_form.scss
+++ b/static/src/stylesheets/module/email-signup/_form.scss
@@ -13,7 +13,6 @@
     // adjustments, off grid, based on element font-size
     width: calc(100% + #{$rounded-adjustment});
     margin-left: -#{$rounded-adjustment / 2};
-    min-height: 260px; // TODO: remove and replace with javascript
 }
 
 .email-sub__form {

--- a/static/src/stylesheets/module/email-signup/_main.scss
+++ b/static/src/stylesheets/module/email-signup/_main.scss
@@ -1,3 +1,4 @@
 @import 'vars';
 @import 'form';
 @import 'header';
+@import 'newDesign';

--- a/static/src/stylesheets/module/email-signup/_newDesign.scss
+++ b/static/src/stylesheets/module/email-signup/_newDesign.scss
@@ -29,17 +29,29 @@ $mobile-img-size: 100px;
     font-family: 'Guardian Egyptian Web', Georgia, serif;
 }
 
+.newsletter-embed__headline-wrapper {
+    margin: 0 0 $base-margin;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    height: $mobile-img-size;
+}
+
+.newsletter-embed__image + .newsletter-embed__headline-wrapper {
+    padding-left: $base-margin;
+}
+
 .newsletter-embed__headline {
     font-size: 24px;
     font-weight: 700;
     line-height: 1;
-    margin: 0 0 $base-margin;
 }
 
 .newsletter-embed__description {
     /* Small hack to get description to go under image if close to fitting under */
     padding-top: 2px;
     font-size: 16px;
+    clear: left;
 }
 
 /* Sign up Form */
@@ -111,8 +123,18 @@ $mobile-img-size: 100px;
         margin: auto;
     }
 
+    .newsletter-embed__headline-wrapper {
+        display: block;
+        height: auto;
+        padding-left: 0;
+    }
+
     .newsletter-embed__headline {
         font-size: 30px;
+    }
+
+    .newsletter-embed__description {
+        clear: none;
     }
 
     .newsletter-embed__image + .newsletter-embed__body {

--- a/static/src/stylesheets/module/email-signup/_newDesign.scss
+++ b/static/src/stylesheets/module/email-signup/_newDesign.scss
@@ -3,6 +3,7 @@
 $base-margin: 8px;
 $desktop-img-size: 200px;
 $mobile-headline-font-size: 24px;
+$mobile-description-font-size: 16px;
 $mobile-img-size: 3 * $mobile-headline-font-size;
 
 .newsletter-embed {
@@ -15,7 +16,7 @@ $mobile-img-size: 3 * $mobile-headline-font-size;
 .newsletter-embed__image {
     max-width: $mobile-img-size;
     float: right;
-    margin: $base-margin;
+    margin: $base-margin $base-margin 0;
 }
 
 .newsletter-embed__image img {
@@ -43,9 +44,9 @@ $mobile-img-size: 3 * $mobile-headline-font-size;
 }
 
 .newsletter-embed__headline {
-    font-size: 24px;
+    font-size: $mobile-headline-font-size;
     font-weight: 700;
-    line-height: 1;
+    line-height: 110%;
 }
 
 .newsletter-embed__description {
@@ -53,13 +54,14 @@ $mobile-img-size: 3 * $mobile-headline-font-size;
     padding-top: 2px;
     font-size: 16px;
     clear: left;
+    line-height: 120%;
 }
 
 /* Sign up Form */
 .newsletter-embed__form {
     clear: left;
-    font-size: 16px;
-    font-family: 'Guardian Text Sans Web', SansSerif;
+    font-size: $mobile-description-font-size;
+    font-family: 'Guardian Text Sans Web', sans-serif;
 }
 
 .newsletter-embed__form-wrapper {
@@ -98,16 +100,18 @@ $mobile-img-size: 3 * $mobile-headline-font-size;
     border-radius: 62.5rem;
     grid-area: button;
     margin-left: 15px;
-    font-size: 16px;
+    font-size: $mobile-description-font-size;
     font-weight: bold;
+    font-family: 'Guardian Text Sans Web', sans-serif;
+    line-height: 100%;
 }
 
 .newsletter-embed__privacy-policy {
     grid-area: privacy-link;
     align-self: end;
     font-size: 12px;
-    font-family: 'Guardian Text Sans', Sans-Serif;
     font-weight: normal;
+    color: black;
 }
 
 

--- a/static/src/stylesheets/module/email-signup/_newDesign.scss
+++ b/static/src/stylesheets/module/email-signup/_newDesign.scss
@@ -2,7 +2,8 @@
 
 $base-margin: 8px;
 $desktop-img-size: 200px;
-$mobile-img-size: 100px;
+$mobile-headline-font-size: 24px;
+$mobile-img-size: 3 * $mobile-headline-font-size;
 
 .newsletter-embed {
     * {
@@ -13,7 +14,7 @@ $mobile-img-size: 100px;
 }
 .newsletter-embed__image {
     max-width: $mobile-img-size;
-    float: left;
+    float: right;
     margin: $base-margin;
 }
 
@@ -33,7 +34,7 @@ $mobile-img-size: 100px;
     margin: 0 0 $base-margin;
     display: flex;
     flex-direction: column;
-    justify-content: center;
+    justify-content: start;
     height: $mobile-img-size;
 }
 
@@ -116,6 +117,7 @@ $mobile-img-size: 100px;
 
     .newsletter-embed__image {
         max-width: $desktop-img-size;
+        float: left;
     }
 
     .newsletter-embed__form {

--- a/static/src/stylesheets/module/email-signup/_newDesign.scss
+++ b/static/src/stylesheets/module/email-signup/_newDesign.scss
@@ -1,0 +1,126 @@
+/* Newsletter Description */
+
+$base-margin: 8px;
+$desktop-img-size: 200px;
+$mobile-img-size: 100px;
+
+.newsletter-embed {
+    * {
+        box-sizing: border-box;
+    }
+    height: 100%;
+    overflow: hidden;
+}
+.newsletter-embed__image {
+    max-width: $mobile-img-size;
+    float: left;
+    margin: $base-margin;
+}
+
+.newsletter-embed__image img {
+    width: 100%;
+}
+
+.newsletter-embed__body {
+    margin: $base-margin;
+}
+
+.newsletter-embed__summary {
+    font-family: 'Guardian Egyptian Web', Georgia, serif;
+}
+
+.newsletter-embed__headline {
+    font-size: 24px;
+    font-weight: 700;
+    line-height: 1;
+    margin: 0 0 $base-margin;
+}
+
+.newsletter-embed__description {
+    /* Small hack to get description to go under image if close to fitting under */
+    padding-top: 2px;
+    font-size: 16px;
+}
+
+/* Sign up Form */
+.newsletter-embed__form {
+    clear: left;
+    font-size: 16px;
+    font-family: 'Guardian Text Sans Web', SansSerif;
+}
+
+.newsletter-embed__form-wrapper {
+    max-width: 500px;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: auto;
+    grid-template-areas:
+    'label label . '
+    'input input button'
+    'privacy-link privacy-link .';
+    justify-items: start;
+}
+
+.newsletter-embed__form label {
+    grid-area: label;
+    align-self: end;
+    font-weight: bold;
+}
+
+.newsletter-embed__input {
+    border: 2px solid #808080;
+    background: #ffffff;
+    outline: 0;
+    grid-area: input;
+    width: 100%;
+    height: 2rem;
+}
+
+
+.newsletter-embed__submit-button {
+    color: #ffffff;
+    background-color: #000000;
+    border: 0;
+    width: 75px;
+    border-radius: 62.5rem;
+    grid-area: button;
+    margin-left: 15px;
+    font-size: 16px;
+    font-weight: bold;
+}
+
+.newsletter-embed__privacy-policy {
+    grid-area: privacy-link;
+    align-self: end;
+    font-size: 12px;
+    font-family: 'Guardian Text Sans', Sans-Serif;
+    font-weight: normal;
+}
+
+
+/* Desktop View */
+
+@media screen and (min-device-width: 600px) and (-webkit-min-device-pixel-ratio: 1) {
+
+    .newsletter-embed__image {
+        max-width: $desktop-img-size;
+    }
+
+    .newsletter-embed__form {
+        clear: none;
+        margin: auto;
+    }
+
+    .newsletter-embed__headline {
+        font-size: 30px;
+    }
+
+    .newsletter-embed__image + .newsletter-embed__body {
+        min-height: calc(#{$base-margin} + #{$desktop-img-size});
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+    }
+
+}

--- a/static/src/stylesheets/module/email-signup/_newDesign.scss
+++ b/static/src/stylesheets/module/email-signup/_newDesign.scss
@@ -111,7 +111,7 @@ $mobile-img-size: 3 * $mobile-headline-font-size;
     align-self: end;
     font-size: 12px;
     font-weight: normal;
-    color: black;
+    color: #000000;
 }
 
 


### PR DESCRIPTION
## What does this change?
Implements new designs for newsletter embeds for the Newsletters Discoverability OKR.

Requires https://github.com/guardian/identity/pull/1833 to be merged and released. **NOTE: This release has upgraded Play, blocking this work until fixed.**

### Questions:
 - Should the CSS be inlined into the iframe? Will this make it more reliable across platform in terms of appearance and behaviour?

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)
  Only the dynamic resizing I believe, which also needs looking at on apps.

## Screenshots

### Mobile Size
![mobile-embed](https://user-images.githubusercontent.com/9122944/95357130-66b75a00-08bf-11eb-89fb-b86c09345857.gif)

### Desktop(Responsive)
![desktop-responsive-embed](https://user-images.githubusercontent.com/9122944/95357101-5dc68880-08bf-11eb-96ee-c6011853bfac.gif)


## What is the value of this and can you measure success?
Improve discoverability as part of OKR

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [x] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
