### PR TITLE
Return content.api.timeout.millis to its normal default value

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -210,7 +210,7 @@ class GuardianConfiguration extends Logging {
 
     lazy val key: Option[String] = configuration.getStringProperty("content.api.key")
     lazy val timeout: FiniteDuration =
-      Duration.create(configuration.getIntegerProperty("content.api.timeout.millis").getOrElse(20000), MILLISECONDS)
+      Duration.create(configuration.getIntegerProperty("content.api.timeout.millis").getOrElse(2000), MILLISECONDS)
 
     lazy val circuitBreakerErrorThreshold: Int =
       configuration.getIntegerProperty("content.api.circuit_breaker.max_failures").getOrElse(30)


### PR DESCRIPTION
## What does this change?

Was accidentally set to a non standard value in this PR ( https://github.com/guardian/frontend/pull/23346 ) while dealing with the tests. 