### PR TITLE
Final update on US Presidential Election 2020 Election Tracker AMP Hack

### DIFF
--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -105,7 +105,7 @@ class InteractiveController(
   override def canRender(i: ItemResponse): Boolean = i.content.exists(_.isInteractive)
 
   override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = {
-    ApplicationsDotcomRenderingInterface.getRenderingTier(path) match {
+    ApplicationsInteractiveRendering.getRenderingTier(path) match {
       case Legacy => {
         lookup(path) map {
           case Left(model)  => render(model)

--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -112,7 +112,7 @@ class InteractiveController(
           case Right(other) => RenderOtherStatus(other)
         }
       }
-      case Election2020Hack => renderInteractivePageElection2020_v2(path)
+      case Election2020AmpElectionTracker => renderInteractivePageElection2020_v2(path)
       case DotcomRendering => {
         val remoteRenderer = DotcomRenderingService()
         val range = ArticleBlocks

--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -15,8 +15,8 @@ import model.dotcomrendering.PageType
 import org.apache.commons.lang.StringEscapeUtils
 import pages.InteractiveHtmlPage
 import renderers.DotcomRenderingService
-import services.ApplicationsSpecial2020Election
-import services.ApplicationsSpecial2020Election.pathToAmpAtomId
+import services.ApplicationsUSElection2020AmpPages
+import services.ApplicationsUSElection2020AmpPages.pathToAmpAtomId
 
 import scala.concurrent.duration._
 import scala.concurrent.Future
@@ -149,7 +149,7 @@ class InteractiveController(
     val atomIdOpt = i.item.content.atoms.flatMap(atoms => atoms.interactives.headOption.map(atom => atom.id))
     atomIdOpt match {
       case Some(atomId) => {
-        val capiLookupString = ApplicationsSpecial2020Election.defaultAtomIdToAmpAtomId(atomId)
+        val capiLookupString = ApplicationsUSElection2020AmpPages.defaultAtomIdToAmpAtomId(atomId)
         val response: Future[ItemResponse] = lookupWithoutModelConvertion(capiLookupString)
         response.map { response =>
           response.interactive match {
@@ -169,7 +169,7 @@ class InteractiveController(
     /*
       This version retrieve the AMP version directly but rely on an predefined map between paths and amp page ids
      */
-    val capiLookupString = ApplicationsSpecial2020Election.pathToAmpAtomId(path)
+    val capiLookupString = ApplicationsUSElection2020AmpPages.pathToAmpAtomId(path)
     val response: Future[ItemResponse] = lookupWithoutModelConvertion(capiLookupString)
     response.map { response =>
       response.interactive match {

--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -112,7 +112,7 @@ class InteractiveController(
           case Right(other) => RenderOtherStatus(other)
         }
       }
-      case Election2020AmpElectionTracker => renderInteractivePageElection2020_v2(path)
+      case USElection2020AmpPage => renderInteractivePageElection2020_v2(path)
       case DotcomRendering => {
         val remoteRenderer = DotcomRenderingService()
         val range = ArticleBlocks

--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -113,45 +113,14 @@ class InteractiveController(
           case Right(other) => RenderOtherStatus(other)
         }
       }
-      case USElection2020AmpPage => renderInteractivePageUSPresidentialElection2020_v2(path)
+      case USElection2020AmpPage => renderInteractivePageUSPresidentialElection2020(path)
     }
   }
 
   // ---------------------------------------------
   // US Presidential Election 2020
 
-  /*
-    The two following functions implement the rendering of the US Election 2020 Election Tracker Amp Page.
-    Only the second version is used, but both are kept for historical interest. Notably, the first version has the code
-    needed to expand that logic to all interactives (if we wanted to do that one day, before DCR takes that kind of
-    rendering over).
-   */
-
-  def renderInteractivePageUSPresidentialElection2020_v1(i: InteractivePage): Future[Result] = {
-    /*
-      This version takes the interactive page, extract the atom id and then make
-      another CAPI query (using a derived id) to retrieve the AMP version
-     */
-    val atomIdOpt = i.item.content.atoms.flatMap(atoms => atoms.interactives.headOption.map(atom => atom.id))
-    atomIdOpt match {
-      case Some(atomId) => {
-        val capiLookupString = ApplicationsUSElection2020AmpPages.defaultAtomIdToAmpAtomId(atomId)
-        val response: Future[ItemResponse] = lookupWithoutModelConvertion(capiLookupString)
-        response.map { response =>
-          response.interactive match {
-            case Some(i2) => {
-              val interactive = InteractiveAtom.make(i2)
-              Ok(StringEscapeUtils.unescapeHtml(interactive.html)).withHeaders("Content-Type" -> "text/html")
-            }
-            case None => Ok("error: 6523e5f4-c4fe-48f6-b307-8f6fb2cadf96")
-          }
-        }
-      }
-      case None => Future.successful(Ok("error: b62cfee4-cdc6-4e13-b965-89d4bd313039"))
-    }
-  }
-
-  def renderInteractivePageUSPresidentialElection2020_v2(path: String): Future[Result] = {
+  def renderInteractivePageUSPresidentialElection2020(path: String): Future[Result] = {
     /*
       This version retrieve the AMP version directly but rely on an predefined map between paths and amp page ids
      */

--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -106,7 +106,7 @@ class InteractiveController(
 
   override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = {
     ApplicationsInteractiveRendering.getRenderingTier(path) match {
-      case Legacy => {
+      case Regular => {
         lookup(path) map {
           case Left(model)  => render(model)
           case Right(other) => RenderOtherStatus(other)

--- a/applications/app/pages/InteractiveHtmlPage.scala
+++ b/applications/app/pages/InteractiveHtmlPage.scala
@@ -16,7 +16,7 @@ import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.fragments._
 import views.html.stacked
 import html.HtmlPageHelpers.ContentCSSFile
-import services.ApplicationsSpecial2020Election
+import services.ApplicationsUSElection2020AmpPages
 
 object InteractiveHtmlPage extends HtmlPage[InteractivePage] {
 
@@ -50,7 +50,7 @@ object InteractiveHtmlPage extends HtmlPage[InteractivePage] {
       ),
     )
 
-    val ampTag = ApplicationsSpecial2020Election.ampTagHtml(request.path)
+    val ampTag = ApplicationsUSElection2020AmpPages.ampTagHtml(request.path)
 
     htmlTag(
       headTag(

--- a/applications/app/services/ApplicationsDotcomRenderingInterface.scala
+++ b/applications/app/services/ApplicationsDotcomRenderingInterface.scala
@@ -19,8 +19,4 @@ object ApplicationsDotcomRenderingInterface {
       case (_, false) => Legacy
     }
   }
-
-  def getHtmlFromDCR(): String = {
-    "Experiment: NGInteractiveDCR (2)"
-  }
 }

--- a/applications/app/services/ApplicationsInteractiveRendering.scala
+++ b/applications/app/services/ApplicationsInteractiveRendering.scala
@@ -8,7 +8,7 @@ object USElection2020AmpPage extends RenderingTier
 
 object ApplicationsInteractiveRendering {
   def getRenderingTier(path: String)(implicit request: RequestHeader): RenderingTier = {
-    val isSpecialElection = ApplicationsSpecial2020Election.pathIsSpecialHanding(path)
+    val isSpecialElection = ApplicationsUSElection2020AmpPages.pathIsSpecialHanding(path)
     val isAmp = request.host.contains("amp")
     if (isSpecialElection && isAmp) USElection2020AmpPage else Legacy
   }

--- a/applications/app/services/ApplicationsInteractiveRendering.scala
+++ b/applications/app/services/ApplicationsInteractiveRendering.scala
@@ -4,12 +4,12 @@ import play.api.mvc.RequestHeader
 
 sealed trait RenderingTier
 object Legacy extends RenderingTier
-object Election2020Hack extends RenderingTier
+object Election2020AmpElectionTracker extends RenderingTier
 
 object ApplicationsInteractiveRendering {
   def getRenderingTier(path: String)(implicit request: RequestHeader): RenderingTier = {
     val isSpecialElection = ApplicationsSpecial2020Election.pathIsSpecialHanding(path)
     val isAmp = request.host.contains("amp")
-    if (isSpecialElection && isAmp) Election2020Hack else Legacy
+    if (isSpecialElection && isAmp) Election2020AmpElectionTracker else Legacy
   }
 }

--- a/applications/app/services/ApplicationsInteractiveRendering.scala
+++ b/applications/app/services/ApplicationsInteractiveRendering.scala
@@ -3,13 +3,27 @@ package services
 import play.api.mvc.RequestHeader
 
 sealed trait RenderingTier
-object Legacy extends RenderingTier
+object Regular extends RenderingTier
 object USElection2020AmpPage extends RenderingTier
+
+/*
+  Author: Pascal
+  Date: 21st Jan 2020
+
+  This object was introduced in late 2020, to handle the routing between regular rendering of interactives
+  versus the code that had been written to handle the US Presidential Election Tracker amp page.
+
+  The tracker (an ng-interactive) didn't have a AMP page and there were two ways to provide one to it.
+  1. Implement the support for it in DCR, or
+  2. Implement support for it directly in the [applications] app, using the AMP page already present in CAPI.
+
+  The former wold have taken too long so we went for the latter.
+ */
 
 object ApplicationsInteractiveRendering {
   def getRenderingTier(path: String)(implicit request: RequestHeader): RenderingTier = {
     val isSpecialElection = ApplicationsUSElection2020AmpPages.pathIsSpecialHanding(path)
     val isAmp = request.host.contains("amp")
-    if (isSpecialElection && isAmp) USElection2020AmpPage else Legacy
+    if (isSpecialElection && isAmp) USElection2020AmpPage else Regular
   }
 }

--- a/applications/app/services/ApplicationsInteractiveRendering.scala
+++ b/applications/app/services/ApplicationsInteractiveRendering.scala
@@ -1,22 +1,15 @@
 package services
 
-import experiments.{ActiveExperiments, NGInteractiveDCR}
 import play.api.mvc.RequestHeader
 
 sealed trait RenderingTier
 object Legacy extends RenderingTier
 object Election2020Hack extends RenderingTier
-object DotcomRendering extends RenderingTier
 
 object ApplicationsInteractiveRendering {
   def getRenderingTier(path: String)(implicit request: RequestHeader): RenderingTier = {
     val isSpecialElection = ApplicationsSpecial2020Election.pathIsSpecialHanding(path)
     val isAmp = request.host.contains("amp")
-    val isExperiment = ActiveExperiments.isParticipating(NGInteractiveDCR)
-    (isSpecialElection && isAmp, isExperiment) match {
-      case (true, _)  => Election2020Hack
-      case (_, true)  => DotcomRendering
-      case (_, false) => Legacy
-    }
+    if (isSpecialElection && isAmp) Election2020Hack else Legacy
   }
 }

--- a/applications/app/services/ApplicationsInteractiveRendering.scala
+++ b/applications/app/services/ApplicationsInteractiveRendering.scala
@@ -8,7 +8,7 @@ object Legacy extends RenderingTier
 object Election2020Hack extends RenderingTier
 object DotcomRendering extends RenderingTier
 
-object ApplicationsDotcomRenderingInterface {
+object ApplicationsInteractiveRendering {
   def getRenderingTier(path: String)(implicit request: RequestHeader): RenderingTier = {
     val isSpecialElection = ApplicationsSpecial2020Election.pathIsSpecialHanding(path)
     val isAmp = request.host.contains("amp")

--- a/applications/app/services/ApplicationsInteractiveRendering.scala
+++ b/applications/app/services/ApplicationsInteractiveRendering.scala
@@ -4,12 +4,12 @@ import play.api.mvc.RequestHeader
 
 sealed trait RenderingTier
 object Legacy extends RenderingTier
-object Election2020AmpElectionTracker extends RenderingTier
+object USElection2020AmpPage extends RenderingTier
 
 object ApplicationsInteractiveRendering {
   def getRenderingTier(path: String)(implicit request: RequestHeader): RenderingTier = {
     val isSpecialElection = ApplicationsSpecial2020Election.pathIsSpecialHanding(path)
     val isAmp = request.host.contains("amp")
-    if (isSpecialElection && isAmp) Election2020AmpElectionTracker else Legacy
+    if (isSpecialElection && isAmp) USElection2020AmpPage else Legacy
   }
 }

--- a/applications/app/services/ApplicationsInteractiveRendering.scala
+++ b/applications/app/services/ApplicationsInteractiveRendering.scala
@@ -9,6 +9,7 @@ object USElection2020AmpPage extends RenderingTier
 /*
   Author: Pascal
   Date: 21st Jan 2020
+  CommentID: DF38D2B4-614D
 
   This object was introduced in late 2020, to handle the routing between regular rendering of interactives
   versus the code that had been written to handle the US Presidential Election Tracker amp page.

--- a/applications/app/services/ApplicationsUSElection2020AmpPages.scala
+++ b/applications/app/services/ApplicationsUSElection2020AmpPages.scala
@@ -9,7 +9,7 @@ import scala.util.matching.Regex
 // something that DCR doesn't yet know how to do. It's essentially the hack version of
 // ApplicationsDotcomRenderingInterface , which is not ready ; a (slower) work in progress.
 
-object ApplicationsSpecial2020Election {
+object ApplicationsUSElection2020AmpPages {
 
   val specialPathsToCapiIdsMap = Map(
     "/world/ng-interactive/2020/oct/20/covid-vaccine-tracker-when-will-a-coronavirus-vaccine-be-ready" -> "atom/interactive/interactives/2020/07/interactive-vaccine-tracker/amp-page",
@@ -86,7 +86,7 @@ object ApplicationsSpecial2020Election {
   }
 
   def ampTagHtml(path: String)(implicit request: RequestHeader): Html = {
-    if (ApplicationsSpecial2020Election.pathIsSpecialHanding(path)) {
+    if (ApplicationsUSElection2020AmpPages.pathIsSpecialHanding(path)) {
       Html(
         s"""<link rel="amphtml" href="https://amp.theguardian.com${ensureStartingForwardSlash(path)}">""",
       )

--- a/applications/app/services/ApplicationsUSElection2020AmpPages.scala
+++ b/applications/app/services/ApplicationsUSElection2020AmpPages.scala
@@ -55,24 +55,6 @@ object ApplicationsUSElection2020AmpPages {
     specialPaths.contains(path1) || pathIsElectionTracker(path1)
   }
 
-  def defaultAtomIdToAmpAtomId(atomId: String): String = {
-    /*
-        This function transforms an atom id
-          "interactives/2020/07/interactive-vaccine-tracker/default"
-
-        into the corresponding amp capi query path
-          "atom/interactive/interactives/2020/07/interactive-vaccine-tracker/amp-page"
-
-        Update: 21st Jan 2020. For the limited purpose of providing an election tracker amp page, we have used
-
-        pathToAmpAtomId(path: String): String // (below)
-
-        but if one day we want to expand the idea to more interactives, then defaultAtomIdToAmpAtomId will be the one to use.
-
-     */
-    (Array("atom", "interactive") ++ atomId.split("/").dropRight(1) ++ Array("amp-page")).mkString("/")
-  }
-
   def pathToAmpAtomId(path: String): String = {
     /*
         This version is a more limited, but much more robust version, of `defaultAtomIdToAmpAtomId`

--- a/applications/app/services/ApplicationsUSElection2020AmpPages.scala
+++ b/applications/app/services/ApplicationsUSElection2020AmpPages.scala
@@ -4,10 +4,12 @@ import play.api.mvc.RequestHeader
 import play.twirl.api.Html
 import scala.util.matching.Regex
 
-// ApplicationsSpecial2020Election is a temporary object introduced for the special handling
-// of the US election Nov 2020 results election tracker, a ng-interactive page which we need an amp version of,
-// something that DCR doesn't yet know how to do. It's essentially the hack version of
-// ApplicationsDotcomRenderingInterface , which is not ready ; a (slower) work in progress.
+/*
+   This object was introduced for the special handling of the US election Nov 2020 results election tracker
+   A ng-interactive page which we need an amp version of, something that DCR doesn't yet know how to do.
+
+   This code will live as long as we want to the Election Tracker to have an AMP URL.
+ */
 
 object ApplicationsUSElection2020AmpPages {
 
@@ -35,9 +37,12 @@ object ApplicationsUSElection2020AmpPages {
 
   def pathIsElectionTracker(path: String): Boolean = {
     // This function was introduced to avoid having to update `specialPathsToCapiIdsMap` every day with new path
-    // by allow listing anything of the form
+
+    // We now assume that anything of the form
     // /us-news/ng-interactive/2020/nov/??/us-election-results-2020-* , or
     // /us-news/ng-interactive/2020/dev/??/us-election-results-2020-*
+    // is a request for the Election Tracker.
+
     electionTrackerPathsRegexes.exists(_.findFirstIn(path).isDefined)
   }
 
@@ -46,11 +51,6 @@ object ApplicationsUSElection2020AmpPages {
   }
 
   def pathIsSpecialHanding(path: String): Boolean = {
-    /*
-      We pass the path through `ensureStartingForwardSlash` because
-      when called from `ApplicationsDotcomRenderingInterface.getRenderingTier` it comes without starting slash, but
-      when called from `InteractiveHtmlPage.html` it comes with it.
-     */
     val path1 = ensureStartingForwardSlash(path)
     specialPaths.contains(path1) || pathIsElectionTracker(path1)
   }
@@ -59,12 +59,16 @@ object ApplicationsUSElection2020AmpPages {
     /*
         This function transforms an atom id
           "interactives/2020/07/interactive-vaccine-tracker/default"
+
         into the corresponding amp capi query path
           "atom/interactive/interactives/2020/07/interactive-vaccine-tracker/amp-page"
 
-        Election tracker:
-          "interactives/2020/11/us-election/prod/default" (expected, to be confirmed)
-          "atom/interactive/interactives/2020/11/us-election/prod/amp-page"
+        Update: 21st Jan 2020. For the limited purpose of providing an election tracker amp page, we have used
+
+        pathToAmpAtomId(path: String): String // (below)
+
+        but if one day we want to expand the idea to more interactives, then defaultAtomIdToAmpAtomId will be the one to use.
+
      */
     (Array("atom", "interactive") ++ atomId.split("/").dropRight(1) ++ Array("amp-page")).mkString("/")
   }
@@ -74,10 +78,6 @@ object ApplicationsUSElection2020AmpPages {
         This version is a more limited, but much more robust version, of `defaultAtomIdToAmpAtomId`
         In particular, it doesn't rely on a particular format for the atom ids, and instead
         maps paths directly to capi query ids, which is fine since we essentially only want to support few urls.
-
-        Update, 17th Nov: with the introduction of `pathIsNovemberElectionTrackerRegex` and `pathIsElectionTracker`
-        The paths that are not in `specialPathsToCapiIdsMap`, but pass the `pathIsElectionTracker` test are missing
-        a CAPI Id. When that happens we are going to default to the election tracker atom Id.
      */
     specialPathsToCapiIdsMap.getOrElse(
       ensureStartingForwardSlash(path),

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -9,7 +9,6 @@ import conf.switches.SwitchGroup.Commercial
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
     DotcomRendering,
-    NGInteractiveDCR,
   )
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -24,15 +23,6 @@ object DotcomRendering
       participationGroup = Perc10A, // Also see ArticlePicker.scala - our main filter mechanism is by page features
       // Friday 20th Nov 2020: we are now showing DCR to users not participating (see: cea453f4-9b71-435e-8a11-35ef690c7821)
       // This means that 90% of the audience is being exposed to DCR
-    )
-
-object NGInteractiveDCR
-    extends Experiment(
-      name = "ng-interactive-dcr",
-      description = "Use DCR to render (ng)-interactives",
-      owners = Seq(Owner.withGithub("shtukas")),
-      sellByDate = new LocalDate(2021, 6, 1),
-      participationGroup = Perc0B,
     )
 
 object NewsletterEmbedDesign


### PR DESCRIPTION
## What does this change?

This PR performs some  cleaning, but doesn't affect existing behaviour.

1. Removes the experiment `NGInteractiveDCR` which I had introduced while trying to explore the possibility of using DCR for rendering the US presidential election 2020 election tracker amp page. 

2. Remove dead code, notably the two functions below comment "[applications] on DCR experiment", which are leftover from that experiment. 

3. Remove `DotcomRendering` as option of `trait RenderingTier`. This is consistent with the above clean up.

And, much more importantly...

4. It's not often that we have code related to one historical event, and this can be unsettling to newcomers to a code base. So we update the comments in `InteractiveController`, `ApplicationsInteractiveRendering`, `ApplicationsUSElection2020AmpPages`, to make the work of future code archeologists easier, above all if they are not me, PR author 😊

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No