### PR TITLE
rejig consent timing

### DIFF
--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -45,18 +45,17 @@ const go = () => {
 
         // keep this in sync with src/web/components/App.tsx in frontend
         let recordedConsentTime = false;
-        cmp.willShowPrivacyMessage().then(willShow => {
-            onConsentChange(() => {
-                if (!recordedConsentTime) {
+        onConsentChange(() => {
+            if (!recordedConsentTime) {
+                recordedConsentTime = true;
+                cmp.willShowPrivacyMessage().then((willShow) => {
                     trackPerformance(
                         'consent',
                         'acquired',
-                        willShow ? 'new' : 'existing'
+                        willShow ? 'new' : 'existing',
                     );
-
-                    recordedConsentTime = true;
-                }
-            });
+                });
+            }
         });
 
         if (config.get('tests.useAusCmpVariant') === 'variant') {

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -43,7 +43,8 @@ const go = () => {
             pageViewId,
         };
 
-        // keep this in sync with src/web/components/App.tsx in frontend
+        // keep this in sync with CONSENT_TIMING in src/web/components/App.tsx in frontend
+        // mark: CONSENT_TIMING
         let recordedConsentTime = false;
         onConsentChange(() => {
             if (!recordedConsentTime) {

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -36,26 +36,29 @@ const go = () => {
 
         // Start CMP
         // CCPA and TCFv2
-        const browserId: ?string = getCookie('bwid') || undefined;;
+        const browserId: ?string = getCookie('bwid') || undefined;
         const pageViewId: ?string = config.get('ophan.pageViewId');
-        const pubData: { browserId?: ?string, pageViewId?: ?string } =
-            { browserId, pageViewId };
+        const pubData: { browserId?: ?string, pageViewId?: ?string } = {
+            browserId,
+            pageViewId,
+        };
 
-
+        // keep this in sync with src/web/components/App.tsx in frontend
         let recordedConsentTime = false;
-        onConsentChange(() => {
-            if (!recordedConsentTime) {
-                markTime('Consent acquired');
-                trackPerformance(
-                    'CMP init',
-                    'Consent acquired',
-                    'Time to get consent'
-                );
-                recordedConsentTime = true;
-            }
-        })
+        cmp.willShowPrivacyMessage().then(willShow => {
+            onConsentChange(() => {
+                if (!recordedConsentTime) {
+                    trackPerformance(
+                        'consent',
+                        'acquired',
+                        willShow ? 'new' : 'existing'
+                    );
 
-        markTime('CMP init');
+                    recordedConsentTime = true;
+                }
+            });
+        });
+
         if (config.get('tests.useAusCmpVariant') === 'variant') {
             cmp.init({ pubData, country: geolocationGetSync() });
         } else {


### PR DESCRIPTION
## What does this change?

- rejigs consent timing to give more useful results
  - records whether consent came from interaction or existing consent
  - uses ga category/variable/label correctly

## Does this change need to be reproduced in dotcom-rendering ?

- [x] Yes https://github.com/guardian/dotcom-rendering/pull/2013
