### PR TITLE
method moveTo in trait TemporaryFile is deprecated

### DIFF
--- a/admin/app/controllers/R2PressController.scala
+++ b/admin/app/controllers/R2PressController.scala
@@ -31,7 +31,7 @@ class R2PressController(
           val rnd = Math.random().toString.replace(".", "")
           val tmpName = s"/tmp/$rnd${theFile.filename}"
           val tmpFile = new File(tmpName)
-          theFile.ref.moveTo(tmpFile)
+          theFile.ref.moveFileTo(tmpFile)
           tmpFile
         }
       }

--- a/admin/app/controllers/RedirectController.scala
+++ b/admin/app/controllers/RedirectController.scala
@@ -52,7 +52,7 @@ class RedirectController(
           val rnd = Math.random().toString.replace(".", "")
           val tmpName = s"/tmp/$rnd${theFile.filename}"
           val tmpFile = new File(tmpName)
-          theFile.ref.moveTo(tmpFile)
+          theFile.ref.moveFileTo(tmpFile)
           tmpFile
         }
       }


### PR DESCRIPTION
## What does this change?

Method `moveTo` in trait `TemporaryFile` has been deprecated in Play 2.6, replaced by `moveFileTo`.