### PR TITLE
Fix for double adslot on Fronts.

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -72,7 +72,7 @@ trait ABTestSwitches {
     "New newsletter signup embeds for discoverability OKR",
     owners = Seq(Owner.withGithub("buck06191")),
     safeState = Off,
-    sellByDate = new LocalDate(2021, 1, 4),
+    sellByDate = new LocalDate(2021, 1, 11),
     exposeClientSide = true,
   )
 

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -780,7 +780,7 @@ case class CommercialMPUForFronts()(implicit val request: RequestHeader) extends
 
     def isMostViewedContainer(element: Element): Boolean =
       Option(element.id()).contains("most-viewed") || Option(element.id()).exists(_.contains("popular-in"))
-     
+
     val sliceSlot = views.html.fragments.items.facia_cards.sliceSlot
 
     val containers: List[Element] = document.getElementsByClass("fc-container").asScala.toList

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -779,7 +779,8 @@ case class CommercialMPUForFronts()(implicit val request: RequestHeader) extends
       Option(element.nextElementSibling()).exists(_.hasClass("fc-container--thrasher"))
 
     def isMostViewedContainer(element: Element): Boolean =
-      Option(element.id()).contains("most-viewed")
+      Option(element.id()).contains("most-viewed") || element.id().contains("popular-in")
+
 
     val sliceSlot = views.html.fragments.items.facia_cards.sliceSlot
 

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -779,9 +779,8 @@ case class CommercialMPUForFronts()(implicit val request: RequestHeader) extends
       Option(element.nextElementSibling()).exists(_.hasClass("fc-container--thrasher"))
 
     def isMostViewedContainer(element: Element): Boolean =
-      Option(element.id()).contains("most-viewed") || element.id().contains("popular-in")
-
-
+      Option(element.id()).contains("most-viewed") || Option(element.id()).exists(_.contains("popular-in"))
+     
     val sliceSlot = views.html.fragments.items.facia_cards.sliceSlot
 
     val containers: List[Element] = document.getElementsByClass("fc-container").asScala.toList

--- a/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-embed-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/newsletter-embed-test.js
@@ -32,7 +32,7 @@ const triggerVariant = (doc: Document, iframeId: string) => {
 export const newsletterEmbeds: ABTest = {
     id: abTestName,
     start: '2020-12-02',
-    expiry: '2021-01-04',
+    expiry: '2021-01-11',
     author: 'Josh Buckland',
     description:
         'Show a new newsletter embed design',


### PR DESCRIPTION
## What does this change?
On section fronts, on mobile, under the Most Viewed section 2 adslots appear back to back. One is an `inline-x` slot and the other is `dfp-ad--mostpop`.

The expected behaviour is that ad-containers aren't added after Most Viewed, because it contains it's own advert, so the `inline-x` is extraneous. 

There was already a check in the code to determine if the adjacent container `isMostViewedContainer` however that check doesn't appear to correctly identify the container which now has the id `popular-in-[section name]`. This change fixes that.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
![unnamed-2-1](https://user-images.githubusercontent.com/768467/103094378-2e3d3780-45f5-11eb-8273-4fdd52bd1679.png)


## What is the value of this and can you measure success?
One ad slot on under Most Viewed on section fronts.

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)
