### PR TITLE
Ensure local SDK data is wiped on logout

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.spec.js
@@ -15,37 +15,9 @@ afterEach(() => {
 });
 
 describe('canShowPreChecks', () => {
-    describe('when the switch is off', () => {
-        it('returns false', () => {
-            const result = canShowPreChecks({
-                brazeSwitch: false,
-                apiKey: 'abcde',
-                userIsGuSupporter: true,
-                pageConfig: {isPaidContent: false},
-            })
-
-            expect(result).toBe(false);
-        });
-    });
-
-    describe('when the api key is empty', () => {
-        it('returns false', () => {
-            const result = canShowPreChecks({
-                brazeSwitch: true,
-                apiKey: '',
-                userIsGuSupporter: true,
-                pageConfig: {isPaidContent: false},
-            })
-
-            expect(result).toBe(false);
-        });
-    });
-
     describe('when not a supporter', () => {
         it('returns false', () => {
             const result = canShowPreChecks({
-                brazeSwitch: true,
-                apiKey: 'abcde',
                 userIsGuSupporter: false,
                 pageConfig: {isPaidContent: false},
             })
@@ -57,8 +29,6 @@ describe('canShowPreChecks', () => {
     describe('when viewing paid content', () => {
         it('returns false', () => {
             const result = canShowPreChecks({
-                brazeSwitch: true,
-                apiKey: 'abcde',
                 userIsGuSupporter: true,
                 pageConfig: {isPaidContent: true},
             })
@@ -70,8 +40,6 @@ describe('canShowPreChecks', () => {
     describe('when all checks pass', () => {
         it('returns true', () => {
             const result = canShowPreChecks({
-                brazeSwitch: true,
-                apiKey: 'abcde',
                 userIsGuSupporter: true,
                 pageConfig: {isPaidContent: false},
             })

--- a/static/src/javascripts/projects/commercial/modules/hasCurrentBrazeUser.js
+++ b/static/src/javascripts/projects/commercial/modules/hasCurrentBrazeUser.js
@@ -1,0 +1,17 @@
+const KEY = 'gu.brazeUserSet';
+
+const hasCurrentBrazeUser = () => localStorage.getItem(KEY) === 'true';
+
+const setHasCurrentBrazeUser = () => {
+    localStorage.setItem(KEY, 'true');
+}
+
+const clearHasCurrentBrazeUser = () => {
+    localStorage.removeItem(KEY);
+}
+
+export {
+    hasCurrentBrazeUser,
+    setHasCurrentBrazeUser,
+    clearHasCurrentBrazeUser,
+}

--- a/static/src/javascripts/projects/commercial/modules/hasCurrentBrazeUser.test.js
+++ b/static/src/javascripts/projects/commercial/modules/hasCurrentBrazeUser.test.js
@@ -1,0 +1,32 @@
+import {
+    clearHasCurrentBrazeUser,
+    hasCurrentBrazeUser,
+    setHasCurrentBrazeUser,
+} from './hasCurrentBrazeUser';
+
+beforeEach(clearHasCurrentBrazeUser);
+
+describe('hasCurrentBrazeUser', () => {
+    it('hasCurrentBrazeUser returns false when not set', () => {
+        const got = hasCurrentBrazeUser();
+
+        expect(got).toEqual(false);
+    });
+
+    it('hasCurrentBrazeUser returns true when set', () => {
+        setHasCurrentBrazeUser();
+
+        const got = hasCurrentBrazeUser();
+
+        expect(got).toEqual(true);
+    });
+
+    it('clearHasCurrentBrazeUser unsets the value', () => {
+        setHasCurrentBrazeUser();
+        clearHasCurrentBrazeUser();
+
+        const got = hasCurrentBrazeUser();
+
+        expect(got).toEqual(false);
+    });
+});


### PR DESCRIPTION
## What does this change?

Ensures that any local SDK data is wiped when a user logs out.

If we’ve recorded in localStorage that there was a braze user, but we haven’t got a brazeUuid, then we treat that as meaning that the user has logged out.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation) guardian/dotcom-rendering#2328

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
