### PR TITLE
fix videos playing under new aus consent

### DIFF
--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -52,11 +52,16 @@ interface AdsConfig {
 let tcfState = null;
 let ccpaState = null;
 let tcfData = {};
-onConsentChange(state => {
-    if (state.ccpa) {
-        ccpaState = state.doNotSell;
-    } else {
-        tcfData = state.tcfv2;
+onConsentChange((consentState) => {
+    if (consentState.ccpa) {
+        ccpaState = consentState.doNotSell;
+    }
+    else if (consentState.aus) {
+        ccpaState = !consentState.aus.personalisedAdvertising;
+    }
+
+    else {
+        tcfData = consentState.tcfv2;
         tcfState = tcfData
             ? Object.values(tcfData.consents).every(Boolean)
             : false


### PR DESCRIPTION
## What does this change?

uses new aus framework for consent playing video

## Does this change need to be reproduced in dotcom-rendering ?

maybe... there may be other places too. investigation after this 

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:
before
<img width="587" alt="image" src="https://user-images.githubusercontent.com/867233/99789941-482dbb00-2b1b-11eb-99d6-08b09f717408.png">

after
<img width="272" alt="image" src="https://user-images.githubusercontent.com/867233/99790092-85924880-2b1b-11eb-8d8b-3e686aaff31f.png">

-->

this is @ashishpuliyel's change really, I'm just PRing it