### PR TITLE
commercial routes: add a comment for future reference

### DIFF
--- a/commercial/conf/routes
+++ b/commercial/conf/routes
@@ -22,9 +22,14 @@ GET         /commercial/api/liveevent.json                                  comm
 
 # Multiple offer merchandising components
 GET         /commercial/api/multi.json                                      commercial.controllers.Multi.getMulti
+
 # Content API merchandising components
+# Attempting to remove ContentApiOffersController, discovered
+# https://github.com/guardian/commercial-templates/blob/dba808f89127d4405f4f4f087208e6135400e61c/src/capi-single-paidfor/web/index.js#L30
+# https://api.nextgen.guardianapps.co.uk/commercial/api/capi-single.json?k=qantas-insurance-rewarding-loyalty/qantas-insurance-rewarding-loyalty
 GET         /commercial/api/capi-single.json                                commercial.controllers.ContentApiOffersController.nativeJson
 GET         /commercial/api/capi-multiple.json                              commercial.controllers.ContentApiOffersController.nativeJsonMulti
+
 GET         /commercial/api/traffic-driver.json                             commercial.controllers.TrafficDriverController.renderJson
 
 # Piggyback pixel from AppNexus, used for resizing mpus


### PR DESCRIPTION
## What does this change?

commercial routes: add a comment for future reference ( was made after this: https://github.com/guardian/frontend/pull/23334 )