### PR TITLE
Update header thankyou copy

### DIFF
--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -35,9 +35,8 @@
                 @if(editionId != "us" && GlobalEoyHeaderSwitch.isSwitchedOn) {
                     <div class="new-header__cta-bar-thankyou hide-until-mobile">
                         <div class="cta-bar__text hide-until-tablet">
-                            <div class="cta-bar__heading">Thank you for your support</div>
-                            <div class="cta-bar__subheading">You’ve powered our journalism</div>
-                            <div class="cta-bar__subheading">through a historic year</div>
+                            <div class="cta-bar__heading">Thank you</div>
+                            <div class="cta-bar__subheading">Your support powers our independent journalism</div>
                         </div>
                     </div>
                 }


### PR DESCRIPTION
This is displayed to supporters in the header. It's currently bumping up against the gifting link.
<img width="598" alt="Screen Shot 2021-01-20 at 11 19 15" src="https://user-images.githubusercontent.com/1513454/105168099-880c2100-5b11-11eb-9ab4-9ac3fc48fca7.png">
