### PR TITLE
Add webPublicationSecondaryDateDisplay To DCR Model

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -21,6 +21,7 @@ case class DotcomRenderingDataModel(
     author: Author,
     webPublicationDate: String,
     webPublicationDateDisplay: String, // TODO remove
+    webPublicationSecondaryDateDisplay: String,
     editionLongForm: String,
     editionId: String,
     pageId: String,
@@ -83,6 +84,7 @@ object DotcomRenderingDataModel {
         "author" -> model.author,
         "webPublicationDate" -> model.webPublicationDate,
         "webPublicationDateDisplay" -> model.webPublicationDateDisplay,
+        "webPublicationSecondaryDateDisplay" -> model.webPublicationSecondaryDateDisplay,
         "editionLongForm" -> model.editionLongForm,
         "editionId" -> model.editionId,
         "pageId" -> model.pageId,

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -529,6 +529,9 @@ object DotcomRenderingUtils {
     val isPaidContent = article.metadata.designType.contains(AdvertisementFeature)
     val edition = Edition(request)
 
+    val displayedDateTimes: DisplayedDateTimesDCR =
+      ArticleDateTimes.makeDisplayedDateTimesDCR(articleDateTimes, request)
+
     DotcomRenderingDataModel(
       version = 3,
       headline = article.trail.headline,
@@ -543,6 +546,7 @@ object DotcomRenderingUtils {
       webPublicationDate = article.trail.webPublicationDate.toString, // TODO check format
       webPublicationDateDisplay =
         GUDateTimeFormatNew.formatDateTimeForDisplay(article.trail.webPublicationDate, request),
+      webPublicationSecondaryDateDisplay = displayedDateTimes.secondaryDateLine,
       editionLongForm = Edition(request).displayName, // TODO check
       editionId = edition.id,
       pageId = article.metadata.id,


### PR DESCRIPTION
## What does this change?
Adds a `webPublicationSecondaryDateDisplay` in the DCR models for articles that have no blocks.
