### PR TITLE
Document some key image models

### DIFF
--- a/common/app/model/Asset.scala
+++ b/common/app/model/Asset.scala
@@ -44,8 +44,13 @@ object ImageAsset {
   implicit val imageAssetWrites: Writes[ImageAsset] = Json.writes[ImageAsset]
 }
 
+/**
+  * ImageAsset is the main internal model for images, and is generated directly from CAPI (atom) data.
+  */
 case class ImageAsset(
+    // Order (zero indexed) if image is in a set.
     index: Int = 0,
+    // Image metadata, such as width, height, role. Use the class helper methods rather than accessing directly.
     fields: Map[String, String],
     mediaType: String,
     mimeType: Option[String],

--- a/common/app/model/Element.scala
+++ b/common/app/model/Element.scala
@@ -60,6 +60,10 @@ object ImageMedia {
     )
   implicit val imageMediaWrites: Writes[ImageMedia] = Json.writes[ImageMedia]
 }
+
+/**
+  * ImageMedia is a collection of ImageAssets with some helper methods.
+  */
 final case class ImageMedia(allImages: Seq[ImageAsset]) {
 
   lazy val imageCrops: Seq[ImageAsset] = allImages.filterNot(_.isMaster)

--- a/common/app/views/support/ImageProfile.scala
+++ b/common/app/views/support/ImageProfile.scala
@@ -13,6 +13,10 @@ import play.api.libs.json.{Json, Writes}
 
 import Function.const
 
+/**
+  * ElementProfile is configuration for displaying an image, and is used to generate custom URLs (with parameters) for
+  * calls to our Fastly image service.
+  */
 sealed trait ElementProfile {
 
   def width: Option[Int]
@@ -68,6 +72,10 @@ sealed trait ElementProfile {
 
 }
 
+/**
+  * ImageProfile is an ElementProfile that provides sensible defaults. It is used as the base class for lots of more
+  * specific profiles.
+  */
 case class ImageProfile(
     override val width: Option[Int] = None,
     override val height: Option[Int] = None,
@@ -90,6 +98,10 @@ case class VideoProfile(
     override val autoFormat: Boolean = true,
 ) extends ElementProfile {}
 
+/**
+  * SrcSet relates to the HTML `srcSet` attribute but only represents a single image source-width combo. For information
+  * on the HTML attribute, see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-srcset.
+  */
 case class SrcSet(src: String, width: Int) {
   def asSrcSetString: String = {
     s"$src ${width}w"


### PR DESCRIPTION
Very small docs addition for some image models.

GIves hints like:

![Screenshot 2021-02-17 at 13 34 12](https://user-images.githubusercontent.com/858402/108211680-e20a0180-7124-11eb-9c51-ddf0a30fa14b.png)
