### PR TITLE
inskin fix 2 - Even more fixed than ever.

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -45,7 +45,8 @@ type PageTargeting = {
 };
 
 let myPageTargetting: {} = {};
-let latestConsentCanRun;
+let latestCmpHasInitalised;
+let latestCMPState;
 
 const findBreakpoint = (): string => {
     switch (getBreakpoint(true)) {
@@ -235,11 +236,29 @@ const getTcfv2ConsentValue = (tcfv2State: boolean | null): string => {
     return 'na';
 };
 
-const buildPageTargetting = (
-    adConsentState: boolean | null,
-    ccpaState: boolean | null,
-    tcfv2EventStatus: string | null
-): { [key: string]: mixed } => {
+const getAdConsentFromState = (state): boolean => {
+    if (state.ccpa) {
+        // CCPA mode
+        return !state.ccpa.doNotSell;
+    } else if (state.tcfv2) {
+        // TCFv2 mode
+        return state.tcfv2.consents
+            ? Object.keys(state.tcfv2.consents).length > 0 &&
+              Object.values(state.tcfv2.consents).every(Boolean)
+            : false;
+    } else if (state.aus) {
+        // AUS mode
+        return state.aus.personalisedAdvertising;
+    } 
+    // Unknown mode
+    return false;
+}
+
+const rebuildPageTargeting = () => {
+    latestCmpHasInitalised = cmp.hasInitialised();
+    const adConsentState = getAdConsentFromState(latestCMPState);
+    const ccpaState = latestCMPState.ccpa ? latestCMPState.ccpa.doNotSell : null;
+    const tcfv2EventStatus = latestCMPState.tcfv2 ? latestCMPState.tcfv2.eventStatus : 'na';
     const page = config.get('page');
     // personalised ads targeting
     if (adConsentState === false) clearPermutiveSegments();
@@ -303,45 +322,29 @@ const buildPageTargetting = (
     page.pageAdTargeting = pageTargeting;
 
     return pageTargeting;
-};
+}
 
 const getPageTargeting = (): { [key: string]: mixed } => {
-    if (Object.keys(myPageTargetting).length !== 0) return myPageTargetting;
 
-    onConsentChange(state => {
-        let canRun: boolean | null;
-        if (state.ccpa) {
-            // CCPA mode
-            canRun = !state.ccpa.doNotSell;
-        } else if (state.tcfv2) {
-            // TCFv2 mode
-            canRun = state.tcfv2.consents
-                ? Object.keys(state.tcfv2.consents).length > 0 &&
-                  Object.values(state.tcfv2.consents).every(Boolean)
-                : false;
-        } else if (state.aus) {
-            // AUS mode
-            canRun = state.aus.personalisedAdvertising;
-        } else canRun = false;
-
-        if (canRun !== latestConsentCanRun) {
-            const ccpaState = state.ccpa ? state.ccpa.doNotSell : null;
-            const eventStatus = state.tcfv2 ? state.tcfv2.eventStatus : 'na';
-            myPageTargetting = buildPageTargetting(
-                canRun,
-                ccpaState,
-                eventStatus
-            );
-            latestConsentCanRun = canRun;
+    if (Object.keys(myPageTargetting).length !== 0) {
+        // If CMP was initalised since the last time myPageTargetting was built - rebuild
+        if (latestCmpHasInitalised !== cmp.hasInitialised()) {
+            myPageTargetting = rebuildPageTargeting();
         }
+        return myPageTargetting;
+    }
+    
+    // First call binds to onConsentChange and returns {}
+    onConsentChange((state)=>{
+    // On every consent change we rebuildPageTageting
+        latestCMPState = state;
+        myPageTargetting = rebuildPageTargeting();
     });
-
-    return myPageTargetting;
+    return myPageTargetting; 
 };
 
 const resetPageTargeting = (): void => {
     myPageTargetting = {};
-    latestConsentCanRun = undefined;
 };
 
 export {


### PR DESCRIPTION
## What does this change?
The previous inskin fix too aggressively cached the pageTargeting values (it was only regenerated on a consent-change that changed the value of `canRun`/`adConsentState`).
I now check if the value of `cmp.hasInitialised` has changed since the last time we built page targeting, and if it's different rebuild it.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
