### PR TITLE
Interscroller CTA action style changes

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/messenger/background.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.js
@@ -136,6 +136,8 @@ const setBackground = (specs: AdSpec, adSlot: HTMLElement): Promise<any> => {
                             ctaURLAnchor.href = specs.ctaUrl;
                             ctaURLAnchor.target = '_new';
                             ctaURLAnchor.appendChild(backgroundParent);
+                            ctaURLAnchor.style.display = 'inline-block';
+                            ctaURLAnchor.style.width = '100%';
                             adSlot.insertBefore(
                                 ctaURLAnchor,
                                 adSlot.firstChild

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.js
@@ -138,6 +138,7 @@ const setBackground = (specs: AdSpec, adSlot: HTMLElement): Promise<any> => {
                             ctaURLAnchor.appendChild(backgroundParent);
                             ctaURLAnchor.style.display = 'inline-block';
                             ctaURLAnchor.style.width = '100%';
+                            ctaURLAnchor.style.height = '100%';
                             adSlot.insertBefore(
                                 ctaURLAnchor,
                                 adSlot.firstChild


### PR DESCRIPTION
## What does this change?

Viewability tracker for interscroller native ad has stopped working back in late September. A fix for that is to add a specific height inside the native template and then apply some styles to make the cta anchor working as expected

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
