### PR TITLE
Added timings for the Braze SDK load and Braze 'appboy'-related calls

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -109,7 +109,16 @@ const getMessageFromQueryString = (): InAppMessage | null => {
 };
 
 const getMessageFromBraze = async (apiKey: string, brazeUuid: string): Promise<boolean> => {
+    const sdkLoadTiming = measureTiming('braze-sdk-load');
+    sdkLoadTiming.start();
+
     appboy = await import(/* webpackChunkName: "braze-web-sdk-core" */ '@braze/web-sdk-core');
+
+    const sdkLoadTimeTaken = sdkLoadTiming.end();
+    ophan.record({
+        component: 'braze-sdk-load-timing',
+        value: sdkLoadTimeTaken,
+    });
 
     appboy.initialize(apiKey, {
         enableLogging: false,
@@ -141,8 +150,8 @@ const getMessageFromBraze = async (apiKey: string, brazeUuid: string): Promise<b
 };
 
 const canShow = async (): Promise<boolean> => {
-    const timing = measureTiming('braze-banner');
-    timing.start();
+    const bannerTiming = measureTiming('braze-banner');
+    bannerTiming.start();
 
     const forcedBrazeMessage = getMessageFromQueryString();
     if (forcedBrazeMessage) {
@@ -170,7 +179,7 @@ const canShow = async (): Promise<boolean> => {
 
     try {
         const result = await getMessageFromBraze(apiKey, brazeUuid)
-        const timeTaken = timing.end();
+        const timeTaken = bannerTiming.end();
 
         if (timeTaken) {
             ophan.record({

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -159,6 +159,7 @@ const getMessageFromBraze = async (apiKey: string, brazeUuid: string): Promise<b
             value: appboyTimeTaken,
         });
     }).catch(() => {
+        appboyTiming.clear()
         console.log("Appboy Timing failed.");
     });
 
@@ -206,6 +207,7 @@ const canShow = async (): Promise<boolean> => {
 
         return result;
     } catch (e) {
+        bannerTiming.clear()
         return false;
     }
 };

--- a/static/src/javascripts/projects/commercial/modules/measure-timing.js
+++ b/static/src/javascripts/projects/commercial/modules/measure-timing.js
@@ -22,10 +22,15 @@ export const measureTiming = (name: string) => {
             return timeTakenInt;
         };
 
+        const clear = () => {
+            perf.clearMarks(startKey)
+        }
+
         return {
             start,
             end,
+            clear
         };
     }
-    return { start: () => null, end: (): TimeTakenInMilliseconds => null }
+    return { start: () => null, end: (): TimeTakenInMilliseconds => null, clear: () => null }
 };


### PR DESCRIPTION
## What does this change?
This adds additional timing measurements. We (TX) want to collect RUM data, which we will pull from Ophan in order to see which calls are taking up the most time. Currently our banner exceeds its time limit roughly 1 in 3 page views where it would otherwise be valid to show.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes - An equivalent PR is available [here](**url**).

## What is the value of this and can you measure success?
TODO: Check changes locally

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
