### PR TITLE
Adding some more guardian social links to footer

### DIFF
--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -86,6 +86,12 @@ object FooterLinks {
     FooterLink("Digital newspaper archive", "https://theguardian.newspapers.com", "digital newspaper archive")
   def facebook(edition: String): FooterLink =
     FooterLink("Facebook", "https://www.facebook.com/theguardian", s"${edition} : footer : facebook")
+  def youtube(edition: String): FooterLink =
+    FooterLink("YouTube", "https://www.youtube.com/user/TheGuardian", s"${edition} : footer : youtube")
+  def linkedin(edition: String): FooterLink =
+    FooterLink("LinkedIn", "https://www.linkedin.com/company/theguardian", s"${edition} : footer : linkedin")
+  def instagram(edition: String): FooterLink =
+    FooterLink("Instagram", "https://www.instagram.com/guardian", s"${edition} : footer : instagram")
   def twitter(edition: String): FooterLink =
     FooterLink("Twitter", "https://twitter.com/guardian", s"${edition}: footer : twitter")
   def newsletters(edition: String): FooterLink =
@@ -105,6 +111,9 @@ object FooterLinks {
     ),
     digitalNewspaperArchive,
     facebook("uk"),
+    youtube("uk"),
+    instagram("uk"),
+    linkedin("uk"),
     twitter("uk"),
     newsletters("uk"),
   )
@@ -114,6 +123,9 @@ object FooterLinks {
     allWriters("us"),
     digitalNewspaperArchive,
     facebook("us"),
+    youtube("us"),
+    instagram("us"),
+    linkedin("us"),
     twitter("us"),
     newsletters("us"),
   )
@@ -124,6 +136,9 @@ object FooterLinks {
     FooterLink("Events", "/guardian-masterclasses/guardian-masterclasses-australia", "au : footer : masterclasses"),
     digitalNewspaperArchive,
     facebook("au"),
+    youtube("au"),
+    instagram("au"),
+    linkedin("au"),
     twitter("au"),
     newsletters("au"),
   )
@@ -133,6 +148,9 @@ object FooterLinks {
     allWriters("international"),
     digitalNewspaperArchive,
     facebook("international"),
+    youtube("international"),
+    instagram("international"),
+    linkedin("international"),
     twitter("international"),
     newsletters("international"),
   )


### PR DESCRIPTION
## What does this change?
At the request of senior eds, I'm just adding  a few more social links to the footer.
<img width="700" alt="Screen Shot 2020-12-18 at 17 45 48" src="https://user-images.githubusercontent.com/2051501/102646565-28aaa200-415c-11eb-92d1-9c4dca20f45d.png">
<img width="700" alt="Screen Shot 2020-12-18 at 17 46 16" src="https://user-images.githubusercontent.com/2051501/102646567-29433880-415c-11eb-849f-e8f1f871d792.png">


## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation) Need to update the test fixtures in DCR

