### PR TITLE
Remove previously deprecated (now unused) DCR nav fields

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
@@ -154,9 +154,6 @@ case class Nav(
     currentPillarTitle: Option[String],
     subNavSections: Option[Subnav],
     readerRevenueLinks: ReaderRevenueLinks,
-    // TODO remove once migrated to Id versions (which serialise better).
-    currentNavLink: Option[NavLink],
-    currentPillar: Option[NavLink],
 )
 
 object Nav {

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -491,8 +491,6 @@ object DotcomRenderingUtils {
         currentPillarTitle = navMenu.currentPillar.map(NavLink.id),
         subNavSections = navMenu.subNavSections,
         readerRevenueLinks = readerRevenueLinks,
-        currentNavLink = navMenu.currentNavLink,
-        currentPillar = navMenu.currentPillar,
       )
     }
 


### PR DESCRIPTION
## What does this change?

Removes some now unused nav fields from the DCR model

## Why?

Part of reducing the size and tidyup of what we send.