### PR TITLE
Reintroduce IDAPI for email embeds afte debugging

### DIFF
--- a/applications/app/AppLoader.scala
+++ b/applications/app/AppLoader.scala
@@ -23,6 +23,7 @@ import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import services._
 import router.Routes
+import services.newsletters.{EmailEmbedAgent, EmailEmbedLifecycle, NewsletterApi}
 
 import scala.concurrent.ExecutionContext
 
@@ -41,6 +42,8 @@ trait ApplicationsServices {
   lazy val ophanApi = wire[OphanApi]
   lazy val facebookGraphApiClient = wire[FacebookGraphApiClient]
   lazy val facebookGraphApi = wire[FacebookGraphApi]
+  lazy val newsletterApi = wire[NewsletterApi]
+  lazy val emailEmbedAgent = wire[EmailEmbedAgent]
 }
 
 trait AppComponents extends FrontendComponents with ApplicationsControllers with ApplicationsServices {
@@ -66,6 +69,7 @@ trait AppComponents extends FrontendComponents with ApplicationsControllers with
     wire[TargetingLifecycle],
     wire[DiscussionExternalAssetsLifecycle],
     wire[SkimLinksCacheLifeCycle],
+    wire[EmailEmbedLifecycle],
   )
 
   lazy val router: Router = wire[Routes]

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -731,6 +731,11 @@ class GuardianConfiguration extends GuLogging {
     lazy val apiKey = configuration.getStringProperty("braze.apikey").getOrElse("")
   }
 
+  object newsletterApi {
+    lazy val host = configuration.getStringProperty("newsletterApi.host")
+    lazy val origin = configuration.getStringProperty("newsletterApi.origin")
+  }
+
 }
 
 object ManifestData {

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -1,6 +1,5 @@
 package controllers
 
-import com.gu.identity.model.EmailNewsletter
 import com.typesafe.scalalogging.LazyLogging
 import common.EmailSubsciptionMetrics._
 import common.{ImplicitControllerExecutionContext, LinkTo, GuLogging}
@@ -15,6 +14,7 @@ import play.api.libs.json._
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc._
 import play.filters.csrf.{CSRFAddToken, CSRFCheck}
+import services.newsletters.{EmailEmbedAgent, NewsletterApi}
 import utils.RemoteAddress
 
 import scala.concurrent.Future
@@ -69,6 +69,7 @@ class EmailSignupController(
     val controllerComponents: ControllerComponents,
     csrfCheck: CSRFCheck,
     csrfAddToken: CSRFAddToken,
+    emailEmbedAgent: EmailEmbedAgent,
 )(implicit context: ApplicationContext)
     extends BaseController
     with ImplicitControllerExecutionContext
@@ -85,6 +86,14 @@ class EmailSignupController(
     )(EmailForm.apply)(EmailForm.unapply),
   )
 
+  def logApiError(error: String): Unit = {
+    log.error(s"API call to get newsletters failed: $error")
+  }
+
+  def logNewsletterNotFoundError(newsletterName: String): Unit = {
+    log.error(s"Newsletter not found: Couldn't find $newsletterName")
+  }
+
   def renderPage(): Action[AnyContent] =
     Action { implicit request =>
       Cached(60)(RevalidatableResult.Ok(views.html.emailLanding(emailLandingPage)))
@@ -93,11 +102,16 @@ class EmailSignupController(
   def renderFooterForm(listName: String): Action[AnyContent] =
     csrfAddToken {
       Action { implicit request =>
-        val identityNewsletter = EmailNewsletter.fromIdentityName(listName)
+        val identityNewsletter = emailEmbedAgent.getNewsletterByName(listName)
         identityNewsletter match {
-          case Some(_) =>
+          case Right(Some(_)) =>
             Cached(1.day)(RevalidatableResult.Ok(views.html.emailFragmentFooter(emailLandingPage, listName)))
-          case _ => Cached(15.minute)(WithoutRevalidationResult(NoContent))
+          case Right(None) =>
+            logNewsletterNotFoundError(listName)
+            Cached(15.minute)(WithoutRevalidationResult(NotFound))
+          case Left(e) =>
+            logApiError(e)
+            Cached(15.minute)(WithoutRevalidationResult(InternalServerError))
         }
       }
     }
@@ -105,11 +119,10 @@ class EmailSignupController(
   def renderForm(emailType: String, listId: Int): Action[AnyContent] =
     csrfAddToken {
       Action { implicit request =>
-        val identityNewsletter = EmailNewsletter(listId)
-          .orElse(EmailNewsletter.fromV1ListId(listId))
+        val identityNewsletter = emailEmbedAgent.getNewsletterById(listId)
 
         identityNewsletter match {
-          case Some(newsletter) =>
+          case Right(Some(newsletter)) =>
             Cached(1.hour)(
               RevalidatableResult.Ok(
                 views.html.emailFragment(
@@ -119,7 +132,12 @@ class EmailSignupController(
                 ),
               ),
             )
-          case _ => Cached(15.minute)(WithoutRevalidationResult(NoContent))
+          case Right(None) =>
+            logNewsletterNotFoundError(listId.toString)
+            Cached(15.minute)(WithoutRevalidationResult(NotFound))
+          case Left(e) =>
+            logApiError(e)
+            Cached(15.minute)(WithoutRevalidationResult(InternalServerError))
         }
       }
     }
@@ -127,9 +145,9 @@ class EmailSignupController(
   def renderFormFromName(emailType: String, listName: String): Action[AnyContent] =
     csrfAddToken {
       Action { implicit request =>
-        val identityNewsletter = EmailNewsletter.fromIdentityName(listName)
+        val identityNewsletter = emailEmbedAgent.getNewsletterByName(listName)
         identityNewsletter match {
-          case Some(newsletter) =>
+          case Right(Some(newsletter)) =>
             Cached(1.hour)(
               RevalidatableResult.Ok(
                 views.html.emailFragment(
@@ -139,7 +157,12 @@ class EmailSignupController(
                 ),
               ),
             )
-          case _ => Cached(15.minute)(WithoutRevalidationResult(NoContent))
+          case Right(None) =>
+            logNewsletterNotFoundError(listName)
+            Cached(15.minute)(WithoutRevalidationResult(NotFound))
+          case Left(e) =>
+            logApiError(e)
+            Cached(15.minute)(WithoutRevalidationResult(InternalServerError))
         }
       }
     }
@@ -159,15 +182,20 @@ class EmailSignupController(
 
   def subscriptionSuccessResult(listName: String): Action[AnyContent] =
     Action { implicit request =>
-      val identityNewsletter = EmailNewsletter.fromIdentityName(listName)
+      val identityNewsletter = emailEmbedAgent.getNewsletterByName(listName)
       identityNewsletter match {
-        case Some(newsletter) =>
+        case Right(Some(newsletter)) =>
           Cached(1.hour)(
             RevalidatableResult.Ok(
               views.html.emailSubscriptionSuccessResult(emailLandingPage, newsletter, listName),
             ),
           )
-        case _ => Cached(15.minute)(WithoutRevalidationResult(NoContent))
+        case Right(None) =>
+          logNewsletterNotFoundError(listName)
+          Cached(15.minute)(WithoutRevalidationResult(NotFound))
+        case Left(e) =>
+          logApiError(e)
+          Cached(15.minute)(WithoutRevalidationResult(InternalServerError))
       }
     }
 

--- a/common/app/services/newsletters/EmailEmbedAgent.scala
+++ b/common/app/services/newsletters/EmailEmbedAgent.scala
@@ -1,0 +1,52 @@
+package services.newsletters
+
+import com.gu.Box
+import common.GuLogging
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class EmailEmbedAgent(newsletterApi: NewsletterApi) extends GuLogging {
+
+  private val agent = Box[Either[String, List[NewsletterResponse]]](Right(Nil))
+
+  def refresh()(implicit ec: ExecutionContext): Future[Either[String, List[NewsletterResponse]]] = {
+    log.info("Refreshing newsletters for newsletter signup embeds.")
+
+    val newslettersQuery = newsletterApi.getNewsletters()
+
+    newslettersQuery.flatMap { newsletters =>
+      agent.alter(newsletters match {
+        case Right(response) =>
+          log.info("Successfully refreshed Newsletters embed cache.")
+          Right(response)
+        case Left(err) =>
+          log.error(s"Failed to refresh Newsletters embed cache: $err")
+          Left(err)
+      })
+    } recover {
+      case e =>
+        val errMessage = s"Call to Newsletter API failed: ${e.getMessage}"
+        log.error(errMessage)
+        Left(errMessage)
+    }
+
+  }
+
+  def getNewsletterByName(listName: String): Either[String, Option[NewsletterResponse]] = {
+    agent.get() match {
+      case Left(err)          => Left(err)
+      case Right(newsletters) => Right(newsletters.find(newsletter => newsletter.id == listName))
+    }
+  }
+
+  def getNewsletterById(listId: Int): Either[String, Option[NewsletterResponse]] = {
+    agent.get() match {
+      case Left(err) => Left(err)
+      case Right(newsletters) =>
+        Right(
+          newsletters.find(newsletter => newsletter.exactTargetListId == listId || newsletter.listIdv1 == listId),
+        )
+    }
+  }
+
+}

--- a/common/app/services/newsletters/EmailEmbedLifecycle.scala
+++ b/common/app/services/newsletters/EmailEmbedLifecycle.scala
@@ -1,0 +1,34 @@
+package services.newsletters
+
+import app.LifecycleComponent
+import common.JobScheduler
+import play.api.inject.ApplicationLifecycle
+
+import java.util.concurrent.Executors
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService, Future}
+
+class EmailEmbedLifecycle(appLifecycle: ApplicationLifecycle, jobs: JobScheduler, emailEmbedAgent: EmailEmbedAgent)(
+    implicit ec: ExecutionContext,
+) extends LifecycleComponent {
+
+  appLifecycle.addStopHook { () =>
+    Future {
+      descheduleAll()
+    }
+  }
+
+  private def descheduleAll(): Unit = {
+    jobs.deschedule("EmailEmbedAgentLowFrequencyRefreshJob")
+  }
+
+  override def start(): Unit = {
+
+    descheduleAll()
+    emailEmbedAgent.refresh()
+    jobs.scheduleEveryNMinutes("EmailEmbedAgentLowFrequencyRefreshJob", 60) {
+      emailEmbedAgent.refresh()
+    }
+
+  }
+
+}

--- a/common/app/services/newsletters/NewsletterApi.scala
+++ b/common/app/services/newsletters/NewsletterApi.scala
@@ -1,0 +1,107 @@
+package services.newsletters
+
+import com.gu.identity.model.{EmailEmbed, NewsletterIllustration}
+import common.{BadConfigurationException, GuLogging}
+import conf.Configuration._
+import play.api.libs.json.{JsError, JsResult, JsSuccess, JsValue, Json}
+import play.api.libs.ws.WSClient
+
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{ExecutionContext, Future}
+
+case class NewsletterResponse(
+    id: String,
+    name: String,
+    brazeNewsletterName: String,
+    brazeSubscribeAttributeName: String,
+    brazeSubscribeEventNamePrefix: String,
+    theme: String,
+    description: String,
+    frequency: String,
+    exactTargetListId: Int,
+    listIdv1: Int,
+    emailEmbed: EmailEmbed,
+    illustration: Option[NewsletterIllustration] = None,
+)
+
+object NewsletterResponse {
+  implicit val emailEmbedReads = Json.reads[EmailEmbed]
+  implicit val newsletterIllustrationReads = Json.reads[NewsletterIllustration]
+  implicit val newsletterResponseReads = Json.reads[NewsletterResponse]
+}
+
+case class GroupedNewsletterResponse(
+    displayName: String,
+    newsletters: List[NewsletterResponse],
+)
+
+object GroupedNewsletterResponse {
+  implicit val groupedNewsletterResponseReads = Json.reads[GroupedNewsletterResponse]
+}
+
+case class GroupedNewslettersResponse(
+    newsRoundups: GroupedNewsletterResponse,
+    newsByTopic: GroupedNewsletterResponse,
+    features: GroupedNewsletterResponse,
+    sport: GroupedNewsletterResponse,
+    culture: GroupedNewsletterResponse,
+    lifestyle: GroupedNewsletterResponse,
+    comment: GroupedNewsletterResponse,
+    work: GroupedNewsletterResponse,
+    fromThePapers: GroupedNewsletterResponse,
+)
+
+object GroupedNewslettersResponse {
+  implicit val groupedNewslettersResponseReads = Json.reads[GroupedNewslettersResponse]
+
+}
+
+case class NewsletterApi(wsClient: WSClient)(implicit executionContext: ExecutionContext)
+    extends GuLogging
+    with implicits.WSRequests {
+
+  private def ensureHostSecure(host: String): String = host.replace("http:", "https:")
+
+  private def getBody(path: String): Future[JsValue] = {
+    val maybeJson: Option[Future[JsValue]] = for {
+      host <- newsletterApi.host
+      origin <- newsletterApi.origin
+    } yield {
+      val url = s"${ensureHostSecure(host)}/$path"
+      log.info(s"Making request to newsletters API: $url")
+      wsClient
+        .url(url)
+        .withRequestTimeout(10.seconds)
+        .withHttpHeaders(("Origin", origin))
+        .getOKResponse()
+        .map(_.json)
+    }
+
+    maybeJson.getOrElse(
+      Future.failed(new BadConfigurationException("Newsletters API host or origin not configured")),
+    )
+  }
+
+  def getGroupedNewsletters(): Future[Either[String, GroupedNewslettersResponse]] = {
+    getBody("newsletters/grouped").map { json =>
+      {
+        json.validate[GroupedNewslettersResponse] match {
+          case succ: JsSuccess[GroupedNewslettersResponse] =>
+            Right(succ.get)
+          case err: JsError => Left(err.toString)
+        }
+      }
+    }
+  }
+
+  def getNewsletters(): Future[Either[String, List[NewsletterResponse]]] = {
+    getBody("newsletters").map { json =>
+      json.validate[List[NewsletterResponse]] match {
+        case succ: JsSuccess[List[NewsletterResponse]] =>
+          Right(succ.get)
+        case err: JsError => Left(err.toString)
+      }
+    }
+  }
+
+}

--- a/common/app/views/emailFragment.scala.html
+++ b/common/app/views/emailFragment.scala.html
@@ -1,5 +1,5 @@
-@import com.gu.identity.model.EmailNewsletter
-@(page: model.Page, emailType: String, emailNewsletter: EmailNewsletter)(implicit request: RequestHeader, context: model.ApplicationContext)
+@import services.newsletters.NewsletterResponse
+@(page: model.Page, emailType: String, emailNewsletter: NewsletterResponse)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @electionNewsletters = @{
     List(
@@ -9,7 +9,7 @@
 }
 
 @emailEmbed(page) {
-    @if(electionNewsletters.contains(emailNewsletter.identityName)) {
+    @if(electionNewsletters.contains(emailNewsletter.id)) {
         @fragments.email.signup.subscription.emailSignUpNewDesign(
             emailType,
             emailNewsletter
@@ -17,7 +17,7 @@
     }
     @fragments.email.signup.subscription.emailSignUp(
         emailType,
-        emailNewsletter.identityName,
+        emailNewsletter.id,
         emailNewsletter.emailEmbed
     )
 }

--- a/common/app/views/emailSubscriptionSuccessResult.scala.html
+++ b/common/app/views/emailSubscriptionSuccessResult.scala.html
@@ -1,6 +1,7 @@
 @import com.gu.identity.model.EmailNewsletter
 @import experiments.{ActiveExperiments, NewsletterEmbedDesign}
-@(page: model.Page, emailNewsletter: EmailNewsletter, listName: String)(implicit request: RequestHeader, context: model.ApplicationContext)
+@import services.newsletters.NewsletterResponse
+@(page: model.Page, emailNewsletter: NewsletterResponse, listName: String)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @electionNewsletters = @{List("minute-us", "us-morning-newsletter", "today-us", "green-light")}
 

--- a/common/app/views/fragments/email/signup/result/emailResultNewDesign.scala.html
+++ b/common/app/views/fragments/email/signup/result/emailResultNewDesign.scala.html
@@ -1,7 +1,6 @@
-@import com.gu.identity.model.EmailNewsletter
-@(listName: String,
-        emailNewsletter: EmailNewsletter,
-        resultHtml: Html)(implicit request: RequestHeader)
+@import services.newsletters.NewsletterResponse
+@(listName: String, emailNewsletter: NewsletterResponse, resultHtml: Html)(implicit request: RequestHeader)
+
 @emailEmbedData = @{emailNewsletter.emailEmbed}
 @wrapperClass = @{
     "newsletter-embed newsletter-embed--result"

--- a/common/app/views/fragments/email/signup/subscription/emailSignUpNewDesign.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUpNewDesign.scala.html
@@ -1,6 +1,6 @@
-@import com.gu.identity.model.EmailNewsletter
+@import services.newsletters.NewsletterResponse
 @(  componentClass: String,
-    emailNewsletter: EmailNewsletter)(implicit request: RequestHeader)
+    emailNewsletter: NewsletterResponse)(implicit request: RequestHeader)
 
 @import common.LinkTo
 
@@ -12,7 +12,7 @@
 @formClass = @{ "newsletter-embed__form" + " newsletter-embed__form--" + componentClass }
 
 @emailEmbedData = @{emailNewsletter.emailEmbed}
-@listName = @{emailNewsletter.identityName}
+@listName = @{emailNewsletter.id}
 @imageAltText = @{s"${emailEmbedData.name} profile image"}
 
 

--- a/dev-build/app/AppLoader.scala
+++ b/dev-build/app/AppLoader.scala
@@ -31,6 +31,7 @@ import services._
 import _root_.commercial.targeting.TargetingLifecycle
 import akka.actor.ActorSystem
 import concurrent.BlockingOperations
+import services.newsletters.{EmailEmbedAgent, EmailEmbedLifecycle, NewsletterApi}
 
 class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents =
@@ -51,6 +52,9 @@ trait Controllers
     with FrontendComponents
     with CricketControllers {
   self: BuiltInComponents =>
+
+  def emailEmbedAgent: EmailEmbedAgent
+
   lazy val accessTokenGenerator = wire[AccessTokenGenerator]
   lazy val apiSandbox = wire[ApiSandbox]
   lazy val devAssetsController = wire[DevAssetsController]
@@ -75,6 +79,9 @@ trait AppComponents
   override lazy val capiHttpClient: HttpClient = wire[CapiHttpClient]
   override lazy val contentApiClient = wire[ContentApiClient]
   override lazy val blockingOperations = wire[BlockingOperations]
+  override lazy val newsletterApi = wire[NewsletterApi]
+  override lazy val emailEmbedAgent = wire[EmailEmbedAgent]
+
   lazy val logbackOperationsPool = wire[LogbackOperationsPool]
 
   lazy val remoteRender = wire[renderers.DotcomRenderingService]
@@ -103,6 +110,7 @@ trait AppComponents
       wire[TargetingLifecycle],
       wire[DiscussionExternalAssetsLifecycle],
       wire[StocksDataLifecycle],
+      wire[EmailEmbedLifecycle],
     )
 
   override lazy val httpFilters = wire[DevFilters].filters

--- a/identity/app/AppLoader.scala
+++ b/identity/app/AppLoader.scala
@@ -18,6 +18,7 @@ import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import play.filters.csrf.{CSRFAddToken, CSRFCheck, CSRFComponents}
 import router.Routes
+import services.newsletters.EmailEmbedLifecycle
 
 class AppLoader extends FrontendApplicationLoader {
   def buildComponents(context: Context): FrontendComponents =
@@ -42,6 +43,7 @@ trait AppLifecycleComponents {
     wire[CloudWatchMetricsLifecycle],
     wire[SwitchboardLifecycle],
     wire[CachedHealthCheckLifeCycle],
+    wire[EmailEmbedLifecycle],
   )
 
   def actorSystem: ActorSystem

--- a/identity/app/services/IdentityServices.scala
+++ b/identity/app/services/IdentityServices.scala
@@ -1,7 +1,6 @@
 package services
 
 import java.util.concurrent.{Executors, ThreadPoolExecutor}
-
 import clients.DiscussionClient
 import com.gu.identity.cookie.IdentityCookieService
 import com.gu.identity.play.IdentityPlayAuthService
@@ -12,6 +11,7 @@ import idapiclient.IdApiComponents
 import org.http4s.Uri
 import play.api.libs.ws.WSClient
 import play.api.mvc.ControllerComponents
+import services.newsletters.{EmailEmbedAgent, NewsletterApi}
 import utils.IdentityApiThreadPoolMonitor
 
 import scala.concurrent.ExecutionContext
@@ -50,4 +50,6 @@ trait IdentityServices extends IdentityConfigurationComponents with IdApiCompone
   lazy val mdapiService = wire[MembersDataApiService]
   lazy val discussionApiService = wire[DiscussionApiService]
   lazy val discussionClient = wire[DiscussionClient]
+  lazy val newsletterApi = wire[NewsletterApi]
+  lazy val emailEmbedAgent = wire[EmailEmbedAgent]
 }

--- a/preview/app/AppLoader.scala
+++ b/preview/app/AppLoader.scala
@@ -28,9 +28,15 @@ import play.api.{BuiltInComponents, BuiltInComponentsFromContext}
 import router.Routes
 import rugby.conf.RugbyLifecycle
 import rugby.controllers.RugbyControllers
+import services.newsletters.EmailEmbedLifecycle
 import services.{ConfigAgentLifecycle, OphanApi, SkimLinksCacheLifeCycle}
 
-trait PreviewLifecycleComponents extends SportServices with CommercialServices with FapiServices with OnwardServices {
+trait PreviewLifecycleComponents
+    extends SportServices
+    with CommercialServices
+    with FapiServices
+    with OnwardServices
+    with ApplicationsServices {
   self: FrontendComponents =>
 
   //Override conflicting members
@@ -53,6 +59,7 @@ trait PreviewLifecycleComponents extends SportServices with CommercialServices w
       wire[TargetingLifecycle],
       wire[SkimLinksCacheLifeCycle],
       wire[CloudWatchMetricsLifecycle],
+      wire[EmailEmbedLifecycle],
     )
 
   def actorSystem: ActorSystem
@@ -67,7 +74,8 @@ trait PreviewControllerComponents
     with FootballControllers
     with CricketControllers
     with FrontendComponents
-    with RugbyControllers {
+    with RugbyControllers
+    with ApplicationsServices {
   self: BuiltInComponents =>
 
   def wsClient: WSClient


### PR DESCRIPTION
## What does this change?
Reintroduce previous changes from #23415 and add more logging to help
with debugging.

The observed error when merging to PROD was not due to the code but with
the appropriate config values not being uploaded to Amazon.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

![image](https://user-images.githubusercontent.com/9122944/104300725-c1fc7800-54be-11eb-8715-b17c5a182103.png)

Taken on CODE. Embeds are visible and working
## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
