### PR TITLE
Sticky mpu fix when sign in gate is present

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
@@ -82,9 +82,6 @@ const stickyMpu = (adSlot: HTMLElement) => {
         .measure(() => referenceElement.offsetTop + stickyPixelBoundary)
         .then(newHeight =>
             fastdom.mutate(() => {
-                console.log("referenceElement.offsetTop", referenceElement.offsetTop);
-                console.log("adSlot.parentNode", adSlot.parentNode);
-                console.log(`**** resize height for : ${adSlot.parentNode} to ${newHeight}px`);
                 (adSlot.parentNode: any).style.height = `${newHeight}px`;
             })
         )

--- a/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
@@ -64,7 +64,8 @@ const stickyMpu = (adSlot: HTMLElement) => {
     }
 
     const referenceElement: ?HTMLElement = document.querySelector(
-        '.js-article__body,.js-liveblog-body-content'
+        '.js-article__body:not([style*="display: none;"]), ' +
+        '.js-liveblog-body-content:not([style*="display: none;"])'
     );
 
     const stickyPixelBoundary: number = 600; // This is the ad-height.
@@ -81,6 +82,9 @@ const stickyMpu = (adSlot: HTMLElement) => {
         .measure(() => referenceElement.offsetTop + stickyPixelBoundary)
         .then(newHeight =>
             fastdom.mutate(() => {
+                console.log("referenceElement.offsetTop", referenceElement.offsetTop);
+                console.log("adSlot.parentNode", adSlot.parentNode);
+                console.log(`**** resize height for : ${adSlot.parentNode} to ${newHeight}px`);
                 (adSlot.parentNode: any).style.height = `${newHeight}px`;
             })
         )

--- a/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
@@ -64,8 +64,8 @@ const stickyMpu = (adSlot: HTMLElement) => {
     }
 
     const referenceElement: ?HTMLElement = document.querySelector(
-        '.js-article__body:not([style*="display: none;"]), ' +
-        '.js-liveblog-body-content:not([style*="display: none;"])'
+        ['.js-article__body:not([style*="display: none;"])',
+        '.js-liveblog-body-content:not([style*="display: none;"])'].join(', ')
     );
 
     const stickyPixelBoundary: number = 600; // This is the ad-height.


### PR DESCRIPTION
## What does this change?
Fixes issue with overflowed ad on the right hand side when the sign gate is present.
In particular when the sign in gate is present it puts a display none to the article body which is used as a reference element to resize the sticky mpu. Changing the selector to only get the elements that are visible fixes the issue.
 
## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/51630004/97889333-ee647d00-1d34-11eb-845c-fed44ac60419.png
[after]: https://user-images.githubusercontent.com/51630004/97889354-f58b8b00-1d34-11eb-828c-2db97d035805.png

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
