### PR TITLE
Adding server side AB test for the ClickToView component

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -9,7 +9,7 @@ import conf.switches.SwitchGroup.Commercial
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
     DotcomRendering,
-    ClickToView
+    ClickToView,
   )
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -9,6 +9,7 @@ import conf.switches.SwitchGroup.Commercial
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
     DotcomRendering,
+    ClickToView
   )
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -32,4 +33,13 @@ object NewsletterEmbedDesign
       owners = Seq(Owner.withGithub("buck06191")),
       sellByDate = new LocalDate(2020, 11, 30),
       participationGroup = Perc20A,
+    )
+
+object ClickToView
+    extends Experiment(
+      name = "click-to-view",
+      description = "Click to provide consent before seeing embedded content",
+      owners = Seq(Owner.withGithub("frj")),
+      sellByDate = new LocalDate(2021, 3, 2),
+      participationGroup = Perc0B,
     )


### PR DESCRIPTION
This PR contains changes to add an additional server side AB test, for the click to view component.

Enabling this test will enable the ClickToView component that requires a user to click to consent to being tracked by third party embeds before seeing the embedded content.

This test is best run as a server side test as switching from one variant to another would cause layout changes on page load. For more details see:

https://github.com/guardian/frontend/blob/e71dc1c521672b28399811c59331e0c2c713bf00/docs/03-dev-howtos/01-ab-testing.md#write-a-server-side-test

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

This test is implemented in DCR.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
