### PR TITLE
Add ad manager field to assign user to a random group

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -24,6 +24,7 @@ import { getUserSegments } from './user-ad-targeting';
 let myPageTargetting = {};
 let latestCmpHasInitalised;
 let latestCMPState;
+const AMTGRP_STORAGE_KEY = 'gu.adManagerGroup';
 
 const findBreakpoint = () => {
     switch (getBreakpoint(true)) {
@@ -225,9 +226,16 @@ const getAdConsentFromState = (state) => {
     } else if (state.aus) {
         // AUS mode
         return state.aus.personalisedAdvertising;
-    } 
+    }
     // Unknown mode
     return false;
+}
+
+const createAdManagerGroup = () => {
+    // users are assigned to groups 1-12
+    const group = String(Math.floor(Math.random() * 12) + 1);
+    storage.local.setRaw(AMTGRP_STORAGE_KEY, group);
+    return group;
 }
 
 const rebuildPageTargeting = () => {
@@ -277,6 +285,7 @@ const rebuildPageTargeting = () => {
             rdp: getRdpValue(ccpaState),
             consent_tcfv2: getTcfv2ConsentValue(adConsentState),
             cmp_interaction: tcfv2EventStatus || 'na',
+            amtgrp: storage.local.getRaw(AMTGRP_STORAGE_KEY) || createAdManagerGroup(),
         },
         page.sharedAdTargeting,
         paTargeting,
@@ -310,14 +319,14 @@ const getPageTargeting = () => {
         }
         return myPageTargetting;
     }
-    
+
     // First call binds to onConsentChange and returns {}
     onConsentChange((state)=>{
     // On every consent change we rebuildPageTageting
         latestCMPState = state;
         myPageTargetting = rebuildPageTargeting();
     });
-    return myPageTargetting; 
+    return myPageTargetting;
 };
 
 const resetPageTargeting = () => {

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -162,10 +162,13 @@ describe('Build Page Targeting', () => {
         getSync.mockReturnValue('US');
         getPrivacyFramework.mockReturnValue({ ccpa: true });
 
+        jest.spyOn(global.Math, 'random').mockReturnValue(0.5);
+
         expect.hasAssertions();
     });
 
     afterEach(() => {
+        jest.spyOn(global.Math, 'random').mockRestore();
         jest.resetAllMocks();
     });
 
@@ -329,6 +332,7 @@ describe('Build Page Targeting', () => {
             rdp: 'na',
             consent_tcfv2: 'na',
             cmp_interaction: 'na',
+            amtgrp: '7',
         });
     });
 
@@ -490,7 +494,6 @@ describe('Build Page Targeting', () => {
         });
     });
 
-
     describe('skinsize targetting', () => {
         it.each([
             ['s', 1280],
@@ -511,5 +514,23 @@ describe('Build Page Targeting', () => {
             getViewport.mockReturnValue(undefined);
             expect(getPageTargeting().skinsize).toBe('s');
         });
-    })
+    });
+
+    describe('ad manager group value', () => {
+        const STORAGE_KEY = 'gu.adManagerGroup';
+        it('if present in localstorage, use value from storage', () => {
+            storage.local.setRaw(STORAGE_KEY, '10');
+            expect(getPageTargeting().amtgrp).toEqual('10');
+            storage.local.remove(STORAGE_KEY);
+        });
+        it('if not present in localstorage, generate a random group 1-12, store in localstorage', () => {
+            // restore Math.random for this test so we can assert the group value range is 1-12
+            jest.spyOn(global.Math, 'random').mockRestore();
+            const valueGenerated = getPageTargeting().amtgrp;
+            expect(Number(valueGenerated)).toBeGreaterThanOrEqual(1);
+            expect(Number(valueGenerated)).toBeLessThanOrEqual(12);
+            const valueFromStorage = storage.local.getRaw(STORAGE_KEY);
+            expect(valueFromStorage).toEqual(valueGenerated);
+        });
+    });
 });


### PR DESCRIPTION
## What does this change?

Add a new property to Google Ad Manager `amtgrp`.

The value is a random number 1-12 inclusive used to assign users to groups.

Once assigned the value is kept in localStorage and used if present on the next visit.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Allows Google ad-manager to 'target' adverts to segments of users for A/B testing.

## Checklist

### Tested

- [X] Locally
- [ ] On CODE (optional)

