### PR TITLE
Ad/embed iframe race condition 2

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -78,7 +78,7 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-newsletter-embeds2",
+    "ab-newsletter-embeds3",
     "New newsletter signup embeds for discoverability OKR",
     owners = Seq(Owner.withGithub("buck06191")),
     safeState = Off,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-embed-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-embed-test.js
@@ -16,14 +16,12 @@ const trackComponentInOphan = (newsletterId: string, variant: string) => {
 };
 
 const triggerVariant = (doc: Document, iframeId: string) => {
-    if (doc) {
-        const oldDesign = doc.querySelector('.js-ab-embed-old-design');
-        const newDesign = doc.querySelector('.js-ab-embed-new-design');
-        if (oldDesign && newDesign) {
-            oldDesign.classList.add("hide-element");
-            newDesign.classList.remove("hide-element");
-            trackComponentInOphan(iframeId, 'variant');
-        }
+    const oldDesign = doc.querySelector('.js-ab-embed-old-design');
+    const newDesign = doc.querySelector('.js-ab-embed-new-design');
+    if (oldDesign && newDesign) {
+        oldDesign.classList.add("hide-element");
+        newDesign.classList.remove("hide-element");
+        trackComponentInOphan(iframeId, 'variant');
     }
 };
 
@@ -53,10 +51,12 @@ export const newsletterEmbeds: ABTest = {
                 iframes.forEach( (ifrm: HTMLIFrameElement) => {
                     if (ifrm.id !== 'footer__email-form') {
                         const doc = ifrm.contentDocument ? ifrm.contentDocument : ifrm.contentWindow.document;
-                        if (doc.readyState !== 'complete' ) {
-                            window.addEventListener('load', () => triggerVariant(doc, ifrm.id));
-                        } else {
-                            triggerVariant(doc, ifrm.id);
+                        if (doc) {
+                            if (doc.readyState !== 'complete') {
+                                window.addEventListener('load', () => triggerVariant(doc, ifrm.id));
+                            } else {
+                                triggerVariant(doc, ifrm.id);
+                            }
                         }
                     }
                 });

--- a/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-embed-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-embed-test.js
@@ -28,7 +28,7 @@ const triggerVariant = (doc: Document, iframeId: string) => {
 };
 
 export const newsletterEmbeds: ABTest = {
-    id: 'NewsletterEmbeds2',
+    id: 'NewsletterEmbeds3',
     start: '2020-12-02',
     expiry: '2021-01-04',
     author: 'Josh Buckland',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-embed-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-embed-test.js
@@ -68,11 +68,13 @@ export const newsletterEmbeds: ABTest = {
             id: 'control',
             test: (): void => {
                 const iframes = ((document.querySelectorAll('.email-sub__iframe'): NodeList<any>): NodeList<HTMLIFrameElement>);
-                iframes.forEach( (ifrm: HTMLIFrameElement) => {
-                    if (ifrm.id !== 'footer__email-form') {
-                        trackComponentInOphan(ifrm.id,'control');
-                    }
-                });
+                if (iframes) {
+                    iframes.forEach((ifrm: HTMLIFrameElement) => {
+                        if (ifrm.id !== 'footer__email-form') {
+                            trackComponentInOphan(ifrm.id, 'control');
+                        }
+                    });
+                }
             },
         }
     ],

--- a/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-embed-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-embed-test.js
@@ -48,18 +48,20 @@ export const newsletterEmbeds: ABTest = {
             id: 'variant',
             test: (): void => {
                 const iframes = ((document.querySelectorAll('.email-sub__iframe'): NodeList<any>): NodeList<HTMLIFrameElement>);
-                iframes.forEach( (ifrm: HTMLIFrameElement) => {
-                    if (ifrm.id !== 'footer__email-form') {
-                        const doc = ifrm.contentDocument ? ifrm.contentDocument : ifrm.contentWindow.document;
-                        if (doc) {
-                            if (doc.readyState !== 'complete') {
-                                window.addEventListener('load', () => triggerVariant(doc, ifrm.id));
-                            } else {
-                                triggerVariant(doc, ifrm.id);
+                if (iframes) {
+                    iframes.forEach((ifrm: HTMLIFrameElement) => {
+                        if (ifrm.id !== 'footer__email-form') {
+                            const doc = ifrm.contentDocument ? ifrm.contentDocument : ifrm.contentWindow.document;
+                            if (doc) {
+                                if (doc.readyState !== 'complete') {
+                                    window.addEventListener('load', () => triggerVariant(doc, ifrm.id));
+                                } else {
+                                    triggerVariant(doc, ifrm.id);
+                                }
                             }
                         }
-                    }
-                });
+                    });
+                }
             },
         },
         {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-embed-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-embed-test.js
@@ -15,6 +15,18 @@ const trackComponentInOphan = (newsletterId: string, variant: string) => {
     });
 };
 
+const triggerVariant = (doc: Document, iframeId: string) => {
+    if (doc) {
+        const oldDesign = doc.querySelector('.js-ab-embed-old-design');
+        const newDesign = doc.querySelector('.js-ab-embed-new-design');
+        if (oldDesign && newDesign) {
+            oldDesign.classList.add("hide-element");
+            newDesign.classList.remove("hide-element");
+            trackComponentInOphan(iframeId, 'variant');
+        }
+    }
+};
+
 export const newsletterEmbeds: ABTest = {
     id: 'NewsletterEmbeds2',
     start: '2020-12-02',
@@ -41,17 +53,11 @@ export const newsletterEmbeds: ABTest = {
                 iframes.forEach( (ifrm: HTMLIFrameElement) => {
                     if (ifrm.id !== 'footer__email-form') {
                         const doc = ifrm.contentDocument ? ifrm.contentDocument : ifrm.contentWindow.document;
-                        window.addEventListener('load', () => {
-                            if (doc) {
-                                const oldDesign = doc.querySelector('.js-ab-embed-old-design');
-                                const newDesign = doc.querySelector('.js-ab-embed-new-design');
-                                if (oldDesign && newDesign) {
-                                    oldDesign.classList.add("hide-element");
-                                    newDesign.classList.remove("hide-element");
-                                    trackComponentInOphan(ifrm.id, 'variant');
-                                }
-                            }
-                        });
+                        if (doc.readyState !== 'complete' ) {
+                            window.addEventListener('load', () => triggerVariant(doc, ifrm.id));
+                        } else {
+                            triggerVariant(doc, ifrm.id);
+                        }
                     }
                 });
             },


### PR DESCRIPTION
## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
