### PR TITLE
Ignore incorrect linting error

### DIFF
--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -21,6 +21,7 @@ __webpack_public_path__ = `${config.get('page.assetsPath')}javascripts/`;
 
 // Debug preact in DEV
 if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line no-unused-expressions
     import(/* webpackChunkName: "preact-debug" */ 'preact/debug');
 }
 


### PR DESCRIPTION
## What does this change?

Ignore incorrect linting error. Was
```
24:5  error  Expected an assignment or function call and instead saw an expression  no-unused-expressions
```
