### PR TITLE
Link rot: Update D3 origin URL

### DIFF
--- a/static/src/javascripts/projects/common/modules/charts/doughnut.js
+++ b/static/src/javascripts/projects/common/modules/charts/doughnut.js
@@ -3,7 +3,7 @@
  * Inspired by
  * - http://www.chartjs.org/
  * - http://codepen.io/githiro/pen/ICfFE
- * - https://github.com/mbostock/d3/blob/master/src/svg/arc.js
+ * - https://github.com/d3/d3-shape/blob/master/src/arc.js
  */
 import $ from 'lib/$';
 import type { bonzo } from 'bonzo';


### PR DESCRIPTION
## What does this change?

Fix a dead link in the code. There is no automated system to point to the new D3 repository, but thankfully the new repo was similarly organised.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes (please indicate your plans for DCR Implementation)

The `dotcom-rendering` [Donut component][Donut.tsx] should attribute its code to the D3 project.

[Donut.tsx]: https://github.com/guardian/dotcom-rendering/blob/main/src/web/components/Donut.tsx

## What is the value of this and can you measure success?

Avoid link rot.