### PR TITLE
Enable liveblog rendering on DCR as an experiment

### DIFF
--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -60,7 +60,7 @@ class LiveBlogController(
           case (minute: MinutePage, HtmlFormat) =>
             Future.successful(common.renderHtml(MinuteHtmlPage.html(minute), minute))
           case (blog: LiveBlogPage, HtmlFormat) => {
-            val remoteRendering = ActiveExperiments.isParticipating(LiveblogRendering)
+            val remoteRendering = request.forceDCR && ActiveExperiments.isParticipating(LiveblogRendering)
             remoteRendering match {
               case false => Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
               case true => {

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -4,6 +4,7 @@ import com.gu.contentapi.client.model.v1.{Blocks, ItemResponse, Content => ApiCo
 import common.`package`.{convertApiExceptions => _, renderFormat => _}
 import common.{JsonComponent, RichRequestHeader, _}
 import contentapi.ContentApiClient
+import experiments.{ActiveExperiments, LiveblogRendering}
 import model.Cached.WithoutRevalidationResult
 import model.LiveBlogHelpers._
 import model.ParseBlockId.{InvalidFormat, ParsedBlockId}
@@ -18,7 +19,6 @@ import model.dotcomrendering.{DotcomRenderingDataModel, DotcomRenderingUtils}
 import renderers.DotcomRenderingService
 
 import scala.concurrent.Future
-
 import model.dotcomrendering.PageType
 
 case class MinutePage(article: Article, related: RelatedContent) extends PageWithStoryPackage
@@ -51,35 +51,43 @@ class LiveBlogController(
     }
   }
 
-  def renderArticle(path: String, page: Option[String] = None, format: Option[String] = None): Action[AnyContent] = {
-    Action.async { implicit request =>
-      def renderWithRange(range: BlockRange): Future[Result] = {
-        mapModel(path, range) { (page, blocks) =>
-          {
-            val isAmpSupported = page.article.content.shouldAmplify
-            val pageType: PageType = PageType(page, request, context)
-            (page, request.getRequestFormat) match {
-              case (minute: MinutePage, HtmlFormat) =>
-                Future.successful(common.renderHtml(MinuteHtmlPage.html(minute), minute))
-              case (blog: LiveBlogPage, HtmlFormat) =>
-                Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
-              case (blog: LiveBlogPage, AmpFormat) if isAmpSupported =>
-                remoteRenderer.getAMPArticle(ws, blog, blocks, pageType)
-              case (blog: LiveBlogPage, AmpFormat) =>
-                Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
-              case _ => Future.successful(NotFound)
+  def renderWithRange(path: String, range: BlockRange)(implicit request: RequestHeader): Future[Result] = {
+    mapModel(path, range) { (page, blocks) =>
+      {
+        val isAmpSupported = page.article.content.shouldAmplify
+        val pageType: PageType = PageType(page, request, context)
+        (page, request.getRequestFormat) match {
+          case (minute: MinutePage, HtmlFormat) =>
+            Future.successful(common.renderHtml(MinuteHtmlPage.html(minute), minute))
+          case (blog: LiveBlogPage, HtmlFormat) => {
+            val remoteRendering = ActiveExperiments.isParticipating(LiveblogRendering)
+            remoteRendering match {
+              case false => Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
+              case true => {
+                val pageType: PageType = PageType(blog, request, context)
+                remoteRenderer.getArticle(ws, path, blog, blocks, pageType)
+              }
             }
           }
+          case (blog: LiveBlogPage, AmpFormat) if isAmpSupported =>
+            remoteRenderer.getAMPArticle(ws, blog, blocks, pageType)
+          case (blog: LiveBlogPage, AmpFormat) =>
+            Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
+          case _ => Future.successful(NotFound)
         }
       }
+    }
+  }
 
+  def renderArticle(path: String, page: Option[String] = None, format: Option[String] = None): Action[AnyContent] = {
+    Action.async { implicit request =>
       page.map(ParseBlockId.fromPageParam) match {
-        case Some(ParsedBlockId(id)) => renderWithRange(PageWithBlock(id)) // we know the id of a block
+        case Some(ParsedBlockId(id)) => renderWithRange(path, PageWithBlock(id)) // we know the id of a block
         case Some(InvalidFormat) =>
           Future.successful(
             Cached(10)(WithoutRevalidationResult(NotFound)),
           ) // page param there but couldn't extract a block id
-        case None => renderWithRange(CanonicalLiveBlog) // no page param
+        case None => renderWithRange(path, CanonicalLiveBlog) // no page param
       }
     }
   }
@@ -90,10 +98,8 @@ class LiveBlogController(
       rendered: Option[Boolean],
       isLivePage: Option[Boolean],
   ): Action[AnyContent] = {
-
     Action.async { implicit request =>
       val range = getRange(lastUpdate, rendered)
-
       mapModel(path, range) {
         case (blog: LiveBlogPage, blocks) if rendered.contains(false) => getJsonForFronts(blog)
         case (blog: LiveBlogPage, blocks) if request.forceDCR         => Future.successful(renderGuuiJson(path, blog, blocks))
@@ -102,7 +108,6 @@ class LiveBlogController(
           Future.successful(common.renderJson(views.html.fragments.minuteBody(minute), minute))
         case _ => Future { Cached(600)(WithoutRevalidationResult(NotFound)) }
       }
-
     }
   }
 

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -18,12 +18,21 @@ object ActiveExperiments extends ExperimentsDefinition {
 object DotcomRendering
     extends Experiment(
       name = "dotcom-rendering",
-      description = "Show DCR pages to users including those with comments",
+      description = "Show DCR eligible pages to users",
       owners = Seq(Owner.withGithub("shtukas")),
       sellByDate = new LocalDate(2021, 6, 1),
       participationGroup = Perc10A, // Also see ArticlePicker.scala - our main filter mechanism is by page features
       // Friday 20th Nov 2020: we are now showing DCR to users not participating (see: cea453f4-9b71-435e-8a11-35ef690c7821)
       // This means that 90% of the audience is being exposed to DCR
+    )
+
+object LiveblogRendering
+    extends Experiment(
+      name = "liveblog-rendering",
+      description = "Use DCR for liveblogs",
+      owners = Seq(Owner.withGithub("shtukas")),
+      sellByDate = new LocalDate(2021, 8, 2),
+      participationGroup = Perc0A,
     )
 
 object NewsletterEmbedDesign

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -10,6 +10,7 @@ object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
     DotcomRendering,
     ClickToView,
+    LiveblogRendering,
   )
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)


### PR DESCRIPTION
## What does this change?

1. Introduce experiment LiveblogRendering.
2. Allows rendering of a liveblog using DCR if in the experiment.  

