### PR TITLE
Bump DCR exposure to 90%

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -21,8 +21,10 @@ object DotcomRendering
       name = "dotcom-rendering",
       description = "Show DCR pages to users including those with comments",
       owners = Seq(Owner.withGithub("shtukas")),
-      sellByDate = new LocalDate(2020, 12, 1),
-      participationGroup = Perc50, // Also see ArticlePicker.scala - our main filter mechanism is by page features
+      sellByDate = new LocalDate(2021, 6, 1),
+      participationGroup = Perc10A, // Also see ArticlePicker.scala - our main filter mechanism is by page features
+      // Friday 20th Nov 2020: we are now showing DCR to users not participating (see: cea453f4-9b71-435e-8a11-35ef690c7821)
+      // This means that 90% of the audience is being exposed to DCR
     )
 
 object NGInteractiveDCR


### PR DESCRIPTION
## What does this change?

Bump DCR exposure to 90%. 

Currently DCR is being showed to users in the [variant] group of a 50% experiment. We cannot increase the share of variant. Instead we are going to show DCR to the non [variant] users ( namely [control] and [excluded] users ) while decreasing the variant to 10%. 

Note that we also limit DCR rendering to PROD and CODE. This is to acknowledge the reality that currently we can't access DCR from local or from the build servers and this "fixes" all the tests which currently rely on legacy rendering being the default renderer. 