### PR TITLE
Refactor "[preview] strip out the avatarUrl in PLAY_SESSION"

### DIFF
--- a/preview/app/http/PreviewFilters.scala
+++ b/preview/app/http/PreviewFilters.scala
@@ -2,13 +2,10 @@ package http
 
 import akka.stream.Materializer
 import GoogleAuthFilters.AuthFilterWithExemptions
-import com.gu.googleauth.UserIdentity
-import common.Logging
 import controllers.HealthCheck
 import googleAuth.FilterExemptions
 import model.ApplicationContext
 import play.api.http.{HttpConfiguration, HttpFilters}
-import play.api.libs.json.Json
 import play.api.mvc.{Filter, RequestHeader, Result}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -27,7 +24,7 @@ class PreviewFilters(
     httpConfiguration,
   )
 
-  val filters = previewAuthFilter :: new NoCacheFilter :: new NoAvatarFilter :: Filters.common
+  val filters = previewAuthFilter :: new NoCacheFilter :: Filters.common
 }
 
 // OBVIOUSLY this is only for the preview server
@@ -35,32 +32,4 @@ class PreviewFilters(
 class NoCacheFilter(implicit val mat: Materializer, executionContext: ExecutionContext) extends Filter {
   override def apply(nextFilter: (RequestHeader) => Future[Result])(request: RequestHeader): Future[Result] =
     nextFilter(request).map(_.withHeaders("Cache-Control" -> "no-cache"))
-}
-
-class NoAvatarFilter(implicit val mat: Materializer, executionContext: ExecutionContext) extends Filter with Logging {
-  override def apply(nextFilter: (RequestHeader) => Future[Result])(request: RequestHeader): Future[Result] =
-    nextFilter(request).map { result =>
-      result.newSession match {
-        case Some(session) if session.get(UserIdentity.KEY).isDefined =>
-          (for {
-            userIdentityStr <- session.get(UserIdentity.KEY).toRight(s"No '${UserIdentity.KEY}' key in session")
-            userIdentityJson = Json.parse(userIdentityStr)
-            userIdentity <-
-              Json
-                .fromJson[UserIdentity](userIdentityJson)
-                .asEither
-                .left
-                .map(parsingError => s"Failed to parse session userId into UserIdentity object: $parsingError")
-            newId = userIdentity.copy(avatarUrl = None)
-            newIdStr = Json.toJson(newId).toString()
-            newResult = result.withSession(session + (UserIdentity.KEY -> newIdStr))
-          } yield newResult) match {
-            case Right(newResult) => newResult
-            case Left(failureMessage) =>
-              log.warn(s"Failed to filter out avatarUrl: $failureMessage")
-              result
-          }
-        case _ => result // no new UserIdentity session so nothing to remove
-      }
-    }
 }

--- a/preview/app/views/previewAuth.scala.html
+++ b/preview/app/views/previewAuth.scala.html
@@ -35,6 +35,9 @@
                     <a href="/logout">Logout</a>
                 </div>
                 <div class="logged-in">
+                    @identity.avatarUrl.map { url =>
+                        <img class="avatar" src="@url" />
+                    }
                     <p class="logged-in-message">You are logged in as @identity.fullName</p>
                 </div>
             }

--- a/preview/app/views/previewAuth.scala.html
+++ b/preview/app/views/previewAuth.scala.html
@@ -35,9 +35,6 @@
                     <a href="/logout">Logout</a>
                 </div>
                 <div class="logged-in">
-                    @identity.avatarUrl.map { url =>
-                        <img class="avatar" src="@url" />
-                    }
                     <p class="logged-in-message">You are logged in as @identity.fullName</p>
                 </div>
             }


### PR DESCRIPTION
## What does this change?
This reverts guardian/frontend#23162 and redoes the work in a much simpler way. It turns out that frontend does not use the version of the oauth callback in the googleplayauth library, but has a copy in it's own codebase which is trivial to modify.

This change does mean that the `avatarUrl` is dropped for **_all_** consumers of this class rather than just `preview`. The only other consumer is the `admin` app which also never uses the avatalUrl so this is a safe thing to do.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## What is the value of this and can you measure success?
The `avatarUrl` field of `UserIdentity` is no longer included in either the play session or the auth cookie. This will dramatically reduce the size of the cookies and no longer cause issues with header and cookie size limits.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
