### PR TITLE
Retrieve page URL via a postMessage

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -23,6 +23,7 @@ import { init as background } from 'commercial/modules/messenger/background';
 import { init as sendClick } from 'commercial/modules/messenger/click';
 import { init as disableRefresh } from 'commercial/modules/messenger/disable-refresh';
 import { init as initGetPageTargeting } from 'commercial/modules/messenger/get-page-targeting';
+import { init as initGetPageUrl } from 'commercial/modules/messenger/get-page-url';
 import { init as getStyles } from 'commercial/modules/messenger/get-stylesheet';
 import { init as hide } from 'commercial/modules/messenger/hide';
 import { init as resize } from 'commercial/modules/messenger/resize';
@@ -34,6 +35,7 @@ initMessenger(
     type,
     getStyles,
     initGetPageTargeting,
+    initGetPageUrl,
     resize,
     hide,
     scroll,

--- a/static/src/javascripts/projects/commercial/modules/messenger/get-page-url.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/get-page-url.js
@@ -1,0 +1,8 @@
+// @flow
+import type { RegisterListeners } from 'commercial/modules/messenger';
+
+const init = (register: RegisterListeners) => {
+    register('get-page-url', () => window.location.origin + window.location.pathname);
+};
+
+export { init };


### PR DESCRIPTION
## What does this change?

Adds a new method to messenger to respond to postMessage requests for getting the full page URL. 
This will be used by teads ads that are served into SafeFrame and need the full URL to allow Cross-origin referrer in Safari

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)


### Tested

- [x] Locally
- [ ] On CODE (optional)

