### PR TITLE
Add a nav link to the Observer Food Monthly from the Observer front

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -182,6 +182,7 @@ private object NavLinks {
       NavLink("Comment", "/theobserver/news/comment"),
       NavLink("The New Review", "/theobserver/new-review"),
       NavLink("Observer Magazine", "/theobserver/magazine"),
+      NavLink("Observer Food Monthly", "/theobserver/foodmonthly"),
     ),
   )
   val weekly = NavLink("Guardian Weekly", "https://www.theguardian.com/weekly")


### PR DESCRIPTION
## What does this change?

This adds a link to the nav on [/observer](https://www.theguardian.com/observer):

<img width="1425" alt="food-nav" src="https://user-images.githubusercontent.com/9820960/95355630-a7ae6f00-08bd-11eb-9882-f85cbdc76de5.png">

As requested by Mariana:

> From: 'Mariana Pereira'
> Subject: Nav request
> To: Dotcom Platform
> 
> Hey dotcom,
> Can someone add the following link ( https://www.theguardian.com/theobserver/foodmonthly) to the Observer front page navigation? (see here, where there are links to comment , magazine, New Review).
> It should be Observer Food Monthly.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
I can't test following the link locally, @jfsoul suggested this is probably to do with the redirect being handled by nginx - I'm not sure how to configure this to make it work.

- [ ] On CODE (optional)
