### PR TITLE
use shouldHideSupportMessaging to determine when to unhide gifting link

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/gifting.js
+++ b/static/src/javascripts/projects/common/modules/navigation/gifting.js
@@ -5,7 +5,7 @@ import { shouldHideSupportMessaging } from 'common/modules/commercial/user-featu
 
 // @flow
 const showGiftingCTA = (): void => {
-    // we want to unhide gifting link if hiding the support messaging
+    // show gifting if support messaging isn't shown
     if (shouldHideSupportMessaging()) {
         const giftingCTA = document.querySelector('.js-gifting-cta');
 

--- a/static/src/javascripts/projects/common/modules/navigation/gifting.js
+++ b/static/src/javascripts/projects/common/modules/navigation/gifting.js
@@ -1,12 +1,12 @@
 // @flow
 import fastdom from 'lib/fastdom-promise';
-import { isDigitalSubscriber, isRecurringContributor } from 'common/modules/commercial/user-features';
+import { shouldHideSupportMessaging } from 'common/modules/commercial/user-features';
 
 
 // @flow
 const showGiftingCTA = (): void => {
-    // Unhide the gifting CTA for Subscribers and Contributors
-    if (isDigitalSubscriber() || isRecurringContributor()) {
+    // we want to unhide gifting link if hiding the support messaging
+    if (shouldHideSupportMessaging()) {
         const giftingCTA = document.querySelector('.js-gifting-cta');
 
         if (!giftingCTA) {


### PR DESCRIPTION
## What does this change?

Rather than using `isDigitalSubscriber()` or `isRecurringContributor()` to determine when to unhide the gifting link use `shouldHideSupportMessaging()`. When `shouldHideSupportMessaging()` is true we don't show the CTA to "Subscribe" or "Contribute", so using this same condition should mean we avoid any edge cases like this...

![unnamed-7](https://user-images.githubusercontent.com/1590704/102623618-b2e20e80-413a-11eb-9058-1ac83eca64a3.png)
