### PR TITLE
liveblog epic: remove support for highlightedText

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-liveblog.js
@@ -1,5 +1,5 @@
 // @flow
-const lastSentenceTemplate = (supportURL: string, ctaText?: string) =>
+const ctaTemplate = (supportURL: string, ctaText?: string) =>
     `<div class="component-button--liveblog-container">
         <a class="component-button component-button--liveblog component-button--hasicon-right contributions__contribute--epic-member"
           href=${supportURL}
@@ -32,7 +32,7 @@ export const epicLiveBlogTemplate = ({
             ${copy.paragraphs
         .map(paragraph => `<p><em>${paragraph}</em></p>`)
         .join('')}
-            <p><em>${lastSentenceTemplate(
+            <p><em>${ctaTemplate(
         supportURL,
         ctaText,
     )}</em></p>

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-liveblog.js
@@ -1,11 +1,6 @@
 // @flow
-const lastSentenceTemplate = (highlightedText?: string, supportURL: string, ctaText?: string) =>
-    `${
-        highlightedText
-            ? `<span className="contributions__highlight">${highlightedText}</span>`
-            : ''
-    }
-    <div class="component-button--liveblog-container">
+const lastSentenceTemplate = (supportURL: string, ctaText?: string) =>
+    `<div class="component-button--liveblog-container">
         <a class="component-button component-button--liveblog component-button--hasicon-right contributions__contribute--epic-member"
           href=${supportURL}
           target="_blank">
@@ -38,7 +33,6 @@ export const epicLiveBlogTemplate = ({
         .map(paragraph => `<p><em>${paragraph}</em></p>`)
         .join('')}
             <p><em>${lastSentenceTemplate(
-        copy.highlightedText,
         supportURL,
         ctaText,
     )}</em></p>


### PR DESCRIPTION
In normal epics, the hightlightedText field is rendered with special styling.
But for the liveblog epic it is pointless, as it looks no different to the rest of the copy.

For existing liveblog epic tests I have copied the text from the `hightlightedText` field into the body text as the final paragraph.
The `hightlightedText` is already hidden in the liveblog epic tool