### PR TITLE
Fixes Front Srcsets by addind missing Quotation

### DIFF
--- a/common/app/views/fragments/items/elements/facia_cards/image.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/image.scala.html
@@ -20,7 +20,7 @@
     @widths.breakpoints.map { breakpointWidth =>
         <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (min-resolution: 120dpi)"
         sizes="@breakpointWidth.width"
-        srcset=@SrcSet.asSrcSetString(ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia, hidpi = true)) />
+        srcset="@SrcSet.asSrcSetString(ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia, hidpi = true))" />
         <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px)"
         sizes="@breakpointWidth.width"
         srcset="@SrcSet.asSrcSetString(ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia))" />


### PR DESCRIPTION
## What does this change?

The sourcesets on Front were missing quotation marks during tag generation leading to incorrect sources.

[Related to this comment](https://github.com/guardian/dotcom-rendering/pull/2070#issuecomment-728161518)

Before:
<img width="1163" alt="Screenshot 2020-12-02 at 16 26 54" src="https://user-images.githubusercontent.com/35331926/100901196-7f0cb500-34bb-11eb-9e80-2927002e51fd.png">

After:
<img width="1163" alt="Screenshot 2020-12-02 at 16 27 46" src="https://user-images.githubusercontent.com/35331926/100901223-8469ff80-34bb-11eb-9ce0-f2e4aaad34f7.png">

