### PR TITLE
🐛 Fix newsletter embed tracking in new designs

### DIFF
--- a/common/app/views/fragments/email/signup/emailSignUpNewDesign.scala.html
+++ b/common/app/views/fragments/email/signup/emailSignUpNewDesign.scala.html
@@ -16,7 +16,7 @@
 
 
 @form = {
-    <form action="@LinkTo(s"/email/$listName")" method="post" id="@formId" class="@formClass" data-email-form-type="@componentClass" data-email-list-name="@listName">
+    <form action="@LinkTo("/email")" method="post" id="@formId" class="@formClass" data-email-form-type="@componentClass" data-email-list-name="@listName">
         @helper.CSRF.formField
 
         <div class="newsletter-embed__form-wrapper">

--- a/common/app/views/fragments/email/signup/emailSignUpNewDesign.scala.html
+++ b/common/app/views/fragments/email/signup/emailSignUpNewDesign.scala.html
@@ -42,6 +42,7 @@
 
             <button
             type="submit"
+            id="email-embed-signup-button"
             class="newsletter-embed__submit-button"
             data-component="email-signup-button @componentClass-@listName--newDesign"
             data-link-name="@componentClass | @listName">
@@ -77,6 +78,7 @@
         <section class="newsletter-embed__signup">
             @form
         </section>
+    </div>
 </div>
 
 <script>


### PR DESCRIPTION
## What does this change?
Bug fixes left over from #23077 
 - Wrong form submission endpoint.
 - No ID on button meant ophan tracking was failing.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?
Fixes tracking and subscription errors

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
