### PR TITLE
Creative wrapper to measure ad load time and measure Prebid events

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.7",
     "@guardian/braze-components": "0.0.19",
-    "@guardian/commercial-core": "^0.10.0",
+    "@guardian/commercial-core": "^0.11.1",
     "@guardian/consent-management-platform": "6.9.1",
     "@guardian/libs": "^1.4.2",
     "@guardian/shimport": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.7",
     "@guardian/braze-components": "0.0.19",
-    "@guardian/commercial-core": "^0.9.2",
+    "@guardian/commercial-core": "^0.10.0",
     "@guardian/consent-management-platform": "6.9.1",
     "@guardian/libs": "^1.4.2",
     "@guardian/shimport": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.7",
     "@guardian/braze-components": "0.0.19",
-    "@guardian/commercial-core": "^0.11.1",
+    "@guardian/commercial-core": "^0.12.0",
     "@guardian/consent-management-platform": "6.9.1",
     "@guardian/libs": "^1.4.2",
     "@guardian/shimport": "^1.0.2",

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -11,7 +11,6 @@ import { cmp, onConsentChange } from '@guardian/consent-management-platform';
 import { getLocale } from '@guardian/libs';
 import { getCookie } from 'lib/cookies';
 import { trackPerformance } from 'common/modules/analytics/google';
-import { EventTimer } from '@guardian/commercial-core';
 
 // Let webpack know where to get files from
 // __webpack_public_path__ is a special webpack variable
@@ -31,9 +30,6 @@ const go = () => {
         // 1. boot standard, always
         markTime('standard boot');
         bootStandard();
-
-        // Init commercial timers
-        EventTimer.init();
 
         // Start CMP
         // CCPA and TCFv2

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -11,6 +11,7 @@ import { cmp, onConsentChange } from '@guardian/consent-management-platform';
 import { getLocale } from '@guardian/libs';
 import { getCookie } from 'lib/cookies';
 import { trackPerformance } from 'common/modules/analytics/google';
+import { EventTimer } from '@guardian/commercial-core';
 
 // Let webpack know where to get files from
 // __webpack_public_path__ is a special webpack variable
@@ -30,6 +31,9 @@ const go = () => {
         // 1. boot standard, always
         markTime('standard boot');
         bootStandard();
+
+        // Init commercial timers
+        EventTimer.init();
 
         // Start CMP
         // CCPA and TCFv2

--- a/static/src/javascripts/bootstraps/commercial.dcr.js
+++ b/static/src/javascripts/bootstraps/commercial.dcr.js
@@ -27,6 +27,7 @@ import { initCommentAdverts } from 'commercial/modules/comment-adverts';
 import { init as prepareA9 } from 'commercial/modules/dfp/prepare-a9';
 import { init as initRedplanet } from 'commercial/modules/dfp/redplanet';
 import {refresh as refreshUserFeatures} from "common/modules/commercial/user-features";
+import { EventTimer } from "@guardian/commercial-core";
 
 const commercialModules = [
     ['cm-setAdTestCookie', setAdTestCookie],
@@ -119,6 +120,10 @@ const loadModules = () => {
 
 const bootCommercial = () => {
     markTime('commercial start');
+
+    // Init Commercial event timers
+    EventTimer.init();
+
     catchErrorsWithContext(
         [
             [

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -26,6 +26,7 @@ import { trackPerformance } from 'common/modules/analytics/google';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { initCommentAdverts } from 'commercial/modules/comment-adverts';
 import { initAdblockAsk } from 'common/modules/commercial/adblock-ask';
+import { EventTimer } from '@guardian/commercial-core';
 
 const commercialModules = [
     ['cm-setAdTestCookie', setAdTestCookie],
@@ -119,6 +120,10 @@ const loadModules = () => {
 
 export const bootCommercial = () => {
     markTime('commercial start');
+
+    // Init Commercial event timers
+    EventTimer.init();
+
     catchErrorsWithContext(
         [
             [

--- a/static/src/javascripts/projects/commercial/modules/dfp/load-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/load-advert.js
@@ -1,6 +1,8 @@
 import prebid from '../header-bidding/prebid/prebid';
 import { markTime } from '../../../../lib/user-timing';
 import a9 from '../header-bidding/a9/a9';
+import { stripDfpAdPrefixFrom } from '../header-bidding/utils';
+import { EventTimer } from "@guardian/commercial-core";
 
 const forcedSlotSize = (advert, hbSlot) => {
     // We only fiddle with top-above-nav hbSlot(s)
@@ -26,13 +28,17 @@ const forcedSlotSize = (advert, hbSlot) => {
     return [];
 };
 
+const eventTimer = EventTimer.get();
+
 export const loadAdvert = (advert) => {
+    const adName = stripDfpAdPrefixFrom(advert.id);
     advert.whenSlotReady
         .catch(() => {
             // The display needs to be called, even in the event of an error.
         })
         .then(() => {
             markTime(`Commercial: Slot Ready: ${advert.id}`);
+            eventTimer.trigger('slotReady', adName);
             advert.startLoading();
             return Promise.all([
                 prebid.requestBids(advert),
@@ -40,6 +46,7 @@ export const loadAdvert = (advert) => {
             ]);
         })
         .then(() => {
+            eventTimer.trigger('slotInitialised', adName);
             window.googletag.display(advert.id);
         });
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -23,6 +23,7 @@ import { init as hide } from '../messenger/hide';
 import { init as resize } from '../messenger/resize';
 import { init as scroll } from '../messenger/scroll';
 import { init as type } from '../messenger/type';
+import { init as initMeasureAdLoad } from 'commercial/modules/messenger/measure-ad-load';
 import { init as viewport } from '../messenger/viewport';
 import { dfpEnv } from './dfp-env';
 import { fillAdvertSlots } from './fill-advert-slots';
@@ -37,6 +38,7 @@ initMessenger(
     getStyles,
     initGetPageTargeting,
     initGetPageUrl,
+    initMeasureAdLoad,
     resize,
     hide,
     scroll,

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
@@ -4,7 +4,8 @@ import { bids } from './bid-config';
 import { getHeaderBiddingAdSlots } from '../slot-config';
 import { priceGranularity } from './price-config';
 import { getAdvertById } from '../../dfp/get-advert-by-id';
-import {markTime} from "../../../../../lib/user-timing";
+import { markTime } from '../../../../../lib/user-timing';
+import { stripDfpAdPrefixFrom } from '../utils';
 
 const bidderTimeout = 1500;
 
@@ -149,8 +150,8 @@ const requestBids = (
             () =>
                 new Promise(resolve => {
                     window.pbjs.que.push(() => {
-                        const adUnitsCodes = adUnits.map(adUnit => adUnit.code).join(", ");
-                        //TODO: Replace markTime with commercial core's API
+                        const adUnitsCodes = adUnits.map(adUnit => stripDfpAdPrefixFrom(adUnit.code)).join(", ");
+                        // TODO: Replace markTime with commercial core's API
                         markTime(`Prebid Started for: ${adUnitsCodes}`);
                         window.pbjs.requestBids({
                             adUnits,
@@ -158,7 +159,7 @@ const requestBids = (
                                 window.pbjs.setTargetingForGPTAsync([
                                     adUnits[0].code,
                                 ]);
-                                //TODO: Replace markTime with commercial core's API
+                                // TODO: Replace markTime with commercial core's API
                                 markTime(`Prebid Ended for: ${adUnitsCodes}`);
                                 resolve();
                             },

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
@@ -163,7 +163,7 @@ const requestBids = (
                     window.pbjs.que.push(() => {
                         // TODO: Replace with commercial core's API
                         // recordFirstPrebidStarted();
-                        EventTimer.trigger('prebidStart');
+                        // EventTimer.trigger('prebidStart');
                         const adUnitsCodes = adUnits.map(adUnit => stripDfpAdPrefixFrom(adUnit.code));
                         if (adUnitsCodes.indexOf('top-above-nav') !== -1) {
                             markTime(`Prebid Started for Top Above Nav (${adUnitsCodes})`);

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
@@ -152,12 +152,7 @@ const requestBids = (
             () =>
                 new Promise(resolve => {
                     window.pbjs.que.push(() => {
-                        eventTimer.trigger('prebidStart');
-                        const adUnitsCodes = adUnits.map(adUnit => stripDfpAdPrefixFrom(adUnit.code));
-                        if (adUnitsCodes.indexOf('top-above-nav') !== -1) {
-                            eventTimer.trigger('prebidStart', 'top-above-nav');
-                        }
-
+                        adUnits.map(adUnit => eventTimer.trigger('prebidStart', stripDfpAdPrefixFrom(adUnit.code)));
 
                         window.pbjs.requestBids({
                             adUnits,
@@ -165,10 +160,7 @@ const requestBids = (
                                 window.pbjs.setTargetingForGPTAsync([
                                     adUnits[0].code,
                                 ]);
-                                eventTimer.trigger('prebidEnd');
-                                if (adUnitsCodes.indexOf('top-above-nav') !== -1) {
-                                    eventTimer.trigger('prebidEnd', 'top-above-nav');
-                                }
+                                adUnits.map(adUnit => eventTimer.trigger('prebidEnd', stripDfpAdPrefixFrom(adUnit.code)));
                                 resolve();
                             },
                         });

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
@@ -150,9 +150,12 @@ const requestBids = (
             () =>
                 new Promise(resolve => {
                     window.pbjs.que.push(() => {
-                        const adUnitsCodes = adUnits.map(adUnit => stripDfpAdPrefixFrom(adUnit.code)).join(", ");
+                        const adUnitsCodes = adUnits.map(adUnit => stripDfpAdPrefixFrom(adUnit.code));
+                        if (adUnitsCodes.indexOf('top-above-nav') !== -1) {
+                            markTime(`Prebid Started for Top Above Nav (${adUnitsCodes})`);
+                        }
                         // TODO: Replace markTime with commercial core's API
-                        markTime(`Prebid Started for: ${adUnitsCodes}`);
+
                         window.pbjs.requestBids({
                             adUnits,
                             bidsBackHandler() {
@@ -160,7 +163,9 @@ const requestBids = (
                                     adUnits[0].code,
                                 ]);
                                 // TODO: Replace markTime with commercial core's API
-                                markTime(`Prebid Ended for: ${adUnitsCodes}`);
+                                if (adUnitsCodes.indexOf('top-above-nav') !== -1) {
+                                    markTime(`Prebid Ended for Top Above Nav (${adUnitsCodes})`);
+                                }
                                 resolve();
                             },
                         });

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
@@ -120,6 +120,15 @@ const initialise = (window) => {
     });
 };
 
+const recordFirstPrebidStarted = once(() => {
+    markTime('First Prebid Ad Request Started');
+});
+
+const recordFirstPrebidEnded = once(() => {
+    markTime('First Prebid Ad Request Ended');
+});
+
+
 // slotFlatMap allows you to dynamically interfere with the PrebidSlot definition
 // for this given request for bids.
 const requestBids = (
@@ -150,11 +159,13 @@ const requestBids = (
             () =>
                 new Promise(resolve => {
                     window.pbjs.que.push(() => {
+                        // TODO: Replace with commercial core's API
+                        recordFirstPrebidStarted();
                         const adUnitsCodes = adUnits.map(adUnit => stripDfpAdPrefixFrom(adUnit.code));
                         if (adUnitsCodes.indexOf('top-above-nav') !== -1) {
                             markTime(`Prebid Started for Top Above Nav (${adUnitsCodes})`);
                         }
-                        // TODO: Replace markTime with commercial core's API
+
 
                         window.pbjs.requestBids({
                             adUnits,
@@ -162,7 +173,8 @@ const requestBids = (
                                 window.pbjs.setTargetingForGPTAsync([
                                     adUnits[0].code,
                                 ]);
-                                // TODO: Replace markTime with commercial core's API
+                                // TODO: Replace with commercial core's API
+                                recordFirstPrebidStarted();
                                 if (adUnitsCodes.indexOf('top-above-nav') !== -1) {
                                     markTime(`Prebid Ended for Top Above Nav (${adUnitsCodes})`);
                                 }

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
@@ -4,6 +4,7 @@ import { bids } from './bid-config';
 import { getHeaderBiddingAdSlots } from '../slot-config';
 import { priceGranularity } from './price-config';
 import { getAdvertById } from '../../dfp/get-advert-by-id';
+import {markTime} from "../../../../../lib/user-timing";
 
 const bidderTimeout = 1500;
 
@@ -19,8 +20,6 @@ const consentManagement = {
 };
 
 class PrebidAdUnit {
-
-
     constructor(advert, slot) {
         this.code = advert.id;
         this.bids = bids(advert.id, slot.sizes);
@@ -150,12 +149,17 @@ const requestBids = (
             () =>
                 new Promise(resolve => {
                     window.pbjs.que.push(() => {
+                        const adUnitsCodes = adUnits.map(adUnit => adUnit.code).join(", ");
+                        //TODO: Replace markTime with commercial core's API
+                        markTime(`Prebid Started for: ${adUnitsCodes}`);
                         window.pbjs.requestBids({
                             adUnits,
                             bidsBackHandler() {
                                 window.pbjs.setTargetingForGPTAsync([
                                     adUnits[0].code,
                                 ]);
+                                //TODO: Replace markTime with commercial core's API
+                                markTime(`Prebid Ended for: ${adUnitsCodes}`);
                                 resolve();
                             },
                         });

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
@@ -6,6 +6,7 @@ import { priceGranularity } from './price-config';
 import { getAdvertById } from '../../dfp/get-advert-by-id';
 import { markTime } from '../../../../../lib/user-timing';
 import { stripDfpAdPrefixFrom } from '../utils';
+import once from 'lodash/once';
 
 const bidderTimeout = 1500;
 

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
@@ -175,7 +175,7 @@ const requestBids = (
                                     adUnits[0].code,
                                 ]);
                                 // TODO: Replace with commercial core's API
-                                recordFirstPrebidStarted();
+                                recordFirstPrebidEnded();
                                 if (adUnitsCodes.indexOf('top-above-nav') !== -1) {
                                     markTime(`Prebid Ended for Top Above Nav (${adUnitsCodes})`);
                                 }

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
@@ -7,6 +7,7 @@ import { getAdvertById } from '../../dfp/get-advert-by-id';
 import { markTime } from '../../../../../lib/user-timing';
 import { stripDfpAdPrefixFrom } from '../utils';
 import once from 'lodash/once';
+import { EventTimer } from '@guardian/commercial-core';
 
 const bidderTimeout = 1500;
 
@@ -161,7 +162,8 @@ const requestBids = (
                 new Promise(resolve => {
                     window.pbjs.que.push(() => {
                         // TODO: Replace with commercial core's API
-                        recordFirstPrebidStarted();
+                        // recordFirstPrebidStarted();
+                        EventTimer.trigger('prebidStart');
                         const adUnitsCodes = adUnits.map(adUnit => stripDfpAdPrefixFrom(adUnit.code));
                         if (adUnitsCodes.indexOf('top-above-nav') !== -1) {
                             markTime(`Prebid Started for Top Above Nav (${adUnitsCodes})`);

--- a/static/src/javascripts/projects/commercial/modules/messenger/measure-ad-load.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/measure-ad-load.js
@@ -23,6 +23,7 @@ top.window.postMessage(JSON.stringify(
 const init = (register) => {
     register('measure-ad-load', (specs) => {
         if (specs.slotId === 'top-above-nav') {
+            // TODO: Replace markTime with commercial core's API
             markTime('topAboveNav Ad loaded')
         }
     });

--- a/static/src/javascripts/projects/commercial/modules/messenger/measure-ad-load.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/measure-ad-load.js
@@ -24,10 +24,7 @@ const eventTimer = EventTimer.get();
 
 const init = (register) => {
     register('measure-ad-load', (specs) => {
-        eventTimer.trigger('adOnPage');
-        if (specs.slotId === 'top-above-nav') {
-            eventTimer.trigger('adOnPage','top-above-nav');
-        }
+        eventTimer.trigger('adOnPage',specs.slotId);
     });
 }
 

--- a/static/src/javascripts/projects/commercial/modules/messenger/measure-ad-load.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/measure-ad-load.js
@@ -1,5 +1,25 @@
 import { markTime } from 'lib/user-timing';
 
+// This message is intended to be used with a DFP creative wrapper.
+// For reference, the wrapper will post a message, like so:
+
+/*
+* <script  id='ad-load-%%CACHEBUSTER%%'>
+//send postMessage to commercial bundle
+const metaData = {
+    slotId: '%%PATTERN:slot%%'
+};
+top.window.postMessage(JSON.stringify(
+    {
+        id: 'bf724866-723c-6b0a-e5d7-ad61535f98b7',
+        slotId: '%%PATTERN:slot%%',
+        type: 'measure-ad-load',
+        value: metaData
+    }
+), '*');
+</script>
+* */
+
 const init = (register) => {
     register('measure-ad-load', (specs) => {
         if (specs.slotId === 'top-above-nav') {

--- a/static/src/javascripts/projects/commercial/modules/messenger/measure-ad-load.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/measure-ad-load.js
@@ -1,0 +1,13 @@
+import { markTime } from 'lib/user-timing';
+
+const init = (register) => {
+    register('measure-ad-load', (specs) => {
+        console.log("*** RECEIVED MEASURE AD LOAD EVENT ");
+        console.log(specs);
+        if (specs.slotId === 'top-above-nav') {
+            markTime('topAboveNav Ad loaded')
+        }
+    });
+}
+
+export { init };

--- a/static/src/javascripts/projects/commercial/modules/messenger/measure-ad-load.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/measure-ad-load.js
@@ -1,7 +1,6 @@
-import { markTime } from 'lib/user-timing';
-import once from 'lodash/once';
+import { EventTimer } from "@guardian/commercial-core";
 
-// This message is intended to be used with a DFP creative wrapper.
+// This message is intended to be used with a GAM creative wrapper.
 // For reference, the wrapper will post a message, like so:
 
 /*
@@ -21,17 +20,13 @@ top.window.postMessage(JSON.stringify(
 </script>
 * */
 
-const recordFirstAdLoaded = once(() => {
-    markTime('First Ad Loaded');
-});
+const eventTimer = EventTimer.get();
 
 const init = (register) => {
     register('measure-ad-load', (specs) => {
-        // TODO: Replace recordFirstAdLoaded with commercial core's API
-        recordFirstAdLoaded();
+        eventTimer.trigger('adOnPage');
         if (specs.slotId === 'top-above-nav') {
-            // TODO: Replace markTime with commercial core's API
-            markTime('topAboveNav Ad loaded')
+            eventTimer.trigger('adOnPage','top-above-nav');
         }
     });
 }

--- a/static/src/javascripts/projects/commercial/modules/messenger/measure-ad-load.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/measure-ad-load.js
@@ -2,8 +2,6 @@ import { markTime } from 'lib/user-timing';
 
 const init = (register) => {
     register('measure-ad-load', (specs) => {
-        console.log("*** RECEIVED MEASURE AD LOAD EVENT ");
-        console.log(specs);
         if (specs.slotId === 'top-above-nav') {
             markTime('topAboveNav Ad loaded')
         }

--- a/static/src/javascripts/projects/commercial/modules/messenger/measure-ad-load.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/measure-ad-load.js
@@ -1,4 +1,5 @@
 import { markTime } from 'lib/user-timing';
+import once from 'lodash/once';
 
 // This message is intended to be used with a DFP creative wrapper.
 // For reference, the wrapper will post a message, like so:
@@ -20,8 +21,14 @@ top.window.postMessage(JSON.stringify(
 </script>
 * */
 
+const recordFirstAdLoaded = once(() => {
+    markTime('First Ad Loaded');
+});
+
 const init = (register) => {
     register('measure-ad-load', (specs) => {
+        // TODO: Replace recordFirstAdLoaded with commercial core's API
+        recordFirstAdLoaded();
         if (specs.slotId === 'top-above-nav') {
             // TODO: Replace markTime with commercial core's API
             markTime('topAboveNav Ad loaded')

--- a/yarn.lock
+++ b/yarn.lock
@@ -1849,10 +1849,10 @@
     "@guardian/src-icons" "2.7.1"
     emotion-theming "^10.0.19"
 
-"@guardian/commercial-core@^0.11.1":
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.11.1.tgz#bd61af5065ff834e35911a4cff3f9b85b2c7ea19"
-  integrity sha512-b+VbUNVzRJ/JFitZ7zYQtslChdpuwG/N3l6PgvJfT3lSv5PjKdFX3+9I636Ssxx6or3Dm7PInnCd9lnFTRyVww==
+"@guardian/commercial-core@^0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.12.0.tgz#45ec5f0958345cfbd7485842ffea5a1410758db1"
+  integrity sha512-/lJznHPqXXtib/d4N3s5sG2FFH5V8WXXN1IXEmrS10Oow7jclaE6gpIt2/+Tw9v7x52Det+jh8AlwQTj4otMiw==
 
 "@guardian/consent-management-platform@6.9.1":
   version "6.9.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1849,10 +1849,10 @@
     "@guardian/src-icons" "2.7.1"
     emotion-theming "^10.0.19"
 
-"@guardian/commercial-core@^0.9.2":
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.9.2.tgz#627db6d1f78f1ef68bdeabcb9ae8e4dc798cbbb0"
-  integrity sha512-7Afm4WgnK5bnnCXwynJmpqCWPABjyIt8I4+TtGZlFkB0hNYkmxgXpnkfIhKupsG5iAc0d2Vqur5cl513SQcQZQ==
+"@guardian/commercial-core@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.10.0.tgz#da2dc2add330ca7de328114a0fd383c106aecb16"
+  integrity sha512-Zlo6hh/6SZE+HrTW2UeKXt/hMIilV1PHmBW6aSXB7pr7vK5a3FG6grkzRrZZFHNUWYzd/XoE1+xxoF4E2hW72A==
 
 "@guardian/consent-management-platform@6.9.1":
   version "6.9.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1849,10 +1849,10 @@
     "@guardian/src-icons" "2.7.1"
     emotion-theming "^10.0.19"
 
-"@guardian/commercial-core@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.10.0.tgz#da2dc2add330ca7de328114a0fd383c106aecb16"
-  integrity sha512-Zlo6hh/6SZE+HrTW2UeKXt/hMIilV1PHmBW6aSXB7pr7vK5a3FG6grkzRrZZFHNUWYzd/XoE1+xxoF4E2hW72A==
+"@guardian/commercial-core@^0.11.1":
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.11.1.tgz#bd61af5065ff834e35911a4cff3f9b85b2c7ea19"
+  integrity sha512-b+VbUNVzRJ/JFitZ7zYQtslChdpuwG/N3l6PgvJfT3lSv5PjKdFX3+9I636Ssxx6or3Dm7PInnCd9lnFTRyVww==
 
 "@guardian/consent-management-platform@6.9.1":
   version "6.9.1"


### PR DESCRIPTION
## What does this change?

This is the first step towards measuring the time an ad needs to load and capturing some prebid events.
Adding a creative wrapper which sends an event to the commercial bundle with the slotId and then capturing that event using the performance API (visible in Speedcurve).

Next steps will include to wrap more timer events into a wrapper

Events measured:

- first prebid start
- first prebid end
- top-above-nav prebid start
- top-above-nav prebid end
- first ad loaded (via creative wrapper)
- top-above-nav loaded (via creative wrapper)

We will replace these events with the commercial-core wrapper when is ready 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
