### PR TITLE
Add sign in gate exemption based on tag

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
@@ -253,6 +253,22 @@ export const isInvalidSection = (include: Array<string> = []): boolean => {
         }, false);
 };
 
+// hide the sign in gate for certain tags on the site
+// add to the include parameter array if there are specific tags that should be included/overridden
+export const isInvalidTag = (include: Array<String> = []): boolean => {
+    const invalidTags = [
+        'newsletters/newsletters'
+    ];
+
+    return invalidTags
+        .filter(el => !include.includes(el))
+        .reduce((isTagInvalid, tag) => {
+            if (isTagInvalid) return true;
+            // look up window.guardian.config object in browser console
+            return config.get(`page.keywordIds`, "").split(',').includes(tag)
+        }, false);
+};
+
 // html event wrapper using bean
 export const addEventHandler: ({
     element: HTMLElement,

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
@@ -257,7 +257,7 @@ export const isInvalidSection = (include: Array<string> = []): boolean => {
 // add to the include parameter array if there are specific tags that should be included/overridden
 export const isInvalidTag = (include: Array<String> = []): boolean => {
     const invalidTags = [
-        'newsletters/newsletters'
+        'info/newsletter-sign-up'
     ];
 
     return invalidTags

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.js
@@ -262,11 +262,9 @@ export const isInvalidTag = (include: Array<String> = []): boolean => {
 
     return invalidTags
         .filter(el => !include.includes(el))
-        .reduce((isTagInvalid, tag) => {
-            if (isTagInvalid) return true;
-            // look up window.guardian.config object in browser console
-            return config.get(`page.keywordIds`, "").split(',').includes(tag)
-        }, false);
+        .some((tag) => config.get(`page.keywordIds`, "")
+            .split(',')
+            .includes(tag));
 };
 
 // html event wrapper using bean

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.spec.js
@@ -4,6 +4,7 @@ import {
     hasUserDismissedGateMoreThanCount,
     incrementUserDismissedGateCount,
     isCountry,
+    isInvalidTag,
 } from './helper';
 
 jest.mock('bean', () => ({
@@ -61,6 +62,7 @@ jest.mock('./component-event-tracking', () => ({
 
 const fakeUserPrefs: any = require('common/modules/user-prefs');
 const fakeLocal: any = require('@guardian/libs').storage.local;
+const fakeConfig: any = require('lib/config');
 
 describe('Sign In Gate Helper functions', () => {
     describe('hasUserDismissedGateInWindow', () => {
@@ -213,6 +215,18 @@ describe('Sign In Gate Helper functions', () => {
 
         test('geolocation is false if not set', () => {
             expect(isCountry('US')).toBe(false);
+        });
+    });
+
+    describe("isInvalidTag('tag')", () => {
+        test("'newsletters/newsletters' article is invalid", () => {
+            fakeConfig.get.mockReturnValueOnce("newsletters/newsletters,us-news/us-news,society/homelessness,society/housing");
+            expect(isInvalidTag()).toBe(true);
+        });
+
+        test("non-Newsletters article is not invalid", () => {
+            fakeConfig.get.mockReturnValueOnce("us-news/us-news,society/homelessness,society/housing");
+            expect(isInvalidTag()).toBe(false);
         });
     });
 });

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/helper.spec.js
@@ -219,8 +219,8 @@ describe('Sign In Gate Helper functions', () => {
     });
 
     describe("isInvalidTag('tag')", () => {
-        test("'newsletters/newsletters' article is invalid", () => {
-            fakeConfig.get.mockReturnValueOnce("newsletters/newsletters,us-news/us-news,society/homelessness,society/housing");
+        test("'info/newsletter-sign-up' article is invalid", () => {
+            fakeConfig.get.mockReturnValueOnce("info/newsletter-sign-up,us-news/us-news,society/homelessness,society/housing");
             expect(isInvalidTag()).toBe(true);
         });
 

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
@@ -151,7 +151,7 @@ describe('Sign in gate test', () => {
         });
 
         it('should return false if its a newsletter landing page', () => {
-            fakeConfig.get.mockReturnValueOnce("newsletters/newsletters,us-news/us-news,society/homelessness,society/housing");
+            fakeConfig.get.mockReturnValueOnce("info/newsletter-sign-up,us-news/us-news,society/homelessness,society/housing");
             return signInGate.canShow().then(show => {
                 expect(show).toBe(false);
             });

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
@@ -81,10 +81,13 @@ describe('Sign in gate test', () => {
     });
 
     describe('canShow returns true', () => {
-        it('should return true using default mocks', () =>
+        it('should return true using default mocks', () => {
+            // Add a fake default config.get call for the keywordIds
+            fakeConfig.get.mockReturnValueOnce("")
             signInGate.canShow().then(show => {
                 expect(show).toBe(true);
-            }));
+            })
+        });
 
         it('should return true if page view is greater than or equal to 2', () => {
             fakeLocal.get.mockReturnValueOnce([{ count: 10, day: 1 }]);
@@ -103,7 +106,7 @@ describe('Sign in gate test', () => {
         });
 
         it('should return false if this is the first page view', () => {
-            fakeLocal.get.mockReturnValueOnce([{ count: 0, day: 1 }]);
+            fakeLocal.get.mockReturnValueOnce([{count: 0, day: 1}]);
             return signInGate.canShow().then(show => {
                 expect(show).toBe(false);
             });
@@ -142,6 +145,13 @@ describe('Sign in gate test', () => {
         it('should return false if its an ios 9 device', () => {
             window.navigator.userAgent =
                 'Mozilla/5.0 (iPad; CPU OS 9_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) CriOS/46.0.2490.73 Mobile/13C143 Safari/600.1.4 (000718)';
+            return signInGate.canShow().then(show => {
+                expect(show).toBe(false);
+            });
+        });
+
+        it('should return false if its a newsletter landing page', () => {
+            fakeConfig.get.mockReturnValueOnce("newsletters/newsletters,us-news/us-news,society/homelessness,society/housing");
             return signInGate.canShow().then(show => {
                 expect(show).toBe(false);
             });

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/main/control.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/main/control.js
@@ -9,6 +9,7 @@ import {
     isInvalidSection,
     isIOS9,
     setGatePageTargeting,
+    isInvalidTag,
 } from '../../helper';
 
 // define the variant name here
@@ -27,6 +28,7 @@ const canShow: (name?: string) => boolean = (name = '') => {
         !isLoggedIn() &&
         !isInvalidArticleType() &&
         !isInvalidSection() &&
+        !isInvalidTag() &&
         !isIOS9();
 
     setGatePageTargeting(isGateDismissed, canShowCheck);

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/main/variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/main/variant.js
@@ -6,6 +6,7 @@ import {
     isLoggedIn,
     isInvalidArticleType,
     isInvalidSection,
+    isInvalidTag,
     isIOS9,
     setGatePageTargeting,
     hasUserDismissedGateMoreThanCount,
@@ -31,6 +32,7 @@ const canShow: (name?: string) => boolean = (name = '') => {
         !isLoggedIn() &&
         !isInvalidArticleType() &&
         !isInvalidSection() &&
+        !isInvalidTag() &&
         !isIOS9();
 
     setGatePageTargeting(isGateDismissed, canShowCheck);


### PR DESCRIPTION
## What does this change?
Newsletter landing pages need to be exempted from the sign-in gate. One
way to do this is to add a `newsletters/newsletters` to the page
`keywordIds` and then add this as an exemption from showing the sign-in
gate.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

Will reproduce on DCR pages.

## Screenshots

| Before      | After      |
|-------------|------------|
![before](https://user-images.githubusercontent.com/9122944/97464374-bde9a100-1938-11eb-96ba-81d5814bbf8e.png)| ![after](https://user-images.githubusercontent.com/9122944/97464465-d8237f00-1938-11eb-8b20-d0c191db31ae.png) |


## What is the value of this and can you measure success?
Increased newsletter sign up

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
