### PR TITLE
outlaw bonzo

### DIFF
--- a/static/src/javascripts/.eslintrc.js
+++ b/static/src/javascripts/.eslintrc.js
@@ -65,6 +65,10 @@ module.exports = {
                     'lodash/compact',
                     'lodash/intersection',
                     'Promise',
+                    {
+                        "name": 'bonzo',
+                        "message": "Use lib/$ instead."
+                    }
                 ],
                 patterns: ['!lodash/*'],
             },

--- a/static/src/javascripts/bootstraps/enhanced/article-liveblog-common.js
+++ b/static/src/javascripts/bootstraps/enhanced/article-liveblog-common.js
@@ -1,7 +1,7 @@
 // @flow
 /** Bootstrap for functionality common to articles and live blogs */
 import fence from 'fence';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import { catchErrorsWithContext } from 'lib/robust';
 import { shouldHideFlashingElements } from 'common/modules/accessibility/helpers';
 import { init as initT, enhanceTweets } from 'common/modules/article/twitter';

--- a/static/src/javascripts/bootstraps/enhanced/article.js
+++ b/static/src/javascripts/bootstraps/enhanced/article.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-new */
 import config from 'lib/config';
 import qwery from 'qwery';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import { catchErrorsWithContext } from 'lib/robust';
 import { isBreakpoint } from 'lib/detect';
 import mediator from 'lib/mediator';

--- a/static/src/javascripts/bootstraps/enhanced/facia.js
+++ b/static/src/javascripts/bootstraps/enhanced/facia.js
@@ -1,5 +1,5 @@
 // @flow
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import config from 'lib/config';
 import { isBreakpoint } from 'lib/detect';
 import mediator from 'lib/mediator';

--- a/static/src/javascripts/bootstraps/enhanced/football.js
+++ b/static/src/javascripts/bootstraps/enhanced/football.js
@@ -1,6 +1,5 @@
 // @flow
 import bean from 'bean';
-import bonzo from 'bonzo';
 import $ from 'lib/$';
 import config from 'lib/config';
 import fetchJson from 'lib/fetch-json';

--- a/static/src/javascripts/bootstraps/enhanced/football.js
+++ b/static/src/javascripts/bootstraps/enhanced/football.js
@@ -1,6 +1,6 @@
 // @flow
 import bean from 'bean';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import config from 'lib/config';
 import fetchJson from 'lib/fetch-json';
 import {
@@ -32,7 +32,7 @@ declare type Extra = {
 
 const renderNav = (
     match: Object,
-    callback?: (resp: Object, $nav: bonzo, endpoint: string) => void
+    callback?: (resp: Object, $nav: $, endpoint: string) => void
 ): Promise<void> => {
     const matchInfo = new MatchInfo(match, config.get('page.pageId'));
 
@@ -124,8 +124,8 @@ const loading = (
         href: string,
     }
 ): void => {
-    bonzo(elem).append(
-        bonzo.create(`
+    $(elem).append(
+        $.create(`
             <div class="loading">
                 <div class="loading__message">${message}</div>
                     <a href="${link.href}"
@@ -341,9 +341,9 @@ const init = (): void => {
                                 const nurl = resp[newData];
 
                                 if (nurl) {
-                                    bonzo(el).attr('href', nurl);
+                                    $(el).attr('href', nurl);
                                 } else {
-                                    bonzo(el).remove();
+                                    $(el).remove();
                                 }
                             });
                         })

--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -2,7 +2,7 @@
 import fastdom from 'lib/fastdom-promise';
 import qwery from 'qwery';
 import raven from 'lib/raven';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import config from 'lib/config';
 import { markTime } from 'lib/user-timing';
 import { catchErrorsWithContext } from 'lib/robust';

--- a/static/src/javascripts/bootstraps/enhanced/media-player.js
+++ b/static/src/javascripts/bootstraps/enhanced/media-player.js
@@ -9,7 +9,7 @@ import 'videojs-contrib-ads';
 import bean from 'bean';
 import fastdom from 'fastdom';
 import raven from 'lib/raven';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import config from 'lib/config';
 import deferToAnalytics from 'lib/defer-to-analytics';
 import { isBreakpoint } from 'lib/detect';
@@ -72,12 +72,12 @@ const initEndSlate = (player: any, endSlatePath: string): void => {
         endSlate.fetch(player.el(), 'html');
 
         player.on('ended', () => {
-            bonzo(player.el()).addClass(endStateClass);
+            $(player.el()).addClass(endStateClass);
         });
     });
 
     player.on('playing', () => {
-        bonzo(player.el()).removeClass(endStateClass);
+        $(player.el()).removeClass(endStateClass);
     });
 };
 
@@ -235,9 +235,9 @@ const enhanceVideo = (el: HTMLMediaElement, autoplay: boolean): any => {
 const initPlayButtons = (root: ?HTMLElement): void => {
     fastdom.read(() => {
         $('.js-video-play-button', root).each(el => {
-            const $el = bonzo(el);
+            const $el = $(el);
             bean.on(el, 'click', () => {
-                const container = bonzo(el)
+                const container = $(el)
                     .parent()
                     .parent();
                 const placeholder = $('.js-video-placeholder', container);

--- a/static/src/javascripts/bootstraps/enhanced/media-player.js
+++ b/static/src/javascripts/bootstraps/enhanced/media-player.js
@@ -7,7 +7,6 @@ import 'videojs-persistvolume';
 import 'videojs-playlist';
 import 'videojs-contrib-ads';
 import bean from 'bean';
-import bonzo from 'bonzo';
 import fastdom from 'fastdom';
 import raven from 'lib/raven';
 import $ from 'lib/$';

--- a/static/src/javascripts/bootstraps/enhanced/newsletters.js
+++ b/static/src/javascripts/bootstraps/enhanced/newsletters.js
@@ -1,7 +1,7 @@
 // @flow
 import bean from 'bean';
 import fastdom from 'fastdom';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import fetch from 'lib/fetch';
 import config from 'lib/config';
 import { getUserFromCookie, getUserFromApi } from 'common/modules/identity/api';

--- a/static/src/javascripts/bootstraps/enhanced/sport.js
+++ b/static/src/javascripts/bootstraps/enhanced/sport.js
@@ -1,6 +1,6 @@
 // @flow
 
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import { Component } from 'common/modules/component';
 import config from 'lib/config';
 import fastdom from 'lib/fastdom-promise';

--- a/static/src/javascripts/bootstraps/enhanced/trail.js
+++ b/static/src/javascripts/bootstraps/enhanced/trail.js
@@ -4,7 +4,7 @@
 
 import fastdom from 'lib/fastdom-promise';
 import qwery from 'qwery';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import config from 'lib/config';
 import { catchErrorsWithContext } from 'lib/robust';
 import { addProximityLoader } from 'lib/proximity-loader';

--- a/static/src/javascripts/bootstraps/enhanced/video-player.js
+++ b/static/src/javascripts/bootstraps/enhanced/video-player.js
@@ -1,7 +1,7 @@
 // @flow
 
 import fastdom from 'lib/fastdom-promise';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import bean from 'bean';
 import raven from 'lib/raven';
 import {

--- a/static/src/javascripts/bootstraps/videojs-embed.js
+++ b/static/src/javascripts/bootstraps/videojs-embed.js
@@ -1,5 +1,4 @@
 // @flow
-import bonzo from 'bonzo';
 import qwery from 'qwery';
 import videojs from 'videojs';
 import 'videojs-embed';

--- a/static/src/javascripts/bootstraps/videojs-embed.js
+++ b/static/src/javascripts/bootstraps/videojs-embed.js
@@ -1,8 +1,7 @@
 // @flow
-import qwery from 'qwery';
 import videojs from 'videojs';
 import 'videojs-embed';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import config from 'lib/config';
 import deferToAnalytics from 'lib/defer-to-analytics';
 import template from 'lodash/template';
@@ -39,14 +38,14 @@ const addTitleBar = (): void => {
 const initPlayer = (): void => {
     videojs.plugin('fullscreener', fullscreener);
 
-    bonzo(qwery('.js-gu-media--enhance')).each(el => {
-        const $el = bonzo(el).addClass('vjs');
+    $('.js-gu-media--enhance').each(el => {
+        const $el = $(el).addClass('vjs');
         const mediaId = $el.attr('data-media-id');
         const canonicalUrl = $el.attr('data-canonical-url');
         const gaEventLabel = canonicalUrl;
         const mediaType = el.tagName.toLowerCase();
 
-        bonzo(el).addClass('vjs');
+        $(el).addClass('vjs');
 
         const player = createVideoPlayer(
             el,

--- a/static/src/javascripts/lib/$.js
+++ b/static/src/javascripts/lib/$.js
@@ -1,6 +1,6 @@
 // @flow
 
-// this is the one place we want to import bonzo – for now...
+// this is the one place we want to import bonzo - for now...
 // eslint-disable-next-line no-restricted-imports
 import bonzo from 'bonzo';
 import qwery from 'qwery';
@@ -12,8 +12,9 @@ bonzo.aug({
     },
 });
 
-// #? Use of `Node` throughout this file may need a second look?
-const $ = (selector: ?string | ?Node, context: ?Node | ?string): bonzo =>
+// #? this shouldn't really be an `any`, but bonzo is and was previously being 'used' as a type
+// this will be good correct whenever we remove bonzo
+const $: any = (selector: ?string | ?Node, context?: Node | string): bonzo =>
     bonzo(qwery(selector, context));
 
 $.create = (s: string | Node): bonzo => bonzo(bonzo.create(s));
@@ -40,6 +41,4 @@ $.forEachElement = (selector: string, fn: Function): Array<Element> => {
     return els;
 };
 
-// #es6 can be named exports once we're es6-only
-// eslint-disable-next-line guardian-frontend/no-default-export
-export default $;
+export { $ };

--- a/static/src/javascripts/lib/$.js
+++ b/static/src/javascripts/lib/$.js
@@ -1,4 +1,7 @@
 // @flow
+
+// this is the one place we want to import bonzo – for now...
+// eslint-disable-next-line no-restricted-imports
 import bonzo from 'bonzo';
 import qwery from 'qwery';
 

--- a/static/src/javascripts/lib/$.spec.js
+++ b/static/src/javascripts/lib/$.spec.js
@@ -1,6 +1,6 @@
 // @flow
 
-import $ from './$';
+import { $ } from './$';
 
 beforeEach(() => {
     if (document.body) {

--- a/static/src/javascripts/lib/formInlineLabels.js
+++ b/static/src/javascripts/lib/formInlineLabels.js
@@ -1,6 +1,6 @@
 // @flow
 import bean from 'bean';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import fastdom from 'fastdom';
 
 const updateClass = (

--- a/static/src/javascripts/lib/page.js
+++ b/static/src/javascripts/lib/page.js
@@ -1,6 +1,6 @@
 // @flow
 
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import config from 'lib/config';
 import { getBreakpoint } from 'lib/detect';
 

--- a/static/src/javascripts/lib/proximity-loader.js
+++ b/static/src/javascripts/lib/proximity-loader.js
@@ -1,6 +1,5 @@
 // @flow
 
-import bonzo from 'bonzo';
 import debounce from 'lodash/debounce';
 import fastdom from 'lib/fastdom-promise';
 import mediator from 'lib/mediator';

--- a/static/src/javascripts/lib/proximity-loader.js
+++ b/static/src/javascripts/lib/proximity-loader.js
@@ -1,5 +1,5 @@
 // @flow
-
+import { $ } from 'lib/$';
 import debounce from 'lodash/debounce';
 import fastdom from 'lib/fastdom-promise';
 import mediator from 'lib/mediator';
@@ -9,7 +9,7 @@ const scroll = { top: 0, bottom: 0 };
 
 const doProximityLoading = (): void => {
     scroll.top = window.pageYOffset;
-    scroll.bottom = scroll.top + bonzo.viewport().height;
+    scroll.bottom = scroll.top + $.viewport().height;
     items = items.filter(item => {
         if (item.conditionFn()) {
             item.loadFn();
@@ -46,7 +46,7 @@ const addProximityLoader = (
 ): void => {
     // calls `loadFn` when screen is within `distanceThreshold` of `el`
     fastdom.read(() => {
-        const $el = bonzo(el);
+        const $el = $(el);
         const conditionFn = () => {
             const elOffset = $el.offset();
             const loadAfter = elOffset.top - distanceThreshold;

--- a/static/src/javascripts/lib/scroller.js
+++ b/static/src/javascripts/lib/scroller.js
@@ -11,7 +11,6 @@
 */
 
 import { createEasing } from 'lib/easing';
-import bonzo from 'bonzo';
 import fastdom from 'fastdom';
 
 const scrollTo = (

--- a/static/src/javascripts/lib/scroller.js
+++ b/static/src/javascripts/lib/scroller.js
@@ -12,6 +12,7 @@
 
 import { createEasing } from 'lib/easing';
 import fastdom from 'fastdom';
+import { $ } from 'lib/$';
 
 const scrollTo = (
     offset: number,
@@ -19,7 +20,7 @@ const scrollTo = (
     easeFn?: string = 'easeOutQuad',
     container: ?HTMLElement = document.body
 ): void => {
-    const $container = bonzo(container);
+    const $container = $(container);
     const from = $container.scrollTop();
     const distance = offset - from;
     const ease = createEasing(easeFn, duration);
@@ -40,7 +41,7 @@ const scrollToElement = (
     easeFn?: string,
     container: ?HTMLElement
 ): void => {
-    const top = bonzo(element).offset().top;
+    const top = $(element).offset().top;
     scrollTo(top, duration, easeFn, container);
 };
 

--- a/static/src/javascripts/projects/admin/modules/abtests/abtest-report-item.js
+++ b/static/src/javascripts/projects/admin/modules/abtests/abtest-report-item.js
@@ -6,7 +6,6 @@
  */
 import { Component } from 'common/modules/component';
 import { Participation } from 'admin/modules/abtests/participation';
-import bonzo from 'bonzo';
 import debounce from 'lodash/debounce';
 
 class ABTestReportItem extends Component {

--- a/static/src/javascripts/projects/admin/modules/abtests/abtest-report-item.js
+++ b/static/src/javascripts/projects/admin/modules/abtests/abtest-report-item.js
@@ -6,6 +6,7 @@
  */
 import { Component } from 'common/modules/component';
 import { Participation } from 'admin/modules/abtests/participation';
+import { $ } from 'lib/$';
 import debounce from 'lodash/debounce';
 
 class ABTestReportItem extends Component {
@@ -52,7 +53,7 @@ class ABTestReportItem extends Component {
             );
         }
 
-        bonzo(this.elem).addClass(
+        $(this.elem).addClass(
             window.abSwitches[`ab${this.config.test.id}`]
                 ? 'abtest-item--switched-on'
                 : 'abtest-item--switched-off'

--- a/static/src/javascripts/projects/admin/modules/abtests/audience-item.js
+++ b/static/src/javascripts/projects/admin/modules/abtests/audience-item.js
@@ -4,7 +4,6 @@
  Description: Displays information about how the test users are divided.
  */
 import { Component } from 'common/modules/component';
-import bonzo from 'bonzo';
 
 class AudienceItem extends Component {
     constructor(config: Object): void {

--- a/static/src/javascripts/projects/admin/modules/abtests/audience-item.js
+++ b/static/src/javascripts/projects/admin/modules/abtests/audience-item.js
@@ -3,6 +3,7 @@
  Module: audience-item.js
  Description: Displays information about how the test users are divided.
  */
+import { $ } from 'lib/$';
 import { Component } from 'common/modules/component';
 
 class AudienceItem extends Component {
@@ -29,7 +30,7 @@ class AudienceItem extends Component {
         const captionRange = this.getElem('caption-range');
 
         if (testLabel) {
-            bonzo(testLabel).prepend(this.config.test.id);
+            $(testLabel).prepend(this.config.test.id);
         }
 
         // Set the width and absolute position to match the audience size and offset.
@@ -43,11 +44,11 @@ class AudienceItem extends Component {
         }
 
         if (captionTest) {
-            bonzo(captionTest).append(this.config.test.id);
+            $(captionTest).append(this.config.test.id);
         }
 
         if (captionRange) {
-            bonzo(captionRange).append(`${audienceOffset}% to ${audienceEnd}%`);
+            $(captionRange).append(`${audienceOffset}% to ${audienceEnd}%`);
         }
     }
 }

--- a/static/src/javascripts/projects/commercial/modules/article-aside-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-aside-adverts.js
@@ -1,9 +1,8 @@
 // @flow strict
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import config from 'lib/config';
 import mediator from 'lib/mediator';
 import fastdom from 'lib/fastdom-promise';
-import { bonzo } from 'bonzo';
 
 const minArticleHeight: number = 1300;
 
@@ -20,16 +19,16 @@ const getAllowedSizesForImmersive = (availableSpace: number): string => {
 };
 
 export const init = (): Promise<boolean> => {
-    const $col: bonzo = $('.js-secondary-column');
+    const $col: $ = $('.js-secondary-column');
 
     // article aside ads are added server-side if the container doesn't exist then stop.
     if (!$col.length || $col.css('display') === 'none') {
         return Promise.resolve(false);
     }
 
-    const $mainCol: bonzo = $('.js-content-main-column');
-    const $adSlot: bonzo = $('.js-ad-slot', $col);
-    const $immersiveEls: bonzo = $('.element--immersive', $mainCol);
+    const $mainCol: $ = $('.js-content-main-column');
+    const $adSlot: $ = $('.js-ad-slot', $col);
+    const $immersiveEls: $ = $('.element--immersive', $mainCol);
 
     if (!$adSlot.length || !$mainCol.length) {
         return Promise.resolve(false);

--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.js
@@ -1,5 +1,5 @@
 // @flow strict
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import config from 'lib/config';
 import mediator from 'lib/mediator';
 import fastdom from 'lib/fastdom-promise';
@@ -13,8 +13,6 @@ import { refreshAdvert } from 'commercial/modules/dfp/load-advert';
 import { getBreakpoint } from 'lib/detect';
 
 import type { Advert } from 'commercial/modules/dfp/Advert';
-import type bonzo from 'bonzo';
-
 
 const createCommentSlots = (
     canBeDmpu: boolean
@@ -31,8 +29,8 @@ const createCommentSlots = (
 };
 
 const insertCommentAd = (
-    $commentMainColumn: bonzo,
-    $adSlotContainer: bonzo,
+    $commentMainColumn: $,
+    $adSlotContainer: $,
     canBeDmpu: boolean
 ): Promise<void> => {
     const commentSlots = createCommentSlots(canBeDmpu);
@@ -67,7 +65,7 @@ const containsDMPU = (ad: Advert): boolean =>
             (el => el[0] === 160 && el[1] === 600)
     );
 
-const maybeUpgradeSlot = (ad: Advert, $adSlot: bonzo): Advert => {
+const maybeUpgradeSlot = (ad: Advert, $adSlot: $): Advert => {
     if (!containsDMPU(ad)) {
         ad.sizes.desktop.push([300, 600], [160, 600]);
         ad.slot.defineSizeMapping([[[0, 0], ad.sizes.desktop]]);
@@ -82,10 +80,10 @@ const maybeUpgradeSlot = (ad: Advert, $adSlot: bonzo): Advert => {
 };
 
 const runSecondStage = (
-    $commentMainColumn: bonzo,
-    $adSlotContainer: bonzo
+    $commentMainColumn: $,
+    $adSlotContainer: $
 ): void => {
-    const $adSlot: bonzo = $('.js-ad-slot', $adSlotContainer);
+    const $adSlot: $ = $('.js-ad-slot', $adSlotContainer);
     const commentAdvert = getAdvertById('dfp-ad--comments');
 
     if (commentAdvert && $adSlot.length) {
@@ -100,7 +98,7 @@ const runSecondStage = (
 };
 
 export const initCommentAdverts = (): Promise<boolean> => {
-    const $adSlotContainer: bonzo = $('.js-discussion__ad-slot');
+    const $adSlotContainer: $ = $('.js-discussion__ad-slot');
     const isMobile = getBreakpoint() === 'mobile';
     if (!commercialFeatures.commentAdverts || !$adSlotContainer.length || isMobile) {
         return Promise.resolve(false);
@@ -110,7 +108,7 @@ export const initCommentAdverts = (): Promise<boolean> => {
         'modules:comments:renderComments:rendered',
         (): void => {
             const isLoggedIn: boolean = isUserLoggedIn();
-            const $commentMainColumn: bonzo = $(
+            const $commentMainColumn: $ = $(
                 '.js-comments .content__main-column'
             );
 

--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import fakeMediator from 'lib/mediator';
 import fastdom from 'lib/fastdom-promise';
 import { addSlot } from 'commercial/modules/dfp/add-slot';

--- a/static/src/javascripts/projects/commercial/modules/creatives/fabric-expandable-video-v2.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/fabric-expandable-video-v2.js
@@ -1,7 +1,7 @@
 // @flow
 import bean from 'bean';
 import fastdom from 'lib/fastdom-promise';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import template from 'lodash/template';
 import fabricExpandableVideoHtml from 'raw-loader!commercial/views/creatives/fabric-expandable-video-v2.html';
 import fabricExpandableCtaHtml from 'raw-loader!commercial/views/creatives/fabric-expandable-video-v2-cta.html';

--- a/static/src/javascripts/projects/commercial/modules/creatives/fabric-expanding-v1.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/fabric-expanding-v1.js
@@ -1,7 +1,7 @@
 // @flow
 import bean from 'bean';
 import fastdom from 'lib/fastdom-promise';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import { getViewport, isBreakpoint, isIOS, isAndroid } from 'lib/detect';
 import mediator from 'lib/mediator';
 import { local } from 'lib/storage';

--- a/static/src/javascripts/projects/commercial/modules/creatives/scrollable-mpu-v2.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/scrollable-mpu-v2.js
@@ -1,11 +1,10 @@
 // @flow
 import fastdom from 'fastdom';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import { isAndroid } from 'lib/detect';
 import mediator from 'lib/mediator';
 import { addTrackingPixel } from 'commercial/modules/creatives/add-tracking-pixel';
 import { addViewabilityTracker } from 'commercial/modules/creatives/add-viewability-tracker';
-import type { bonzo } from 'bonzo';
 
 /**
  * TODO: rather blunt instrument this, due to the fact *most* mobile devices don't have a fixed
@@ -48,8 +47,8 @@ const scrollableMpuTpl = (params: Object) => `
 class ScrollableMpu {
     adSlot: HTMLElement;
     params: ScrollableMpuParams;
-    $scrollableImage: ?bonzo;
-    $scrollableMpu: ?bonzo;
+    $scrollableImage: ?$;
+    $scrollableMpu: ?$;
 
     constructor(adSlot: HTMLElement, params: Object) {
         this.adSlot = adSlot;

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slots.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slots.spec.js
@@ -1,7 +1,6 @@
 // @flow
 import { createSlots } from 'commercial/modules/dfp/create-slots';
 import { adSizes } from 'commercial/modules/ad-sizes';
-import bonzo from 'bonzo';
 
 const imHtml = `
 <div id="dfp-ad--im"

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slots.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slots.spec.js
@@ -1,6 +1,7 @@
 // @flow
 import { createSlots } from 'commercial/modules/dfp/create-slots';
 import { adSizes } from 'commercial/modules/ad-sizes';
+import { $ } from 'lib/$';
 
 const imHtml = `
 <div id="dfp-ad--im"
@@ -60,7 +61,7 @@ describe('Create Ad Slot', () => {
         const adSlots = createSlots('inline', { classes: 'inline-extra' });
         const adSlot = adSlots[0];
 
-        expect(bonzo(adSlot).hasClass('ad-slot--inline-extra')).toBeTruthy();
+        expect($(adSlot).hasClass('ad-slot--inline-extra')).toBeTruthy();
     });
 
     it('should create "inline1" ad slot with additional size', () => {
@@ -70,14 +71,14 @@ describe('Create Ad Slot', () => {
         const adSlot = adSlots[0];
 
         expect(
-            bonzo(adSlot)
+            $(adSlot)
                 .attr('data-desktop')
                 .indexOf(adSizes.leaderboard.toString())
         ).toBeTruthy();
     });
 
     it('should use correct sizes for the mobile top-above-nav slot', () => {
-        const topAboveNavSlot = bonzo(createSlots('top-above-nav')[0]);
+        const topAboveNavSlot = $(createSlots('top-above-nav')[0]);
         const mobileSizes = topAboveNavSlot.attr('data-mobile');
         expect(mobileSizes).toBe('1,1|2,2|88,71|300,197|300,250|fluid');
     });

--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import { getBreakpoint as getBreakpoint_ } from 'lib/detect';
 import config from 'lib/config';
 import { init as prepareGoogletag } from 'commercial/modules/dfp/prepare-googletag';

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.spec.js
@@ -1,5 +1,6 @@
 // @flow
 import { renderAdvertLabel } from 'commercial/modules/dfp/render-advert-label';
+import { $ } from 'lib/$';
 
 jest.mock('lib/detect', () => {});
 jest.mock('common/modules/commercial/commercial-features', () => ({
@@ -11,24 +12,24 @@ const labelSelector = '.ad-slot__label';
 
 describe('Rendering advert labels', () => {
     beforeAll(() => {
-        adverts.withLabel = bonzo(
-            bonzo.create('<div class="js-ad-slot"></div>')
+        adverts.withLabel = $(
+            $.create('<div class="js-ad-slot"></div>')
         );
 
-        adverts.labelDisabled = bonzo(
-            bonzo.create('<div class="js-ad-slot" data-label="false"></div>')
+        adverts.labelDisabled = $(
+            $.create('<div class="js-ad-slot" data-label="false"></div>')
         );
 
-        adverts.alreadyLabelled = bonzo(
-            bonzo.create(`
+        adverts.alreadyLabelled = $(
+            $.create(`
                 <div class="js-ad-slot">
                     <div class="ad-slot__label">Advertisement</div>
                 </div>
             `)
         );
 
-        adverts.frame = bonzo(
-            bonzo.create('<div class="js-ad-slot ad-slot--frame"></div>')
+        adverts.frame = $(
+            $.create('<div class="js-ad-slot ad-slot--frame"></div>')
         );
     });
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.spec.js
@@ -1,6 +1,5 @@
 // @flow
 import { renderAdvertLabel } from 'commercial/modules/dfp/render-advert-label';
-import bonzo from 'bonzo';
 
 jest.mock('lib/detect', () => {});
 jest.mock('common/modules/commercial/commercial-features', () => ({

--- a/static/src/javascripts/projects/commercial/modules/hosted/about.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/about.js
@@ -1,7 +1,7 @@
 // @flow
 
 import fastdom from 'lib/fastdom-promise';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import crossIcon from 'svgs/icon/cross.svg';
 import paidContent from 'svgs/commercial/paid-content.svg';
 
@@ -22,8 +22,8 @@ const template = (): string => `
                 </div>
                 <div class="survey-text">
                     <p class="survey-text__paragraph">
-                        Advertiser content. This article was paid for, produced and controlled by the advertiser rather 
-                        than the publisher. It is subject to regulation by the Advertising Standards Authority. This 
+                        Advertiser content. This article was paid for, produced and controlled by the advertiser rather
+                        than the publisher. It is subject to regulation by the Advertising Standards Authority. This
                         content is produced by the advertiser with no involvement from Guardian News and Media staff.
                     </p>
                 </div>

--- a/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
@@ -1,6 +1,6 @@
 // @flow
 import fastdom from 'fastdom';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import qwery from 'qwery';
 import config from 'lib/config';
 import { pushUrl } from 'lib/url';
@@ -17,23 +17,23 @@ class HostedGallery {
     swipeContainerWidth: number;
     index: number;
     imageRatios: number[];
-    $galleryEl: bonzo;
-    $galleryFrame: bonzo;
-    $header: bonzo;
-    $imagesContainer: bonzo;
-    $captionContainer: bonzo;
-    $captions: bonzo;
-    $scrollEl: bonzo;
-    $images: bonzo;
-    $progress: bonzo;
-    $border: bonzo;
+    $galleryEl: $;
+    $galleryFrame: $;
+    $header: $;
+    $imagesContainer: $;
+    $captionContainer: $;
+    $captions: $;
+    $scrollEl: $;
+    $images: $;
+    $progress: $;
+    $border: $;
     prevBtn: HTMLElement;
     nextBtn: HTMLElement;
     infoBtn: HTMLElement;
-    $counter: bonzo;
-    $ctaFloat: bonzo;
-    $ojFloat: bonzo;
-    $meta: bonzo;
+    $counter: $;
+    $ctaFloat: $;
+    $ojFloat: $;
+    $meta: $;
     ojClose: HTMLElement;
     resize: (data?: Object) => void;
     resizer: () => void;
@@ -116,7 +116,7 @@ class HostedGallery {
     }
 
     toggleOj() {
-        bonzo(this.$ojFloat).toggleClass('minimise-oj');
+        $(this.$ojFloat).toggleClass('minimise-oj');
     }
 
     initScroll() {
@@ -289,19 +289,19 @@ class HostedGallery {
             $sizer.css('top', imageSize.topBottom);
             $sizer.css('left', imageSize.leftRight);
             if (imgIndex === ctaIndex) {
-                bonzo($ctaFloat).css('bottom', ctaSize.topBottom);
+                $($ctaFloat).css('bottom', ctaSize.topBottom);
             }
             if (imgIndex === $images.length - 1) {
-                bonzo($ojFloat).css('bottom', ctaSize.topBottom);
+                $($ojFloat).css('bottom', ctaSize.topBottom);
             }
             if (imgIndex === $images.length - 1) {
-                bonzo($ojFloat).css(
+                $($ojFloat).css(
                     'padding-bottom',
                     ctaSize.topBottom > 40 || width > tabletSize ? 0 : 40
                 );
             }
             if (imgIndex === 0) {
-                bonzo($meta).css(
+                $($meta).css(
                     'padding-bottom',
                     imageSize.topBottom > 40 || width > tabletSize ? 20 : 40
                 );
@@ -325,7 +325,7 @@ class HostedGallery {
         galleryEl.style.transform = `translate(${px +
             offset}px,0) translateZ(0)`;
         fastdom.write(() => {
-            bonzo($meta).css('opacity', offset !== 0 ? 0 : 1);
+            $($meta).css('opacity', offset !== 0 ? 0 : 1);
         });
     }
 
@@ -344,27 +344,27 @@ class HostedGallery {
         fastdom.write(() => {
             this.$images.each((image, index) => {
                 const opacity = ((progress - index + 1) * 16) / 11 - 0.0625;
-                bonzo(image).css('opacity', Math.min(Math.max(opacity, 0), 1));
+                $(image).css('opacity', Math.min(Math.max(opacity, 0), 1));
             });
 
-            bonzo(this.$border).css('transform', `rotate(${deg}deg)`);
-            bonzo(this.$border).css('-webkit-transform', `rotate(${deg}deg)`);
+            $(this.$border).css('transform', `rotate(${deg}deg)`);
+            $(this.$border).css('-webkit-transform', `rotate(${deg}deg)`);
 
-            bonzo(this.$galleryEl).toggleClass(
+            $(this.$galleryEl).toggleClass(
                 'show-cta',
                 progress <= ctaIndex && progress >= ctaIndex - 0.25
             );
-            bonzo(this.$galleryEl).toggleClass(
+            $(this.$galleryEl).toggleClass(
                 'show-oj',
                 progress >= length - 1.25
             );
 
-            bonzo(this.$progress).toggleClass(
+            $(this.$progress).toggleClass(
                 'first-half',
                 fractionProgress && fractionProgress < 0.5
             );
 
-            bonzo(this.$meta).css('opacity', progress !== 0 ? 0 : 1);
+            $(this.$meta).css('opacity', progress !== 0 ? 0 : 1);
         });
 
         if (newIndex && newIndex !== this.index) {
@@ -483,20 +483,20 @@ HostedGallery.prototype.states = {
             // load prev/current/next
             this.loadSurroundingImages(this.index, this.$images.length);
             this.$captions.each((caption, index) => {
-                bonzo(caption).toggleClass(
+                $(caption).toggleClass(
                     'current-caption',
                     that.index === index + 1
                 );
             });
-            bonzo(this.$counter).html(`${this.index}/${this.$images.length}`);
+            $(this.$counter).html(`${this.index}/${this.$images.length}`);
 
             if (this.useSwipe) {
                 this.translateContent(this.index, 0, 100);
-                bonzo(this.$galleryEl).toggleClass(
+                $(this.$galleryEl).toggleClass(
                     'show-oj',
                     this.index === this.$images.length
                 );
-                bonzo(this.$galleryEl).toggleClass(
+                $(this.$galleryEl).toggleClass(
                     'show-cta',
                     this.index === HostedGallery.ctaIndex() + 1
                 );

--- a/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
@@ -1,5 +1,4 @@
 // @flow
-import bonzo from 'bonzo';
 import fastdom from 'fastdom';
 import $ from 'lib/$';
 import qwery from 'qwery';

--- a/static/src/javascripts/projects/commercial/modules/hosted/next-video-autoplay.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/next-video-autoplay.js
@@ -2,7 +2,7 @@
 import bean from 'bean';
 import fastdom from 'fastdom';
 import { load } from 'commercial/modules/hosted/next-video';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import { trackNonClickInteraction } from 'common/modules/analytics/google';
 
 let nextVideoInterval;

--- a/static/src/javascripts/projects/commercial/modules/hosted/onward-journey-carousel.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/onward-journey-carousel.js
@@ -1,7 +1,7 @@
 // @flow
 import qwery from 'qwery';
 import fastdom from 'fastdom';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 
 class HostedCarousel {
     $carousel: Object;

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/plista-renderer.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/plista-renderer.js
@@ -5,7 +5,7 @@ import { plista } from 'commercial/modules/third-party-tags/plista';
 import template from 'lodash/template';
 import config from 'lib/config';
 import fastdom from 'lib/fastdom-promise';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 
 const findAnchor = (): Promise<HTMLElement | null> => {
     const selector = !(

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/plista.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/plista.js
@@ -1,7 +1,7 @@
 // @flow
 
 import fastdom from 'fastdom';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import config from 'lib/config';
 import { adblockInUse as adblockInUse_ } from 'lib/detect';
 import { trackAdRender } from 'commercial/modules/dfp/track-ad-render';

--- a/static/src/javascripts/projects/common/modules/analytics/discussion.js
+++ b/static/src/javascripts/projects/common/modules/analytics/discussion.js
@@ -1,7 +1,6 @@
 // @flow
 
 import $ from 'lib/$';
-import bonzo from 'bonzo';
 import config from 'lib/config';
 import debounce from 'lodash/debounce';
 import mediator from 'lib/mediator';

--- a/static/src/javascripts/projects/common/modules/analytics/discussion.js
+++ b/static/src/javascripts/projects/common/modules/analytics/discussion.js
@@ -1,6 +1,6 @@
 // @flow
 
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import config from 'lib/config';
 import debounce from 'lodash/debounce';
 import mediator from 'lib/mediator';
@@ -47,7 +47,7 @@ const scrolledToComments = (): void => {
 const areCommentsVisible = (): boolean => {
     const comments = $('#comments').offset();
     const scrollTop = window.pageYOffset;
-    const viewport = bonzo.viewport().height;
+    const viewport = $.viewport().height;
 
     if (
         comments.top - viewport / 2 < scrollTop &&

--- a/static/src/javascripts/projects/common/modules/article/membership-events.js
+++ b/static/src/javascripts/projects/common/modules/article/membership-events.js
@@ -1,6 +1,6 @@
 // @flow
 import fastdom from 'fastdom';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import fetchJson from 'lib/fetch-json';
 import reportError from 'lib/report-error';
 

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -7,7 +7,7 @@ import { constructQuery } from 'lib/url';
 import { onConsentChange } from '@guardian/consent-management-platform';
 import { getPageTargeting } from 'common/modules/commercial/build-page-targeting';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import { buildPfpEvent } from 'common/modules/video/ga-helper';
 
 import { getPermutivePFPSegments } from '../commercial/permutive';

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -1,6 +1,5 @@
 // @flow
 import fastdom from 'lib/fastdom-promise';
-import bonzo from 'bonzo';
 import fetchJson from 'lib/fetch-json';
 import reportError from 'lib/report-error';
 import { initYoutubePlayer } from 'common/modules/atoms/youtube-player';

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -8,7 +8,7 @@ import {
     initYoutubeEvents,
 } from 'common/modules/atoms/youtube-tracking';
 import { Component } from 'common/modules/component';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import config from 'lib/config';
 import { isIOS, isAndroid, isBreakpoint } from 'lib/detect';
 import debounce from 'lodash/debounce';
@@ -75,7 +75,7 @@ document.addEventListener('focusout', () => {
                     return $('.vjs-big-play-button', iframe.parentElement);
                 }
             })
-            .then(($playButton: ?bonzo) => {
+            .then(($playButton: ?$) => {
                 fastdom.write(() => {
                     if ($playButton) {
                         $playButton.addClass('youtube-play-btn-focussed');
@@ -88,7 +88,7 @@ document.addEventListener('focusout', () => {
 document.addEventListener('focusin', () => {
     fastdom
         .read(() => $('.vjs-big-play-button'))
-        .then(($playButton: ?bonzo) => {
+        .then(($playButton: ?$) => {
             fastdom.write(() => {
                 if ($playButton) {
                     $playButton.removeClass('youtube-play-btn-focussed');

--- a/static/src/javascripts/projects/common/modules/business/stocks.js
+++ b/static/src/javascripts/projects/common/modules/business/stocks.js
@@ -1,5 +1,5 @@
 // @flow
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import config from 'lib/config';
 import fetchJson from 'lib/fetch-json';
 import reportError from 'lib/report-error';

--- a/static/src/javascripts/projects/common/modules/charts/doughnut.js
+++ b/static/src/javascripts/projects/common/modules/charts/doughnut.js
@@ -5,10 +5,9 @@
  * - http://codepen.io/githiro/pen/ICfFE
  * - https://github.com/mbostock/d3/blob/master/src/svg/arc.js
  */
-import $ from 'lib/$';
-import type { bonzo } from 'bonzo';
+import { $ } from 'lib/$';
 
-const svgEl = (type: string): bonzo =>
+const svgEl = (type: string): $ =>
     $.create(document.createElementNS('http://www.w3.org/2000/svg', type));
 
 const translate = (v: Array<number>): string => `translate(${v.toString()})`;
@@ -18,7 +17,7 @@ const translate = (v: Array<number>): string => `translate(${v.toString()})`;
  * @param {Object.<string, *>} o the options
  * @return {Bonzo} SVG Element
  */
-const Doughnut = (data: Object, o: Object): bonzo => {
+const Doughnut = (data: Object, o: Object): $ => {
     const obj: Object = Object.assign(
         {
             percentCutout: 35,

--- a/static/src/javascripts/projects/common/modules/charts/table-doughnut.js
+++ b/static/src/javascripts/projects/common/modules/charts/table-doughnut.js
@@ -1,5 +1,4 @@
 // @flow
-import bonzo from 'bonzo';
 import $ from 'lib/$';
 import { Doughnut } from 'common/modules/charts/doughnut';
 

--- a/static/src/javascripts/projects/common/modules/charts/table-doughnut.js
+++ b/static/src/javascripts/projects/common/modules/charts/table-doughnut.js
@@ -1,5 +1,5 @@
 // @flow
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import { Doughnut } from 'common/modules/charts/doughnut';
 
 const TableDoughnut = () => {};
@@ -14,14 +14,14 @@ TableDoughnut.prototype.render = (el: Element) => {
         color: td.getAttribute('data-chart-color'),
     }));
 
-    bonzo(el).addClass('u-h');
+    $(el).addClass('u-h');
     const $doughnut = new Doughnut(data, {
         showValues: el.getAttribute('data-chart-show-values') === 'true',
         unit: el.getAttribute('data-chart-unit'),
         width,
     });
 
-    // can't use bonzo's class methods, don't play well in IE
+    // can't use $'s class methods, don't play well in IE
     const currentClasses = $doughnut.attr('class');
     return $doughnut.attr(
         'class',

--- a/static/src/javascripts/projects/common/modules/commercial/adblock-ask.js
+++ b/static/src/javascripts/projects/common/modules/commercial/adblock-ask.js
@@ -1,7 +1,7 @@
 // @flow
 
 import fastdom from 'lib/fastdom-promise';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 
 import { supportSubscribeDigitalURL } from 'common/modules/commercial/support-utilities';
 import { shouldHideSupportMessaging } from 'common/modules/commercial/user-features';

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-liveblog-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-liveblog-utilities.js
@@ -1,6 +1,6 @@
 // @flow
 import { logView } from 'common/modules/commercial/acquisitions-view-log';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import mediator from 'lib/mediator';
 import { elementInView } from 'lib/element-inview';
 import fastdom from 'lib/fastdom-promise';

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -10,7 +10,7 @@ import {
     submitInsertEvent,
     submitViewEvent,
 } from 'common/modules/commercial/acquisitions-ophan';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import config from 'lib/config';
 import { local } from 'lib/storage';
 import { elementInView } from 'lib/element-inview';

--- a/static/src/javascripts/projects/common/modules/commercial/epic/epic-utils.js
+++ b/static/src/javascripts/projects/common/modules/commercial/epic/epic-utils.js
@@ -1,7 +1,7 @@
 // @flow
 
 import fastdom from 'lib/fastdom-promise';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import { elementInView } from 'lib/element-inview';
 import reportError from 'lib/report-error';
 import mediator from 'lib/mediator';

--- a/static/src/javascripts/projects/common/modules/component.js
+++ b/static/src/javascripts/projects/common/modules/component.js
@@ -2,7 +2,6 @@
 /* eslint-disable no-underscore-dangle */
 
 import bean from 'bean';
-import bonzo from 'bonzo';
 import fetchJSON from 'lib/fetch-json';
 import qwery from 'qwery';
 

--- a/static/src/javascripts/projects/common/modules/component.js
+++ b/static/src/javascripts/projects/common/modules/component.js
@@ -4,6 +4,7 @@
 import bean from 'bean';
 import fetchJSON from 'lib/fetch-json';
 import qwery from 'qwery';
+import { $ } from 'lib/$'
 
 class ComponentError {
     constructor(message) {
@@ -75,9 +76,9 @@ class Component {
         }
 
         if (template) {
-            this.elem = bonzo.create(template)[0];
+            this.elem = $.create(template)[0];
             this._prerender();
-            bonzo(parent)[this.manipulationType](this.elem);
+            $(parent)[this.manipulationType](this.elem);
         }
 
         this._ready();
@@ -102,11 +103,11 @@ class Component {
 
         return this._fetch()
             .then(resp => {
-                this.elem = bonzo.create(resp[this.responseDataKey])[0];
+                this.elem = $.create(resp[this.responseDataKey])[0];
                 this._prerender();
 
                 if (!this.destroyed) {
-                    bonzo(parent)[this.manipulationType](this.elem);
+                    $(parent)[this.manipulationType](this.elem);
                     this._ready(this.elem);
                 }
             })
@@ -167,7 +168,7 @@ class Component {
             this._fetch()
                 .then(resp => {
                     this.autoupdate(
-                        bonzo.create(resp[this.responseDataKey])[0]
+                        $.create(resp[this.responseDataKey])[0]
                     );
 
                     if (this.autoupdated) {
@@ -220,7 +221,7 @@ class Component {
         this.elem = elem;
 
         this._prerender();
-        bonzo(oldElem).replaceWith(this.elem);
+        $(oldElem).replaceWith(this.elem);
     }
 
     /**
@@ -277,7 +278,7 @@ class Component {
 
     setState(state: string, elemName: ?string): void {
         const elem = elemName ? this.getElem(elemName) : this.elem;
-        const $elem = bonzo(elem);
+        const $elem = $(elem);
 
         if (this.componentClass) {
             $elem.addClass(
@@ -289,7 +290,7 @@ class Component {
 
     removeState(state: string, elemName: ?string): void {
         const elem = elemName ? this.getElem(elemName) : this.elem;
-        const $elem = bonzo(elem);
+        const $elem = $(elem);
 
         if (this.componentClass) {
             $elem.removeClass(
@@ -301,7 +302,7 @@ class Component {
 
     toggleState(state: string, elemName: ?string): void {
         const elem = elemName ? this.getElem(elemName) : this.elem;
-        const $elem = bonzo(elem);
+        const $elem = $(elem);
 
         if (this.componentClass) {
             $elem.toggleClass(
@@ -313,7 +314,7 @@ class Component {
 
     hasState(state: string, elemName: ?string): boolean {
         const elem = elemName ? this.getElem(elemName) : this.elem;
-        const $elem = bonzo(elem);
+        const $elem = $(elem);
 
         if (this.componentClass) {
             return $elem.hasClass(
@@ -339,7 +340,7 @@ class Component {
      */
     destroy(): void {
         if (this.elem) {
-            bonzo(this.elem).remove();
+            $(this.elem).remove();
             delete this.elem;
         }
 

--- a/static/src/javascripts/projects/common/modules/crosswords/crossword.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/crossword.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { Component, findDOMNode } from 'preact-compat';
 import fastdom from 'fastdom';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import mediator from 'lib/mediator';
 import { isIOS, isBreakpoint } from 'lib/detect';
 import { scrollTo } from 'lib/scroller';

--- a/static/src/javascripts/projects/common/modules/crosswords/hidden-input.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/hidden-input.js
@@ -1,5 +1,6 @@
 // @flow
 import React, { Component, findDOMNode } from 'preact-compat';
+import { $ } from 'lib/$';
 import fastdom from 'fastdom';
 import { scrollTo } from 'lib/scroller';
 import { isBreakpoint } from 'lib/detect';
@@ -19,7 +20,7 @@ class HiddenInput extends Component<*, *> {
             })
         ) {
             fastdom.read(() => {
-                const offsets = bonzo(findDOMNode(this.input)).offset();
+                const offsets = $(findDOMNode(this.input)).offset();
                 const clueHeight = document.getElementsByClassName(
                     'crossword__sticky-clue'
                 )[0].offsetHeight;

--- a/static/src/javascripts/projects/common/modules/crosswords/hidden-input.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/hidden-input.js
@@ -1,6 +1,5 @@
 // @flow
 import React, { Component, findDOMNode } from 'preact-compat';
-import bonzo from 'bonzo';
 import fastdom from 'fastdom';
 import { scrollTo } from 'lib/scroller';
 import { isBreakpoint } from 'lib/detect';

--- a/static/src/javascripts/projects/common/modules/crosswords/main.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/main.js
@@ -3,7 +3,7 @@
 import React, { render } from 'preact-compat';
 import bean from 'bean';
 import fastdom from 'lib/fastdom-promise';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import Crossword from 'common/modules/crosswords/crossword';
 
 const initCrosswords = (): void => {

--- a/static/src/javascripts/projects/common/modules/discussion/activity-stream.js
+++ b/static/src/javascripts/projects/common/modules/discussion/activity-stream.js
@@ -1,6 +1,5 @@
 // @flow
 
-import bonzo from 'bonzo';
 import bean from 'bean';
 import $ from 'lib/$';
 import {

--- a/static/src/javascripts/projects/common/modules/discussion/activity-stream.js
+++ b/static/src/javascripts/projects/common/modules/discussion/activity-stream.js
@@ -1,7 +1,7 @@
 // @flow
 
 import bean from 'bean';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import {
     getUrlVars,
     constructQuery,
@@ -42,13 +42,13 @@ class ActivityStream extends Component {
 
             $('.tabs__tab--selected').removeClass('tabs__tab--selected');
 
-            bonzo($(`a[data-stream-type=${type}]`))
+            $($(`a[data-stream-type=${type}]`))
                 .parent()
                 .addClass('tabs__tab--selected');
         };
 
         // update display
-        const $el = bonzo(this.elem).empty();
+        const $el = $(this.elem).empty();
 
         this.setState('loading');
 
@@ -122,7 +122,7 @@ class ActivityStream extends Component {
         if (id) {
             recommendComment(id);
 
-            bonzo(el).addClass('disc-comment__recommend--active');
+            $(el).addClass('disc-comment__recommend--active');
 
             $('.js-disc-recommend-count', el).each(countEl => {
                 countEl.innerHTML = parseInt(countEl.innerHTML, 10) + 1;

--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -1,7 +1,6 @@
 // @flow
 
 import bean from 'bean';
-import bonzo from 'bonzo';
 import config from 'lib/config';
 import mediator from 'lib/mediator';
 import { Component } from 'common/modules/component';

--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -1,5 +1,6 @@
 // @flow
 
+import { $ } from 'lib/$';
 import bean from 'bean';
 import config from 'lib/config';
 import mediator from 'lib/mediator';
@@ -257,7 +258,7 @@ class CommentBox extends Component {
             </div>`;
 
         if (messages) {
-            messages.appendChild(bonzo.create(errorMessage)[0]);
+            messages.appendChild($.create(errorMessage)[0]);
         }
 
         this.errors.push(type);

--- a/static/src/javascripts/projects/common/modules/discussion/comments.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comments.js
@@ -2,7 +2,6 @@
 
 import $ from 'lib/$';
 import bean from 'bean';
-import bonzo from 'bonzo';
 import qwery from 'qwery';
 import config from 'lib/config';
 import fetchJson from 'lib/fetch-json';

--- a/static/src/javascripts/projects/common/modules/discussion/comments.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comments.js
@@ -1,6 +1,6 @@
 // @flow
 
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import bean from 'bean';
 import qwery from 'qwery';
 import config from 'lib/config';
@@ -77,7 +77,7 @@ class Comments extends Component {
             li.innerHTML = 'Loading…';
         }
 
-        const source = bonzo(target).data('source-comment');
+        const source = $(target).data('source-comment');
         const commentId = currentTarget.getAttribute('data-comment-id');
 
         if (commentId) {
@@ -87,16 +87,16 @@ class Comments extends Component {
                 mode: 'cors',
             })
                 .then(resp => {
-                    const comment = bonzo.create(resp.html);
+                    const comment = $.create(resp.html);
                     const replies = qwery(
                         this.getClass('reply'),
                         comment
                     ).slice(this.options && this.options.showRepliesCount);
 
-                    bonzo(qwery('.d-thread--responses', source)).append(
+                    $(qwery('.d-thread--responses', source)).append(
                         replies
                     );
-                    bonzo(li).addClass('u-h');
+                    $(li).addClass('u-h');
 
                     this.emit('untruncate-thread');
 
@@ -248,7 +248,7 @@ class Comments extends Component {
         }
     }
 
-    pickComment(commentId: string, $thisButton: bonzo): Promise<void> {
+    pickComment(commentId: string, $thisButton: $): Promise<void> {
         const comment = qwery(`#comment-${commentId}`, this.elem);
 
         return pickComment(commentId).then(() => {
@@ -305,7 +305,7 @@ class Comments extends Component {
         }
     }
 
-    unPickComment(commentId: string, $thisButton: bonzo): Promise<void> {
+    unPickComment(commentId: string, $thisButton: $): Promise<void> {
         const comment = qwery(`#comment-${commentId}`);
 
         return unPickComment(commentId).then(() => {
@@ -324,8 +324,8 @@ class Comments extends Component {
     }
 
     addComment(comment: CommentType, parent?: HTMLElement): void {
-        const commentElem = bonzo.create(this.postedCommentEl)[0];
-        const $commentElem = bonzo(commentElem);
+        const commentElem = $.create(this.postedCommentEl)[0];
+        const $commentElem = $(commentElem);
         const replyButton =
             commentElem &&
             commentElem.getElementsByClassName(
@@ -383,7 +383,7 @@ class Comments extends Component {
         } else {
             $commentElem.removeClass(this.getClass('topLevelComment', true));
             $commentElem.addClass(this.getClass('reply', true));
-            bonzo(parent).append($commentElem);
+            $(parent).append($commentElem);
         }
 
         window.location.replace(`#comment-${comment.id}`);
@@ -416,7 +416,7 @@ class Comments extends Component {
         const replyToAuthorId = replyToComment.getAttribute(
             'data-comment-author-id'
         );
-        const $replyToComment = bonzo(replyToComment);
+        const $replyToComment = $(replyToComment);
         const replyToBody = qwery(
             this.getClass('commentBody'),
             replyToComment
@@ -442,7 +442,7 @@ class Comments extends Component {
             focus: true,
         });
 
-        // this is a bit toffee, but we don't have .parents() in bonzo
+        // this is a bit toffee, but we don't have .parents() in $
         const parentCommentEl = $replyToComment.hasClass(
             this.getClass('topLevelComment', true)
         )
@@ -456,7 +456,7 @@ class Comments extends Component {
 
         if (
             showRepliesElem.length > 0 &&
-            !bonzo(showRepliesElem).hasClass('u-h')
+            !$(showRepliesElem).hasClass('u-h')
         ) {
             showRepliesElem[0].click();
         }
@@ -467,10 +467,10 @@ class Comments extends Component {
             let responses = qwery('.d-thread--responses', parentCommentEl)[0];
 
             if (!responses) {
-                responses = bonzo.create(
+                responses = $.create(
                     '<ul class="d-thread d-thread--responses"></ul>'
                 )[0];
-                bonzo(parentCommentEl).append(responses);
+                $(parentCommentEl).append(responses);
             }
 
             commentBox.destroy();
@@ -605,10 +605,10 @@ class Comments extends Component {
         paginationHtml: string,
         postedCommentHtml: string,
     }): void {
-        const contentEl = bonzo.create(resp.commentsHtml);
+        const contentEl = $.create(resp.commentsHtml);
         const comments = qwery(this.getClass('comment'), contentEl);
 
-        bonzo(this.elem)
+        $(this.elem)
             .empty()
             .append(contentEl);
         this.addMoreRepliesButtons(comments);

--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -1,7 +1,6 @@
 // @flow
 
 import bean from 'bean';
-import bonzo from 'bonzo';
 import qwery from 'qwery';
 import $ from 'lib/$';
 import raven from 'lib/raven';

--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -2,7 +2,7 @@
 
 import bean from 'bean';
 import qwery from 'qwery';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import raven from 'lib/raven';
 import config from 'lib/config';
 import { isBreakpoint } from 'lib/detect';
@@ -84,7 +84,7 @@ class Loader extends Component {
         window.location.replace(`#comment-${id}`);
     }
 
-    $topCommentsContainer: bonzo;
+    $topCommentsContainer: $;
     comments: ?Comments;
     topCommentCount: number;
     user: ?DiscussionProfile;
@@ -203,7 +203,7 @@ class Loader extends Component {
 
                 if (this.comments) {
                     // $FlowFixMe
-                    this.comments.options.order = bonzo(e.currentTarget).data(
+                    this.comments.options.order = $(e.currentTarget).data(
                         'order'
                     );
                 }
@@ -230,7 +230,7 @@ class Loader extends Component {
 
                 if (this.comments) {
                     // $FlowFixMe
-                    this.comments.options.threading = bonzo(
+                    this.comments.options.threading = $(
                         e.currentTarget
                     ).data('threading');
                 }
@@ -270,7 +270,7 @@ class Loader extends Component {
                 'click',
                 '.js-timestamps-dropdown .popup__action',
                 (e: Event) => {
-                    const format = bonzo(e.currentTarget).data('timestamp');
+                    const format = $(e.currentTarget).data('timestamp');
 
                     bean.fire(
                         qwery('.js-timestamps-dropdown [data-toggle]')[0],
@@ -299,7 +299,7 @@ class Loader extends Component {
             'click',
             '.js-comment-pagesize-dropdown .popup__action',
             (e: Event) => {
-                const selectedPageSize = bonzo(e.currentTarget).data(
+                const selectedPageSize = $(e.currentTarget).data(
                     'pagesize'
                 );
 
@@ -360,7 +360,7 @@ class Loader extends Component {
 
         if (this.comments) {
             this.comments.on('rendered', (paginationHtml: string) => {
-                const newPagination = bonzo.create(paginationHtml);
+                const newPagination = $.create(paginationHtml);
                 const toolbarEl = qwery('.js-discussion-toolbar', this.elem)[0];
                 const container = $(
                     '.js-discussion-pagination',
@@ -431,7 +431,7 @@ class Loader extends Component {
 
         this.on('click', '.js-jump-to-comment', (e: Event) => {
             e.preventDefault();
-            const commentId = bonzo(e.currentTarget).data('comment-id');
+            const commentId = $(e.currentTarget).data('comment-id');
             this.gotoComment(commentId);
         });
 

--- a/static/src/javascripts/projects/common/modules/discussion/user-avatars.js
+++ b/static/src/javascripts/projects/common/modules/discussion/user-avatars.js
@@ -3,16 +3,17 @@
 import avatarApi from 'common/modules/avatar/api';
 import config from 'lib/config';
 import fastdom from 'lib/fastdom-promise';
+import { $ } from 'lib/$'
 
 const avatarify = (container: HTMLElement): void => {
-    const updating = bonzo(bonzo.create('<div class="is-updating"></div>'));
-    const avatar = bonzo(
-        bonzo.create('<img class="user-avatar__image" alt="" />')
+    const updating = $($.create('<div class="is-updating"></div>'));
+    const avatar = $(
+        $.create('<img class="user-avatar__image" alt="" />')
     );
     const avatarUserId = container.dataset.userid;
     const userId = config.get('user.id', null);
 
-    const updateCleanup = (upd: bonzo, avat: bonzo) => {
+    const updateCleanup = (upd: $, avat: $) => {
         upd.remove();
         avat.appendTo(container);
     };

--- a/static/src/javascripts/projects/common/modules/discussion/user-avatars.js
+++ b/static/src/javascripts/projects/common/modules/discussion/user-avatars.js
@@ -1,7 +1,6 @@
 // @flow
 
 import avatarApi from 'common/modules/avatar/api';
-import bonzo from 'bonzo';
 import config from 'lib/config';
 import fastdom from 'lib/fastdom-promise';
 

--- a/static/src/javascripts/projects/common/modules/discussion/whole-discussion.js
+++ b/static/src/javascripts/projects/common/modules/discussion/whole-discussion.js
@@ -1,6 +1,6 @@
 // @flow
 
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import fetchJson from 'lib/fetch-json';
 import { constructQuery } from 'lib/url';
 import range from 'lodash/range';
@@ -53,9 +53,9 @@ const runConcurrently = (
     });
 
 class WholeDiscussion {
-    commentsThread: bonzo;
+    commentsThread: $;
     discussion: Array<Object>;
-    discussionContainer: bonzo;
+    discussionContainer: $;
     discussionId: number;
     lastPage: number;
     params: {
@@ -83,7 +83,7 @@ class WholeDiscussion {
 
         /* Keep a copy of the comments thread and discussion container so it
            can be easily reduced later. */
-        this.discussionContainer = bonzo.create(resp.commentsHtml);
+        this.discussionContainer = $.create(resp.commentsHtml);
         this.postedCommentHtml = resp.postedCommentHtml;
         this.lastPage = resp.lastPage;
         this.commentsThread = $(
@@ -100,12 +100,12 @@ class WholeDiscussion {
         return range(2, this.lastPage + 1);
     }
 
-    /* Caches a bonzo object/array of comments, so that they can be
+    /* Caches a $ object/array of comments, so that they can be
        re-assembled when the load is complete. */
     storeCommentPage(response: Object, page: number): void {
         const container = $(
             '.d-thread--comments',
-            bonzo.create(response.commentsHtml)
+            $.create(response.commentsHtml)
         );
         let comments = $('.d-comment--top-level', container);
 

--- a/static/src/javascripts/projects/common/modules/discussion/whole-discussion.js
+++ b/static/src/javascripts/projects/common/modules/discussion/whole-discussion.js
@@ -1,7 +1,6 @@
 // @flow
 
 import $ from 'lib/$';
-import bonzo from 'bonzo';
 import fetchJson from 'lib/fetch-json';
 import { constructQuery } from 'lib/url';
 import range from 'lodash/range';

--- a/static/src/javascripts/projects/common/modules/email/email.js
+++ b/static/src/javascripts/projects/common/modules/email/email.js
@@ -2,7 +2,7 @@
 import formInlineLabels from 'lib/formInlineLabels';
 import bean from 'bean';
 import fastdom from 'lib/fastdom-promise';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import config from 'lib/config';
 import { getUserAgent } from 'lib/detect';
 import fetch from 'lib/fetch';
@@ -17,7 +17,6 @@ import envelope from 'svgs/icon/envelope.svg';
 import crossIcon from 'svgs/icon/cross.svg';
 
 import type { IdentityUser } from 'common/modules/identity/api';
-import type { bonzo } from 'bonzo';
 
 type Analytics = {
     formType: string,
@@ -44,7 +43,7 @@ const classes = {
     listNameHiddenInput: 'js-email-sub__listname-input',
 };
 
-const replaceContent = (isSuccess: boolean, $form: bonzo, $formHeader: ?bonzo): void => {
+const replaceContent = (isSuccess: boolean, $form: $, $formHeader: ?$): void => {
     const formData = $form.data('formData');
     const statusClass = isSuccess
         ? 'email-sub__message--success'
@@ -115,7 +114,7 @@ const updateFormForLoggedIn = (
 
 const updateForm = (
     thisRootEl: HTMLElement,
-    $el: bonzo,
+    $el: $,
     analytics: Analytics
 ): void => {
     const formData = $(thisRootEl).data();
@@ -193,7 +192,7 @@ const updateForm = (
     });
 };
 
-const heightSetter = ($wrapper: bonzo, reset: boolean): (() => void) => {
+const heightSetter = ($wrapper: $, reset: boolean): (() => void) => {
     let wrapperHeight;
 
     const getHeight = () => {
@@ -240,14 +239,14 @@ const setIframeHeight = (
         .then(callback());
 };
 
-const handleSubmit = (isSuccess: boolean, $form: bonzo, $formHeader: ?bonzo): (() => void) => () => {
+const handleSubmit = (isSuccess: boolean, $form: $, $formHeader: ?$): (() => void) => () => {
     replaceContent(isSuccess, $form, $formHeader);
     state.submitting = false;
 };
 
 const submitForm = (
-    $form: bonzo,
-    $formHeader: ?bonzo,
+    $form: $,
+    $formHeader: ?$,
     url: string,
     analytics: Analytics
 ): (Event => ?Promise<any>) => {
@@ -324,7 +323,7 @@ const submitForm = (
     };
 };
 
-const bindSubmit = ($form: bonzo, $formHeader: ?bonzo, analytics: Analytics): void => {
+const bindSubmit = ($form: $, $formHeader: ?$, analytics: Analytics): void => {
     const url = '/email';
 
     bean.on($form[0], 'submit', submitForm($form, $formHeader, url, analytics));

--- a/static/src/javascripts/projects/common/modules/experiments/affix.js
+++ b/static/src/javascripts/projects/common/modules/experiments/affix.js
@@ -1,5 +1,6 @@
 // @flow
 
+import { $ } from 'lib/$';
 import mediator from 'lib/mediator';
 import fastdom from 'lib/fastdom-promise';
 
@@ -8,11 +9,11 @@ const getPixels = (top: string): number =>
 
 class Affix {
     affixed: boolean;
-    $markerTop: bonzo;
-    $markerBottom: bonzo;
-    $container: bonzo;
-    $element: bonzo;
-    $window: bonzo;
+    $markerTop: $;
+    $markerBottom: $;
+    $container: $;
+    $element: $;
+    $window: $;
 
     constructor(options: {
         element: ?HTMLElement,
@@ -33,11 +34,11 @@ class Affix {
         });
 
         this.affixed = false;
-        this.$markerTop = bonzo(options.topMarker);
-        this.$markerBottom = bonzo(options.bottomMarker);
-        this.$container = bonzo(options.containerElement);
-        this.$element = bonzo(options.element);
-        this.$window = bonzo(document.body);
+        this.$markerTop = $(options.topMarker);
+        this.$markerBottom = $(options.bottomMarker);
+        this.$container = $(options.containerElement);
+        this.$element = $(options.element);
+        this.$window = $(document.body);
 
         this.checkPosition();
         this.calculateContainerPositioning();
@@ -69,7 +70,7 @@ class Affix {
         const elHeight = this.$element.dim().height;
         const topCheck = scrollTop >= markerTopTop;
         const bottomCheck = scrollTop + elHeight < markerBottomTop;
-        const viewportCheck = elHeight < bonzo.viewport().height;
+        const viewportCheck = elHeight < $.viewport().height;
         const affixClass = 'affix';
         const affixBottomClass = 'affix-bottom';
         const affix = bottomCheck && topCheck && viewportCheck; // This is true when the element is positioned below the top threshold and above the bottom threshold.

--- a/static/src/javascripts/projects/common/modules/experiments/affix.js
+++ b/static/src/javascripts/projects/common/modules/experiments/affix.js
@@ -1,6 +1,5 @@
 // @flow
 
-import bonzo from 'bonzo';
 import mediator from 'lib/mediator';
 import fastdom from 'lib/fastdom-promise';
 

--- a/static/src/javascripts/projects/common/modules/experiments/index.js
+++ b/static/src/javascripts/projects/common/modules/experiments/index.js
@@ -1,7 +1,7 @@
 // @flow
 import template from 'lodash/template';
 import { local as storage } from 'lib/storage';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import bean from 'bean';
 import config from 'lib/config';
 import overlay from 'raw-loader!common/views/experiments/overlay.html';

--- a/static/src/javascripts/projects/common/modules/gallery/lightbox.js
+++ b/static/src/javascripts/projects/common/modules/gallery/lightbox.js
@@ -1,6 +1,5 @@
 // @flow
 import bean from 'bean';
-import bonzo from 'bonzo';
 import qwery from 'qwery';
 import $ from 'lib/$';
 import config from 'lib/config';

--- a/static/src/javascripts/projects/common/modules/gallery/lightbox.js
+++ b/static/src/javascripts/projects/common/modules/gallery/lightbox.js
@@ -1,7 +1,7 @@
 // @flow
 import bean from 'bean';
 import qwery from 'qwery';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import config from 'lib/config';
 import { getBreakpoint, hasTouchScreen, isBreakpoint } from 'lib/detect';
 import FiniteStateMachine from 'lib/fsm';
@@ -39,7 +39,7 @@ type GalleryJson = {
 };
 
 const pulseButton = (button: HTMLElement): void => {
-    const $btn: bonzo = bonzo(button);
+    const $btn: $ = $(button);
     $btn.addClass('gallery-lightbox__button-pulse');
 
     window.setTimeout(() => {
@@ -49,7 +49,7 @@ const pulseButton = (button: HTMLElement): void => {
 
 class Endslate extends Component {
     prerender(): void {
-        bonzo(this.elem).addClass(this.componentClass);
+        $(this.elem).addClass(this.componentClass);
     }
 }
 
@@ -57,28 +57,28 @@ class GalleryLightbox {
     showEndslate: boolean;
     useSwipe: boolean;
     swipeThreshold: number;
-    lightboxEl: bonzo;
-    $lightboxEl: bonzo;
-    $indexEl: bonzo;
-    $countEl: bonzo;
-    $contentEl: bonzo;
+    lightboxEl: $;
+    $lightboxEl: $;
+    $indexEl: $;
+    $countEl: $;
+    $contentEl: $;
     nextBtn: HTMLElement;
     prevBtn: HTMLElement;
     closeBtn: HTMLElement;
     infoBtn: HTMLElement;
-    $swipeContainer: bonzo;
+    $swipeContainer: $;
     resize: Function;
     toggleInfo: Function;
     fsm: FiniteStateMachine;
     states: Object;
     images: Array<ImageJson>;
     swipeContainerWidth: number;
-    $slides: bonzo;
+    $slides: $;
     index: number;
-    $images: bonzo;
+    $images: $;
     galleryJson: GalleryJson;
     bodyScrollPosition: number;
-    endslateEl: bonzo;
+    endslateEl: $;
     endslate: Object;
     startIndex: number;
     handleKeyEvents: (KeyboardEvent) => void;
@@ -119,8 +119,8 @@ class GalleryLightbox {
             </div>`;
 
         // ELEMENT BINDINGS
-        this.lightboxEl = bonzo.create(galleryLightboxHtml);
-        this.$lightboxEl = bonzo(this.lightboxEl).prependTo(document.body);
+        this.lightboxEl = $.create(galleryLightboxHtml);
+        this.$lightboxEl = $(this.lightboxEl).prependTo(document.body);
         this.$indexEl = $('.js-gallery-index', this.lightboxEl);
         this.$countEl = $('.js-gallery-count', this.lightboxEl);
         this.$contentEl = $('.js-gallery-content', this.lightboxEl);
@@ -136,7 +136,7 @@ class GalleryLightbox {
         this.resize = this.trigger.bind(this, 'resize');
         this.toggleInfo = (e): void => {
             const infoPanelClick =
-                bonzo(e.target).hasClass('js-gallery-lightbox-info') ||
+                $(e.target).hasClass('js-gallery-lightbox-info') ||
                 $.ancestor(e.target, 'js-gallery-lightbox-info');
 
             if (!infoPanelClick) {
@@ -349,7 +349,7 @@ class GalleryLightbox {
                         .reverse()
                         .concat(galleryJson.images, next);
                     if (allImages.length < 2) {
-                        bonzo([this.nextBtn, this.prevBtn]).hide();
+                        $([this.nextBtn, this.prevBtn]).hide();
                         $(
                             '.gallery-lightbox__progress',
                             this.lightboxEl
@@ -384,10 +384,10 @@ class GalleryLightbox {
             .map(i => (index + i === 0 ? count - 1 : (index - 1 + i) % count))
             .forEach(i => {
                 imageContent = this.images[i];
-                $img = bonzo(this.$images[i]);
+                $img = $(this.$images[i]);
 
                 if (!$img.attr('src')) {
-                    $img.parent().append(bonzo.create(loaderTpl));
+                    $img.parent().append($.create(loaderTpl));
 
                     $img.attr('src', imageContent.src);
                     $img.attr('srcset', imageContent.srcsets);
@@ -417,7 +417,7 @@ class GalleryLightbox {
     }
 
     show(): void {
-        const $body = bonzo(document.body);
+        const $body = $(document.body);
         this.bodyScrollPosition = $body.scrollTop();
         $body.addClass('has-overlay');
         this.$lightboxEl.addClass('gallery-lightbox--open');
@@ -437,7 +437,7 @@ class GalleryLightbox {
     hide(): void {
         // remove has-overlay first to show body behind lightbox then scroll and
         // close the lightbox at the same time. this way we get no scroll flicker
-        const $body = bonzo(document.body);
+        const $body = $(document.body);
         $body.removeClass('has-overlay');
         bean.off(document.body, 'keydown', this.handleKeyEvents);
         window.setTimeout(() => {
@@ -475,7 +475,7 @@ class GalleryLightbox {
 
     loadEndslate(): void {
         if (!this.endslate.rendered && this.$contentEl) {
-            this.endslateEl = bonzo.create(endslateTpl);
+            this.endslateEl = $.create(endslateTpl);
             this.$contentEl.append(this.endslateEl);
 
             this.endslate.componentClass = 'gallery-lightbox__endslate';
@@ -669,7 +669,7 @@ const init = (): void => {
             bean.on(document.body, 'click', '.js-gallerythumbs', (e: Event) => {
                 e.preventDefault();
 
-                const $el = bonzo(e.currentTarget);
+                const $el = $(e.currentTarget);
                 const galleryHref =
                     $el.attr('href') || $el.attr('data-gallery-url');
                 const galleryHrefParts = galleryHref.split('#img-');

--- a/static/src/javascripts/projects/common/modules/identity/account-profile.js
+++ b/static/src/javascripts/projects/common/modules/identity/account-profile.js
@@ -6,7 +6,6 @@
  */
 import $ from 'lib/$';
 import bean from 'bean';
-import bonzo from 'bonzo';
 import { pushUrl } from 'lib/url';
 import avatarApi from 'common/modules/avatar/api';
 import {

--- a/static/src/javascripts/projects/common/modules/identity/account-profile.js
+++ b/static/src/javascripts/projects/common/modules/identity/account-profile.js
@@ -4,7 +4,7 @@
  *  Handle History updates and monitor for unsaved changes on account profile
  *  forms.
  */
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import bean from 'bean';
 import { pushUrl } from 'lib/url';
 import avatarApi from 'common/modules/avatar/api';
@@ -138,7 +138,7 @@ class AccountProfile {
                 // Prevent multiple errors from appearing
                 if (!form.querySelector(classes.formError)) {
                     // Append error message
-                    bonzo(form).prepend(this.genUnsavedError());
+                    $(form).prepend(this.genUnsavedError());
                     // Bind form submit to error message 'save' action
                     bean.on(
                         form.querySelector('.js-save-unsaved'),
@@ -216,7 +216,7 @@ class AccountProfile {
         const input = ((event.target: any):
             | HTMLInputElement
             | HTMLTextAreaElement);
-        bonzo(input.form).addClass(classes.changed);
+        $(input.form).addClass(classes.changed);
         this.unsavedChangesForm = input.form;
         if (!this.unsavedFields.some(el => el === input)) {
             this.unsavedFields.push(input);

--- a/static/src/javascripts/projects/common/modules/identity/delete-account.js
+++ b/static/src/javascripts/projects/common/modules/identity/delete-account.js
@@ -1,5 +1,5 @@
 // @flow
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import bean from 'bean';
 import fastdom from 'fastdom';
 

--- a/static/src/javascripts/projects/common/modules/identity/forms.js
+++ b/static/src/javascripts/projects/common/modules/identity/forms.js
@@ -1,5 +1,6 @@
 // @flow
 import bean from 'bean';
+import { $ } from 'lib/$';
 
 export const forgottenEmail = (): void => {
     let hashEmail;
@@ -27,7 +28,7 @@ export const passwordToggle = (): void => {
                     <a href="#toggle-password" class="'${toggleClass}" data-password-label="Show password"
                     data-text-label="Hide password" data-link-name="Toggle password field">Show password</a>
                 </div>`;
-            const $toggle = bonzo(bonzo.create(toggleTmpl)).insertBefore(
+            const $toggle = $($.create(toggleTmpl)).insertBefore(
                 password
             );
 
@@ -44,7 +45,7 @@ export const passwordToggle = (): void => {
                 if (password) {
                     password.setAttribute('type', inputType);
                 }
-                bonzo(link).text(label);
+                $(link).text(label);
             });
         }
     }

--- a/static/src/javascripts/projects/common/modules/identity/forms.js
+++ b/static/src/javascripts/projects/common/modules/identity/forms.js
@@ -1,6 +1,5 @@
 // @flow
 import bean from 'bean';
-import bonzo from 'bonzo';
 
 export const forgottenEmail = (): void => {
     let hashEmail;
@@ -24,7 +23,7 @@ export const passwordToggle = (): void => {
         if (form) {
             const password = form.querySelector('.js-register-password');
             const toggleClass = 'js-toggle-password';
-            const toggleTmpl = `<div class="form-field__note form-field__note--right mobile-only"> 
+            const toggleTmpl = `<div class="form-field__note form-field__note--right mobile-only">
                     <a href="#toggle-password" class="'${toggleClass}" data-password-label="Show password"
                     data-text-label="Hide password" data-link-name="Toggle password field">Show password</a>
                 </div>`;

--- a/static/src/javascripts/projects/common/modules/identity/modules/button.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/button.js
@@ -1,6 +1,6 @@
 // @flow
 import fastdom from 'lib/fastdom-promise';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 
 export const addUpdatingState = (buttonEl: HTMLButtonElement) =>
     fastdom.write(() => {

--- a/static/src/javascripts/projects/common/modules/identity/modules/switch.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/modules/switch.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import { addSpinner, removeSpinner, getInfo } from './switch';
 
 beforeEach(() => {

--- a/static/src/javascripts/projects/common/modules/media/videojs-plugins/fullscreener.js
+++ b/static/src/javascripts/projects/common/modules/media/videojs-plugins/fullscreener.js
@@ -1,5 +1,6 @@
 // @flow
 import bean from 'bean';
+import { $ } from 'lib/$';
 
 /**
     videojs plugins can't use arrow functions
@@ -7,11 +8,11 @@ import bean from 'bean';
     represents an instance of the videojs player
 * */
 const fullscreener = function fullscreener(): void {
-    const clickbox = bonzo.create(
+    const clickbox = $.create(
         '<div class="vjs-fullscreen-clickbox"></div>'
     )[0];
 
-    bonzo(clickbox).appendTo(this.contentEl());
+    $(clickbox).appendTo(this.contentEl());
 
     bean.on(
         clickbox,

--- a/static/src/javascripts/projects/common/modules/media/videojs-plugins/fullscreener.js
+++ b/static/src/javascripts/projects/common/modules/media/videojs-plugins/fullscreener.js
@@ -1,10 +1,9 @@
 // @flow
 import bean from 'bean';
-import bonzo from 'bonzo';
 
 /**
     videojs plugins can't use arrow functions
-    as 'this' needs to be available as it 
+    as 'this' needs to be available as it
     represents an instance of the videojs player
 * */
 const fullscreener = function fullscreener(): void {

--- a/static/src/javascripts/projects/common/modules/navigation/navigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/navigation.js
@@ -4,7 +4,7 @@ import bean from 'bean';
 import fastdom from 'lib/fastdom-promise';
 import mediator from 'lib/mediator';
 import { isIOS, getUserAgent } from 'lib/detect';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 
 const jsEnableFooterNav = (): Promise<void> =>
     fastdom.write(() => {

--- a/static/src/javascripts/projects/common/modules/navigation/profile.js
+++ b/static/src/javascripts/projects/common/modules/navigation/profile.js
@@ -1,5 +1,6 @@
 // @flow
 
+import { $ } from 'lib/$';
 import fastdom from 'fastdom';
 import { getUserFromCookie } from 'common/modules/identity/api';
 
@@ -65,10 +66,10 @@ class Profile {
     init(): void {
         // setFragmentFromCookie
         const user = getUserFromCookie();
-        const $container = bonzo(this.dom.container);
-        const $content = bonzo(this.dom.content);
-        const $register = bonzo(this.dom.register);
-        const $commentActivity = bonzo(this.dom.commentActivity);
+        const $container = $(this.dom.container);
+        const $content = $(this.dom.content);
+        const $register = $(this.dom.register);
+        const $commentActivity = $(this.dom.commentActivity);
         if (user) {
             // Run this code only if we haven't already inserted
             // the username in the header

--- a/static/src/javascripts/projects/common/modules/navigation/profile.js
+++ b/static/src/javascripts/projects/common/modules/navigation/profile.js
@@ -1,6 +1,5 @@
 // @flow
 
-import bonzo from 'bonzo';
 import fastdom from 'fastdom';
 import { getUserFromCookie } from 'common/modules/identity/api';
 

--- a/static/src/javascripts/projects/common/modules/navigation/search.js
+++ b/static/src/javascripts/projects/common/modules/navigation/search.js
@@ -2,7 +2,7 @@
 
 import bean from 'bean';
 import fastdom from 'lib/fastdom-promise';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import config from 'lib/config';
 
 // TODO refactor to singleton

--- a/static/src/javascripts/projects/common/modules/onward/breaking-news.js
+++ b/static/src/javascripts/projects/common/modules/onward/breaking-news.js
@@ -1,6 +1,5 @@
 // @flow
 import bean from 'bean';
-import bonzo from 'bonzo';
 import $ from 'lib/$';
 import fastdom from 'fastdom';
 import qwery from 'qwery';

--- a/static/src/javascripts/projects/common/modules/onward/breaking-news.js
+++ b/static/src/javascripts/projects/common/modules/onward/breaking-news.js
@@ -1,6 +1,6 @@
 // @flow
 import bean from 'bean';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import fastdom from 'fastdom';
 import qwery from 'qwery';
 import config from 'lib/config';
@@ -138,10 +138,10 @@ const filterAlertsByAge = (alerts: Array<Alert>): Array<Alert> =>
 const pickNewest = (alerts: Array<Alert>): Alert =>
     alerts.sort((a, b) => b.frontPublicationDate - a.frontPublicationDate)[0];
 
-const renderAlert = (alert: Alert): bonzo => {
+const renderAlert = (alert: Alert): $ => {
     alert.closeIcon = inlineSvg('closeCentralIcon');
 
-    const $alert = bonzo.create(template(alertHtml)(alert));
+    const $alert = $.create(template(alertHtml)(alert));
 
     const closeButton = $('.js-breaking-news__item__close', $alert)[0];
 
@@ -157,14 +157,14 @@ const renderAlert = (alert: Alert): bonzo => {
     return $alert;
 };
 
-const renderSpectre = ($breakingNews: bonzo): bonzo =>
-    bonzo(bonzo.create($breakingNews[0]))
+const renderSpectre = ($breakingNews: $): $ =>
+    $($.create($breakingNews[0]))
         .addClass('breaking-news--spectre')
         .removeClass('breaking-news--fade-in breaking-news--hidden');
 
 const show = (): Promise<boolean> => {
-    const $body = bonzo(document.body);
-    const $breakingNews = bonzo(qwery('.js-breaking-news-placeholder'));
+    const $body = $(document.body);
+    const $breakingNews = $(qwery('.js-breaking-news-placeholder'));
 
     // if its the first time we've seen this alert, we wait 3 secs to show it
     // otherwise we show it immediately

--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -4,12 +4,11 @@
  Description: Gets and sets users reading history
  */
 import fastdom from 'fastdom';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import { local } from 'lib/storage';
 import { getPath } from 'lib/url';
 import isObject from 'lodash/isObject';
 
-import type { bonzo } from 'bonzo';
 import {getCookie} from "lib/cookies";
 import { ARTICLES_VIEWED_OPT_OUT_COOKIE } from "common/modules/commercial/user-features";
 
@@ -411,7 +410,7 @@ const logSummary = (pageConfig: Object, mockToday?: number): void => {
     saveSummary(summary);
 };
 
-const getMegaNav = (): bonzo => $('.js-global-navigation');
+const getMegaNav = (): $ => $('.js-global-navigation');
 
 const removeFromMegaNav = (): void => {
     getMegaNav().each(megaNav => {

--- a/static/src/javascripts/projects/common/modules/onward/tech-feedback.js
+++ b/static/src/javascripts/projects/common/modules/onward/tech-feedback.js
@@ -1,6 +1,6 @@
 // @flow
 
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import { adblockInUse } from 'lib/detect';
 import { getSynchronousParticipations as getABParticipations } from 'common/modules/experiments/ab';
 import { getCookie } from 'lib/cookies';

--- a/static/src/javascripts/projects/common/modules/social/share-count.js
+++ b/static/src/javascripts/projects/common/modules/social/share-count.js
@@ -2,7 +2,7 @@
 
 import fastdom from 'fastdom';
 import reportError from 'lib/report-error';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import fetchJSON from 'lib/fetch-json';
 import config from 'lib/config';
 import { integerCommas } from 'lib/formatters';

--- a/static/src/javascripts/projects/common/modules/sport/football/match-list-live.js
+++ b/static/src/javascripts/projects/common/modules/sport/football/match-list-live.js
@@ -1,7 +1,6 @@
 // @flow
 
 import $ from 'lib/$';
-import bonzo from 'bonzo';
 import { Component } from 'common/modules/component';
 
 class MatchListLive extends Component {

--- a/static/src/javascripts/projects/common/modules/sport/football/match-list-live.js
+++ b/static/src/javascripts/projects/common/modules/sport/football/match-list-live.js
@@ -1,6 +1,6 @@
 // @flow
 
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import { Component } from 'common/modules/component';
 
 class MatchListLive extends Component {
@@ -20,8 +20,8 @@ class MatchListLive extends Component {
         const updated = $('.football-match', elem);
 
         $('.football-match', this.elem).each((match, i) => {
-            const $match = bonzo(match).removeClass('football-match--updated');
-            const $updated = bonzo(updated[i]);
+            const $match = $(match).removeClass('football-match--updated');
+            const $updated = $(updated[i]);
 
             ['score-home', 'score-away', 'match-status'].forEach(state => {
                 const stateData = `data-${state}`;

--- a/static/src/javascripts/projects/common/modules/sport/score-board.js
+++ b/static/src/javascripts/projects/common/modules/sport/score-board.js
@@ -1,6 +1,5 @@
 // @flow
 
-import bonzo from 'bonzo';
 import { Component } from 'common/modules/component';
 import { isBreakpoint } from 'lib/detect';
 import $ from 'lib/$';

--- a/static/src/javascripts/projects/common/modules/sport/score-board.js
+++ b/static/src/javascripts/projects/common/modules/sport/score-board.js
@@ -2,7 +2,7 @@
 
 import { Component } from 'common/modules/component';
 import { isBreakpoint } from 'lib/detect';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 
 type PageTypes = 'minbymin' | 'preview' | 'report' | 'stats';
 
@@ -10,7 +10,7 @@ type ScoreBoardContext = {
     autoupdated: boolean,
     pageType: PageTypes,
     placeholder?: HTMLElement,
-    parent: bonzo,
+    parent: $,
     responseDataKey: string,
     updateEvery?: number,
 };
@@ -36,7 +36,7 @@ class ScoreBoard extends Component {
         });
 
         this.updateEvery = isBreakpoint({ min: 'desktop' }) ? 30 : 60;
-        this.placeholder = bonzo.create(scoreContainerHtml)[0];
+        this.placeholder = $.create(scoreContainerHtml)[0];
 
         if (this.pageType === 'report') {
             context.parent.after(this.placeholder);
@@ -47,7 +47,7 @@ class ScoreBoard extends Component {
 
     placeholder: HTMLElement;
     pageType: PageTypes;
-    parent: bonzo;
+    parent: $;
 
     prerender(): void {
         const scoreLoadingPlaceholder = $(

--- a/static/src/javascripts/projects/common/modules/ui/autoupdate.js
+++ b/static/src/javascripts/projects/common/modules/ui/autoupdate.js
@@ -1,7 +1,6 @@
 // @flow
 
 import bean from 'bean';
-import bonzo from 'bonzo';
 import qwery from 'qwery';
 
 import $ from 'lib/$';

--- a/static/src/javascripts/projects/common/modules/ui/autoupdate.js
+++ b/static/src/javascripts/projects/common/modules/ui/autoupdate.js
@@ -3,7 +3,7 @@
 import bean from 'bean';
 import qwery from 'qwery';
 
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import fastdom from 'lib/fastdom-promise';
 import fetchJSON from 'lib/fetch-json';
 import { isBreakpoint, pageVisible, initPageVisibility } from 'lib/detect';
@@ -92,7 +92,7 @@ const autoUpdate = (opts?: autoUpdateOptions): void => {
         let elementsToAdd;
 
         fastdom.write(() => {
-            bonzo(resultHtml.children).addClass('autoupdate--hidden');
+            $(resultHtml.children).addClass('autoupdate--hidden');
             elementsToAdd = Array.from(resultHtml.children);
 
             // Insert new blocks

--- a/static/src/javascripts/projects/common/modules/ui/expandable.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/expandable.spec.js
@@ -1,6 +1,6 @@
 // @flow
 
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import { Expandable } from 'common/modules/ui/expandable';
 
 describe('Expandable', () => {

--- a/static/src/javascripts/projects/common/modules/ui/full-height.js
+++ b/static/src/javascripts/projects/common/modules/ui/full-height.js
@@ -1,6 +1,6 @@
 // @flow
 
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import fastdom from 'lib/fastdom-promise';
 import mediator from 'lib/mediator';
 import { getBreakpoint } from 'lib/detect';

--- a/static/src/javascripts/projects/common/modules/ui/message.js
+++ b/static/src/javascripts/projects/common/modules/ui/message.js
@@ -1,5 +1,5 @@
 // @flow
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import { noop } from 'lib/noop';
 import bean from 'bean';
 import userPrefs from 'common/modules/user-prefs';

--- a/static/src/javascripts/projects/common/modules/ui/message.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/message.spec.js
@@ -1,6 +1,6 @@
 // @flow
 
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import userPrefs from 'common/modules/user-prefs';
 import { Message } from './message';
 

--- a/static/src/javascripts/projects/common/modules/ui/relativedates.js
+++ b/static/src/javascripts/projects/common/modules/ui/relativedates.js
@@ -1,5 +1,5 @@
 // @flow
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 
 type RelativeDateOptions = {
     notAfter?: number,
@@ -164,7 +164,7 @@ const makeRelativeDate = (
     );
 };
 
-const findValidTimestamps = (): bonzo =>
+const findValidTimestamps = (): $ =>
     // `.blocktime time` used in blog html
     $('.js-timestamp, .js-item__timestamp');
 
@@ -174,7 +174,7 @@ const replaceLocaleTimestamps = (html: ?Element): void => {
 
     $(`.${cls}`, context).each(el => {
         let datetime;
-        const $el = bonzo(el);
+        const $el = $(el);
         const timestamp = parseInt($el.attr('data-timestamp'), 10);
 
         if (timestamp) {
@@ -190,7 +190,7 @@ const replaceLocaleTimestamps = (html: ?Element): void => {
 const replaceValidTimestamps = (opts: RelativeDateOptions = {}): void => {
     findValidTimestamps().each(el => {
         let targetEl;
-        const $el = bonzo(el);
+        const $el = $(el);
 
         const // Epoch dates are more reliable, fallback to datetime for liveblog blocks
             timestamp =
@@ -201,7 +201,7 @@ const replaceValidTimestamps = (opts: RelativeDateOptions = {}): void => {
 
         const relativeDate = makeRelativeDate(datetime.getTime(), {
             // NOTE: if this is in a block (blog), assume we want added time on > 1 day old dates
-            showTime: bonzo($el.parent()).hasClass('block-time'),
+            showTime: $($el.parent()).hasClass('block-time'),
             format: $el.attr('data-relativeformat'),
             notAfter: opts.notAfter,
         });
@@ -210,7 +210,7 @@ const replaceValidTimestamps = (opts: RelativeDateOptions = {}): void => {
             // If we find .timestamp__text (facia), use that instead
             targetEl = $el[0].querySelector('.timestamp__text') || $el[0];
             if (!targetEl.getAttribute('title')) {
-                targetEl.setAttribute('title', bonzo(targetEl).text());
+                targetEl.setAttribute('title', $(targetEl).text());
             }
             targetEl.innerHTML = relativeDate;
         } else if (opts.notAfter) {

--- a/static/src/javascripts/projects/common/modules/ui/relativedates.js
+++ b/static/src/javascripts/projects/common/modules/ui/relativedates.js
@@ -1,6 +1,5 @@
 // @flow
 import $ from 'lib/$';
-import bonzo from 'bonzo';
 
 type RelativeDateOptions = {
     notAfter?: number,

--- a/static/src/javascripts/projects/common/modules/ui/rhc.js
+++ b/static/src/javascripts/projects/common/modules/ui/rhc.js
@@ -1,5 +1,5 @@
 // @flow
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 
 const addComponent = (content: Element, importance: number = 1): void => {
     const container = $('.js-components-container');

--- a/static/src/javascripts/projects/common/modules/ui/rhc.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/rhc.spec.js
@@ -1,6 +1,6 @@
 // @flow
 
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import Chance from 'chance';
 import { addComponent } from './rhc';
 

--- a/static/src/javascripts/projects/common/modules/ui/selection-sharing.js
+++ b/static/src/javascripts/projects/common/modules/ui/selection-sharing.js
@@ -1,7 +1,7 @@
 // @flow
 import bean from 'bean';
 import Rangefix from 'rangefix';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import config from 'lib/config';
 import { hasTouchScreen } from 'lib/detect';
 import mediator from 'lib/mediator';

--- a/static/src/javascripts/projects/common/modules/ui/selection-sharing.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/selection-sharing.spec.js
@@ -1,6 +1,6 @@
 // @flow
 
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import {
     init as selectionSharingInit,
     updateSelection,

--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -1,6 +1,6 @@
 // @flow
 import fastdom from 'fastdom';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import { getCookie, addCookie } from 'lib/cookies';
 import { isIOS, isAndroid, getBreakpoint, getUserAgent } from 'lib/detect';
 import template from 'lodash/template';

--- a/static/src/javascripts/projects/common/modules/video/events.js
+++ b/static/src/javascripts/projects/common/modules/video/events.js
@@ -2,7 +2,7 @@
 import bean from 'bean';
 import mediator from 'lib/mediator';
 import reportError from 'lib/report-error';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import config from 'lib/config';
 import { isBreakpoint } from 'lib/detect';
 import { isRevisit } from 'common/modules/onward/history';

--- a/static/src/javascripts/projects/common/modules/video/video-container.js
+++ b/static/src/javascripts/projects/common/modules/video/video-container.js
@@ -1,7 +1,7 @@
 // @flow
 import bean from 'bean';
 import fastdom from 'lib/fastdom-promise';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import { elementInView } from 'lib/element-inview';
 import { onVideoContainerNavigation } from 'common/modules/atoms/youtube';
 import { isBreakpoint } from 'lib/detect';

--- a/static/src/javascripts/projects/facia/modules/onwards/geo-most-popular-front-extended.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/geo-most-popular-front-extended.js
@@ -4,12 +4,11 @@
  Description: replaces general most popular trails with geo based most popular on fronts.
  */
 import qwery from 'qwery';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import config from 'lib/config';
 import mediator from 'lib/mediator';
 import { begin, end } from 'common/modules/analytics/register';
 import { Component } from 'common/modules/component';
-import type bonzo from 'bonzo';
 
 export class GeoMostPopularFrontExtended extends Component {
     constructor() {
@@ -19,7 +18,7 @@ export class GeoMostPopularFrontExtended extends Component {
         this.manipulationType = 'html';
     }
 
-    parent: ?bonzo;
+    parent: ?$;
 
     prerender(): void {
         const isInternational = config.get('page.pageId') === 'international';

--- a/static/src/javascripts/projects/facia/modules/onwards/geo-most-popular-front.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/geo-most-popular-front.js
@@ -4,14 +4,13 @@
  Description: replaces general most popular trails with geo based most popular on fronts.
  */
 import qwery from 'qwery';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import config from 'lib/config';
 import mediator from 'lib/mediator';
 import { begin, end } from 'common/modules/analytics/register';
 import { Component } from 'common/modules/component';
-import type bonzo from 'bonzo';
 
-const hideTabs = (parent: bonzo): void => {
+const hideTabs = (parent: $): void => {
     $('.js-tabs-content', parent).addClass('tabs__content--no-border');
     $('.js-tabs', parent).addClass('u-h');
 };
@@ -31,7 +30,7 @@ export class GeoMostPopularFront extends Component {
     isNetworkFront: boolean;
     isVideoFront: boolean;
     isInternational: boolean;
-    parent: ?bonzo;
+    parent: ?$;
 
     prerender(): void {
         this.elem = qwery('.headline-list', this.elem)[0];

--- a/static/src/javascripts/projects/facia/modules/onwards/search-tool.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/search-tool.js
@@ -4,7 +4,6 @@ import $ from 'lib/$';
 import fetchJson from 'lib/fetch-json';
 import mediator from 'lib/mediator';
 import reportError from 'lib/report-error';
-import bonzo from 'bonzo';
 
 type WeatherSearchOptions = {
     container: bonzo,

--- a/static/src/javascripts/projects/facia/modules/onwards/search-tool.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/search-tool.js
@@ -1,12 +1,12 @@
 // @flow
 import bean from 'bean';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import fetchJson from 'lib/fetch-json';
 import mediator from 'lib/mediator';
 import reportError from 'lib/report-error';
 
 type WeatherSearchOptions = {
-    container: bonzo,
+    container: $,
     apiUrl: string,
 };
 
@@ -32,8 +32,8 @@ export type CityPreference = {
 
 export class SearchTool {
     apiUrl: string;
-    $list: bonzo;
-    $input: bonzo;
+    $list: $;
+    $input: $;
     oldQuery: string;
     newQuery: string;
     inputTmp: string;
@@ -262,7 +262,7 @@ export class SearchTool {
         this.clear().append(docFragment);
     }
 
-    clear(): bonzo {
+    clear(): $ {
         return this.$list.html('');
     }
 

--- a/static/src/javascripts/projects/facia/modules/onwards/search-tool.spec.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/search-tool.spec.js
@@ -1,7 +1,7 @@
 // @flow
 
 import bean from 'bean';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import fetchJson_ from 'lib/fetch-json';
 import { SearchTool } from 'facia/modules/onwards/search-tool';
 import mediator from 'lib/mediator';

--- a/static/src/javascripts/projects/facia/modules/onwards/weather.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/weather.js
@@ -15,7 +15,7 @@
 
 import bean from 'bean';
 import reportError from 'lib/report-error';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import config from 'lib/config';
 import fetchJson from 'lib/fetch-json';
 import mediator from 'lib/mediator';

--- a/static/src/javascripts/projects/facia/modules/ui/container-show-more.js
+++ b/static/src/javascripts/projects/facia/modules/ui/container-show-more.js
@@ -1,5 +1,4 @@
 // @flow
-import bonzo from 'bonzo';
 import fastdom from 'fastdom';
 import qwery from 'qwery';
 import $ from 'lib/$';

--- a/static/src/javascripts/projects/facia/modules/ui/container-show-more.js
+++ b/static/src/javascripts/projects/facia/modules/ui/container-show-more.js
@@ -1,7 +1,7 @@
 // @flow
 import fastdom from 'fastdom';
 import qwery from 'qwery';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import config from 'lib/config';
 import fetchJson from 'lib/fetch-json';
 import mediator from 'lib/mediator';
@@ -64,17 +64,17 @@ const loadShowMore = (pageId: string, containerId: string): Promise<any> => {
     );
 };
 
-const itemsByArticleId = ($el: bonzo): Object =>
+const itemsByArticleId = ($el: $): Object =>
     groupBy(qwery(ITEM_SELECTOR, $el), el =>
-        bonzo(el).attr(ARTICLE_ID_ATTRIBUTE)
+        $(el).attr(ARTICLE_ID_ATTRIBUTE)
     );
 
-const dedupShowMore = ($container: bonzo, html: string): bonzo => {
+const dedupShowMore = ($container: $, html: string): $ => {
     const seenArticles = itemsByArticleId($container);
-    const $html = bonzo.create(html);
+    const $html = $.create(html);
 
     $(ITEM_SELECTOR, $html).each(article => {
-        const $article = bonzo(article);
+        const $article = $(article);
         const articleClass = $article.attr('class');
         if (
             $article.attr(ARTICLE_ID_ATTRIBUTE) in seenArticles ||
@@ -93,15 +93,15 @@ class Button {
     id: string;
     state: DisplayState;
     isLoaded: boolean;
-    $el: bonzo;
-    $container: bonzo;
-    $iconEl: bonzo;
-    $placeholder: bonzo;
-    $textEl: bonzo;
-    $errorMessage: ?bonzo;
+    $el: $;
+    $container: $;
+    $iconEl: $;
+    $placeholder: $;
+    $textEl: $;
+    $errorMessage: ?$;
     messages: Map<DisplayState, string>;
 
-    constructor(el: bonzo, container: bonzo) {
+    constructor(el: $, container: $) {
         this.id = container.attr('data-id');
         this.state = readDisplayPrefForContainer(this.id);
         this.$el = el;
@@ -193,8 +193,8 @@ class Button {
             this.$errorMessage.remove();
         }
 
-        this.$errorMessage = bonzo(
-            bonzo.create(
+        this.$errorMessage = $(
+            $.create(
                 '<div class="show-more__error-message">' +
                     'Sorry, failed to load more stories. Please try again.' +
                     '</div>'
@@ -244,7 +244,7 @@ const renderToDom = (button: Button): void => {
 
 export const init = (): void => {
     fastdom.read(() => {
-        const containers = qwery('.js-container--fc-show-more').map(bonzo);
+        const containers = qwery('.js-container--fc-show-more').map($);
         const buttons = containers
             .map(container => {
                 const el = $('.js-show-more-button', container);

--- a/static/src/javascripts/projects/facia/modules/ui/container-show-more.spec.js
+++ b/static/src/javascripts/projects/facia/modules/ui/container-show-more.spec.js
@@ -1,6 +1,7 @@
 // @flow
 
 import qwery from 'qwery';
+import { $ } from 'lib/$';
 
 import { _ } from 'facia/modules/ui/container-show-more';
 
@@ -14,8 +15,8 @@ describe('Container Show More', () => {
     const itemWithId = id => `<div class="js-fc-item" data-id="${id}"></div>`;
 
     beforeEach(() => {
-        $container = bonzo(
-            bonzo.create(
+        $container = $(
+            $.create(
                 `<div>${itemWithId('loldongs')}${itemWithId(
                     'corgi'
                 )}${itemWithId('geekpie')}</div>`

--- a/static/src/javascripts/projects/facia/modules/ui/container-show-more.spec.js
+++ b/static/src/javascripts/projects/facia/modules/ui/container-show-more.spec.js
@@ -1,6 +1,5 @@
 // @flow
 
-import bonzo from 'bonzo';
 import qwery from 'qwery';
 
 import { _ } from 'facia/modules/ui/container-show-more';

--- a/static/src/javascripts/projects/facia/modules/ui/container-toggle.js
+++ b/static/src/javascripts/projects/facia/modules/ui/container-toggle.js
@@ -1,5 +1,4 @@
 // @flow
-import bonzo from 'bonzo';
 import fastdom from 'fastdom';
 import $ from 'lib/$';
 import mediator from 'lib/mediator';

--- a/static/src/javascripts/projects/facia/modules/ui/container-toggle.js
+++ b/static/src/javascripts/projects/facia/modules/ui/container-toggle.js
@@ -1,6 +1,6 @@
 // @flow
 import fastdom from 'fastdom';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import mediator from 'lib/mediator';
 import userPrefs from 'common/modules/user-prefs';
 
@@ -19,13 +19,13 @@ const btnTmpl = ({ text, dataLink }) => `
 `;
 
 export class ContainerToggle {
-    $container: bonzo;
+    $container: $;
     state: ToggleState;
-    $button: bonzo;
+    $button: $;
     constructor(container: Element) {
-        this.$container = bonzo(container);
-        this.$button = bonzo(
-            bonzo.create(
+        this.$container = $(container);
+        this.$button = $(
+            $.create(
                 btnTmpl({
                     text: 'Hide',
                     dataLink: 'Show',
@@ -35,7 +35,7 @@ export class ContainerToggle {
         this.state = 'displayed';
     }
 
-    buttonText(): bonzo {
+    buttonText(): $ {
         return $('.fc-container__toggle__text', this.$button);
     }
 

--- a/static/src/javascripts/projects/facia/modules/ui/container-toggle.spec.js
+++ b/static/src/javascripts/projects/facia/modules/ui/container-toggle.spec.js
@@ -1,5 +1,5 @@
 // @flow
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import fastdom from 'fastdom';
 import mediator from 'lib/mediator';
 import userPrefs from 'common/modules/user-prefs';
@@ -32,14 +32,14 @@ describe('Container Toggle', () => {
     };
 
     beforeEach(() => {
-        container = bonzo.create(
+        container = $.create(
             `<section class="fc-container js-container--toggle fc-container__will-have-toggle" data-id="${containerId}">` +
                 `<div class="fc-container__header js-container__header">` +
                 `<h2>A container</h2>` +
                 `</div>` +
                 `</section>`
         );
-        $container = bonzo(container[0]);
+        $container = $(container[0]);
     });
 
     afterEach(() => {

--- a/static/src/javascripts/projects/facia/modules/ui/container-toggle.spec.js
+++ b/static/src/javascripts/projects/facia/modules/ui/container-toggle.spec.js
@@ -1,6 +1,5 @@
 // @flow
 import $ from 'lib/$';
-import bonzo from 'bonzo';
 import fastdom from 'fastdom';
 import mediator from 'lib/mediator';
 import userPrefs from 'common/modules/user-prefs';

--- a/static/src/javascripts/projects/facia/modules/ui/football-snaps.js
+++ b/static/src/javascripts/projects/facia/modules/ui/football-snaps.js
@@ -1,5 +1,4 @@
 // @flow
-import bonzo from 'bonzo';
 import { getBreakpoint } from 'lib/detect';
 
 /**

--- a/static/src/javascripts/projects/facia/modules/ui/football-snaps.js
+++ b/static/src/javascripts/projects/facia/modules/ui/football-snaps.js
@@ -1,12 +1,13 @@
 // @flow
 import { getBreakpoint } from 'lib/detect';
+import { $ } from 'lib/$';
 
 /**
  * All the football snaps sitting in a "big" slice (if any) will take the height of their trail trails
  */
-export const resizeForFootballSnaps = (el: bonzo): void => {
+export const resizeForFootballSnaps = (el: $): void => {
     if (el && getBreakpoint() !== 'mobile') {
-        const $el = bonzo(el);
+        const $el = $(el);
         $el.css('height', $el.parent().css('height'));
     }
 };

--- a/static/src/javascripts/projects/facia/modules/ui/live-blog-updates.js
+++ b/static/src/javascripts/projects/facia/modules/ui/live-blog-updates.js
@@ -1,6 +1,6 @@
 // @flow
 import { makeRelativeDate } from 'common/modules/ui/relativedates';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import { getViewport } from 'lib/detect';
 import fastdomPromise from 'lib/fastdom-promise';
 import fetchJson from 'lib/fetch-json';
@@ -123,7 +123,7 @@ const applyUpdate = (
     content: Array<Element>
 ): Promise<void> =>
     fastdomPromise.write(() => {
-        bonzo(container)
+        $(container)
             .empty()
             .append(content);
     });
@@ -208,7 +208,7 @@ const showBlocks = (
             })
             .slice(0, calculateBlockCount(hasNewBlock, isDynamic(element)));
 
-        const el = bonzo.create(
+        const el = $.create(
             `<div class="${wrapperClasses.join(' ')}">${blocksHtml.join(
                 ''
             )}</div>`

--- a/static/src/javascripts/projects/facia/modules/ui/live-blog-updates.js
+++ b/static/src/javascripts/projects/facia/modules/ui/live-blog-updates.js
@@ -1,5 +1,4 @@
 // @flow
-import bonzo from 'bonzo';
 import { makeRelativeDate } from 'common/modules/ui/relativedates';
 import $ from 'lib/$';
 import { getViewport } from 'lib/detect';

--- a/static/src/javascripts/projects/facia/modules/ui/snaps.js
+++ b/static/src/javascripts/projects/facia/modules/ui/snaps.js
@@ -1,7 +1,6 @@
 // @flow
 
 import bean from 'bean';
-import bonzo from 'bonzo';
 import fastdom from 'fastdom';
 import $ from 'lib/$';
 import { isIOS } from 'lib/detect';

--- a/static/src/javascripts/projects/facia/modules/ui/snaps.js
+++ b/static/src/javascripts/projects/facia/modules/ui/snaps.js
@@ -2,7 +2,7 @@
 
 import bean from 'bean';
 import fastdom from 'fastdom';
-import $ from 'lib/$';
+import { $ } from 'lib/$';
 import { isIOS } from 'lib/detect';
 import fetch from 'lib/fetch';
 import mediator from 'lib/mediator';
@@ -25,7 +25,7 @@ const bindIframeMsgReceiverOnce = once(() => {
             message = JSON.parse(event.data);
 
             if (message.type === 'set-height') {
-                bonzo(iframe)
+                $(iframe)
                     .parent()
                     .css('height', message.value);
             }
@@ -35,7 +35,7 @@ const bindIframeMsgReceiverOnce = once(() => {
 
 const setSnapPoint = (el: HTMLElement, isResize: boolean): void => {
     let width;
-    const $el = bonzo(el);
+    const $el = $(el);
     const prefix = 'facia-snap-point--';
     const breakpoints: Array<{
         width: number,
@@ -104,7 +104,7 @@ const addCss = (el: HTMLElement, isResize: boolean = false): void => {
 };
 
 const injectIframe = (el: HTMLElement): void => {
-    const spec = bonzo(el).offset();
+    const spec = $(el).offset();
     const minIframeHeight = Math.ceil((spec.width || 0) / 2);
     const maxIframeHeight = 400;
     const src = el.getAttribute('data-snap-uri') || '';
@@ -112,19 +112,19 @@ const injectIframe = (el: HTMLElement): void => {
         Math.max(spec.height || 0, minIframeHeight),
         maxIframeHeight
     );
-    const containerEl = bonzo.create(
+    const containerEl = $.create(
         `<div style="width: 100%; height: ${height}px; overflow: hidden; -webkit-overflow-scrolling:touch"></div>`
     )[0];
-    const iframe = bonzo.create(
+    const iframe = $.create(
         `<iframe src="${src}" style="width: 100%; height: 100%; border: none;"></iframe>`
     )[0];
 
-    bonzo(containerEl).append(iframe);
+    $(containerEl).append(iframe);
     snapIframes.push(iframe);
     bindIframeMsgReceiverOnce();
 
     fastdom.write(() => {
-        bonzo(el)
+        $(el)
             .empty()
             .append(containerEl);
     });
@@ -151,7 +151,7 @@ const fetchFragment = (el: HTMLElement, asJson: boolean = false): void => {
         .then(resp => {
             $.create(resp).each(html => {
                 fastdom.write(() => {
-                    bonzo(el).html(html);
+                    $(el).html(html);
                 });
             });
             initRelativeDates(el);
@@ -166,7 +166,7 @@ const fetchFragment = (el: HTMLElement, asJson: boolean = false): void => {
 const initStandardSnap = (el: HTMLElement): void => {
     addProximityLoader(el, 1500, () => {
         fastdom.write(() => {
-            bonzo(el).addClass('facia-snap-embed');
+            $(el).addClass('facia-snap-embed');
         });
         addCss(el);
 


### PR DESCRIPTION
## What does this change?

- removes all (nearly) references to `bonzo` in favour of `$`
- adds a linting rule to prevent `bonzo` creeping back in

## Why?

- first step to being able to remove `bonzo` and `qwery`

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No