### PR TITLE
Liveblog epic - fall back on italics

### DIFF
--- a/static/src/stylesheets/module/reader-revenue/_epic.scss
+++ b/static/src/stylesheets/module/reader-revenue/_epic.scss
@@ -255,13 +255,15 @@ div.contributions__secondary-button.contributions__secondary-button--epic {
     }
 }
 
-.content--pillar-news:not(.paid-content) .block--content.liveblog-epic-test__control {
+.content--pillar-news:not(.paid-content) .block--content.is-epic {
     font-style: italic;
 }
 
 .content--pillar-news:not(.paid-content) .block--content.liveblog-epic-test__v1 {
     border-top-color: $highlight-main;
     background-color: $brightness-93;
+
+    font-style: normal;
 
     .component-button--liveblog {
         background: $highlight-main;


### PR DESCRIPTION
We're currently running a design test on the liveblog epic.
While it's still running we need the ability to temporarily switch it off, and instead take epic copy from the tool.

This change ensures it uses the correct style when the design test is disabled. So it falls back on the old italics version:
![Screen Shot 2020-12-01 at 12 56 10](https://user-images.githubusercontent.com/1513454/100743928-e56ad800-33d4-11eb-8710-7c5623bec7f2.png)
