### PR TITLE
Bump @guardian/braze-components to 0.0.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@guardian/atom-renderer": "1.2.2",
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.7",
-    "@guardian/braze-components": "0.0.14",
+    "@guardian/braze-components": "0.0.15",
     "@guardian/commercial-core": "^0.9.0",
     "@guardian/consent-management-platform": "6.9.1",
     "@guardian/dotcom-rendering": "git://github.com/guardian/dotcom-rendering.git#version-1-alpha",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1742,10 +1742,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/braze-components@0.0.14":
-  version "0.0.14"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-0.0.14.tgz#da0edde0b1758a713019b1bdc7d643fdb9dcaab8"
-  integrity sha512-kdaEU6tAx5Rcq6jw2lxyNunXMLtrpyiX1dgZuGjDTvZM1RTJOEOI/36+/U9agB9oXpHmZ2y4mst5rvsa42uaqg==
+"@guardian/braze-components@0.0.15":
+  version "0.0.15"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-0.0.15.tgz#60de1a5886d6ffd191fa3b2fd7de9f25c610a712"
+  integrity sha512-AClH4hKyRr2aD6Z5O9wFZ/6sazSjKREgjXR8aINCVqEc2vEACb0nHfBwBvE8pyNeBj+P9mipTSxVtXxB3Jl5ag==
   dependencies:
     "@guardian/src-button" "2.4.0"
     "@guardian/src-foundations" "2.4.0"


### PR DESCRIPTION
## What does this change?

Bumps the version of @guardian/braze-components. This mostly includes some changes to dev tooling to support upcoming features and some refactoring of the components. There shouldn't be any user facing changes. Underlying changes can be seen [here](https://github.com/guardian/braze-components/compare/v0.0.14...v0.0.15).

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation) guardian/dotcom-rendering#2241

## Screenshots

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
