### PR TITLE
Don't follow redirects to non-amp pages in validator

### DIFF
--- a/tools/amp-validation/fetch-page.js
+++ b/tools/amp-validation/fetch-page.js
@@ -20,7 +20,10 @@ const fetch = options => {
                 const errorMessage = `Unable to fetch ${options.endpoint}`;
 
                 request(
-                    `${options.host + options.endpoint}`,
+                    {
+                        uri: `${options.host + options.endpoint}`,
+                        followRedirect: false
+                    },
                     (error, resp, body) => {
                         if (error || resp.statusCode !== 200) {
                             console.error(errorMessage);


### PR DESCRIPTION
## What does this change?
In #22959 we added redirects from AMP to the canonical page when AMP rendering returns a 500 error, but that means that some of the articles we validate are non-AMP and will fail validation. These pages are not sensible to validate here, but if there are increasing numbers of pages we are serving 500s for on AMP we should monitor through google search console and address as a separate process.

By not following the redirect we will skip the validation rather than failing it. A big increase in skipped pages might be a concern, which we could add a check for as a later change.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
Validator passes again so we can start to receive useful signals about validation status of our pages again.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
