### PR TITLE
Fix for check-node-env.js message

### DIFF
--- a/tools/check-node-env.js
+++ b/tools/check-node-env.js
@@ -45,7 +45,7 @@ installIfNecessary('semver', 'chalk').then(([semver, chalk]) => {
         console.log(`${chalk.red('✗')} Node ${foundNodeVersion}`);
         console.log(
             chalk.dim(
-                `Frontend requires Node v${nvmrcVersion}.\nIf you're using NVM, you can 'nvm use'...`
+                `Frontend requires Node ${nvmrcVersion}.\nIf you're using NVM, you can 'nvm use'...`
             )
         );
         process.exit(1);


### PR DESCRIPTION
The message displayed the version incorrectly. Now it doesn't.

## What does this change?
The message prepended the the contents of the .nvmrc with `v` but that resulted in the version starting with `vv` because the .nvmrc file has the version already prepended with a `v`

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
|<img width="337" alt="Screenshot 2020-11-10 at 12 21 06" src="https://user-images.githubusercontent.com/768467/98673958-0a2cdc00-2350-11eb-96de-39cf30524a30.png"> | <img width="422" alt="Screenshot 2020-11-10 at 12 25 01" src="https://user-images.githubusercontent.com/768467/98673973-0d27cc80-2350-11eb-95bd-c9dd7043e3ea.png"> |


## What is the value of this and can you measure success?
It's just a typo. But it annoyed me to see it.

## Checklist

### Does this affect other platforms?

- [x] No

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
