### PR TITLE
In skin cmp fix aus

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@guardian/automat-modules": "^0.3.7",
     "@guardian/braze-components": "0.0.12",
     "@guardian/commercial-core": "^0.9.0",
-    "@guardian/consent-management-platform": "6.7.4",
+    "@guardian/consent-management-platform": "6.8.0",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/libs": "^1.4.2",
     "@guardian/shimport": "^1.0.2",

--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
@@ -12,10 +12,12 @@ import { fillAdvertSlots as fillAdvertSlots_ } from 'commercial/modules/dfp/fill
 import {
     onConsentChange as onConsentChange_,
     getConsentFor as getConsentFor_,
+    cmp as cmp_,
 } from '@guardian/consent-management-platform';
 
 const onConsentChange: any = onConsentChange_;
 const getConsentFor: any = getConsentFor_;
+const cmp: any = cmp_;
 
 // $FlowFixMe property requireActual is actually not missing Flow.
 const { fillAdvertSlots: actualFillAdvertSlots } = jest.requireActual(
@@ -102,7 +104,12 @@ jest.mock('commercial/modules/dfp/load-advert', () => ({
 jest.mock('@guardian/consent-management-platform', () => ({
     onConsentChange: jest.fn(),
     getConsentFor: jest.fn(),
+    cmp: {
+        willShowPrivacyMessage: jest.fn(),
+    },
 }));
+
+cmp.willShowPrivacyMessage.mockResolvedValue(true);
 
 let $style;
 const makeFakeEvent = (creativeId, id) => ({

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -62,10 +62,10 @@ const setDfpListeners = (): void => {
     }
 };
 
-const setPageTargeting = (): void => {
+const setPageTargeting = async (): Promise<void> => {
     const pubads = window.googletag.pubads();
     // because commercialFeatures may export itself as {} in the event of an exception during construction
-    const targeting = getPageTargeting();
+    const targeting = await getPageTargeting();
     Object.keys(targeting).forEach(key => {
         pubads.setTargeting(key, targeting[key]);
     });

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -10,6 +10,7 @@ import {
     onConsentChange,
     getConsentFor,
 } from '@guardian/consent-management-platform';
+import type { ConsentState } from '@guardian/consent-management-platform/dist/types/index.js.flow';
 import { getPageTargeting } from 'common/modules/commercial/build-page-targeting';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { adFreeSlotRemove } from 'commercial/modules/ad-free-slot-remove';

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
@@ -5,6 +5,7 @@ import {
     onConsentChange,
     getConsentFor,
 } from '@guardian/consent-management-platform';
+import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { getPageTargeting } from 'common/modules/commercial/build-page-targeting';
 import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
@@ -13,7 +14,7 @@ import prebid from 'commercial/modules/header-bidding/prebid/prebid';
 import { isGoogleProxy } from 'lib/detect';
 import { shouldIncludeOnlyA9 } from 'commercial/modules/header-bidding/utils';
 
-const loadPrebid: () => void = () => {
+const loadPrebid: (state: ConsentState) => void = state => {
     if (
         dfpEnv.hbImpl.prebid &&
         commercialFeatures.dfpAdvertising &&
@@ -24,7 +25,7 @@ const loadPrebid: () => void = () => {
     ) {
         import(/* webpackChunkName: "Prebid.js" */ 'prebid.js/build/dist/prebid').then(
             async () => {
-                await getPageTargeting();
+                await getPageTargeting(state);
                 prebid.initialise(window);
             }
         );
@@ -35,7 +36,7 @@ const setupPrebid: () => Promise<void> = () => {
     onConsentChange(state => {
         const canRun: boolean = getConsentFor('prebid', state);
         if (canRun) {
-            loadPrebid();
+            loadPrebid(state);
         }
     });
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
@@ -23,8 +23,8 @@ const loadPrebid: () => void = () => {
         !shouldIncludeOnlyA9
     ) {
         import(/* webpackChunkName: "Prebid.js" */ 'prebid.js/build/dist/prebid').then(
-            () => {
-                getPageTargeting();
+            async () => {
+                await getPageTargeting();
                 prebid.initialise(window);
             }
         );

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
@@ -5,7 +5,7 @@ import {
     onConsentChange,
     getConsentFor,
 } from '@guardian/consent-management-platform';
-import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
+import type { ConsentState } from '@guardian/consent-management-platform/dist/types/index.js.flow';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { getPageTargeting } from 'common/modules/commercial/build-page-targeting';
 import { dfpEnv } from 'commercial/modules/dfp/dfp-env';

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.js
@@ -6,9 +6,7 @@ import {
     buildAppNexusTargetingObject,
 } from 'common/modules/commercial/build-page-targeting';
 
-import {
-    isInUsOrCa,
-    isInAuOrNz } from 'common/modules/commercial/geo-utils';
+import { isInUsOrCa, isInAuOrNz } from 'common/modules/commercial/geo-utils';
 
 import {
     getLargestSize,
@@ -16,7 +14,7 @@ import {
     containsLeaderboardOrBillboard,
     containsMpu,
     containsMpuOrDmpu,
-    getBreakpointKey
+    getBreakpointKey,
 } from '../utils';
 
 import type { PrebidAppNexusParams, HeaderBiddingSize } from '../types';
@@ -101,9 +99,9 @@ export const getAppNexusDirectPlacementId = (
     }
 };
 
-export const getAppNexusDirectBidParams = (
+export const getAppNexusDirectBidParams = async (
     sizes: HeaderBiddingSize[]
-): PrebidAppNexusParams => {
+): Promise<PrebidAppNexusParams> => {
     if (isInAuOrNz() && config.get('switches.prebidAppnexusInvcode')) {
         const invCode = getAppNexusInvCode(sizes);
         // flowlint sketchy-null-string:warn
@@ -113,14 +111,14 @@ export const getAppNexusDirectBidParams = (
                 member: '7012',
                 keywords: {
                     invc: [invCode],
-                    ...buildAppNexusTargetingObject(getPageTargeting()),
+                    ...buildAppNexusTargetingObject(await getPageTargeting()),
                 },
             };
         }
     }
     return {
         placementId: getAppNexusDirectPlacementId(sizes),
-        keywords: buildAppNexusTargetingObject(getPageTargeting()),
+        keywords: buildAppNexusTargetingObject(await getPageTargeting()),
     };
 };
 

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.spec.js
@@ -1,15 +1,15 @@
 // @flow
 import config from 'lib/config';
-import { isInUsOrCa as isInUsOrCa_,
-    isInAuOrNz as isInAuOrNz_} from 'common/modules/commercial/geo-utils';
+import {
+    isInUsOrCa as isInUsOrCa_,
+    isInAuOrNz as isInAuOrNz_,
+} from 'common/modules/commercial/geo-utils';
 import {
     _,
     getAppNexusDirectBidParams,
     getAppNexusServerSideBidParams,
 } from './appnexus';
-import {
-    getBreakpointKey as getBreakpointKey_
-} from '../utils';
+import { getBreakpointKey as getBreakpointKey_ } from '../utils';
 import type { HeaderBiddingSize } from '../types';
 
 jest.mock('common/modules/commercial/build-page-targeting', () => ({
@@ -32,8 +32,8 @@ jest.mock('../utils', () => {
 });
 
 jest.mock('common/modules/commercial/geo-utils', () => ({
-        isInAuOrNz: jest.fn(),
-        isInUsOrCa: jest.fn(),
+    isInAuOrNz: jest.fn(),
+    isInUsOrCa: jest.fn(),
 }));
 
 jest.mock('lib/cookies', () => ({
@@ -269,20 +269,20 @@ describe('getAppNexusDirectBidParams', () => {
         resetConfig();
     });
 
-    test('should include placementId for AU region when invCode switch is off', () => {
+    test('should include placementId for AU region when invCode switch is off', async () => {
         getBreakpointKey.mockReturnValue('M');
         isInAuOrNz.mockReturnValue(true);
-        expect(getAppNexusDirectBidParams([[300, 250]])).toEqual({
+        expect(await getAppNexusDirectBidParams([[300, 250]])).toEqual({
             keywords: { edition: 'UK', sens: 'f', url: 'gu.com' },
             placementId: '11016434',
         });
     });
 
-    test('should exclude placementId for AU region when including member and invCode', () => {
+    test('should exclude placementId for AU region when including member and invCode', async () => {
         config.set('switches.prebidAppnexusInvcode', true);
         getBreakpointKey.mockReturnValue('M');
         isInAuOrNz.mockReturnValueOnce(true);
-        expect(getAppNexusDirectBidParams([[300, 250]])).toEqual({
+        expect(await getAppNexusDirectBidParams([[300, 250]])).toEqual({
             keywords: {
                 edition: 'UK',
                 sens: 'f',
@@ -294,10 +294,10 @@ describe('getAppNexusDirectBidParams', () => {
         });
     });
 
-    test('should include placementId and not include invCode if outside AU region', () => {
+    test('should include placementId and not include invCode if outside AU region', async () => {
         config.set('switches.prebidAppnexusInvcode', true);
         getBreakpointKey.mockReturnValue('M');
-        expect(getAppNexusDirectBidParams([[300, 250]])).toEqual({
+        expect(await getAppNexusDirectBidParams([[300, 250]])).toEqual({
             keywords: { edition: 'UK', sens: 'f', url: 'gu.com' },
             placementId: '4298191',
         });

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
@@ -58,8 +58,6 @@ import {
 import { getAppNexusDirectBidParams } from './appnexus';
 
 // The below line is needed for page skins to show
-// Now it's a Promise, is this needed? 2020-10-23
-getPageTargeting();
 
 const isInSafeframeTestVariant = (): boolean =>
     isInVariantSynchronous(commercialPrebidSafeframe, 'variant');

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
@@ -525,10 +525,12 @@ export const bids: (
     HeaderBiddingSize[]
 ) => Promise<PrebidBid[]> = async (slotId, slotSizes) => {
     const currentBiddersAsync = await currentBidders(slotSizes);
-    return (await currentBiddersAsync).map(async (bidder: PrebidBidder) => ({
-        bidder: bidder.name,
-        params: await bidder.bidParams(slotId, slotSizes),
-    }));
+    return Promise.all(
+        currentBiddersAsync.map(async (bidder: PrebidBidder) => ({
+            bidder: bidder.name,
+            params: await bidder.bidParams(slotId, slotSizes),
+        }))
+    );
 };
 
 export const _ = {

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
@@ -332,21 +332,23 @@ const openxClientSideBidder: PrebidBidder = {
 const ozoneClientSideBidder: PrebidBidder = {
     name: 'ozone',
     switchName: 'prebidOzone',
-    bidParams: (): PrebidOzoneParams =>
-        Object.assign(
-            {},
-            (() => ({
-                publisherId: 'OZONEGMG0001',
-                siteId: '4204204209',
-                placementId: '0420420500',
-                customData: [
-                    {
-                        settings: {},
-                        targeting: getOzoneTargeting(),
-                    },
-                ],
-                ozoneData: {}, // TODO: confirm if we need to send any
-            }))()
+    bidParams: (): Promise<PrebidOzoneParams> =>
+        Promise.resolve(
+            Object.assign(
+                {},
+                (() => ({
+                    publisherId: 'OZONEGMG0001',
+                    siteId: '4204204209',
+                    placementId: '0420420500',
+                    customData: [
+                        {
+                            settings: {},
+                            targeting: getOzoneTargeting(),
+                        },
+                    ],
+                    ozoneData: {}, // TODO: confirm if we need to send any
+                }))()
+            )
         ),
 };
 
@@ -354,17 +356,19 @@ const sonobiBidder: PrebidBidder = {
     name: 'sonobi',
     switchName: 'prebidSonobi',
     bidParams: async (slotId: string): Promise<PrebidSonobiParams> =>
-        Object.assign(
-            {},
-            {
-                ad_unit: config.get('page.adUnit'),
-                dom_id: slotId,
-                appNexusTargeting: buildAppNexusTargeting(
-                    await getPageTargeting()
-                ),
-                pageViewId: config.get('ophan.pageViewId'),
-            },
-            isInSafeframeTestVariant() ? { render: 'safeframe' } : {}
+        Promise.resolve(
+            Object.assign(
+                {},
+                {
+                    ad_unit: config.get('page.adUnit'),
+                    dom_id: slotId,
+                    appNexusTargeting: buildAppNexusTargeting(
+                        await getPageTargeting()
+                    ),
+                    pageViewId: config.get('ophan.pageViewId'),
+                },
+                isInSafeframeTestVariant() ? { render: 'safeframe' } : {}
+            )
         ),
 };
 
@@ -381,22 +385,25 @@ const getPubmaticPublisherId = (): string => {
 const pubmaticBidder: PrebidBidder = {
     name: 'pubmatic',
     switchName: 'prebidPubmatic',
-    bidParams: (slotId: string): PrebidPubmaticParams =>
-        Object.assign(
-            {},
-            {
-                publisherId: getPubmaticPublisherId(),
-                adSlot: stripDfpAdPrefixFrom(slotId),
-            }
+    bidParams: (slotId: string): Promise<PrebidPubmaticParams> =>
+        Promise.resolve(
+            Object.assign(
+                {},
+                {
+                    publisherId: getPubmaticPublisherId(),
+                    adSlot: stripDfpAdPrefixFrom(slotId),
+                }
+            )
         ),
 };
 
 const trustXBidder: PrebidBidder = {
     name: 'trustx',
     switchName: 'prebidTrustx',
-    bidParams: (slotId: string): PrebidTrustXParams => ({
-        uid: getTrustXAdUnitId(slotId, isDesktopAndArticle),
-    }),
+    bidParams: (slotId: string): Promise<PrebidTrustXParams> =>
+        Promise.resolve({
+            uid: getTrustXAdUnitId(slotId, isDesktopAndArticle),
+        }),
 };
 
 const tripleLiftBidder: PrebidBidder = {
@@ -405,9 +412,10 @@ const tripleLiftBidder: PrebidBidder = {
     bidParams: (
         slotId: string,
         sizes: HeaderBiddingSize[]
-    ): PrebidTripleLiftParams => ({
-        inventoryCode: getTripleLiftInventoryCode(slotId, sizes),
-    }),
+    ): Promise<PrebidTripleLiftParams> =>
+        Promise.resolve({
+            inventoryCode: getTripleLiftInventoryCode(slotId, sizes),
+        }),
 };
 
 const improveDigitalBidder: PrebidBidder = {
@@ -416,10 +424,11 @@ const improveDigitalBidder: PrebidBidder = {
     bidParams: (
         slotId: string,
         sizes: HeaderBiddingSize[]
-    ): PrebidImproveParams => ({
-        placementId: getImprovePlacementId(sizes),
-        size: getImproveSizeParam(slotId),
-    }),
+    ): Promise<PrebidImproveParams> =>
+        Promise.resolve({
+            placementId: getImprovePlacementId(sizes),
+            size: getImproveSizeParam(slotId),
+        }),
 };
 
 const xaxisBidder: PrebidBidder = {
@@ -428,34 +437,35 @@ const xaxisBidder: PrebidBidder = {
     bidParams: (
         slotId: string,
         sizes: HeaderBiddingSize[]
-    ): PrebidXaxisParams => ({
-        placementId: getXaxisPlacementId(sizes),
-    }),
+    ): Promise<PrebidXaxisParams> =>
+        Promise.resolve({
+            placementId: getXaxisPlacementId(sizes),
+        }),
 };
 
 const adYouLikeBidder: PrebidBidder = {
     name: 'adyoulike',
     switchName: 'prebidAdYouLike',
-    bidParams: (): PrebidAdYouLikeParams => {
+    bidParams: (): Promise<PrebidAdYouLikeParams> => {
         if (isInUk()) {
-            return {
+            return Promise.resolve({
                 placement: '2b4d757e0ec349583ce704699f1467dd',
-            };
+            });
         }
         if (isInUsOrCa()) {
-            return {
+            return Promise.resolve({
                 placement: '7fdf0cd05e1d4bf39a2d3df9c61b3495',
-            };
+            });
         }
         if (isInAuOrNz()) {
-            return {
+            return Promise.resolve({
                 placement: '5cf05e1705a2d57ba5d51e03f2af9208',
-            };
+            });
         }
         // ROW
-        return {
+        return Promise.resolve({
             placement: 'c1853ee8bfe0d4e935cbf2db9bb76a8b',
-        };
+        });
     },
 };
 
@@ -467,10 +477,11 @@ const indexExchangeBidders: (
     return slotSizes.map(size => ({
         name: 'ix',
         switchName: 'prebidIndexExchange',
-        bidParams: (): PrebidIndexExchangeParams => ({
-            siteId: indexSiteId,
-            size,
-        }),
+        bidParams: (): Promise<PrebidIndexExchangeParams> =>
+            Promise.resolve({
+                siteId: indexSiteId,
+                size,
+            }),
     }));
 };
 
@@ -514,7 +525,7 @@ export const bids: (
     HeaderBiddingSize[]
 ) => Promise<PrebidBid[]> = async (slotId, slotSizes) => {
     const currentBiddersAsync = await currentBidders(slotSizes);
-    currentBiddersAsync.map(async (bidder: PrebidBidder) => ({
+    return (await currentBiddersAsync).map(async (bidder: PrebidBidder) => ({
         bidder: bidder.name,
         params: await bidder.bidParams(slotId, slotSizes),
     }));

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
@@ -266,7 +266,7 @@ const getTripleLiftInventoryCode = (
     return '';
 };
 
-const getOzoneTargeting = async (): {} => {
+const getOzoneTargeting = async (): Promise<{}> => {
     const lotameData = getLotameData();
     const appNexusTargetingObject = buildAppNexusTargetingObject(
         await getPageTargeting()
@@ -332,18 +332,18 @@ const openxClientSideBidder: PrebidBidder = {
 const ozoneClientSideBidder: PrebidBidder = {
     name: 'ozone',
     switchName: 'prebidOzone',
-    bidParams: (): Promise<PrebidOzoneParams> =>
+    bidParams: async (): Promise<PrebidOzoneParams> =>
         Promise.resolve(
             Object.assign(
                 {},
-                (() => ({
+                (async () => ({
                     publisherId: 'OZONEGMG0001',
                     siteId: '4204204209',
                     placementId: '0420420500',
                     customData: [
                         {
                             settings: {},
-                            targeting: getOzoneTargeting(),
+                            targeting: await getOzoneTargeting(),
                         },
                     ],
                     ozoneData: {}, // TODO: confirm if we need to send any

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.spec.js
@@ -55,12 +55,8 @@ const isInUk: any = isInUk_;
 const isInUsOrCa: any = isInUsOrCa_;
 const isInVariantSynchronous: any = isInVariantSynchronous_;
 
-const getBidders = async () => {
-    const asyncBids = await Promise.all(
-        await bids('dfp-ad--top-above-nav', [[728, 90]])
-    );
-    return asyncBids.map(bid => bid.bidder);
-};
+const getBidders = async () =>
+    (await bids('dfp-ad--top-above-nav', [[728, 90]])).map(bid => bid.bidder);
 
 const {
     getIndexSiteId,
@@ -486,9 +482,9 @@ describe('bids', () => {
 
     test('should include ix bidder for each size that slot can take', async () => {
         const rightSlotBidders = async () =>
-            (await Promise.all(
-                await bids('dfp-right', [[300, 600], [300, 250]])
-            )).map(bid => bid.bidder);
+            (await bids('dfp-right', [[300, 600], [300, 250]])).map(
+                bid => bid.bidder
+            );
         expect(await rightSlotBidders()).toEqual(['ix', 'ix', 'adyoulike']);
     });
 
@@ -527,9 +523,7 @@ describe('bids', () => {
     test('should use correct parameters in OpenX bids geolocated in UK', async () => {
         shouldIncludeOpenx.mockReturnValue(true);
         isInUk.mockReturnValue(true);
-        const openXBid = (await Promise.all(
-            await bids('dfp-ad--top-above-nav', [[728, 90]])
-        ))[2];
+        const openXBid = (await bids('dfp-ad--top-above-nav', [[728, 90]]))[2];
         expect(openXBid.params).toEqual({
             customParams: 'someAppNexusTargetingObject',
             delDomain: 'guardian-d.openx.net',
@@ -540,9 +534,7 @@ describe('bids', () => {
     test('should use correct parameters in OpenX bids geolocated in US', async () => {
         shouldIncludeOpenx.mockReturnValue(true);
         isInUsOrCa.mockReturnValue(true);
-        const openXBid = (await Promise.all(
-            await bids('dfp-ad--top-above-nav', [[728, 90]])
-        ))[2];
+        const openXBid = (await bids('dfp-ad--top-above-nav', [[728, 90]]))[2];
         expect(openXBid.params).toEqual({
             customParams: 'someAppNexusTargetingObject',
             delDomain: 'guardian-us-d.openx.net',
@@ -553,9 +545,7 @@ describe('bids', () => {
     test('should use correct parameters in OpenX bids geolocated in AU', async () => {
         shouldIncludeOpenx.mockReturnValue(true);
         isInAuOrNz.mockReturnValue(true);
-        const openXBid = (await Promise.all(
-            await bids('dfp-ad--top-above-nav', [[728, 90]])
-        ))[2];
+        const openXBid = (await bids('dfp-ad--top-above-nav', [[728, 90]]))[2];
         expect(openXBid.params).toEqual({
             customParams: 'someAppNexusTargetingObject',
             delDomain: 'guardian-aus-d.openx.net',
@@ -566,9 +556,7 @@ describe('bids', () => {
     test('should use correct parameters in OpenX bids geolocated in FR', async () => {
         shouldIncludeOpenx.mockReturnValue(true);
         isInRow.mockReturnValue(true);
-        const openXBid = (await Promise.all(
-            await bids('dfp-ad--top-above-nav', [[728, 90]])
-        ))[2];
+        const openXBid = (await bids('dfp-ad--top-above-nav', [[728, 90]]))[2];
         expect(openXBid.params).toEqual({
             customParams: 'someAppNexusTargetingObject',
             delDomain: 'guardian-d.openx.net',
@@ -598,9 +586,9 @@ describe('triplelift adapter', () => {
         containsDmpu.mockReturnValueOnce(false);
         containsMobileSticky.mockReturnValueOnce(false);
 
-        const tripleLiftBids = (await Promise.all(
-            await bids('dfp-ad--top-above-nav', [[728, 90]])
-        ))[1].params;
+        const tripleLiftBids = (await bids('dfp-ad--top-above-nav', [
+            [728, 90],
+        ]))[1].params;
         expect(tripleLiftBids).toEqual({
             inventoryCode: 'theguardian_topbanner_728x90_prebid',
         });
@@ -612,9 +600,8 @@ describe('triplelift adapter', () => {
         containsDmpu.mockReturnValueOnce(false);
         containsMobileSticky.mockReturnValueOnce(false);
 
-        const tripleLiftBids = (await Promise.all(
-            await bids('dfp-ad--inline1', [[300, 250]])
-        ))[1].params;
+        const tripleLiftBids = (await bids('dfp-ad--inline1', [[300, 250]]))[1]
+            .params;
         expect(tripleLiftBids).toEqual({
             inventoryCode: 'theguardian_sectionfront_300x250_prebid',
         });
@@ -626,9 +613,9 @@ describe('triplelift adapter', () => {
         containsDmpu.mockReturnValueOnce(false);
         containsMobileSticky.mockReturnValueOnce(true);
 
-        const tripleLiftBids = (await Promise.all(
-            await bids('dfp-ad--top-above-nav', [[320, 50]])
-        ))[1].params;
+        const tripleLiftBids = (await bids('dfp-ad--top-above-nav', [
+            [320, 50],
+        ]))[1].params;
         expect(tripleLiftBids).toEqual({
             inventoryCode: 'theguardian_320x50_HDX',
         });

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.spec.js
@@ -30,6 +30,7 @@ import {
     shouldIncludeSonobi as shouldIncludeSonobi_,
     stripMobileSuffix as stripMobileSuffix_,
     shouldIncludeTripleLift as shouldIncludeTripleLift_,
+    shouldUseOzoneAdaptor as shouldUseOzoneAdaptor_,
 } from '../utils';
 
 const containsBillboard: any = containsBillboard_;
@@ -47,6 +48,7 @@ const shouldIncludeTrustX: any = shouldIncludeTrustX_;
 const shouldIncludeXaxis: any = shouldIncludeXaxis_;
 const shouldIncludeSonobi: any = shouldIncludeSonobi_;
 const shouldIncludeTripleLift: any = shouldIncludeTripleLift_;
+const shouldUseOzoneAdaptor: any = shouldUseOzoneAdaptor_;
 const stripMobileSuffix: any = stripMobileSuffix_;
 const getBreakpointKey: any = getBreakpointKey_;
 const isInAuOrNz: any = isInAuOrNz_;
@@ -95,6 +97,7 @@ const resetConfig = () => {
     config.set('switches.prebidXaxis', true);
     config.set('switches.prebidAdYouLike', true);
     config.set('switches.prebidTriplelift', true);
+    config.set('switches.prebidOzone', true);
     config.set('ophan', { pageViewId: 'pvid' });
     config.set('page.contentType', 'Article');
     config.set('page.section', 'Magic');
@@ -619,5 +622,21 @@ describe('triplelift adapter', () => {
         expect(tripleLiftBids).toEqual({
             inventoryCode: 'theguardian_320x50_HDX',
         });
+    });
+});
+
+describe('ozone adapter', () => {
+    beforeEach(() => {
+        resetConfig();
+        config.set('page.contentType', 'Article');
+        shouldUseOzoneAdaptor.mockReturnValue(true);
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    test('should include ozone adapter if condition is true ', async () => {
+        expect(await getBidders()).toEqual(['ix', 'ozone']);
     });
 });

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
@@ -234,15 +234,12 @@ const requestBids = async (
         return requestQueue;
     }
 
-    const adUnits: Array<PrebidAdUnit> = getHeaderBiddingAdSlots(
-        advert,
-        slotFlatMap
-    )
-        .map(slot => {
-            const prebidAdUnit = new PrebidAdUnit(advert, slot);
-            return prebidAdUnit.build(advert, slot);
-        })
-        .filter(adUnit => !adUnit.isEmpty());
+    const adUnits: Array<PrebidAdUnit> = (await Promise.all(
+        getHeaderBiddingAdSlots(advert, slotFlatMap).map(
+            // eslint-disable-next-line new-cap
+            async slot => new PrebidAdUnit.build(advert, slot)
+        )
+    )).filter(adUnit => !adUnit.isEmpty());
 
     if (adUnits.length === 0) {
         return requestQueue;

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
@@ -103,6 +103,7 @@ class PrebidAdUnit {
 
     constructor(advert: Advert, slot: HeaderBiddingSlot) {
         this.code = advert.id;
+        // How to make a constructor Async? 2020-10-23
         this.bids = bids(advert.id, slot.sizes);
         this.mediaTypes = { banner: { sizes: slot.sizes } };
     }

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/types.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/types.js
@@ -86,7 +86,7 @@ export type PrebidBidder = {
     bidParams: (
         slotId: string,
         sizes: HeaderBiddingSize[]
-    ) =>
+    ) => Promise<
         | PrebidSonobiParams
         | PrebidIndexExchangeParams
         | PrebidTrustXParams
@@ -97,7 +97,8 @@ export type PrebidBidder = {
         | PrebidOpenXParams
         | PrebidOzoneParams
         | PrebidAdYouLikeParams
-        | PrebidPubmaticParams,
+        | PrebidPubmaticParams
+    >,
 };
 
 export type PrebidBid = {

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -128,7 +128,7 @@ const onPlayerReadyEvent = (event, handlers: Handlers, el: ?HTMLElement) => {
     }
 };
 
-const createAdsConfig = (
+const createAdsConfig = async (
     adFree: boolean,
     tcfStateFlag: boolean | null,
     ccpaStateFlag: boolean | null
@@ -137,7 +137,7 @@ const createAdsConfig = (
         return { disableAds: true };
     }
 
-    const custParams = getPageTargeting();
+    const custParams = await getPageTargeting();
     custParams.permutive = getPermutivePFPSegments();
 
     const adsConfig: AdsConfig = {

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.js
@@ -2,7 +2,7 @@
 import { _ as youtubePlayer } from 'common/modules/atoms/youtube-player';
 
 jest.mock('common/modules/commercial/build-page-targeting', () => ({
-    getPageTargeting: jest.fn(() => ({ key: 'value' })),
+    getPageTargeting: jest.fn(() => (Promise.resolve({ key: 'value' }))),
 }));
 
 jest.mock('common/modules/commercial/permutive', () => ({
@@ -38,8 +38,8 @@ jest.mock('common/modules/experiments/ab', () => ({
 }));
 
 describe('create ads config', () => {
-    it('disables ads in ad-free', () => {
-        const result = youtubePlayer.createAdsConfig(
+    it('disables ads in ad-free', async () => {
+        const result = await youtubePlayer.createAdsConfig(
             true, // ad-free
             null,
             null
@@ -48,14 +48,14 @@ describe('create ads config', () => {
         expect(result.disableAds).toBeTruthy();
     });
 
-    it('does not disable ads when we are not in ad-free', () => {
-        const result = youtubePlayer.createAdsConfig(false, null, null);
+    it('does not disable ads when we are not in ad-free', async () => {
+        const result = await youtubePlayer.createAdsConfig(false, null, null);
 
         expect(result.disableAds).toBeFalsy();
     });
 
-    it('in non ad-free, returns false nonPersonalizedAd without consent in TCF', () => {
-        const result = youtubePlayer.createAdsConfig(false, false, null);
+    it('in non ad-free, returns false nonPersonalizedAd without consent in TCF', async () => {
+        const result = await youtubePlayer.createAdsConfig(false, false, null);
 
         if (result.hasOwnProperty('nonPersonalizedAd')) {
             expect(result.nonPersonalizedAd).toBeTruthy();
@@ -96,8 +96,8 @@ describe('create ads config', () => {
         expect(result.nonPersonalizedAd).toBeUndefined();
     });
 
-    it('in non ad-free includes adUnit', () => {
-        const result = youtubePlayer.createAdsConfig(false, null, null);
+    it('in non ad-free includes adUnit', async () => {
+        const result = await youtubePlayer.createAdsConfig(false, null, null);
 
         expect(result.adTagParameters).toBeDefined();
         if (result.adTagParameters) {
@@ -105,8 +105,8 @@ describe('create ads config', () => {
         }
     });
 
-    it('in non ad-free includes url-escaped and tcfv2 targeting params', () => {
-        const result = youtubePlayer.createAdsConfig(false, null, null);
+    it('in non ad-free includes url-escaped and tcfv2 targeting params', async () => {
+        const result = await youtubePlayer.createAdsConfig(false, null, null);
         const expectedAdTargetingParams =  {
             "cmpGdpr": 1,
             "cmpGvcd": "testaddtlConsent",

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -71,7 +71,7 @@ const inskinTargetting = async (): Promise<string> => {
         return 'f';
     }
     const willShowPrivacyMessage: boolean = await cmp.willShowPrivacyMessage();
-    return willShowPrivacyMessage ? 't' : 'f';
+    return willShowPrivacyMessage ? 'f' : 't';
 };
 
 const format = (keyword: string): string =>

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -65,7 +65,7 @@ const findBreakpoint = (): string => {
     }
 };
 
-const inskinTargetting = async (): string => {
+const inskinTargetting = async (): Promise<string> => {
     const vp = getViewport();
     const willShowPrivacyMessage: boolean = await cmp.willShowPrivacyMessage();
     return vp && vp.width >= 1560 && willShowPrivacyMessage ? 't' : 'f';

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -303,8 +303,8 @@ const buildPageTargetting = async (
     return Promise.resolve(pageTargeting);
 };
 
-const getPageTargeting = (): { [key: string]: mixed } => {
-    if (Object.keys(myPageTargetting).length !== 0) return myPageTargetting;
+const getPageTargeting = async (): Promise<{ [key: string]: mixed }> => {
+    if (Object.keys(myPageTargetting).length !== 0) return Promise.resolve(myPageTargetting);
 
     let resolveOnConsentChange;
     const pageTargetingPromise = new Promise(resolve => {

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -303,8 +303,13 @@ const buildPageTargetting = async (
     return pageTargeting;
 };
 
-const getPageTargeting = (): { [key: string]: mixed } => {
+const getPageTargeting = async (): { [key: string]: mixed } => {
     if (Object.keys(myPageTargetting).length !== 0) return myPageTargetting;
+
+    let resolveOnConsentChange: typeof Promise.resolve;
+    const pageTargetingPromise = new Promise(resolve => {
+        resolveOnConsentChange = resolve;
+    });
 
     onConsentChange(async state => {
         let canRun: boolean | null;
@@ -330,11 +335,12 @@ const getPageTargeting = (): { [key: string]: mixed } => {
                 ccpaState,
                 eventStatus
             );
+            resolveOnConsentChange(myPageTargetting);
             latestConsentCanRun = canRun;
         }
     });
 
-    return myPageTargetting;
+    return pageTargetingPromise;
 };
 
 const resetPageTargeting = (): void => {

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -322,7 +322,7 @@ const getPageTargeting = async (): Promise<PageTargettingLoose> =>
 
             const ccpaState = state.ccpa ? state.ccpa.doNotSell : null;
             const eventStatus = state.tcfv2 ? state.tcfv2.eventStatus : 'na';
-            resolve(await buildPageTargetting(canRun, ccpaState, eventStatus));
+            resolve(buildPageTargetting(canRun, ccpaState, eventStatus));
         });
     });
 

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -307,7 +307,7 @@ const buildPageTargetting = async (
 
 const getPageTargeting = async (): Promise<PageTargettingLoose> => {
     if (Object.keys(myPageTargetting).length !== 0)
-        return Promise.resolve(myPageTargetting);
+        return myPageTargetting;
 
     let resolveOnConsentChange;
     const pageTargetingPromise: Promise<PageTargettingLoose> = new Promise(

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -11,7 +11,7 @@ import { storage } from '@guardian/libs';
 import { getUrlVars } from 'lib/url';
 import { getPrivacyFramework } from 'lib/getPrivacyFramework';
 import { cmp } from '@guardian/consent-management-platform';
-import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
+import type { ConsentState } from '@guardian/consent-management-platform/dist/types/index.js.flow';
 import {
     getPermutiveSegments,
     clearPermutiveSegments,

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -67,8 +67,11 @@ const findBreakpoint = (): string => {
 
 const inskinTargetting = async (): Promise<string> => {
     const vp = getViewport();
+    if (vp && vp.width < 1560) {
+        return 'f';
+    }
     const willShowPrivacyMessage: boolean = await cmp.willShowPrivacyMessage();
-    return vp && vp.width >= 1560 && willShowPrivacyMessage ? 't' : 'f';
+    return willShowPrivacyMessage ? 't' : 'f';
 };
 
 const format = (keyword: string): string =>

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -302,12 +302,11 @@ const buildPageTargetting = async (
     // This can be removed once we get sign-off from third parties who prefer to use appNexusPageTargeting.
     page.pageAdTargeting = pageTargeting;
 
-    return Promise.resolve(pageTargeting);
+    return pageTargeting;
 };
 
 const getPageTargeting = async (): Promise<PageTargettingLoose> => {
-    if (Object.keys(myPageTargetting).length !== 0)
-        return myPageTargetting;
+    if (Object.keys(myPageTargetting).length !== 0) return myPageTargetting;
 
     let resolveOnConsentChange;
     const pageTargetingPromise: Promise<PageTargettingLoose> = new Promise(

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -303,7 +303,7 @@ const buildPageTargetting = async (
     return Promise.resolve(pageTargeting);
 };
 
-const getPageTargeting = async (): { [key: string]: mixed } => {
+const getPageTargeting = (): { [key: string]: mixed } => {
     if (Object.keys(myPageTargetting).length !== 0) return myPageTargetting;
 
     let resolveOnConsentChange;

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -237,7 +237,7 @@ const buildPageTargetting = async (
     adConsentState: boolean | null,
     ccpaState: boolean | null,
     tcfv2EventStatus: string | null
-): { [key: string]: mixed } => {
+): Promise<{ [key: string]: mixed }> => {
     const page = config.get('page');
     // personalised ads targeting
     if (adConsentState === false) clearPermutiveSegments();
@@ -300,7 +300,7 @@ const buildPageTargetting = async (
     // This can be removed once we get sign-off from third parties who prefer to use appNexusPageTargeting.
     page.pageAdTargeting = pageTargeting;
 
-    return pageTargeting;
+    return Promise.resolve(pageTargeting);
 };
 
 const getPageTargeting = async (): { [key: string]: mixed } => {

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -47,7 +47,6 @@ type PageTargeting = {
 type PageTargettingLoose = { [key: string]: mixed };
 
 let myPageTargetting: {} = {};
-let latestConsentCanRun;
 
 const findBreakpoint = (): string => {
     switch (getBreakpoint(true)) {
@@ -307,9 +306,6 @@ const buildPageTargetting = async (
 
 const getPageTargeting = async (): Promise<PageTargettingLoose> =>
     new Promise(resolve => {
-        if (Object.keys(myPageTargetting).length !== 0)
-            return resolve(myPageTargetting);
-
         onConsentChange(async state => {
             let canRun: boolean | null;
             if (state.ccpa) {
@@ -326,25 +322,19 @@ const getPageTargeting = async (): Promise<PageTargettingLoose> =>
                 canRun = state.aus.personalisedAdvertising;
             } else canRun = false;
 
-            if (canRun !== latestConsentCanRun) {
-                const ccpaState = state.ccpa ? state.ccpa.doNotSell : null;
-                const eventStatus = state.tcfv2
-                    ? state.tcfv2.eventStatus
-                    : 'na';
-                myPageTargetting = await buildPageTargetting(
-                    canRun,
-                    ccpaState,
-                    eventStatus
-                );
-                latestConsentCanRun = canRun;
-                resolve(myPageTargetting);
-            }
+            const ccpaState = state.ccpa ? state.ccpa.doNotSell : null;
+            const eventStatus = state.tcfv2 ? state.tcfv2.eventStatus : 'na';
+            myPageTargetting = await buildPageTargetting(
+                canRun,
+                ccpaState,
+                eventStatus
+            );
+            resolve(myPageTargetting);
         });
     });
 
 const resetPageTargeting = (): void => {
     myPageTargetting = {};
-    latestConsentCanRun = undefined;
 };
 
 export {

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -306,7 +306,7 @@ const buildPageTargetting = async (
 const getPageTargeting = async (): { [key: string]: mixed } => {
     if (Object.keys(myPageTargetting).length !== 0) return myPageTargetting;
 
-    let resolveOnConsentChange: typeof Promise.resolve;
+    let resolveOnConsentChange;
     const pageTargetingPromise = new Promise(resolve => {
         resolveOnConsentChange = resolve;
     });

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -46,8 +46,6 @@ type PageTargeting = {
 
 type PageTargettingLoose = { [key: string]: mixed };
 
-let myPageTargetting: {} = {};
-
 const findBreakpoint = (): string => {
     switch (getBreakpoint(true)) {
         case 'mobile':
@@ -324,25 +322,12 @@ const getPageTargeting = async (): Promise<PageTargettingLoose> =>
 
             const ccpaState = state.ccpa ? state.ccpa.doNotSell : null;
             const eventStatus = state.tcfv2 ? state.tcfv2.eventStatus : 'na';
-            myPageTargetting = await buildPageTargetting(
-                canRun,
-                ccpaState,
-                eventStatus
-            );
-            resolve(myPageTargetting);
+            resolve(await buildPageTargetting(canRun, ccpaState, eventStatus));
         });
     });
-
-const resetPageTargeting = (): void => {
-    myPageTargetting = {};
-};
 
 export {
     getPageTargeting,
     buildAppNexusTargeting,
     buildAppNexusTargetingObject,
-};
-
-export const _ = {
-    resetPageTargeting,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -44,6 +44,8 @@ type PageTargeting = {
     urlkw: string,
 };
 
+type PageTargettingLoose = { [key: string]: mixed };
+
 let myPageTargetting: {} = {};
 let latestConsentCanRun;
 
@@ -237,7 +239,7 @@ const buildPageTargetting = async (
     adConsentState: boolean | null,
     ccpaState: boolean | null,
     tcfv2EventStatus: string | null
-): Promise<{ [key: string]: mixed }> => {
+): Promise<PageTargettingLoose> => {
     const page = config.get('page');
     // personalised ads targeting
     if (adConsentState === false) clearPermutiveSegments();
@@ -287,7 +289,7 @@ const buildPageTargetting = async (
     );
 
     // filter out empty values
-    const pageTargeting: {} = pickBy(pageTargets, target => {
+    const pageTargeting: PageTargettingLoose = pickBy(pageTargets, target => {
         if (Array.isArray(target)) {
             return target.length > 0;
         }
@@ -303,13 +305,16 @@ const buildPageTargetting = async (
     return Promise.resolve(pageTargeting);
 };
 
-const getPageTargeting = async (): Promise<{ [key: string]: mixed }> => {
-    if (Object.keys(myPageTargetting).length !== 0) return Promise.resolve(myPageTargetting);
+const getPageTargeting = async (): Promise<PageTargettingLoose> => {
+    if (Object.keys(myPageTargetting).length !== 0)
+        return Promise.resolve(myPageTargetting);
 
     let resolveOnConsentChange;
-    const pageTargetingPromise = new Promise(resolve => {
-        resolveOnConsentChange = resolve;
-    });
+    const pageTargetingPromise: Promise<PageTargettingLoose> = new Promise(
+        resolve => {
+            resolveOnConsentChange = resolve;
+        }
+    );
 
     onConsentChange(async state => {
         let canRun: boolean | null;

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -437,14 +437,15 @@ describe('Build Page Targeting', () => {
     });
 
     describe('URL Keywords', () => {
-        it('should return correct keywords from pageId', () => {
-            expect(getPageTargeting().urlkw).toEqual(['footballweekly']);
+        it('should return correct keywords from pageId', async() => {
+            const pageTargeting = await getPageTargeting();
+            expect(pageTargeting.urlkw).toEqual(['footballweekly']);
         });
 
-        it('should extract multiple url keywords correctly', () => {
+        it('should extract multiple url keywords correctly', async () => {
             config.page.pageId =
                 'stage/2016/jul/26/harry-potter-cursed-child-review-palace-theatre-london';
-            expect(getPageTargeting().urlkw).toEqual([
+            expect((await getPageTargeting()).urlkw).toEqual([
                 'harry',
                 'potter',
                 'cursed',
@@ -456,10 +457,10 @@ describe('Build Page Targeting', () => {
             ]);
         });
 
-        it('should get correct keywords when trailing slash is present',  () => {
+        it('should get correct keywords when trailing slash is present',  async () => {
             config.page.pageId =
                 'stage/2016/jul/26/harry-potter-cursed-child-review-palace-theatre-london/';
-            expect(getPageTargeting().urlkw).toEqual([
+            expect((await getPageTargeting()).urlkw).toEqual([
                 'harry',
                 'potter',
                 'cursed',

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -335,6 +335,7 @@ describe('Build Page Targeting', () => {
     });
 
     describe('Breakpoint targeting', () => {
+<<<<<<< HEAD
         it('should set correct breakpoint targeting for a mobile device', async () => {
             getBreakpoint.mockReturnValue('mobile');
             expect((await getPageTargeting()).bp).toEqual('mobile');
@@ -374,6 +375,25 @@ describe('Build Page Targeting', () => {
             getBreakpoint.mockReturnValue('wide');
             expect((await getPageTargeting()).bp).toEqual('desktop');
         });
+=======
+        // $FlowFixMe -- it.each does not have a type
+        it.each([
+            ['mobile', 'mobile'],
+            ['mobileMedium', 'mobile'],
+            ['mobileLandscape', 'mobile'],
+            ['phablet', 'tablet'],
+            ['tablet', 'tablet'],
+            ['desktop', 'desktop'],
+            ['leftCol', 'desktop'],
+            ['wide', 'desktop'],
+        ])(
+            'should set correct breakpoint targetting for a %s device (%s)',
+            async (mock, value) => {
+                getBreakpoint.mockReturnValue(mock);
+                expect((await getPageTargeting()).bp).toEqual(value);
+            }
+        );
+>>>>>>> 41c00d142c... ignore missing Jest flow types
     });
 
     describe('Build Page Targeting (ad-free)', () => {
@@ -406,6 +426,7 @@ describe('Build Page Targeting', () => {
     });
 
     describe('Referrer', () => {
+<<<<<<< HEAD
         it('should set ref to Facebook', async () => {
             getReferrer.mockReturnValue(
                 'https://www.facebook.com/feel-the-force'
@@ -432,6 +453,23 @@ describe('Build Page Targeting', () => {
                 'https://www.google.com/i-find-your-lack-of-faith-distrubing'
             );
             expect((await getPageTargeting()).ref).toEqual('google');
+=======
+        // $FlowFixMe -- it.each does not have a type
+        it.each([
+            ['facebook', 'https://www.facebook.com/feel-the-force'],
+            [
+                'twitter',
+                'https://www.t.co/you-must-unlearn-what-you-have-learned',
+            ],
+            ['reddit', 'https://www.reddit.com/its-not-my-fault'],
+            [
+                'google',
+                'https://www.google.com/i-find-your-lack-of-faith-distrubing',
+            ],
+        ])('should set ref to %s', async (ref, url) => {
+            getReferrer.mockReturnValue(url);
+            expect((await getPageTargeting()).ref).toEqual(ref);
+>>>>>>> 41c00d142c... ignore missing Jest flow types
         });
 
         it('should set ref empty string if referrer does not match', async () => {

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -17,7 +17,7 @@ import { getPrivacyFramework as getPrivacyFramework_ } from 'lib/getPrivacyFrame
 import { isUserLoggedIn as isUserLoggedIn_ } from 'common/modules/identity/api';
 import { getUserSegments as getUserSegments_ } from 'common/modules/commercial/user-ad-targeting';
 import { getSynchronousParticipations as getSynchronousParticipations_ } from 'common/modules/experiments/ab';
-import { onConsentChange } from '@guardian/consent-management-platform';
+import {cmp, onConsentChange} from '@guardian/consent-management-platform';
 
 const getCookie: any = getCookie_;
 const getUserSegments: any = getUserSegments_;
@@ -59,6 +59,9 @@ jest.mock('common/modules/commercial/commercial-features', () => ({
 }));
 jest.mock('@guardian/consent-management-platform', () => ({
     onConsentChange: jest.fn(),
+    cmp: {
+        willShowPrivacyMessage: jest.fn(),
+    },
 }));
 
 // TCFv1
@@ -156,6 +159,7 @@ describe('Build Page Targeting', () => {
 
         getSync.mockReturnValue('US');
         getPrivacyFramework.mockReturnValue({ ccpa: true });
+        cmp.willShowPrivacyMessage.mockResolvedValue(true);
 
         expect.hasAssertions();
     });
@@ -452,7 +456,7 @@ describe('Build Page Targeting', () => {
             ]);
         });
 
-        it('should get correct keywords when trailing slash is present', () => {
+        it('should get correct keywords when trailing slash is present',  () => {
             config.page.pageId =
                 'stage/2016/jul/26/harry-potter-cursed-child-review-palace-theatre-london/';
             expect(getPageTargeting().urlkw).toEqual([

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -335,7 +335,6 @@ describe('Build Page Targeting', () => {
     });
 
     describe('Breakpoint targeting', () => {
-<<<<<<< HEAD
         it('should set correct breakpoint targeting for a mobile device', async () => {
             getBreakpoint.mockReturnValue('mobile');
             expect((await getPageTargeting()).bp).toEqual('mobile');
@@ -375,25 +374,6 @@ describe('Build Page Targeting', () => {
             getBreakpoint.mockReturnValue('wide');
             expect((await getPageTargeting()).bp).toEqual('desktop');
         });
-=======
-        // $FlowFixMe -- it.each does not have a type
-        it.each([
-            ['mobile', 'mobile'],
-            ['mobileMedium', 'mobile'],
-            ['mobileLandscape', 'mobile'],
-            ['phablet', 'tablet'],
-            ['tablet', 'tablet'],
-            ['desktop', 'desktop'],
-            ['leftCol', 'desktop'],
-            ['wide', 'desktop'],
-        ])(
-            'should set correct breakpoint targetting for a %s device (%s)',
-            async (mock, value) => {
-                getBreakpoint.mockReturnValue(mock);
-                expect((await getPageTargeting()).bp).toEqual(value);
-            }
-        );
->>>>>>> 41c00d142c... ignore missing Jest flow types
     });
 
     describe('Build Page Targeting (ad-free)', () => {
@@ -426,7 +406,6 @@ describe('Build Page Targeting', () => {
     });
 
     describe('Referrer', () => {
-<<<<<<< HEAD
         it('should set ref to Facebook', async () => {
             getReferrer.mockReturnValue(
                 'https://www.facebook.com/feel-the-force'
@@ -453,23 +432,6 @@ describe('Build Page Targeting', () => {
                 'https://www.google.com/i-find-your-lack-of-faith-distrubing'
             );
             expect((await getPageTargeting()).ref).toEqual('google');
-=======
-        // $FlowFixMe -- it.each does not have a type
-        it.each([
-            ['facebook', 'https://www.facebook.com/feel-the-force'],
-            [
-                'twitter',
-                'https://www.t.co/you-must-unlearn-what-you-have-learned',
-            ],
-            ['reddit', 'https://www.reddit.com/its-not-my-fault'],
-            [
-                'google',
-                'https://www.google.com/i-find-your-lack-of-faith-distrubing',
-            ],
-        ])('should set ref to %s', async (ref, url) => {
-            getReferrer.mockReturnValue(url);
-            expect((await getPageTargeting()).ref).toEqual(ref);
->>>>>>> 41c00d142c... ignore missing Jest flow types
         });
 
         it('should set ref empty string if referrer does not match', async () => {

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -102,7 +102,7 @@ const tcfv2MixedConsentMock = (callback): void =>
     });
 
 describe('Build Page Targeting', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
         config.page = {
             authorIds: 'profile/gabrielle-chan',
             blogIds: 'a/blog',
@@ -172,8 +172,8 @@ describe('Build Page Targeting', () => {
         expect(getPageTargeting).toBeDefined();
     });
 
-    it('should build correct page targeting', () => {
-        const pageTargeting = getPageTargeting();
+    it('should build correct page targeting', async () => {
+        const pageTargeting = await getPageTargeting();
 
         expect(pageTargeting.sens).toBe('f');
         expect(pageTargeting.edition).toBe('us');
@@ -195,123 +195,127 @@ describe('Build Page Targeting', () => {
         expect(pageTargeting.rp).toEqual('dotcom-platform');
     });
 
-    it('should set correct personalized ad (pa) param', () => {
+    it('should set correct personalized ad (pa) param', async () => {
         onConsentChange.mockImplementation(tcfv2WithConsentMock);
-        expect(getPageTargeting().pa).toBe('t');
+        expect((await getPageTargeting()).pa).toBe('t');
 
         _.resetPageTargeting();
         onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
-        expect(getPageTargeting().pa).toBe('f');
+        expect((await getPageTargeting()).pa).toBe('f');
 
         _.resetPageTargeting();
         onConsentChange.mockImplementation(tcfv2NullConsentMock);
-        expect(getPageTargeting().pa).toBe('f');
+        expect((await getPageTargeting()).pa).toBe('f');
 
         _.resetPageTargeting();
         onConsentChange.mockImplementation(tcfv2MixedConsentMock);
-        expect(getPageTargeting().pa).toBe('f');
+        expect((await getPageTargeting()).pa).toBe('f');
 
         _.resetPageTargeting();
         onConsentChange.mockImplementation(ccpaWithConsentMock);
-        expect(getPageTargeting().pa).toBe('t');
+        expect((await getPageTargeting()).pa).toBe('t');
 
         _.resetPageTargeting();
         onConsentChange.mockImplementation(ccpaWithoutConsentMock);
-        expect(getPageTargeting().pa).toBe('f');
+        expect((await getPageTargeting()).pa).toBe('f');
     });
 
-    it('Should correctly set the RDP flag (rdp) param', () => {
+    it('Should correctly set the RDP flag (rdp) param', async () => {
         onConsentChange.mockImplementation(tcfWithConsentMock);
-        expect(getPageTargeting().rdp).toBe('na');
+        expect((await getPageTargeting()).rdp).toBe('na');
 
         _.resetPageTargeting();
         onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
-        expect(getPageTargeting().rdp).toBe('na');
+        expect((await getPageTargeting()).rdp).toBe('na');
 
         _.resetPageTargeting();
         onConsentChange.mockImplementation(tcfv2NullConsentMock);
-        expect(getPageTargeting().rdp).toBe('na');
+        expect((await getPageTargeting()).rdp).toBe('na');
 
         _.resetPageTargeting();
         onConsentChange.mockImplementation(tcfMixedConsentMock);
-        expect(getPageTargeting().rdp).toBe('na');
+        expect((await getPageTargeting()).rdp).toBe('na');
 
         _.resetPageTargeting();
         onConsentChange.mockImplementation(ccpaWithConsentMock);
-        expect(getPageTargeting().rdp).toBe('f');
+        expect((await getPageTargeting()).rdp).toBe('f');
 
         _.resetPageTargeting();
         onConsentChange.mockImplementation(ccpaWithoutConsentMock);
-        expect(getPageTargeting().rdp).toBe('t');
+        expect((await getPageTargeting()).rdp).toBe('t');
     });
 
-    it('Should correctly set the TCFv2 (consent_tcfv2, cmp_interaction) params', () => {
+    it('Should correctly set the TCFv2 (consent_tcfv2, cmp_interaction) params', async () => {
         _.resetPageTargeting();
         getPrivacyFramework.mockReturnValue({ tcfv2: true });
 
         onConsentChange.mockImplementation(tcfv2WithConsentMock);
 
-        expect(getPageTargeting().consent_tcfv2).toBe('t');
-        expect(getPageTargeting().cmp_interaction).toBe('useractioncomplete');
+        expect((await getPageTargeting()).consent_tcfv2).toBe('t');
+        expect((await getPageTargeting()).cmp_interaction).toBe(
+            'useractioncomplete'
+        );
 
         _.resetPageTargeting();
         onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
 
-        expect(getPageTargeting().consent_tcfv2).toBe('f');
-        expect(getPageTargeting().cmp_interaction).toBe('cmpuishown');
+        expect((await getPageTargeting()).consent_tcfv2).toBe('f');
+        expect((await getPageTargeting()).cmp_interaction).toBe('cmpuishown');
 
         _.resetPageTargeting();
         onConsentChange.mockImplementation(tcfv2MixedConsentMock);
 
-        expect(getPageTargeting().consent_tcfv2).toBe('f');
-        expect(getPageTargeting().cmp_interaction).toBe('useractioncomplete');
+        expect((await getPageTargeting()).consent_tcfv2).toBe('f');
+        expect((await getPageTargeting()).cmp_interaction).toBe(
+            'useractioncomplete'
+        );
 
         _.resetPageTargeting();
         getPrivacyFramework.mockReturnValue({ tcfv1: true });
         onConsentChange.mockImplementation(tcfWithConsentMock);
 
-        expect(getPageTargeting().consent_tcfv2).toBe('na');
-        expect(getPageTargeting().cmp_interaction).toBe('na');
+        expect((await getPageTargeting()).consent_tcfv2).toBe('na');
+        expect((await getPageTargeting()).cmp_interaction).toBe('na');
     });
 
-    it('should set correct edition param', () => {
-        expect(getPageTargeting().edition).toBe('us');
+    it('should set correct edition param', async () => {
+        expect((await getPageTargeting()).edition).toBe('us');
     });
 
-    it('should set correct se param', () => {
-        expect(getPageTargeting().se).toEqual(['filmweekly']);
+    it('should set correct se param', async () => {
+        expect((await getPageTargeting()).se).toEqual(['filmweekly']);
     });
 
-    it('should set correct k param', () => {
-        expect(getPageTargeting().k).toEqual([
+    it('should set correct k param', async () => {
+        expect((await getPageTargeting()).k).toEqual([
             'prince-charles-letters',
             'uk/uk',
             'prince-charles',
         ]);
     });
 
-    it('should set correct ab param', () => {
-        expect(getPageTargeting().ab).toEqual(['MtMaster-variantName']);
+    it('should set correct ab param', async () => {
+        expect((await getPageTargeting()).ab).toEqual(['MtMaster-variantName']);
     });
 
-    it('should set Observer flag for Observer content', () => {
-        expect(getPageTargeting().ob).toEqual('t');
+    it('should set Observer flag for Observer content', async () => {
+        expect((await getPageTargeting()).ob).toEqual('t');
     });
 
-    it('should set correct branding param for paid content', () => {
-        expect(getPageTargeting().br).toEqual('p');
+    it('should set correct branding param for paid content', async () => {
+        expect((await getPageTargeting()).br).toEqual('p');
     });
 
-    it('should not contain an ad-free targeting value', () => {
-        expect(getPageTargeting().af).toBeUndefined();
+    it('should not contain an ad-free targeting value', async () => {
+        expect((await getPageTargeting()).af).toBeUndefined();
     });
 
-    it('should remove empty values', () => {
+    it('should remove empty values', async () => {
         config.page = {};
         config.ophan = { pageViewId: '123456' };
         getUserSegments.mockReturnValue([]);
 
-        expect(getPageTargeting()).toEqual({
+        expect(await getPageTargeting()).toEqual({
             sens: 'f',
             bp: 'mobile',
             at: 'ng101',
@@ -331,108 +335,108 @@ describe('Build Page Targeting', () => {
     });
 
     describe('Breakpoint targeting', () => {
-        it('should set correct breakpoint targeting for a mobile device', () => {
+        it('should set correct breakpoint targeting for a mobile device', async () => {
             getBreakpoint.mockReturnValue('mobile');
-            expect(getPageTargeting().bp).toEqual('mobile');
+            expect((await getPageTargeting()).bp).toEqual('mobile');
         });
 
-        it('should set correct breakpoint targeting for a medium mobile device', () => {
+        it('should set correct breakpoint targeting for a medium mobile device', async () => {
             getBreakpoint.mockReturnValue('mobileMedium');
-            expect(getPageTargeting().bp).toEqual('mobile');
+            expect((await getPageTargeting()).bp).toEqual('mobile');
         });
 
-        it('should set correct breakpoint targeting for a mobile device in landscape mode', () => {
+        it('should set correct breakpoint targeting for a mobile device in landscape mode', async () => {
             getBreakpoint.mockReturnValue('mobileLandscape');
-            expect(getPageTargeting().bp).toEqual('mobile');
+            expect((await getPageTargeting()).bp).toEqual('mobile');
         });
 
-        it('should set correct breakpoint targeting for a phablet device', () => {
+        it('should set correct breakpoint targeting for a phablet device', async () => {
             getBreakpoint.mockReturnValue('phablet');
-            expect(getPageTargeting().bp).toEqual('tablet');
+            expect((await getPageTargeting()).bp).toEqual('tablet');
         });
 
-        it('should set correct breakpoint targeting for a tablet device', () => {
+        it('should set correct breakpoint targeting for a tablet device', async () => {
             getBreakpoint.mockReturnValue('tablet');
-            expect(getPageTargeting().bp).toEqual('tablet');
+            expect((await getPageTargeting()).bp).toEqual('tablet');
         });
 
-        it('should set correct breakpoint targeting for a desktop device', () => {
+        it('should set correct breakpoint targeting for a desktop device', async () => {
             getBreakpoint.mockReturnValue('desktop');
-            expect(getPageTargeting().bp).toEqual('desktop');
+            expect((await getPageTargeting()).bp).toEqual('desktop');
         });
 
-        it('should set correct breakpoint targeting for a leftCol device', () => {
+        it('should set correct breakpoint targeting for a leftCol device', async () => {
             getBreakpoint.mockReturnValue('leftCol');
-            expect(getPageTargeting().bp).toEqual('desktop');
+            expect((await getPageTargeting()).bp).toEqual('desktop');
         });
 
-        it('should set correct breakpoint targeting for a wide device', () => {
+        it('should set correct breakpoint targeting for a wide device', async () => {
             getBreakpoint.mockReturnValue('wide');
-            expect(getPageTargeting().bp).toEqual('desktop');
+            expect((await getPageTargeting()).bp).toEqual('desktop');
         });
     });
 
     describe('Build Page Targeting (ad-free)', () => {
-        it('should set the ad-free param to t when enabled', () => {
+        it('should set the ad-free param to t when enabled', async () => {
             commercialFeatures.adFree = true;
-            expect(getPageTargeting().af).toBe('t');
+            expect((await getPageTargeting()).af).toBe('t');
         });
     });
 
     describe('Already visited frequency', () => {
-        it('can pass a value of five or less', () => {
+        it('can pass a value of five or less', async () => {
             storage.local.setRaw('gu.alreadyVisited', 5);
-            expect(getPageTargeting().fr).toEqual('5');
+            expect((await getPageTargeting()).fr).toEqual('5');
         });
 
-        it('between five and thirty, includes it in a bucket in the form "x-y"', () => {
+        it('between five and thirty, includes it in a bucket in the form "x-y"', async () => {
             storage.local.setRaw('gu.alreadyVisited', 18);
-            expect(getPageTargeting().fr).toEqual('16-19');
+            expect((await getPageTargeting()).fr).toEqual('16-19');
         });
 
-        it('over thirty, includes it in the bucket "30plus"', () => {
+        it('over thirty, includes it in the bucket "30plus"', async () => {
             storage.local.setRaw('gu.alreadyVisited', 300);
-            expect(getPageTargeting().fr).toEqual('30plus');
+            expect((await getPageTargeting()).fr).toEqual('30plus');
         });
 
-        it('passes a value of 0 if the value is not stored', () => {
+        it('passes a value of 0 if the value is not stored', async () => {
             storage.local.remove('gu.alreadyVisited');
-            expect(getPageTargeting().fr).toEqual('0');
+            expect((await getPageTargeting()).fr).toEqual('0');
         });
     });
 
     describe('Referrer', () => {
-        it('should set ref to Facebook', () => {
+        it('should set ref to Facebook', async () => {
             getReferrer.mockReturnValue(
                 'https://www.facebook.com/feel-the-force'
             );
-            expect(getPageTargeting().ref).toEqual('facebook');
+            expect((await getPageTargeting()).ref).toEqual('facebook');
         });
 
-        it('should set ref to Twitter', () => {
+        it('should set ref to Twitter', async () => {
             getReferrer.mockReturnValue(
                 'https://www.t.co/you-must-unlearn-what-you-have-learned'
             );
-            expect(getPageTargeting().ref).toEqual('twitter');
+            expect((await getPageTargeting()).ref).toEqual('twitter');
         });
 
-        it('should set ref to reddit', () => {
+        it('should set ref to reddit', async () => {
             getReferrer.mockReturnValue(
                 'https://www.reddit.com/its-not-my-fault'
             );
-            expect(getPageTargeting().ref).toEqual('reddit');
+            expect((await getPageTargeting()).ref).toEqual('reddit');
         });
 
-        it('should set ref to google', () => {
+        it('should set ref to google', async () => {
             getReferrer.mockReturnValue(
                 'https://www.google.com/i-find-your-lack-of-faith-distrubing'
             );
-            expect(getPageTargeting().ref).toEqual('google');
+            expect((await getPageTargeting()).ref).toEqual('google');
         });
 
-        it('should set ref empty string if referrer does not match', () => {
+        it('should set ref empty string if referrer does not match', async () => {
             getReferrer.mockReturnValue('https://theguardian.com');
-            expect(getPageTargeting().ref).toEqual(undefined);
+            expect((await getPageTargeting()).ref).toEqual(undefined);
         });
     });
 

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -476,4 +476,28 @@ describe('Build Page Targeting', () => {
             ]);
         });
     });
+
+    describe('asynchronous setting', () => {
+        it('will return the targetting object on the first run', async () => {
+            _.resetPageTargeting();
+            onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
+
+            let myPageTargetting = await getPageTargeting();
+
+            expect(myPageTargetting.pv).toEqual('presetOphanPageViewId');
+            expect(myPageTargetting.pa).toEqual('f');
+            expect(myPageTargetting.rp).toEqual('dotcom-platform');
+            expect(myPageTargetting.edition).toEqual('us');
+
+            config.page.sharedAdTargeting.edition = 'au';
+            myPageTargetting = await getPageTargeting();
+
+            expect(myPageTargetting.edition).toEqual('au');
+            onConsentChange.mockImplementation(tcfv2WithConsentMock);
+            myPageTargetting = await getPageTargeting();
+
+            // Only when we change the consent will the targetting change
+            expect(myPageTargetting.edition).toEqual('au');
+        });
+    });
 });

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -2,10 +2,7 @@
 import { storage } from '@guardian/libs';
 
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
-import {
-    getPageTargeting,
-    _,
-} from 'common/modules/commercial/build-page-targeting';
+import { getPageTargeting } from 'common/modules/commercial/build-page-targeting';
 import config from 'lib/config';
 import { getCookie as getCookie_ } from 'lib/cookies';
 import {
@@ -139,7 +136,6 @@ describe('Build Page Targeting', () => {
 
         // Reset mocking to default values.
         getCookie.mockReturnValue('ng101');
-        _.resetPageTargeting();
         onConsentChange.mockImplementation(tcfv2NullConsentMock);
 
         getBreakpoint.mockReturnValue('mobile');
@@ -199,23 +195,18 @@ describe('Build Page Targeting', () => {
         onConsentChange.mockImplementation(tcfv2WithConsentMock);
         expect((await getPageTargeting()).pa).toBe('t');
 
-        _.resetPageTargeting();
         onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
         expect((await getPageTargeting()).pa).toBe('f');
 
-        _.resetPageTargeting();
         onConsentChange.mockImplementation(tcfv2NullConsentMock);
         expect((await getPageTargeting()).pa).toBe('f');
 
-        _.resetPageTargeting();
         onConsentChange.mockImplementation(tcfv2MixedConsentMock);
         expect((await getPageTargeting()).pa).toBe('f');
 
-        _.resetPageTargeting();
         onConsentChange.mockImplementation(ccpaWithConsentMock);
         expect((await getPageTargeting()).pa).toBe('t');
 
-        _.resetPageTargeting();
         onConsentChange.mockImplementation(ccpaWithoutConsentMock);
         expect((await getPageTargeting()).pa).toBe('f');
     });
@@ -224,29 +215,23 @@ describe('Build Page Targeting', () => {
         onConsentChange.mockImplementation(tcfWithConsentMock);
         expect((await getPageTargeting()).rdp).toBe('na');
 
-        _.resetPageTargeting();
         onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
         expect((await getPageTargeting()).rdp).toBe('na');
 
-        _.resetPageTargeting();
         onConsentChange.mockImplementation(tcfv2NullConsentMock);
         expect((await getPageTargeting()).rdp).toBe('na');
 
-        _.resetPageTargeting();
         onConsentChange.mockImplementation(tcfMixedConsentMock);
         expect((await getPageTargeting()).rdp).toBe('na');
 
-        _.resetPageTargeting();
         onConsentChange.mockImplementation(ccpaWithConsentMock);
         expect((await getPageTargeting()).rdp).toBe('f');
 
-        _.resetPageTargeting();
         onConsentChange.mockImplementation(ccpaWithoutConsentMock);
         expect((await getPageTargeting()).rdp).toBe('t');
     });
 
     it('Should correctly set the TCFv2 (consent_tcfv2, cmp_interaction) params', async () => {
-        _.resetPageTargeting();
         getPrivacyFramework.mockReturnValue({ tcfv2: true });
 
         onConsentChange.mockImplementation(tcfv2WithConsentMock);
@@ -256,13 +241,11 @@ describe('Build Page Targeting', () => {
             'useractioncomplete'
         );
 
-        _.resetPageTargeting();
         onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
 
         expect((await getPageTargeting()).consent_tcfv2).toBe('f');
         expect((await getPageTargeting()).cmp_interaction).toBe('cmpuishown');
 
-        _.resetPageTargeting();
         onConsentChange.mockImplementation(tcfv2MixedConsentMock);
 
         expect((await getPageTargeting()).consent_tcfv2).toBe('f');
@@ -270,7 +253,6 @@ describe('Build Page Targeting', () => {
             'useractioncomplete'
         );
 
-        _.resetPageTargeting();
         getPrivacyFramework.mockReturnValue({ tcfv1: true });
         onConsentChange.mockImplementation(tcfWithConsentMock);
 
@@ -479,7 +461,6 @@ describe('Build Page Targeting', () => {
 
     describe('asynchronous setting', () => {
         it('will return the targetting object on the first run', async () => {
-            _.resetPageTargeting();
             onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
 
             let myPageTargetting = await getPageTargeting();

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -17,7 +17,7 @@ import { getPrivacyFramework as getPrivacyFramework_ } from 'lib/getPrivacyFrame
 import { isUserLoggedIn as isUserLoggedIn_ } from 'common/modules/identity/api';
 import { getUserSegments as getUserSegments_ } from 'common/modules/commercial/user-ad-targeting';
 import { getSynchronousParticipations as getSynchronousParticipations_ } from 'common/modules/experiments/ab';
-import {cmp, onConsentChange} from '@guardian/consent-management-platform';
+import { cmp, onConsentChange } from '@guardian/consent-management-platform';
 
 const getCookie: any = getCookie_;
 const getUserSegments: any = getUserSegments_;
@@ -437,7 +437,7 @@ describe('Build Page Targeting', () => {
     });
 
     describe('URL Keywords', () => {
-        it('should return correct keywords from pageId', async() => {
+        it('should return correct keywords from pageId', async () => {
             const pageTargeting = await getPageTargeting();
             expect(pageTargeting.urlkw).toEqual(['footballweekly']);
         });
@@ -457,7 +457,7 @@ describe('Build Page Targeting', () => {
             ]);
         });
 
-        it('should get correct keywords when trailing slash is present',  async () => {
+        it('should get correct keywords when trailing slash is present', async () => {
             config.page.pageId =
                 'stage/2016/jul/26/harry-potter-cursed-child-review-palace-theatre-london/';
             expect((await getPageTargeting()).urlkw).toEqual([

--- a/yarn.lock
+++ b/yarn.lock
@@ -1758,10 +1758,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.9.0.tgz#2c578b61a6af99436abd83760d3349ef99d53ab8"
   integrity sha512-2o/au3c/SRUYrlPA1x6Rog6+UpXkSf6UrSX16lD19VaFyia60LaIXtBu9mkZNhSm0FWqfLSgync8RTCeCRG47w==
 
-"@guardian/consent-management-platform@6.7.4":
-  version "6.7.4"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.7.4.tgz#ae75775c40f8234a2e2774c126a688e9a98f5df4"
-  integrity sha512-f/XieB0dOyGYZDhP/UmyrHiyuehETt2L1GKqacsySFdcD/++fKe7LLcXbza4NE54MHyS0wbvd+Qh4avjG4IPLg==
+"@guardian/consent-management-platform@6.8.0":
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.8.0.tgz#295d5aaeb41bf46f02a4e124ef23908c92d728fe"
+  integrity sha512-z37UdPuH2cLGDfEmIH9koQWio0Tamvp53OJvkjP8Xiwcx5GlEqMxmBTYSeYc7eEXvGz2448cnVU7YDwCAjuiSQ==
 
 "@guardian/dotcom-rendering@git://github.com/guardian/dotcom-rendering.git#version-1-alpha":
   version "0.1.0-alpha"


### PR DESCRIPTION
## What does this change?

Co-authored-by: @mxdvl 

Depend on `willShowPrivacyMessage` to decide if an inskin should be shown. All the rest of the changes are for converting the `getPageTargeting` calls to asynchronous nature

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
