### PR TITLE
Add AB test for newsletters merch unit

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -75,4 +75,24 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2020, 11, 10),
     exposeClientSide = true,
   )
+
+  Switch(
+    ABTests,
+    "ab-liveblog-epic-design-test-r1b",
+    "Test designs for the liveblog epic",
+    owners = Seq(Owner.withGithub("tomrf1")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 12, 1),
+    exposeClientSide = true,
+  )
+
+  Switch(
+    ABTests,
+    "ab-newsletter-merch-unit",
+    "Test impact of newsletter merch unit across lighthouse segments",
+    owners = Seq(Owner.withGithub("buck06191")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 12, 1),
+    exposeClientSide = true,
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -3,7 +3,6 @@ import { commercialPrebidSafeframe } from 'common/modules/experiments/tests/comm
 import { contributionsBannerArticlesViewedOptOut } from 'common/modules/experiments/tests/contribs-banner-articles-viewed-opt-out';
 import { signInGateMainVariant } from 'common/modules/experiments/tests/sign-in-gate-main-variant';
 import { signInGateMainControl } from 'common/modules/experiments/tests/sign-in-gate-main-control';
-import { liveblogEpicDesignTest } from 'common/modules/experiments/tests/liveblog-epic-design-test';
 import { newsletterMerchUnit } from 'common/modules/experiments/tests/newsletter-merch-unit-test';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -3,11 +3,14 @@ import { commercialPrebidSafeframe } from 'common/modules/experiments/tests/comm
 import { contributionsBannerArticlesViewedOptOut } from 'common/modules/experiments/tests/contribs-banner-articles-viewed-opt-out';
 import { signInGateMainVariant } from 'common/modules/experiments/tests/sign-in-gate-main-variant';
 import { signInGateMainControl } from 'common/modules/experiments/tests/sign-in-gate-main-control';
+import { liveblogEpicDesignTest } from 'common/modules/experiments/tests/liveblog-epic-design-test';
+import { newsletterMerchUnit } from 'common/modules/experiments/tests/newsletter-merch-unit-test';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
     signInGateMainVariant,
     signInGateMainControl,
+    newsletterMerchUnit,
 ];
 
 export const epicTests: $ReadOnlyArray<EpicABTest> = [];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-merch-unit-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-merch-unit-test.js
@@ -6,7 +6,7 @@ export const newsletterMerchUnit: ABTest = {
     expiry: '2020-12-01',
     author: 'Josh Buckland',
     description:
-        'Show a newsletter advert in the merchandising unit to 50% of ',
+        'Show a newsletter advert in the merchandising unit to 50% of users',
     audience: 1,
     audienceOffset: 0.0,
     successMeasure: 'We see increased engagement from users shown the Newsletters ad unit',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-merch-unit-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-merch-unit-test.js
@@ -1,0 +1,27 @@
+// @flow
+
+export const newsletterMerchUnit: ABTest = {
+    id: 'NewsletterMerchUnit',
+    start: '2020-11-02',
+    expiry: '2020-12-01',
+    author: 'Josh Buckland',
+    description:
+        'Show a newsletter advert in the merchandising unit to 50% of ',
+    audience: 1,
+    audienceOffset: 0.0,
+    successMeasure: 'We see increased engagement from users shown the Newsletters ad unit',
+    audienceCriteria:
+        'Website users only.',
+    ophanComponentId: 'newsletter_merch_unit',
+    dataLinkNames: 'n/a',
+    idealOutcome:
+        'Increase engagement for lighthouse segments 4 and 5 via newsletters',
+    showForSensitive: false,
+    canRun: () => true,
+    variants: [
+        {
+            id: 'variant',
+            test: (): void => {},
+        },
+    ],
+};


### PR DESCRIPTION
## What does this change?
In order to test the impact of a newsletters merch unit across
lighthouse segments we want to roll out a 50/50 AB test. The variant
will then be targeted with the newsletters merch unit.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)
DCR implementation to follow.
## Screenshots
### AB test info visible in Google Ad Manager
![image](https://user-images.githubusercontent.com/9122944/97600297-d02f1200-1a00-11eb-9102-0ecdc7ffd35b.png)

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
