### PR TITLE
Refactor to common.GuLogging and Logger.logger.[name]

### DIFF
--- a/admin/app/controllers/AnalyticsController.scala
+++ b/admin/app/controllers/AnalyticsController.scala
@@ -1,14 +1,14 @@
 package controllers.admin
 
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
-import common.{ImplicitControllerExecutionContext, Logging}
+import common.{ImplicitControllerExecutionContext, GuLogging}
 import model.{ApplicationContext, NoCache}
 
 import scala.concurrent.Future
 
 class AnalyticsController(val controllerComponents: ControllerComponents)(implicit context: ApplicationContext)
     extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
   def abtests(): Action[AnyContent] =
     Action.async { implicit request =>

--- a/admin/app/controllers/AppConfigController.scala
+++ b/admin/app/controllers/AppConfigController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import common.{ImplicitControllerExecutionContext, Logging}
+import common.{ImplicitControllerExecutionContext, GuLogging}
 import model.{ApplicationContext, NoCache}
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
@@ -9,7 +9,7 @@ import services.ParameterStoreService
 class AppConfigController(val controllerComponents: ControllerComponents, parameterStoreService: ParameterStoreService)(
     implicit context: ApplicationContext,
 ) extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   def renderAppConfig(): Action[AnyContent] =

--- a/admin/app/controllers/DeploysController.scala
+++ b/admin/app/controllers/DeploysController.scala
@@ -1,6 +1,6 @@
 package controllers.admin
 
-import common.{ImplicitControllerExecutionContext, Logging}
+import common.{ImplicitControllerExecutionContext, GuLogging}
 import implicits.Requests
 import model.NoCache
 import model.deploys.{ApiResults, RiffRaffService}
@@ -8,7 +8,7 @@ import play.api.mvc._
 import model.deploys._
 import play.api.libs.ws.WSClient
 
-trait DeploysController extends BaseController with Logging with Requests with ImplicitControllerExecutionContext {
+trait DeploysController extends BaseController with GuLogging with Requests with ImplicitControllerExecutionContext {
 
   val riffRaff: RiffRaffService
 

--- a/admin/app/controllers/FrontPressController.scala
+++ b/admin/app/controllers/FrontPressController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import common.{AkkaAsync, ImplicitControllerExecutionContext, Logging}
+import common.{AkkaAsync, ImplicitControllerExecutionContext, GuLogging}
 import jobs.{HighFrequency, LowFrequency, RefreshFrontsJob, StandardFrequency}
 import model.ApplicationContext
 import play.api.mvc._
@@ -8,7 +8,7 @@ import play.api.mvc._
 class FrontPressController(akkaAsync: AkkaAsync, val controllerComponents: ControllerComponents)(implicit
     context: ApplicationContext,
 ) extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   def press(): Action[AnyContent] =

--- a/admin/app/controllers/R2PressController.scala
+++ b/admin/app/controllers/R2PressController.scala
@@ -3,7 +3,7 @@ package controllers.admin
 import java.io.File
 import java.net.URL
 
-import common.{AkkaAsync, ImplicitControllerExecutionContext, Logging}
+import common.{AkkaAsync, ImplicitControllerExecutionContext, GuLogging}
 import model.{ApplicationContext, R2PressMessage}
 import play.api.mvc._
 import services.{R2PagePressNotifier, R2PressedPageTakedownNotifier, RedirectService}
@@ -15,7 +15,7 @@ class R2PressController(
     val controllerComponents: ControllerComponents,
 )(implicit context: ApplicationContext)
     extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   def pressForm(urlMsgs: List[String] = List.empty, fileMsgs: List[String] = List.empty): Action[AnyContent] =

--- a/admin/app/controllers/RedirectController.scala
+++ b/admin/app/controllers/RedirectController.scala
@@ -3,7 +3,7 @@ package controllers.admin
 import java.io.File
 
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
-import common.Logging
+import common.GuLogging
 import model.ApplicationContext
 import play.api.data._
 import play.api.data.Forms._
@@ -18,7 +18,7 @@ class RedirectController(
     val controllerComponents: ControllerComponents,
 )(implicit context: ApplicationContext)
     extends BaseController
-    with Logging {
+    with GuLogging {
 
   val redirectForm = Form(mapping("from" -> text, "to" -> text)(PageRedirect.apply)(PageRedirect.unapply))
 

--- a/admin/app/controllers/SportTroubleshooterController.scala
+++ b/admin/app/controllers/SportTroubleshooterController.scala
@@ -1,13 +1,13 @@
 package controllers.admin
 
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
-import common.Logging
+import common.GuLogging
 import model.{ApplicationContext, NoCache}
 
 class SportTroubleshooterController(val controllerComponents: ControllerComponents)(implicit
     context: ApplicationContext,
 ) extends BaseController
-    with Logging {
+    with GuLogging {
 
   def renderFootballTroubleshooter(): Action[AnyContent] =
     Action { implicit request =>

--- a/admin/app/controllers/SwitchboardController.scala
+++ b/admin/app/controllers/SwitchboardController.scala
@@ -13,7 +13,7 @@ import model.{ApplicationContext, NoCache}
 class SwitchboardController(akkaAsync: AkkaAsync, val controllerComponents: ControllerComponents)(implicit
     context: ApplicationContext,
 ) extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   val SwitchPattern = """([a-z\d-]+)=(on|off)""".r

--- a/admin/app/controllers/TroubleshooterController.scala
+++ b/admin/app/controllers/TroubleshooterController.scala
@@ -2,7 +2,7 @@ package controllers.admin
 
 import contentapi.{CapiHttpClient, ContentApiClient, PreviewContentApi, PreviewSigner}
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
-import common.{ImplicitControllerExecutionContext, Logging}
+import common.{ImplicitControllerExecutionContext, GuLogging}
 import model.{ApplicationContext, NoCache}
 import play.api.libs.ws.WSClient
 import tools.LoadBalancer
@@ -29,7 +29,7 @@ object TestFailed {
 class TroubleshooterController(wsClient: WSClient, val controllerComponents: ControllerComponents)(implicit
     appContext: ApplicationContext,
 ) extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   private val capiLiveHttpClient = new CapiHttpClient(wsClient)

--- a/admin/app/controllers/admin/AnalyticsConfidenceController.scala
+++ b/admin/app/controllers/admin/AnalyticsConfidenceController.scala
@@ -1,6 +1,6 @@
 package controllers.admin
 
-import common.{ImplicitControllerExecutionContext, Logging}
+import common.{ImplicitControllerExecutionContext, GuLogging}
 import model.ApplicationContext
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 import tools._
@@ -8,7 +8,7 @@ import tools._
 class AnalyticsConfidenceController(val controllerComponents: ControllerComponents)(implicit
     context: ApplicationContext,
 ) extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
   def renderConfidence(): Action[AnyContent] =
     Action.async { implicit request =>

--- a/admin/app/controllers/admin/CommercialController.scala
+++ b/admin/app/controllers/admin/CommercialController.scala
@@ -1,7 +1,7 @@
 package controllers.admin
 
 import common.dfp.{GuCreativeTemplate, GuCustomField, GuLineItem}
-import common.{ImplicitControllerExecutionContext, JsonComponent, Logging}
+import common.{ImplicitControllerExecutionContext, JsonComponent, GuLogging}
 import conf.Configuration
 import dfp.{AdvertiserAgent, CreativeTemplateAgent, CustomFieldAgent, DfpApi, DfpDataExtractor, OrderAgent}
 import model._
@@ -34,7 +34,7 @@ class CommercialController(
     dfpApi: DfpApi,
 )(implicit context: ApplicationContext)
     extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   def renderCommercialMenu(): Action[AnyContent] =

--- a/admin/app/controllers/admin/ReaderRevenueAdminController.scala
+++ b/admin/app/controllers/admin/ReaderRevenueAdminController.scala
@@ -1,7 +1,7 @@
 package controllers.admin
 
 import com.gu.googleauth.UserIdentity
-import common.{ImplicitControllerExecutionContext, Logging}
+import common.{ImplicitControllerExecutionContext, GuLogging}
 import model.{ApplicationContext, NoCache}
 import model.readerRevenue._
 import org.joda.time.DateTime
@@ -17,7 +17,7 @@ import scala.concurrent.Future
 class ReaderRevenueAdminController(wsClient: WSClient, val controllerComponents: ControllerComponents)(implicit
     context: ApplicationContext,
 ) extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   def renderReaderRevenueMenu(): Action[AnyContent] =

--- a/admin/app/controllers/admin/commercial/AdsDotTextEditController.scala
+++ b/admin/app/controllers/admin/commercial/AdsDotTextEditController.scala
@@ -1,6 +1,6 @@
 package controllers.admin.commercial
 
-import common.Logging
+import common.GuLogging
 import model.{ApplicationContext, NoCache}
 import play.api.data.Form
 import play.api.data.Forms._
@@ -22,7 +22,7 @@ object AdsTextSellers {
 class AdsDotTextEditController(val controllerComponents: ControllerComponents)(implicit context: ApplicationContext)
     extends BaseController
     with I18nSupport
-    with Logging {
+    with GuLogging {
 
   final private def renderDotText(name: String, s3DotTextKey: String, saveRoute: Call): Action[AnyContent] =
     Action { implicit request =>

--- a/admin/app/controllers/admin/commercial/TeamKPIController.scala
+++ b/admin/app/controllers/admin/commercial/TeamKPIController.scala
@@ -2,7 +2,7 @@ package controllers.admin.commercial
 
 import java.time.LocalDate
 
-import common.Logging
+import common.GuLogging
 import jobs.CommercialDfpReporting
 import model.{ApplicationContext, NoCache}
 import play.api.i18n.I18nSupport
@@ -13,7 +13,7 @@ import tools.{Chart, ChartFormat, ChartRow}
 class TeamKPIController(val controllerComponents: ControllerComponents)(implicit context: ApplicationContext)
     extends BaseController
     with I18nSupport
-    with Logging {
+    with GuLogging {
 
   def renderPrebidDashboard(): Action[AnyContent] =
     Action { implicit request =>

--- a/admin/app/controllers/cache/ImageDecacheController.scala
+++ b/admin/app/controllers/cache/ImageDecacheController.scala
@@ -4,7 +4,7 @@ import java.net.URI
 import java.util.UUID
 
 import com.gu.googleauth.UserIdentity
-import common.{ImplicitControllerExecutionContext, Logging}
+import common.{ImplicitControllerExecutionContext, GuLogging}
 import controllers.admin.AdminAuthController
 import model.{ApplicationContext, NoCache}
 import play.api.libs.ws.{WSClient, WSResponse}
@@ -19,7 +19,7 @@ class ImageDecacheController(
     val controllerComponents: ControllerComponents,
 )(implicit context: ApplicationContext)
     extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext
     with AdminAuthController {
   import ImageDecacheController._

--- a/admin/app/controllers/cache/PageDecacheController.scala
+++ b/admin/app/controllers/cache/PageDecacheController.scala
@@ -3,7 +3,7 @@ package controllers.cache
 import java.net.URI
 
 import com.gu.googleauth.UserIdentity
-import common.{ImplicitControllerExecutionContext, Logging}
+import common.{ImplicitControllerExecutionContext, GuLogging}
 import controllers.admin.AdminAuthController
 import model.{ApplicationContext, NoCache}
 import org.apache.commons.codec.digest.DigestUtils
@@ -20,7 +20,7 @@ case class PrePurgeTestResult(url: String, passed: Boolean)
 class PageDecacheController(wsClient: WSClient, val controllerComponents: ControllerComponents)(implicit
     context: ApplicationContext,
 ) extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext
     with AdminAuthController {
 

--- a/admin/app/controllers/metrics/FastlyController.scala
+++ b/admin/app/controllers/metrics/FastlyController.scala
@@ -1,13 +1,13 @@
 package controllers.admin
 
-import common.{ImplicitControllerExecutionContext, Logging}
+import common.{ImplicitControllerExecutionContext, GuLogging}
 import model.ApplicationContext
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 import tools.CloudWatch
 
 class FastlyController(val controllerComponents: ControllerComponents)(implicit context: ApplicationContext)
     extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
   def renderFastly(): Action[AnyContent] =
     Action.async { implicit request =>

--- a/admin/app/controllers/metrics/MetricsController.scala
+++ b/admin/app/controllers/metrics/MetricsController.scala
@@ -1,6 +1,6 @@
 package controllers.admin
 
-import common.{ImplicitControllerExecutionContext, Logging}
+import common.{ImplicitControllerExecutionContext, GuLogging}
 import play.api.libs.ws.WSClient
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 import tools._
@@ -12,7 +12,7 @@ class MetricsController(
     val controllerComponents: ControllerComponents,
 )(implicit context: ApplicationContext)
     extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
   // We only do PROD metrics
 

--- a/admin/app/dfp/ApiHelper.scala
+++ b/admin/app/dfp/ApiHelper.scala
@@ -1,10 +1,10 @@
 package dfp
 
 import com.google.api.ads.admanager.axis.v202011._
-import common.Logging
+import common.GuLogging
 import org.joda.time.{DateTime => JodaDateTime, DateTimeZone}
 
-private[dfp] object ApiHelper extends Logging {
+private[dfp] object ApiHelper extends GuLogging {
 
   def isPageSkin(dfpLineItem: LineItem): Boolean = {
 

--- a/admin/app/dfp/CustomTargetingAgent.scala
+++ b/admin/app/dfp/CustomTargetingAgent.scala
@@ -2,7 +2,7 @@ package dfp
 
 import com.google.api.ads.admanager.axis.utils.v202011.StatementBuilder
 import com.google.api.ads.admanager.axis.v202011.{CustomTargetingKey, CustomTargetingValue}
-import common.Logging
+import common.GuLogging
 import common.dfp.{GuCustomTargeting, GuCustomTargetingValue}
 import concurrent.BlockingOperations
 
@@ -10,7 +10,7 @@ import scala.util.Try
 
 class CustomTargetingAgent(val blockingOperations: BlockingOperations)
     extends DataAgent[Long, GuCustomTargeting]
-    with Logging {
+    with GuLogging {
 
   def loadFreshData(): Try[Map[Long, GuCustomTargeting]] =
     Try {

--- a/admin/app/dfp/DataAgent.scala
+++ b/admin/app/dfp/DataAgent.scala
@@ -1,13 +1,13 @@
 package dfp
 
 import com.gu.Box
-import common.Logging
+import common.GuLogging
 import concurrent.BlockingOperations
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
-trait DataAgent[K, V] extends Logging with implicits.Strings {
+trait DataAgent[K, V] extends GuLogging with implicits.Strings {
 
   private val initialCache: DataCache[K, V] = DataCache(Map.empty[K, V])
   private lazy val cache = Box(initialCache)

--- a/admin/app/dfp/DfpAdUnitCacheJob.scala
+++ b/admin/app/dfp/DfpAdUnitCacheJob.scala
@@ -1,12 +1,12 @@
 package dfp
 
-import common.{AkkaAsync, Logging}
+import common.{AkkaAsync, GuLogging}
 import conf.Configuration
 import tools.Store
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class DfpAdUnitCacher(val rootAdUnit: Any, val filename: String, dfpApi: DfpApi) extends Logging {
+class DfpAdUnitCacher(val rootAdUnit: Any, val filename: String, dfpApi: DfpApi) extends GuLogging {
 
   def run(akkaAsync: AkkaAsync)(implicit executionContext: ExecutionContext): Future[Unit] =
     Future {

--- a/admin/app/dfp/DfpApi.scala
+++ b/admin/app/dfp/DfpApi.scala
@@ -4,13 +4,13 @@ package dfp
 // https://developers.google.com/ad-manager/api/pqlreference
 import com.google.api.ads.admanager.axis.utils.v202011.StatementBuilder
 import com.google.api.ads.admanager.axis.v202011._
-import common.Logging
+import common.GuLogging
 import common.dfp._
 import org.joda.time.DateTime
 
 case class DfpLineItems(validItems: Seq[GuLineItem], invalidItems: Seq[GuLineItem])
 
-class DfpApi(dataMapper: DataMapper, dataValidation: DataValidation) extends Logging {
+class DfpApi(dataMapper: DataMapper, dataValidation: DataValidation) extends GuLogging {
   import dfp.DfpApi._
 
   private def readLineItems(

--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -1,7 +1,7 @@
 package dfp
 
 import common.dfp._
-import common.Logging
+import common.GuLogging
 import org.joda.time.DateTime
 import play.api.libs.json.Json.{toJson, _}
 import tools.Store
@@ -14,7 +14,7 @@ class DfpDataCacheJob(
     customTargetingAgent: CustomTargetingAgent,
     placementAgent: PlacementAgent,
     dfpApi: DfpApi,
-) extends Logging {
+) extends GuLogging {
 
   case class LineItemLoadSummary(validLineItems: Seq[GuLineItem], invalidLineItems: Seq[GuLineItem])
 

--- a/admin/app/dfp/SessionLogger.scala
+++ b/admin/app/dfp/SessionLogger.scala
@@ -2,11 +2,11 @@ package dfp
 
 import com.google.api.ads.admanager.axis.utils.v202011.StatementBuilder
 import com.google.api.ads.admanager.axis.v202011._
-import common.Logging
+import common.GuLogging
 
 import scala.util.control.NonFatal
 
-private[dfp] object SessionLogger extends Logging {
+private[dfp] object SessionLogger extends GuLogging {
 
   def logAroundRead[T](typesToRead: String, stmtBuilder: StatementBuilder)(read: => Seq[T]): Seq[T] = {
     logAroundSeq(typesToRead, opName = "reading", Some(stmtBuilder.toStatement))(read)

--- a/admin/app/dfp/SessionWrapper.scala
+++ b/admin/app/dfp/SessionWrapper.scala
@@ -6,7 +6,7 @@ import com.google.api.ads.admanager.axis.utils.v202011.{ReportDownloader, Statem
 import com.google.api.ads.admanager.axis.v202011._
 import com.google.api.ads.admanager.lib.client.AdManagerSession
 import com.google.common.io.CharSource
-import common.Logging
+import common.GuLogging
 import conf.{AdminConfiguration, Configuration}
 import dfp.Reader.read
 import dfp.SessionLogger.{logAroundCreate, logAroundPerform, logAroundRead, logAroundReadSingle}
@@ -199,7 +199,7 @@ private[dfp] class SessionWrapper(dfpSession: AdManagerSession) {
   }
 }
 
-object SessionWrapper extends Logging {
+object SessionWrapper extends GuLogging {
 
   def apply(networkId: Option[String] = None): Option[SessionWrapper] = {
     val dfpSession =

--- a/admin/app/dfp/rubicon/Creative.scala
+++ b/admin/app/dfp/rubicon/Creative.scala
@@ -3,10 +3,10 @@ package dfp.rubicon
 import com.google.api.ads.admanager.axis.utils.v202011.StatementBuilder
 import com.google.api.ads.admanager.axis.v202011.LineItemCreativeAssociationStatus.ACTIVE
 import com.google.api.ads.admanager.axis.v202011._
-import common.Logging
+import common.GuLogging
 import dfp.SessionWrapper
 
-object Creative extends Logging {
+object Creative extends GuLogging {
 
   def replaceTagCreatives(
       networkId: Long,

--- a/admin/app/dfp/rubicon/CreativeTemplate.scala
+++ b/admin/app/dfp/rubicon/CreativeTemplate.scala
@@ -1,11 +1,11 @@
 package dfp.rubicon
 
 import com.google.api.ads.admanager.axis.v202011._
-import common.Logging
+import common.GuLogging
 import conf.Configuration
 import play.api.libs.json.{JsValue, Json}
 
-object CreativeTemplate extends Logging with implicits.Collections {
+object CreativeTemplate extends GuLogging with implicits.Collections {
 
   private val ukOrder = 171545367
   private val ukMobileOrder = 170179047

--- a/admin/app/dfp/rubicon/package.scala
+++ b/admin/app/dfp/rubicon/package.scala
@@ -2,11 +2,11 @@ package dfp
 
 import com.google.api.ads.admanager.axis.utils.v202011.StatementBuilder
 import com.google.api.ads.admanager.axis.v202011.{LineItemCreativeAssociationStatus, ThirdPartyCreative}
-import common.Logging
+import common.GuLogging
 
 import scala.util.matching.Regex
 
-package object rubicon extends Logging {
+package object rubicon extends GuLogging {
 
   def withDfpSession[T](networkId: String)(block: SessionWrapper => Seq[T]): Seq[T] = {
     val results = for {

--- a/admin/app/football/controllers/FrontsController.scala
+++ b/admin/app/football/controllers/FrontsController.scala
@@ -4,7 +4,7 @@ import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents, RequestHeader, Result => PlayResult}
 import play.api.libs.ws.WSClient
 import play.twirl.api.Html
-import common.{ImplicitControllerExecutionContext, Logging}
+import common.{ImplicitControllerExecutionContext, GuLogging}
 import football.services.PaFootballClient
 import football.model.PA
 import model.{ApplicationContext, Cached, NoCache}
@@ -26,7 +26,7 @@ class FrontsController(
     extends BaseController
     with ImplicitControllerExecutionContext
     with PaFootballClient
-    with Logging {
+    with GuLogging {
 
   val SNAP_TYPE = "json.html"
   val SNAP_CSS = "football"

--- a/admin/app/football/controllers/PaBrowserController.scala
+++ b/admin/app/football/controllers/PaBrowserController.scala
@@ -3,7 +3,7 @@ package controllers.admin
 import model.Cached.RevalidatableResult
 import play.api.mvc._
 import football.services.PaFootballClient
-import common.{ImplicitControllerExecutionContext, Logging}
+import common.{ImplicitControllerExecutionContext, GuLogging}
 import java.net.URLDecoder
 
 import scala.language.postfixOps
@@ -15,7 +15,7 @@ class PaBrowserController(val wsClient: WSClient, val controllerComponents: Cont
 ) extends BaseController
     with ImplicitControllerExecutionContext
     with PaFootballClient
-    with Logging {
+    with GuLogging {
 
   def browserSubstitution(): Action[AnyContent] =
     Action { implicit request =>

--- a/admin/app/football/controllers/PlayerController.scala
+++ b/admin/app/football/controllers/PlayerController.scala
@@ -5,7 +5,7 @@ import play.api.mvc._
 import football.services.PaFootballClient
 import pa.{PlayerAppearances, PlayerProfile, StatsSummary}
 import implicits.Requests
-import common.{ImplicitControllerExecutionContext, JsonComponent, Logging}
+import common.{ImplicitControllerExecutionContext, JsonComponent, GuLogging}
 import org.joda.time.LocalDate
 import football.model.PA
 
@@ -22,7 +22,7 @@ class PlayerController(val wsClient: WSClient, val controllerComponents: Control
     with ImplicitControllerExecutionContext
     with PaFootballClient
     with Requests
-    with Logging {
+    with GuLogging {
 
   def playerIndex: Action[AnyContent] =
     Action.async { implicit request =>

--- a/admin/app/football/controllers/TablesController.scala
+++ b/admin/app/football/controllers/TablesController.scala
@@ -1,6 +1,6 @@
 package controllers.admin
 
-import common.{ImplicitControllerExecutionContext, Logging}
+import common.{ImplicitControllerExecutionContext, GuLogging}
 import football.model.PA
 import football.services.PaFootballClient
 import model.Cached.RevalidatableResult
@@ -17,7 +17,7 @@ class TablesController(val wsClient: WSClient, val controllerComponents: Control
 ) extends BaseController
     with ImplicitControllerExecutionContext
     with PaFootballClient
-    with Logging {
+    with GuLogging {
 
   def tablesIndex: Action[AnyContent] =
     Action.async { implicit request =>

--- a/admin/app/football/services/Client.scala
+++ b/admin/app/football/services/Client.scala
@@ -8,7 +8,7 @@ import java.io.File
 
 import scala.util.{Failure, Success}
 import play.Logger
-import common.{Logging}
+import common.{GuLogging}
 import pa.{Http, PaClient, PaClientErrorsException, Response, Season, Team}
 import conf.AdminConfiguration
 import football.model.PA
@@ -82,7 +82,7 @@ private case class TestClient(wsClient: WSClient, environment: Environment) exte
 }
 
 trait PaFootballClient {
-  self: PaFootballClient with Logging =>
+  self: PaFootballClient with GuLogging =>
 
   implicit val executionContext: ExecutionContext
   implicit val context: ApplicationContext

--- a/admin/app/football/services/Client.scala
+++ b/admin/app/football/services/Client.scala
@@ -7,7 +7,9 @@ import org.joda.time.LocalDate
 import java.io.File
 
 import scala.util.{Failure, Success}
-import play.Logger
+import play.api.Logger
+import play.api.Logger.logger
+
 import common.{GuLogging}
 import pa.{Http, PaClient, PaClientErrorsException, Response, Season, Team}
 import conf.AdminConfiguration
@@ -57,11 +59,11 @@ private case class TestClient(wsClient: WSClient, environment: Environment) exte
         val xml = scala.io.Source.fromFile(file, "UTF-8").getLines().mkString
         Future(xml)(context)
       case None =>
-        Logger.warn(s"Missing fixture for API response: $suffix ($filename)")
+        Logger.logger.warn(s"Missing fixture for API response: $suffix ($filename)")
         val response = realClient.get(realApiCallPath)(context)
         response.onComplete {
           case Success(str) => {
-            Logger.info(s"writing response to testdata, $filename.xml, $str")
+            Logger.logger.info(s"writing response to testdata, $filename.xml, $str")
             writeToFile(s"${environment.rootPath}/admin/test/football/testdata/$filename.xml", str)
           }
           case Failure(writeError) => throw writeError

--- a/admin/app/indexes/ContentApiTagsEnumerator.scala
+++ b/admin/app/indexes/ContentApiTagsEnumerator.scala
@@ -1,6 +1,6 @@
 package indexes
 
-import common.Logging
+import common.GuLogging
 import common.StringEncodings.asAscii
 import contentapi.ContentApiClient
 
@@ -11,7 +11,7 @@ import scala.concurrent.duration._
 import play.api.libs.iteratee.{Enumeratee, Enumerator}
 
 class ContentApiTagsEnumerator(contentApiClient: ContentApiClient)(implicit executionContext: ExecutionContext)
-    extends Logging {
+    extends GuLogging {
   val DelayBetweenRetries = 100.millis
   val MaxNumberRetries = 5
   val MaxPageSize = 1000

--- a/admin/app/indexes/TagPages.scala
+++ b/admin/app/indexes/TagPages.scala
@@ -1,6 +1,6 @@
 package indexes
 
-import common.Logging
+import common.GuLogging
 import common.Maps._
 import com.gu.contentapi.client.model.v1.Tag
 import model.{TagDefinition, TagIndex}
@@ -85,7 +85,7 @@ object TagPages {
   )
 }
 
-class TagPages(implicit executionContext: ExecutionContext) extends Logging {
+class TagPages(implicit executionContext: ExecutionContext) extends GuLogging {
 
   def alphaIndexKey(s: String): String = {
     val badCharacters = """[^a-z0-9]+""".r

--- a/admin/app/jobs/AnalyticsSanityCheckJob.scala
+++ b/admin/app/jobs/AnalyticsSanityCheckJob.scala
@@ -3,7 +3,7 @@ package jobs
 import java.util.concurrent.atomic.AtomicLong
 
 import com.amazonaws.services.cloudwatch.model.{GetMetricStatisticsResult, StandardUnit}
-import common.Logging
+import common.GuLogging
 import metrics.GaugeMetric
 import model.diagnostics.CloudWatch
 import org.joda.time.DateTime
@@ -12,7 +12,7 @@ import services.{CloudWatchStats, OphanApi}
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 
-class AnalyticsSanityCheckJob(ophanApi: OphanApi) extends Logging {
+class AnalyticsSanityCheckJob(ophanApi: OphanApi) extends GuLogging {
 
   private val rawPageViews = new AtomicLong(0L)
   private val ophanPageViews = new AtomicLong(0L)

--- a/admin/app/jobs/CommercialDfpReporting.scala
+++ b/admin/app/jobs/CommercialDfpReporting.scala
@@ -8,13 +8,13 @@ import com.google.api.ads.admanager.axis.v202011.DateRangeType.CUSTOM_DATE
 import com.google.api.ads.admanager.axis.v202011.Dimension.{CUSTOM_CRITERIA, DATE}
 import com.google.api.ads.admanager.axis.v202011._
 import com.gu.Box
-import common.{AkkaAsync, JobScheduler, Logging}
+import common.{AkkaAsync, JobScheduler, GuLogging}
 import dfp.DfpApi
 import play.api.inject.ApplicationLifecycle
 
 import scala.concurrent.{ExecutionContext, Future}
 
-object CommercialDfpReporting extends Logging {
+object CommercialDfpReporting extends GuLogging {
 
   case class DfpReportRow(value: String) {
     val fields = value.split(",").toSeq
@@ -91,7 +91,7 @@ class CommercialDfpReportingLifecycle(
     dfpApi: DfpApi,
 )(implicit ec: ExecutionContext)
     extends LifecycleComponent
-    with Logging {
+    with GuLogging {
 
   appLifecycle.addStopHook { () =>
     Future {

--- a/admin/app/jobs/ExpiringSwitchesEmailJob.scala
+++ b/admin/app/jobs/ExpiringSwitchesEmailJob.scala
@@ -1,6 +1,6 @@
 package jobs
 
-import common.Logging
+import common.GuLogging
 import conf.Configuration.frontend.{dotcomPlatformEmail, webEngineersEmail}
 import conf.switches.{Switch, Switches}
 import services.EmailService
@@ -8,7 +8,7 @@ import services.EmailService
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
-case class ExpiringSwitchesEmailJob(emailService: EmailService) extends Logging {
+case class ExpiringSwitchesEmailJob(emailService: EmailService) extends GuLogging {
 
   def run()(implicit executionContext: ExecutionContext): Future[Unit] = runJob(webEngineersEmail)
   def runReminder()(implicit executionContext: ExecutionContext): Future[Unit] = runJob(dotcomPlatformEmail)

--- a/admin/app/jobs/FastlyCloudwatchLoadJob.scala
+++ b/admin/app/jobs/FastlyCloudwatchLoadJob.scala
@@ -1,7 +1,7 @@
 package jobs
 
 import com.amazonaws.services.cloudwatch.model.StandardUnit
-import common.Logging
+import common.GuLogging
 import metrics.SamplerMetric
 import model.diagnostics.CloudWatch
 import services.{FastlyStatistic, FastlyStatisticService}
@@ -12,7 +12,7 @@ import org.joda.time.DateTime
 
 import scala.concurrent.ExecutionContext
 
-class FastlyCloudwatchLoadJob(fastlyStatisticService: FastlyStatisticService) extends Logging {
+class FastlyCloudwatchLoadJob(fastlyStatisticService: FastlyStatisticService) extends GuLogging {
   // Samples in CloudWatch are additive so we want to limit duplicate reporting.
   // We do not want to corrupt the past either, so set a default value (the most
   // recent 15 minutes of results are unstable).

--- a/admin/app/jobs/R2PagePressJob.scala
+++ b/admin/app/jobs/R2PagePressJob.scala
@@ -18,7 +18,7 @@ import services.RedirectService.ArchiveRedirect
 import scala.concurrent.{ExecutionContext, Future}
 
 class R2PagePressJob(wsClient: WSClient, redirects: RedirectService)(implicit executionContext: ExecutionContext)
-    extends Logging {
+    extends GuLogging {
   private lazy val waitTimeSeconds = Configuration.r2Press.pressQueueWaitTimeInSeconds
   private lazy val maxMessages = Configuration.r2Press.pressQueueMaxMessages
   private lazy val credentials = Configuration.aws.mandatoryCredentials

--- a/admin/app/jobs/RebuildIndexJob.scala
+++ b/admin/app/jobs/RebuildIndexJob.scala
@@ -1,6 +1,6 @@
 package jobs
 
-import common.{Logging, StopWatch}
+import common.{GuLogging, StopWatch}
 import contentapi.ContentApiClient
 import indexes.{ContentApiTagsEnumerator, TagPages}
 import model.{TagIndexListings, TagIndex}
@@ -9,7 +9,8 @@ import services.TagIndexesS3
 
 import scala.concurrent.{ExecutionContext, Future, blocking}
 
-class RebuildIndexJob(contentApiClient: ContentApiClient)(implicit executionContext: ExecutionContext) extends Logging {
+class RebuildIndexJob(contentApiClient: ContentApiClient)(implicit executionContext: ExecutionContext)
+    extends GuLogging {
 
   val contentApiTagsEnumerator = new ContentApiTagsEnumerator(contentApiClient)
   val tagPages = new TagPages

--- a/admin/app/jobs/RefreshFrontsJob.scala
+++ b/admin/app/jobs/RefreshFrontsJob.scala
@@ -1,7 +1,7 @@
 package jobs
 
 import com.gu.facia.api.models.{CommercialPriority, EditorialPriority, EmailPriority, TrainingPriority}
-import common.{AkkaAsync, Logging}
+import common.{AkkaAsync, GuLogging}
 import conf.Configuration
 import services.{ConfigAgent, FrontPressNotification}
 
@@ -18,7 +18,7 @@ object HighFrequency extends FrontType {
 
 case class CronUpdate(path: String, frontType: FrontType)
 
-object RefreshFrontsJob extends Logging {
+object RefreshFrontsJob extends GuLogging {
   def getAllCronUpdates: Seq[CronUpdate] = {
     ConfigAgent.getPathIds.map(path => CronUpdate(path, getFrontType(path)))
   }

--- a/admin/app/model/AdminLifecycle.scala
+++ b/admin/app/model/AdminLifecycle.scala
@@ -25,7 +25,7 @@ class AdminLifecycle(
     rebuildIndexJob: RebuildIndexJob,
 )(implicit ec: ExecutionContext)
     extends LifecycleComponent
-    with Logging {
+    with GuLogging {
 
   appLifecycle.addStopHook { () =>
     Future {

--- a/admin/app/model/abtests/AbTestJob.scala
+++ b/admin/app/model/abtests/AbTestJob.scala
@@ -1,13 +1,13 @@
 package model.abtests
 
-import common.Logging
+import common.GuLogging
 import tools.CloudWatch
 import views.support.CamelCase
 
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 
-object AbTestJob extends Logging {
+object AbTestJob extends GuLogging {
   def run()(implicit executionContext: ExecutionContext) {
 
     log.info("Downloading abtests info from CloudWatch")

--- a/admin/app/pagepresser/HtmlCleaner.scala
+++ b/admin/app/pagepresser/HtmlCleaner.scala
@@ -1,14 +1,14 @@
 package pagepresser
 
 import com.netaporter.uri.Uri.parse
-import common.{Logging}
+import common.{GuLogging}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Element, Document}
 import conf.Configuration
 
 import scala.collection.JavaConverters._
 
-abstract class HtmlCleaner extends Logging {
+abstract class HtmlCleaner extends GuLogging {
   lazy val fallbackCacheBustId = Configuration.r2Press.fallbackCachebustId
   lazy val staticRegEx = """//static.guim.co.uk/static/(\w+)/(.+)(\.\w+)$""".r("cacheBustId", "paths", "extension")
   lazy val nonDigitRegEx = """\D+""".r

--- a/admin/app/purge/CdnPurge.scala
+++ b/admin/app/purge/CdnPurge.scala
@@ -1,6 +1,6 @@
 package purge
 
-import common.Logging
+import common.GuLogging
 import conf.AdminConfiguration.fastly
 import conf.Configuration.environment
 import implicits.Dates
@@ -13,7 +13,7 @@ sealed trait FastlyService { def serviceId: String }
 case object GuardianHost extends FastlyService { val serviceId = fastly.serviceId }
 case object AjaxHost extends FastlyService { val serviceId = fastly.ajaxServiceId }
 
-object CdnPurge extends Dates with Logging {
+object CdnPurge extends Dates with GuLogging {
 
   // Performs soft purge which will still serve stale if there is an error
   def soft(

--- a/admin/app/services/CloudWatchStats.scala
+++ b/admin/app/services/CloudWatchStats.scala
@@ -2,7 +2,7 @@ package services
 
 import com.amazonaws.services.cloudwatch.{AmazonCloudWatchAsync, AmazonCloudWatchAsyncClient}
 import com.amazonaws.services.cloudwatch.model._
-import common.Logging
+import common.GuLogging
 import conf.Configuration
 import conf.Configuration.environment
 import org.joda.time.DateTime
@@ -10,7 +10,7 @@ import awswrappers.cloudwatch._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-object CloudWatchStats extends Logging {
+object CloudWatchStats extends GuLogging {
   val stage = new Dimension().withName("Stage").withValue(environment.stage)
 
   lazy val cloudwatch: AmazonCloudWatchAsync = {

--- a/admin/app/services/EmailService.scala
+++ b/admin/app/services/EmailService.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.TimeoutException
 import com.amazonaws.handlers.AsyncHandler
 import com.amazonaws.services.simpleemail._
 import com.amazonaws.services.simpleemail.model.{Destination => EmailDestination, _}
-import common.{AkkaAsync, Logging}
+import common.{AkkaAsync, GuLogging}
 import conf.Configuration.aws.mandatoryCredentials
 
 import scala.collection.JavaConverters._
@@ -14,7 +14,7 @@ import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success}
 
-class EmailService(akkaAsync: AkkaAsync) extends Logging {
+class EmailService(akkaAsync: AkkaAsync) extends GuLogging {
 
   private lazy val client: AmazonSimpleEmailServiceAsync = AmazonSimpleEmailServiceAsyncClient
     .asyncBuilder()

--- a/admin/app/services/Fastly.scala
+++ b/admin/app/services/Fastly.scala
@@ -1,6 +1,6 @@
 package services
 
-import common.Logging
+import common.GuLogging
 import conf.AdminConfiguration.fastly
 import com.amazonaws.services.cloudwatch.model.{Dimension, MetricDatum}
 import org.joda.time.DateTime
@@ -23,7 +23,7 @@ case class FastlyStatistic(service: String, region: String, timestamp: Long, nam
     .withValue(value.toDouble)
 }
 
-class FastlyStatisticService(wsClient: WSClient) extends Logging {
+class FastlyStatisticService(wsClient: WSClient) extends GuLogging {
 
   private case class FastlyApiStat(
       hits: Int,

--- a/admin/app/services/R2PagePressNotifier.scala
+++ b/admin/app/services/R2PagePressNotifier.scala
@@ -1,13 +1,13 @@
 package services
 
-import common.{AkkaAsync, Logging}
+import common.{AkkaAsync, GuLogging}
 import implicits.R2PressNotification.pressMessageFormatter
 import model.R2PressMessage
 import play.api.libs.json.Json
 
 import scala.concurrent.ExecutionContext
 
-object R2PagePressNotifier extends Logging {
+object R2PagePressNotifier extends GuLogging {
 
   def enqueue(akkaAsync: AkkaAsync)(message: R2PressMessage)(implicit executionContext: ExecutionContext): String = {
     try {

--- a/admin/app/services/R2PressedPageTakedownNotifier.scala
+++ b/admin/app/services/R2PressedPageTakedownNotifier.scala
@@ -1,10 +1,10 @@
 package services
 
-import common.{AkkaAsync, Logging}
+import common.{AkkaAsync, GuLogging}
 
 import scala.concurrent.ExecutionContext
 
-object R2PressedPageTakedownNotifier extends Logging {
+object R2PressedPageTakedownNotifier extends GuLogging {
 
   def enqueue(akkaAsync: AkkaAsync)(path: String)(implicit executionContext: ExecutionContext): String = {
     try {

--- a/admin/app/tools/AssetMetrics.scala
+++ b/admin/app/tools/AssetMetrics.scala
@@ -3,7 +3,7 @@ package tools
 import awswrappers.cloudwatch._
 import com.amazonaws.services.cloudwatch.model._
 import com.gu.Box
-import common.Logging
+import common.GuLogging
 import org.joda.time.DateTime
 import tools.CloudWatch._
 
@@ -76,7 +76,7 @@ object AssetMetrics {
     metrics(dimension = gzipped, yLabel = "Size").map(_.sortBy(m => (-m.change, m.name)))
 }
 
-object AssetMetricsCache extends Logging {
+object AssetMetricsCache extends GuLogging {
 
   sealed trait ReportType
   object ReportTypes {

--- a/admin/app/tools/CloudWatch.scala
+++ b/admin/app/tools/CloudWatch.scala
@@ -7,7 +7,7 @@ import com.amazonaws.services.cloudwatch.{
   AmazonCloudWatchAsyncClientBuilder,
 }
 import com.amazonaws.services.cloudwatch.model._
-import common.Logging
+import common.GuLogging
 import conf.Configuration
 import conf.Configuration._
 import org.joda.time.DateTime
@@ -19,7 +19,7 @@ case class MaximumMetric(metric: GetMetricStatisticsResult) {
   lazy val max: Double = metric.getDatapoints.asScala.headOption.map(_.getMaximum.doubleValue()).getOrElse(0.0)
 }
 
-object CloudWatch extends Logging {
+object CloudWatch extends GuLogging {
   def shutdown(): Unit = {
     euWestClient.shutdown()
     defaultClient.shutdown()

--- a/admin/app/tools/LoadBalancer.scala
+++ b/admin/app/tools/LoadBalancer.scala
@@ -1,6 +1,6 @@
 package tools
 
-import common.Logging
+import common.GuLogging
 import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancingClient
 import com.gu.Box
 
@@ -14,7 +14,7 @@ case class LoadBalancer(
     testPath: Option[String] = None,
 )
 
-object LoadBalancer extends Logging {
+object LoadBalancer extends GuLogging {
 
   import conf.Configuration.aws.credentials
 

--- a/admin/app/tools/Store.scala
+++ b/admin/app/tools/Store.scala
@@ -1,6 +1,6 @@
 package tools
 
-import common.Logging
+import common.GuLogging
 import common.dfp._
 import conf.Configuration.commercial._
 import conf.{AdminConfiguration, Configuration}
@@ -10,7 +10,7 @@ import play.api.libs.json.{JsError, JsSuccess, Json}
 import play.api.libs.json.Json.toJson
 import services.S3
 
-trait Store extends Logging with Dates {
+trait Store extends GuLogging with Dates {
   lazy val switchesKey = Configuration.switches.key
   lazy val topStoriesKey = AdminConfiguration.topStoriesKey
 

--- a/applications/app/controllers/AllIndexController.scala
+++ b/applications/app/controllers/AllIndexController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import com.gu.contentapi.client.model.ContentApiError
 import common.Edition.defaultEdition
-import common.{Edition, ImplicitControllerExecutionContext, Logging}
+import common.{Edition, ImplicitControllerExecutionContext, GuLogging}
 import contentapi.{ContentApiClient, SectionsLookUp}
 import implicits.{Dates, ItemResponses}
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
@@ -25,7 +25,7 @@ class AllIndexController(
     with ImplicitControllerExecutionContext
     with ItemResponses
     with Dates
-    with Logging {
+    with GuLogging {
 
   private val indexController = new IndexController(contentApiClient, sectionsLookUp, controllerComponents)
 

--- a/applications/app/controllers/AtomPageController.scala
+++ b/applications/app/controllers/AtomPageController.scala
@@ -26,7 +26,7 @@ class AtomPageController(
     val controllerComponents: ControllerComponents,
 )(implicit context: ApplicationContext)
     extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   case class AnswersSignupForm(

--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import com.gu.contentapi.client.model.v1.{Crossword, ItemResponse, Content => ApiContent, Section => ApiSection}
-import common.{Edition, ImplicitControllerExecutionContext, Logging}
+import common.{Edition, ImplicitControllerExecutionContext, GuLogging}
 import conf.Static
 import contentapi.ContentApiClient
 import pages.{CrosswordHtmlPage, IndexHtmlPage, PrintableCrosswordHtmlPage}
@@ -25,7 +25,7 @@ import html.HtmlPageHelpers.ContentCSSFile
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-trait CrosswordController extends BaseController with Logging with ImplicitControllerExecutionContext {
+trait CrosswordController extends BaseController with GuLogging with ImplicitControllerExecutionContext {
 
   def contentApiClient: ContentApiClient
 

--- a/applications/app/controllers/EmbedController.scala
+++ b/applications/app/controllers/EmbedController.scala
@@ -11,7 +11,7 @@ import contentapi.ContentApiClient
 class EmbedController(contentApiClient: ContentApiClient, val controllerComponents: ControllerComponents)(implicit
     context: ApplicationContext,
 ) extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   def render(path: String): Action[AnyContent] =

--- a/applications/app/controllers/GalleryController.scala
+++ b/applications/app/controllers/GalleryController.scala
@@ -16,7 +16,7 @@ class GalleryController(contentApiClient: ContentApiClient, val controllerCompon
     context: ApplicationContext,
 ) extends BaseController
     with RendersItemResponse
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   def renderJson(path: String): Action[AnyContent] = render(path)

--- a/applications/app/controllers/ImageContentController.scala
+++ b/applications/app/controllers/ImageContentController.scala
@@ -29,7 +29,7 @@ class ImageContentController(
     extends BaseController
     with RendersItemResponse
     with ImageQuery
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   def renderJson(path: String): Action[AnyContent] = render(path)

--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -33,7 +33,7 @@ class InteractiveController(
 )(implicit context: ApplicationContext)
     extends BaseController
     with RendersItemResponse
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   val capiLookup: CAPILookup = new CAPILookup(contentApiClient)

--- a/applications/app/controllers/LatestIndexController.scala
+++ b/applications/app/controllers/LatestIndexController.scala
@@ -15,7 +15,7 @@ class LatestIndexController(contentApiClient: ContentApiClient, val controllerCo
     extends BaseController
     with ImplicitControllerExecutionContext
     with implicits.ItemResponses
-    with Logging {
+    with GuLogging {
 
   def latest(path: String): Action[AnyContent] =
     Action.async { implicit request =>

--- a/applications/app/controllers/MediaController.scala
+++ b/applications/app/controllers/MediaController.scala
@@ -21,7 +21,7 @@ class MediaController(contentApiClient: ContentApiClient, val controllerComponen
     context: ApplicationContext,
 ) extends BaseController
     with RendersItemResponse
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   def renderJson(path: String): Action[AnyContent] = render(path)

--- a/applications/app/controllers/NewspaperController.scala
+++ b/applications/app/controllers/NewspaperController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import common.{ImplicitControllerExecutionContext, Logging}
+import common.{ImplicitControllerExecutionContext, GuLogging}
 import contentapi.ContentApiClient
 import layout.FaciaContainer
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
@@ -14,7 +14,7 @@ class NewspaperController(
     val controllerComponents: ControllerComponents,
 )(implicit context: ApplicationContext)
     extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   private val newspaperQuery = new NewspaperQuery(contentApiClient)

--- a/applications/app/controllers/QuizController.scala
+++ b/applications/app/controllers/QuizController.scala
@@ -45,7 +45,7 @@ class QuizController(
 )(implicit context: ApplicationContext)
     extends BaseController
     with ImplicitControllerExecutionContext
-    with Logging {
+    with GuLogging {
 
   def submit(quizId: String, path: String): Action[AnyContent] =
     Action.async { implicit request =>

--- a/applications/app/controllers/ReaderRevenueAppController.scala
+++ b/applications/app/controllers/ReaderRevenueAppController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import common.{ImplicitControllerExecutionContext, Logging}
+import common.{ImplicitControllerExecutionContext, GuLogging}
 import model._
 import play.api.mvc._
 import services.S3
@@ -13,7 +13,7 @@ import model.readerRevenue._
 class ReaderRevenueAppController(val controllerComponents: ControllerComponents)(implicit context: ApplicationContext)
     extends BaseController
     with ImplicitControllerExecutionContext
-    with Logging {
+    with GuLogging {
 
   private[this] def getBannerDeployLog(strRegion: String, bannerType: BannerType): Option[String] = {
     ReaderRevenueRegion.fromName(strRegion).fold(Option.empty[String]) { region: ReaderRevenueRegion =>

--- a/applications/app/controllers/ShareCountController.scala
+++ b/applications/app/controllers/ShareCountController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import common.{ImplicitControllerExecutionContext, JsonComponent, Logging}
+import common.{ImplicitControllerExecutionContext, JsonComponent, GuLogging}
 import model.{ApplicationContext, CacheTime, Cached}
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 import services.FacebookGraphApi
@@ -10,7 +10,7 @@ class ShareCountController(
     val controllerComponents: ControllerComponents,
 )(implicit context: ApplicationContext)
     extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   def fetch(path: String): Action[AnyContent] =

--- a/applications/app/controllers/ShortUrlsController.scala
+++ b/applications/app/controllers/ShortUrlsController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import common.{ImplicitControllerExecutionContext, LinkTo, Logging}
+import common.{ImplicitControllerExecutionContext, LinkTo, GuLogging}
 import common.`package`._
 import _root_.commercial.campaigns.ShortCampaignCodes
 import contentapi.ContentApiClient
@@ -14,7 +14,7 @@ class ShortUrlsController(
     val controllerComponents: ControllerComponents,
 )(implicit context: ApplicationContext)
     extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   def redirectShortUrl(shortUrl: String): Action[AnyContent] =

--- a/applications/app/controllers/TagIndexController.scala
+++ b/applications/app/controllers/TagIndexController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import common.{ImplicitControllerExecutionContext, Logging}
+import common.{ImplicitControllerExecutionContext, GuLogging}
 import model.Cached.RevalidatableResult
 import model._
 import pages.TagIndexHtmlPage
@@ -10,7 +10,7 @@ import services._
 class TagIndexController(val controllerComponents: ControllerComponents)(implicit context: ApplicationContext)
     extends BaseController
     with ImplicitControllerExecutionContext
-    with Logging {
+    with GuLogging {
 
   private val TagIndexCacheTime = 600
 

--- a/applications/app/controllers/WebAppController.scala
+++ b/applications/app/controllers/WebAppController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import common.{ImplicitControllerExecutionContext, Logging}
+import common.{ImplicitControllerExecutionContext, GuLogging}
 import model.Cached.RevalidatableResult
 import model._
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
@@ -8,7 +8,7 @@ import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 class WebAppController(val controllerComponents: ControllerComponents)(implicit context: ApplicationContext)
     extends BaseController
     with ImplicitControllerExecutionContext
-    with Logging {
+    with GuLogging {
 
   def serviceWorker(): Action[AnyContent] =
     Action { implicit request =>

--- a/applications/app/controllers/YoutubeController.scala
+++ b/applications/app/controllers/YoutubeController.scala
@@ -15,7 +15,7 @@ class YoutubeController(
     wsClient: WSClient,
     val controllerComponents: ControllerComponents,
 ) extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   def getAtomId(youtubeId: String): Action[AnyContent] =

--- a/applications/app/jobs/SitemapLifecycle.scala
+++ b/applications/app/jobs/SitemapLifecycle.scala
@@ -23,7 +23,7 @@ class SiteMapLifecycle(jobs: JobScheduler, akkaAsync: AkkaAsync, siteMapJob: Sit
   }
 }
 
-class SiteMapJob(contentApiClient: ContentApiClient) extends Logging {
+class SiteMapJob(contentApiClient: ContentApiClient) extends GuLogging {
   case class SiteMapContent(news: xml.NodeSeq, video: xml.NodeSeq)
 
   private val newsSiteMap = new NewsSiteMap(contentApiClient)

--- a/applications/app/services/FacebookGraphApi.scala
+++ b/applications/app/services/FacebookGraphApi.scala
@@ -2,7 +2,7 @@ package services
 
 import java.util.concurrent.TimeoutException
 
-import common.Logging
+import common.GuLogging
 import conf.Configuration
 import play.api.libs.json.Json
 import play.api.libs.ws.{WSClient, WSResponse}
@@ -18,7 +18,7 @@ object URLResponseDeserializer {
 case class Engagement(share_count: Int)
 case class URLResponse(id: String, engagement: Engagement)
 
-class FacebookGraphApiClient(wsClient: WSClient) extends implicits.WSRequests with Logging {
+class FacebookGraphApiClient(wsClient: WSClient) extends implicits.WSRequests with GuLogging {
   val apiRootUrl = s"https://graph.facebook.com/v${Configuration.facebook.graphApi.version}"
 
   def GET(endpoint: Option[String], timeout: Duration, queryString: (String, String)*)(implicit

--- a/applications/app/services/NewspaperQuery.scala
+++ b/applications/app/services/NewspaperQuery.scala
@@ -19,7 +19,7 @@ case class ContentByPage(page: Int, content: ApiContent)
 case class TagWithContent(tag: Tag, content: ApiContent)
 case class BookSectionContentByPage(page: Int, booksectionContent: BookSectionContent)
 
-class NewspaperQuery(contentApiClient: ContentApiClient) extends Dates with Logging {
+class NewspaperQuery(contentApiClient: ContentApiClient) extends Dates with GuLogging {
 
   val dateForFrontPagePattern = DateTimeFormat.forPattern("EEEE d MMMM y")
   private val hrefFormat = DateTimeFormat.forPattern("yyyy/MMM/dd").withZone(DateTimeZone.UTC)

--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -26,7 +26,7 @@ import metrics.TimingMetric
 
 class ArchiveController(redirects: RedirectService, val controllerComponents: ControllerComponents, ws: WSClient)
     extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   private val R1ArtifactUrl = """^/(.*)/[0|1]?,[\d]*,(-?\d+),[\d]*(.*)""".r

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -26,7 +26,7 @@ class ArticleController(
 )(implicit context: ApplicationContext)
     extends BaseController
     with RendersItemResponse
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   val capiLookup: CAPILookup = new CAPILookup(contentApiClient)

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -30,7 +30,7 @@ class LiveBlogController(
     remoteRenderer: renderers.DotcomRenderingService = DotcomRenderingService(),
 )(implicit context: ApplicationContext)
     extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   val capiLookup: CAPILookup = new CAPILookup(contentApiClient)

--- a/article/app/controllers/PublicationController.scala
+++ b/article/app/controllers/PublicationController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import common.{ImplicitControllerExecutionContext, Logging}
+import common.{ImplicitControllerExecutionContext, GuLogging}
 import implicits.{Dates, ItemResponses}
 import model.ApplicationContext
 import org.joda.time.format.DateTimeFormat
@@ -20,7 +20,7 @@ class PublicationController(
     with ImplicitControllerExecutionContext
     with ItemResponses
     with Dates
-    with Logging {
+    with GuLogging {
 
   private val dateFormatUTC = DateTimeFormat.forPattern("yyyy/MMM/dd").withZone(DateTimeZone.UTC)
 

--- a/article/app/services/dotcomponents/DotcomponentsLogger.scala
+++ b/article/app/services/dotcomponents/DotcomponentsLogger.scala
@@ -1,6 +1,6 @@
 package services.dotcomponents
 
-import common.Logging
+import common.GuLogging
 import common.LoggingField._
 import model.PageWithStoryPackage
 import play.api.mvc.RequestHeader
@@ -27,7 +27,7 @@ case class DotcomponentsLoggerFields(request: Option[RequestHeader]) {
 
 }
 
-case class DotcomponentsLogger(request: Option[RequestHeader]) extends Logging {
+case class DotcomponentsLogger(request: Option[RequestHeader]) extends GuLogging {
 
   private def customFields: List[LogField] = DotcomponentsLoggerFields(request).customFields
 

--- a/commercial/app/CommercialLifecycle.scala
+++ b/commercial/app/CommercialLifecycle.scala
@@ -6,7 +6,7 @@ import commercial.model.merchandise.jobs.Industries
 import app.LifecycleComponent
 import commercial.model.feeds._
 import common.LoggingField._
-import common.{AkkaAsync, JobScheduler, Logging}
+import common.{AkkaAsync, JobScheduler, GuLogging}
 import metrics.MetricUploader
 import play.api.inject.ApplicationLifecycle
 
@@ -25,7 +25,7 @@ class CommercialLifecycle(
     feedsParser: FeedsParser,
     industries: Industries,
 ) extends LifecycleComponent
-    with Logging {
+    with GuLogging {
 
   // This class does work that should be kept separate from the EC used to serve requests
   implicit private val ec = ExecutionContext.fromExecutorService(

--- a/commercial/app/RefreshJob.scala
+++ b/commercial/app/RefreshJob.scala
@@ -1,11 +1,11 @@
 package commercial
 
-import common.{JobScheduler, Logging}
+import common.{JobScheduler, GuLogging}
 import commercial.model.merchandise.jobs.Industries
 
 import scala.concurrent.ExecutionContext
 
-trait RefreshJob extends Logging {
+trait RefreshJob extends GuLogging {
 
   def name: String
   def jobs: JobScheduler

--- a/commercial/app/controllers/BookOffersController.scala
+++ b/commercial/app/controllers/BookOffersController.scala
@@ -3,7 +3,7 @@ package commercial.controllers
 import commercial.model.Segment
 import commercial.model.merchandise.Book
 import commercial.model.merchandise.books.{BestsellersAgent, BookFinder}
-import common.{ImplicitControllerExecutionContext, JsonComponent, JsonNotFound, Logging}
+import common.{ImplicitControllerExecutionContext, JsonComponent, JsonNotFound, GuLogging}
 import model.Cached
 import play.api.libs.json.{JsNull, JsValue, Json}
 import play.api.mvc._
@@ -16,7 +16,7 @@ class BookOffersController(
     val controllerComponents: ControllerComponents,
 ) extends BaseController
     with ImplicitControllerExecutionContext
-    with Logging
+    with GuLogging
     with implicits.Collections
     with implicits.Requests {
 

--- a/commercial/app/controllers/ContentApiOffersController.scala
+++ b/commercial/app/controllers/ContentApiOffersController.scala
@@ -1,7 +1,7 @@
 package commercial.controllers
 
 import commercial.model.capi.{CapiAgent, CapiMultiple, CapiSingle, Lookup}
-import common.{Edition, ImplicitControllerExecutionContext, JsonComponent, Logging}
+import common.{Edition, ImplicitControllerExecutionContext, JsonComponent, GuLogging}
 import contentapi.ContentApiClient
 import model.{Cached, ContentType}
 import play.api.mvc._
@@ -21,7 +21,7 @@ class ContentApiOffersController(
 ) extends BaseController
     with ImplicitControllerExecutionContext
     with implicits.Requests
-    with Logging {
+    with GuLogging {
 
   private val lookup = new Lookup(contentApiClient)
 

--- a/commercial/app/controllers/HostedContentController.scala
+++ b/commercial/app/controllers/HostedContentController.scala
@@ -5,7 +5,7 @@ import com.gu.contentapi.client.model.ItemQuery
 import com.gu.contentapi.client.model.v1.ContentType.Video
 import commercial.model.hosted.HostedTrails
 import common.commercial.hosted._
-import common.{Edition, ImplicitControllerExecutionContext, JsonComponent, JsonNotFound, Logging}
+import common.{Edition, ImplicitControllerExecutionContext, JsonComponent, JsonNotFound, GuLogging}
 import contentapi.ContentApiClient
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model.{ApplicationContext, Cached, NoCache}
@@ -24,7 +24,7 @@ class HostedContentController(
 )(implicit context: ApplicationContext)
     extends BaseController
     with ImplicitControllerExecutionContext
-    with Logging
+    with GuLogging
     with implicits.Requests {
 
   private def cacheDuration: Int = 60

--- a/commercial/app/controllers/PiggybackPixelController.scala
+++ b/commercial/app/controllers/PiggybackPixelController.scala
@@ -1,6 +1,6 @@
 package commercial.controllers
 
-import common.{ImplicitControllerExecutionContext, Logging}
+import common.{ImplicitControllerExecutionContext, GuLogging}
 import model.Cached
 import model.Cached.RevalidatableResult
 import play.api.mvc._
@@ -9,7 +9,7 @@ class PiggybackPixelController(val controllerComponents: ControllerComponents)
     extends BaseController
     with ImplicitControllerExecutionContext
     with implicits.Requests
-    with Logging {
+    with GuLogging {
 
   def resize(): Action[AnyContent] =
     Action { implicit request =>

--- a/commercial/app/controllers/PrebidAnalyticsController.scala
+++ b/commercial/app/controllers/PrebidAnalyticsController.scala
@@ -1,13 +1,13 @@
 package commercial.controllers
 
-import common.Logging
+import common.GuLogging
 import conf.Configuration.commercial.prebidAnalyticsStream
 import conf.switches.Switches
 import play.api.mvc._
 
 import scala.concurrent.ExecutionContext
 
-class PrebidAnalyticsController(val controllerComponents: ControllerComponents) extends BaseController with Logging {
+class PrebidAnalyticsController(val controllerComponents: ControllerComponents) extends BaseController with GuLogging {
 
   private implicit val ec: ExecutionContext = controllerComponents.executionContext
 

--- a/commercial/app/controllers/TrafficDriverController.scala
+++ b/commercial/app/controllers/TrafficDriverController.scala
@@ -2,7 +2,7 @@ package commercial.controllers
 
 import commercial.model.capi.CapiAgent
 import commercial.model.merchandise.TrafficDriver
-import common.{Edition, ImplicitControllerExecutionContext, JsonComponent, Logging}
+import common.{Edition, ImplicitControllerExecutionContext, JsonComponent, GuLogging}
 import contentapi.ContentApiClient
 import model.{Cached, ContentType}
 import play.api.mvc._
@@ -18,7 +18,7 @@ class TrafficDriverController(
 ) extends BaseController
     with ImplicitControllerExecutionContext
     with implicits.Requests
-    with Logging {
+    with GuLogging {
 
   // Request information about the article from cAPI.
   private def retrieveContent()(implicit request: Request[AnyContent]): Future[Option[ContentType]] = {

--- a/commercial/app/model/capi/CapiAgent.scala
+++ b/commercial/app/model/capi/CapiAgent.scala
@@ -1,14 +1,14 @@
 package commercial.model.capi
 
 import com.gu.Box
-import common.Logging
+import common.GuLogging
 import contentapi.ContentApiClient
 import model.ContentType
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
-class CapiAgent(contentApiClient: ContentApiClient) extends Logging {
+class CapiAgent(contentApiClient: ContentApiClient) extends GuLogging {
 
   private lazy val shortUrlAgent = Box[Map[String, Option[ContentType]]](Map.empty)
   private val lookup = new Lookup(contentApiClient)

--- a/commercial/app/model/capi/Lookup.scala
+++ b/commercial/app/model/capi/Lookup.scala
@@ -2,14 +2,14 @@ package commercial.model.capi
 
 import com.gu.contentapi.client.model.v1.Tag
 import common.Edition.defaultEdition
-import common.Logging
+import common.GuLogging
 import contentapi.ContentApiClient
 import model.{Content, ContentType, ImageElement}
 import utils.ShortUrls
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class Lookup(contentApiClient: ContentApiClient) extends Logging with implicits.Strings {
+class Lookup(contentApiClient: ContentApiClient) extends GuLogging with implicits.Strings {
 
   def content(contentId: String)(implicit executionContext: ExecutionContext): Future[Option[ContentType]] = {
     val response =

--- a/commercial/app/model/feeds/FeedReader.scala
+++ b/commercial/app/model/feeds/FeedReader.scala
@@ -1,7 +1,7 @@
 package commercial.model.feeds
 
 import commercial.CommercialMetrics
-import common.Logging
+import common.GuLogging
 import conf.switches.Switch
 import play.api.libs.json.{JsValue, Json}
 import play.api.libs.ws.{WSClient, WSRequest, WSResponse, WSSignatureCalculator}
@@ -12,7 +12,7 @@ import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 import scala.xml.{Elem, XML}
 
-class FeedReader(wsClient: WSClient) extends Logging {
+class FeedReader(wsClient: WSClient) extends GuLogging {
 
   def read[T](
       request: FeedRequest,

--- a/commercial/app/model/hosted/HostedTrails.scala
+++ b/commercial/app/model/hosted/HostedTrails.scala
@@ -1,10 +1,10 @@
 package commercial.model.hosted
 
 import com.gu.contentapi.client.model.v1.Content
-import common.Logging
+import common.GuLogging
 import common.commercial.hosted.HostedPage
 
-object HostedTrails extends Logging {
+object HostedTrails extends GuLogging {
 
   private def publishedDateTime(item: Content): Long = item.webPublicationDate.map(_.dateTime).getOrElse(0L)
 

--- a/commercial/app/model/merchandise/MerchandiseAgent.scala
+++ b/commercial/app/model/merchandise/MerchandiseAgent.scala
@@ -2,12 +2,12 @@ package commercial.model.merchandise
 
 import com.gu.Box
 import commercial.model.Segment
-import common.Logging
+import common.GuLogging
 
 import scala.concurrent.Future
 import scala.util.Random
 
-trait MerchandiseAgent[T] extends Logging {
+trait MerchandiseAgent[T] extends GuLogging {
 
   private lazy val agent = Box[Seq[T]](Nil)
 

--- a/commercial/app/model/merchandise/books/BookFinder.scala
+++ b/commercial/app/model/merchandise/books/BookFinder.scala
@@ -6,7 +6,7 @@ import akka.util.Timeout
 import com.gu.Box
 import commercial.model.feeds.{FeedParseException, FeedReadException, FeedReader, FeedRequest}
 import commercial.model.merchandise.Book
-import common.Logging
+import common.GuLogging
 import conf.Configuration
 import conf.switches.Switches.BookLookupSwitch
 import play.api.libs.json._
@@ -17,7 +17,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
-class BookFinder(actorSystem: ActorSystem, magentoService: MagentoService) extends Logging {
+class BookFinder(actorSystem: ActorSystem, magentoService: MagentoService) extends GuLogging {
 
   private implicit val bookActorExecutionContext: ExecutionContext =
     actorSystem.dispatchers.lookup("akka.actor.book-lookup")
@@ -27,7 +27,7 @@ class BookFinder(actorSystem: ActorSystem, magentoService: MagentoService) exten
   def findByIsbn(isbn: String): Option[Book] = BookAgent.get(isbn) map { _.as[Book] }
 }
 
-object BookAgent extends Logging {
+object BookAgent extends GuLogging {
 
   private lazy val cache = Box(Map.empty[String, JsValue])
 
@@ -50,7 +50,7 @@ object BookAgent extends Logging {
   }
 }
 
-class MagentoService(actorSystem: ActorSystem, wsClient: WSClient) extends Logging {
+class MagentoService(actorSystem: ActorSystem, wsClient: WSClient) extends GuLogging {
 
   private case class MagentoProperties(oauth: WSSignatureCalculator, urlPrefix: String)
 

--- a/commercial/app/model/merchandise/books/MagentoBestsellersFeed.scala
+++ b/commercial/app/model/merchandise/books/MagentoBestsellersFeed.scala
@@ -4,7 +4,7 @@ import java.lang.System._
 
 import commercial.model.OptString
 import commercial.model.feeds._
-import common.Logging
+import common.GuLogging
 import commercial.model.merchandise.Book
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -12,7 +12,7 @@ import scala.concurrent.duration._
 import scala.util.control.NonFatal
 import scala.xml.{Elem, XML}
 
-object MagentoBestsellersFeed extends Logging {
+object MagentoBestsellersFeed extends GuLogging {
 
   def parse(xml: Elem): Seq[Book] = {
     xml \ "Entry" map { entry =>

--- a/commercial/app/model/merchandise/books/MagentoException.scala
+++ b/commercial/app/model/merchandise/books/MagentoException.scala
@@ -1,11 +1,11 @@
 package commercial.model.merchandise.books
 
-import common.Logging
+import common.GuLogging
 import play.api.libs.json.{JsError, JsSuccess, JsValue}
 
 case class MagentoException(code: Int, message: String)
 
-object MagentoException extends Logging {
+object MagentoException extends GuLogging {
 
   def apply(json: JsValue): Option[MagentoException] = {
     val error = (json \ "messages" \ "error")(0)

--- a/commercial/app/model/merchandise/events/Eventbrite.scala
+++ b/commercial/app/model/merchandise/events/Eventbrite.scala
@@ -3,7 +3,7 @@ package commercial.model.merchandise.events
 import java.lang.System._
 
 import commercial.model.feeds.{FeedMetaData, MissingFeedException, ParsedFeed, SwitchOffException}
-import common.Logging
+import common.GuLogging
 import org.joda.time.DateTime
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
@@ -13,7 +13,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
-object Eventbrite extends Logging {
+object Eventbrite extends GuLogging {
 
   case class Response(pagination: Pagination, events: Seq[Event])
 

--- a/commercial/app/model/merchandise/events/LiveEventAgent.scala
+++ b/commercial/app/model/merchandise/events/LiveEventAgent.scala
@@ -4,7 +4,7 @@ import java.lang.System._
 
 import com.gu.Box
 import commercial.model.feeds._
-import common.Logging
+import common.GuLogging
 import conf.Configuration
 import commercial.model.merchandise.LiveEvent
 import play.api.libs.json.JsValue
@@ -14,7 +14,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
-class LiveEventAgent(wsClient: WSClient) extends Logging {
+class LiveEventAgent(wsClient: WSClient) extends GuLogging {
 
   private lazy val liveEventAgent = Box[Seq[LiveEvent]](Seq.empty)
 

--- a/commercial/app/model/merchandise/events/MasterclassAgent.scala
+++ b/commercial/app/model/merchandise/events/MasterclassAgent.scala
@@ -4,12 +4,12 @@ import commercial.model.Segment
 import commercial.model.capi.{Keyword, Lookup}
 import commercial.model.feeds.{FeedMetaData, ParsedFeed}
 import commercial.model.merchandise.{Masterclass, MerchandiseAgent}
-import common.Logging
+import common.GuLogging
 import contentapi.ContentApiClient
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class MasterclassAgent(contentApiClient: ContentApiClient) extends MerchandiseAgent[Masterclass] with Logging {
+class MasterclassAgent(contentApiClient: ContentApiClient) extends MerchandiseAgent[Masterclass] with GuLogging {
 
   private val lookup = new Lookup(contentApiClient)
 

--- a/commercial/app/model/merchandise/jobs/JobsFeed.scala
+++ b/commercial/app/model/merchandise/jobs/JobsFeed.scala
@@ -4,7 +4,7 @@ import java.lang.System.currentTimeMillis
 import java.util.concurrent.TimeUnit.MILLISECONDS
 
 import commercial.model.feeds.{FeedMetaData, MissingFeedException, ParsedFeed, SwitchOffException}
-import common.Logging
+import common.GuLogging
 import conf.switches.Switches.JobsFeedParseSwitch
 import commercial.model.merchandise.Job
 
@@ -13,7 +13,7 @@ import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
 import scala.xml.{Elem, XML}
 
-object JobsFeed extends Logging {
+object JobsFeed extends GuLogging {
 
   def parse(xml: Elem): Seq[Job] =
     for {

--- a/commercial/app/model/merchandise/travel/TravelOffersApi.scala
+++ b/commercial/app/model/merchandise/travel/TravelOffersApi.scala
@@ -3,7 +3,7 @@ package commercial.model.merchandise.travel
 import java.lang.System.currentTimeMillis
 
 import commercial.model.feeds.{FeedMetaData, MissingFeedException, ParsedFeed, SwitchOffException}
-import common.Logging
+import common.GuLogging
 import commercial.model.merchandise.TravelOffer
 import org.joda.time.format.DateTimeFormat
 
@@ -12,7 +12,7 @@ import scala.concurrent.duration._
 import scala.util.control.NonFatal
 import scala.xml.{Elem, XML}
 
-object TravelOffersApi extends Logging {
+object TravelOffersApi extends GuLogging {
 
   private val dateFormat = DateTimeFormat.forPattern("dd-MMM-yyyy")
 

--- a/common/app/assets/DiscussionAssets.scala
+++ b/common/app/assets/DiscussionAssets.scala
@@ -4,7 +4,7 @@ import java.net.URI
 
 import app.LifecycleComponent
 import com.gu.Box
-import common.{GuardianConfiguration, JobScheduler, Logging}
+import common.{GuardianConfiguration, JobScheduler, GuLogging}
 import conf.switches.Switches
 import play.api.libs.ws.{WSClient, WSResponse}
 
@@ -29,7 +29,7 @@ class DiscussionExternalAssetsLifecycle(
     jobs: JobScheduler,
 )(implicit executionContext: ExecutionContext)
     extends LifecycleComponent
-    with Logging {
+    with GuLogging {
 
   def refresh(): Future[Map[String, String]] = {
     config.discussion.frontendAssetsMap match {

--- a/common/app/assets/assets.scala
+++ b/common/app/assets/assets.scala
@@ -2,7 +2,7 @@ package common.Assets
 
 import java.nio.charset.Charset
 
-import common.{Logging, RelativePathEscaper}
+import common.{GuLogging, RelativePathEscaper}
 import conf.Configuration
 import model.ApplicationContext
 import org.apache.commons.io.IOUtils
@@ -16,7 +16,7 @@ import scala.util.{Failure, Success, Try}
 
 // turns an unhashed name into a name that's hashed if it needs to be
 class Assets(base: String, mapResource: String, useHashedBundles: Boolean = Configuration.assets.useHashedBundles)
-    extends Logging {
+    extends GuLogging {
 
   lazy val lookup: Map[String, String] = Get(assetMap(mapResource))
 

--- a/common/app/bindables/LocalDateBindable.scala
+++ b/common/app/bindables/LocalDateBindable.scala
@@ -1,13 +1,13 @@
 package bindables
 
-import common.Logging
+import common.GuLogging
 import org.joda.time.LocalDate
 import org.joda.time.format.DateTimeFormat
 import play.api.mvc.PathBindable
 
 import scala.util.{Failure, Success, Try}
 
-class LocalDateBindable extends PathBindable[LocalDate] with Logging {
+class LocalDateBindable extends PathBindable[LocalDate] with GuLogging {
   val Format = "yyyy-MM-dd"
 
   override def bind(key: String, value: String): Either[String, LocalDate] = {

--- a/common/app/commercial/targeting/CampaignAgent.scala
+++ b/common/app/commercial/targeting/CampaignAgent.scala
@@ -8,7 +8,7 @@ import conf.Configuration
 import scala.concurrent.{ExecutionContext, Future}
 import conf.switches.Switches.Targeting
 
-object CampaignAgent extends Logging {
+object CampaignAgent extends GuLogging {
   private val agent = Box[CampaignCache](CampaignCache(Nil, None))
 
   def refresh()(implicit executionContext: ExecutionContext): Future[Unit] = {

--- a/common/app/common/AutoRefresh.scala
+++ b/common/app/common/AutoRefresh.scala
@@ -8,7 +8,7 @@ import scala.util.{Failure, Success}
 import com.gu.Box
 
 /** Simple class for repeatedly updating a value on a schedule */
-abstract class AutoRefresh[A](initialDelay: FiniteDuration, interval: FiniteDuration) extends Logging {
+abstract class AutoRefresh[A](initialDelay: FiniteDuration, interval: FiniteDuration) extends GuLogging {
 
   private lazy val agent = Box[Option[A]](None)
 

--- a/common/app/common/GuLogging.scala
+++ b/common/app/common/GuLogging.scala
@@ -2,14 +2,12 @@ package common
 
 import common.LoggingField._
 import play.api.Logger
-import play.api.Logger.logger
 import org.apache.commons.lang.exception.ExceptionUtils
 import net.logstash.logback.marker.LogstashMarker
 import net.logstash.logback.marker.Markers._
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.implicitConversions
-import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
 trait GuLogging {
@@ -41,7 +39,7 @@ trait GuLogging {
   def errorLogging[A](message: String)(block: => A): A = {
     Try(block) match {
       case Success(result) => result
-      case Failure(e)      => logger.error(message, e); throw e
+      case Failure(e)      => Logger.logger.error(message, e); throw e
     }
   }
 }

--- a/common/app/common/GuLogging.scala
+++ b/common/app/common/GuLogging.scala
@@ -11,7 +11,7 @@ import scala.language.implicitConversions
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
-trait Logging {
+trait GuLogging {
 
   lazy implicit val log = Logger(getClass)
 

--- a/common/app/common/GuLogging.scala
+++ b/common/app/common/GuLogging.scala
@@ -2,6 +2,7 @@ package common
 
 import common.LoggingField._
 import play.api.Logger
+import play.api.Logger.logger
 import org.apache.commons.lang.exception.ExceptionUtils
 import net.logstash.logback.marker.LogstashMarker
 import net.logstash.logback.marker.Markers._
@@ -32,15 +33,15 @@ trait GuLogging {
   // Transparent error logging on exceptions: log context and exception on error, and pass on the exception
   def errorLoggingF[A](context: String)(task: => Future[A])(implicit ec: ExecutionContext): Future[A] = {
     Try(task) match {
-      case Success(f) => f.failed.foreach(Logger.error(context, _)); f
-      case Failure(e) => Logger.error(context, e); throw e
+      case Success(f) => f.failed.foreach(logger.error(context, _)); f
+      case Failure(e) => logger.error(context, e); throw e
     }
   }
 
   def errorLogging[A](message: String)(block: => A): A = {
     Try(block) match {
       case Success(result) => result
-      case Failure(e)      => Logger.error(message, e); throw e
+      case Failure(e)      => logger.error(message, e); throw e
     }
   }
 }

--- a/common/app/common/GuLogging.scala
+++ b/common/app/common/GuLogging.scala
@@ -33,8 +33,8 @@ trait GuLogging {
   // Transparent error logging on exceptions: log context and exception on error, and pass on the exception
   def errorLoggingF[A](context: String)(task: => Future[A])(implicit ec: ExecutionContext): Future[A] = {
     Try(task) match {
-      case Success(f) => f.failed.foreach(logger.error(context, _)); f
-      case Failure(e) => logger.error(context, e); throw e
+      case Success(f) => f.failed.foreach(Logger.logger.error(context, _)); f
+      case Failure(e) => Logger.logger.error(context, e); throw e
     }
   }
 

--- a/common/app/common/InlineStyles.scala
+++ b/common/app/common/InlineStyles.scala
@@ -106,7 +106,7 @@ object InlineStyles {
         val source = new InputSource(new StringReader(element.html))
         val cssParser = new CSSOMParser(new SACParserCSS3())
         Retry(3)(cssParser.parseStyleSheet(source, null, null)) { (exception, attemptNumber) =>
-          Logger.error(s"Attempt $attemptNumber to parse stylesheet failed", exception)
+          Logger.logger.error(s"Attempt $attemptNumber to parse stylesheet failed", exception)
         } match {
           case Failure(_) => (inline, head :+ element.html)
           case Success(sheet) =>

--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -13,7 +13,7 @@ import scala.collection.JavaConverters._
 /*
  * Builds absolute links to the core site (www.theguardian.com)
  */
-trait LinkTo extends Logging {
+trait LinkTo extends GuLogging {
 
   lazy val host = Configuration.site.host
 

--- a/common/app/common/Logback/LogbackConfig.scala
+++ b/common/app/common/Logback/LogbackConfig.scala
@@ -76,12 +76,12 @@ class LogbackConfig(logbackOperationsPool: LogbackOperationsPool) {
           )
           lb.addAppender(appender)
           lb.info("Configured Logback")
-        } getOrElse PlayLogger.info("not running using logback")
+        } getOrElse PlayLogger.logger.info("not running using logback")
       } catch {
-        case ex: Throwable => PlayLogger.info(s"Error while adding Logback Kinesis appender: $ex")
+        case ex: Throwable => PlayLogger.logger.info(s"Error while adding Logback Kinesis appender: $ex")
       }
     } else {
-      PlayLogger.info("Logging disabled")
+      PlayLogger.logger.info("Logging disabled")
     }
   }
 

--- a/common/app/common/Logback/Logstash.scala
+++ b/common/app/common/Logback/Logstash.scala
@@ -58,13 +58,13 @@ class Logstash(logbackOperationsPool: LogbackOperationsPool) {
     Switches.LogstashLogging.isGuaranteedSwitchedOn.onComplete {
       case Success(isOn) =>
         if (isOn) {
-          config(playConfig).fold(PlayLogger.info("Logstash config is missing"))(
+          config(playConfig).fold(PlayLogger.logger.info("Logstash config is missing"))(
             new LogbackConfig(logbackOperationsPool).init,
           )
         } else {
-          PlayLogger.info("Logstash logging switch is Off")
+          PlayLogger.logger.info("Logstash logging switch is Off")
         }
-      case Failure(_) => PlayLogger.error("Failed retrieving the logtash-logging switch value")
+      case Failure(_) => PlayLogger.logger.error("Failed retrieving the logtash-logging switch value")
     }
   }
 }

--- a/common/app/common/ModelOrResult.scala
+++ b/common/app/common/ModelOrResult.scala
@@ -10,7 +10,7 @@ import java.net.URI
 // TODO 'Convention dictates that Left is used for failure and Right is used for success.'
 // We got this the other way around, it not an error, but we should fix it.
 // Assuming that 'I can serve this to the user' is the least error state.
-object ModelOrResult extends Results with Logging {
+object ModelOrResult extends Results with GuLogging {
 
   def apply[T](item: Option[T], response: ItemResponse, maybeSection: Option[ApiSection] = None)(implicit
       request: RequestHeader,
@@ -22,7 +22,7 @@ object ModelOrResult extends Results with Logging {
 }
 
 // Content API owns the URL space, if they say this belongs on a different URL then we follow
-private object ItemOrRedirect extends ItemResponses with Logging {
+private object ItemOrRedirect extends ItemResponses with GuLogging {
 
   def apply[T](item: T, response: ItemResponse, maybeSection: Option[ApiSection])(implicit
       request: RequestHeader,
@@ -70,7 +70,7 @@ private object ItemOrRedirect extends ItemResponses with Logging {
 
 // http://wiki.nginx.org/X-accel
 // this might have ended up at the wrong server if it has a 'funny' url
-object InternalRedirect extends implicits.Requests with Logging {
+object InternalRedirect extends implicits.Requests with GuLogging {
 
   lazy val ShortUrl = """^(/p/.*)$""".r
 

--- a/common/app/common/RequestLogger.scala
+++ b/common/app/common/RequestLogger.scala
@@ -81,7 +81,7 @@ case class RequestLoggerFields(request: Option[RequestHeader], response: Option[
 }
 
 case class RequestLogger(request: Option[RequestHeader], response: Option[Result], stopWatch: Option[StopWatch])
-    extends Logging {
+    extends GuLogging {
 
   private def allFields: List[LogField] = RequestLoggerFields(request, response, stopWatch).toList
 

--- a/common/app/common/commercial/AdUnitMaker.scala
+++ b/common/app/common/commercial/AdUnitMaker.scala
@@ -1,9 +1,9 @@
 package common.commercial
 
-import common.Logging
+import common.GuLogging
 import conf.Configuration.commercial.{dfpAccountId, dfpAdUnitGuRoot}
 
-object AdUnitMaker extends Logging {
+object AdUnitMaker extends GuLogging {
 
   def make(pageId: String, adUnitSuffix: String): String = {
 

--- a/common/app/common/commercial/ClientSideLogging.scala
+++ b/common/app/common/commercial/ClientSideLogging.scala
@@ -1,12 +1,12 @@
 package common.commercial
 
 import com.redis.RedisClient
-import common.Logging
+import common.GuLogging
 import conf.Configuration
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
 
-object ClientSideLogging extends Logging {
+object ClientSideLogging extends GuLogging {
 
   val reportFormat = DateTimeFormat.forPattern("ddMMYYYY-HH:mm:ss").withZoneUTC()
 

--- a/common/app/common/commercial/hosted/HostedArticlePage.scala
+++ b/common/app/common/commercial/hosted/HostedArticlePage.scala
@@ -1,7 +1,7 @@
 package common.commercial.hosted
 
 import com.gu.contentapi.client.model.v1.{Content => ApiContent}
-import common.Logging
+import common.GuLogging
 import common.commercial.hosted.ContentUtils.{findLargestMainImageAsset, imageForSocialShare, thumbnailUrl}
 import common.commercial.hosted.LoggingUtils.getAndLog
 import model.{Content, MetaData}
@@ -25,7 +25,7 @@ case class HostedArticlePage(
   override val mainImageUrl = mainPicture
 }
 
-object HostedArticlePage extends Logging {
+object HostedArticlePage extends GuLogging {
 
   def fromContent(content: ApiContent): Option[HostedArticlePage] = {
     log.info(s"Building hosted article ${content.id} ...")

--- a/common/app/common/commercial/hosted/HostedGalleryPage.scala
+++ b/common/app/common/commercial/hosted/HostedGalleryPage.scala
@@ -1,7 +1,7 @@
 package common.commercial.hosted
 
 import com.gu.contentapi.client.model.v1.Content
-import common.Logging
+import common.GuLogging
 import common.commercial.hosted.ContentUtils._
 import common.commercial.hosted.LoggingUtils.getAndLog
 import model.MetaData
@@ -32,7 +32,7 @@ case class HostedGalleryImage(
     credit: String = "",
 )
 
-object HostedGalleryPage extends Logging {
+object HostedGalleryPage extends GuLogging {
 
   def fromContent(content: Content): Option[HostedGalleryPage] = {
     log.info(s"Building hosted gallery ${content.id} ...")

--- a/common/app/common/commercial/hosted/HostedPage.scala
+++ b/common/app/common/commercial/hosted/HostedPage.scala
@@ -5,7 +5,7 @@ import java.net.URLEncoder
 import com.gu.commercial.branding.Dimensions
 import com.gu.contentapi.client.model.v1.ContentType.{Article, Gallery, Video}
 import com.gu.contentapi.client.model.v1.{Content, SponsorshipLogoDimensions}
-import common.Logging
+import common.GuLogging
 import common.commercial.hosted.HostedVideoPage.log
 import common.commercial.hosted.LoggingUtils.getAndLog
 import conf.Configuration.site
@@ -38,7 +38,7 @@ trait HostedPage extends StandalonePage {
   def fontColour: Colour = campaign.map(_.fontColour).getOrElse(Colour.black)
 }
 
-object HostedPage extends Logging {
+object HostedPage extends GuLogging {
 
   def fromContent(item: Content): Option[HostedPage] = {
     if (item.isHosted) {

--- a/common/app/common/commercial/hosted/HostedVideoPage.scala
+++ b/common/app/common/commercial/hosted/HostedVideoPage.scala
@@ -2,7 +2,7 @@ package common.commercial.hosted
 
 import com.gu.contentapi.client.model.v1.Content
 import com.gu.contentatom.thrift.AtomData
-import common.Logging
+import common.GuLogging
 import common.commercial.hosted.ContentUtils.{imageForSocialShare, thumbnailUrl}
 import common.commercial.hosted.LoggingUtils.getAndLog
 import model.{Encoding, EncodingOrdering, MetaData}
@@ -23,7 +23,7 @@ case class HostedVideoPage(
   override val mainImageUrl = video.posterUrl
 }
 
-object HostedVideoPage extends Logging {
+object HostedVideoPage extends GuLogging {
   private implicit val ordering = EncodingOrdering
 
   def fromContent(content: Content): Option[HostedVideoPage] = {

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -20,7 +20,7 @@ import scala.util.{Failure, Success, Try}
 
 class BadConfigurationException(msg: String) extends RuntimeException(msg)
 
-object Environment extends Logging {
+object Environment extends GuLogging {
 
   private[this] val installVars = {
     val source = new File("/etc/gu/install_vars") match {
@@ -58,7 +58,7 @@ object Environment extends Logging {
   *     facia.stage=CODE
   *   }
   */
-object GuardianConfiguration extends Logging {
+object GuardianConfiguration extends GuLogging {
 
   import com.typesafe.config.Config
 
@@ -134,7 +134,7 @@ object GuardianConfiguration extends Logging {
 
 }
 
-class GuardianConfiguration extends Logging {
+class GuardianConfiguration extends GuLogging {
   import GuardianConfiguration._
 
   case class OAuthCredentials(oauthClientId: String, oauthSecret: String, oauthCallback: String)

--- a/common/app/common/dfp/PageSkinSponsorship.scala
+++ b/common/app/common/dfp/PageSkinSponsorship.scala
@@ -1,6 +1,6 @@
 package common.dfp
 
-import common.{Edition, Logging}
+import common.{Edition, GuLogging}
 import play.api.libs.json._
 
 /** A PageSkinSponsorship
@@ -42,7 +42,7 @@ object PageSkin {
   def isValidAdUnit(adUnitPath: String): Boolean = validAdUnitSuffixes.exists(suffix => adUnitPath endsWith suffix)
 }
 
-object PageSkinSponsorshipReportParser extends Logging {
+object PageSkinSponsorshipReportParser extends GuLogging {
 
   def apply(jsonString: String): Option[PageSkinSponsorshipReport] = {
 

--- a/common/app/common/dfp/TagSponsorship.scala
+++ b/common/app/common/dfp/TagSponsorship.scala
@@ -1,6 +1,6 @@
 package common.dfp
 
-import common.{Edition, Logging}
+import common.{Edition, GuLogging}
 import model.Tag
 import play.api.libs.json._
 
@@ -57,7 +57,7 @@ object InlineMerchandisingTargetedTagsReport {
 
 case class InlineMerchandisingTargetedTagsReport(updatedTimeStamp: String, targetedTags: InlineMerchandisingTagSet)
 
-object InlineMerchandisingTargetedTagsReportParser extends Logging {
+object InlineMerchandisingTargetedTagsReportParser extends GuLogging {
   def apply(jsonString: String): Option[InlineMerchandisingTargetedTagsReport] = {
     val json = Json.parse(jsonString)
     json.validate[InlineMerchandisingTargetedTagsReport] match {
@@ -115,7 +115,7 @@ object HighMerchandisingTargetedTagsReport {
 
 case class HighMerchandisingTargetedTagsReport(updatedTimeStamp: String, lineItems: HighMerchandisingLineItems)
 
-object HighMerchandisingTargetedTagsReportParser extends Logging {
+object HighMerchandisingTargetedTagsReportParser extends GuLogging {
   def apply(jsonString: String): Option[HighMerchandisingTargetedTagsReport] = {
     val json = Json.parse(jsonString)
     json.validate[HighMerchandisingTargetedTagsReport] match {

--- a/common/app/common/jobs.scala
+++ b/common/app/common/jobs.scala
@@ -17,7 +17,7 @@ object JobsState {
   val outstanding = Box(Map[String, Int]().withDefaultValue(0))
 }
 
-class FunctionJob extends Job with Logging {
+class FunctionJob extends Job with GuLogging {
   import JobsState._
   def execute(context: JobExecutionContext) {
     val name = context.getJobDetail.getKey.getName
@@ -39,7 +39,7 @@ class FunctionJob extends Job with Logging {
   }
 }
 
-class JobScheduler(context: ApplicationContext) extends Logging {
+class JobScheduler(context: ApplicationContext) extends GuLogging {
   import JobsState._
 
   val scheduler = StdSchedulerFactory.getDefaultScheduler

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -188,7 +188,7 @@ class CloudWatchMetricsLifecycle(
     jobs: JobScheduler,
 )(implicit ec: ExecutionContext)
     extends LifecycleComponent
-    with Logging {
+    with GuLogging {
   val applicationMetricsNamespace: String = "Application"
   val applicationDimension = List(new Dimension().withName("ApplicationName").withValue(appIdentity.name))
 

--- a/common/app/concurrent/CircuitBreakerRegistry.scala
+++ b/common/app/concurrent/CircuitBreakerRegistry.scala
@@ -2,12 +2,12 @@ package concurrent
 
 import akka.actor.ActorSystem
 import akka.pattern.CircuitBreaker
-import common.Logging
+import common.GuLogging
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
-object CircuitBreakerRegistry extends Logging {
+object CircuitBreakerRegistry extends GuLogging {
 
   def withConfig(
       name: String,

--- a/common/app/conf/HealthCheck.scala
+++ b/common/app/conf/HealthCheck.scala
@@ -68,7 +68,7 @@ private[conf] case class HealthCheckResult(
       .getOrElse("Never expires")
 }
 
-private[conf] trait HealthCheckFetcher extends Logging {
+private[conf] trait HealthCheckFetcher extends GuLogging {
 
   val wsClient: WSClient
 
@@ -167,7 +167,7 @@ abstract class CachedHealthCheck(policy: HealthCheckPolicy, preconditionMaybe: O
     extends HealthCheckController
     with Results
     with ImplicitControllerExecutionContext
-    with Logging {
+    with GuLogging {
 
   val controllerComponents: ControllerComponents
 

--- a/common/app/conf/switches/SwitchboardLifecycle.scala
+++ b/common/app/conf/switches/SwitchboardLifecycle.scala
@@ -10,7 +10,7 @@ import scala.concurrent.{Future, ExecutionContext}
 class SwitchboardLifecycle(appLifecycle: ApplicationLifecycle, jobs: JobScheduler, akkaAsync: AkkaAsync)(implicit
     ec: ExecutionContext,
 ) extends LifecycleComponent
-    with Logging {
+    with GuLogging {
 
   appLifecycle.addStopHook { () =>
     Future {

--- a/common/app/conf/switches/Switches.scala
+++ b/common/app/conf/switches/Switches.scala
@@ -44,7 +44,7 @@ object SwitchGroup {
   val TX = SwitchGroup("TX")
 }
 
-trait Initializable[T] extends Logging {
+trait Initializable[T] extends GuLogging {
 
   private val initialized = Promise[T]()
 

--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -72,7 +72,7 @@ object QueryDefaults extends implicits.Collections {
   }
 }
 
-trait ApiQueryDefaults extends Logging {
+trait ApiQueryDefaults extends GuLogging {
 
   def item(id: String): ItemQuery = CapiContentApiClient.item(id)
   def search: SearchQuery = CapiContentApiClient.search
@@ -105,7 +105,7 @@ trait ApiQueryDefaults extends Logging {
 
 // This trait extends ContentApiClient with Cloudwatch metrics that monitor
 // the average response time, and the number of timeouts, from Content Api.
-trait MonitoredContentApiClientLogic extends CapiContentApiClient with ApiQueryDefaults with Logging {
+trait MonitoredContentApiClientLogic extends CapiContentApiClient with ApiQueryDefaults with GuLogging {
 
   val httpClient: HttpClient
 

--- a/common/app/contentapi/SectionsLookUp.scala
+++ b/common/app/contentapi/SectionsLookUp.scala
@@ -2,12 +2,12 @@ package contentapi
 
 import com.gu.Box
 import com.gu.contentapi.client.model.v1.Section
-import common.Logging
+import common.GuLogging
 
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success}
 
-class SectionsLookUp(contentApiClient: ContentApiClient) extends Logging {
+class SectionsLookUp(contentApiClient: ContentApiClient) extends GuLogging {
   private val sections = Box[Option[Map[String, Section]]](None)
 
   def refresh()(implicit executionContext: ExecutionContext): Unit = {

--- a/common/app/contentapi/SectionsLookUpLifecycle.scala
+++ b/common/app/contentapi/SectionsLookUpLifecycle.scala
@@ -13,7 +13,7 @@ class SectionsLookUpLifecycle(
     sectionsLookUp: SectionsLookUp,
 )(implicit ec: ExecutionContext)
     extends LifecycleComponent
-    with Logging {
+    with GuLogging {
 
   appLifecycle.addStopHook { () =>
     Future {

--- a/common/app/contentapi/http.scala
+++ b/common/app/contentapi/http.scala
@@ -7,7 +7,7 @@ import com.amazonaws.DefaultRequest
 import com.amazonaws.auth.{AWS4Signer, AWSCredentials}
 import com.amazonaws.http.HttpMethodName
 import common.ContentApiMetrics.{ContentApi404Metric, ContentApiErrorMetric, ContentApiRequestsMetric}
-import common.{ContentApiMetrics, Logging}
+import common.{ContentApiMetrics, GuLogging}
 import conf.Configuration
 import conf.Configuration.contentApi.capiPreviewCredentials
 import play.api.libs.ws.WSClient
@@ -30,7 +30,9 @@ trait HttpClient {
   def GET(url: String, headers: Iterable[(String, String)]): Future[Response]
 }
 
-class CapiHttpClient(wsClient: WSClient)(implicit executionContext: ExecutionContext) extends HttpClient with Logging {
+class CapiHttpClient(wsClient: WSClient)(implicit executionContext: ExecutionContext)
+    extends HttpClient
+    with GuLogging {
 
   import java.lang.System.currentTimeMillis
 

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -3,7 +3,7 @@ package controllers
 import com.gu.identity.model.EmailNewsletter
 import com.typesafe.scalalogging.LazyLogging
 import common.EmailSubsciptionMetrics._
-import common.{ImplicitControllerExecutionContext, LinkTo, Logging}
+import common.{ImplicitControllerExecutionContext, LinkTo, GuLogging}
 import conf.Configuration
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model._
@@ -72,7 +72,7 @@ class EmailSignupController(
 )(implicit context: ApplicationContext)
     extends BaseController
     with ImplicitControllerExecutionContext
-    with Logging {
+    with GuLogging {
   val emailFormService = new EmailFormService(wsClient)
 
   val emailForm: Form[EmailForm] = Form(

--- a/common/app/controllers/IndexControllerCommon.scala
+++ b/common/app/controllers/IndexControllerCommon.scala
@@ -17,7 +17,7 @@ trait IndexControllerCommon
     extends BaseController
     with Index
     with RendersItemResponse
-    with Logging
+    with GuLogging
     with Paging
     with ImplicitControllerExecutionContext {
   private val TagPattern = """^([\w\d-]+)/([\w\d-]+)$""".r

--- a/common/app/googleAuth/OAuthLoginController.scala
+++ b/common/app/googleAuth/OAuthLoginController.scala
@@ -1,7 +1,7 @@
 package googleAuth
 
 import com.gu.googleauth.{GoogleAuth, GoogleAuthConfig, UserIdentity}
-import common.{Crypto, ImplicitControllerExecutionContext, Logging}
+import common.{Crypto, ImplicitControllerExecutionContext, GuLogging}
 import conf.Configuration
 import org.joda.time.DateTime
 import play.api.http.HttpConfiguration
@@ -112,7 +112,7 @@ trait OAuthLoginController extends BaseController with ImplicitControllerExecuti
     }
 }
 
-class AuthCookie(httpConfiguration: HttpConfiguration) extends Logging {
+class AuthCookie(httpConfiguration: HttpConfiguration) extends GuLogging {
 
   private val cookieName = "GU_PV_AUTH"
   private val oneDayInSeconds: Int = 86400

--- a/common/app/html/BrazeEmailFormatter.scala
+++ b/common/app/html/BrazeEmailFormatter.scala
@@ -1,7 +1,7 @@
 package html
 
 import java.net.URL
-import common.Logging
+import common.GuLogging
 import model.EmailAddons
 import org.jsoup.Jsoup
 import org.jsoup.nodes._
@@ -9,7 +9,7 @@ import play.twirl.api.Html
 import scala.collection.JavaConverters._
 import scala.util.Try
 
-object BrazeEmailFormatter extends Logging {
+object BrazeEmailFormatter extends GuLogging {
 
   def apply(html: Html): Html = {
     val documentBody = Jsoup.parse(html.toString)

--- a/common/app/http/RequestLoggingFilter.scala
+++ b/common/app/http/RequestLoggingFilter.scala
@@ -1,7 +1,7 @@
 package http
 
 import akka.stream.Materializer
-import common.{Logging, RequestLogger, StopWatch}
+import common.{GuLogging, RequestLogger, StopWatch}
 import play.api.mvc.{Filter, RequestHeader, Result}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -9,7 +9,7 @@ import scala.util.{Failure, Success}
 
 class RequestLoggingFilter(implicit val mat: Materializer, executionContext: ExecutionContext)
     extends Filter
-    with Logging {
+    with GuLogging {
 
   override def apply(next: RequestHeader => Future[Result])(rh: RequestHeader): Future[Result] = {
 

--- a/common/app/layout/slices/Container.scala
+++ b/common/app/layout/slices/Container.scala
@@ -1,7 +1,7 @@
 package layout.slices
 
 import model.pressed.{CollectionConfig, PressedContent}
-import common.Logging
+import common.GuLogging
 import layout.{EmailContentContainer, Front}
 import model.facia.PressedCollection
 
@@ -17,7 +17,7 @@ case object NavMediaList extends Container
 case object MostPopular extends Container
 case object Video extends Container
 
-object Container extends Logging {
+object Container extends GuLogging {
 
   /** This is THE top level resolver for containers */
   def all(adFree: Boolean = false): Map[String, Container] =

--- a/common/app/model/content/Atom.scala
+++ b/common/app/model/content/Atom.scala
@@ -196,7 +196,7 @@ final case class MediaAsset(
 
 sealed trait MediaAssetPlatform extends EnumEntry
 
-object MediaAtom extends common.Logging {
+object MediaAtom extends common.GuLogging {
 
   def make(atom: AtomApiAtom): MediaAtom = {
     val id = atom.id
@@ -328,7 +328,7 @@ final case class QuizAtom(
     shareLinks: ShareLinkMeta,
 ) extends Atom
 
-object QuizAtom extends common.Logging {
+object QuizAtom extends common.GuLogging {
 
   implicit val assetFormat = Json.format[Asset]
   implicit val imageFormat = Json.format[Image]

--- a/common/app/model/content/Atoms.scala
+++ b/common/app/model/content/Atoms.scala
@@ -37,7 +37,7 @@ final case class Atoms(
     )
 }
 
-object Atoms extends common.Logging {
+object Atoms extends common.GuLogging {
 
   def articleConfig(isAdFree: Boolean = false, useAcast: Boolean = false): ArticleConfiguration = {
     val audioSettings = AudioSettings(externalAdvertising = !isAdFree && useAcast)

--- a/common/app/model/diagnostics/CloudWatch.scala
+++ b/common/app/model/diagnostics/CloudWatch.scala
@@ -3,14 +3,14 @@ package model.diagnostics
 import com.amazonaws.handlers.AsyncHandler
 import com.amazonaws.services.cloudwatch.{AmazonCloudWatchAsync, AmazonCloudWatchAsyncClient}
 import com.amazonaws.services.cloudwatch.model._
-import common.Logging
+import common.GuLogging
 import conf.Configuration
 import conf.Configuration._
 import metrics.{FrontendMetric, FrontendStatisticSet}
 
 import scala.collection.JavaConverters._
 
-trait CloudWatch extends Logging {
+trait CloudWatch extends GuLogging {
 
   lazy val stageDimension = new Dimension().withName("Stage").withValue(environment.stage)
 
@@ -22,7 +22,7 @@ trait CloudWatch extends Logging {
       .build()
   }
 
-  trait LoggingAsyncHandler extends AsyncHandler[PutMetricDataRequest, PutMetricDataResult] with Logging {
+  trait LoggingAsyncHandler extends AsyncHandler[PutMetricDataRequest, PutMetricDataResult] with GuLogging {
     def onError(exception: Exception) {
       log.info(s"CloudWatch PutMetricDataRequest error: ${exception.getMessage}}")
     }

--- a/common/app/model/facia.scala
+++ b/common/app/model/facia.scala
@@ -2,7 +2,7 @@ package model
 
 import com.gu.commercial.branding.Branding
 import common.commercial.{CommercialProperties, EditionBranding}
-import common.{Edition, Logging}
+import common.{Edition, GuLogging}
 import play.api.libs.json.Json
 
 case class SeoDataJson(
@@ -15,7 +15,7 @@ case class SeoDataJson(
 
 case class SeoData(id: String, navSection: String, webTitle: String, title: Option[String], description: Option[String])
 
-object SeoData extends Logging {
+object SeoData extends GuLogging {
   implicit val seoFormatter = Json.format[SeoData]
 
   val editions = Edition.all.map(_.id.toLowerCase)

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -2,7 +2,7 @@ package renderers
 
 import akka.actor.ActorSystem
 import com.gu.contentapi.client.model.v1.Blocks
-import common.{LinkTo, Logging}
+import common.{LinkTo, GuLogging}
 import concurrent.CircuitBreakerRegistry
 import conf.Configuration
 import conf.switches.Switches.CircuitBreakerSwitch
@@ -21,7 +21,7 @@ import model.dotcomrendering.PageType
 import http.ResultWithPreconnectPreload
 import http.HttpPreconnections
 
-class DotcomRenderingService extends Logging with ResultWithPreconnectPreload {
+class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload {
 
   private[this] val circuitBreaker = CircuitBreakerRegistry.withConfig(
     name = "dotcom-rendering-client",

--- a/common/app/services/ConciergeRepository.scala
+++ b/common/app/services/ConciergeRepository.scala
@@ -1,11 +1,11 @@
 package services
 
 import com.gu.contentapi.client.model.ContentApiError
-import common.Logging
+import common.GuLogging
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait ConciergeRepository extends Logging {
+trait ConciergeRepository extends GuLogging {
   implicit val executionContext: ExecutionContext
   implicit class future2RecoverApi404With[T](response: Future[T]) {
     def recoverApi404With(t: T): Future[T] =

--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -20,7 +20,7 @@ import scala.util.{Failure, Success}
 
 case class CollectionConfigWithId(id: String, config: CollectionConfig)
 
-object ConfigAgent extends Logging {
+object ConfigAgent extends GuLogging {
   implicit lazy val alterTimeout: Timeout = Configuration.faciatool.configBeforePressTimeout.millis
   private lazy val configAgent = Box[Option[ConfigJson]](None)
 

--- a/common/app/services/Notification.scala
+++ b/common/app/services/Notification.scala
@@ -2,14 +2,14 @@ package services
 
 import com.amazonaws.services.sns.{AmazonSNSAsync, AmazonSNSAsyncClient}
 import com.amazonaws.services.sns.model.PublishRequest
-import common.{AkkaAsync, Logging}
+import common.{AkkaAsync, GuLogging}
 import conf.Configuration
 import awswrappers.sns._
 
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success}
 
-trait Notification extends Logging {
+trait Notification extends GuLogging {
 
   val topic: String
 

--- a/common/app/services/OphanApi.scala
+++ b/common/app/services/OphanApi.scala
@@ -5,7 +5,7 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 
-import common.{BadConfigurationException, Logging}
+import common.{BadConfigurationException, GuLogging}
 import conf.Configuration._
 import play.api.libs.json._
 import play.api.libs.ws.WSClient
@@ -24,7 +24,7 @@ object OphanDeeplyReadItem {
 }
 
 class OphanApi(wsClient: WSClient)(implicit executionContext: ExecutionContext)
-    extends Logging
+    extends GuLogging
     with implicits.WSRequests {
   private val mostViewedDateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
 

--- a/common/app/services/RedirectService.scala
+++ b/common/app/services/RedirectService.scala
@@ -5,7 +5,7 @@ import java.net.URL
 import com.gu.scanamo.error.MissingProperty
 import com.gu.scanamo.syntax._
 import com.gu.scanamo.{DynamoFormat, Scanamo, ScanamoAsync, Table}
-import common.Logging
+import common.GuLogging
 import conf.Configuration
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -60,7 +60,7 @@ object RedirectService {
   case class ArchiveRedirect(source: String, location: String) extends Destination
 }
 
-class RedirectService(implicit executionContext: ExecutionContext) extends Logging {
+class RedirectService(implicit executionContext: ExecutionContext) extends GuLogging {
   import RedirectService._
 
   // protocol fixed to http so that lookups to dynamo find existing

--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -10,7 +10,7 @@ import com.amazonaws.services.s3.{AmazonS3, AmazonS3Client}
 import com.amazonaws.services.s3.model.CannedAccessControlList.{Private, PublicRead}
 import com.amazonaws.services.s3.model._
 import com.amazonaws.util.StringInputStream
-import common.Logging
+import common.GuLogging
 import conf.Configuration
 import model.PressedPageType
 import org.joda.time.{DateTime, DateTimeZone}
@@ -19,7 +19,7 @@ import sun.misc.BASE64Encoder
 
 import scala.io.{Codec, Source}
 
-trait S3 extends Logging {
+trait S3 extends GuLogging {
 
   lazy val bucket = Configuration.aws.frontendStoreBucket
 

--- a/common/app/services/SkimLinksCache.scala
+++ b/common/app/services/SkimLinksCache.scala
@@ -4,13 +4,13 @@ import java.net.URL
 import java.util.concurrent.atomic.AtomicReference
 
 import app.LifecycleComponent
-import common.Logging
+import common.GuLogging
 import conf.Configuration.affiliateLinks
 
 import scala.concurrent.ExecutionContext
 import scala.util.Try
 
-object SkimLinksCache extends Logging {
+object SkimLinksCache extends GuLogging {
 
   private val skimLinkDomains = new AtomicReference(Set[String]())
 

--- a/common/app/services/ophan/SurgingContentAgent.scala
+++ b/common/app/services/ophan/SurgingContentAgent.scala
@@ -11,7 +11,7 @@ import services.OphanApi
 
 import scala.concurrent.{ExecutionContext, Future}
 
-object SurgingContentAgent extends SurgeLookupService with Logging {
+object SurgingContentAgent extends SurgeLookupService with GuLogging {
 
   private val agent = Box[SurgingContent](SurgingContent())
 

--- a/common/app/utils/RemoteAddress.scala
+++ b/common/app/utils/RemoteAddress.scala
@@ -2,7 +2,7 @@ package utils
 
 import play.api.mvc.RequestHeader
 
-trait RemoteAddress extends common.Logging {
+trait RemoteAddress extends common.GuLogging {
   private val Ip = """(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})""".r
 
   def clientIp(request: RequestHeader): Option[String] = {

--- a/common/app/views/support/CutOut.scala
+++ b/common/app/views/support/CutOut.scala
@@ -1,6 +1,6 @@
 package views.support
 
-import common.Logging
+import common.GuLogging
 import model.pressed.{PressedContent, Cutout}
 
 import scala.util.{Failure, Success, Try}
@@ -15,7 +15,7 @@ object Orientation {
 
 case class CutOut(imageUrl: String, orientation: Orientation)
 
-object CutOut extends Logging {
+object CutOut extends GuLogging {
   /* If a CutOut comes with width and height, it's proabably coming from facia-tool
      Otherwise, it is probably coming from Content API Content type via tags (This gives no src and width)
    */

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -4,7 +4,7 @@ import java.net.URI
 import java.util.regex.{Matcher, Pattern}
 
 import com.gu.contentatom.renderer.ArticleConfiguration
-import common.{Edition, LinkTo, Logging}
+import common.{Edition, LinkTo, GuLogging}
 import conf.Configuration.affiliateLinks._
 import conf.Configuration.site.host
 import conf.switches.Switches
@@ -880,7 +880,7 @@ case class AffiliateLinksCleaner(
     tags: List[String],
     publishedDate: Option[DateTime],
 ) extends HtmlCleaner
-    with Logging {
+    with GuLogging {
 
   override def clean(document: Document): Document = {
     if (

--- a/common/app/views/support/ImageProfile.scala
+++ b/common/app/views/support/ImageProfile.scala
@@ -3,7 +3,7 @@ package views.support
 import java.net.{URI, URISyntaxException}
 import java.util.Base64
 
-import common.Logging
+import common.GuLogging
 import conf.switches.Switches.{ImageServerSwitch}
 import conf.{Configuration}
 import layout.{BreakpointWidth, WidthsByBreakpoint}
@@ -326,7 +326,7 @@ object SeoOptimisedContentImage extends ImageProfile(width = Some(460))
 // Just degrade the image quality without adjusting the width/height
 object Naked extends ImageProfile(None, None)
 
-object ImgSrc extends Logging with implicits.Strings {
+object ImgSrc extends GuLogging with implicits.Strings {
 
   private val imageServiceHost: String = Configuration.images.host
 

--- a/diagnostics/app/common/DiagnosticsLifecycle.scala
+++ b/diagnostics/app/common/DiagnosticsLifecycle.scala
@@ -10,7 +10,7 @@ class DiagnosticsLifecycle(appLifecycle: ApplicationLifecycle, jobs: JobSchedule
     ec: ExecutionContext,
     actorSystem: ActorSystem,
 ) extends LifecycleComponent
-    with Logging {
+    with GuLogging {
 
   appLifecycle.addStopHook { () =>
     Future {

--- a/diagnostics/app/controllers/DiagnosticsController.scala
+++ b/diagnostics/app/controllers/DiagnosticsController.scala
@@ -5,7 +5,7 @@ import model.TinyResponse
 import model.diagnostics.analytics.Analytics
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 
-class DiagnosticsController(val controllerComponents: ControllerComponents) extends BaseController with Logging {
+class DiagnosticsController(val controllerComponents: ControllerComponents) extends BaseController with GuLogging {
   val r = scala.util.Random
 
   def analytics(prefix: String): Action[AnyContent] =

--- a/diagnostics/app/model/diagnostics/analytics/Metric.scala
+++ b/diagnostics/app/model/diagnostics/analytics/Metric.scala
@@ -1,9 +1,9 @@
 package model.diagnostics.analytics
 
-import common.Logging
+import common.GuLogging
 import metrics.CountMetric
 
-object Metric extends Logging {
+object Metric extends GuLogging {
 
   val namespace = "Diagnostics"
 

--- a/diagnostics/app/model/diagnostics/analytics/UploadJob.scala
+++ b/diagnostics/app/model/diagnostics/analytics/UploadJob.scala
@@ -1,9 +1,9 @@
 package model.diagnostics.analytics
 
-import common.Logging
+import common.GuLogging
 import model.diagnostics.CloudWatch
 
-object UploadJob extends Logging {
+object UploadJob extends GuLogging {
   def run() {
 
     log.info("Uploading analytics count metrics")

--- a/discussion/app/controllers/DiscussionController.scala
+++ b/discussion/app/controllers/DiscussionController.scala
@@ -1,12 +1,12 @@
 package controllers
 
 import play.api.mvc.BaseController
-import common.{ImplicitControllerExecutionContext, Logging}
+import common.{ImplicitControllerExecutionContext, GuLogging}
 import discussion.api.DiscussionApiLike
 
 trait DiscussionController
     extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext
     with implicits.Requests {
 

--- a/discussion/app/discussion/api/DiscussionApi.scala
+++ b/discussion/app/discussion/api/DiscussionApi.scala
@@ -3,7 +3,7 @@ package discussion.api
 import java.net.URLEncoder
 
 import com.netaporter.uri.dsl._
-import common.Logging
+import common.GuLogging
 import conf.Configuration
 import discussion.model.{CommentCount, _}
 import discussion.model._
@@ -17,7 +17,7 @@ import conf.switches.Switches._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait DiscussionApiLike extends Http with Logging {
+trait DiscussionApiLike extends Http with GuLogging {
 
   protected def GET(url: String, headers: (String, String)*)(implicit
       executionContext: ExecutionContext,

--- a/discussion/app/discussion/util/Http.scala
+++ b/discussion/app/discussion/util/Http.scala
@@ -3,13 +3,13 @@ package discussion.util
 import common.LoggingField.LogField
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.libs.json.{JsValue, Json}
-import common.{Logging, StopWatch}
+import common.{GuLogging, StopWatch}
 import discussion.api.{NotFoundException, OtherException}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 
-trait Http extends Logging {
+trait Http extends GuLogging {
 
   val wsClient: WSClient
 

--- a/facia-press/app/controllers/HealthCheck.scala
+++ b/facia-press/app/controllers/HealthCheck.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import common.Logging
+import common.GuLogging
 import play.api.mvc.{Action, AnyContent, ControllerComponents, Results}
 import conf.HealthCheckController
 import frontpress.ToolPressQueueWorker
@@ -13,7 +13,7 @@ class HealthCheck(
     val controllerComponents: ControllerComponents,
 ) extends HealthCheckController
     with Results
-    with Logging {
+    with GuLogging {
   val ConsecutiveProcessingErrorsThreshold = 5
   override def healthCheck(): Action[AnyContent] =
     Action.async {

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -111,7 +111,7 @@ case class EmailExtraCollections(
     breaking: List[PressedCollectionVisibility],
 )
 
-trait EmailFrontPress extends Logging {
+trait EmailFrontPress extends GuLogging {
 
   implicit def fapiClient: ApiClient
   def generatePressedVersions(
@@ -186,7 +186,7 @@ trait EmailFrontPress extends Logging {
 
 }
 
-trait FapiFrontPress extends EmailFrontPress with Logging {
+trait FapiFrontPress extends EmailFrontPress with GuLogging {
 
   val dependentFrontPaths: Map[String, Seq[String]] = Map(
     "uk" -> Seq("email/uk/daily"),
@@ -529,7 +529,7 @@ trait FapiFrontPress extends EmailFrontPress with Logging {
   }
 }
 
-object Enrichment extends Logging {
+object Enrichment extends GuLogging {
   def enrichSnap(
       embedUri: Option[String],
       beforeEnrichment: EnrichedContent,

--- a/facia-press/app/frontpress/JsonQueueWorker.scala
+++ b/facia-press/app/frontpress/JsonQueueWorker.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import com.amazonaws.services.sqs.model.ReceiveMessageRequest
 import com.gu.contentapi.client.model.ContentApiError
-import common.{JsonMessageQueue, Logging, Message}
+import common.{JsonMessageQueue, GuLogging, Message}
 import org.joda.time.DateTime
 import play.api.libs.json.Reads
 
@@ -60,7 +60,7 @@ object JsonQueueWorker {
   *
   * @tparam A The job
   */
-abstract class JsonQueueWorker[A: Reads]()(implicit executionContext: ExecutionContext) extends Logging {
+abstract class JsonQueueWorker[A: Reads]()(implicit executionContext: ExecutionContext) extends GuLogging {
   import JsonQueueWorker._
 
   val queue: JsonMessageQueue[A]

--- a/facia-press/app/frontpress/StatusNotification.scala
+++ b/facia-press/app/frontpress/StatusNotification.scala
@@ -9,7 +9,6 @@ import com.gu.facia.api.ApiError
 import conf.Configuration
 import conf.switches.Switches.FaciaPressStatusNotifications
 import play.api.Logger
-import play.api.Logger.logger
 import play.api.libs.json.Json
 
 object StatusNotificationMessage {

--- a/facia-press/app/frontpress/StatusNotification.scala
+++ b/facia-press/app/frontpress/StatusNotification.scala
@@ -9,6 +9,7 @@ import com.gu.facia.api.ApiError
 import conf.Configuration
 import conf.switches.Switches.FaciaPressStatusNotifications
 import play.api.Logger
+import play.api.Logger.logger
 import play.api.libs.json.Json
 
 object StatusNotificationMessage {
@@ -26,10 +27,10 @@ object StatusNotification {
 
   object KinesisLoggingAsyncHandler extends AsyncHandler[PutRecordRequest, PutRecordResult] {
     def onError(exception: Exception) {
-      Logger.error(s"Kinesis PutRecord request error: ${exception.getMessage}}")
+      Logger.logger.error(s"Kinesis PutRecord request error: ${exception.getMessage}}")
     }
     def onSuccess(request: PutRecordRequest, result: PutRecordResult) {
-      Logger.info(s"Kinesis status notification sent to stream:${request.getStreamName}")
+      Logger.logger.info(s"Kinesis status notification sent to stream:${request.getStreamName}")
     }
   }
 
@@ -74,7 +75,7 @@ object StatusNotification {
               .withData(ByteBuffer.wrap(Json.toJson(message).toString.getBytes("UTF-8"))),
             KinesisLoggingAsyncHandler,
           )
-        case None => Logger.info("Kinesis status notification not configured.")
+        case None => Logger.logger.info("Kinesis status notification not configured.")
       }
     }
   }

--- a/facia-press/app/frontpress/ToolPressQueueWorker.scala
+++ b/facia-press/app/frontpress/ToolPressQueueWorker.scala
@@ -13,7 +13,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class ToolPressQueueWorker(liveFapiFrontPress: LiveFapiFrontPress, draftFapiFrontPress: DraftFapiFrontPress)(implicit
     executionContext: ExecutionContext,
 ) extends JsonQueueWorker[PressJob]
-    with Logging {
+    with GuLogging {
   override lazy val queue: JsonMessageQueue[PressJob] = (Configuration.faciatool.frontPressToolQueue map { queueUrl =>
     val credentials = Configuration.aws.mandatoryCredentials
 

--- a/facia-press/test/frontpress/FapiFrontPressTest.scala
+++ b/facia-press/test/frontpress/FapiFrontPressTest.scala
@@ -5,7 +5,7 @@ import com.gu.contentapi.client.model.v1.ItemResponse
 import com.gu.contentapi.client.{ContentApiClient => CapiContentApiClient}
 import com.gu.contentatom.thrift.{Atom, AtomData, AtomDataAliases}
 import com.gu.facia.api.models.Collection
-import common.Logging
+import common.GuLogging
 import model.pressed.EnrichedContent
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
@@ -15,7 +15,7 @@ import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 
 import scala.concurrent.Future
 
-class FapiFrontPressTest extends AsyncFlatSpec with Matchers with MockitoSugar with Logging {
+class FapiFrontPressTest extends AsyncFlatSpec with Matchers with MockitoSugar with GuLogging {
   "EnrichedContent.enrichSnap" should "enrich with snap HTML" in {
     val embedUri = "http://www.example.com/snap"
     val beforeEnrichment = EnrichedContent.empty

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -26,7 +26,7 @@ import scala.concurrent.Future.successful
 
 trait FaciaController
     extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext
     with implicits.Collections
     with implicits.Requests {

--- a/facia/app/controllers/front/Front.scala
+++ b/facia/app/controllers/front/Front.scala
@@ -2,7 +2,7 @@ package controllers.front
 
 import common._
 
-class Front extends Logging {
+class Front extends GuLogging {
 
   def idFromEditionKey(section: String): String = {
     val editions = Edition.all.map { _.id.toLowerCase }

--- a/facia/app/controllers/front/FrontHeadline.scala
+++ b/facia/app/controllers/front/FrontHeadline.scala
@@ -1,12 +1,12 @@
 package controllers.front
 
-import common.Logging
+import common.GuLogging
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model.facia.PressedCollection
 import model.{Cached, PressedPage}
 import play.api.mvc.Results
 
-object FrontHeadline extends Results with Logging {
+object FrontHeadline extends Results with GuLogging {
 
   val headlineNotFound: Cached.CacheableResult = WithoutRevalidationResult(
     NotFound("Could not extract headline from front"),

--- a/facia/app/controllers/front/FrontJsonFapi.scala
+++ b/facia/app/controllers/front/FrontJsonFapi.scala
@@ -1,6 +1,6 @@
 package controllers.front
 
-import common.{FaciaPressMetrics, Logging}
+import common.{FaciaPressMetrics, GuLogging}
 import concurrent.{BlockingOperations, FutureSemaphore}
 import conf.Configuration
 import metrics.DurationMetric
@@ -10,7 +10,7 @@ import services.S3
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait FrontJsonFapi extends Logging {
+trait FrontJsonFapi extends GuLogging {
   lazy val stage: String = Configuration.facia.stage.toUpperCase
   val bucketLocation: String
   val parallelJsonPresses = 32

--- a/identity/app/jobs/TorExitNodeList.scala
+++ b/identity/app/jobs/TorExitNodeList.scala
@@ -1,6 +1,6 @@
 package jobs
 
-import common.Logging
+import common.GuLogging
 
 import scala.collection.JavaConverters._
 import java.net.{InetAddress, URL}
@@ -9,7 +9,7 @@ import com.gu.Box
 
 import scala.io.Source
 
-object TorExitNodeList extends Logging {
+object TorExitNodeList extends GuLogging {
 
   private val torExitNodeAgent = Box[Set[String]](Set.empty)
   private val torNodeListUrl = "https://check.torproject.org/cgi-bin/TorBulkExitList.py"

--- a/onward/app/business/StocksData.scala
+++ b/onward/app/business/StocksData.scala
@@ -1,6 +1,6 @@
 package business
 
-import common.{AutoRefresh, Logging}
+import common.{AutoRefresh, GuLogging}
 import conf.Configuration
 import play.api.libs.json.{JsError, JsSuccess, Json}
 import play.api.libs.ws.WSClient
@@ -9,7 +9,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class StocksData(wsClient: WSClient) extends AutoRefresh[Stocks](0 seconds, 1 minute) with Logging {
+class StocksData(wsClient: WSClient) extends AutoRefresh[Stocks](0 seconds, 1 minute) with GuLogging {
   override protected def refresh()(implicit executionContext: ExecutionContext): Future[Stocks] = {
     // Decommissioned, see marker: 7dde429f00b1
     try {

--- a/onward/app/business/massagedModels.scala
+++ b/onward/app/business/massagedModels.scala
@@ -1,6 +1,6 @@
 package business
 
-import common.Logging
+import common.GuLogging
 import play.api.libs.json.{Json, JsString, JsValue, Writes}
 
 import scala.util.Try
@@ -41,7 +41,7 @@ case class StockValue(
     closed: Boolean,
 )
 
-object Stocks extends Logging {
+object Stocks extends GuLogging {
   implicit val jsonWrites = Json.writes[Stocks]
 
   private val Commas = """,+""".r

--- a/onward/app/controllers/CardController.scala
+++ b/onward/app/controllers/CardController.scala
@@ -16,7 +16,7 @@ class CardController(
     wsClient: WSClient,
     val controllerComponents: ControllerComponents,
 ) extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   def opengraph(resource: String): Action[AnyContent] =

--- a/onward/app/controllers/MediaInSectionController.scala
+++ b/onward/app/controllers/MediaInSectionController.scala
@@ -19,7 +19,7 @@ class MediaInSectionController(
     val controllerComponents: ControllerComponents,
 )(implicit context: ApplicationContext)
     extends BaseController
-    with Logging
+    with GuLogging
     with Paging
     with ImplicitControllerExecutionContext
     with Requests {

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -36,7 +36,7 @@ class MostPopularController(
     val controllerComponents: ControllerComponents,
 )(implicit context: ApplicationContext)
     extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
   val page = SimplePage(
     MetaData.make(

--- a/onward/app/controllers/MostViewedAudioController.scala
+++ b/onward/app/controllers/MostViewedAudioController.scala
@@ -14,7 +14,7 @@ class MostViewedAudioController(
     val controllerComponents: ControllerComponents,
 )(implicit context: ApplicationContext)
     extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   def renderMostViewed(): Action[AnyContent] =

--- a/onward/app/controllers/MostViewedGalleryController.scala
+++ b/onward/app/controllers/MostViewedGalleryController.scala
@@ -14,7 +14,7 @@ class MostViewedGalleryController(
     val controllerComponents: ControllerComponents,
 )(implicit context: ApplicationContext)
     extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   private val page = SimplePage(

--- a/onward/app/controllers/MostViewedVideoController.scala
+++ b/onward/app/controllers/MostViewedVideoController.scala
@@ -11,7 +11,7 @@ class MostViewedVideoController(
     mostViewedVideoAgent: MostViewedVideoAgent,
     val controllerComponents: ControllerComponents,
 ) extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   // Move this out of here if the test is successful

--- a/onward/app/controllers/OnwardContentCardController.scala
+++ b/onward/app/controllers/OnwardContentCardController.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import com.gu.contentapi.client.model.v1.ItemResponse
-import common.{Edition, ImplicitControllerExecutionContext, JsonComponent, Logging}
+import common.{Edition, ImplicitControllerExecutionContext, JsonComponent, GuLogging}
 import contentapi.ContentApiClient
 import implicits.Requests
 import model.{ApplicationContext, Cached, NoCache}
@@ -16,7 +16,7 @@ abstract class OnwardContentCardController(
 )(implicit context: ApplicationContext)
     extends BaseController
     with Paging
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext
     with Requests {
 

--- a/onward/app/controllers/PopularInTag.scala
+++ b/onward/app/controllers/PopularInTag.scala
@@ -20,7 +20,7 @@ class PopularInTag(
     extends BaseController
     with Related
     with Containers
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   import implicits.Requests._

--- a/onward/app/controllers/RelatedController.scala
+++ b/onward/app/controllers/RelatedController.scala
@@ -23,7 +23,7 @@ class RelatedController(
     extends BaseController
     with Related
     with Containers
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   private val RelatedLabel: String = "Related stories"

--- a/onward/app/controllers/RichLinkController.scala
+++ b/onward/app/controllers/RichLinkController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import common.{Edition, ImplicitControllerExecutionContext, JsonComponent, Logging}
+import common.{Edition, ImplicitControllerExecutionContext, JsonComponent, GuLogging}
 import contentapi.ContentApiClient
 import implicits.Requests
 import model.{ApplicationContext, Cached, Content, ContentType}
@@ -15,7 +15,7 @@ class RichLinkController(contentApiClient: ContentApiClient, controllerComponent
     context: ApplicationContext,
 ) extends OnwardContentCardController(contentApiClient, controllerComponents)
     with Paging
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext
     with Requests {
   def render(path: String): Action[AnyContent] =

--- a/onward/app/controllers/SeriesController.scala
+++ b/onward/app/controllers/SeriesController.scala
@@ -23,7 +23,7 @@ class SeriesController(
     val controllerComponents: ControllerComponents,
 )(implicit context: ApplicationContext)
     extends BaseController
-    with Logging
+    with GuLogging
     with Paging
     with ImplicitControllerExecutionContext
     with Requests {

--- a/onward/app/controllers/StoryPackageController.scala
+++ b/onward/app/controllers/StoryPackageController.scala
@@ -17,7 +17,7 @@ class StoryPackageController(val contentApiClient: ContentApiClient, val control
     implicit context: ApplicationContext,
 ) extends BaseController
     with Containers
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   private[this] def getRelatedContent(path: String): Future[Seq[RelatedContentItem]] = {

--- a/onward/app/controllers/TaggedContentController.scala
+++ b/onward/app/controllers/TaggedContentController.scala
@@ -17,7 +17,7 @@ class TaggedContentController(
     val controllerComponents: ControllerComponents,
 ) extends BaseController
     with Related
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   def renderJson(tag: String): Action[AnyContent] =

--- a/onward/app/controllers/TopStoriesController.scala
+++ b/onward/app/controllers/TopStoriesController.scala
@@ -16,7 +16,7 @@ class TopStoriesController(
     val controllerComponents: ControllerComponents,
 )(implicit context: ApplicationContext)
     extends BaseController
-    with Logging
+    with GuLogging
     with Paging
     with ImplicitControllerExecutionContext {
 

--- a/onward/app/feed/DeeplyReadAgent.scala
+++ b/onward/app/feed/DeeplyReadAgent.scala
@@ -63,7 +63,7 @@ object DeeplyReadItem {
   }
 }
 
-class DeeplyReadAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) extends Logging {
+class DeeplyReadAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) extends GuLogging {
 
   /*
       This (DeeplyReadAgent) agent is similar in purpose and interface as the ones we already have at the

--- a/onward/app/feed/MostPopularAgent.scala
+++ b/onward/app/feed/MostPopularAgent.scala
@@ -31,7 +31,7 @@ object MostPopularRefresh {
   }
 }
 
-class MostPopularAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi, wsClient: WSClient) extends Logging {
+class MostPopularAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi, wsClient: WSClient) extends GuLogging {
 
   private val relatedContentsBox = Box[Map[String, Seq[RelatedContentItem]]](Map.empty)
 
@@ -118,7 +118,7 @@ class MostPopularAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi, w
   }
 }
 
-class GeoMostPopularAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) extends Logging {
+class GeoMostPopularAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) extends GuLogging {
 
   private val box = Box[Map[String, Seq[RelatedContentItem]]](Map.empty)
 
@@ -159,7 +159,7 @@ class GeoMostPopularAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi
   }
 }
 
-class DayMostPopularAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) extends Logging {
+class DayMostPopularAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) extends GuLogging {
 
   private val box = Box[Map[String, Seq[RelatedContentItem]]](Map.empty)
 

--- a/onward/app/feed/MostReadAgent.scala
+++ b/onward/app/feed/MostReadAgent.scala
@@ -6,7 +6,7 @@ import services.OphanApi
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class MostReadAgent(ophanApi: OphanApi) extends Logging {
+class MostReadAgent(ophanApi: OphanApi) extends GuLogging {
 
   private val agent = Box[Map[String, Int]](Map.empty)
 

--- a/onward/app/feed/MostViewed.scala
+++ b/onward/app/feed/MostViewed.scala
@@ -1,14 +1,14 @@
 package feed
 
 import com.gu.commercial.branding.BrandingFinder
-import common.{Edition, Logging}
+import common.{Edition, GuLogging}
 import contentapi.{ContentApiClient, QueryDefaults}
 import model.RelatedContentItem
 import services.OphanMostReadItem
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
-object MostViewed extends Logging {
+object MostViewed extends GuLogging {
 
   def relatedContentItems(ophanMostViewed: Future[Seq[OphanMostReadItem]], edition: Edition = Edition.defaultEdition)(
       contentApiClient: ContentApiClient,

--- a/onward/app/feed/MostViewedAudioAgent.scala
+++ b/onward/app/feed/MostViewedAudioAgent.scala
@@ -8,7 +8,7 @@ import model.RelatedContentItem
 import scala.concurrent.{ExecutionContext, Future}
 import services.OphanApi
 
-class MostViewedAudioAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) extends Logging {
+class MostViewedAudioAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) extends GuLogging {
 
   private val audioAgent = Box[Seq[RelatedContentItem]](Nil)
   private val podcastAgent = Box[Seq[RelatedContentItem]](Nil)

--- a/onward/app/feed/MostViewedGalleryAgent.scala
+++ b/onward/app/feed/MostViewedGalleryAgent.scala
@@ -8,7 +8,7 @@ import model.RelatedContentItem
 import scala.concurrent.{ExecutionContext, Future}
 import services.OphanApi
 
-class MostViewedGalleryAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) extends Logging {
+class MostViewedGalleryAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) extends GuLogging {
 
   private val agent = Box[Seq[RelatedContentItem]](Nil)
 

--- a/onward/app/feed/MostViewedVideoAgent.scala
+++ b/onward/app/feed/MostViewedVideoAgent.scala
@@ -11,7 +11,7 @@ import services.OphanApi
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class MostViewedVideoAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) extends Logging {
+class MostViewedVideoAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) extends GuLogging {
 
   case class QueryResult(id: String, count: Double, paths: Seq[String])
 

--- a/onward/app/services/breakingnews/BreakingNewsApi.scala
+++ b/onward/app/services/breakingnews/BreakingNewsApi.scala
@@ -1,6 +1,6 @@
 package services.breakingnews
 
-import common.{Logging}
+import common.{GuLogging}
 import conf.Configuration
 import play.api.libs.json._
 import play.api.{Environment, Mode}
@@ -14,7 +14,7 @@ class S3BreakingNews(environment: Environment) extends S3 {
   def getKeyForPath(path: String): String = s"$location/$path.json"
 }
 
-class BreakingNewsApi(s3: S3BreakingNews) extends Logging {
+class BreakingNewsApi(s3: S3BreakingNews) extends GuLogging {
 
   val breakingNewskey = s3.getKeyForPath("breaking-news")
 

--- a/onward/app/services/breakingnews/BreakingNewsUpdater.scala
+++ b/onward/app/services/breakingnews/BreakingNewsUpdater.scala
@@ -2,7 +2,7 @@ package services.breakingnews
 
 import akka.actor.Status.{Failure => ActorFailure}
 import akka.actor.{Actor, Props}
-import common.{Logging}
+import common.{GuLogging}
 import models.BreakingNewsFormats._
 import models.{BreakingNews, NewsAlertNotification}
 import play.api.libs.json.{JsValue, Json}
@@ -11,7 +11,7 @@ sealed trait BreakingNewsUpdaterMessage
 case class NewNotificationRequest(notification: NewsAlertNotification) extends BreakingNewsUpdaterMessage
 case object GetAlertsRequest extends BreakingNewsUpdaterMessage
 
-class BreakingNewsUpdater(breakingNewsApi: BreakingNewsApi) extends Actor with Logging {
+class BreakingNewsUpdater(breakingNewsApi: BreakingNewsApi) extends Actor with GuLogging {
 
   def getAlerts(): Unit = {
     val origin = sender

--- a/onward/app/weather/WeatherApi.scala
+++ b/onward/app/weather/WeatherApi.scala
@@ -4,7 +4,7 @@ import java.net.{URI, URLEncoder}
 import java.util.concurrent.TimeoutException
 
 import akka.actor.{ActorSystem, Scheduler}
-import common.{Logging, ResourcesHelper}
+import common.{GuLogging, ResourcesHelper}
 import conf.Configuration
 import play.api.libs.json.{JsValue, Json}
 import play.api.libs.ws.WSClient
@@ -24,7 +24,7 @@ import akka.pattern.after
 class WeatherApi(wsClient: WSClient, context: ApplicationContext, actorSystem: ActorSystem)(implicit
     ec: ExecutionContext,
 ) extends ResourcesHelper
-    with Logging {
+    with GuLogging {
 
   // NOTE: If you change the API Key, you must also update the weatherapi fastly configuration, as it is enforced there
   lazy val weatherApiKey: String = Configuration.weather.apiKey.getOrElse(
@@ -112,7 +112,7 @@ class WeatherApi(wsClient: WSClient, context: ApplicationContext, actorSystem: A
     })
 }
 
-object WeatherApi extends Logging {
+object WeatherApi extends GuLogging {
 
   def retryWeatherRequest(
       request: () => Future[JsValue],

--- a/onward/app/weather/controllers/LocationsController.scala
+++ b/onward/app/weather/controllers/LocationsController.scala
@@ -14,7 +14,7 @@ import scala.concurrent.Future
 class LocationsController(weatherApi: WeatherApi, val controllerComponents: ControllerComponents)
     extends BaseController
     with ImplicitControllerExecutionContext
-    with Logging {
+    with GuLogging {
 
   def findCity(query: String): Action[AnyContent] =
     Action.async { implicit request =>

--- a/sport/app/cricket/controllers/CricketMatchController.scala
+++ b/sport/app/cricket/controllers/CricketMatchController.scala
@@ -20,7 +20,7 @@ case class CricketMatchPage(theMatch: Match, matchId: String, team: CricketTeam)
 class CricketMatchController(cricketStatsJob: CricketStatsJob, val controllerComponents: ControllerComponents)(implicit
     context: ApplicationContext,
 ) extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   def renderMatchIdJson(date: String, teamId: String): Action[AnyContent] = renderMatchId(date, teamId)

--- a/sport/app/cricket/feed/cricketPaFeed.scala
+++ b/sport/app/cricket/feed/cricketPaFeed.scala
@@ -2,7 +2,7 @@ package conf.cricketPa
 
 import akka.actor.ActorSystem
 import akka.stream.Materializer
-import common.Logging
+import common.GuLogging
 import cricket.feed.CricketThrottler
 import org.joda.time.{DateTime, LocalDate}
 import org.joda.time.format.{DateTimeFormat, DateTimeFormatter}
@@ -17,7 +17,7 @@ object PaFeed {
   val dateFormat: DateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd")
 }
 
-class PaFeed(wsClient: WSClient, actorSystem: ActorSystem, materializer: Materializer) extends Logging {
+class PaFeed(wsClient: WSClient, actorSystem: ActorSystem, materializer: Materializer) extends GuLogging {
 
   private val paEndpoint = "https://cricket.api.press.net/v1"
   private val credentials = conf.SportConfiguration.pa.cricketKey.map { ("Apikey", _) }

--- a/sport/app/cricket/jobs/CricketStatsJob.scala
+++ b/sport/app/cricket/jobs/CricketStatsJob.scala
@@ -1,7 +1,7 @@
 package jobs
 
 import com.gu.Box
-import common.Logging
+import common.GuLogging
 import conf.cricketPa.{CricketFeedException, CricketTeam, CricketTeams, PaFeed}
 import cricketModel.Match
 import org.joda.time.{DateTimeZone, Days, LocalDate}
@@ -9,7 +9,7 @@ import org.joda.time.format.DateTimeFormat
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class CricketStatsJob(paFeed: PaFeed) extends Logging {
+class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
 
   private val cricketStatsAgents = CricketTeams.teams.map(Team => (Team, Box[Map[String, Match]](Map.empty)))
 

--- a/sport/app/football/conf/context.scala
+++ b/sport/app/football/conf/context.scala
@@ -80,7 +80,7 @@ class FootballLifecycle(
 class FootballClient(wsClient: WSClient)(implicit executionContext: ExecutionContext)
     extends PaClient
     with Http
-    with Logging {
+    with GuLogging {
 
   // Runs the API calls via a CDN
   override lazy val base: String = "https://football-api.guardianapis.com/v1.5"

--- a/sport/app/football/controllers/CompetitionListController.scala
+++ b/sport/app/football/controllers/CompetitionListController.scala
@@ -12,7 +12,7 @@ class CompetitionListController(
 )(implicit context: ApplicationContext)
     extends BaseController
     with CompetitionListFilters
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   val page = new FootballPage("football/competitions", "football", "Leagues & competitions")

--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -21,7 +21,7 @@ class LeagueTableController(
     val controllerComponents: ControllerComponents,
 )(implicit context: ApplicationContext)
     extends BaseController
-    with Logging
+    with GuLogging
     with CompetitionTableFilters
     with ImplicitControllerExecutionContext {
 

--- a/sport/app/football/controllers/MatchController.scala
+++ b/sport/app/football/controllers/MatchController.scala
@@ -141,7 +141,7 @@ class MatchController(
     extends BaseController
     with Football
     with Requests
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   private val dateFormat = DateTimeFormat.forPattern("yyyyMMMdd")

--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -203,7 +203,7 @@ class MoreOnMatchController(
 ) extends BaseController
     with Football
     with Requests
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext
     with implicits.Dates {
   def interval(contentDate: LocalDate): Imports.Interval =

--- a/sport/app/football/controllers/WallchartController.scala
+++ b/sport/app/football/controllers/WallchartController.scala
@@ -3,7 +3,7 @@ package football.controllers
 import feed.CompetitionsService
 import model.Cached.RevalidatableResult
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
-import common.{ImplicitControllerExecutionContext, JsonComponent, Logging}
+import common.{ImplicitControllerExecutionContext, JsonComponent, GuLogging}
 import model.{ApplicationContext, Cached}
 import football.model.{CompetitionStage, KnockoutSpider}
 import org.joda.time.DateTime
@@ -14,7 +14,7 @@ class WallchartController(
     val controllerComponents: ControllerComponents,
 )(implicit context: ApplicationContext)
     extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   def renderWallchartEmbed(competitionTag: String): Action[AnyContent] = renderWallchart(competitionTag, true)

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -299,7 +299,7 @@ class CompetitionsService(val footballClient: FootballClient, competitionDefinit
     extends Competitions
     with LiveMatches
     with Lineups
-    with Logging
+    with GuLogging
     with implicits.Collections
     with implicits.Football {
 

--- a/sport/app/football/feed/agent.scala
+++ b/sport/app/football/feed/agent.scala
@@ -9,7 +9,7 @@ import model.{Competition, TeamNameBuilder}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait Lineups extends Logging {
+trait Lineups extends GuLogging {
   def footballClient: FootballClient
   def teamNameBuilder: TeamNameBuilder
   def getLineup(theMatch: FootballMatch)(implicit executionContext: ExecutionContext): Future[LineUp] =
@@ -23,7 +23,7 @@ trait Lineups extends Logging {
       .recover(footballClient.logErrorsWithMessage(s"Failed getting line-up for match ${theMatch.id}"))
 }
 
-trait LiveMatches extends Logging {
+trait LiveMatches extends GuLogging {
 
   def footballClient: FootballClient
   def teamNameBuilder: TeamNameBuilder
@@ -46,7 +46,7 @@ trait LiveMatches extends Logging {
       .recover(footballClient.logErrorsWithMessage(s"Failed getting live matches"))
 }
 
-trait LeagueTables extends Logging {
+trait LeagueTables extends GuLogging {
 
   def footballClient: FootballClient
   def teamNameBuilder: TeamNameBuilder
@@ -67,7 +67,7 @@ trait LeagueTables extends Logging {
   }
 }
 
-trait Fixtures extends Logging {
+trait Fixtures extends GuLogging {
 
   def footballClient: FootballClient
   def teamNameBuilder: TeamNameBuilder
@@ -87,7 +87,7 @@ trait Fixtures extends Logging {
   }
 }
 
-trait Results extends Logging with implicits.Collections {
+trait Results extends GuLogging with implicits.Collections {
 
   def footballClient: FootballClient
   def teamNameBuilder: TeamNameBuilder

--- a/sport/app/football/model/TeamMap.scala
+++ b/sport/app/football/model/TeamMap.scala
@@ -16,7 +16,7 @@ case class Team(team: FootballTeam, tag: Option[Tag], shortName: Option[String])
   override lazy val id = team.id
 }
 
-object TeamMap extends Logging {
+object TeamMap extends GuLogging {
 
   val teamAgent = Box(Map.empty[String, Tag])
 

--- a/sport/app/football/views/support.scala
+++ b/sport/app/football/views/support.scala
@@ -1,7 +1,7 @@
 package views
 
 import pa.{LineUpPlayer, Team}
-import common.Logging
+import common.GuLogging
 import play.twirl.api.Html
 
 object ShortName {
@@ -12,7 +12,7 @@ object ShortName {
 
 }
 
-object MatchStatus extends Logging {
+object MatchStatus extends GuLogging {
 
   // This is the list of possible statuses from the docs
   // http://pads6.pa-sport.com/API/Football/Documents/Football%20API%20Programmers%20Usage%20Guide%20V1.5.pdf

--- a/sport/app/rugby/controllers/MatchesController.scala
+++ b/sport/app/rugby/controllers/MatchesController.scala
@@ -22,7 +22,7 @@ class MatchesController(
     val controllerComponents: ControllerComponents,
 )(implicit context: ApplicationContext)
     extends BaseController
-    with Logging
+    with GuLogging
     with ImplicitControllerExecutionContext {
 
   def scoreJson(year: String, month: String, day: String, homeTeamId: String, awayTeamId: String): Action[AnyContent] =

--- a/sport/app/rugby/feed/CapiFeed.scala
+++ b/sport/app/rugby/feed/CapiFeed.scala
@@ -1,6 +1,6 @@
 package rugby.feed
 
-import common.{Edition, Logging}
+import common.{Edition, GuLogging}
 import contentapi.ContentApiClient
 import model.{Content, ContentType}
 import org.joda.time.DateTimeZone
@@ -13,7 +13,7 @@ case class MatchNavigation(
     minByMin: ContentType,
 )
 
-class CapiFeed(contentApiClient: ContentApiClient) extends Logging {
+class CapiFeed(contentApiClient: ContentApiClient) extends GuLogging {
 
   def getMatchArticles(
       matches: Seq[Match],

--- a/sport/app/rugby/feed/PAFeed.scala
+++ b/sport/app/rugby/feed/PAFeed.scala
@@ -1,6 +1,6 @@
 package rugby.feed
 
-import common.Logging
+import common.GuLogging
 import play.api.libs.json.{JsBoolean, Json}
 import play.api.libs.ws.WSClient
 import rugby.model._
@@ -53,7 +53,7 @@ object WorldCupPAIDs {
   val worldCupGroupIDs = worldCup2019GroupIDs
 }
 
-class PARugbyFeed(rugbyClient: RugbyClient) extends RugbyFeed with Logging {
+class PARugbyFeed(rugbyClient: RugbyClient) extends RugbyFeed with GuLogging {
 
   import WorldCupPAIDs._
 
@@ -66,7 +66,7 @@ class PARugbyFeed(rugbyClient: RugbyClient) extends RugbyFeed with Logging {
   }
 }
 
-class PARugbyClient(wsClient: WSClient) extends RugbyClient with Logging {
+class PARugbyClient(wsClient: WSClient) extends RugbyClient with GuLogging {
 
   val apiKey = conf.SportConfiguration.pa.rugbyKey.getOrElse("")
   val basePath = conf.SportConfiguration.pa.rugbyEndpoint.getOrElse("")

--- a/sport/app/rugby/jobs/RugbyStatsJob.scala
+++ b/sport/app/rugby/jobs/RugbyStatsJob.scala
@@ -1,7 +1,7 @@
 package rugby.jobs
 
 import com.gu.Box
-import common.Logging
+import common.GuLogging
 import org.joda.time.format.{DateTimeFormat, DateTimeFormatter}
 import rugby.feed.{Event, MatchNavigation, PARugbyAPIException, RugbyFeed}
 import rugby.model._
@@ -9,7 +9,7 @@ import rugby.model._
 import scala.collection.immutable
 import scala.concurrent.{ExecutionContext, Future}
 
-class RugbyStatsJob(feed: RugbyFeed) extends Logging {
+class RugbyStatsJob(feed: RugbyFeed) extends GuLogging {
   protected val fixturesAndResultsMatches = Box[Map[String, Match]](Map.empty)
   protected val matchNavContent = Box[Map[String, MatchNavigation]](Map.empty)
   protected val pastScoreEvents = Box[Map[String, Seq[ScoreEvent]]](Map.empty)

--- a/sport/app/rugby/model/paRugby.scala
+++ b/sport/app/rugby/model/paRugby.scala
@@ -1,6 +1,6 @@
 package rugby.feed
 
-import common.Logging
+import common.GuLogging
 import org.joda.time.DateTime
 import play.api.libs.json.{JsError, JsResult, JsSuccess, Json}
 import rugby.model.Stage.Stage
@@ -123,7 +123,7 @@ case class PAMatchesResponse(
     items: List[PAMatch],
 )
 
-object PAMatchesResponse extends Logging {
+object PAMatchesResponse extends GuLogging {
 
   def fromJSON(json: String): Try[PAMatchesResponse] = {
     val jsvalue = Json.parse(json)


### PR DESCRIPTION
## What does this change?

Play 2.7 introduces a `Logging` trait which conflicts with our `common.Logging`. One way to address this problem (the one chosen here) is to rename `common.Logging` into `common.GuLogging`. 

Then in `common.GuLogging` (and everywhere else `play.api.Logger` is used) we can no longer use `Logger.[name]` but instead must use `Logger.logger.[name]`.

Note that this change simply upgrades the existing code to compile with both Play 2.6 and Play 2.7, but once we upgrade to Play 2.7, we should probably then use `play.api.Logging` which was introduced in Play 2.7.