### PR TITLE
Set absolute iframe path

### DIFF
--- a/common/app/views/fragments/email/signup/emailIframe.scala.html
+++ b/common/app/views/fragments/email/signup/emailIframe.scala.html
@@ -4,7 +4,7 @@
 
 <iframe
     title="Guardian Email Sign-up Form"
-    src="@{"/email/form/" + formType + "/" + listName}"
+    src="@{"https://www.theguardian.com/email/form/" + formType + "/" + listName}"
     scrolling="no" seamless
     id="@{formType + "__email-form"}" frameborder="0"
     class="iframed--overflow-hidden email-sub__iframe"


### PR DESCRIPTION
## What does this change?
Set absolute frame path on the footer. This is needed as we want to host the footer from a single endpoint now. This makes maintenance easier.

Requires https://github.com/guardian/fastly-edge-cache/pull/888 to be merged as the newer endpoints need the `X-Frame-Options: SAMEORIGIN` header removing to work across subdomains.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)
We'll update the absolute path to be safe once this one has gone out. It shouldn't stop anything working at the moment, but better to be safe on this one.

## Screenshots

## What is the value of this and can you measure success?
Footer will work on profile.theguardian.com.
## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
