### PR TITLE
Extend curated onwards container

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -70,9 +70,9 @@ trait ABTestSwitches {
     ABTests,
     "ab-curated-container-test",
     "Tests an additional 'curated' onwards container below the article body.",
-    owners = Seq(Owner.withGithub("nicl")),
+    owners = Seq(Owner.withGithub("gtrufitt")),
     safeState = Off,
-    sellByDate = new LocalDate(2020, 11, 2),
+    sellByDate = new LocalDate(2020, 11, 10),
     exposeClientSide = true,
   )
 


### PR DESCRIPTION
## What does this change?

Extends the test for (just over) a week while we gather results

## Does this change need to be reproduced in dotcom-rendering ?

https://github.com/guardian/dotcom-rendering/pull/2012

