### PR TITLE
Increase idle time to see if it affects deeply read retrieval

### DIFF
--- a/onward/conf/application.conf
+++ b/onward/conf/application.conf
@@ -38,7 +38,7 @@ play {
         #The maximum time to wait when connecting to the remote host (default is 120 seconds).
         connection: 1000ms
         #The maximum time the request can stay idle (connection is established but waiting for more data) (default is 120 seconds).
-        idle: 1000ms
+        idle: 2000ms
         #The total time you accept a request to take (it will be interrupted even if the remote host is still sending data) (default is 120 seconds).
         request: 2000ms
     }

--- a/onward/conf/application.conf
+++ b/onward/conf/application.conf
@@ -36,11 +36,11 @@ play {
 
     timeout {
         #The maximum time to wait when connecting to the remote host (default is 120 seconds).
-        connection: 1000ms
+        connection: 2000ms
         #The maximum time the request can stay idle (connection is established but waiting for more data) (default is 120 seconds).
-        idle: 2000ms
+        idle: 3000ms
         #The total time you accept a request to take (it will be interrupted even if the remote host is still sending data) (default is 120 seconds).
-        request: 2000ms
+        request: 3000ms
     }
   }
 


### PR DESCRIPTION
## What does this change?
Increases idle time in the onwards application config from 1 seconds. This helps to avoid `An error has occured during job OnwardJourneyAgentsHighFrequencyRefreshJob` and allows the deeply read articles to refresh.
