### PR TITLE
Remove Professional networks from the nav

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -527,7 +527,6 @@ private object NavLinks {
     insideTheGuardian,
     observer,
     weekly.copy(url = s"${weekly.url}?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_UK"),
-    NavLink("Professional networks", "/guardian-professional"),
     crosswords,
   )
   val auOtherLinks = List(


### PR DESCRIPTION
## What does this change?

At the the request of Katherine Purvis this removes 'Professional networks' from the nav.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes (please indicate your plans for DCR Implementation)


