### PR TITLE
add elementId to keyEvents

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -80,23 +80,20 @@ object ElementsEnhancer {
     elements.as[JsArray].value.map(element => enhanceElement(element))
   }
 
-  def enhanceBlock(block: JsValue): JsValue = {
+  def enhanceObjectWithElementsAtDepth1(block: JsValue): JsValue = {
     val elements = block.as[JsObject].value("elements")
     block.as[JsObject] ++ Json.obj("elements" -> enhanceElements(elements))
   }
 
-  def enhanceBlocks(blocks: JsValue): IndexedSeq[JsValue] = {
-    blocks.as[JsArray].value.map(block => enhanceBlock(block))
-  }
-
-  def enhanceMainMediaElements(value: JsValue): IndexedSeq[JsValue] = {
-    value.as[JsArray].value.map(element => enhanceElement(element))
+  def enhanceObjectsWithElementsAtDepth1(blocks: JsValue): IndexedSeq[JsValue] = {
+    blocks.as[JsArray].value.map(block => enhanceObjectWithElementsAtDepth1(block))
   }
 
   def enhanceDcrObject(obj: JsObject): JsObject = {
     obj ++
-      Json.obj("blocks" -> enhanceBlocks(obj.value("blocks"))) ++
-      Json.obj("mainMediaElements" -> enhanceMainMediaElements(obj.value("mainMediaElements")))
+      Json.obj("blocks" -> enhanceObjectsWithElementsAtDepth1(obj.value("blocks"))) ++
+      Json.obj("mainMediaElements" -> enhanceElements(obj.value("mainMediaElements"))) ++
+      Json.obj("keyEvents" -> enhanceObjectsWithElementsAtDepth1(obj.value("keyEvents")))
   }
 }
 

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -80,13 +80,13 @@ object ElementsEnhancer {
     elements.as[JsArray].value.map(element => enhanceElement(element))
   }
 
-  def enhanceObjectWithElementsAtDepth1(block: JsValue): JsValue = {
-    val elements = block.as[JsObject].value("elements")
-    block.as[JsObject] ++ Json.obj("elements" -> enhanceElements(elements))
+  def enhanceObjectWithElementsAtDepth1(obj: JsValue): JsValue = {
+    val elements = obj.as[JsObject].value("elements")
+    obj.as[JsObject] ++ Json.obj("elements" -> enhanceElements(elements))
   }
 
-  def enhanceObjectsWithElementsAtDepth1(blocks: JsValue): IndexedSeq[JsValue] = {
-    blocks.as[JsArray].value.map(block => enhanceObjectWithElementsAtDepth1(block))
+  def enhanceObjectsWithElementsAtDepth1(objs: JsValue): IndexedSeq[JsValue] = {
+    objs.as[JsArray].value.map(obj => enhanceObjectWithElementsAtDepth1(obj))
   }
 
   def enhanceDcrObject(obj: JsObject): JsObject = {


### PR DESCRIPTION
## What does this change?

add `elementId` to `keyEvents`. This is the follow up of https://github.com/guardian/frontend/pull/23562 and https://github.com/guardian/frontend/pull/23571.

![Screenshot 2021-02-25 at 14 09 41](https://user-images.githubusercontent.com/6035518/109165481-828aa200-7773-11eb-993a-fc5c5732e95b.png)
