### PR TITLE
Crosswords thumbnails svg fix

### DIFF
--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -124,7 +124,7 @@ class CrosswordPageController(val contentApiClient: ContentApiClient, val contro
         val globalStylesheet = Static(s"stylesheets/$ContentCSSFile.css")
 
         Cached(60) {
-          val body = s"""<?xml-stylesheet type="text/css" href="$globalStylesheet" ?>$xml"""
+          val body = s"""$xml"""
           RevalidatableResult(
             Cors {
               Ok(body).as("image/svg+xml")

--- a/applications/app/crosswords/CrosswordSvg.scala
+++ b/applications/app/crosswords/CrosswordSvg.scala
@@ -14,7 +14,7 @@ object CrosswordSvg extends CrosswordGridDataOrdering {
                      y={y.toString}
                      width={CellSize.toString}
                      height={CellSize.toString}
-                     style="fill: #ffffff" />
+                     fill="#fff" />
 
     cell.number map { n =>
       <g>
@@ -24,16 +24,20 @@ object CrosswordSvg extends CrosswordGridDataOrdering {
     } getOrElse cellRect
   }
 
+  val style =
+    "text { font-family: 'Guardian Text Sans Web','Helvetica Neue',Helvetica,Arial,'Lucida Grande',sans-serif; font-size: 10px; }"
+
   def apply(crossword: Crossword, boxWidth: Option[String], boxHeight: Option[String], trim: Boolean): Elem = {
     val CrosswordDimensions(columns, rows) = crossword.dimensions
 
     val width = columns * (BorderSize + CellSize) + BorderSize
     val height = rows * (BorderSize + CellSize) + BorderSize
 
-    val viewBoxHeight = if (trim) width * 0.6 else height
+    val viewBoxHeight = if (trim) (width * 0.6).ceil.toString else height
 
-    <svg viewBox={s"0, 0, $width, $viewBoxHeight"} class="crossword__grid" xmlns="http://www.w3.org/2000/svg">
-      <rect x="0" y="0" width={width.toString} height={height.toString} class="crossword__grid-background" />
+    <svg viewBox={s"0 0, $width $viewBoxHeight"} xmlns="http://www.w3.org/2000/svg">
+      <style>{style}</style>
+      <rect x="0" y="0" width={width.toString} height={height.toString} fill="#000" />
       {
       for {
         (CrosswordPosition(x, y), cell) <- Grid.fromCrossword(crossword).cells.toSeq.sortBy(_._1)


### PR DESCRIPTION
## What does this change?

Embeds all the CSS necessary for the crossword thumbnails, and remove external dependencies.

cc. @paperboyo 

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<img width="1440" alt="Screenshot 2020-10-16 at 11 18 41" src="https://user-images.githubusercontent.com/76776/96247252-c984b180-0fa1-11eb-9f16-031de5fd47ae.png">


## What is the value of this and can you measure success?

Much more pleasing to the eyes.

## Checklist

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [X] On CODE (optional)