### PR TITLE
move githooks sync to make install

### DIFF
--- a/makefile
+++ b/makefile
@@ -20,6 +20,7 @@ list: # PRIVATE
 # Install all 3rd party dependencies.
 install: check-node-env
 	@yarn -s install
+	@./tools/sync-githooks.js
 
 # Remove all 3rd party dependencies.
 uninstall: # PRIVATE

--- a/package.json
+++ b/package.json
@@ -175,7 +175,6 @@
     ]
   },
   "scripts": {
-    "postinstall": "./tools/sync-githooks.js",
     "eslint-fix": "eslint --color --fix",
     "test": "jest"
   },


### PR DESCRIPTION
## What does this change?

- moves the githooks sync script call from `postinstall` nom-script to `make install`

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

`postinstall` is intended to be run after the package it lives in has been installed elsewhere. after adding #23453 it throws an error when installing it, because really it's a maintenance script for frontend, not the place frontend is being installed.