### PR TITLE
Allow Devs to attempt to run Frontend on Java 11

### DIFF
--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -15,7 +15,6 @@ import conf.Configuration
 import model.PressedPageType
 import org.joda.time.{DateTime, DateTimeZone}
 import play.api.libs.ws.{WSClient, WSRequest}
-import sun.misc.BASE64Encoder
 
 import scala.io.{Codec, Source}
 

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -36,8 +36,8 @@ object ProjectSettings {
     initialize := {
       val _ = initialize.value
       assert(
-        sys.props("java.specification.version") == "1.8",
-        "Java 8 is required for this project.",
+        Set("1.8", "11").contains(sys.props("java.specification.version")),
+        "Java 8 or 11 is required for this project.",
       )
     },
     cleanAll := Def.taskDyn {


### PR DESCRIPTION
## What does this change?

In February 2015, we added a check with PR https://github.com/guardian/frontend/pull/8448 that asserted Frontend _had_ to run under Java 8 (many developers didn't have it yet). This change amends that check, to permit developers to run their code locally under Java 11 if they want to - Java 11 use is gaining traction at the Guardian (eg https://github.com/guardian/ophan/pull/4047) as it has much better performance on ARM than Java 8.

## What is the value of this and can you measure success?

I just want to allow myself to use Java 11 now that I've updated my dev box to have it as the default! This doesn't require that DotCom Frontend moves to running on Java 11 in PROD, or Java 11 in CI (though it probably would be a good idea!)  - I just want to allow casual developers who have to run Frontend as part of something else the luxury of not switching back to Java 8 if they don't have to!

## Checklist

### Tested

- [x] Locally  - minimum testing
- [ ] On CODE (optional)

I was able to run these sbt commands:

```
project dev-build
run
```

...and get an article page served, I didn't look much further than that!