### PR TITLE
Robust shortUrl checks for onward journeys

### DIFF
--- a/onward/app/controllers/MediaInSectionController.scala
+++ b/onward/app/controllers/MediaInSectionController.scala
@@ -50,7 +50,7 @@ class MediaInSectionController(
     def isCurrentStory(content: ApiContent) =
       content.fields
         .flatMap(fields => fields.shortUrl.map(ShortUrls.shortUrlToShortId))
-        .exists(url => currentShortUrl.exists(url.endsWith))
+        .exists(url => currentShortUrl.exists(_.endsWith(url)))
 
     val promiseOrResponse = contentApiClient
       .getResponse(

--- a/onward/app/controllers/MediaInSectionController.scala
+++ b/onward/app/controllers/MediaInSectionController.scala
@@ -11,6 +11,7 @@ import model.pressed.CollectionConfig
 import play.api.mvc._
 import services.CollectionConfigWithId
 import layout.slices.{Fixed, FixedContainers}
+import utils.ShortUrls
 
 import scala.concurrent.Future
 
@@ -47,7 +48,9 @@ class MediaInSectionController(
     val tags = (s"type/$mediaType" +: excludeTags).mkString(",")
 
     def isCurrentStory(content: ApiContent) =
-      content.fields.flatMap(_.shortUrl).exists(!_.equals(currentShortUrl))
+      content.fields
+        .flatMap(fields => fields.shortUrl.map(ShortUrls.shortUrlToShortId))
+        .exists(currentShortUrl.endsWith)
 
     val promiseOrResponse = contentApiClient
       .getResponse(

--- a/onward/app/controllers/SeriesController.scala
+++ b/onward/app/controllers/SeriesController.scala
@@ -71,7 +71,7 @@ class SeriesController(
     def isCurrentStory(content: ApiContent) =
       content.fields
         .flatMap(fields => fields.shortUrl.map(ShortUrls.shortUrlToShortId))
-        .exists(url => currentShortUrl.exists(url.endsWith))
+        .exists(url => currentShortUrl.exists(_.endsWith(url)))
 
     val query = queryModifier {
       contentApiClient.item(seriesId, edition).showFields("all")

--- a/onward/app/controllers/SeriesController.scala
+++ b/onward/app/controllers/SeriesController.scala
@@ -66,12 +66,12 @@ class SeriesController(
   private def lookup(edition: Edition, seriesId: String, queryModifier: ItemQuery => ItemQuery = identity)(implicit
       request: RequestHeader,
   ): Future[Option[Series]] = {
-    val currentShortUrl = request.getQueryString("shortUrl").getOrElse("")
+    val currentShortUrl = request.getQueryString("shortUrl")
 
     def isCurrentStory(content: ApiContent) =
       content.fields
         .flatMap(fields => fields.shortUrl.map(ShortUrls.shortUrlToShortId))
-        .exists(currentShortUrl.endsWith)
+        .exists(url => currentShortUrl.exists(url.endsWith))
 
     val query = queryModifier {
       contentApiClient.item(seriesId, edition).showFields("all")

--- a/onward/app/controllers/SeriesController.scala
+++ b/onward/app/controllers/SeriesController.scala
@@ -1,19 +1,19 @@
 package controllers
 
 import java.net.URI
-
 import com.gu.contentapi.client.model.{ContentApiError, ItemQuery}
 import com.gu.contentapi.client.model.v1.{Content => ApiContent}
 import common.{JsonComponent, _}
 import contentapi.ContentApiClient
 import implicits.Requests
-import layout.{FaciaContainer}
+import layout.FaciaContainer
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model._
 import play.api.libs.json.{JsArray, Json}
 import play.api.mvc._
 import views.support.FaciaToMicroFormat2Helpers._
 import models.{Series, SeriesHelper, SeriesStoriesDCR}
+import utils.ShortUrls
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -69,7 +69,9 @@ class SeriesController(
     val currentShortUrl = request.getQueryString("shortUrl").getOrElse("")
 
     def isCurrentStory(content: ApiContent) =
-      content.fields.flatMap(_.shortUrl).exists(_.equals(currentShortUrl))
+      content.fields
+        .flatMap(fields => fields.shortUrl.map(ShortUrls.shortUrlToShortId))
+        .exists(currentShortUrl.endsWith)
 
     val query = queryModifier {
       contentApiClient.item(seriesId, edition).showFields("all")


### PR DESCRIPTION
## What does this change?
Adds a bit of safety to shortUrls used for de-duping onward containers - we now match the short URL path e.g. `/p/abcd` to the _end_ of the current short URL e.g. `https://gu.com/p/abcd` or `https://www.theguardian.com/p/abcd`. This is useful so that we are not affected by switching of the domain used in short URLs.