### PR TITLE
Increase Deeply test length

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -52,7 +52,7 @@ trait ABTestSwitches {
     "Tests an onward hypothesis by replacing the second tab in the Most Popular container with deeply read items.",
     owners = Seq(Owner.withGithub("nitro-marky")),
     safeState = Off,
-    sellByDate = new LocalDate(2021, 1, 25),
+    sellByDate = new LocalDate(2021, 1, 29),
     exposeClientSide = true,
   )
 


### PR DESCRIPTION
## What does this change?

Increase switch expiry so it doens't end this Friday.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

