### PR TITLE
Add ThreeQuartersTall to playable video cards

### DIFF
--- a/common/app/layout/cards/CardType.scala
+++ b/common/app/layout/cards/CardType.scala
@@ -17,7 +17,7 @@ sealed trait CardType {
 
   def youTubeMediaAtomPlayer: VideoPlayerMode =
     this match {
-      case FullMedia50 | FullMedia75 | FullMedia100 | ThreeQuarters | ThreeQuartersRight =>
+      case FullMedia50 | FullMedia75 | FullMedia100 | ThreeQuarters | ThreeQuartersRight | ThreeQuartersTall =>
         VideoPlayerMode(show = true, showEndSlate = true)
       case Half | Third =>
         VideoPlayerMode(show = true, showEndSlate = false)


### PR DESCRIPTION
## What does this change?

Add the ThreeQuartersTall layout to the playable videos card types.

## Screenshot

The following layout was not playable video on a front on desktop. It now will be.

![image](https://user-images.githubusercontent.com/638051/102501666-96c86980-4075-11eb-9007-7f324b2477fb.png)
