### PR TITLE
Update newsletter merch unit AB test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -98,8 +98,18 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-newsletter-merch-unit-lighthouse",
-    "Test impact of newsletter merch unit across lighthouse segments",
+    "ab-newsletter-merch-unit-lighthouse-control",
+    "Test impact of newsletter merch unit across lighthouse segments (Control bucket)",
+    owners = Seq(Owner.withGithub("buck06191")),
+    safeState = Off,
+    sellByDate = new LocalDate(2020, 12, 1),
+    exposeClientSide = true,
+  )
+
+  Switch(
+    ABTests,
+    "ab-newsletter-merch-unit-lighthouse-variants",
+    "Test impact of newsletter merch unit across lighthouse segments (Variant buckets)",
     owners = Seq(Owner.withGithub("buck06191")),
     safeState = Off,
     sellByDate = new LocalDate(2020, 12, 1),

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -98,7 +98,7 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-newsletter-merch-unit",
+    "ab-newsletter-merch-unit-lighthouse",
     "Test impact of newsletter merch unit across lighthouse segments",
     owners = Seq(Owner.withGithub("buck06191")),
     safeState = Off,

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -6,6 +6,7 @@ import { signInGateMainControl } from 'common/modules/experiments/tests/sign-in-
 import { newsletterEmbeds } from 'common/modules/experiments/tests/newsletter-embed-test';
 import { newsletterMerchUnit } from 'common/modules/experiments/tests/newsletter-merch-unit-test';
 
+
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
     signInGateMainVariant,

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -4,7 +4,7 @@ import { contributionsBannerArticlesViewedOptOut } from 'common/modules/experime
 import { signInGateMainVariant } from 'common/modules/experiments/tests/sign-in-gate-main-variant';
 import { signInGateMainControl } from 'common/modules/experiments/tests/sign-in-gate-main-control';
 import { newsletterEmbeds } from 'common/modules/experiments/tests/newsletter-embed-test';
-import { newsletterMerchUnitLighthouse } from 'common/modules/experiments/tests/newsletter-merch-unit-test';
+import { newsletterMerchUnitLighthouseControl, newsletterMerchUnitLighthouseVariant } from 'common/modules/experiments/tests/newsletter-merch-unit-test';
 
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
@@ -12,7 +12,8 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     signInGateMainVariant,
     signInGateMainControl,
     newsletterEmbeds,
-    newsletterMerchUnitLighthouse
+    newsletterMerchUnitLighthouseControl,
+    newsletterMerchUnitLighthouseVariant
 ];
 
 export const epicTests: $ReadOnlyArray<EpicABTest> = [];

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -4,7 +4,7 @@ import { contributionsBannerArticlesViewedOptOut } from 'common/modules/experime
 import { signInGateMainVariant } from 'common/modules/experiments/tests/sign-in-gate-main-variant';
 import { signInGateMainControl } from 'common/modules/experiments/tests/sign-in-gate-main-control';
 import { newsletterEmbeds } from 'common/modules/experiments/tests/newsletter-embed-test';
-import { newsletterMerchUnit } from 'common/modules/experiments/tests/newsletter-merch-unit-test';
+import { newsletterMerchUnitLighthouse } from 'common/modules/experiments/tests/newsletter-merch-unit-test';
 
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
@@ -12,7 +12,7 @@ export const concurrentTests: $ReadOnlyArray<ABTest> = [
     signInGateMainVariant,
     signInGateMainControl,
     newsletterEmbeds,
-    newsletterMerchUnit
+    newsletterMerchUnitLighthouse
 ];
 
 export const epicTests: $ReadOnlyArray<EpicABTest> = [];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-merch-unit-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-merch-unit-test.js
@@ -1,7 +1,7 @@
 // @flow
 
 export const newsletterMerchUnitLighthouseControl: ABTest = {
-    id: 'NewsletterMerchUnitLighthouse',
+    id: 'NewsletterMerchUnitLighthouseControl',
     start: '2020-11-11',
     expiry: '2020-12-01',
     author: 'Josh Buckland & Alex Dufournet',
@@ -26,13 +26,14 @@ export const newsletterMerchUnitLighthouseControl: ABTest = {
 };
 
 export const newsletterMerchUnitLighthouseVariant: ABTest = {
-    id: 'NewsletterMerchUnitLighthouse',
+    id: 'NewsletterMerchUnitLighthouseVariants',
     start: '2020-11-11',
     expiry: '2020-12-01',
     author: 'Josh Buckland & Alex Dufournet',
-    description: 'Show a newsletter advert in the merchandising unit to 25% of users. ' +
-        'These two variants test value of showing newsletter merch units instead of reader revenue ones. ' +
-        'This test needs to run at the same time as NewsletterMerchUnitLighthouseControl',
+    description: 'Show a newsletter advert in the merchandising unit to 25% of users and reader revenue' +
+        'to another 25%. The remaining 50% are covered by NewsletterMerchUnitLighthouseControl ' +
+        'which needs to run at the same time. These two variants test the value of showing ' +
+        'newsletter merch units instead of reader revenue ones.',
     audience: 0.5,
     audienceOffset: 0.5,
     successMeasure: 'We see increased engagement from users shown the Newsletters ad unit',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-merch-unit-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-merch-unit-test.js
@@ -1,13 +1,12 @@
 // @flow
 
-export const newsletterMerchUnitLighthouse: ABTest = {
+export const newsletterMerchUnitLighthouseControl: ABTest = {
     id: 'NewsletterMerchUnitLighthouse',
     start: '2020-11-11',
     expiry: '2020-12-01',
-    author: 'Josh Buckland',
-    description:
-        'Show a newsletter advert in the merchandising unit to 50% of users',
-    audience: 1.0,
+    author: 'Josh Buckland & Alex Dufournet',
+    description: 'Show BAU merch unit to 50% of users. This is the control for the NewsletterMerchUnitLighthouseVariants test.',
+    audience: 0.5,
     audienceOffset: 0.0,
     successMeasure: 'We see increased engagement from users shown the Newsletters ad unit',
     audienceCriteria:
@@ -22,9 +21,36 @@ export const newsletterMerchUnitLighthouse: ABTest = {
         {
             id: 'control',
             test: (): void => {},
+        }
+    ],
+};
+
+export const newsletterMerchUnitLighthouseVariant: ABTest = {
+    id: 'NewsletterMerchUnitLighthouse',
+    start: '2020-11-11',
+    expiry: '2020-12-01',
+    author: 'Josh Buckland & Alex Dufournet',
+    description: 'Show a newsletter advert in the merchandising unit to 25% of users. ' +
+        'These two variants test value of showing newsletter merch units instead of reader revenue ones. ' +
+        'This test needs to run at the same time as NewsletterMerchUnitLighthouseControl',
+    audience: 0.5,
+    audienceOffset: 0.5,
+    successMeasure: 'We see increased engagement from users shown the Newsletters ad unit',
+    audienceCriteria:
+        'Website users only.',
+    ophanComponentId: 'newsletter_merch_unit',
+    dataLinkNames: 'n/a',
+    idealOutcome:
+        'Investigate lighthouse segment engagement via newsletters',
+    showForSensitive: false,
+    canRun: () => true,
+    variants: [
+        {
+            id: 'newsletter',
+            test: (): void => {},
         },
         {
-            id: 'variant',
+            id: 'reader-revenue',
             test: (): void => {},
         }
     ],

--- a/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-merch-unit-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-merch-unit-test.js
@@ -2,12 +2,12 @@
 
 export const newsletterMerchUnit: ABTest = {
     id: 'NewsletterMerchUnit',
-    start: '2020-11-02',
+    start: '2020-11-12',
     expiry: '2020-12-01',
     author: 'Josh Buckland',
     description:
         'Show a newsletter advert in the merchandising unit to 50% of users',
-    audience: 0.5,
+    audience: 1.0,
     audienceOffset: 0.0,
     successMeasure: 'We see increased engagement from users shown the Newsletters ad unit',
     audienceCriteria:
@@ -15,13 +15,17 @@ export const newsletterMerchUnit: ABTest = {
     ophanComponentId: 'newsletter_merch_unit',
     dataLinkNames: 'n/a',
     idealOutcome:
-        'Increase engagement for lighthouse segments 4 and 5 via newsletters',
+        'Investigate lighthouse segment engagement via newsletters',
     showForSensitive: false,
     canRun: () => true,
     variants: [
         {
-            id: 'variant',
+            id: 'control',
             test: (): void => {},
         },
+        {
+            id: 'variant',
+            test: (): void => {},
+        }
     ],
 };

--- a/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-merch-unit-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-merch-unit-test.js
@@ -1,8 +1,8 @@
 // @flow
 
-export const newsletterMerchUnit: ABTest = {
-    id: 'NewsletterMerchUnit',
-    start: '2020-11-12',
+export const newsletterMerchUnitLighthouse: ABTest = {
+    id: 'NewsletterMerchUnitLighthouse',
+    start: '2020-11-11',
     expiry: '2020-12-01',
     author: 'Josh Buckland',
     description:


### PR DESCRIPTION
## What does this change?
Roll out newsletter merch unit to 100% of the audience and include a control variant

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

Will add this AB test to DCR

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
