### PR TITLE
[ng-interactive] Election2020 test

### DIFF
--- a/applications/app/services/ApplicationsDotcomRenderingInterface.scala
+++ b/applications/app/services/ApplicationsDotcomRenderingInterface.scala
@@ -1,22 +1,38 @@
 package services
 
 import experiments.{ActiveExperiments, NGInteractiveDCR}
-import play.api.mvc.RequestHeader
+import play.api.mvc.{RequestHeader}
 
 sealed trait RenderingTier
 object Legacy extends RenderingTier
+object Election2020Hack extends RenderingTier
 object DotcomRendering extends RenderingTier
 
+// Special2020Election is a temporary case introduced for the special handling of the work needed
+// for the US election Nov 20202. It's essentially the hack version of DotcomRendering , which is
+// not going to be ready on time.
+
 object ApplicationsDotcomRenderingInterface {
-  def getRenderingTier(implicit request: RequestHeader): RenderingTier = {
-    if (ActiveExperiments.isParticipating(NGInteractiveDCR)) {
-      DotcomRendering
-    } else {
-      Legacy
+  def getRenderingTier(path: String)(implicit request: RequestHeader): RenderingTier = {
+    val isSpecialElection =
+      (path == "world/ng-interactive/2020/oct/20/covid-vaccine-tracker-when-will-a-coronavirus-vaccine-be-ready")
+    val isExperiment = ActiveExperiments.isParticipating(NGInteractiveDCR)
+    (isSpecialElection, isExperiment) match {
+      case (true, _)  => Election2020Hack
+      case (_, true)  => DotcomRendering
+      case (_, false) => Legacy
     }
   }
 
   def getHtmlFromDCR(): String = {
     "Experiment: NGInteractiveDCR (2)"
   }
+}
+
+object ApplicationsSpecial2020Election {
+  def atomIdToCapiPath(atomId: String): String = {
+    // atomId = "interactives/2020/07/interactive-vaccine-tracker/default"
+    "atom/interactive/interactives/2020/07/interactive-vaccine-tracker/amp-page"
+  }
+
 }


### PR DESCRIPTION
## What does this change?

[ng-interactive] Election2020 test.

The return value of `ApplicationsSpecial2020Election.atomIdToCapiPath` is currently hard-coded for simplicity.