### PR TITLE
Remove footer hiding on interactives

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_interactive.scss
+++ b/static/src/stylesheets/module/content-garnett/_interactive.scss
@@ -141,8 +141,7 @@
 .is-immersive-interactive {
     .content--interactive .content__head,
     .content--interactive .content__main,
-    .content--interactive ~ *,
-    .l-footer {
+    .content--interactive ~ * {
         display: none;
     }
 }


### PR DESCRIPTION
## What does this change?

Stops hiding the footer on interactive articles.

PR that added this was here: https://github.com/guardian/frontend/pull/10840 - immersive interactive articles expect a hidden footer.

Visuals team should review old articles that will now show footer when expectation at the time of build was not showing.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

