### PR TITLE
Revert "fix preview reload loop (bump play-googleauth to 0.7.2)"

### DIFF
--- a/admin/app/conf/GoogleAuth.scala
+++ b/admin/app/conf/GoogleAuth.scala
@@ -1,9 +1,8 @@
 package conf
 
-import com.gu.googleauth.{AntiForgeryChecker, GoogleAuthConfig}
-import play.api.http.HttpConfiguration
+import com.gu.googleauth.GoogleAuthConfig
 
-case class GoogleAuth(httpConfiguration: HttpConfiguration, currentHost: Option[String] = None) {
+case class GoogleAuth(currentHost: Option[String]) {
   val config = AdminConfiguration.oauthCredentials.flatMap { cred =>
     for {
       callback <- cred.authorizedOauthCallbacks.collectFirst {
@@ -18,8 +17,7 @@ case class GoogleAuth(httpConfiguration: HttpConfiguration, currentHost: Option[
         cred.oauthClientId, // The client ID from the dev console
         cred.oauthSecret, // The client secret from the dev console
         callback, // The redirect URL Google send users back to (must be the same as that configured in the developer console)
-        "guardian.co.uk", // Google App domain to restrict login,
-        antiForgeryChecker = AntiForgeryChecker.borrowSettingsFromPlay(httpConfiguration),
+        "guardian.co.uk", // Google App domain to restrict login
       )
     }
   }
@@ -29,3 +27,5 @@ case class GoogleAuth(httpConfiguration: HttpConfiguration, currentHost: Option[
       throw new RuntimeException("You must set up credentials for Google Auth")
     }
 }
+
+object GoogleAuth extends GoogleAuth(None)

--- a/admin/app/controllers/IndexController.scala
+++ b/admin/app/controllers/IndexController.scala
@@ -3,15 +3,14 @@ package controllers.admin
 import com.gu.googleauth.AuthAction
 import play.api.mvc._
 import model.{ApplicationContext, NoCache}
-import play.components.HttpConfigurationComponents
 
-trait AdminAuthController extends HttpConfigurationComponents {
+trait AdminAuthController {
 
   def controllerComponents: ControllerComponents
 
   object AdminAuthAction
       extends AuthAction(
-        conf.GoogleAuth(httpConfiguration).getConfigOrDie,
+        conf.GoogleAuth.getConfigOrDie,
         routes.OAuthLoginAdminController.login(),
         controllerComponents.parsers.default,
       )(controllerComponents.executionContext)

--- a/admin/app/controllers/OAuthLoginAdminController.scala
+++ b/admin/app/controllers/OAuthLoginAdminController.scala
@@ -21,6 +21,6 @@ class OAuthLoginAdminController(
     }
   override def googleAuthConfig(request: Request[AnyContent]): Option[GoogleAuthConfig] = {
     val host = Some(s"${if (request.secure) "https" else "http"}://${request.host}")
-    conf.GoogleAuth(httpConfiguration, host).config
+    conf.GoogleAuth(host).config
   }
 }

--- a/admin/app/controllers/cache/ImageDecacheController.scala
+++ b/admin/app/controllers/cache/ImageDecacheController.scala
@@ -7,7 +7,6 @@ import com.gu.googleauth.UserIdentity
 import common.{ImplicitControllerExecutionContext, Logging}
 import controllers.admin.AdminAuthController
 import model.{ApplicationContext, NoCache}
-import play.api.http.HttpConfiguration
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc._
@@ -17,7 +16,6 @@ import scala.concurrent.Future.successful
 
 class ImageDecacheController(
     wsClient: WSClient,
-    val httpConfiguration: HttpConfiguration,
     val controllerComponents: ControllerComponents,
 )(implicit context: ApplicationContext)
     extends BaseController

--- a/admin/app/controllers/cache/PageDecacheController.scala
+++ b/admin/app/controllers/cache/PageDecacheController.scala
@@ -7,7 +7,6 @@ import common.{ImplicitControllerExecutionContext, Logging}
 import controllers.admin.AdminAuthController
 import model.{ApplicationContext, NoCache}
 import org.apache.commons.codec.digest.DigestUtils
-import play.api.http.HttpConfiguration
 import play.api.libs.ws.WSClient
 import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc._
@@ -18,12 +17,9 @@ import scala.concurrent.Future.successful
 
 case class PrePurgeTestResult(url: String, passed: Boolean)
 
-class PageDecacheController(
-    wsClient: WSClient,
-    val httpConfiguration: HttpConfiguration,
-    val controllerComponents: ControllerComponents,
-)(implicit context: ApplicationContext)
-    extends BaseController
+class PageDecacheController(wsClient: WSClient, val controllerComponents: ControllerComponents)(implicit
+    context: ApplicationContext,
+) extends BaseController
     with Logging
     with ImplicitControllerExecutionContext
     with AdminAuthController {

--- a/common/app/googleAuth/OAuthLoginController.scala
+++ b/common/app/googleAuth/OAuthLoginController.scala
@@ -21,6 +21,7 @@ trait OAuthLoginController extends BaseController with ImplicitControllerExecuti
   val authCookie = new AuthCookie(httpConfiguration)
 
   val LOGIN_ORIGIN_KEY = "loginOriginUrl"
+  val ANTI_FORGERY_KEY = "antiForgeryToken"
   val forbiddenNoCredentials = Forbidden("Invalid OAuth credentials set")
   lazy val validRedirectDomain = """^(\w+:\/\/[^/]+\.(?:dev-)?gutools\.co\.uk\/.*)$""".r
 
@@ -31,9 +32,12 @@ trait OAuthLoginController extends BaseController with ImplicitControllerExecuti
     Action.async { implicit request =>
       googleAuthConfig(request)
         .flatMap(overrideRedirectUrl)
-        .map { authConfig =>
-          authConfig.antiForgeryChecker.ensureUserHasSessionId { sessionId =>
-            GoogleAuth.redirectToGoogle(authConfig, sessionId)
+        .map { config =>
+          val antiForgeryToken = GoogleAuth.generateAntiForgeryToken()
+          GoogleAuth.redirectToGoogle(config, antiForgeryToken).map {
+            _.withSession {
+              request.session + (ANTI_FORGERY_KEY -> antiForgeryToken)
+            }
           }
         }
         .getOrElse(Future.successful(forbiddenNoCredentials))
@@ -58,33 +62,41 @@ trait OAuthLoginController extends BaseController with ImplicitControllerExecuti
       googleAuthConfig(request)
         .flatMap(overrideRedirectUrl)
         .map { config =>
-          GoogleAuth.validatedUserIdentity(config).map { userIdentity: UserIdentity =>
-            // We store the URL a user was trying to get to in the LOGIN_ORIGIN_KEY in AuthAction
-            // Redirect a user back there now if it exists
-            val redirect = request.session.get(LOGIN_ORIGIN_KEY) match {
-              case Some(url) => Redirect(url)
-              case None      => Redirect("/")
-            }
-            // Store the JSON representation of the identity in the session - this is checked by AuthAction later
-            val sessionAdd: Seq[(String, String)] = Seq(
-              Option((UserIdentity.KEY, Json.toJson(userIdentity).toString())),
-              Option((Configuration.cookies.lastSeenKey, DateTime.now.toString())),
-            ).flatten
+          request.session.get(ANTI_FORGERY_KEY) match {
+            case None =>
+              Future.successful(
+                Redirect("/login").withNewSession
+                  .flashing("error" -> "Anti forgery token missing in session"),
+              )
+            case Some(token) =>
+              GoogleAuth.validatedUserIdentity(config, token).map { userIdentity: UserIdentity =>
+                // We store the URL a user was trying to get to in the LOGIN_ORIGIN_KEY in AuthAction
+                // Redirect a user back there now if it exists
+                val redirect = request.session.get(LOGIN_ORIGIN_KEY) match {
+                  case Some(url) => Redirect(url)
+                  case None      => Redirect("/")
+                }
+                // Store the JSON representation of the identity in the session - this is checked by AuthAction later
+                val sessionAdd: Seq[(String, String)] = Seq(
+                  Option((UserIdentity.KEY, Json.toJson(userIdentity).toString())),
+                  Option((Configuration.cookies.lastSeenKey, DateTime.now.toString())),
+                ).flatten
 
-            val result = redirect
-              .addingToSession(sessionAdd: _*)
-              .removingFromSession(LOGIN_ORIGIN_KEY)
+                val result = redirect
+                  .addingToSession(sessionAdd: _*)
+                  .removingFromSession(ANTI_FORGERY_KEY, LOGIN_ORIGIN_KEY)
 
-            authCookie
-              .from(userIdentity)
-              .map(authCookie => result.withCookies(authCookie))
-              .getOrElse(result)
-          } recover {
-            case t =>
-              // you might want to record login failures here - we just redirect to the login page
-              Redirect("/login")
-                .withSession(request.session)
-                .flashing("error" -> s"Login failure: ${t.toString}")
+                authCookie
+                  .from(userIdentity)
+                  .map(authCookie => result.withCookies(authCookie))
+                  .getOrElse(result)
+              } recover {
+                case t =>
+                  // you might want to record login failures here - we just redirect to the login page
+                  Redirect("/login")
+                    .withSession(request.session - ANTI_FORGERY_KEY)
+                    .flashing("error" -> s"Login failure: ${t.toString}")
+              }
           }
         }
         .getOrElse(Future.successful(forbiddenNoCredentials))

--- a/preview/app/controllers/OAuthLoginPreviewController.scala
+++ b/preview/app/controllers/OAuthLoginPreviewController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import com.gu.googleauth.{AntiForgeryChecker, GoogleAuthConfig, UserIdentity}
+import com.gu.googleauth.{GoogleAuthConfig, UserIdentity}
 import conf.Configuration
 import googleAuth.OAuthLoginController
 import model.ApplicationContext
@@ -27,8 +27,7 @@ class OAuthLoginPreviewController(
         cred.oauthCallback, // The redirect URL Google send users back to (must be the same as
         // that configured in the developer console)
         "guardian.co.uk", // Google App domain to restrict login
-        maxAuthAge = None,
-        antiForgeryChecker = AntiForgeryChecker.borrowSettingsFromPlay(httpConfiguration),
+        None,
       )
     }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -46,7 +46,7 @@ object Dependencies {
   val macwire = "com.softwaremill.macwire" %% "macros" % "2.3.0" % "provided"
   val mockito = "org.mockito" % "mockito-all" % "1.10.19" % Test
   val paClient = "com.gu" %% "pa-client" % "6.1.0"
-  val playGoogleAuth = "com.gu" %% "play-googleauth" % "0.7.2"
+  val playGoogleAuth = "com.gu" %% "play-googleauth" % "0.7.0"
   val quartzScheduler = "org.quartz-scheduler" % "quartz" % "2.2.3"
   val redisClient = "net.debasishg" %% "redisclient" % "3.4"
   val rome = "rome" % "rome" % romeVersion


### PR DESCRIPTION
The guardian/frontend#23105 PR did not solve the issue we were seeing and is possibly clouding the issue that we are continuing to debug. We've now successfully dealt with one issue in #23146 so want to revert this. 

We are keen to redo this at some stage in the future but to get it out of the mix for the time being.