### PR TITLE
Add quiz atom metadata needed to support personality type quizzes in DCR

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -358,12 +358,25 @@ object QABlockElement {
   implicit val QABlockElementWrites: Writes[QABlockElement] = Json.writes[QABlockElement]
 }
 
-case class QuizAtomAnswer(id: String, text: String, revealText: Option[String], isCorrect: Boolean)
+case class QuizAtomAnswer(
+    id: String,
+    text: String,
+    revealText: Option[String],
+    answerBuckets: Seq[String],
+    isCorrect: Boolean,
+)
+case class QuizAtomResultBucket(id: String, title: String, description: String)
 case class QuizAtomQuestion(id: String, text: String, answers: Seq[QuizAtomAnswer], imageUrl: Option[String])
-case class QuizAtomBlockElement(id: String, quizType: String, questions: Seq[QuizAtomQuestion]) extends PageElement
+case class QuizAtomBlockElement(
+    id: String,
+    quizType: String,
+    questions: Seq[QuizAtomQuestion],
+    resultBuckets: Seq[QuizAtomResultBucket],
+) extends PageElement
 object QuizAtomBlockElement {
   implicit val QuizAtomAnswerWrites: Writes[QuizAtomAnswer] = Json.writes[QuizAtomAnswer]
   implicit val QuizAtomQuestionWrites: Writes[QuizAtomQuestion] = Json.writes[QuizAtomQuestion]
+  implicit val QuizAtomResultBucketWrites: Writes[QuizAtomResultBucket] = Json.writes[QuizAtomResultBucket]
   implicit val QuizAtomBlockElementWrites: Writes[QuizAtomBlockElement] = Json.writes[QuizAtomBlockElement]
 }
 
@@ -932,6 +945,7 @@ object PageElement {
                     id = a.id,
                     text = a.text,
                     revealText = a.revealText,
+                    answerBuckets = a.buckets,
                     isCorrect = a.weight == 1,
                   ),
                 ),
@@ -943,6 +957,9 @@ object PageElement {
                 id = quizAtom.id,
                 quizType = quizAtom.quizType,
                 questions = questions,
+                resultBuckets = quizAtom.content.resultBuckets.map { bucket =>
+                  QuizAtomResultBucket(bucket.id, bucket.title, bucket.description)
+                },
               ),
             )
           }


### PR DESCRIPTION
## What does this change?

Here we add information about the "result buckets" to our quiz atom data model exposed to DCR, so that we can support personality quizes

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

Running article locally and testing for [this personality quiz](https://www.theguardian.com/world/2016/mar/09/how-millennial-are-you-the-generation-y-quiz), we get the required fields passed back in the [json response](http://localhost:9000/world/2016/mar/09/how-millennial-are-you-the-generation-y-quiz.json?dcr):

![image](https://user-images.githubusercontent.com/9820960/100452557-4632a180-30b1-11eb-8e29-430e68ae3acc.png)


<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->




### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)



### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
