### PR TITLE
Add Ipsos Mori Tagging To Specific Sections

### DIFF
--- a/common/app/model/IpsosTags.scala
+++ b/common/app/model/IpsosTags.scala
@@ -26,6 +26,7 @@ object IpsosTags {
     "uk/environment" -> "environment", /* There is no US or AU environment tag - should these map to environment? */
     "environment" -> "environment", /* Default for environment articles */
     "fashion" -> "fashion",
+    "fashion/beauty" -> "fashion",
     "uk/film" -> "film", /* There is no US or AU film tag - should these map to film? */
     "film" -> "film",
     "food" -> "food",
@@ -42,10 +43,19 @@ object IpsosTags {
     "uk/lifeandstyle" -> "lifeandstyle", /* There is no US or AU lifeandstyle tag - should these map to lifeandstyle? */
     "lifeandstyle" -> "lifeandstyle",
     "lifeandstyle/love-and-sex" -> "lifeandstyle",
+    "lifeandstyle/women" -> "lifeandstyle",
+    "lifeandstyle/men" -> "lifeandstyle",
+    "lifeandstyle/home-and-garden" -> "lifeandstyle",
     "us/lifeandstyle" -> "lifeandstyle",
+    "lifeandstyle/home-and-garden" -> "lifeandstyle",
     "uk/media" -> "media", /* There is no US or AU media tag - should these map to media? */
     "membership" -> "membership",
     "uk/money" -> "money", /* There is no US or AU money tag - should these map to money? */
+    "money" -> "money",
+    "money/debt" -> "money",
+    "money/property" -> "money",
+    "money/work-and-careers" -> "money",
+    "money/pensions" -> "money",
     "music" -> "music",
     "international" -> "international",
     "/email-newsletters" -> "emailnewsletters",
@@ -77,6 +87,8 @@ object IpsosTags {
     "theguardian" -> "theguardian",
     "theobserver" -> "theobserver",
     "uk/travel" -> "travel",
+    "travel/europe" -> "travel",
+    "travel/usa" -> "travel",
     "travel" -> "travel", /* Default for travel articles */
     "us/travel" -> "travel",
     "au/travel" -> "travel",

--- a/static/src/javascripts/bootstraps/commercial.dcr.js
+++ b/static/src/javascripts/bootstraps/commercial.dcr.js
@@ -20,7 +20,7 @@ import { init as initStickyTopBanner } from 'commercial/modules/sticky-top-banne
 import { init as initThirdPartyTags } from 'commercial/modules/third-party-tags';
 import { init as initPaidForBand } from 'commercial/modules/paidfor-band';
 import { init as initComscore } from 'commercial/modules/comscore';
-import { init as initIpsosMori } from 'commercial/modules/ipsosTaggingScript';
+import { init as initIpsosMori } from 'commercial/modules/ipsos-mori';
 import { paidContainers } from 'commercial/modules/paid-containers';
 import { trackPerformance } from 'common/modules/analytics/google';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -20,7 +20,7 @@ import { init as initStickyTopBanner } from 'commercial/modules/sticky-top-banne
 import { init as initThirdPartyTags } from 'commercial/modules/third-party-tags';
 import { init as initPaidForBand } from 'commercial/modules/paidfor-band';
 import { init as initComscore } from 'commercial/modules/comscore';
-import { init as initIpsosMori } from 'commercial/modules/ipsosTaggingScript';
+import { init as initIpsosMori } from 'commercial/modules/ipsos-mori';
 import { paidContainers } from 'commercial/modules/paid-containers';
 import { trackPerformance } from 'common/modules/analytics/google';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';

--- a/static/src/javascripts/projects/commercial/modules/ipsos-mori.js
+++ b/static/src/javascripts/projects/commercial/modules/ipsos-mori.js
@@ -1,8 +1,7 @@
 // @flow
 import { onConsentChange, getConsentFor } from '@guardian/consent-management-platform';
 import config from 'lib/config';
-import { loadScript } from '@guardian/libs';
-import { isInUk } from 'common/modules/commercial/geo-utils'
+import { loadScript, getLocale } from '@guardian/libs';
 
 /* Sections to be included in initial release of Ipsos Mori tagging */
 const allowSections = [
@@ -42,15 +41,17 @@ const loadIpsosScript = () => {
 
 export const init = (): Promise<void> => {
 
-    if (isInUk()) {
-        onConsentChange(state => {
-            if (getConsentFor('ipsos', state)) {
-                if (allowSections.includes(config.get('page.section'))) {
-                    return loadIpsosScript();
+    getLocale().then((locale) => {
+        if(locale === 'GB') {
+            onConsentChange(state => {
+                if (getConsentFor('ipsos', state)) {
+                    if (allowSections.includes(config.get('page.section'))) {
+                        return loadIpsosScript();
+                    }
                 }
-            }
-        });
-    }
+            });
+        }
+    });
 
     return Promise.resolve();
 };

--- a/static/src/javascripts/projects/commercial/modules/ipsosTaggingScript.js
+++ b/static/src/javascripts/projects/commercial/modules/ipsosTaggingScript.js
@@ -3,7 +3,7 @@ import { onConsentChange, getConsentFor } from '@guardian/consent-management-pla
 import config from 'lib/config';
 import { loadScript } from '@guardian/libs';
 
-const allowSections = ["lifeandstyle", "food", "travel", "sport"];
+const allowSections = ["lifeandstyle", "food", "travel", "sport"]; // eslint-disable-line no-unused-vars
 
 const loadIpsosScript = function () {
 

--- a/static/src/javascripts/projects/commercial/modules/ipsosTaggingScript.js
+++ b/static/src/javascripts/projects/commercial/modules/ipsosTaggingScript.js
@@ -3,6 +3,8 @@ import { onConsentChange, getConsentFor } from '@guardian/consent-management-pla
 import config from 'lib/config';
 import { loadScript } from '@guardian/libs';
 
+const allowSections = ["lifeandstyle", "food", "travel", "sport"];
+
 const loadIpsosScript = function () {
 
     console.debug("Ipsos tag fired");
@@ -25,12 +27,10 @@ export const init = (): Promise<void> => {
         onConsentChange(state => {
             // Initial testing only
             console.log(getConsentFor('ipsos', state));
-            if(document.location.pathname === "/science/grrlscientist/2012/aug/07/3")
-                {
-                    if (getConsentFor('ipsos', state))
-                    {
-                        loadIpsosScript();
-                    }
+            if(document.location.href === "https://www.theguardian.com/science/grrlscientist/2012/aug/07/3" || document.location.href === "https://www.theguardian.com/science/grrlscientist/2012/aug/07/3?dcr=true") {
+                if (getConsentFor('ipsos', state)) {
+                    loadIpsosScript();
+                }
             }
         });
 

--- a/static/src/javascripts/projects/commercial/modules/ipsosTaggingScript.js
+++ b/static/src/javascripts/projects/commercial/modules/ipsosTaggingScript.js
@@ -3,7 +3,25 @@ import { onConsentChange, getConsentFor } from '@guardian/consent-management-pla
 import config from 'lib/config';
 import { loadScript } from '@guardian/libs';
 
-const allowSections = ["lifeandstyle", "food", "travel", "sport"]; // eslint-disable-line no-unused-vars
+/* Sections to be included in initial release of Ipsos Mori tagging */
+const allowSections = [
+    "lifeandstyle", /* Lifestyle sections */
+    "fashion",
+    "food",
+    "travel",
+    "fashion",
+    "money",
+    "technology",
+    "culture", /* Culture sections */
+    "film",
+    "music",
+    "tv-and-radio",
+    "books",
+    "artanddesign",
+    "stage",
+    "games",
+    "sport", /* Sport sections */
+    "football",];
 
 const loadIpsosScript = function () {
 
@@ -25,10 +43,9 @@ const loadIpsosScript = function () {
 export const init = (): Promise<void> => {
 
         onConsentChange(state => {
-            // Initial testing only
-            console.log(getConsentFor('ipsos', state));
-            if(document.location.href === "https://www.theguardian.com/science/grrlscientist/2012/aug/07/3" || document.location.href === "https://www.theguardian.com/science/grrlscientist/2012/aug/07/3?dcr=true") {
-                if (getConsentFor('ipsos', state)) {
+            if (getConsentFor('ipsos', state))
+            {
+                if(allowSections.includes(config.get('page.section'))) {
                     loadIpsosScript();
                 }
             }
@@ -36,5 +53,4 @@ export const init = (): Promise<void> => {
 
     return Promise.resolve();
 };
-
 


### PR DESCRIPTION
## What does this change?

This adds a list of allowed sections for the Ipsos tagging to be trialed on. The tag definitions have also been updated.

We've added a check for the user's locale so that we only load the tag in the UK (as it's quite heavy, this seems sensible).

As this is ready to go with the section restrictions, I suggest we merge as-is, monitor things and then on 30/11 turn on for all sections if no problems found.

~Not to be merged until given green light by @jfsoul~ Green light given

### Tested

- [x] Locally
- [ ] On CODE (optional)
