### PR TITLE
EOY header test: new variant

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/global-eoy-header-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/global-eoy-header-test.js
@@ -15,7 +15,7 @@ const componentId = 'header_support';
 const campaignCode = 'header_support';
 const testName = 'GlobalEoyHeaderTest';
 
-type VariantName = 'variant' | 'control';
+type VariantName = 'variant' | 'variant2' | 'control';
 
 const onView = (variant: VariantName): void => submitViewEvent({
     component: {
@@ -121,6 +121,17 @@ export const globalEoyHeaderTest: ABTest = {
                     const heading = month === 12 ? `Support us this December` : 'Support us in 2021';
                     bar.innerHTML = buildHtml(heading, 'Power vital, open, independent journalism', 'variant');
                     onView('variant')
+                }
+            },
+        },
+        {
+            id: 'variant2',
+            test: (): void => {
+                const bar = getHeaderCtaBar();
+                if (bar) {
+                    const heading = month === 12 ? `Support us this December` : 'Support us in 2021';
+                    bar.innerHTML = buildHtml(heading, 'Available for everyone, funded by readers', 'variant2');
+                    onView('variant2')
                 }
             },
         },


### PR DESCRIPTION
We've been testing a variant with different heading + subheading.
Now we want another variant with different heading but the same subheading as the control.

The variant names here aren't great, but changing the original variant name will mess up the analysis at this point.

<img width="316" alt="Screen Shot 2021-01-04 at 11 35 55" src="https://user-images.githubusercontent.com/1513454/103532145-a2dc6580-4e82-11eb-9587-4deb12b3d5b8.png">
