### PR TITLE
remove-old-class-member-types

### DIFF
--- a/static/src/javascripts/lib/__mocks__/storage.js
+++ b/static/src/javascripts/lib/__mocks__/storage.js
@@ -1,6 +1,5 @@
 class StorageMock {
-    storage;
-    available;
+
 
     constructor() {
         this.storage = {};

--- a/static/src/javascripts/lib/fsm.js
+++ b/static/src/javascripts/lib/fsm.js
@@ -34,10 +34,7 @@ import { noop } from 'lib/noop';
 */
 
 class FiniteStateMachine {
-    context;
-    states;
-    debug;
-    onChangeState;
+
 
     constructor(options) {
         this.context = options.context;

--- a/static/src/javascripts/projects/admin/modules/abtests/abtest-report-item.js
+++ b/static/src/javascripts/projects/admin/modules/abtests/abtest-report-item.js
@@ -27,8 +27,7 @@ class ABTestReportItem extends Component {
         }
     }
 
-    chart;
-    config;
+
 
     ready() {
         if (this.chart) {
@@ -87,7 +86,7 @@ class ABTestReportItem extends Component {
         }
 
         if (elements.expiry) {
-            
+
             elements.expiry.textContent =
                 Math.floor(daysTillExpiry).toString() +
                 (daysTillExpiry === 1 ? ' day' : ' days');

--- a/static/src/javascripts/projects/admin/modules/abtests/audience-item.js
+++ b/static/src/javascripts/projects/admin/modules/abtests/audience-item.js
@@ -20,7 +20,7 @@ class AudienceItem extends Component {
         );
     }
 
-    config;
+
 
     prerender() {
         const testEl = this.getElem('test');

--- a/static/src/javascripts/projects/admin/modules/abtests/audience.js
+++ b/static/src/javascripts/projects/admin/modules/abtests/audience.js
@@ -20,7 +20,7 @@ class Audience extends Component {
         );
     }
 
-    config;
+
 
     prerender() {
         const testsContainer = this.getElem('tests');

--- a/static/src/javascripts/projects/admin/modules/abtests/participation-item.js
+++ b/static/src/javascripts/projects/admin/modules/abtests/participation-item.js
@@ -22,7 +22,7 @@ class ParticipationItem extends Component {
         );
     }
 
-    config;
+
 
     prerender() {
         const origin = /gutools.co.uk$/.test(document.location.origin)

--- a/static/src/javascripts/projects/admin/modules/abtests/participation.js
+++ b/static/src/javascripts/projects/admin/modules/abtests/participation.js
@@ -20,7 +20,7 @@ class Participation extends Component {
         );
     }
 
-    config;
+
 
     prerender() {
         const test = this.config.test;

--- a/static/src/javascripts/projects/commercial/modules/creatives/fabric-expanding-v1.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/fabric-expanding-v1.js
@@ -15,15 +15,7 @@ import { addViewabilityTracker } from 'commercial/modules/creatives/add-viewabil
 
 // Forked from expandable-v3.js
 class FabricExpandingV1 {
-    adSlot;
-    params;
-    isClosed;
-    initialExpandCounter;
-    closedHeight;
-    openedHeight;
 
-    $button;
-    $ad;
 
     static hasScrollEnabled;
 

--- a/static/src/javascripts/projects/commercial/modules/creatives/fabric-v1.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/fabric-v1.js
@@ -21,12 +21,7 @@ let scrollBgTpl;
 // This is a hasty clone of fluid250.js
 
 class FabricV1 {
-    adSlot;
-    params;
 
-    scrollingBg;
-    layer2;
-    scrollType;
 
     constructor(adSlot, params) {
         this.adSlot = adSlot;

--- a/static/src/javascripts/projects/commercial/modules/creatives/fabric-video.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/fabric-video.js
@@ -9,13 +9,7 @@ import fabricVideoStr from 'raw-loader!commercial/views/creatives/fabric-video.h
 import objectFitVideos from 'object-fit-videos';
 
 class FabricVideo {
-    isUpdating;
-    adSlot;
-    params;
-    layer2;
-    video;
-    hasVideo;
-    inView;
+
 
     constructor(adSlot, params) {
         const isSmallScreen = isBreakpoint({

--- a/static/src/javascripts/projects/commercial/modules/creatives/frame.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/frame.js
@@ -10,8 +10,7 @@ import externalLink from 'svgs/icon/external-link.svg';
 import arrow from 'svgs/icon/arrow.svg';
 
 class Frame {
-    adSlot;
-    params;
+
 
     constructor(adSlot, params) {
         this.adSlot = adSlot;

--- a/static/src/javascripts/projects/commercial/modules/creatives/scrollable-mpu-v2.js
+++ b/static/src/javascripts/projects/commercial/modules/creatives/scrollable-mpu-v2.js
@@ -31,10 +31,7 @@ const scrollableMpuTpl = (params) => `
 `;
 
 class ScrollableMpu {
-    adSlot;
-    params;
-    $scrollableImage;
-    $scrollableMpu;
+
 
     constructor(adSlot, params) {
         this.adSlot = adSlot;

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.js
@@ -29,26 +29,7 @@ const getAdBreakpointSizes = (advertNode) =>
     }, {});
 
 class Advert {
-    id;
-    node;
-    sizes;
-    size;
-    slot;
-    isEmpty;
-    isLoading;
-    isRendering;
-    isLoaded;
-    isRendered;
-    shouldRefresh;
-    maxViewPercentage;
-    whenLoaded;
-    whenLoadedResolver;
-    whenRendered;
-    whenRenderedResolver;
-    whenSlotReady;
-    extraNodeClasses;
-    timings;
-    hasPrebidSize;
+
 
     constructor(adSlotNode) {
         const sizes = getAdBreakpointSizes(adSlotNode);

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.js
@@ -6,9 +6,7 @@ import { dfpEnv } from 'commercial/modules/dfp/dfp-env';
 
 
 class A9AdUnit {
-    slotID;
-    slotName;
-    sizes;
+
 
     constructor(advert, slot) {
         this.slotID = advert.id;

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
@@ -33,9 +33,7 @@ const consentManagement = {
 };
 
 class PrebidAdUnit {
-    code;
-    bids;
-    mediaTypes;
+
 
     constructor(advert, slot) {
         this.code = advert.id;

--- a/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
@@ -12,32 +12,7 @@ import interactionTracking from 'common/modules/analytics/interaction-tracking';
 import { loadCssPromise } from 'lib/load-css-promise';
 
 class HostedGallery {
-    useSwipe;
-    swipeThreshold;
-    swipeContainerWidth;
-    index;
-    imageRatios;
-    $galleryEl;
-    $galleryFrame;
-    $header;
-    $imagesContainer;
-    $captionContainer;
-    $captions;
-    $scrollEl;
-    $images;
-    $progress;
-    $border;
-    prevBtn;
-    nextBtn;
-    infoBtn;
-    $counter;
-    $ctaFloat;
-    $ojFloat;
-    $meta;
-    ojClose;
-    resize;
-    resizer;
-    fsm;
+
     constructor() {
         // CONFIG
         const breakpoint = getBreakpoint();
@@ -86,7 +61,7 @@ class HostedGallery {
                 initial: 'image',
                 onChangeState() {},
                 context: this,
-                
+
                 states: this.states,
             });
 

--- a/static/src/javascripts/projects/commercial/modules/hosted/onward-journey-carousel.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/onward-journey-carousel.js
@@ -3,12 +3,7 @@ import fastdom from 'fastdom';
 import $ from 'lib/$';
 
 class HostedCarousel {
-    $carousel;
-    $nextItem;
-    $prevItem;
-    $dots;
-    pageCount;
-    index;
+
 
     moveCarouselBy(direction) {
         this.moveCarouselTo(this.index + direction);

--- a/static/src/javascripts/projects/common/modules/analytics/scrollDepth.js
+++ b/static/src/javascripts/projects/common/modules/analytics/scrollDepth.js
@@ -21,9 +21,7 @@ const getPercentageInViewPort = (el) => {
 };
 
 class ScrollDepth {
-    opts;
-    data;
-    timeoutId;
+
 
     constructor(options) {
         this.opts = Object.assign(

--- a/static/src/javascripts/projects/common/modules/article/space-filler.js
+++ b/static/src/javascripts/projects/common/modules/article/space-filler.js
@@ -9,7 +9,7 @@ const onError = (e) => {
 };
 
 class SpaceFiller {
-    queue;
+
 
     constructor() {
         this.queue = Promise.resolve();

--- a/static/src/javascripts/projects/common/modules/audio/AudioPlayer.js
+++ b/static/src/javascripts/projects/common/modules/audio/AudioPlayer.js
@@ -391,9 +391,7 @@ export class AudioPlayer extends Component {
         this.audio.pause();
     };
 
-    audio;
-    wave;
-    waveBuffered;
+
 
     ready = () => {
         this.setState({ duration: this.audio.duration });

--- a/static/src/javascripts/projects/common/modules/audio/ProgressBar.js
+++ b/static/src/javascripts/projects/common/modules/audio/ProgressBar.js
@@ -61,7 +61,7 @@ export default class ProgressBar extends Component {
         }
     }
 
-    onChange;
+
 
     getElement = (el) => {
         if (el) {
@@ -69,7 +69,7 @@ export default class ProgressBar extends Component {
         }
     };
 
-    element;
+
 
     start = (e) => {
         const position = e.clientX - this.state.left;

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
@@ -6,22 +6,7 @@ import userPrefs from 'common/modules/user-prefs';
 
 // Having a constructor means we can easily re-instantiate the object in a test
 class CommercialFeatures {
-    dfpAdvertising;
-    isSecureContact;
-    stickyTopBannerAd;
-    articleBodyAdverts;
-    articleAsideAdverts;
-    carrotTrafficDriver;
-    highMerch;
-    thirdPartyTags;
-    relatedWidgetEnabled;
-    commentAdverts;
-    liveblogAdverts;
-    paidforBand;
-    asynchronous;
-    adFree;
-    comscore;
-    launchpad;
+
 
     constructor(config = defaultConfig) {
         // this is used for SpeedCurve tests

--- a/static/src/javascripts/projects/common/modules/component.js
+++ b/static/src/javascripts/projects/common/modules/component.js
@@ -12,24 +12,7 @@ class ComponentError {
 }
 
 class Component {
-    useBem;
-    templateName;
-    componentClass;
-    endpoint;
-    classes;
-    elem;
-    template;
-    rendered;
-    destroyed;
-    elems;
-    options;
-    defaultOptions;
-    responseDataKey;
-    autoupdated;
-    updateEvery;
-    fetchData;
-    manipulationType;
-    t;
+
 
     constructor() {
         this.useBem = false;

--- a/static/src/javascripts/projects/common/modules/crosswords/crossword.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/crossword.js
@@ -355,12 +355,7 @@ class Crossword extends Component {
         this.returnPosition = position;
     }
 
-    columns;
-    rows;
-    clueMap;
-    $gridWrapper;
-    gridHeightIsSet;
-    returnPosition;
+
 
     insertCharacter(character) {
         const characterUppercase = character.toUpperCase();

--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -163,12 +163,11 @@ class CommentBox extends Component {
     // eslint-disable-next-line class-methods-use-this
     getUserData() {
         // User will always exists at this point.
-        
+
         return getUserFromCookie();
     }
 
-    errors;
-    errorMessages;
+
 
     clearErrors() {
         const messages = this.getElem('messages');
@@ -576,7 +575,7 @@ class CommentBox extends Component {
         const comment = {
             body: body.value,
         };
-        
+
         const callback = this[methodName].bind(this);
 
         this.clearErrors();

--- a/static/src/javascripts/projects/common/modules/discussion/comments.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comments.js
@@ -107,11 +107,7 @@ class Comments extends Component {
         }
     }
 
-    comments;
-    topLevelComments;
-    user;
-    postedCommentEl;
-    wholeDiscussionErrors;
+
 
     addMoreRepliesButtons(comms) {
         const comments = comms || this.topLevelComments;
@@ -545,7 +541,7 @@ class Comments extends Component {
 
         // Determine user staff status
         if (this.user && this.user.badge) {
-            
+
             this.user.isStaff = this.user.badge.some(e => e.name === 'Staff');
         }
 

--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -83,11 +83,7 @@ class Loader extends Component {
         window.location.replace(`#comment-${id}`);
     }
 
-    $topCommentsContainer;
-    comments;
-    topCommentCount;
-    user;
-    username;
+
 
     commentPosted(comment) {
         this.removeState('truncated');
@@ -201,7 +197,7 @@ class Loader extends Component {
                 );
 
                 if (this.comments) {
-                    
+
                     this.comments.options.order = bonzo(e.currentTarget).data(
                         'order'
                     );
@@ -228,7 +224,7 @@ class Loader extends Component {
                 );
 
                 if (this.comments) {
-                    
+
                     this.comments.options.threading = bonzo(
                         e.currentTarget
                     ).data('threading');

--- a/static/src/javascripts/projects/common/modules/discussion/whole-discussion.js
+++ b/static/src/javascripts/projects/common/modules/discussion/whole-discussion.js
@@ -46,13 +46,7 @@ const runConcurrently = (
     });
 
 class WholeDiscussion {
-    commentsThread;
-    discussion;
-    discussionContainer;
-    discussionId;
-    lastPage;
-    params;
-    postedCommentHtml;
+
 
     constructor(options) {
         this.discussionId = options.discussionId;

--- a/static/src/javascripts/projects/common/modules/experiments/affix.js
+++ b/static/src/javascripts/projects/common/modules/experiments/affix.js
@@ -6,12 +6,7 @@ const getPixels = (top) =>
     top !== 'auto' ? parseInt(top, 10) : 0;
 
 class Affix {
-    affixed;
-    $markerTop;
-    $markerBottom;
-    $container;
-    $element;
-    $window;
+
 
     constructor(options) {
         window.addEventListener('click', () => {

--- a/static/src/javascripts/projects/common/modules/gallery/lightbox.js
+++ b/static/src/javascripts/projects/common/modules/gallery/lightbox.js
@@ -37,34 +37,7 @@ class Endslate extends Component {
 }
 
 class GalleryLightbox {
-    showEndslate;
-    useSwipe;
-    swipeThreshold;
-    lightboxEl;
-    $lightboxEl;
-    $indexEl;
-    $countEl;
-    $contentEl;
-    nextBtn;
-    prevBtn;
-    closeBtn;
-    infoBtn;
-    $swipeContainer;
-    resize;
-    toggleInfo;
-    fsm;
-    states;
-    images;
-    swipeContainerWidth;
-    $slides;
-    index;
-    $images;
-    galleryJson;
-    bodyScrollPosition;
-    endslateEl;
-    endslate;
-    startIndex;
-    handleKeyEvents;
+
 
     constructor() {
         // CONFIG
@@ -215,7 +188,7 @@ class GalleryLightbox {
 
             // Flow doesn't accept the WebKit-specific TouchEvent.scale
             // https://developer.apple.com/documentation/webkitjs/touchevent/1632169-scale
-            
+
             if (e.touches.length > 1 || (e.scale && e.scale !== 1)) {
                 return;
             }

--- a/static/src/javascripts/projects/common/modules/identity/account-profile.js
+++ b/static/src/javascripts/projects/common/modules/identity/account-profile.js
@@ -70,9 +70,7 @@ const avatarUploadByApi = (avatarForm) => {
 };
 
 class AccountProfile {
-    unsavedFields;
-    accountProfileForms;
-    unsavedChangesForm;
+
 
     constructor() {
         this.unsavedFields = [];

--- a/static/src/javascripts/projects/common/modules/identity/ad-prefs.js
+++ b/static/src/javascripts/projects/common/modules/identity/ad-prefs.js
@@ -55,8 +55,7 @@ class AdPrefsWrapper extends Component {
         });
     }
 
-    FeedbackFlashBoxRef;
-    SubmitButtonRef;
+
 
     render() {
         return (

--- a/static/src/javascripts/projects/common/modules/identity/formstack-iframe-embed.js
+++ b/static/src/javascripts/projects/common/modules/identity/formstack-iframe-embed.js
@@ -57,10 +57,7 @@ const sendHeight = () => {
 
 // TODO: Remove repitition with common/modules/identity/formstack
 class FormstackEmbedIframe {
-    el;
-    form;
-    formId;
-    config;
+
 
     constructor(el, formstackId) {
         this.el = el;

--- a/static/src/javascripts/projects/common/modules/identity/formstack-iframe.js
+++ b/static/src/javascripts/projects/common/modules/identity/formstack-iframe.js
@@ -2,7 +2,7 @@ import config from 'lib/config';
 import mediator from 'lib/mediator';
 
 class FormstackIframe {
-    el;
+
 
     constructor(el) {
         this.el = el;

--- a/static/src/javascripts/projects/common/modules/identity/formstack.js
+++ b/static/src/javascripts/projects/common/modules/identity/formstack.js
@@ -3,10 +3,7 @@ import { getUserOrSignIn } from 'common/modules/identity/api';
 
 // TODO: Remove repitition with common/modules/identity/formstack-iframe-embed
 class Formstack {
-    el;
-    form;
-    formId;
-    config;
+
 
     constructor(el, formstackId) {
         this.el = el;

--- a/static/src/javascripts/projects/common/modules/identity/identity-features.js
+++ b/static/src/javascripts/projects/common/modules/identity/identity-features.js
@@ -1,9 +1,9 @@
 class IdentityFeatures {
-    promptForSignIn;
+
 
     constructor() {
         this.promptForSignIn =
-            
+
             navigator.credentials && window.PasswordCredential;
     }
 }

--- a/static/src/javascripts/projects/common/modules/identity/upsell/store/types.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/store/types.js
@@ -6,10 +6,7 @@ import {
 
 
 class ConsentWithState {
-    consent;
-    uniqueId;
-    hasConsented;
-    updateInApiFn;
+
 
     constructor(consent, hasConsented) {
         this.consent = consent;

--- a/static/src/javascripts/projects/common/modules/navigation/profile.js
+++ b/static/src/javascripts/projects/common/modules/navigation/profile.js
@@ -14,8 +14,7 @@ const CONFIG = {
 };
 
 class Profile {
-    dom;
-    opts;
+
 
     constructor(options) {
         const opts = {

--- a/static/src/javascripts/projects/common/modules/navigation/search.js
+++ b/static/src/javascripts/projects/common/modules/navigation/search.js
@@ -5,8 +5,7 @@ import config from 'lib/config';
 
 // TODO refactor to singleton
 class Search {
-    gcsUrl;
-    resultSetSize;
+
 
     constructor() {
         fastdom

--- a/static/src/javascripts/projects/common/modules/onward/tonal.js
+++ b/static/src/javascripts/projects/common/modules/onward/tonal.js
@@ -53,7 +53,7 @@ class TonalComponent extends Component {
         return `/container/${endpoint}.json`;
     }
 
-    edition;
+
 
     isSupported() {
         return TonalComponent.getTone() in tones[this.edition];

--- a/static/src/javascripts/projects/common/modules/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/spacefinder.js
@@ -240,8 +240,6 @@ const enforceRules = (
 };
 
 class SpaceError extends Error {
-    name;
-    message;
 
     constructor(rules) {
         super();

--- a/static/src/javascripts/projects/common/modules/sport/football/match-info.js
+++ b/static/src/javascripts/projects/common/modules/sport/football/match-info.js
@@ -8,7 +8,6 @@ class MatchInfo {
         this.endpoint = `${base}/${slug}.json?page=${page}`;
     }
 
-    endpoint;
 
     fetch() {
         return fetchJSON(this.endpoint, {

--- a/static/src/javascripts/projects/common/modules/sport/score-board.js
+++ b/static/src/javascripts/projects/common/modules/sport/score-board.js
@@ -35,9 +35,7 @@ class ScoreBoard extends Component {
         }
     }
 
-    placeholder;
-    pageType;
-    parent;
+
 
     prerender() {
         const scoreLoadingPlaceholder = $(

--- a/static/src/javascripts/projects/common/modules/ui/expandable.js
+++ b/static/src/javascripts/projects/common/modules/ui/expandable.js
@@ -5,11 +5,7 @@
 
 
 class Expandable {
-    opts;
-    dom;
-    cta;
-    expanded;
-    showCount;
+
 
     constructor(options) {
         this.opts = options;

--- a/static/src/javascripts/projects/common/modules/ui/message.js
+++ b/static/src/javascripts/projects/common/modules/ui/message.js
@@ -16,24 +16,7 @@ import uniq from 'lodash/uniq';
  * @param {Object=} options
  */
 class Message {
-    id;
-    important;
-    permanent;
-    blocking;
-    trackDisplay;
-    type;
-    position;
-    siteMessageComponentName;
-    siteMessageLinkName;
-    siteMessageCloseBtn;
-    prefs;
-    widthBasedMessage;
-    cssModifierClass;
-    customJs;
-    customOpts;
-    $siteMessage;
-    $siteMessageContainer;
-    $siteMessageOverlay;
+
 
     constructor(id, options) {
         const opts = options || {};

--- a/static/src/javascripts/projects/common/modules/ui/selection-sharing.spec.js
+++ b/static/src/javascripts/projects/common/modules/ui/selection-sharing.spec.js
@@ -38,10 +38,7 @@ test('should be initially hidden in the article body', () => {
 test('should be visible when text is selected in the article body', () => {
     // required mocks (not present in jsdom at time of writing)
     class MockRange {
-        startContainer;
-        endContainer;
-        startOffset;
-        endOffset;
+
 
         constructor() {
             this.startContainer = null;
@@ -72,8 +69,7 @@ test('should be visible when text is selected in the article body', () => {
     }
 
     class MockSelection {
-        ranges;
-        rangeCount;
+
 
         constructor(range) {
             this.ranges = [range];
@@ -99,7 +95,7 @@ test('should be visible when text is selected in the article body', () => {
     // feels like overkill. It may be that JSDOM implements Range in the future
     // though, which we can then sub in (see:
     // https://github.com/tmpvar/jsdom/issues/317).
-    
+
     document.createRange = jest.fn(() => new MockRange());
 
     if (document.body) {

--- a/static/src/javascripts/projects/common/modules/ui/sticky.js
+++ b/static/src/javascripts/projects/common/modules/ui/sticky.js
@@ -5,10 +5,7 @@ import fastdom from 'fastdom';
  * @todo: check if browser natively supports "position: sticky"
  */
 class Sticky {
-    element;
-    opts;
-    offsetFromParent;
-    lastMessage;
+
 
     constructor(element, options = {}) {
         this.element = element;

--- a/static/src/javascripts/projects/common/modules/ui/toggles.js
+++ b/static/src/javascripts/projects/common/modules/ui/toggles.js
@@ -1,8 +1,7 @@
 import mediator from 'lib/mediator';
 
 class Toggles {
-    component;
-    controls;
+
 
     constructor(component = document.body) {
         if (component) {

--- a/static/src/javascripts/projects/facia/modules/onwards/geo-most-popular-front-extended.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/geo-most-popular-front-extended.js
@@ -17,7 +17,7 @@ export class GeoMostPopularFrontExtended extends Component {
         this.manipulationType = 'html';
     }
 
-    parent;
+
 
     prerender() {
         const isInternational = config.get('page.pageId') === 'international';

--- a/static/src/javascripts/projects/facia/modules/onwards/geo-most-popular-front.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/geo-most-popular-front.js
@@ -26,10 +26,7 @@ export class GeoMostPopularFront extends Component {
         this.manipulationType = 'html';
     }
 
-    isNetworkFront;
-    isVideoFront;
-    isInternational;
-    parent;
+
 
     prerender() {
         this.elem = qwery('.headline-list', this.elem)[0];

--- a/static/src/javascripts/projects/facia/modules/onwards/search-tool.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/search-tool.js
@@ -16,12 +16,7 @@ const keyCodeMap = {
 
 
 export class SearchTool {
-    apiUrl;
-    $list;
-    $input;
-    oldQuery;
-    newQuery;
-    inputTmp;
+
 
     constructor(options) {
         const container = options.container;

--- a/static/src/javascripts/projects/facia/modules/ui/container-show-more.js
+++ b/static/src/javascripts/projects/facia/modules/ui/container-show-more.js
@@ -89,16 +89,7 @@ const dedupShowMore = ($container, html) => {
 };
 
 class Button {
-    id;
-    state;
-    isLoaded;
-    $el;
-    $container;
-    $iconEl;
-    $placeholder;
-    $textEl;
-    $errorMessage;
-    messages;
+
 
     constructor(el, container) {
         this.id = container.attr('data-id');

--- a/static/src/javascripts/projects/facia/modules/ui/container-toggle.js
+++ b/static/src/javascripts/projects/facia/modules/ui/container-toggle.js
@@ -18,9 +18,7 @@ const btnTmpl = ({ text, dataLink }) => `
 `;
 
 export class ContainerToggle {
-    $container;
-    state;
-    $button;
+
     constructor(container) {
         this.$container = bonzo(container);
         this.$button = bonzo(


### PR DESCRIPTION
## What does this change?

removes some bits missed removing flow in #23382 to stop linting when using frontend as a package with #23453 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

