### PR TITLE
onward: some refactoring 

### DIFF
--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -191,7 +191,7 @@ class MostPopularController(
     val tabs = mostPopulars.map { section =>
       OnwardCollectionResponse(
         heading = section.heading,
-        trails = OnwardItemNx2.pressedContentsToOnwardItemsNx2(section.trails),
+        trails = section.trails.map(OnwardItemNx2.pressedContentToOnwardItemNx2).take(10),
       )
     }
     val mostCommented = mostCards.getOrElse("most_commented", None).flatMap { contentCard =>
@@ -226,7 +226,7 @@ class MostPopularController(
     val data = MostPopularGeoResponse(
       country = countryNames.get(countryCode),
       heading = mostPopular.heading,
-      trails = OnwardItemNx2.pressedContentsToOnwardItemsNx2(mostPopular.trails),
+      trails = mostPopular.trails.map(OnwardItemNx2.pressedContentToOnwardItemNx2).take(10),
     )
     Cached(900)(JsonComponent(data))
   }

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -116,10 +116,15 @@ class MostPopularController(
       val globalPopular: Option[MostPopularNx2] = {
         val globalPopularContent = mostPopularAgent.mostPopular(edition)
         if (globalPopularContent.nonEmpty) {
-          val items = globalPopularContent
-            .map(_.faciaContent)
-            .map(pc => OnwardItemNx2.pressedContentToOnwardItemNx2(pc))
-          Some(MostPopularNx2("Across The&nbsp;Guardian", "", items))
+          Some(
+            MostPopularNx2(
+              "Across The&nbsp;Guardian",
+              "",
+              globalPopularContent
+                .map(_.faciaContent)
+                .map(OnwardItemNx2.pressedContentToOnwardItemNx2),
+            ),
+          )
         } else
           None
       }

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -16,7 +16,7 @@ import models.{
   MostPopularGeoResponse,
   MostPopularNx2,
   OnwardCollectionResponse,
-  OnwardCollectionResponseForDCR,
+  OnwardCollectionResponseDCR,
   OnwardItemNx2,
 }
 import implicits.FaciaContentFrontendHelpers._
@@ -200,7 +200,7 @@ class MostPopularController(
     val mostShared = mostCards.getOrElse("most_shared", None).flatMap { contentCard =>
       OnwardItemNx2.contentCardToOnwardItemNx2(contentCard)
     }
-    val response = OnwardCollectionResponseForDCR(tabs, mostCommented, mostShared)
+    val response = OnwardCollectionResponseDCR(tabs, mostCommented, mostShared)
     Cached(900)(JsonComponent(response))
   }
 
@@ -216,7 +216,7 @@ class MostPopularController(
     val mostShared = mostCards.getOrElse("most_shared", None).flatMap { contentCard =>
       OnwardItemNx2.contentCardToOnwardItemNx2(contentCard)
     }
-    val response = OnwardCollectionResponseForDCR(tabs, mostCommented, mostShared)
+    val response = OnwardCollectionResponseDCR(tabs, mostCommented, mostShared)
     // Value is 1 fr the moment.
     // We do caching in Fasty and the Ophan/CAPI updates are on schedule and async
     Cached(1)(JsonComponent(response))

--- a/onward/app/controllers/PopularInTag.scala
+++ b/onward/app/controllers/PopularInTag.scala
@@ -45,7 +45,7 @@ class PopularInTag(
         JsonComponent(
           OnwardCollectionResponse(
             heading = "Related content",
-            trails = OnwardItemNx2.pressedContentsToOnwardItemsNx2(trails.items.map(_.faciaContent)),
+            trails = trails.items.map(_.faciaContent).map(OnwardItemNx2.pressedContentToOnwardItemNx2).take(10),
           ),
         )
       } else {

--- a/onward/app/controllers/RelatedController.scala
+++ b/onward/app/controllers/RelatedController.scala
@@ -60,7 +60,7 @@ class RelatedController(
       if (request.forceDCR) {
         val data = OnwardCollectionResponse(
           heading = containerTitle,
-          trails = OnwardItemNx2.pressedContentsToOnwardItemsNx2(trails.map(_.faciaContent)),
+          trails = trails.map(_.faciaContent).map(OnwardItemNx2.pressedContentToOnwardItemNx2).take(10),
         )
 
         JsonComponent(data)

--- a/onward/app/controllers/StoryPackageController.scala
+++ b/onward/app/controllers/StoryPackageController.scala
@@ -34,10 +34,9 @@ class StoryPackageController(val contentApiClient: ContentApiClient, val control
         val json = JsonComponent(
           OnwardCollectionResponse(
             heading = "More on this story",
-            trails = OnwardItemNx2.pressedContentsToOnwardItemsNx2(items.map(_.faciaContent)),
+            trails = items.map(_.faciaContent).map(OnwardItemNx2.pressedContentToOnwardItemNx2).take(10),
           ),
         )
-
         Cached(5.minutes)(json)
       })
     }

--- a/onward/app/models/MostPopularNx2.scala
+++ b/onward/app/models/MostPopularNx2.scala
@@ -118,14 +118,6 @@ object OnwardItemNx2 {
       avatarUrl = None,
     )
   }
-
-  def pressedContentsToOnwardItemsNx2(
-      pcs: Seq[PressedContent],
-  )(implicit request: RequestHeader): Seq[OnwardItemNx2] = {
-    pcs
-      .take(10)
-      .map(content => pressedContentToOnwardItemNx2(content))
-  }
 }
 
 case class OnwardCollectionResponse(

--- a/onward/app/models/MostPopularNx2.scala
+++ b/onward/app/models/MostPopularNx2.scala
@@ -35,7 +35,7 @@ object OnwardItemNx2 {
 
   implicit val onwardItemWrites = Json.writes[OnwardItemNx2]
 
-  def contentCardToAvatarUrl(contentCard: ContentCard): Option[String] = {
+  private def contentCardToAvatarUrl(contentCard: ContentCard): Option[String] = {
 
     val maybeUrl1 = if (contentCard.cardTypes.showCutOut) {
       contentCard.cutOut.map { cutOut => cutOut.imageUrl }

--- a/onward/app/models/MostPopularNx2.scala
+++ b/onward/app/models/MostPopularNx2.scala
@@ -120,9 +120,9 @@ object OnwardItemNx2 {
   }
 
   def pressedContentsToOnwardItemsNx2(
-      trails: Seq[PressedContent],
+      pcs: Seq[PressedContent],
   )(implicit request: RequestHeader): Seq[OnwardItemNx2] = {
-    trails
+    pcs
       .take(10)
       .map(content => pressedContentToOnwardItemNx2(content))
   }

--- a/onward/app/models/MostPopularNx2.scala
+++ b/onward/app/models/MostPopularNx2.scala
@@ -136,13 +136,13 @@ object OnwardCollectionResponse {
   implicit val collectionWrites = Json.writes[OnwardCollectionResponse]
 }
 
-case class OnwardCollectionResponseForDCR(
+case class OnwardCollectionResponseDCR(
     tabs: Seq[OnwardCollectionResponse],
     mostCommented: Option[OnwardItemNx2],
     mostShared: Option[OnwardItemNx2],
 )
-object OnwardCollectionResponseForDCR {
-  implicit val onwardCollectionResponseForDRCWrites = Json.writes[OnwardCollectionResponseForDCR]
+object OnwardCollectionResponseDCR {
+  implicit val onwardCollectionResponseForDRCWrites = Json.writes[OnwardCollectionResponseDCR]
 }
 
 case class MostPopularGeoResponse(

--- a/onward/app/models/MostPopularNx2.scala
+++ b/onward/app/models/MostPopularNx2.scala
@@ -161,7 +161,4 @@ case class MostPopularNx2(heading: String, section: String, trails: Seq[OnwardIt
 
 object MostPopularNx2 {
   implicit val mostPopularNx2Writes = Json.writes[MostPopularNx2]
-  def mostPopularToMostPopularNx2(mostPopular: MostPopular): MostPopularNx2 = {
-    MostPopularNx2("", "", List())
-  }
 }

--- a/onward/app/models/Series.scala
+++ b/onward/app/models/Series.scala
@@ -29,13 +29,12 @@ object SeriesStoriesDCR {
   implicit val onwardItemWrites = Json.writes[OnwardItemNx2]
   implicit val seriesStoriesDCRWrites = Json.writes[SeriesStoriesDCR]
   def fromSeries(series: Series)(implicit request: RequestHeader): SeriesStoriesDCR = {
-    val trails = OnwardItemNx2.pressedContentsToOnwardItemsNx2(series.trails.faciaItems)
     SeriesStoriesDCR(
       id = series.id,
       displayname = series.displayName,
       description = series.tag.properties.description,
       url = series.tag.properties.webUrl,
-      trails = trails,
+      trails = series.trails.faciaItems.map(OnwardItemNx2.pressedContentToOnwardItemNx2).take(10),
     )
   }
 }


### PR DESCRIPTION
## What does this change?

Tiny refactoring to improve the onward type system a little bit. Originally this change was aimed at removing the use of [common] `MostPopular` from [onward] in favour of `MostPopularNx2`, but this will not be possible at this time [1] due to the deep use of `PressedContent` in the [onward] html views.

[1] This will come later in the DCR migration.