### PR TITLE
Remove session max age from identity session cookie

### DIFF
--- a/identity/conf/application.conf
+++ b/identity/conf/application.conf
@@ -29,7 +29,6 @@ play {
     #If you are on a dev machine, this is set to false in Global.scala
     session {
         secure=true
-        maxAge=15minutes
     }
 
     forwarded.trustedProxies = [ "0.0.0.0/0" ]


### PR DESCRIPTION
A max age was added to the Play session cookie as part of this PR: https://github.com/guardian/frontend/commit/c8bcf99a3d3e5e4cc2ca6dbc02571252c9087e05 to prevent the /complete-registration page from showing a user's email address for longer than 15 minutes. The session cookie has other uses though, including the newsletter signup flow, so it should go back to being a Session length cookie.