### PR TITLE
Fix for bug on "most-viewed" check

### DIFF
--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -779,7 +779,7 @@ case class CommercialMPUForFronts()(implicit val request: RequestHeader) extends
       Option(element.nextElementSibling()).exists(_.hasClass("fc-container--thrasher"))
 
     def isMostViewedContainer(element: Element): Boolean =
-      Option(element.id()).contains("most-viewed") || Option(element.id()).exists(_.contains("popular-in"))
+      Option(element.id()).exists(_.contains("most-viewed")) || Option(element.id()).exists(_.contains("popular-in"))
 
     val sliceSlot = views.html.fragments.items.facia_cards.sliceSlot
 


### PR DESCRIPTION
## What does this change?
This is an extension of this PR: https://github.com/guardian/frontend/pull/23423/files
That one added a check for `popular-in`. This one fixes the check for `most-viewed` which contained a bug that meant it incorrectly evaluated to false even when the `element.id()` contained `most-viewed`

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
![103094378-2e3d3780-45f5-11eb-8273-4fdd52bd1679](https://user-images.githubusercontent.com/768467/103539704-67489800-4e90-11eb-930c-a60ede10565b.png)

## What is the value of this and can you measure success?
Prevent back-to-back ads on section fronts.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
