### PR TITLE
remove RR from admin page

### DIFF
--- a/admin/app/views/admin.scala.html
+++ b/admin/app/views/admin.scala.html
@@ -107,13 +107,12 @@
         <div>
             <div class="panel panel-default well--front">
                 <div class="panel-heading">
-                    <h3>Commercial & RR Tools</h3>
+                    <h3>Commercial</h3>
                     Tools for the teams that make money
                 </div>
                 <div class="panel-body">
                     <ul class="nav nav-pills nav-stacked nav-bleed">
                         <li><a href="@controllers.admin.routes.CommercialController.renderCommercialMenu()">Commercial Tools</a></li>
-                        <li><a href="@controllers.admin.routes.ReaderRevenueAdminController.renderReaderRevenueMenu()">Reader Revenue Tools</a></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
The banner deploy had stopped working.
We have moved the deploy timestamp files to the membership aws account, so this needs to be removed from the UI now.

TODO - clean up the unused code later