### PR TITLE
Add media atom to allowed elements

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -77,7 +77,7 @@ object ArticlePageChecks {
           // ContentAtomBlockElement was expanded to include atomtype.
           // To support an atom type, just add it to supportedAtomTypes
           val supportedAtomTypes =
-            List("audio", "chart", "explainer", "guide", "profile", "qanda", "timeline")
+            List("audio", "chart", "explainer", "guide", "media", "profile", "qanda", "timeline")
           !supportedAtomTypes.contains(atomtype)
         }
         case _ => true


### PR DESCRIPTION
## What does this change?
Adds media atoms to allowed elements now they're fully supported. Replaces #23264 since it was quicker to replace than rebase 😄 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)