### PR TITLE
Fonts - Avoid error message and fix detection on modern browsers

### DIFF
--- a/common/app/templates/inlineJS/blocking/loadFonts.scala.js
+++ b/common/app/templates/inlineJS/blocking/loadFonts.scala.js
@@ -62,10 +62,10 @@ do you have fonts in localStorage?
                         // https://github.com/filamentgroup/woff2-feature-test
                         if ("FontFace" in window) {
                             try {
-                                const f = new window.FontFace('t', 'url("data:application/font-woff2,") format("woff2")', {});
+                                const f = new FontFace('t', 'url( "data:font/woff2;base64,d09GMgABAAAAAADwAAoAAAAAAiQAAACoAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAABmAALAogOAE2AiQDBgsGAAQgBSAHIBuDAciO1EZ3I/mL5/+5/rfPnTt9/9Qa8H4cUUZxaRbh36LiKJoVh61XGzw6ufkpoeZBW4KphwFYIJGHB4LAY4hby++gW+6N1EN94I49v86yCpUdYgqeZrOWN34CMQg2tAmthdli0eePIwAKNIIRS4AGZFzdX9lbBUAQlm//f262/61o8PlYO/D1/X4FrWFFgdCQD9DpGJSxmFyjOAGUU4P0qigcNb82GAAA" ) format( "woff2" )', {});
 
                                 f.load().catch(() => {});
-                                if (f.status === 'loading') {
+                                if (f.status === 'loading' || f.status == 'loaded') {
                                     return true;
                                 }
                             } catch (e) {


### PR DESCRIPTION
## What does this change?

Following #23026 I noticed that code for detecting `woff2` was not updated and notably not working with latest version of `Firefox` and `Chrome`.  Since it was copied from [original project](https://github.com/filamentgroup/woff2-feature-test) it notably missing following fixes:
- https://github.com/filamentgroup/woff2-feature-test/commit/9e7c0151241c44e30cb623a6589dfba96ebb84a6
- https://github.com/filamentgroup/woff2-feature-test/commit/71f0fd71ee7f320d6b3b0994e929f4f8e875e587

The associated changes incorporate those changes:
-  removal of the warning that Chrome issues because there was not a valid font to load
-  use the correct mimetype (see https://twitter.com/svgeesus/status/923605815659061251)
- correctly identify the `loaded` status as a success.

With those changes the `woff2` detection works properly on lastest version of `Chrome` and `Firefox` and avoid the execution of fallback testing.

```js
// some browsers (e.g. FF40) support WOFF2 but not window.FontFace,
                        // so fall back to known support
                        if (!/edge\/([0-9]+)/.test(ua.toLowerCase())) { // don't let edge tell you it's chrome when it's not
                            const browser = /(chrome|firefox)\/([0-9]+)/.exec(ua.toLowerCase());
                            const supportsWoff2 = {
                                'chrome': 36,
                                'firefox': 39
                            };
                            return !!browser && supportsWoff2[browser[1]] < parseInt(browser[2], 10);
```




## Does this change need to be reproduced in dotcom-rendering ?
- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Less code executed and fastest font loading

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)
