### PR TITLE
Increase height of sticky mpu ad container only for liveblogs

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
@@ -67,7 +67,8 @@ const stickyMpu = (adSlot: HTMLElement) => {
         '.js-article__body,.js-liveblog-body-content'
     );
 
-    const stickyPixelBoundary: number = 600; // This is the ad-height.
+    // Fixes overlapping ad issue on liveblogs by Setting to max ad height.
+    const stickyPixelBoundary: number = config.get('page.isLiveBlog') ? 600 : 300;
 
     if (
         !referenceElement ||


### PR DESCRIPTION
## What does this change?
Increases height of sticky mpu ad container only for liveblogs

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
