### PR TITLE
Identity - Add pageview sign in gate AB test 

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -88,6 +88,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-sign-in-gate-pageview",
+    "Show sign in gate on 3rd vs 2nd article view, with dismiss rule variants",
+    owners = Seq(Owner.withGithub("vlbee")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 12, 1),
+    exposeClientSide = true,
+  )
+
+  Switch(
+    ABTests,
     "ab-remote-epic-variants",
     "Serve epics from remote service for subset of audience",
     owners = Seq(Owner.withGithub("nicl")),

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -8,6 +8,7 @@ import { remoteEpicVariants } from 'common/modules/experiments/tests/remote-epic
 import { signInGatePatientia } from 'common/modules/experiments/tests/sign-in-gate-patientia';
 import { signInGateMainVariant } from 'common/modules/experiments/tests/sign-in-gate-main-variant';
 import { signInGateMainControl } from 'common/modules/experiments/tests/sign-in-gate-main-control';
+import { signInGatePageview } from 'common/modules/experiments/tests/sign-in-gate-pageview';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
@@ -15,6 +16,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     signInGatePatientia,
     signInGateMainVariant,
     signInGateMainControl,
+    signInGatePageview,
 ];
 
 export const priorityEpicTest: AcquisitionsABTest = remoteEpicVariants;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
@@ -10,7 +10,7 @@ export const signInGateMainVariant: ABTest = {
     author: 'Mahesh Makani',
     description:
         'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Main/Variant Audience.',
-    audience: 0.9,
+    audience: 0.6667,
     audienceOffset: 0.0,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
@@ -10,7 +10,7 @@ export const signInGateMainVariant: ABTest = {
     author: 'Mahesh Makani',
     description:
         'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Main/Variant Audience.',
-    audience: 0.6667,
+    audience: 0.771,
     audienceOffset: 0.0,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-pageview.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-pageview.js
@@ -6,8 +6,8 @@ export const signInGatePageview: ABTest = {
     author: 'vlbee',
     description:
         'Compare showing the gate on the 2nd vs 3rd article view with new and old dimiss rule variants, on simple article templates, with higher priority over banners and epi, excluding the US',
-    audience: 0.2333,
-    audienceOffset: 0.6667,
+    audience: 0.129,
+    audienceOffset: 0.771,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:
         '2nd or 3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss or reshown after 5 dismisses, not on help, info sections etc. Exclude US, iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-pageview.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-pageview.js
@@ -1,0 +1,37 @@
+// @flow
+export const signInGatePageview: ABTest = {
+    id: 'SignInGatePageview',
+    start: '2020-10-09',
+    expiry: '2020-12-01',
+    author: 'vlbee',
+    description:
+        'Compare showing the gate on the 2nd vs 3rd article view with new and old dimiss rule variants, on simple article templates, with higher priority over banners and epi, excluding the US',
+    audience: 0.2333,
+    audienceOffset: 0.6667,
+    successMeasure: 'Users sign in or create a Guardian account',
+    audienceCriteria:
+        '2nd or 3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss or reshown after 5 dismisses, not on help, info sections etc. Exclude US, iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
+    dataLinkNames: 'SignInGatePageview',
+    idealOutcome:
+        'Moving to a second page view gate would lead to an estimated increase in the number of weekly sign ins of between +25% and +35%.',
+    showForSensitive: false,
+    canRun: () => true,
+    variants: [
+        {
+            id: 'pageview-variant-1', // 3rd page view & new dismiss rule (capped at 5)
+            test: (): void => {},
+        },
+        {
+            id: 'pageview-variant-2', // 2nd page view & new dismiss rule (capped at 5)
+            test: (): void => {},
+        },
+        {
+            id: 'pageview-variant-3', // 3rd page view & old dismiss rule (never see gate again after first dismissal)
+            test: (): void => {},
+        },
+        {
+            id: 'pageview-variant-4', // 2nd page view & new dismiss rule (never see gate again after first dismissal)
+            test: (): void => {},
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/README.md
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/README.md
@@ -5,12 +5,11 @@ When making changes to a test, for example adding a new variant, it is worth mod
 To do this you have to modify a few files files:
 1. in `static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate.js` change the `id` parameter of the test
 2. in `common/app/conf/switches/ABTestSwitches.scala`, under the switch for the sign in gate, change the first parameter by turning the id in the file above into a kebab-case string with `ab-` appended at the front, e.g. `SignInGateTertius` would turn into `ab-sign-in-gate-tertius`
-3. in `static/src/javascripts/projects/common/modules/identity/sign-in-gate/component.js` change the `component.id` to reflect the new test too
-4. finally in `static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js` update the `common/modules/experiments/ab` mock to reflect the new test too
+3. finally in `static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js` update the `common/modules/experiments/ab` mock to reflect the new test too
 
 ## Adding Variants
 
-1. Add the new variant to the sign in gate ab test definition in the `variants` array: `static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate.js`
+1. Add the new variant to the sign in gate ab test definition in the `concurrentTests` array: `static/src/javascripts/projects/common/modules/experiments/ab-tests.js`
 2. Clone the `example.js` file in the `./variants` folder, have the name of the file reflect the variant name, e.g. `control.js`.
 3. Modify this file to reflect the new variant information.
     - First define the variant name, by changing `example` in `const name = 'example'` to the new variant name
@@ -18,7 +17,7 @@ To do this you have to modify a few files files:
     - Then modify the `canShow` method, this method determines if the test can be shown on that page view for that variant
     - After modify the `show` method to run anything thats needed to get the gate to show, e.g. setting the template, adding click handlers etc.
     - Finally export a `SignInGateVariant` type, which is an object that exports `name`, `canShow`, and `show`.
-4. Import this object in `./variants/index.js`, and add it to the export array. From this point on the variant will be able to be used.
+4. Import this object in `./variants/index.js`, and add it to the export `tests` array. From this point on the variant will be able to be used.
 
 ## Styling the gate
 

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
@@ -186,9 +186,8 @@ export const isNPageOrHigherPageView = (n: number = 2): boolean => {
 // use gu.location to determine is the browser is in the specified country
 // Note, use country codes specified in /static/src/javascripts/lib/geolocation.js
 export const isCountry = (countryCode: string): boolean => {
-    const geolocation: Object = geolocationGetSync();
-    const countryCodeFromStorage = geolocation && geolocation.value;
-    return countryCodeFromStorage === countryCode;
+    const geolocation = geolocationGetSync();
+    return geolocation === countryCode;
 };
 
 // determine if the useragent is running iOS 9 (known to be buggy for sign in flow)

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.spec.js
@@ -200,16 +200,12 @@ describe('Sign In Gate Helper functions', () => {
 
     describe("isCountry('countryCode')", () => {
         test('geolocation is US', () => {
-            fakeLocal.get.mockReturnValueOnce({
-                value: 'US',
-            });
+            fakeLocal.get.mockReturnValueOnce('US');
             expect(isCountry('US')).toBe(true);
         });
 
         test('geolocation is not US', () => {
-            fakeLocal.get.mockReturnValueOnce({
-                value: 'GB',
-            });
+            fakeLocal.get.mockReturnValueOnce('GB');
             expect(isCountry('US')).toBe(false);
         });
 

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/index.js
@@ -6,6 +6,7 @@ import type { Banner } from 'common/modules/ui/bannerPicker';
 import { signInGatePatientia } from 'common/modules/experiments/tests/sign-in-gate-patientia';
 import { signInGateMainVariant } from 'common/modules/experiments/tests/sign-in-gate-main-variant';
 import { signInGateMainControl } from 'common/modules/experiments/tests/sign-in-gate-main-control';
+import { signInGatePageview } from 'common/modules/experiments/tests/sign-in-gate-pageview';
 import { submitViewEventTracking } from './component-event-tracking';
 import { getVariant, isInTest, getTestforMultiTest } from './helper';
 import { withComponentId, componentName } from './component';
@@ -21,6 +22,7 @@ const tests = [
     signInGatePatientia,
     signInGateMainVariant,
     signInGateMainControl,
+    signInGatePageview,
 ];
 
 const canShow: () => Promise<boolean> = () =>

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/index.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/index.js
@@ -6,6 +6,10 @@ import { signInGateVariant as patientiaControl } from './patientia/control';
 import { signInGateVariant as patientiaVariant } from './patientia/variant';
 import { signInGateVariant as mainVariant } from './main/variant';
 import { signInGateVariant as mainControl } from './main/control';
+import { signInGateVariant as pageviewVariant1 } from './pageview/variant-1';
+import { signInGateVariant as pageviewVariant2 } from './pageview/variant-2';
+import { signInGateVariant as pageviewVariant3 } from './pageview/variant-3';
+import { signInGateVariant as pageviewVariant4 } from './pageview/variant-4';
 
 // to add a variant, first import the variant in the SignInGateVariant type, and then add to this exported array
 export const variants: Array<SignInGateVariant> = [
@@ -14,4 +18,8 @@ export const variants: Array<SignInGateVariant> = [
     patientiaVariant,
     mainVariant,
     mainControl,
+    pageviewVariant1,
+    pageviewVariant2,
+    pageviewVariant3,
+    pageviewVariant4,
 ];

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/pageview/variant-1.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/pageview/variant-1.js
@@ -1,0 +1,59 @@
+// @flow
+import type { CurrentABTest, SignInGateVariant } from '../../types';
+import { componentName } from '../../component';
+import {
+    isNPageOrHigherPageView,
+    isLoggedIn,
+    isInvalidArticleType,
+    isInvalidSection,
+    isIOS9,
+    setGatePageTargeting,
+    hasUserDismissedGateMoreThanCount,
+    isCountry,
+} from '../../helper';
+
+// pull in the show method from the design folder, which has the html template and and click handlers etc.
+import { designShow } from '../design/main-variant';
+
+// define the variant name here
+const variant = 'pageview-variant-1'; // 3rd page view & new dismiss rule (capped at 5)
+
+// method which returns a boolean determining if this variant can be shown on the current pageview
+const canShow: (name?: string) => boolean = (name = '') => {
+    const isGateDismissed = hasUserDismissedGateMoreThanCount(
+        variant,
+        name,
+        componentName,
+        5
+    );
+
+    const canShowCheck =
+        !isGateDismissed &&
+        isNPageOrHigherPageView(3) &&
+        !isLoggedIn() &&
+        !isInvalidArticleType() &&
+        !isInvalidSection() &&
+        !isIOS9() &&
+        !isCountry('US');
+
+    setGatePageTargeting(isGateDismissed, canShowCheck);
+    return canShowCheck;
+};
+
+// method which runs if the canShow method returns true, used to display the gate and logic associated with it
+// it returns a boolean, since the sign in gate is based on a `Banner` type who's show method returns a Promise<boolean>
+// in our case it returns true if the design ran successfully, and false if there were any problems encountered
+const show: ({
+    abTest: CurrentABTest,
+    guUrl: string,
+    signInUrl: string,
+    ophanComponentId: string,
+}) => boolean = ({ abTest, guUrl, signInUrl, ophanComponentId }) =>
+    designShow({ abTest, guUrl, signInUrl, ophanComponentId });
+
+// export the variant as a SignInGateVariant type
+export const signInGateVariant: SignInGateVariant = {
+    name: variant,
+    canShow,
+    show,
+};

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/pageview/variant-2.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/pageview/variant-2.js
@@ -1,0 +1,59 @@
+// @flow
+import type { CurrentABTest, SignInGateVariant } from '../../types';
+import { componentName } from '../../component';
+import {
+    isNPageOrHigherPageView,
+    isLoggedIn,
+    isInvalidArticleType,
+    isInvalidSection,
+    isIOS9,
+    setGatePageTargeting,
+    hasUserDismissedGateMoreThanCount,
+    isCountry,
+} from '../../helper';
+
+// pull in the show method from the design folder, which has the html template and and click handlers etc.
+import { designShow } from '../design/main-variant';
+
+// define the variant name here
+const variant = 'pageview-variant-2'; // 2nd page view & new dismiss rule (capped at 5)
+
+// method which returns a boolean determining if this variant can be shown on the current pageview
+const canShow: (name?: string) => boolean = (name = '') => {
+    const isGateDismissed = hasUserDismissedGateMoreThanCount(
+        variant,
+        name,
+        componentName,
+        5
+    );
+
+    const canShowCheck =
+        !isGateDismissed &&
+        isNPageOrHigherPageView(2) &&
+        !isLoggedIn() &&
+        !isInvalidArticleType() &&
+        !isInvalidSection() &&
+        !isIOS9() &&
+        !isCountry('US');
+
+    setGatePageTargeting(isGateDismissed, canShowCheck);
+    return canShowCheck;
+};
+
+// method which runs if the canShow method returns true, used to display the gate and logic associated with it
+// it returns a boolean, since the sign in gate is based on a `Banner` type who's show method returns a Promise<boolean>
+// in our case it returns true if the design ran successfully, and false if there were any problems encountered
+const show: ({
+    abTest: CurrentABTest,
+    guUrl: string,
+    signInUrl: string,
+    ophanComponentId: string,
+}) => boolean = ({ abTest, guUrl, signInUrl, ophanComponentId }) =>
+    designShow({ abTest, guUrl, signInUrl, ophanComponentId });
+
+// export the variant as a SignInGateVariant type
+export const signInGateVariant: SignInGateVariant = {
+    name: variant,
+    canShow,
+    show,
+};

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/pageview/variant-3.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/pageview/variant-3.js
@@ -1,0 +1,58 @@
+// @flow
+import type { CurrentABTest, SignInGateVariant } from '../../types';
+import { componentName } from '../../component';
+import {
+    hasUserDismissedGate,
+    isNPageOrHigherPageView,
+    isLoggedIn,
+    isInvalidArticleType,
+    isInvalidSection,
+    isIOS9,
+    setGatePageTargeting,
+    isCountry,
+} from '../../helper';
+
+// pull in the show method from the design folder, which has the html template and and click handlers etc.
+import { designShow } from '../design/main-variant';
+
+// define the variant name here
+const variant = 'pageview-variant-3'; // 3rd page view & old dismiss rule (never see gate again after first dismissal)
+
+// method which returns a boolean determining if this variant can be shown on the current pageview
+const canShow: (name?: string) => boolean = (name = '') => {
+    const isGateDismissed = hasUserDismissedGate({
+        name,
+        variant,
+        componentName,
+    });
+
+    const canShowCheck =
+        !isGateDismissed &&
+        isNPageOrHigherPageView(3) &&
+        !isLoggedIn() &&
+        !isInvalidArticleType() &&
+        !isInvalidSection() &&
+        !isIOS9() &&
+        !isCountry('US');
+
+    setGatePageTargeting(isGateDismissed, canShowCheck);
+    return canShowCheck;
+};
+
+// method which runs if the canShow method returns true, used to display the gate and logic associated with it
+// it returns a boolean, since the sign in gate is based on a `Banner` type who's show method returns a Promise<boolean>
+// in our case it returns true if the design ran successfully, and false if there were any problems encountered
+const show: ({
+    abTest: CurrentABTest,
+    guUrl: string,
+    signInUrl: string,
+    ophanComponentId: string,
+}) => boolean = ({ abTest, guUrl, signInUrl, ophanComponentId }) =>
+    designShow({ abTest, guUrl, signInUrl, ophanComponentId });
+
+// export the variant as a SignInGateVariant type
+export const signInGateVariant: SignInGateVariant = {
+    name: variant,
+    canShow,
+    show,
+};

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/pageview/variant-4.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/pageview/variant-4.js
@@ -1,0 +1,58 @@
+// @flow
+import type { CurrentABTest, SignInGateVariant } from '../../types';
+import { componentName } from '../../component';
+import {
+    hasUserDismissedGate,
+    isNPageOrHigherPageView,
+    isLoggedIn,
+    isInvalidArticleType,
+    isInvalidSection,
+    isIOS9,
+    setGatePageTargeting,
+    isCountry,
+} from '../../helper';
+
+// pull in the show method from the design folder, which has the html template and and click handlers etc.
+import { designShow } from '../design/main-variant';
+
+// define the variant name here
+const variant = 'pageview-variant-4'; // 2nd page view & new dismiss rule (never see gate again after first dismissal)
+
+// method which returns a boolean determining if this variant can be shown on the current pageview
+const canShow: (name?: string) => boolean = (name = '') => {
+    const isGateDismissed = hasUserDismissedGate({
+        name,
+        variant,
+        componentName,
+    });
+
+    const canShowCheck =
+        !isGateDismissed &&
+        isNPageOrHigherPageView(2) &&
+        !isLoggedIn() &&
+        !isInvalidArticleType() &&
+        !isInvalidSection() &&
+        !isIOS9() &&
+        !isCountry('US');
+
+    setGatePageTargeting(isGateDismissed, canShowCheck);
+    return canShowCheck;
+};
+
+// method which runs if the canShow method returns true, used to display the gate and logic associated with it
+// it returns a boolean, since the sign in gate is based on a `Banner` type who's show method returns a Promise<boolean>
+// in our case it returns true if the design ran successfully, and false if there were any problems encountered
+const show: ({
+    abTest: CurrentABTest,
+    guUrl: string,
+    signInUrl: string,
+    ophanComponentId: string,
+}) => boolean = ({ abTest, guUrl, signInUrl, ophanComponentId }) =>
+    designShow({ abTest, guUrl, signInUrl, ophanComponentId });
+
+// export the variant as a SignInGateVariant type
+export const signInGateVariant: SignInGateVariant = {
+    name: variant,
+    canShow,
+    show,
+};


### PR DESCRIPTION
## What does this change?

- Adds a new Sign In Gate AB test called SignInGatePageview  - compares showing the gate on the 2nd vs 3rd article view with new and old dimiss rule variants, on simple article templates, with higher priority over banners and epi, excluding the US.

- Fixes a bug in the new `isCountry('countryCodeString`) Display Rule in helper.js file

DCR PR is 

##### TODO
- [x] Waiting confirmation on Audience Size prior to merging