### PR TITLE
[deeplyread] Set the isLiveBlog field to a proper value

### DIFF
--- a/onward/app/feed/DeeplyReadAgent.scala
+++ b/onward/app/feed/DeeplyReadAgent.scala
@@ -161,7 +161,7 @@ class DeeplyReadAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) ex
       byline = fields.byline,
       image = fields.thumbnail,
       ageWarning = None,
-      isLiveBlog = true,
+      isLiveBlog = fields.liveBloggingNow.getOrElse(false),
       pillar = correctPillar(pillar.toLowerCase),
       designType = content.`type`.toString,
       webPublicationDate = webPublicationDate.toString(),


### PR DESCRIPTION
## What does this change?

Set the `isLiveBlog` field to the correct value (remove hardcoded `true` from when object was prototyped).
