### PR TITLE
Add AB test for carousel onwards content;

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -54,4 +54,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2021, 2, 24),
     exposeClientSide = true,
   )
+
+  Switch(
+    ABTests,
+    "ab-curated-content-3-carousel",
+    "Test the impact of a Carousel for onwards journeys",
+    owners = Seq(Owner.withGithub("buck06191")),
+    safeState = Off,
+    sellByDate = new LocalDate(2021, 2, 26),
+    exposeClientSide = true,
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -2,10 +2,12 @@ import { signInGateMainVariant } from 'common/modules/experiments/tests/sign-in-
 import { signInGateMainControl } from 'common/modules/experiments/tests/sign-in-gate-main-control';
 import { signInGateDesignOpt } from 'common/modules/experiments/tests/sign-in-gate-design-opt';
 import { xaxisPrebidTest } from 'common/modules/experiments/tests/updated-xaxis-prebid';
+import { curatedContentCarouselTest } from 'common/modules/experiments/tests/curated-content-carousel-test';
 
 export const concurrentTests = [
     signInGateMainVariant,
     signInGateMainControl,
     signInGateDesignOpt,
     xaxisPrebidTest,
+    curatedContentCarouselTest
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/curated-content-carousel-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/curated-content-carousel-test.js
@@ -1,0 +1,33 @@
+export const curatedContentCarouselTest = {
+    id: 'CuratedContent3Carousel',
+    start: '2021-02-10',
+    expiry: '2021-02-26',
+    author: 'buck06191',
+    description:
+        'Compare two carousel designs against existing fixed content for onwards journeys',
+    audience: 0.05,
+    audienceOffset: 0.95,
+    successMeasure: 'The carousel drives increased engagement with onwards content as compared to control',
+    audienceCriteria:
+        '5% of all audience on articles',
+    dataLinkNames: 'carousel-[large/small]-article-position-[X] where [X] is the index of the clicked card',
+    idealOutcome:
+        'We believe that we can increase onwards journey conversion using a carousel',
+    showForSensitive: false,
+    canRun: () => true,
+    variants: [
+        {
+            id: 'curated-content-control',
+            test: () => {},
+        },
+        {
+            id: 'curated-content-variant-carousel-small',
+            test: () => {},
+        },
+        {
+            id: 'curated-content-variant-carousel-large',
+            test: () => {},
+        },
+
+    ],
+};


### PR DESCRIPTION
## What does this change?
Adds AB tests for the new onwards content carousel.

https://github.com/guardian/dotcom-rendering/pull/2416
https://github.com/guardian/dotcom-rendering/pull/2448
https://github.com/guardian/dotcom-rendering/pull/2456
https://github.com/guardian/dotcom-rendering/pull/2515

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)
PR to follow

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
