### PR TITLE
Add documentation for PageElement's _type in json

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -1642,7 +1642,6 @@ object PageElement {
     }
   }
 
-  val pageElementWrites: Writes[PageElement] = Json.writes[PageElement]
   /*
      Note: The JSON serialization of `PageElement`s shows a "_type" attribute (that is a crucial part of how DCR
      recognise and parse `BlockElement`s). This attribute is added by Play Framework itself.
@@ -1652,4 +1651,6 @@ object PageElement {
        Because this attribute is a defacto a part of the frontend DCR datamodel contract, it would be nice to stop
        relying on the framework to provide it (for safety)
    */
+  val pageElementWrites: Writes[PageElement] = Json.writes[PageElement]
+
 }

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -1643,4 +1643,13 @@ object PageElement {
   }
 
   val pageElementWrites: Writes[PageElement] = Json.writes[PageElement]
+  /*
+     Note: The JSON serialization of `PageElement`s shows a "_type" attribute (that is a crucial part of how DCR
+     recognise and parse `BlockElement`s). This attribute is added by Play Framework itself.
+     See: https://www.playframework.com/documentation/2.7.x/ScalaJsonAutomated#Requirements
+
+     TODO:
+       Because this attribute is a defacto a part of the frontend DCR datamodel contract, it would be nice to stop
+       relying on the framework to provide it (for safety)
+   */
 }


### PR DESCRIPTION
## What does this change?

Encoding, for future selves and others, what @nicl and I discovered while looking for the source of `"_type"`

![Screenshot 2021-02-22 at 12 19 47](https://user-images.githubusercontent.com/6035518/108713210-ced5a800-750f-11eb-95c6-d1d9bb2b6604.png)

https://www.playframework.com/documentation/2.7.x/ScalaJsonAutomated#Requirements