### PR TITLE
Remove Lotame

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -287,16 +287,6 @@ trait CommercialSwitches {
     exposeClientSide = true,
   )
 
-  val LotameSwitch: Switch = Switch(
-    group = Commercial,
-    name = "lotame",
-    description = "When this is switched on the Lotame script will be included in the commercial bootstrap",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true,
-  )
-
   val AffiliateLinks: Switch = Switch(
     group = Commercial,
     name = "affiliate-links",

--- a/common/app/views/fragments/inlineJSNonBlocking.scala.html
+++ b/common/app/views/fragments/inlineJSNonBlocking.scala.html
@@ -1,5 +1,5 @@
 @import common.InlineJs
-@import conf.switches.Switches.{IdentityProfileNavigationSwitch, LotameSwitch}
+@import conf.switches.Switches.IdentityProfileNavigationSwitch
 @import conf.Configuration
 @import model.Page
 @import templates.inlineJS.nonBlocking.js._

--- a/docs/02-architecture/06-client-side-architecture.md
+++ b/docs/02-architecture/06-client-side-architecture.md
@@ -147,10 +147,6 @@ Secrets.
 
 The [prepareCmp JS](https://github.com/guardian/frontend/blob/main/common/app/templates/inlineJS/nonBlocking/prepareCmp.scala.js) is a stub that will be enhanced by the cmp module loaded in the Commercial bootstrap. Importantly, prepareCmp will create a command queue so that calls to the CMP can be processed once it is fully loaded. it will also define the stub postMessage handler for cross-origin iframe requests.
 
-#### prepareLotame
-
-The [prepareLotame JS](https://github.com/guardian/frontend/blob/main/common/app/templates/inlineJS/nonBlocking/prepareLotame.scala.js) is depended upon by modules within the commercial bootstrap and they are not happy when it is missing, so it needs to load and run ASAP.
-
 #### Ophan config
 
 Gets the [Ophan browserId](https://github.com/guardian/frontend/blob/main/common/app/templates/inlineJS/nonBlocking/ophanConfig.scala.js) which is used across analytics to tie data together.

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.js
@@ -132,8 +132,7 @@ export const getAppNexusServerSideBidParams = (
         {
             placementId: getAppNexusPlacementId(sizes),
             keywords: buildAppNexusTargetingObject(getPageTargeting()), // Ok to duplicate call. Lodash 'once' is used.
-        },
-        window.OzoneLotameData ? { lotame: window.OzoneLotameData } : {}
+        }
     );
 
 export const _ = {

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.js
@@ -1,14 +1,10 @@
-
-
 import config from 'lib/config';
 import {
     getPageTargeting,
     buildAppNexusTargetingObject,
 } from 'common/modules/commercial/build-page-targeting';
 
-import {
-    isInUsOrCa,
-    isInAuOrNz } from 'common/modules/commercial/geo-utils';
+import { isInUsOrCa, isInAuOrNz } from 'common/modules/commercial/geo-utils';
 
 import {
     getLargestSize,
@@ -16,11 +12,10 @@ import {
     containsLeaderboardOrBillboard,
     containsMpu,
     containsMpuOrDmpu,
-    getBreakpointKey
+    getBreakpointKey,
 } from '../utils';
 
-
-const getAppNexusInvCode = (sizes) => {
+const getAppNexusInvCode = sizes => {
     const device = getBreakpointKey() === 'M' ? 'M' : 'D';
     // section is optional and makes it through to the config object as an empty string... OTL
     const sectionName =
@@ -33,7 +28,7 @@ const getAppNexusInvCode = (sizes) => {
     }
 };
 
-export const getAppNexusPlacementId = (sizes) => {
+export const getAppNexusPlacementId = sizes => {
     const defaultPlacementId = '13915593';
     if (isInUsOrCa() || isInAuOrNz()) {
         return defaultPlacementId;
@@ -65,9 +60,7 @@ export const getAppNexusPlacementId = (sizes) => {
     }
 };
 
-export const getAppNexusDirectPlacementId = (
-    sizes
-) => {
+export const getAppNexusDirectPlacementId = sizes => {
     if (isInAuOrNz()) {
         return '11016434';
     }
@@ -100,9 +93,7 @@ export const getAppNexusDirectPlacementId = (
     }
 };
 
-export const getAppNexusDirectBidParams = (
-    sizes
-) => {
+export const getAppNexusDirectBidParams = sizes => {
     if (isInAuOrNz() && config.get('switches.prebidAppnexusInvcode')) {
         const invCode = getAppNexusInvCode(sizes);
         // flowlint sketchy-null-string:warn
@@ -124,9 +115,7 @@ export const getAppNexusDirectBidParams = (
 };
 
 // TODO are we using getAppNexusServerSideBidParams anywhere?
-export const getAppNexusServerSideBidParams = (
-    sizes
-) =>
+export const getAppNexusServerSideBidParams = sizes =>
     Object.assign(
         {},
         {

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.spec.js
@@ -4,7 +4,6 @@ import { isInUsOrCa as isInUsOrCa_,
 import {
     _,
     getAppNexusDirectBidParams,
-    getAppNexusServerSideBidParams,
 } from './appnexus';
 import {
     getBreakpointKey as getBreakpointKey_

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.spec.js
@@ -118,13 +118,11 @@ describe('getAppNexusInvCode', () => {
 describe('getAppNexusDirectPlacementId', () => {
     beforeEach(() => {
         resetConfig();
-        window.OzoneLotameData = { some: 'lotamedata' };
     });
 
     afterEach(() => {
         jest.resetAllMocks();
         resetConfig();
-        window.OzoneLotameData = undefined;
     });
 
     const prebidSizes = [
@@ -164,13 +162,11 @@ describe('getAppNexusPlacementId', () => {
         resetConfig();
         isInAuOrNz.mockReturnValue(false);
         isInUsOrCa.mockReturnValue(false);
-        window.OzoneLotameData = { some: 'lotamedata' };
     });
 
     afterEach(() => {
         jest.resetAllMocks();
         resetConfig();
-        window.OzoneLotameData = undefined;
     });
 
     const generateTestIds = () => {
@@ -235,25 +231,6 @@ describe('getAppNexusServerSideBidParams', () => {
     afterEach(() => {
         jest.resetAllMocks();
         resetConfig();
-        window.OzoneLotameData = undefined;
-    });
-
-    test('should include OzoneLotameData if available', () => {
-        getBreakpointKey.mockReturnValue('M');
-        window.OzoneLotameData = { some: 'lotamedata' };
-        expect(getAppNexusServerSideBidParams([[300, 250]])).toEqual({
-            keywords: { edition: 'UK', sens: 'f', url: 'gu.com' },
-            placementId: '13366904',
-            lotame: { some: 'lotamedata' },
-        });
-    });
-
-    test('should excude lotame if data is unavailable', () => {
-        getBreakpointKey.mockReturnValue('M');
-        expect(getAppNexusServerSideBidParams([[300, 250]])).toEqual({
-            keywords: { edition: 'UK', sens: 'f', url: 'gu.com' },
-            placementId: '13366904',
-        });
     });
 });
 

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.spec.js
@@ -1,13 +1,10 @@
 import config from 'lib/config';
-import { isInUsOrCa as isInUsOrCa_,
-    isInAuOrNz as isInAuOrNz_} from 'common/modules/commercial/geo-utils';
 import {
-    _,
-    getAppNexusDirectBidParams,
-} from './appnexus';
-import {
-    getBreakpointKey as getBreakpointKey_
-} from '../utils';
+    isInUsOrCa as isInUsOrCa_,
+    isInAuOrNz as isInAuOrNz_,
+} from 'common/modules/commercial/geo-utils';
+import { _, getAppNexusDirectBidParams } from './appnexus';
+import { getBreakpointKey as getBreakpointKey_ } from '../utils';
 
 jest.mock('common/modules/commercial/build-page-targeting', () => ({
     buildAppNexusTargeting: () => 'someTestAppNexusTargeting',
@@ -20,7 +17,6 @@ jest.mock('common/modules/commercial/build-page-targeting', () => ({
 }));
 
 jest.mock('../utils', () => {
-    
     const original = jest.requireActual('../utils');
     return {
         ...original,
@@ -29,8 +25,8 @@ jest.mock('../utils', () => {
 });
 
 jest.mock('common/modules/commercial/geo-utils', () => ({
-        isInAuOrNz: jest.fn(),
-        isInUsOrCa: jest.fn(),
+    isInAuOrNz: jest.fn(),
+    isInUsOrCa: jest.fn(),
 }));
 
 jest.mock('lib/cookies', () => ({

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
@@ -14,7 +14,6 @@ import { isInUk,
     isInUsOrCa,
     isInAuOrNz,
     isInRow } from 'common/modules/commercial/geo-utils';
-import { getLotameData } from '@guardian/commercial-core';
 import {
     containsBillboard,
     containsDmpu,
@@ -248,15 +247,9 @@ const getTripleLiftInventoryCode = (
 };
 
 const getOzoneTargeting = () => {
-    const lotameData = getLotameData();
-    const appNexusTargetingObject = buildAppNexusTargetingObject(getPageTargeting());
-    if (typeof lotameData !== 'undefined') {
-        return {
-            ...appNexusTargetingObject,
-            'lotameSegs': lotameData.ozoneLotameData,
-            'lotamePid': lotameData.ozoneLotameProfileId,
-        }
-    }
+    const appNexusTargetingObject = buildAppNexusTargetingObject(
+        getPageTargeting()
+    );
     return appNexusTargetingObject;
 };
 

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
@@ -1,5 +1,3 @@
-
-
 import config from 'lib/config';
 import { pbTestNameMap } from 'lib/url';
 import isEmpty from 'lodash/isEmpty';
@@ -10,10 +8,12 @@ import {
 } from 'common/modules/commercial/build-page-targeting';
 import { commercialPrebidSafeframe } from 'common/modules/experiments/tests/commercial-prebid-safeframe';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
-import { isInUk,
+import {
+    isInUk,
     isInUsOrCa,
     isInAuOrNz,
-    isInRow } from 'common/modules/commercial/geo-utils';
+    isInRow,
+} from 'common/modules/commercial/geo-utils';
 import {
     containsBillboard,
     containsDmpu,
@@ -48,10 +48,7 @@ const isArticle = config.get('page.contentType') === 'Article';
 
 const isDesktopAndArticle = getBreakpointKey() === 'D' && isArticle;
 
-const getTrustXAdUnitId = (
-    slotId,
-    isDesktopArticle
-) => {
+const getTrustXAdUnitId = (slotId, isDesktopArticle) => {
     switch (stripMobileSuffix(slotId)) {
         case 'dfp-ad--inline1':
             return '2960';
@@ -123,7 +120,7 @@ const getIndexSiteId = () => {
     }
 };
 
-const getImprovePlacementId = (sizes) => {
+const getImprovePlacementId = sizes => {
     if (isInSafeframeTestVariant()) {
         switch (getBreakpointKey()) {
             case 'D':
@@ -210,7 +207,7 @@ const getImprovePlacementId = (sizes) => {
 
 // Improve has to have single size as parameter if slot doesn't accept multiple sizes,
 // because it uses same placement ID for multiple slot sizes and has no other size information
-const getImproveSizeParam = (slotId) => {
+const getImproveSizeParam = slotId => {
     const key = stripTrailingNumbersAbove1(stripMobileSuffix(slotId));
     return key &&
         (key.endsWith('mostpop') ||
@@ -221,17 +218,14 @@ const getImproveSizeParam = (slotId) => {
         : {};
 };
 
-const getXaxisPlacementId = (sizes) => {
+const getXaxisPlacementId = sizes => {
     if (containsDmpu(sizes)) return 13663297;
     if (containsMpu(sizes)) return 13663304;
     if (containsBillboard(sizes)) return 13663284;
     return 13663304;
 };
 
-const getTripleLiftInventoryCode = (
-    slotId,
-    sizes
-) => {
+const getTripleLiftInventoryCode = (slotId, sizes) => {
     if (containsLeaderboard(sizes))
         return 'theguardian_topbanner_728x90_prebid';
 
@@ -256,16 +250,13 @@ const getOzoneTargeting = () => {
 // Is pbtest being used?
 const isPbTestOn = () => !isEmpty(pbTestNameMap());
 // Helper for conditions
-const inPbTestOr = (liveClause) => isPbTestOn() || liveClause;
+const inPbTestOr = liveClause => isPbTestOn() || liveClause;
 
 /* Bidders */
 const appNexusBidder = {
     name: 'and',
     switchName: 'prebidAppnexus',
-    bidParams: (
-        slotId,
-        sizes
-    ) => getAppNexusDirectBidParams(sizes),
+    bidParams: (slotId, sizes) => getAppNexusDirectBidParams(sizes),
 };
 
 const openxClientSideBidder = {
@@ -312,14 +303,14 @@ const ozoneClientSideBidder = {
                     },
                 ],
                 ozoneData: {}, // TODO: confirm if we need to send any
-            }))(),
+            }))()
         ),
 };
 
 const sonobiBidder = {
     name: 'sonobi',
     switchName: 'prebidSonobi',
-    bidParams: (slotId) =>
+    bidParams: slotId =>
         Object.assign(
             {},
             {
@@ -345,7 +336,7 @@ const getPubmaticPublisherId = () => {
 const pubmaticBidder = {
     name: 'pubmatic',
     switchName: 'prebidPubmatic',
-    bidParams: (slotId) =>
+    bidParams: slotId =>
         Object.assign(
             {},
             {
@@ -358,7 +349,7 @@ const pubmaticBidder = {
 const trustXBidder = {
     name: 'trustx',
     switchName: 'prebidTrustx',
-    bidParams: (slotId) => ({
+    bidParams: slotId => ({
         uid: getTrustXAdUnitId(slotId, isDesktopAndArticle),
     }),
 };
@@ -366,10 +357,7 @@ const trustXBidder = {
 const tripleLiftBidder = {
     name: 'triplelift',
     switchName: 'prebidTriplelift',
-    bidParams: (
-        slotId,
-        sizes
-    ) => ({
+    bidParams: (slotId, sizes) => ({
         inventoryCode: getTripleLiftInventoryCode(slotId, sizes),
     }),
 };
@@ -377,10 +365,7 @@ const tripleLiftBidder = {
 const improveDigitalBidder = {
     name: 'improvedigital',
     switchName: 'prebidImproveDigital',
-    bidParams: (
-        slotId,
-        sizes
-    ) => ({
+    bidParams: (slotId, sizes) => ({
         placementId: getImprovePlacementId(sizes),
         size: getImproveSizeParam(slotId),
     }),
@@ -389,10 +374,7 @@ const improveDigitalBidder = {
 const xaxisBidder = {
     name: 'xhb',
     switchName: 'prebidXaxis',
-    bidParams: (
-        slotId,
-        sizes
-    ) => ({
+    bidParams: (slotId, sizes) => ({
         placementId: getXaxisPlacementId(sizes),
     }),
 };
@@ -440,8 +422,7 @@ const biddersBeingTested = allBidders =>
     allBidders.filter(bidder => pbTestNameMap()[bidder.name]);
 
 const biddersSwitchedOn = allBidders => {
-    const isSwitchedOn = bidder =>
-        config.get(`switches.${bidder.switchName}`);
+    const isSwitchedOn = bidder => config.get(`switches.${bidder.switchName}`);
     return allBidders.filter(bidder => isSwitchedOn(bidder));
 };
 
@@ -463,18 +444,14 @@ const currentBidders = slotSizes => {
         ...(shouldIncludeOpenx() ? [openxClientSideBidder] : []),
     ];
 
-    const allBidders = indexExchangeBidders(slotSizes)
-        .concat(otherBidders);
+    const allBidders = indexExchangeBidders(slotSizes).concat(otherBidders);
     return isPbTestOn()
         ? biddersBeingTested(allBidders)
         : biddersSwitchedOn(allBidders);
 };
 
-export const bids = (
-    slotId,
-    slotSizes
-) =>
-    currentBidders(slotSizes).map((bidder) => ({
+export const bids = (slotId, slotSizes) =>
+    currentBidders(slotSizes).map(bidder => ({
         bidder: bidder.name,
         params: bidder.bidParams(slotId, slotSizes),
     }));

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -1,4 +1,3 @@
-
 /* A regionalised container for all the commercial tags. */
 
 import fastdom from 'lib/fastdom-promise';
@@ -19,7 +18,7 @@ import {
 } from '@guardian/commercial-core';
 import config from 'lib/config';
 
-const addScripts = (tags) => {
+const addScripts = tags => {
     const ref = document.scripts[0];
     const frag = document.createDocumentFragment();
     let hasScriptsToInsert = false;

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -18,7 +18,6 @@ import {
     inizio,
 } from '@guardian/commercial-core';
 import config from 'lib/config';
-import { isInAuOrNz, isInUsOrCa } from 'common/modules/commercial/geo-utils';
 
 const addScripts = (tags) => {
     const ref = document.scripts[0];

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -13,7 +13,6 @@ import {
     ias,
     permutive,
     twitter,
-    lotame,
     fbPixel,
     remarketing,
     inizio,
@@ -91,11 +90,6 @@ const loadOther = () => {
             shouldRun: config.get('switches.facebookTrackingPixel', false),
         }),
         twitter({ shouldRun: config.get('switches.twitterUwt', false) }),
-        lotame({
-            shouldRun:
-                config.get('switches.lotame', false) &&
-                !(isInUsOrCa() || isInAuOrNz()),
-        }),
     ].filter(_ => _.shouldRun);
 
     const performanceServices = [

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
@@ -147,7 +147,7 @@ describe('third party tags', () => {
             shouldRun: true,
             url: '//fakeThirdPartyAdvertisingTag2.js',
             onLoad: jest.fn(),
-            name: 'lotame',
+            name: 'inizio',
         };
         const fakeThirdPartyPerformanceTag = {
             shouldRun: true,

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
@@ -1,6 +1,6 @@
 import {
     getConsentFor as getConsentFor_,
-    onConsentChange as onConsentChange_
+    onConsentChange as onConsentChange_,
 } from '@guardian/consent-management-platform';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { init, _ } from './third-party-tags';
@@ -11,13 +11,13 @@ jest.mock('lib/raven');
 
 jest.mock('@guardian/consent-management-platform', () => ({
     onConsentChange: jest.fn(),
-    getConsentFor: jest.fn()
+    getConsentFor: jest.fn(),
 }));
 
 const onConsentChange = onConsentChange_;
 const getConsentFor = getConsentFor_;
 
-const tcfv2AllConsentMock = (callback) =>
+const tcfv2AllConsentMock = callback =>
     callback({
         tcfv2: {
             consents: {
@@ -36,7 +36,7 @@ const tcfv2AllConsentMock = (callback) =>
         },
     });
 
-const tcfv2WithConsentMock = (callback) =>
+const tcfv2WithConsentMock = callback =>
     callback({
         tcfv2: {
             consents: {
@@ -55,7 +55,7 @@ const tcfv2WithConsentMock = (callback) =>
         },
     });
 
-const tcfv2WithoutConsentMock = (callback) =>
+const tcfv2WithoutConsentMock = callback =>
     callback({
         tcfv2: {
             consents: {
@@ -114,7 +114,7 @@ describe('third party tags', () => {
     it('should not run if disabled in commercial features', done => {
         commercialFeatures.thirdPartyTags = false;
         init()
-            .then((enabled) => {
+            .then(enabled => {
                 expect(enabled).toBe(false);
                 done();
             })
@@ -127,7 +127,7 @@ describe('third party tags', () => {
         commercialFeatures.thirdPartyTags = true;
         commercialFeatures.adFree = false;
         init()
-            .then((enabled) => {
+            .then(enabled => {
                 expect(enabled).toBe(true);
                 done();
             })


### PR DESCRIPTION
⚠️ Do not merge before Jan 14th, 2021 ⚠️

## What does this change?

Remove Lotame, as it’s no longer required to run as part of Ozone.

It’s easier to see the code change without the linting: [main...d419615](https://github.com/guardian/frontend/compare/main...6566f21d7ff6cf1c641f85f487b259d1e0f9d712)

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

This vendor is no longer needed, and will thus reduce the size of the commercial bundle.

### Tested

- [x] Locally
- [x] On CODE (optional)