### PR TITLE
Removing curated container test switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -58,16 +58,6 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-curated-container-test2",
-    "Tests an additional 'curated' onwards container below the article body that is relevant to the article's pillar.",
-    owners = Seq(Owner.withGithub("rcrphillips")),
-    safeState = Off,
-    sellByDate = new LocalDate(2021, 1, 12),
-    exposeClientSide = true,
-  )
-
-  Switch(
-    ABTests,
     "ab-deeply-read-test",
     "Tests an onward hypothesis by replacing the second tab in the Most Popular container with deeply read items.",
     owners = Seq(Owner.withGithub("nitro-marky")),


### PR DESCRIPTION
## What does this change?
Rather than continually extending this, we can remove it for now.