### PR TITLE
Setup 1% AB test of Updated Xaxis bidder

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -49,7 +49,7 @@ trait ABTestSwitches {
     ABTests,
     "ab-updated-xaxis-prebid",
     "Test the performance of updated xaxis adapter in prebid",
-    owners = Seq(Owner.withGithub("ioanna0")),
+    owners = Owner.group(Commercial),
     safeState = Off,
     sellByDate = new LocalDate(2021, 2, 24),
     exposeClientSide = true,

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -44,4 +44,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2021, 4, 1),
     exposeClientSide = true,
   )
+
+  Switch(
+    ABTests,
+    "ab-updated-xaxis-prebid",
+    "Test the performance of updated xaxis adapter in prebid",
+    owners = Seq(Owner.withGithub("ioanna0")),
+    safeState = Off,
+    sellByDate = new LocalDate(2021, 2, 24),
+    exposeClientSide = true,
+  )
 }

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
@@ -174,10 +174,31 @@ const getImproveSizeParam = slotId => {
 };
 
 const getXaxisPlacementId = sizes => {
-    if (containsDmpu(sizes)) return 13663297;
-    if (containsMpu(sizes)) return 13663304;
-    if (containsBillboard(sizes)) return 13663284;
-    return 13663304;
+    switch (getBreakpointKey()) {
+        case 'D':
+            if (containsMpuOrDmpu(sizes)) {
+                return 20943665;
+            }
+            if (containsLeaderboardOrBillboard(sizes)) {
+                return 20943666;
+            }
+            return 20943668;
+        case 'M':
+            if (containsMpuOrDmpu(sizes)) {
+                return 20943669;
+            }
+            return 20943670;
+        case 'T':
+            if (containsMpuOrDmpu(sizes)) {
+                return 20943671;
+            }
+            if (containsLeaderboardOrBillboard(sizes)) {
+                return 20943672;
+            }
+            return 20943674;
+        default:
+            return -1;
+    }
 };
 
 const getTripleLiftInventoryCode = (slotId, sizes) => {
@@ -410,6 +431,7 @@ export const bids = (slotId, slotSizes) =>
 export const _ = {
     getIndexSiteId,
     getImprovePlacementId,
+    getXaxisPlacementId,
     getTrustXAdUnitId,
     indexExchangeBidders,
 };

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.spec.js
@@ -530,6 +530,13 @@ describe('getXaxisPlacementId', () => {
     beforeEach(() => {
         resetConfig();
         getBreakpointKey.mockReturnValue('D');
+
+        containsMpuOrDmpu.mockReturnValueOnce(true)
+            .mockReturnValueOnce(true)
+            .mockReturnValue(false);
+        containsLeaderboardOrBillboard.mockReturnValueOnce(true)
+            .mockReturnValueOnce(true)
+            .mockReturnValue(false);
     });
 
     afterEach(() => {
@@ -553,12 +560,7 @@ describe('getXaxisPlacementId', () => {
 
     test('should return the expected values for desktop device', () => {
         getBreakpointKey.mockReturnValue('D');
-        containsMpuOrDmpu.mockReturnValueOnce(true);
-        containsMpuOrDmpu.mockReturnValueOnce(true);
-        containsMpuOrDmpu.mockReturnValue(false);
-        containsLeaderboardOrBillboard.mockReturnValueOnce(true);
-        containsLeaderboardOrBillboard.mockReturnValueOnce(true);
-        containsLeaderboardOrBillboard.mockReturnValue(false);
+
         expect(generateTestIds()).toEqual([
             20943665,
             20943665,
@@ -570,12 +572,6 @@ describe('getXaxisPlacementId', () => {
 
     test('should return the expected values for tablet device', () => {
         getBreakpointKey.mockReturnValue('T');
-        containsMpuOrDmpu.mockReturnValueOnce(true);
-        containsMpuOrDmpu.mockReturnValueOnce(true);
-        containsMpuOrDmpu.mockReturnValue(false);
-        containsLeaderboardOrBillboard.mockReturnValueOnce(true);
-        containsLeaderboardOrBillboard.mockReturnValueOnce(true);
-        containsLeaderboardOrBillboard.mockReturnValue(false);
         expect(generateTestIds()).toEqual([
             20943671,
             20943671,
@@ -587,12 +583,6 @@ describe('getXaxisPlacementId', () => {
 
     test('should return the expected values for mobile device', () => {
         getBreakpointKey.mockReturnValue('M');
-        containsMpuOrDmpu.mockReturnValueOnce(true);
-        containsMpuOrDmpu.mockReturnValueOnce(true);
-        containsMpuOrDmpu.mockReturnValue(false);
-        containsLeaderboardOrBillboard.mockReturnValueOnce(true);
-        containsLeaderboardOrBillboard.mockReturnValueOnce(true);
-        containsLeaderboardOrBillboard.mockReturnValue(false);
         expect(generateTestIds()).toEqual([
             20943669,
             20943669,

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.spec.js
@@ -58,6 +58,7 @@ const getBidders = () =>
 const {
     getIndexSiteId,
     getImprovePlacementId,
+    getXaxisPlacementId,
     getTrustXAdUnitId,
     indexExchangeBidders,
 } = _;
@@ -522,5 +523,81 @@ describe('triplelift adapter', () => {
         expect(tripleLiftBids).toEqual({
             inventoryCode: 'theguardian_320x50_HDX',
         });
+    });
+});
+
+describe('getXaxisPlacementId', () => {
+    beforeEach(() => {
+        resetConfig();
+        getBreakpointKey.mockReturnValue('D');
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    const generateTestIds = () => {
+        const prebidSizes = [
+            [[300, 250]],
+            [[300, 600]],
+            [[970, 250]],
+            [[728, 90]],
+            [[1, 2]],
+        ];
+        return prebidSizes.map(getXaxisPlacementId);
+    };
+
+    test('should return -1 if no cases match', () => {
+        expect(getImprovePlacementId([[1, 2]])).toBe(-1);
+    });
+
+    test('should return the expected values for desktop device', () => {
+        getBreakpointKey.mockReturnValue('D');
+        containsMpuOrDmpu.mockReturnValueOnce(true);
+        containsMpuOrDmpu.mockReturnValueOnce(true);
+        containsMpuOrDmpu.mockReturnValue(false);
+        containsLeaderboardOrBillboard.mockReturnValueOnce(true);
+        containsLeaderboardOrBillboard.mockReturnValueOnce(true);
+        containsLeaderboardOrBillboard.mockReturnValue(false);
+        expect(generateTestIds()).toEqual([
+            20943665,
+            20943665,
+            20943666,
+            20943666,
+            20943668,
+        ]);
+    });
+
+    test('should return the expected values for tablet device', () => {
+        getBreakpointKey.mockReturnValue('T');
+        containsMpuOrDmpu.mockReturnValueOnce(true);
+        containsMpuOrDmpu.mockReturnValueOnce(true);
+        containsMpuOrDmpu.mockReturnValue(false);
+        containsLeaderboardOrBillboard.mockReturnValueOnce(true);
+        containsLeaderboardOrBillboard.mockReturnValueOnce(true);
+        containsLeaderboardOrBillboard.mockReturnValue(false);
+        expect(generateTestIds()).toEqual([
+            20943671,
+            20943671,
+            20943672,
+            20943672,
+            20943674,
+        ]);
+    });
+
+    test('should return the expected values for mobile device', () => {
+        getBreakpointKey.mockReturnValue('M');
+        containsMpuOrDmpu.mockReturnValueOnce(true);
+        containsMpuOrDmpu.mockReturnValueOnce(true);
+        containsMpuOrDmpu.mockReturnValue(false);
+        containsLeaderboardOrBillboard.mockReturnValueOnce(true);
+        containsLeaderboardOrBillboard.mockReturnValueOnce(true);
+        containsLeaderboardOrBillboard.mockReturnValue(false);
+        expect(generateTestIds()).toEqual([
+            20943669,
+            20943669,
+            20943670,
+            20943670,
+            20943670]);
     });
 });

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
@@ -93,6 +93,9 @@ const initialise = (window) => {
                     },
                 },
             ],
+            bidCpmAdjustment : (bidCpm) => {
+                return bidCpm * 0.5;
+            }
         };
     }
 

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
@@ -94,7 +94,7 @@ const initialise = (window) => {
                 },
             ],
             bidCpmAdjustment : (bidCpm) => {
-                return bidCpm * 0.5;
+                return bidCpm * 1.05;
             }
         };
     }

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/utils.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/utils.js
@@ -8,6 +8,11 @@ import once from 'lodash/once';
 import config from '../../../../lib/config';
 import { getBreakpoint, isBreakpoint } from '../../../../lib/detect';
 import { pbTestNameMap } from '../../../../lib/url';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { xaxisPrebidTest } from 'common/modules/experiments/tests/updated-xaxis-prebid';
+
+const isInXaxisTestVariant = () =>
+    isInVariantSynchronous(xaxisPrebidTest, 'variant');
 
 const SUFFIX_REGEXPS = {};
 const stripSuffix = (s, suffix) => {
@@ -127,9 +132,7 @@ export const shouldIncludeAppNexus = () =>
         !!pbTestNameMap().and);
 
 export const shouldIncludeXaxis = () =>
-    // 10% of UK page views
-    isInUk() &&
-    (config.get('page.isDev', true) || getRandomIntInclusive(1, 10) === 1);
+    isInUk() && isInXaxisTestVariant();
 
 export const shouldIncludeImproveDigital = () =>
     isInUk() || isInRow();

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -1,9 +1,11 @@
 import { signInGateMainVariant } from 'common/modules/experiments/tests/sign-in-gate-main-variant';
 import { signInGateMainControl } from 'common/modules/experiments/tests/sign-in-gate-main-control';
 import { signInGateDesignOpt } from 'common/modules/experiments/tests/sign-in-gate-design-opt';
+import { xaxisPrebidTest } from 'common/modules/experiments/tests/updated-xaxis-prebid';
 
 export const concurrentTests = [
     signInGateMainVariant,
     signInGateMainControl,
     signInGateDesignOpt,
+    xaxisPrebidTest,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/updated-xaxis-prebid.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/updated-xaxis-prebid.js
@@ -1,0 +1,28 @@
+// @flow strict
+import { isInUk } from 'common/modules/commercial/geo-utils';
+
+export const xaxisPrebidTest = {
+    id: 'UpdatedXaxisPrebid',
+    start: '2020-09-02',
+    expiry: '2020-24-02',
+    author: 'Ioanna Kyprianou',
+    description: 'Test the performance of updated xaxis adapter in prebid',
+    audience: 0.01,
+    audienceOffset: 0.0,
+    successMeasure: 'No negative impact',
+    audienceCriteria: 'n/a',
+    dataLinkNames: 'n/a',
+    idealOutcome: 'Updated xaxis adapter works',
+    showForSensitive: false,
+    canRun: () => isInUk(),
+    variants: [
+        {
+            id: 'control',
+            test: () => {},
+        },
+        {
+            id: 'variant',
+            test: () => {},
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/updated-xaxis-prebid.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/updated-xaxis-prebid.js
@@ -1,10 +1,9 @@
-// @flow strict
 import { isInUk } from 'common/modules/commercial/geo-utils';
 
 export const xaxisPrebidTest = {
     id: 'UpdatedXaxisPrebid',
-    start: '2020-09-02',
-    expiry: '2020-24-02',
+    start: '2021-02-09',
+    expiry: '2021-02-24',
     author: 'Ioanna Kyprianou',
     description: 'Test the performance of updated xaxis adapter in prebid',
     audience: 0.01,


### PR DESCRIPTION
## What does this change?
Reactivate the Xaxis prebid adaptor with updated IDs so we can remove them from Ozone

Add it behind 1% AB test as we want to ensure that adding this bidder does not impact the performance of prebid (D&I will be working on the analysis)

Apply a 5% bid boost

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
