### PR TITLE
Enforce AMP public key content-type to text/plain

### DIFF
--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -420,7 +420,7 @@ X4fw/fFcAzZ4mizXr/msHGHtXU9lc/TS2yKMWjunSwQOxDIKnxueU8LMkdduYrve
 /bSPgXHAMlJ/Oz8df4e/8hz1FISnD4Y4morh/oPg0yemFfMya7GplzqWd27moE/R
 aQIDAQAB
 -----END PUBLIC KEY-----"""
-      Ok(rsakey)
+      Ok(rsakey).as("text/plain")
     }
   }
 


### PR DESCRIPTION
## What does this change?

Play naturally serves text as `text/plain; charset=utf-8` which might be a conflicting with the instruction here ( https://developers.google.com/amp/cache/update-cache ) to serve `text/plain`. 

```
pascal@Lucille20 frontend % curl -I "http://localhost:9000/.well-known/amphtml/apikey.pub"                    
HTTP/1.1 200 OK
Surrogate-Key: 6b049a099977f2226c6a6488d402a7a9
X-Gu-Backend-App: facia
content-length: 450
Content-Type: text/plain
Date: Tue, 05 Jan 2021 15:17:49 GMT
```