### PR TITLE
Hf tifpodcast page update

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_container--podcast.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--podcast.scss
@@ -41,7 +41,7 @@
 
 .fc-podcast-container__episode,
 .fc-podcast-container__series {
-    border-top: solid 1px #c70000;
+    border-top: solid 1px #FC6DFB;
 }
 
 .fc-podcast-container__episode-details {
@@ -90,7 +90,7 @@
 
 .fc-podcast-container__episode-details .fc-item__kicker,
 .fc-podcast-container__series .fc-item__kicker {
-    color: #ff6a56;
+    color: #FC6DFB;
 }
 
 /* GENERIC IMAGE */
@@ -208,7 +208,7 @@
     width: 23px;
     height: 23px;
     display: inline-block;
-    background-color: #ff6a56;
+    background-color: #FC6DFB;
     border-radius: 50%;
 
     svg {

--- a/static/src/stylesheets/module/facia-garnett/_container--podcast.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container--podcast.scss
@@ -41,7 +41,7 @@
 
 .fc-podcast-container__episode,
 .fc-podcast-container__series {
-    border-top: solid 1px #FC6DFB;
+    border-top: solid 1px #fc6dfb;
 }
 
 .fc-podcast-container__episode-details {
@@ -90,7 +90,7 @@
 
 .fc-podcast-container__episode-details .fc-item__kicker,
 .fc-podcast-container__series .fc-item__kicker {
-    color: #FC6DFB;
+    color: #fc6dfb;
 }
 
 /* GENERIC IMAGE */
@@ -208,7 +208,7 @@
     width: 23px;
     height: 23px;
     display: inline-block;
-    background-color: #FC6DFB;
+    background-color: #fc6dfb;
     border-radius: 50%;
 
     svg {

--- a/static/src/stylesheets/module/journalism/_audio-flagship-tag-page-container.scss
+++ b/static/src/stylesheets/module/journalism/_audio-flagship-tag-page-container.scss
@@ -34,7 +34,7 @@
             flex-direction: row;
 
             &::before {
-                background-color: #ff6a56;
+                background-color: #FC6DFB;
             }
 
             .fc-date-headline {
@@ -88,14 +88,14 @@
 
                 .fc-item__title {
                     .fc-item__kicker {
-                        color: #ff6a56;
+                        color: #FC6DFB;
                     }
                 }
                 .fc-item__footer-meta-wrapper {
                     margin-top: auto;
                     .fc-item__media-meta {
                         .inline-icon {
-                            background-color: #ff6a56;
+                            background-color: #FC6DFB;
                         }
                     }
                 }

--- a/static/src/stylesheets/module/journalism/_audio-flagship-tag-page-container.scss
+++ b/static/src/stylesheets/module/journalism/_audio-flagship-tag-page-container.scss
@@ -34,7 +34,7 @@
             flex-direction: row;
 
             &::before {
-                background-color: #FC6DFB;
+                background-color: #fc6dfb;
             }
 
             .fc-date-headline {
@@ -88,14 +88,14 @@
 
                 .fc-item__title {
                     .fc-item__kicker {
-                        color: #FC6DFB;
+                        color: #fc6dfb;
                     }
                 }
                 .fc-item__footer-meta-wrapper {
                     margin-top: auto;
                     .fc-item__media-meta {
                         .inline-icon {
-                            background-color: #FC6DFB;
+                            background-color: #fc6dfb;
                         }
                     }
                 }

--- a/static/src/stylesheets/module/journalism/_audio-flagship-tag-page.scss
+++ b/static/src/stylesheets/module/journalism/_audio-flagship-tag-page.scss
@@ -65,7 +65,7 @@
                     width: 115px;
                 }
                 @include mq($from: wide) {
-                    right: 100px;
+                    right: 90px;
                 }
             }
 
@@ -156,8 +156,8 @@
                     bottom: 0;
                     z-index: 8;
                 }
-                @include mq($from: leftCol) {
-                    right: 18px;
+                @include mq($from: desktop) {
+                    right:20px;
                 }
                 @include mq($from: wide) {
                     right: 100px;

--- a/static/src/stylesheets/module/journalism/_audio-flagship-tag-page.scss
+++ b/static/src/stylesheets/module/journalism/_audio-flagship-tag-page.scss
@@ -157,7 +157,7 @@
                     z-index: 8;
                 }
                 @include mq($from: desktop) {
-                    right:20px;
+                    right: 20px;
                 }
                 @include mq($from: wide) {
                     right: 100px;


### PR DESCRIPTION
## What does this change?
Updated Today in focus tag page to have magenta kickers, border-top and audio icon. Also updated the container on main front with same changes.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
![image](https://user-images.githubusercontent.com/20658471/106288281-bdb2b780-623f-11eb-8542-d1f4152c4b07.png)
![image](https://user-images.githubusercontent.com/20658471/106288366-db801c80-623f-11eb-98d0-02a52124fe0e.png)

<img width="914" alt="Screenshot 2021-01-29 at 13 49 12" src="https://user-images.githubusercontent.com/20658471/106288328-cdca9700-623f-11eb-878d-b9c5c5337f64.png">



<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
