### PR TITLE
Map additional paths to the election tracker

### DIFF
--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -169,20 +169,15 @@ class InteractiveController(
     /*
       This version retrieve the AMP version directly but rely on an predefined map between paths and amp page ids
      */
-    ApplicationsSpecial2020Election.pathToAmpAtomId(path) match {
-      case None =>
-        Future.successful(Ok("error: 5ce31f26-6dfe-4981-aad0-5d858e6dba8a (amp document not available at this path)"))
-      case Some(capiLookupString) => {
-        val response: Future[ItemResponse] = lookupWithoutModelConvertion(capiLookupString)
-        response.map { response =>
-          response.interactive match {
-            case Some(i2) => {
-              val interactive = InteractiveAtom.make(i2)
-              Ok(StringEscapeUtils.unescapeHtml(interactive.html)).withHeaders("Content-Type" -> "text/html")
-            }
-            case None => Ok("error: 6a0a6be4-e702-4b51-8f26-01f9921c6b74")
-          }
+    val capiLookupString = ApplicationsSpecial2020Election.pathToAmpAtomId(path)
+    val response: Future[ItemResponse] = lookupWithoutModelConvertion(capiLookupString)
+    response.map { response =>
+      response.interactive match {
+        case Some(i2) => {
+          val interactive = InteractiveAtom.make(i2)
+          Ok(StringEscapeUtils.unescapeHtml(interactive.html)).withHeaders("Content-Type" -> "text/html")
         }
+        case None => Ok("error: 6a0a6be4-e702-4b51-8f26-01f9921c6b74")
       }
     }
   }

--- a/applications/app/services/ApplicationsSpecial2020Election.scala
+++ b/applications/app/services/ApplicationsSpecial2020Election.scala
@@ -65,13 +65,20 @@ object ApplicationsSpecial2020Election {
     (Array("atom", "interactive") ++ atomId.split("/").dropRight(1) ++ Array("amp-page")).mkString("/")
   }
 
-  def pathToAmpAtomId(path: String): Option[String] = {
+  def pathToAmpAtomId(path: String): String = {
     /*
         This version is a more limited, but much more robust version, of `defaultAtomIdToAmpAtomId`
         In particular, it doesn't rely on a particular format for the atom ids, and instead
-        maps paths dirctly to capi query ids, which is fine since we essentially only want to support a couple of urls.
+        maps paths directly to capi query ids, which is fine since we essentially only want to support few urls.
+
+        Update, 17th Nov: with the introduction of `pathIsNovemberElectionTrackerRegex` and `pathIsElectionTracker`
+        The paths that are not in `specialPathsToCapiIdsMap`, but pass the `pathIsElectionTracker` test are missing
+        a CAPI Id. When that happens we are going to default to the election tracker atom Id.
      */
-    specialPathsToCapiIdsMap.get(ensureStartingForwardSlash(path))
+    specialPathsToCapiIdsMap.getOrElse(
+      ensureStartingForwardSlash(path),
+      "atom/interactive/interactives/2020/11/us-election/prod/amp-page",
+    )
   }
 
   def ampTagHtml(path: String)(implicit request: RequestHeader): Html = {


### PR DESCRIPTION
## What does this change?

This is the follow up of https://github.com/guardian/frontend/pull/23258. We now map the additional urls to the right content.