### PR TITLE
Upgrade commercial-core to 0.16.1 and use commercial events for ga/performance api

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.7",
     "@guardian/braze-components": "0.0.19",
-    "@guardian/commercial-core": "^0.13.0",
+    "@guardian/commercial-core": "^0.16.1",
     "@guardian/consent-management-platform": "6.9.1",
     "@guardian/libs": "^1.6.3",
     "@guardian/shimport": "^1.0.2",

--- a/static/src/javascripts/bootstraps/commercial.dcr.js
+++ b/static/src/javascripts/bootstraps/commercial.dcr.js
@@ -119,8 +119,6 @@ const loadModules = () => {
 };
 
 const bootCommercial = () => {
-    markTime('commercial start');
-
     // Init Commercial event timers
     EventTimer.init();
 
@@ -129,11 +127,7 @@ const bootCommercial = () => {
             [
                 'ga-user-timing-commercial-start',
                 function runTrackPerformance() {
-                    trackPerformance(
-                        'Javascript Load',
-                        'commercialStart',
-                        'Commercial start parse time'
-                    );
+                    EventTimer.get().trigger('commercialStart');
                 },
             ],
         ],
@@ -150,17 +144,12 @@ const bootCommercial = () => {
     return loadHostedBundle()
         .then(loadModules)
         .then(() => {
-            markTime('commercial end');
             catchErrorsWithContext(
                 [
                     [
                         'ga-user-timing-commercial-end',
                         function runTrackPerformance() {
-                            trackPerformance(
-                                'Javascript Load',
-                                'commercialEnd',
-                                'Commercial end parse time'
-                            );
+                            EventTimer.get().trigger('commercialEnd');
                         },
                     ],
                 ],

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -119,8 +119,6 @@ const loadModules = () => {
 };
 
 export const bootCommercial = () => {
-    markTime('commercial start');
-
     // Init Commercial event timers
     EventTimer.init();
 
@@ -129,11 +127,7 @@ export const bootCommercial = () => {
             [
                 'ga-user-timing-commercial-start',
                 function runTrackPerformance() {
-                    trackPerformance(
-                        'Javascript Load',
-                        'commercialStart',
-                        'Commercial start parse time'
-                    );
+                    EventTimer.get().trigger('commercialStart');
                 },
             ],
         ],
@@ -156,11 +150,7 @@ export const bootCommercial = () => {
                     [
                         'ga-user-timing-commercial-end',
                         function runTrackPerformance() {
-                            trackPerformance(
-                                'Javascript Load',
-                                'commercialEnd',
-                                'Commercial end parse time'
-                            );
+                            EventTimer.get().trigger('commercialEnd');
                         },
                     ],
                 ],

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -144,7 +144,6 @@ export const bootCommercial = () => {
     return loadHostedBundle()
         .then(loadModules)
         .then(() => {
-            markTime('commercial end');
             catchErrorsWithContext(
                 [
                     [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1849,10 +1849,10 @@
     "@guardian/src-icons" "2.7.1"
     emotion-theming "^10.0.19"
 
-"@guardian/commercial-core@^0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.13.0.tgz#863c1acd0d520999b1ff3d91b6e6c640813602b3"
-  integrity sha512-Yygnt/slYais1Xc0qi/2LAk7DdLSD6sL/inf8TmssFiYE9o9nI9yDGKnJJHmU+H8eKZuyLd9pTqFV/I760FkDA==
+"@guardian/commercial-core@^0.16.1":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.16.1.tgz#32b48306f91f1118e6edd36b55628df1a25c9926"
+  integrity sha512-E1br/XRLpw8QwLhZBYAXWZcuZ9onBmCSeR+Qg6cy8hmyAbuto5v197PdBBa+VOy6//61IBeank2A0r+N00+3Xw==
 
 "@guardian/consent-management-platform@6.9.1":
   version "6.9.1"


### PR DESCRIPTION
## What does this change?

- Upgrade commercial-core to 0.16.1 
- Replace usage of performance mark and google analytics with [commercial events ](https://github.com/guardian/commercial-core/pull/176) to mark `commercialStart` and `commercialEnd`

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
