### PR TITLE
Extend sign in gate ab switches

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -42,7 +42,7 @@ trait ABTestSwitches {
     "Control audience for the sign in gate to 9% audience. Will never see the sign in gate.",
     owners = Seq(Owner.withGithub("coldlink")),
     safeState = Off,
-    sellByDate = new LocalDate(2020, 12, 1),
+    sellByDate = new LocalDate(2021, 12, 1),
     exposeClientSide = true,
   )
 
@@ -52,7 +52,7 @@ trait ABTestSwitches {
     "Show sign in gate to 90% of users on 3rd article view, variant/full audience",
     owners = Seq(Owner.withGithub("coldlink")),
     safeState = Off,
-    sellByDate = new LocalDate(2020, 12, 1),
+    sellByDate = new LocalDate(2021, 12, 1),
     exposeClientSide = true,
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-control.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-control.js
@@ -6,7 +6,7 @@
 export const signInGateMainControl: ABTest = {
     id: 'SignInGateMainControl',
     start: '2020-05-20',
-    expiry: '2020-12-01',
+    expiry: '2021-12-01',
     author: 'Mahesh Makani',
     description:
         'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Control Audience.',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
@@ -6,7 +6,7 @@
 export const signInGateMainVariant: ABTest = {
     id: 'SignInGateMainVariant',
     start: '2020-05-20',
-    expiry: '2020-12-01',
+    expiry: '2021-12-01',
     author: 'Mahesh Makani',
     description:
         'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Main/Variant Audience.',


### PR DESCRIPTION
## What does this change?
- Extend the sign in gate ab switches to next year to stop explosions from occurring on the 1st December.
