### PR TITLE
Revert "do not use getSync geolocation for CMP"

### DIFF
--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -10,9 +10,10 @@ import { markTime } from 'lib/user-timing';
 import { captureOphanInfo } from 'lib/capture-ophan-info';
 import reportError from 'lib/report-error';
 import { cmp, onConsentChange } from '@guardian/consent-management-platform';
-import { getLocale, storage } from '@guardian/libs';
+import { storage } from '@guardian/libs';
 import { getCookie } from 'lib/cookies';
 import { isInUsa } from 'common/modules/commercial/geo-utils';
+import { getSync as geolocationGetSync } from 'lib/geolocation';
 import { trackPerformance } from 'common/modules/analytics/google';
 
 // Let webpack know where to get files from
@@ -29,7 +30,7 @@ if (process.env.NODE_ENV !== 'production') {
 
 // kick off the app
 const go = () => {
-    domready(async () => {
+    domready(() => {
         // 1. boot standard, always
         markTime('standard boot');
         bootStandard();
@@ -67,7 +68,7 @@ const go = () => {
             config.get('switches.auConsent', false) ||
             config.get('tests.useAusCmpVariant') === 'variant'
         ) {
-            cmp.init({ pubData, country: await getLocale() });
+            cmp.init({ pubData, country: geolocationGetSync() });
         } else {
             cmp.init({ pubData, isInUsa: isInUsa() });
         }


### PR DESCRIPTION
Reverts guardian/frontend#23284