### PR TITLE
[experimental] send AMP RSA key with correct mime-type

### DIFF
--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -408,6 +408,22 @@ trait FaciaController
     if (request.isAdFree) FullAdFreeType else FullType
   def liteRequestType(implicit request: RequestHeader): PressedPageType =
     if (request.isAdFree) LiteAdFreeType else LiteType
+
+  def ampRsaPublicKey: Action[AnyContent] = {
+    Action {
+      val rsakey: String = """-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArLbfdMxclHAJvmVW7IXf
+SYjWoLl6qtwRY7CzX3Y7xV2vUx0O0YIyvXhjRsqrIBdUatDyukAM+m/3pPlYLTV5
+LniZcSDq/vjjaueCoTWjfpnp/cgS2mvOmReaa9lTdvQhYvckJaLD5vrr37XRqq8r
+McdNaVF84z8zdZoEAXigQVgQ7uPlBGiBTDl+nrNyUpBC4nL/9yozTS8To7MkNT1w
+X4fw/fFcAzZ4mizXr/msHGHtXU9lc/TS2yKMWjunSwQOxDIKnxueU8LMkdduYrve
+/bSPgXHAMlJ/Oz8df4e/8hz1FISnD4Y4morh/oPg0yemFfMya7GplzqWd27moE/R
+aQIDAQAB
+-----END PUBLIC KEY-----"""
+      Ok(rsakey)
+    }
+  }
+
 }
 
 class FaciaControllerImpl(

--- a/facia/conf/application.conf
+++ b/facia/conf/application.conf
@@ -6,9 +6,6 @@
 "assets.cache./public/security.txt"="public, max-age=900"
 "assets.cache./public/security.txt.asc"="public, max-age=900"
 
-# Caching for AMP RSA public key
-"assets.cache./public/amphtml/apikey.pub"="public, max-age=900"
-
 akka {
   loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
   loglevel = WARNING

--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -16,7 +16,7 @@ GET        /humans.txt                                                          
 GET        /.well-known/security.txt                                                controllers.Assets.at(path="/public", file="security.txt")
 GET        /.well-known/security.txt.asc                                            controllers.Assets.at(path="/public", file="security.txt.asc")
 
-GET        /.well-known/amphtml/apikey.pub                                          controllers.Assets.at(path="/public/amphtml", file="apikey.pub")
+GET        /.well-known/amphtml/apikey.pub                                          controllers.FaciaController.ampRsaPublicKey()
 
 # AMP
 GET        /container/count/:count/offset/:offset/mf2.json                                      controllers.FaciaController.renderSomeFrontContainersMf2(count: Int, offset: Int, section = "", edition = "")


### PR DESCRIPTION
## What does this change?

This experimental release attempts to correct the situation with the AMP `update-cache` request, by sending the RSA public key with the correct mime-type. This replaces https://github.com/guardian/frontend/pull/23417 which was incorrect as sending the key with type `content-type: application/octet-stream`. This should improve the situation, and if that is indeed the case, we will put the key in a better place.
