### PR TITLE
deeply read 6/. : Plug the DeeplyReadAgent function to the onward app lifecycle

### DIFF
--- a/onward/app/AppLoader.scala
+++ b/onward/app/AppLoader.scala
@@ -45,6 +45,7 @@ trait OnwardServices {
   lazy val geoMostPopularAgent = wire[GeoMostPopularAgent]
   lazy val dayMostPopularAgent = wire[DayMostPopularAgent]
   lazy val mostPopularAgent = wire[MostPopularAgent]
+  lazy val deeplyReadAgent = wire[DeeplyReadAgent]
   lazy val mostReadAgent = wire[MostReadAgent]
   lazy val mostPopularSocialAutoRefresh = wire[MostPopularSocialAutoRefresh]
   lazy val mostViewedAudioAgent = wire[MostViewedAudioAgent]

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -6,7 +6,7 @@ import java.time.temporal.ChronoUnit
 import common._
 import conf.switches.Switches
 import contentapi.ContentApiClient
-import feed.{DayMostPopularAgent, GeoMostPopularAgent, MostPopularAgent}
+import feed.{DayMostPopularAgent, GeoMostPopularAgent, MostPopularAgent, DeeplyReadAgent}
 import layout.ContentCard
 import model.Cached.RevalidatableResult
 import model._
@@ -29,6 +29,7 @@ class MostPopularController(
     geoMostPopularAgent: GeoMostPopularAgent,
     dayMostPopularAgent: DayMostPopularAgent,
     mostPopularAgent: MostPopularAgent,
+    deeplyReadAgent: DeeplyReadAgent,
     val controllerComponents: ControllerComponents,
 )(implicit context: ApplicationContext)
     extends BaseController

--- a/onward/app/controllers/OnwardControllers.scala
+++ b/onward/app/controllers/OnwardControllers.scala
@@ -22,6 +22,7 @@ trait OnwardControllers {
   def geoMostPopularAgent: GeoMostPopularAgent
   def dayMostPopularAgent: DayMostPopularAgent
   def mostPopularAgent: MostPopularAgent
+  def deeplyReadAgent: DeeplyReadAgent
   def mostReadAgent: MostReadAgent
   def mostPopularSocialAutoRefresh: MostPopularSocialAutoRefresh
   def mostViewedVideoAgent: MostViewedVideoAgent

--- a/onward/app/feed/DeeplyReadAgent.scala
+++ b/onward/app/feed/DeeplyReadAgent.scala
@@ -4,6 +4,7 @@ import contentapi.ContentApiClient
 import com.gu.contentapi.client.model.v1.{Content}
 import services.{OphanApi, OphanDeeplyReadItem}
 import play.api.libs.json._
+import common._
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -31,7 +32,7 @@ object DeeplyReadItem {
   implicit val jsonWrites = Json.writes[DeeplyReadItem]
 }
 
-class DeeplyReadAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) {
+class DeeplyReadAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) extends Logging {
 
   /*
       This (DeeplyReadAgent) agent is similar in purpose and interface as the ones we already have at the
@@ -54,7 +55,7 @@ class DeeplyReadAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) {
     ophanApi.getDeeplyReadContent().map { seq =>
       seq.foreach { i =>
         val path = i.path
-        println(s"Looking up data for path: ${path}")
+        log.info(s"Looking up data for path: ${path}")
         val capiItem = contentApiClient
           .item(path)
           .showTags("all")

--- a/onward/app/feed/OnwardJourneyLifecycle.scala
+++ b/onward/app/feed/OnwardJourneyLifecycle.scala
@@ -14,6 +14,7 @@ class OnwardJourneyLifecycle(
     geoMostPopularAgent: GeoMostPopularAgent,
     dayMostPopularAgent: DayMostPopularAgent,
     mostPopularAgent: MostPopularAgent,
+    deeplyReadAgent: DeeplyReadAgent,
     mostViewedAudioAgent: MostViewedAudioAgent,
     mostViewedGalleryAgent: MostViewedGalleryAgent,
     mostViewedVideoAgent: MostViewedVideoAgent,
@@ -47,6 +48,7 @@ class OnwardJourneyLifecycle(
       mostViewedAudioAgent.refresh()
       mostViewedGalleryAgent.refresh()
       mostReadAgent.refresh()
+      deeplyReadAgent.refresh()
     }
 
     jobs.scheduleEveryNMinutes("OnwardJourneyAgentsLowFrequencyRefreshJob", 60) {
@@ -61,6 +63,7 @@ class OnwardJourneyLifecycle(
       mostViewedGalleryAgent.refresh()
       mostViewedVideoAgent.refresh()
       mostReadAgent.refresh()
+      deeplyReadAgent.refresh()
     }
   }
 }

--- a/onward/test/MostPopularControllerTest.scala
+++ b/onward/test/MostPopularControllerTest.scala
@@ -1,7 +1,7 @@
 package test
 
 import controllers.MostPopularController
-import feed.{DayMostPopularAgent, GeoMostPopularAgent, MostPopularAgent}
+import feed.{DayMostPopularAgent, GeoMostPopularAgent, MostPopularAgent, DeeplyReadAgent}
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 import play.api.test._
 import play.api.test.Helpers._
@@ -25,6 +25,7 @@ import services.OphanApi
     new GeoMostPopularAgent(testContentApiClient, ophanApi),
     new DayMostPopularAgent(testContentApiClient, ophanApi),
     new MostPopularAgent(testContentApiClient, ophanApi, wsClient),
+    new DeeplyReadAgent(testContentApiClient, ophanApi),
     play.api.test.Helpers.stubControllerComponents(),
   )
 


### PR DESCRIPTION
## What does this change?

Plug the DeeplyReadAgent function to the onward app lifecycle. The data from Ophan is collected and enhance at application start and then every 30 minutes. This is the immediate follow up of: https://github.com/guardian/frontend/pull/23368

<img width="1114" alt="Screenshot 2020-12-14 at 14 37 57" src="https://user-images.githubusercontent.com/6035518/102094335-1bb74700-3e1a-11eb-8f06-bdd7aefdf1e9.png">
