### PR TITLE
rename /tests.json to /experiments.json

### DIFF
--- a/applications/app/controllers/Nx1ConfigController.scala
+++ b/applications/app/controllers/Nx1ConfigController.scala
@@ -22,7 +22,7 @@ import experiments.ActiveExperiments._
  */
 
 object Nx1Config {
-  def makeAbTestReport(implicit request: RequestHeader) = {
+  def makeExperimentsReport(implicit request: RequestHeader) = {
     ActiveExperiments.allExperiments
       .filter(e => isParticipating(e) || isControl(e))
       .toSeq
@@ -42,9 +42,9 @@ class Nx1ConfigController(val controllerComponents: ControllerComponents) extend
       Ok(Json.toJson(switches))
     }
 
-  def tests: Action[AnyContent] =
+  def experiments: Action[AnyContent] =
     Action { implicit request =>
-      val abTests = Nx1Config.makeAbTestReport(request)
-      Ok(Json.toJson(abTests))
+      val currentExperiments = Nx1Config.makeExperimentsReport(request)
+      Ok(Json.toJson(currentExperiments))
     }
 }

--- a/applications/app/controllers/Nx1ConfigController.scala
+++ b/applications/app/controllers/Nx1ConfigController.scala
@@ -44,7 +44,7 @@ class Nx1ConfigController(val controllerComponents: ControllerComponents) extend
 
   def experiments: Action[AnyContent] =
     Action { implicit request =>
-      val currentExperiments = Nx1Config.makeExperimentsReport(request)
-      Ok(Json.toJson(currentExperiments))
+      val activeExperiments = Nx1Config.makeExperimentsReport(request)
+      Ok(Json.toJson(activeExperiments))
     }
 }

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -87,7 +87,7 @@ GET        /atom/youtube/:id.json                                               
 # Nx1Config
 # mark: 2QJfZo - keep these in sync with other instances https://git.io/JkRox
 GET        /switches.json                                                       controllers.Nx1ConfigController.switches
-GET        /tests.json                                                          controllers.Nx1ConfigController.tests
+GET        /experiments.json                                                          controllers.Nx1ConfigController.experiments
 
 GET        /$path<.+/\d\d\d\d/\w\w\w/\d\d>                                      controllers.AllIndexController.on(path)
 GET        /$path<.+>/latest                                                    controllers.LatestIndexController.latest(path)

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -373,7 +373,7 @@ GET            /atom/youtube/:id.json                                           
 # Nx1Config
 # mark: 2QJfZo - keep these in sync with other instances https://git.io/JkRox
 GET            /switches.json                                                       controllers.Nx1ConfigController.switches
-GET            /tests.json                                                          controllers.Nx1ConfigController.tests
+GET            /experiments.json                                                          controllers.Nx1ConfigController.experiments
 
 # Newspaper pages
 GET            /theguardian                                                                                                      controllers.NewspaperController.latestGuardianNewspaper()


### PR DESCRIPTION
## What does this change?

renames the endpoint from #23265

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No

## What is the value of this and can you measure success?

- it better reflects the content of the end point
- it tries to disambiguate what the endpoint returns with what https://github.com/guardian/ab-testing gets you

pr for https://github.com/guardian/platform forthcoming