### PR TITLE
Liveblog epic test round 1b: no italics

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -108,7 +108,7 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-liveblog-epic-design-test-r1",
+    "ab-liveblog-epic-design-test-r1b",
     "Test designs for the liveblog epic",
     owners = Seq(Owner.withGithub("tomrf1")),
     safeState = Off,

--- a/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-liveblog.js
+++ b/static/src/javascripts/projects/common/modules/commercial/templates/acquisitions-epic-liveblog.js
@@ -30,11 +30,11 @@ export const epicLiveBlogTemplate = ({
         </p>
         <div class="block-elements block-elements--no-byline">
             ${copy.paragraphs
-        .map(paragraph => `<p><em>${paragraph}</em></p>`)
+        .map(paragraph => `<p>${paragraph}</p>`)
         .join('')}
-            <p><em>${ctaTemplate(
+            <p>${ctaTemplate(
         supportURL,
         ctaText,
-    )}</em></p>
+    )}</p>
         </div>
     </div>`;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-epic-design-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-epic-design-test.js
@@ -21,7 +21,7 @@ const copyGlobal: AcquisitionsEpicTemplateCopy = {
 
 const copyElectionNonUS: AcquisitionsEpicTemplateCopy = {
     paragraphs: [
-        'Four more years of Donald Trump  would have serious consequences for the world. America faces an epic choice in November and the result of the presidential election will have global repercussions for democracy, progress and solidarity for generations. Transatlantic ties, superpower relations and the climate emergency are all in the balance.',
+        'Four more years of Donald Trump would have serious consequences for the world. America faces an epic choice in November and the result of the presidential election will have global repercussions for democracy, progress and solidarity for generations. Transatlantic ties, superpower relations and the climate emergency are all in the balance.',
         'In these chaotic, perilous times, an independent, truth-seeking news organisation like the Guardian is essential. Free from commercial or political bias, we can report fearlessly on critical events like this, bringing you a clear, international perspective.',
         'Support from readers funds our work, motivating us to do better, investigate deeper, challenge more. It means we can keep our quality reporting open for everyone to read, and protects our independence for the long term. Every contribution, however big or small, makes a difference.',
         'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-epic-design-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-epic-design-test.js
@@ -21,7 +21,7 @@ const copyGlobal: AcquisitionsEpicTemplateCopy = {
 
 const copyElectionNonUS: AcquisitionsEpicTemplateCopy = {
     paragraphs: [
-        'Four more years of Donald Trump is a real possibility. America faces an epic choice in November and the result of the presidential election will have global repercussions for democracy, progress and solidarity for generations. Transatlantic ties, superpower relations and the climate emergency are all in the balance.',
+        'Four more years of Donald Trump  would have serious consequences for the world. America faces an epic choice in November and the result of the presidential election will have global repercussions for democracy, progress and solidarity for generations. Transatlantic ties, superpower relations and the climate emergency are all in the balance.',
         'In these chaotic, perilous times, an independent, truth-seeking news organisation like the Guardian is essential. Free from commercial or political bias, we can report fearlessly on critical events like this, bringing you a clear, international perspective.',
         'Support from readers funds our work, motivating us to do better, investigate deeper, challenge more. It means we can keep our quality reporting open for everyone to read, and protects our independence for the long term. Every contribution, however big or small, makes a difference.',
         'Support the Guardian from as little as %%CURRENCY_SYMBOL%%1 – and it only takes a minute. Thank you.',
@@ -51,8 +51,8 @@ const getCopy = (): AcquisitionsEpicTemplateCopy => {
 };
 
 export const liveblogEpicDesignTest: EpicABTest = makeEpicABTest({
-    id: 'LiveblogEpicDesignTestR1',
-    campaignId: 'liveblog-epic-design-test-r1',
+    id: 'LiveblogEpicDesignTestR1b',
+    campaignId: 'liveblog-epic-design-test-r1b',
 
     geolocation,
     highPriority: false,
@@ -84,14 +84,7 @@ export const liveblogEpicDesignTest: EpicABTest = makeEpicABTest({
             id: 'v1',
             products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
             test: setupEpicInLiveblog,
-            template: liveBlogTemplate('liveblog-epic-test__v1'),
-            copy: buildEpicCopy(getCopy(), false, geolocation),
-        },
-        {
-            id: 'v2',
-            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
-            test: setupEpicInLiveblog,
-            template: liveBlogTemplate('liveblog-epic-test__v2'),
+            template: liveBlogTemplate('liveblog-epic-test__v1b'),
             copy: buildEpicCopy(getCopy(), false, geolocation),
         },
     ],

--- a/static/src/stylesheets/module/reader-revenue/_epic.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic.scss
@@ -254,3 +254,9 @@ div.contributions__secondary-button.contributions__secondary-button--epic {
         object-fit: cover;
     }
 }
+
+.block--content.is-epic {
+    &:not(.liveblog-epic-test__v1b) {
+        font-style: italic;
+    }
+}

--- a/static/src/stylesheets/module/reader-revenue/_reader-revenue-button.scss
+++ b/static/src/stylesheets/module/reader-revenue/_reader-revenue-button.scss
@@ -106,24 +106,6 @@ $gu-cta-height: 42px;
     margin-left: 8px;
 }
 
-.content--pillar-news:not(.paid-content) .block--content.liveblog-epic-test__v1 {
-    .component-button--liveblog {
-        border: 1px solid $news-main;
-    }
-    background-color: $opinion-faded;
-}
-
-.content--pillar-news:not(.paid-content) .block--content.liveblog-epic-test__v2 {
-    border-top-color: $highlight-main;
-    background-color: $brightness-93;
-
-    .component-button--liveblog {
-        background: $highlight-main;
-        border-color: $highlight-main;
-        color: $brightness-7;
-    }
-}
-
 .component-button--reminder-prompt {
     background-color: transparent;
     border-color: $brightness-7;


### PR DESCRIPTION
In the previous liveblog epic design test there was no significant difference against the control.

The next round is to try without italics.

### Control
![Screen Shot 2020-10-27 at 14 34 10](https://user-images.githubusercontent.com/1513454/97316802-0eda9600-1862-11eb-88ff-2886680fadc1.png)


### Variant
![Screen Shot 2020-10-27 at 14 32 44](https://user-images.githubusercontent.com/1513454/97316894-2d409180-1862-11eb-963e-82a1bd71ad74.png)


### Copy for US
![Screen Shot 2020-10-27 at 14 33 13](https://user-images.githubusercontent.com/1513454/97316936-3893bd00-1862-11eb-966b-b2980ec3f028.png)


### Copy for non-US, on US politics tags
![Screen Shot 2020-10-27 at 14 32 54](https://user-images.githubusercontent.com/1513454/97317076-595c1280-1862-11eb-872d-b8f7592b9980.png)
