### PR TITLE
Add resultGroups to QuizAtomBlockElement

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -398,16 +398,19 @@ case class QuizAtomAnswer(
 )
 case class QuizAtomResultBucket(id: String, title: String, description: String)
 case class QuizAtomQuestion(id: String, text: String, answers: Seq[QuizAtomAnswer], imageUrl: Option[String])
+case class QuizAtomResultGroup(id: String, title: String, shareText: String, minScore: Int)
 case class QuizAtomBlockElement(
     id: String,
     quizType: String,
     questions: Seq[QuizAtomQuestion],
     resultBuckets: Seq[QuizAtomResultBucket],
+    resultGroups: Seq[QuizAtomResultGroup],
 ) extends PageElement
 object QuizAtomBlockElement {
   implicit val QuizAtomAnswerWrites: Writes[QuizAtomAnswer] = Json.writes[QuizAtomAnswer]
   implicit val QuizAtomQuestionWrites: Writes[QuizAtomQuestion] = Json.writes[QuizAtomQuestion]
   implicit val QuizAtomResultBucketWrites: Writes[QuizAtomResultBucket] = Json.writes[QuizAtomResultBucket]
+  implicit val QuizAtomResultGroupWrites: Writes[QuizAtomResultGroup] = Json.writes[QuizAtomResultGroup]
   implicit val QuizAtomBlockElementWrites: Writes[QuizAtomBlockElement] = Json.writes[QuizAtomBlockElement]
 }
 
@@ -1040,6 +1043,8 @@ object PageElement {
                 resultBuckets = quizAtom.content.resultBuckets.map { bucket =>
                   QuizAtomResultBucket(bucket.id, bucket.title, bucket.description)
                 },
+                resultGroups =
+                  quizAtom.content.resultGroups.map(x => QuizAtomResultGroup(x.id, x.title, x.shareText, x.minScore)),
               ),
             )
           }


### PR DESCRIPTION
## What does this change?

Add resultGroups to QuizAtomBlockElement.

<img width="800" alt="Screenshot 2021-01-13 at 10 53 06" src="https://user-images.githubusercontent.com/6035518/104443224-0d318c00-558e-11eb-9d69-9a520df4cbf3.png">
