### PR TITLE
Fix for Commercial Sentry errors

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-load.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-load.js
@@ -22,6 +22,9 @@ export const onSlotLoad = (event: SlotOnloadEvent) => {
     }
 
     const iframe = advert.node.getElementsByTagName('iframe')[0];
+    if (!iframe) {
+        return;
+    }
     postMessage(
         {
             id: iframe.id,

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-load.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-load.js
@@ -23,6 +23,7 @@ export const onSlotLoad = (event: SlotOnloadEvent) => {
 
     const iframe = advert.node.getElementsByTagName('iframe')[0];
     if (!iframe) {
+        console.log("No iFrame found for slot", advert.id,  advert.slot)
         return;
     }
     postMessage(

--- a/static/src/javascripts/projects/commercial/modules/messenger.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger.js
@@ -81,8 +81,8 @@ const getIframe = (data: StandardMessage): ?HTMLElement => {
 // such as validating the anatomy of the payload and whitelisting
 // event type
 const isValidPayload = (payload: StandardMessage): boolean =>
-    !!payload && //typeof null==='object' because... javascript
     typeof payload === 'object' &&
+    !!payload && // Needed because typeof null==='object'
     'type' in payload &&
     'value' in payload &&
     'id' in payload &&

--- a/static/src/javascripts/projects/commercial/modules/messenger.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger.js
@@ -81,6 +81,8 @@ const getIframe = (data: StandardMessage): ?HTMLElement => {
 // such as validating the anatomy of the payload and whitelisting
 // event type
 const isValidPayload = (payload: StandardMessage): boolean =>
+    !!payload && //typeof null==='object' because... javascript
+    typeof payload === 'object' &&
     'type' in payload &&
     'value' in payload &&
     'id' in payload &&


### PR DESCRIPTION
## What does this change?
Addresses 2 of the highest volume errors logged to sentry.

These are the top uncaught errors from commercial (also top uncaught errors overall)

1: https://sentry.io/organizations/the-guardian/issues/587538044/?project=35463&query=is%3Aunresolved
2: https://sentry.io/organizations/the-guardian/issues/2036102297/?project=35463&query=is%3Aunresolved&statsPeriod=14d

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
