### PR TITLE
Remove overflow-x from banner

### DIFF
--- a/static/src/stylesheets/module/site-messages/_engagement-banner.scss
+++ b/static/src/stylesheets/module/site-messages/_engagement-banner.scss
@@ -6,5 +6,7 @@
     top: auto !important;
     position: fixed !important;
     max-height: 80vh;
-    overflow: auto;
+    overflow-y: auto;
+    overflow-x: hidden;
 }
+


### PR DESCRIPTION
It is important to have overflow-y on our banners because users with large browser font sizes need the ability to scroll down.
But overflow-x is not necessary because the close button is always in view.
Removing overflow-x will make it easier to do custom designs (see [here](https://github.com/guardian/support-dotcom-components/pull/364/files#diff-683a5eae023f7b3a9fb984b256e841bf65005481dfa6ebc6e173e0098f66d6feR42))

Example of large font size set in browser:
![Screen Shot 2021-02-16 at 10 54 47](https://user-images.githubusercontent.com/1513454/108053790-c7ad2680-7045-11eb-9fdf-b3e99cf1cddc.png)
