### PR TITLE
Add survey slot to puzzles pages

### DIFF
--- a/applications/app/pages/CrosswordHtmlPage.scala
+++ b/applications/app/pages/CrosswordHtmlPage.scala
@@ -23,6 +23,7 @@ import views.html.fragments.page.head._
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import html.HtmlPageHelpers.ContentCSSFile
 import views.html.stacked
+import views.html.fragments.commercial.survey
 
 object CrosswordHtmlPage extends HtmlPage[CrosswordPage] {
 
@@ -59,6 +60,7 @@ object CrosswordHtmlPage extends HtmlPage[CrosswordPage] {
       ),
       bodyTag(classes = defaultBodyClasses)(
         skipToMainContent(),
+        survey(),
         pageSkin() when page.metadata.hasPageSkin(request),
         guardianHeaderHtml(),
         mainContent(),

--- a/applications/app/views/fragments/crosswords/crosswordContent.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordContent.scala.html
@@ -4,11 +4,18 @@
 @import views.html.fragments.crosswords._
 @import conf.switches.Switches.CommercialSwitch
 @import views.support.Commercial.{shouldShowAds, isAdFree}
+@import conf.switches.Switches.{SurveySwitch}
+
+
 
 @defining(CommercialSwitch.isSwitchedOn && shouldShowAds(crosswordPage) && !isAdFree(request)) { adsEnabled =>
     <div class="l-side-margins">
         <article id="crossword" class="content content--article tonal tonal--tone-news" role="main">
             @crosswordMetaHeader(crosswordPage)
+
+            @if(SurveySwitch.isSwitchedOn) {
+                @fragments.commercial.survey()
+            }
 
             <div class="content__main tonal__main tonal__main--tone-news">
                 <div class="gs-container">

--- a/applications/app/views/fragments/crosswords/crosswordContent.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordContent.scala.html
@@ -4,18 +4,11 @@
 @import views.html.fragments.crosswords._
 @import conf.switches.Switches.CommercialSwitch
 @import views.support.Commercial.{shouldShowAds, isAdFree}
-@import conf.switches.Switches.{SurveySwitch}
-
-
 
 @defining(CommercialSwitch.isSwitchedOn && shouldShowAds(crosswordPage) && !isAdFree(request)) { adsEnabled =>
     <div class="l-side-margins">
         <article id="crossword" class="content content--article tonal tonal--tone-news" role="main">
             @crosswordMetaHeader(crosswordPage)
-
-            @if(SurveySwitch.isSwitchedOn) {
-                @fragments.commercial.survey()
-            }
 
             <div class="content__main tonal__main tonal__main--tone-news">
                 <div class="gs-container">


### PR DESCRIPTION
## What does this change?
This makes the survey slot available on puzzles pages.

## Does this change need to be reproduced in dotcom-rendering ?
- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
You can check if the slot is available on a given page by disabling javascript and running `document.querySelectorAll('[data-name="survey"')`

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?
- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?
- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?
- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist
It probably does affect the usability of the page, but not in a way that is in scope to control!

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested
- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
