### PR TITLE
Async page targetting

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
@@ -2,7 +2,10 @@
 import $ from 'lib/$';
 import { getBreakpoint as getBreakpoint_ } from 'lib/detect';
 import config from 'lib/config';
-import { init as prepareGoogletag } from 'commercial/modules/dfp/prepare-googletag';
+import {
+    init as prepareGoogletag,
+    _,
+} from 'commercial/modules/dfp/prepare-googletag';
 import { getAdverts } from 'commercial/modules/dfp/get-adverts';
 import { getCreativeIDs } from 'commercial/modules/dfp/get-creative-ids';
 import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
@@ -126,6 +129,7 @@ const reset = () => {
     dfpEnv.advertsToLoad = [];
     dfpEnv.hbImpl = { prebid: false, a9: false };
     fillAdvertSlots.mockReset();
+    _.resetHasTargettingPromise();
 };
 
 const tcfv2WithConsent = {
@@ -358,12 +362,17 @@ describe('DFP', () => {
         });
     });
 
-    it('should set listeners', () =>
+    it('should set listeners', () => {
+        onConsentChange.mockImplementation(callback =>
+            callback(tcfv2WithoutConsent)
+        );
+
         prepareGoogletag().then(() => {
             expect(
                 window.googletag.pubads().addEventListener
             ).toHaveBeenCalledWith('slotRenderEnded', expect.anything());
-        }));
+        });
+    });
 
     it('should define slots', () =>
         new Promise(resolve => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
@@ -12,6 +12,7 @@ import { fillAdvertSlots as fillAdvertSlots_ } from 'commercial/modules/dfp/fill
 import {
     onConsentChange as onConsentChange_,
     getConsentFor as getConsentFor_,
+    cmp,
 } from '@guardian/consent-management-platform';
 
 const onConsentChange: any = onConsentChange_;
@@ -102,6 +103,9 @@ jest.mock('commercial/modules/dfp/load-advert', () => ({
 jest.mock('@guardian/consent-management-platform', () => ({
     onConsentChange: jest.fn(),
     getConsentFor: jest.fn(),
+    cmp: {
+        willShowPrivacyMessage: jest.fn(),
+    },
 }));
 
 let $style;
@@ -294,6 +298,8 @@ describe('DFP', () => {
         window.__switch_zero = false;
 
         commercialFeatures.dfpAdvertising = true;
+
+        cmp.willShowPrivacyMessage.mockResolvedValue(true);
     });
 
     afterEach(() => {
@@ -498,7 +504,7 @@ describe('DFP', () => {
                 callback(tcfv2WithConsent)
             );
             getConsentFor.mockReturnValue(true);
-            prepareGoogletag().then(() => {
+            return prepareGoogletag().then(() => {
                 expect(
                     window.googletag.pubads().setTargeting
                 ).toHaveBeenCalledWith('k', ['korea', 'ukraine']);
@@ -512,7 +518,7 @@ describe('DFP', () => {
                 callback(tcfv2WithConsent)
             );
             getConsentFor.mockReturnValue(true);
-            prepareGoogletag().then(() => {
+            return prepareGoogletag().then(() => {
                 expect(
                     window.googletag.pubads().setRequestNonPersonalizedAds
                 ).toHaveBeenCalledWith(0);
@@ -523,7 +529,7 @@ describe('DFP', () => {
                 callback(tcfv2NullConsent)
             );
             getConsentFor.mockReturnValue(true);
-            prepareGoogletag().then(() => {
+            return prepareGoogletag().then(() => {
                 expect(
                     window.googletag.pubads().setRequestNonPersonalizedAds
                 ).toHaveBeenCalledWith(0);
@@ -534,7 +540,7 @@ describe('DFP', () => {
                 callback(tcfv2WithoutConsent)
             );
             getConsentFor.mockReturnValue(false);
-            prepareGoogletag().then(() => {
+            return prepareGoogletag().then(() => {
                 expect(
                     window.googletag.pubads().setRequestNonPersonalizedAds
                 ).toHaveBeenCalledWith(1);
@@ -545,7 +551,7 @@ describe('DFP', () => {
                 callback(tcfv2MixedConsent)
             );
             getConsentFor.mockReturnValue(false);
-            prepareGoogletag().then(() => {
+            return prepareGoogletag().then(() => {
                 expect(
                     window.googletag.pubads().setRequestNonPersonalizedAds
                 ).toHaveBeenCalledWith(1);
@@ -582,7 +588,7 @@ describe('DFP', () => {
                 callback(ccpaWithConsent)
             );
             getConsentFor.mockReturnValue(true);
-            prepareGoogletag().then(() => {
+            return prepareGoogletag().then(() => {
                 expect(
                     window.googletag.pubads().setPrivacySettings
                 ).toHaveBeenCalledWith({
@@ -595,7 +601,7 @@ describe('DFP', () => {
                 callback(ccpaWithoutConsent)
             );
             getConsentFor.mockReturnValue(false);
-            prepareGoogletag().then(() => {
+            return prepareGoogletag().then(() => {
                 expect(
                     window.googletag.pubads().setPrivacySettings
                 ).toHaveBeenCalledWith({

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -62,10 +62,10 @@ const setDfpListeners = (): void => {
     }
 };
 
-const setPageTargeting = (): void => {
+const setPageTargeting = async (): Promise<void> => {
     const pubads = window.googletag.pubads();
     // because commercialFeatures may export itself as {} in the event of an exception during construction
-    const targeting = getPageTargeting();
+    const targeting = await getPageTargeting();
     Object.keys(targeting).forEach(key => {
         pubads.setTargeting(key, targeting[key]);
     });

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -53,6 +53,12 @@ let hasTargettingPromise: Promise<void> = new Promise(resolve => {
     hasTargettingResolve = resolve;
 });
 
+const resetHasTargettingPromise = () => {
+    hasTargettingPromise = new Promise(resolve => {
+        hasTargettingResolve = resolve;
+    });
+};
+
 const setDfpListeners = (): void => {
     const pubads = window.googletag.pubads();
     pubads.addEventListener('slotRenderEnded', raven.wrap(onSlotRender));
@@ -167,4 +173,8 @@ export const init = (): Promise<void> => {
     }
 
     return removeAdSlots();
+};
+
+export const _ = {
+    resetHasTargettingPromise,
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -48,6 +48,11 @@ initMessenger(
     disableRefresh
 );
 
+let hasTargettingResolve: (value?: void) => void;
+let hasTargettingPromise: Promise<void> = new Promise(resolve => {
+    hasTargettingResolve = resolve;
+});
+
 const setDfpListeners = (): void => {
     const pubads = window.googletag.pubads();
     pubads.addEventListener('slotRenderEnded', raven.wrap(onSlotRender));
@@ -69,6 +74,7 @@ const setPageTargeting = async (): Promise<void> => {
     Object.keys(targeting).forEach(key => {
         pubads.setTargeting(key, targeting[key]);
     });
+    hasTargettingResolve(); // let init() resolve
 };
 
 // This is specifically a separate function to close-disabled-slots. One is for
@@ -157,7 +163,7 @@ export const init = (): Promise<void> => {
             .then(adFreeSlotRemove)
             .catch(removeAdSlots);
 
-        return Promise.resolve();
+        return hasTargettingPromise;
     }
 
     return removeAdSlots();

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
@@ -23,8 +23,8 @@ const loadPrebid: () => void = () => {
         !shouldIncludeOnlyA9
     ) {
         import(/* webpackChunkName: "Prebid.js" */ 'prebid.js/build/dist/prebid').then(
-            () => {
-                getPageTargeting();
+            async () => {
+                await getPageTargeting();
                 prebid.initialise(window);
             }
         );

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.js
@@ -6,9 +6,7 @@ import {
     buildAppNexusTargetingObject,
 } from 'common/modules/commercial/build-page-targeting';
 
-import {
-    isInUsOrCa,
-    isInAuOrNz } from 'common/modules/commercial/geo-utils';
+import { isInUsOrCa, isInAuOrNz } from 'common/modules/commercial/geo-utils';
 
 import {
     getLargestSize,
@@ -16,7 +14,7 @@ import {
     containsLeaderboardOrBillboard,
     containsMpu,
     containsMpuOrDmpu,
-    getBreakpointKey
+    getBreakpointKey,
 } from '../utils';
 
 import type { PrebidAppNexusParams, HeaderBiddingSize } from '../types';
@@ -101,9 +99,9 @@ export const getAppNexusDirectPlacementId = (
     }
 };
 
-export const getAppNexusDirectBidParams = (
+export const getAppNexusDirectBidParams = async (
     sizes: HeaderBiddingSize[]
-): PrebidAppNexusParams => {
+): Promise<PrebidAppNexusParams> => {
     if (isInAuOrNz() && config.get('switches.prebidAppnexusInvcode')) {
         const invCode = getAppNexusInvCode(sizes);
         // flowlint sketchy-null-string:warn
@@ -113,26 +111,26 @@ export const getAppNexusDirectBidParams = (
                 member: '7012',
                 keywords: {
                     invc: [invCode],
-                    ...buildAppNexusTargetingObject(getPageTargeting()),
+                    ...buildAppNexusTargetingObject(await getPageTargeting()),
                 },
             };
         }
     }
     return {
         placementId: getAppNexusDirectPlacementId(sizes),
-        keywords: buildAppNexusTargetingObject(getPageTargeting()),
+        keywords: buildAppNexusTargetingObject(await getPageTargeting()),
     };
 };
 
 // TODO are we using getAppNexusServerSideBidParams anywhere?
-export const getAppNexusServerSideBidParams = (
+export const getAppNexusServerSideBidParams = async (
     sizes: HeaderBiddingSize[]
-): PrebidAppNexusParams =>
+): Promise<PrebidAppNexusParams> =>
     Object.assign(
         {},
         {
             placementId: getAppNexusPlacementId(sizes),
-            keywords: buildAppNexusTargetingObject(getPageTargeting()), // Ok to duplicate call. Lodash 'once' is used.
+            keywords: buildAppNexusTargetingObject(await getPageTargeting()), // Ok to duplicate call. Lodash 'once' is used.
         },
         window.OzoneLotameData ? { lotame: window.OzoneLotameData } : {}
     );

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.spec.js
@@ -1,15 +1,15 @@
 // @flow
 import config from 'lib/config';
-import { isInUsOrCa as isInUsOrCa_,
-    isInAuOrNz as isInAuOrNz_} from 'common/modules/commercial/geo-utils';
+import {
+    isInUsOrCa as isInUsOrCa_,
+    isInAuOrNz as isInAuOrNz_,
+} from 'common/modules/commercial/geo-utils';
 import {
     _,
     getAppNexusDirectBidParams,
     getAppNexusServerSideBidParams,
 } from './appnexus';
-import {
-    getBreakpointKey as getBreakpointKey_
-} from '../utils';
+import { getBreakpointKey as getBreakpointKey_ } from '../utils';
 import type { HeaderBiddingSize } from '../types';
 
 jest.mock('common/modules/commercial/build-page-targeting', () => ({
@@ -32,8 +32,8 @@ jest.mock('../utils', () => {
 });
 
 jest.mock('common/modules/commercial/geo-utils', () => ({
-        isInAuOrNz: jest.fn(),
-        isInUsOrCa: jest.fn(),
+    isInAuOrNz: jest.fn(),
+    isInUsOrCa: jest.fn(),
 }));
 
 jest.mock('lib/cookies', () => ({
@@ -269,20 +269,20 @@ describe('getAppNexusDirectBidParams', () => {
         resetConfig();
     });
 
-    test('should include placementId for AU region when invCode switch is off', () => {
+    test('should include placementId for AU region when invCode switch is off', async () => {
         getBreakpointKey.mockReturnValue('M');
         isInAuOrNz.mockReturnValue(true);
-        expect(getAppNexusDirectBidParams([[300, 250]])).toEqual({
+        expect(await getAppNexusDirectBidParams([[300, 250]])).toEqual({
             keywords: { edition: 'UK', sens: 'f', url: 'gu.com' },
             placementId: '11016434',
         });
     });
 
-    test('should exclude placementId for AU region when including member and invCode', () => {
+    test('should exclude placementId for AU region when including member and invCode', async () => {
         config.set('switches.prebidAppnexusInvcode', true);
         getBreakpointKey.mockReturnValue('M');
         isInAuOrNz.mockReturnValueOnce(true);
-        expect(getAppNexusDirectBidParams([[300, 250]])).toEqual({
+        expect(await getAppNexusDirectBidParams([[300, 250]])).toEqual({
             keywords: {
                 edition: 'UK',
                 sens: 'f',
@@ -294,10 +294,10 @@ describe('getAppNexusDirectBidParams', () => {
         });
     });
 
-    test('should include placementId and not include invCode if outside AU region', () => {
+    test('should include placementId and not include invCode if outside AU region', async () => {
         config.set('switches.prebidAppnexusInvcode', true);
         getBreakpointKey.mockReturnValue('M');
-        expect(getAppNexusDirectBidParams([[300, 250]])).toEqual({
+        expect(await getAppNexusDirectBidParams([[300, 250]])).toEqual({
             keywords: { edition: 'UK', sens: 'f', url: 'gu.com' },
             placementId: '4298191',
         });

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.spec.js
@@ -240,19 +240,19 @@ describe('getAppNexusServerSideBidParams', () => {
         window.OzoneLotameData = undefined;
     });
 
-    test('should include OzoneLotameData if available', () => {
+    test('should include OzoneLotameData if available', async () => {
         getBreakpointKey.mockReturnValue('M');
         window.OzoneLotameData = { some: 'lotamedata' };
-        expect(getAppNexusServerSideBidParams([[300, 250]])).toEqual({
+        expect(await getAppNexusServerSideBidParams([[300, 250]])).toEqual({
             keywords: { edition: 'UK', sens: 'f', url: 'gu.com' },
             placementId: '13366904',
             lotame: { some: 'lotamedata' },
         });
     });
 
-    test('should excude lotame if data is unavailable', () => {
+    test('should excude lotame if data is unavailable', async () => {
         getBreakpointKey.mockReturnValue('M');
-        expect(getAppNexusServerSideBidParams([[300, 250]])).toEqual({
+        expect(await getAppNexusServerSideBidParams([[300, 250]])).toEqual({
             keywords: { edition: 'UK', sens: 'f', url: 'gu.com' },
             placementId: '13366904',
         });

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
@@ -525,10 +525,12 @@ export const bids: (
     HeaderBiddingSize[]
 ) => Promise<PrebidBid[]> = async (slotId, slotSizes) => {
     const currentBiddersAsync = await currentBidders(slotSizes);
-    return (await currentBiddersAsync).map(async (bidder: PrebidBidder) => ({
-        bidder: bidder.name,
-        params: await bidder.bidParams(slotId, slotSizes),
-    }));
+    return Promise.all(
+        currentBiddersAsync.map(async (bidder: PrebidBidder) => ({
+            bidder: bidder.name,
+            params: await bidder.bidParams(slotId, slotSizes),
+        }))
+    );
 };
 
 export const _ = {

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
@@ -332,21 +332,23 @@ const openxClientSideBidder: PrebidBidder = {
 const ozoneClientSideBidder: PrebidBidder = {
     name: 'ozone',
     switchName: 'prebidOzone',
-    bidParams: (): PrebidOzoneParams =>
-        Object.assign(
-            {},
-            (() => ({
-                publisherId: 'OZONEGMG0001',
-                siteId: '4204204209',
-                placementId: '0420420500',
-                customData: [
-                    {
-                        settings: {},
-                        targeting: getOzoneTargeting(),
-                    },
-                ],
-                ozoneData: {}, // TODO: confirm if we need to send any
-            }))()
+    bidParams: (): Promise<PrebidOzoneParams> =>
+        Promise.resolve(
+            Object.assign(
+                {},
+                (() => ({
+                    publisherId: 'OZONEGMG0001',
+                    siteId: '4204204209',
+                    placementId: '0420420500',
+                    customData: [
+                        {
+                            settings: {},
+                            targeting: getOzoneTargeting(),
+                        },
+                    ],
+                    ozoneData: {}, // TODO: confirm if we need to send any
+                }))()
+            )
         ),
 };
 
@@ -354,17 +356,19 @@ const sonobiBidder: PrebidBidder = {
     name: 'sonobi',
     switchName: 'prebidSonobi',
     bidParams: async (slotId: string): Promise<PrebidSonobiParams> =>
-        Object.assign(
-            {},
-            {
-                ad_unit: config.get('page.adUnit'),
-                dom_id: slotId,
-                appNexusTargeting: buildAppNexusTargeting(
-                    await getPageTargeting()
-                ),
-                pageViewId: config.get('ophan.pageViewId'),
-            },
-            isInSafeframeTestVariant() ? { render: 'safeframe' } : {}
+        Promise.resolve(
+            Object.assign(
+                {},
+                {
+                    ad_unit: config.get('page.adUnit'),
+                    dom_id: slotId,
+                    appNexusTargeting: buildAppNexusTargeting(
+                        await getPageTargeting()
+                    ),
+                    pageViewId: config.get('ophan.pageViewId'),
+                },
+                isInSafeframeTestVariant() ? { render: 'safeframe' } : {}
+            )
         ),
 };
 
@@ -381,22 +385,25 @@ const getPubmaticPublisherId = (): string => {
 const pubmaticBidder: PrebidBidder = {
     name: 'pubmatic',
     switchName: 'prebidPubmatic',
-    bidParams: (slotId: string): PrebidPubmaticParams =>
-        Object.assign(
-            {},
-            {
-                publisherId: getPubmaticPublisherId(),
-                adSlot: stripDfpAdPrefixFrom(slotId),
-            }
+    bidParams: (slotId: string): Promise<PrebidPubmaticParams> =>
+        Promise.resolve(
+            Object.assign(
+                {},
+                {
+                    publisherId: getPubmaticPublisherId(),
+                    adSlot: stripDfpAdPrefixFrom(slotId),
+                }
+            )
         ),
 };
 
 const trustXBidder: PrebidBidder = {
     name: 'trustx',
     switchName: 'prebidTrustx',
-    bidParams: (slotId: string): PrebidTrustXParams => ({
-        uid: getTrustXAdUnitId(slotId, isDesktopAndArticle),
-    }),
+    bidParams: (slotId: string): Promise<PrebidTrustXParams> =>
+        Promise.resolve({
+            uid: getTrustXAdUnitId(slotId, isDesktopAndArticle),
+        }),
 };
 
 const tripleLiftBidder: PrebidBidder = {
@@ -405,9 +412,10 @@ const tripleLiftBidder: PrebidBidder = {
     bidParams: (
         slotId: string,
         sizes: HeaderBiddingSize[]
-    ): PrebidTripleLiftParams => ({
-        inventoryCode: getTripleLiftInventoryCode(slotId, sizes),
-    }),
+    ): Promise<PrebidTripleLiftParams> =>
+        Promise.resolve({
+            inventoryCode: getTripleLiftInventoryCode(slotId, sizes),
+        }),
 };
 
 const improveDigitalBidder: PrebidBidder = {
@@ -416,10 +424,11 @@ const improveDigitalBidder: PrebidBidder = {
     bidParams: (
         slotId: string,
         sizes: HeaderBiddingSize[]
-    ): PrebidImproveParams => ({
-        placementId: getImprovePlacementId(sizes),
-        size: getImproveSizeParam(slotId),
-    }),
+    ): Promise<PrebidImproveParams> =>
+        Promise.resolve({
+            placementId: getImprovePlacementId(sizes),
+            size: getImproveSizeParam(slotId),
+        }),
 };
 
 const xaxisBidder: PrebidBidder = {
@@ -428,34 +437,35 @@ const xaxisBidder: PrebidBidder = {
     bidParams: (
         slotId: string,
         sizes: HeaderBiddingSize[]
-    ): PrebidXaxisParams => ({
-        placementId: getXaxisPlacementId(sizes),
-    }),
+    ): Promise<PrebidXaxisParams> =>
+        Promise.resolve({
+            placementId: getXaxisPlacementId(sizes),
+        }),
 };
 
 const adYouLikeBidder: PrebidBidder = {
     name: 'adyoulike',
     switchName: 'prebidAdYouLike',
-    bidParams: (): PrebidAdYouLikeParams => {
+    bidParams: (): Promise<PrebidAdYouLikeParams> => {
         if (isInUk()) {
-            return {
+            return Promise.resolve({
                 placement: '2b4d757e0ec349583ce704699f1467dd',
-            };
+            });
         }
         if (isInUsOrCa()) {
-            return {
+            return Promise.resolve({
                 placement: '7fdf0cd05e1d4bf39a2d3df9c61b3495',
-            };
+            });
         }
         if (isInAuOrNz()) {
-            return {
+            return Promise.resolve({
                 placement: '5cf05e1705a2d57ba5d51e03f2af9208',
-            };
+            });
         }
         // ROW
-        return {
+        return Promise.resolve({
             placement: 'c1853ee8bfe0d4e935cbf2db9bb76a8b',
-        };
+        });
     },
 };
 
@@ -467,10 +477,11 @@ const indexExchangeBidders: (
     return slotSizes.map(size => ({
         name: 'ix',
         switchName: 'prebidIndexExchange',
-        bidParams: (): PrebidIndexExchangeParams => ({
-            siteId: indexSiteId,
-            size,
-        }),
+        bidParams: (): Promise<PrebidIndexExchangeParams> =>
+            Promise.resolve({
+                siteId: indexSiteId,
+                size,
+            }),
     }));
 };
 
@@ -514,7 +525,7 @@ export const bids: (
     HeaderBiddingSize[]
 ) => Promise<PrebidBid[]> = async (slotId, slotSizes) => {
     const currentBiddersAsync = await currentBidders(slotSizes);
-    currentBiddersAsync.map(async (bidder: PrebidBidder) => ({
+    return (await currentBiddersAsync).map(async (bidder: PrebidBidder) => ({
         bidder: bidder.name,
         params: await bidder.bidParams(slotId, slotSizes),
     }));

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.spec.js
@@ -344,14 +344,14 @@ describe('indexExchangeBidders', () => {
         ]);
     });
 
-    test('should include methods in the response that generate the correct bid params', () => {
+    test('should include methods in the response that generate the correct bid params', async () => {
         const slotSizes: Array<HeaderBiddingSize> = [[300, 250], [300, 600]];
         const bidders: Array<PrebidBidder> = indexExchangeBidders(slotSizes);
-        expect(bidders[0].bidParams('type', [[1, 2]])).toEqual({
+        expect(await bidders[0].bidParams('type', [[1, 2]])).toEqual({
             siteId: '123456',
             size: [300, 250],
         });
-        expect(bidders[1].bidParams('type', [[1, 2]])).toEqual({
+        expect(await bidders[1].bidParams('type', [[1, 2]])).toEqual({
             siteId: '123456',
             size: [300, 600],
         });
@@ -485,7 +485,7 @@ describe('bids', () => {
             (await bids('dfp-right', [[300, 600], [300, 250]])).map(
                 bid => bid.bidder
             );
-        expect(rightSlotBidders()).toEqual(['ix', 'ix', 'adyoulike']);
+        expect(await rightSlotBidders()).toEqual(['ix', 'ix', 'adyoulike']);
     });
 
     test('should only include bidder being tested', async () => {
@@ -576,8 +576,8 @@ describe('triplelift adapter', () => {
         jest.resetAllMocks();
     });
 
-    test('should include triplelift adapter if condition is true ', () => {
-        expect(getBidders()).toEqual(['ix', 'triplelift']);
+    test('should include triplelift adapter if condition is true ', async () => {
+        expect(await getBidders()).toEqual(['ix', 'triplelift']);
     });
 
     test('should return correct triplelift adapter params for leaderboard', async () => {

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
@@ -234,15 +234,12 @@ const requestBids = async (
         return requestQueue;
     }
 
-    const adUnits: Array<PrebidAdUnit> = getHeaderBiddingAdSlots(
-        advert,
-        slotFlatMap
-    )
-        .map(slot => {
-            const prebidAdUnit = new PrebidAdUnit(advert, slot);
-            return prebidAdUnit.build(advert, slot);
-        })
-        .filter(adUnit => !adUnit.isEmpty());
+    const adUnits: Array<PrebidAdUnit> = (await Promise.all(
+        getHeaderBiddingAdSlots(advert, slotFlatMap).map(
+            // eslint-disable-next-line new-cap
+            async slot => new PrebidAdUnit.build(advert, slot)
+        )
+    )).filter(adUnit => !adUnit.isEmpty());
 
     if (adUnits.length === 0) {
         return requestQueue;

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
@@ -103,6 +103,7 @@ class PrebidAdUnit {
 
     constructor(advert: Advert, slot: HeaderBiddingSlot) {
         this.code = advert.id;
+        // How to make a constructor Async? 2020-10-23
         this.bids = bids(advert.id, slot.sizes);
         this.mediaTypes = { banner: { sizes: slot.sizes } };
     }

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/types.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/types.js
@@ -86,7 +86,7 @@ export type PrebidBidder = {
     bidParams: (
         slotId: string,
         sizes: HeaderBiddingSize[]
-    ) =>
+    ) => Promise<
         | PrebidSonobiParams
         | PrebidIndexExchangeParams
         | PrebidTrustXParams
@@ -97,7 +97,8 @@ export type PrebidBidder = {
         | PrebidOpenXParams
         | PrebidOzoneParams
         | PrebidAdYouLikeParams
-        | PrebidPubmaticParams,
+        | PrebidPubmaticParams
+    >,
 };
 
 export type PrebidBid = {

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.js
@@ -128,7 +128,7 @@ const onPlayerReadyEvent = (event, handlers: Handlers, el: ?HTMLElement) => {
     }
 };
 
-const createAdsConfig = (
+const createAdsConfig = async (
     adFree: boolean,
     tcfStateFlag: boolean | null,
     ccpaStateFlag: boolean | null
@@ -137,7 +137,7 @@ const createAdsConfig = (
         return { disableAds: true };
     }
 
-    const custParams = getPageTargeting();
+    const custParams = await getPageTargeting();
     custParams.permutive = getPermutivePFPSegments();
 
     const adsConfig: AdsConfig = {

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.js
@@ -2,7 +2,7 @@
 import { _ as youtubePlayer } from 'common/modules/atoms/youtube-player';
 
 jest.mock('common/modules/commercial/build-page-targeting', () => ({
-    getPageTargeting: jest.fn(() => ({ key: 'value' })),
+    getPageTargeting: jest.fn(() => (Promise.resolve({ key: 'value' }))),
 }));
 
 jest.mock('common/modules/commercial/permutive', () => ({
@@ -38,8 +38,8 @@ jest.mock('common/modules/experiments/ab', () => ({
 }));
 
 describe('create ads config', () => {
-    it('disables ads in ad-free', () => {
-        const result = youtubePlayer.createAdsConfig(
+    it('disables ads in ad-free', async () => {
+        const result = await youtubePlayer.createAdsConfig(
             true, // ad-free
             null,
             null
@@ -48,14 +48,14 @@ describe('create ads config', () => {
         expect(result.disableAds).toBeTruthy();
     });
 
-    it('does not disable ads when we are not in ad-free', () => {
-        const result = youtubePlayer.createAdsConfig(false, null, null);
+    it('does not disable ads when we are not in ad-free', async () => {
+        const result = await youtubePlayer.createAdsConfig(false, null, null);
 
         expect(result.disableAds).toBeFalsy();
     });
 
-    it('in non ad-free, returns false nonPersonalizedAd without consent in TCF', () => {
-        const result = youtubePlayer.createAdsConfig(false, false, null);
+    it('in non ad-free, returns false nonPersonalizedAd without consent in TCF', async () => {
+        const result = await youtubePlayer.createAdsConfig(false, false, null);
 
         if (result.hasOwnProperty('nonPersonalizedAd')) {
             expect(result.nonPersonalizedAd).toBeTruthy();
@@ -96,8 +96,8 @@ describe('create ads config', () => {
         expect(result.nonPersonalizedAd).toBeUndefined();
     });
 
-    it('in non ad-free includes adUnit', () => {
-        const result = youtubePlayer.createAdsConfig(false, null, null);
+    it('in non ad-free includes adUnit', async () => {
+        const result = await youtubePlayer.createAdsConfig(false, null, null);
 
         expect(result.adTagParameters).toBeDefined();
         if (result.adTagParameters) {
@@ -105,8 +105,8 @@ describe('create ads config', () => {
         }
     });
 
-    it('in non ad-free includes url-escaped and tcfv2 targeting params', () => {
-        const result = youtubePlayer.createAdsConfig(false, null, null);
+    it('in non ad-free includes url-escaped and tcfv2 targeting params', async () => {
+        const result = await youtubePlayer.createAdsConfig(false, null, null);
         const expectedAdTargetingParams =  {
             "cmpGdpr": 1,
             "cmpGvcd": "testaddtlConsent",

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -72,7 +72,7 @@ const inskinTargetting = async (): Promise<string> => {
         return 'f';
     }
     const willShowPrivacyMessage: boolean = await cmp.willShowPrivacyMessage();
-    return willShowPrivacyMessage ? 't' : 'f';
+    return willShowPrivacyMessage ? 'f' : 't';
 };
 
 const format = (keyword: string): string =>

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -44,8 +44,7 @@ type PageTargeting = {
     urlkw: string,
 };
 
-let myPageTargetting: {} = {};
-let latestConsentCanRun;
+let myPageTargetting: Promise<{}> = Promise.resolve({});
 
 const findBreakpoint = (): string => {
     switch (getBreakpoint(true)) {
@@ -233,11 +232,11 @@ const getTcfv2ConsentValue = (tcfv2State: boolean | null): string => {
     return 'na';
 };
 
-const buildPageTargetting = (
+const buildPageTargetting = async (
     adConsentState: boolean | null,
     ccpaState: boolean | null,
     tcfv2EventStatus: string | null
-): { [key: string]: mixed } => {
+): Promise<{ [key: string]: mixed }> => {
     const page = config.get('page');
     // personalised ads targeting
     if (adConsentState === false) clearPermutiveSegments();
@@ -274,7 +273,7 @@ const buildPageTargetting = (
             // Indicates whether the page is DCR eligible. This happens when the page
             // was DCR eligible and was actually rendered by DCR or
             // was DCR eligible but rendered by frontend for a user not in the DotcomRendering experiment
-            inskin: inskinTargetting(),
+            inskin: await inskinTargetting(),
             urlkw: getUrlKeywords(page.pageId),
             rdp: getRdpValue(ccpaState),
             consent_tcfv2: getTcfv2ConsentValue(adConsentState),
@@ -303,42 +302,32 @@ const buildPageTargetting = (
     return pageTargeting;
 };
 
-const getPageTargeting = (): { [key: string]: mixed } => {
-    if (Object.keys(myPageTargetting).length !== 0) return myPageTargetting;
+const getPageTargeting = async (): Promise<{ [key: string]: mixed }> =>
+    myPageTargetting;
 
-    onConsentChange(state => {
-        let canRun: boolean | null;
-        if (state.ccpa) {
-            // CCPA mode
-            canRun = !state.ccpa.doNotSell;
-        } else if (state.tcfv2) {
-            // TCFv2 mode
-            canRun = state.tcfv2.consents
-                ? Object.keys(state.tcfv2.consents).length > 0 &&
-                  Object.values(state.tcfv2.consents).every(Boolean)
-                : false;
-        } else if (state.aus) {
-            // AUS mode
-            canRun = state.aus.personalisedAdvertising;
-        } else canRun = false;
+onConsentChange(state => {
+    let canRun: boolean | null;
+    if (state.ccpa) {
+        // CCPA mode
+        canRun = !state.ccpa.doNotSell;
+    } else if (state.tcfv2) {
+        // TCFv2 mode
+        canRun = state.tcfv2.consents
+            ? Object.keys(state.tcfv2.consents).length > 0 &&
+              Object.values(state.tcfv2.consents).every(Boolean)
+            : false;
+    } else if (state.aus) {
+        // AUS mode
+        canRun = state.aus.personalisedAdvertising;
+    } else canRun = false;
 
-        if (canRun !== latestConsentCanRun) {
-            const ccpaState = state.ccpa ? state.ccpa.doNotSell : null;
-            const eventStatus = state.tcfv2 ? state.tcfv2.eventStatus : 'na';
-            myPageTargetting = buildPageTargetting(
-                canRun,
-                ccpaState,
-                eventStatus
-            );
-            latestConsentCanRun = canRun;
-        }
-    });
-
-    return myPageTargetting;
-};
+    const ccpaState = state.ccpa ? state.ccpa.doNotSell : null;
+    const eventStatus = state.tcfv2 ? state.tcfv2.eventStatus : 'na';
+    myPageTargetting = buildPageTargetting(canRun, ccpaState, eventStatus);
+});
 
 const resetPageTargeting = (): void => {
-    myPageTargetting = {};
+    myPageTargetting = Promise.resolve({});
     latestConsentCanRun = undefined;
 };
 

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -10,7 +10,7 @@ import { getSync as geolocationGetSync } from 'lib/geolocation';
 import { storage } from '@guardian/libs';
 import { getUrlVars } from 'lib/url';
 import { getPrivacyFramework } from 'lib/getPrivacyFramework';
-import { onConsentChange } from '@guardian/consent-management-platform';
+import { cmp, onConsentChange } from '@guardian/consent-management-platform';
 import {
     getPermutiveSegments,
     clearPermutiveSegments,
@@ -65,12 +65,13 @@ const findBreakpoint = (): string => {
     }
 };
 
-const inskinTargetting = (): string => {
-    if (storage.local.get('gu.hasSeenPrivacyBanner')) {
-        const vp = getViewport();
-        if (vp && vp.width >= 1560) return 't';
+const inskinTargetting = async (): Promise<string> => {
+    const vp = getViewport();
+    if (vp && vp.width < 1560) {
+        return 'f';
     }
-    return 'f';
+    const willShowPrivacyMessage: boolean = await cmp.willShowPrivacyMessage();
+    return willShowPrivacyMessage ? 't' : 'f';
 };
 
 const format = (keyword: string): string =>

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -44,7 +44,9 @@ type PageTargeting = {
     urlkw: string,
 };
 
-let myPageTargetting: Promise<{}> = Promise.resolve({});
+type PageTargettingLoose = { [key: string]: mixed };
+
+let myPageTargetting: Promise<PageTargettingLoose> = Promise.resolve({});
 
 const findBreakpoint = (): string => {
     switch (getBreakpoint(true)) {
@@ -236,7 +238,7 @@ const buildPageTargetting = async (
     adConsentState: boolean | null,
     ccpaState: boolean | null,
     tcfv2EventStatus: string | null
-): Promise<{ [key: string]: mixed }> => {
+): Promise<PageTargettingLoose> => {
     const page = config.get('page');
     // personalised ads targeting
     if (adConsentState === false) clearPermutiveSegments();
@@ -286,7 +288,7 @@ const buildPageTargetting = async (
     );
 
     // filter out empty values
-    const pageTargeting: {} = pickBy(pageTargets, target => {
+    const pageTargeting: PageTargettingLoose = pickBy(pageTargets, target => {
         if (Array.isArray(target)) {
             return target.length > 0;
         }
@@ -302,7 +304,7 @@ const buildPageTargetting = async (
     return pageTargeting;
 };
 
-const getPageTargeting = async (): Promise<{ [key: string]: mixed }> =>
+const getPageTargeting = async (): Promise<PageTargettingLoose> =>
     myPageTargetting;
 
 onConsentChange(state => {

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -308,34 +308,38 @@ const buildPageTargetting = async (
 };
 
 const getPageTargeting = async (): Promise<PageTargettingLoose> => {
-    onConsentChange(async state => {
-        myPageTargetting = new Promise(async resolve => {
-            let canRun: boolean | null;
-            if (state.ccpa) {
-                // CCPA mode
-                canRun = !state.ccpa.doNotSell;
-            } else if (state.tcfv2) {
-                // TCFv2 mode
-                canRun = state.tcfv2.consents
-                    ? Object.keys(state.tcfv2.consents).length > 0 &&
-                      Object.values(state.tcfv2.consents).every(Boolean)
-                    : false;
-            } else if (state.aus) {
-                // AUS mode
-                canRun = state.aus.personalisedAdvertising;
-            } else canRun = false;
+    once(
+        onConsentChange(async state => {
+            myPageTargetting = new Promise(async resolve => {
+                let canRun: boolean | null;
+                if (state.ccpa) {
+                    // CCPA mode
+                    canRun = !state.ccpa.doNotSell;
+                } else if (state.tcfv2) {
+                    // TCFv2 mode
+                    canRun = state.tcfv2.consents
+                        ? Object.keys(state.tcfv2.consents).length > 0 &&
+                          Object.values(state.tcfv2.consents).every(Boolean)
+                        : false;
+                } else if (state.aus) {
+                    // AUS mode
+                    canRun = state.aus.personalisedAdvertising;
+                } else canRun = false;
 
-            const ccpaState = state.ccpa ? state.ccpa.doNotSell : null;
-            const eventStatus = state.tcfv2 ? state.tcfv2.eventStatus : 'na';
-            const pageTargetting = await buildPageTargetting(
-                canRun,
-                ccpaState,
-                eventStatus
-            );
-            resolve(pageTargetting);
-            resolveInitialPageTargetting(pageTargetting);
-        });
-    });
+                const ccpaState = state.ccpa ? state.ccpa.doNotSell : null;
+                const eventStatus = state.tcfv2
+                    ? state.tcfv2.eventStatus
+                    : 'na';
+                const pageTargetting = await buildPageTargetting(
+                    canRun,
+                    ccpaState,
+                    eventStatus
+                );
+                resolve(pageTargetting);
+                resolveInitialPageTargetting(pageTargetting);
+            });
+        })
+    );
     return myPageTargetting;
 };
 

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -17,7 +17,7 @@ import { getPrivacyFramework as getPrivacyFramework_ } from 'lib/getPrivacyFrame
 import { isUserLoggedIn as isUserLoggedIn_ } from 'common/modules/identity/api';
 import { getUserSegments as getUserSegments_ } from 'common/modules/commercial/user-ad-targeting';
 import { getSynchronousParticipations as getSynchronousParticipations_ } from 'common/modules/experiments/ab';
-import { onConsentChange } from '@guardian/consent-management-platform';
+import {cmp, onConsentChange} from '@guardian/consent-management-platform';
 
 const getCookie: any = getCookie_;
 const getUserSegments: any = getUserSegments_;
@@ -59,6 +59,9 @@ jest.mock('common/modules/commercial/commercial-features', () => ({
 }));
 jest.mock('@guardian/consent-management-platform', () => ({
     onConsentChange: jest.fn(),
+    cmp: {
+        willShowPrivacyMessage: jest.fn(),
+    },
 }));
 
 // TCFv1
@@ -156,6 +159,7 @@ describe('Build Page Targeting', () => {
 
         getSync.mockReturnValue('US');
         getPrivacyFramework.mockReturnValue({ ccpa: true });
+        cmp.willShowPrivacyMessage.mockResolvedValue(true);
 
         expect.hasAssertions();
     });
@@ -452,7 +456,7 @@ describe('Build Page Targeting', () => {
             ]);
         });
 
-        it('should get correct keywords when trailing slash is present', () => {
+        it('should get correct keywords when trailing slash is present',  () => {
             config.page.pageId =
                 'stage/2016/jul/26/harry-potter-cursed-child-review-palace-theatre-london/';
             expect(getPageTargeting().urlkw).toEqual([

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -17,7 +17,7 @@ import { getPrivacyFramework as getPrivacyFramework_ } from 'lib/getPrivacyFrame
 import { isUserLoggedIn as isUserLoggedIn_ } from 'common/modules/identity/api';
 import { getUserSegments as getUserSegments_ } from 'common/modules/commercial/user-ad-targeting';
 import { getSynchronousParticipations as getSynchronousParticipations_ } from 'common/modules/experiments/ab';
-import {cmp, onConsentChange} from '@guardian/consent-management-platform';
+import { cmp, onConsentChange } from '@guardian/consent-management-platform';
 
 const getCookie: any = getCookie_;
 const getUserSegments: any = getUserSegments_;
@@ -102,7 +102,7 @@ const tcfv2MixedConsentMock = (callback): void =>
     });
 
 describe('Build Page Targeting', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
         config.page = {
             authorIds: 'profile/gabrielle-chan',
             blogIds: 'a/blog',
@@ -172,8 +172,8 @@ describe('Build Page Targeting', () => {
         expect(getPageTargeting).toBeDefined();
     });
 
-    it('should build correct page targeting', () => {
-        const pageTargeting = getPageTargeting();
+    it('should build correct page targeting', async () => {
+        const pageTargeting = await getPageTargeting();
 
         expect(pageTargeting.sens).toBe('f');
         expect(pageTargeting.edition).toBe('us');
@@ -195,123 +195,127 @@ describe('Build Page Targeting', () => {
         expect(pageTargeting.rp).toEqual('dotcom-platform');
     });
 
-    it('should set correct personalized ad (pa) param', () => {
+    it('should set correct personalized ad (pa) param', async () => {
         onConsentChange.mockImplementation(tcfv2WithConsentMock);
-        expect(getPageTargeting().pa).toBe('t');
+        expect((await getPageTargeting()).pa).toBe('t');
 
         _.resetPageTargeting();
         onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
-        expect(getPageTargeting().pa).toBe('f');
+        expect((await getPageTargeting()).pa).toBe('f');
 
         _.resetPageTargeting();
         onConsentChange.mockImplementation(tcfv2NullConsentMock);
-        expect(getPageTargeting().pa).toBe('f');
+        expect((await getPageTargeting()).pa).toBe('f');
 
         _.resetPageTargeting();
         onConsentChange.mockImplementation(tcfv2MixedConsentMock);
-        expect(getPageTargeting().pa).toBe('f');
+        expect((await getPageTargeting()).pa).toBe('f');
 
         _.resetPageTargeting();
         onConsentChange.mockImplementation(ccpaWithConsentMock);
-        expect(getPageTargeting().pa).toBe('t');
+        expect((await getPageTargeting()).pa).toBe('t');
 
         _.resetPageTargeting();
         onConsentChange.mockImplementation(ccpaWithoutConsentMock);
-        expect(getPageTargeting().pa).toBe('f');
+        expect((await getPageTargeting()).pa).toBe('f');
     });
 
-    it('Should correctly set the RDP flag (rdp) param', () => {
+    it('Should correctly set the RDP flag (rdp) param', async () => {
         onConsentChange.mockImplementation(tcfWithConsentMock);
-        expect(getPageTargeting().rdp).toBe('na');
+        expect((await getPageTargeting()).rdp).toBe('na');
 
         _.resetPageTargeting();
         onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
-        expect(getPageTargeting().rdp).toBe('na');
+        expect((await getPageTargeting()).rdp).toBe('na');
 
         _.resetPageTargeting();
         onConsentChange.mockImplementation(tcfv2NullConsentMock);
-        expect(getPageTargeting().rdp).toBe('na');
+        expect((await getPageTargeting()).rdp).toBe('na');
 
         _.resetPageTargeting();
         onConsentChange.mockImplementation(tcfMixedConsentMock);
-        expect(getPageTargeting().rdp).toBe('na');
+        expect((await getPageTargeting()).rdp).toBe('na');
 
         _.resetPageTargeting();
         onConsentChange.mockImplementation(ccpaWithConsentMock);
-        expect(getPageTargeting().rdp).toBe('f');
+        expect((await getPageTargeting()).rdp).toBe('f');
 
         _.resetPageTargeting();
         onConsentChange.mockImplementation(ccpaWithoutConsentMock);
-        expect(getPageTargeting().rdp).toBe('t');
+        expect((await getPageTargeting()).rdp).toBe('t');
     });
 
-    it('Should correctly set the TCFv2 (consent_tcfv2, cmp_interaction) params', () => {
+    it('Should correctly set the TCFv2 (consent_tcfv2, cmp_interaction) params', async () => {
         _.resetPageTargeting();
         getPrivacyFramework.mockReturnValue({ tcfv2: true });
 
         onConsentChange.mockImplementation(tcfv2WithConsentMock);
 
-        expect(getPageTargeting().consent_tcfv2).toBe('t');
-        expect(getPageTargeting().cmp_interaction).toBe('useractioncomplete');
+        expect((await getPageTargeting()).consent_tcfv2).toBe('t');
+        expect((await getPageTargeting()).cmp_interaction).toBe(
+            'useractioncomplete'
+        );
 
         _.resetPageTargeting();
         onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
 
-        expect(getPageTargeting().consent_tcfv2).toBe('f');
-        expect(getPageTargeting().cmp_interaction).toBe('cmpuishown');
+        expect((await getPageTargeting()).consent_tcfv2).toBe('f');
+        expect((await getPageTargeting()).cmp_interaction).toBe('cmpuishown');
 
         _.resetPageTargeting();
         onConsentChange.mockImplementation(tcfv2MixedConsentMock);
 
-        expect(getPageTargeting().consent_tcfv2).toBe('f');
-        expect(getPageTargeting().cmp_interaction).toBe('useractioncomplete');
+        expect((await getPageTargeting()).consent_tcfv2).toBe('f');
+        expect((await getPageTargeting()).cmp_interaction).toBe(
+            'useractioncomplete'
+        );
 
         _.resetPageTargeting();
         getPrivacyFramework.mockReturnValue({ tcfv1: true });
         onConsentChange.mockImplementation(tcfWithConsentMock);
 
-        expect(getPageTargeting().consent_tcfv2).toBe('na');
-        expect(getPageTargeting().cmp_interaction).toBe('na');
+        expect((await getPageTargeting()).consent_tcfv2).toBe('na');
+        expect((await getPageTargeting()).cmp_interaction).toBe('na');
     });
 
-    it('should set correct edition param', () => {
-        expect(getPageTargeting().edition).toBe('us');
+    it('should set correct edition param', async () => {
+        expect((await getPageTargeting()).edition).toBe('us');
     });
 
-    it('should set correct se param', () => {
-        expect(getPageTargeting().se).toEqual(['filmweekly']);
+    it('should set correct se param', async () => {
+        expect((await getPageTargeting()).se).toEqual(['filmweekly']);
     });
 
-    it('should set correct k param', () => {
-        expect(getPageTargeting().k).toEqual([
+    it('should set correct k param', async () => {
+        expect((await getPageTargeting()).k).toEqual([
             'prince-charles-letters',
             'uk/uk',
             'prince-charles',
         ]);
     });
 
-    it('should set correct ab param', () => {
-        expect(getPageTargeting().ab).toEqual(['MtMaster-variantName']);
+    it('should set correct ab param', async () => {
+        expect((await getPageTargeting()).ab).toEqual(['MtMaster-variantName']);
     });
 
-    it('should set Observer flag for Observer content', () => {
-        expect(getPageTargeting().ob).toEqual('t');
+    it('should set Observer flag for Observer content', async () => {
+        expect((await getPageTargeting()).ob).toEqual('t');
     });
 
-    it('should set correct branding param for paid content', () => {
-        expect(getPageTargeting().br).toEqual('p');
+    it('should set correct branding param for paid content', async () => {
+        expect((await getPageTargeting()).br).toEqual('p');
     });
 
-    it('should not contain an ad-free targeting value', () => {
-        expect(getPageTargeting().af).toBeUndefined();
+    it('should not contain an ad-free targeting value', async () => {
+        expect((await getPageTargeting()).af).toBeUndefined();
     });
 
-    it('should remove empty values', () => {
+    it('should remove empty values', async () => {
         config.page = {};
         config.ophan = { pageViewId: '123456' };
         getUserSegments.mockReturnValue([]);
 
-        expect(getPageTargeting()).toEqual({
+        expect(await getPageTargeting()).toEqual({
             sens: 'f',
             bp: 'mobile',
             at: 'ng101',
@@ -331,120 +335,122 @@ describe('Build Page Targeting', () => {
     });
 
     describe('Breakpoint targeting', () => {
-        it('should set correct breakpoint targeting for a mobile device', () => {
+        it('should set correct breakpoint targeting for a mobile device', async () => {
             getBreakpoint.mockReturnValue('mobile');
-            expect(getPageTargeting().bp).toEqual('mobile');
+            expect((await getPageTargeting()).bp).toEqual('mobile');
         });
 
-        it('should set correct breakpoint targeting for a medium mobile device', () => {
+        it('should set correct breakpoint targeting for a medium mobile device', async () => {
             getBreakpoint.mockReturnValue('mobileMedium');
-            expect(getPageTargeting().bp).toEqual('mobile');
+            expect((await getPageTargeting()).bp).toEqual('mobile');
         });
 
-        it('should set correct breakpoint targeting for a mobile device in landscape mode', () => {
+        it('should set correct breakpoint targeting for a mobile device in landscape mode', async () => {
             getBreakpoint.mockReturnValue('mobileLandscape');
-            expect(getPageTargeting().bp).toEqual('mobile');
+            expect((await getPageTargeting()).bp).toEqual('mobile');
         });
 
-        it('should set correct breakpoint targeting for a phablet device', () => {
+        it('should set correct breakpoint targeting for a phablet device', async () => {
             getBreakpoint.mockReturnValue('phablet');
-            expect(getPageTargeting().bp).toEqual('tablet');
+            expect((await getPageTargeting()).bp).toEqual('tablet');
         });
 
-        it('should set correct breakpoint targeting for a tablet device', () => {
+        it('should set correct breakpoint targeting for a tablet device', async () => {
             getBreakpoint.mockReturnValue('tablet');
-            expect(getPageTargeting().bp).toEqual('tablet');
+            expect((await getPageTargeting()).bp).toEqual('tablet');
         });
 
-        it('should set correct breakpoint targeting for a desktop device', () => {
+        it('should set correct breakpoint targeting for a desktop device', async () => {
             getBreakpoint.mockReturnValue('desktop');
-            expect(getPageTargeting().bp).toEqual('desktop');
+            expect((await getPageTargeting()).bp).toEqual('desktop');
         });
 
-        it('should set correct breakpoint targeting for a leftCol device', () => {
+        it('should set correct breakpoint targeting for a leftCol device', async () => {
             getBreakpoint.mockReturnValue('leftCol');
-            expect(getPageTargeting().bp).toEqual('desktop');
+            expect((await getPageTargeting()).bp).toEqual('desktop');
         });
 
-        it('should set correct breakpoint targeting for a wide device', () => {
+        it('should set correct breakpoint targeting for a wide device', async () => {
             getBreakpoint.mockReturnValue('wide');
-            expect(getPageTargeting().bp).toEqual('desktop');
+            expect((await getPageTargeting()).bp).toEqual('desktop');
         });
     });
 
     describe('Build Page Targeting (ad-free)', () => {
-        it('should set the ad-free param to t when enabled', () => {
+        it('should set the ad-free param to t when enabled', async () => {
             commercialFeatures.adFree = true;
-            expect(getPageTargeting().af).toBe('t');
+            expect((await getPageTargeting()).af).toBe('t');
         });
     });
 
     describe('Already visited frequency', () => {
-        it('can pass a value of five or less', () => {
+        it('can pass a value of five or less', async () => {
             storage.local.setRaw('gu.alreadyVisited', 5);
-            expect(getPageTargeting().fr).toEqual('5');
+            expect((await getPageTargeting()).fr).toEqual('5');
         });
 
-        it('between five and thirty, includes it in a bucket in the form "x-y"', () => {
+        it('between five and thirty, includes it in a bucket in the form "x-y"', async () => {
             storage.local.setRaw('gu.alreadyVisited', 18);
-            expect(getPageTargeting().fr).toEqual('16-19');
+            expect((await getPageTargeting()).fr).toEqual('16-19');
         });
 
-        it('over thirty, includes it in the bucket "30plus"', () => {
+        it('over thirty, includes it in the bucket "30plus"', async () => {
             storage.local.setRaw('gu.alreadyVisited', 300);
-            expect(getPageTargeting().fr).toEqual('30plus');
+            expect((await getPageTargeting()).fr).toEqual('30plus');
         });
 
-        it('passes a value of 0 if the value is not stored', () => {
+        it('passes a value of 0 if the value is not stored', async () => {
             storage.local.remove('gu.alreadyVisited');
-            expect(getPageTargeting().fr).toEqual('0');
+            expect((await getPageTargeting()).fr).toEqual('0');
         });
     });
 
     describe('Referrer', () => {
-        it('should set ref to Facebook', () => {
+        it('should set ref to Facebook', async () => {
             getReferrer.mockReturnValue(
                 'https://www.facebook.com/feel-the-force'
             );
-            expect(getPageTargeting().ref).toEqual('facebook');
+            expect((await getPageTargeting()).ref).toEqual('facebook');
         });
 
-        it('should set ref to Twitter', () => {
+        it('should set ref to Twitter', async () => {
             getReferrer.mockReturnValue(
                 'https://www.t.co/you-must-unlearn-what-you-have-learned'
             );
-            expect(getPageTargeting().ref).toEqual('twitter');
+            expect((await getPageTargeting()).ref).toEqual('twitter');
         });
 
-        it('should set ref to reddit', () => {
+        it('should set ref to reddit', async () => {
             getReferrer.mockReturnValue(
                 'https://www.reddit.com/its-not-my-fault'
             );
-            expect(getPageTargeting().ref).toEqual('reddit');
+            expect((await getPageTargeting()).ref).toEqual('reddit');
         });
 
-        it('should set ref to google', () => {
+        it('should set ref to google', async () => {
             getReferrer.mockReturnValue(
                 'https://www.google.com/i-find-your-lack-of-faith-distrubing'
             );
-            expect(getPageTargeting().ref).toEqual('google');
+            expect((await getPageTargeting()).ref).toEqual('google');
         });
 
-        it('should set ref empty string if referrer does not match', () => {
+        it('should set ref empty string if referrer does not match', async () => {
             getReferrer.mockReturnValue('https://theguardian.com');
-            expect(getPageTargeting().ref).toEqual(undefined);
+            expect((await getPageTargeting()).ref).toEqual(undefined);
         });
     });
 
     describe('URL Keywords', () => {
-        it('should return correct keywords from pageId', () => {
-            expect(getPageTargeting().urlkw).toEqual(['footballweekly']);
+        it('should return correct keywords from pageId', async () => {
+            expect((await getPageTargeting()).urlkw).toEqual([
+                'footballweekly',
+            ]);
         });
 
-        it('should extract multiple url keywords correctly', () => {
+        it('should extract multiple url keywords correctly', async () => {
             config.page.pageId =
                 'stage/2016/jul/26/harry-potter-cursed-child-review-palace-theatre-london';
-            expect(getPageTargeting().urlkw).toEqual([
+            expect((await getPageTargeting()).urlkw).toEqual([
                 'harry',
                 'potter',
                 'cursed',
@@ -456,10 +462,10 @@ describe('Build Page Targeting', () => {
             ]);
         });
 
-        it('should get correct keywords when trailing slash is present',  () => {
+        it('should get correct keywords when trailing slash is present', async () => {
             config.page.pageId =
                 'stage/2016/jul/26/harry-potter-cursed-child-review-palace-theatre-london/';
-            expect(getPageTargeting().urlkw).toEqual([
+            expect((await getPageTargeting()).urlkw).toEqual([
                 'harry',
                 'potter',
                 'cursed',


### PR DESCRIPTION
## What does this change?

Page targetting is fundamentally an asynchronous function. For page targetting to be built, we first need to have a consent state. In Australia, knowing whether a privacy message will be shown is also essential to know if `inskin` targetting can be applied. This change requires all calls to `getPageTargetting` to be asynchronous.

Key points to note:

- Callbacks to `onConsentChange` in `build-page-targetting` are now only added once with lodash.
- Page targetting is now a Promise, `<pending>` until the first `onConsentChange` callback is fired.
- Page targetting is built when and only when consent changes. It will be `<pending>` until the new targetting is available.
- Page targetting is still memoized, albeit wrapped in a Promise.

Ripples in other files:
- Jest tests against promises should return the Promise, otherwise a unfulfilled promise will fail silently (this is an improvement)
- Jest test now mock `cmp.willShowPrivacyMessage`, otherwise page targetting will not resolve.
- Prebid ad units now return promises.

Alternative solution that have been discussed, but ultimately discard:
- change the signature of `getPageTargetting` to accept `state` as an argument. Not all places where `getPageTargetting` have access to a consent state.
- create a new CMP method that resolves when an initial consent state is available. This was achieved with `resolveInitialPageTargetting` in `build-page-targeting.js`.


---


## Does this change need to be reproduced in dotcom-rendering ?

- [X] No **(it comes with the bundle)**
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
