### PR TITLE
Remove google-analytics.com from header preconnect/prefetch

### DIFF
--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -26,12 +26,10 @@
 <link rel="dns-prefetch" href="//j.ophan.co.uk" />
 <link rel="dns-prefetch" href="//ophan.theguardian.com" />
 <link rel="dns-prefetch" href="@Configuration.debug.beaconUrl" />
-<link rel="dns-prefetch" href="//www.google-analytics.com" />
 
 <link rel="preconnect" href="@Configuration.assets.path" />
 <link rel="preconnect" href="@Configuration.images.host" />
 <link rel="preconnect" href="//interactive.guim.co.uk" />
-<link rel="preconnect" href="//www.google-analytics.com" />
 
 
 @if(ComscoreSwitch.isSwitchedOn) {


### PR DESCRIPTION
## What does this change?

Remove google-analytics.com from header preconnect/prefetch, which we cannot connect to without user consent. 