### PR TITLE
Changes to page targeting

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -45,7 +45,7 @@ const findBreakpoint = () => {
 
 const skinsizeTargetting = () => {
     const vp = getViewport();
-    return (vp && vp.width > 1560) ? "l" : "s";
+    return (vp && vp.width >= 1560) ? "l" : "s";
 };
 
 const inskinTargetting = () => {

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -43,13 +43,13 @@ const findBreakpoint = () => {
     }
 };
 
-const inskinTargetting = () => {
+const skinsizeTargetting = () => {
     const vp = getViewport();
-    if (!vp || vp.width < 1560) {
-        return 'f';
-    }
+    return (vp && vp.width > 1560) ? "l" : "s";
+};
 
-    // Don’t show inskin if we cannot tell if a privacy message will be shown
+const inskinTargetting = () => {
+// Don’t show inskin if we cannot tell if a privacy message will be shown
     if (!cmp.hasInitialised()) return 'f';
     return cmp.willShowPrivacyMessageSync() ? 'f' : 't';
 };
@@ -272,6 +272,7 @@ const rebuildPageTargeting = () => {
             // was DCR eligible and was actually rendered by DCR or
             // was DCR eligible but rendered by frontend for a user not in the DotcomRendering experiment
             inskin: inskinTargetting(),
+            skinsize: skinsizeTargetting(),
             urlkw: getUrlKeywords(page.pageId),
             rdp: getRdpValue(ccpaState),
             consent_tcfv2: getTcfv2ConsentValue(adConsentState),

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -317,6 +317,7 @@ describe('Build Page Targeting', () => {
             bp: 'mobile',
             at: 'ng101',
             si: 't',
+            skinsize: 's',
             ab: ['MtMaster-variantName'],
             pv: '123456',
             fr: '0',
@@ -487,26 +488,28 @@ describe('Build Page Targeting', () => {
             getViewport.mockReturnValue({ width: 1920, height: 1080 });
             expect(getPageTargeting().inskin).toBe('f');
         });
+    });
 
-        
+
+    describe('skinsize targetting', () => {
         it.each([
-            ['f', 1280],
-            ['f', 1440],
-            ['f', 1559],
-            ['t', 1560],
-            ['t', 1561],
-            ['t', 1920],
-            ['t', 2560],
+            ['s', 1280],
+            ['s', 1440],
+            ['s', 1559],
+            ['l', 1560],
+            ['l', 1561],
+            ['l', 1920],
+            ['l', 2560],
         ])("should return '%s' if viewport width is %s", (expected, width) => {
             cmp.hasInitialised.mockReturnValue(true);
             cmp.willShowPrivacyMessageSync.mockReturnValue(false);
             getViewport.mockReturnValue({ width, height: 800 });
-            expect(getPageTargeting().inskin).toBe(expected);
+            expect(getPageTargeting().skinsize).toBe(expected);
         });
 
-        it("should return 'f' if vp does not have a width", () => {
+        it("should return 's' if vp does not have a width", () => {
             getViewport.mockReturnValue(undefined);
-            expect(getPageTargeting().inskin).toBe('f');
+            expect(getPageTargeting().skinsize).toBe('s');
         });
-    });
+    })
 });


### PR DESCRIPTION
## What does this change?
Two changes to the page targeting:

- Changing inskin to refer just to the CMP status (going to show banner returns "f" in the targeting)
- Adding skinsize: either "s" or "l" to refer to screen size.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshot
### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
