### PR TITLE
Set adtest cookie on DCR

### DIFF
--- a/static/src/javascripts/bootstraps/commercial.dcr.js
+++ b/static/src/javascripts/bootstraps/commercial.dcr.js
@@ -5,6 +5,7 @@ import config from 'lib/config';
 import { catchErrorsWithContext } from 'lib/robust';
 import { markTime } from 'lib/user-timing';
 import reportError from 'lib/report-error';
+import { init as setAdTestCookie } from 'commercial/modules/set-adtest-cookie';
 import { init as initHighMerch } from 'commercial/modules/high-merch';
 import { init as initArticleAsideAdverts } from 'commercial/modules/article-aside-adverts';
 import { init as initArticleBodyAdverts } from 'commercial/modules/article-body-adverts';
@@ -30,6 +31,7 @@ import { init as initRedplanet } from 'commercial/modules/dfp/redplanet';
 import {refresh as refreshUserFeatures} from "common/modules/commercial/user-features";
 
 const commercialModules: Array<Array<any>> = [
+    ['cm-setAdTestCookie', setAdTestCookie],
     ['cm-adFreeSlotRemove', adFreeSlotRemove],
     ['cm-closeDisabledSlots', closeDisabledSlots],
     ['cm-comscore', initComscore],

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -3,6 +3,7 @@ import config from 'lib/config';
 import { catchErrorsWithContext } from 'lib/robust';
 import { markTime } from 'lib/user-timing';
 import reportError from 'lib/report-error';
+import { init as setAdTestCookie } from 'commercial/modules/set-adtest-cookie';
 import { init as initHighMerch } from 'commercial/modules/high-merch';
 import { init as initArticleAsideAdverts } from 'commercial/modules/article-aside-adverts';
 import { init as initArticleBodyAdverts } from 'commercial/modules/article-body-adverts';
@@ -28,6 +29,7 @@ import { initCommentAdverts } from 'commercial/modules/comment-adverts';
 import { initAdblockAsk } from 'common/modules/commercial/adblock-ask';
 
 const commercialModules: Array<Array<any>> = [
+    ['cm-setAdTestCookie', setAdTestCookie],
     ['cm-adFreeSlotRemove', adFreeSlotRemove],
     ['cm-closeDisabledSlots', closeDisabledSlots],
     ['cm-comscore', initComscore],

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -26,8 +26,7 @@ import {
     isUserLoggedIn,
     init as identityInit,
 } from 'common/modules/identity/api';
-import { removeCookie, addCookie } from 'lib/cookies';
-import { getUrlVars } from 'lib/url';
+import { addCookie } from 'lib/cookies';
 import { catchErrorsWithContext } from 'lib/robust';
 import { markTime } from 'lib/user-timing';
 import { isBreakpoint } from 'lib/detect';
@@ -41,15 +40,6 @@ import ophan from 'ophan/ng';
 import { initAtoms } from './atoms';
 import { initEmbedResize } from "./emailEmbeds";
 
-const setAdTestCookie = (): void => {
-    const queryParams = getUrlVars();
-
-    if (queryParams.adtest === 'clear') {
-        removeCookie('adtest');
-    } else if (queryParams.adtest) {
-        addCookie('adtest', encodeURIComponent(queryParams.adtest), 10);
-    }
-};
 
 const showHiringMessage = (): void => {
     try {
@@ -205,9 +195,6 @@ const bootStandard = (): void => {
 
     // polyfill dynamic import
     initDynamicImport();
-
-    // Set adtest query if url param declares it
-    setAdTestCookie();
 
     // set a short-lived cookie to trigger server-side ad-freeness
     // if the user is genuinely ad-free, this one will be overwritten

--- a/static/src/javascripts/projects/commercial/modules/set-adtest-cookie.js
+++ b/static/src/javascripts/projects/commercial/modules/set-adtest-cookie.js
@@ -1,0 +1,16 @@
+import { getUrlVars } from 'lib/url';
+import { removeCookie, addCookie } from 'lib/cookies';
+
+
+const init = (): Promise<void> => {
+    const queryParams = getUrlVars();
+
+    if (queryParams.adtest === 'clear') {
+        removeCookie('adtest');
+    } else if (queryParams.adtest) {
+        addCookie('adtest', encodeURIComponent(queryParams.adtest), 10);
+    }
+    return Promise.resolve();
+};
+
+export { init };

--- a/static/src/javascripts/projects/commercial/modules/set-adtest-cookie.js
+++ b/static/src/javascripts/projects/commercial/modules/set-adtest-cookie.js
@@ -1,3 +1,5 @@
+// @flow
+
 import { getUrlVars } from 'lib/url';
 import { removeCookie, addCookie } from 'lib/cookies';
 


### PR DESCRIPTION
## What does this change?
Frontend (DCP) checks for an `adtest` param in the url, and sets a cookie using it's value (or clears it if the value is `clear`).
DCR did not do this. I've moved the code which was previously in main.js into a commercial module and included it in both the DCR and DCP bundles.

Example: `https://www.theguardian.com/us-news/2020/dec/09/fort-hood-army-base-officers-fired-deaths-sexual-assault?adtest=connatix_test`

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Testing

Check the value of `window.guardian.config.page.pageAdTargeting.at`
and/or the value of the cookie. Setting the url param should affect it.
As it's set in a cookie, once it's set it should be retained until cleared by setting the url param with value `clear`

## What is the value of this and can you measure success?
DCR is now 90% for articles, supporting adtest param still matters.

## Checklist

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
