### PR TITLE
Add InteractiveBlockElement with boot.js script to article picker

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -24,6 +24,7 @@ import model.liveblog.{
   UnknownBlockElement,
   VideoBlockElement,
   WitnessBlockElement,
+  InteractiveBlockElement
 }
 import play.api.mvc.RequestHeader
 import views.support.Commercial
@@ -75,6 +76,12 @@ object ArticlePageChecks {
           val supportedAtomTypes =
             List("audio", "chart", "explainer", "guide", "media", "profile", "qanda", "timeline")
           !supportedAtomTypes.contains(atomtype)
+        }
+        case InteractiveBlockElement(_, scriptUrl) => {
+          scriptUrl match {
+            case Some("https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js") => false
+            case _ => true
+          }
         }
         case _ => true
       }

--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -24,7 +24,7 @@ import model.liveblog.{
   UnknownBlockElement,
   VideoBlockElement,
   WitnessBlockElement,
-  InteractiveBlockElement
+  InteractiveBlockElement,
 }
 import play.api.mvc.RequestHeader
 import views.support.Commercial
@@ -80,7 +80,7 @@ object ArticlePageChecks {
         case InteractiveBlockElement(_, scriptUrl) => {
           scriptUrl match {
             case Some("https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js") => false
-            case _ => true
+            case _                                                                       => true
           }
         }
         case _ => true

--- a/common/app/model/liveblog/BlockElement.scala
+++ b/common/app/model/liveblog/BlockElement.scala
@@ -42,7 +42,6 @@ case class GuVideoBlockElement(assets: Seq[VideoAsset], imageMedia: ImageMedia, 
 case class VideoBlockElement(data: Map[String, String]) extends BlockElement
 case class EmbedBlockElement(html: Option[String], safe: Option[Boolean], alt: Option[String]) extends BlockElement
 case class ContentAtomBlockElement(atomId: String, atomtype: String) extends BlockElement
-case class InteractiveBlockElement(html: Option[String]) extends BlockElement
 case class CommentBlockElement(html: Option[String]) extends BlockElement
 case class TableBlockElement(html: Option[String]) extends BlockElement
 case class WitnessBlockElement(html: Option[String]) extends BlockElement
@@ -51,6 +50,8 @@ case class InstagramBlockElement(html: Option[String]) extends BlockElement
 case class VineBlockElement(html: Option[String]) extends BlockElement
 case class MapBlockElement(html: Option[String]) extends BlockElement
 case class UnknownBlockElement(html: Option[String]) extends BlockElement
+
+case class InteractiveBlockElement(html: Option[String], scriptUrl: Option[String] = None) extends BlockElement
 
 case class MembershipBlockElement(
     originalUrl: Option[String],
@@ -157,7 +158,7 @@ object BlockElement {
       case Contentatom => element.contentAtomTypeData.map(d => ContentAtomBlockElement(d.atomId, d.atomType))
 
       case Pullquote       => element.pullquoteTypeData.map(d => PullquoteBlockElement(d.html))
-      case Interactive     => element.interactiveTypeData.map(d => InteractiveBlockElement(d.html))
+      case Interactive     => element.interactiveTypeData.map(d => InteractiveBlockElement(d.html, d.scriptUrl))
       case Comment         => element.commentTypeData.map(d => CommentBlockElement(d.html))
       case Table           => element.tableTypeData.map(d => TableBlockElement(d.html))
       case Witness         => element.witnessTypeData.map(d => WitnessBlockElement(d.html))


### PR DESCRIPTION
## What does this change?

Adds InteractiveBlockElement to the ArticlePicker - supported if the standard boot script is used (this is unlikely to modify the page, instead used for graphics, charts and maps).

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No - DCR supports these already

## Checklist

### Does this affect other platforms?

No

### Tested

- [X] Locally
- [ ] On CODE (optional)

