### PR TITLE
deeply read 3/. : refactorings

### DIFF
--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -189,7 +189,7 @@ class MostPopularController(
 
   // Get "Most Commented" & "Most Shared" cards for Extended "Most Read" container
   private def mostCards(): Map[String, Option[ContentCard]] =
-    mostPopularAgent.mostSingleCards.get().mapValues(ContentCard.fromApiContent(_))
+    mostPopularAgent.mostSingleCardsBox.get().mapValues(ContentCard.fromApiContent(_))
 
   private def lookup(edition: Edition, path: String)(implicit request: RequestHeader): Future[Option[MostPopular]] = {
     log.info(s"Fetching most popular: $path for edition $edition")

--- a/onward/app/feed/MostPopularAgent.scala
+++ b/onward/app/feed/MostPopularAgent.scala
@@ -17,7 +17,9 @@ case class Country(code: String, edition: Edition)
 
 object MostPopularRefresh {
 
-  def all[A](as: Seq[A])(
+  // This function takes a sequence of items and a function that maps each item to a future.
+  // Each future carries a map, all the maps are collapsed into one using a reduce
+  def refreshAll[A](as: Seq[A])(
       refreshOne: A => Future[Map[String, Seq[RelatedContentItem]]],
   )(implicit ec: ExecutionContext): Future[Map[String, Seq[RelatedContentItem]]] = {
     as.map(refreshOne)
@@ -112,7 +114,7 @@ class MostPopularAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi, w
 
   // Note that here we are in procedural land here (not functional)
   def refresh()(implicit ec: ExecutionContext): Unit = {
-    MostPopularRefresh.all(Edition.all)(refresh)
+    MostPopularRefresh.refreshAll(Edition.all)(refresh)
     refreshGlobal()
   }
 }
@@ -154,7 +156,7 @@ class GeoMostPopularAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi
 
   def refresh()(implicit ec: ExecutionContext): Future[Map[String, Seq[RelatedContentItem]]] = {
     log.info("Refreshing most popular for countries.")
-    MostPopularRefresh.all(countries)(refresh)
+    MostPopularRefresh.refreshAll(countries)(refresh)
   }
 }
 
@@ -172,7 +174,7 @@ class DayMostPopularAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi
 
   def refresh()(implicit ec: ExecutionContext): Future[Map[String, Seq[RelatedContentItem]]] = {
     log.info("Refreshing most popular for the day.")
-    MostPopularRefresh.all(countries)(refresh)
+    MostPopularRefresh.refreshAll(countries)(refresh)
   }
 
   def refresh(country: Country)(implicit ec: ExecutionContext): Future[Map[String, Seq[RelatedContentItem]]] = {

--- a/onward/app/feed/MostPopularAgent.scala
+++ b/onward/app/feed/MostPopularAgent.scala
@@ -13,6 +13,8 @@ import play.api.libs.ws.{WSClient, WSResponse}
 
 import scala.concurrent.{ExecutionContext, Future}
 
+case class Country(code: String, edition: Edition)
+
 object MostPopularRefresh {
 
   def all[A](as: Seq[A])(
@@ -114,8 +116,6 @@ class MostPopularAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi, w
     refreshGlobal()
   }
 }
-
-case class Country(code: String, edition: Edition)
 
 class GeoMostPopularAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) extends Logging {
 


### PR DESCRIPTION
## What does this change?

1. Rename the main function of `MostPopularRefresh` from `all` to `refreshAll` to enhance understanding and make the code less opaque. 

2. Rename boxes (away from `agent`). This last change significantly reduces mental load when accessing the code the first time. 