### PR TITLE
Refactor the AMP Flush public key away from the source code

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -348,6 +348,8 @@ class GuardianConfiguration extends GuLogging {
     private lazy val scheme = configuration.getStringProperty("amp.scheme").getOrElse("")
     lazy val host = configuration.getStringProperty("amp.host").getOrElse("")
     lazy val baseUrl = scheme + host
+
+    lazy val flushPublicKey = configuration.getMandatoryStringProperty("google.amp.flush.key.public")
   }
 
   object id {
@@ -735,7 +737,6 @@ class GuardianConfiguration extends GuLogging {
     lazy val host = configuration.getStringProperty("newsletterApi.host")
     lazy val origin = configuration.getStringProperty("newsletterApi.origin")
   }
-
 }
 
 object ManifestData {

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -20,6 +20,7 @@ import conf.switches.Switches.InlineEmailStyles
 import implicits.GUHeaders
 import pages.{FrontEmailHtmlPage, FrontHtmlPage}
 import utils.TargetedCollections
+import conf.Configuration
 
 import scala.concurrent.Future
 import scala.concurrent.Future.successful
@@ -411,19 +412,10 @@ trait FaciaController
 
   def ampRsaPublicKey: Action[AnyContent] = {
     Action {
-      val rsakey: String = """-----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApCXxbFZh32bQtP7XTcN8
-Qu7tUqOKgtdwrhH0d8Virw+Q5YuTxAEKaSL864TPPl02uWz3/zYUFmfEWj0iheVF
-anR7Ws8lUJa+VNFIfVk4ldVc0uatdmsd6F2BoSYKXQit7mpeljn9OQ9FZ2xJTd3M
-7stPudsYd0XTrKwJdqx4XX2yGb+Qig7bJvyzzXKQAyW7QLhqKdPMIKPFX8puNd2V
-3JLsabOONcRO8mXM21jX6s9P5nI4rw5szhe3F7zrdNuWK1hN9l76a6iygZZYOJ9Q
-WE6jcX2DPtRveAucdVs4hZgB3sxeSRTXm3juoQw2cjEqqJw8loXn54wNeU1JAj17
-OQIDAQAB
------END PUBLIC KEY-----"""
-      Ok(rsakey).as("text/plain")
+      // The private key is in the CAPI account, see the documentation at https://github.com/guardian/fastly-cache-purger
+      Ok(Configuration.amp.flushPublicKey).as("text/plain")
     }
   }
-
 }
 
 class FaciaControllerImpl(


### PR DESCRIPTION
## What does this change?

Move the AMP flush public key away from the code. 

<img width="636" alt="Screenshot 2021-02-02 at 13 13 26" src="https://user-images.githubusercontent.com/6035518/106605170-805c6b80-6558-11eb-881e-ad4e9312c08d.png">
