### PR TITLE
Update Newsletters page

### DIFF
--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -83,7 +83,7 @@
 
 @displayNewslettersByTheme = {
     @List(
-        "News round ups" -> newsRoundUpEmails,
+        "News roundups"  -> newsRoundUpEmails,
         "News by topic"  -> newsEmails,
         "Features"       -> featureEmails,
         "Sport"          -> sportEmails,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.232"
+  val identityLibVersion = "3.233"
   val awsVersion = "1.11.240"
   val capiVersion = "17.2"
   val faciaVersion = "3.2.0"


### PR DESCRIPTION
## What does this change?
Updates Newsletters round up page. Requires https://github.com/guardian/identity/pull/1842 to be merged and released first.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

![Screenshot 2020-11-12 at 14 46 42](https://user-images.githubusercontent.com/9122944/98955390-bad4e000-24f6-11eb-8016-b51d38515f3e.png)
![Screenshot 2020-11-12 at 14 46 55](https://user-images.githubusercontent.com/9122944/98955393-bb6d7680-24f6-11eb-9fc8-7d838897f4fc.png)
![Screenshot 2020-11-12 at 14 47 00](https://user-images.githubusercontent.com/9122944/98955394-bc060d00-24f6-11eb-8ed0-726fab24d739.png)
![Screenshot 2020-11-12 at 14 47 07](https://user-images.githubusercontent.com/9122944/98955395-bc060d00-24f6-11eb-9ac4-a2fc5085ccbf.png)
![Screenshot 2020-11-12 at 14 47 12](https://user-images.githubusercontent.com/9122944/98955398-bc060d00-24f6-11eb-9313-9a5829f15892.png)
![Screenshot 2020-11-12 at 14 47 17](https://user-images.githubusercontent.com/9122944/98955399-bc9ea380-24f6-11eb-858a-cc036363f109.png)
![Screenshot 2020-11-12 at 14 47 25](https://user-images.githubusercontent.com/9122944/98955403-bc9ea380-24f6-11eb-8b19-ee3331a65f1c.png)
![Screenshot 2020-11-12 at 14 47 33](https://user-images.githubusercontent.com/9122944/98955404-bd373a00-24f6-11eb-9869-f26f8ae3308a.png)

## What is the value of this and can you measure success?
Requested by Editorial

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
