### PR TITLE
Introduce Backend Experiement NGInteractiveDCR

### DIFF
--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -10,6 +10,7 @@ import play.api.libs.ws.WSClient
 import play.api.mvc._
 import views.support.RenderOtherStatus
 import conf.Configuration.interactive.cdnPath
+import experiments.{ActiveExperiments, NGInteractiveDCR}
 import pages.InteractiveHtmlPage
 
 import scala.concurrent.duration._
@@ -82,11 +83,16 @@ class InteractiveController(
     renderFormat(htmlResponse, jsonResponse, model, Switches.all)
   }
 
-  override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] =
-    lookup(path) map {
-      case Left(model)  => render(model)
-      case Right(other) => RenderOtherStatus(other)
+  override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = {
+    if (ActiveExperiments.isParticipating(NGInteractiveDCR)) {
+      Future.successful(Ok("Experiment: NGInteractiveDCR"))
+    } else {
+      lookup(path) map {
+        case Left(model)  => render(model)
+        case Right(other) => RenderOtherStatus(other)
+      }
     }
+  }
 
   override def canRender(i: ItemResponse): Boolean = i.content.exists(_.isInteractive)
 }

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -41,6 +41,15 @@ object DCRBubble
       name = "always-dcr-rendering",
       description = "Use DCR for all article pages (equivalent to always adding ?dcr)",
       owners = Seq(Owner.withGithub("shtukas")),
-      sellByDate = new LocalDate(2020, 12, 1),
-      participationGroup = Perc0B, // Also see ArticlePicker.scala - our main filter mechanism is by page features
+      sellByDate = new LocalDate(2021, 6, 1),
+      participationGroup = Perc0A, // Also see ArticlePicker.scala - our main filter mechanism is by page features
+    )
+
+object NGInteractiveDCR
+    extends Experiment(
+      name = "ng-interactive-dcr",
+      description = "Use DCR to render (ng)-interactives",
+      owners = Seq(Owner.withGithub("shtukas")),
+      sellByDate = new LocalDate(2021, 6, 1),
+      participationGroup = Perc0B,
     )


### PR DESCRIPTION
## What does this change?

1. Expand lifetime of experiment `DCRBubble` and move it to bucket `Perc0A`.

2. Introduce experiment `NGInteractiveDCR` at `Perc0B` to shield the coming work on rendering ng-interactives in DCR away from the users.