### PR TITLE
Podcast -  Add missing RSS Feed

### DIFF
--- a/applications/app/views/fragments/audioBody.scala.html
+++ b/applications/app/views/fragments/audioBody.scala.html
@@ -114,6 +114,16 @@
                             </a>
                         </li>
                     }
+                    @audio.seriesFeedUrl.map { seriesFeedUrl =>
+                        <li class="podcast__meta-item podcast__meta-item--feed">
+                           <a class="podcast__meta__item-link podcast__section-link"
+                               href="@seriesFeedUrl"
+                               data-link-name="@trackingCode("feed")"
+                               >
+                               RSS Feed
+                           </a>
+                        </li>
+                    }
                     @audio.downloadUrl.map { downloadUrl =>
                         <li class="podcast__meta-item podcast__meta-item--download">
                             <a class="podcast__meta__item-link podcast__section-link"


### PR DESCRIPTION
## What does this change?

Add missing option to discover the RSS feed in `More way to listen`.
I did not add an SVG but that will be quite easy to add later if needed for esthetics.

I think this was missed few time ago and the [previous rendering](https://github.com/guardian/frontend/blob/main/common/app/views/fragments/media/audio.scala.html) is likely to be not [used anymore](https://github.com/guardian/frontend/search?q=%22fragments.media.audio%22), which would be a good candidate for cleanup (including css).

## Before


<img width="998" alt="Screenshot 2020-12-09 at 12 51 16" src="https://user-images.githubusercontent.com/615085/101632106-4e79cd80-3a1d-11eb-88da-ffcadf273498.png">

## After

<img width="971" alt="Screenshot 2020-12-09 at 12 56 59" src="https://user-images.githubusercontent.com/615085/101632647-1b840980-3a1e-11eb-9427-ca7090b9a4dd.png">


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No until audio pages have been migrated

## What is the value of this and can you measure success?

People can discover the RSS feed without asking user help.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
