### PR TITLE
Optional ga tracker  name

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/google.js
+++ b/static/src/javascripts/projects/common/modules/analytics/google.js
@@ -4,7 +4,7 @@ import mediator from 'lib/mediator';
 
 const trackerName = config.get('googleAnalytics.trackers.editorial');
 
-const send = `${trackerName}.send`;
+const send = trackerName ? `${trackerName}.send` : 'send';
 
 const getTextContent = (el) =>
     (el.textContent || '').trim();


### PR DESCRIPTION
## What does this change?
If tracker name does not exist in window.config just call `ga('send')`

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
Will keep working as is but `ga` will have cleaner parameter for tracker name without an `undefined` 

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
