### PR TITLE
Send PPID based on consent

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -99,7 +99,6 @@ export const init = () => {
         window.googletag.cmd.push(
             setDfpListeners,
             setPageTargeting,
-            setPublisherProvidedId,
             refreshOnResize,
             () => {
                 fillAdvertSlots();
@@ -115,6 +114,11 @@ export const init = () => {
                         restrictDataProcessing: state.ccpa.doNotSell,
                     });
                 });
+                if (!state.ccpa.doNotSell) {
+                    window.googletag.cmd.push(
+                        setPublisherProvidedId,
+                    );
+                }
             } else {
                 let npaFlag;
                 if (state.tcfv2) {
@@ -127,6 +131,11 @@ export const init = () => {
                     // AUS mode
                     // canRun stays true, set NPA flag if consent is retracted
                     npaFlag = !getConsentFor('googletag', state);
+                    if (!npaFlag) {
+                        window.googletag.cmd.push(
+                            setPublisherProvidedId,
+                        );
+                    }
                 }
                 window.googletag.cmd.push(() => {
                     window.googletag

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -131,17 +131,17 @@ export const init = () => {
                     // AUS mode
                     // canRun stays true, set NPA flag if consent is retracted
                     npaFlag = !getConsentFor('googletag', state);
-                    if (!npaFlag) {
-                        window.googletag.cmd.push(
-                            setPublisherProvidedId,
-                        );
-                    }
                 }
                 window.googletag.cmd.push(() => {
                     window.googletag
                         .pubads()
                         .setRequestNonPersonalizedAds(npaFlag ? 1 : 0);
                 });
+                if (!npaFlag) {
+                    window.googletag.cmd.push(
+                        setPublisherProvidedId,
+                    );
+                }
             }
             // Prebid will already be loaded, and window.googletag is stubbed in `commercial.js`.
             // Just load googletag. Prebid will already be loaded, and googletag is already added to the window by Prebid.


### PR DESCRIPTION
## What does this change?
Send PPID based on consent

In CCPA (America): If the user sets 'doNotSell' we set the restrictDataProcessing Flag with google. We should not be setting PPID if the user is opting for doNotSell

In Australia: Just the "NonPersonalisedAdvertising" flag is set according to the users choice. We should not be setting PPID if the user has chosen NPA

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
