### PR TITLE
Extend Deeply Read Switch Until decision is made

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -41,7 +41,7 @@ trait ABTestSwitches {
     "Tests an onward hypothesis by replacing the second tab in the Most Popular container with deeply read items.",
     owners = Seq(Owner.withGithub("nitro-marky")),
     safeState = Off,
-    sellByDate = new LocalDate(2021, 2, 5),
+    sellByDate = new LocalDate(2021, 4, 1),
     exposeClientSide = true,
   )
 }


### PR DESCRIPTION
## What does this change?

Extends switch to 1st April

