### PR TITLE
Enable EmbedBlockElement(s) in Article Picker

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -59,7 +59,7 @@ object ArticlePageChecks {
         case _: AudioBlockElement     => false
         case _: CommentBlockElement   => false
         case _: DocumentBlockElement  => false
-        case _: EmbedBlockElement     => true
+        case _: EmbedBlockElement     => false
         case _: GuVideoBlockElement   => false
         case _: ImageBlockElement     => false
         case _: InstagramBlockElement => false


### PR DESCRIPTION
## What does this change?

Enable `EmbedBlockElement` in Article Picker.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No