### PR TITLE
Take the first non-empty headline from all containers for email

### DIFF
--- a/facia/app/controllers/front/FrontHeadline.scala
+++ b/facia/app/controllers/front/FrontHeadline.scala
@@ -13,10 +13,12 @@ object FrontHeadline extends Results with Logging {
   )
 
   private[this] def headline(collection: PressedCollection): Option[String] = {
-    for {
-      content <- collection.curatedPlusBackfillDeduplicated.headOption
+    val headlines = for {
+      content <- collection.curatedPlusBackfillDeduplicated
       if content.properties.webTitle != ""
     } yield content.properties.webTitle
+
+    headlines.headOption
   }
 
   def renderEmailHeadline(faciaPage: PressedPage): Cached.CacheableResult = {


### PR DESCRIPTION
## What does this change?
This means that email subject lines for fronts whose top container's first item has no web title (e.g. all network fronts with election tracker interactives) will be taken from the remainder of the top container before moving onto the second container.

So for this front:
![image](https://user-images.githubusercontent.com/8754692/98130792-8b98f000-1eb2-11eb-8ebd-557dd50dfeed.png)

We will have the headline "US election 2020 live: Democrats say 'results indicate we're on clear path to victory today'". This is instead of some headline from the second container (headlines).

Requested by Celine so she doesn't need to manually edit the email subjects before they go out in the very early morning.  Tested locally on all the live fronts Celine and I could think of checking.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
