### PR TITLE
Spacefinder rule fix for adratio

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -74,19 +74,16 @@ const filterNearbyCandidates = (maximumAdHeight: number) => (
     return false;
 };
 
-const getBodySelector = (): string =>
-    !config.get('isDotcomRendering', false)
-        ? '.js-article__body'
-        : '.article-body-commercial-selector';
+const isDotcomRendering = config.get('isDotcomRendering', false);
+const articleBodySelector = isDotcomRendering ? '.article-body-commercial-selector' : '.js-article__body';
 
 const addDesktopInlineAds = (isInline1: boolean): Promise<number> => {
     const isImmersive = config.get('page.isImmersive');
-
     const defaultRules = {
-        bodySelector: getBodySelector(),
+        bodySelector: articleBodySelector,
         slotSelector: ' > p',
         minAbove: isImmersive ? 700 : 300,
-        minBelow: 700,
+        minBelow: isDotcomRendering ? 300 : 700,
         selectors: {
             ' > h2': {
                 minAbove: 5,
@@ -111,10 +108,10 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<number> => {
 
     // For any other inline
     const relaxedRules = {
-        bodySelector: getBodySelector(),
+        bodySelector: articleBodySelector,
         slotSelector: ' > p',
         minAbove: isPaidContent ? 1600 : 1000,
-        minBelow: 800,
+        minBelow: isDotcomRendering ? 300 : 800,
         selectors: {
             ' .ad-slot': adSlotClassSelectorSizes,
             ' figure.element--immersive': {
@@ -156,7 +153,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<number> => {
 
 const addMobileInlineAds = (): Promise<number> => {
     const rules = {
-        bodySelector: getBodySelector(),
+        bodySelector: articleBodySelector,
         slotSelector: ' > p',
         minAbove: 200,
         minBelow: 200,
@@ -212,7 +209,7 @@ const addInlineAds = (): Promise<number> => {
 
 const attemptToAddInlineMerchAd = (): Promise<boolean> => {
     const rules = {
-        bodySelector: getBodySelector(),
+        bodySelector: articleBodySelector,
         slotSelector: ' > p',
         minAbove: 300,
         minBelow: 0,


### PR DESCRIPTION
## What does this change?
Adjust spacefinder's minBelow rule for DCR

The DCR article body container doesn't contain as much content after the article text as front-end. The long "Since you're here..." section, for example, is within the article body container on Frontend, and in a separate container under the article body container on DCR. 
As a result of the shorter article body container the current rules (which were the same for DCR and frontend) there are fewer potential slots on DCR vs Frontend. This change reduces the minBelow rule when run on DCR, but keeps it as is on frontend.

This article is an identified test case:
`/cities/2017/jan/31/building-zion-controversial-plan-mormon-inspired-city-vermont`
`document.querySelectorAll('.ad-slot--inline').length` is typically `8` on Frontend and `7` on DCR.
Following the fix both are `8`.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
Adratio is being tracked on an ongoing basis here:
https://tableau.ophan.co.uk/views/dotcomrendering/slotsindcrvsdcp?iframeSizedToWindow=true&%3Aembed=y&%3AshowAppBanner=false&%3Adisplay_count=no&%3AshowVizHome=no
We're targeting parity. 
## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

The change only affects desktop on DCR.

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

Not applicable.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
