### PR TITLE
Remove unused import causing deprecation warning during compilation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 import com.gu.riffraff.artifact.RiffRaffArtifact.autoImport._
-import play.sbt.Play.autoImport._
 import play.sbt.routes.RoutesKeys
 import com.typesafe.sbt.web.SbtWeb.autoImport._
 import com.gu.Dependencies._
@@ -42,7 +41,7 @@ val common = library("common")
       jerseyClient,
       cssParser,
       w3cSac,
-      logback2,// logback2: to prevent "error: reference to logback is ambiguous;"
+      logback2, // logback2: to prevent "error: reference to logback is ambiguous;"
       kinesisLogbackAppender,
       targetingClient,
       scanamo,


### PR DESCRIPTION
## What does this change?

Remove unused import causing deprecation warning during compilation. 

<img width="1301" alt="Screenshot 2021-02-02 at 16 53 43" src="https://user-images.githubusercontent.com/6035518/106716076-e21ee300-65f5-11eb-9e77-fcbdc6462fa2.png">
