### PR TITLE
Permutive segments consent

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@guardian/automat-modules": "^0.3.7",
     "@guardian/braze-components": "0.0.12",
     "@guardian/commercial-core": "^0.9.0",
-    "@guardian/consent-management-platform": "6.6.1",
+    "@guardian/consent-management-platform": "6.7.0",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/libs": "^1.3.0",
     "@guardian/shimport": "^1.0.2",

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-permutive.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-permutive.js
@@ -77,8 +77,8 @@ const generatePayload = (
             ? new Date(webPublicationDate).toISOString()
             : '';
     const safeToneIds = (toneIds && typeof toneIds === 'string'
-            ? toneIds.split(',')
-            : []
+        ? toneIds.split(',')
+        : []
     ).map(str => str.trim());
     const cleanPayload = removeEmpty({
         content: {

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -14,7 +14,10 @@ import {
     onConsentChange,
     getConsentFor,
 } from '@guardian/consent-management-platform';
-import { getPermutiveSegments } from 'common/modules/commercial/permutive';
+import {
+    getPermutiveSegments,
+    clearPermutiveSegments,
+} from 'common/modules/commercial/permutive';
 import { isUserLoggedIn } from 'common/modules/identity/api';
 import { getUserSegments } from 'common/modules/commercial/user-ad-targeting';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
@@ -243,7 +246,10 @@ const buildPageTargetting = (
     const pageTargets: PageTargeting = Object.assign(
         {
             sens: page.isSensitive ? 't' : 'f',
-            permutive: adConsentState !== false ? getPermutiveSegments() : [],
+            permutive:
+                adConsentState !== false
+                    ? getPermutiveSegments()
+                    : clearPermutiveSegments(),
             pv: config.get('ophan.pageViewId'),
             bp: findBreakpoint(),
             at: getCookie('adtest') || undefined,

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -322,9 +322,6 @@ const getPageTargeting = (): { [key: string]: mixed } => {
         } else if (state.aus) {
             // AUS mode
             canRun = getConsentFor('aus-advertising', state);
-        } else {
-            // TCFv1 mode
-            canRun = state[1] && state[2] && state[3] && state[4] && state[5];
         }
 
         if (canRun !== latestConsentCanRun) {

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -243,7 +243,7 @@ const buildPageTargetting = (
     const pageTargets: PageTargeting = Object.assign(
         {
             sens: page.isSensitive ? 't' : 'f',
-            permutive: adConsentState ? getPermutiveSegments() : [],
+            permutive: getPermutiveSegments(adConsentState),
             pv: config.get('ophan.pageViewId'),
             bp: findBreakpoint(),
             at: getCookie('adtest') || undefined,

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -240,16 +240,14 @@ const buildPageTargetting = (
 ): { [key: string]: mixed } => {
     const page = config.get('page');
     // personalised ads targeting
+    if (adConsentState === false) clearPermutiveSegments();
     // flowlint-next-line sketchy-null-bool:off
     const paTargeting: {} = { pa: adConsentState ? 't' : 'f' };
     const adFreeTargeting: {} = commercialFeatures.adFree ? { af: 't' } : {};
     const pageTargets: PageTargeting = Object.assign(
         {
             sens: page.isSensitive ? 't' : 'f',
-            permutive:
-                adConsentState !== false
-                    ? getPermutiveSegments()
-                    : clearPermutiveSegments(),
+            permutive: getPermutiveSegments(),
             pv: config.get('ophan.pageViewId'),
             bp: findBreakpoint(),
             at: getCookie('adtest') || undefined,
@@ -322,7 +320,7 @@ const getPageTargeting = (): { [key: string]: mixed } => {
         } else if (state.aus) {
             // AUS mode
             canRun = getConsentFor('aus-advertising', state);
-        }
+        } else canRun = false;
 
         if (canRun !== latestConsentCanRun) {
             const ccpaState = state.ccpa ? state.ccpa.doNotSell : null;

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -243,7 +243,7 @@ const buildPageTargetting = (
     const pageTargets: PageTargeting = Object.assign(
         {
             sens: page.isSensitive ? 't' : 'f',
-            permutive: getPermutiveSegments(adConsentState),
+            permutive: adConsentState !== false ? getPermutiveSegments() : [],
             pv: config.get('ophan.pageViewId'),
             bp: findBreakpoint(),
             at: getCookie('adtest') || undefined,

--- a/static/src/javascripts/projects/common/modules/commercial/permutive.js
+++ b/static/src/javascripts/projects/common/modules/commercial/permutive.js
@@ -19,10 +19,9 @@ const getSegments = (key: string): Array<string> => {
 export const getPermutiveSegments = () => getSegments(PERMUTIVE_KEY);
 export const getPermutivePFPSegments = () => getSegments(PERMUTIVE_PFP_KEY);
 
-export const clearPermutiveSegments = () => {
+export const clearPermutiveSegments = (): void => {
     storage.local.remove(PERMUTIVE_KEY);
     storage.local.remove(PERMUTIVE_PFP_KEY);
-    return [];
 };
 
 export const _ = {

--- a/static/src/javascripts/projects/common/modules/commercial/permutive.js
+++ b/static/src/javascripts/projects/common/modules/commercial/permutive.js
@@ -19,6 +19,12 @@ const getSegments = (key: string): Array<string> => {
 export const getPermutiveSegments = () => getSegments(PERMUTIVE_KEY);
 export const getPermutivePFPSegments = () => getSegments(PERMUTIVE_PFP_KEY);
 
+export const clearPermutiveSegments = () => {
+    storage.local.clear(PERMUTIVE_KEY);
+    storage.local.clear(PERMUTIVE_PFP_KEY);
+    return [];
+};
+
 export const _ = {
     PERMUTIVE_KEY,
     PERMUTIVE_PFP_KEY,

--- a/static/src/javascripts/projects/common/modules/commercial/permutive.js
+++ b/static/src/javascripts/projects/common/modules/commercial/permutive.js
@@ -20,8 +20,8 @@ export const getPermutiveSegments = () => getSegments(PERMUTIVE_KEY);
 export const getPermutivePFPSegments = () => getSegments(PERMUTIVE_PFP_KEY);
 
 export const clearPermutiveSegments = () => {
-    storage.local.clear(PERMUTIVE_KEY);
-    storage.local.clear(PERMUTIVE_PFP_KEY);
+    storage.local.remove(PERMUTIVE_KEY);
+    storage.local.remove(PERMUTIVE_PFP_KEY);
     return [];
 };
 

--- a/static/src/javascripts/projects/common/modules/commercial/permutive.js
+++ b/static/src/javascripts/projects/common/modules/commercial/permutive.js
@@ -16,8 +16,10 @@ const getSegments = (key: string): Array<string> => {
     }
 };
 
-export const getPermutiveSegments = () => getSegments(PERMUTIVE_KEY);
-export const getPermutivePFPSegments = () => getSegments(PERMUTIVE_PFP_KEY);
+export const getPermutiveSegments = (adConsentState: boolean | null) =>
+    adConsentState !== false ? getSegments(PERMUTIVE_KEY) : [];
+export const getPermutivePFPSegments = (adConsentState: boolean | null) =>
+    adConsentState !== false ? getSegments(PERMUTIVE_PFP_KEY) : [];
 
 export const _ = {
     PERMUTIVE_KEY,

--- a/static/src/javascripts/projects/common/modules/commercial/permutive.js
+++ b/static/src/javascripts/projects/common/modules/commercial/permutive.js
@@ -16,10 +16,8 @@ const getSegments = (key: string): Array<string> => {
     }
 };
 
-export const getPermutiveSegments = (adConsentState: boolean | null) =>
-    adConsentState !== false ? getSegments(PERMUTIVE_KEY) : [];
-export const getPermutivePFPSegments = (adConsentState: boolean | null) =>
-    adConsentState !== false ? getSegments(PERMUTIVE_PFP_KEY) : [];
+export const getPermutiveSegments = () => getSegments(PERMUTIVE_KEY);
+export const getPermutivePFPSegments = () => getSegments(PERMUTIVE_PFP_KEY);
 
 export const _ = {
     PERMUTIVE_KEY,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1758,10 +1758,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.9.0.tgz#2c578b61a6af99436abd83760d3349ef99d53ab8"
   integrity sha512-2o/au3c/SRUYrlPA1x6Rog6+UpXkSf6UrSX16lD19VaFyia60LaIXtBu9mkZNhSm0FWqfLSgync8RTCeCRG47w==
 
-"@guardian/consent-management-platform@6.6.1":
-  version "6.6.1"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.6.1.tgz#34a8f9c4e78d9813063312290f27e4096852b2d8"
-  integrity sha512-bCCeqdIlO7lrg/qOM7XQYhghZn1ruxAUqyhvW7mo23nghu8Xz5hRZ6AbK9Juis6g0DeFGKkvBSAMtxrEEheM2Q==
+"@guardian/consent-management-platform@6.7.0":
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.7.0.tgz#d129694886442c6d5d5d41fa4e0f4328a26f102e"
+  integrity sha512-ltF+pGlc4CMnoxril09cFUbAR5LPOSxD79fnMf2nQJI/+2I/N00SObk3JFnklz608I7iVHL6o0ifVEodbmwTDg==
 
 "@guardian/dotcom-rendering@git://github.com/guardian/dotcom-rendering.git#version-1-alpha":
   version "0.1.0-alpha"


### PR DESCRIPTION
## What does this change?

Puts Permutive segments behind consent. It is currently possible that a segments are passed to ad calls, even if a non-personalised flag comes through.

If personalised advertising is off, the local storage values need to be emptied, as otherwise there the Permutive script will pick this information up on its own, outside of the `buildPageTargeting` call. See https://github.com/guardian/frontend/blob/3d04f4f32a5f946c850456884f736211294b3c7a/static/src/javascripts/projects/commercial/modules/dfp/prepare-permutive.js#L201

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/99113993-1cac4d00-25be-11eb-9f99-1578244822cb.png

[after]: https://user-images.githubusercontent.com/76776/99117162-4451e400-25c3-11eb-9bef-4c312625616b.png



## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
