### PR TITLE
Add carousel Images to onwards content

### DIFF
--- a/onward/app/feed/DeeplyReadAgent.scala
+++ b/onward/app/feed/DeeplyReadAgent.scala
@@ -48,7 +48,7 @@ object DeeplyReadItem {
       showByline = item.showByline,
       byline = item.byline,
       image = item.image,
-      carouselImages = Nil, // Not implemented for Deeply Read at the moment
+      carouselImages = Map("N/A" -> None), // Not implemented for Deeply Read at the moment
       ageWarning = item.ageWarning,
       isLiveBlog = item.isLiveBlog,
       pillar = item.pillar,

--- a/onward/app/feed/DeeplyReadAgent.scala
+++ b/onward/app/feed/DeeplyReadAgent.scala
@@ -48,6 +48,7 @@ object DeeplyReadItem {
       showByline = item.showByline,
       byline = item.byline,
       image = item.image,
+      carouselImages = List(Some("deeply")),
       ageWarning = item.ageWarning,
       isLiveBlog = item.isLiveBlog,
       pillar = item.pillar,

--- a/onward/app/feed/DeeplyReadAgent.scala
+++ b/onward/app/feed/DeeplyReadAgent.scala
@@ -48,7 +48,7 @@ object DeeplyReadItem {
       showByline = item.showByline,
       byline = item.byline,
       image = item.image,
-      carouselImages = List(Some("deeply")),
+      carouselImages = Nil, // Not implemented for Deeply Read at the moment
       ageWarning = item.ageWarning,
       isLiveBlog = item.isLiveBlog,
       pillar = item.pillar,

--- a/onward/app/models/MostPopularNx2.scala
+++ b/onward/app/models/MostPopularNx2.scala
@@ -2,14 +2,13 @@ package models
 
 import com.github.nscala_time.time.Imports.DateTimeZone
 import common.{Edition, LinkTo}
-import feed.DeeplyReadItem
 import model.pressed.PressedContent
 import play.api.mvc.RequestHeader
 import views.support.{ContentOldAgeDescriber, ImageProfile, ImgSrc, Item300, Item460, RemoveOuterParaHtml}
 import play.api.libs.json._
 import implicits.FaciaContentFrontendHelpers._
 import layout.ContentCard
-import model.{Article, ImageAsset, ImageMedia, InlineImage, MostPopular, Pillar}
+import model.{Article, ImageMedia, InlineImage, Pillar}
 import models.dotcomponents.OnwardsUtils.{correctPillar, determinePillar}
 
 case class OnwardItemNx2(

--- a/onward/app/models/MostPopularNx2.scala
+++ b/onward/app/models/MostPopularNx2.scala
@@ -66,7 +66,7 @@ object OnwardItemNx2 {
       profile: ImageProfile <- List(Item300, Item460)
       width: Int <- profile.width
       trailPicture: ImageMedia <- imageMedia
-    } yield{
+    } yield {
       width.toString -> profile.bestSrcFor(trailPicture)
     }
     images.toMap

--- a/onward/app/models/MostPopularNx2.scala
+++ b/onward/app/models/MostPopularNx2.scala
@@ -17,7 +17,7 @@ case class OnwardItemNx2(
     showByline: Boolean,
     byline: Option[String],
     image: Option[String],
-    carouselImages: List[Option[String]],
+    carouselImages: Map[String, Option[String]],
     ageWarning: Option[String],
     isLiveBlog: Boolean,
     pillar: String,
@@ -57,13 +57,15 @@ object OnwardItemNx2 {
 
   }
 
-  def getImageSrcList(imageMedia: Option[ImageMedia]): List[Option[String]] = {
-    for {
+  def getImageSources(imageMedia: Option[ImageMedia]): Map[String, Option[String]] = {
+    var images = for {
       profile: ImageProfile <- List(Item300, Item460)
+      width: Int <- profile.width
       trailPicture: ImageMedia <- imageMedia
     } yield{
-      profile.bestSrcFor(trailPicture)
+      width.toString -> profile.bestSrcFor(trailPicture)
     }
+    images.toMap
   }
   def contentCardToOnwardItemNx2(contentCard: ContentCard): Option[OnwardItemNx2] = {
     for {
@@ -83,7 +85,7 @@ object OnwardItemNx2 {
       showByline = showByline,
       byline = contentCard.byline.map(x => x.get),
       image = maybeContent.trail.thumbnailPath,
-      carouselImages = getImageSrcList(maybeContent.trail.trailPicture),
+      carouselImages = getImageSources(maybeContent.trail.trailPicture),
       ageWarning = None,
       isLiveBlog = isLiveBlog,
       pillar = correctPillar(pillar.toString.toLowerCase),
@@ -115,7 +117,7 @@ object OnwardItemNx2 {
       showByline = content.properties.showByline,
       byline = content.properties.byline,
       image = content.trailPicture.flatMap(ImgSrc.getFallbackUrl),
-      carouselImages = getImageSrcList(content.trailPicture),
+      carouselImages = getImageSources(content.trailPicture),
       ageWarning = content.ageWarning,
       isLiveBlog = content.properties.isLiveBlog,
       pillar = content.maybePillar.map(pillarToString).getOrElse("news"),

--- a/onward/app/models/MostPopularNx2.scala
+++ b/onward/app/models/MostPopularNx2.scala
@@ -57,6 +57,10 @@ object OnwardItemNx2 {
 
   }
 
+  // We ideally want this to be replaced by something else in the near future. Probably
+  // image-rendering or similar. But this will do for now.
+  // TODO: Replace this.
+  
   def getImageSources(imageMedia: Option[ImageMedia]): Map[String, Option[String]] = {
     var images = for {
       profile: ImageProfile <- List(Item300, Item460)

--- a/onward/app/models/MostPopularNx2.scala
+++ b/onward/app/models/MostPopularNx2.scala
@@ -5,11 +5,11 @@ import common.{Edition, LinkTo}
 import feed.DeeplyReadItem
 import model.pressed.PressedContent
 import play.api.mvc.RequestHeader
-import views.support.{ContentOldAgeDescriber, ImgSrc, RemoveOuterParaHtml}
+import views.support.{ContentOldAgeDescriber, ImageProfile, ImgSrc, Item300, Item460, RemoveOuterParaHtml}
 import play.api.libs.json._
 import implicits.FaciaContentFrontendHelpers._
 import layout.ContentCard
-import model.{Article, InlineImage, MostPopular, Pillar}
+import model.{Article, ImageAsset, ImageMedia, InlineImage, MostPopular, Pillar}
 import models.dotcomponents.OnwardsUtils.{correctPillar, determinePillar}
 
 case class OnwardItemNx2(
@@ -18,6 +18,7 @@ case class OnwardItemNx2(
     showByline: Boolean,
     byline: Option[String],
     image: Option[String],
+    carouselImages: List[Option[String]],
     ageWarning: Option[String],
     isLiveBlog: Boolean,
     pillar: String,
@@ -56,6 +57,15 @@ object OnwardItemNx2 {
     }
 
   }
+
+  def getImageSrcList(imageMedia: Option[ImageMedia]): List[Option[String]] = {
+    for {
+      profile: ImageProfile <- List(Item300, Item460)
+      trailPicture: ImageMedia <- imageMedia
+    } yield{
+      profile.bestSrcFor(trailPicture)
+    }
+  }
   def contentCardToOnwardItemNx2(contentCard: ContentCard): Option[OnwardItemNx2] = {
     for {
       properties <- contentCard.properties
@@ -74,6 +84,7 @@ object OnwardItemNx2 {
       showByline = showByline,
       byline = contentCard.byline.map(x => x.get),
       image = maybeContent.trail.thumbnailPath,
+      carouselImages = getImageSrcList(maybeContent.trail.trailPicture),
       ageWarning = None,
       isLiveBlog = isLiveBlog,
       pillar = correctPillar(pillar.toString.toLowerCase),
@@ -105,6 +116,7 @@ object OnwardItemNx2 {
       showByline = content.properties.showByline,
       byline = content.properties.byline,
       image = content.trailPicture.flatMap(ImgSrc.getFallbackUrl),
+      carouselImages = getImageSrcList(content.trailPicture),
       ageWarning = content.ageWarning,
       isLiveBlog = content.properties.isLiveBlog,
       pillar = content.maybePillar.map(pillarToString).getOrElse("news"),

--- a/onward/app/models/MostPopularNx2.scala
+++ b/onward/app/models/MostPopularNx2.scala
@@ -60,7 +60,7 @@ object OnwardItemNx2 {
   // We ideally want this to be replaced by something else in the near future. Probably
   // image-rendering or similar. But this will do for now.
   // TODO: Replace this.
-  
+
   def getImageSources(imageMedia: Option[ImageMedia]): Map[String, Option[String]] = {
     var images = for {
       profile: ImageProfile <- List(Item300, Item460)

--- a/onward/app/models/MostPopularNx2.scala
+++ b/onward/app/models/MostPopularNx2.scala
@@ -62,7 +62,7 @@ object OnwardItemNx2 {
   // TODO: Replace this.
 
   def getImageSources(imageMedia: Option[ImageMedia]): Map[String, Option[String]] = {
-    var images = for {
+    val images = for {
       profile: ImageProfile <- List(Item300, Item460)
       width: Int <- profile.width
       trailPicture: ImageMedia <- imageMedia
@@ -71,6 +71,7 @@ object OnwardItemNx2 {
     }
     images.toMap
   }
+
   def contentCardToOnwardItemNx2(contentCard: ContentCard): Option[OnwardItemNx2] = {
     for {
       properties <- contentCard.properties


### PR DESCRIPTION
## What does this change?
Adds a new field to the onwards content to pass through URLs to specific
image sizes for the different breakpoints we expect to use in the
Carousel.

I've not modified the existing image field as I don't want to break
backwards compatibility, but I think that there is scope to change this
to create a set of images for different breakpoints even outside of the
Carousel.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No - but it does need to be implemented there. https://github.com/guardian/dotcom-rendering/pull/2539
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/9122944/108077176-2aadb600-7064-11eb-911c-02110ce95f05.png
[after]: https://user-images.githubusercontent.com/9122944/108079961-49617c00-7067-11eb-95d6-f7e7efd16f8b.png


## What is the value of this and can you measure success?
Needed for the Carousel AB test to work correctly.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
