### PR TITLE
Update liveblog epic design

### DIFF
--- a/static/src/stylesheets/module/reader-revenue/_epic.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic.scss
@@ -255,6 +255,13 @@ div.contributions__secondary-button.contributions__secondary-button--epic {
     }
 }
 
-.block--content.is-epic {
-    font-style: italic;
+.content--pillar-news:not(.paid-content) .block--content.is-epic {
+    border-top-color: $highlight-main;
+    background-color: $brightness-93;
+
+    .component-button--liveblog {
+        background: $highlight-main;
+        border-color: $highlight-main;
+        color: $brightness-7;
+    }
 }


### PR DESCRIPTION
We've tried a few design tweaks recently, this is what we're now settling on:

### Before:
<img width="646" alt="Screen Shot 2020-11-03 at 20 59 33" src="https://user-images.githubusercontent.com/1513454/98040007-85096a80-1e17-11eb-8807-65c31b8d3a8b.png">

### After:
<img width="646" alt="Screen Shot 2020-11-03 at 20 56 43" src="https://user-images.githubusercontent.com/1513454/98039941-67d49c00-1e17-11eb-9dd8-7e626230c40b.png">

### CODE:
<img width="1028" alt="Screen Shot 2020-11-04 at 09 49 29" src="https://user-images.githubusercontent.com/1515970/98096138-45786800-1e83-11eb-8864-b6354e686a0f.png">
