### PR TITLE
make liveblog epic cta configurable

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -138,6 +138,7 @@ const liveBlogTemplate: EpicTemplate = (
         copy,
         componentName: variant.componentName,
         supportURL: variant.supportURL,
+        ctaText: variant.ctaText,
     });
 
 const doTagsMatch = (test: EpicABTest): boolean =>

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-liveblog.js
@@ -1,5 +1,5 @@
 // @flow
-const lastSentenceTemplate = (highlightedText?: string, supportURL: string) =>
+const lastSentenceTemplate = (highlightedText?: string, supportURL: string, ctaText?: string) =>
     `${
         highlightedText
             ? `<span className="contributions__highlight">${highlightedText}</span>`
@@ -9,7 +9,7 @@ const lastSentenceTemplate = (highlightedText?: string, supportURL: string) =>
         <a class="component-button component-button--liveblog component-button--hasicon-right contributions__contribute--epic-member"
           href=${supportURL}
           target="_blank">
-          Make a contribution
+          ${ctaText || 'Support the Guardian'}
         </a>
     </div>`;
 
@@ -17,10 +17,12 @@ export const epicLiveBlogTemplate = ({
                                          copy,
                                          componentName,
                                          supportURL,
+                                         ctaText,
                                      }: {
     copy: AcquisitionsEpicTemplateCopy,
     componentName: string,
     supportURL: string,
+    ctaText?: string
 }) =>
     `<div class="block block--content is-epic" data-component="${componentName}">
         <p class="block-time published-time">
@@ -35,7 +37,8 @@ export const epicLiveBlogTemplate = ({
         .join('')}
             <p><em>${lastSentenceTemplate(
         copy.highlightedText,
-        supportURL
+        supportURL,
+        ctaText,
     )}</em></p>
         </div>
     </div>`;


### PR DESCRIPTION
Currently the liveblog epic CTA text is hardcoded in frontend. Instead we should take it from the tool.