### PR TITLE
Ads sometimes overlap content in sidepanel in liveblog

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
@@ -67,7 +67,7 @@ const stickyMpu = (adSlot: HTMLElement) => {
         '.js-article__body,.js-liveblog-body-content'
     );
 
-    const stickyPixelBoundary: number = 300;
+    const stickyPixelBoundary: number = 600; //this is the ad-height.
 
     if (
         !referenceElement ||

--- a/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
@@ -67,7 +67,7 @@ const stickyMpu = (adSlot: HTMLElement) => {
         '.js-article__body,.js-liveblog-body-content'
     );
 
-    const stickyPixelBoundary: number = 600; //this is the ad-height.
+    const stickyPixelBoundary: number = 600; // This is the ad-height.
 
     if (
         !referenceElement ||


### PR DESCRIPTION
## What does this change?
Fixes an issue where the advert sometimes overlaps content under it in the liveblog

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots


This only affects long adverts. The solution pushes down the "More on this story" element 300px further down the page.

| Issue      | Resolution      |
|-------------|------------|
| ![Screenshot 2020-11-04 at 11 49 19](https://user-images.githubusercontent.com/768467/98109821-1f0ff800-1e96-11eb-8131-b5bfbbafb1a9.png) | ![Screenshot 2020-11-04 at 12 39 05](https://user-images.githubusercontent.com/768467/98112958-ddce1700-1e9a-11eb-92f6-70eae208b0fa.png) |


## What is the value of this and can you measure success?
It should prevent the page looking bad if a long advert appears

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
