### PR TITLE
bump libs

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@guardian/commercial-core": "^0.9.0",
     "@guardian/consent-management-platform": "6.7.4",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
-    "@guardian/libs": "^1.3.0",
+    "@guardian/libs": "^1.4.2",
     "@guardian/shimport": "^1.0.2",
     "@guardian/src-button": "^0.16.1",
     "@guardian/src-foundations": "^0.16.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1775,10 +1775,10 @@
     inquirer "^5.2.0"
     pretty-bytes "^4.0.2"
 
-"@guardian/libs@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-1.3.0.tgz#abe4b55c14335a151d0b6cc65a290eb87defd6ab"
-  integrity sha512-WnkeD0Hh8MOxhBGrfL/3eRu74m3FDgLcbhwpjtASUrIcD9I3ALzc79PNao/NwXubK1SZMGTTe4taJxfonB6EKA==
+"@guardian/libs@^1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-1.4.2.tgz#76f525cf37b37ad58d17288c85008e4ab176a929"
+  integrity sha512-ZACBS1NmAjss8Q60c3SWHZ7alsS2tvjI5rQipEidW3fvWI8kdWWXck6FSM4F42vNzLdRFjAGmzEA36rG/NsZSg==
 
 "@guardian/shimport@^1.0.2":
   version "1.0.2"


### PR DESCRIPTION
## What does this change?

bumps `@guardian/libs` to latest

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

