### PR TITLE
Bump commercial-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.7",
     "@guardian/braze-components": "0.0.19",
-    "@guardian/commercial-core": "^0.12.0",
+    "@guardian/commercial-core": "^0.13.0",
     "@guardian/consent-management-platform": "6.9.1",
     "@guardian/libs": "^1.4.2",
     "@guardian/shimport": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1849,10 +1849,10 @@
     "@guardian/src-icons" "2.7.1"
     emotion-theming "^10.0.19"
 
-"@guardian/commercial-core@^0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.12.0.tgz#45ec5f0958345cfbd7485842ffea5a1410758db1"
-  integrity sha512-/lJznHPqXXtib/d4N3s5sG2FFH5V8WXXN1IXEmrS10Oow7jclaE6gpIt2/+Tw9v7x52Det+jh8AlwQTj4otMiw==
+"@guardian/commercial-core@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.13.0.tgz#863c1acd0d520999b1ff3d91b6e6c640813602b3"
+  integrity sha512-Yygnt/slYais1Xc0qi/2LAk7DdLSD6sL/inf8TmssFiYE9o9nI9yDGKnJJHmU+H8eKZuyLd9pTqFV/I760FkDA==
 
 "@guardian/consent-management-platform@6.9.1":
   version "6.9.1"


### PR DESCRIPTION
## What does this change?

bump version to 0.13.0 in order to start tracking [commercial events in GA](https://github.com/guardian/commercial-core/pull/171) (currently only `slotReady` or `slotInitalized`)

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
