### PR TITLE
[preview] strip out the avatarUrl in PLAY_SESSION

### DIFF
--- a/preview/app/http/PreviewFilters.scala
+++ b/preview/app/http/PreviewFilters.scala
@@ -2,10 +2,13 @@ package http
 
 import akka.stream.Materializer
 import GoogleAuthFilters.AuthFilterWithExemptions
+import com.gu.googleauth.UserIdentity
+import common.Logging
 import controllers.HealthCheck
 import googleAuth.FilterExemptions
 import model.ApplicationContext
 import play.api.http.{HttpConfiguration, HttpFilters}
+import play.api.libs.json.Json
 import play.api.mvc.{Filter, RequestHeader, Result}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -24,7 +27,7 @@ class PreviewFilters(
     httpConfiguration,
   )
 
-  val filters = previewAuthFilter :: new NoCacheFilter :: Filters.common
+  val filters = previewAuthFilter :: new NoCacheFilter :: new NoAvatarFilter :: Filters.common
 }
 
 // OBVIOUSLY this is only for the preview server
@@ -32,4 +35,32 @@ class PreviewFilters(
 class NoCacheFilter(implicit val mat: Materializer, executionContext: ExecutionContext) extends Filter {
   override def apply(nextFilter: (RequestHeader) => Future[Result])(request: RequestHeader): Future[Result] =
     nextFilter(request).map(_.withHeaders("Cache-Control" -> "no-cache"))
+}
+
+class NoAvatarFilter(implicit val mat: Materializer, executionContext: ExecutionContext) extends Filter with Logging {
+  override def apply(nextFilter: (RequestHeader) => Future[Result])(request: RequestHeader): Future[Result] =
+    nextFilter(request).map { result =>
+      result.newSession match {
+        case Some(session) if session.get(UserIdentity.KEY).isDefined =>
+          (for {
+            userIdentityStr <- session.get(UserIdentity.KEY).toRight(s"No '${UserIdentity.KEY}' key in session")
+            userIdentityJson = Json.parse(userIdentityStr)
+            userIdentity <-
+              Json
+                .fromJson[UserIdentity](userIdentityJson)
+                .asEither
+                .left
+                .map(parsingError => s"Failed to parse session userId into UserIdentity object: $parsingError")
+            newId = userIdentity.copy(avatarUrl = None)
+            newIdStr = Json.toJson(newId).toString()
+            newResult = result.withSession(session + (UserIdentity.KEY -> newIdStr))
+          } yield newResult) match {
+            case Right(newResult) => newResult
+            case Left(failureMessage) =>
+              log.warn(s"Failed to filter out avatarUrl: $failureMessage")
+              result
+          }
+        case _ => result // no new UserIdentity session so nothing to remove
+      }
+    }
 }

--- a/preview/app/views/previewAuth.scala.html
+++ b/preview/app/views/previewAuth.scala.html
@@ -35,9 +35,6 @@
                     <a href="/logout">Logout</a>
                 </div>
                 <div class="logged-in">
-                    @identity.avatarUrl.map { url =>
-                        <img class="avatar" src="@url" />
-                    }
                     <p class="logged-in-message">You are logged in as @identity.fullName</p>
                 </div>
             }


### PR DESCRIPTION
For some time we've been having issues with `preview` (and subsequently [`viewer`](https://github.com/guardian/editorial-viewer) too)...

- **Some users** were getting `Bad Request` because the value of their `Cookie` header was greater than the standard 8k limit (temporarily worked around by increasing that limit in https://github.com/guardian/frontend/pull/23146 and https://github.com/guardian/editorial-viewer/pull/93)
- **Some users** were stuck in a strange auth loop in [`viewer`](https://github.com/guardian/editorial-viewer) which proxies `preview` and writes the preview `PLAY_SESSION` cookie into the `preview-session` field of its own `PLAY_SESSION` Cookie (which we think was falling foul of Chrome's 4k per cookie limit, as Firefox users didn't suffer from this problem).

... it turns out upon inspection of the affected user's sessions, we see they had very long `avatarUrl`s (Google) which when combined with their other cookies ended up tipping them over the limit.

This was proven when we asked one of the affected users to re-upload their avatar (to generate a new `avatarUrl` - which are much shorter these days, for some reason).

Since this `avatarUrl` is not really used, it doesn't make sense to encode in the `PLAY_SESSION` then double encode it in [`viewer`'s](https://github.com/guardian/editorial-viewer) `PLAY_SESSION` cookie.

Co-authored-by: @sihil 

## What does this change?
This introduces a new `NoAvatarFilter` that strips out the `avatarUrl` (which can be huge for some users) from the `identity` section of the `PLAY_SESSION` as it's not needed and causes heaps of problems .

We also remove the display of this avatar from the /login page, because it's now not available and was pretty pointless.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
