### PR TITLE
[CMP] Add platform to pubData

### DIFF
--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -37,7 +37,12 @@ const go = () => {
         // CCPA and TCFv2
         const browserId: ?string = getCookie('bwid') || undefined;
         const pageViewId: ?string = config.get('ophan.pageViewId');
-        const pubData: { browserId?: ?string, pageViewId?: ?string } = {
+        const pubData: {
+            browserId?: ?string,
+            platform?: ?string,
+            pageViewId?: ?string,
+        } = {
+            platform: 'next-gen',
             browserId,
             pageViewId,
         };


### PR DESCRIPTION
## What does this change?

Add `platform` to `pubData`, so we can pinpoint which consent signals are missing a `pageView`.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes https://github.com/guardian/dotcom-rendering/pull/2263

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
