### PR TITLE
EOY header test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -86,7 +86,7 @@ trait ABTestSwitches {
     exposeClientSide = true,
   )
 
-  Switch(
+  val GlobalEoyHeaderSwitch = Switch(
     ABTests,
     "ab-global-eoy-header-test",
     "Test reader revenue message in header",

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -85,4 +85,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2021, 1, 4),
     exposeClientSide = true,
   )
+
+  Switch(
+    ABTests,
+    "ab-global-eoy-header-test",
+    "Test reader revenue message in header",
+    owners = Seq(Owner.withGithub("tomrf1")),
+    safeState = Off,
+    sellByDate = new LocalDate(2021, 2, 1),
+    exposeClientSide = true,
+  )
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -424,16 +424,6 @@ trait FeatureSwitches {
     exposeClientSide = true,
   )
 
-  val UsHeaderAndFooterSubscribeLinkSwitch = Switch(
-    SwitchGroup.Feature,
-    "us-header-and-footer-subscribe-link-switch",
-    "If switched off, the US edition header and footer will not contain a Subscribe link.",
-    owners = Seq(Owner.withName("dotcom.platform")),
-    safeState = On,
-    sellByDate = never,
-    exposeClientSide = true,
-  )
-
   val slotBodyEnd = Switch(
     SwitchGroup.Feature,
     "slot-body-end",

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -9,7 +9,7 @@
 @import navigation.UrlHelpers.{getReaderRevenueUrl, Footer, AmpFooter}
 @import common.editions.{Au, Uk, Us, International}
 @import model.Page
-@import conf.switches.Switches.{ EmailInlineInFooterSwitch, UsHeaderAndFooterSubscribeLinkSwitch }
+@import conf.switches.Switches.{ EmailInlineInFooterSwitch }
 @import com.gu.identity.model.EmailNewsletters
 @import model.NoCache
 @import views.support.{RenderClasses}
@@ -174,16 +174,14 @@
             @fragments.inlineSvg("arrow-right", "icon")
         </a>
 
-        @if(editionId != "us" || UsHeaderAndFooterSubscribeLinkSwitch.isSwitchedOn) {
-            <a class="cta-bar__cta js-subscribe js-acquisition-link"
-            data-link-name="footer : subscribe-cta"
-            data-edition="@{
-                editionId
-            }"
-            href="@getReaderRevenueUrl(SupportSubscribe, Footer)">
-                Subscribe
-                @fragments.inlineSvg("arrow-right", "icon")
-            </a>
-        }
+        <a class="cta-bar__cta js-subscribe js-acquisition-link"
+        data-link-name="footer : subscribe-cta"
+        data-edition="@{
+            editionId
+        }"
+        href="@getReaderRevenueUrl(SupportSubscribe, Footer)">
+            Subscribe
+            @fragments.inlineSvg("arrow-right", "icon")
+        </a>
     </div>
 }

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -5,7 +5,7 @@
 @import navigation.NavMenu
 @import navigation.UrlHelpers.{getJobUrl, Header, getReaderRevenueUrl}
 @import navigation.ReaderRevenueSite.{Support, SupportSubscribe, SupportContribute}
-@import conf.switches.Switches.{ IdentityProfileNavigationSwitch, SearchSwitch }
+@import conf.switches.Switches.{ IdentityProfileNavigationSwitch, SearchSwitch, GlobalEoyHeaderSwitch }
 
 @defining(NavMenu(page, Edition(request))) { navMenu: NavMenu =>
     <header class="@RenderClasses(Map(
@@ -33,49 +33,15 @@
 
             @defining(Edition(request).id.toLowerCase()) { editionId =>
                 <div class="new-header__cta-bar hide-until-mobile">
-                    @if(!page.metadata.hasSlimHeader) {
-                        <div class="cta-bar__text hide-until-tablet">
-                            <div class="cta-bar__heading">
-                                Support The Guardian
+                    @if(!GlobalEoyHeaderSwitch.isSwitchedOn) {
+                        @if(!page.metadata.hasSlimHeader) {
+                            <div class="cta-bar__text hide-until-tablet">
+                                <div class="cta-bar__heading">Support The Guardian</div>
+                                <div class="cta-bar__subheading">Available for everyone, funded by readers</div>
                             </div>
-                            <div class="cta-bar__subheading">
-                                Available for everyone, funded by readers
-                            </div>
-                        </div>
-                    }
+                        }
 
-                    <a class="cta-bar__cta hide-until-tablet js-change-become-member-link js-acquisition-link"
-                    data-link-name="nav2 : contribute-cta"
-                    data-edition="@{
-                        editionId
-                    }"
-                    href="@getReaderRevenueUrl(SupportContribute, Header)">
-                        Contribute
-                        @fragments.inlineSvg("arrow-right", "icon")
-                    </a>
-
-                    <a class="cta-bar__cta hide-until-tablet js-subscribe js-acquisition-link"
-                    data-link-name="nav2 : subscribe-cta"
-                    data-edition="@{
-                        editionId
-                    }"
-                    href="@getReaderRevenueUrl(SupportSubscribe, Header)">
-                        Subscribe
-                        @fragments.inlineSvg("arrow-right", "icon")
-                    </a>
-
-                    @if(editionId == "uk") {
-                        <a class="cta-bar__cta hide-from-tablet js-change-become-member-link js-acquisition-link"
-                        data-link-name="nav2 : support-cta"
-                        data-edition="@{
-                            editionId
-                        }"
-                        href="@getReaderRevenueUrl(SupportSubscribe, Header)">
-                            Subscribe
-                            @fragments.inlineSvg("arrow-right", "icon")
-                        </a>
-                    } else {
-                        <a class="cta-bar__cta hide-from-tablet js-change-become-member-link js-acquisition-link"
+                        <a class="cta-bar__cta hide-until-tablet js-change-become-member-link js-acquisition-link"
                         data-link-name="nav2 : contribute-cta"
                         data-edition="@{
                             editionId
@@ -84,6 +50,38 @@
                             Contribute
                             @fragments.inlineSvg("arrow-right", "icon")
                         </a>
+
+                        <a class="cta-bar__cta hide-until-tablet js-subscribe js-acquisition-link"
+                        data-link-name="nav2 : subscribe-cta"
+                        data-edition="@{
+                            editionId
+                        }"
+                        href="@getReaderRevenueUrl(SupportSubscribe, Header)">
+                            Subscribe
+                            @fragments.inlineSvg("arrow-right", "icon")
+                        </a>
+
+                        @if(editionId == "uk") {
+                            <a class="cta-bar__cta hide-from-tablet js-change-become-member-link js-acquisition-link"
+                            data-link-name="nav2 : support-cta"
+                            data-edition="@{
+                                editionId
+                            }"
+                            href="@getReaderRevenueUrl(SupportSubscribe, Header)">
+                                Subscribe
+                                @fragments.inlineSvg("arrow-right", "icon")
+                            </a>
+                        } else {
+                            <a class="cta-bar__cta hide-from-tablet js-change-become-member-link js-acquisition-link"
+                            data-link-name="nav2 : contribute-cta"
+                            data-edition="@{
+                                editionId
+                            }"
+                            href="@getReaderRevenueUrl(SupportContribute, Header)">
+                                Contribute
+                                @fragments.inlineSvg("arrow-right", "icon")
+                            </a>
+                        }
                     }
                 </div>
             }

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -33,7 +33,7 @@
 
             @defining(Edition(request).id.toLowerCase()) { editionId =>
                 <div class="new-header__cta-bar hide-until-mobile">
-                    @if(!GlobalEoyHeaderSwitch.isSwitchedOn) {
+                    @if(editionId == "us" || !GlobalEoyHeaderSwitch.isSwitchedOn) {
                         @if(!page.metadata.hasSlimHeader) {
                             <div class="cta-bar__text hide-until-tablet">
                                 <div class="cta-bar__heading">Support The Guardian</div>

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -5,7 +5,7 @@
 @import navigation.NavMenu
 @import navigation.UrlHelpers.{getJobUrl, Header, getReaderRevenueUrl}
 @import navigation.ReaderRevenueSite.{Support, SupportSubscribe, SupportContribute}
-@import conf.switches.Switches.{ IdentityProfileNavigationSwitch, SearchSwitch, UsHeaderAndFooterSubscribeLinkSwitch }
+@import conf.switches.Switches.{ IdentityProfileNavigationSwitch, SearchSwitch }
 
 @defining(NavMenu(page, Edition(request))) { navMenu: NavMenu =>
     <header class="@RenderClasses(Map(
@@ -32,42 +32,50 @@
             </a>
 
             @defining(Edition(request).id.toLowerCase()) { editionId =>
-                @defining(editionId == "au") { ausEdition =>
-                    @if(ausEdition) {
-                        <div class="new-header__cta-bar-aus-moment hide-until-mobile">
-                            @if(!page.metadata.hasSlimHeader) {
-                                <div class="cta-bar__text-aus-supporter hide-until-tablet">
-                                    <div class="cta-bar__heading">
-                                        Thank you
-                                    </div>
-                                    <div class="cta-bar__subheading">
-                                        <a class="cta-bar__cta cta-bar__aus-map-cta hide-until-tablet"
-                                        data-link-name="nav2 : aus-map-cta"
-                                        data-edition="@{
-                                            editionId
-                                        }"
-                                        href="https://support.theguardian.com/aus-2020-map?INTCMP=Aus_moment_2020_frontend_header">
-                                            Hear from other supporters
-                                            @fragments.inlineSvg("arrow-right", "icon")
-                                        </a>
-                                    </div>
-                                </div>
-                            }
+                <div class="new-header__cta-bar hide-until-mobile">
+                    @if(!page.metadata.hasSlimHeader) {
+                        <div class="cta-bar__text hide-until-tablet">
+                            <div class="cta-bar__heading">
+                                Support The Guardian
+                            </div>
+                            <div class="cta-bar__subheading">
+                                Available for everyone, funded by readers
+                            </div>
                         </div>
                     }
-                    <div class="new-header__cta-bar hide-until-mobile">
-                        @if(!page.metadata.hasSlimHeader) {
-                            <div class="cta-bar__text hide-until-tablet">
-                                <div class="cta-bar__heading">
-                                    Support The Guardian
-                                </div>
-                                <div class="cta-bar__subheading">
-                                    Available for everyone, funded by readers
-                                </div>
-                            </div>
-                        }
 
-                        <a class="cta-bar__cta hide-until-tablet js-change-become-member-link js-acquisition-link"
+                    <a class="cta-bar__cta hide-until-tablet js-change-become-member-link js-acquisition-link"
+                    data-link-name="nav2 : contribute-cta"
+                    data-edition="@{
+                        editionId
+                    }"
+                    href="@getReaderRevenueUrl(SupportContribute, Header)">
+                        Contribute
+                        @fragments.inlineSvg("arrow-right", "icon")
+                    </a>
+
+                    <a class="cta-bar__cta hide-until-tablet js-subscribe js-acquisition-link"
+                    data-link-name="nav2 : subscribe-cta"
+                    data-edition="@{
+                        editionId
+                    }"
+                    href="@getReaderRevenueUrl(SupportSubscribe, Header)">
+                        Subscribe
+                        @fragments.inlineSvg("arrow-right", "icon")
+                    </a>
+
+                    @if(editionId == "uk") {
+                        <a class="cta-bar__cta hide-from-tablet js-change-become-member-link js-acquisition-link"
+                        data-link-name="nav2 : support-cta"
+                        data-edition="@{
+                            editionId
+                        }"
+                        href="@getReaderRevenueUrl(SupportSubscribe, Header)">
+                            Subscribe
+                            @fragments.inlineSvg("arrow-right", "icon")
+                        </a>
+                    } else {
+                        <a class="cta-bar__cta hide-from-tablet js-change-become-member-link js-acquisition-link"
                         data-link-name="nav2 : contribute-cta"
                         data-edition="@{
                             editionId
@@ -76,42 +84,8 @@
                             Contribute
                             @fragments.inlineSvg("arrow-right", "icon")
                         </a>
-
-                        @if(editionId != "us" || UsHeaderAndFooterSubscribeLinkSwitch.isSwitchedOn) {
-                            <a class="cta-bar__cta hide-until-tablet js-subscribe js-acquisition-link"
-                            data-link-name="nav2 : subscribe-cta"
-                            data-edition="@{
-                                editionId
-                            }"
-                            href="@getReaderRevenueUrl(SupportSubscribe, Header)">
-                                Subscribe
-                                @fragments.inlineSvg("arrow-right", "icon")
-                            </a>
-                        }
-
-                        @if(editionId == "uk") {
-                            <a class="cta-bar__cta hide-from-tablet js-change-become-member-link js-acquisition-link"
-                            data-link-name="nav2 : support-cta"
-                            data-edition="@{
-                                editionId
-                            }"
-                            href="@getReaderRevenueUrl(SupportSubscribe, Header)">
-                                Subscribe
-                                @fragments.inlineSvg("arrow-right", "icon")
-                            </a>
-                        } else {
-                            <a class="cta-bar__cta hide-from-tablet js-change-become-member-link js-acquisition-link"
-                            data-link-name="nav2 : contribute-cta"
-                            data-edition="@{
-                                editionId
-                            }"
-                            href="@getReaderRevenueUrl(SupportContribute, Header)">
-                                Contribute
-                                @fragments.inlineSvg("arrow-right", "icon")
-                            </a>
-                        }
-                    </div>
-                }
+                    }
+                </div>
             }
 
             <div class="new-header__top-bar hide-until-mobile">

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -4,12 +4,14 @@ import { signInGateMainVariant } from 'common/modules/experiments/tests/sign-in-
 import { signInGateMainControl } from 'common/modules/experiments/tests/sign-in-gate-main-control';
 import { newsletterEmbeds } from 'common/modules/experiments/tests/newsletter-embed-test';
 import { liveblogEpicDesignTest } from 'common/modules/experiments/tests/liveblog-epic-design-test';
+import { globalEoyHeaderTest } from 'common/modules/experiments/tests/global-eoy-header-test';
 
 export const concurrentTests: $ReadOnlyArray<ABTest> = [
     commercialPrebidSafeframe,
     signInGateMainVariant,
     signInGateMainControl,
-    newsletterEmbeds
+    newsletterEmbeds,
+    globalEoyHeaderTest,
 ];
 
 export const epicTests: $ReadOnlyArray<EpicABTest> = [liveblogEpicDesignTest];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/global-eoy-header-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/global-eoy-header-test.js
@@ -1,0 +1,128 @@
+// @flow
+import config from "lib/config";
+import {
+    addTrackingCodesToUrl,
+    submitViewEvent,
+} from 'common/modules/commercial/acquisitions-ophan';
+import {addCountryGroupToSupportLink} from "common/modules/commercial/support-utilities";
+
+const edition = config.get('page.edition', '').toLowerCase();
+
+const componentType = 'ACQUISITIONS_HEADER';
+const componentId = 'header_support';
+const campaignCode = 'header_support';
+const testName = 'GlobalEoyHeaderTest';
+
+type VariantName = 'variant' | 'control';
+
+const onView = (variant: VariantName): void => submitViewEvent({
+    component: {
+        componentType,
+        products: [],
+        campaignCode,
+        id: componentId,
+    },
+    abTest: {
+        name: testName,
+        variant,
+    }
+});
+
+const buildUrl = (rrType: 'contribute' | 'subscribe', variant: VariantName): string => addTrackingCodesToUrl({
+    base: addCountryGroupToSupportLink(`https://support.theguardian.com/${rrType}`),
+    componentType,
+    componentId,
+    campaignCode,
+    abTest: {
+        name: testName,
+        variant,
+    },
+});
+
+const buildHtml = (heading: string, subheading: string, variant: VariantName): string => `
+    <div class="cta-bar__text hide-until-tablet">
+        <div class="cta-bar__heading">${heading}</div>
+        <div class="cta-bar__subheading">${subheading}</div>
+    </div>
+                    
+    <a class="cta-bar__cta hide-until-tablet js-change-become-member-link js-acquisition-link" data-link-name="nav2 : contribute-cta" data-edition="${edition}" href="${buildUrl('contribute', variant)}">
+        Contribute
+        <span class="inline-arrow-right inline-icon ">
+            <svg width="30" height="30" viewBox="0 0 30 30" class="inline-arrow-right__svg inline-icon__svg">
+                <path d="M22.8 14.6L15.2 7l-.7.7 5.5 6.6H6v1.5h14l-5.5 6.6.7.7 7.6-7.6v-.9"></path>
+            </svg>
+        </span>
+    </a>
+
+    <a class="cta-bar__cta hide-until-tablet js-subscribe js-acquisition-link" data-link-name="nav2 : subscribe-cta" data-edition="${edition}" href="${buildUrl('subscribe', variant)}">
+        Subscribe
+        <span class="inline-arrow-right inline-icon ">
+            <svg width="30" height="30" viewBox="0 0 30 30" class="inline-arrow-right__svg inline-icon__svg">
+                <path d="M22.8 14.6L15.2 7l-.7.7 5.5 6.6H6v1.5h14l-5.5 6.6.7.7 7.6-7.6v-.9"></path>
+            </svg>
+        </span>
+    </a>
+
+    ${edition === 'uk' ?
+        `<a class="cta-bar__cta hide-from-tablet js-change-become-member-link js-acquisition-link" data-link-name="nav2 : support-cta" data-edition="${edition}" href="${buildUrl('subscribe', variant)}">
+            Subscribe
+            <span class="inline-arrow-right inline-icon ">
+                <svg width="30" height="30" viewBox="0 0 30 30" class="inline-arrow-right__svg inline-icon__svg">
+                    <path d="M22.8 14.6L15.2 7l-.7.7 5.5 6.6H6v1.5h14l-5.5 6.6.7.7 7.6-7.6v-.9"></path>
+                </svg>
+            </span>
+        </a>` :
+        `<a class="cta-bar__cta hide-from-tablet js-change-become-member-link js-acquisition-link"
+           data-link-name="nav2 : contribute-cta" data-edition="${edition}"
+           href="${buildUrl('contribute', variant)}">
+            Contribute
+            <span class="inline-arrow-right inline-icon ">
+                <svg width="30" height="30" viewBox="0 0 30 30" class="inline-arrow-right__svg inline-icon__svg">
+                    <path d="M22.8 14.6L15.2 7l-.7.7 5.5 6.6H6v1.5h14l-5.5 6.6.7.7 7.6-7.6v-.9"></path>
+                </svg>
+            </span>
+        </a>`
+    }
+`;
+
+const controlHtml = (): string => buildHtml('Support The Guardian', 'Available for everyone, funded by readers', 'control');
+const variantHtml = (): string => buildHtml('Support us this December', 'Power vital, open, independent journalism', 'variant');
+
+const getHeaderCtaBar = () => window.document.querySelector('.new-header__cta-bar');
+
+export const globalEoyHeaderTest: ABTest = {
+    id: testName,
+    start: '2020-12-02',
+    expiry: '2021-01-02',
+    author: 'Tom Forbes',
+    description: 'Test reader revenue message in header',
+    audience: 1.0,
+    audienceOffset: 0,
+    successMeasure: 'AV',
+    idealOutcome: 'AV',
+    showForSensitive: false,
+    audienceCriteria: 'All',
+    canRun: () => true,
+    variants: [
+        {
+            id: 'control',
+            test: (): void => {
+                const bar = getHeaderCtaBar();
+                if (bar) {
+                    bar.innerHTML = controlHtml();
+                    onView('control')
+                }
+            },
+        },
+        {
+            id: 'variant',
+            test: (): void => {
+                const bar = getHeaderCtaBar();
+                if (bar) {
+                    bar.innerHTML = variantHtml();
+                    onView('variant')
+                }
+            },
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/global-eoy-header-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/global-eoy-header-test.js
@@ -5,8 +5,10 @@ import {
     submitViewEvent,
 } from 'common/modules/commercial/acquisitions-ophan';
 import {addCountryGroupToSupportLink} from "common/modules/commercial/support-utilities";
+import { getSync as geolocationGetSync } from 'lib/geolocation';
 
 const edition = config.get('page.edition', '').toLowerCase();
+const geolocation = geolocationGetSync();
 
 const componentType = 'ACQUISITIONS_HEADER';
 const componentId = 'header_support';
@@ -102,7 +104,7 @@ export const globalEoyHeaderTest: ABTest = {
     idealOutcome: 'AV',
     showForSensitive: false,
     audienceCriteria: 'All',
-    canRun: () => true,
+    canRun: () => geolocation !== 'US',
     variants: [
         {
             id: 'control',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/global-eoy-header-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/global-eoy-header-test.js
@@ -5,10 +5,8 @@ import {
     submitViewEvent,
 } from 'common/modules/commercial/acquisitions-ophan';
 import {addCountryGroupToSupportLink} from "common/modules/commercial/support-utilities";
-import { getSync as geolocationGetSync } from 'lib/geolocation';
 
 const edition = config.get('page.edition', '').toLowerCase();
-const geolocation = geolocationGetSync();
 
 const month = new Date().getMonth() + 1;    // js date month begins at 0
 
@@ -103,7 +101,7 @@ export const globalEoyHeaderTest: ABTest = {
     idealOutcome: 'AV',
     showForSensitive: false,
     audienceCriteria: 'All',
-    canRun: () => geolocation !== 'US' && (month === 12 || month === 1),
+    canRun: () => edition !== 'US' && (month === 12 || month === 1),
     variants: [
         {
             id: 'control',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/global-eoy-header-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/global-eoy-header-test.js
@@ -101,7 +101,7 @@ export const globalEoyHeaderTest: ABTest = {
     idealOutcome: 'AV',
     showForSensitive: false,
     audienceCriteria: 'All',
-    canRun: () => edition !== 'US' && (month === 12 || month === 1),
+    canRun: () => edition !== 'us' && (month === 12 || month === 1),
     variants: [
         {
             id: 'control',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/global-eoy-header-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/global-eoy-header-test.js
@@ -10,6 +10,8 @@ import { getSync as geolocationGetSync } from 'lib/geolocation';
 const edition = config.get('page.edition', '').toLowerCase();
 const geolocation = geolocationGetSync();
 
+const month = new Date().getMonth() + 1;    // js date month begins at 0
+
 const componentType = 'ACQUISITIONS_HEADER';
 const componentId = 'header_support';
 const campaignCode = 'header_support';
@@ -87,15 +89,12 @@ const buildHtml = (heading: string, subheading: string, variant: VariantName): s
     }
 `;
 
-const controlHtml = (): string => buildHtml('Support The Guardian', 'Available for everyone, funded by readers', 'control');
-const variantHtml = (): string => buildHtml('Support us this December', 'Power vital, open, independent journalism', 'variant');
-
 const getHeaderCtaBar = () => window.document.querySelector('.new-header__cta-bar');
 
 export const globalEoyHeaderTest: ABTest = {
     id: testName,
     start: '2020-12-02',
-    expiry: '2021-01-02',
+    expiry: '2021-02-01',
     author: 'Tom Forbes',
     description: 'Test reader revenue message in header',
     audience: 1.0,
@@ -104,14 +103,14 @@ export const globalEoyHeaderTest: ABTest = {
     idealOutcome: 'AV',
     showForSensitive: false,
     audienceCriteria: 'All',
-    canRun: () => geolocation !== 'US',
+    canRun: () => geolocation !== 'US' && (month === 12 || month === 1),
     variants: [
         {
             id: 'control',
             test: (): void => {
                 const bar = getHeaderCtaBar();
                 if (bar) {
-                    bar.innerHTML = controlHtml();
+                    bar.innerHTML = buildHtml('Support The Guardian', 'Available for everyone, funded by readers', 'control');
                     onView('control')
                 }
             },
@@ -121,7 +120,8 @@ export const globalEoyHeaderTest: ABTest = {
             test: (): void => {
                 const bar = getHeaderCtaBar();
                 if (bar) {
-                    bar.innerHTML = variantHtml();
+                    const heading = month === 12 ? `Support us this December` : 'Support us for 2021';
+                    bar.innerHTML = buildHtml(heading, 'Power vital, open, independent journalism', 'variant');
                     onView('variant')
                 }
             },

--- a/static/src/stylesheets/layout/nav/_cta-bar.scss
+++ b/static/src/stylesheets/layout/nav/_cta-bar.scss
@@ -32,7 +32,7 @@
     }
 
     @include mq(desktop) {
-        max-width: 300px;
+        max-width: 310px;
     }
 
     @include mq(leftCol) {


### PR DESCRIPTION
A/B test different copy in the header cta bar.

### Control
![Screen Shot 2020-12-03 at 13 59 02](https://user-images.githubusercontent.com/1513454/101027221-b9d02500-356f-11eb-960d-dd1ffa64c8c8.png)

### Variant in December
![Screen Shot 2020-12-03 at 13 58 48](https://user-images.githubusercontent.com/1513454/101027315-c81e4100-356f-11eb-9b13-72b61d84d8d5.png)


### Variant in January
![Screen Shot 2020-12-03 at 13 58 35](https://user-images.githubusercontent.com/1513454/101027302-c3598d00-356f-11eb-839d-1b67a839f4ae.png)

Changes:
1. tidy up header.scala.html and footer.scala.html to remove old features for US and Aus (first commit)
2. add a switch for an A/B test, `GlobalEoyHeaderSwitch`. If this is enabled then `header.scala.html` does not render the header cta bar.
3. add a client-side test which renders the header cta bar once the user has been allocated to a variant. This means there will be a slight pause before it is rendered. I don't think a server-side test is possible here.

Note - for simplicity I copied the html into the js file. It would be far too complicated to work with the twirl template and then modify things client-side.

This A/B test will also be applied in DCR.