### PR TITLE
Update ophan tracker js to 1.3.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "fence": "guardian/fence#0.2.11",
     "lodash": "^4.17.13",
     "object-fit-videos": "^1.0.3",
-    "ophan-tracker-js": "1.3.22",
+    "ophan-tracker-js": "1.3.23",
     "preact": "^8.2.9",
     "preact-compat": "^3.18.4",
     "prebid.js": "https://github.com/guardian/Prebid.js#681fbb",


### PR DESCRIPTION
## What does this change?

We may receive garbage in iframe message that will result in client side errors which we could safely ignore.
We currently have about [10k errors per day in Sentry with this problem](https://sentry.io/organizations/the-guardian/issues/1813121539/?project=35463&query=is%3Aunresolved) 

See https://github.com/guardian/ophan/pull/3964

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes 

## What is the value of this and can you measure success?


## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other
- [X] No

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

- [X] No
- [ ] Yes 

### Does this change break ad-free?

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [X] In the console
- [ ] Locally
- [ ] On CODE (optional)

