### PR TITLE
Revert "Fix play session clash on log in pages"

### DIFF
--- a/identity/conf/application.conf
+++ b/identity/conf/application.conf
@@ -30,9 +30,6 @@ play {
     session {
         secure=true
         maxAge=15minutes
-        httpOnly = true
-        sameSite = "strict"
-        path = "/complete-registration"
     }
 
     forwarded.trustedProxies = [ "0.0.0.0/0" ]


### PR DESCRIPTION
Reverts guardian/frontend#23374 as this causes a CSRF error on the newsletters consents flow