### PR TITLE
Temporarily manipulate discussion IDs returned by the facia scala client

### DIFF
--- a/common/app/layout/DiscussionSettings.scala
+++ b/common/app/layout/DiscussionSettings.scala
@@ -13,6 +13,8 @@ object DiscussionSettings {
     DiscussionSettings(
       faciaContent.discussion.isCommentable,
       faciaContent.discussion.isClosedForComments,
-      faciaContent.discussion.discussionId,
+      //TODO: this is a quick fix only - remove once we've released a fixed fapi client
+      faciaContent.discussion.discussionId
+        .map(_.replaceFirst("^[a-zA-Z]+://www.theguardian.com", "")),
     )
 }

--- a/common/app/model/PressedDiscussionSettings.scala
+++ b/common/app/model/PressedDiscussionSettings.scala
@@ -14,6 +14,9 @@ object PressedDiscussionSettings {
     PressedDiscussionSettings(
       isCommentable = FaciaContentUtils.isCommentable(content),
       isClosedForComments = FaciaContentUtils.isClosedForComments(content),
-      discussionId = FaciaContentUtils.discussionId(content),
+      discussionId = FaciaContentUtils
+        .discussionId(content)
+        //TODO: this is a quick fix only - remove once we've released a fixed fapi client
+        .map(_.replaceFirst("^[a-zA-Z]+://www.theguardian.com", "")),
     )
 }


### PR DESCRIPTION
## What does this change?
After the switch to use our full domain name in shortURLs from CAPI, the facia scala client needs to be updated to support shortIds/discussionIds created from the format i.e. `https://www.theguardian.com/p/23123 -> /p/23123`. This is currently affecting comment count display on fronts so this is a temporary quick fix while we work on a new release of the library - at which point we can remove this.