### PR TITLE
CMP Version Bump to 6.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@guardian/automat-modules": "^0.3.7",
     "@guardian/braze-components": "0.0.12",
     "@guardian/commercial-core": "^0.9.0",
-    "@guardian/consent-management-platform": "6.5.2",
+    "@guardian/consent-management-platform": "6.6.0",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/libs": "^1.3.0",
     "@guardian/shimport": "^1.0.2",

--- a/static/src/javascripts/projects/commercial/modules/IpsosTaggingScript.js
+++ b/static/src/javascripts/projects/commercial/modules/IpsosTaggingScript.js
@@ -1,5 +1,5 @@
 // @flow
-import { onConsentChange, getConsentFor } from '@guardian/consent-management-platform';
+//import { onConsentChange, getConsentFor } from '@guardian/consent-management-platform';
 import config from 'lib/config';
 import { loadScript } from '@guardian/libs';
 
@@ -22,16 +22,15 @@ const IpsosTagging = function () {
 };
 
 // Need to change to correct consent vendor
-export const init = (): Promise<void> =>{
+export const init = (): Promise<void> => {
 
     // Initial testing only
-    /* if(document.location.href === "https://www.theguardian.com/science/grrlscientist/2012/aug/07/3")
+    if(document.location.href === "https://www.theguardian.com/science/grrlscientist/2012/aug/07/3")
     {
-        console.log("Href condition met");
         IpsosTagging();
     }
-    */
 
+    /*
 
     onConsentChange(state => {
         console.log(getConsentFor('5f745ab96f3aae0163740409', state));
@@ -40,7 +39,7 @@ export const init = (): Promise<void> =>{
         }
     });
 
-
+    */
 
     return Promise.resolve();
 };

--- a/static/src/javascripts/projects/commercial/modules/IpsosTaggingScript.js
+++ b/static/src/javascripts/projects/commercial/modules/IpsosTaggingScript.js
@@ -33,13 +33,13 @@ export const init = (): Promise<void> => {
     /*
 
     onConsentChange(state => {
-        console.log(getConsentFor('5f745ab96f3aae0163740409', state));
-        if (getConsentFor('5f745ab96f3aae0163740409', state)) {
+        console.log(getConsentFor('a9', state));
+        if (getConsentFor('a9', state)) {
             IpsosTagging();
         }
     });
 
-    */
+     */
 
     return Promise.resolve();
 };

--- a/static/src/javascripts/projects/commercial/modules/IpsosTaggingScript.js
+++ b/static/src/javascripts/projects/commercial/modules/IpsosTaggingScript.js
@@ -1,5 +1,5 @@
 // @flow
-//import { onConsentChange, getConsentFor } from '@guardian/consent-management-platform';
+// import { onConsentChange, getConsentFor } from '@guardian/consent-management-platform';
 import config from 'lib/config';
 import { loadScript } from '@guardian/libs';
 

--- a/static/src/javascripts/projects/commercial/modules/IpsosTaggingScript.js
+++ b/static/src/javascripts/projects/commercial/modules/IpsosTaggingScript.js
@@ -1,5 +1,5 @@
 // @flow
-// import { onConsentChange, getConsentFor } from '@guardian/consent-management-platform';
+import { onConsentChange, getConsentFor } from '@guardian/consent-management-platform';
 import config from 'lib/config';
 import { loadScript } from '@guardian/libs';
 
@@ -22,24 +22,25 @@ const IpsosTagging = function () {
 };
 
 // Need to change to correct consent vendor
-export const init = (): Promise<void> => {
+export const init = (): Promise<void> =>{
 
     // Initial testing only
-    if(document.location.href === "https://www.theguardian.com/science/grrlscientist/2012/aug/07/3")
+    /* if(document.location.href === "https://www.theguardian.com/science/grrlscientist/2012/aug/07/3")
     {
+        console.log("Href condition met");
         IpsosTagging();
     }
+    */
 
-    /*
 
     onConsentChange(state => {
-        console.log(getConsentFor('a9', state));
-        if (getConsentFor('a9', state)) {
+        console.log(getConsentFor('5f745ab96f3aae0163740409', state));
+        if (getConsentFor('5f745ab96f3aae0163740409', state)) {
             IpsosTagging();
         }
     });
 
-     */
+
 
     return Promise.resolve();
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1758,10 +1758,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.9.0.tgz#2c578b61a6af99436abd83760d3349ef99d53ab8"
   integrity sha512-2o/au3c/SRUYrlPA1x6Rog6+UpXkSf6UrSX16lD19VaFyia60LaIXtBu9mkZNhSm0FWqfLSgync8RTCeCRG47w==
 
-"@guardian/consent-management-platform@6.5.2":
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.5.2.tgz#e61e0b015af0ee3f943f6b2c6054096974b1323f"
-  integrity sha512-hs+4G4Fcubb+UKF2fDpmqQgVNSs9y++YC4yjXJQbLkt0wY6qQ2EOscjkGgAQCxdQNaFXpFZFdC8o27W6hUXJjw==
+"@guardian/consent-management-platform@6.6.0":
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.6.0.tgz#e6328fdfba40bb423f8a63084b1096423041a564"
+  integrity sha512-QIEd65+sPN56VMekx5JinZZIFHq0ahfG1HGISfG9HRG6+31r1VNv8d6VXySszJXhY1ksCh4Rtn0BW3MmSq5NkQ==
 
 "@guardian/dotcom-rendering@git://github.com/guardian/dotcom-rendering.git#version-1-alpha":
   version "0.1.0-alpha"


### PR DESCRIPTION
## What does this change?

This updates CMP which now includes Ipsos Mori as a Vendor.
