### PR TITLE
Update liveblog epic test copy

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-epic-design-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-epic-design-test.js
@@ -19,6 +19,15 @@ const copyGlobal: AcquisitionsEpicTemplateCopy = {
     ],
 };
 
+const copyElectionNonUS: AcquisitionsEpicTemplateCopy = {
+    paragraphs: [
+        'Four more years of Donald Trump is a real possibility. America faces an epic choice in November and the result of the presidential election will have global repercussions for democracy, progress and solidarity for generations. Transatlantic ties, superpower relations and the climate emergency are all in the balance.',
+        'In these chaotic, perilous times, an independent, truth-seeking news organisation like the Guardian is essential. Free from commercial or political bias, we can report fearlessly on critical events like this, bringing you a clear, international perspective.',
+        'Support from readers funds our work, motivating us to do better, investigate deeper, challenge more. It means we can keep our quality reporting open for everyone to read, and protects our independence for the long term. Every contribution, however big or small, makes a difference.',
+        'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
+    ],
+};
+
 const copyUS: AcquisitionsEpicTemplateCopy = {
     paragraphs: [
         '<b>America faces an epic choice … </b>',
@@ -28,7 +37,18 @@ const copyUS: AcquisitionsEpicTemplateCopy = {
     ],
 };
 
-const copy = geolocation === 'US' ? copyUS : copyGlobal;
+const USElectionTags = ['us-news/us-elections-2020', 'us-news/series/us-politics-live'];
+
+const getCopy = (): AcquisitionsEpicTemplateCopy => {
+    console.log("tags",config.get('page.keywordIds'))
+    if (geolocation === 'US') {
+        return copyUS;
+    }
+    if (USElectionTags.some(tag => config.get('page.keywordIds').includes(tag))) {
+        return copyElectionNonUS;
+    }
+    return copyGlobal;
+};
 
 export const liveblogEpicDesignTest: EpicABTest = makeEpicABTest({
     id: 'LiveblogEpicDesignTestR1',
@@ -58,21 +78,21 @@ export const liveblogEpicDesignTest: EpicABTest = makeEpicABTest({
             products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
             test: setupEpicInLiveblog,
             template: liveBlogTemplate('liveblog-epic-test__control'),
-            copy: buildEpicCopy(copy, false, geolocation),
+            copy: buildEpicCopy(getCopy(), false, geolocation),
         },
         {
             id: 'v1',
             products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
             test: setupEpicInLiveblog,
             template: liveBlogTemplate('liveblog-epic-test__v1'),
-            copy: buildEpicCopy(copy, false, geolocation),
+            copy: buildEpicCopy(getCopy(), false, geolocation),
         },
         {
             id: 'v2',
             products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
             test: setupEpicInLiveblog,
             template: liveBlogTemplate('liveblog-epic-test__v2'),
-            copy: buildEpicCopy(copy, false, geolocation),
+            copy: buildEpicCopy(getCopy(), false, geolocation),
         },
     ],
 });

--- a/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-epic-design-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-epic-design-test.js
@@ -38,12 +38,13 @@ const copyUS: AcquisitionsEpicTemplateCopy = {
 };
 
 const USElectionTags = ['us-news/us-elections-2020', 'us-news/series/us-politics-live'];
+const keywordTags = config.get('page.keywordIds');
 
 const getCopy = (): AcquisitionsEpicTemplateCopy => {
     if (geolocation === 'US') {
         return copyUS;
     }
-    if (USElectionTags.some(tag => `${config.get('page.keywordIds')}`.includes(tag))) {
+    if (USElectionTags.some(tag => `${keywordTags}`.includes(tag))) {
         return copyElectionNonUS;
     }
     return copyGlobal;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-epic-design-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-epic-design-test.js
@@ -44,7 +44,7 @@ const getCopy = (): AcquisitionsEpicTemplateCopy => {
     if (geolocation === 'US') {
         return copyUS;
     }
-    if (USElectionTags.some(tag => config.get('page.keywordIds').includes(tag))) {
+    if (USElectionTags.some(tag => `${config.get('page.keywordIds')}`.includes(tag))) {
         return copyElectionNonUS;
     }
     return copyGlobal;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-epic-design-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-epic-design-test.js
@@ -40,7 +40,6 @@ const copyUS: AcquisitionsEpicTemplateCopy = {
 const USElectionTags = ['us-news/us-elections-2020', 'us-news/series/us-politics-live'];
 
 const getCopy = (): AcquisitionsEpicTemplateCopy => {
-    console.log("tags",config.get('page.keywordIds'))
     if (geolocation === 'US') {
         return copyUS;
     }


### PR DESCRIPTION
Adds some new copy for US election tags, for _non-US_ users.

### not a US user, not on a US politics liveblog:
![Screen Shot 2020-10-22 at 14 56 58](https://user-images.githubusercontent.com/1513454/96883297-2daee600-1478-11eb-9540-eaff95ddb80d.png)

### not a US user, on a US politics liveblog:
![Screen Shot 2020-10-22 at 14 58 19](https://user-images.githubusercontent.com/1513454/96883327-369fb780-1478-11eb-9b6a-956aa896ba8d.png)

### a US user:
![Screen Shot 2020-10-22 at 14 56 45](https://user-images.githubusercontent.com/1513454/96883365-40291f80-1478-11eb-9952-e4ec85892dfb.png)
