### PR TITLE
invoke storage cleanup with key explicitly

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -142,7 +142,7 @@ const cleanupLocalStorage = (): void => {
         'gu.recommendationsEnabled',
         'gu.abb3.exempt',
     ];
-    deprecatedKeys.forEach(storage.local.remove);
+    deprecatedKeys.forEach(key => storage.local.remove(key));
 };
 
 const updateHistory = (): void => {


### PR DESCRIPTION
## What does this change?

- explicitly calls `storage.local.remove` with the key name when cleaning up storage
- it breaks without it (though i don't get why)
- reverts a change from #23167 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
