### PR TITLE
Allow EmbedBlockElement in Article Picker

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -10,6 +10,7 @@ import model.liveblog.{
   CommentBlockElement,
   ContentAtomBlockElement,
   DocumentBlockElement,
+  EmbedBlockElement,
   GuVideoBlockElement,
   ImageBlockElement,
   InstagramBlockElement,
@@ -58,6 +59,7 @@ object ArticlePageChecks {
         case _: AudioBlockElement     => false
         case _: CommentBlockElement   => false
         case _: DocumentBlockElement  => false
+        case _: EmbedBlockElement     => true
         case _: GuVideoBlockElement   => false
         case _: ImageBlockElement     => false
         case _: InstagramBlockElement => false


### PR DESCRIPTION
## What does this change?

Allow `model.liveblog.EmbedBlockElement` (the type looked up by Article Picker) in Article Picker. This will enable `[PageElement]CalloutBlockElement`. 

Note that `model.liveblog.EmbedBlockElement` is also transformed into `[PageElement]SoundcloudBlockElement` and `[PageElement]EmbedBlockElement`, which are already supported in DCR.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No