### PR TITLE
Remove redundant and conflicting akka-contrib import

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -92,7 +92,6 @@ val sport = application("sport")
   .settings(
     libraryDependencies ++= Seq(
       paClient,
-      akkaContrib,
     ),
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,6 @@ object Dependencies {
   val playJsonVersion = "2.6.3"
   val playJsonExtensionsVersion = "0.10.0"
   val guBox = "com.gu" %% "box" % "0.1.0"
-  val akkaContrib = "com.typesafe.akka" %% "akka-contrib" % "2.5.6"
   val apacheCommonsLang = "org.apache.commons" % "commons-lang3" % "3.11"
   val awsCore = "com.amazonaws" % "aws-java-sdk-core" % awsVersion
   val awsCloudwatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsVersion


### PR DESCRIPTION
## What does this change?

Remove redundant and conflicting akka-contrib import (same as https://github.com/guardian/frontend/pull/23527)
