### PR TITLE
Bump sbt version to 1.4.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ static/vendor/data/cmp_vendorlist.json
 .sbt
 .sbt.*
 .metals
+.bsp
 
 log
 logs

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -58,7 +58,7 @@ object ProjectSettings {
       "Guardian Editorial Tools Bintray" at "https://dl.bintray.com/guardian/editorial-tools",
       Resolver.bintrayRepo("guardian", "ophan"),
       "Spy" at "https://files.couchbase.com/maven2/",
-      "emueller-bintray" at "http://dl.bintray.com/emueller/maven",
+      "emueller-bintray" at "https://dl.bintray.com/emueller/maven",
     ),
     evictionWarningOptions in update := EvictionWarningOptions.default
       .withWarnTransitiveEvictions(false)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.4.7


### PR DESCRIPTION
## What does this change?

Bump sbt version to 1.4.7. and update emueller-bintray url to use https (unsecured connections are no longer allowed). 

(Note: `.bsp` is a side effect of using Metals with Sublime Text)