### PR TITLE
Platform support for new Braze banner campaign 

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -62,7 +62,7 @@ type InAppMessageCallback = (InAppMessage) => void;
 
 type AppBoy = {
     initialize: (string, any) => void,
-    subscribeToInAppMessage: (InAppMessageCallback) => {},
+    subscribeToInAppMessage: (InAppMessageCallback) => string,
     removeSubscription: (string) => void,
     changeUser: (string) => void,
     openSession: () => void,
@@ -155,7 +155,7 @@ const getMessageFromBraze = async (apiKey: string, brazeUuid: string): Promise<b
             return;
         }
 
-        let subscriptionId: string | undefined;
+        let subscriptionId: ?string;
 
         const callback = (message: InAppMessage) => {
             if (message.extras) {
@@ -166,7 +166,7 @@ const getMessageFromBraze = async (apiKey: string, brazeUuid: string): Promise<b
             }
 
             // Unsubscribe
-            if (subscriptionId) {
+            if (appboy && subscriptionId) {
                 appboy.removeSubscription(subscriptionId);
             }
         };

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -213,6 +213,10 @@ const canShow = async (): Promise<boolean> => {
         userIsGuSupporter: shouldNotBeShownSupportMessaging(),
         pageConfig: config.get('page'),
     })) {
+        // Currently all active web canvases in Braze target existing supporters,
+        // subscribers or otherwise those with a Guardian product. We can use the
+        // (inverse) value of `shouldNotBeShownSupportMessaging` to identify these users,
+        // limiting the number of requests we need to initialise Braze on the page:
         return false;
     }
 

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -165,7 +165,6 @@ const getMessageFromBraze = async (apiKey: string, brazeUuid: string): Promise<b
                 resolve(false);
             }
 
-            // Unsubscribe
             if (appboy && subscriptionId) {
                 appboy.removeSubscription(subscriptionId);
             }

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -215,7 +215,7 @@ const canShow = async (): Promise<boolean> => {
     })) {
         // Currently all active web canvases in Braze target existing supporters,
         // subscribers or otherwise those with a Guardian product. We can use the
-        // (inverse) value of `shouldNotBeShownSupportMessaging` to identify these users,
+        // value of `shouldNotBeShownSupportMessaging` to identify these users,
         // limiting the number of requests we need to initialise Braze on the page:
         return false;
     }

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.spec.js
@@ -22,7 +22,7 @@ describe('canShowPreChecks', () => {
             const result = canShowPreChecks({
                 brazeSwitch: false,
                 apiKey: 'abcde',
-                isDigiSubscriber: true,
+                userIsGuSupporter: true,
                 pageConfig: {isPaidContent: false},
             })
 
@@ -35,7 +35,7 @@ describe('canShowPreChecks', () => {
             const result = canShowPreChecks({
                 brazeSwitch: true,
                 apiKey: '',
-                isDigiSubscriber: true,
+                userIsGuSupporter: true,
                 pageConfig: {isPaidContent: false},
             })
 
@@ -43,12 +43,12 @@ describe('canShowPreChecks', () => {
         });
     });
 
-    describe('when not a digital subscriber', () => {
+    describe('when not a supporter', () => {
         it('returns false', () => {
             const result = canShowPreChecks({
                 brazeSwitch: true,
                 apiKey: 'abcde',
-                isDigiSubscriber: false,
+                userIsGuSupporter: false,
                 pageConfig: {isPaidContent: false},
             })
 
@@ -61,7 +61,7 @@ describe('canShowPreChecks', () => {
             const result = canShowPreChecks({
                 brazeSwitch: true,
                 apiKey: 'abcde',
-                isDigiSubscriber: true,
+                userIsGuSupporter: true,
                 pageConfig: {isPaidContent: true},
             })
 
@@ -74,7 +74,7 @@ describe('canShowPreChecks', () => {
             const result = canShowPreChecks({
                 brazeSwitch: true,
                 apiKey: 'abcde',
-                isDigiSubscriber: true,
+                userIsGuSupporter: true,
                 pageConfig: {isPaidContent: false},
             })
 


### PR DESCRIPTION
## What does this change?
The Frontend implementation of our [DCR PR](https://github.com/guardian/dotcom-rendering/pull/2225).

This PR includes a few changes to the platform code around showing Braze banners, to support a new campaign which will run alongside the existing one.

In particular:

Because users might now be eligible for > 1 message from Braze we now unsubscribe from in-app message events after we receive an event. This is so that we don't have multiple messages delivered from Braze in the same page request (we wouldn't actually show > 1 message because we wrap the callback logic up in a promise which can only ever resolve once).

The pre-check is now derived from `shouldNotBeShownSupportMessaging` rather than `isDigitalSubscriber`. The new campaign has a wider audience, though we'd still like to restrict the number of readers we load the Braze SDK for. Broadening to users who shouldn't see support messaging (which means they have a product, or have otherwise subscribed/contributed).

Also includes a bonus fix to move the force-braze-message host check further down so we only ever show it if the query string was specified.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes (already implemented - see above link)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)
