### PR TITLE
deeply read 9/. : Decommission OnwardItemMost

### DIFF
--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -10,13 +10,7 @@ import layout.ContentCard
 import model.Cached.RevalidatableResult
 import model._
 import models.OnwardCollection._
-import models.{
-  MostPopularGeoResponse,
-  OnwardCollection,
-  OnwardCollectionForDCRv2,
-  OnwardCollectionResponse,
-  OnwardItemMost,
-}
+import models.{MostPopularGeoResponse, OnwardCollection, OnwardCollectionForDCRv2, OnwardCollectionResponse, OnwardItem}
 import play.api.libs.json._
 import play.api.mvc._
 import views.support.FaciaToMicroFormat2Helpers._
@@ -141,10 +135,10 @@ class MostPopularController(
       )
     }
     val mostCommented = mostCards.getOrElse("most_commented", None).flatMap { contentCard =>
-      OnwardItemMost.maybeFromContentCard(contentCard)
+      OnwardItem.maybeFromContentCard(contentCard)
     }
     val mostShared = mostCards.getOrElse("most_shared", None).flatMap { contentCard =>
-      OnwardItemMost.maybeFromContentCard(contentCard)
+      OnwardItem.maybeFromContentCard(contentCard)
     }
     val response = OnwardCollectionForDCRv2(tabs, mostCommented, mostShared)
     Cached(900)(JsonComponent(response))

--- a/onward/app/models/OnwardCollection.scala
+++ b/onward/app/models/OnwardCollection.scala
@@ -31,30 +31,7 @@ case class OnwardItem(
     avatarUrl: Option[String],
 )
 
-// OnwardItemMost was introduced only to be the type of mostCommentedAndMostShared in OnwardCollectionForDCRv2
-// The only difference between OnwardItem and OnwardItemMost
-// is that the image is optional in OnwardItem but not in OnwardItemMost
-
-case class OnwardItemMost(
-    designType: String,
-    pillar: String,
-    url: String,
-    headline: String,
-    isLiveBlog: Boolean,
-    linkText: String,
-    showByline: Boolean,
-    byline: Option[String],
-    image: Option[String],
-    webPublicationDate: String,
-    ageWarning: Option[String],
-    mediaType: Option[String],
-    avatarUrl: Option[String],
-    kickerText: Option[String],
-    starRating: Option[Int],
-    shortUrl: String,
-)
-
-object OnwardItemMost {
+object OnwardItem {
 
   def contentCardToAvatarUrl(contentCard: ContentCard): Option[String] = {
 
@@ -77,7 +54,7 @@ object OnwardItemMost {
     }
 
   }
-  def maybeFromContentCard(contentCard: ContentCard): Option[OnwardItemMost] = {
+  def maybeFromContentCard(contentCard: ContentCard): Option[OnwardItem] = {
     for {
       properties <- contentCard.properties
       maybeContent <- properties.maybeContent
@@ -89,23 +66,23 @@ object OnwardItemMost {
       showByline = properties.showByline
       webPublicationDate <- contentCard.webPublicationDate.map(x => x.toDateTime().toString())
       shortUrl <- contentCard.shortUrl
-    } yield OnwardItemMost(
-      designType = metadata.designType.toString,
-      pillar = correctPillar(pillar.toString.toLowerCase),
+    } yield OnwardItem(
       url = url,
-      headline = headline,
-      isLiveBlog = isLiveBlog,
       linkText = "",
       showByline = showByline,
       byline = contentCard.byline.map(x => x.get),
       image = maybeContent.trail.thumbnailPath,
-      webPublicationDate = webPublicationDate,
       ageWarning = None,
+      isLiveBlog = isLiveBlog,
+      pillar = correctPillar(pillar.toString.toLowerCase),
+      designType = metadata.designType.toString,
+      webPublicationDate = webPublicationDate,
+      headline = headline,
       mediaType = contentCard.mediaType.map(x => x.toString),
-      avatarUrl = contentCardToAvatarUrl(contentCard),
+      shortUrl = shortUrl,
       kickerText = contentCard.header.kicker.flatMap(_.properties.kickerText),
       starRating = contentCard.starRating,
-      shortUrl = shortUrl,
+      avatarUrl = contentCardToAvatarUrl(contentCard),
     )
   }
 }
@@ -123,14 +100,13 @@ case class OnwardCollectionResponse(
 
 case class OnwardCollectionForDCRv2(
     tabs: Seq[OnwardCollectionResponse],
-    mostCommented: Option[OnwardItemMost],
-    mostShared: Option[OnwardItemMost],
+    mostCommented: Option[OnwardItem],
+    mostShared: Option[OnwardItem],
 )
 
 object OnwardCollection {
 
   implicit val onwardItemWrites = Json.writes[OnwardItem]
-  implicit val onwardItemMostWrites = Json.writes[OnwardItemMost]
   implicit val popularGeoWrites = Json.writes[MostPopularGeoResponse]
   implicit val collectionWrites = Json.writes[OnwardCollectionResponse]
   implicit val onwardCollectionResponseForDRCv2Writes = Json.writes[OnwardCollectionForDCRv2]

--- a/onward/app/models/OnwardCollection.scala
+++ b/onward/app/models/OnwardCollection.scala
@@ -28,6 +28,7 @@ case class OnwardItem(
     shortUrl: String,
     kickerText: Option[String],
     starRating: Option[Int],
+    avatarUrl: Option[String],
 )
 
 // OnwardItemMost was introduced only to be the type of mostCommentedAndMostShared in OnwardCollectionForDCRv2
@@ -50,6 +51,7 @@ case class OnwardItemMost(
     avatarUrl: Option[String],
     kickerText: Option[String],
     starRating: Option[Int],
+    shortUrl: String,
 )
 
 object OnwardItemMost {
@@ -86,6 +88,7 @@ object OnwardItemMost {
       isLiveBlog = properties.isLiveBlog
       showByline = properties.showByline
       webPublicationDate <- contentCard.webPublicationDate.map(x => x.toDateTime().toString())
+      shortUrl <- contentCard.shortUrl
     } yield OnwardItemMost(
       designType = metadata.designType.toString,
       pillar = correctPillar(pillar.toString.toLowerCase),
@@ -102,6 +105,7 @@ object OnwardItemMost {
       avatarUrl = contentCardToAvatarUrl(contentCard),
       kickerText = contentCard.header.kicker.flatMap(_.properties.kickerText),
       starRating = contentCard.starRating,
+      shortUrl = shortUrl,
     )
   }
 }
@@ -151,6 +155,7 @@ object OnwardCollection {
           shortUrl = content.card.shortUrl,
           kickerText = content.header.kicker.flatMap(_.properties.kickerText),
           starRating = content.card.starRating,
+          avatarUrl = None,
         ),
       )
   }


### PR DESCRIPTION
## What does this change?

1. Upgrade `OnwardItem` and `OnwardItemMost` to carry the same data.
2. Decommission `OnwardItemMost` to simplify the onward type system.

This is the follow up of https://github.com/guardian/frontend/pull/23376
