### PR TITLE
Identity | Sign in gate | Stop scroll on dismiss

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/example.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/example.js
@@ -88,10 +88,6 @@ export const designShow: ({
                 component: ophanComponent,
                 value: 'not-now',
                 callback: () => {
-                    // reposition window to top of page without affecting browser's 'back' navigation
-                    const maincontent = document.getElementById('maincontent');
-                    if (maincontent) maincontent.scrollIntoView(true);
-
                     // show the current body. Remove the shadow one
                     articleBody.style.display = 'block';
                     shadowArticleBody.remove();

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/main-variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/main-variant.js
@@ -111,10 +111,6 @@ export const designShow: ({
                 component: ophanComponent,
                 value: 'not-now',
                 callback: () => {
-                    // reposition window to top of page without affecting browser's 'back' navigation
-                    const maincontent = document.getElementById('maincontent');
-                    if (maincontent) maincontent.scrollIntoView(true);
-
                     // show the current body. Remove the shadow one
                     articleBody.style.display = 'block';
                     shadowArticleBody.remove();


### PR DESCRIPTION
## What does this change?
- Remove scrolling to the top of the article body on sign in gate dismiss

## Why?
 Cumulative Layout Shift Score of 0.43 (https://web.dev/cls/) - 'Good' total CLS is below 0.1, and because CrUX reports are used for Google search rankings now, this will have a big impact on our rankings.

We should allow the sign in gate just to expand from its current position, rather than shifting back to the top of the page.