### PR TITLE
Extend ab-curated-container-test switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -72,7 +72,7 @@ trait ABTestSwitches {
     "Tests an additional 'curated' onwards container below the article body.",
     owners = Seq(Owner.withGithub("gtrufitt")),
     safeState = Off,
-    sellByDate = new LocalDate(2020, 11, 18),
+    sellByDate = new LocalDate(2020, 12, 09),
     exposeClientSide = true,
   )
 

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -72,7 +72,7 @@ trait ABTestSwitches {
     "Tests an additional 'curated' onwards container below the article body.",
     owners = Seq(Owner.withGithub("gtrufitt")),
     safeState = Off,
-    sellByDate = new LocalDate(2020, 12, 09),
+    sellByDate = new LocalDate(2020, 12, 9),
     exposeClientSide = true,
   )
 


### PR DESCRIPTION
## What does this change?
We want to repurpose the test, so extending the switch for the moment instead of deleting everything.