### PR TITLE
bump cmp to 6.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@guardian/automat-modules": "^0.3.7",
     "@guardian/braze-components": "0.0.12",
     "@guardian/commercial-core": "^0.6.0",
-    "@guardian/consent-management-platform": "6.2.0",
+    "@guardian/consent-management-platform": "6.4.0",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/libs": "^1.0.0",
     "@guardian/shimport": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1758,10 +1758,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.6.0.tgz#0dc4a868e7d1c70e200627496e6a66b0e387745b"
   integrity sha512-CUZxEmWoJ8kEE6OwFKcE6xyODDF5ktln9JhtmbwxKhGqzOkQnYI0e3PtqA/tpIc+qTIfeew9tRr9nRTFrcp8Ug==
 
-"@guardian/consent-management-platform@6.2.0":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.2.0.tgz#85f7ffa30318fc190be1d664945da0b30076a592"
-  integrity sha512-vlA3wjRnOBtCvDXNh6BCMliR/UZ5k9aLzN7opWvZVWe1j7/c3709B148AOEhWpn5PbZk8gd/Y1XVfQUn0USrrQ==
+"@guardian/consent-management-platform@6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.4.0.tgz#9fbebb2a12c2bec6e4f62ae440b75ccd0367e28f"
+  integrity sha512-dzvGiM5Zi4ew2L1H3iV2wmDLfIlWxPBlJ+XEOUz7JaTZUBqZQLrwR+FXy7sLv2OUr//QAfEyIjAMFnRYxK1xZw==
 
 "@guardian/dotcom-rendering@git://github.com/guardian/dotcom-rendering.git#version-1-alpha":
   version "0.1.0-alpha"


### PR DESCRIPTION
## What does this change?

6.4.0 includes new A9 vendor ID which is urgently needed today

