### PR TITLE
Fix some wiring compile errors

### DIFF
--- a/applications/app/AppLoader.scala
+++ b/applications/app/AppLoader.scala
@@ -16,7 +16,7 @@ import jobs.{SiteMapJob, SiteMapLifecycle}
 import model.{ApplicationContext, ApplicationIdentity}
 import services.ophan.SurgingContentAgentLifecycle
 import play.api.ApplicationLoader.Context
-import play.api.BuiltInComponentsFromContext
+import play.api.{BuiltInComponentsFromContext, OptionalDevContext}
 import play.api.http.{HttpErrorHandler, HttpRequestHandler}
 import play.api.libs.ws.WSClient
 import play.api.mvc.EssentialFilter

--- a/common/app/app/FrontendApplicationLoader.scala
+++ b/common/app/app/FrontendApplicationLoader.scala
@@ -9,7 +9,7 @@ import play.api.mvc.{ControllerComponents, EssentialFilter}
 import play.api.routing.Router
 import play.filters.csrf.CSRFComponents
 import controllers.AssetsComponents
-import play.api.{Application, ApplicationLoader, BuiltInComponents, LoggerConfigurator}
+import play.api.{Application, ApplicationLoader, BuiltInComponents, LoggerConfigurator, OptionalDevContext}
 
 trait FrontendApplicationLoader extends ApplicationLoader {
 
@@ -43,6 +43,8 @@ trait FrontendComponents
   lazy val appMetrics = ApplicationMetrics()
   lazy val guardianConf = new GuardianConfiguration
   lazy val mode = environment.mode
+  lazy val optionalDevContext = new OptionalDevContext(devContext)
+  override lazy val sourceMapper = devContext.map(_.sourceMapper)
 
   // here are the attributes you must provide for your app to start
   def appIdentity: ApplicationIdentity

--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -6,14 +6,18 @@ import play.api.mvc.{Handler, RequestHeader}
 import common.CanonicalLink
 import model.ApplicationContext
 import play.api.Mode.Prod
+import play.api.OptionalDevContext
+import play.core.WebCommands
 
 class DevParametersHttpRequestHandler(
+    optionalDevContext: OptionalDevContext,
+    webCommands: WebCommands,
     router: Router,
     errorHandler: HttpErrorHandler,
     configuration: HttpConfiguration,
     filters: HttpFilters,
     context: ApplicationContext,
-) extends DefaultHttpRequestHandler(router, errorHandler, configuration, filters)
+) extends DefaultHttpRequestHandler(webCommands, optionalDevContext, router, errorHandler, configuration, filters)
     with implicits.Requests {
 
   /*


### PR DESCRIPTION
## What does this change?

Resolve the error:

```
constructor DefaultHttpRequestHandler in class DefaultHttpRequestHandler is deprecated
```

while compiling. Play 2.7.  Work done by @adamnfish 
