### PR TITLE
Undo "Revert "Remove Ophan Tracking Duplication in DCR Bundle""

### DIFF
--- a/static/src/javascripts/bootstraps/commercial-ophan.dcr.js
+++ b/static/src/javascripts/bootstraps/commercial-ophan.dcr.js
@@ -1,0 +1,40 @@
+// @flow strict
+// Monkey patch to facilitate the removal of ophan tracking from the commercial bundle sent to DCR.
+export default {
+    // $FlowFixMe
+    record: (value) => {
+        if (window && window.guardian && window.guardian.ophan && window.guardian.ophan.record)
+        {
+            window.guardian.ophan.record(value);
+        }
+    },
+    // $FlowFixMe
+    trackComponentAttention: (name, el, visibilityThreshhold) => {
+        if (window && window.guardian && window.guardian.ophan && window.guardian.ophan.trackComponentAttention)
+        {
+            window.guardian.ophan.trackComponentAttention(name,el,visibilityThreshhold);
+        }
+    },
+    // $FlowFixMe
+    setEventEmitter: (value) => {
+        if (window && window.guardian && window.guardian.ophan && window.guardian.ophan.setEventEmitter)
+        {
+            window.guardian.ophan.setEventEmitter(value);
+        }
+    },
+    viewId: (() => {
+        if (window && window.guardian && window.guardian.ophan && window.guardian.ophan.viewId)
+        {
+            return window.guardian.ophan.viewId;
+        }
+        return null;
+    })(),
+    pageViewId: (() => {
+        if (window && window.guardian && window.guardian.ophan && window.guardian.ophan.pageViewId)
+        {
+            return window.guardian.ophan.pageViewId;
+        }
+        return null;
+
+    })()
+};

--- a/webpack.config.dcr.js
+++ b/webpack.config.dcr.js
@@ -17,8 +17,14 @@ config.entry = {
     ),
 };
 
+// The Ophan alias removes duplicating the js in the commercial bundle sent to DCR.
 module.exports = webpackMerge.smart(config, {
     output: {
         path: path.join(__dirname, 'static', 'target', 'javascripts'),
+    },
+    resolve: {
+        alias: {
+            "ophan/ng": path.join(__dirname, 'static', 'src', 'javascripts', 'bootstraps', 'commercial-ophan.dcr.js'),
+        },
     },
 });


### PR DESCRIPTION
Reverts guardian/frontend#23271 to test the change before we increase DCR to 90%.