### PR TITLE
Update ArticlePicker to include comment blocks for DCR

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -7,6 +7,7 @@ import implicits.Requests._
 import model.liveblog.{
   AudioBlockElement,
   BlockElement,
+  CommentBlockElement,
   ContentAtomBlockElement,
   DocumentBlockElement,
   GuVideoBlockElement,
@@ -53,6 +54,7 @@ object ArticlePageChecks {
     def unsupportedElement(blockElement: BlockElement) =
       blockElement match {
         case _: AudioBlockElement     => false
+        case _: CommentBlockElement   => false
         case _: DocumentBlockElement  => false
         case _: GuVideoBlockElement   => false
         case _: ImageBlockElement     => false


### PR DESCRIPTION
## What does this change?

Now that @HarryFischer has done the work [to render comment blocks](https://github.com/guardian/dotcom-rendering/pull/1996), we can allow them to be served by DCR.

See https://www.theguardian.com/music/2016/apr/28/readers-recommend-playlist-songs-about-climate-change?dcr=true for an example.

<img width="665" alt="Screen Shot 2020-10-29 at 13 15 05" src="https://user-images.githubusercontent.com/2051501/97578750-23956600-19e9-11eb-911f-f347d381f5d9.png">
