### PR TITLE
Fix image tag insertion logic

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -19,16 +19,14 @@ const addScripts = (tags: Array<ThirdPartyTag>): void => {
     let hasScriptsToInsert = false;
 
     tags.forEach(tag => {
-        if (tag.loaded === true) {
-            return;
-        }
-        if (tag.beforeLoad) {
-            tag.beforeLoad();
-        }
+        if (tag.loaded === true) return;
+        
+        if (tag.beforeLoad) tag.beforeLoad();
+
+        // Tag is either an image, a snippet or a script.
         if (tag.useImage === true && typeof tag.url !== 'undefined') {
             new Image().src = tag.url;
-        }
-        if (tag.insertSnippet) {
+        } else if (tag.insertSnippet) {
             tag.insertSnippet();
         } else {
             hasScriptsToInsert = true;

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -9,9 +9,17 @@ import {
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { imrWorldwide } from 'commercial/modules/third-party-tags/imr-worldwide';
 import { imrWorldwideLegacy } from 'commercial/modules/third-party-tags/imr-worldwide-legacy';
-import { ias, permutive, twitter, lotame, fbPixel, remarketing, inizio } from '@guardian/commercial-core';
+import {
+    ias,
+    permutive,
+    twitter,
+    lotame,
+    fbPixel,
+    remarketing,
+    inizio,
+} from '@guardian/commercial-core';
 import config from 'lib/config';
-import { isInAuOrNz, isInUsOrCa } from "common/modules/commercial/geo-utils";
+import { isInAuOrNz, isInUsOrCa } from 'common/modules/commercial/geo-utils';
 
 const addScripts = (tags: Array<ThirdPartyTag>): void => {
     const ref = document.scripts[0];
@@ -20,7 +28,7 @@ const addScripts = (tags: Array<ThirdPartyTag>): void => {
 
     tags.forEach(tag => {
         if (tag.loaded === true) return;
-        
+
         if (tag.beforeLoad) tag.beforeLoad();
 
         // Tag is either an image, a snippet or a script.
@@ -79,9 +87,15 @@ const loadOther = (): void => {
         permutive({ shouldRun: config.get('switches.permutive', false) }),
         ias({ shouldRun: config.get('switches.iasAdTargeting', false) }),
         inizio({ shouldRun: config.get('switches.inizio', false) }),
-        fbPixel({ shouldRun: config.get('switches.facebookTrackingPixel', false)}),
-        twitter({ shouldRun: config.get('switches.twitterUwt', false)}),
-        lotame({ shouldRun:  config.get('switches.lotame', false) && !(isInUsOrCa() || isInAuOrNz())}),
+        fbPixel({
+            shouldRun: config.get('switches.facebookTrackingPixel', false),
+        }),
+        twitter({ shouldRun: config.get('switches.twitterUwt', false) }),
+        lotame({
+            shouldRun:
+                config.get('switches.lotame', false) &&
+                !(isInUsOrCa() || isInAuOrNz()),
+        }),
     ].filter(_ => _.shouldRun);
 
     const performanceServices: Array<ThirdPartyTag> = [


### PR DESCRIPTION
## What does this change?

Fix the way third party tags are inserted. They are either an `img`, `snippet` or `script`.

Currently, an image is also inserted as a script. It looks like this regression was introduced in https://github.com/guardian/frontend/pull/22949#discussion_r542627270.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No (comes with the bundle)
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

No more error in the logs. No attempt to parse an image as a script.

```
Refused to execute script from 'https://www.facebook.com/tr?id=279880532344561&ev=PageView&noscript=1'
because its MIME type ('image/gif') is not executable.
```

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
