### PR TITLE
Remove deprecated IDAPI user model fields

### DIFF
--- a/identity/app/controllers/editprofile/ProfileForms.scala
+++ b/identity/app/controllers/editprofile/ProfileForms.scala
@@ -2,86 +2,22 @@ package controllers.editprofile
 
 import com.gu.identity.model.User
 import form._
-import idapiclient.responses.Error
 import model.IdentityPage
 import play.api.data.Form
-import play.api.data.FormBinding.Implicits.formBinding
 import play.api.i18n.MessagesProvider
-import play.api.mvc.Request
 
 /**
   * Holds all Edit Profile forms and designates which one is user currently viewing
   *
-  * @param publicForm   /public/edit
   * @param accountForm  /account/edit
   * @param privacyForm  /privacy/edit
   * @param activePage   which page is user currently viewing and hence which form
-  * @param profileFormsMapping Case class with mappings for all the forms
   */
 case class ProfileForms(
     accountForm: Form[AccountFormData],
     privacyForm: Form[PrivacyFormData],
     activePage: IdentityPage,
-)(implicit profileFormsMapping: ProfileFormsMapping) {
-
-  lazy val activeForm = activePage match {
-    case AccountEditProfilePage => accountForm
-    case EmailPrefsProfilePage  => privacyForm
-    case page                   => throw new RuntimeException(s"Unexpected page $page")
-  }
-
-  private lazy val activeMapping = activePage match {
-    case AccountEditProfilePage => profileFormsMapping.accountDetailsMapping
-    case EmailPrefsProfilePage  => profileFormsMapping.privacyMapping
-    case page                   => throw new RuntimeException(s"Unexpected page $page")
-  }
-
-  /** Fills all Edit Profile forms (Public, Account, Privacy) with the provided User value */
-  def bindForms(user: User)(implicit messagesProvider: MessagesProvider): ProfileForms = {
-    copy(
-      accountForm = profileFormsMapping.accountDetailsMapping.fillForm(user),
-      privacyForm = profileFormsMapping.privacyMapping.fillForm(user),
-    )
-  }
-
-  /**
-    * Binds request data to currently active profile form, and re-maps address error to different key.
-    * Note that other profile forms remain unchanged, which means they remain bound bound to
-    * "old user form api" instance.
-    */
-  def bindFromRequestWithAddressErrorHack(implicit request: Request[_]): ProfileForms =
-    transform { form =>
-      // Hack to get the postcode error into the correct context.
-      val boundForm = form.bindFromRequest()
-      boundForm.error("address") map { e =>
-        boundForm.withError(e.copy(key = "address.postcode"))
-      } getOrElse boundForm
-    }
-
-  /** Adds errors to the form */
-  def withErrors(idapiErrors: List[Error]): ProfileForms = {
-    transform { form =>
-      idapiErrors.foldLeft(form) { (formWithErrors, idapiError) =>
-        val formErrorFieldKey = activeMapping.formFieldKeyBy(idapiError.context getOrElse "")
-        formWithErrors.withError(formErrorFieldKey, idapiError.description)
-      }
-    }
-  }
-
-  /**
-    * Create a copy of ProfileForms with applied change to the currently active form
-    *
-    * @param changeFunc function that takes currently active form and returns a modified version of the form
-    * @return copy of ProfileForms with applied change to the currently active form
-    */
-  private def transform(changeFunc: (Form[_ <: UserFormData]) => Form[_ <: UserFormData]): ProfileForms = {
-    activePage match {
-      case AccountEditProfilePage => copy(accountForm = changeFunc(accountForm).asInstanceOf[Form[AccountFormData]])
-      case EmailPrefsProfilePage  => copy(privacyForm = changeFunc(privacyForm).asInstanceOf[Form[PrivacyFormData]])
-      case page                   => throw new RuntimeException(s"Unexpected page $page")
-    }
-  }
-}
+)
 
 object ProfileForms {
 

--- a/identity/app/form/AccountDetailsMapping.scala
+++ b/identity/app/form/AccountDetailsMapping.scala
@@ -27,24 +27,6 @@ class AccountDetailsMapping
 
   protected def toUserFormData(user: User) = AccountFormData(user)
 
-  protected lazy val idapiErrorContextToFormFieldKeyMap = Map(
-    ("privateFields.title", "title"),
-    ("privateFields.firstName", "firstName"),
-    ("privateFields.secondName", "secondName"),
-    ("privateFields.address1", "address.line1"),
-    ("privateFields.address2", "address.line2"),
-    ("privateFields.address3", "address.line3"),
-    ("privateFields.address4", "address.line4"),
-    ("privateFields.postcode", "address.postcode"),
-    ("privateFields.country", "address.country"),
-    ("privateFields.billingAddress1", "billingAddress.line1"),
-    ("privateFields.billingAddress2", "billingAddress.line2"),
-    ("privateFields.billingAddress3", "billingAddress.line3"),
-    ("privateFields.billingAddress4", "billingAddress.line4"),
-    ("privateFields.billingPostcode", "billingAddress.postcode"),
-    ("privateFields.billingCountry", "billingAddress.country"),
-    ("privateFields.telephoneNumber", "telephoneNumber"),
-  )
 }
 
 case class AccountFormData(
@@ -56,38 +38,7 @@ case class AccountFormData(
     billingAddress: Option[AddressFormData],
     telephoneNumber: Option[TelephoneNumberFormData],
     deleteTelephone: Boolean = false,
-) extends UserFormData {
-
-  def toUserUpdateDTO(currentUser: User): UserUpdateDTO =
-    UserUpdateDTO(
-      primaryEmailAddress = toUpdate(primaryEmailAddress, Some(currentUser.primaryEmailAddress)),
-      privateFields = Some(
-        PrivateFields(
-          title = toUpdate(title, currentUser.privateFields.title),
-          firstName = toUpdate(firstName, currentUser.privateFields.firstName),
-          secondName = toUpdate(secondName, currentUser.privateFields.secondName),
-          address1 = toUpdate(address.address1, currentUser.privateFields.address1),
-          address2 = toUpdate(address.address2, currentUser.privateFields.address2),
-          address3 = toUpdate(address.address3, currentUser.privateFields.address3),
-          address4 = toUpdate(address.address4, currentUser.privateFields.address4),
-          postcode = toUpdate(address.postcode, currentUser.privateFields.postcode),
-          country = toUpdate(address.country, currentUser.privateFields.country),
-          billingAddress1 =
-            billingAddress.flatMap(x => toUpdate(x.address1, currentUser.privateFields.billingAddress1)),
-          billingAddress2 =
-            billingAddress.flatMap(x => toUpdate(x.address2, currentUser.privateFields.billingAddress2)),
-          billingAddress3 =
-            billingAddress.flatMap(x => toUpdate(x.address3, currentUser.privateFields.billingAddress3)),
-          billingAddress4 =
-            billingAddress.flatMap(x => toUpdate(x.address4, currentUser.privateFields.billingAddress4)),
-          billingPostcode =
-            billingAddress.flatMap(x => toUpdate(x.postcode, currentUser.privateFields.billingPostcode)),
-          billingCountry = billingAddress.flatMap(x => toUpdate(x.country, currentUser.privateFields.billingCountry)),
-          telephoneNumber = telephoneNumber.flatMap(_.telephoneNumber),
-        ),
-      ),
-    )
-}
+) extends UserFormData
 
 object AccountFormData {
 

--- a/identity/app/form/PrivacyMapping.scala
+++ b/identity/app/form/PrivacyMapping.scala
@@ -31,19 +31,12 @@ class PrivacyMapping extends UserFormMapping[PrivacyFormData] {
   protected def toUserFormData(userDO: User): PrivacyFormData =
     PrivacyFormData(userDO)
 
-  protected lazy val idapiErrorContextToFormFieldKeyMap = Map(
-    "consents" -> "consents",
-  )
 }
 
 /**
   * Form specific DTO representing marketing consent subset of User model
   */
-case class PrivacyFormData(consents: List[Consent]) extends UserFormData {
-
-  def toUserUpdateDTO(oldUserDO: User): UserUpdateDTO =
-    UserUpdateDTO(consents = Some(consents))
-}
+case class PrivacyFormData(consents: List[Consent]) extends UserFormData
 
 object PrivacyFormData extends SafeLogging {
 

--- a/identity/app/form/PrivacyMapping.scala
+++ b/identity/app/form/PrivacyMapping.scala
@@ -16,7 +16,6 @@ class PrivacyMapping extends UserFormMapping[PrivacyFormData] {
 
   def formMapping(implicit messagesProvider: MessagesProvider): Mapping[PrivacyFormData] =
     mapping(
-      "allowThirdPartyProfiling" -> optional(boolean),
       "consents" -> list(
         mapping(
           "actor" -> text,
@@ -33,24 +32,17 @@ class PrivacyMapping extends UserFormMapping[PrivacyFormData] {
     PrivacyFormData(userDO)
 
   protected lazy val idapiErrorContextToFormFieldKeyMap = Map(
-    "statusFields.allowThirdPartyProfiling" -> "allowThirdPartyProfiling",
+    "consents" -> "consents",
   )
 }
 
 /**
   * Form specific DTO representing marketing consent subset of User model
   */
-case class PrivacyFormData(allowThirdPartyProfiling: Option[Boolean], consents: List[Consent]) extends UserFormData {
+case class PrivacyFormData(consents: List[Consent]) extends UserFormData {
 
   def toUserUpdateDTO(oldUserDO: User): UserUpdateDTO =
-    UserUpdateDTO(
-      statusFields = Some(
-        oldUserDO.statusFields.copy(
-          allowThirdPartyProfiling = Some(allowThirdPartyProfiling.getOrElse(false)),
-        ),
-      ),
-      consents = Some(consents),
-    )
+    UserUpdateDTO(consents = Some(consents))
 }
 
 object PrivacyFormData extends SafeLogging {
@@ -63,7 +55,6 @@ object PrivacyFormData extends SafeLogging {
     */
   def apply(userDO: User): PrivacyFormData = {
     PrivacyFormData(
-      allowThirdPartyProfiling = userDO.statusFields.allowThirdPartyProfiling,
       consents = if (userDO.consents.isEmpty) defaultConsents else onlyValidConsents(userDO),
     )
   }

--- a/identity/app/form/UserFormMapping.scala
+++ b/identity/app/form/UserFormMapping.scala
@@ -2,7 +2,6 @@ package form
 
 import play.api.data.{Form, Mapping}
 import com.gu.identity.model.User
-import idapiclient.UserUpdateDTO
 import play.api.i18n.MessagesProvider
 
 trait UserFormMapping[T <: UserFormData] extends Mappings {
@@ -21,12 +20,6 @@ trait UserFormMapping[T <: UserFormData] extends Mappings {
   def fillForm(userDO: User)(implicit messagesProvider: MessagesProvider): Form[T] =
     Form(formMapping) fill toUserFormData(userDO) // note the indirection where userDO is converted to UserFormData
 
-  /**
-    * Returns Form field key given IDAPI error context
-    */
-  def formFieldKeyBy(idapiErrorContext: IdapiErrorContext): String =
-    idapiErrorContextToFormFieldKeyMap.getOrElse(idapiErrorContext, default = idapiErrorContext)
-
   def formMapping(implicit messagesProvider: MessagesProvider): Mapping[T]
 
   /**
@@ -37,10 +30,6 @@ trait UserFormMapping[T <: UserFormData] extends Mappings {
     */
   protected def toUserFormData(userDO: User): T
 
-  /**
-    * Mapping from IDAPI error context to Form field key
-    */
-  protected def idapiErrorContextToFormFieldKeyMap: Map[IdapiErrorContext, FormFieldKey]
 }
 
 /**
@@ -48,11 +37,6 @@ trait UserFormMapping[T <: UserFormData] extends Mappings {
   * These DTOs are meant to represent parts of User Domain Object form
   */
 trait UserFormData {
-
-  /**
-    * Converts User DO to UserUpdate DTO used for serialisation over wire
-    */
-  def toUserUpdateDTO(oldUserDO: User): UserUpdateDTO
 
   protected def toUpdate[T](newValue: T, current: Option[T]): Option[T] =
     (newValue, current) match {

--- a/identity/test/idapiclient/IdApiTest.scala
+++ b/identity/test/idapiclient/IdApiTest.scala
@@ -83,7 +83,6 @@ class IdApiTest
       |            "usernameLowerCase": "testusername"
       |        },
       |        "statusFields": {
-      |            "allowThirdPartyProfiling": true,
       |            "userEmailValidated": false
       |        }
       |    }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
- Remove deprecated IDAPI user model fields - these fields are now represented by items in the consents array on the user model.
- Remove unused form data handling code. 

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Avoid confusion of unused deprecated fields.
