### PR TITLE
Extend newsletter merch unit test by one week

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -82,7 +82,7 @@ trait ABTestSwitches {
     "Test impact of newsletter merch unit across lighthouse segments (Control bucket)",
     owners = Seq(Owner.withGithub("buck06191")),
     safeState = Off,
-    sellByDate = new LocalDate(2020, 12, 1),
+    sellByDate = new LocalDate(2020, 12, 8),
     exposeClientSide = true,
   )
 
@@ -92,7 +92,7 @@ trait ABTestSwitches {
     "Test impact of newsletter merch unit across lighthouse segments (Variant buckets)",
     owners = Seq(Owner.withGithub("buck06191")),
     safeState = Off,
-    sellByDate = new LocalDate(2020, 12, 1),
+    sellByDate = new LocalDate(2020, 12, 8),
     exposeClientSide = true,
   )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-merch-unit-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-merch-unit-test.js
@@ -3,7 +3,7 @@
 export const newsletterMerchUnitLighthouseControl: ABTest = {
     id: 'NewsletterMerchUnitLighthouseControl',
     start: '2020-11-11',
-    expiry: '2020-12-01',
+    expiry: '2020-12-08',
     author: 'Josh Buckland & Alex Dufournet',
     description: 'Show BAU merch unit to 50% of users. This is the control for the NewsletterMerchUnitLighthouseVariants test.',
     audience: 0.5,
@@ -28,7 +28,7 @@ export const newsletterMerchUnitLighthouseControl: ABTest = {
 export const newsletterMerchUnitLighthouseVariant: ABTest = {
     id: 'NewsletterMerchUnitLighthouseVariants',
     start: '2020-11-11',
-    expiry: '2020-12-01',
+    expiry: '2020-12-08',
     author: 'Josh Buckland & Alex Dufournet',
     description: 'Show a newsletter advert in the merchandising unit to 25% of users and reader revenue' +
         'to another 25%. The remaining 50% are covered by NewsletterMerchUnitLighthouseControl ' +


### PR DESCRIPTION
## What does this change?
Extends Newsletters Merch Unit test by one week to add a grace period whilst significance is calculated

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)
PR to follow

