### PR TITLE
Newsletters ab test clientside

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -47,7 +47,14 @@ class ArticleController(
   def renderArticle(path: String): Action[AnyContent] = {
     Action.async { implicit request =>
       mapModel(path, ArticleBlocks) { (article, blocks) =>
-        render(path, article, blocks)
+        val originalBody = article.article.content.fields.body
+        val newBody =
+          originalBody.replaceAll("https://www.theguardian.com/email/form/plaintone", "/email/form/plaintone")
+        val newFields = article.article.content.fields.copy(body = newBody)
+        val newContent = article.article.content.copy(fields = newFields)
+        val newArticle = article.article.copy(content = newContent)
+        val newArticlePage = article.copy(article = newArticle)
+        render(path, newArticlePage, blocks)
       }
     }
   }

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -47,14 +47,7 @@ class ArticleController(
   def renderArticle(path: String): Action[AnyContent] = {
     Action.async { implicit request =>
       mapModel(path, ArticleBlocks) { (article, blocks) =>
-        val originalBody = article.article.content.fields.body
-        val newBody =
-          originalBody.replaceAll("https://www.theguardian.com/email/form/plaintone", "/email/form/plaintone")
-        val newFields = article.article.content.fields.copy(body = newBody)
-        val newContent = article.article.content.copy(fields = newFields)
-        val newArticle = article.article.copy(content = newContent)
-        val newArticlePage = article.copy(article = newArticle)
-        render(path, newArticlePage, blocks)
+        render(path, article, blocks)
       }
     }
   }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -78,6 +78,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-newsletter-embeds",
+    "New newsletter signup embeds for discoverability OKR",
+    owners = Seq(Owner.withGithub("buck06191")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 12, 3),
+    exposeClientSide = true,
+  )
+
+  Switch(
+    ABTests,
     "ab-liveblog-epic-design-test-r1b",
     "Test designs for the liveblog epic",
     owners = Seq(Owner.withGithub("tomrf1")),

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -12,7 +12,6 @@ object ActiveExperiments extends ExperimentsDefinition {
     DotcomRendering,
     DCRBubble,
     NGInteractiveDCR,
-    NewsletterEmbedDesign,
     UseAusCmp,
   )
 

--- a/common/app/views/emailFragment.scala.html
+++ b/common/app/views/emailFragment.scala.html
@@ -5,18 +5,18 @@
 @electionNewsletters = @{List("minute-us", "us-morning-newsletter", "today-us", "green-light")}
 
 @emailEmbed(page) {
-    @if(ActiveExperiments.isParticipating(NewsletterEmbedDesign) && electionNewsletters.contains(listName)){
+    @if(electionNewsletters.contains(listName)){
         @fragments.email.signup.subscription.emailSignUpNewDesign(
             emailType,
             listName,
             emailEmbedData
         )
-    } else {
-      @fragments.email.signup.subscription.emailSignUp(
-          emailType,
-          listName,
-          emailEmbedData
-        )
     }
+    @fragments.email.signup.subscription.emailSignUp(
+        emailType,
+        listName,
+        emailEmbedData
+    )
+
 
 }

--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -54,7 +54,7 @@
 }
 
 
-<div class="@wrapperClass @wrapperToneClass">
+<div class="@wrapperClass @wrapperToneClass js-ab-embed-old-design">
     <div class="@headerClass">
         <h2 class="email-sub__heading">@Html(emailEmbedData.title)</h2>
         <div class="email-sub__description">@Html(emailEmbedData.description)</div>

--- a/common/app/views/fragments/email/signup/subscription/emailSignUpNewDesign.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUpNewDesign.scala.html
@@ -56,7 +56,7 @@
 }
 
 
-<div class="@wrapperClass" style="background-color: @emailEmbedData.hexCode">
+<div class="@wrapperClass js-ab-embed-new-design hide-element" style="background-color: @emailEmbedData.hexCode">
     @if(emailEmbedData.imageUrl.nonEmpty){
         <aside class="newsletter-embed__image">
             <img

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -10,8 +10,8 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
     signInGateMainVariant,
     signInGateMainControl,
-    newsletterEmbeds
-    newsletterMerchUnit,
+    newsletterEmbeds,
+    newsletterMerchUnit
 ];
 
 export const epicTests: $ReadOnlyArray<EpicABTest> = [];

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -3,12 +3,14 @@ import { commercialPrebidSafeframe } from 'common/modules/experiments/tests/comm
 import { contributionsBannerArticlesViewedOptOut } from 'common/modules/experiments/tests/contribs-banner-articles-viewed-opt-out';
 import { signInGateMainVariant } from 'common/modules/experiments/tests/sign-in-gate-main-variant';
 import { signInGateMainControl } from 'common/modules/experiments/tests/sign-in-gate-main-control';
+import { newsletterEmbeds } from 'common/modules/experiments/tests/newsletter-embed-test';
 import { newsletterMerchUnit } from 'common/modules/experiments/tests/newsletter-merch-unit-test';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
     signInGateMainVariant,
     signInGateMainControl,
+    newsletterEmbeds
     newsletterMerchUnit,
 ];
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-embed-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-embed-test.js
@@ -26,7 +26,6 @@ export const newsletterEmbeds: ABTest = {
                 iframes.forEach(
                     (ifrm) => {
                         const ifrmElement = (ifrm: HTMLIFrameElement)
-                        ifrmElement.setAttribute("height", "224px")
                         const doc = ifrmElement.contentDocument ? ifrm.contentDocument : ifrm.contentWindow.document;
                         if (doc) {
                             const oldDesign = doc.querySelector('.js-ab-embed-old-design');

--- a/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-embed-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-embed-test.js
@@ -22,13 +22,21 @@ export const newsletterEmbeds: ABTest = {
         {
             id: 'variant',
             test: (): void => {
-                const iframes = document.querySelectorAll('.email-sub__iframe')
+                const iframes = ((document.querySelectorAll('.email-sub__iframe'): NodeList<any>): NodeList<HTMLIFrameElement>);
                 iframes.forEach(
                     (ifrm) => {
-                        ifrm.setAttribute("height", "224px")
-                        const doc = ifrm.contentDocument ? ifrm.contentDocument : ifrm.contentWindow.document;
-                        doc.querySelector('.js-ab-embed-old-design').classList.add("hide-element")
-                        doc.querySelector('.js-ab-embed-new-design').classList.remove("hide-element")
+                        const ifrmElement = (ifrm: HTMLIFrameElement)
+                        ifrmElement.setAttribute("height", "224px")
+                        const doc = ifrmElement.contentDocument ? ifrm.contentDocument : ifrm.contentWindow.document;
+                        if (doc) {
+                            const oldDesign = doc.querySelector('.js-ab-embed-old-design');
+                            const newDesign = doc.querySelector('.js-ab-embed-new-design');
+                            if (oldDesign && newDesign) {
+                                oldDesign.classList.add("hide-element")
+                                newDesign.classList.remove("hide-element")
+
+                            }
+                        }
                     })
             },
         },

--- a/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-embed-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-embed-test.js
@@ -1,0 +1,36 @@
+// @flow
+
+export const newsletterEmbeds: ABTest = {
+    id: 'NewsletterEmbeds',
+    start: '2020-11-02',
+    expiry: '2020-12-01',
+    author: 'Josh Buckland',
+    description:
+        'Show a new newsletter embed design',
+    audience: 1,
+    audienceOffset: 0.0,
+    successMeasure: 'We see increased engagement from users shown the new design',
+    audienceCriteria:
+        'Website users only.',
+    ophanComponentId: 'newsletter_embed',
+    dataLinkNames: 'n/a',
+    idealOutcome:
+        'Increase engagement for lighthouse segments 4 and 5 via newsletters',
+    showForSensitive: false,
+    canRun: () => true,
+    variants: [
+        {
+            id: 'variant',
+            test: (): void => {
+                const iframes = document.querySelectorAll('.email-sub__iframe')
+                iframes.forEach(
+                    (ifrm) => {
+                        ifrm.setAttribute("height", "224px")
+                        const doc = ifrm.contentDocument ? ifrm.contentDocument : ifrm.contentWindow.document;
+                        doc.querySelector('.js-ab-embed-old-design').classList.add("hide-element")
+                        doc.querySelector('.js-ab-embed-new-design').classList.remove("hide-element")
+                    })
+            },
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-embed-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-embed-test.js
@@ -7,8 +7,8 @@ export const newsletterEmbeds: ABTest = {
     author: 'Josh Buckland',
     description:
         'Show a new newsletter embed design',
-    audience: 1,
-    audienceOffset: 0.0,
+    audience: 0.5,
+    audienceOffset: 0.5,
     successMeasure: 'We see increased engagement from users shown the new design',
     audienceCriteria:
         'Website users only.',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-merch-unit-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-merch-unit-test.js
@@ -7,7 +7,7 @@ export const newsletterMerchUnit: ABTest = {
     author: 'Josh Buckland',
     description:
         'Show a newsletter advert in the merchandising unit to 50% of users',
-    audience: 1,
+    audience: 0.5,
     audienceOffset: 0.0,
     successMeasure: 'We see increased engagement from users shown the Newsletters ad unit',
     audienceCriteria:

--- a/static/src/stylesheets/module/email-signup/_newDesign.scss
+++ b/static/src/stylesheets/module/email-signup/_newDesign.scss
@@ -6,6 +6,14 @@ $mobile-headline-font-size: 24px;
 $mobile-description-font-size: 16px;
 $mobile-img-size: 3 * $mobile-headline-font-size;
 
+/* iframe hacks for AB test */
+
+.hide-element {
+    display: none;
+}
+
+/* Design CSS for new designs */
+
 .newsletter-embed {
     * {
         box-sizing: border-box;


### PR DESCRIPTION
## What does this change?
Moves newsletter embeds design AB test to using clientside code.

Previously we used a serverside test for the new design, but this meant that the designs appeared on apps unintentionally and had a broken UX. Instead we move to using clientside code that won't run on apps. 

We put the new and old design inside the iframe at the same time and then set the default behaviour of the new design to be `display: none`. The AB test then inverts this when the user is in the variant bucket so that the old design is hidden and the new design is displayed.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
