### PR TITLE
Add CSS and button to access MMA

### DIFF
--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -106,15 +106,13 @@
             <div class="newsletters-heading">
                 Guardian newsletters: sign&nbsp;up
             </div>
-            <div class="newsletters-heading__manage-button-wrapper">
-                <a
-                data-link-name="all-newsletters : manage-emails"
-                href=@manageEmailsUrl>
-                    <button class="newsletters-heading__manage-button">
-                        <span>Manage my newsletters</span>
-                    </button>
-                </a>
-            </div>
+            <a data-link-name="all-newsletters : manage-emails" href="@manageEmailsUrl">
+                <div class="newsletters-heading__manage-button">
+                    <span class="">
+                        Manage my newsletters
+                    </span>
+                </div>
+            </a>
         </div>
         @displayNewslettersByTheme
     </div>

--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -7,6 +7,8 @@
 
 @(signupPage: Page)(implicit request: RequestHeader, context: model.ApplicationContext)
 
+@manageEmailsUrl = @{"https://manage.theguardian.com/email-prefs"}
+
 @emailListCategoryList(theme: String, emailListings: List[EmailNewsletter]) = {
     <div class="newsletters-category__heading">
         @theme
@@ -100,7 +102,20 @@
 <div class="l-side-margins">
 <div class="content">
     <div class="gs-container">
-        <div class="newsletters-heading">Guardian newsletters: sign up</div>
+        <div class="newsletters-heading__container">
+            <div class="newsletters-heading">
+                Guardian newsletters: sign&nbsp;up
+            </div>
+            <div class="newsletters-heading__manage-button-wrapper">
+                <a
+                data-link-name="all-newsletters : manage-emails"
+                href=@manageEmailsUrl>
+                    <button class="newsletters-heading__manage-button">
+                        <span>Manage my newsletters</span>
+                    </button>
+                </a>
+            </div>
+        </div>
         @displayNewslettersByTheme
     </div>
 </div>

--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -108,9 +108,7 @@
             </div>
             <a data-link-name="all-newsletters : manage-emails" href="@manageEmailsUrl">
                 <div class="newsletters-heading__manage-button">
-                    <span class="">
-                        Manage my newsletters
-                    </span>
+                    <span> Manage my newsletters </span>
                 </div>
             </a>
         </div>

--- a/static/src/stylesheets/module/signup/_newsletters.scss
+++ b/static/src/stylesheets/module/signup/_newsletters.scss
@@ -3,7 +3,7 @@
     justify-content: space-between;
     align-items: center;
     flex-wrap: wrap;
-    padding-bottom: 8px;
+    padding-bottom: 16px;
 }
 
 .newsletters-heading {
@@ -32,12 +32,7 @@
 
     @include mq($from: tablet) {
         @include fs-textSans(5);
-        width: 120px;
         height: auto;
-    }
-
-    @include mq($until: tablet) {
-        padding: 5px;
     }
 
     @include fs-textSans(3);
@@ -49,6 +44,7 @@
     text-align: center;
     text-decoration: none;
     height: auto;
+    padding: 5px;
 
     &:hover,
     &:focus {

--- a/static/src/stylesheets/module/signup/_newsletters.scss
+++ b/static/src/stylesheets/module/signup/_newsletters.scss
@@ -25,30 +25,29 @@
     }
 }
 
-.newsletters-heading__manage-button-wrapper {
+.newsletters-heading__manage-button {
     @include mq($from: desktop) {
         margin-top: 24px;
     }
 
     @include mq($from: tablet) {
+        @include fs-textSans(5);
         width: 120px;
         height: auto;
     }
-}
 
-.newsletters-heading__manage-button {
+    @include mq($until: tablet) {
+        padding: 5px;
+    }
 
     @include fs-textSans(3);
 
-    @include mq($from: tablet) {
-        @include fs-textSans(5);
-    }
-    
     border-radius: 1000px;
     color: #ffffff;
     border: 1px solid $sport-dark;
     background-color: $sport-dark;
-
+    text-align: center;
+    text-decoration: none;
     height: auto;
 
     &:hover,

--- a/static/src/stylesheets/module/signup/_newsletters.scss
+++ b/static/src/stylesheets/module/signup/_newsletters.scss
@@ -1,16 +1,60 @@
+.newsletters-heading__container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    padding-bottom: 8px;
+}
+
 .newsletters-heading {
     @include fs-headline(8);
     font-weight: 700;
     color: $brightness-7;
     padding-top: $gs-baseline;
+    margin-bottom: $gs-baseline;
+    margin-right: $gs-baseline;
 
     @include mq($from: tablet) {
         @include fs-headline(9, true);
         padding-top: $gs-baseline * 2;
+        width: 80%;
     }
 
     @include mq($until: tablet) {
         @include fs-headline(4);
+    }
+}
+
+.newsletters-heading__manage-button-wrapper {
+    @include mq($from: desktop) {
+        margin-top: 24px;
+    }
+
+    @include mq($from: tablet) {
+        width: 120px;
+        height: auto;
+    }
+}
+
+.newsletters-heading__manage-button {
+
+    @include fs-textSans(3);
+
+    @include mq($from: tablet) {
+        @include fs-textSans(5);
+    }
+    
+    border-radius: 1000px;
+    color: #ffffff;
+    border: 1px solid $sport-dark;
+    background-color: $sport-dark;
+
+    height: auto;
+
+    &:hover,
+    &:focus {
+        border-color: darken($sport-dark, 10%);
+        background-color: darken($sport-dark, 10%);
     }
 }
 
@@ -102,7 +146,6 @@
         border: 1px solid $sport-dark;
         background-color: $sport-dark;
         border-radius: 1000px;
-        border-width: 1px;
         height: 3em;
         width: 48%;
         margin: 0;
@@ -216,7 +259,7 @@
 
 .newsletters-category {
     border-top: 1px solid $brightness-86;
-    margin-top: $gs-baseline * 2;
+    margin-bottom: $gs-baseline * 2;
 
     @include mq(tablet) {
         margin-left: -$gs-gutter;


### PR DESCRIPTION
## What does this change?
Add a manage my account button to the top of the all newsletters page.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

### Desktop

| Before      | After      |
|-------------|------------|
| ![before](https://user-images.githubusercontent.com/9122944/98528797-b5686300-2274-11eb-9d36-bf689bbd092b.png) | ![image](https://user-images.githubusercontent.com/9122944/98542074-4563d800-2288-11eb-8388-1199455b5893.png) |

### Mobile

| Before      | After      |
|-------------|------------|
| ![before](https://user-images.githubusercontent.com/9122944/98528883-d0d36e00-2274-11eb-81d3-9b495e783e2d.png) |![image](https://user-images.githubusercontent.com/9122944/98542112-54e32100-2288-11eb-8c17-f1edb5ec189f.png)|


## What is the value of this and can you measure success?
Improve user experience and hopefully increase sign up.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
