### PR TITLE
Fetch user data from members-data-api in commercial.dcr.js

### DIFF
--- a/static/src/javascripts/bootstraps/commercial.dcr.js
+++ b/static/src/javascripts/bootstraps/commercial.dcr.js
@@ -27,12 +27,14 @@ import { commercialFeatures } from 'common/modules/commercial/commercial-feature
 import { initCommentAdverts } from 'commercial/modules/comment-adverts';
 import { init as prepareA9 } from 'commercial/modules/dfp/prepare-a9';
 import { init as initRedplanet } from 'commercial/modules/dfp/redplanet';
+import {refresh as refreshUserFeatures} from "common/modules/commercial/user-features";
 
 const commercialModules: Array<Array<any>> = [
     ['cm-adFreeSlotRemove', adFreeSlotRemove],
     ['cm-closeDisabledSlots', closeDisabledSlots],
     ['cm-comscore', initComscore],
     ['cm-ipsosmori', initIpsosMori],
+    ['c-user-features', refreshUserFeatures],
 ];
 
 if (!commercialFeatures.adFree) {


### PR DESCRIPTION
frontend pages make a request to members-data-api in order to find the user's supporter status and set cookies.
This is necessary for e.g. hiding ads, support messaging.

Currently DCR reads these cookies, but does not set them.
This PR changes that.

This is a short-term fix, as it doesn't really belong in commercial code.
The proper solution is to move this code into a library where it can be shared by frontend/DCR.

Tested in CODE by:
1. signing in (using a page served by frontend because DCR sends you to the PROD sign in page)
2. deleting the gu_user_features_expiry cookie
3. navigating to a DCR page and observing the network tab:

![Screen Shot 2020-11-13 at 10 44 45](https://user-images.githubusercontent.com/1513454/99064040-4ef98280-259d-11eb-954a-55dae5539bd0.png)
