### PR TITLE
Increase contrast for frequency field text

### DIFF
--- a/static/src/stylesheets/module/signup/_newsletters.scss
+++ b/static/src/stylesheets/module/signup/_newsletters.scss
@@ -205,11 +205,11 @@
 
 .newsletter-card__frequency {
     @include fs-textSans(1);
-    color: $brightness-46;
+    color: $brightness-20;
     padding-bottom: $gs-baseline / 2;
 
     .inline-icon {
-        fill: $brightness-86;
+        fill: $brightness-20;
     }
 }
 


### PR DESCRIPTION
## What does this change?
Increases the contrast of the frequency text on newsletter cards at `/email-newsletters`. The contrast at present means that it's difficult to read the text and it falls short of WCAG.

I've chosen one of the existing neutral colours, chosen to offer good contrast.

[Contrast before](https://webaim.org/resources/contrastchecker/?fcolor=767676&bcolor=EDEDED)
[Contrast after](https://webaim.org/resources/contrastchecker/?fcolor=333333&bcolor=EDEDED)

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots



| Before      | After      |
|-------------|------------|
| ![before](https://user-images.githubusercontent.com/9122944/99083051-e3bfa880-25bc-11eb-8058-06726e9152b1.png)| ![after](https://user-images.githubusercontent.com/9122944/99083322-4b75f380-25bd-11eb-860f-2b36eead9532.png)|


## What is the value of this and can you measure success?
Improves accessibility of the website

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
