### PR TITLE
Pageskin: inskin conflict with banner fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@guardian/automat-modules": "^0.3.7",
     "@guardian/braze-components": "0.0.14",
     "@guardian/commercial-core": "^0.9.0",
-    "@guardian/consent-management-platform": "6.7.4",
+    "@guardian/consent-management-platform": "6.9.0",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/libs": "^1.4.2",
     "@guardian/shimport": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@guardian/automat-modules": "^0.3.7",
     "@guardian/braze-components": "0.0.14",
     "@guardian/commercial-core": "^0.9.0",
-    "@guardian/consent-management-platform": "6.9.0",
+    "@guardian/consent-management-platform": "6.9.1",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",
     "@guardian/libs": "^1.4.2",
     "@guardian/shimport": "^1.0.2",

--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
@@ -102,6 +102,10 @@ jest.mock('commercial/modules/dfp/load-advert', () => ({
 jest.mock('@guardian/consent-management-platform', () => ({
     onConsentChange: jest.fn(),
     getConsentFor: jest.fn(),
+    cmp: {
+        hasInitialised: jest.fn(),
+        willShowPrivacySync: jest.fn(),
+    },
 }));
 
 let $style;

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -10,7 +10,7 @@ import { getSync as geolocationGetSync } from 'lib/geolocation';
 import { storage } from '@guardian/libs';
 import { getUrlVars } from 'lib/url';
 import { getPrivacyFramework } from 'lib/getPrivacyFramework';
-import { onConsentChange } from '@guardian/consent-management-platform';
+import { cmp, onConsentChange } from '@guardian/consent-management-platform';
 import {
     getPermutiveSegments,
     clearPermutiveSegments,
@@ -66,11 +66,14 @@ const findBreakpoint = (): string => {
 };
 
 const inskinTargetting = (): string => {
-    if (storage.local.get('gu.hasSeenPrivacyBanner')) {
-        const vp = getViewport();
-        if (vp && vp.width >= 1560) return 't';
+    const vp = getViewport();
+    if (vp && vp.width < 1560) {
+        return 'f';
     }
-    return 'f';
+
+    // Don’t show inskin if we cannot tell if a privacy message will be shown
+    if (!cmp.hasInitialised()) return 'f';
+    return cmp.willShowPrivacyMessageSync() ? 'f' : 't';
 };
 
 const format = (keyword: string): string =>

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -67,7 +67,7 @@ const findBreakpoint = (): string => {
 
 const inskinTargetting = (): string => {
     const vp = getViewport();
-    if (vp && vp.width < 1560) {
+    if (!vp || vp.width < 1560) {
         return 'f';
     }
 

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -467,4 +467,36 @@ describe('Build Page Targeting', () => {
             ]);
         });
     });
+
+    describe('inskin targetting', () => {
+        it('should not allow inskin if cmp has not initialised', () => {
+            cmp.hasInitialised.mockReturnValue(false);
+            cmp.willShowPrivacyMessageSync.mockReturnValue(false);
+            getViewport.mockReturnValue({ width: 1920, height: 1080 });
+            expect(getPageTargeting().inskin).toBe('f');
+        });
+
+        it('should not allow inskin if cmp will show a banner', () => {
+            cmp.hasInitialised.mockReturnValue(true);
+            cmp.willShowPrivacyMessageSync.mockReturnValue(true);
+            getViewport.mockReturnValue({ width: 1920, height: 1080 });
+            expect(getPageTargeting().inskin).toBe('f');
+        });
+
+        // $FlowFixMe -- it.each does not have a type
+        it.each([
+            ['f', 1280],
+            ['f', 1440],
+            ['f', 1559],
+            ['t', 1560],
+            ['t', 1561],
+            ['t', 1920],
+            ['t', 2560],
+        ])("should return '%s' if viewport width is %s", (expected, width) => {
+            cmp.hasInitialised.mockReturnValue(true);
+            cmp.willShowPrivacyMessageSync.mockReturnValue(false);
+            getViewport.mockReturnValue({ width, height: 800 });
+            expect(getPageTargeting().inskin).toBe(expected);
+        });
+    });
 });

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -508,5 +508,10 @@ describe('Build Page Targeting', () => {
             getViewport.mockReturnValue({ width, height: 800 });
             expect(getPageTargeting().inskin).toBe(expected);
         });
+
+        it("should return 'f' if vp does not have a width", () => {
+            getViewport.mockReturnValue(undefined);
+            expect(getPageTargeting().inskin).toBe('f');
+        });
     });
 });

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -11,22 +11,28 @@ import { getCookie as getCookie_ } from 'lib/cookies';
 import {
     getReferrer as getReferrer_,
     getBreakpoint as getBreakpoint_,
+    getViewport as getViewport_,
 } from 'lib/detect';
 import { getSync as getSync_ } from 'lib/geolocation';
 import { getPrivacyFramework as getPrivacyFramework_ } from 'lib/getPrivacyFramework';
 import { isUserLoggedIn as isUserLoggedIn_ } from 'common/modules/identity/api';
 import { getUserSegments as getUserSegments_ } from 'common/modules/commercial/user-ad-targeting';
 import { getSynchronousParticipations as getSynchronousParticipations_ } from 'common/modules/experiments/ab';
-import { onConsentChange } from '@guardian/consent-management-platform';
+import {
+    cmp as cmp_,
+    onConsentChange,
+} from '@guardian/consent-management-platform';
 
 const getCookie: any = getCookie_;
 const getUserSegments: any = getUserSegments_;
 const getSynchronousParticipations: any = getSynchronousParticipations_;
 const getReferrer: any = getReferrer_;
 const getBreakpoint: any = getBreakpoint_;
+const getViewport: any = getViewport_;
 const isUserLoggedIn: any = isUserLoggedIn_;
 const getSync: any = getSync_;
 const getPrivacyFramework: any = getPrivacyFramework_;
+const cmp: any = cmp_;
 
 jest.mock('lib/config');
 jest.mock('lib/cookies', () => ({
@@ -59,6 +65,10 @@ jest.mock('common/modules/commercial/commercial-features', () => ({
 }));
 jest.mock('@guardian/consent-management-platform', () => ({
     onConsentChange: jest.fn(),
+    cmp: {
+        hasInitialised: jest.fn(),
+        willShowPrivacyMessageSync: jest.fn(),
+    },
 }));
 
 // TCFv1

--- a/yarn.lock
+++ b/yarn.lock
@@ -1758,10 +1758,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.9.0.tgz#2c578b61a6af99436abd83760d3349ef99d53ab8"
   integrity sha512-2o/au3c/SRUYrlPA1x6Rog6+UpXkSf6UrSX16lD19VaFyia60LaIXtBu9mkZNhSm0FWqfLSgync8RTCeCRG47w==
 
-"@guardian/consent-management-platform@6.7.4":
-  version "6.7.4"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.7.4.tgz#ae75775c40f8234a2e2774c126a688e9a98f5df4"
-  integrity sha512-f/XieB0dOyGYZDhP/UmyrHiyuehETt2L1GKqacsySFdcD/++fKe7LLcXbza4NE54MHyS0wbvd+Qh4avjG4IPLg==
+"@guardian/consent-management-platform@6.9.0":
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.9.0.tgz#33c9d73b753d928eb421ecf6a50026821f49e1aa"
+  integrity sha512-JlFl1rhYJ5AAYOMDjWyfauydRKREKoxHMiVArYic71H0Kws1HotWWPjSOkXyOb+oHl7KGFuMV+tPbBAbfOliPg==
 
 "@guardian/dotcom-rendering@git://github.com/guardian/dotcom-rendering.git#version-1-alpha":
   version "0.1.0-alpha"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1758,10 +1758,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.9.0.tgz#2c578b61a6af99436abd83760d3349ef99d53ab8"
   integrity sha512-2o/au3c/SRUYrlPA1x6Rog6+UpXkSf6UrSX16lD19VaFyia60LaIXtBu9mkZNhSm0FWqfLSgync8RTCeCRG47w==
 
-"@guardian/consent-management-platform@6.9.0":
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.9.0.tgz#33c9d73b753d928eb421ecf6a50026821f49e1aa"
-  integrity sha512-JlFl1rhYJ5AAYOMDjWyfauydRKREKoxHMiVArYic71H0Kws1HotWWPjSOkXyOb+oHl7KGFuMV+tPbBAbfOliPg==
+"@guardian/consent-management-platform@6.9.1":
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.9.1.tgz#78aaf208dfc25b4f3fb8d6cbc4991d64cf8242db"
+  integrity sha512-52kRmS0u1NJSAyfHOcDiL8/zoQQ8Tii4dQcJ1ENyJ0x6Gn8CE6j+9bNLwc4AGP6Oj80FQdCBd9fx+3Yrhx1vdg==
 
 "@guardian/dotcom-rendering@git://github.com/guardian/dotcom-rendering.git#version-1-alpha":
   version "0.1.0-alpha"


### PR DESCRIPTION
## What does this change?

This prevents targeting `inskin` if the CMP banner is shown to a user.
This is a more robust fix to #23275.

- Bump the CMP to v6.9.1 which brings `cmp.hasInitialised` and `cmp.willShowPrivacyMessageSync`.
- Updates the inskin logic to use `cmp.willShowPrivacyMessageSync()`

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Inskin skins can take over the page styling and prevent the banner from being seen by new users. This brings a formal solution to our quick fixes.

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
