### PR TITLE
Lower the TTL of the newsletter forms

### DIFF
--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -110,7 +110,7 @@ class EmailSignupController(
 
         identityNewsletter match {
           case Some(newsletter) =>
-            Cached(1.day)(
+            Cached(1.hour)(
               RevalidatableResult.Ok(
                 views.html.emailFragment(
                   emailLandingPage,
@@ -131,7 +131,7 @@ class EmailSignupController(
         val identityNewsletter = EmailNewsletter.fromIdentityName(listName)
         identityNewsletter match {
           case Some(newsletter) =>
-            Cached(1.day)(
+            Cached(1.hour)(
               RevalidatableResult.Ok(
                 views.html.emailFragment(
                   emailLandingPage,
@@ -148,7 +148,7 @@ class EmailSignupController(
 
   def subscriptionResultFooter(result: String): Action[AnyContent] =
     Action { implicit request =>
-      Cached(7.days)(result match {
+      Cached(1.hour)(result match {
         case "success" =>
           RevalidatableResult.Ok(views.html.emailSubscriptionResultFooter(emailLandingPage, Subscribed))
         case "invalid" =>
@@ -164,7 +164,7 @@ class EmailSignupController(
       val identityNewsletter = EmailNewsletter.fromIdentityName(listName)
       identityNewsletter match {
         case Some(newsletter) =>
-          Cached(7.days)(
+          Cached(1.hour)(
             RevalidatableResult.Ok(
               views.html.emailSubscriptionSuccessResult(emailLandingPage, newsletter.emailEmbed, listName),
             ),
@@ -175,7 +175,7 @@ class EmailSignupController(
 
   def subscriptionNonsuccessResult(result: String): Action[AnyContent] =
     Action { implicit request =>
-      Cached(7.days)(result match {
+      Cached(1.hour)(result match {
         case "invalid" =>
           RevalidatableResult.Ok(
             views.html.emailSubscriptionNonsuccessResult(emailLandingPage, InvalidEmail),


### PR DESCRIPTION
## What does this change?

This change decreases the caching time of the newsletter forms. This is to make deployments easier so we don't have to decache every forms, and also help us spot mistakes within hours rather than days.

Note that I've voluntarily left the cache of footer form untouched as this form gets loaded on every pageview of the website.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
N/A

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
