### PR TITLE
What is a Special Report?

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -105,6 +105,10 @@ object ArticlePageChecks {
   // Custom Tag that can be added to articles + special reports tags while we don't support them
   private[this] val tagsBlockList: Set[String] = Set(
     "tracking/platformfunctional/dcrblacklist",
+  )
+  
+  // If an article has one of these series tags then it is a Special Report
+  private[this] val specialReportTags: Set[String] = Set(
     "business/series/undercover-in-the-chicken-industry",
     "business/series/britains-debt-timebomb",
     "world/series/this-is-europe",
@@ -122,6 +126,10 @@ object ArticlePageChecks {
 
   def isNotInTagBlockList(page: PageWithStoryPackage): Boolean = {
     !page.item.tags.tags.exists(t => tagsBlockList(t.id))
+  }
+
+  def isNotSpecialReport(page: PageWithStoryPackage): Boolean = {
+    !page.item.tags.tags.exists(t => specialReportTags(t.id))
   }
 
   def isNotNumberedList(page: PageWithStoryPackage): Boolean = !page.item.isNumberedList
@@ -162,6 +170,7 @@ object ArticlePicker {
       ("isNotAMP", ArticlePageChecks.isNotAMP(request)),
       ("isNotPaidContent", ArticlePageChecks.isNotPaidContent(page)),
       ("isNotInTagBlockList", ArticlePageChecks.isNotInTagBlockList(page)),
+      ("isNotSpecialReport", ArticlePageChecks.isNotSpecialReport(page)),
       ("isNotNumberedList", ArticlePageChecks.isNotNumberedList(page)),
     )
   }
@@ -179,6 +188,7 @@ object ArticlePicker {
         "isNotLiveBlog",
         "isNotAMP",
         "isNotInTagBlockList",
+        "isNotSpecialReport",
         "isNotPaidContent",
       ),
     )

--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -106,7 +106,7 @@ object ArticlePageChecks {
   private[this] val tagsBlockList: Set[String] = Set(
     "tracking/platformfunctional/dcrblacklist",
   )
-  
+
   // If an article has one of these series tags then it is a Special Report
   private[this] val specialReportTags: Set[String] = Set(
     "business/series/undercover-in-the-chicken-industry",


### PR DESCRIPTION
## What does this change?
This PR encodes the definition of a Special Report by extracting the tags that we're using in the dcr blocklist that informally represent this type of article and encoding them into a function

## Why?
Because we want to have a way to change the model that Frontend sends to DCR so that we mark special report articles with a boolean `isSpecialReport`. But before we can do this we need to agree that definition.