### PR TITLE
Check if creative templates are used

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -3,7 +3,6 @@ package conf.switches
 import conf.switches.Expiry.never
 import conf.switches.Owner.group
 import conf.switches.SwitchGroup.{Commercial, CommercialPrebid, Membership}
-import org.joda.time.LocalDate
 
 trait CommercialSwitches {
 
@@ -478,6 +477,16 @@ trait PrebidSwitches {
     description = "Include Mobile Sticky leaderboard banner in Prebid",
     owners = group(Commercial),
     safeState = On,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
+
+  val applyCreativeTemplate: Switch = Switch(
+    group = Commercial,
+    name = "apply-creative-template",
+    description = "Test what happens if we remove apply creative template code",
+    owners = group(Commercial),
+    safeState = Off,
     sellByDate = never,
     exposeClientSide = true,
   )

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -1,6 +1,5 @@
 import config from 'lib/config';
 import { catchErrorsWithContext } from 'lib/robust';
-import { markTime } from 'lib/user-timing';
 import reportError from 'lib/report-error';
 import { init as setAdTestCookie } from 'commercial/modules/set-adtest-cookie';
 import { init as initHighMerch } from 'commercial/modules/high-merch';
@@ -22,7 +21,6 @@ import { init as initPaidForBand } from 'commercial/modules/paidfor-band';
 import { init as initComscore } from 'commercial/modules/comscore';
 import { init as initIpsosMori } from 'commercial/modules/ipsos-mori';
 import { paidContainers } from 'commercial/modules/paid-containers';
-import { trackPerformance } from 'common/modules/analytics/google';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { initCommentAdverts } from 'commercial/modules/comment-adverts';
 import { initAdblockAsk } from 'common/modules/commercial/adblock-ask';

--- a/static/src/javascripts/projects/commercial/modules/dfp/apply-creative-template.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/apply-creative-template.js
@@ -1,12 +1,12 @@
 import fastdom from '../../../../lib/fastdom-promise';
 import reportError from '../../../../lib/report-error';
-
 import { Frame } from '../creatives/frame';
 import { FabricV1 } from '../creatives/fabric-v1';
 import { FabricExpandingV1 } from '../creatives/fabric-expanding-v1';
 import { FabricExpandableVideoV2 } from '../creatives/fabric-expandable-video-v2';
 import { FabricVideo } from '../creatives/fabric-video';
 import { ScrollableMpu } from '../creatives/scrollable-mpu-v2';
+import config from 'lib/config';
 
 const creativeLookup = {
     frame: Frame,
@@ -62,6 +62,16 @@ const renderCreativeTemplate = (
 
     const creativeConfig = fetchCreativeConfig();
 
+    if (config.get('switches.applyCreativeTemplate', false) && creativeConfig) {
+        reportError(
+            Error(`Apply Creative Templates is used: ${creativeConfig}`),
+            {
+                feature: 'commercial',
+            },
+            false
+        );
+    }
+
     if (creativeConfig) {
         return hideIframe()
             .then(() => JSON.parse(creativeConfig))
@@ -94,7 +104,7 @@ const getAdvertIframe = (adSlot) =>
         } else if (
             // According to Flow, readyState exists on the Document, not the HTMLIFrameElement
             // Is this different for old IE?
-            
+
             contentFrame.readyState &&
             contentFrame.readyState !== 'complete'
         ) {
@@ -102,7 +112,7 @@ const getAdvertIframe = (adSlot) =>
             const getIeIframe = e => {
                 const updatedIFrame = e.srcElement;
 
-                
+
                 if (updatedIFrame && updatedIFrame.readyState === 'complete') {
                     updatedIFrame.removeEventListener(
                         'readystatechange',


### PR DESCRIPTION
## What does this change?

Added a switch which if turned on and commercial template config is set, it will throw an expected error to be picked up in Sentry.

### Why?

We suspect this code is no longer used and it was a solution implemented before [commercial templates](https://github.com/guardian/commercial-templates) was introduced

We will turn the switch on for 10 minutes and check in sentry

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
