### PR TITLE
Revert "Revert "Increase SurrogateCache for live blog to 60s""

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -31,7 +31,7 @@ trait PerformanceSwitches {
     "long-cache-switch",
     "If this switch is on then content will get a longer cache time",
     owners = Owner.group(SwitchGroup.Performance),
-    safeState = Off,
+    safeState = On,
     sellByDate = never,
     exposeClientSide = false,
   )


### PR DESCRIPTION
Reverts guardian/frontend#23363 to reinstate #23361 
I plan to merge this once https://github.com/guardian/fastly-edge-cache/pull/894 is deployed