### PR TITLE
Network Front Videos Don't redirect on click

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_container--video.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--video.scss
@@ -270,6 +270,12 @@ $video-width-desktop: 700px;
         width: $video-width-desktop;
         margin: 0;
     }
+
+    @include mq($until: tablet) {
+    .video-container-overlay-link {
+        z-index: 3;
+    }
+
 }
 
 .video-playlist__item--first {

--- a/static/src/stylesheets/module/facia-garnett/_container--video.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--video.scss
@@ -275,7 +275,6 @@ $video-width-desktop: 700px;
     .video-container-overlay-link {
         z-index: 3;
     }
-
 }
 
 .video-playlist__item--first {

--- a/static/src/stylesheets/module/facia-garnett/_container--video.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--video.scss
@@ -272,8 +272,9 @@ $video-width-desktop: 700px;
     }
 
     @include mq($until: tablet) {
-    .video-container-overlay-link {
-        z-index: 3;
+        .video-container-overlay-link {
+            z-index: 3;
+        }
     }
 }
 


### PR DESCRIPTION
## What does this change?

Currently on fronts clicking on a video on a front at a very narrow screen-width causes nothing to happen, and it was only when the title was clicked that the article would navigate to it's own page. This fix changes the z-index of the video which means clicking on it will redirect to the video page.

## Before
![ezgif com-gif-maker](https://user-images.githubusercontent.com/35331926/100765032-f32d5700-33ee-11eb-82f7-83528a714d79.gif)

## After
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/35331926/100765135-10622580-33ef-11eb-986c-951b703cd268.gif)



