### PR TITLE
Consider adtest param when deciding to shrink fronts for page skins

### DIFF
--- a/applications/app/pages/ContentHtmlPage.scala
+++ b/applications/app/pages/ContentHtmlPage.scala
@@ -29,7 +29,7 @@ object ContentHtmlPage extends HtmlPage[Page] {
       CommercialComponentHigh(
         isPaidContent = false,
         isNetworkFront = false,
-        hasPageSkin = page.metadata.hasPageSkin(edition, request),
+        hasPageSkin = page.metadata.hasPageSkin(request),
       ),
     )
   }
@@ -85,7 +85,7 @@ object ContentHtmlPage extends HtmlPage[Page] {
       bodyTag(classes = bodyClasses)(
         tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
-        pageSkin() when page.metadata.hasPageSkin(Edition(request), request),
+        pageSkin() when page.metadata.hasPageSkin(request),
         guardianHeaderHtml(),
         mainContent(),
         breakingNewsDiv(),

--- a/applications/app/pages/ContentHtmlPage.scala
+++ b/applications/app/pages/ContentHtmlPage.scala
@@ -29,7 +29,7 @@ object ContentHtmlPage extends HtmlPage[Page] {
       CommercialComponentHigh(
         isPaidContent = false,
         isNetworkFront = false,
-        hasPageSkin = page.metadata.hasPageSkin(edition),
+        hasPageSkin = page.metadata.hasPageSkin(edition, request),
       ),
     )
   }
@@ -85,7 +85,7 @@ object ContentHtmlPage extends HtmlPage[Page] {
       bodyTag(classes = bodyClasses)(
         tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
-        pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
+        pageSkin() when page.metadata.hasPageSkin(Edition(request), request),
         guardianHeaderHtml(),
         mainContent(),
         breakingNewsDiv(),

--- a/applications/app/pages/CrosswordHtmlPage.scala
+++ b/applications/app/pages/CrosswordHtmlPage.scala
@@ -61,7 +61,7 @@ object CrosswordHtmlPage extends HtmlPage[CrosswordPage] {
       bodyTag(classes = defaultBodyClasses)(
         tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
-        pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
+        pageSkin() when page.metadata.hasPageSkin(Edition(request), request),
         guardianHeaderHtml(),
         mainContent(),
         breakingNewsDiv(),

--- a/applications/app/pages/CrosswordHtmlPage.scala
+++ b/applications/app/pages/CrosswordHtmlPage.scala
@@ -61,7 +61,7 @@ object CrosswordHtmlPage extends HtmlPage[CrosswordPage] {
       bodyTag(classes = defaultBodyClasses)(
         tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
-        pageSkin() when page.metadata.hasPageSkin(Edition(request), request),
+        pageSkin() when page.metadata.hasPageSkin(request),
         guardianHeaderHtml(),
         mainContent(),
         breakingNewsDiv(),

--- a/applications/app/pages/GalleryHtmlPage.scala
+++ b/applications/app/pages/GalleryHtmlPage.scala
@@ -50,7 +50,7 @@ object GalleryHtmlPage extends HtmlPage[GalleryPage] {
       bodyTag(classes = bodyClasses)(
         tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
-        pageSkin() when page.metadata.hasPageSkin(Edition(request), request),
+        pageSkin() when page.metadata.hasPageSkin(request),
         galleryTop(),
         breakingNewsDiv(),
         galleryBody(page),

--- a/applications/app/pages/GalleryHtmlPage.scala
+++ b/applications/app/pages/GalleryHtmlPage.scala
@@ -50,7 +50,7 @@ object GalleryHtmlPage extends HtmlPage[GalleryPage] {
       bodyTag(classes = bodyClasses)(
         tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
-        pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
+        pageSkin() when page.metadata.hasPageSkin(Edition(request), request),
         galleryTop(),
         breakingNewsDiv(),
         galleryBody(page),

--- a/applications/app/pages/IndexHtmlPage.scala
+++ b/applications/app/pages/IndexHtmlPage.scala
@@ -52,7 +52,7 @@ object IndexHtml {
       bodyTag(classes = defaultBodyClasses)(
         tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
-        pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
+        pageSkin() when page.metadata.hasPageSkin(Edition(request), request),
         guardianHeaderHtml(),
         mainContent(),
         breakingNewsDiv(),

--- a/applications/app/pages/IndexHtmlPage.scala
+++ b/applications/app/pages/IndexHtmlPage.scala
@@ -52,7 +52,7 @@ object IndexHtml {
       bodyTag(classes = defaultBodyClasses)(
         tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
-        pageSkin() when page.metadata.hasPageSkin(Edition(request), request),
+        pageSkin() when page.metadata.hasPageSkin(request),
         guardianHeaderHtml(),
         mainContent(),
         breakingNewsDiv(),

--- a/applications/app/pages/InteractiveHtmlPage.scala
+++ b/applications/app/pages/InteractiveHtmlPage.scala
@@ -63,7 +63,7 @@ object InteractiveHtmlPage extends HtmlPage[InteractivePage] {
       bodyTag(classes = bodyClasses)(
         tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
-        pageSkin() when page.metadata.hasPageSkin(Edition(request), request),
+        pageSkin() when page.metadata.hasPageSkin(request),
         guardianHeaderHtml(),
         mainContent(),
         breakingNewsDiv(),

--- a/applications/app/pages/InteractiveHtmlPage.scala
+++ b/applications/app/pages/InteractiveHtmlPage.scala
@@ -63,7 +63,7 @@ object InteractiveHtmlPage extends HtmlPage[InteractivePage] {
       bodyTag(classes = bodyClasses)(
         tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
-        pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
+        pageSkin() when page.metadata.hasPageSkin(Edition(request), request),
         guardianHeaderHtml(),
         mainContent(),
         breakingNewsDiv(),

--- a/applications/app/pages/NewsletterHtmlPage.scala
+++ b/applications/app/pages/NewsletterHtmlPage.scala
@@ -47,7 +47,7 @@ object NewsletterHtmlPage extends HtmlPage[SimplePage] {
       bodyTag(classes = defaultBodyClasses)(
         tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
-        pageSkin() when page.metadata.hasPageSkin(Edition(request), request),
+        pageSkin() when page.metadata.hasPageSkin(request),
         guardianHeaderHtml(),
         breakingNewsDiv(),
         newsletterContent(page),

--- a/applications/app/pages/NewsletterHtmlPage.scala
+++ b/applications/app/pages/NewsletterHtmlPage.scala
@@ -47,7 +47,7 @@ object NewsletterHtmlPage extends HtmlPage[SimplePage] {
       bodyTag(classes = defaultBodyClasses)(
         tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
-        pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
+        pageSkin() when page.metadata.hasPageSkin(Edition(request), request),
         guardianHeaderHtml(),
         breakingNewsDiv(),
         newsletterContent(page),

--- a/applications/app/pages/TagIndexHtmlPage.scala
+++ b/applications/app/pages/TagIndexHtmlPage.scala
@@ -66,7 +66,7 @@ object TagIndexHtmlPage extends HtmlPage[StandalonePage] {
       bodyTag(classes = defaultBodyClasses)(
         tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
-        pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
+        pageSkin() when page.metadata.hasPageSkin(Edition(request), request),
         guardianHeaderHtml(),
         mainContent(),
         breakingNewsDiv(),

--- a/applications/app/pages/TagIndexHtmlPage.scala
+++ b/applications/app/pages/TagIndexHtmlPage.scala
@@ -66,7 +66,7 @@ object TagIndexHtmlPage extends HtmlPage[StandalonePage] {
       bodyTag(classes = defaultBodyClasses)(
         tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
-        pageSkin() when page.metadata.hasPageSkin(Edition(request), request),
+        pageSkin() when page.metadata.hasPageSkin(request),
         guardianHeaderHtml(),
         mainContent(),
         breakingNewsDiv(),

--- a/applications/app/views/package.scala
+++ b/applications/app/views/package.scala
@@ -26,7 +26,7 @@ object IndexCleaner {
       CommercialComponentHigh(
         isPaidContent = false,
         isNetworkFront = false,
-        hasPageSkin = page.page.metadata.hasPageSkin(edition),
+        hasPageSkin = page.page.metadata.hasPageSkin(edition, request),
       ),
       CommercialMPUForFronts(),
     )

--- a/applications/app/views/package.scala
+++ b/applications/app/views/package.scala
@@ -26,7 +26,7 @@ object IndexCleaner {
       CommercialComponentHigh(
         isPaidContent = false,
         isNetworkFront = false,
-        hasPageSkin = page.page.metadata.hasPageSkin(edition, request),
+        hasPageSkin = page.page.metadata.hasPageSkin(request),
       ),
       CommercialMPUForFronts(),
     )

--- a/article/app/pages/StoryHtmlPage.scala
+++ b/article/app/pages/StoryHtmlPage.scala
@@ -67,7 +67,7 @@ object StoryHtmlPage {
       bodyTag(classes = bodyClasses)(
         tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
-        pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
+        pageSkin() when page.metadata.hasPageSkin(Edition(request), request),
         survey() when SurveySwitch.isSwitchedOn,
         header,
         mainContent(),

--- a/article/app/pages/StoryHtmlPage.scala
+++ b/article/app/pages/StoryHtmlPage.scala
@@ -67,7 +67,7 @@ object StoryHtmlPage {
       bodyTag(classes = bodyClasses)(
         tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
-        pageSkin() when page.metadata.hasPageSkin(Edition(request), request),
+        pageSkin() when page.metadata.hasPageSkin(request),
         survey() when SurveySwitch.isSwitchedOn,
         header,
         mainContent(),

--- a/common/app/common/dfp/PageskinAdAgent.scala
+++ b/common/app/common/dfp/PageskinAdAgent.scala
@@ -58,9 +58,10 @@ trait PageskinAdAgent {
 
   // The ad unit is considered to have a page skin if it has a corresponding sponsorship.
   // If the sponsorship is targetting an adtest we also consider that the request URL includes the same adtest param
-  def hasPageSkin(fullAdUnitPath: String, metaData: MetaData, edition: Edition, request: RequestHeader): Boolean = {
+  def hasPageSkin(fullAdUnitPath: String, metaData: MetaData, request: RequestHeader): Boolean = {
     if (metaData.isFront) {
       val adTestParam = request.getQueryString("adtest")
+      val edition = Edition(request)
       findSponsorships(fullAdUnitPath, metaData, edition) exists (sponsorship =>
         if (sponsorship.targetsAdTest) {
           sponsorship.adTestValue == adTestParam

--- a/common/app/common/dfp/PageskinAdAgent.scala
+++ b/common/app/common/dfp/PageskinAdAgent.scala
@@ -2,11 +2,11 @@ package common.dfp
 
 import com.gu.commercial.display.AdTargetParam.toMap
 import com.gu.commercial.display.{AdTargetParamValue, MultipleValues}
-import common.Edition
+import common.{Edition, Logging}
 import model.MetaData
 import play.api.mvc.RequestHeader
 
-trait PageskinAdAgent {
+trait PageskinAdAgent extends Logging {
 
   protected val environmentIsProd: Boolean
 
@@ -61,6 +61,7 @@ trait PageskinAdAgent {
   def hasPageSkin(fullAdUnitPath: String, metaData: MetaData, edition: Edition, request: RequestHeader): Boolean = {
     if (metaData.isFront) {
       val adTestParam = request.getQueryString("adtest")
+      log.info(s"**** ADTEST PARAM '$adTestParam' ")
       findSponsorships(fullAdUnitPath, metaData, edition) exists (sponsorship =>
         if (sponsorship.targetsAdTest) {
           sponsorship.adTestValue == adTestParam

--- a/common/app/common/dfp/PageskinAdAgent.scala
+++ b/common/app/common/dfp/PageskinAdAgent.scala
@@ -2,11 +2,11 @@ package common.dfp
 
 import com.gu.commercial.display.AdTargetParam.toMap
 import com.gu.commercial.display.{AdTargetParamValue, MultipleValues}
-import common.{Edition, Logging}
+import common.Edition
 import model.MetaData
 import play.api.mvc.RequestHeader
 
-trait PageskinAdAgent extends Logging {
+trait PageskinAdAgent {
 
   protected val environmentIsProd: Boolean
 
@@ -61,7 +61,6 @@ trait PageskinAdAgent extends Logging {
   def hasPageSkin(fullAdUnitPath: String, metaData: MetaData, edition: Edition, request: RequestHeader): Boolean = {
     if (metaData.isFront) {
       val adTestParam = request.getQueryString("adtest")
-      log.info(s"**** ADTEST PARAM '$adTestParam' ")
       findSponsorships(fullAdUnitPath, metaData, edition) exists (sponsorship =>
         if (sponsorship.targetsAdTest) {
           sponsorship.adTestValue == adTestParam

--- a/common/app/html/HtmlPage.scala
+++ b/common/app/html/HtmlPage.scala
@@ -42,7 +42,7 @@ object HtmlPageHelpers {
   ): Map[String, Boolean] = {
     val edition = Edition(request)
     Map(
-      ("has-page-skin", page.metadata.hasPageSkin(edition)),
+      ("has-page-skin", page.metadata.hasPageSkin(edition, request)),
       ("has-membership-access-requirement", page.metadata.requiresMembershipAccess),
       ("childrens-books-site", page.metadata.sectionId == "childrens-books-site"),
     )

--- a/common/app/html/HtmlPage.scala
+++ b/common/app/html/HtmlPage.scala
@@ -42,7 +42,7 @@ object HtmlPageHelpers {
   ): Map[String, Boolean] = {
     val edition = Edition(request)
     Map(
-      ("has-page-skin", page.metadata.hasPageSkin(edition, request)),
+      ("has-page-skin", page.metadata.hasPageSkin(request)),
       ("has-membership-access-requirement", page.metadata.requiresMembershipAccess),
       ("childrens-books-site", page.metadata.sectionId == "childrens-books-site"),
     )

--- a/common/app/model/dotcomrendering/DotcomRenderingTransforms.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingTransforms.scala
@@ -280,7 +280,7 @@ object DotcomRenderingTransforms {
       frontendAssetsFullURL = Configuration.assets.fullURL(common.Environment.stage),
     )
 
-    val jsPageConfig = JavaScriptPage.getMap(page, Edition(request), false)
+    val jsPageConfig = JavaScriptPage.getMap(page, Edition(request), false, request)
     val combinedConfig = Json.toJsObject(config).deepMerge(JsObject(jsPageConfig))
     val calloutsUrl = combinedConfig.fields.toList
       .filter(entry => entry._1 == "calloutsUrl")

--- a/common/app/model/dotcomrendering/PageType.scala
+++ b/common/app/model/dotcomrendering/PageType.scala
@@ -21,13 +21,15 @@ object PageType {
 
   def apply(articlePage: PageWithStoryPackage, request: RequestHeader, context: ApplicationContext): PageType = {
     PageType(
-      getMap(articlePage, Edition(request), false).getOrElse("hasShowcaseMainElement", JsBoolean(false)).as[Boolean],
-      getMap(articlePage, Edition(request), false).getOrElse("isFront", JsBoolean(false)).as[Boolean],
-      getMap(articlePage, Edition(request), false).getOrElse("isLiveBlog", JsBoolean(false)).as[Boolean],
-      getMap(articlePage, Edition(request), false).getOrElse("isMinuteArticle", JsBoolean(false)).as[Boolean],
-      getMap(articlePage, Edition(request), false).getOrElse("isPaidContent", JsBoolean(false)).as[Boolean],
+      getMap(articlePage, Edition(request), false, request)
+        .getOrElse("hasShowcaseMainElement", JsBoolean(false))
+        .as[Boolean],
+      getMap(articlePage, Edition(request), false, request).getOrElse("isFront", JsBoolean(false)).as[Boolean],
+      getMap(articlePage, Edition(request), false, request).getOrElse("isLiveBlog", JsBoolean(false)).as[Boolean],
+      getMap(articlePage, Edition(request), false, request).getOrElse("isMinuteArticle", JsBoolean(false)).as[Boolean],
+      getMap(articlePage, Edition(request), false, request).getOrElse("isPaidContent", JsBoolean(false)).as[Boolean],
       context.isPreview,
-      getMap(articlePage, Edition(request), false).getOrElse("isSensitive", JsBoolean(false)).as[Boolean],
+      getMap(articlePage, Edition(request), false, request).getOrElse("isSensitive", JsBoolean(false)).as[Boolean],
     )
   }
 }

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -250,8 +250,8 @@ final case class MetaData(
 
   private val fullAdUnitPath = AdUnitMaker.make(id, adUnitSuffix)
 
-  def hasPageSkin(edition: Edition, request: RequestHeader): Boolean =
-    DfpAgent.hasPageSkin(fullAdUnitPath, this, edition, request)
+  def hasPageSkin(request: RequestHeader): Boolean =
+    DfpAgent.hasPageSkin(fullAdUnitPath, this, request)
 
   def omitMPUsFromContainers(edition: Edition): Boolean =
     if (isPressedPage) {

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -250,9 +250,8 @@ final case class MetaData(
 
   private val fullAdUnitPath = AdUnitMaker.make(id, adUnitSuffix)
 
-  def hasPageSkin(edition: Edition): Boolean = DfpAgent.hasPageSkin(fullAdUnitPath, this, edition)
-  def hasPageSkinOrAdTestPageSkin(edition: Edition): Boolean =
-    DfpAgent.hasPageSkinOrAdTestPageSkin(fullAdUnitPath, this, edition)
+  def hasPageSkin(edition: Edition, request: RequestHeader): Boolean =
+    DfpAgent.hasPageSkin(fullAdUnitPath, this, edition, request)
 
   def omitMPUsFromContainers(edition: Edition): Boolean =
     if (isPressedPage) {

--- a/common/app/templates/javaScriptConfig.scala.js
+++ b/common/app/templates/javaScriptConfig.scala.js
@@ -10,7 +10,7 @@
 @defining(Edition(request)) { edition =>
     {
         "isDotcomRendering": false,
-        "page": @JavaScript(StringEncodings.jsonToJS(Json.stringify(JavaScriptPage.get(item, Edition(request), context.isPreview)))),
+        "page": @JavaScript(StringEncodings.jsonToJS(Json.stringify(JavaScriptPage.get(item, Edition(request), context.isPreview, request)))),
         "nav": @JavaScript(Json.stringify(Json.toJson(NavMenu(item, edition)))),
         "switches" : { @{JavaScript(conf.switches.Switches.all.filter(_.exposeClientSide).map{ switch =>
             s""""${CamelCase.fromHyphenated(switch.name)}":${switch.isSwitchedOn}"""}.mkString(","))}

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -42,7 +42,7 @@
 
         <a class="u-h skip" href="#maincontent" data-link-name="skip : main content">Skip to main content</a>
 
-        @if(page.metadata.hasPageSkinOrAdTestPageSkin(edition)) {
+        @if(page.metadata.hasPageSkin(edition, request)) {
             @fragments.commercial.pageSkin()
         }
 

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -31,7 +31,7 @@
     <body
         id="top"
         class="@RenderClasses(Map(
-            ("has-page-skin", page.metadata.hasPageSkin(edition, request)),
+            ("has-page-skin", page.metadata.hasPageSkin(request)),
             ("has-membership-access-requirement", page.metadata.requiresMembershipAccess),
             ("childrens-books-site", page.metadata.sectionId == "childrens-books-site"),
             ("has-super-sticky-banner", false),
@@ -42,7 +42,7 @@
 
         <a class="u-h skip" href="#maincontent" data-link-name="skip : main content">Skip to main content</a>
 
-        @if(page.metadata.hasPageSkin(edition, request)) {
+        @if(page.metadata.hasPageSkin(request)) {
             @fragments.commercial.pageSkin()
         }
 

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -31,7 +31,7 @@
     <body
         id="top"
         class="@RenderClasses(Map(
-            ("has-page-skin", page.metadata.hasPageSkin(edition)),
+            ("has-page-skin", page.metadata.hasPageSkin(edition, request)),
             ("has-membership-access-requirement", page.metadata.requiresMembershipAccess),
             ("childrens-books-site", page.metadata.sectionId == "childrens-books-site"),
             ("has-super-sticky-banner", false),

--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -43,7 +43,7 @@ object JavaScriptPage {
 
     val commercialMetaData = Map(
       "dfpHost" -> JsString("pubads.g.doubleclick.net"),
-      "hasPageSkin" -> JsBoolean(metaData.hasPageSkin(edition, request)),
+      "hasPageSkin" -> JsBoolean(metaData.hasPageSkin(request)),
       "dfpNonRefreshableLineItemIds" -> nonRefreshableLineItemIds,
       "shouldHideAdverts" -> JsBoolean(page match {
         case c: ContentPage if c.item.content.shouldHideAdverts => true

--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -10,12 +10,14 @@ import conf.switches.Switches.a9Switch
 import conf.{Configuration, DiscussionAsset}
 import model._
 import play.api.libs.json._
+import play.api.mvc.RequestHeader
 
 object JavaScriptPage {
 
-  def get(page: Page, edition: Edition, isPreview: Boolean): JsValue = Json.toJson(getMap(page, edition, isPreview))
+  def get(page: Page, edition: Edition, isPreview: Boolean, request: RequestHeader): JsValue =
+    Json.toJson(getMap(page, edition, isPreview, request))
 
-  def getMap(page: Page, edition: Edition, isPreview: Boolean): Map[String, JsValue] = {
+  def getMap(page: Page, edition: Edition, isPreview: Boolean, request: RequestHeader): Map[String, JsValue] = {
     val metaData = page.metadata
     val content: Option[Content] = Page.getContent(page).map(_.content)
 
@@ -41,7 +43,7 @@ object JavaScriptPage {
 
     val commercialMetaData = Map(
       "dfpHost" -> JsString("pubads.g.doubleclick.net"),
-      "hasPageSkin" -> JsBoolean(metaData.hasPageSkin(edition)),
+      "hasPageSkin" -> JsBoolean(metaData.hasPageSkin(edition, request)),
       "dfpNonRefreshableLineItemIds" -> nonRefreshableLineItemIds,
       "shouldHideAdverts" -> JsBoolean(page match {
         case c: ContentPage if c.item.content.shouldHideAdverts => true

--- a/common/test/common/dfp/PageskinAdAgentTest.scala
+++ b/common/test/common/dfp/PageskinAdAgentTest.scala
@@ -19,10 +19,10 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
     prebidIndexSites = None,
   )
 
-  val requestAU = FakeRequest(GET, "/au")
-  val requestUS = FakeRequest(GET, "/us")
-  val requestUK = FakeRequest(GET, "/uk")
-  val requestWithAdTestParam = FakeRequest(GET, "/uk?adtest=6")
+  val requestAU = FakeRequest(GET, "/au?_edition=au")
+  val requestUS = FakeRequest(GET, "/us?_edition=us")
+  val requestUK = FakeRequest(GET, "/uk?_edition=uk")
+  val requestWithAdTestParam = FakeRequest(GET, "/uk?_edition=uk&adtest=6")
   val colourSeriesCommercial = CommercialProperties(
     editionBrandings = Set.empty,
     prebidIndexSites = None,

--- a/common/test/common/dfp/PageskinAdAgentTest.scala
+++ b/common/test/common/dfp/PageskinAdAgentTest.scala
@@ -8,6 +8,8 @@ import common.editions.{Au, Uk, Us}
 import conf.Configuration.commercial.dfpAdUnitGuRoot
 import model.MetaData
 import org.scalatest.{FlatSpec, Matchers}
+import play.api.test.FakeRequest
+import play.api.test.Helpers.GET
 
 class PageskinAdAgentTest extends FlatSpec with Matchers {
   val keywordParamSet: Set[AdTargetParam] = KeywordParam.fromItemId("sport-keyword").toSet
@@ -17,6 +19,8 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
     prebidIndexSites = None,
   )
 
+  val requestWithNoAdTestParam = FakeRequest(GET, "/uk")
+  val requestWithAdTestParam = FakeRequest(GET, "/uk?adtest=6")
   val colourSeriesCommercial = CommercialProperties(
     editionBrandings = Set.empty,
     prebidIndexSites = None,
@@ -153,7 +157,12 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
   }
 
   "isPageSkinned" should "be true for a front with a pageskin in given edition" in {
-    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/business/front", pressedFrontMeta, Uk) should be(true)
+    TestPageskinAdAgent.hasPageSkin(
+      s"$dfpAdUnitGuRoot/business/front",
+      pressedFrontMeta,
+      Uk,
+      requestWithNoAdTestParam,
+    ) should be(true)
   }
 
   it should "be true for a series front" in {
@@ -161,44 +170,81 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
       s"$dfpAdUnitGuRoot/fake-series-adunit/new-view-series",
       colourSeriesMeta,
       Uk,
+      requestWithNoAdTestParam,
     ) should be(true)
   }
 
   it should "be false for a front with a pageskin in another edition" in {
-    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/business/front", pressedFrontMeta, Au) should be(false)
+    TestPageskinAdAgent.hasPageSkin(
+      s"$dfpAdUnitGuRoot/business/front",
+      pressedFrontMeta,
+      Au,
+      requestWithNoAdTestParam,
+    ) should be(false)
   }
 
   it should "be false for a front without a pageskin" in {
-    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/culture/front", pressedFrontMeta, defaultEdition) should be(
+    TestPageskinAdAgent.hasPageSkin(
+      s"$dfpAdUnitGuRoot/culture/front",
+      pressedFrontMeta,
+      defaultEdition,
+      requestWithNoAdTestParam,
+    ) should be(
       false,
     )
   }
 
   it should "be false for a front with a pageskin in no edition" in {
-    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/music/front", pressedFrontMeta, defaultEdition) should be(false)
-    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/music/front", pressedFrontMeta, Us) should be(false)
+    TestPageskinAdAgent.hasPageSkin(
+      s"$dfpAdUnitGuRoot/music/front",
+      pressedFrontMeta,
+      defaultEdition,
+      requestWithNoAdTestParam,
+    ) should be(false)
+    TestPageskinAdAgent.hasPageSkin(
+      s"$dfpAdUnitGuRoot/music/front",
+      pressedFrontMeta,
+      Us,
+      requestWithNoAdTestParam,
+    ) should be(false)
   }
 
   it should "be false for a content (non-front) page" in {
-    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/sport", articleMeta, defaultEdition) should be(false)
+    TestPageskinAdAgent.hasPageSkin(
+      s"$dfpAdUnitGuRoot/sport",
+      articleMeta,
+      defaultEdition,
+      requestWithNoAdTestParam,
+    ) should be(false)
   }
 
   it should "be true for an index front (tag page)" in {
-    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/sport-index", sportIndexFrontMeta, defaultEdition) should be(
+    TestPageskinAdAgent.hasPageSkin(
+      s"$dfpAdUnitGuRoot/sport-index",
+      sportIndexFrontMeta,
+      defaultEdition,
+      requestWithNoAdTestParam,
+    ) should be(
       true,
     )
   }
 
-  "non production DfpAgent" should "should recognise adtest targetted line items" in {
+  "non production DfpAgent" should "should recognise adtest targetted line items only if the request includes the same adtest param" in {
     NotProductionTestPageskinAdAgent.hasPageSkin(
       s"$dfpAdUnitGuRoot/testSport/front",
       pressedFrontMeta,
       defaultEdition,
+      requestWithAdTestParam,
     ) should be(true)
   }
 
-  "production DfpAgent" should "should recognise adtest targetted line items" in {
-    TestPageskinAdAgent.hasPageSkin(s"$dfpAdUnitGuRoot/testSport/front", pressedFrontMeta, defaultEdition) should be(
+  "production DfpAgent" should "should recognise adtest targetted line items only if the request includes the same adtest param" in {
+    TestPageskinAdAgent.hasPageSkin(
+      s"$dfpAdUnitGuRoot/testSport/front",
+      pressedFrontMeta,
+      defaultEdition,
+      requestWithAdTestParam,
+    ) should be(
       true,
     )
   }

--- a/common/test/common/dfp/PageskinAdAgentTest.scala
+++ b/common/test/common/dfp/PageskinAdAgentTest.scala
@@ -19,7 +19,9 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
     prebidIndexSites = None,
   )
 
-  val requestWithNoAdTestParam = FakeRequest(GET, "/uk")
+  val requestAU = FakeRequest(GET, "/au")
+  val requestUS = FakeRequest(GET, "/us")
+  val requestUK = FakeRequest(GET, "/uk")
   val requestWithAdTestParam = FakeRequest(GET, "/uk?adtest=6")
   val colourSeriesCommercial = CommercialProperties(
     editionBrandings = Set.empty,
@@ -160,8 +162,7 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
     TestPageskinAdAgent.hasPageSkin(
       s"$dfpAdUnitGuRoot/business/front",
       pressedFrontMeta,
-      Uk,
-      requestWithNoAdTestParam,
+      requestUK,
     ) should be(true)
   }
 
@@ -169,8 +170,7 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
     TestPageskinAdAgent.hasPageSkin(
       s"$dfpAdUnitGuRoot/fake-series-adunit/new-view-series",
       colourSeriesMeta,
-      Uk,
-      requestWithNoAdTestParam,
+      requestUK,
     ) should be(true)
   }
 
@@ -178,8 +178,7 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
     TestPageskinAdAgent.hasPageSkin(
       s"$dfpAdUnitGuRoot/business/front",
       pressedFrontMeta,
-      Au,
-      requestWithNoAdTestParam,
+      requestAU,
     ) should be(false)
   }
 
@@ -187,8 +186,7 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
     TestPageskinAdAgent.hasPageSkin(
       s"$dfpAdUnitGuRoot/culture/front",
       pressedFrontMeta,
-      defaultEdition,
-      requestWithNoAdTestParam,
+      requestUK,
     ) should be(
       false,
     )
@@ -198,14 +196,12 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
     TestPageskinAdAgent.hasPageSkin(
       s"$dfpAdUnitGuRoot/music/front",
       pressedFrontMeta,
-      defaultEdition,
-      requestWithNoAdTestParam,
+      requestUK,
     ) should be(false)
     TestPageskinAdAgent.hasPageSkin(
       s"$dfpAdUnitGuRoot/music/front",
       pressedFrontMeta,
-      Us,
-      requestWithNoAdTestParam,
+      requestUK,
     ) should be(false)
   }
 
@@ -213,8 +209,7 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
     TestPageskinAdAgent.hasPageSkin(
       s"$dfpAdUnitGuRoot/sport",
       articleMeta,
-      defaultEdition,
-      requestWithNoAdTestParam,
+      requestUK,
     ) should be(false)
   }
 
@@ -222,8 +217,7 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
     TestPageskinAdAgent.hasPageSkin(
       s"$dfpAdUnitGuRoot/sport-index",
       sportIndexFrontMeta,
-      defaultEdition,
-      requestWithNoAdTestParam,
+      requestUK,
     ) should be(
       true,
     )
@@ -233,7 +227,6 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
     NotProductionTestPageskinAdAgent.hasPageSkin(
       s"$dfpAdUnitGuRoot/testSport/front",
       pressedFrontMeta,
-      defaultEdition,
       requestWithAdTestParam,
     ) should be(true)
   }
@@ -242,7 +235,6 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
     TestPageskinAdAgent.hasPageSkin(
       s"$dfpAdUnitGuRoot/testSport/front",
       pressedFrontMeta,
-      defaultEdition,
       requestWithAdTestParam,
     ) should be(
       true,

--- a/common/test/model/ContentTest.scala
+++ b/common/test/model/ContentTest.scala
@@ -13,6 +13,8 @@ import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import views.support.JavaScriptPage
 import common.Edition
 import play.api.libs.json.JsBoolean
+import play.api.test.FakeRequest
+import play.api.test.Helpers.GET
 
 class ContentTest
     extends FlatSpec
@@ -63,6 +65,10 @@ class ContentTest
     trail.metadata.url should be("/foo/2012/jan/07/bar")
     trail.elements.mainPicture.flatMap(_.images.largestImage.flatMap(_.url)) should be(Some("http://www.foo.com/bar"))
   }
+
+  val requestWithNoAdTestParam = FakeRequest(GET, "/uk")
+  val requestWithAdTestParam = FakeRequest(GET, "/uk?adtest=6")
+  val noAdTestParam: Option[String] = None
 
   "Tags" should "understand tag types" in {
 
@@ -173,7 +179,7 @@ class ContentTest
     val content =
       Content(article.copy(webPublicationDate = dateBeforeCutoff, fields = Some(ContentFields(sensitive = Some(true)))))
     JavaScriptPage
-      .getMap(SimpleContentPage(content), edition, isPreview = false)
+      .getMap(SimpleContentPage(content), edition, isPreview = false, requestWithNoAdTestParam)
       .get("shouldHideReaderRevenue") should equal(Some(JsBoolean(true)))
   }
 
@@ -183,7 +189,7 @@ class ContentTest
       article.copy(webPublicationDate = dateBeforeCutoff, fields = Some(ContentFields(sensitive = Some(false)))),
     )
     JavaScriptPage
-      .getMap(SimpleContentPage(content), edition, isPreview = false)
+      .getMap(SimpleContentPage(content), edition, isPreview = false, requestWithNoAdTestParam)
       .get("shouldHideReaderRevenue") should be(Some(JsBoolean(false)))
   }
 
@@ -196,7 +202,7 @@ class ContentTest
       ),
     )
     JavaScriptPage
-      .getMap(SimpleContentPage(content), edition, isPreview = false)
+      .getMap(SimpleContentPage(content), edition, isPreview = false, requestWithNoAdTestParam)
       .get("shouldHideReaderRevenue") should be(Some(JsBoolean(false)))
   }
 
@@ -209,7 +215,7 @@ class ContentTest
       ),
     )
     JavaScriptPage
-      .getMap(SimpleContentPage(content), edition, isPreview = false)
+      .getMap(SimpleContentPage(content), edition, isPreview = false, requestWithNoAdTestParam)
       .get("shouldHideReaderRevenue") should be(Some(JsBoolean(true)))
   }
 
@@ -222,7 +228,7 @@ class ContentTest
       ),
     )
     JavaScriptPage
-      .getMap(SimpleContentPage(content), edition, isPreview = false)
+      .getMap(SimpleContentPage(content), edition, isPreview = false, requestWithNoAdTestParam)
       .get("shouldHideReaderRevenue") should be(Some(JsBoolean(true)))
   }
 
@@ -236,7 +242,9 @@ class ContentTest
           tags = List(tag(s"tone/advertisement-features")),
         ),
       )
-    JavaScriptPage.getMap(SimpleContentPage(content), edition, false).get("shouldHideReaderRevenue") should be(
+    JavaScriptPage
+      .getMap(SimpleContentPage(content), edition, false, requestWithNoAdTestParam)
+      .get("shouldHideReaderRevenue") should be(
       Some(JsBoolean(true)),
     )
   }

--- a/facia/app/pages/FrontHtmlPage.scala
+++ b/facia/app/pages/FrontHtmlPage.scala
@@ -61,7 +61,7 @@ object FrontHtmlPage extends HtmlPage[PressedPage] {
       bodyTag(classes = defaultBodyClasses)(
         tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
-        pageSkin() when page.metadata.hasPageSkin(Edition(request), request),
+        pageSkin() when page.metadata.hasPageSkin(request),
         guardianHeaderHtml(),
         mainContent(),
         breakingNewsDiv(),

--- a/facia/app/pages/FrontHtmlPage.scala
+++ b/facia/app/pages/FrontHtmlPage.scala
@@ -28,7 +28,7 @@ object FrontHtmlPage extends HtmlPage[PressedPage] {
       CommercialComponentHigh(
         page.frontProperties.isPaidContent,
         page.isNetworkFront,
-        page.metadata.hasPageSkin(edition, request),
+        page.metadata.hasPageSkin(request),
       ),
       CommercialMPUForFronts(),
     )

--- a/facia/app/pages/FrontHtmlPage.scala
+++ b/facia/app/pages/FrontHtmlPage.scala
@@ -23,7 +23,6 @@ object FrontHtmlPage extends HtmlPage[PressedPage] {
     import views.support.`package`.withJsoup
     import views.support.{BulletCleaner, CommercialComponentHigh, CommercialMPUForFronts}
     val html: Html = frontBody(page)
-    val edition = Edition(request)
     withJsoup(BulletCleaner(html.toString))(
       CommercialComponentHigh(
         page.frontProperties.isPaidContent,

--- a/facia/app/pages/FrontHtmlPage.scala
+++ b/facia/app/pages/FrontHtmlPage.scala
@@ -28,7 +28,7 @@ object FrontHtmlPage extends HtmlPage[PressedPage] {
       CommercialComponentHigh(
         page.frontProperties.isPaidContent,
         page.isNetworkFront,
-        page.metadata.hasPageSkin(edition),
+        page.metadata.hasPageSkin(edition, request),
       ),
       CommercialMPUForFronts(),
     )
@@ -61,7 +61,7 @@ object FrontHtmlPage extends HtmlPage[PressedPage] {
       bodyTag(classes = defaultBodyClasses)(
         tlsWarning() when ActiveExperiments.isParticipating(OldTLSSupportDeprecation),
         skipToMainContent(),
-        pageSkin() when page.metadata.hasPageSkinOrAdTestPageSkin(Edition(request)),
+        pageSkin() when page.metadata.hasPageSkin(Edition(request), request),
         guardianHeaderHtml(),
         mainContent(),
         breakingNewsDiv(),

--- a/facia/app/views/package.scala
+++ b/facia/app/views/package.scala
@@ -14,7 +14,7 @@ object FrontsCleaner {
       CommercialComponentHigh(
         page.frontProperties.isPaidContent,
         page.isNetworkFront,
-        page.metadata.hasPageSkin(edition),
+        page.metadata.hasPageSkin(edition, request),
       ),
       CommercialMPUForFronts(),
     )

--- a/facia/app/views/package.scala
+++ b/facia/app/views/package.scala
@@ -14,7 +14,7 @@ object FrontsCleaner {
       CommercialComponentHigh(
         page.frontProperties.isPaidContent,
         page.isNetworkFront,
-        page.metadata.hasPageSkin(edition, request),
+        page.metadata.hasPageSkin(request),
       ),
       CommercialMPUForFronts(),
     )


### PR DESCRIPTION
## What does this change?
Re-introduce: https://github.com/guardian/frontend/pull/22792 after adding adtest param to fastly allow-list query params

depends on: https://github.com/guardian/fastly-edge-cache/pull/893

Tested this on CODE with fastly edge change and it works