### PR TITLE
Braze banner 'canShow' timeout metrics to Ophan

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -141,8 +141,8 @@ const getMessageFromBraze = async (apiKey: string, brazeUuid: string): Promise<b
 };
 
 const canShow = async (): Promise<boolean> => {
-    const canShowTiming = measureTiming('braze-banner');
-    canShowTiming.start();
+    const timing = measureTiming('braze-banner');
+    timing.start();
 
     const forcedBrazeMessage = getMessageFromQueryString();
     if (forcedBrazeMessage) {
@@ -170,12 +170,14 @@ const canShow = async (): Promise<boolean> => {
 
     try {
         const result = await getMessageFromBraze(apiKey, brazeUuid)
-        const timeTaken = canShowTiming.end();
+        const timeTaken = timing.end();
 
-        ophan.record({
-            component: 'braze-banner-timing',
-            value: timeTaken,
-        });
+        if (timeTaken) {
+            ophan.record({
+                component: 'braze-banner-timing',
+                value: timeTaken,
+            });
+        }
 
         return result;
     } catch (e) {

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -8,36 +8,11 @@ import {mountDynamic} from "@guardian/automat-modules";
 import {submitViewEvent, submitComponentEvent} from 'common/modules/commercial/acquisitions-ophan';
 import { getUrlVars } from 'lib/url';
 import ophan from 'ophan/ng';
-
-import {getUserFromApi} from '../../common/modules/identity/api';
-import {isDigitalSubscriber} from "../../common/modules/commercial/user-features";
+import {getUserFromApi} from 'common/modules/identity/api';
+import {isDigitalSubscriber} from "common/modules/commercial/user-features";
+import {measureTiming} from './measure-timing';
 
 const brazeVendorId = '5ed8c49c4b8ce4571c7ad801';
-
-const measureTiming = (name: string) => {
-    const perf = window.performance;
-    const startKey = `${name}-start`;
-    const endKey = `${name}-end`;
-
-    const start = () => {
-        perf.mark(startKey);
-    };
-
-    const endAndReturn = () => {
-        perf.mark(endKey);
-        perf.measure(name, startKey, endKey);
-        const measureEntries = perf.getEntriesByName(name, "measure");
-        const timeTakenFloat = measureEntries[0].duration;
-        const timeTakenInt = Math.float(timeTakenFloat);
-
-        return timeTakenInt;
-    };
-
-    return {
-        start,
-        endAndReturn,
-    };
-};
 
 const getBrazeUuid = (): Promise<?string> =>
     new Promise((resolve) => {
@@ -195,7 +170,7 @@ const canShow = async (): Promise<boolean> => {
 
     try {
         const result = await getMessageFromBraze(apiKey, brazeUuid)
-        const timeTaken = canShowTiming.endAndReturn();
+        const timeTaken = canShowTiming.end();
 
         ophan.record({
             component: 'braze-banner-timing',

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -28,7 +28,7 @@ const measureTiming = (name: string) => {
         perf.measure(name, startKey, endKey);
         const measureEntries = perf.getEntriesByName(name, "measure");
         const timeTakenFloat = measureEntries[0].duration;
-        const timeTakenInt = Math.trunc(timeTakenFloat);
+        const timeTakenInt = Math.float(timeTakenFloat);
 
         return timeTakenInt;
     };
@@ -194,14 +194,15 @@ const canShow = async (): Promise<boolean> => {
     }
 
     try {
-        return await getMessageFromBraze(apiKey, brazeUuid).then(result => {
-            const timeTaken = canShowTiming.endAndReturn();
-            ophan.record({
-                component: 'braze-banner-timing',
-                value: timeTaken,
-            });
-            return result;
+        const result = await getMessageFromBraze(apiKey, brazeUuid)
+        const timeTaken = canShowTiming.endAndReturn();
+
+        ophan.record({
+            component: 'braze-banner-timing',
+            value: timeTaken,
         });
+
+        return result;
     } catch (e) {
         return false;
     }

--- a/static/src/javascripts/projects/commercial/modules/measure-timing.js
+++ b/static/src/javascripts/projects/commercial/modules/measure-timing.js
@@ -1,0 +1,28 @@
+// @flow
+
+export const measureTiming = (name: string) => {
+    type TimeTakenInMilliseconds = number;
+    const perf = window.performance;
+    const startKey = `${name}-start`;
+    const endKey = `${name}-end`;
+
+    const start = () => {
+        perf.mark(startKey);
+    };
+
+    const end = ():TimeTakenInMilliseconds => {
+        perf.mark(endKey);
+        perf.measure(name, startKey, endKey);
+
+        const measureEntries = perf.getEntriesByName(name, "measure");
+        const timeTakenFloat = measureEntries[0].duration;
+        const timeTakenInt = Math.round(timeTakenFloat);
+
+        return timeTakenInt;
+    };
+
+    return {
+        start,
+        end,
+    };
+};

--- a/static/src/javascripts/projects/commercial/modules/measure-timing.js
+++ b/static/src/javascripts/projects/commercial/modules/measure-timing.js
@@ -1,28 +1,31 @@
 // @flow
 
 export const measureTiming = (name: string) => {
-    type TimeTakenInMilliseconds = number;
-    const perf = window.performance;
-    const startKey = `${name}-start`;
-    const endKey = `${name}-end`;
+    type TimeTakenInMilliseconds = number | null;
+    if (window.performance && window.performance.now) {
+        const perf = window.performance;
+        const startKey = `${name}-start`;
+        const endKey = `${name}-end`;
 
-    const start = () => {
-        perf.mark(startKey);
-    };
+        const start = () => {
+            perf.mark(startKey);
+        };
 
-    const end = ():TimeTakenInMilliseconds => {
-        perf.mark(endKey);
-        perf.measure(name, startKey, endKey);
+        const end = (): TimeTakenInMilliseconds => {
+            perf.mark(endKey);
+            perf.measure(name, startKey, endKey);
 
-        const measureEntries = perf.getEntriesByName(name, "measure");
-        const timeTakenFloat = measureEntries[0].duration;
-        const timeTakenInt = Math.round(timeTakenFloat);
+            const measureEntries = perf.getEntriesByName(name, "measure");
+            const timeTakenFloat = measureEntries[0].duration;
+            const timeTakenInt = Math.round(timeTakenFloat);
 
-        return timeTakenInt;
-    };
+            return timeTakenInt;
+        };
 
-    return {
-        start,
-        end,
-    };
+        return {
+            start,
+            end,
+        };
+    }
+    return { start: () => null, end: (): TimeTakenInMilliseconds => null }
 };


### PR DESCRIPTION
## What does this change?

Measures the time taken for the braze-banner eligibility logic to take place, and sends that data to Ophan, so that we can measure how long it tends to take, and crucially how often it exceeds the 2 second limit specified by the Dotcom team for this logic to take place.

## Does this change need to be reproduced in dotcom-rendering ?

There's a twin PR for DCR [here](https://github.com/guardian/dotcom-rendering/pull/1981)

## Screenshots

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->
 (Not relevant to this PR)

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
