### PR TITLE
DCR nav json endpoint

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -2,6 +2,7 @@ package model.dotcomrendering
 
 import common.commercial.EditionCommercialProperties
 import model.dotcomrendering.pageElements.PageElement
+import navigation.Nav
 import play.api.libs.json._
 
 // -----------------------------------------------------------------

--- a/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
@@ -66,29 +66,6 @@ object Pagination {
   implicit val writes = Json.writes[Pagination]
 }
 
-case class ReaderRevenueLink(
-    contribute: String,
-    subscribe: String,
-    support: String,
-    gifting: String,
-)
-
-object ReaderRevenueLink {
-  implicit val writes = Json.writes[ReaderRevenueLink]
-}
-
-case class ReaderRevenueLinks(
-    header: ReaderRevenueLink,
-    footer: ReaderRevenueLink,
-    sideMenu: ReaderRevenueLink,
-    ampHeader: ReaderRevenueLink,
-    ampFooter: ReaderRevenueLink,
-)
-
-object ReaderRevenueLinks {
-  implicit val writes = Json.writes[ReaderRevenueLinks]
-}
-
 case class Commercial(
     editionCommercialProperties: Map[String, EditionCommercialProperties],
     prebidIndexSites: List[PrebidIndexSite],
@@ -143,50 +120,6 @@ case class DCRBadge(seriesTag: String, imageUrl: String)
 
 object DCRBadge {
   implicit val writes = Json.writes[DCRBadge]
-}
-
-case class Nav(
-    currentUrl: String,
-    pillars: Seq[NavLink],
-    otherLinks: Seq[NavLink],
-    brandExtensions: Seq[NavLink],
-    currentNavLinkTitle: Option[String],
-    currentPillarTitle: Option[String],
-    subNavSections: Option[Subnav],
-    readerRevenueLinks: ReaderRevenueLinks,
-)
-
-object Nav {
-  implicit val flatSubnavWrites = Json.writes[FlatSubnav]
-  implicit val parentSubnavWrites = Json.writes[ParentSubnav]
-  implicit val subnavWrites = Writes[Subnav] {
-    case nav: FlatSubnav   => flatSubnavWrites.writes(nav)
-    case nav: ParentSubnav => parentSubnavWrites.writes(nav)
-  }
-
-  def nullableSeq[A](path: JsPath, writer: => Writes[A]): OWrites[Seq[A]] =
-    OWrites[Seq[A]] { a =>
-      a match {
-        case nonEmpty if nonEmpty.nonEmpty =>
-          JsPath.createObj(path -> Json.toJson(nonEmpty)(Writes.seq(writer)))
-        case _ => JsObject.empty
-      }
-    }
-
-  // Custom writer so that we can drop sequences altogether. It is really important to minimise the data sent to DCR and
-  // this really helps.
-  implicit lazy val navLinkWrites: Writes[NavLink] = {
-    ((__ \ "title").write[String]
-      and (__ \ "url").write[String]
-      and (__ \ "longTitle").writeNullable[String]
-      and (__ \ "iconName").writeNullable[String]
-      and (nullableSeq[NavLink](__ \ "children", navLinkWrites))
-      and (nullableSeq[String](__ \ "classList", Writes.StringWrites)))(nl =>
-      (nl.title, nl.url, nl.longTitle, nl.iconName, nl.children, nl.classList),
-    )
-  }
-
-  implicit val writes = Json.writes[Nav]
 }
 
 case class PageFooter(

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -5,17 +5,19 @@ import java.net.URLEncoder
 import com.gu.contentapi.client.model.v1.ElementType.Text
 import com.gu.contentapi.client.model.v1.{Block => APIBlock, BlockElement => ClientBlockElement, Blocks => APIBlocks}
 import com.gu.contentapi.client.utils.{AdvertisementFeature, DesignType}
-import common.Edition
 import common.Maps.RichMap
+import common.{Edition, RichRequestHeader}
 import common.commercial.EditionCommercialProperties
 import conf.Configuration.affiliateLinks
 import conf.switches.Switches
 import conf.{Configuration, Static}
+import experiments.ActiveExperiments
 import model.content.Atom
 import model.dotcomrendering.pageElements.{DisclaimerBlockElement, PageElement, TextCleaner}
 import model.{
   Article,
   ArticleDateTimes,
+  ArticlePage,
   Badges,
   CanonicalLiveBlog,
   DisplayedDateTimesDCR,
@@ -24,19 +26,13 @@ import model.{
   PageWithStoryPackage,
   Pillar,
 }
-import navigation.ReaderRevenueSite.{Support, SupportContribute, SupportGifting, SupportSubscribe}
-import navigation.UrlHelpers._
-import navigation.{FooterLinks, NavLink, NavMenu}
-import play.api.libs.json._
-import play.api.mvc.RequestHeader
-import common.RichRequestHeader
-import views.html.fragments.affiliateLinksDisclaimer
-import views.support.{AffiliateLinksCleaner, CamelCase, ContentLayout, ImgSrc, Item300}
-import model.ArticlePage
-import experiments.ActiveExperiments
+import navigation._
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
-import views.support.JavaScriptPage
+import play.api.libs.json._
+import play.api.mvc.RequestHeader
+import views.html.fragments.affiliateLinksDisclaimer
+import views.support.{AffiliateLinksCleaner, CamelCase, ContentLayout, ImgSrc, Item300, JavaScriptPage}
 
 // We have introduced our own set of objects for serializing data to the DotComponents API,
 // because we don't want people changing the core frontend models and as a side effect,
@@ -437,49 +433,6 @@ object DotcomRenderingUtils {
       ),
     )
 
-    val headerReaderRevenueLink: ReaderRevenueLink = ReaderRevenueLink(
-      getReaderRevenueUrl(SupportContribute, Header)(request),
-      getReaderRevenueUrl(SupportSubscribe, Header)(request),
-      getReaderRevenueUrl(Support, Header)(request),
-      getReaderRevenueUrl(SupportGifting, Header)(request),
-    )
-
-    val footerReaderRevenueLink: ReaderRevenueLink = ReaderRevenueLink(
-      getReaderRevenueUrl(SupportContribute, Footer)(request),
-      getReaderRevenueUrl(SupportSubscribe, Footer)(request),
-      getReaderRevenueUrl(Support, Footer)(request),
-      getReaderRevenueUrl(SupportGifting, Footer)(request),
-    )
-
-    val sideMenuReaderRevenueLink: ReaderRevenueLink = ReaderRevenueLink(
-      getReaderRevenueUrl(SupportContribute, SideMenu)(request),
-      getReaderRevenueUrl(SupportSubscribe, SideMenu)(request),
-      getReaderRevenueUrl(Support, SideMenu)(request),
-      getReaderRevenueUrl(SupportGifting, SideMenu)(request),
-    )
-
-    val ampHeaderReaderRevenueLink: ReaderRevenueLink = ReaderRevenueLink(
-      getReaderRevenueUrl(SupportContribute, AmpHeader)(request),
-      getReaderRevenueUrl(SupportSubscribe, AmpHeader)(request),
-      getReaderRevenueUrl(Support, AmpHeader)(request),
-      getReaderRevenueUrl(SupportGifting, AmpHeader)(request),
-    )
-
-    val ampFooterReaderRevenueLink: ReaderRevenueLink = ReaderRevenueLink(
-      getReaderRevenueUrl(SupportContribute, AmpFooter)(request),
-      getReaderRevenueUrl(SupportSubscribe, AmpFooter)(request),
-      getReaderRevenueUrl(Support, AmpFooter)(request),
-      getReaderRevenueUrl(SupportGifting, AmpFooter)(request),
-    )
-
-    val readerRevenueLinks = ReaderRevenueLinks(
-      headerReaderRevenueLink,
-      footerReaderRevenueLink,
-      sideMenuReaderRevenueLink,
-      ampHeaderReaderRevenueLink,
-      ampFooterReaderRevenueLink,
-    )
-
     val nav = {
       val navMenu = NavMenu(page, Edition(request))
       Nav(
@@ -490,7 +443,7 @@ object DotcomRenderingUtils {
         currentNavLinkTitle = navMenu.currentNavLink.map(NavLink.id),
         currentPillarTitle = navMenu.currentPillar.map(NavLink.id),
         subNavSections = navMenu.subNavSections,
-        readerRevenueLinks = readerRevenueLinks,
+        readerRevenueLinks = ReaderRevenueLinks.all,
       )
     }
 

--- a/common/app/navigation/DCRNavigation.scala
+++ b/common/app/navigation/DCRNavigation.scala
@@ -1,0 +1,93 @@
+package navigation
+
+import navigation.ReaderRevenueSite.{Support, SupportContribute, SupportGifting, SupportSubscribe}
+import navigation.UrlHelpers._
+import play.api.libs.json.{Json, Writes}
+
+case class ReaderRevenueLink(
+    contribute: String,
+    subscribe: String,
+    support: String,
+    gifting: String,
+)
+
+object ReaderRevenueLink {
+  implicit val writes = Json.writes[ReaderRevenueLink]
+}
+
+case class ReaderRevenueLinks(
+    header: ReaderRevenueLink,
+    footer: ReaderRevenueLink,
+    sideMenu: ReaderRevenueLink,
+    ampHeader: ReaderRevenueLink,
+    ampFooter: ReaderRevenueLink,
+)
+
+object ReaderRevenueLinks {
+  implicit val writes = Json.writes[ReaderRevenueLinks]
+
+  val headerReaderRevenueLink: ReaderRevenueLink = ReaderRevenueLink(
+    getReaderRevenueUrl(SupportContribute, Header),
+    getReaderRevenueUrl(SupportSubscribe, Header),
+    getReaderRevenueUrl(Support, Header),
+    getReaderRevenueUrl(SupportGifting, Header),
+  )
+
+  val footerReaderRevenueLink: ReaderRevenueLink = ReaderRevenueLink(
+    getReaderRevenueUrl(SupportContribute, Footer),
+    getReaderRevenueUrl(SupportSubscribe, Footer),
+    getReaderRevenueUrl(Support, Footer),
+    getReaderRevenueUrl(SupportGifting, Footer),
+  )
+
+  val sideMenuReaderRevenueLink: ReaderRevenueLink = ReaderRevenueLink(
+    getReaderRevenueUrl(SupportContribute, SideMenu),
+    getReaderRevenueUrl(SupportSubscribe, SideMenu),
+    getReaderRevenueUrl(Support, SideMenu),
+    getReaderRevenueUrl(SupportGifting, SideMenu),
+  )
+
+  val ampHeaderReaderRevenueLink: ReaderRevenueLink = ReaderRevenueLink(
+    getReaderRevenueUrl(SupportContribute, AmpHeader),
+    getReaderRevenueUrl(SupportSubscribe, AmpHeader),
+    getReaderRevenueUrl(Support, AmpHeader),
+    getReaderRevenueUrl(SupportGifting, AmpHeader),
+  )
+
+  val ampFooterReaderRevenueLink: ReaderRevenueLink = ReaderRevenueLink(
+    getReaderRevenueUrl(SupportContribute, AmpFooter),
+    getReaderRevenueUrl(SupportSubscribe, AmpFooter),
+    getReaderRevenueUrl(Support, AmpFooter),
+    getReaderRevenueUrl(SupportGifting, AmpFooter),
+  )
+
+  val all = ReaderRevenueLinks(
+    headerReaderRevenueLink,
+    footerReaderRevenueLink,
+    sideMenuReaderRevenueLink,
+    ampHeaderReaderRevenueLink,
+    ampFooterReaderRevenueLink,
+  )
+}
+
+case class Nav(
+    currentUrl: String,
+    pillars: Seq[NavLink],
+    otherLinks: Seq[NavLink],
+    brandExtensions: Seq[NavLink],
+    currentNavLinkTitle: Option[String],
+    currentPillarTitle: Option[String],
+    subNavSections: Option[Subnav],
+    readerRevenueLinks: ReaderRevenueLinks,
+)
+
+object Nav {
+  implicit val flatSubnavWrites = Json.writes[FlatSubnav]
+  implicit val parentSubnavWrites = Json.writes[ParentSubnav]
+  implicit val subnavWrites = Writes[Subnav] {
+    case nav: FlatSubnav   => flatSubnavWrites.writes(nav)
+    case nav: ParentSubnav => parentSubnavWrites.writes(nav)
+  }
+
+  implicit val writes = Json.writes[Nav]
+}

--- a/common/app/navigation/Navigation.scala
+++ b/common/app/navigation/Navigation.scala
@@ -2,7 +2,9 @@ package navigation
 
 import _root_.model.{NavItem, Page, Tags}
 import common.{Edition, editions}
-import play.api.libs.json.{Json, Writes}
+import navigation.NavMenu.navRoot
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
+import play.api.libs.json.{Json, Writes, _}
 
 import scala.annotation.tailrec
 
@@ -22,13 +24,30 @@ case class NavLink(
 
 object NavLink {
   def id(link: NavLink): String = link.title
-}
 
-case class SimpleMenu(
-    pillars: Seq[NavLink],
-    otherLinks: Seq[NavLink],
-    brandExtensions: Seq[NavLink],
-)
+  def nullableSeq[A](path: JsPath, writer: => Writes[A]): OWrites[Seq[A]] =
+    OWrites[Seq[A]] { a =>
+      a match {
+        case nonEmpty if nonEmpty.nonEmpty =>
+          JsPath.createObj(path -> Json.toJson(nonEmpty)(Writes.seq(writer)))
+        case _ => JsObject.empty
+      }
+    }
+
+  // Custom writer so that we can drop sequences altogether. It is really important to minimise the data sent to DCR and
+  // this really helps.
+  implicit lazy val navLinkWrites: Writes[NavLink] = {
+    ((__ \ "title").write[String]
+      and (__ \ "url").write[String]
+      and (__ \ "longTitle").writeNullable[String]
+      and (__ \ "iconName").writeNullable[String]
+      and (nullableSeq[NavLink](__ \ "children", navLinkWrites))
+      and (nullableSeq[String](__ \ "classList", Writes.StringWrites)))(nl =>
+      (nl.title, nl.url, nl.longTitle, nl.iconName, nl.children, nl.classList),
+    )
+  }
+
+}
 
 case class NavMenu(
     currentUrl: String,
@@ -78,11 +97,6 @@ object NavMenu {
     )
   }
 
-  def apply(edition: Edition): SimpleMenu = {
-    val root = navRoot(edition)
-    SimpleMenu(root.children, root.otherLinks, root.brandExtensions)
-  }
-
   /*
    * Useful when looking for a link, which may not exist in current edition, but
    * does in another.
@@ -104,7 +118,7 @@ object NavMenu {
     }
   }
 
-  private[navigation] def findDescendantByUrl(
+  def findDescendantByUrl(
       url: String,
       edition: Edition,
       pillars: Seq[NavLink],
@@ -116,7 +130,7 @@ object NavMenu {
       .orElse(find(getChildrenFromOtherEditions(edition), hasUrl))
   }
 
-  private[navigation] def findParent(
+  def findParent(
       currentNavLink: NavLink,
       edition: Edition,
       pillars: Seq[NavLink],
@@ -134,7 +148,7 @@ object NavMenu {
       .orElse(find(getChildrenFromOtherEditions(edition), isParent))
   }
 
-  private[navigation] def getPillar(
+  def getPillar(
       currentParent: Option[NavLink],
       edition: Edition,
       pillars: Seq[NavLink],
@@ -149,7 +163,7 @@ object NavMenu {
     )
   }
 
-  private[navigation] def navRoot(edition: Edition): NavRoot = {
+  def navRoot(edition: Edition): NavRoot = {
 
     val editionLinks: EditionNavLinks = edition match {
       case editions.Uk            => navigationData.uk
@@ -218,7 +232,7 @@ object NavMenu {
 
   }
 
-  private[navigation] def getSubnav(
+  def getSubnav(
       customSignPosting: Option[NavItem],
       currentNavLink: Option[NavLink],
       currentParent: Option[NavLink],
@@ -260,4 +274,21 @@ object NavMenu {
         }
     }
   }
+}
+
+// Used by AMP and DCR
+case class SimpleMenu(
+    pillars: Seq[NavLink],
+    otherLinks: Seq[NavLink],
+    brandExtensions: Seq[NavLink],
+    readerRevenueLinks: ReaderRevenueLinks,
+)
+
+object SimpleMenu {
+  def apply(edition: Edition): SimpleMenu = {
+    val root = navRoot(edition)
+    SimpleMenu(root.children, root.otherLinks, root.brandExtensions, ReaderRevenueLinks.all)
+  }
+
+  implicit val writes = Json.writes[SimpleMenu]
 }

--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -2,12 +2,11 @@ package navigation
 
 import com.netaporter.uri.config.UriConfig
 import com.netaporter.uri.encoding.PercentEncoder
+import navigation.ReaderRevenueSite._
 import play.api.libs.json.Json
 import play.api.mvc.RequestHeader
-import common.Edition
-import navigation.ReaderRevenueSite._
 
-import PartialFunction.condOpt
+import scala.PartialFunction.condOpt
 
 object UrlHelpers {
 
@@ -24,9 +23,7 @@ object UrlHelpers {
   case object ManageMyAccountUpsell extends Position
   case object ManageMyAccountCancel extends Position
 
-  def getComponentId(destination: ReaderRevenueSite, position: Position)(implicit
-      request: RequestHeader,
-  ): Option[String] = {
+  def getComponentId(destination: ReaderRevenueSite, position: Position): Option[String] = {
     condOpt((destination, position)) {
       case (Support, Header | SlimHeaderDropdown) => "header_support"
       case (Support, AmpHeader)                   => "amp_header_support"
@@ -70,9 +67,7 @@ object UrlHelpers {
     queryEncoder = PercentEncoder(PercentEncoder.QUERY_CHARS_TO_ENCODE + '"'),
   )
 
-  def getReaderRevenueUrl(destination: ReaderRevenueSite, position: Position)(implicit
-      request: RequestHeader,
-  ): String = {
+  def getReaderRevenueUrl(destination: ReaderRevenueSite, position: Position): String = {
     val componentId = getComponentId(destination, position)
     val componentType = getComponentType(position)
 

--- a/common/test/navigation/NavigationTest.scala
+++ b/common/test/navigation/NavigationTest.scala
@@ -31,7 +31,9 @@ import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, Wi
   }
 
   "Simple menu" should "just return the 5 primary links" in {
-    NavMenu(Uk).pillars should be(Seq(ukNewsPillar, ukOpinionPillar, ukSportPillar, ukCulturePillar, ukLifestylePillar))
+    SimpleMenu(Uk).pillars should be(
+      Seq(ukNewsPillar, ukOpinionPillar, ukSportPillar, ukCulturePillar, ukLifestylePillar),
+    )
   }
 
   "On `/index/contributors`, the parent" should "be Opinion" in {

--- a/common/test/navigation/helpers/UrlHelpersTest.scala
+++ b/common/test/navigation/helpers/UrlHelpersTest.scala
@@ -11,39 +11,39 @@ class UrlHelpersTest extends WordSpec with Matchers {
   "UrlHelpers" can {
     "getComponentId" should {
       "return header_support when called with Support, Header" in {
-        UrlHelpers.getComponentId(Support, Header)(TestRequest()) should be(Some("header_support"))
+        UrlHelpers.getComponentId(Support, Header) should be(Some("header_support"))
       }
 
       "return amp_header_support when called with Support, AmpHeader" in {
-        UrlHelpers.getComponentId(Support, AmpHeader)(TestRequest()) should be(Some("amp_header_support"))
+        UrlHelpers.getComponentId(Support, AmpHeader) should be(Some("amp_header_support"))
       }
 
       "return footer_support_contribute when called with SupportContribute, Footer" in {
-        UrlHelpers.getComponentId(SupportContribute, Footer)(TestRequest()) should be(Some("footer_support_contribute"))
+        UrlHelpers.getComponentId(SupportContribute, Footer) should be(Some("footer_support_contribute"))
       }
 
       "return amp_footer_support_contribute when called with SupportContribute, AmpFooter" in {
-        UrlHelpers.getComponentId(SupportContribute, AmpFooter)(TestRequest()) should be(
+        UrlHelpers.getComponentId(SupportContribute, AmpFooter) should be(
           Some("amp_footer_support_contribute"),
         )
       }
 
       "return footer_support_subscribe when called with SupportSubscribe, Footer" in {
-        UrlHelpers.getComponentId(SupportSubscribe, Footer)(TestRequest()) should be(Some("footer_support_subscribe"))
+        UrlHelpers.getComponentId(SupportSubscribe, Footer) should be(Some("footer_support_subscribe"))
       }
 
       "return footer_support_gifting when called with SupportGifting, Footer" in {
-        UrlHelpers.getComponentId(SupportGifting, Footer)(TestRequest()) should be(Some("footer_support_gifting"))
+        UrlHelpers.getComponentId(SupportGifting, Footer) should be(Some("footer_support_gifting"))
       }
 
       "return amp_footer_support_subscribe when called with SupportSubscribe, AmpFooter" in {
-        UrlHelpers.getComponentId(SupportSubscribe, AmpFooter)(TestRequest()) should be(
+        UrlHelpers.getComponentId(SupportSubscribe, AmpFooter) should be(
           Some("amp_footer_support_subscribe"),
         )
       }
 
       "return amp_footer_support_gifting when called with SupportGifting, AmpFooter" in {
-        UrlHelpers.getComponentId(SupportGifting, AmpFooter)(TestRequest()) should be(
+        UrlHelpers.getComponentId(SupportGifting, AmpFooter) should be(
           Some("amp_footer_support_gifting"),
         )
       }

--- a/dev-build/app/controllers/commercial/magento/AccessTokenGenerator.scala
+++ b/dev-build/app/controllers/commercial/magento/AccessTokenGenerator.scala
@@ -6,9 +6,9 @@ import play.api.libs.oauth._
 import play.api.mvc._
 
 /**
- * For one-off generation of Magento access tokens.
- * The bookshop is a Magento service.
- */
+  * For one-off generation of Magento access tokens.
+  * The bookshop is a Magento service.
+  */
 class AccessTokenGenerator(val controllerComponents: ControllerComponents) extends BaseController {
 
   private lazy val authService = for {
@@ -17,52 +17,55 @@ class AccessTokenGenerator(val controllerComponents: ControllerComponents) exten
     consumerSecret <- Configuration.commercial.magento.consumerSecret
     authorizationPath <- Configuration.commercial.magento.authorizationPath
   } yield {
-    OAuth(ServiceInfo(
-      requestTokenURL = s"https://$domain/oauth/initiate",
-      accessTokenURL = s"https://$domain/oauth/token",
-      authorizationURL = s"https://$domain/$authorizationPath",
-      key = ConsumerKey(consumerKey, consumerSecret)),
-      use10a = true)
+    OAuth(
+      ServiceInfo(
+        requestTokenURL = s"https://$domain/oauth/initiate",
+        accessTokenURL = s"https://$domain/oauth/token",
+        authorizationURL = s"https://$domain/$authorizationPath",
+        key = ConsumerKey(consumerKey, consumerSecret),
+      ),
+      use10a = true,
+    )
   }
 
   private val unavailable: Result = ServiceUnavailable("Missing properties.")
 
-  def generate: Action[AnyContent] = Action { implicit request =>
-
-    def genRequestToken(): Result = {
-      authService.fold(unavailable) { auth =>
-        val callbackUrl = routes.AccessTokenGenerator.generate().absoluteURL()
-        auth.retrieveRequestToken(callbackUrl) match {
-          case Right(t) =>
-            Redirect(auth.redirectUrl(t.token)).withSession("token" -> t.token, "secret" -> t.secret)
-          case Left(e) => throw e
+  def generate: Action[AnyContent] =
+    Action { implicit request =>
+      def genRequestToken(): Result = {
+        authService.fold(unavailable) { auth =>
+          val callbackUrl = routes.AccessTokenGenerator.generate().absoluteURL()
+          auth.retrieveRequestToken(callbackUrl) match {
+            case Right(t) =>
+              Redirect(auth.redirectUrl(t.token)).withSession("token" -> t.token, "secret" -> t.secret)
+            case Left(e) => throw e
+          }
         }
       }
-    }
 
-    def requestTokenFromSession: RequestToken = {
-      (for {
-        token <- request.session.get("token")
-        secret <- request.session.get("secret")
-      } yield {
-        RequestToken(token, secret)
-      }).get
-    }
+      def requestTokenFromSession: RequestToken = {
+        (for {
+          token <- request.session.get("token")
+          secret <- request.session.get("secret")
+        } yield {
+          RequestToken(token, secret)
+        }).get
+      }
 
-    def genAccessToken(tokenPair: RequestToken, verifier: String): Result = {
-      authService.fold(unavailable) { auth =>
-        auth.retrieveAccessToken(tokenPair, verifier) match {
-          case Left(e) => throw e
-          case Right(accessToken) =>
-            Ok(s"Token: ${accessToken.token}\nSecret: ${accessToken.secret}").withSession()
+      def genAccessToken(tokenPair: RequestToken, verifier: String): Result = {
+        authService.fold(unavailable) { auth =>
+          auth.retrieveAccessToken(tokenPair, verifier) match {
+            case Left(e) => throw e
+            case Right(accessToken) =>
+              Ok(s"Token: ${accessToken.token}\nSecret: ${accessToken.secret}").withSession()
+          }
         }
       }
+
+      val result = request.getQueryString("oauth_verifier") map { verifier =>
+        genAccessToken(requestTokenFromSession, verifier)
+      } getOrElse genRequestToken()
+
+      NoCache(result)
     }
-
-    val result = request.getQueryString("oauth_verifier") map { verifier =>
-      genAccessToken(requestTokenFromSession, verifier)
-    } getOrElse genRequestToken()
-
-    NoCache(result)
-  }
 }

--- a/dev-build/app/controllers/commercial/magento/ApiSandbox.scala
+++ b/dev-build/app/controllers/commercial/magento/ApiSandbox.scala
@@ -1,6 +1,5 @@
 package controllers.commercial.magento
 
-
 import common.ImplicitControllerExecutionContext
 import conf.Configuration.commercial.magento
 import model.NoCache
@@ -9,27 +8,40 @@ import play.api.libs.ws.WSClient
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 
 /**
- * This allows us to check the content of protected Magento endpoints.
- *
+  * This allows us to check the content of protected Magento endpoints.
+  *
  * See:
- * http://www.magentocommerce.com/api/rest/Resources/resources.html
- * http://www.magentocommerce.com/api/rest/get_filters.html
- */
-class ApiSandbox(wsClient: WSClient, val controllerComponents: ControllerComponents) extends BaseController with ImplicitControllerExecutionContext {
+  * http://www.magentocommerce.com/api/rest/Resources/resources.html
+  * http://www.magentocommerce.com/api/rest/get_filters.html
+  */
+class ApiSandbox(wsClient: WSClient, val controllerComponents: ControllerComponents)
+    extends BaseController
+    with ImplicitControllerExecutionContext {
 
-  private val domain = magento.domain.getOrElse(throw new RuntimeException("Unable to get [magento.domain] property. Is it set in the configuration?"))
+  private val domain = magento.domain.getOrElse(
+    throw new RuntimeException("Unable to get [magento.domain] property. Is it set in the configuration?"),
+  )
   private val oauth = {
     val key = ConsumerKey(magento.consumerKey.get, magento.consumerSecret.get)
-    val accessToken = RequestToken(magento.accessToken.getOrElse(throw new RuntimeException("update frontend.properties in your .gu folder - change \"magento.access.token\" to \"magento.access.token.key\"")), magento.accessTokenSecret.get)
+    val accessToken = RequestToken(
+      magento.accessToken.getOrElse(
+        throw new RuntimeException(
+          "update frontend.properties in your .gu folder - change \"magento.access.token\" to \"magento.access.token.key\"",
+        ),
+      ),
+      magento.accessTokenSecret.get,
+    )
     OAuthCalculator(key, accessToken)
   }
 
-  def getResource(path: String): Action[AnyContent] = Action.async { implicit request =>
-    wsClient.url(s"http://$domain/$path")
-      .sign(oauth)
-      .get()
-      .map(result => NoCache(Ok(result.body)))
-  }
+  def getResource(path: String): Action[AnyContent] =
+    Action.async { implicit request =>
+      wsClient
+        .url(s"http://$domain/$path")
+        .sign(oauth)
+        .get()
+        .map(result => NoCache(Ok(result.body)))
+    }
 
   def getBooks(csvIsbns: String): Action[AnyContent] = {
     val isbns = csvIsbns split ","

--- a/dev-build/app/http/DevFilters.scala
+++ b/dev-build/app/http/DevFilters.scala
@@ -11,45 +11,51 @@ import scala.concurrent.ExecutionContext
 // obviously this is only for devbuild and should never end up in one of our
 // prod projects
 class DevCacheWarningFilter(implicit executionContext: ExecutionContext) extends EssentialFilter {
-  def apply(next: EssentialAction): EssentialAction = new EssentialAction {
-    def apply(rh: RequestHeader) = {
-      next(rh).map{ result =>
-        val header = result.header
-        val path = rh.path
-        if (
-          header.status == 200 &&
+  def apply(next: EssentialAction): EssentialAction =
+    new EssentialAction {
+      def apply(rh: RequestHeader) = {
+        next(rh).map { result =>
+          val header = result.header
+          val path = rh.path
+          if (
+            header.status == 200 &&
             !header.headers.keySet.contains("Cache-Control") &&
             path != "/favicon.ico" &&
             !path.startsWith("/assets/") // these are only used on DEV machines
-        ) {
-          // nice big warning to devs if they are working on something uncached
-          println("\n\n\n---------------------------- WARNING ------------------------------------")
-          println(s"URL $path has NO CACHE-CONTROL header")
-          println("-------------------------------------------------------------------------------\n\n\n")
+          ) {
+            // nice big warning to devs if they are working on something uncached
+            println("\n\n\n---------------------------- WARNING ------------------------------------")
+            println(s"URL $path has NO CACHE-CONTROL header")
+            println("-------------------------------------------------------------------------------\n\n\n")
+          }
+          result
         }
-        result
       }
     }
-  }
 }
 
 // obviously this is only for devbuild and should never end up in one of our
 // prod projects
 class DevJsonExtensionFilter extends EssentialFilter with Requests {
-  def apply(next: EssentialAction): EssentialAction = new EssentialAction {
-    def apply(rh: RequestHeader) = {
-      if (rh.isJson && !rh.path.endsWith(".json") && !rh.path.endsWith(".js")) {
-        // makes it easy for devs to see what has happened
-        println("\n\n\n---------------------------- WARNING ------------------------------------")
-        println(s"URL ${rh.path} does not have a .json extension")
-        println("-------------------------------------------------------------------------------\n\n\n")
-        throw new IllegalArgumentException("JSON endpoints must end with '.json'")
+  def apply(next: EssentialAction): EssentialAction =
+    new EssentialAction {
+      def apply(rh: RequestHeader) = {
+        if (rh.isJson && !rh.path.endsWith(".json") && !rh.path.endsWith(".js")) {
+          // makes it easy for devs to see what has happened
+          println("\n\n\n---------------------------- WARNING ------------------------------------")
+          println(s"URL ${rh.path} does not have a .json extension")
+          println("-------------------------------------------------------------------------------\n\n\n")
+          throw new IllegalArgumentException("JSON endpoints must end with '.json'")
+        }
+        next(rh)
       }
-      next(rh)
     }
-  }
 }
 
-class DevFilters(implicit val mat: Materializer, applicationContext: ApplicationContext, executionContext: ExecutionContext) extends HttpFilters {
+class DevFilters(implicit
+    val mat: Materializer,
+    applicationContext: ApplicationContext,
+    executionContext: ExecutionContext,
+) extends HttpFilters {
   override def filters: Seq[EssentialFilter] = new DevJsonExtensionFilter :: new DevCacheWarningFilter :: Filters.common
 }

--- a/onward/conf/routes
+++ b/onward/conf/routes
@@ -78,6 +78,7 @@ GET        /business-data/stocks.json                 controllers.StocksControll
 
 # DCR
 GET        /story-package/*path.json                  controllers.StoryPackageController.render(path)
+GET        /nav/:editionId.json                     controllers.NavigationController.renderDCRNav(editionId: String)
 
 # AMP
 GET        /most-read-mf2.json                        controllers.MostPopularController.renderPopularMicroformat2()


### PR DESCRIPTION
## What does this change?

Adds a `/nav/:editionId.json` endpoint that returns a simple nav model. This will be used by DCR for the sticky nav test. Depending on the success of that test we will keep or throw afterwards.

The endpoint is cached for 900 seconds on success, or 60 on (client) error - when the edition ID provided is invalid.

**Edit to provide additional context:** for performance reasons, we don't want to include nav data clientside in DCR unless we have to. This endpoint provides a way to load nav data 'lazily' - by making an HTTP request client-side only when required (when a reader expands the main menu).