### PR TITLE
Restrict where we support force-braze-message

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -87,25 +87,39 @@ const canShowPreChecks = ({
 let messageConfig: InAppMessage;
 let appboy: ?AppBoy;
 
-const getMessageFromQueryString = (): InAppMessage | null => {
-        const params = getUrlVars();
-        const qsArg = 'force-braze-message';
-        const value = params[qsArg];
-        if (value) {
-            try {
-                const dataFromBraze = JSON.parse(value);
+const FORCE_BRAZE_ALLOWLIST = [
+    'preview.gutools.co.uk',
+    'preview.code.dev-gutools.co.uk',
+    'localhost',
+    'm.thegulocal.com',
+];
 
-                return {
-                    extras: dataFromBraze,
-                };
-            } catch (e) {
-                // Parsing failed. Log a message and fall through.
-                console.log(
-                    `There was an error with ${qsArg}:`,
-                    e.message,
-                );
-            }
+const getMessageFromQueryString = (): InAppMessage | null => {
+    const qsArg = 'force-braze-message';
+
+    if (!FORCE_BRAZE_ALLOWLIST.includes(window.location.hostname)) {
+        console.log(`${qsArg} is not supported on this domain`)
+        return null;
+    }
+
+    const params = getUrlVars();
+    const value = params[qsArg];
+
+    if (value) {
+        try {
+            const dataFromBraze = JSON.parse(value);
+
+            return {
+                extras: dataFromBraze,
+            };
+        } catch (e) {
+            // Parsing failed. Log a message and fall through.
+            console.log(
+                `There was an error with ${qsArg}:`,
+                e.message,
+            );
         }
+    }
 
     return null;
 };


### PR DESCRIPTION
## What does this change?

Restrict the domains where we support the force-braze-message query string arg. Marketing can use this to force the Braze banner to appear. As we make the banner configuration more flexible it doesn't make sense to support this on the main website, so restrict to preview (and dev environments).

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation) guardian/dotcom-rendering#2148.

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
