### PR TITLE
Add AU consent switch

### DIFF
--- a/common/app/conf/switches/PrivacySwitches.scala
+++ b/common/app/conf/switches/PrivacySwitches.scala
@@ -21,7 +21,7 @@ trait PrivacySwitches {
     "au-consent",
     "Enable consent management for Australia.",
     owners = group(Commercial),
-    safeState = On,
+    safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
   )

--- a/common/app/conf/switches/PrivacySwitches.scala
+++ b/common/app/conf/switches/PrivacySwitches.scala
@@ -15,4 +15,14 @@ trait PrivacySwitches {
     sellByDate = never,
     exposeClientSide = true,
   )
+
+  val AuConsent = Switch(
+    SwitchGroup.Privacy,
+    "au-consent",
+    "Enable consent management for Australia.",
+    owners = group(Commercial),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
 }

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -49,17 +49,20 @@ const go = () => {
         onConsentChange(() => {
             if (!recordedConsentTime) {
                 recordedConsentTime = true;
-                cmp.willShowPrivacyMessage().then((willShow) => {
+                cmp.willShowPrivacyMessage().then(willShow => {
                     trackPerformance(
                         'consent',
                         'acquired',
-                        willShow ? 'new' : 'existing',
+                        willShow ? 'new' : 'existing'
                     );
                 });
             }
         });
 
-        if (config.get('tests.useAusCmpVariant') === 'variant') {
+        if (
+            config.get('switches.auConsent', false) ||
+            config.get('tests.useAusCmpVariant') === 'variant'
+        ) {
             cmp.init({ pubData, country: geolocationGetSync() });
         } else {
             cmp.init({ pubData, isInUsa: isInUsa() });


### PR DESCRIPTION
## What does this change?

- adds a switch to turn on consent in AU

## Does this change need to be reproduced in dotcom-rendering ?

- [x] Yes https://github.com/guardian/dotcom-rendering/pull/2025

