### PR TITLE
Revert "Refactor commercial timers"

### DIFF
--- a/static/src/javascripts/bootstraps/commercial.dcr.js
+++ b/static/src/javascripts/bootstraps/commercial.dcr.js
@@ -1,6 +1,7 @@
 import 'lib/dotcom-rendering/public-path';
 import config from 'lib/config';
 import { catchErrorsWithContext } from 'lib/robust';
+import { markTime } from 'lib/user-timing';
 import reportError from 'lib/report-error';
 import { init as setAdTestCookie } from 'commercial/modules/set-adtest-cookie';
 import { init as initHighMerch } from 'commercial/modules/high-merch';
@@ -20,6 +21,7 @@ import { init as initPaidForBand } from 'commercial/modules/paidfor-band';
 import { init as initComscore } from 'commercial/modules/comscore';
 import { init as initIpsosMori } from 'commercial/modules/ipsos-mori';
 import { paidContainers } from 'commercial/modules/paid-containers';
+import { trackPerformance } from 'common/modules/analytics/google';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { initCommentAdverts } from 'commercial/modules/comment-adverts';
 import { init as prepareA9 } from 'commercial/modules/dfp/prepare-a9';
@@ -119,7 +121,20 @@ const loadModules = () => {
 const bootCommercial = () => {
     // Init Commercial event timers
     EventTimer.init();
-    EventTimer.get().trigger('commercialStart');
+
+    catchErrorsWithContext(
+        [
+            [
+                'ga-user-timing-commercial-start',
+                function runTrackPerformance() {
+                    EventTimer.get().trigger('commercialStart');
+                },
+            ],
+        ],
+        {
+            feature: 'commercial',
+        }
+    );
 
     // Stub the command queue
     window.googletag = {
@@ -129,7 +144,19 @@ const bootCommercial = () => {
     return loadHostedBundle()
         .then(loadModules)
         .then(() => {
-            EventTimer.get().trigger('commercialEnd');
+            catchErrorsWithContext(
+                [
+                    [
+                        'ga-user-timing-commercial-end',
+                        function runTrackPerformance() {
+                            EventTimer.get().trigger('commercialEnd');
+                        },
+                    ],
+                ],
+                {
+                    feature: 'commercial',
+                }
+            );
         })
         .catch(err => {
             // report async errors in bootCommercial to Sentry with the commercial feature tag

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -1,5 +1,6 @@
 import config from 'lib/config';
 import { catchErrorsWithContext } from 'lib/robust';
+import { markTime } from 'lib/user-timing';
 import reportError from 'lib/report-error';
 import { init as setAdTestCookie } from 'commercial/modules/set-adtest-cookie';
 import { init as initHighMerch } from 'commercial/modules/high-merch';
@@ -21,6 +22,7 @@ import { init as initPaidForBand } from 'commercial/modules/paidfor-band';
 import { init as initComscore } from 'commercial/modules/comscore';
 import { init as initIpsosMori } from 'commercial/modules/ipsos-mori';
 import { paidContainers } from 'commercial/modules/paid-containers';
+import { trackPerformance } from 'common/modules/analytics/google';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { initCommentAdverts } from 'commercial/modules/comment-adverts';
 import { initAdblockAsk } from 'common/modules/commercial/adblock-ask';
@@ -119,7 +121,20 @@ const loadModules = () => {
 export const bootCommercial = () => {
     // Init Commercial event timers
     EventTimer.init();
-    EventTimer.get().trigger('commercialStart');
+
+    catchErrorsWithContext(
+        [
+            [
+                'ga-user-timing-commercial-start',
+                function runTrackPerformance() {
+                    EventTimer.get().trigger('commercialStart');
+                },
+            ],
+        ],
+        {
+            feature: 'commercial',
+        }
+    );
 
     // Stub the command queue
     window.googletag = {
@@ -129,7 +144,19 @@ export const bootCommercial = () => {
     return loadHostedBundle()
         .then(loadModules)
         .then(() => {
-            EventTimer.get().trigger('commercialEnd');
+            catchErrorsWithContext(
+                [
+                    [
+                        'ga-user-timing-commercial-end',
+                        function runTrackPerformance() {
+                            EventTimer.get().trigger('commercialEnd');
+                        },
+                    ],
+                ],
+                {
+                    feature: 'commercial',
+                }
+            );
         })
         .catch(err => {
             // report async errors in bootCommercial to Sentry with the commercial feature tag


### PR DESCRIPTION
Reverts guardian/frontend#23583

This PR is a candidate for breaking e2e tests in DCR