### PR TITLE
remove liveblog epic variant

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-epic-design-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-epic-design-test.js
@@ -67,12 +67,5 @@ export const liveblogEpicDesignTest: EpicABTest = makeEpicABTest({
             template: liveBlogTemplate('liveblog-epic-test__v1'),
             copy: buildEpicCopy(copy, false, geolocation),
         },
-        {
-            id: 'v2',
-            products: ['CONTRIBUTION', 'MEMBERSHIP_SUPPORTER'],
-            test: setupEpicInLiveblog,
-            template: liveBlogTemplate('liveblog-epic-test__v2'),
-            copy: buildEpicCopy(copy, false, geolocation),
-        },
     ],
 });

--- a/static/src/stylesheets/module/reader-revenue/_epic.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic.scss
@@ -269,14 +269,3 @@ div.contributions__secondary-button.contributions__secondary-button--epic {
         color: $brightness-7;
     }
 }
-
-.content--pillar-news:not(.paid-content) .block--content.liveblog-epic-test__v2 {
-    border-top-color: $brand-main;
-    background-color: $brightness-93;
-
-    .component-button--liveblog {
-        background: $brand-main;
-        border-color: $brand-main;
-        color: $brightness-100;
-    }
-}


### PR DESCRIPTION
Original PR for this test had 3 variants: https://github.com/guardian/frontend/pull/23262
We're removing V2 to speed things up.