### PR TITLE
Rollback support for interactive atoms in DCR

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -72,7 +72,7 @@ object ArticlePageChecks {
           // ContentAtomBlockElement was expanded to include atomtype.
           // To support an atom type, just add it to supportedAtomTypes
           val supportedAtomTypes =
-            List("audio", "chart", "explainer", "guide", "interactive", "profile", "qanda", "timeline")
+            List("audio", "chart", "explainer", "guide", "profile", "qanda", "timeline")
           !supportedAtomTypes.contains(atomtype)
         }
         case _ => true


### PR DESCRIPTION
## What does this change?

We're currently not supporting weighting for atoms in DCR, which is going to cause problems for an upcoming campaign that relies on supporting weighting. While prioritising the fix, we are removing interactive atom support from DCR for the moment.

## Does this change need to be reproduced in dotcom-rendering ?

It needs to be fixed in dotcom-rendering.
