### PR TITLE
Multiple template updates (Prelude to Play 2.7)

### DIFF
--- a/article/app/views/liveblog/dateBlock.scala.html
+++ b/article/app/views/liveblog/dateBlock.scala.html
@@ -2,8 +2,8 @@
 
 @(date: Option[LiveBlogDate])
 
-@date.map { dat =>
-    <time datetime="@dat.fullDate" data-relativeformat="med" class=" js-timestamp" itemprop="datePublished">@dat.ampm <span class="timezone">@dat.gmt</span></time>
-    <span class="block-time__absolute">@dat.hhmm</span>
+@date.map { date =>
+    <time datetime="@date.fullDate" data-relativeformat="med" class=" js-timestamp" itemprop="datePublished">@date.ampm <span class="timezone">@date.gmt</span></time>
+    <span class="block-time__absolute">@date.hhmm</span>
 }
 

--- a/article/app/views/liveblog/dateBlock.scala.html
+++ b/article/app/views/liveblog/dateBlock.scala.html
@@ -2,8 +2,8 @@
 
 @(date: Option[LiveBlogDate])
 
-@date.map { case LiveBlogDate(referenceDate, hhmm, ampm, gmt) =>
-    <time datetime="@referenceDate" data-relativeformat="med" class=" js-timestamp" itemprop="datePublished">@ampm <span class="timezone">@gmt</span></time>
-    <span class="block-time__absolute">@hhmm</span>
+@date.map { dat =>
+    <time datetime="@dat.fullDate" data-relativeformat="med" class=" js-timestamp" itemprop="datePublished">@dat.ampm <span class="timezone">@dat.gmt</span></time>
+    <span class="block-time__absolute">@dat.hhmm</span>
 }
 

--- a/article/app/views/liveblog/liveBlogBlocks.scala.html
+++ b/article/app/views/liveblog/liveBlogBlocks.scala.html
@@ -51,9 +51,9 @@
         <div class="block-elements@if(block.contributors.isEmpty){ block-elements--no-byline}" itemprop="articleBody">
         @BodyProcessor(article, block.bodyHtml)
         </div>
-        @block.republishedDate(timezone).map { case LiveBlogDate(republishedDate, _, ampm, gmt) =>
+        @block.republishedDate(timezone).map { date =>
         <p class="block-time updated-time">Updated
-            <time datetime="@republishedDate">at @ampm @gmt</time>
+            <time datetime="@date.fullDate">at @date.ampm @date.gmt</time>
         </p>
         }
         @views.html.fragments.share.blockLevelSharing(

--- a/onward/app/views/fragments/rightMostPopularGeoGarnett.scala.html
+++ b/onward/app/views/fragments/rightMostPopularGeoGarnett.scala.html
@@ -8,39 +8,43 @@
 @import views.html.fragments
 @import model.pressed._
 
+@template1(trail: PressedContent, row: RowInfo) = {
+    <li class="right-most-popular-item" data-link-name="trail | @row.rowNum">
+        <a class="right-most-popular-item__url media u-cf" href="@LinkTo{@trail.header.url}">
+            @trail.trailPicture.map{ imageMedia =>
+                <div class="right-most-popular-item__img media__img">
+                    <img class="responsiveimg" src="@ImgSrc.getFallbackUrl(imageMedia)" alt="" />
+                </div>
+            }
+            <div class="media__body right-most-popular__content">
+                <h4 class="right-most-popular-item__headline">
+                    @if(trail.properties.isLiveBlog) {
+                        <span class="right-most-popular__kicker">Live</span>
+                    }
+                    @trail.header.headline
+                </h4>
+                @if(trail.properties.showByline) {
+                    <span class="
+                                    right-most-popular__byline
+                                    right-most-popular__byline--opinion
+                                ">@trail.properties.byline</span>
+                }
+                @trail.properties.maybeContent.map { content =>
+                    @if(content.tags.tags.exists(_.id == "tone/news") || content.tags.tags.exists(_.id == "tone/comment")) {
+                        @fragments.contentAgeNotice(ContentOldAgeDescriber(content))
+                    }
+                }
+            </div>
+        </a>
+    </li>
+}
+
 @if(popular.trails.nonEmpty) {
     <div class="js-right-most-popular right-most-popular right-most-popular--image component--rhc hide-on-childrens-books-site" data-component="geo-most-popular" data-importance="-1" data-test-id="right-most-popular">
         <h3 class="content__meta-heading right-most-popular__heading">most viewed @{country.map{ name => s"in $name"}}</h3>
         <ul class="right-most-popular__items u-unstyled" data-link-name="Right hand most popular geo @countryCode">
-            @popular.trails.take(5).zipWithRowInfo.map{ case((trail: PressedContent), row) =>
-                <li class="right-most-popular-item" data-link-name="trail | @row.rowNum">
-                    <a class="right-most-popular-item__url media u-cf" href="@LinkTo{@trail.header.url}">
-                         @trail.trailPicture.map{ imageMedia =>
-                            <div class="right-most-popular-item__img media__img">
-                                <img class="responsiveimg" src="@ImgSrc.getFallbackUrl(imageMedia)" alt="" />
-                            </div>
-                         }
-                        <div class="media__body right-most-popular__content">
-                            <h4 class="right-most-popular-item__headline">
-                                @if(trail.properties.isLiveBlog) {
-                                    <span class="right-most-popular__kicker">Live</span>
-                                }
-                                @trail.header.headline
-                            </h4>
-                            @if(trail.properties.showByline) {
-                                <span class="
-                                    right-most-popular__byline
-                                    right-most-popular__byline--opinion
-                                ">@trail.properties.byline</span>
-                            }
-                            @trail.properties.maybeContent.map { content =>
-                                @if(content.tags.tags.exists(_.id == "tone/news") || content.tags.tags.exists(_.id == "tone/comment")) {
-                                    @fragments.contentAgeNotice(ContentOldAgeDescriber(content))
-                                }
-                            }
-                        </div>
-                    </a>
-                </li>
+            @popular.trails.take(5).zipWithRowInfo.map{ data =>
+                @template1(data._1, data._2)
             }
         </ul>
     </div>

--- a/onward/app/views/fragments/rightMostPopularGeoGarnett.scala.html
+++ b/onward/app/views/fragments/rightMostPopularGeoGarnett.scala.html
@@ -43,8 +43,8 @@
     <div class="js-right-most-popular right-most-popular right-most-popular--image component--rhc hide-on-childrens-books-site" data-component="geo-most-popular" data-importance="-1" data-test-id="right-most-popular">
         <h3 class="content__meta-heading right-most-popular__heading">most viewed @{country.map{ name => s"in $name"}}</h3>
         <ul class="right-most-popular__items u-unstyled" data-link-name="Right hand most popular geo @countryCode">
-            @popular.trails.take(5).zipWithRowInfo.map{ data =>
-                @mostPopularItem(data._1, data._2)
+            @popular.trails.take(5).zipWithRowInfo.map{ case(trail, row) =>
+                @mostPopularItem(trail, row)
             }
         </ul>
     </div>

--- a/onward/app/views/fragments/rightMostPopularGeoGarnett.scala.html
+++ b/onward/app/views/fragments/rightMostPopularGeoGarnett.scala.html
@@ -8,7 +8,7 @@
 @import views.html.fragments
 @import model.pressed._
 
-@template1(trail: PressedContent, row: RowInfo) = {
+@mostPopularItem(trail: PressedContent, row: RowInfo) = {
     <li class="right-most-popular-item" data-link-name="trail | @row.rowNum">
         <a class="right-most-popular-item__url media u-cf" href="@LinkTo{@trail.header.url}">
             @trail.trailPicture.map{ imageMedia =>
@@ -44,7 +44,7 @@
         <h3 class="content__meta-heading right-most-popular__heading">most viewed @{country.map{ name => s"in $name"}}</h3>
         <ul class="right-most-popular__items u-unstyled" data-link-name="Right hand most popular geo @countryCode">
             @popular.trails.take(5).zipWithRowInfo.map{ data =>
-                @template1(data._1, data._2)
+                @mostPopularItem(data._1, data._2)
             }
         </ul>
     </div>

--- a/sport/app/football/model/CompetitionStages.scala
+++ b/sport/app/football/model/CompetitionStages.scala
@@ -1,7 +1,6 @@
 package football.model
 
 import org.joda.time.{DateTime, DateTimeZone, Interval}
-import feed.Competitions
 import model.Competition
 import pa._
 import implicits.Football._

--- a/sport/app/football/views/matchList/matchesComponent.scala.html
+++ b/sport/app/football/views/matchList/matchesComponent.scala.html
@@ -25,7 +25,7 @@
 
 <div data-component="football-matches-embed" class="c-football-matches football-embed">
     @football.views.html.fragments.componentStyles()
-    @matchesList.matchesGroupedByDateAndCompetition.zipWithRowInfo.map { data =>
-        @footballMatchDay(data._1._1, data._1._2, data._2)
+    @matchesList.matchesGroupedByDateAndCompetition.zipWithRowInfo.map { case (matches, row) =>
+        @footballMatchDay(matches._1, matches._2, row)
     }
 </div>

--- a/sport/app/football/views/matchList/matchesComponent.scala.html
+++ b/sport/app/football/views/matchList/matchesComponent.scala.html
@@ -1,25 +1,31 @@
+@import org.joda.time.LocalDate
 @import football.model.MatchesList
+@import model.Competition
+@import pa.FootballMatch
 @import views.support.`package`.Seq2zipWithRowInfo
+@import views.support.RowInfo
 
 @(matchesList: MatchesList, customLink: Option[(String, String)] = None)(implicit request: RequestHeader, context: model.ApplicationContext)
 
-<div data-component="football-matches-embed" class="c-football-matches football-embed">
-
-    @football.views.html.fragments.componentStyles()
-
-    @matchesList.matchesGroupedByDateAndCompetition.zipWithRowInfo.map { case ((date, competitionMatches), dateRow) =>
+@template1(date: LocalDate, competitionMatches: List[(Competition, List[FootballMatch])], dateRow: RowInfo) = {
     <div class="football-matches__day">
-        @{competitionMatches.zipWithRowInfo.map { case ((competition, matches), matchRow) =>
-            football.views.html.matchList.matchesList(
-                matches,
-                competition,
-                date,
-                matchType = matchesList.pageType,
-                heading = if(dateRow.isFirst) Some((competition.fullName, Option(competition.url))) else None,
-                link = customLink orElse (if(dateRow.isLast && matchRow.isLast)
-                    Some(("View all "+matchesList.pageType, "/football/"+matchesList.pageType)) else None)
-            )
-        }}
+    @{competitionMatches.zipWithRowInfo.map { case ((competition, matches), matchRow) =>
+        football.views.html.matchList.matchesList(
+            matches,
+            competition,
+            date,
+            matchType = matchesList.pageType,
+            heading = if(dateRow.isFirst) Some((competition.fullName, Option(competition.url))) else None,
+            link = customLink orElse (if(dateRow.isLast && matchRow.isLast)
+                Some(("View all "+matchesList.pageType, "/football/"+matchesList.pageType)) else None)
+        )
+    }}
     </div>
+}
+
+<div data-component="football-matches-embed" class="c-football-matches football-embed">
+    @football.views.html.fragments.componentStyles()
+    @matchesList.matchesGroupedByDateAndCompetition.zipWithRowInfo.map { data =>
+        @template1(data._1._1, data._1._2, data._2)
     }
 </div>

--- a/sport/app/football/views/matchList/matchesComponent.scala.html
+++ b/sport/app/football/views/matchList/matchesComponent.scala.html
@@ -8,18 +8,18 @@
     @football.views.html.fragments.componentStyles()
 
     @matchesList.matchesGroupedByDateAndCompetition.zipWithRowInfo.map { case ((date, competitionMatches), dateRow) =>
-        <div class="football-matches__day">
-            @competitionMatches.zipWithRowInfo.map { case ((competition, matches), matchRow) =>
-                @football.views.html.matchList.matchesList(
-                    matches,
-                    competition,
-                    date,
-                    matchType = matchesList.pageType,
-                    heading = if(dateRow.isFirst) Some((competition.fullName, Option(competition.url))) else None,
-                    link = customLink orElse (if(dateRow.isLast && matchRow.isLast)
-                            Some(("View all "+matchesList.pageType, "/football/"+matchesList.pageType)) else None)
-                )
-            }
-        </div>
+    <div class="football-matches__day">
+        @{competitionMatches.zipWithRowInfo.map { case ((competition, matches), matchRow) =>
+            football.views.html.matchList.matchesList(
+                matches,
+                competition,
+                date,
+                matchType = matchesList.pageType,
+                heading = if(dateRow.isFirst) Some((competition.fullName, Option(competition.url))) else None,
+                link = customLink orElse (if(dateRow.isLast && matchRow.isLast)
+                    Some(("View all "+matchesList.pageType, "/football/"+matchesList.pageType)) else None)
+            )
+        }}
+    </div>
     }
 </div>

--- a/sport/app/football/views/matchList/matchesComponent.scala.html
+++ b/sport/app/football/views/matchList/matchesComponent.scala.html
@@ -7,7 +7,7 @@
 
 @(matchesList: MatchesList, customLink: Option[(String, String)] = None)(implicit request: RequestHeader, context: model.ApplicationContext)
 
-@template1(date: LocalDate, competitionMatches: List[(Competition, List[FootballMatch])], dateRow: RowInfo) = {
+@footballMatchDay(date: LocalDate, competitionMatches: List[(Competition, List[FootballMatch])], dateRow: RowInfo) = {
     <div class="football-matches__day">
     @{competitionMatches.zipWithRowInfo.map { case ((competition, matches), matchRow) =>
         football.views.html.matchList.matchesList(
@@ -26,6 +26,6 @@
 <div data-component="football-matches-embed" class="c-football-matches football-embed">
     @football.views.html.fragments.componentStyles()
     @matchesList.matchesGroupedByDateAndCompetition.zipWithRowInfo.map { data =>
-        @template1(data._1._1, data._1._2, data._2)
+        @footballMatchDay(data._1._1, data._1._2, data._2)
     }
 </div>

--- a/sport/app/football/views/matchList/moreMatchesComponent.scala.html
+++ b/sport/app/football/views/matchList/moreMatchesComponent.scala.html
@@ -1,3 +1,4 @@
+
 @(matchesList: football.model.MatchesList)(implicit request: RequestHeader)
 
 <div data-component="football-matches-embed" class="football-matches">

--- a/sport/app/football/views/wallchart/groups.scala.html
+++ b/sport/app/football/views/wallchart/groups.scala.html
@@ -1,36 +1,40 @@
 @import implicits.Football._
+@import pa._
 @import views.support.`package`.Seq2zipWithRowInfo
+@import views.support.RowInfo
 
 @(competition: model.Competition, groupStage: _root_.football.model.Groups)(implicit request: RequestHeader)
 
-<ul class="football-groups u-unstyled u-cf">
-    @groupStage.groupTables.zipWithRowInfo.map{ case ((round, leagueTableEntries), row) =>
-        @defining(groupStage.matchesList(competition, round)) { matches =>
-            <li class="football-group">
-                <div class="football-group__container table--hide-from-importance-3">
-                    @round.name.map{ name =>
-                        <div class="football-group__table">
-                            @football.views.html.tablesList.tableView(competition, model.Group(round, leagueTableEntries),
-                                heading = round.name,
-                                headingLink = groupTag(competition.id, round),
-                                striped = true,
-                                withCrests = true
+@template1(round: Round, leagueTableEntries: Seq[LeagueTableEntry], row: RowInfo) = {
+    @defining(groupStage.matchesList(competition, round)) { matches =>
+        <li class="football-group">
+            <div class="football-group__container table--hide-from-importance-3">
+                @round.name.map{ name =>
+                    <div class="football-group__table">
+                        @football.views.html.tablesList.tableView(competition, model.Group(round, leagueTableEntries),
+                            heading = round.name,
+                            headingLink = groupTag(competition.id, round),
+                            striped = true,
+                            withCrests = true
+                        )
+                    </div>
+                    <div class="football-group__matches">
+                    @{matches.matchesGroupedByDateAndCompetition.zipWithRowInfo.map { case ((date, competitionMatches), info) =>
+                        competitionMatches.map { case (competition, matches) =>
+                            football.views.html.matchList.matchesList(matches, competition, date,
+                                linkToCompetition = false,
+                                heading = if(info.isFirst) Option(("Fixtures and results", None)) else None
                             )
-                        </div>
-
-                        <div class="football-group__matches">
-                            @matches.matchesGroupedByDateAndCompetition.zipWithRowInfo.map { case ((date, competitionMatches), info) =>
-                                @competitionMatches.map { case (competition, matches) =>
-                                    @football.views.html.matchList.matchesList(matches, competition, date,
-                                        linkToCompetition = false,
-                                        heading = if(info.isFirst) Option(("Fixtures and results", None)) else None
-                                    )
-                                }
-                            }
-                        </div>
-                    }
-                </div>
-            </li>
-        }
+                        }
+                    }}
+                    </div>
+                }
+            </div>
+        </li>
+    }
+}
+<ul class="football-groups u-unstyled u-cf">
+    @groupStage.groupTables.zipWithRowInfo.map{ data =>
+        @template1(data._1._1, data._1._2, data._2)
     }
 </ul>

--- a/sport/app/football/views/wallchart/groups.scala.html
+++ b/sport/app/football/views/wallchart/groups.scala.html
@@ -5,7 +5,7 @@
 
 @(competition: model.Competition, groupStage: _root_.football.model.Groups)(implicit request: RequestHeader)
 
-@template1(round: Round, leagueTableEntries: Seq[LeagueTableEntry], row: RowInfo) = {
+@footballGroup(round: Round, leagueTableEntries: Seq[LeagueTableEntry], row: RowInfo) = {
     @defining(groupStage.matchesList(competition, round)) { matches =>
         <li class="football-group">
             <div class="football-group__container table--hide-from-importance-3">
@@ -35,6 +35,6 @@
 }
 <ul class="football-groups u-unstyled u-cf">
     @groupStage.groupTables.zipWithRowInfo.map{ data =>
-        @template1(data._1._1, data._1._2, data._2)
+        @footballGroup(data._1._1, data._1._2, data._2)
     }
 </ul>

--- a/sport/app/football/views/wallchart/groups.scala.html
+++ b/sport/app/football/views/wallchart/groups.scala.html
@@ -34,9 +34,7 @@
     }
 }
 <ul class="football-groups u-unstyled u-cf">
-    @groupStage.groupTables.zipWithRowInfo.map{ data =>
-        @defining(data._1, data._2) { case(groupTable, row) =>
-            @footballGroup(groupTable._1, groupTable._2, row)
-        }
+    @groupStage.groupTables.zipWithRowInfo.map{ case (groupTable, row) =>
+        @footballGroup(groupTable._1, groupTable._2, row)
     }
 </ul>

--- a/sport/app/football/views/wallchart/groups.scala.html
+++ b/sport/app/football/views/wallchart/groups.scala.html
@@ -35,6 +35,8 @@
 }
 <ul class="football-groups u-unstyled u-cf">
     @groupStage.groupTables.zipWithRowInfo.map{ data =>
-        @footballGroup(data._1._1, data._1._2, data._2)
+        @defining(data._1, data._2) { case(groupTable, row) =>
+            @footballGroup(groupTable._1, groupTable._2, row)
+        }
     }
 </ul>


### PR DESCRIPTION
## What does this change?

Context: this continues the work we started in ( https://github.com/guardian/frontend/pull/23448 ), of upgrading Play HTML templates for the 2.7 upgrade. 

Play 2.7 has stricter rules regarding the scope of variables in templates and we can no longer expect that variables bound during destructuration have the same (ambiguous) scope as before. This change makes things cleaner. 

Style Note:

There are moment where moving from 

```
case ((date, competitionMatches), dateRow)
``` 

to 

```
@template1(data._1._1, data._1._2, data._2)
``` 

it looks like we are losing information. This is compensated by the fact that the template signatures, eg:

```
@template1(date: LocalDate, competitionMatches: List[(Competition, List[FootballMatch])], dateRow: RowInfo) 
```

carry the missing information (and even more than that since the types are not visible).

