### PR TITLE
Add Prebid user sync

### DIFF
--- a/static/vendor/data/amp-iframe.html
+++ b/static/vendor/data/amp-iframe.html
@@ -10,5 +10,10 @@
             height="0"
             width="0"
         ></iframe>
+        <iframe
+            src="https://acdn.adnxs.com/prebid/amp/user-sync/load-cookie-with-consent.html?endpoint=appnexus&max_sync_count=5&gdpr_consent=CONSENT_STRING"
+            height="0"
+            width="0"
+        ></iframe>
     </body>
 </html>

--- a/static/vendor/data/amp-iframe.html
+++ b/static/vendor/data/amp-iframe.html
@@ -1,19 +1,14 @@
 <html>
-    <body>
-        <iframe
-            src="https://cdn.jsdelivr.net/npm/prebid-universal-creative@latest/dist/load-cookie.html"
-            height="0"
-            width="0"
-        ></iframe>
-        <iframe
-            src="https://guardian.amp.permutive.com/amp-iframe.html?project=d6691a17-6fdb-4d26-85d6-b3dd27f55f08&key=359ba275-5edd-4756-84f8-21a24369ce0b"
-            height="0"
-            width="0"
-        ></iframe>
-        <iframe
-            src="https://acdn.adnxs.com/prebid/amp/user-sync/load-cookie-with-consent.html?endpoint=appnexus&max_sync_count=5&gdpr_consent=CONSENT_STRING"
-            height="0"
-            width="0"
-        ></iframe>
-    </body>
+	<body>
+		<iframe
+			src="https://cdn.jsdelivr.net/npm/prebid-universal-creative@latest/dist/load-cookie-with-consent.html"
+			height="0"
+			width="0"
+		></iframe>
+		<iframe
+			src="https://guardian.amp.permutive.com/amp-iframe.html?project=d6691a17-6fdb-4d26-85d6-b3dd27f55f08&key=359ba275-5edd-4756-84f8-21a24369ce0b"
+			height="0"
+			width="0"
+		></iframe>
+	</body>
 </html>


### PR DESCRIPTION
## What does this change?

Add user sync capabilities to Prebid, and respect GDPR.

Switch from spaces to tabs, due to the Prettier Config. Should we extend the `.editorconfig` to match?

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes — See PR [guardian/dotcom-rendering#2582](https://github.com/guardian/dotcom-rendering/pull/2582)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [X] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
