### PR TITLE
amp head tag for experimental ng-interactive pages

### DIFF
--- a/applications/app/pages/InteractiveHtmlPage.scala
+++ b/applications/app/pages/InteractiveHtmlPage.scala
@@ -16,7 +16,8 @@ import views.html.fragments.page.head.stylesheets.{criticalStyleInline, critical
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.fragments._
 import views.html.stacked
-import html.HtmlPageHelpers.{ContentCSSFile}
+import html.HtmlPageHelpers.ContentCSSFile
+import services.ApplicationsSpecial2020Election
 
 object InteractiveHtmlPage extends HtmlPage[InteractivePage] {
 
@@ -50,9 +51,12 @@ object InteractiveHtmlPage extends HtmlPage[InteractivePage] {
       ),
     )
 
+    val ampTag = ApplicationsSpecial2020Election.ampTagHtml(request.path)
+
     htmlTag(
       headTag(
         weAreHiring() when WeAreHiring.isSwitchedOn,
+        ampTag,
         titleTag(),
         metaData(),
         styles(allStyles),

--- a/applications/app/services/ApplicationsDotcomRenderingInterface.scala
+++ b/applications/app/services/ApplicationsDotcomRenderingInterface.scala
@@ -1,7 +1,7 @@
 package services
 
 import experiments.{ActiveExperiments, NGInteractiveDCR}
-import play.api.mvc.{RequestHeader}
+import play.api.mvc.RequestHeader
 
 sealed trait RenderingTier
 object Legacy extends RenderingTier
@@ -28,20 +28,4 @@ object ApplicationsDotcomRenderingInterface {
   def getHtmlFromDCR(): String = {
     "Experiment: NGInteractiveDCR (2)"
   }
-}
-
-object ApplicationsSpecial2020Election {
-  def atomIdToCapiPath(atomId: String): String = {
-    /*
-        This function transforms and atom id
-          "interactives/2020/07/interactive-vaccine-tracker/default"
-        into the corresponding amp capi query path
-          "atom/interactive/interactives/2020/07/interactive-vaccine-tracker/amp-page"
-
-        I realise that this code is a little bit fragile, hopefully we will double check beforehand
-        that the logic still applies for the election result tracker.
-     */
-    (Array("atom", "interactive") ++ atomId.split("/").dropRight(1) ++ Array("amp-page")).mkString("/")
-  }
-
 }

--- a/applications/app/services/ApplicationsSpecial2020Election.scala
+++ b/applications/app/services/ApplicationsSpecial2020Election.scala
@@ -1,0 +1,35 @@
+package services
+
+import play.api.mvc.RequestHeader
+import play.twirl.api.Html
+
+object ApplicationsSpecial2020Election {
+  def atomIdToCapiPath(atomId: String): String = {
+    /*
+        This function transforms and atom id
+          "interactives/2020/07/interactive-vaccine-tracker/default"
+        into the corresponding amp capi query path
+          "atom/interactive/interactives/2020/07/interactive-vaccine-tracker/amp-page"
+
+        I realise that this code is a little bit fragile, hopefully we will double check beforehand
+        that the logic still applies for the election result tracker.
+     */
+    (Array("atom", "interactive") ++ atomId.split("/").dropRight(1) ++ Array("amp-page")).mkString("/")
+  }
+
+  def ampTagHtml(path: String)(implicit request: RequestHeader): Html = {
+    ApplicationsDotcomRenderingInterface.getRenderingTier(path) match {
+      case Election2020Hack => {
+        Html(
+          // The following simple string interpolation wasn't compiling.
+          // (probable reason: Proximity of string interpolation and quote escaping.)
+          // s"<link rel=\"amphtml\" href=\"https://amp.theguardian.com/${path}\">",
+
+          // Going for another solution then
+          List("<link rel=\"amphtml\" href=\"https://amp.theguardian.com/", path, "\">").mkString(""),
+        )
+      }
+      case _ => Html("")
+    }
+  }
+}

--- a/applications/app/services/ApplicationsSpecial2020Election.scala
+++ b/applications/app/services/ApplicationsSpecial2020Election.scala
@@ -26,7 +26,7 @@ object ApplicationsSpecial2020Election {
           // s"<link rel=\"amphtml\" href=\"https://amp.theguardian.com/${path}\">",
 
           // Going for another solution then
-          List("<link rel=\"amphtml\" href=\"https://amp.theguardian.com/", path, "\">").mkString(""),
+          Array("<link rel=\"amphtml\" href=\"https://amp.theguardian.com/", path, "\">").mkString(""),
         )
       }
       case _ => Html("")


### PR DESCRIPTION
## What does this change?

We are currently experimenting with giving AMP pages to some ng-interactive pages. This is currently driven by the `ApplicationsSpecial2020Election` object (which at least until the election will perform for `ApplicationsDotcomRenderingInterface` which is a work in progress).

This PR, gives the selected www pages the required amp tag for discovery.
