### PR TITLE
Add main element types to DCR logs

### DIFF
--- a/article/app/services/dotcomponents/DotcomponentsLogger.scala
+++ b/article/app/services/dotcomponents/DotcomponentsLogger.scala
@@ -46,6 +46,10 @@ case class DotcomponentsLogger(request: Option[RequestHeader]) extends GuLogging
         ).distinct.mkString(", "),
       ),
       LogFieldString(
+        "page.mainElements",
+        page.article.blocks.flatMap(_.main.map(_.getClass.getSimpleName)).getOrElse(""),
+      ),
+      LogFieldString(
         "page.tone",
         page.article.tags.tones.headOption.map(_.name).getOrElse(""),
       ),


### PR DESCRIPTION
## What does this change?
Adds `page.mainElements` to our custom log fields so that we can see the element types used in the main block, in addition to the body.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
![image](https://user-images.githubusercontent.com/8754692/107936258-56547180-6f7a-11eb-9413-a9155e402fe1.png)


## What is the value of this and can you measure success?
We can monitor which element types we might be missing from main support.