### PR TITLE
YoutubeBlockElement: Limit the imageOverride alt text pickup to main block

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -854,7 +854,7 @@ object PageElement {
                     posterImage = mediaAtom.posterImage.map(NSImage1.imageMediaToSequence),
                     expired = mediaAtom.expired.getOrElse(false),
                     duration = mediaAtom.duration, // Duration in seconds
-                    altText = altText,
+                    altText = if (isMainBlock) altText else None,
                   )
                 })
               }


### PR DESCRIPTION
## What does this change?

This is an addition to this PR: https://github.com/guardian/frontend/pull/23296 . It limits the lookup of the alt text, from the imageOverride, to the case the video is itself in main media position (otherwise we end up with non main media videos down the page carrying the alt text of the main media).
