### PR TITLE
Add isNotALiveBlog check to the article picker

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -130,6 +130,8 @@ object ArticlePageChecks {
 
   def isNotAGallery(page: PageWithStoryPackage): Boolean = !page.item.tags.isGallery
 
+  def isNotLiveBlog(page: PageWithStoryPackage): Boolean = !page.item.tags.isLiveBlog
+
   def isNotAMP(request: RequestHeader): Boolean = !request.isAmp
 
   def isNotOpinion(page: PageWithStoryPackage): Boolean = !page.item.tags.isComment
@@ -156,6 +158,7 @@ object ArticlePicker {
       ("hasOnlySupportedMainElements", ArticlePageChecks.hasOnlySupportedMainElements(page)),
       ("isNotPhotoEssay", ArticlePageChecks.isNotPhotoEssay(page)),
       ("isNotAGallery", ArticlePageChecks.isNotAGallery(page)),
+      ("isNotLiveBlog", ArticlePageChecks.isNotLiveBlog(page)),
       ("isNotAMP", ArticlePageChecks.isNotAMP(request)),
       ("isNotPaidContent", ArticlePageChecks.isNotPaidContent(page)),
       ("isNotInTagBlockList", ArticlePageChecks.isNotInTagBlockList(page)),
@@ -173,6 +176,7 @@ object ArticlePicker {
       Set(
         "isSupportedType",
         "isNotAGallery",
+        "isNotLiveBlog",
         "isNotAMP",
         "isNotInTagBlockList",
         "isNotPaidContent",


### PR DESCRIPTION
## What does this change?

Old pre-2014 liveblogs do not have `/live` in the url, which means that we [don't accept them in Dotcom into the liveblog renderer](https://github.com/guardian/frontend/blob/main/article/conf/routes#L17-L22) they fall through into the standard [renderArticle](https://github.com/guardian/frontend/blob/main/article/conf/routes#L43). 

Because of this they fall into the DCR code path and we do not do a check explicitly for whether they have the `tone/minute-by-minute` tag used to denote livelogs.

but the CAPI response for [these articles](https://www.theguardian.com/travel/reality-check/2012/aug/27/lion-loose-essex-real-story) is vastly different that the article structure, not conforming to our expectations of an elements array.

We likely want to in the future map these to the liveblog rendering (as Apps do) but in the meantime we need to remove them via the `articlePicker` by check the liveblog tags.

`isLiveblog` that we use as a negative check is defined here: https://github.com/guardian/frontend/blob/3be4f4bda70c3c11f0595b0d874b118a6ddbc1b0/common/app/model/meta.scala#L679 with `liveMappings` being defined as simply `tone/minute-by-minute` here: https://github.com/guardian/frontend/blob/3be4f4bda70c3c11f0595b0d874b118a6ddbc1b0/common/app/model/meta.scala#L766-L768

