### PR TITLE
fix preview reload loop (bump play-googleauth to 0.7.2)

### DIFF
--- a/admin/app/conf/GoogleAuth.scala
+++ b/admin/app/conf/GoogleAuth.scala
@@ -1,8 +1,9 @@
 package conf
 
-import com.gu.googleauth.GoogleAuthConfig
+import com.gu.googleauth.{AntiForgeryChecker, GoogleAuthConfig}
+import play.api.http.HttpConfiguration
 
-case class GoogleAuth(currentHost: Option[String]) {
+case class GoogleAuth(httpConfiguration: HttpConfiguration, currentHost: Option[String] = None) {
   val config = AdminConfiguration.oauthCredentials.flatMap { cred =>
     for {
       callback <- cred.authorizedOauthCallbacks.collectFirst {
@@ -17,7 +18,8 @@ case class GoogleAuth(currentHost: Option[String]) {
         cred.oauthClientId, // The client ID from the dev console
         cred.oauthSecret, // The client secret from the dev console
         callback, // The redirect URL Google send users back to (must be the same as that configured in the developer console)
-        "guardian.co.uk", // Google App domain to restrict login
+        "guardian.co.uk", // Google App domain to restrict login,
+        antiForgeryChecker = AntiForgeryChecker.borrowSettingsFromPlay(httpConfiguration)
       )
     }
   }
@@ -27,5 +29,3 @@ case class GoogleAuth(currentHost: Option[String]) {
       throw new RuntimeException("You must set up credentials for Google Auth")
     }
 }
-
-object GoogleAuth extends GoogleAuth(None)

--- a/admin/app/conf/GoogleAuth.scala
+++ b/admin/app/conf/GoogleAuth.scala
@@ -19,7 +19,7 @@ case class GoogleAuth(httpConfiguration: HttpConfiguration, currentHost: Option[
         cred.oauthSecret, // The client secret from the dev console
         callback, // The redirect URL Google send users back to (must be the same as that configured in the developer console)
         "guardian.co.uk", // Google App domain to restrict login,
-        antiForgeryChecker = AntiForgeryChecker.borrowSettingsFromPlay(httpConfiguration)
+        antiForgeryChecker = AntiForgeryChecker.borrowSettingsFromPlay(httpConfiguration),
       )
     }
   }

--- a/admin/app/controllers/IndexController.scala
+++ b/admin/app/controllers/IndexController.scala
@@ -3,14 +3,15 @@ package controllers.admin
 import com.gu.googleauth.AuthAction
 import play.api.mvc._
 import model.{ApplicationContext, NoCache}
+import play.components.HttpConfigurationComponents
 
-trait AdminAuthController {
+trait AdminAuthController extends HttpConfigurationComponents {
 
   def controllerComponents: ControllerComponents
 
   object AdminAuthAction
       extends AuthAction(
-        conf.GoogleAuth.getConfigOrDie,
+        conf.GoogleAuth(httpConfiguration).getConfigOrDie,
         routes.OAuthLoginAdminController.login(),
         controllerComponents.parsers.default,
       )(controllerComponents.executionContext)

--- a/admin/app/controllers/OAuthLoginAdminController.scala
+++ b/admin/app/controllers/OAuthLoginAdminController.scala
@@ -21,6 +21,6 @@ class OAuthLoginAdminController(
     }
   override def googleAuthConfig(request: Request[AnyContent]): Option[GoogleAuthConfig] = {
     val host = Some(s"${if (request.secure) "https" else "http"}://${request.host}")
-    conf.GoogleAuth(host).config
+    conf.GoogleAuth(httpConfiguration, host).config
   }
 }

--- a/admin/app/controllers/cache/ImageDecacheController.scala
+++ b/admin/app/controllers/cache/ImageDecacheController.scala
@@ -23,8 +23,7 @@ class ImageDecacheController(
     extends BaseController
     with Logging
     with ImplicitControllerExecutionContext
-    with AdminAuthController
-{
+    with AdminAuthController {
   import ImageDecacheController._
 
   private val iGuim = """i.(guim|guimcode).co.uk/img/(static|media|uploads|sport)(/.*)""".r

--- a/admin/app/controllers/cache/ImageDecacheController.scala
+++ b/admin/app/controllers/cache/ImageDecacheController.scala
@@ -7,6 +7,7 @@ import com.gu.googleauth.UserIdentity
 import common.{ImplicitControllerExecutionContext, Logging}
 import controllers.admin.AdminAuthController
 import model.{ApplicationContext, NoCache}
+import play.api.http.HttpConfiguration
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc._
@@ -16,12 +17,14 @@ import scala.concurrent.Future.successful
 
 class ImageDecacheController(
     wsClient: WSClient,
+    val httpConfiguration: HttpConfiguration,
     val controllerComponents: ControllerComponents,
 )(implicit context: ApplicationContext)
     extends BaseController
     with Logging
     with ImplicitControllerExecutionContext
-    with AdminAuthController {
+    with AdminAuthController
+{
   import ImageDecacheController._
 
   private val iGuim = """i.(guim|guimcode).co.uk/img/(static|media|uploads|sport)(/.*)""".r

--- a/admin/app/controllers/cache/PageDecacheController.scala
+++ b/admin/app/controllers/cache/PageDecacheController.scala
@@ -7,6 +7,7 @@ import common.{ImplicitControllerExecutionContext, Logging}
 import controllers.admin.AdminAuthController
 import model.{ApplicationContext, NoCache}
 import org.apache.commons.codec.digest.DigestUtils
+import play.api.http.HttpConfiguration
 import play.api.libs.ws.WSClient
 import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc._
@@ -17,9 +18,12 @@ import scala.concurrent.Future.successful
 
 case class PrePurgeTestResult(url: String, passed: Boolean)
 
-class PageDecacheController(wsClient: WSClient, val controllerComponents: ControllerComponents)(implicit
-    context: ApplicationContext,
-) extends BaseController
+class PageDecacheController(
+  wsClient: WSClient,
+  val httpConfiguration: HttpConfiguration,
+  val controllerComponents: ControllerComponents,
+)(implicit context: ApplicationContext)
+  extends BaseController
     with Logging
     with ImplicitControllerExecutionContext
     with AdminAuthController {

--- a/admin/app/controllers/cache/PageDecacheController.scala
+++ b/admin/app/controllers/cache/PageDecacheController.scala
@@ -19,11 +19,11 @@ import scala.concurrent.Future.successful
 case class PrePurgeTestResult(url: String, passed: Boolean)
 
 class PageDecacheController(
-  wsClient: WSClient,
-  val httpConfiguration: HttpConfiguration,
-  val controllerComponents: ControllerComponents,
+    wsClient: WSClient,
+    val httpConfiguration: HttpConfiguration,
+    val controllerComponents: ControllerComponents,
 )(implicit context: ApplicationContext)
-  extends BaseController
+    extends BaseController
     with Logging
     with ImplicitControllerExecutionContext
     with AdminAuthController {

--- a/common/app/googleAuth/OAuthLoginController.scala
+++ b/common/app/googleAuth/OAuthLoginController.scala
@@ -21,7 +21,6 @@ trait OAuthLoginController extends BaseController with ImplicitControllerExecuti
   val authCookie = new AuthCookie(httpConfiguration)
 
   val LOGIN_ORIGIN_KEY = "loginOriginUrl"
-  val ANTI_FORGERY_KEY = "antiForgeryToken"
   val forbiddenNoCredentials = Forbidden("Invalid OAuth credentials set")
   lazy val validRedirectDomain = """^(\w+:\/\/[^/]+\.(?:dev-)?gutools\.co\.uk\/.*)$""".r
 
@@ -74,7 +73,7 @@ trait OAuthLoginController extends BaseController with ImplicitControllerExecuti
 
             val result = redirect
               .addingToSession(sessionAdd: _*)
-              .removingFromSession(ANTI_FORGERY_KEY, LOGIN_ORIGIN_KEY)
+              .removingFromSession(LOGIN_ORIGIN_KEY)
 
             authCookie
               .from(userIdentity)
@@ -84,7 +83,7 @@ trait OAuthLoginController extends BaseController with ImplicitControllerExecuti
             case t =>
               // you might want to record login failures here - we just redirect to the login page
               Redirect("/login")
-                .withSession(request.session - ANTI_FORGERY_KEY)
+                .withSession(request.session)
                 .flashing("error" -> s"Login failure: ${t.toString}")
           }
         }

--- a/preview/app/controllers/OAuthLoginPreviewController.scala
+++ b/preview/app/controllers/OAuthLoginPreviewController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import com.gu.googleauth.{GoogleAuthConfig, UserIdentity}
+import com.gu.googleauth.{AntiForgeryChecker, GoogleAuthConfig, UserIdentity}
 import conf.Configuration
 import googleAuth.OAuthLoginController
 import model.ApplicationContext
@@ -27,7 +27,8 @@ class OAuthLoginPreviewController(
         cred.oauthCallback, // The redirect URL Google send users back to (must be the same as
         // that configured in the developer console)
         "guardian.co.uk", // Google App domain to restrict login
-        None,
+        maxAuthAge = None,
+        antiForgeryChecker = AntiForgeryChecker.borrowSettingsFromPlay(httpConfiguration)
       )
     }
 }

--- a/preview/app/controllers/OAuthLoginPreviewController.scala
+++ b/preview/app/controllers/OAuthLoginPreviewController.scala
@@ -28,7 +28,7 @@ class OAuthLoginPreviewController(
         // that configured in the developer console)
         "guardian.co.uk", // Google App domain to restrict login
         maxAuthAge = None,
-        antiForgeryChecker = AntiForgeryChecker.borrowSettingsFromPlay(httpConfiguration)
+        antiForgeryChecker = AntiForgeryChecker.borrowSettingsFromPlay(httpConfiguration),
       )
     }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -46,7 +46,7 @@ object Dependencies {
   val macwire = "com.softwaremill.macwire" %% "macros" % "2.3.0" % "provided"
   val mockito = "org.mockito" % "mockito-all" % "1.10.19" % Test
   val paClient = "com.gu" %% "pa-client" % "6.1.0"
-  val playGoogleAuth = "com.gu" %% "play-googleauth" % "0.7.0"
+  val playGoogleAuth = "com.gu" %% "play-googleauth" % "0.7.2"
   val quartzScheduler = "org.quartz-scheduler" % "quartz" % "2.2.3"
   val redisClient = "net.debasishg" %% "redisclient" % "3.4"
   val rome = "rome" % "rome" % romeVersion


### PR DESCRIPTION
https://trello.com/c/Xy0HRTFa/2070-bump-play-lib-in-dotcom-in-the-hope-of-solving-an-issue-with-preview-in-chrome

## What does this change?
A bump of `play-googleauth` to make use of https://github.com/guardian/play-googleauth/pull/52 (as suggested by @sihil)... in the hope of fixing an auth related reload loop that some users are experiencing in Chrome, see https://chat.google.com/room/AAAAgU85_rM/4A1NoNZcJMY. 

Changes are the minimum required to get it to compile, taking inspiration from https://github.com/guardian/subscriptions-frontend/pull/1065 and https://github.com/guardian/ophan/pull/2622 (two PRs I found which include this upgrade).

## Does this change need to be reproduced in dotcom-rendering ?

> I don't think so??

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
