### PR TITLE
Identity | Sign in Gate | Copy test and switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -26,6 +26,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-sign-in-gate-copy-opt",
+    "Compare 6 different sign-in gate copy updates",
+    owners = Seq(Owner.withGithub("rebecca-thompson")),
+    safeState = Off,
+    sellByDate = new LocalDate(2021, 12, 1),
+    exposeClientSide = true,
+  )
+
+  Switch(
+    ABTests,
     "ab-deeply-read-test",
     "Tests an onward hypothesis by replacing the second tab in the Most Popular container with deeply read items.",
     owners = Seq(Owner.withGithub("nitro-marky")),

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -1,9 +1,11 @@
 import { signInGateMainVariant } from 'common/modules/experiments/tests/sign-in-gate-main-variant';
 import { signInGateMainControl } from 'common/modules/experiments/tests/sign-in-gate-main-control';
+import { signInGateCopyOpt } from 'common/modules/experiments/tests/sign-in-gate-copy-opt';
 import { curatedContentCarouselTest } from 'common/modules/experiments/tests/curated-content-carousel-test';
 
 export const concurrentTests = [
     signInGateMainVariant,
     signInGateMainControl,
+    signInGateCopyOpt,
     curatedContentCarouselTest
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-copy-opt.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-copy-opt.js
@@ -1,0 +1,49 @@
+export const signInGateCopyOpt = {
+    id: 'SignInGateCopyOpt',
+    start: '2021-02-24',
+    expiry: '2021-12-01',
+    author: 'rebecca-thompson',
+    description:
+        'Compare 6 different gate copy changes, on 3rd page view of the day, on simple article templates, with higher priority over banners and epi',
+    audience: 0.2,
+    audienceOffset: 0.7,
+    successMeasure: 'Users sign in or create a Guardian account',
+    audienceCriteria:
+        '3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
+    ophanComponentId: 'copy_opt',
+    dataLinkNames: 'SignInGateCopyOpt',
+    idealOutcome:
+        'We believe that we could increase sign in conversion by at least 5% by implementing these copy changes',
+    showForSensitive: false,
+    canRun: () => true,
+    variants: [
+        {
+            id: 'copy-opt-control',
+            test: () => {},
+        },
+        {
+            id: 'copy-opt-variant-1', // Transparency 1 - You need to register to keep reading
+            test: () => {},
+        },
+        {
+            id: 'copy-opt-variant-2', // Transparency 2 - Register to keep reading
+            test: () => {},
+        },
+        {
+            id: 'copy-opt-variant-3', // Purpose - We’ll keep holding power to account
+            test: () => {},
+        },
+        {
+            id: 'copy-opt-variant-4', // Petition - Do you believe in independent journalism?
+            test: () => {},
+        },
+        {
+            id: 'copy-opt-variant-5', // Belonging 1 - Join our mission
+            test: () => {},
+        },
+        {
+            id: 'copy-opt-variant-6', // Belonging 2 - Register to keep reading
+            test: () => {},
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
@@ -8,7 +8,7 @@ export const signInGateMainVariant = {
     author: 'Mahesh Makani',
     description:
         'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Main/Variant Audience.',
-    audience: 0.9,
+    audience: 0.7,
     audienceOffset: 0.0,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:


### PR DESCRIPTION
## What does this change?
Set up the AB Test definition and switch for the Sign In Gate Copy Optimisation test. The actual tests and designs have only been implemented on [DCR](https://github.com/guardian/dotcom-rendering/pull/2622), but the audience for both platforms has to be identical to get relevant results.

### Tested

- [ ] Locally
- [x] On CODE (optional)