### PR TITLE
Send pageViewId into initialisation of the CMP

### DIFF
--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -35,9 +35,10 @@ const go = () => {
         // Start CMP
         // CCPA and TCFv2
         const browserId: ?string = getCookie('bwid');
-        const pubData: { browserId?: string } | void = browserId
-            ? { browserId }
-            : undefined;
+        const pageViewId: ?string = config.get('ophan.pageViewId');
+        const cmpInitTimeUtc: ?number = new Date().getTime();
+        const pubData: { browserId?: ?string, pageViewId?: ?string, cmpInitTimeUtc?: ?number } =
+            { browserId, pageViewId, cmpInitTimeUtc };
         cmp.init({ pubData, isInUsa: isInUsa() });
 
         // 2. once standard is done, next is commercial

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -36,9 +36,8 @@ const go = () => {
         // CCPA and TCFv2
         const browserId: ?string = getCookie('bwid');
         const pageViewId: ?string = config.get('ophan.pageViewId');
-        const cmpInitTimeUtc: ?number = new Date().getTime();
-        const pubData: { browserId?: ?string, pageViewId?: ?string, cmpInitTimeUtc?: ?number } =
-            { browserId, pageViewId, cmpInitTimeUtc };
+        const pubData: { browserId?: ?string, pageViewId?: ?string } =
+            { browserId, pageViewId };
         cmp.init({ pubData, isInUsa: isInUsa() });
 
         // 2. once standard is done, next is commercial


### PR DESCRIPTION
## What does this change?

This updates the initialisation of the CMP by adding in the generated `pageViewId`; this generation happens before the CMP is initialised in the [transmit module of Ophan.](https://github.com/guardian/ophan/blob/master/tracker-js/assets/coffee/ophan/transmit.coffee#L12)

## What is the value of this and can you measure success?

This is going to help us report more clearly on CMP rates by allowing us to join back to `browserId`.

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->

@guardian/commercial-dev 
