### PR TITLE
[CMP] add NPA flag support in AUS

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@guardian/automat-modules": "^0.3.7",
     "@guardian/braze-components": "0.0.12",
     "@guardian/commercial-core": "^0.9.0",
-    "@guardian/consent-management-platform": "6.6.0",
+    "@guardian/consent-management-platform": "6.6.1",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/libs": "^1.3.0",
     "@guardian/shimport": "^1.0.2",

--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
@@ -187,14 +187,12 @@ const tcfv2MixedConsent = {
 
 const ausNotRejected = {
     aus: {
-        ccpaApplies: true,
         rejectedCategories: [],
     },
 };
 
 const ausRejected = {
     aus: {
-        ccpaApplies: true,
         rejectedCategories: [
             {
                 _id: '5f859c3420e4ec3e476c7006',
@@ -559,6 +557,7 @@ describe('DFP', () => {
             onConsentChange.mockImplementation(callback =>
                 callback(ausNotRejected)
             );
+            getConsentFor.mockReturnValue(true);
             return prepareGoogletag().then(() => {
                 expect(
                     window.googletag.pubads().setRequestNonPersonalizedAds
@@ -569,6 +568,7 @@ describe('DFP', () => {
             onConsentChange.mockImplementation(callback =>
                 callback(ausRejected)
             );
+            getConsentFor.mockReturnValue(false);
             return prepareGoogletag().then(() => {
                 expect(
                     window.googletag.pubads().setRequestNonPersonalizedAds

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -6,7 +6,10 @@ import fastdom from 'lib/fastdom-promise';
 import { loadScript, storage } from '@guardian/libs';
 import raven from 'lib/raven';
 import sha1 from 'lib/sha1';
-import { onConsentChange, getConsentFor } from '@guardian/consent-management-platform';
+import {
+    onConsentChange,
+    getConsentFor,
+} from '@guardian/consent-management-platform';
 import { getPageTargeting } from 'common/modules/commercial/build-page-targeting';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { adFreeSlotRemove } from 'commercial/modules/ad-free-slot-remove';
@@ -120,6 +123,19 @@ export const init = (): Promise<void> => {
                         Object.keys(state.tcfv2.consents).length === 0 ||
                         Object.values(state.tcfv2.consents).includes(false);
                     canRun = getConsentFor('googletag', state);
+                } else if (state.aus) {
+                    // AUS mode
+                    const advertising = '5f859c3420e4ec3e476c7006';
+                    if (typeof state.aus.rejectedCategories === 'undefined')
+                        npaFlag = false;
+                    else
+                        npaFlag =
+                            state.aus.rejectedCategories.filter(
+                                rejectedCategory =>
+                                    // eslint-disable-next-line no-underscore-dangle
+                                    rejectedCategory._id === advertising
+                            ).length > 0;
+                    canRun = true;
                 }
                 window.googletag.cmd.push(() => {
                     window.googletag

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -125,8 +125,8 @@ export const init = (): Promise<void> => {
                     canRun = getConsentFor('googletag', state);
                 } else if (state.aus) {
                     // AUS mode
+                    // canRun stays true, set NPA flag if consent is retracted
                     npaFlag = !getConsentFor('googletag', state);
-                    canRun = true;
                 }
                 window.googletag.cmd.push(() => {
                     window.googletag

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -125,16 +125,7 @@ export const init = (): Promise<void> => {
                     canRun = getConsentFor('googletag', state);
                 } else if (state.aus) {
                     // AUS mode
-                    const advertising = '5f859c3420e4ec3e476c7006';
-                    if (typeof state.aus.rejectedCategories === 'undefined')
-                        npaFlag = false;
-                    else
-                        npaFlag =
-                            state.aus.rejectedCategories.filter(
-                                rejectedCategory =>
-                                    // eslint-disable-next-line no-underscore-dangle
-                                    rejectedCategory._id === advertising
-                            ).length > 0;
+                    npaFlag = !getConsentFor('googletag', state);
                     canRun = true;
                 }
                 window.googletag.cmd.push(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1758,10 +1758,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.9.0.tgz#2c578b61a6af99436abd83760d3349ef99d53ab8"
   integrity sha512-2o/au3c/SRUYrlPA1x6Rog6+UpXkSf6UrSX16lD19VaFyia60LaIXtBu9mkZNhSm0FWqfLSgync8RTCeCRG47w==
 
-"@guardian/consent-management-platform@6.6.0":
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.6.0.tgz#e6328fdfba40bb423f8a63084b1096423041a564"
-  integrity sha512-QIEd65+sPN56VMekx5JinZZIFHq0ahfG1HGISfG9HRG6+31r1VNv8d6VXySszJXhY1ksCh4Rtn0BW3MmSq5NkQ==
+"@guardian/consent-management-platform@6.6.1":
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.6.1.tgz#34a8f9c4e78d9813063312290f27e4096852b2d8"
+  integrity sha512-bCCeqdIlO7lrg/qOM7XQYhghZn1ruxAUqyhvW7mo23nghu8Xz5hRZ6AbK9Juis6g0DeFGKkvBSAMtxrEEheM2Q==
 
 "@guardian/dotcom-rendering@git://github.com/guardian/dotcom-rendering.git#version-1-alpha":
   version "0.1.0-alpha"


### PR DESCRIPTION
## What does this change?

This adds a logic for setting the NPA flag in the new AUS framework.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

If a user decides to retract consent to advertising, they should be served non-personalised ads.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
