### PR TITLE
Fetch the fonts and store in localstorage for AMP interactive atoms

### DIFF
--- a/applications/app/views/atomEmbed.scala.html
+++ b/applications/app/views/atomEmbed.scala.html
@@ -1,6 +1,9 @@
 @import model.AtomPage
+@import templates.inlineJS.blocking.js.loadFonts
+@import common.InlineJs
 
 @(page: AtomPage)(implicit request: RequestHeader, context: model.ApplicationContext)
+
 
 <!DOCTYPE html>
 <html lang="en-GB" class="gu-atom-embed-html">
@@ -10,19 +13,26 @@
         <base target="_top">
         @fragments.atomPageHead(page)
         <script>
-            // Interactive Atoms expect window.resize to exist. In the context of Amp we want to let the parent know that
-            // the iframe should be resized. See https://amp.dev/documentation/components/amp-iframe/.
-            window.resize = function() {
-                window.parent.postMessage(
-                    {
-                        sentinel: 'amp',
-                        type: 'embed-size',
-                        height: document.body.scrollHeight,
-                    },
-                    '*'
-                );
-            }
+                // Interactive Atoms expect window.resize to exist. In the context of Amp we want to let the parent know that
+                // the iframe should be resized. See https://amp.dev/documentation/components/amp-iframe/.
+                window.resize = function () {
+                    window.parent.postMessage(
+                            {
+                                sentinel: 'amp',
+                                type: 'embed-size',
+                                height: document.body.scrollHeight,
+                            },
+                            '*'
+                    );
+                }
         </script>
+
+        @fragments.fontDefinitions()
+
+        <script>
+            @InlineJs(loadFonts(true).body, "loadFonts.js")
+        </script>
+
     </head>
     <body>
         @page.body


### PR DESCRIPTION
## What does this change?

This uses the current font loading mechanisms for fonts inside of AMP interactives.

The 'atomPage' is used to load interactive atoms in AMP with a src. On web, we use srcDoc and have access to the iframe, so we pass the fonts straight through. But on AMP we're more restricted so we have to let interactives fetch the fonts themselves - we mitigate these extra requests by using the same urls and mechanisms so that a) we use browser cache and b) store in localstorage (note there's discussion about removing the localstorage mechanism, but keeping things consistent in this case).


## Does this change need to be reproduced in dotcom-rendering ?

- [X] No - This will 'just work' by virtue of atom page being requested from Frontend.

## Screenshots

### Before
(Note Georgia and Helvetica)

![Screen Shot 2020-10-26 at 17 48 28](https://user-images.githubusercontent.com/638051/97209299-10e61b80-17b4-11eb-8297-302853c57174.png)

### After

![Screen Shot 2020-10-26 at 17 48 06](https://user-images.githubusercontent.com/638051/97209328-180d2980-17b4-11eb-9027-b4da97c9025b.png)