### PR TITLE
Fix Ophan Api Timeout Problem

### DIFF
--- a/common/app/services/OphanApi.scala
+++ b/common/app/services/OphanApi.scala
@@ -32,7 +32,7 @@ class OphanApi(wsClient: WSClient)(implicit executionContext: ExecutionContext)
       val queryString = params map {
         case (k, v) => s"$k=${URLEncoder.encode(v, "utf-8")}"
       } mkString "&"
-      val url = s"$host/$path?$queryString&api-key=$key"
+      val url = s"${host.replace("http:", "https:")}/$path?$queryString&api-key=$key"
       log.info(s"Making request to Ophan API: $url")
       wsClient.url(url).withRequestTimeout(10.seconds).getOKResponse().map(_.json)
     }


### PR DESCRIPTION
## What does this change?

Fix Ophan Api Timeout Problem. The correct url of the Ophan API is `https`, but `ophanApi.host` is still `http`. This causes failure in queries taking a longer time than usual, for instance `deeplyread`, I believe that this might be because the HTTP client doesn't respect its timeout instruction when dealing with a redirection. 
