### PR TITLE
Refactoring: dotcomponents -> dotcomrendering

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -5,7 +5,7 @@ import common._
 import contentapi.ContentApiClient
 import implicits.{AmpFormat, EmailFormat, HtmlFormat, JsonFormat}
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
-import model.dotcomponents.{DCRDataModel, DotcomponentsDataModel, PageType}
+import model.dotcomrendering.{DCRDataModel, DotcomponentsDataModel, PageType}
 import model.{ContentType, PageWithStoryPackage, _}
 import pages.{ArticleEmailHtmlPage, ArticleHtmlPage}
 import play.api.libs.json.Json

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -14,12 +14,12 @@ import play.api.mvc._
 import services.CAPILookup
 import views.support.RenderOtherStatus
 import implicits.{AmpFormat, HtmlFormat}
-import model.dotcomponents.{DCRDataModel, DotcomponentsDataModel}
+import model.dotcomrendering.{DCRDataModel, DotcomponentsDataModel}
 import renderers.RemoteRenderer
 
 import scala.concurrent.Future
 
-import model.dotcomponents.PageType
+import model.dotcomrendering.PageType
 
 case class MinutePage(article: Article, related: RelatedContent) extends PageWithStoryPackage
 

--- a/article/app/model/dotcomrendering/DotcomponentsDataModel.scala
+++ b/article/app/model/dotcomrendering/DotcomponentsDataModel.scala
@@ -1,4 +1,4 @@
-package model.dotcomponents
+package model.dotcomrendering
 
 import java.net.URLEncoder
 

--- a/article/app/model/dotcomrendering/LinkedData.scala
+++ b/article/app/model/dotcomrendering/LinkedData.scala
@@ -1,4 +1,4 @@
-package model.dotcomponents
+package model.dotcomrendering
 
 import com.gu.contentapi.client.model.v1.{Block => CAPIBlock}
 import model.{Article, LiveBlogPage}

--- a/article/app/model/dotcomrendering/PageType.scala
+++ b/article/app/model/dotcomrendering/PageType.scala
@@ -1,4 +1,4 @@
-package model.dotcomponents
+package model.dotcomrendering
 
 import common.Edition
 import model.{ApplicationContext, PageWithStoryPackage}

--- a/article/app/renderers/RemoteRenderer.scala
+++ b/article/app/renderers/RemoteRenderer.scala
@@ -7,7 +7,7 @@ import concurrent.CircuitBreakerRegistry
 import conf.Configuration
 import conf.switches.Switches.CircuitBreakerSwitch
 import model.Cached.RevalidatableResult
-import model.dotcomponents.{DCRDataModel, DotcomponentsDataModel}
+import model.dotcomrendering.{DCRDataModel, DotcomponentsDataModel}
 import model.{Cached, NoCache, PageWithStoryPackage}
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc.{RequestHeader, Result}
@@ -16,7 +16,7 @@ import play.twirl.api.Html
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import model.dotcomponents.PageType
+import model.dotcomrendering.PageType
 
 class RemoteRenderer extends Logging {
 

--- a/article/test/ArticleControllerTest.scala
+++ b/article/test/ArticleControllerTest.scala
@@ -3,7 +3,7 @@ package test
 import com.gu.contentapi.client.model.v1.Blocks
 import controllers.{ArticleController, ArticlePage}
 import model.Cached.RevalidatableResult
-import model.dotcomponents.PageType
+import model.dotcomrendering.PageType
 import model.{ApplicationContext, Cached, PageWithStoryPackage}
 import org.apache.commons.codec.digest.DigestUtils
 import org.scalatest.mockito.MockitoSugar


### PR DESCRIPTION
## What does this change?

This is the first part of a two parts refactoring to move the model for dotcom-rendering from [article] (where it has mostly been living until now), to [common]. This to enable [applications] to access the same types. 
