### PR TITLE
Revert "Temporarily disable smart app banner to measure impact"

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -66,7 +66,7 @@ const canShow = (): Promise<boolean> =>
             isDevice() &&
             validImpressionCount() &&
             !hasUserAcknowledgedBanner(messageCode);
-        resolve(result && false); // Temporarily disabling this banner to measure performance metric impact
+        resolve(result);
     });
 
 const show = (): Promise<boolean> =>


### PR DESCRIPTION
Reverts guardian/frontend#23171

No difference seen in CLS statistics according to google search console that I can see.