### PR TITLE
deeply read 13/. : Puts deeplyReadAgent.refresh() back in Akka schedule

### DIFF
--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -104,9 +104,7 @@ class MostPopularController(
 
   def renderDeeplyRead(): Action[AnyContent] =
     Action.async { implicit request =>
-      deeplyReadAgent.getReport().map { report =>
-        Ok(Json.toJson(report))
-      }
+      Future.successful(Ok(Json.toJson(deeplyReadAgent.getReport())))
     }
 
   // Experimental (December 2020)
@@ -129,9 +127,15 @@ class MostPopularController(
       // Async section specific most Popular.
       val sectionPopular: Future[List[MostPopularNx2]] = {
         if (path.nonEmpty) {
-          deeplyReadAgent.getReport().map { items =>
-            List(MostPopularNx2("Deeply read", "", items.map(DeeplyReadItem.deeplyReadItemToOnwardItemNx2)))
-          }
+          Future.successful(
+            List(
+              MostPopularNx2(
+                "Deeply read",
+                "",
+                deeplyReadAgent.getReport().map(DeeplyReadItem.deeplyReadItemToOnwardItemNx2),
+              ),
+            ),
+          )
         } else { Future(Nil) }
       }
 

--- a/onward/app/feed/OnwardJourneyLifecycle.scala
+++ b/onward/app/feed/OnwardJourneyLifecycle.scala
@@ -42,6 +42,7 @@ class OnwardJourneyLifecycle(
     jobs.scheduleEveryNMinutes("OnwardJourneyAgentsHighFrequencyRefreshJob", 5) {
       mostPopularAgent.refresh()
       geoMostPopularAgent.refresh()
+      deeplyReadAgent.refresh()
     }
 
     jobs.scheduleEveryNMinutes("OnwardJourneyAgentsMediumFrequencyRefreshJob", 30) {
@@ -49,7 +50,6 @@ class OnwardJourneyLifecycle(
       mostViewedAudioAgent.refresh()
       mostViewedGalleryAgent.refresh()
       mostReadAgent.refresh()
-      // deeplyReadAgent.refresh()
     }
 
     jobs.scheduleEveryNMinutes("OnwardJourneyAgentsLowFrequencyRefreshJob", 60) {
@@ -64,7 +64,7 @@ class OnwardJourneyLifecycle(
       mostViewedGalleryAgent.refresh()
       mostViewedVideoAgent.refresh()
       mostReadAgent.refresh()
-      // deeplyReadAgent.refresh()
+      deeplyReadAgent.refresh()
     }
   }
 }


### PR DESCRIPTION
## What does this change?

Puts `deeplyReadAgent.refresh()` back in Akka schedule ( This is the follow up of: https://github.com/guardian/frontend/pull/23390 )

A correction was added here: https://github.com/guardian/frontend/pull/23395

Followed by: https://github.com/guardian/frontend/pull/23396
