### PR TITLE
Correct the pillar: Arts -> Culture

### DIFF
--- a/onward/app/feed/DeeplyReadAgent.scala
+++ b/onward/app/feed/DeeplyReadAgent.scala
@@ -139,7 +139,11 @@ class DeeplyReadAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) ex
     pathToCapiContentMapping.get(removeStartingSlash(path))
   }
 
+  def correctPillar(pillar: String): String = if (pillar == "Arts") "Culture" else pillar
+
   def ophanItemToDeeplyReadItem(item: OphanDeeplyReadItem): Option[DeeplyReadItem] = {
+    // We are doing the pillar correction during the OphanDeeplyReadItem to DeeplyReadItem transformation
+    // Note that we could also do it during the DeeplyReadItem to OnwardItemNx2 transformation
     for {
       content <- getDataForPath(removeStartingSlash(item.path))
       webPublicationDate <- content.webPublicationDate
@@ -158,7 +162,7 @@ class DeeplyReadAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) ex
       image = fields.thumbnail,
       ageWarning = None,
       isLiveBlog = true,
-      pillar = pillar,
+      pillar = correctPillar(pillar),
       designType = content.`type`.toString,
       webPublicationDate = webPublicationDate.toString(),
       headline = headline,

--- a/onward/app/feed/DeeplyReadAgent.scala
+++ b/onward/app/feed/DeeplyReadAgent.scala
@@ -139,7 +139,7 @@ class DeeplyReadAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) ex
     pathToCapiContentMapping.get(removeStartingSlash(path))
   }
 
-  def correctPillar(pillar: String): String = if (pillar == "Arts") "Culture" else pillar
+  def correctPillar(pillar: String): String = if (pillar == "arts") "culture" else pillar
 
   def ophanItemToDeeplyReadItem(item: OphanDeeplyReadItem): Option[DeeplyReadItem] = {
     // We are doing the pillar correction during the OphanDeeplyReadItem to DeeplyReadItem transformation
@@ -162,7 +162,7 @@ class DeeplyReadAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) ex
       image = fields.thumbnail,
       ageWarning = None,
       isLiveBlog = true,
-      pillar = correctPillar(pillar),
+      pillar = correctPillar(pillar.toLowerCase),
       designType = content.`type`.toString,
       webPublicationDate = webPublicationDate.toString(),
       headline = headline,


### PR DESCRIPTION
## What does this change?

The backend usually performs the `Arts` -> `Culture` substitution before sending data to clients. We apply that to the most-read-deeply-read API end point. Moreover pillar is sent lowercase (in particular `culture`).

BEFORE (Deeply read data from Ophan items)

![Screenshot 2021-01-04 at 14 24 12 (2)](https://user-images.githubusercontent.com/6035518/103545794-fa3a0000-4e99-11eb-9c49-ec6094f458e0.png)

AFTER

![Screenshot 2021-01-04 at 14 44 51](https://user-images.githubusercontent.com/6035518/103546813-7d0f8a80-4e9b-11eb-8e54-d3f9ee4c8def.png)


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No (not directly)