### PR TITLE
Remove duplicated a9 consent

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
@@ -1,7 +1,6 @@
 // @flow strict
 
 import config from 'lib/config';
-import { onConsentChange, getConsentFor } from '@guardian/consent-management-platform';
 
 import { Advert } from 'commercial/modules/dfp/Advert';
 import { getHeaderBiddingAdSlots } from 'commercial/modules/header-bidding/slot-config';
@@ -34,7 +33,7 @@ let requestQueue: Promise<void> = Promise.resolve();
 const bidderTimeout: number = 1500;
 
 const initialise = (): void => {
-    if (!initialised && canRun) {
+    if (!initialised) {
         initialised = true;
         window.apstag.init({
             pubID: config.get('page.a9PublisherId'),

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
@@ -34,18 +34,14 @@ let requestQueue: Promise<void> = Promise.resolve();
 const bidderTimeout: number = 1500;
 
 const initialise = (): void => {
-    onConsentChange(state => {
-        const canRun: boolean = getConsentFor('a9', state);
-
-        if (!initialised && canRun) {
-            initialised = true;
-            window.apstag.init({
-                pubID: config.get('page.a9PublisherId'),
-                adServer: 'googletag',
-                bidTimeout: bidderTimeout,
-            });
-        }
-    });
+    if (!initialised && canRun) {
+        initialised = true;
+        window.apstag.init({
+            pubID: config.get('page.a9PublisherId'),
+            adServer: 'googletag',
+            bidTimeout: bidderTimeout,
+        });
+    }
 };
 
 // slotFlatMap allows you to dynamically interfere with the PrebidSlot definition


### PR DESCRIPTION
## What does this change?
Removes consent from initialising A9 as it got added to prepare-a9 (https://github.com/guardian/frontend/pull/23092) for not adding the script when user didn't consent
 
## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

