### PR TITLE
Refactor Deeply Read Cache

### DIFF
--- a/onward/app/feed/DeeplyReadAgent.scala
+++ b/onward/app/feed/DeeplyReadAgent.scala
@@ -82,7 +82,7 @@ class DeeplyReadAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) ex
     if (path.startsWith("/")) path.stripPrefix("/") else path
   }
 
-  def refresh()(implicit ec: ExecutionContext): Future[Unit] = {
+  def refresh()(implicit ec: ExecutionContext): Future[Seq[Option[(OphanDeeplyReadItem, Content)]]] = {
     log.info(s"[cb01a845] Deeply Read Agent refresh()")
     /*
         Here we simply go through the OphanDeeplyReadItem we got from Ophan and for each
@@ -119,17 +119,14 @@ class DeeplyReadAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) ex
       }
       Future.sequence(deeplyReadSeq)
 
-    // We now perform the atomic update of ophanItems to faithfully reflects the state of the Ophan answer.
+    // We now perform the atomic update of deeplyReadItems to faithfully reflects the state of the Ophan answer.
     // It is done as last step of the process because by then the CAPI content has been loaded.
-    // This prevents a race condition by which new ophan items are already in `ophanItems`, but the corresponding
-    // CAPI content are not yet in `pathToCapiContentMapping`, resulting in less items appearing in `getReport()` than expected.
-    // deeplyReadFuture.map: {
-    // ophanItems = seq.toArray
-    // pathToCapiContentMapping = deeplyReadContents}
     }
     deeplyReadFuture.foreach { sequence =>
-      sequence.flatten.foreach {}
+      val mapDeeplyReadItems = sequence.filter(_.isDefined).map(_.get).toMap
+      deeplyReadItems = collection.mutable.Map(mapDeeplyReadItems.toSeq: _*)
     }
+    deeplyReadFuture
   }
 
   def correctPillar(pillar: String): String = if (pillar == "arts") "culture" else pillar

--- a/onward/conf/routes
+++ b/onward/conf/routes
@@ -36,8 +36,7 @@ GET        /deeply-read.json                          controllers.MostPopularCon
 # Experimental (December 2020)
 # This route is for the experimental deeply-read tab of the most read container
 # Because it's only a test, it doesn't have a dev-build equivalent
-GET        /most-read-deeply-read.json                controllers.MostPopularController.renderWithDeeplyRead(path = "")
-GET        /most-read-deeply-read/*path.json          controllers.MostPopularController.renderWithDeeplyRead(path)
+GET        /most-read-deeply-read.json                controllers.MostPopularController.renderWithDeeplyRead()
 
 GET        /top-stories.json                          controllers.TopStoriesController.renderTopStories()
 GET        /top-stories/trails.json                   controllers.TopStoriesController.renderTrails()


### PR DESCRIPTION
## What does this change?

This refactors the frontend nextgen api which delivers the Deeply Read data for the next engagement test.

Before:

![Screenshot 2021-01-07 at 16 36 05](https://user-images.githubusercontent.com/35331926/104031577-cb3acb80-51c4-11eb-84e3-1913bc3ba443.png)

After:
![Screenshot 2021-01-11 at 10 51 48](https://user-images.githubusercontent.com/35331926/104180453-09263280-5405-11eb-9784-2236abfc0448.png)

