### PR TITLE
Adding the newsletter link in the footer

### DIFF
--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -82,12 +82,18 @@ object FooterLinks {
     FooterLink("All topics", "/index/subjects/a", s"${edition} : footer : all topics")
   def allWriters(edition: String): FooterLink =
     FooterLink("All writers", "/index/contributors", s"${edition} : footer : all contributors")
-  val digitalNewspaperArchive =
+  val digitalNewspaperArchive: FooterLink =
     FooterLink("Digital newspaper archive", "https://theguardian.newspapers.com", "digital newspaper archive")
   def facebook(edition: String): FooterLink =
     FooterLink("Facebook", "https://www.facebook.com/theguardian", s"${edition} : footer : facebook")
   def twitter(edition: String): FooterLink =
     FooterLink("Twitter", "https://twitter.com/guardian", s"${edition}: footer : twitter")
+  def newsletters(edition: String): FooterLink =
+    FooterLink(
+      text = "Newsletters",
+      url = s"/email-newsletters?INTCMP=DOTCOM_FOOTER_NEWSLETTER_${edition.toUpperCase}",
+      dataLinkName = s"$edition : footer : newsletters",
+    )
 
   val ukListTwo = List(
     allTopics("uk"),
@@ -100,6 +106,7 @@ object FooterLinks {
     digitalNewspaperArchive,
     facebook("uk"),
     twitter("uk"),
+    newsletters("uk"),
   )
 
   val usListTwo = List(
@@ -108,6 +115,7 @@ object FooterLinks {
     digitalNewspaperArchive,
     facebook("us"),
     twitter("us"),
+    newsletters("us"),
   )
 
   val auListTwo = List(
@@ -117,6 +125,7 @@ object FooterLinks {
     digitalNewspaperArchive,
     facebook("au"),
     twitter("au"),
+    newsletters("au"),
   )
 
   val intListTwo = List(
@@ -125,6 +134,7 @@ object FooterLinks {
     digitalNewspaperArchive,
     facebook("international"),
     twitter("international"),
+    newsletters("international"),
   )
 
   // Footer column three


### PR DESCRIPTION
## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes => working on it

## Screenshots
![image](https://user-images.githubusercontent.com/3389563/96003488-2d886800-0e32-11eb-8dee-2afcf9af16e8.png)

## What is the value of this and can you measure success?
Better visibility of the newsletter onboarding page

## Checklist

### Does this affect other platforms?

- [x] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
