### PR TITLE
Only initialise Google Analytics tracking if the user has consented to this tracking

### DIFF
--- a/common/app/templates/inlineJS/blocking/config.scala.js
+++ b/common/app/templates/inlineJS/blocking/config.scala.js
@@ -30,6 +30,9 @@ window.guardian = {
         active: undefined,
         onDetect: []
     },
+    googleAnalytics: {
+        initialiseGa: undefined
+    },
     config: @JavaScript(templates.js.javaScriptConfig(page).body)
 };
 

--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -17,7 +17,7 @@
 // (where the user has not given their consent for GA tracking)
 window.ga = function() {};
 
-window.initialiseGa = function() {
+window.guardian.ga.initialiseGa = function() {
     // Remove spaces from content type and convert it to lower case
     function convertContentType(contentType) {
         var result = contentType;
@@ -61,6 +61,8 @@ window.initialiseGa = function() {
     }
     var isLoggedIn = (!!identityId).toString();
 
+    // If we have stubbed window.ga = function() {};, remove the stub before Google attempts
+    // to initialise it properly (it will not get initialised if the stub already exists)
     delete window.ga;
     @***************************************************************************************
     * Standard copy 'n paste Google Analytics code                                         *
@@ -73,6 +75,7 @@ window.initialiseGa = function() {
     @***************************************************************************************
     * Code that is customised by us                                                        *
     ***************************************************************************************@
+    window.guardian.ga.hasInitialised = true;
     @for(tracker <- Seq(GoogleAnalyticsAccount.editorialProd, GoogleAnalyticsAccount.editorialTest)) {
         ga('create', '@tracker.trackingId', 'auto', '@tracker.trackerName', {
             'sampleRate': @{ if (context.environment.mode == Dev) 100 else tracker.samplePercentage },

--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -17,7 +17,7 @@
 // (where the user has not given their consent for GA tracking)
 window.ga = function() {};
 
-window.guardian.config.googleAnalytics.initialiseGa = function() {
+window.guardian.googleAnalytics.initialiseGa = function() {
     // Remove spaces from content type and convert it to lower case
     function convertContentType(contentType) {
         var result = contentType;

--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -13,9 +13,11 @@
     var pillar = '@{navMenu.currentPillar.map(_.title).getOrElse("")}';
 }
 
+// This is to prevent console errors from code calling window.ga for sessions where we have not loaded the tracking script
+// (where the user has not given their consent for GA tracking)
+window.ga = function() {};
 
-(function() {
-
+window.initialiseGa = function() {
     // Remove spaces from content type and convert it to lower case
     function convertContentType(contentType) {
         var result = contentType;
@@ -59,6 +61,7 @@
     }
     var isLoggedIn = (!!identityId).toString();
 
+    delete window.ga;
     @***************************************************************************************
     * Standard copy 'n paste Google Analytics code                                         *
     ***************************************************************************************@
@@ -161,7 +164,7 @@
     // Mediator will be intialised if we need to use this, otherwise just use GA straight away
     guardian.app && guardian.app.mediator && guardian.app.mediator.emit('modules:ga:ready');
 
-})();
+};
 </script>
 
 @*

--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -17,7 +17,7 @@
 // (where the user has not given their consent for GA tracking)
 window.ga = function() {};
 
-window.guardian.ga.initialiseGa = function() {
+window.guardian.config.googleAnalytics.initialiseGa = function() {
     // Remove spaces from content type and convert it to lower case
     function convertContentType(contentType) {
         var result = contentType;
@@ -75,7 +75,7 @@ window.guardian.ga.initialiseGa = function() {
     @***************************************************************************************
     * Code that is customised by us                                                        *
     ***************************************************************************************@
-    window.guardian.ga.hasInitialised = true;
+    window.guardian.config.page.gaIsInitalised = true;
     @for(tracker <- Seq(GoogleAnalyticsAccount.editorialProd, GoogleAnalyticsAccount.editorialTest)) {
         ga('create', '@tracker.trackingId', 'auto', '@tracker.trackerName', {
             'sampleRate': @{ if (context.environment.mode == Dev) 100 else tracker.samplePercentage },

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -124,7 +124,7 @@ const loadAnalytics = (): void => {
 const loadGoogleAnalytics = (): void => {
     const handleGoogleAnalytics = (gaHasConsent: boolean): void => {
         if (gaHasConsent && !config.get('page.gaIsInitalised')) {
-            window.guardian.config.googleAnalytics.initialiseGa()
+            window.guardian.googleAnalytics.initialiseGa()
         } else {
             // set window.ga back to a stub function when ga consents are removed so that we don't track events
             window.ga = function() {}

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -123,12 +123,12 @@ const loadAnalytics = (): void => {
 
 const loadGoogleAnalytics = (): void => {
     const handleGoogleAnalytics = (gaHasConsent: boolean): void => {
-        if (gaHasConsent && !window.guardian.config.page.gaIsInitalised) {
+        if (gaHasConsent && !config.get('page.gaIsInitalised')) {
             window.guardian.config.googleAnalytics.initialiseGa()
         } else {
             // set window.ga back to a stub function when ga consents are removed so that we don't track events
             window.ga = function() {}
-            window.guardian.config.googleAnalytics.page.gaIsInitalised = false
+            config.set('page.gaIsInitalised', false)
         }
     }
     mediator.on('ga:gaConsentChange', handleGoogleAnalytics)

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -60,6 +60,7 @@ import { signInGate } from 'common/modules/identity/sign-in-gate';
 import { brazeBanner } from 'commercial/modules/brazeBanner';
 import { readerRevenueBanner } from 'common/modules/commercial/reader-revenue-banner';
 import { getArticleCountConsent } from 'common/modules/commercial/contributions-service';
+import { init as initGoogleAnalytics } from 'common/modules/tracking/google-analytics';
 
 const initialiseTopNavItems = (): void => {
     const header: ?HTMLElement = document.getElementById('header');
@@ -119,6 +120,18 @@ const loadAnalytics = (): void => {
         }
     }
 };
+
+const loadGoogleAnalytics = (): void => {
+    const handleGoogleAnalytics = (gaHasConsent: boolean): void => {
+        if (gaHasConsent && !window.ga.loaded) {
+            window.initialiseGa()
+        } else {
+            // set window.ga back to a stub function when ga consents are removed so that we don't track events
+            window.ga = function() {}
+        }
+    }
+    mediator.on('ga:gaConsentChange', handleGoogleAnalytics)
+}
 
 const cleanupCookies = (): void => {
     cleanUp([
@@ -335,6 +348,8 @@ const init = (): void => {
         ['c-increment-article-counts', updateArticleCounts],
         ['c-reader-revenue-dev-utils', initReaderRevenueDevUtils],
         ['c-add-privacy-settings-link', addPrivacySettingsLink],
+        ['c-load-google-analytics', loadGoogleAnalytics],
+        ['c-google-analytics', initGoogleAnalytics],
     ]);
 };
 

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -123,12 +123,12 @@ const loadAnalytics = (): void => {
 
 const loadGoogleAnalytics = (): void => {
     const handleGoogleAnalytics = (gaHasConsent: boolean): void => {
-        if (gaHasConsent && !window.guardian.ga.hasInitialised) {
-            window.guardian.ga.initialiseGa()
+        if (gaHasConsent && !window.guardian.config.page.gaIsInitalised) {
+            window.guardian.config.googleAnalytics.initialiseGa()
         } else {
             // set window.ga back to a stub function when ga consents are removed so that we don't track events
             window.ga = function() {}
-            window.guardian.ga.hasInitialised = false
+            window.guardian.config.googleAnalytics.page.gaIsInitalised = false
         }
     }
     mediator.on('ga:gaConsentChange', handleGoogleAnalytics)

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -123,11 +123,12 @@ const loadAnalytics = (): void => {
 
 const loadGoogleAnalytics = (): void => {
     const handleGoogleAnalytics = (gaHasConsent: boolean): void => {
-        if (gaHasConsent && !window.ga.loaded) {
-            window.initialiseGa()
+        if (gaHasConsent && !window.guardian.ga.hasInitialised) {
+            window.guardian.ga.initialiseGa()
         } else {
             // set window.ga back to a stub function when ga consents are removed so that we don't track events
             window.ga = function() {}
+            window.guardian.ga.hasInitialised = false
         }
     }
     mediator.on('ga:gaConsentChange', handleGoogleAnalytics)

--- a/static/src/javascripts/projects/common/modules/tracking/google-analytics.js
+++ b/static/src/javascripts/projects/common/modules/tracking/google-analytics.js
@@ -1,0 +1,11 @@
+// @flow
+
+import mediator from 'lib/mediator';
+import {onConsentChange, getConsentFor} from '@guardian/consent-management-platform';
+
+export const init: () => void = () => {
+  onConsentChange(state => {
+      const gaHasConsent = getConsentFor('google-analytics', state);
+      mediator.emit('ga:gaConsentChange', gaHasConsent);
+  })
+};


### PR DESCRIPTION
## What does this change?

Here we load the script used for sending tracking events to Google Analytics only after the consent status
- is acquired (e.g. after initialising) and the user has consented

or

- changes (eg. if a user changes their privacy preferences) to a state where the user has consented

(see [`onconsentchange(callback)`](https://github.com/guardian/consent-management-platform#onconsentchangecallback) definition in the [consent-management-platform repo](https://github.com/guardian/consent-management-platform)).

This means we do not send tracking events to GA unless and until we report that the user has consented to this tracking.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (see Trello ticket [here](https://trello.com/c/RtcjeoIF/2138-put-ga-tracking-behind-consents-dcr))

## Screenshots

### We see that where tracking has been allowed, we see the same events being sent to GA locally as in production:
PROD:
<img width="1432" alt="prodWithConsentsTracking" src="https://user-images.githubusercontent.com/9820960/98701963-c2b74780-2371-11eb-978f-73f8d86aa3c3.png">

LOCAL:
<img width="1432" alt="localWithConsentsTracking" src="https://user-images.githubusercontent.com/9820960/98702017-d19dfa00-2371-11eb-8eda-3ac46eeccb18.png">

### Before a user has consented to tracking, we no longer send events to GA
PROD: pageview event sent to GA
<img width="1432" alt="prodTrackingBeforeConsent" src="https://user-images.githubusercontent.com/9820960/98700643-525bf680-2370-11eb-928c-71b89232634f.png">
LOCAL: no events sent to GA
<img width="1432" alt="localNoTrackingBeforeConsent" src="https://user-images.githubusercontent.com/9820960/98700711-656ec680-2370-11eb-9216-1820d0a38f8f.png">

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?
TODO: check this

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Tested

- [x] Locally
- [ ] On CODE (optional)




