### PR TITLE
update workforus links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## We're hiring!
 Ever thought about joining us?
-https://workforus.theguardian.com/careers/digital-development/
+https://workforus.theguardian.com/careers/product-engineering/
 
 # Frontend
 The Guardian website frontend.

--- a/common/app/views/fragments/head.scala.html
+++ b/common/app/views/fragments/head.scala.html
@@ -14,7 +14,7 @@
         \_/\_/ \___|  \__,_|_|  \___| |_| |_|_|_|  |_|_| |_|\__, |
                                                             |___/
     Ever thought about joining us?
-    https://workforus.theguardian.com/careers/digital-development/
+    https://workforus.theguardian.com/careers/product-engineering/
      --->
 }
 <title>@views.support.Title(page)</title>

--- a/common/app/views/fragments/page/head/weAreHiring.scala.html
+++ b/common/app/views/fragments/page/head/weAreHiring.scala.html
@@ -8,5 +8,5 @@
         \_/\_/ \___|  \__,_|_|  \___| |_| |_|_|_|  |_|_| |_|\__, |
                                                             |___/
     Ever thought about joining us?
-    https://workforus.theguardian.com/careers/digital-development/
+    https://workforus.theguardian.com/careers/product-engineering/
      --->

--- a/static/src/javascripts.flow.archive/bootstraps/standard/main.js
+++ b/static/src/javascripts.flow.archive/bootstraps/standard/main.js
@@ -61,7 +61,7 @@ const showHiringMessage = (): void => {
                     '%cHello.\n' +
                     '\n' +
                     '%cWe are hiring – ever thought about joining us? \n' +
-                    '%chttps://workforus.theguardian.com/careers/digital-development%c \n' +
+                    '%chttps://workforus.theguardian.com/careers/product-engineering%c \n' +
                     '\n',
                 'font-family: Georgia, serif; font-size: 32px; color: #052962',
                 'font-family: Georgia, serif; font-size: 16px; color: #767676',

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -46,7 +46,7 @@ const showHiringMessage = () => {
                     '%cHello.\n' +
                     '\n' +
                     '%cWe are hiring – ever thought about joining us? \n' +
-                    '%chttps://workforus.theguardian.com/careers/digital-development%c \n' +
+                    '%chttps://workforus.theguardian.com/careers/product-engineering%c \n' +
                     '\n',
                 'font-family: Georgia, serif; font-size: 32px; color: #052962',
                 'font-family: Georgia, serif; font-size: 16px; color: #767676',


### PR DESCRIPTION
## What does this change?
Digital Development was our old departmental name, we're now Product and Engineering - update the [paths](https://workforus.theguardian.com/careers/product-engineering/).

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No - I couldn't find the old URL [within the repo](https://github.com/guardian/dotcom-rendering/search?q=%22digital-development%22)
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

n/a

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
