### PR TITLE
Expand ResultWithPreload to allow domain preconnections

### DIFF
--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -129,9 +129,10 @@ object `package` extends implicits.Strings with implicits.Requests with play.api
     }
 
   def renderHtml(html: Html, page: model.Page)(implicit request: RequestHeader, context: ApplicationContext): Result = {
-    Cached(page)(RevalidatableResult.Ok(html)).withPreload(
-      Preload.config(request).getOrElse(context.applicationIdentity, Seq.empty),
-    )(context, request)
+    Cached(page)(RevalidatableResult.Ok(html))
+      .withPreload(
+        Preload.config(request).getOrElse(context.applicationIdentity, Seq.empty),
+      )(context, request)
   }
 
   def renderJson(json: List[(String, Any)], page: model.Page)(implicit

--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -18,6 +18,7 @@ import play.api.mvc.{RequestHeader, Result}
 import play.twirl.api.Html
 import model.ApplicationContext
 import http.ResultWithPreconnectPreload
+import http.HttpPreconnections
 
 object `package`
     extends implicits.Strings
@@ -137,6 +138,7 @@ object `package`
       .withPreload(
         Preload.config(request).getOrElse(context.applicationIdentity, Seq.empty),
       )(context, request)
+      .withPreconnect(HttpPreconnections.defaultUrls)
   }
 
   def renderJson(json: List[(String, Any)], page: model.Page)(implicit

--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -17,9 +17,13 @@ import play.api.libs.json.{JsObject, JsString}
 import play.api.mvc.{RequestHeader, Result}
 import play.twirl.api.Html
 import model.ApplicationContext
-import http.ResultWithPreload
+import http.ResultWithPreconnectPreload
 
-object `package` extends implicits.Strings with implicits.Requests with play.api.mvc.Results with ResultWithPreload {
+object `package`
+    extends implicits.Strings
+    with implicits.Requests
+    with play.api.mvc.Results
+    with ResultWithPreconnectPreload {
 
   def isCommercialExpiry(error: ErrorResponse): Boolean = {
     error.message == "The requested resource has expired for commercial reason."

--- a/common/app/http/H2PreloadFilter.scala
+++ b/common/app/http/H2PreloadFilter.scala
@@ -13,7 +13,7 @@ class H2PreloadFilter(implicit
     executionContext: ExecutionContext,
 ) extends Filter
     with implicits.Requests
-    with ResultWithPreload {
+    with ResultWithPreconnectPreload {
 
   def apply(nextFilter: RequestHeader => Future[Result])(request: RequestHeader): Future[Result] = {
     nextFilter(request).map { result =>

--- a/common/app/http/ResultWithPreconnectPreload.scala
+++ b/common/app/http/ResultWithPreconnectPreload.scala
@@ -27,5 +27,46 @@ trait ResultWithPreconnectPreload {
         self.withHeaders(linkHeaderKey -> linkHeaderValue)
       } else self
     }
+
+    def withPreconnect(urls: Seq[String]): Result = {
+      // Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link
+      // Reference: https://www.w3.org/TR/resource-hints/
+      /*
+        Note that the two above references disagree on the exact grammar. The first indicates
+        Link: <https://example.com>; rel="preconnect"
+
+        while the second indicates:
+        Link: <https://example.com>; rel=preconnect
+
+        The difference being the presence of quotes around "preconnect".
+
+        Let's adopt the second version to be consistent with the choice made in def withPreload
+       */
+      if (urls.nonEmpty) {
+        val preconnections = urls
+          .map(url => s"<${url}>; rel=preconnect")
+          .mkString(",")
+        val linkHeaderValue =
+          self.header.headers.get(linkHeaderKey).map(_ ++ s",$preconnections") getOrElse preconnections
+        self.withHeaders(linkHeaderKey -> linkHeaderValue)
+      } else self
+    }
+
   }
+}
+
+object HttpPreconnections {
+  val defaultUrls = Seq(
+    "https://assets.guim.co.uk/",
+    "https://i.guim.co.uk",
+    "https://j.ophan.co.uk",
+    "https://ophan.theguardian.com",
+    "https://api.nextgen.guardianapps.co.uk",
+    "https://hits-secure.theguardian.com",
+    "https://interactive.guim.co.uk",
+    "https://ipv6.guim.co.uk",
+    "https://phar.gu-web.net",
+    "https://static.theguardian.com",
+    "https://support.theguardian.com",
+  )
 }

--- a/common/app/http/ResultWithPreconnectPreload.scala
+++ b/common/app/http/ResultWithPreconnectPreload.scala
@@ -4,7 +4,7 @@ import common.{CssPreloadAsset, JsPreloadAsset, PreloadAsset, ThirdPartyJsPreloa
 import model.ApplicationContext
 import play.api.mvc.{RequestHeader, Result}
 
-trait ResultWithPreload {
+trait ResultWithPreconnectPreload {
   final implicit class RichResult(self: Result) {
 
     val linkHeaderKey = "Link"


### PR DESCRIPTION
## What does this change?

As part of improving performance on the site, we introduce HTTP headers pre-connections.

The `Link` header is already used for some assets, for instance `/assets/stylesheets/content.garnett.css`, which comes as 
```
</assets/stylesheets/content.garnett.css>; rel=preload; as=style; nopush
```

This expands the existing `ResultWithPreload` (renaming it `ResultWithPreconnectPreload` in the process) and gives it a new function called  `withPreconnect` which mirrors the existing `withPreload` (although with a simplified signature since `withPreconnect` doesn't need to discriminate the various file types supported here:  https://github.com/guardian/frontend/blob/e1ce7883505b9b4fccdd387d57b71619a645c9bf/common/app/common/PreloadAsset.scala ). 

Function `withPreconnect` allows pre-connection to domains which appear as new items in the `Link` header, for instance 
```
<https://ophan.theguardian.com>; rel=preconnect
```

The hardcoded list of urls comes from the existing list of urls we have preconnections tags in our HTML document headers.
