### PR TITLE
Small refactorings

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -176,9 +176,9 @@ object ArticlePicker {
   }
 
   def dcrDisabled(request: RequestHeader): Boolean = {
-    val forceDCROff = request.forceDCROff
     val dcrEnabled = conf.switches.Switches.DotcomRendering.isSwitchedOn
-    forceDCROff || !dcrEnabled
+    val forceDCROff = request.forceDCROff
+    !dcrEnabled || forceDCROff
   }
 
   def getTier(page: PageWithStoryPackage)(implicit request: RequestHeader): RenderType = {

--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -168,8 +168,7 @@ object ArticlePicker {
         "isNotPaidContent",
       ),
     )
-    val isArticle100PercentPage = article100PercentPageFeatures.forall({ case (test, isMet) => isMet })
-    isArticle100PercentPage
+    article100PercentPageFeatures.forall({ case (test, isMet) => isMet })
   }
 
   def dcrForced(request: RequestHeader): Boolean = {

--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -153,11 +153,6 @@ object ArticlePicker {
     )
   }
 
-  def isInAllowList(path: String): Boolean = {
-    // our allow-list is only one article at the moment
-    path == "/info/2019/dec/08/migrating-the-guardian-website-to-react";
-  }
-
   def forall(features: Map[String, Boolean]): Boolean = {
     features.forall({ case (_, isMet) => isMet })
   }
@@ -178,7 +173,7 @@ object ArticlePicker {
   }
 
   def dcrForced(request: RequestHeader): Boolean = {
-    request.forceDCR || isInAllowList(request.path)
+    request.forceDCR
   }
 
   def dcrDisabled(request: RequestHeader): Boolean = {


### PR DESCRIPTION
## What does this change?

Small refactorings without change in behaviour just to simplify the way https://github.com/guardian/frontend/pull/23278 comes across.

1. Remove `isInAllowList`, which no longer fulfil any purpose.
2. Simplify `dcrArticle100PercentPage`
3. Make `dcrDisabled` more clear/intuitive
4. Rename `userInDCRTest` into `userInDCRGroup`