### PR TITLE
Stop requiring users to be signed in to reach the complete-registration page

### DIFF
--- a/identity/app/controllers/EmailVerificationController.scala
+++ b/identity/app/controllers/EmailVerificationController.scala
@@ -52,10 +52,10 @@ class EmailVerificationController(
                 idUrlBuilder,
                 verifiedReturnUrlAsOpt,
                 returnUrlVerifier.defaultReturnUrl,
-                email
+                email,
               ),
-            )(page, request, context)
-          )
+            )(page, request, context),
+          ),
         )
     }
   }

--- a/identity/app/controllers/EmailVerificationController.scala
+++ b/identity/app/controllers/EmailVerificationController.scala
@@ -73,7 +73,7 @@ class EmailVerificationController(
           logger.error(s"Could not resend email verification email: $errors")
           InternalServerError("Internal error: Could not resend email verification email")
         }
-        case Right(_) => Ok("")
+        case Right(_) => NoContent
       }
     }
   }

--- a/identity/app/idapiclient/IdApiClient.scala
+++ b/identity/app/idapiclient/IdApiClient.scala
@@ -184,6 +184,13 @@ class IdApiClient(idJsonBodyParser: IdApiJsonBodyParser, conf: IdConfig, httpCli
     response map extractUnit
   }
 
+  def resendEmailValidationEmailByToken(token: String, returnUrl: Option[String]): Future[Response[Unit]] = {
+    val apiPath = urlJoin("signin-token", "send-validation-email", token)
+    val parameters = returnUrl.map(url => Iterable("returnUrl" -> url)).getOrElse(Iterable.empty)
+    val response = httpClient.POST(uri = apiUrl(apiPath), None, None, buildHeaders(extra = parameters))
+    response map extractUnit
+  }
+
   def setPasswordGuest(password: String, token: String): Future[Response[CookiesResponse]] = {
     val body: JObject = "password" -> password
     put(

--- a/identity/app/views/verificationEmailResent.scala.html
+++ b/identity/app/views/verificationEmailResent.scala.html
@@ -31,7 +31,7 @@
             <footer class="identity-forms-message__body">
                 <a class="manage-account__button manage-account__button--center" href="@LinkTo {@verifiedReturnUrl.getOrElse(defaultReturnUrl)}" data-link-name="mma : verify-email : exit-to-gu">
                 @(verifiedReturnUrl match {
-                    case Some(_) => "Exit and continue"
+                    case Some(_) => "Exit and continue to The Guardian"
                     case None => "Exit and go to The Guardian home page"
                 })
                 </a>

--- a/identity/app/views/verificationEmailResent.scala.html
+++ b/identity/app/views/verificationEmailResent.scala.html
@@ -1,49 +1,39 @@
 @(
-    user: com.gu.identity.model.User,
-    idRequest: services.IdentityRequest,
     idUrlBuilder: services.IdentityUrlBuilder,
     verifiedReturnUrl: Option[String],
     defaultReturnUrl: String,
-    isSignupFlow: Boolean = false
+    email: Option[String] = None
 )(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import common.LinkTo
 
-@emailBlock = {
-    <div class="identity-forms-email-wrap">
-        <header>@user.primaryEmailAddress</header>
-        <aside>
-            Not the right email? <a href="@idUrlBuilder.buildUrl(controllers.editprofile.routes.EditProfileController.redirectToAccountSettings.url, idRequest)" data-link-name="mma : verify-email : update-email-from-error">Change it here</a>
-        </aside>
-    </div>
-}
-
 <div class="identity-wrapper monocolumn-wrapper">
     <section class="identity-forms-message">
-        @if(isSignupFlow) {
-            <h1 class="identity-title">Please check your inbox</h1>
+        @if(email.isDefined) {
+            <h1 class="identity-title">Please verify your email to complete your registration</h1>
+            <div class="identity-forms-message__body">
+                <p>We've sent a verification email to:</p>
+                <p><b>@email</b></p>
+                <p>Please click on the link in this email to confirm your email address and complete your registration.</p>
+            </div>
+            <aside class="identity-forms-message__body">
+                <p class="identity-forms-message__explainer">Note that the link is only valid for 30 minutes. If you can't find it, it may be in your spam folder.</p>
+            </aside>
+                <footer class="identity-forms-message__body">
+                    <p>Didn't receive it? <a class="u-underline js-id-send-validation-email-not-signed-in">Resend link</a></p>
+                    <p>Wrong email address? <a class="u-underline" href="@idUrlBuilder.buildUrl("/signin")" data-link-name="mma : verify-email : update-email-from-error">Change it here</a></p>
+                </footer>
         } else {
-            <h1 class="identity-title">To continue, you must confirm this is your email address</h1>
-        }
-        @emailBlock
-        <div class="identity-forms-message__body">
-            @if(isSignupFlow) {
-                <p>We've sent you an email – please open it up and click on the verify button to confirm your email address.</p>
-            } else {
-                <p>We have sent a link to this email address. Please check your inbox and follow the instructions.</p>
-            }
-        </div>
-        <aside class="identity-forms-message__body">
-            <p class="identity-forms-message__explainer">Note that the link is only valid for 30 minutes, so be sure to open it soon!</p>
-            <a class="manage-account__button manage-account__button--center js-id-send-validation-email" data-link-name="mma : verify-email : resent">Resend confirmation email</a>
-        </aside>
-        @if(isSignupFlow) {
+            <h1 class="identity-title">Sorry, something went wrong</h1>
+            <div class="identity-forms-message__body">
+                <p>Having troubles registering? Please visit our <a class="u-underline" href="@LinkTo("/help/identity-faq")">help page</a> or <a class="u-underline" href="https://manage.theguardian.com/contact-us">contact our support team</a>.</p>
+            </div>
             <footer class="identity-forms-message__body">
-                <a class="u-underline" href="@LinkTo {@verifiedReturnUrl.getOrElse(defaultReturnUrl)}" data-link-name="mma : verify-email : exit-to-gu">
-                    @(verifiedReturnUrl match {
-                        case Some(_) => "Exit and continue"
-                        case None => "Exit and go to The Guardian home page"
-                    })
+                <a class="manage-account__button manage-account__button--center" href="@LinkTo {@verifiedReturnUrl.getOrElse(defaultReturnUrl)}" data-link-name="mma : verify-email : exit-to-gu">
+                @(verifiedReturnUrl match {
+                    case Some(_) => "Exit and continue"
+                    case None => "Exit and go to The Guardian home page"
+                })
                 </a>
             </footer>
         }

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -15,6 +15,7 @@ GET         /user/:vanityUrl                        controllers.PublicProfileCon
 GET         /user/:vanityUrl/:activityType          controllers.PublicProfileController.renderProfileFromVanityUrl(vanityUrl: String, activityType: String)
 
 GET         /complete-registration                  controllers.EmailVerificationController.completeRegistration
+POST        /resend-validation-email/:token         controllers.EmailVerificationController.resendValidationEmail(token: String)
 
 GET         /form/complete                          controllers.FormstackController.complete
 GET         /form/:formReference                    controllers.FormstackController.formstackForm(formReference: String, composer: Boolean = false)

--- a/identity/test/controllers/EmailVerificationControllerTest.scala
+++ b/identity/test/controllers/EmailVerificationControllerTest.scala
@@ -81,17 +81,17 @@ class EmailVerificationControllerTest
 
       "should render the proper view" in {
         when(returnUrlVerifier.getVerifiedReturnUrl(any[Request[_]])).thenReturn(None)
-        val result = controller.completeRegistration()(testRequest)
-        contentAsString(result) should include("Please check your inbox")
-        contentAsString(result) should include("Exit and go to The Guardian home page")
+        when(api.decryptEmailToken(anyString())).thenReturn(Future.successful(Right("an email address")))
+        val result = controller.completeRegistration()(TestRequest("/foo?encryptedEmail=someEncryptedString"))
+        contentAsString(result) should include("Please verify your email to complete your registration")
       }
 
-      "should link to the return url" in {
+      "should link to the return url if encrypted email parameter is not present" in {
         when(returnUrlVerifier.getVerifiedReturnUrl(any[Request[_]]))
           .thenReturn(Some("https://jobs.theguardian.com/test-string-test"))
         val result = controller.completeRegistration()(testRequest)
         contentAsString(result) should include("test-string-test")
-        contentAsString(result) should include("Exit and continue")
+        contentAsString(result) should include("Exit and continue to The Guardian")
       }
     }
   }

--- a/static/src/javascripts/bootstraps/enhanced/profile.js
+++ b/static/src/javascripts/bootstraps/enhanced/profile.js
@@ -6,6 +6,7 @@ import { Formstack } from 'common/modules/identity/formstack';
 import { FormstackIframe } from 'common/modules/identity/formstack-iframe';
 import { FormstackEmbedIframe } from 'common/modules/identity/formstack-iframe-embed';
 import { init as initValidationEmail } from 'common/modules/identity/validation-email';
+import { init as initValidationEmailNotSignedIn } from 'common/modules/identity/validation-email-not-signed-in';
 import { AccountProfile } from 'common/modules/identity/account-profile';
 import { init as initPublicProfile } from 'common/modules/identity/public-profile';
 import { enhanceFormAjax } from 'common/modules/identity/form-ajax';
@@ -56,6 +57,7 @@ const initProfile = (): void => {
         ['forgotten-email', forgottenEmail],
         ['password-toggle', passwordToggle],
         ['init-validation-email', initValidationEmail],
+        ['init-validation-email-not-signed-in', initValidationEmailNotSignedIn],
         ['init-user-avatars', initUserAvatars],
         ['init-user-edit-link', initUserEditLink],
         ['init-tabs', initTabs],

--- a/static/src/javascripts/projects/common/modules/identity/validation-email-not-signed-in.js
+++ b/static/src/javascripts/projects/common/modules/identity/validation-email-not-signed-in.js
@@ -77,7 +77,7 @@ const init = (): void => {
         });
 };
 
-const emailToken = (): string => new URLSearchParams(window.location.search).get('encryptedEmail');
+const emailToken = (): string | null => new URLSearchParams(window.location.search).get('encryptedEmail');
 
 const sendValidationEmail = (token: string): any => {
     const endpoint = `/resend-validation-email/${token}`;

--- a/static/src/javascripts/projects/common/modules/identity/validation-email-not-signed-in.js
+++ b/static/src/javascripts/projects/common/modules/identity/validation-email-not-signed-in.js
@@ -1,0 +1,93 @@
+// @flow
+import fastdom from 'lib/fastdom-promise';
+import mediator from 'lib/mediator';
+import fetch from 'lib/fetch';
+
+const init = (): void => {
+    fastdom
+        .measure(() =>
+            document.getElementsByClassName('js-id-send-validation-email-not-signed-in')
+        )
+        .then(elems => {
+            if (elems.length) {
+                const resendButton = elems[0];
+
+                resendButton.addEventListener(
+                    'click',
+                    (event: Event): void => {
+                        event.preventDefault();
+                        let token = emailToken();
+                        if (token) {
+                            sendValidationEmail(token).then(
+                                resp => {
+                                    if (resp.status !== 200) {
+                                        mediator.emit(
+                                            'module:identity:validation-email:fail'
+                                        );
+
+                                        fastdom.mutate(() => {
+                                            resendButton.innerHTML =
+                                                'An error occured, please click here to try again.';
+                                        });
+                                    } else {
+                                        mediator.emit(
+                                            'module:identity:validation-email:success'
+                                        );
+
+                                        const resendButtonParent =
+                                            resendButton.parentNode;
+
+                                        if (resendButtonParent) {
+                                            const sentMsgEl = document.createElement(
+                                                'p'
+                                            );
+
+                                            sentMsgEl.innerText =
+                                                'Sent. Please check your email and follow the link.';
+
+                                            fastdom.mutate(() => {
+                                                resendButtonParent.replaceChild(
+                                                    sentMsgEl,
+                                                    resendButton
+                                                );
+                                            });
+                                        }
+                                    }
+                                },
+                                () => {
+                                    mediator.emit(
+                                        'module:identity:validation-email:fail'
+                                    );
+
+                                    fastdom.mutate(() => {
+                                        resendButton.innerHTML =
+                                            'An error occured, please click here to try again.';
+                                    });
+                                }
+                            );
+                        } else {
+                            fastdom.mutate(() => {
+                                resendButton.innerHTML =
+                                    'No token found';
+                            });
+                        }
+                    }
+                );
+            }
+        });
+};
+
+const emailToken = (): string => new URLSearchParams(window.location.search).get('encryptedEmail');
+
+const sendValidationEmail = (token: string): any => {
+    const endpoint = `/resend-validation-email/${token}`;
+    return fetch(endpoint, {
+        method: 'post',
+        headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+        },
+    });
+};
+
+export { init };

--- a/static/src/javascripts/projects/common/modules/identity/validation-email-not-signed-in.js
+++ b/static/src/javascripts/projects/common/modules/identity/validation-email-not-signed-in.js
@@ -33,7 +33,7 @@ const init = (): void => {
                         if (token) {
                             sendValidationEmail(token).then(
                                 resp => {
-                                    if (resp.status !== 200) {
+                                    if (resp.status !== 204) {
                                         mediator.emit(
                                             'module:identity:validation-email:fail'
                                         );

--- a/static/src/javascripts/projects/common/modules/identity/validation-email-not-signed-in.js
+++ b/static/src/javascripts/projects/common/modules/identity/validation-email-not-signed-in.js
@@ -3,6 +3,19 @@ import fastdom from 'lib/fastdom-promise';
 import mediator from 'lib/mediator';
 import fetch from 'lib/fetch';
 
+const emailToken = (): string | null => new URLSearchParams(window.location.search).get('encryptedEmail');
+
+const sendValidationEmail = (token: string): any => {
+    const endpoint = `/resend-validation-email/${token}`;
+    return fetch(endpoint, {
+        method: 'post',
+        headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+        },
+    });
+};
+
 const init = (): void => {
     fastdom
         .measure(() =>
@@ -16,7 +29,7 @@ const init = (): void => {
                     'click',
                     (event: Event): void => {
                         event.preventDefault();
-                        let token = emailToken();
+                        const token = emailToken();
                         if (token) {
                             sendValidationEmail(token).then(
                                 resp => {
@@ -75,19 +88,6 @@ const init = (): void => {
                 );
             }
         });
-};
-
-const emailToken = (): string | null => new URLSearchParams(window.location.search).get('encryptedEmail');
-
-const sendValidationEmail = (token: string): any => {
-    const endpoint = `/resend-validation-email/${token}`;
-    return fetch(endpoint, {
-        method: 'post',
-        headers: {
-            Accept: 'application/json',
-            'Content-Type': 'application/json',
-        },
-    });
 };
 
 export { init };


### PR DESCRIPTION
## What does this change?
As part of the Identity team's work to require mandatory email validation before signing a user into The Guardian, we are changing the way the https://profile.theguardian.com/complete-registration page works. Where it previously required the user to be logged in to access the page and display the user's email address, we are now passing in an encryptedEmail parameter from the previous step to be decrypted and displayed. If the email address is not available, the page displays an error message.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/33927854/100092591-3a937080-2e4e-11eb-8cdb-349f152860d5.png
[after]: https://user-images.githubusercontent.com/33927854/100085200-aa502e00-2e43-11eb-9b9a-56249a19c947.png

Error case:
<img width="955" alt="Screenshot 2020-11-24 at 10 53 09" src="https://user-images.githubusercontent.com/33927854/100092639-4f700400-2e4e-11eb-9fed-8d358ff692f8.png">

## What is the value of this and can you measure success?

Not signing users in automatically after they have registered is a key requirement following our security audit earlier in the year. It supports data cleanliness and assures us that the user has access to the email account they are using and that they 'are who they say they are'.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
