### PR TITLE
Remote liveblog epics

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-liveblog-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-liveblog-utilities.js
@@ -4,6 +4,7 @@ import mediator from 'lib/mediator';
 import { elementInView } from 'lib/element-inview';
 import fastdom from 'lib/fastdom-promise';
 import {submitInsertEvent, submitViewEvent} from "common/modules/commercial/acquisitions-ophan";
+import { mountDynamic } from "@guardian/automat-modules";
 
 let isAutoUpdateHandlerBound = false;
 const INSERT_EPIC_AFTER_CLASS = 'js-insert-epic-after';
@@ -126,6 +127,20 @@ const addEpicToBlocks = (
             setupViewTracking(el, variant, parentTest);
         });
     });
+};
+
+export const setupRemoteEpicInLiveblog = (
+    Component,
+    props,
+) => {
+    const blocks = getBlocksToInsertEpicAfter();
+    if (blocks[0]) {
+        const epic = $.create('<div class="block"/>');
+        epic.insertAfter(blocks[0]);
+        mountDynamic(epic[0], Component, props, true);
+
+        return epic[0];
+    }
 };
 
 export const setupEpicInLiveblog = (

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-liveblog-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-liveblog-utilities.js
@@ -134,6 +134,7 @@ export const setupRemoteEpicInLiveblog = (
     props,
 ) => {
     const blocks = getBlocksToInsertEpicAfter();
+    // Only insert 1 epic. The existing code will be cleaned up in a follow-up PR
     if (blocks[0]) {
         const epic = $.create('<div class="block"/>');
         epic.insertAfter(blocks[0]);

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -230,8 +230,7 @@ const getStickyBottomBanner = (payload) => {
 const getEpicUrl = (contentType) => {
     const path = contentType === 'LiveBlog' ? 'liveblog-epic' : 'epic';
     return config.get('page.isDev') ?
-        // `https://contributions.code.dev-guardianapis.com/${path}` :
-        `http://localhost:8082/${path}` :
+        `https://contributions.code.dev-guardianapis.com/${path}` :
         `https://contributions.guardianapis.com/${path}`
 };
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -21,28 +21,10 @@ import { getForcedParticipationsFromUrl } from 'common/modules/experiments/ab-ur
 import {
     concurrentTests,
     engagementBannerTests,
-    epicTests as hardcodedEpicTests,
 } from 'common/modules/experiments/ab-tests';
 import {
     getEngagementBannerTestsFromGoogleDoc,
-    getConfiguredLiveblogEpicTests,
 } from 'common/modules/commercial/contributions-utilities';
-
-export const getLiveblogEpicTest = memoize(
-    () => {
-        if (config.get('page').contentType === 'LiveBlog') {
-            return getConfiguredLiveblogEpicTests().then(configuredEpicTests => {
-                configuredEpicTests.forEach(test =>
-                    config.set(`switches.ab${test.id}`, true)
-                );
-
-                return firstRunnableTest([...hardcodedEpicTests, ...configuredEpicTests]);
-            });
-        }
-
-        return Promise.resolve(null);
-    }
-);
 
 export const getEngagementBannerTestToRun = memoize(
     () => {
@@ -75,7 +57,7 @@ export const getSynchronousTestsToRun = memoize(() =>
 );
 
 export const getAsyncTestsToRun = () =>
-    Promise.all([getLiveblogEpicTest(), getEngagementBannerTestToRun()]).then(
+    Promise.all([getEngagementBannerTestToRun()]).then(
         tests => tests.filter(Boolean)
     );
 


### PR DESCRIPTION
Normal article epics are served by support-dotcom-components.
See https://github.com/guardian/support-dotcom-components/blob/main/docs/architecture.md for details.

But the liveblog epic is still rendered 'natively'. This PR migrates frontend to use dotcom-components for the liveblog epic.
The backend change is here: https://github.com/guardian/support-dotcom-components/pull/251

Note - there's a lot of epic-related code that can now be cleaned up but that can happen later.

![Screen Shot 2020-11-23 at 14 26 38](https://user-images.githubusercontent.com/1513454/99979467-090f9c00-2d9f-11eb-8425-6e7787294d97.png)
![Screen Shot 2020-11-23 at 14 27 02](https://user-images.githubusercontent.com/1513454/99979480-0b71f600-2d9f-11eb-906f-e8677648f6d8.png)
![Screen Shot 2020-11-23 at 14 27 33](https://user-images.githubusercontent.com/1513454/99979488-0ca32300-2d9f-11eb-97f0-58273fc8f40c.png)
