### PR TITLE
Use actions-setup-node

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -7,9 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
-              with:
-                  node-version: '10.x'
+            - uses: guardian/actions-setup-node@main
 
             # Cache npm dependencies using https://github.com/bahmutov/npm-install
             - uses: bahmutov/npm-install@v1


### PR DESCRIPTION
## What does this change?

uses `guardian/actions-setup-node` in github actions

## Why?

[it uses your .nvmrc](https://github.com/guardian/actions-setup-node#about-this-fork) to pick the node version you want