### PR TITLE
make frontend static dir installable from github

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "frontend",
+  "name": "@guardian/frontend",
   "version": "0.1.0",
   "private": true,
   "engines": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "engines": {
     "yarn": ">=1.13.0"
   },
+  "files": ["static/src/**/*"],
   "dependencies": {
-    "@babel/runtime": "^7.11.2",
     "@braze/web-sdk-core": "3.1.0",
     "@emotion/core": "^10.0.27",
     "@emotion/styled": "^10.0.27",
@@ -25,7 +25,6 @@
     "bonzo": "~2.0.0",
     "bootstrap-sass": "^3.4.1",
     "classnames": "~2.2.0",
-    "core-js": "^2.5.3",
     "curl": "cujojs/curl#0.8.9",
     "domready": "^1.0.8",
     "dynamic-import-polyfill": "^0.1.1",
@@ -46,7 +45,6 @@
     "react": "^16.8.3",
     "react-dom": "16.7.0",
     "reqwest": "2.0.5",
-    "tcp-ping": "^0.1.1",
     "video.js": "~5.3",
     "videojs-contrib-ads": "3.1.3",
     "videojs-embed": "guardian/videojs-embed#v0.3.3",
@@ -54,7 +52,6 @@
     "videojs-persistvolume": "guardian/videojs-persistvolume#0.1.4",
     "videojs-playlist": "guardian/videojs-playlist#0.1.4",
     "web-vitals": "^0.2.4",
-    "webshot": "^0.18.0",
     "wolfy87-eventemitter": "~5.2.4"
   },
   "devDependencies": {
@@ -67,6 +64,7 @@
     "@babel/preset-env": "^7.11.5",
     "@babel/preset-react": "^7.10.4",
     "@babel/register": "^7.11.5",
+    "@babel/runtime": "^7.11.2",
     "amphtml-validator": "^1.0.21",
     "any-observable": "^0.2.0",
     "autoprefixer": "^9.1.5",
@@ -83,6 +81,7 @@
     "chance": "^1.0.11",
     "chokidar": "^1.7.0",
     "circular-dependency-plugin": "^5.0.1",
+    "core-js": "^2.5.3",
     "cp-file": "^7.0.0",
     "cpy": "^7.3.0",
     "cssstats": "^3.1.0",
@@ -132,12 +131,14 @@
     "split": "^1.0.0",
     "stream-to-observable": "^0.2.0",
     "svgo": "^0.7.2",
+    "tcp-ping": "^0.1.1",
     "uglify-js": "^2.7.4",
     "uglifyjs-webpack-plugin": "^1.2.5",
     "webpack": "^4.44.2",
     "webpack-bundle-analyzer": "^3.3.2",
     "webpack-merge": "^4.1.0",
     "webpack-visualizer-plugin": "^0.1.11",
+    "webshot": "^0.18.0",
     "yargs": "^11.0.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
## What does this change?

makes it possible to install frontend static files in another repo, for help with the commercial-core migration

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
