### PR TITLE
add MD table template for comparison

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,17 @@
 
 ## Screenshots
 
+<!-- Please use the following table template to make image comparison easier to parse:
+
+| before      | after      |
+|-------------|------------|
+| ![before][] | ![after][] |
+
+[before]: https://example.com/before.png
+[after]: https://example.com/after.png
+
+-->
+
 ## What is the value of this and can you measure success?
 
 ## Checklist

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@
 
 <!-- Please use the following table template to make image comparison easier to parse:
 
-| before      | after      |
+| Before      | After      |
 |-------------|------------|
 | ![before][] | ![after][] |
 


### PR DESCRIPTION
## What does this change?

Ads a table template for screenshot, so they can be compared side-by-side.

As seen in https://github.com/guardian/image-rendering/pull/73#issue-505906845, by @JamieB-gu.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] Maybe?

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |
| &rarr; [Source #532][src-532] | &rarr; [IR #73][ir-73] |

[after]: https://user-images.githubusercontent.com/76776/96467029-6d7c9000-1222-11eb-967f-2778f7058577.png

[ir-73]: https://github.com/guardian/image-rendering/pull/73 

[before]: https://user-images.githubusercontent.com/76776/96467154-8a18c800-1222-11eb-87c0-8e217b7c507c.png
[src-532]: https://github.com/guardian/source/pull/523


## What is the value of this and can you measure success?

Easier to parse visual changes.

## N.B.

MD as in Markdown, not Max Duval :)