### PR TITLE
Use updated atom-renderer to respect consent changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@braze/web-sdk-core": "^3.0.0",
     "@emotion/core": "^10.0.27",
     "@emotion/styled": "^10.0.27",
-    "@guardian/atom-renderer": "1.2.1",
+    "@guardian/atom-renderer": "1.2.2",
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.7",
     "@guardian/braze-components": "0.0.12",

--- a/static/src/javascripts/projects/atoms/services.js
+++ b/static/src/javascripts/projects/atoms/services.js
@@ -31,15 +31,11 @@ const promisify = (fdaction: FastdomAction) => (
         });
     });
 
-const acastConsentState = (): Promise<boolean> => {
-    const p = new Promise(resolve => {
-        onConsentChange(state => {
-            const consented = getConsentFor('acast', state);
-            resolve(consented);
-        });
+const onAcastConsentChange = (callback: boolean => void): void => {
+    onConsentChange(state => {
+        const consented = getConsentFor('acast', state);
+        callback(consented);
     });
-
-    return p;
 };
 
 const services: Services = {
@@ -50,7 +46,7 @@ const services: Services = {
     },
     viewport,
     consent: {
-        acast: acastConsentState(),
+        onAcastConsentChange,
     },
     commercial: {
         isAdFree: isAdFreeUser(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1705,10 +1705,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@guardian/atom-renderer@1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@guardian/atom-renderer/-/atom-renderer-1.2.1.tgz#b908676560d66154f3d812eff0643db3d6e4732c"
-  integrity sha512-tx3CKQknhWOtxCeAqvTHAYFwsVt3cfGiAIwU3oKbqq9cx4DkfN3aXqodfESkbb22qUEH+dEKxSvUG6VYiLcCYw==
+"@guardian/atom-renderer@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@guardian/atom-renderer/-/atom-renderer-1.2.2.tgz#db10b98ed73636c4bd6941ec103c9f60ff15549e"
+  integrity sha512-c7jdT48JQk3NiJozkg86ah+QiHF9MaQBXQG/p07NGzAOAQflyzJ4qn8mJijOMB78o/JYQQjUhnQF+zsJQgvkyg==
   dependencies:
     "@babel/preset-env" "^7.3.1"
     "@babel/preset-flow" "^7.0.0"


### PR DESCRIPTION
## What does this change?

Previously Acast consent was modelled as a (single-fire) promise. Now it is handled via a callback, which is what the underlying CMP library expects.

See also: https://github.com/guardian/atom-renderer/pull/86 for atom-renderer change and https://github.com/guardian/consent-management-platform/#onconsentchangecallback which is the interface we are mirroring.

## What is the value of this and can you measure success?

Will fix an Acast consent error - at the moment consent fires false on first load, which will prevent ads for Audio Atoms regardless of whether the user eventually consents or not.

### Tested

- [x] Locally
- [ ] On CODE (optional)

