### PR TITLE
AB test hack to fix centering of new embed designs

### DIFF
--- a/static/src/stylesheets/module/email-signup/_newDesign.scss
+++ b/static/src/stylesheets/module/email-signup/_newDesign.scss
@@ -12,6 +12,10 @@ $mobile-img-size: 3 * $mobile-headline-font-size;
     }
     height: 100%;
     overflow: hidden;
+    /* Filthy hacks during AB test */
+    /* TODO: Remove these and update iframe class post-AB test */
+    width: calc(100% - #{$rounded-adjustment});
+    margin-left: #{$rounded-adjustment / 2};
 }
 .newsletter-embed__image {
     max-width: $mobile-img-size;


### PR DESCRIPTION
## What does this change?
Basic CSS hack to centre the new embed designs appropriately. This basically just cancels out the [CSS specifying iframe width and margins](https://github.com/guardian/frontend/blob/279094865383a9fa1215fa7f48bad37a18417bee/static/src/stylesheets/module/email-signup/_form.scss#L14-L15). After the AB test of the new designs I can go in and tidy up all the news CSS and remove this hack.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
### Before
![Screenshot before change](https://user-images.githubusercontent.com/9122944/96710965-b94f4680-1394-11eb-8d98-c94ac16b5ac2.png)
### After
![Screenshot after change](https://user-images.githubusercontent.com/9122944/96710958-b7858300-1394-11eb-8985-b6209de6a69f.png)



## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
