### PR TITLE
deeply read 2/. : refactorings

### DIFF
--- a/common/app/services/OphanApi.scala
+++ b/common/app/services/OphanApi.scala
@@ -24,6 +24,8 @@ class OphanApi(wsClient: WSClient)(implicit executionContext: ExecutionContext)
     with implicits.WSRequests {
   private val mostViewedDateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
 
+  private def ensureHostSecure(host: String): String = host.replace("http:", "https:")
+
   // getBody is the general function that queries Ophan
   private def getBody(path: String)(params: Map[String, String] = Map.empty): Future[JsValue] = {
     val maybeJson = for {
@@ -33,7 +35,7 @@ class OphanApi(wsClient: WSClient)(implicit executionContext: ExecutionContext)
       val queryString = params map {
         case (k, v) => s"$k=${URLEncoder.encode(v, "utf-8")}"
       } mkString "&"
-      val url = s"${host.replace("http:", "https:")}/$path?$queryString&api-key=$key"
+      val url = s"${ensureHostSecure(host)}/$path?$queryString&api-key=$key"
       log.info(s"Making request to Ophan API: $url")
       wsClient.url(url).withRequestTimeout(10.seconds).getOKResponse().map(_.json)
     }

--- a/common/app/services/OphanApi.scala
+++ b/common/app/services/OphanApi.scala
@@ -13,11 +13,11 @@ import play.api.libs.ws.WSClient
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.DurationInt
 
-object MostReadItem {
-  implicit val jsonReads = Json.reads[MostReadItem]
+object OphanMostReadItem {
+  implicit val jsonReads = Json.reads[OphanMostReadItem]
 }
 
-case class MostReadItem(url: String, count: Int)
+case class OphanMostReadItem(url: String, count: Int)
 
 class OphanApi(wsClient: WSClient)(implicit executionContext: ExecutionContext)
     extends Logging
@@ -49,8 +49,8 @@ class OphanApi(wsClient: WSClient)(implicit executionContext: ExecutionContext)
 
   private def getBreakdown: (Map[String, String]) => Future[JsValue] = getBody("breakdown") _
 
-  private def getMostRead(params: Map[String, String]): Future[Seq[MostReadItem]] =
-    getBody("mostread")(params).map(_.as[Seq[MostReadItem]])
+  private def getMostRead(params: Map[String, String]): Future[Seq[OphanMostReadItem]] =
+    getBody("mostread")(params).map(_.as[Seq[OphanMostReadItem]])
 
   // The below functions are convenience functions to call particular API paths
   // Some return a Future[JsValue] and others Future[Seq[MostReadItem]]
@@ -60,31 +60,31 @@ class OphanApi(wsClient: WSClient)(implicit executionContext: ExecutionContext)
 
   def getBreakdown(path: String): Future[JsValue] = getBreakdown(Map("path" -> s"/$path"))
 
-  def getMostReadFacebook(hours: Int): Future[Seq[MostReadItem]] =
+  def getMostReadFacebook(hours: Int): Future[Seq[OphanMostReadItem]] =
     getMostRead("Facebook", hours)
 
-  def getMostReadTwitter(hours: Int): Future[Seq[MostReadItem]] =
+  def getMostReadTwitter(hours: Int): Future[Seq[OphanMostReadItem]] =
     getMostRead("Twitter", hours)
 
-  def getMostRead(referrer: String, hours: Int): Future[Seq[MostReadItem]] =
+  def getMostRead(referrer: String, hours: Int): Future[Seq[OphanMostReadItem]] =
     getMostRead(Map("referrer" -> referrer, "hours" -> hours.toString))
 
-  def getMostRead(hours: Int, count: Int): Future[Seq[MostReadItem]] =
+  def getMostRead(hours: Int, count: Int): Future[Seq[OphanMostReadItem]] =
     getMostRead(Map("hours" -> hours.toString, "count" -> count.toString))
 
-  def getMostRead(hours: Int, count: Int, country: String): Future[Seq[MostReadItem]] =
+  def getMostRead(hours: Int, count: Int, country: String): Future[Seq[OphanMostReadItem]] =
     getMostRead(Map("hours" -> hours.toString, "count" -> count.toString, "country" -> country))
 
-  def getMostReadInSection(section: String, days: Int, count: Int): Future[Seq[MostReadItem]] =
+  def getMostReadInSection(section: String, days: Int, count: Int): Future[Seq[OphanMostReadItem]] =
     getMostRead(Map("days" -> days.toString, "count" -> count.toString, "section" -> section))
 
-  def getMostReferredFromSocialMedia(days: Int): Future[Seq[MostReadItem]] =
+  def getMostReferredFromSocialMedia(days: Int): Future[Seq[OphanMostReadItem]] =
     getMostRead(Map("days" -> days.toString, "referrer" -> "social media"))
 
-  def getMostViewedGalleries(hours: Int, count: Int): Future[Seq[MostReadItem]] =
+  def getMostViewedGalleries(hours: Int, count: Int): Future[Seq[OphanMostReadItem]] =
     getMostRead(Map("content-type" -> "gallery", "hours" -> hours.toString, "count" -> count.toString))
 
-  def getMostViewedAudio(hours: Int, count: Int): Future[Seq[MostReadItem]] =
+  def getMostViewedAudio(hours: Int, count: Int): Future[Seq[OphanMostReadItem]] =
     getMostRead(Map("content-type" -> "audio", "hours" -> hours.toString, "count" -> count.toString))
 
   def getAdsRenderTime(params: Map[String, Seq[String]]): Future[JsValue] = {

--- a/onward/app/feed/MostPopularAgent.scala
+++ b/onward/app/feed/MostPopularAgent.scala
@@ -5,7 +5,7 @@ import conf.Configuration
 import contentapi.ContentApiClient
 import com.gu.contentapi.client.model.v1.{Content, ContentFields, ContentType}
 import common._
-import services.{MostReadItem, OphanApi}
+import services.{OphanMostReadItem, OphanApi}
 import model.RelatedContentItem
 
 import play.api.libs.json._

--- a/onward/app/feed/MostPopularSocialAutoRefresh.scala
+++ b/onward/app/feed/MostPopularSocialAutoRefresh.scala
@@ -4,11 +4,11 @@ import akka.actor.ActorSystem
 import app.LifecycleComponent
 import common.AutoRefresh
 import play.api.inject.ApplicationLifecycle
-import services.{MostReadItem, OphanApi}
+import services.{OphanMostReadItem, OphanApi}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 
-case class MostReadSocial(twitter: Seq[MostReadItem], facebook: Seq[MostReadItem])
+case class MostReadSocial(twitter: Seq[OphanMostReadItem], facebook: Seq[OphanMostReadItem])
 
 class MostPopularSocialAutoRefresh(ophanApi: OphanApi) extends AutoRefresh[MostReadSocial](0.seconds, 3.minutes) {
   val Hours = 3

--- a/onward/app/feed/MostViewed.scala
+++ b/onward/app/feed/MostViewed.scala
@@ -4,13 +4,13 @@ import com.gu.commercial.branding.BrandingFinder
 import common.{Edition, Logging}
 import contentapi.{ContentApiClient, QueryDefaults}
 import model.RelatedContentItem
-import services.MostReadItem
+import services.OphanMostReadItem
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
 object MostViewed extends Logging {
 
-  def relatedContentItems(ophanMostViewed: Future[Seq[MostReadItem]], edition: Edition = Edition.defaultEdition)(
+  def relatedContentItems(ophanMostViewed: Future[Seq[OphanMostReadItem]], edition: Edition = Edition.defaultEdition)(
       contentApiClient: ContentApiClient,
   )(implicit ec: ExecutionContext): Future[Seq[Option[RelatedContentItem]]] = {
 


### PR DESCRIPTION
## What does this change?

Here we do two things

1. Abstract the correction of the Ophan API url ( which first happened here:  https://github.com/guardian/frontend/pull/23305 ) to a separate function

2. Rename `MostReadItem` to `OphanMostReadItem`, this is to remove an ambiguity around whether the type is frontend defined or the type of objects we get from Ophan (making the code more difficult to understand for newcomers). This also sets a convention for the name of the deeplyread Ophan types that are coming shortly.