### PR TITLE
Fix the lookup of allowed path for ng-interactive special handling

### DIFF
--- a/applications/app/services/ApplicationsSpecial2020Election.scala
+++ b/applications/app/services/ApplicationsSpecial2020Election.scala
@@ -15,7 +15,7 @@ object ApplicationsSpecial2020Election {
     "/world/ng-interactive/2020/oct/29/covid-vaccine-tracker-when-will-a-coronavirus-vaccine-be-ready" -> "atom/interactive/interactives/2020/07/interactive-vaccine-tracker/amp-page",
     "/us-news/ng-interactive/2020/nov/03/us-election-2020-live-results-donald-trump-joe-biden-who-won-presidential-republican-democrat" -> "atom/interactive/interactives/2020/11/us-election/prod/amp-page",
   )
-  val specialPaths = specialPathsToCapiIdsMap.values.toList
+  val specialPaths = specialPathsToCapiIdsMap.keys.toList
 
   def ensureStartingForwardSlash(str: String): String = {
     if (!str.startsWith("/")) ("/" + str) else str


### PR DESCRIPTION
## What does this change?

Fix the lookup of allowed path for ng-interactive special handling. ( mistake was introduced in this refactoring: https://github.com/guardian/frontend/pull/23197 )
