### PR TITLE
Return 204 for missing newsletter

### DIFF
--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -108,7 +108,7 @@ class EmailSignupController(
             Cached(1.day)(RevalidatableResult.Ok(views.html.emailFragmentFooter(emailLandingPage, listName)))
           case Right(None) =>
             logNewsletterNotFoundError(listName)
-            Cached(15.minute)(WithoutRevalidationResult(NotFound))
+            Cached(15.minute)(WithoutRevalidationResult(NoContent))
           case Left(e) =>
             logApiError(e)
             Cached(15.minute)(WithoutRevalidationResult(InternalServerError))
@@ -134,7 +134,7 @@ class EmailSignupController(
             )
           case Right(None) =>
             logNewsletterNotFoundError(listId.toString)
-            Cached(15.minute)(WithoutRevalidationResult(NotFound))
+            Cached(15.minute)(WithoutRevalidationResult(NoContent))
           case Left(e) =>
             logApiError(e)
             Cached(15.minute)(WithoutRevalidationResult(InternalServerError))
@@ -159,7 +159,7 @@ class EmailSignupController(
             )
           case Right(None) =>
             logNewsletterNotFoundError(listName)
-            Cached(15.minute)(WithoutRevalidationResult(NotFound))
+            Cached(15.minute)(WithoutRevalidationResult(NoContent))
           case Left(e) =>
             logApiError(e)
             Cached(15.minute)(WithoutRevalidationResult(InternalServerError))
@@ -176,7 +176,7 @@ class EmailSignupController(
           RevalidatableResult.Ok(views.html.emailSubscriptionResultFooter(emailLandingPage, InvalidEmail))
         case "error" =>
           RevalidatableResult.Ok(views.html.emailSubscriptionResultFooter(emailLandingPage, OtherError))
-        case _ => WithoutRevalidationResult(NotFound)
+        case _ => WithoutRevalidationResult(NoContent)
       })
     }
 
@@ -192,7 +192,7 @@ class EmailSignupController(
           )
         case Right(None) =>
           logNewsletterNotFoundError(listName)
-          Cached(15.minute)(WithoutRevalidationResult(NotFound))
+          Cached(15.minute)(WithoutRevalidationResult(NoContent))
         case Left(e) =>
           logApiError(e)
           Cached(15.minute)(WithoutRevalidationResult(InternalServerError))
@@ -210,7 +210,7 @@ class EmailSignupController(
           RevalidatableResult.Ok(
             views.html.emailSubscriptionNonsuccessResult(emailLandingPage, OtherError),
           )
-        case _ => WithoutRevalidationResult(NotFound)
+        case _ => WithoutRevalidationResult(NoContent)
       })
     }
 


### PR DESCRIPTION
## What does this change?

If a newsletter has been removed/retired we want to return a 204 and not
a 404. Without this the iframe embeds a 404 error page.

Ideally we'd have a way to remove these iframes when the newsletter is
retired, but that is for another day. Not a friday.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |


[before]: https://user-images.githubusercontent.com/9122944/104729330-2d994c00-5730-11eb-9ed4-0375fd085810.png
[after]: https://user-images.githubusercontent.com/9122944/104729380-430e7600-5730-11eb-8572-ffaeb4be074a.png


## What is the value of this and can you measure success?
Doesn't look (as) broken anymore.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
