### PR TITLE
Implement Ipsos tagging script on all pages

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/ipsos-mori.js
+++ b/static/src/javascripts/projects/commercial/modules/ipsos-mori.js
@@ -3,26 +3,6 @@ import { onConsentChange, getConsentFor } from '@guardian/consent-management-pla
 import config from 'lib/config';
 import { loadScript, getLocale } from '@guardian/libs';
 
-/* Sections to be included in initial release of Ipsos Mori tagging */
-const allowSections = [
-    "lifeandstyle", /* Lifestyle sections */
-    "fashion",
-    "food",
-    "travel",
-    "fashion",
-    "money",
-    "technology",
-    "culture", /* Culture sections */
-    "film",
-    "music",
-    "tv-and-radio",
-    "books",
-    "artanddesign",
-    "stage",
-    "games",
-    "sport", /* Sport sections */
-    "football",];
-
 const loadIpsosScript = () => {
 
     window.dm = window.dm ||{ AjaxData:[]};
@@ -45,9 +25,7 @@ export const init = (): Promise<void> => {
         if(locale === 'GB') {
             onConsentChange(state => {
                 if (getConsentFor('ipsos', state)) {
-                    if (allowSections.includes(config.get('page.section'))) {
-                        return loadIpsosScript();
-                    }
+                    return loadIpsosScript();
                 }
             });
         }


### PR DESCRIPTION
## What does this change?

This removes the `allowSection` to implement Ipsos Mori tagging on all pages on the site (if consent has been given).
