### PR TITLE
Add duration from CAPI to the Youtube media atom for DCR

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -457,6 +457,7 @@ case class YoutubeBlockElement(
     mediaTitle: String,
     overrideImage: Option[String],
     expired: Boolean,
+    duration: Option[Long],
 ) extends PageElement
 object YoutubeBlockElement {
   implicit val YoutubeBlockElementWrites: Writes[YoutubeBlockElement] = Json.writes[YoutubeBlockElement]
@@ -804,6 +805,7 @@ object PageElement {
                     mediaTitle = mediaAtom.title, // Caption
                     overrideImage = if (isMainBlock) imageOverride else None,
                     expired = mediaAtom.expired.getOrElse(false),
+                    duration = mediaAtom.duration, // Duration in seconds
                   )
                 })
               }


### PR DESCRIPTION
## What does this change?

Adds the duration prop to the DCR model.

![image](https://user-images.githubusercontent.com/638051/96742143-7a33ec00-13ba-11eb-9e89-8ae22a2523a8.png)


## Does this change need to be reproduced in dotcom-rendering ?

- [x] Yes - Duration can be added the the DCR model as an optional field on the youtube block element

Tested locally.