### PR TITLE
add dependabot for @guardian packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,5 @@ updates:
     allow:
       - dependency-name: "@guardian/*"
     reviewers:
-      - "@guardian/dotcom-platform"
+      - "@guardian/guardian-frontend-team"
     open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    allow:
+      - dependency-name: "@guardian/*"
+    reviewers:
+      - "@guardian/dotcom-platform"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## What does this change?

- adds dependabot for `@guardian/*` packages

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No

#23284 relied on a newer version of the library than was currently installed and broke consent. 

it's not a replacement for testing or breaking the build if you refer to code that doesn't exist, but this could have helped ensure it was up to date