### PR TITLE
Limit banner height and allow scroll

### DIFF
--- a/static/src/stylesheets/module/site-messages/_engagement-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_engagement-banner.scss
@@ -227,4 +227,6 @@
     background: none !important;
     top: auto !important;
     position: fixed !important;
+    max-height: 80vh;
+    overflow: auto;
 }


### PR DESCRIPTION
DCR PR https://github.com/guardian/dotcom-rendering/pull/1988

We have had reports of the close button being out of view on our banners if the user has set a very high font size in their browser.
This is because the banner container is position: fixed.

We can ensure the button is not too high with 80vh.
This doesn't work for the width, which still overflows on mobile if the font is too large. So we allow scrolling in this case.

Now scrollable and with a limited height:
![Screen Shot 2020-10-20 at 08 46 27](https://user-images.githubusercontent.com/1513454/96556624-21c4f780-12b1-11eb-9f9f-814261a4a417.png)
![Screen Shot 2020-10-20 at 08 46 55](https://user-images.githubusercontent.com/1513454/96556633-24275180-12b1-11eb-807c-89153b057ebe.png)

