### PR TITLE
Add isSpecialReport to the DCR data object

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -27,6 +27,7 @@ import model.liveblog.{
 import play.api.mvc.RequestHeader
 import views.support.Commercial
 import conf.Configuration
+import model.dotcomrendering.DotcomRenderingDataModelFunctions
 
 object ArticlePageChecks {
 
@@ -107,29 +108,8 @@ object ArticlePageChecks {
     "tracking/platformfunctional/dcrblacklist",
   )
 
-  // If an article has one of these series tags then it is a Special Report
-  private[this] val specialReportTags: Set[String] = Set(
-    "business/series/undercover-in-the-chicken-industry",
-    "business/series/britains-debt-timebomb",
-    "world/series/this-is-europe",
-    "environment/series/the-polluters",
-    "news/series/hsbc-files",
-    "news/series/panama-papers",
-    "us-news/homan-square",
-    "uk-news/series/the-new-world-of-work",
-    "world/series/the-new-arrivals",
-    "news/series/nauru-files",
-    "us-news/series/counted-us-police-killings",
-    "australia-news/series/healthcare-in-detention",
-    "society/series/this-is-the-nhs",
-  )
-
   def isNotInTagBlockList(page: PageWithStoryPackage): Boolean = {
     !page.item.tags.tags.exists(t => tagsBlockList(t.id))
-  }
-
-  def isNotSpecialReport(page: PageWithStoryPackage): Boolean = {
-    !page.item.tags.tags.exists(t => specialReportTags(t.id))
   }
 
   def isNotNumberedList(page: PageWithStoryPackage): Boolean = !page.item.isNumberedList
@@ -170,7 +150,7 @@ object ArticlePicker {
       ("isNotAMP", ArticlePageChecks.isNotAMP(request)),
       ("isNotPaidContent", ArticlePageChecks.isNotPaidContent(page)),
       ("isNotInTagBlockList", ArticlePageChecks.isNotInTagBlockList(page)),
-      ("isNotSpecialReport", ArticlePageChecks.isNotSpecialReport(page)),
+      ("isNotSpecialReport", !DotcomRenderingDataModelFunctions.isSpecialReport(page)),
       ("isNotNumberedList", ArticlePageChecks.isNotNumberedList(page)),
     )
   }

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -61,6 +61,7 @@ case class DotcomRenderingDataModel(
     badge: Option[DCRBadge],
     // Match Data
     matchUrl: Option[String], // Optional url used for match data
+    isSpecialReport: Boolean, // Indicates whether the page is a special report.
 )
 
 object DotcomRenderingDataModel {
@@ -120,6 +121,7 @@ object DotcomRenderingDataModel {
         "contributionsServiceUrl" -> model.contributionsServiceUrl,
         "badge" -> model.badge,
         "matchUrl" -> model.matchUrl,
+        "isSpecialReport" -> model.isSpecialReport,
       )
   }
 

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModelFunctions.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModelFunctions.scala
@@ -270,6 +270,26 @@ object DotcomRenderingDataModelFunctions {
     )
   }
 
+  val specialReportTags: Set[String] = Set(
+    "business/series/undercover-in-the-chicken-industry",
+    "business/series/britains-debt-timebomb",
+    "world/series/this-is-europe",
+    "environment/series/the-polluters",
+    "news/series/hsbc-files",
+    "news/series/panama-papers",
+    "us-news/homan-square",
+    "uk-news/series/the-new-world-of-work",
+    "world/series/the-new-arrivals",
+    "news/series/nauru-files",
+    "us-news/series/counted-us-police-killings",
+    "australia-news/series/healthcare-in-detention",
+    "society/series/this-is-the-nhs",
+  )
+
+  def isSpecialReport(page: PageWithStoryPackage): Boolean = {
+    page.item.tags.tags.exists(t => specialReportTags(t.id))
+  }
+
   // -----------------------------------------------------------------------
 
   def fromArticle(
@@ -566,6 +586,7 @@ object DotcomRenderingDataModelFunctions {
       badge = badge,
       // Match Data
       matchUrl = makeMatchUrl(page),
+      isSpecialReport = isSpecialReport(page),
     )
   }
 }


### PR DESCRIPTION
## What does this change?

This is the follow up of https://github.com/guardian/frontend/pull/23503 . We add ` isSpecialReport` to the DCR data object. 

![Screenshot 2021-01-28 at 16 32 29](https://user-images.githubusercontent.com/6035518/106168830-a19f0f80-6186-11eb-947f-7923fd4b587c.png)


![Screenshot 2021-01-28 at 16 42 57](https://user-images.githubusercontent.com/6035518/106170004-e8d9d000-6187-11eb-8fae-90924595c2e7.png)
