### PR TITLE
Override targetOrigin of native templates to *

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-load.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-load.js
@@ -27,6 +27,7 @@ export const onSlotLoad = (event: SlotOnloadEvent) => {
             id: iframe.id,
             host,
         },
-        iframe.contentWindow
+        iframe.contentWindow,
+        "*"
     );
 };


### PR DESCRIPTION
## What does this change?
With the use of safeframes the targetOrigin of iframes has changed. We now allow all origins by overriding to *
It will help fix an issue with receiving messages inside native templates

