### PR TITLE
Bump Identity version

### DIFF
--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -18,8 +18,8 @@
             <div class="newsletter-card" data-component="newsletter-card @emailListing.identityName">
                 <div class="newsletter-card__content js-newsletter-content">
 
-                    <div class="newsletter-card__name">@emailListing.name
-                        @if(emailListing.subheading.isDefined){ @emailListing.subheading }
+                    <div class="newsletter-card__name">
+                        @emailListing.name
                     </div>
 
                     <div>

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -115,8 +115,7 @@ class EmailSignupController(
                 views.html.emailFragment(
                   emailLandingPage,
                   emailType,
-                  newsletter.identityName,
-                  newsletter.emailEmbed,
+                  newsletter,
                 ),
               ),
             )
@@ -136,8 +135,7 @@ class EmailSignupController(
                 views.html.emailFragment(
                   emailLandingPage,
                   emailType,
-                  newsletter.identityName,
-                  newsletter.emailEmbed,
+                  newsletter,
                 ),
               ),
             )
@@ -166,7 +164,7 @@ class EmailSignupController(
         case Some(newsletter) =>
           Cached(1.hour)(
             RevalidatableResult.Ok(
-              views.html.emailSubscriptionSuccessResult(emailLandingPage, newsletter.emailEmbed, listName),
+              views.html.emailSubscriptionSuccessResult(emailLandingPage, newsletter, listName),
             ),
           )
         case _ => Cached(15.minute)(WithoutRevalidationResult(NoContent))

--- a/common/app/views/emailFragment.scala.html
+++ b/common/app/views/emailFragment.scala.html
@@ -1,5 +1,5 @@
-@import com.gu.identity.model.EmailEmbed
-@(page: model.Page, emailType: String, listName: String, emailEmbedData: EmailEmbed)(implicit request: RequestHeader, context: model.ApplicationContext)
+@import com.gu.identity.model.EmailNewsletter
+@(page: model.Page, emailType: String, emailNewsletter: EmailNewsletter)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @electionNewsletters = @{
     List(
@@ -8,19 +8,17 @@
     )
 }
 
-
 @emailEmbed(page) {
-    @if(electionNewsletters.contains(listName)) {
+    @if(electionNewsletters.contains(emailNewsletter.identityName)) {
         @fragments.email.signup.subscription.emailSignUpNewDesign(
             emailType,
-            listName,
-            emailEmbedData
+            emailNewsletter
         )
     }
     @fragments.email.signup.subscription.emailSignUp(
         emailType,
-        listName,
-        emailEmbedData
+        emailNewsletter.identityName,
+        emailNewsletter.emailEmbed
     )
 }
 

--- a/common/app/views/emailSubscriptionSuccessResult.scala.html
+++ b/common/app/views/emailSubscriptionSuccessResult.scala.html
@@ -1,6 +1,6 @@
-@import com.gu.identity.model.EmailEmbed
+@import com.gu.identity.model.EmailNewsletter
 @import experiments.{ActiveExperiments, NewsletterEmbedDesign}
-@(page: model.Page, emailEmbedData: EmailEmbed, listName: String)(implicit request: RequestHeader, context: model.ApplicationContext)
+@(page: model.Page, emailNewsletter: EmailNewsletter, listName: String)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @electionNewsletters = @{List("minute-us", "us-morning-newsletter", "today-us", "green-light")}
 
@@ -8,11 +8,11 @@
     @if(ActiveExperiments.isParticipating(NewsletterEmbedDesign) && electionNewsletters.contains(listName)) {
         @fragments.email.signup.result.emailResultNewDesign(
             listName,
-            emailEmbedData,
-            fragments.email.signup.result.emailSuccess(emailEmbedData)
+            emailNewsletter,
+            fragments.email.signup.result.emailSuccess(emailNewsletter.emailEmbed)
         )
     } else {
-        @fragments.email.signup.result.emailSuccess(emailEmbedData)
+        @fragments.email.signup.result.emailSuccess(emailNewsletter.emailEmbed)
     }
 
 }

--- a/common/app/views/fragments/email/signup/result/emailResultNewDesign.scala.html
+++ b/common/app/views/fragments/email/signup/result/emailResultNewDesign.scala.html
@@ -1,8 +1,8 @@
-@import com.gu.identity.model.EmailEmbed
+@import com.gu.identity.model.EmailNewsletter
 @(listName: String,
-        emailEmbedData: EmailEmbed,
+        emailNewsletter: EmailNewsletter,
         resultHtml: Html)(implicit request: RequestHeader)
-
+@emailEmbedData = @{emailNewsletter.emailEmbed}
 @wrapperClass = @{
     "newsletter-embed newsletter-embed--result"
 }
@@ -13,10 +13,11 @@
 
 
 <div class="@wrapperClass" style="background-color: @emailEmbedData.hexCode">
-    @if(emailEmbedData.imageUrl.nonEmpty) {
+    @image = @{emailNewsletter.illustration.flatMap(_.circle)}
+    @if(image.nonEmpty) {
         <aside class="newsletter-embed__image">
             <img
-            src="@emailEmbedData.imageUrl"
+            src="@image"
             alt="@imageAltText"/>
         </aside>
     }

--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -1,6 +1,5 @@
 @import com.gu.identity.model.EmailNewsletters._
 @import com.gu.identity.model.EmailEmbed
-@import com.gu.identity.model.EmailNewsletter
 @(  componentClass: String,
     listName:String,
     emailEmbedData: EmailEmbed)(implicit request: RequestHeader)

--- a/common/app/views/fragments/email/signup/subscription/emailSignUpNewDesign.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUpNewDesign.scala.html
@@ -1,7 +1,6 @@
-@import com.gu.identity.model.EmailEmbed
+@import com.gu.identity.model.EmailNewsletter
 @(  componentClass: String,
-    listName:String,
-    emailEmbedData: EmailEmbed)(implicit request: RequestHeader)
+    emailNewsletter: EmailNewsletter)(implicit request: RequestHeader)
 
 @import common.LinkTo
 
@@ -12,6 +11,8 @@
 @wrapperClass = @{ "newsletter-embed" + " newsletter-embed--" + componentClass  }
 @formClass = @{ "newsletter-embed__form" + " newsletter-embed__form--" + componentClass }
 
+@emailEmbedData = @{emailNewsletter.emailEmbed}
+@listName = @{emailNewsletter.identityName}
 @imageAltText = @{s"${emailEmbedData.name} profile image"}
 
 
@@ -57,10 +58,11 @@
 
 
 <div class="@wrapperClass js-ab-embed-new-design hide-element" style="background-color: @emailEmbedData.hexCode">
-    @if(emailEmbedData.imageUrl.nonEmpty){
+    @image = @{emailNewsletter.illustration.flatMap(_.circle)}
+    @if(image){
         <aside class="newsletter-embed__image">
             <img
-            src="@emailEmbedData.imageUrl"
+            src="@image"
             alt="@imageAltText"/>
         </aside>
     }

--- a/identity/app/views/fragments/consentSwitch.scala.html
+++ b/identity/app/views/fragments/consentSwitch.scala.html
@@ -28,7 +28,6 @@
 
 @fragments.form.switch(
     title = titleProvider(getConsentText(consentField)),
-    subheading = None,
     description = descriptionProvider(getConsentText(consentField)),
     behaviour = ConsentSwitch,
     field = consentField("consented"),

--- a/identity/app/views/fragments/form/switch.scala.html
+++ b/identity/app/views/fragments/form/switch.scala.html
@@ -3,7 +3,6 @@
 
 @(
     title: String,
-    subheading: Option[String],
     description: Option[String],
     behaviour: SwitchBehaviour,
     field: Field,
@@ -33,16 +32,10 @@
         @if(boldTitle) {
             <h3 class="manage-account__switch-title">
                 @title
-                @if(subheading) {
-                    <em>@subheading</em>
-                }
             </h3>
         } else {
             <p class="manage-account__switch-copy">
                 @title
-                @if(subheading) {
-                    <em>@subheading</em>
-                }
             </p>
         }
         @if(description) {

--- a/identity/app/views/fragments/newsletterSwitch.scala.html
+++ b/identity/app/views/fragments/newsletterSwitch.scala.html
@@ -50,7 +50,6 @@
 
 @fragments.form.switch(
     title = newsletter.name,
-    subheading = newsletter.subheading,
     description = Some(newsletter.description),
     behaviour = NewsletterSwitch,
     field = newsletterField,

--- a/identity/app/views/profile/smsConsent.scala.html
+++ b/identity/app/views/profile/smsConsent.scala.html
@@ -18,7 +18,6 @@
                 <li>
                 @fragments.form.switch(
                     title = "",
-                    subheading = None,
                     description = Some(
                         Consent.CommunicationSms.latestWording.description.getOrElse("")
                             .replaceFirst("The Guardian products and services I['’]ve selected above", "<b>$0</b>")),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.235"
+  val identityLibVersion = "3.236"
   val awsVersion = "1.11.240"
   val capiVersion = "17.5"
   val faciaVersion = "3.2.0"


### PR DESCRIPTION
## What does this change?
Bumps Identity version following https://github.com/guardian/identity/pull/1857

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

