### PR TITLE
Use name instead of description in the tests report

### DIFF
--- a/applications/app/controllers/Nx1ConfigController.scala
+++ b/applications/app/controllers/Nx1ConfigController.scala
@@ -26,7 +26,7 @@ object Nx1Config {
     ActiveExperiments.allExperiments
       .filter(e => isParticipating(e) || isControl(e))
       .toSeq
-      .map { e => (e.description, e.value) }
+      .map { e => (e.name, e.value) }
       .toMap
   }
 }


### PR DESCRIPTION
## What does this change?

Use name instead of description in the tests report. This is the follow up on https://github.com/guardian/frontend/pull/23265  