### PR TITLE
Add sticky nav test switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -53,4 +53,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2021, 3, 8),
     exposeClientSide = true,
   )
+
+  Switch(
+    ABTests,
+    "ab-sticky-nav-test",
+    "Tests sticky nav behaviour",
+    owners = Seq(Owner.withGithub("nicl")),
+    safeState = Off,
+    sellByDate = new LocalDate(2021, 5, 3),
+    exposeClientSide = true,
+  )
 }


### PR DESCRIPTION
Required by https://github.com/guardian/dotcom-rendering/pull/2652. 

See the original Trello card for wider context: https://trello.com/c/fy5HsbwD/2347-sticky-nav-test.