### PR TITLE
Restart global EOY header test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -78,7 +78,7 @@ trait ABTestSwitches {
 
   val GlobalEoyHeaderSwitch = Switch(
     ABTests,
-    "ab-global-eoy-header-test",
+    "ab-global-eoy-header-test-r2",
     "Test reader revenue message in header",
     owners = Seq(Owner.withGithub("tomrf1")),
     safeState = Off,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/global-eoy-header-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/global-eoy-header-test.js
@@ -12,7 +12,7 @@ const month = new Date().getMonth() + 1;    // js date month begins at 0
 const componentType = 'ACQUISITIONS_HEADER';
 const componentId = 'header_support';
 const campaignCode = 'header_support';
-const testName = 'GlobalEoyHeaderTest';
+const testName = 'GlobalEoyHeaderTestR2';
 
 
 const onView = (variant) => submitViewEvent({


### PR DESCRIPTION
Adding a 3rd variant has confused the analysis, so I'm changing the test name to restart the test