### PR TITLE
Introduce ElementsEnhancer and elementId

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -100,6 +100,10 @@ object ElementsEnhancer {
    */
 
   def enhanceElement(element: JsValue): JsValue = {
+    // Note: the value of renderId is used to link serverside and client side elements together for portals and
+    // hydration which was previously done with the array index (brittle, particularly when now dealing with main
+    // media array too). The actual value is irrelevant and can vary from one call to another. Here we are using UUIDs
+
     element.as[JsObject] ++ Json.obj("renderId" -> java.util.UUID.randomUUID.toString)
   }
 

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -68,42 +68,11 @@ case class DotcomRenderingDataModel(
 
 object ElementsEnhancer {
 
-  /*
-    Originally the TextBlockElement, for instance, comes like this:
-
-    {
-        "_type": "model.dotcomrendering.pageElements.TextBlockElement",
-        "html": "<p>Something</p>"
-    }
-
-    But there is a request from DCR to add a `renderId` attribute, whose value is a random string to it, for instance
-
-    {
-        "renderId": "b11904da-4f57-4320-bdde-800e55825d1d",
-        "_type": "model.dotcomrendering.pageElements.TextBlockElement",
-        "html": "<p>Something</p>"
-    }
-
-    This request does not only apply to TextBlockElement, but to each variant of the PageElement trait.
-
-    There were two ways to implement this:
-
-    1. Update the type of each PageElement case class to have a new renderId field, and use a value when initializing the
-       case class.
-
-    2. What we are doing here: adding that field as a transformation applied to PageElements during the Json
-       serialisation.
-
-    We decided to go for solution 2, because `renderId` doesn't itself have real semantics for backend types. It' ok
-       for the backend to provide the field to DCR from the backend but doing it at json serialization seems the right
-       place to perform that operation.
-   */
+  // Note:
+  //     In the file PageElement-Identifiers.md you will find a discussion of identifiers used by PageElements
+  //     Also look for "03feb394-a17d-4430-8384-edd1891e0d01"
 
   def enhanceElement(element: JsValue): JsValue = {
-    // Note: the value of renderId is used to link serverside and client side elements together for portals and
-    // hydration which was previously done with the array index (brittle, particularly when now dealing with main
-    // media array too). The actual value is irrelevant and can vary from one call to another. Here we are using UUIDs
-
     element.as[JsObject] ++ Json.obj("elementId" -> java.util.UUID.randomUUID.toString)
   }
 

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -104,7 +104,7 @@ object ElementsEnhancer {
     // hydration which was previously done with the array index (brittle, particularly when now dealing with main
     // media array too). The actual value is irrelevant and can vary from one call to another. Here we are using UUIDs
 
-    element.as[JsObject] ++ Json.obj("renderId" -> java.util.UUID.randomUUID.toString)
+    element.as[JsObject] ++ Json.obj("elementId" -> java.util.UUID.randomUUID.toString)
   }
 
   def enhanceElements(elements: JsValue): IndexedSeq[JsValue] = {

--- a/common/app/model/dotcomrendering/PageElement-Identifiers.md
+++ b/common/app/model/dotcomrendering/PageElement-Identifiers.md
@@ -1,0 +1,56 @@
+( document id: 03feb394-a17d-4430-8384-edd1891e0d01 )
+
+This document present the conventions around the use of IDs for `PageElements` and DCR's `BlockElements`
+
+### Introduction
+
+`trait PageElement` and its members model the objects the backend send to DCR for rendering. In the DCR data object, they are referred to as `BlockElement`s, for instance 
+
+```
+model.dotcomrendering.pageElements.TextBlockElement
+```
+
+### The State of PageElement Identifiers
+
+`BlockElement` do not per se have a neturally defined identifier. This is because although some of them correspond to CAPI elements who have a natural identifer, for instance atoms, PageElements are more general than content held in CAPI. 
+
+Due to historical reasons a few `PageElement`s have a field called `id`, for instance
+
+```
+case class MediaAtomBlockElement(
+    id: String,
+    title: String,
+    ...
+```
+
+but this `id` should be seen as metadata about the original data the PageElement represents. 
+
+In Feb 2021, the DCR team requested that PageElements be given an identifier that would help with rendering, notably to be used for DOM reconciliation during React rendering. Although DCR itself could be responsible to provide them (ultil this point it actually did using integer indices), the backend accepted to provide one, called `elementId`. 
+
+We then moved to serving, say, `TextBlockElement` like this:   
+
+```
+{
+  "_type": "model.dotcomrendering.pageElements.TextBlockElement",
+  "html": "<p>Something</p>"
+}
+```
+
+to this:
+
+```
+{
+  "elementId": "ae4e4580-dd0b-4aed-a958-f9ba6aa79ca2",
+  "_type": "model.dotcomrendering.pageElements.TextBlockElement",
+  "html": "<p>Something</p>"
+}
+```
+
+*NB*:
+
+1. The backend type `trait PageElement`, does not itself enforces the presence of `elementId`, this attribute is added (at the time these lines are written), as per this [https://github.com/guardian/frontend/pull/23562](https://github.com/guardian/frontend/pull/23562) , using a data enhancer applied to the JSON representation of the DCR data object. This choice was made on the basis that the `elementId` is a courtesy provided to DCR by the backend and not a real property of the data as seen by the backend
+
+
+2. The initial implementation uses UUIDs, but the contract is that any reasonably unique string can do 
+
+3. The value of `elementId` for each element is, as per original implementation, randomly chosen at each generation. In any case, there is no 1-2-1 mapping between `PageElement`s / `BlockElement`s and those values. 

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -23,6 +23,10 @@ import views.support.{ImgSrc, SrcSet, Video700}
 
 import scala.collection.JavaConverters._
 
+// ------------------------------------------------------
+// PageElement Supporting Types and Traits
+// ------------------------------------------------------
+
 // TODO dates are being rendered as strings to avoid duplication of the
 // to-string logic, but ultimately we should pass unformatted date info to
 // DCR.
@@ -75,6 +79,12 @@ object NSImage1 {
   }
 }
 
+trait ThirdPartyEmbeddedContent {
+  def isThirdPartyTracking: Boolean
+  def source: Option[String]
+  def sourceDomain: Option[String]
+}
+
 // ------------------------------------------------------
 // PageElement
 // ------------------------------------------------------
@@ -84,12 +94,12 @@ object NSImage1 {
   model.liveblog._ elements but replaced in full here
  */
 
-sealed trait PageElement
+sealed trait PageElement {
 
-trait ThirdPartyEmbeddedContent {
-  def isThirdPartyTracking: Boolean
-  def source: Option[String]
-  def sourceDomain: Option[String]
+  // renderId: unique identifier used by DCR's rendering logic
+  // We are not using the existing `id` field that some page elements already have, because not all of them have one and
+  // they do not have the same purpose.
+  val renderId: String = ""
 }
 
 case class AudioAtomBlockElement(

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -94,13 +94,7 @@ trait ThirdPartyEmbeddedContent {
   model.liveblog._ elements but replaced in full here
  */
 
-sealed trait PageElement {
-
-  // renderId: unique identifier used by DCR's rendering logic
-  // We are not using the existing `id` field that some page elements already have, because not all of them have one and
-  // they do not have the same purpose.
-  val renderId: String = ""
-}
+sealed trait PageElement
 
 case class AudioAtomBlockElement(
     id: String,

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -96,6 +96,10 @@ trait ThirdPartyEmbeddedContent {
 
 sealed trait PageElement
 
+// Note:
+//     In the file PageElement-Identifiers.md you will find a discussion of identifiers used by PageElements
+//     Also look for "03feb394-a17d-4430-8384-edd1891e0d01"
+
 case class AudioAtomBlockElement(
     id: String,
     kicker: String,


### PR DESCRIPTION

### Introduction

`trait PageElement` and its members model the objects the backend send to DCR for rendering. In the DCR data object, they are referred to as `BlockElement`s, for instance 

```
model.dotcomrendering.pageElements.TextBlockElement
```

### The State of PageElement Identifiers

`BlockElement` do not per se have a neturally defined identifier. This is because although some of them correspond to CAPI elements who have a natural identifer, for instance atoms, PageElements are more general than content held in CAPI. 

Due to historical reasons a few `PageElement`s have a field called `id`, for instance

```
case class MediaAtomBlockElement(
    id: String,
    title: String,
    ...
```

but this `id` should be seen as metadata about the original data the PageElement represents. 

In Feb 2021, the DCR team requested that PageElements be given an identifier that would help with rendering, notably to be used for DOM reconciliation during React rendering. Although DCR itself could be responsible to provide them (ultil this point it actually did using integer indices), the backend accepted to provide one, called `elementId`. 

We then moved to serving, say, `TextBlockElement` like this:   

```
{
  "_type": "model.dotcomrendering.pageElements.TextBlockElement",
  "html": "<p>Something</p>"
}
```

to this:

```
{
  "elementId": "ae4e4580-dd0b-4aed-a958-f9ba6aa79ca2",
  "_type": "model.dotcomrendering.pageElements.TextBlockElement",
  "html": "<p>Something</p>"
}
```

*NB*:

1. The backend type `trait PageElement`, does not itself enforces the presence of `elementId`, this attribute is added (at the time these lines are written), as per this [https://github.com/guardian/frontend/pull/23562](https://github.com/guardian/frontend/pull/23562) , using a data enhancer applied to the JSON representation of the DCR data object. This choice was made on the basis that the `elementId` is a courtesy provided to DCR by the backend and not a real property of the data as seen by the backend


2. The initial implementation uses UUIDs, but the contract is that any reasonably unique string can do 

3. The value of `elementId` for each element is, as per original implementation, randomly chosen at each generation. In any case, there is no 1-2-1 mapping between `PageElement`s / `BlockElement`s and those values. 
