### PR TITLE
Enable PhotoEssays for DCR

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -109,8 +109,6 @@ object ArticlePageChecks {
 
   def isNotNumberedList(page: PageWithStoryPackage): Boolean = !page.item.isNumberedList
 
-  def isNotPhotoEssay(page: PageWithStoryPackage): Boolean = !page.item.isPhotoEssay
-
   def isNotAGallery(page: PageWithStoryPackage): Boolean = !page.item.tags.isGallery
 
   def isNotLiveBlog(page: PageWithStoryPackage): Boolean = !page.item.tags.isLiveBlog
@@ -138,7 +136,6 @@ object ArticlePicker {
       ("isSupportedType", ArticlePageChecks.isSupportedType(page)),
       ("hasOnlySupportedElements", ArticlePageChecks.hasOnlySupportedElements(page)),
       ("hasOnlySupportedMainElements", ArticlePageChecks.hasOnlySupportedMainElements(page)),
-      ("isNotPhotoEssay", ArticlePageChecks.isNotPhotoEssay(page)),
       ("isNotAGallery", ArticlePageChecks.isNotAGallery(page)),
       ("isNotLiveBlog", ArticlePageChecks.isNotLiveBlog(page)),
       ("isNotAMP", ArticlePageChecks.isNotAMP(request)),


### PR DESCRIPTION
## What does this change?
Removes the `isNotPhotoEssay` filter from `ArticlePicker` so that we now send these articles to DCR
