### PR TITLE
deeply read 12/. : Fix deeply read agent and refresh scheduling

### DIFF
--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -104,7 +104,9 @@ class MostPopularController(
 
   def renderDeeplyRead(): Action[AnyContent] =
     Action.async { implicit request =>
-      Future.successful(Ok(Json.toJson(deeplyReadAgent.getReport())))
+      deeplyReadAgent.getReport().map { report =>
+        Ok(Json.toJson(report))
+      }
     }
 
   // Experimental (December 2020)
@@ -127,8 +129,9 @@ class MostPopularController(
       // Async section specific most Popular.
       val sectionPopular: Future[List[MostPopularNx2]] = {
         if (path.nonEmpty) {
-          val items = deeplyReadAgent.getReport().map(DeeplyReadItem.deeplyReadItemToOnwardItemNx2)
-          Future.successful(List(MostPopularNx2("Deeply read", "", items)))
+          deeplyReadAgent.getReport().map { items =>
+            List(MostPopularNx2("Deeply read", "", items.map(DeeplyReadItem.deeplyReadItemToOnwardItemNx2)))
+          }
         } else { Future(Nil) }
       }
 

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -95,11 +95,16 @@ class MostPopularController(
       }
     }
 
+  def runDeeplyReadRefreshCycle(): Action[AnyContent] =
+    Action.async { implicit request =>
+      deeplyReadAgent.refresh().map { unit =>
+        Ok("done")
+      }
+    }
+
   def renderDeeplyRead(): Action[AnyContent] =
     Action.async { implicit request =>
-      deeplyReadAgent.getReport().map { report =>
-        Ok(Json.toJson(report))
-      }
+      Future.successful(Ok(Json.toJson(deeplyReadAgent.getReport())))
     }
 
   // Experimental (December 2020)
@@ -122,10 +127,8 @@ class MostPopularController(
       // Async section specific most Popular.
       val sectionPopular: Future[List[MostPopularNx2]] = {
         if (path.nonEmpty) {
-          deeplyReadAgent.getReport().map { sequence =>
-            val items = sequence.map(DeeplyReadItem.deeplyReadItemToOnwardItemNx2)
-            List(MostPopularNx2("Deeply read", "", items))
-          }
+          val items = deeplyReadAgent.getReport().map(DeeplyReadItem.deeplyReadItemToOnwardItemNx2)
+          Future.successful(List(MostPopularNx2("Deeply read", "", items)))
         } else { Future(Nil) }
       }
 

--- a/onward/app/feed/OnwardJourneyLifecycle.scala
+++ b/onward/app/feed/OnwardJourneyLifecycle.scala
@@ -49,14 +49,14 @@ class OnwardJourneyLifecycle(
       mostViewedAudioAgent.refresh()
       mostViewedGalleryAgent.refresh()
       mostReadAgent.refresh()
-      deeplyReadAgent.refresh()
+      // deeplyReadAgent.refresh()
     }
 
     jobs.scheduleEveryNMinutes("OnwardJourneyAgentsLowFrequencyRefreshJob", 60) {
       dayMostPopularAgent.refresh()
     }
 
-    akkaAsync.after(1.second) {
+    akkaAsync.after1s {
       mostPopularAgent.refresh()
       geoMostPopularAgent.refresh()
       dayMostPopularAgent.refresh()
@@ -64,10 +64,7 @@ class OnwardJourneyLifecycle(
       mostViewedGalleryAgent.refresh()
       mostViewedVideoAgent.refresh()
       mostReadAgent.refresh()
-    }
-
-    akkaAsync.after(10.second) {
-      deeplyReadAgent.refresh()
+      // deeplyReadAgent.refresh()
     }
   }
 }

--- a/onward/app/feed/OnwardJourneyLifecycle.scala
+++ b/onward/app/feed/OnwardJourneyLifecycle.scala
@@ -5,6 +5,7 @@ import app.LifecycleComponent
 import common.{AkkaAsync, JobScheduler}
 import play.api.inject.ApplicationLifecycle
 import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
 
 class OnwardJourneyLifecycle(
     appLifecycle: ApplicationLifecycle,
@@ -55,7 +56,7 @@ class OnwardJourneyLifecycle(
       dayMostPopularAgent.refresh()
     }
 
-    akkaAsync.after1s {
+    akkaAsync.after(1.second) {
       mostPopularAgent.refresh()
       geoMostPopularAgent.refresh()
       dayMostPopularAgent.refresh()
@@ -63,6 +64,9 @@ class OnwardJourneyLifecycle(
       mostViewedGalleryAgent.refresh()
       mostViewedVideoAgent.refresh()
       mostReadAgent.refresh()
+    }
+
+    akkaAsync.after(10.second) {
       deeplyReadAgent.refresh()
     }
   }

--- a/onward/conf/routes
+++ b/onward/conf/routes
@@ -30,6 +30,7 @@ GET        /most-read-day.json                        controllers.MostPopularCon
 # December 2020
 # This route, /deeply-read.json, is for testing purposes only
 # Has no equivalent in dev-build
+GET        /deeply-read-run-refresh-cycle.json        controllers.MostPopularController.runDeeplyReadRefreshCycle()
 GET        /deeply-read.json                          controllers.MostPopularController.renderDeeplyRead()
 
 # Experimental (December 2020)


### PR DESCRIPTION
## What does this change?

This is the latest episode of the ongoing implementation of deeply read as new most viewed tab; follow up of https://github.com/guardian/frontend/pull/23383

Here we do 3 things

1. Correct the implementation of the agent. We now have separate variables (1) for the Ophan deeply data and (2) for the Ophan Items -> CAPI content mapping. 

2. The deeply read agent refresh cycle is now much more gentle to CAPI.

3. As a temporary measure (to allow the start of the client side work), we stop relying on the Akka agent scheduling we have been using so far to initiate the onward app. The reason is simple: it's not correctly implemented. We use one execution context for a bunch of agent (7 of them not even counting deeply read) which all start at the same time and either fail to connect to Ophan and silently fail or spam CAPI to the point of triggering the circuit breaker (this is auto corrected by the scheduler which reruns them later), causing various unexpected failures in other agents. Future work will correct those problems.  

