### PR TITLE
bump CMP to 6.7.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@guardian/automat-modules": "^0.3.7",
     "@guardian/braze-components": "0.0.12",
     "@guardian/commercial-core": "^0.9.0",
-    "@guardian/consent-management-platform": "6.7.3",
+    "@guardian/consent-management-platform": "6.7.4",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/libs": "^1.3.0",
     "@guardian/shimport": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@guardian/automat-modules": "^0.3.7",
     "@guardian/braze-components": "0.0.12",
     "@guardian/commercial-core": "^0.9.0",
-    "@guardian/consent-management-platform": "6.7.2",
+    "@guardian/consent-management-platform": "6.7.3",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/libs": "^1.3.0",
     "@guardian/shimport": "^1.0.2",

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -10,10 +10,7 @@ import { getSync as geolocationGetSync } from 'lib/geolocation';
 import { storage } from '@guardian/libs';
 import { getUrlVars } from 'lib/url';
 import { getPrivacyFramework } from 'lib/getPrivacyFramework';
-import {
-    onConsentChange,
-    getConsentFor,
-} from '@guardian/consent-management-platform';
+import { onConsentChange } from '@guardian/consent-management-platform';
 import {
     getPermutiveSegments,
     clearPermutiveSegments,
@@ -319,7 +316,7 @@ const getPageTargeting = (): { [key: string]: mixed } => {
                 : false;
         } else if (state.aus) {
             // AUS mode
-            canRun = getConsentFor('aus-advertising', state);
+            canRun = state.aus.personalisedAdvertising;
         } else canRun = false;
 
         if (canRun !== latestConsentCanRun) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1758,10 +1758,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.9.0.tgz#2c578b61a6af99436abd83760d3349ef99d53ab8"
   integrity sha512-2o/au3c/SRUYrlPA1x6Rog6+UpXkSf6UrSX16lD19VaFyia60LaIXtBu9mkZNhSm0FWqfLSgync8RTCeCRG47w==
 
-"@guardian/consent-management-platform@6.7.2":
-  version "6.7.2"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.7.2.tgz#4a6e2c7757bb014dc2adf4853db5e668f2798530"
-  integrity sha512-tAl+oohzjkRFqLkd5NcZKAp6v5hH0cKdwzX2LwLhQVgwVmtyPVdfr9UZZaIFK4xcHOOqXLQ+Jcy3oBAgOfs47w==
+"@guardian/consent-management-platform@6.7.3":
+  version "6.7.3"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.7.3.tgz#46a3f137430190bfaad192f82b6898d89bd4cc44"
+  integrity sha512-Vfb4zQrl0zDASVjeQ/6M+MkeRHCnVJhoN8dr99JKlU9rYG9Rk7WICJa3cpMk2vz7QBox8i6SaZlegjcleGsm2w==
 
 "@guardian/dotcom-rendering@git://github.com/guardian/dotcom-rendering.git#version-1-alpha":
   version "0.1.0-alpha"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1758,10 +1758,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.9.0.tgz#2c578b61a6af99436abd83760d3349ef99d53ab8"
   integrity sha512-2o/au3c/SRUYrlPA1x6Rog6+UpXkSf6UrSX16lD19VaFyia60LaIXtBu9mkZNhSm0FWqfLSgync8RTCeCRG47w==
 
-"@guardian/consent-management-platform@6.7.3":
-  version "6.7.3"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.7.3.tgz#46a3f137430190bfaad192f82b6898d89bd4cc44"
-  integrity sha512-Vfb4zQrl0zDASVjeQ/6M+MkeRHCnVJhoN8dr99JKlU9rYG9Rk7WICJa3cpMk2vz7QBox8i6SaZlegjcleGsm2w==
+"@guardian/consent-management-platform@6.7.4":
+  version "6.7.4"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.7.4.tgz#ae75775c40f8234a2e2774c126a688e9a98f5df4"
+  integrity sha512-f/XieB0dOyGYZDhP/UmyrHiyuehETt2L1GKqacsySFdcD/++fKe7LLcXbza4NE54MHyS0wbvd+Qh4avjG4IPLg==
 
 "@guardian/dotcom-rendering@git://github.com/guardian/dotcom-rendering.git#version-1-alpha":
   version "0.1.0-alpha"


### PR DESCRIPTION
## What does this change?

Version bump. Follows #23253.

DCR PR: https://github.com/guardian/dotcom-rendering/pull/2093

- Fixes `getConsentFor` errors for `aus-advertising`, which was removed.
- Fixes CORS `unsafe-eval` issues (seen on https://support.theguardian.com/)

### Tested

- [X] Locally
- [X] On CODE (optional)