### PR TITLE
Bumped version of braze-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@guardian/atom-renderer": "1.2.2",
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.7",
-    "@guardian/braze-components": "0.0.16",
+    "@guardian/braze-components": "0.0.17",
     "@guardian/commercial-core": "^0.9.0",
     "@guardian/consent-management-platform": "6.9.1",
     "@guardian/libs": "^1.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1719,10 +1719,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/braze-components@0.0.16":
-  version "0.0.16"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-0.0.16.tgz#e827afb4ee06b599ee1b14069763cd26d6c3b560"
-  integrity sha512-GA6OWg48iUS83O/316uynHm4xvYzEp8efwRjfqLTfr0gTtcgsiUb/eebh94RgFiDQM5cylpmEeDzsWXGkE7N+w==
+"@guardian/braze-components@0.0.17":
+  version "0.0.17"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-0.0.17.tgz#178e4740ab722873b9d0e6dd9d836f1e153d5ada"
+  integrity sha512-xB+cAwaM/iSJwyC/rM1cjEkFX5Gx4JlFNS9HghFqHJb6u+k7B9oFdwQS6GhH7evZxbh2F3klTVpHT6lUD+vCUg==
   dependencies:
     "@guardian/src-button" "2.7.1"
     "@guardian/src-foundations" "2.7.1"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Bumps version of `@guardian/braze-components` in order to support new marketing banner.

DCR equivalent available [here](https://github.com/guardian/dotcom-rendering/pull/2323).
