### PR TITLE
make liveblog epic italics

### DIFF
--- a/static/src/stylesheets/module/reader-revenue/_epic.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic.scss
@@ -254,3 +254,7 @@ div.contributions__secondary-button.contributions__secondary-button--epic {
         object-fit: cover;
     }
 }
+
+.block--content.is-epic {
+    font-style: italic;
+}


### PR DESCRIPTION
We decided to remove the italics in https://github.com/guardian/frontend/pull/23191
Now we've decided to bring it back...

<img width="626" alt="Screen Shot 2020-11-02 at 10 33 25" src="https://user-images.githubusercontent.com/1513454/97858298-db32bc80-1cf6-11eb-9dfa-4031e8d8f095.png">
