### PR TITLE
Update to Preact X

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,14 +38,11 @@
     "lodash-es": "^4.17.21",
     "object-fit-videos": "^1.0.3",
     "ophan-tracker-js": "1.3.23",
-    "preact": "^8.2.9",
-    "preact-compat": "^3.18.4",
+    "preact": "^10.5.13",
     "prebid.js": "https://github.com/guardian/Prebid.js#681fbb",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",
-    "react": "^16.8.3",
-    "react-dom": "16.7.0",
     "reqwest": "2.0.5",
     "video.js": "~5.3",
     "videojs-contrib-ads": "3.1.3",
@@ -127,7 +124,6 @@
     "pify": "^3.0.0",
     "postcss": "^6.0.10",
     "postcss-pxtorem": "^4.0.1",
-    "preact-x": "npm:preact@10.3.1",
     "prettier": "^2.2.1",
     "prettysize": "^0.1.0",
     "raw-loader": "^0.5.1",
@@ -191,8 +187,7 @@
       "^(.*)\\.svg$": "<rootDir>/__mocks__/svgMock.js",
       "^(.*)\\.html$": "<rootDir>/__mocks__/templateMock.js",
       "ophan/ng": "ophan-tracker-js",
-      "ophan/embed": "ophan-tracker-js/build/ophan.embed",
-      "preact/hooks": "preact-x/hooks"
+      "ophan/embed": "ophan-tracker-js/build/ophan.embed"
     },
     "testResultsProcessor": "jest-teamcity-reporter",
     "setupFilesAfterEnv": [

--- a/static/src/javascripts.flow.archive/bootstraps/enhanced/accessibility.js
+++ b/static/src/javascripts.flow.archive/bootstraps/enhanced/accessibility.js
@@ -11,109 +11,110 @@
  */
 
 // @flow
-import React, { Component, render } from 'preact-compat';
+import React, { Component, render } from 'react';
 
 import { saveState, isOn } from 'common/modules/accessibility/main';
 
 const DOM_ID: string = 'js-accessibility-preferences';
 
 type AccessibilityState = {
-    'flashing-elements': boolean,
+	'flashing-elements': boolean,
 };
 
 class BinaryToggle extends Component<*, *> {
-    render() {
-        return (
-            <div className="form-field">
-                <div className="checkbox">
-                    <label
-                        className="label"
-                        htmlFor={`checkbox-${this.props.name}`}>
-                        <input
-                            id={`checkbox-${this.props.name}`}
-                            key={this.props.name}
-                            type="checkbox"
-                            data-link-name={this.props.name}
-                            defaultChecked={this.props.enabled}
-                            onChange={this.props.handleChange.bind(this)}
-                            // TODO damn me when I decided to implement this page
-                            // global.css includes pasteup-forms 5 which applies ugly styles
-                            // on all inputs. The proper solution is to upgrade pasteup to 6
-                            // but I prefer to leave the pleasure to someone else
-                            // The style object should be removed once we upgrade. Never probably.
-                            style={{
-                                float: 'none',
-                                margin: '3px 0.5ex',
-                            }}
-                        />
-                        {this.props.label}
-                    </label>
-                </div>
-            </div>
-        );
-    }
+	render() {
+		return (
+			<div className="form-field">
+				<div className="checkbox">
+					<label
+						className="label"
+						htmlFor={`checkbox-${this.props.name}`}
+					>
+						<input
+							id={`checkbox-${this.props.name}`}
+							key={this.props.name}
+							type="checkbox"
+							data-link-name={this.props.name}
+							defaultChecked={this.props.enabled}
+							onChange={this.props.handleChange.bind(this)}
+							// TODO damn me when I decided to implement this page
+							// global.css includes pasteup-forms 5 which applies ugly styles
+							// on all inputs. The proper solution is to upgrade pasteup to 6
+							// but I prefer to leave the pleasure to someone else
+							// The style object should be removed once we upgrade. Never probably.
+							style={{
+								float: 'none',
+								margin: '3px 0.5ex',
+							}}
+						/>
+						{this.props.label}
+					</label>
+				</div>
+			</div>
+		);
+	}
 }
 
 class Accessibility extends Component<*, *> {
-    constructor() {
-        super();
-        this.state = ({
-            'flashing-elements': isOn('flashing-elements'),
-        }: AccessibilityState);
-    }
+	constructor() {
+		super();
+		this.state = ({
+			'flashing-elements': isOn('flashing-elements'),
+		}: AccessibilityState);
+	}
 
-    toggle(key: string): void {
-        const newState = {};
-        newState[key] = !this.state[key];
-        this.setState(newState, function() {
-            saveState(this.state);
-        });
-    }
+	toggle(key: string): void {
+		const newState = {};
+		newState[key] = !this.state[key];
+		this.setState(newState, function () {
+			saveState(this.state);
+		});
+	}
 
-    render(): Object {
-        return (
-            <form className="form">
-                <fieldset className="fieldset">
-                    <p key="p1">
-                        We aim to make this site accessible to a wide audience
-                        and to ensure a great experience for all users by
-                        conforming to World Wide Web Consortium accessibility
-                        guidelines (W3C&apos;s WCAG)
-                    </p>
-                    <p key="p2">
-                        However, if you are having trouble reading this website
-                        you can change the way it looks or disable some of its
-                        functionalities.
-                    </p>
-                    <BinaryToggle
-                        key="flashing-elements"
-                        name="flashing-elements"
-                        label={[
-                            <strong key="label">
-                                Allow flashing elements
-                            </strong>,
-                            this.state['flashing-elements']
-                                ? ' Untick this to disable flashing and moving elements'
-                                : ' Tick this to enable flashing or moving elements.',
-                        ]}
-                        enabled={this.state['flashing-elements']}
-                        handleChange={this.toggle.bind(
-                            this,
-                            'flashing-elements'
-                        )}
-                    />
-                </fieldset>
-            </form>
-        );
-    }
+	render(): Object {
+		return (
+			<form className="form">
+				<fieldset className="fieldset">
+					<p key="p1">
+						We aim to make this site accessible to a wide audience
+						and to ensure a great experience for all users by
+						conforming to World Wide Web Consortium accessibility
+						guidelines (W3C&apos;s WCAG)
+					</p>
+					<p key="p2">
+						However, if you are having trouble reading this website
+						you can change the way it looks or disable some of its
+						functionalities.
+					</p>
+					<BinaryToggle
+						key="flashing-elements"
+						name="flashing-elements"
+						label={[
+							<strong key="label">
+								Allow flashing elements
+							</strong>,
+							this.state['flashing-elements']
+								? ' Untick this to disable flashing and moving elements'
+								: ' Tick this to enable flashing or moving elements.',
+						]}
+						enabled={this.state['flashing-elements']}
+						handleChange={this.toggle.bind(
+							this,
+							'flashing-elements',
+						)}
+					/>
+				</fieldset>
+			</form>
+		);
+	}
 }
 
 const init = (callback: () => void): void => {
-    const el = document.getElementById(DOM_ID);
+	const el = document.getElementById(DOM_ID);
 
-    if (el) {
-        render(<Accessibility />, el, callback);
-    }
+	if (el) {
+		render(<Accessibility />, el, callback);
+	}
 };
 
 export { DOM_ID, init };

--- a/static/src/javascripts.flow.archive/bootstraps/enhanced/preferences.js
+++ b/static/src/javascripts.flow.archive/bootstraps/enhanced/preferences.js
@@ -11,106 +11,109 @@
  */
 
 // @flow
-import React, { Component, render } from 'preact-compat';
+import React, { Component, render } from 'react';
 import {
-    getPopularFiltered,
-    deleteFromSummary,
-    showInMegaNav,
-    showInMegaNavEnable,
-    showInMegaNavEnabled,
+	getPopularFiltered,
+	deleteFromSummary,
+	showInMegaNav,
+	showInMegaNavEnable,
+	showInMegaNavEnabled,
 } from 'common/modules/onward/history';
 
 class SummaryTagsList extends Component<*, *> {
-    constructor() {
-        super();
-        this.state = {
-            popular: getPopularFiltered(),
-        };
-    }
+	constructor() {
+		super();
+		this.state = {
+			popular: getPopularFiltered(),
+		};
+	}
 
-    handleRemove(tag: string) {
-        deleteFromSummary(tag);
-        this.setState({
-            popular: getPopularFiltered({ flush: true }),
-        });
-        showInMegaNav();
-    }
+	handleRemove(tag: string) {
+		deleteFromSummary(tag);
+		this.setState({
+			popular: getPopularFiltered({ flush: true }),
+		});
+		showInMegaNav();
+	}
 
-    render() {
-        const tagElements = this.state.popular.map(tag => (
-            <span
-                className="button button--small button--tag button--secondary"
-                key={tag[0]}>
-                <button
-                    onClick={this.handleRemove.bind(this, tag[0])}
-                    data-link-name={`remove | ${tag[1]}`}>
-                    X
-                </button>
-                <a href={`/${tag[0]}`}>{tag[1]}</a>
-            </span>
-        ));
+	render() {
+		const tagElements = this.state.popular.map((tag) => (
+			<span
+				className="button button--small button--tag button--secondary"
+				key={tag[0]}
+			>
+				<button
+					onClick={this.handleRemove.bind(this, tag[0])}
+					data-link-name={`remove | ${tag[1]}`}
+				>
+					X
+				</button>
+				<a href={`/${tag[0]}`}>{tag[1]}</a>
+			</span>
+		));
 
-        let helperText;
+		let helperText;
 
-        if (!tagElements.length) {
-            helperText = "(You don't have any recently visited topics.)";
-        } else {
-            helperText =
-                "Remove individual topics by clicking 'X' or switch off the functionality below. We respect your privacy and your shortcuts will never be made public.";
-        }
-        tagElements.push(<p key="helper-text">{helperText}</p>);
+		if (!tagElements.length) {
+			helperText = "(You don't have any recently visited topics.)";
+		} else {
+			helperText =
+				"Remove individual topics by clicking 'X' or switch off the functionality below. We respect your privacy and your shortcuts will never be made public.";
+		}
+		tagElements.push(<p key="helper-text">{helperText}</p>);
 
-        return <div>{tagElements}</div>;
-    }
+		return <div>{tagElements}</div>;
+	}
 }
 
 class SummaryTagsSettings extends Component<*, *> {
-    constructor() {
-        super();
-        this.state = {
-            enabled: showInMegaNavEnabled(),
-        };
-    }
+	constructor() {
+		super();
+		this.state = {
+			enabled: showInMegaNavEnabled(),
+		};
+	}
 
-    handleToggle() {
-        const isEnabled = !this.state.enabled;
+	handleToggle() {
+		const isEnabled = !this.state.enabled;
 
-        this.setState({
-            enabled: isEnabled,
-        });
-        showInMegaNavEnable(isEnabled);
-    }
+		this.setState({
+			enabled: isEnabled,
+		});
+		showInMegaNavEnable(isEnabled);
+	}
 
-    render() {
-        const toggleAction = this.state.enabled ? 'OFF' : 'ON';
+	render() {
+		const toggleAction = this.state.enabled ? 'OFF' : 'ON';
 
-        return (
-            <div data-link-name="suggested links">
-                <p>
-                    These are based on the topics you visit most. You can access
-                    them at any time by opening the &quot;all sections&quot;
-                    menu.
-                </p>
-                {this.state.enabled ? <SummaryTagsList /> : null}
-                <button
-                    onClick={this.handleToggle.bind(this)}
-                    className="button button--medium button--primary"
-                    data-link-name={toggleAction}>
-                    Switch recently visited links {toggleAction}
-                </button>
-            </div>
-        );
-    }
+		return (
+			<div data-link-name="suggested links">
+				<p>
+					These are based on the topics you visit most. You can access
+					them at any time by opening the &quot;all sections&quot;
+					menu.
+				</p>
+				{this.state.enabled ? <SummaryTagsList /> : null}
+				<button
+					onClick={this.handleToggle.bind(this)}
+					className="button button--medium button--primary"
+					data-link-name={toggleAction}
+				>
+					Switch recently visited links {toggleAction}
+				</button>
+			</div>
+		);
+	}
 }
 
 const init = (): void => {
-    const placeholder: ?HTMLElement = document.getElementById(
-        'preferences-history-tags'
-    );
+	const placeholder: ?HTMLElement = document.getElementById(
+		'preferences-history-tags',
+	);
 
-    if (placeholder) {
-        render(<SummaryTagsSettings />, placeholder);
-    }
+	if (placeholder) {
+		render(<SummaryTagsSettings />, placeholder);
+	}
 };
 
 export { init };

--- a/static/src/javascripts.flow.archive/projects/common/modules/crosswords/anagram-helper/clue-input.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/crosswords/anagram-helper/clue-input.js
@@ -11,55 +11,55 @@
  */
 
 // @flow
-import React, { Component, findDOMNode } from 'preact-compat';
+import React, { Component, findDOMNode } from 'react';
 
 class ClueInput extends Component<*, *> {
-    componentDidMount() {
-        const el: HTMLElement = (findDOMNode(this): any);
+	componentDidMount() {
+		const el: HTMLElement = (findDOMNode(this): any);
 
-        if (el) {
-            el.focus();
-        }
-    }
+		if (el) {
+			el.focus();
+		}
+	}
 
-    componentDidUpdate() {
-        const el: HTMLElement = (findDOMNode(this): any);
+	componentDidUpdate() {
+		const el: HTMLElement = (findDOMNode(this): any);
 
-        // focus on reset
-        if (this.props.value === '' && el) {
-            el.focus();
-        }
-    }
+		// focus on reset
+		if (this.props.value === '' && el) {
+			el.focus();
+		}
+	}
 
-    onInputChange(e: Event) {
-        if (!(e.target instanceof HTMLInputElement)) {
-            return;
-        }
-        this.props.onChange(e.target.value.toLowerCase());
-    }
+	onInputChange(e: Event) {
+		if (!(e.target instanceof HTMLInputElement)) {
+			return;
+		}
+		this.props.onChange(e.target.value.toLowerCase());
+	}
 
-    onKeyDown(e: KeyboardEvent) {
-        const el: HTMLElement = (findDOMNode(this): any);
+	onKeyDown(e: KeyboardEvent) {
+		const el: HTMLElement = (findDOMNode(this): any);
 
-        if (e.keyCode === 13 && el) {
-            el.blur();
-            this.props.onEnter();
-        }
-    }
+		if (e.keyCode === 13 && el) {
+			el.blur();
+			this.props.onEnter();
+		}
+	}
 
-    render() {
-        return (
-            <input
-                type="text"
-                className="crossword__anagram-helper__clue-input"
-                placeholder="Enter letters"
-                maxLength={this.props.clue.length}
-                value={this.props.value}
-                onChange={this.onInputChange.bind(this)}
-                onKeyDown={this.onKeyDown.bind(this)}
-            />
-        );
-    }
+	render() {
+		return (
+			<input
+				type="text"
+				className="crossword__anagram-helper__clue-input"
+				placeholder="Enter letters"
+				maxLength={this.props.clue.length}
+				value={this.props.value}
+				onChange={this.onInputChange.bind(this)}
+				onKeyDown={this.onKeyDown.bind(this)}
+			/>
+		);
+	}
 }
 
 export { ClueInput };

--- a/static/src/javascripts.flow.archive/projects/common/modules/crosswords/anagram-helper/clue-preview.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/crosswords/anagram-helper/clue-preview.js
@@ -11,92 +11,94 @@
  */
 
 // @flow
-import React, { Component } from 'preact-compat';
+import React, { Component } from 'react';
 
 type WordSeparator = ',' | '-';
 
 // Checks a object in the form{",":[4,7]}
 const checkIfLetterHasSeparator = (
-    locations: { [k: WordSeparator]: number[] },
-    letterIndex: number
+	locations: { [k: WordSeparator]: number[] },
+	letterIndex: number,
 ): string => {
-    const spaces = locations[','];
-    const letterHasBoundary = (separators: number[]): boolean =>
-        separators.includes(letterIndex);
+	const spaces = locations[','];
+	const letterHasBoundary = (separators: number[]): boolean =>
+		separators.includes(letterIndex);
 
-    if (spaces && letterHasBoundary(spaces)) {
-        return 'crossword__anagram-helper__cell crossword__anagram-helper__cell--with-space';
-    }
+	if (spaces && letterHasBoundary(spaces)) {
+		return 'crossword__anagram-helper__cell crossword__anagram-helper__cell--with-space';
+	}
 
-    const dashes = locations['-'];
-    if (dashes && letterHasBoundary(dashes)) {
-        return 'crossword__anagram-helper__cell crossword__anagram-helper__cell--with-hyphen';
-    }
+	const dashes = locations['-'];
+	if (dashes && letterHasBoundary(dashes)) {
+		return 'crossword__anagram-helper__cell crossword__anagram-helper__cell--with-hyphen';
+	}
 
-    return 'crossword__anagram-helper__cell';
+	return 'crossword__anagram-helper__cell';
 };
 
 class CluePreview extends Component<*, *> {
-    /**
-     * Get the entries for the preview cells: first filter the user's input to
-     * remove anything anything that's already been entered into the grid.
-     *
-     * With that, we map over the entries, and wherever there's an empty space
-     * we insert one of the shuffled input characters.
-     *
-     * If the user hasn't yet clicked 'shuffle' (this.props.hasShuffled) just
-     * display the entries as they are, preserving any blank spaces.
-     */
-    getEntries(): Object[] {
-        const unsolved = this.props.letters.filter(l => !l.entered);
+	/**
+	 * Get the entries for the preview cells: first filter the user's input to
+	 * remove anything anything that's already been entered into the grid.
+	 *
+	 * With that, we map over the entries, and wherever there's an empty space
+	 * we insert one of the shuffled input characters.
+	 *
+	 * If the user hasn't yet clicked 'shuffle' (this.props.hasShuffled) just
+	 * display the entries as they are, preserving any blank spaces.
+	 */
+	getEntries(): Object[] {
+		const unsolved = this.props.letters.filter((l) => !l.entered);
 
-        return this.props.entries.map(entry => {
-            entry.solved = !!entry.value;
+		return this.props.entries.map((entry) => {
+			entry.solved = !!entry.value;
 
-            const returnVal = this.props.hasShuffled
-                ? (entry.value && entry) || unsolved.shift()
-                : entry;
+			const returnVal = this.props.hasShuffled
+				? (entry.value && entry) || unsolved.shift()
+				: entry;
 
-            return Object.assign({}, { key: entry.key }, returnVal);
-        });
-    }
+			return Object.assign({}, { key: entry.key }, returnVal);
+		});
+	}
 
-    render() {
-        const entries = this.getEntries();
+	render() {
+		const entries = this.getEntries();
 
-        return (
-            <div
-                className={`crossword__anagram-helper__clue-preview ${
-                    entries.length >= 9 ? 'long' : ''
-                }`}>
-                <div>
-                    <strong>
-                        {this.props.clue.number}{' '}
-                        <span className="crossword__anagram-helper__direction">
-                            {this.props.clue.direction}
-                        </span>
-                    </strong>{' '}
-                    {this.props.clue.clue}
-                </div>
-                {entries.map((entry: Object, i: number) => {
-                    const classNames = checkIfLetterHasSeparator(
-                        this.props.clue.separatorLocations,
-                        i + 1
-                    ); // Separators are one indexed in CAPI, annoyingly
+		return (
+			<div
+				className={`crossword__anagram-helper__clue-preview ${
+					entries.length >= 9 ? 'long' : ''
+				}`}
+			>
+				<div>
+					<strong>
+						{this.props.clue.number}{' '}
+						<span className="crossword__anagram-helper__direction">
+							{this.props.clue.direction}
+						</span>
+					</strong>{' '}
+					{this.props.clue.clue}
+				</div>
+				{entries.map((entry: Object, i: number) => {
+					const classNames = checkIfLetterHasSeparator(
+						this.props.clue.separatorLocations,
+						i + 1,
+					); // Separators are one indexed in CAPI, annoyingly
 
-                    return (
-                        <span
-                            className={
-                                classNames + (entry.solved ? ' has-value' : '')
-                            }
-                            key={entry.key}>
-                            {entry.value || ''}
-                        </span>
-                    );
-                })}
-            </div>
-        );
-    }
+					return (
+						<span
+							className={
+								classNames + (entry.solved ? ' has-value' : '')
+							}
+							key={entry.key}
+						>
+							{entry.value || ''}
+						</span>
+					);
+				})}
+			</div>
+		);
+	}
 }
 
 export { CluePreview };

--- a/static/src/javascripts.flow.archive/projects/common/modules/crosswords/anagram-helper/main.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/crosswords/anagram-helper/main.js
@@ -11,11 +11,11 @@
  */
 
 // @flow
-import React, { Component } from 'preact-compat';
+import React, { Component } from 'react';
 import { markup as closeCentralIcon } from 'svgs/icon/close-central.svg';
 import {
-    cellsForClue,
-    getAnagramClueData,
+	cellsForClue,
+	getAnagramClueData,
 } from 'common/modules/crosswords/helpers';
 import shuffle from 'lodash/shuffle';
 import { ClueInput } from './clue-input';
@@ -23,163 +23,166 @@ import { CluePreview } from './clue-preview';
 import { Ring } from './ring';
 
 class AnagramHelper extends Component<*, *> {
-    constructor() {
-        super();
-        this.state = {
-            clueInput: '',
-            showInput: true,
-        };
-    }
+	constructor() {
+		super();
+		this.state = {
+			clueInput: '',
+			showInput: true,
+		};
+	}
 
-    componentWillReceiveProps(next: Object) {
-        // reset on clue change
-        if (next.clue !== this.props.focussedEntry) {
-            this.reset();
-        }
-    }
+	componentWillReceiveProps(next: Object) {
+		// reset on clue change
+		if (next.clue !== this.props.focussedEntry) {
+			this.reset();
+		}
+	}
 
-    onClueInput(text: string) {
-        if (!/\s|\d/g.test(text)) {
-            this.setState({
-                clueInput: text,
-            });
-        }
-    }
+	onClueInput(text: string) {
+		if (!/\s|\d/g.test(text)) {
+			this.setState({
+				clueInput: text,
+			});
+		}
+	}
 
-    /**
-     * Shuffle the letters in the user's input.
-     *
-     * First, create an array of input characters that have already been entered
-     * into the grid. Then build a new collection of letters, using the first
-     * array to flag letters that are already entered in the puzzle, and
-     * shuffle it.
-     *
-     */
-    // eslint-disable-next-line class-methods-use-this
-    shuffleWord(
-        word: string,
-        entries: { value: string }[]
-    ): Array<{ value: string, entered: boolean }> {
-        const wordEntries = entries
-            .map(entry => entry.value.toLowerCase())
-            .filter(entry => word.includes(entry))
-            .filter(Boolean)
-            .sort();
+	/**
+	 * Shuffle the letters in the user's input.
+	 *
+	 * First, create an array of input characters that have already been entered
+	 * into the grid. Then build a new collection of letters, using the first
+	 * array to flag letters that are already entered in the puzzle, and
+	 * shuffle it.
+	 *
+	 */
+	// eslint-disable-next-line class-methods-use-this
+	shuffleWord(
+		word: string,
+		entries: { value: string }[],
+	): Array<{ value: string, entered: boolean }> {
+		const wordEntries = entries
+			.map((entry) => entry.value.toLowerCase())
+			.filter((entry) => word.includes(entry))
+			.filter(Boolean)
+			.sort();
 
-        return shuffle(
-            word
-                .trim()
-                .split('')
-                .sort()
-                .reduce(
-                    (acc, letter) => {
-                        const [head, ...tail] = acc.entries;
-                        const entered = head === letter.toLowerCase();
+		return shuffle(
+			word
+				.trim()
+				.split('')
+				.sort()
+				.reduce(
+					(acc, letter) => {
+						const [head, ...tail] = acc.entries;
+						const entered = head === letter.toLowerCase();
 
-                        return {
-                            letters: acc.letters.concat({
-                                value: letter,
-                                entered,
-                            }),
-                            entries: entered ? tail : acc.entries,
-                        };
-                    },
-                    {
-                        letters: [],
-                        entries: wordEntries,
-                    }
-                ).letters
-        );
-    }
+						return {
+							letters: acc.letters.concat({
+								value: letter,
+								entered,
+							}),
+							entries: entered ? tail : acc.entries,
+						};
+					},
+					{
+						letters: [],
+						entries: wordEntries,
+					},
+				).letters,
+		);
+	}
 
-    shuffle() {
-        if (this.canShuffle()) {
-            this.setState({
-                showInput: false,
-            });
-        }
-    }
+	shuffle() {
+		if (this.canShuffle()) {
+			this.setState({
+				showInput: false,
+			});
+		}
+	}
 
-    reset() {
-        if (this.state.clueInput) {
-            this.setState({
-                clueInput: '',
-                showInput: true,
-            });
-        }
-    }
+	reset() {
+		if (this.state.clueInput) {
+			this.setState({
+				clueInput: '',
+				showInput: true,
+			});
+		}
+	}
 
-    canShuffle(): boolean {
-        return !!this.state.clueInput && this.state.clueInput.length > 0;
-    }
+	canShuffle(): boolean {
+		return !!this.state.clueInput && this.state.clueInput.length > 0;
+	}
 
-    render() {
-        const closeIcon = {
-            __html: closeCentralIcon,
-        };
-        const clue = getAnagramClueData(
-            this.props.entries,
-            this.props.focussedEntry
-        );
-        const cells = cellsForClue(
-            this.props.entries,
-            this.props.focussedEntry
-        );
-        const entries = cells.map(coords =>
-            Object.assign({}, this.props.grid[coords.x][coords.y], {
-                key: `${coords.x},${coords.y}`,
-            })
-        );
+	render() {
+		const closeIcon = {
+			__html: closeCentralIcon,
+		};
+		const clue = getAnagramClueData(
+			this.props.entries,
+			this.props.focussedEntry,
+		);
+		const cells = cellsForClue(
+			this.props.entries,
+			this.props.focussedEntry,
+		);
+		const entries = cells.map((coords) =>
+			Object.assign({}, this.props.grid[coords.x][coords.y], {
+				key: `${coords.x},${coords.y}`,
+			}),
+		);
 
-        const letters = this.shuffleWord(this.state.clueInput, entries);
+		const letters = this.shuffleWord(this.state.clueInput, entries);
 
-        const inner = this.state.showInput ? (
-            <ClueInput
-                value={this.state.clueInput}
-                clue={clue}
-                onChange={this.onClueInput.bind(this)}
-                onEnter={this.shuffle.bind(this)}
-            />
-        ) : (
-            <Ring letters={letters} />
-        );
+		const inner = this.state.showInput ? (
+			<ClueInput
+				value={this.state.clueInput}
+				clue={clue}
+				onChange={this.onClueInput.bind(this)}
+				onEnter={this.shuffle.bind(this)}
+			/>
+		) : (
+			<Ring letters={letters} />
+		);
 
-        return (
-            <div
-                className="crossword__anagram-helper-outer"
-                data-link-name="Anagram Helper">
-                <div className="crossword__anagram-helper-inner">{inner}</div>
-                <button
-                    className="button button--large button--tertiary crossword__anagram-helper-close"
-                    onClick={this.props.close.bind(this.props.crossword)}
-                    dangerouslySetInnerHTML={closeIcon}
-                    data-link-name="Close"
-                />
-                <button
-                    className={`button button--large ${
-                        !this.state.clueInput ? 'button--tertiary' : ''
-                    }`}
-                    onClick={this.reset.bind(this)}
-                    data-link-name="Start Again">
-                    start again
-                </button>
-                <button
-                    className={`button button--large ${
-                        this.canShuffle() ? '' : 'button--tertiary'
-                    }`}
-                    onClick={this.shuffle.bind(this)}
-                    data-link-name="Shuffle">
-                    shuffle
-                </button>
-                <CluePreview
-                    clue={clue}
-                    entries={entries}
-                    letters={letters}
-                    hasShuffled={!this.state.showInput}
-                />
-            </div>
-        );
-    }
+		return (
+			<div
+				className="crossword__anagram-helper-outer"
+				data-link-name="Anagram Helper"
+			>
+				<div className="crossword__anagram-helper-inner">{inner}</div>
+				<button
+					className="button button--large button--tertiary crossword__anagram-helper-close"
+					onClick={this.props.close.bind(this.props.crossword)}
+					dangerouslySetInnerHTML={closeIcon}
+					data-link-name="Close"
+				/>
+				<button
+					className={`button button--large ${
+						!this.state.clueInput ? 'button--tertiary' : ''
+					}`}
+					onClick={this.reset.bind(this)}
+					data-link-name="Start Again"
+				>
+					start again
+				</button>
+				<button
+					className={`button button--large ${
+						this.canShuffle() ? '' : 'button--tertiary'
+					}`}
+					onClick={this.shuffle.bind(this)}
+					data-link-name="Shuffle"
+				>
+					shuffle
+				</button>
+				<CluePreview
+					clue={clue}
+					entries={entries}
+					letters={letters}
+					hasShuffled={!this.state.showInput}
+				/>
+			</div>
+		);
+	}
 }
 
 export { AnagramHelper };

--- a/static/src/javascripts.flow.archive/projects/common/modules/crosswords/anagram-helper/ring.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/crosswords/anagram-helper/ring.js
@@ -11,9 +11,9 @@
  */
 
 // @flow
-import React, { Component } from 'preact-compat';
+import React, { Component } from 'react';
 
-const round = x => Math.round(x * 100) / 100;
+const round = (x) => Math.round(x * 100) / 100;
 /**
  * Get coordinates for a letter as percentages.
  *
@@ -21,38 +21,39 @@ const round = x => Math.round(x * 100) / 100;
  *   (width of .crossword__anagram-helper-shuffler) - (2 * desired padding)
  */
 const getPosition = (
-    angle: number,
-    i: number
+	angle: number,
+	i: number,
 ): { left: string, top: string } => {
-    const diameter = 40;
-    const theta = ((angle * Math.PI) / 180) * i;
+	const diameter = 40;
+	const theta = ((angle * Math.PI) / 180) * i;
 
-    return {
-        left: `${diameter + round(diameter * Math.sin(theta))}%`,
-        top: `${diameter + round(diameter * Math.cos(theta))}%`,
-    };
+	return {
+		left: `${diameter + round(diameter * Math.sin(theta))}%`,
+		top: `${diameter + round(diameter * Math.cos(theta))}%`,
+	};
 };
 
 class Ring extends Component<*, *> {
-    render() {
-        const angle = 360 / this.props.letters.length;
+	render() {
+		const angle = 360 / this.props.letters.length;
 
-        return (
-            <div className="crossword__anagram-helper-shuffler">
-                {this.props.letters.map((letter, i) => (
-                    <div
-                        className={`crossword__anagram-helper-shuffler__letter ${
-                            letter.entered ? 'entered' : ''
-                        }`}
-                        style={getPosition(angle, i)}
-                        // eslint-disable-next-line react/no-array-index-key
-                        key={`${letter.value}-${i}`}>
-                        {letter.value}
-                    </div>
-                ))}
-            </div>
-        );
-    }
+		return (
+			<div className="crossword__anagram-helper-shuffler">
+				{this.props.letters.map((letter, i) => (
+					<div
+						className={`crossword__anagram-helper-shuffler__letter ${
+							letter.entered ? 'entered' : ''
+						}`}
+						style={getPosition(angle, i)}
+						// eslint-disable-next-line react/no-array-index-key
+						key={`${letter.value}-${i}`}
+					>
+						{letter.value}
+					</div>
+				))}
+			</div>
+		);
+	}
 }
 
 export { Ring };

--- a/static/src/javascripts.flow.archive/projects/common/modules/crosswords/cell.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/crosswords/cell.js
@@ -11,71 +11,73 @@
  */
 
 // @flow
-import React, { Component } from 'preact-compat';
+import React, { Component } from 'react';
 import { gridSize } from 'common/modules/crosswords/helpers';
 import { constants } from 'common/modules/crosswords/constants';
 import { classNames } from 'common/modules/crosswords/classNames';
 
 class Cell extends Component<*, *> {
-    onClick(event: Event) {
-        event.preventDefault();
-        this.props.handleSelect(this.props.x, this.props.y);
-    }
+	onClick(event: Event) {
+		event.preventDefault();
+		this.props.handleSelect(this.props.x, this.props.y);
+	}
 
-    render() {
-        const top = gridSize(this.props.y);
-        const left = gridSize(this.props.x);
+	render() {
+		const top = gridSize(this.props.y);
+		const left = gridSize(this.props.x);
 
-        let cellNumber = null;
-        if (this.props.number !== undefined) {
-            cellNumber = (
-                <text
-                    x={left + 1}
-                    y={top + constants.numberSize}
-                    key="number"
-                    className="crossword__cell-number">
-                    {this.props.number}
-                </text>
-            );
-        }
+		let cellNumber = null;
+		if (this.props.number !== undefined) {
+			cellNumber = (
+				<text
+					x={left + 1}
+					y={top + constants.numberSize}
+					key="number"
+					className="crossword__cell-number"
+				>
+					{this.props.number}
+				</text>
+			);
+		}
 
-        let cellValue = null;
-        if (this.props.value !== undefined) {
-            cellValue = (
-                <text
-                    x={left + constants.cellSize * 0.5}
-                    y={top + constants.cellSize * 0.675}
-                    key="entry"
-                    className={classNames({
-                        'crossword__cell-text': true,
-                        'crossword__cell-text--focussed': this.props.isFocussed,
-                        'crossword__cell-text--error': this.props.isError,
-                    })}
-                    textAnchor="middle">
-                    {this.props.value}
-                </text>
-            );
-        }
+		let cellValue = null;
+		if (this.props.value !== undefined) {
+			cellValue = (
+				<text
+					x={left + constants.cellSize * 0.5}
+					y={top + constants.cellSize * 0.675}
+					key="entry"
+					className={classNames({
+						'crossword__cell-text': true,
+						'crossword__cell-text--focussed': this.props.isFocussed,
+						'crossword__cell-text--error': this.props.isError,
+					})}
+					textAnchor="middle"
+				>
+					{this.props.value}
+				</text>
+			);
+		}
 
-        return (
-            <g onClick={this.onClick.bind(this)}>
-                <rect
-                    x={left}
-                    y={top}
-                    width={constants.cellSize}
-                    height={constants.cellSize}
-                    className={classNames({
-                        crossword__cell: true,
-                        'crossword__cell--focussed': this.props.isFocussed,
-                        'crossword__cell--highlighted': this.props
-                            .isHighlighted,
-                    })}
-                />
-                {cellNumber}
-                {cellValue}
-            </g>
-        );
-    }
+		return (
+			<g onClick={this.onClick.bind(this)}>
+				<rect
+					x={left}
+					y={top}
+					width={constants.cellSize}
+					height={constants.cellSize}
+					className={classNames({
+						crossword__cell: true,
+						'crossword__cell--focussed': this.props.isFocussed,
+						'crossword__cell--highlighted': this.props
+							.isHighlighted,
+					})}
+				/>
+				{cellNumber}
+				{cellValue}
+			</g>
+		);
+	}
 }
 
 export default Cell;

--- a/static/src/javascripts.flow.archive/projects/common/modules/crosswords/clues.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/crosswords/clues.js
@@ -11,7 +11,7 @@
  */
 
 // @flow
-import React, { Component, findDOMNode } from 'preact-compat';
+import React, { Component, findDOMNode } from 'react';
 import bean from 'bean';
 import fastdom from 'fastdom';
 import { classNames } from 'common/modules/crosswords/classNames';
@@ -19,146 +19,149 @@ import { isBreakpoint } from 'lib/detect';
 import { scrollTo } from 'lib/scroller';
 
 class Clue extends Component<*, *> {
-    onClick() {
-        this.props.setReturnPosition();
-    }
+	onClick() {
+		this.props.setReturnPosition();
+	}
 
-    render() {
-        return (
-            <li>
-                <a
-                    href={`#${this.props.id}`}
-                    onClick={this.onClick.bind(this)}
-                    className={classNames({
-                        crossword__clue: true,
-                        'crossword__clue--answered': this.props.hasAnswered,
-                        'crossword__clue--selected': this.props.isSelected,
-                        'crossword__clue--display-group-order':
-                            JSON.stringify(this.props.number) !==
-                            this.props.humanNumber,
-                    })}>
-                    <div className="crossword__clue__number">
-                        {this.props.humanNumber}
-                    </div>
-                    <div
-                        className="crossword__clue__text"
-                        dangerouslySetInnerHTML={{ __html: this.props.clue }}
-                    />
-                </a>
-            </li>
-        );
-    }
+	render() {
+		return (
+			<li>
+				<a
+					href={`#${this.props.id}`}
+					onClick={this.onClick.bind(this)}
+					className={classNames({
+						crossword__clue: true,
+						'crossword__clue--answered': this.props.hasAnswered,
+						'crossword__clue--selected': this.props.isSelected,
+						'crossword__clue--display-group-order':
+							JSON.stringify(this.props.number) !==
+							this.props.humanNumber,
+					})}
+				>
+					<div className="crossword__clue__number">
+						{this.props.humanNumber}
+					</div>
+					<div
+						className="crossword__clue__text"
+						dangerouslySetInnerHTML={{ __html: this.props.clue }}
+					/>
+				</a>
+			</li>
+		);
+	}
 }
 
 class Clues extends Component<*, *> {
-    constructor(props: Object) {
-        super(props);
-        this.state = {
-            showGradient: true,
-        };
-    }
+	constructor(props: Object) {
+		super(props);
+		this.state = {
+			showGradient: true,
+		};
+	}
 
-    componentDidMount() {
-        this.$cluesNode = (findDOMNode(this.clues): any);
+	componentDidMount() {
+		this.$cluesNode = (findDOMNode(this.clues): any);
 
-        const height =
-            this.$cluesNode.scrollHeight - this.$cluesNode.clientHeight;
+		const height =
+			this.$cluesNode.scrollHeight - this.$cluesNode.clientHeight;
 
-        bean.on(this.$cluesNode, 'scroll', e => {
-            const showGradient = height - e.currentTarget.scrollTop > 25;
+		bean.on(this.$cluesNode, 'scroll', (e) => {
+			const showGradient = height - e.currentTarget.scrollTop > 25;
 
-            if (this.state.showGradient !== showGradient) {
-                this.setState({
-                    showGradient,
-                });
-            }
-        });
-    }
+			if (this.state.showGradient !== showGradient) {
+				this.setState({
+					showGradient,
+				});
+			}
+		});
+	}
 
-    /**
-     * Scroll clues into view when they're activated (i.e. clicked in the grid)
-     */
-    componentDidUpdate(prev: Object) {
-        if (
-            isBreakpoint({
-                min: 'tablet',
-                max: 'leftCol',
-            }) &&
-            (this.props.focussed &&
-                (!prev.focussed || prev.focussed.id !== this.props.focussed.id))
-        ) {
-            fastdom.measure(() => {
-                this.scrollIntoView(this.props.focussed);
-            });
-        }
-    }
+	/**
+	 * Scroll clues into view when they're activated (i.e. clicked in the grid)
+	 */
+	componentDidUpdate(prev: Object) {
+		if (
+			isBreakpoint({
+				min: 'tablet',
+				max: 'leftCol',
+			}) &&
+			this.props.focussed &&
+			(!prev.focussed || prev.focussed.id !== this.props.focussed.id)
+		) {
+			fastdom.measure(() => {
+				this.scrollIntoView(this.props.focussed);
+			});
+		}
+	}
 
-    $cluesNode: HTMLElement;
+	$cluesNode: HTMLElement;
 
-    scrollIntoView(clue: Object) {
-        const buffer = 100;
-        const node: HTMLElement = (findDOMNode(this[clue.id]): any);
-        const visible =
-            node.offsetTop - buffer > this.$cluesNode.scrollTop &&
-            node.offsetTop + buffer <
-                this.$cluesNode.scrollTop + this.$cluesNode.clientHeight;
+	scrollIntoView(clue: Object) {
+		const buffer = 100;
+		const node: HTMLElement = (findDOMNode(this[clue.id]): any);
+		const visible =
+			node.offsetTop - buffer > this.$cluesNode.scrollTop &&
+			node.offsetTop + buffer <
+				this.$cluesNode.scrollTop + this.$cluesNode.clientHeight;
 
-        if (!visible) {
-            const offset = node.offsetTop - this.$cluesNode.clientHeight / 2;
-            scrollTo(offset, 250, 'easeOutQuad', this.$cluesNode);
-        }
-    }
+		if (!visible) {
+			const offset = node.offsetTop - this.$cluesNode.clientHeight / 2;
+			scrollTo(offset, 250, 'easeOutQuad', this.$cluesNode);
+		}
+	}
 
-    render() {
-        const headerClass = 'crossword__clues-header';
-        const cluesByDirection = direction =>
-            this.props.clues
-                .filter(clue => clue.entry.direction === direction)
-                .map(clue => (
-                    <Clue
-                        ref={clueRef => {
-                            this[clue.entry.id] = clueRef;
-                        }}
-                        id={clue.entry.id}
-                        key={clue.entry.id}
-                        number={clue.entry.number}
-                        humanNumber={clue.entry.humanNumber}
-                        clue={clue.entry.clue}
-                        hasAnswered={clue.hasAnswered}
-                        isSelected={clue.isSelected}
-                        setReturnPosition={() => {
-                            this.props.setReturnPosition(window.scrollY);
-                        }}
-                    />
-                ));
+	render() {
+		const headerClass = 'crossword__clues-header';
+		const cluesByDirection = (direction) =>
+			this.props.clues
+				.filter((clue) => clue.entry.direction === direction)
+				.map((clue) => (
+					<Clue
+						ref={(clueRef) => {
+							this[clue.entry.id] = clueRef;
+						}}
+						id={clue.entry.id}
+						key={clue.entry.id}
+						number={clue.entry.number}
+						humanNumber={clue.entry.humanNumber}
+						clue={clue.entry.clue}
+						hasAnswered={clue.hasAnswered}
+						isSelected={clue.isSelected}
+						setReturnPosition={() => {
+							this.props.setReturnPosition(window.scrollY);
+						}}
+					/>
+				));
 
-        return (
-            <div
-                className={`crossword__clues--wrapper ${
-                    this.state.showGradient ? '' : 'hide-gradient'
-                }`}>
-                <div
-                    className="crossword__clues"
-                    ref={clues => {
-                        this.clues = clues;
-                    }}>
-                    <div className="crossword__clues--across">
-                        <h3 className={headerClass}>Across</h3>
-                        <ol className="crossword__clues-list">
-                            {cluesByDirection('across')}
-                        </ol>
-                    </div>
-                    <div className="crossword__clues--down">
-                        <h3 className={headerClass}>Down</h3>
-                        <ol className="crossword__clues-list">
-                            {cluesByDirection('down')}
-                        </ol>
-                    </div>
-                </div>
-                <div className="crossword__clues__gradient" />
-            </div>
-        );
-    }
+		return (
+			<div
+				className={`crossword__clues--wrapper ${
+					this.state.showGradient ? '' : 'hide-gradient'
+				}`}
+			>
+				<div
+					className="crossword__clues"
+					ref={(clues) => {
+						this.clues = clues;
+					}}
+				>
+					<div className="crossword__clues--across">
+						<h3 className={headerClass}>Across</h3>
+						<ol className="crossword__clues-list">
+							{cluesByDirection('across')}
+						</ol>
+					</div>
+					<div className="crossword__clues--down">
+						<h3 className={headerClass}>Down</h3>
+						<ol className="crossword__clues-list">
+							{cluesByDirection('down')}
+						</ol>
+					</div>
+				</div>
+				<div className="crossword__clues__gradient" />
+			</div>
+		);
+	}
 }
 
 export { Clues };

--- a/static/src/javascripts.flow.archive/projects/common/modules/crosswords/confirm-button.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/crosswords/confirm-button.js
@@ -11,58 +11,58 @@
  */
 
 // @flow
-import React, { Component } from 'preact-compat';
+import React, { Component } from 'react';
 import { classNames } from 'common/modules/crosswords/classNames';
 
 const timeout = 2000;
 
 class ConfirmButton extends Component<*, *> {
-    constructor(props: {}) {
-        super(props);
-        this.state = {
-            confirming: false,
-        };
-    }
+	constructor(props: {}) {
+		super(props);
+		this.state = {
+			confirming: false,
+		};
+	}
 
-    confirm() {
-        if (this.state.confirming) {
-            this.setState({
-                confirming: false,
-            });
-            this.props.onClick();
-        } else {
-            this.setState({
-                confirming: true,
-            });
-            setTimeout(() => {
-                this.setState({
-                    confirming: false,
-                });
-            }, timeout);
-        }
-    }
+	confirm() {
+		if (this.state.confirming) {
+			this.setState({
+				confirming: false,
+			});
+			this.props.onClick();
+		} else {
+			this.setState({
+				confirming: true,
+			});
+			setTimeout(() => {
+				this.setState({
+					confirming: false,
+				});
+			}, timeout);
+		}
+	}
 
-    render() {
-        const inner = this.state.confirming
-            ? `Confirm ${this.props.text.toLowerCase()}`
-            : this.props.text;
+	render() {
+		const inner = this.state.confirming
+			? `Confirm ${this.props.text.toLowerCase()}`
+			: this.props.text;
 
-        const classes = {};
-        const className = classNames(
-            ((classes[
-                'crossword__controls__button--confirm'
-            ] = this.state.confirming),
-            (classes[this.props.className] = true),
-            classes)
-        );
-        const props = {
-            'data-link-name': this.props['data-link-name'],
-            onClick: this.confirm.bind(this),
-            className,
-        };
+		const classes = {};
+		const className = classNames(
+			((classes[
+				'crossword__controls__button--confirm'
+			] = this.state.confirming),
+			(classes[this.props.className] = true),
+			classes),
+		);
+		const props = {
+			'data-link-name': this.props['data-link-name'],
+			onClick: this.confirm.bind(this),
+			className,
+		};
 
-        return <button {...props}>{inner}</button>;
-    }
+		return <button {...props}>{inner}</button>;
+	}
 }
 
 export { ConfirmButton };

--- a/static/src/javascripts.flow.archive/projects/common/modules/crosswords/controls.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/crosswords/controls.js
@@ -11,7 +11,7 @@
  */
 
 // @flow
-import React, { Component } from 'preact-compat';
+import React, { Component } from 'react';
 import { ConfirmButton } from 'common/modules/crosswords/confirm-button';
 
 const buttonClassName = 'button button--primary';
@@ -19,115 +19,119 @@ const buttonCurrentClassName = 'button--crossword--current';
 const buttonGenericClassName = 'button--secondary';
 
 class Controls extends Component<*, *> {
-    render() {
-        const hasSolutions = this.props.hasSolutions;
-        const hasFocus = this.props.clueInFocus;
-        const controls = {
-            clue: [],
-            grid: [],
-        };
+	render() {
+		const hasSolutions = this.props.hasSolutions;
+		const hasFocus = this.props.clueInFocus;
+		const controls = {
+			clue: [],
+			grid: [],
+		};
 
-        // GRID CONTROLS
-        controls.grid.unshift(
-            <ConfirmButton
-                className={`${buttonClassName} ${buttonGenericClassName}`}
-                onClick={this.props.crossword.onClearAll.bind(
-                    this.props.crossword
-                )}
-                key="clear"
-                data-link-name="Clear all"
-                text="Clear all"
-            />
-        );
+		// GRID CONTROLS
+		controls.grid.unshift(
+			<ConfirmButton
+				className={`${buttonClassName} ${buttonGenericClassName}`}
+				onClick={this.props.crossword.onClearAll.bind(
+					this.props.crossword,
+				)}
+				key="clear"
+				data-link-name="Clear all"
+				text="Clear all"
+			/>,
+		);
 
-        if (hasSolutions) {
-            controls.grid.unshift(
-                <ConfirmButton
-                    className={`${buttonClassName} ${buttonGenericClassName}`}
-                    onClick={this.props.crossword.onSolution.bind(
-                        this.props.crossword
-                    )}
-                    key="solution"
-                    data-link-name="Reveal all"
-                    text="Reveal all"
-                />
-            );
-            controls.grid.unshift(
-                <ConfirmButton
-                    className={`${buttonClassName} ${buttonGenericClassName}`}
-                    onClick={this.props.crossword.onCheckAll.bind(
-                        this.props.crossword
-                    )}
-                    key="checkAll"
-                    data-link-name="Check all"
-                    text="Check all"
-                />
-            );
-        }
+		if (hasSolutions) {
+			controls.grid.unshift(
+				<ConfirmButton
+					className={`${buttonClassName} ${buttonGenericClassName}`}
+					onClick={this.props.crossword.onSolution.bind(
+						this.props.crossword,
+					)}
+					key="solution"
+					data-link-name="Reveal all"
+					text="Reveal all"
+				/>,
+			);
+			controls.grid.unshift(
+				<ConfirmButton
+					className={`${buttonClassName} ${buttonGenericClassName}`}
+					onClick={this.props.crossword.onCheckAll.bind(
+						this.props.crossword,
+					)}
+					key="checkAll"
+					data-link-name="Check all"
+					text="Check all"
+				/>,
+			);
+		}
 
-        // HIGHLIGHTED CLUE CONTROLS  - published solution
-        if (hasFocus) {
-            controls.clue.unshift(
-                <button
-                    className={`${buttonClassName} ${buttonCurrentClassName}`}
-                    onClick={this.props.crossword.onClearSingle.bind(
-                        this.props.crossword
-                    )}
-                    key="clear-single"
-                    data-link-name="Clear this">
-                    Clear this
-                </button>
-            );
+		// HIGHLIGHTED CLUE CONTROLS  - published solution
+		if (hasFocus) {
+			controls.clue.unshift(
+				<button
+					className={`${buttonClassName} ${buttonCurrentClassName}`}
+					onClick={this.props.crossword.onClearSingle.bind(
+						this.props.crossword,
+					)}
+					key="clear-single"
+					data-link-name="Clear this"
+				>
+					Clear this
+				</button>,
+			);
 
-            // anagram helper
-            controls.clue.push(
-                <button
-                    className={`${buttonClassName} ${buttonCurrentClassName}`}
-                    onClick={this.props.crossword.onToggleAnagramHelper.bind(
-                        this.props.crossword
-                    )}
-                    key="anagram"
-                    data-link-name="Show anagram helper">
-                    Anagram helper
-                </button>
-            );
+			// anagram helper
+			controls.clue.push(
+				<button
+					className={`${buttonClassName} ${buttonCurrentClassName}`}
+					onClick={this.props.crossword.onToggleAnagramHelper.bind(
+						this.props.crossword,
+					)}
+					key="anagram"
+					data-link-name="Show anagram helper"
+				>
+					Anagram helper
+				</button>,
+			);
 
-            if (hasSolutions) {
-                controls.clue.unshift(
-                    <button
-                        className={`${buttonClassName} ${buttonCurrentClassName}`}
-                        onClick={this.props.crossword.onCheat.bind(
-                            this.props.crossword
-                        )}
-                        key="cheat"
-                        data-link-name="Reveal this">
-                        Reveal this
-                    </button>
-                );
-                controls.clue.unshift(
-                    <button
-                        className={`${buttonClassName} ${buttonCurrentClassName}`}
-                        onClick={this.props.crossword.onCheck.bind(
-                            this.props.crossword
-                        )}
-                        key="check"
-                        data-link-name="Check this">
-                        Check this
-                    </button>
-                );
-            }
-        }
+			if (hasSolutions) {
+				controls.clue.unshift(
+					<button
+						className={`${buttonClassName} ${buttonCurrentClassName}`}
+						onClick={this.props.crossword.onCheat.bind(
+							this.props.crossword,
+						)}
+						key="cheat"
+						data-link-name="Reveal this"
+					>
+						Reveal this
+					</button>,
+				);
+				controls.clue.unshift(
+					<button
+						className={`${buttonClassName} ${buttonCurrentClassName}`}
+						onClick={this.props.crossword.onCheck.bind(
+							this.props.crossword,
+						)}
+						key="check"
+						data-link-name="Check this"
+					>
+						Check this
+					</button>,
+				);
+			}
+		}
 
-        return (
-            <div className="crossword__controls">
-                <div className="crossword__controls__clue">{controls.clue}</div>
-                <div className="crossword__controls__grid">{controls.grid}</div>
-                <div className="crossword__controls_autosave_label">
-                    Crosswords are saved automatically
-                </div>
-            </div>
-        );
-    }
+		return (
+			<div className="crossword__controls">
+				<div className="crossword__controls__clue">{controls.clue}</div>
+				<div className="crossword__controls__grid">{controls.grid}</div>
+				<div className="crossword__controls_autosave_label">
+					Crosswords are saved automatically
+				</div>
+			</div>
+		);
+	}
 }
 
 export { Controls };

--- a/static/src/javascripts.flow.archive/projects/common/modules/crosswords/crossword.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/crosswords/crossword.js
@@ -11,7 +11,7 @@
  */
 
 // @flow
-import React, { Component, findDOMNode } from 'preact-compat';
+import React, { Component, findDOMNode } from 'react';
 import fastdom from 'fastdom';
 import $ from 'lib/$';
 import mediator from 'lib/mediator';
@@ -25,816 +25,823 @@ import { Controls } from 'common/modules/crosswords/controls';
 import { HiddenInput } from 'common/modules/crosswords/hidden-input';
 import { Grid } from 'common/modules/crosswords/grid';
 import {
-    buildClueMap,
-    buildGrid,
-    otherDirection,
-    entryHasCell,
-    cluesFor,
-    mapGrid,
-    getClearableCellsForClue,
-    getLastCellInClue,
-    getPreviousClueInGroup,
-    isFirstCellInClue,
-    getNextClueInGroup,
-    isLastCellInClue,
-    gridSize,
-    checkClueHasBeenAnswered,
-    buildSeparatorMap,
-    cellsForEntry,
+	buildClueMap,
+	buildGrid,
+	otherDirection,
+	entryHasCell,
+	cluesFor,
+	mapGrid,
+	getClearableCellsForClue,
+	getLastCellInClue,
+	getPreviousClueInGroup,
+	isFirstCellInClue,
+	getNextClueInGroup,
+	isLastCellInClue,
+	gridSize,
+	checkClueHasBeenAnswered,
+	buildSeparatorMap,
+	cellsForEntry,
 } from 'common/modules/crosswords/helpers';
 import { keycodes } from 'common/modules/crosswords/keycodes';
 import {
-    saveGridState,
-    loadGridState,
+	saveGridState,
+	loadGridState,
 } from 'common/modules/crosswords/persistence';
 import { classNames } from 'common/modules/crosswords/classNames';
 import type { GridProps } from 'common/modules/crosswords/grid';
 
 type CrosswordState = {
-    grid: Array<Array<Cell>>,
-    cellInFocus?: ?Position,
-    directionOfEntry?: ?Direction,
-    showAnagramHelper?: boolean,
+	grid: Array<Array<Cell>>,
+	cellInFocus?: ?Position,
+	directionOfEntry?: ?Direction,
+	showAnagramHelper?: boolean,
 };
 
 class Crossword extends Component<*, CrosswordState> {
-    constructor(props: Object) {
-        super(props);
-        const dimensions = this.props.data.dimensions;
+	constructor(props: Object) {
+		super(props);
+		const dimensions = this.props.data.dimensions;
 
-        this.columns = dimensions.cols;
-        this.rows = dimensions.rows;
-        this.clueMap = buildClueMap(this.props.data.entries);
+		this.columns = dimensions.cols;
+		this.rows = dimensions.rows;
+		this.clueMap = buildClueMap(this.props.data.entries);
 
-        this.state = {
-            grid: buildGrid(
-                dimensions.rows,
-                dimensions.cols,
-                this.props.data.entries,
-                loadGridState(this.props.data.id)
-            ),
-            cellInFocus: null,
-            directionOfEntry: null,
-            showAnagramHelper: false,
-        };
-    }
+		this.state = {
+			grid: buildGrid(
+				dimensions.rows,
+				dimensions.cols,
+				this.props.data.entries,
+				loadGridState(this.props.data.id),
+			),
+			cellInFocus: null,
+			directionOfEntry: null,
+			showAnagramHelper: false,
+		};
+	}
 
-    componentDidMount(): void {
-        // Sticky clue
-        const $stickyClueWrapper = $(findDOMNode(this.stickyClueWrapper));
-        const $grid = $(findDOMNode(this.grid));
-        const $game = $(findDOMNode(this.game));
+	componentDidMount(): void {
+		// Sticky clue
+		const $stickyClueWrapper = $(findDOMNode(this.stickyClueWrapper));
+		const $grid = $(findDOMNode(this.grid));
+		const $game = $(findDOMNode(this.game));
 
-        mediator.on(
-            'window:resize',
-            debounce(this.setGridHeight.bind(this), 200)
-        );
-        mediator.on(
-            'window:orientationchange',
-            debounce(this.setGridHeight.bind(this), 200)
-        );
-        this.setGridHeight();
+		mediator.on(
+			'window:resize',
+			debounce(this.setGridHeight.bind(this), 200),
+		);
+		mediator.on(
+			'window:orientationchange',
+			debounce(this.setGridHeight.bind(this), 200),
+		);
+		this.setGridHeight();
 
-        mediator.on('window:throttledScroll', () => {
-            const gridOffset = $grid.offset();
-            const gameOffset = $game.offset();
-            const stickyClueWrapperOffset = $stickyClueWrapper.offset();
-            const scrollY = window.scrollY;
+		mediator.on('window:throttledScroll', () => {
+			const gridOffset = $grid.offset();
+			const gameOffset = $game.offset();
+			const stickyClueWrapperOffset = $stickyClueWrapper.offset();
+			const scrollY = window.scrollY;
 
-            fastdom.mutate(() => {
-                // Clear previous state
-                $stickyClueWrapper
-                    .css('top', '')
-                    .css('bottom', '')
-                    .removeClass('is-fixed');
+			fastdom.mutate(() => {
+				// Clear previous state
+				$stickyClueWrapper
+					.css('top', '')
+					.css('bottom', '')
+					.removeClass('is-fixed');
 
-                const scrollYPastGame = scrollY - gameOffset.top;
+				const scrollYPastGame = scrollY - gameOffset.top;
 
-                if (scrollYPastGame >= 0) {
-                    const gridOffsetBottom = gridOffset.top + gridOffset.height;
+				if (scrollYPastGame >= 0) {
+					const gridOffsetBottom = gridOffset.top + gridOffset.height;
 
-                    if (
-                        scrollY >
-                        gridOffsetBottom - stickyClueWrapperOffset.height
-                    ) {
-                        $stickyClueWrapper.css('top', 'auto').css('bottom', 0);
-                    } else if (isIOS()) {
-                        // iOS doesn't support sticky things when the keyboard
-                        // is open, so we use absolute positioning and
-                        // programatically update the value of top
-                        $stickyClueWrapper.css('top', scrollYPastGame);
-                    } else {
-                        $stickyClueWrapper.addClass('is-fixed');
-                    }
-                }
-            });
-        });
-    }
+					if (
+						scrollY >
+						gridOffsetBottom - stickyClueWrapperOffset.height
+					) {
+						$stickyClueWrapper.css('top', 'auto').css('bottom', 0);
+					} else if (isIOS()) {
+						// iOS doesn't support sticky things when the keyboard
+						// is open, so we use absolute positioning and
+						// programatically update the value of top
+						$stickyClueWrapper.css('top', scrollYPastGame);
+					} else {
+						$stickyClueWrapper.addClass('is-fixed');
+					}
+				}
+			});
+		});
+	}
 
-    componentDidUpdate(prevProps: Object, prevState: Object): void {
-        // return focus to active cell after exiting anagram helper
-        if (
-            !this.state.showAnagramHelper &&
-            this.state.showAnagramHelper !== prevState.showAnagramHelper
-        ) {
-            this.focusCurrentCell();
-        }
-    }
+	componentDidUpdate(prevProps: Object, prevState: Object): void {
+		// return focus to active cell after exiting anagram helper
+		if (
+			!this.state.showAnagramHelper &&
+			this.state.showAnagramHelper !== prevState.showAnagramHelper
+		) {
+			this.focusCurrentCell();
+		}
+	}
 
-    onKeyDown(event: KeyboardEvent): void {
-        const cell = this.state.cellInFocus;
+	onKeyDown(event: KeyboardEvent): void {
+		const cell = this.state.cellInFocus;
 
-        if (event.keyCode === keycodes.tab) {
-            event.preventDefault();
-            if (event.shiftKey) {
-                this.focusPreviousClue();
-            } else {
-                this.focusNextClue();
-            }
-        } else if (!event.metaKey && !event.ctrlKey && !event.altKey) {
-            if (
-                event.keyCode === keycodes.backspace ||
-                event.keyCode === keycodes.delete
-            ) {
-                event.preventDefault();
-                if (cell) {
-                    if (this.cellIsEmpty(cell.x, cell.y)) {
-                        this.focusPrevious();
-                    } else {
-                        this.setCellValue(cell.x, cell.y, '');
-                        this.save();
-                    }
-                }
-            } else if (event.keyCode === keycodes.left) {
-                event.preventDefault();
-                this.moveFocus(-1, 0);
-            } else if (event.keyCode === keycodes.up) {
-                event.preventDefault();
-                this.moveFocus(0, -1);
-            } else if (event.keyCode === keycodes.right) {
-                event.preventDefault();
-                this.moveFocus(1, 0);
-            } else if (event.keyCode === keycodes.down) {
-                event.preventDefault();
-                this.moveFocus(0, 1);
-            }
-        }
-    }
+		if (event.keyCode === keycodes.tab) {
+			event.preventDefault();
+			if (event.shiftKey) {
+				this.focusPreviousClue();
+			} else {
+				this.focusNextClue();
+			}
+		} else if (!event.metaKey && !event.ctrlKey && !event.altKey) {
+			if (
+				event.keyCode === keycodes.backspace ||
+				event.keyCode === keycodes.delete
+			) {
+				event.preventDefault();
+				if (cell) {
+					if (this.cellIsEmpty(cell.x, cell.y)) {
+						this.focusPrevious();
+					} else {
+						this.setCellValue(cell.x, cell.y, '');
+						this.save();
+					}
+				}
+			} else if (event.keyCode === keycodes.left) {
+				event.preventDefault();
+				this.moveFocus(-1, 0);
+			} else if (event.keyCode === keycodes.up) {
+				event.preventDefault();
+				this.moveFocus(0, -1);
+			} else if (event.keyCode === keycodes.right) {
+				event.preventDefault();
+				this.moveFocus(1, 0);
+			} else if (event.keyCode === keycodes.down) {
+				event.preventDefault();
+				this.moveFocus(0, 1);
+			}
+		}
+	}
 
-    // called when cell is selected (by click or programtically focussed)
-    onSelect(x: number, y: number): void {
-        const cellInFocus = this.state.cellInFocus;
-        const clue = cluesFor(this.clueMap, x, y);
-        const focussedClue = this.clueInFocus();
-        let newDirection;
+	// called when cell is selected (by click or programtically focussed)
+	onSelect(x: number, y: number): void {
+		const cellInFocus = this.state.cellInFocus;
+		const clue = cluesFor(this.clueMap, x, y);
+		const focussedClue = this.clueInFocus();
+		let newDirection;
 
-        const isInsideFocussedClue = (): boolean =>
-            focussedClue ? entryHasCell(focussedClue, x, y) : false;
+		const isInsideFocussedClue = (): boolean =>
+			focussedClue ? entryHasCell(focussedClue, x, y) : false;
 
-        if (
-            cellInFocus &&
-            cellInFocus.x === x &&
-            cellInFocus.y === y &&
-            this.state.directionOfEntry
-        ) {
-            /** User has clicked again on the highlighted cell, meaning we ought to swap direction */
-            newDirection = otherDirection(this.state.directionOfEntry);
+		if (
+			cellInFocus &&
+			cellInFocus.x === x &&
+			cellInFocus.y === y &&
+			this.state.directionOfEntry
+		) {
+			/** User has clicked again on the highlighted cell, meaning we ought to swap direction */
+			newDirection = otherDirection(this.state.directionOfEntry);
 
-            if (clue[newDirection]) {
-                this.focusClue(x, y, newDirection);
-            }
-        } else if (isInsideFocussedClue() && this.state.directionOfEntry) {
-            /**
-             * If we've clicked inside the currently highlighted clue, then we ought to just shift the cursor
-             * to the new cell, not change direction or anything funny.
-             */
+			if (clue[newDirection]) {
+				this.focusClue(x, y, newDirection);
+			}
+		} else if (isInsideFocussedClue() && this.state.directionOfEntry) {
+			/**
+			 * If we've clicked inside the currently highlighted clue, then we ought to just shift the cursor
+			 * to the new cell, not change direction or anything funny.
+			 */
 
-            this.focusClue(x, y, this.state.directionOfEntry);
-        } else {
-            this.state.cellInFocus = {
-                x,
-                y,
-            };
+			this.focusClue(x, y, this.state.directionOfEntry);
+		} else {
+			this.state.cellInFocus = {
+				x,
+				y,
+			};
 
-            const isStartOfClue = (sourceClue): boolean =>
-                !!sourceClue &&
-                sourceClue.position.x === x &&
-                sourceClue.position.y === y;
+			const isStartOfClue = (sourceClue): boolean =>
+				!!sourceClue &&
+				sourceClue.position.x === x &&
+				sourceClue.position.y === y;
 
-            /**
-             * If the user clicks on the start of a down clue midway through an across clue, we should
-             * prefer to highlight the down clue.
-             */
-            if (!isStartOfClue(clue.across) && isStartOfClue(clue.down)) {
-                newDirection = 'down';
-            } else if (clue.across) {
-                /** Across is the default focus otherwise */
-                newDirection = 'across';
-            } else {
-                newDirection = 'down';
-            }
-            this.focusClue(x, y, newDirection);
-        }
-    }
+			/**
+			 * If the user clicks on the start of a down clue midway through an across clue, we should
+			 * prefer to highlight the down clue.
+			 */
+			if (!isStartOfClue(clue.across) && isStartOfClue(clue.down)) {
+				newDirection = 'down';
+			} else if (clue.across) {
+				/** Across is the default focus otherwise */
+				newDirection = 'across';
+			} else {
+				newDirection = 'down';
+			}
+			this.focusClue(x, y, newDirection);
+		}
+	}
 
-    onCheat(): void {
-        this.allHighlightedClues().forEach(clue => this.cheat(clue));
-        this.save();
-    }
+	onCheat(): void {
+		this.allHighlightedClues().forEach((clue) => this.cheat(clue));
+		this.save();
+	}
 
-    onCheck(): void {
-        // 'Check this' checks single and grouped clues
-        this.allHighlightedClues().forEach(clue => this.check(clue));
-        this.save();
-    }
+	onCheck(): void {
+		// 'Check this' checks single and grouped clues
+		this.allHighlightedClues().forEach((clue) => this.check(clue));
+		this.save();
+	}
 
-    onSolution(): void {
-        this.props.data.entries.forEach(clue => this.cheat(clue));
-        this.save();
-    }
+	onSolution(): void {
+		this.props.data.entries.forEach((clue) => this.cheat(clue));
+		this.save();
+	}
 
-    onCheckAll(): void {
-        this.props.data.entries.forEach(clue => this.check(clue));
-        this.save();
-    }
+	onCheckAll(): void {
+		this.props.data.entries.forEach((clue) => this.check(clue));
+		this.save();
+	}
 
-    onClearAll(): void {
-        this.setState({
-            grid: mapGrid(this.state.grid, cell => {
-                cell.value = '';
-                return cell;
-            }),
-        });
+	onClearAll(): void {
+		this.setState({
+			grid: mapGrid(this.state.grid, (cell) => {
+				cell.value = '';
+				return cell;
+			}),
+		});
 
-        this.save();
-    }
+		this.save();
+	}
 
-    onClearSingle(): void {
-        const clueInFocus = this.clueInFocus();
+	onClearSingle(): void {
+		const clueInFocus = this.clueInFocus();
 
-        if (clueInFocus) {
-            // Merge arrays of cells from all highlighted clues
-            // const cellsInFocus = _.flatten(_.map(this.allHighlightedClues(), helpers.cellsForEntry, this));
-            const cellsInFocus = getClearableCellsForClue(
-                this.state.grid,
-                this.clueMap,
-                this.props.data.entries,
-                clueInFocus
-            );
+		if (clueInFocus) {
+			// Merge arrays of cells from all highlighted clues
+			// const cellsInFocus = _.flatten(_.map(this.allHighlightedClues(), helpers.cellsForEntry, this));
+			const cellsInFocus = getClearableCellsForClue(
+				this.state.grid,
+				this.clueMap,
+				this.props.data.entries,
+				clueInFocus,
+			);
 
-            this.setState({
-                grid: mapGrid(this.state.grid, (cell, gridX, gridY) => {
-                    if (
-                        cellsInFocus.some(c => c.x === gridX && c.y === gridY)
-                    ) {
-                        cell.value = '';
-                    }
-                    return cell;
-                }),
-            });
+			this.setState({
+				grid: mapGrid(this.state.grid, (cell, gridX, gridY) => {
+					if (
+						cellsInFocus.some((c) => c.x === gridX && c.y === gridY)
+					) {
+						cell.value = '';
+					}
+					return cell;
+				}),
+			});
 
-            this.save();
-        }
-    }
+			this.save();
+		}
+	}
 
-    onToggleAnagramHelper(): void {
-        // only show anagram helper if a clue is active
-        if (!this.state.showAnagramHelper) {
-            if (this.clueInFocus()) {
-                this.setState({
-                    showAnagramHelper: true,
-                });
-            }
-        } else {
-            this.setState({
-                showAnagramHelper: false,
-            });
-        }
-    }
+	onToggleAnagramHelper(): void {
+		// only show anagram helper if a clue is active
+		if (!this.state.showAnagramHelper) {
+			if (this.clueInFocus()) {
+				this.setState({
+					showAnagramHelper: true,
+				});
+			}
+		} else {
+			this.setState({
+				showAnagramHelper: false,
+			});
+		}
+	}
 
-    onClickHiddenInput(event: Event): void {
-        const focussed = this.state.cellInFocus;
+	onClickHiddenInput(event: Event): void {
+		const focussed = this.state.cellInFocus;
 
-        if (focussed) {
-            this.onSelect(focussed.x, focussed.y);
-        }
+		if (focussed) {
+			this.onSelect(focussed.x, focussed.y);
+		}
 
-        /* We need to handle touch seperately as touching an input on iPhone does not fire the
+		/* We need to handle touch seperately as touching an input on iPhone does not fire the
          click event - listen for a touchStart and preventDefault to avoid calling onSelect twice on
          devices that fire click AND touch events. The click event doesn't fire only when the input is already focused */
-        if (event.type === 'touchstart') {
-            event.preventDefault();
-        }
-    }
+		if (event.type === 'touchstart') {
+			event.preventDefault();
+		}
+	}
 
-    setGridHeight(): void {
-        if (!this.$gridWrapper) {
-            this.$gridWrapper = $(findDOMNode(this.gridWrapper));
-        }
+	setGridHeight(): void {
+		if (!this.$gridWrapper) {
+			this.$gridWrapper = $(findDOMNode(this.gridWrapper));
+		}
 
-        if (
-            isBreakpoint({
-                max: 'tablet',
-            })
-        ) {
-            fastdom.measure(() => {
-                // Our grid is a square, set the height of the grid wrapper
-                // to the width of the grid wrapper
-                fastdom.mutate(() => {
-                    this.$gridWrapper.css(
-                        'height',
-                        `${this.$gridWrapper.offset().width}px`
-                    );
-                });
-                this.gridHeightIsSet = true;
-            });
-        } else if (this.gridHeightIsSet) {
-            // Remove inline style if tablet and wider
-            this.$gridWrapper.attr('style', '');
-        }
-    }
+		if (
+			isBreakpoint({
+				max: 'tablet',
+			})
+		) {
+			fastdom.measure(() => {
+				// Our grid is a square, set the height of the grid wrapper
+				// to the width of the grid wrapper
+				fastdom.mutate(() => {
+					this.$gridWrapper.css(
+						'height',
+						`${this.$gridWrapper.offset().width}px`,
+					);
+				});
+				this.gridHeightIsSet = true;
+			});
+		} else if (this.gridHeightIsSet) {
+			// Remove inline style if tablet and wider
+			this.$gridWrapper.attr('style', '');
+		}
+	}
 
-    setCellValue(x: number, y: number, value: string): void {
-        this.setState({
-            grid: mapGrid(this.state.grid, (cell, gridX, gridY) => {
-                if (gridX === x && gridY === y) {
-                    cell.value = value;
-                    cell.isError = false;
-                }
+	setCellValue(x: number, y: number, value: string): void {
+		this.setState({
+			grid: mapGrid(this.state.grid, (cell, gridX, gridY) => {
+				if (gridX === x && gridY === y) {
+					cell.value = value;
+					cell.isError = false;
+				}
 
-                return cell;
-            }),
-        });
-    }
+				return cell;
+			}),
+		});
+	}
 
-    getCellValue(x: number, y: number): string {
-        return this.state.grid[x][y].value;
-    }
+	getCellValue(x: number, y: number): string {
+		return this.state.grid[x][y].value;
+	}
 
-    setReturnPosition(position: number): void {
-        this.returnPosition = position;
-    }
+	setReturnPosition(position: number): void {
+		this.returnPosition = position;
+	}
 
-    columns: any;
-    rows: any;
-    clueMap: any;
-    $gridWrapper: any;
-    gridHeightIsSet: ?boolean;
-    returnPosition: ?number;
+	columns: any;
+	rows: any;
+	clueMap: any;
+	$gridWrapper: any;
+	gridHeightIsSet: ?boolean;
+	returnPosition: ?number;
 
-    insertCharacter(character: string): void {
-        const characterUppercase = character.toUpperCase();
-        const cell = this.state.cellInFocus;
-        if (
-            /[A-Za-zÀ-ÿ0-9]/.test(characterUppercase) &&
-            characterUppercase.length === 1 &&
-            cell
-        ) {
-            this.setCellValue(cell.x, cell.y, characterUppercase);
-            this.save();
-            this.focusNext();
-        }
-    }
+	insertCharacter(character: string): void {
+		const characterUppercase = character.toUpperCase();
+		const cell = this.state.cellInFocus;
+		if (
+			/[A-Za-zÀ-ÿ0-9]/.test(characterUppercase) &&
+			characterUppercase.length === 1 &&
+			cell
+		) {
+			this.setCellValue(cell.x, cell.y, characterUppercase);
+			this.save();
+			this.focusNext();
+		}
+	}
 
-    cellIsEmpty(x: number, y: number): boolean {
-        return !this.getCellValue(x, y);
-    }
+	cellIsEmpty(x: number, y: number): boolean {
+		return !this.getCellValue(x, y);
+	}
 
-    goToReturnPosition(): void {
-        if (
-            isBreakpoint({
-                max: 'mobile',
-            })
-        ) {
-            if (this.returnPosition) {
-                scrollTo(this.returnPosition, 250, 'easeOutQuad');
-            }
-            this.returnPosition = null;
-        }
-    }
+	goToReturnPosition(): void {
+		if (
+			isBreakpoint({
+				max: 'mobile',
+			})
+		) {
+			if (this.returnPosition) {
+				scrollTo(this.returnPosition, 250, 'easeOutQuad');
+			}
+			this.returnPosition = null;
+		}
+	}
 
-    indexOfClueInFocus(): number {
-        return this.props.data.entries.indexOf(this.clueInFocus());
-    }
+	indexOfClueInFocus(): number {
+		return this.props.data.entries.indexOf(this.clueInFocus());
+	}
 
-    focusPreviousClue(): void {
-        const i = this.indexOfClueInFocus();
-        const entries = this.props.data.entries;
+	focusPreviousClue(): void {
+		const i = this.indexOfClueInFocus();
+		const entries = this.props.data.entries;
 
-        if (i !== -1) {
-            const newClue = entries[i === 0 ? entries.length - 1 : i - 1];
-            this.focusClue(
-                newClue.position.x,
-                newClue.position.y,
-                newClue.direction
-            );
-        }
-    }
+		if (i !== -1) {
+			const newClue = entries[i === 0 ? entries.length - 1 : i - 1];
+			this.focusClue(
+				newClue.position.x,
+				newClue.position.y,
+				newClue.direction,
+			);
+		}
+	}
 
-    focusNextClue(): void {
-        const i = this.indexOfClueInFocus();
-        const entries = this.props.data.entries;
+	focusNextClue(): void {
+		const i = this.indexOfClueInFocus();
+		const entries = this.props.data.entries;
 
-        if (i !== -1) {
-            const newClue = entries[i === entries.length - 1 ? 0 : i + 1];
-            this.focusClue(
-                newClue.position.x,
-                newClue.position.y,
-                newClue.direction
-            );
-        }
-    }
+		if (i !== -1) {
+			const newClue = entries[i === entries.length - 1 ? 0 : i + 1];
+			this.focusClue(
+				newClue.position.x,
+				newClue.position.y,
+				newClue.direction,
+			);
+		}
+	}
 
-    moveFocus(deltaX: number, deltaY: number): void {
-        const cell = this.state.cellInFocus;
+	moveFocus(deltaX: number, deltaY: number): void {
+		const cell = this.state.cellInFocus;
 
-        if (!cell) {
-            return;
-        }
+		if (!cell) {
+			return;
+		}
 
-        const x = cell.x + deltaX;
-        const y = cell.y + deltaY;
-        let direction: Direction = 'down';
+		const x = cell.x + deltaX;
+		const y = cell.y + deltaY;
+		let direction: Direction = 'down';
 
-        if (
-            this.state.grid[x] &&
-            this.state.grid[x][y] &&
-            this.state.grid[x][y].isEditable
-        ) {
-            if (deltaY !== 0) {
-                direction = 'down';
-            } else if (deltaX !== 0) {
-                direction = 'across';
-            }
-            this.focusClue(x, y, direction);
-        }
-    }
+		if (
+			this.state.grid[x] &&
+			this.state.grid[x][y] &&
+			this.state.grid[x][y].isEditable
+		) {
+			if (deltaY !== 0) {
+				direction = 'down';
+			} else if (deltaX !== 0) {
+				direction = 'across';
+			}
+			this.focusClue(x, y, direction);
+		}
+	}
 
-    isAcross(): boolean {
-        return this.state.directionOfEntry === 'across';
-    }
+	isAcross(): boolean {
+		return this.state.directionOfEntry === 'across';
+	}
 
-    focusPrevious(): void {
-        const cell = this.state.cellInFocus;
-        const clue = this.clueInFocus();
+	focusPrevious(): void {
+		const cell = this.state.cellInFocus;
+		const clue = this.clueInFocus();
 
-        if (cell && clue) {
-            if (isFirstCellInClue(cell, clue)) {
-                const newClue = getPreviousClueInGroup(
-                    this.props.data.entries,
-                    clue
-                );
-                if (newClue) {
-                    const newCell = getLastCellInClue(newClue);
-                    this.focusClue(newCell.x, newCell.y, newClue.direction);
-                }
-            } else if (this.isAcross()) {
-                this.moveFocus(-1, 0);
-            } else {
-                this.moveFocus(0, -1);
-            }
-        }
-    }
+		if (cell && clue) {
+			if (isFirstCellInClue(cell, clue)) {
+				const newClue = getPreviousClueInGroup(
+					this.props.data.entries,
+					clue,
+				);
+				if (newClue) {
+					const newCell = getLastCellInClue(newClue);
+					this.focusClue(newCell.x, newCell.y, newClue.direction);
+				}
+			} else if (this.isAcross()) {
+				this.moveFocus(-1, 0);
+			} else {
+				this.moveFocus(0, -1);
+			}
+		}
+	}
 
-    focusNext(): void {
-        const cell = this.state.cellInFocus;
-        const clue = this.clueInFocus();
+	focusNext(): void {
+		const cell = this.state.cellInFocus;
+		const clue = this.clueInFocus();
 
-        if (cell && clue) {
-            if (isLastCellInClue(cell, clue)) {
-                const newClue = getNextClueInGroup(
-                    this.props.data.entries,
-                    clue
-                );
-                if (newClue) {
-                    this.focusClue(
-                        newClue.position.x,
-                        newClue.position.y,
-                        newClue.direction
-                    );
-                }
-            } else if (this.isAcross()) {
-                this.moveFocus(1, 0);
-            } else {
-                this.moveFocus(0, 1);
-            }
-        }
-    }
+		if (cell && clue) {
+			if (isLastCellInClue(cell, clue)) {
+				const newClue = getNextClueInGroup(
+					this.props.data.entries,
+					clue,
+				);
+				if (newClue) {
+					this.focusClue(
+						newClue.position.x,
+						newClue.position.y,
+						newClue.direction,
+					);
+				}
+			} else if (this.isAcross()) {
+				this.moveFocus(1, 0);
+			} else {
+				this.moveFocus(0, 1);
+			}
+		}
+	}
 
-    asPercentage(x: number, y: number): Object {
-        const width = gridSize(this.columns);
-        const height = gridSize(this.rows);
+	asPercentage(x: number, y: number): Object {
+		const width = gridSize(this.columns);
+		const height = gridSize(this.rows);
 
-        return {
-            x: (100 * x) / width,
-            y: (100 * y) / height,
-        };
-    }
+		return {
+			x: (100 * x) / width,
+			y: (100 * y) / height,
+		};
+	}
 
-    focusHiddenInput(x: number, y: number): void {
-        const wrapper: HTMLElement = (findDOMNode(
-            this.hiddenInputComponent.wrapper
-        ): any);
-        const left = gridSize(x);
-        const top = gridSize(y);
-        const position = this.asPercentage(left, top);
+	focusHiddenInput(x: number, y: number): void {
+		const wrapper: HTMLElement = (findDOMNode(
+			this.hiddenInputComponent.wrapper,
+		): any);
+		const left = gridSize(x);
+		const top = gridSize(y);
+		const position = this.asPercentage(left, top);
 
-        /** This has to be done before focus to move viewport accordingly */
-        wrapper.style.left = `${position.x}%`;
-        wrapper.style.top = `${position.y}%`;
+		/** This has to be done before focus to move viewport accordingly */
+		wrapper.style.left = `${position.x}%`;
+		wrapper.style.top = `${position.y}%`;
 
-        const hiddenInputNode: HTMLElement = (findDOMNode(
-            this.hiddenInputComponent.input
-        ): any);
+		const hiddenInputNode: HTMLElement = (findDOMNode(
+			this.hiddenInputComponent.input,
+		): any);
 
-        if (document.activeElement !== hiddenInputNode) {
-            hiddenInputNode.focus();
-        }
-    }
+		if (document.activeElement !== hiddenInputNode) {
+			hiddenInputNode.focus();
+		}
+	}
 
-    // Focus corresponding clue for a given cell
-    focusClue(x: number, y: number, direction: Direction): void {
-        const clues = cluesFor(this.clueMap, x, y);
-        const clue = clues[direction];
+	// Focus corresponding clue for a given cell
+	focusClue(x: number, y: number, direction: Direction): void {
+		const clues = cluesFor(this.clueMap, x, y);
+		const clue = clues[direction];
 
-        if (clues && clue) {
-            this.focusHiddenInput(x, y);
+		if (clues && clue) {
+			this.focusHiddenInput(x, y);
 
-            this.setState({
-                grid: this.state.grid,
-                cellInFocus: {
-                    x,
-                    y,
-                },
-                directionOfEntry: direction,
-            });
+			this.setState({
+				grid: this.state.grid,
+				cellInFocus: {
+					x,
+					y,
+				},
+				directionOfEntry: direction,
+			});
 
-            // Side effect
-            window.history.replaceState(
-                undefined,
-                document.title,
-                `#${clue.id}`
-            );
-        }
-    }
+			// Side effect
+			window.history.replaceState(
+				undefined,
+				document.title,
+				`#${clue.id}`,
+			);
+		}
+	}
 
-    // Focus first cell in given clue
-    focusFirstCellInClue(entry: Object): void {
-        this.focusClue(entry.position.x, entry.position.y, entry.direction);
-    }
+	// Focus first cell in given clue
+	focusFirstCellInClue(entry: Object): void {
+		this.focusClue(entry.position.x, entry.position.y, entry.direction);
+	}
 
-    focusCurrentCell(): void {
-        if (this.state.cellInFocus) {
-            this.focusHiddenInput(
-                this.state.cellInFocus.x,
-                this.state.cellInFocus.y
-            );
-        }
-    }
+	focusCurrentCell(): void {
+		if (this.state.cellInFocus) {
+			this.focusHiddenInput(
+				this.state.cellInFocus.x,
+				this.state.cellInFocus.y,
+			);
+		}
+	}
 
-    clueInFocus(): ?Object {
-        if (this.state.cellInFocus) {
-            const cluesForCell = cluesFor(
-                this.clueMap,
-                this.state.cellInFocus.x,
-                this.state.cellInFocus.y
-            );
+	clueInFocus(): ?Object {
+		if (this.state.cellInFocus) {
+			const cluesForCell = cluesFor(
+				this.clueMap,
+				this.state.cellInFocus.x,
+				this.state.cellInFocus.y,
+			);
 
-            if (this.state.directionOfEntry) {
-                return cluesForCell[this.state.directionOfEntry];
-            }
-        }
-        return null;
-    }
+			if (this.state.directionOfEntry) {
+				return cluesForCell[this.state.directionOfEntry];
+			}
+		}
+		return null;
+	}
 
-    allHighlightedClues(): Array<Object> {
-        return this.props.data.entries.filter(clue =>
-            this.clueIsInFocusGroup(clue)
-        );
-    }
+	allHighlightedClues(): Array<Object> {
+		return this.props.data.entries.filter((clue) =>
+			this.clueIsInFocusGroup(clue),
+		);
+	}
 
-    clueIsInFocusGroup(clue: Object): boolean {
-        if (this.state.cellInFocus) {
-            const cluesForCell = cluesFor(
-                this.clueMap,
-                this.state.cellInFocus.x,
-                this.state.cellInFocus.y
-            );
+	clueIsInFocusGroup(clue: Object): boolean {
+		if (this.state.cellInFocus) {
+			const cluesForCell = cluesFor(
+				this.clueMap,
+				this.state.cellInFocus.x,
+				this.state.cellInFocus.y,
+			);
 
-            if (
-                this.state.directionOfEntry &&
-                cluesForCell[this.state.directionOfEntry]
-            ) {
-                return cluesForCell[this.state.directionOfEntry].group.includes(
-                    clue.id
-                );
-            }
-        }
-        return false;
-    }
+			if (
+				this.state.directionOfEntry &&
+				cluesForCell[this.state.directionOfEntry]
+			) {
+				return cluesForCell[this.state.directionOfEntry].group.includes(
+					clue.id,
+				);
+			}
+		}
+		return false;
+	}
 
-    cluesData(): Array<Object> {
-        return this.props.data.entries.map(entry => {
-            const hasAnswered = checkClueHasBeenAnswered(
-                this.state.grid,
-                entry
-            );
-            return {
-                entry,
-                hasAnswered,
-                isSelected: this.clueIsInFocusGroup(entry),
-            };
-        });
-    }
+	cluesData(): Array<Object> {
+		return this.props.data.entries.map((entry) => {
+			const hasAnswered = checkClueHasBeenAnswered(
+				this.state.grid,
+				entry,
+			);
+			return {
+				entry,
+				hasAnswered,
+				isSelected: this.clueIsInFocusGroup(entry),
+			};
+		});
+	}
 
-    save(): void {
-        saveGridState(this.props.data.id, this.state.grid);
-    }
+	save(): void {
+		saveGridState(this.props.data.id, this.state.grid);
+	}
 
-    cheat(entry: Object): void {
-        const cells = cellsForEntry(entry);
+	cheat(entry: Object): void {
+		const cells = cellsForEntry(entry);
 
-        if (entry.solution) {
-            this.setState({
-                grid: mapGrid(this.state.grid, (cell, x, y) => {
-                    if (cells.some(c => c.x === x && c.y === y)) {
-                        const n =
-                            entry.direction === 'across'
-                                ? x - entry.position.x
-                                : y - entry.position.y;
+		if (entry.solution) {
+			this.setState({
+				grid: mapGrid(this.state.grid, (cell, x, y) => {
+					if (cells.some((c) => c.x === x && c.y === y)) {
+						const n =
+							entry.direction === 'across'
+								? x - entry.position.x
+								: y - entry.position.y;
 
-                        cell.value = entry.solution[n];
-                    }
+						cell.value = entry.solution[n];
+					}
 
-                    return cell;
-                }),
-            });
-        }
-    }
+					return cell;
+				}),
+			});
+		}
+	}
 
-    check(entry: Object): void {
-        const cells = cellsForEntry(entry);
+	check(entry: Object): void {
+		const cells = cellsForEntry(entry);
 
-        if (entry.solution) {
-            const badCells = zip(cells, entry.solution.split(''))
-                .filter(cellAndSolution => {
-                    const coords = cellAndSolution[0];
-                    const cell = this.state.grid[coords.x][coords.y];
-                    const solution = cellAndSolution[1];
-                    return (
-                        /^[A-Z]$/.test(cell.value) && cell.value !== solution
-                    );
-                })
-                .map(cellAndSolution => cellAndSolution[0]);
+		if (entry.solution) {
+			const badCells = zip(cells, entry.solution.split(''))
+				.filter((cellAndSolution) => {
+					const coords = cellAndSolution[0];
+					const cell = this.state.grid[coords.x][coords.y];
+					const solution = cellAndSolution[1];
+					return (
+						/^[A-Z]$/.test(cell.value) && cell.value !== solution
+					);
+				})
+				.map((cellAndSolution) => cellAndSolution[0]);
 
-            this.setState({
-                grid: mapGrid(this.state.grid, (cell, gridX, gridY) => {
-                    if (
-                        badCells.some(bad => bad.x === gridX && bad.y === gridY)
-                    ) {
-                        cell.isError = true;
-                        cell.value = '';
-                    }
+			this.setState({
+				grid: mapGrid(this.state.grid, (cell, gridX, gridY) => {
+					if (
+						badCells.some(
+							(bad) => bad.x === gridX && bad.y === gridY,
+						)
+					) {
+						cell.isError = true;
+						cell.value = '';
+					}
 
-                    return cell;
-                }),
-            });
+					return cell;
+				}),
+			});
 
-            setTimeout(() => {
-                this.setState({
-                    grid: mapGrid(this.state.grid, (cell, gridX, gridY) => {
-                        if (
-                            badCells.some(
-                                bad => bad.x === gridX && bad.y === gridY
-                            )
-                        ) {
-                            cell.isError = false;
-                            cell.value = '';
-                        }
+			setTimeout(() => {
+				this.setState({
+					grid: mapGrid(this.state.grid, (cell, gridX, gridY) => {
+						if (
+							badCells.some(
+								(bad) => bad.x === gridX && bad.y === gridY,
+							)
+						) {
+							cell.isError = false;
+							cell.value = '';
+						}
 
-                        return cell;
-                    }),
-                });
-            }, 150);
-        }
-    }
+						return cell;
+					}),
+				});
+			}, 150);
+		}
+	}
 
-    hiddenInputValue(): string {
-        const cell = this.state.cellInFocus;
+	hiddenInputValue(): string {
+		const cell = this.state.cellInFocus;
 
-        let currentValue;
+		let currentValue;
 
-        if (cell) {
-            currentValue = this.state.grid[cell.x][cell.y].value;
-        }
+		if (cell) {
+			currentValue = this.state.grid[cell.x][cell.y].value;
+		}
 
-        return currentValue || '';
-    }
+		return currentValue || '';
+	}
 
-    hasSolutions(): boolean {
-        return 'solution' in this.props.data.entries[0];
-    }
+	hasSolutions(): boolean {
+		return 'solution' in this.props.data.entries[0];
+	}
 
-    isHighlighted(x: number, y: number): boolean {
-        const focused = this.clueInFocus();
-        return focused
-            ? focused.group.some(id => {
-                  const entry = this.props.data.entries.find(e => e.id === id);
-                  return entryHasCell(entry, x, y);
-              })
-            : false;
-    }
+	isHighlighted(x: number, y: number): boolean {
+		const focused = this.clueInFocus();
+		return focused
+			? focused.group.some((id) => {
+					const entry = this.props.data.entries.find(
+						(e) => e.id === id,
+					);
+					return entryHasCell(entry, x, y);
+			  })
+			: false;
+	}
 
-    render(): React$Node {
-        const focused = this.clueInFocus();
+	render(): React$Node {
+		const focused = this.clueInFocus();
 
-        const anagramHelper = this.state.showAnagramHelper && (
-            <AnagramHelper
-                crossword={this}
-                focussedEntry={focused}
-                entries={this.props.data.entries}
-                grid={this.state.grid}
-                close={this.onToggleAnagramHelper}
-            />
-        );
+		const anagramHelper = this.state.showAnagramHelper && (
+			<AnagramHelper
+				crossword={this}
+				focussedEntry={focused}
+				entries={this.props.data.entries}
+				grid={this.state.grid}
+				close={this.onToggleAnagramHelper}
+			/>
+		);
 
-        const gridProps: GridProps = {
-            rows: this.rows,
-            columns: this.columns,
-            cells: this.state.grid,
-            separators: buildSeparatorMap(this.props.data.entries),
-            crossword: this,
-            focussedCell: this.state.cellInFocus,
-            ref: grid => {
-                this.grid = grid;
-            },
-        };
+		const gridProps: GridProps = {
+			rows: this.rows,
+			columns: this.columns,
+			cells: this.state.grid,
+			separators: buildSeparatorMap(this.props.data.entries),
+			crossword: this,
+			focussedCell: this.state.cellInFocus,
+			ref: (grid) => {
+				this.grid = grid;
+			},
+		};
 
-        return (
-            <div
-                className={`crossword__container crossword__container--${
-                    this.props.data.crosswordType
-                } crossword__container--react`}
-                data-link-name="Crosswords">
-                <div
-                    className="crossword__container__game"
-                    ref={game => {
-                        this.game = game;
-                    }}>
-                    <div
-                        className="crossword__sticky-clue-wrapper"
-                        ref={stickyClueWrapper => {
-                            this.stickyClueWrapper = stickyClueWrapper;
-                        }}>
-                        <div
-                            className={classNames({
-                                'crossword__sticky-clue': true,
-                                'is-hidden': !focused,
-                            })}>
-                            {focused && (
-                                <div className="crossword__sticky-clue__inner">
-                                    <div className="crossword__sticky-clue__inner__inner">
-                                        <strong>
-                                            {focused.number}{' '}
-                                            <span className="crossword__sticky-clue__direction">
-                                                {focused.direction}
-                                            </span>
-                                        </strong>{' '}
-                                        {focused.clue}
-                                    </div>
-                                </div>
-                            )}
-                        </div>
-                    </div>
-                    <div
-                        className="crossword__container__grid-wrapper"
-                        ref={gridWrapper => {
-                            this.gridWrapper = gridWrapper;
-                        }}>
-                        {Grid(gridProps)}
-                        <HiddenInput
-                            crossword={this}
-                            value={this.hiddenInputValue()}
-                            ref={hiddenInputComponent => {
-                                this.hiddenInputComponent = hiddenInputComponent;
-                            }}
-                        />
-                        {anagramHelper}
-                    </div>
-                </div>
-                <Controls
-                    hasSolutions={this.hasSolutions()}
-                    clueInFocus={focused}
-                    crossword={this}
-                />
-                <Clues
-                    clues={this.cluesData()}
-                    focussed={focused}
-                    setReturnPosition={this.setReturnPosition.bind(this)}
-                />
-            </div>
-        );
-    }
+		return (
+			<div
+				className={`crossword__container crossword__container--${this.props.data.crosswordType} crossword__container--react`}
+				data-link-name="Crosswords"
+			>
+				<div
+					className="crossword__container__game"
+					ref={(game) => {
+						this.game = game;
+					}}
+				>
+					<div
+						className="crossword__sticky-clue-wrapper"
+						ref={(stickyClueWrapper) => {
+							this.stickyClueWrapper = stickyClueWrapper;
+						}}
+					>
+						<div
+							className={classNames({
+								'crossword__sticky-clue': true,
+								'is-hidden': !focused,
+							})}
+						>
+							{focused && (
+								<div className="crossword__sticky-clue__inner">
+									<div className="crossword__sticky-clue__inner__inner">
+										<strong>
+											{focused.number}{' '}
+											<span className="crossword__sticky-clue__direction">
+												{focused.direction}
+											</span>
+										</strong>{' '}
+										{focused.clue}
+									</div>
+								</div>
+							)}
+						</div>
+					</div>
+					<div
+						className="crossword__container__grid-wrapper"
+						ref={(gridWrapper) => {
+							this.gridWrapper = gridWrapper;
+						}}
+					>
+						{Grid(gridProps)}
+						<HiddenInput
+							crossword={this}
+							value={this.hiddenInputValue()}
+							ref={(hiddenInputComponent) => {
+								this.hiddenInputComponent = hiddenInputComponent;
+							}}
+						/>
+						{anagramHelper}
+					</div>
+				</div>
+				<Controls
+					hasSolutions={this.hasSolutions()}
+					clueInFocus={focused}
+					crossword={this}
+				/>
+				<Clues
+					clues={this.cluesData()}
+					focussed={focused}
+					setReturnPosition={this.setReturnPosition.bind(this)}
+				/>
+			</div>
+		);
+	}
 }
 
 export default Crossword;

--- a/static/src/javascripts.flow.archive/projects/common/modules/crosswords/grid.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/crosswords/grid.js
@@ -11,7 +11,7 @@
  */
 
 // @flow
-import React from 'preact-compat';
+import React from 'react';
 import { gridSize, clueMapKey } from 'common/modules/crosswords/helpers';
 import { constants } from 'common/modules/crosswords/constants';
 import GridCell from 'common/modules/crosswords/cell';
@@ -19,169 +19,170 @@ import { classNames } from 'common/modules/crosswords/classNames';
 import type Crossword from 'common/modules/crosswords/crossword';
 
 export type GridProps = {
-    rows: number,
-    columns: number,
-    cells: Array<Array<Cell>>,
-    separators: SeparatorMap,
-    crossword: Crossword,
-    focussedCell: ?Position,
+	rows: number,
+	columns: number,
+	cells: Array<Array<Cell>>,
+	separators: SeparatorMap,
+	crossword: Crossword,
+	focussedCell: ?Position,
 };
 
 // Position at end of previous cell
 const createWordSeparator = (
-    x: number,
-    y: number,
-    direction: Direction
+	x: number,
+	y: number,
+	direction: Direction,
 ): ?React$Node => {
-    const top = gridSize(y);
-    const left = gridSize(x);
-    const borderWidth = 1;
+	const top = gridSize(y);
+	const left = gridSize(x);
+	const borderWidth = 1;
 
-    if (direction === 'across') {
-        const width = 1;
-        return (
-            <rect
-                x={left - borderWidth - width}
-                y={top}
-                key={['sep', direction, x, y].join('_')}
-                width={width}
-                height={constants.cellSize}
-            />
-        );
-    } else if (direction === 'down') {
-        const height = 1;
-        return (
-            <rect
-                x={left}
-                y={top - borderWidth - height}
-                key={['sep', direction, x, y].join('_')}
-                width={constants.cellSize}
-                height={height}
-            />
-        );
-    }
+	if (direction === 'across') {
+		const width = 1;
+		return (
+			<rect
+				x={left - borderWidth - width}
+				y={top}
+				key={['sep', direction, x, y].join('_')}
+				width={width}
+				height={constants.cellSize}
+			/>
+		);
+	} else if (direction === 'down') {
+		const height = 1;
+		return (
+			<rect
+				x={left}
+				y={top - borderWidth - height}
+				key={['sep', direction, x, y].join('_')}
+				width={constants.cellSize}
+				height={height}
+			/>
+		);
+	}
 };
 
 // Position in-between this and previous cells
 const createHyphenSeparator = (
-    x: number,
-    y: number,
-    direction: Direction
+	x: number,
+	y: number,
+	direction: Direction,
 ): ?React$Node => {
-    const top = gridSize(y);
-    const left = gridSize(x);
-    const borderWidth = 1;
-    let width;
-    let height;
+	const top = gridSize(y);
+	const left = gridSize(x);
+	const borderWidth = 1;
+	let width;
+	let height;
 
-    if (direction === 'across') {
-        width = constants.cellSize / 4;
-        height = 1;
-        return (
-            <rect
-                x={left - borderWidth / 2 - width / 2}
-                y={top + constants.cellSize / 2 + height / 2}
-                key={['sep', direction, x, y].join('_')}
-                width={width}
-                height={height}
-            />
-        );
-    } else if (direction === 'down') {
-        width = 1;
-        height = constants.cellSize / 4;
-        return (
-            <rect
-                x={left + constants.cellSize / 2 + width / 2}
-                y={top - borderWidth / 2 - height / 2}
-                key={['sep', direction, x, y].join('_')}
-                width={width}
-                height={height}
-            />
-        );
-    }
+	if (direction === 'across') {
+		width = constants.cellSize / 4;
+		height = 1;
+		return (
+			<rect
+				x={left - borderWidth / 2 - width / 2}
+				y={top + constants.cellSize / 2 + height / 2}
+				key={['sep', direction, x, y].join('_')}
+				width={width}
+				height={height}
+			/>
+		);
+	} else if (direction === 'down') {
+		width = 1;
+		height = constants.cellSize / 4;
+		return (
+			<rect
+				x={left + constants.cellSize / 2 + width / 2}
+				y={top - borderWidth / 2 - height / 2}
+				key={['sep', direction, x, y].join('_')}
+				width={width}
+				height={height}
+			/>
+		);
+	}
 };
 
 const createSeparator = (
-    x: number,
-    y: number,
-    separatorDescription: ?SeparatorDescription
+	x: number,
+	y: number,
+	separatorDescription: ?SeparatorDescription,
 ): ?React$Node => {
-    if (separatorDescription) {
-        if (separatorDescription.separator === ',') {
-            return createWordSeparator(x, y, separatorDescription.direction);
-        } else if (separatorDescription.separator === '-') {
-            return createHyphenSeparator(x, y, separatorDescription.direction);
-        }
-    }
+	if (separatorDescription) {
+		if (separatorDescription.separator === ',') {
+			return createWordSeparator(x, y, separatorDescription.direction);
+		} else if (separatorDescription.separator === '-') {
+			return createHyphenSeparator(x, y, separatorDescription.direction);
+		}
+	}
 };
 
 export const Grid = (props: GridProps): React$Node => {
-    const getSeparators = (x: number, y: number): ?SeparatorDescription =>
-        props.separators[clueMapKey(x, y)];
+	const getSeparators = (x: number, y: number): ?SeparatorDescription =>
+		props.separators[clueMapKey(x, y)];
 
-    const handleSelect = (x: number, y: number): void =>
-        props.crossword.onSelect(x, y);
+	const handleSelect = (x: number, y: number): void =>
+		props.crossword.onSelect(x, y);
 
-    const width = gridSize(props.columns);
-    const height = gridSize(props.rows);
-    const cells = [];
-    let separators = [];
+	const width = gridSize(props.columns);
+	const height = gridSize(props.rows);
+	const cells = [];
+	let separators = [];
 
-    const range = n => Array.from({ length: n }, (value, key) => key);
+	const range = (n) => Array.from({ length: n }, (value, key) => key);
 
-    // This is needed to appease ESLint (https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md#false-positives-sfc)
-    const cellsIn = props.cells;
+	// This is needed to appease ESLint (https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md#false-positives-sfc)
+	const cellsIn = props.cells;
 
-    range(props.rows).forEach(y =>
-        range(props.columns).forEach(x => {
-            const cellProps = cellsIn[x][y];
+	range(props.rows).forEach((y) =>
+		range(props.columns).forEach((x) => {
+			const cellProps = cellsIn[x][y];
 
-            if (cellProps.isEditable) {
-                const isHighlighted = props.crossword.isHighlighted(x, y);
-                cells.push(
-                    <GridCell
-                        {...Object.assign(
-                            {},
-                            cellProps,
-                            {
-                                handleSelect,
-                                x,
-                                y,
-                                key: `cell_${x}_${y}`,
-                                isHighlighted,
-                                isFocussed:
-                                    props.focussedCell &&
-                                    x === props.focussedCell.x &&
-                                    y === props.focussedCell.y,
-                            },
-                            this
-                        )}
-                    />
-                );
+			if (cellProps.isEditable) {
+				const isHighlighted = props.crossword.isHighlighted(x, y);
+				cells.push(
+					<GridCell
+						{...Object.assign(
+							{},
+							cellProps,
+							{
+								handleSelect,
+								x,
+								y,
+								key: `cell_${x}_${y}`,
+								isHighlighted,
+								isFocussed:
+									props.focussedCell &&
+									x === props.focussedCell.x &&
+									y === props.focussedCell.y,
+							},
+							this,
+						)}
+					/>,
+				);
 
-                separators = separators.concat(
-                    createSeparator(x, y, getSeparators(x, y))
-                );
-            }
-        })
-    );
+				separators = separators.concat(
+					createSeparator(x, y, getSeparators(x, y)),
+				);
+			}
+		}),
+	);
 
-    return (
-        <svg
-            viewBox={`0 0 ${width} ${height}`}
-            className={classNames({
-                crossword__grid: true,
-                'crossword__grid--focussed': !!props.focussedCell,
-            })}>
-            <rect
-                x={0}
-                y={0}
-                width={width}
-                height={height}
-                className="crossword__grid-background"
-            />
-            {cells}
-            <g className="crossword__grid__separators">{separators}</g>
-        </svg>
-    );
+	return (
+		<svg
+			viewBox={`0 0 ${width} ${height}`}
+			className={classNames({
+				crossword__grid: true,
+				'crossword__grid--focussed': !!props.focussedCell,
+			})}
+		>
+			<rect
+				x={0}
+				y={0}
+				width={width}
+				height={height}
+				className="crossword__grid-background"
+			/>
+			{cells}
+			<g className="crossword__grid__separators">{separators}</g>
+		</svg>
+	);
 };

--- a/static/src/javascripts.flow.archive/projects/common/modules/crosswords/hidden-input.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/crosswords/hidden-input.js
@@ -11,91 +11,92 @@
  */
 
 // @flow
-import React, { Component, findDOMNode } from 'preact-compat';
+import React, { Component, findDOMNode } from 'react';
 import bonzo from 'bonzo';
 import fastdom from 'fastdom';
 import { scrollTo } from 'lib/scroller';
 import { isBreakpoint } from 'lib/detect';
 
 class HiddenInput extends Component<*, *> {
-    constructor(props: Object) {
-        super(props);
-        this.state = {
-            value: this.props.value,
-        };
-    }
+	constructor(props: Object) {
+		super(props);
+		this.state = {
+			value: this.props.value,
+		};
+	}
 
-    componentDidUpdate() {
-        if (
-            isBreakpoint({
-                max: 'mobile',
-            })
-        ) {
-            fastdom.measure(() => {
-                const offsets = bonzo(findDOMNode(this.input)).offset();
-                const clueHeight = document.getElementsByClassName(
-                    'crossword__sticky-clue'
-                )[0].offsetHeight;
+	componentDidUpdate() {
+		if (
+			isBreakpoint({
+				max: 'mobile',
+			})
+		) {
+			fastdom.measure(() => {
+				const offsets = bonzo(findDOMNode(this.input)).offset();
+				const clueHeight = document.getElementsByClassName(
+					'crossword__sticky-clue',
+				)[0].offsetHeight;
 
-                scrollTo(
-                    offsets.top - offsets.height * 1.5 - clueHeight,
-                    250,
-                    'easeOutQuad'
-                );
-            });
-        }
-    }
+				scrollTo(
+					offsets.top - offsets.height * 1.5 - clueHeight,
+					250,
+					'easeOutQuad',
+				);
+			});
+		}
+	}
 
-    onClick(event: SyntheticInputEvent<HTMLInputElement>) {
-        this.props.crossword.onClickHiddenInput(event);
-    }
+	onClick(event: SyntheticInputEvent<HTMLInputElement>) {
+		this.props.crossword.onClickHiddenInput(event);
+	}
 
-    onKeyDown(event: SyntheticInputEvent<HTMLInputElement>) {
-        this.props.crossword.onKeyDown(event);
-    }
+	onKeyDown(event: SyntheticInputEvent<HTMLInputElement>) {
+		this.props.crossword.onKeyDown(event);
+	}
 
-    onBlur(event: SyntheticInputEvent<HTMLInputElement>) {
-        this.props.crossword.goToReturnPosition(event);
-    }
+	onBlur(event: SyntheticInputEvent<HTMLInputElement>) {
+		this.props.crossword.goToReturnPosition(event);
+	}
 
-    touchStart(event: SyntheticInputEvent<HTMLInputElement>) {
-        this.props.crossword.onClickHiddenInput(event);
-    }
+	touchStart(event: SyntheticInputEvent<HTMLInputElement>) {
+		this.props.crossword.onClickHiddenInput(event);
+	}
 
-    handleChange(event: SyntheticInputEvent<HTMLInputElement>) {
-        this.props.crossword.insertCharacter(event.target.value);
-        this.setState({
-            value: '',
-        });
-    }
+	handleChange(event: SyntheticInputEvent<HTMLInputElement>) {
+		this.props.crossword.insertCharacter(event.target.value);
+		this.setState({
+			value: '',
+		});
+	}
 
-    render() {
-        return (
-            <div
-                className="crossword__hidden-input-wrapper"
-                ref={wrapper => {
-                    this.wrapper = wrapper;
-                }}>
-                <input
-                    type="text"
-                    className="crossword__hidden-input"
-                    maxLength="1"
-                    onClick={this.onClick.bind(this)}
-                    onChange={this.handleChange.bind(this)}
-                    onTouchStart={this.touchStart.bind(this)}
-                    onKeyDown={this.onKeyDown.bind(this)}
-                    onBlur={this.onBlur.bind(this)}
-                    value={this.state.value}
-                    autoComplete="off"
-                    spellCheck="false"
-                    autoCorrect="off"
-                    ref={input => {
-                        this.input = input;
-                    }}
-                />
-            </div>
-        );
-    }
+	render() {
+		return (
+			<div
+				className="crossword__hidden-input-wrapper"
+				ref={(wrapper) => {
+					this.wrapper = wrapper;
+				}}
+			>
+				<input
+					type="text"
+					className="crossword__hidden-input"
+					maxLength="1"
+					onClick={this.onClick.bind(this)}
+					onChange={this.handleChange.bind(this)}
+					onTouchStart={this.touchStart.bind(this)}
+					onKeyDown={this.onKeyDown.bind(this)}
+					onBlur={this.onBlur.bind(this)}
+					value={this.state.value}
+					autoComplete="off"
+					spellCheck="false"
+					autoCorrect="off"
+					ref={(input) => {
+						this.input = input;
+					}}
+				/>
+			</div>
+		);
+	}
 }
 
 export { HiddenInput };

--- a/static/src/javascripts.flow.archive/projects/common/modules/crosswords/main.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/crosswords/main.js
@@ -12,61 +12,61 @@
 
 // @flow
 
-import React, { render } from 'preact-compat';
+import React, { render } from 'react';
 import bean from 'bean';
 import fastdom from 'lib/fastdom-promise';
 import $ from 'lib/$';
 import Crossword from 'common/modules/crosswords/crossword';
 
 const initCrosswords = (): void => {
-    fastdom
-        .measure(() => document.getElementsByClassName('js-crossword'))
-        .then(elements => {
-            Array.from(elements).forEach(element => {
-                const data = element.getAttribute('data-crossword-data');
+	fastdom
+		.measure(() => document.getElementsByClassName('js-crossword'))
+		.then((elements) => {
+			Array.from(elements).forEach((element) => {
+				const data = element.getAttribute('data-crossword-data');
 
-                if (!data) {
-                    throw new Error(
-                        'JavaScript crossword without associated data in data-crossword-data'
-                    );
-                }
+				if (!data) {
+					throw new Error(
+						'JavaScript crossword without associated data in data-crossword-data',
+					);
+				}
 
-                const crosswordComponent = render(
-                    <Crossword data={JSON.parse(data)} />,
-                    element
-                );
+				const crosswordComponent = render(
+					<Crossword data={JSON.parse(data)} />,
+					element,
+				);
 
-                const entryId = window.location.hash.replace('#', '');
-                const entry = crosswordComponent.props.data.entries.find(
-                    val => val.id === entryId
-                );
+				const entryId = window.location.hash.replace('#', '');
+				const entry = crosswordComponent.props.data.entries.find(
+					(val) => val.id === entryId,
+				);
 
-                if (entry) {
-                    crosswordComponent.focusFirstCellInClue(entry);
-                }
+				if (entry) {
+					crosswordComponent.focusFirstCellInClue(entry);
+				}
 
-                bean.on(element, 'click', $('.crossword__clue'), e => {
-                    e.preventDefault();
+				bean.on(element, 'click', $('.crossword__clue'), (e) => {
+					e.preventDefault();
 
-                    const idMatch = e.currentTarget.hash.match(/#.*/);
-                    const newEntryId = idMatch && idMatch[0].replace('#', '');
-                    const newEntry = crosswordComponent.props.data.entries.find(
-                        val => val.id === newEntryId
-                    );
-                    const focussedEntry = crosswordComponent.clueInFocus();
-                    const isNewEntry =
-                        focussedEntry && focussedEntry.id !== newEntry.id;
+					const idMatch = e.currentTarget.hash.match(/#.*/);
+					const newEntryId = idMatch && idMatch[0].replace('#', '');
+					const newEntry = crosswordComponent.props.data.entries.find(
+						(val) => val.id === newEntryId,
+					);
+					const focussedEntry = crosswordComponent.clueInFocus();
+					const isNewEntry =
+						focussedEntry && focussedEntry.id !== newEntry.id;
 
-                    // Only focus the first cell in the new clue if it's not already
-                    // focussed. When focussing a cell in a new clue, we update the
-                    // hash fragment afterwards, in which case we do not want to
-                    // reset focus to the first cell.
-                    if (newEntry && (focussedEntry ? isNewEntry : true)) {
-                        crosswordComponent.focusFirstCellInClue(newEntry);
-                    }
-                });
-            });
-        });
+					// Only focus the first cell in the new clue if it's not already
+					// focussed. When focussing a cell in a new clue, we update the
+					// hash fragment afterwards, in which case we do not want to
+					// reset focus to the first cell.
+					if (newEntry && (focussedEntry ? isNewEntry : true)) {
+						crosswordComponent.focusFirstCellInClue(newEntry);
+					}
+				});
+			});
+		});
 };
 
 export { initCrosswords };

--- a/static/src/javascripts.flow.archive/projects/common/modules/identity/ad-prefs.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/identity/ad-prefs.js
@@ -12,139 +12,142 @@
 
 // @flow
 
-import React, { Component, render } from 'preact-compat';
+import React, { Component, render } from 'react';
 import { FeedbackFlashBox } from 'common/modules/identity/ad-prefs/FeedbackFlashBox';
 import { ConsentBox } from 'common/modules/identity/ad-prefs/ConsentBox';
 
 import fastdom from 'lib/fastdom-promise';
 import {
-    getAdConsentState,
-    setAdConsentState,
-    getAllAdConsentsWithState,
+	getAdConsentState,
+	setAdConsentState,
+	getAllAdConsentsWithState,
 } from 'common/modules/commercial/ad-prefs.lib';
 import type {
-    AdConsent,
-    AdConsentWithState,
+	AdConsent,
+	AdConsentWithState,
 } from 'common/modules/commercial/ad-prefs.lib';
 
 type AdPrefsWrapperProps = {
-    getAdConsentState: (consent: AdConsent) => ?boolean,
-    setAdConsentState: (consent: AdConsent, state: boolean) => void,
-    initialConsentsWithState: AdConsentWithState[],
+	getAdConsentState: (consent: AdConsent) => ?boolean,
+	setAdConsentState: (consent: AdConsent, state: boolean) => void,
+	initialConsentsWithState: AdConsentWithState[],
 };
 
 const rootSelector: string = '.js-manage-account__ad-prefs';
 
 class AdPrefsWrapper extends Component<
-    AdPrefsWrapperProps,
-    {
-        consentsWithState: AdConsentWithState[],
-        changesPending: boolean,
-        flashing: boolean,
-    }
+	AdPrefsWrapperProps,
+	{
+		consentsWithState: AdConsentWithState[],
+		changesPending: boolean,
+		flashing: boolean,
+	},
 > {
-    constructor(props: AdPrefsWrapperProps): void {
-        super(props);
-        this.state = {
-            changesPending: false,
-            flashing: false,
-            consentsWithState: [...this.props.initialConsentsWithState],
-        };
-    }
+	constructor(props: AdPrefsWrapperProps): void {
+		super(props);
+		this.state = {
+			changesPending: false,
+			flashing: false,
+			consentsWithState: [...this.props.initialConsentsWithState],
+		};
+	}
 
-    onUpdate(consentId: number, state: ?boolean): void {
-        const consentsWithState = [...this.state.consentsWithState];
-        const changesPending =
-            this.props.getAdConsentState(
-                consentsWithState[consentId].consent
-            ) !== state;
-        consentsWithState[consentId].state = state;
-        if (this.SubmitButtonRef) {
-            this.SubmitButtonRef.scrollIntoView(false);
-        }
-        this.setState({
-            consentsWithState,
-            changesPending,
-            flashing: false,
-        });
-    }
+	onUpdate(consentId: number, state: ?boolean): void {
+		const consentsWithState = [...this.state.consentsWithState];
+		const changesPending =
+			this.props.getAdConsentState(
+				consentsWithState[consentId].consent,
+			) !== state;
+		consentsWithState[consentId].state = state;
+		if (this.SubmitButtonRef) {
+			this.SubmitButtonRef.scrollIntoView(false);
+		}
+		this.setState({
+			consentsWithState,
+			changesPending,
+			flashing: false,
+		});
+	}
 
-    onSubmit(event: SyntheticInputEvent<HTMLFormElement>): void {
-        event.preventDefault();
-        this.state.consentsWithState.forEach(consentWithState => {
-            if (typeof consentWithState.state === 'boolean') {
-                this.props.setAdConsentState(
-                    consentWithState.consent,
-                    consentWithState.state
-                );
-            }
-        });
-        this.setState({
-            changesPending: false,
-            flashing: true,
-        });
-    }
+	onSubmit(event: SyntheticInputEvent<HTMLFormElement>): void {
+		event.preventDefault();
+		this.state.consentsWithState.forEach((consentWithState) => {
+			if (typeof consentWithState.state === 'boolean') {
+				this.props.setAdConsentState(
+					consentWithState.consent,
+					consentWithState.state,
+				);
+			}
+		});
+		this.setState({
+			changesPending: false,
+			flashing: true,
+		});
+	}
 
-    FeedbackFlashBoxRef: ?FeedbackFlashBox;
-    SubmitButtonRef: ?HTMLElement;
+	FeedbackFlashBoxRef: ?FeedbackFlashBox;
+	SubmitButtonRef: ?HTMLElement;
 
-    render() {
-        return (
-            <form
-                className="identity-ad-prefs-manager"
-                onSubmit={ev => this.onSubmit(ev)}>
-                <div>
-                    {this.state.consentsWithState.map(
-                        (consentWithState, index) => (
-                            <ConsentBox
-                                consent={consentWithState.consent}
-                                state={consentWithState.state}
-                                key={consentWithState.consent.cookie}
-                                onUpdate={(state: ?boolean) => {
-                                    this.onUpdate(index, state);
-                                }}
-                            />
-                        )
-                    )}
-                </div>
-                <div
-                    className="identity-ad-prefs-manager__footer"
-                    ref={child => {
-                        this.SubmitButtonRef = child;
-                    }}>
-                    <button
-                        disabled={this.state.changesPending ? null : 'disabled'}
-                        className="manage-account__button manage-account__button--center"
-                        data-link-name="ad-prefs : submit"
-                        type="submit">
-                        Save my settings
-                    </button>
-                    <FeedbackFlashBox flashing={this.state.flashing}>
-                        Your settings have been saved.
-                    </FeedbackFlashBox>
-                </div>
-            </form>
-        );
-    }
+	render() {
+		return (
+			<form
+				className="identity-ad-prefs-manager"
+				onSubmit={(ev) => this.onSubmit(ev)}
+			>
+				<div>
+					{this.state.consentsWithState.map(
+						(consentWithState, index) => (
+							<ConsentBox
+								consent={consentWithState.consent}
+								state={consentWithState.state}
+								key={consentWithState.consent.cookie}
+								onUpdate={(state: ?boolean) => {
+									this.onUpdate(index, state);
+								}}
+							/>
+						),
+					)}
+				</div>
+				<div
+					className="identity-ad-prefs-manager__footer"
+					ref={(child) => {
+						this.SubmitButtonRef = child;
+					}}
+				>
+					<button
+						disabled={this.state.changesPending ? null : 'disabled'}
+						className="manage-account__button manage-account__button--center"
+						data-link-name="ad-prefs : submit"
+						type="submit"
+					>
+						Save my settings
+					</button>
+					<FeedbackFlashBox flashing={this.state.flashing}>
+						Your settings have been saved.
+					</FeedbackFlashBox>
+				</div>
+			</form>
+		);
+	}
 }
 
 const enhanceAdPrefs = (): void => {
-    fastdom
-        .measure(() => Array.from(document.querySelectorAll(rootSelector)))
-        .then((wrapperEls: HTMLElement[]) => {
-            wrapperEls.forEach(_ => {
-                fastdom.mutate(() => {
-                    render(
-                        <AdPrefsWrapper
-                            initialConsentsWithState={getAllAdConsentsWithState()}
-                            getAdConsentState={getAdConsentState}
-                            setAdConsentState={setAdConsentState}
-                        />,
-                        _
-                    );
-                });
-            });
-        });
+	fastdom
+		.measure(() => Array.from(document.querySelectorAll(rootSelector)))
+		.then((wrapperEls: HTMLElement[]) => {
+			wrapperEls.forEach((_) => {
+				fastdom.mutate(() => {
+					render(
+						<AdPrefsWrapper
+							initialConsentsWithState={getAllAdConsentsWithState()}
+							getAdConsentState={getAdConsentState}
+							setAdConsentState={setAdConsentState}
+						/>,
+						_,
+					);
+				});
+			});
+		});
 };
 
 export { enhanceAdPrefs };

--- a/static/src/javascripts.flow.archive/projects/common/modules/identity/ad-prefs/ConsentBox.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/identity/ad-prefs/ConsentBox.js
@@ -12,100 +12,100 @@
 
 // @flow
 
-import React, { Component } from 'preact-compat';
+import React, { Component } from 'react';
 import type { AdConsent } from 'common/modules/commercial/ad-prefs.lib';
 import { getConsentWording } from './wordings';
 import type { ConsentWording, CheckboxWording } from './wordings';
 
 type ConsentRadioButtonProps = {
-    value: string,
-    checked: boolean,
-    wording: CheckboxWording,
-    consent: AdConsent,
-    onToggle: () => void,
+	value: string,
+	checked: boolean,
+	wording: CheckboxWording,
+	consent: AdConsent,
+	onToggle: () => void,
 };
 
 type ConsentBoxProps = {
-    consent: AdConsent,
-    state: ?boolean,
-    onUpdate: (state: ?boolean) => void,
+	consent: AdConsent,
+	state: ?boolean,
+	onUpdate: (state: ?boolean) => void,
 };
 
 class ConsentRadioButton extends Component<ConsentRadioButtonProps, {}> {
-    handleChange(event: SyntheticInputEvent<HTMLInputElement>): void {
-        if (event.target.checked) {
-            this.props.onToggle();
-        }
-    }
-    render() {
-        const id = `gu-ad-prefs-${this.props.value.toString()}-${
-            this.props.consent.cookie
-        }`;
-        const name = `gu-ad-prefs-${this.props.consent.cookie}`;
+	handleChange(event: SyntheticInputEvent<HTMLInputElement>): void {
+		if (event.target.checked) {
+			this.props.onToggle();
+		}
+	}
+	render() {
+		const id = `gu-ad-prefs-${this.props.value.toString()}-${
+			this.props.consent.cookie
+		}`;
+		const name = `gu-ad-prefs-${this.props.consent.cookie}`;
 
-        return (
-            <div className="identity-ad-prefs-input identity-ad-prefs-manager">
-                <label className="identity-ad-prefs-input__label" htmlFor={id}>
-                    <input
-                        type="radio"
-                        name={name}
-                        id={id}
-                        data-link-name={`ad-prefs - ${
-                            this.props.consent.cookie
-                        } - ${this.props.value.toString()}`}
-                        value={this.props.value.toString()}
-                        checked={this.props.checked}
-                        onChange={this.handleChange.bind(this)}
-                    />
-                    <span>{this.props.wording.title}</span>
-                </label>
-                {this.props.wording.text && (
-                    <span
-                        className="identity-ad-prefs-input__wording"
-                        dangerouslySetInnerHTML={{
-                            __html: this.props.wording.text,
-                        }}
-                    />
-                )}
-            </div>
-        );
-    }
+		return (
+			<div className="identity-ad-prefs-input identity-ad-prefs-manager">
+				<label className="identity-ad-prefs-input__label" htmlFor={id}>
+					<input
+						type="radio"
+						name={name}
+						id={id}
+						data-link-name={`ad-prefs - ${
+							this.props.consent.cookie
+						} - ${this.props.value.toString()}`}
+						value={this.props.value.toString()}
+						checked={this.props.checked}
+						onChange={this.handleChange.bind(this)}
+					/>
+					<span>{this.props.wording.title}</span>
+				</label>
+				{this.props.wording.text && (
+					<span
+						className="identity-ad-prefs-input__wording"
+						dangerouslySetInnerHTML={{
+							__html: this.props.wording.text,
+						}}
+					/>
+				)}
+			</div>
+		);
+	}
 }
 
 class ConsentBox extends Component<ConsentBoxProps, {}> {
-    render() {
-        const wording: ConsentWording = getConsentWording(this.props.consent);
+	render() {
+		const wording: ConsentWording = getConsentWording(this.props.consent);
 
-        return (
-            <fieldset>
-                <legend className="identity-title identity-title--small">
-                    {wording.question.title}
-                </legend>
-                {wording.question.text && (
-                    <div className="identity-ad-prefs-input__wording">
-                        {wording.question.text}
-                    </div>
-                )}
+		return (
+			<fieldset>
+				<legend className="identity-title identity-title--small">
+					{wording.question.title}
+				</legend>
+				{wording.question.text && (
+					<div className="identity-ad-prefs-input__wording">
+						{wording.question.text}
+					</div>
+				)}
 
-                <div className="identity-ad-prefs-options">
-                    <ConsentRadioButton
-                        value="true"
-                        wording={wording.yesCheckbox}
-                        checked={this.props.state === true}
-                        consent={this.props.consent}
-                        onToggle={() => this.props.onUpdate(true)}
-                    />
-                    <ConsentRadioButton
-                        value="false"
-                        wording={wording.noCheckbox}
-                        checked={this.props.state === false}
-                        consent={this.props.consent}
-                        onToggle={() => this.props.onUpdate(false)}
-                    />
-                </div>
-            </fieldset>
-        );
-    }
+				<div className="identity-ad-prefs-options">
+					<ConsentRadioButton
+						value="true"
+						wording={wording.yesCheckbox}
+						checked={this.props.state === true}
+						consent={this.props.consent}
+						onToggle={() => this.props.onUpdate(true)}
+					/>
+					<ConsentRadioButton
+						value="false"
+						wording={wording.noCheckbox}
+						checked={this.props.state === false}
+						consent={this.props.consent}
+						onToggle={() => this.props.onUpdate(false)}
+					/>
+				</div>
+			</fieldset>
+		);
+	}
 }
 
 export { ConsentBox };

--- a/static/src/javascripts.flow.archive/projects/common/modules/identity/ad-prefs/FeedbackFlashBox.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/identity/ad-prefs/FeedbackFlashBox.js
@@ -11,28 +11,29 @@
  */
 
 // @flow
-import React, { Component } from 'preact-compat';
+import React, { Component } from 'react';
 
 type FeedbackFlashBoxProps = {
-    children: any,
-    flashing: boolean,
+	children: any,
+	flashing: boolean,
 };
 
 class FeedbackFlashBox extends Component<FeedbackFlashBoxProps> {
-    render() {
-        return (
-            <div
-                className={[
-                    'identity-ad-prefs-manager__flash',
-                    this.props.flashing
-                        ? 'identity-ad-prefs-manager__flash--flashing'
-                        : '',
-                ].join(' ')}
-                aria-hidden="true">
-                {this.props.children}
-            </div>
-        );
-    }
+	render() {
+		return (
+			<div
+				className={[
+					'identity-ad-prefs-manager__flash',
+					this.props.flashing
+						? 'identity-ad-prefs-manager__flash--flashing'
+						: '',
+				].join(' ')}
+				aria-hidden="true"
+			>
+				{this.props.children}
+			</div>
+		);
+	}
 }
 
 export { FeedbackFlashBox };

--- a/static/src/javascripts.flow.archive/projects/common/modules/identity/ad-prefs/wordings.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/identity/ad-prefs/wordings.js
@@ -11,77 +11,79 @@
  */
 
 // @flow
-import React, { Node } from 'preact-compat';
+import React, { Node } from 'react';
 import type { AdConsent } from 'common/modules/commercial/ad-prefs.lib';
 import { thirdPartyTrackingAdConsent } from 'common/modules/commercial/ad-prefs.lib';
 
 type CheckboxWording = {
-    title: string,
-    text?: string,
+	title: string,
+	text?: string,
 };
 
 type QuestionWording = {
-    title: string,
-    text?: Node,
+	title: string,
+	text?: Node,
 };
 
 type ConsentWording = {
-    question: QuestionWording,
-    yesCheckbox: CheckboxWording,
-    noCheckbox: CheckboxWording,
+	question: QuestionWording,
+	yesCheckbox: CheckboxWording,
+	noCheckbox: CheckboxWording,
 };
 
 const ThirdPartyConsentWording: ConsentWording = {
-    question: {
-        title: 'Set your personalised ads preferences',
-        text: (
-            <div>
-                <p>
-                    We work with{' '}
-                    <a
-                        className="u-underline"
-                        href="https://www.theguardian.com/info/cookies">
-                        advertising partners
-                    </a>{' '}
-                    (including Google and the Ozone project) to show you ads for
-                    products and services you might be interested in. You can
-                    choose whether the ads you see on our sites are personalised
-                    by selecting one of the options below.
-                </p>
-                <p>
-                    Don&apos;t worry, you can always revisit these settings by
-                    following the link on our{' '}
-                    <a
-                        className="u-underline"
-                        href="https://www.theguardian.com/info/cookies#nav4">
-                        cookies policy page.
-                    </a>
-                </p>
-            </div>
-        ),
-    },
-    yesCheckbox: {
-        title: 'I am OK with personalised ads',
-        text: `We and our advertising partners will use your data to show you ads that you might be interested in.`,
-    },
-    noCheckbox: {
-        title: 'I do not want to see personalised ads',
-        text: `We will ask our advertising partners not to show you personalised ads. Please note that you will still see advertising, but it will be less relevant.`,
-    },
+	question: {
+		title: 'Set your personalised ads preferences',
+		text: (
+			<div>
+				<p>
+					We work with{' '}
+					<a
+						className="u-underline"
+						href="https://www.theguardian.com/info/cookies"
+					>
+						advertising partners
+					</a>{' '}
+					(including Google and the Ozone project) to show you ads for
+					products and services you might be interested in. You can
+					choose whether the ads you see on our sites are personalised
+					by selecting one of the options below.
+				</p>
+				<p>
+					Don&apos;t worry, you can always revisit these settings by
+					following the link on our{' '}
+					<a
+						className="u-underline"
+						href="https://www.theguardian.com/info/cookies#nav4"
+					>
+						cookies policy page.
+					</a>
+				</p>
+			</div>
+		),
+	},
+	yesCheckbox: {
+		title: 'I am OK with personalised ads',
+		text: `We and our advertising partners will use your data to show you ads that you might be interested in.`,
+	},
+	noCheckbox: {
+		title: 'I do not want to see personalised ads',
+		text: `We will ask our advertising partners not to show you personalised ads. Please note that you will still see advertising, but it will be less relevant.`,
+	},
 };
 
 const getConsentWording = (consent: AdConsent): ConsentWording => {
-    if (consent.cookie === thirdPartyTrackingAdConsent.cookie)
-        return ThirdPartyConsentWording;
-    return {
-        question: { title: consent.label },
-        yesCheckbox: {
-            title: 'yes',
-        },
-        noCheckbox: {
-            title: 'no',
-        },
-    };
+	if (consent.cookie === thirdPartyTrackingAdConsent.cookie)
+		return ThirdPartyConsentWording;
+	return {
+		question: { title: consent.label },
+		yesCheckbox: {
+			title: 'yes',
+		},
+		noCheckbox: {
+			title: 'no',
+		},
+	};
 };
 
 export type { ConsentWording, CheckboxWording, QuestionWording };

--- a/static/src/javascripts.flow.archive/projects/common/modules/identity/follow.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/identity/follow.js
@@ -11,34 +11,34 @@
  */
 
 // @flow
-import React, { render } from 'preact-compat';
+import React, { render } from 'react';
 import fastdom from 'lib/fastdom-promise';
 import { FollowButtonWrap } from './upsell/button/FollowButtonWrap';
 import loadEnhancers from './modules/loadEnhancers';
 
 const bindFollow = (el): void => {
-    fastdom
-        .measure(() => el.querySelector('.identity-follow__button-target'))
-        .then((wrapperEl: HTMLElement) => {
-            fastdom.mutate(() => {
-                render(
-                    <FollowButtonWrap
-                        following
-                        onFollow={() => {
-                            console.log('following');
-                        }}
-                        onUnfollow={() => {
-                            console.log('not following');
-                        }}
-                    />,
-                    wrapperEl
-                );
-            });
-        });
+	fastdom
+		.measure(() => el.querySelector('.identity-follow__button-target'))
+		.then((wrapperEl: HTMLElement) => {
+			fastdom.mutate(() => {
+				render(
+					<FollowButtonWrap
+						following
+						onFollow={() => {
+							console.log('following');
+						}}
+						onUnfollow={() => {
+							console.log('not following');
+						}}
+					/>,
+					wrapperEl,
+				);
+			});
+		});
 };
 
 const enhanceFollow = (): void => {
-    loadEnhancers([['.identity-follow', bindFollow]]);
+	loadEnhancers([['.identity-follow', bindFollow]]);
 };
 
 export { enhanceFollow };

--- a/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/account-creation/AccountBenefits.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/account-creation/AccountBenefits.js
@@ -11,117 +11,118 @@
  */
 
 // @flow
-import React from 'preact-compat';
+import React from 'react';
 import config from 'lib/config';
 
 type BenefitCta = {
-    name: string,
-    link: string,
+	name: string,
+	link: string,
 };
 
 type Benefit = {
-    title: string,
-    blurb: string,
+	title: string,
+	blurb: string,
 };
 
 type ActionableBenefit = Benefit & {
-    cta: BenefitCta[],
+	cta: BenefitCta[],
 };
 
 const benefits: Benefit[] = [
-    {
-        title: `Get closer to our journalism`,
-        blurb: `Choose from over 40 exclusive newsletters and updates on the variety of topics that matter to you.`,
-    },
-    {
-        title: `Join the conversation`,
-        blurb: `Get involved – post or recommend comments below an article.`,
-    },
-    {
-        title: `Take your career to the next level `,
-        blurb: `Browse a huge variety of jobs, create your jobseeker profile and receive job alerts for vacancies you want to hear about.`,
-    },
-    {
-        title: `Enjoy our free iOS and Android apps`,
-        blurb: `Save articles for later, tailor your news and get notified about topics that matter to you.`,
-    },
+	{
+		title: `Get closer to our journalism`,
+		blurb: `Choose from over 40 exclusive newsletters and updates on the variety of topics that matter to you.`,
+	},
+	{
+		title: `Join the conversation`,
+		blurb: `Get involved – post or recommend comments below an article.`,
+	},
+	{
+		title: `Take your career to the next level `,
+		blurb: `Browse a huge variety of jobs, create your jobseeker profile and receive job alerts for vacancies you want to hear about.`,
+	},
+	{
+		title: `Enjoy our free iOS and Android apps`,
+		blurb: `Save articles for later, tailor your news and get notified about topics that matter to you.`,
+	},
 ];
 
 const actionableBenefits: ActionableBenefit[] = [
-    {
-        title: `Get closer to our journalism`,
-        blurb: `Browse over 40 curated newsletters on a variety of topics - from daily news headlines to weekly culture highlights, and diverse dedicated topics like science, documentary films and fashion. You can also sign up to receive updates about Guardian events, holidays and offers.`,
-        cta: [
-            {
-                name: `Find your favourite newsletter`,
-                link: `${config.get('page.host')}/email-newsletters`,
-            },
-        ],
-    },
-    {
-        title: `Join the conversation`,
-        blurb: `We believe in having open debate and in giving readers a voice in our journalism. With your Guardian profile, you can recommend comments added by other Guardian readers at the bottom of the articles or contribute your thoughts for other readers to see. Complete your public profile and join the debate.`,
-        cta: [
-            {
-                name: `Complete your profile`,
-                link: `${config.get('page.idUrl')}/public/edit`,
-            },
-        ],
-    },
-    {
-        title: `Download our award-winning app`,
-        blurb: `Available on iOS and Android. Sign in with your Guardian account to use exclusive features such as ‘save for later’ or mobile alerts when your favourite writers publish an article, or your football team scores.`,
-        cta: [
-            {
-                name: `Explore our apps`,
-                link: `${config.get(
-                    'page.host'
-                )}/technology/ng-interactive/2018/may/15/the-guardian-app`,
-            },
-        ],
-    },
-    {
-        title: `Take your career to the next level`,
-        blurb: `Your account allows you to set up a Guardian Jobs profile, browse a huge variety of jobs and be the first to hear about vacancies in your preferred industry.`,
-        cta: [
-            {
-                name: `Browse jobs`,
-                link: `https://jobs.theguardian.com/`,
-            },
-        ],
-    },
+	{
+		title: `Get closer to our journalism`,
+		blurb: `Browse over 40 curated newsletters on a variety of topics - from daily news headlines to weekly culture highlights, and diverse dedicated topics like science, documentary films and fashion. You can also sign up to receive updates about Guardian events, holidays and offers.`,
+		cta: [
+			{
+				name: `Find your favourite newsletter`,
+				link: `${config.get('page.host')}/email-newsletters`,
+			},
+		],
+	},
+	{
+		title: `Join the conversation`,
+		blurb: `We believe in having open debate and in giving readers a voice in our journalism. With your Guardian profile, you can recommend comments added by other Guardian readers at the bottom of the articles or contribute your thoughts for other readers to see. Complete your public profile and join the debate.`,
+		cta: [
+			{
+				name: `Complete your profile`,
+				link: `${config.get('page.idUrl')}/public/edit`,
+			},
+		],
+	},
+	{
+		title: `Download our award-winning app`,
+		blurb: `Available on iOS and Android. Sign in with your Guardian account to use exclusive features such as ‘save for later’ or mobile alerts when your favourite writers publish an article, or your football team scores.`,
+		cta: [
+			{
+				name: `Explore our apps`,
+				link: `${config.get(
+					'page.host',
+				)}/technology/ng-interactive/2018/may/15/the-guardian-app`,
+			},
+		],
+	},
+	{
+		title: `Take your career to the next level`,
+		blurb: `Your account allows you to set up a Guardian Jobs profile, browse a huge variety of jobs and be the first to hear about vacancies in your preferred industry.`,
+		cta: [
+			{
+				name: `Browse jobs`,
+				link: `https://jobs.theguardian.com/`,
+			},
+		],
+	},
 ];
 
 export const AccountActionableBenefits = () => (
-    <ul className="identity-upsell-account-creation-bullets identity-upsell-account-creation-bullets--super">
-        {actionableBenefits.map(({ title, blurb, cta }) => (
-            <li>
-                <h4 className="identity-upsell-account-creation-bullets__title">
-                    {title}
-                </h4>
-                <p>{blurb}</p>
-                {cta.map(({ name, link }) => (
-                    <a
-                        data-link-name={`benefit : ${title}`}
-                        href={link}
-                        className="manage-account__button manage-account__button--light">
-                        {name}
-                    </a>
-                ))}
-            </li>
-        ))}
-    </ul>
+	<ul className="identity-upsell-account-creation-bullets identity-upsell-account-creation-bullets--super">
+		{actionableBenefits.map(({ title, blurb, cta }) => (
+			<li>
+				<h4 className="identity-upsell-account-creation-bullets__title">
+					{title}
+				</h4>
+				<p>{blurb}</p>
+				{cta.map(({ name, link }) => (
+					<a
+						data-link-name={`benefit : ${title}`}
+						href={link}
+						className="manage-account__button manage-account__button--light"
+					>
+						{name}
+					</a>
+				))}
+			</li>
+		))}
+	</ul>
 );
 
 export const AccountBenefits = () => (
-    <ul className="identity-upsell-account-creation-bullets">
-        {benefits.map(benefit => (
-            <li>
-                <h4 className="identity-upsell-account-creation-bullets__title">
-                    {benefit.title}
-                </h4>
-                <p>{benefit.blurb}</p>
-            </li>
-        ))}
-    </ul>
+	<ul className="identity-upsell-account-creation-bullets">
+		{benefits.map((benefit) => (
+			<li>
+				<h4 className="identity-upsell-account-creation-bullets__title">
+					{benefit.title}
+				</h4>
+				<p>{benefit.blurb}</p>
+			</li>
+		))}
+	</ul>
 );

--- a/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/account-creation/AccountCreationBlock.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/account-creation/AccountCreationBlock.js
@@ -11,49 +11,50 @@
  */
 
 // @flow
-import React, { Component } from 'preact-compat';
+import React, { Component } from 'react';
 import { AccountCreationForm } from './AccountCreationForm';
 import { AccountActionableBenefits, AccountBenefits } from './AccountBenefits';
 import { Block } from '../block/Block';
 
 type AccountCreationBlockProps = {
-    csrfToken: string,
-    accountToken: string,
-    email: string,
+	csrfToken: string,
+	accountToken: string,
+	email: string,
 };
 
 class AccountCreationBlock extends Component<
-    AccountCreationBlockProps,
-    {
-        hasCreatedAccount?: boolean,
-    }
+	AccountCreationBlockProps,
+	{
+		hasCreatedAccount?: boolean,
+	},
 > {
-    onAccountCreated = () => {
-        this.setState({
-            hasCreatedAccount: true,
-        });
-    };
+	onAccountCreated = () => {
+		this.setState({
+			hasCreatedAccount: true,
+		});
+	};
 
-    render() {
-        return !this.state.hasCreatedAccount ? (
-            <Block
-                sideBySide
-                title="Want more from The Guardian?"
-                subtitle="Create your account now to manage your preferences and explore your free benefits.">
-                <AccountCreationForm
-                    {...this.props}
-                    onAccountCreated={this.onAccountCreated}
-                />
-                <div>
-                    <AccountBenefits />
-                </div>
-            </Block>
-        ) : (
-            <Block title="Start exploring your benefits">
-                <AccountActionableBenefits />
-            </Block>
-        );
-    }
+	render() {
+		return !this.state.hasCreatedAccount ? (
+			<Block
+				sideBySide
+				title="Want more from The Guardian?"
+				subtitle="Create your account now to manage your preferences and explore your free benefits."
+			>
+				<AccountCreationForm
+					{...this.props}
+					onAccountCreated={this.onAccountCreated}
+				/>
+				<div>
+					<AccountBenefits />
+				</div>
+			</Block>
+		) : (
+			<Block title="Start exploring your benefits">
+				<AccountActionableBenefits />
+			</Block>
+		);
+	}
 }
 
 export { AccountCreationBlock };

--- a/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/account-creation/AccountCreationCompleteConsentsFlow.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/account-creation/AccountCreationCompleteConsentsFlow.js
@@ -11,63 +11,63 @@
  */
 
 // @flow
-import React, { Component } from 'preact-compat';
+import React, { Component } from 'react';
 import { AccountCreationFeatures } from './AccountCreationFeatures';
 import { AccountCreationForm } from './AccountCreationForm';
 import { AccountBenefits } from './AccountBenefits';
 
 type AccountCreationCompleteConsentsFlowProps = {
-    csrfToken: string,
-    returnUrl: string,
-    accountToken: string,
-    email: string,
+	csrfToken: string,
+	returnUrl: string,
+	accountToken: string,
+	email: string,
 };
 
 class AccountCreationCompleteConsentsFlow extends Component<
-    AccountCreationCompleteConsentsFlowProps,
-    {
-        hasCreatedAccount?: boolean,
-    }
+	AccountCreationCompleteConsentsFlowProps,
+	{
+		hasCreatedAccount?: boolean,
+	},
 > {
-    onAccountCreated = () => {
-        this.setState({
-            hasCreatedAccount: true,
-        });
-    };
+	onAccountCreated = () => {
+		this.setState({
+			hasCreatedAccount: true,
+		});
+	};
 
-    render() {
-        return !this.state.hasCreatedAccount ? (
-            <div>
-                <hr className="manage-account-small-divider" />
-                <div className="form">
-                    <h1 className="identity-upsell-title">
-                        <h1 className="identity-upsell-title__title">
-                            Want more from The Guardian?
-                        </h1>
-                        <p className="identity-upsell-title__subtitle">
-                            Create your account now to manage your preferences
-                            and explore your free benefits.
-                        </p>
-                    </h1>
-                    <div>
-                        <AccountCreationForm
-                            {...this.props}
-                            onAccountCreated={this.onAccountCreated}
-                        />
-                    </div>
-                    <aside className="identity-upsell-account-creation-block">
-                        <hr className="manage-account-small-divider" />
-                        <AccountBenefits />
-                    </aside>
-                </div>
-            </div>
-        ) : (
-            <div>
-                <hr className="manage-account-small-divider" />
-                <AccountCreationFeatures returnUrl={this.props.returnUrl} />
-            </div>
-        );
-    }
+	render() {
+		return !this.state.hasCreatedAccount ? (
+			<div>
+				<hr className="manage-account-small-divider" />
+				<div className="form">
+					<h1 className="identity-upsell-title">
+						<h1 className="identity-upsell-title__title">
+							Want more from The Guardian?
+						</h1>
+						<p className="identity-upsell-title__subtitle">
+							Create your account now to manage your preferences
+							and explore your free benefits.
+						</p>
+					</h1>
+					<div>
+						<AccountCreationForm
+							{...this.props}
+							onAccountCreated={this.onAccountCreated}
+						/>
+					</div>
+					<aside className="identity-upsell-account-creation-block">
+						<hr className="manage-account-small-divider" />
+						<AccountBenefits />
+					</aside>
+				</div>
+			</div>
+		) : (
+			<div>
+				<hr className="manage-account-small-divider" />
+				<AccountCreationFeatures returnUrl={this.props.returnUrl} />
+			</div>
+		);
+	}
 }
 
 export { AccountCreationCompleteConsentsFlow };

--- a/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/account-creation/AccountCreationFeatures.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/account-creation/AccountCreationFeatures.js
@@ -11,25 +11,25 @@
  */
 
 // @flow
-import React, { Component } from 'preact-compat';
+import React, { Component } from 'react';
 import { AccountActionableBenefits } from './AccountBenefits';
 
 export class AccountCreationFeatures extends Component {
-    render() {
-        return (
-            <div>
-                <header className="identity-upsell-title">
-                    <h1 className="identity-upsell-title__title">
-                        Your account has been created.
-                    </h1>
-                    <p className="identity-upsell-title__subtitle">
-                        Start exploring your benefits:
-                    </p>
-                </header>
-                <div className="identity-forms-message__body">
-                    <AccountActionableBenefits />
-                </div>
-            </div>
-        );
-    }
+	render() {
+		return (
+			<div>
+				<header className="identity-upsell-title">
+					<h1 className="identity-upsell-title__title">
+						Your account has been created.
+					</h1>
+					<p className="identity-upsell-title__subtitle">
+						Start exploring your benefits:
+					</p>
+				</header>
+				<div className="identity-forms-message__body">
+					<AccountActionableBenefits />
+				</div>
+			</div>
+		);
+	}
 }

--- a/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/account-creation/AccountCreationForm.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/account-creation/AccountCreationForm.js
@@ -11,157 +11,161 @@
  */
 
 // @flow
-import React, { Component } from 'preact-compat';
+import React, { Component } from 'react';
 import reqwest from 'reqwest';
 import ophan from 'ophan/ng';
 import reportError from 'lib/report-error';
 import { ErrorBar, genericErrorStr } from '../error-bar/ErrorBar';
 
 type AccountCreationFormProps = {
-    csrfToken: string,
-    accountToken: string,
-    email: string,
-    onAccountCreated: () => {},
+	csrfToken: string,
+	accountToken: string,
+	email: string,
+	onAccountCreated: () => {},
 };
 
 class AccountCreationForm extends Component<
-    AccountCreationFormProps,
-    {
-        password?: string,
-        isLoading?: boolean,
-        errors: string[],
-    }
+	AccountCreationFormProps,
+	{
+		password?: string,
+		isLoading?: boolean,
+		errors: string[],
+	},
 > {
-    constructor(props: AccountCreationFormProps) {
-        super(props);
-        this.setState({
-            errors: [],
-        });
-    }
+	constructor(props: AccountCreationFormProps) {
+		super(props);
+		this.setState({
+			errors: [],
+		});
+	}
 
-    onSubmit = (ev: Event) => {
-        ev.preventDefault();
-        this.setState({
-            isLoading: true,
-            errors: [],
-        });
+	onSubmit = (ev: Event) => {
+		ev.preventDefault();
+		this.setState({
+			isLoading: true,
+			errors: [],
+		});
 
-        reqwest({
-            url: '/password/guest',
-            method: 'post',
-            data: {
-                csrfToken: this.props.csrfToken,
-                token: this.props.accountToken,
-                password: this.state.password,
-            },
-            success: () => {
-                ophan.record({
-                    component: 'set-password',
-                    value: 'set-password',
-                });
-                this.props.onAccountCreated();
-            },
-            error: response => {
-                reportError(
-                    Error(response),
-                    {
-                        feature: 'identity-create-account-upsell',
-                    },
-                    false
-                );
-                try {
-                    const apiError = JSON.parse(response.responseText)[0];
-                    this.setState({
-                        errors: [apiError.description],
-                    });
-                } catch (exception) {
-                    this.setState({ errors: [genericErrorStr] });
-                }
-            },
-            complete: () => {
-                this.setState({ isLoading: false });
-            },
-        });
-    };
+		reqwest({
+			url: '/password/guest',
+			method: 'post',
+			data: {
+				csrfToken: this.props.csrfToken,
+				token: this.props.accountToken,
+				password: this.state.password,
+			},
+			success: () => {
+				ophan.record({
+					component: 'set-password',
+					value: 'set-password',
+				});
+				this.props.onAccountCreated();
+			},
+			error: (response) => {
+				reportError(
+					Error(response),
+					{
+						feature: 'identity-create-account-upsell',
+					},
+					false,
+				);
+				try {
+					const apiError = JSON.parse(response.responseText)[0];
+					this.setState({
+						errors: [apiError.description],
+					});
+				} catch (exception) {
+					this.setState({ errors: [genericErrorStr] });
+				}
+			},
+			complete: () => {
+				this.setState({ isLoading: false });
+			},
+		});
+	};
 
-    handlePasswordChange = (ev: Event) => {
-        if (!(ev.target instanceof HTMLInputElement)) {
-            return;
-        }
-        this.setState({ password: ev.target.value });
-    };
+	handlePasswordChange = (ev: Event) => {
+		if (!(ev.target instanceof HTMLInputElement)) {
+			return;
+		}
+		this.setState({ password: ev.target.value });
+	};
 
-    render() {
-        const { errors, isLoading } = this.state;
-        const { email } = this.props;
-        return (
-            <form onSubmit={this.onSubmit}>
-                <ul className="identity-forms-fields">
-                    <ErrorBar tagName="li" errors={errors} />
-                    {email && (
-                        <li id="email_field" aria-hidden>
-                            <label
-                                className="identity-forms-input-wrap"
-                                htmlFor="email">
-                                <div className="identity-forms-label">
-                                    Email
-                                </div>
-                                <input
-                                    className="identity-forms-input"
-                                    type="email"
-                                    id="email"
-                                    value={email}
-                                    autoComplete="off"
-                                    autoCapitalize="off"
-                                    autoCorrect="off"
-                                    spellCheck="false"
-                                    aria-required="true"
-                                    required
-                                    disabled
-                                />
-                            </label>
-                        </li>
-                    )}
-                    <li id="password_field">
-                        <label
-                            className="identity-forms-input-wrap"
-                            htmlFor="password">
-                            <div className="identity-forms-label">Password</div>
-                            <input
-                                className="identity-forms-input"
-                                type="password"
-                                id="password"
-                                name="password"
-                                value={this.state.password}
-                                autoComplete="off"
-                                onChange={this.handlePasswordChange}
-                                autoCapitalize="off"
-                                autoCorrect="off"
-                                spellCheck="false"
-                                aria-required="true"
-                                required
-                            />
-                        </label>
-                    </li>
-                    <li>
-                        {isLoading ? (
-                            <button
-                                disabled
-                                className="manage-account__button manage-account__button--light manage-account__button--center">
-                                Hang on...
-                            </button>
-                        ) : (
-                            <button
-                                type="submit"
-                                className="manage-account__button manage-account__button--icon manage-account__button--main">
-                                Create an account
-                            </button>
-                        )}
-                    </li>
-                </ul>
-            </form>
-        );
-    }
+	render() {
+		const { errors, isLoading } = this.state;
+		const { email } = this.props;
+		return (
+			<form onSubmit={this.onSubmit}>
+				<ul className="identity-forms-fields">
+					<ErrorBar tagName="li" errors={errors} />
+					{email && (
+						<li id="email_field" aria-hidden>
+							<label
+								className="identity-forms-input-wrap"
+								htmlFor="email"
+							>
+								<div className="identity-forms-label">
+									Email
+								</div>
+								<input
+									className="identity-forms-input"
+									type="email"
+									id="email"
+									value={email}
+									autoComplete="off"
+									autoCapitalize="off"
+									autoCorrect="off"
+									spellCheck="false"
+									aria-required="true"
+									required
+									disabled
+								/>
+							</label>
+						</li>
+					)}
+					<li id="password_field">
+						<label
+							className="identity-forms-input-wrap"
+							htmlFor="password"
+						>
+							<div className="identity-forms-label">Password</div>
+							<input
+								className="identity-forms-input"
+								type="password"
+								id="password"
+								name="password"
+								value={this.state.password}
+								autoComplete="off"
+								onChange={this.handlePasswordChange}
+								autoCapitalize="off"
+								autoCorrect="off"
+								spellCheck="false"
+								aria-required="true"
+								required
+							/>
+						</label>
+					</li>
+					<li>
+						{isLoading ? (
+							<button
+								disabled
+								className="manage-account__button manage-account__button--light manage-account__button--center"
+							>
+								Hang on...
+							</button>
+						) : (
+							<button
+								type="submit"
+								className="manage-account__button manage-account__button--icon manage-account__button--main"
+							>
+								Create an account
+							</button>
+						)}
+					</li>
+				</ul>
+			</form>
+		);
+	}
 }
 
 export type { AccountCreationFormProps };

--- a/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/block/Block.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/block/Block.js
@@ -11,64 +11,66 @@
  */
 
 // @flow
-import React, { Component } from 'preact-compat';
+import React, { Component } from 'react';
 
 type BlockProps = {
-    title: string,
-    subtitle: ?string,
-    subtext: ?string,
-    sideBySide: ?boolean,
-    sideBySideBackwards: ?boolean,
-    halfWidth: ?boolean,
-    children: any,
+	title: string,
+	subtitle: ?string,
+	subtext: ?string,
+	sideBySide: ?boolean,
+	sideBySideBackwards: ?boolean,
+	halfWidth: ?boolean,
+	children: any,
 };
 
 export class Block extends Component<BlockProps> {
-    render() {
-        const {
-            title,
-            subtitle,
-            subtext,
-            children,
-            sideBySide,
-            sideBySideBackwards,
-            halfWidth,
-        } = this.props;
-        return (
-            <section
-                className={[
-                    'identity-upsell-block',
-                    sideBySide || sideBySideBackwards
-                        ? 'identity-upsell-block--side-by-side'
-                        : '',
-                    sideBySideBackwards
-                        ? 'identity-upsell-block--side-by-side identity-upsell-block--side-by-side--backwards'
-                        : '',
-                ].join(' ')}>
-                <div
-                    className={
-                        halfWidth ? 'identity-upsell-block--half-width' : ''
-                    }>
-                    <div className="identity-upsell-title">
-                        <h2 className="identity-upsell-title__title">
-                            {title}
-                        </h2>
-                        {subtitle && (
-                            <h3 className="identity-upsell-title__subtitle">
-                                {subtitle}
-                            </h3>
-                        )}
-                        {subtext && (
-                            <p className="identity-upsell-title__subtext">
-                                {subtext}
-                            </p>
-                        )}
-                    </div>
-                    <div className="identity-upsell-block__container">
-                        {children}
-                    </div>
-                </div>
-            </section>
-        );
-    }
+	render() {
+		const {
+			title,
+			subtitle,
+			subtext,
+			children,
+			sideBySide,
+			sideBySideBackwards,
+			halfWidth,
+		} = this.props;
+		return (
+			<section
+				className={[
+					'identity-upsell-block',
+					sideBySide || sideBySideBackwards
+						? 'identity-upsell-block--side-by-side'
+						: '',
+					sideBySideBackwards
+						? 'identity-upsell-block--side-by-side identity-upsell-block--side-by-side--backwards'
+						: '',
+				].join(' ')}
+			>
+				<div
+					className={
+						halfWidth ? 'identity-upsell-block--half-width' : ''
+					}
+				>
+					<div className="identity-upsell-title">
+						<h2 className="identity-upsell-title__title">
+							{title}
+						</h2>
+						{subtitle && (
+							<h3 className="identity-upsell-title__subtitle">
+								{subtitle}
+							</h3>
+						)}
+						{subtext && (
+							<p className="identity-upsell-title__subtext">
+								{subtext}
+							</p>
+						)}
+					</div>
+					<div className="identity-upsell-block__container">
+						{children}
+					</div>
+				</div>
+			</section>
+		);
+	}
 }

--- a/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/block/LegalTextBlock.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/block/LegalTextBlock.js
@@ -11,10 +11,10 @@
  */
 
 // @flow
-import React from 'preact-compat';
+import React from 'react';
 
 const LegalTextBlock = ({ children }: { children: any }) => (
-    <div className="identity-upsell-legal-text-block">{children}</div>
+	<div className="identity-upsell-legal-text-block">{children}</div>
 );
 
 export { LegalTextBlock };

--- a/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/button/FollowButtonWrap.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/button/FollowButtonWrap.js
@@ -11,151 +11,155 @@
  */
 
 // @flow
-import React, { Component } from 'preact-compat';
+import React, { Component } from 'react';
 import envelopeRemove from 'svgs/icon/envelope-remove.svg';
 import envelopeAdd from 'svgs/icon/envelope-add.svg';
 import tick from 'svgs/icon/tick.svg';
 
 const getButtonClassNames = (...modifiers: string[]) => [
-    'manage-account__button',
-    ...modifiers.map(m => `manage-account__button--${m}`),
+	'manage-account__button',
+	...modifiers.map((m) => `manage-account__button--${m}`),
 ];
 
 type FollowButtonWrapProps = {
-    following: boolean,
-    onFollow: () => Promise<void>,
-    onUnfollow: () => Promise<void>,
-    trackingName: ?string,
+	following: boolean,
+	onFollow: () => Promise<void>,
+	onUnfollow: () => Promise<void>,
+	trackingName: ?string,
 };
 
 type FollowButtonWrapState = {
-    mousedOutOnce: boolean,
+	mousedOutOnce: boolean,
 };
 
 class FollowButtonWrap extends Component<
-    FollowButtonWrapProps,
-    FollowButtonWrapState
+	FollowButtonWrapProps,
+	FollowButtonWrapState,
 > {
-    constructor(props: FollowButtonWrapProps) {
-        super(props);
-        this.setState({
-            mousedOutOnce: true,
-        });
-    }
+	constructor(props: FollowButtonWrapProps) {
+		super(props);
+		this.setState({
+			mousedOutOnce: true,
+		});
+	}
 
-    onMouseOut = () => {
-        this.setState({
-            mousedOutOnce: true,
-        });
-    };
+	onMouseOut = () => {
+		this.setState({
+			mousedOutOnce: true,
+		});
+	};
 
-    updateFollowing = (to: boolean) => {
-        if (to) {
-            this.props.onFollow();
-            this.setState({
-                mousedOutOnce: false,
-            });
-        } else {
-            this.props.onUnfollow();
-        }
-    };
+	updateFollowing = (to: boolean) => {
+		if (to) {
+			this.props.onFollow();
+			this.setState({
+				mousedOutOnce: false,
+			});
+		} else {
+			this.props.onUnfollow();
+		}
+	};
 
-    render() {
-        const { following, trackingName } = this.props;
-        const { mousedOutOnce } = this.state;
+	render() {
+		const { following, trackingName } = this.props;
+		const { mousedOutOnce } = this.state;
 
-        const followingFeedbackButton = (...classNames: string[]) => (
-            <div
-                role="alert"
-                className={[
-                    ...getButtonClassNames(
-                        'green-secondary',
-                        'center',
-                        'icon-left'
-                    ),
-                    ...classNames,
-                ].join(' ')}>
-                <span
-                    className="manage-account__button-react-icon"
-                    dangerouslySetInnerHTML={{ __html: tick.markup }}
-                />
-                Signed up
-            </div>
-        );
+		const followingFeedbackButton = (...classNames: string[]) => (
+			<div
+				role="alert"
+				className={[
+					...getButtonClassNames(
+						'green-secondary',
+						'center',
+						'icon-left',
+					),
+					...classNames,
+				].join(' ')}
+			>
+				<span
+					className="manage-account__button-react-icon"
+					dangerouslySetInnerHTML={{ __html: tick.markup }}
+				/>
+				Signed up
+			</div>
+		);
 
-        const unfollowButton = (...classNames: string[]) => (
-            <button
-                data-link-name={
-                    trackingName
-                        ? `upsell-consent : ${trackingName} : untick`
-                        : false
-                }
-                type="button"
-                className={[
-                    ...getButtonClassNames('danger', 'center', 'icon-left'),
-                    ...classNames,
-                ].join(' ')}
-                onClick={() => {
-                    this.updateFollowing(false);
-                }}>
-                <span
-                    className="manage-account__button-react-icon"
-                    dangerouslySetInnerHTML={{
-                        __html: envelopeRemove.markup,
-                    }}
-                />
-                Unsubscribe
-            </button>
-        );
+		const unfollowButton = (...classNames: string[]) => (
+			<button
+				data-link-name={
+					trackingName
+						? `upsell-consent : ${trackingName} : untick`
+						: false
+				}
+				type="button"
+				className={[
+					...getButtonClassNames('danger', 'center', 'icon-left'),
+					...classNames,
+				].join(' ')}
+				onClick={() => {
+					this.updateFollowing(false);
+				}}
+			>
+				<span
+					className="manage-account__button-react-icon"
+					dangerouslySetInnerHTML={{
+						__html: envelopeRemove.markup,
+					}}
+				/>
+				Unsubscribe
+			</button>
+		);
 
-        const followButton = () => (
-            <button
-                data-link-name={
-                    trackingName
-                        ? `upsell-consent : ${trackingName} : tick`
-                        : false
-                }
-                type="button"
-                className={getButtonClassNames('green', 'icon-left').join(' ')}
-                onClick={() => {
-                    this.updateFollowing(true);
-                }}>
-                <span
-                    className="manage-account__button-react-icon"
-                    dangerouslySetInnerHTML={{ __html: envelopeAdd.markup }}
-                />
-                Sign me up
-            </button>
-        );
+		const followButton = () => (
+			<button
+				data-link-name={
+					trackingName
+						? `upsell-consent : ${trackingName} : tick`
+						: false
+				}
+				type="button"
+				className={getButtonClassNames('green', 'icon-left').join(' ')}
+				onClick={() => {
+					this.updateFollowing(true);
+				}}
+			>
+				<span
+					className="manage-account__button-react-icon"
+					dangerouslySetInnerHTML={{ __html: envelopeAdd.markup }}
+				/>
+				Sign me up
+			</button>
+		);
 
-        return following ? (
-            <div
-                aria-live="polite"
-                className={[
-                    'identity-upsell-follow-button-wrap',
-                    mousedOutOnce
-                        ? ''
-                        : 'identity-upsell-follow-button-wrap--blocked',
-                ].join(' ')}
-                onMouseOut={() => {
-                    this.onMouseOut();
-                }}
-                onBlur={() => {
-                    this.onMouseOut();
-                }}>
-                {followingFeedbackButton(
-                    'identity-upsell-follow-button-wrap__button'
-                )}
-                {unfollowButton(
-                    'identity-upsell-follow-button-wrap__button',
-                    'identity-upsell-follow-button-wrap__button--longer',
-                    'identity-upsell-follow-button-wrap__button--hoverable'
-                )}
-            </div>
-        ) : (
-            followButton()
-        );
-    }
+		return following ? (
+			<div
+				aria-live="polite"
+				className={[
+					'identity-upsell-follow-button-wrap',
+					mousedOutOnce
+						? ''
+						: 'identity-upsell-follow-button-wrap--blocked',
+				].join(' ')}
+				onMouseOut={() => {
+					this.onMouseOut();
+				}}
+				onBlur={() => {
+					this.onMouseOut();
+				}}
+			>
+				{followingFeedbackButton(
+					'identity-upsell-follow-button-wrap__button',
+				)}
+				{unfollowButton(
+					'identity-upsell-follow-button-wrap__button',
+					'identity-upsell-follow-button-wrap__button--longer',
+					'identity-upsell-follow-button-wrap__button--hoverable',
+				)}
+			</div>
+		) : (
+			followButton()
+		);
+	}
 }
 
 export { FollowButtonWrap };

--- a/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/button/FollowCardExpanderButton.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/button/FollowCardExpanderButton.js
@@ -11,54 +11,56 @@
  */
 
 // @flow
-import React from 'preact-compat';
+import React from 'react';
 import arrowDown from 'svgs/icon/arrow-down.svg';
 import arrowUp from 'svgs/icon/arrow-up.svg';
 
 type ExpanderButtonText = {
-    more: string,
-    less: string,
+	more: string,
+	less: string,
 };
 
 type ExpanderButtonProps = {
-    isExpanded: boolean,
-    onToggle: (state: boolean) => void,
-    linkName: ?string,
-    text: ?ExpanderButtonText,
+	isExpanded: boolean,
+	onToggle: (state: boolean) => void,
+	linkName: ?string,
+	text: ?ExpanderButtonText,
 };
 
 const defaultExpanderButtonText = {
-    more: 'More',
-    less: 'Less',
+	more: 'More',
+	less: 'Less',
 };
 
 const FollowCardExpanderButton = ({
-    isExpanded,
-    onToggle,
-    linkName,
-    text,
+	isExpanded,
+	onToggle,
+	linkName,
+	text,
 }: ExpanderButtonProps) =>
-    isExpanded ? (
-        <button
-            data-link-name={linkName ? `${linkName} : shrink` : null}
-            className="manage-account__button manage-account__button--secondary manage-account__button--icon"
-            onClick={() => onToggle(false)}>
-            {(text || defaultExpanderButtonText).less}
-            <span
-                className="manage-account__button-react-icon"
-                dangerouslySetInnerHTML={{ __html: arrowUp.markup }}
-            />
-        </button>
-    ) : (
-        <button
-            data-link-name={linkName ? `${linkName} : expand` : null}
-            className="manage-account__button manage-account__button--secondary manage-account__button--icon"
-            onClick={() => onToggle(true)}>
-            {(text || defaultExpanderButtonText).more}
-            <span
-                className="manage-account__button-react-icon"
-                dangerouslySetInnerHTML={{ __html: arrowDown.markup }}
-            />
-        </button>
-    );
+	isExpanded ? (
+		<button
+			data-link-name={linkName ? `${linkName} : shrink` : null}
+			className="manage-account__button manage-account__button--secondary manage-account__button--icon"
+			onClick={() => onToggle(false)}
+		>
+			{(text || defaultExpanderButtonText).less}
+			<span
+				className="manage-account__button-react-icon"
+				dangerouslySetInnerHTML={{ __html: arrowUp.markup }}
+			/>
+		</button>
+	) : (
+		<button
+			data-link-name={linkName ? `${linkName} : expand` : null}
+			className="manage-account__button manage-account__button--secondary manage-account__button--icon"
+			onClick={() => onToggle(true)}
+		>
+			{(text || defaultExpanderButtonText).more}
+			<span
+				className="manage-account__button-react-icon"
+				dangerouslySetInnerHTML={{ __html: arrowDown.markup }}
+			/>
+		</button>
+	);
 export { FollowCardExpanderButton };

--- a/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/button/OptoutsExpanderButton.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/button/OptoutsExpanderButton.js
@@ -11,44 +11,46 @@
  */
 
 // @flow
-import React from 'preact-compat';
+import React from 'react';
 import plus from 'svgs/icon/plus.svg';
 import minus from 'svgs/icon/minus.svg';
 
 type OptoutsExpanderButtonProps = {
-    isExpanded: boolean,
-    onToggle: (state: boolean) => void,
-    linkName: ?string,
-    text: ?string,
+	isExpanded: boolean,
+	onToggle: (state: boolean) => void,
+	linkName: ?string,
+	text: ?string,
 };
 
 const OptoutsExpanderButton = ({
-    isExpanded,
-    onToggle,
-    linkName,
-    text,
+	isExpanded,
+	onToggle,
+	linkName,
+	text,
 }: OptoutsExpanderButtonProps) =>
-    isExpanded ? (
-        <button
-            data-link-name={linkName ? `${linkName} : shrink` : null}
-            className="manage-account__button manage-account__button--secondary manage-account__button--icon manage-account__button--long manage-account__button--long-expanded"
-            onClick={() => onToggle(false)}>
-            {text}
-            <span
-                className="manage-account__button-react-icon"
-                dangerouslySetInnerHTML={{ __html: minus.markup }}
-            />
-        </button>
-    ) : (
-        <button
-            data-link-name={linkName ? `${linkName} : expand` : null}
-            className="manage-account__button manage-account__button--secondary manage-account__button--icon manage-account__button--long"
-            onClick={() => onToggle(true)}>
-            {text}
-            <span
-                className="manage-account__button-react-icon"
-                dangerouslySetInnerHTML={{ __html: plus.markup }}
-            />
-        </button>
-    );
+	isExpanded ? (
+		<button
+			data-link-name={linkName ? `${linkName} : shrink` : null}
+			className="manage-account__button manage-account__button--secondary manage-account__button--icon manage-account__button--long manage-account__button--long-expanded"
+			onClick={() => onToggle(false)}
+		>
+			{text}
+			<span
+				className="manage-account__button-react-icon"
+				dangerouslySetInnerHTML={{ __html: minus.markup }}
+			/>
+		</button>
+	) : (
+		<button
+			data-link-name={linkName ? `${linkName} : expand` : null}
+			className="manage-account__button manage-account__button--secondary manage-account__button--icon manage-account__button--long"
+			onClick={() => onToggle(true)}
+		>
+			{text}
+			<span
+				className="manage-account__button-react-icon"
+				dangerouslySetInnerHTML={{ __html: plus.markup }}
+			/>
+		</button>
+	);
 export { OptoutsExpanderButton };

--- a/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/checkbox/Checkbox.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/checkbox/Checkbox.js
@@ -11,32 +11,33 @@
  */
 
 // @flow
-import React from 'preact-compat';
+import React from 'react';
 
 type CheckboxHtmlProps = {
-    checked: ?boolean,
-    onChange: (ev: Event) => void,
+	checked: ?boolean,
+	onChange: (ev: Event) => void,
 };
 
 type CheckboxProps = {
-    title: string,
-    uniqueId: string,
-    checkboxHtmlProps: CheckboxHtmlProps,
+	title: string,
+	uniqueId: string,
+	checkboxHtmlProps: CheckboxHtmlProps,
 };
 
 const Checkbox = ({ title, uniqueId, checkboxHtmlProps }: CheckboxProps) => (
-    <label
-        data-link-name={`upsell-consent : checkbox : ${uniqueId} : ${
-            checkboxHtmlProps.checked ? 'untick' : 'tick'
-        }`}
-        className="identity-upsell-checkbox"
-        htmlFor={uniqueId}>
-        <span className="identity-upsell-checkbox__title">{title}</span>
-        <input type="checkbox" id={uniqueId} {...checkboxHtmlProps} />
-        <span className="identity-upsell-checkbox__checkmark">
-            <span className="identity-upsell-checkbox__checkmark_tick" />
-        </span>
-    </label>
+	<label
+		data-link-name={`upsell-consent : checkbox : ${uniqueId} : ${
+			checkboxHtmlProps.checked ? 'untick' : 'tick'
+		}`}
+		className="identity-upsell-checkbox"
+		htmlFor={uniqueId}
+	>
+		<span className="identity-upsell-checkbox__title">{title}</span>
+		<input type="checkbox" id={uniqueId} {...checkboxHtmlProps} />
+		<span className="identity-upsell-checkbox__checkmark">
+			<span className="identity-upsell-checkbox__checkmark_tick" />
+		</span>
+	</label>
 );
 
 export { Checkbox };

--- a/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/consent-card/FollowCard.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/consent-card/FollowCard.js
@@ -11,39 +11,39 @@
  */
 
 // @flow
-import React from 'preact-compat';
+import React from 'react';
 import { FollowButtonWrap } from 'common/modules/identity/upsell/button/FollowButtonWrap';
 import type { Consent } from '../store/types';
 
 export type FollowCardProps = {
-    consent: Consent,
-    onChange: boolean => void,
-    hasConsented: boolean,
+	consent: Consent,
+	onChange: (boolean) => void,
+	hasConsented: boolean,
 };
 
 const FollowCard = (props: FollowCardProps) => {
-    const { hasConsented } = props;
-    const { name, description } = props.consent;
-    return (
-        <div className="identity-upsell-consent-card">
-            <h1 className="identity-upsell-consent-card__title">{name}</h1>
-            <p className="identity-upsell-consent-card__description">
-                {description}
-            </p>
-            <div className="identity-upsell-consent-card__footer">
-                <FollowButtonWrap
-                    trackingName={name}
-                    following={hasConsented}
-                    onFollow={() => {
-                        props.onChange(true);
-                    }}
-                    onUnfollow={() => {
-                        props.onChange(false);
-                    }}
-                />
-            </div>
-        </div>
-    );
+	const { hasConsented } = props;
+	const { name, description } = props.consent;
+	return (
+		<div className="identity-upsell-consent-card">
+			<h1 className="identity-upsell-consent-card__title">{name}</h1>
+			<p className="identity-upsell-consent-card__description">
+				{description}
+			</p>
+			<div className="identity-upsell-consent-card__footer">
+				<FollowButtonWrap
+					trackingName={name}
+					following={hasConsented}
+					onFollow={() => {
+						props.onChange(true);
+					}}
+					onUnfollow={() => {
+						props.onChange(false);
+					}}
+				/>
+			</div>
+		</div>
+	);
 };
 
 export { FollowCard };

--- a/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/consent-card/FollowCardList.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/consent-card/FollowCardList.js
@@ -11,13 +11,13 @@
  */
 
 // @flow
-import React from 'preact-compat';
+import React from 'react';
 import config from 'lib/config';
 import { FollowCard } from 'common/modules/identity/upsell/consent-card/FollowCard';
 import {
-    setConsentsInApi,
-    getNewsletterConsent,
-    getUserConsent,
+	setConsentsInApi,
+	getNewsletterConsent,
+	getUserConsent,
 } from 'common/modules/identity/upsell/store/consents';
 import { LegalTextBlock } from 'common/modules/identity/upsell/block/LegalTextBlock';
 import type { ConsentWithState } from '../store/types';
@@ -25,145 +25,147 @@ import { ErrorBar, genericErrorStr } from '../error-bar/ErrorBar';
 import { FollowCardExpanderButton } from '../button/FollowCardExpanderButton';
 
 const getConsents = (): Promise<(?ConsentWithState)[]> =>
-    Promise.all([
-        getUserConsent('supporter'),
-        getNewsletterConsent('the-long-read'),
-        getUserConsent('holidays'),
-        getNewsletterConsent('bookmarks'),
-        getUserConsent('events'),
-        getNewsletterConsent('brexit-briefing'),
-        getUserConsent('offers'),
-        getUserConsent('jobs'),
-        getNewsletterConsent('green-light'),
-        getNewsletterConsent('lab-notes'),
-    ]);
+	Promise.all([
+		getUserConsent('supporter'),
+		getNewsletterConsent('the-long-read'),
+		getUserConsent('holidays'),
+		getNewsletterConsent('bookmarks'),
+		getUserConsent('events'),
+		getNewsletterConsent('brexit-briefing'),
+		getUserConsent('offers'),
+		getUserConsent('jobs'),
+		getNewsletterConsent('green-light'),
+		getNewsletterConsent('lab-notes'),
+	]);
 
 type Props = {
-    cutoff: number,
+	cutoff: number,
 };
 
 type State = {
-    consents: ConsentWithState[],
-    isLoading: boolean,
-    isExpanded: boolean,
-    errors: string[],
+	consents: ConsentWithState[],
+	isLoading: boolean,
+	isExpanded: boolean,
+	errors: string[],
 };
 
 // TODO: seperate this into a stateless component and a stateful wrapper.
 class FollowCardList extends React.Component<Props, State> {
-    constructor(props: Props) {
-        super(props);
-        this.setState({
-            consents: [],
-            isLoading: true,
-            isExpanded: false,
-            errors: [],
-        });
-    }
+	constructor(props: Props) {
+		super(props);
+		this.setState({
+			consents: [],
+			isLoading: true,
+			isExpanded: false,
+			errors: [],
+		});
+	}
 
-    componentDidMount() {
-        getConsents().then(consents =>
-            this.setState({
-                consents,
-                isLoading: false,
-            })
-        );
-    }
+	componentDidMount() {
+		getConsents().then((consents) =>
+			this.setState({
+				consents,
+				isLoading: false,
+			}),
+		);
+	}
 
-    updateConsentState(consent: ConsentWithState) {
-        this.setState(state => ({
-            errors: [],
-            consents: state.consents.map(original =>
-                original.uniqueId === consent.uniqueId ? consent : original
-            ),
-        }));
-        setConsentsInApi([consent]).catch(() => {
-            consent.flipState();
-            this.setState(state => ({
-                errors: [genericErrorStr],
-                consents: state.consents.map(original =>
-                    original.uniqueId === consent.uniqueId ? consent : original
-                ),
-            }));
-        });
-    }
+	updateConsentState(consent: ConsentWithState) {
+		this.setState((state) => ({
+			errors: [],
+			consents: state.consents.map((original) =>
+				original.uniqueId === consent.uniqueId ? consent : original,
+			),
+		}));
+		setConsentsInApi([consent]).catch(() => {
+			consent.flipState();
+			this.setState((state) => ({
+				errors: [genericErrorStr],
+				consents: state.consents.map((original) =>
+					original.uniqueId === consent.uniqueId ? consent : original,
+				),
+			}));
+		});
+	}
 
-    updateExpandState = (isExpanded: boolean) => {
-        this.setState({
-            isExpanded,
-        });
-    };
+	updateExpandState = (isExpanded: boolean) => {
+		this.setState({
+			isExpanded,
+		});
+	};
 
-    render() {
-        const { consents, isLoading, isExpanded, errors } = this.state;
-        const { cutoff } = this.props;
+	render() {
+		const { consents, isLoading, isExpanded, errors } = this.state;
+		const { cutoff } = this.props;
 
-        const displayables = isExpanded
-            ? consents
-            : [...consents].splice(0, cutoff);
+		const displayables = isExpanded
+			? consents
+			: [...consents].splice(0, cutoff);
 
-        return (
-            <div>
-                {isLoading && (
-                    <div className="identity-forms-loading u-identity-forms-padded">
-                        <div className="identity-forms-loading__spinner is-updating" />
-                    </div>
-                )}
-                <ErrorBar errors={errors} />
-                <div className="identity-upsell-consent-card-grid">
-                    {displayables.map(consent => (
-                        <FollowCard
-                            key={consent.uniqueId}
-                            consent={consent.consent}
-                            hasConsented={consent.hasConsented}
-                            onChange={hasConsented => {
-                                consent.setState(hasConsented);
-                                this.updateConsentState(consent);
-                            }}
-                        />
-                    ))}
-                </div>
-                {[...consents].splice(cutoff).length > 0 && (
-                    <div className="identity-upsell-consent-card-footer">
-                        <FollowCardExpanderButton
-                            isExpanded={isExpanded}
-                            linkName="upsell-follow-expander"
-                            onToggle={this.updateExpandState}
-                            text={{
-                                more: 'See more',
-                                less: 'Less',
-                            }}
-                        />
-                        {isExpanded && (
-                            <div>
-                                <a
-                                    data-link-name="upsell-newsletter-link"
-                                    className="u-underline identity-upsell-consent-card__link"
-                                    href={`${config.get(
-                                        'page.idUrl'
-                                    )}/email-prefs`}>
-                                    View all Guardian newsletters
-                                </a>
-                            </div>
-                        )}
-                    </div>
-                )}
-                <LegalTextBlock>
-                    By subscribing, you confirm that you are 13 years or older.
-                    The Guardian’s newsletters may include advertising and
-                    messages about the Guardian’s other products and services,
-                    such as Jobs and Masterclasses. To find out what personal
-                    data we collect and how we use it, please visit our&nbsp;
-                    <a
-                        data-link-name="upsell-privacy-link"
-                        className="u-underline identity-upsell-consent-card__link"
-                        href="https://www.theguardian.com/info/privacy">
-                        Privacy Policy.
-                    </a>
-                </LegalTextBlock>
-            </div>
-        );
-    }
+		return (
+			<div>
+				{isLoading && (
+					<div className="identity-forms-loading u-identity-forms-padded">
+						<div className="identity-forms-loading__spinner is-updating" />
+					</div>
+				)}
+				<ErrorBar errors={errors} />
+				<div className="identity-upsell-consent-card-grid">
+					{displayables.map((consent) => (
+						<FollowCard
+							key={consent.uniqueId}
+							consent={consent.consent}
+							hasConsented={consent.hasConsented}
+							onChange={(hasConsented) => {
+								consent.setState(hasConsented);
+								this.updateConsentState(consent);
+							}}
+						/>
+					))}
+				</div>
+				{[...consents].splice(cutoff).length > 0 && (
+					<div className="identity-upsell-consent-card-footer">
+						<FollowCardExpanderButton
+							isExpanded={isExpanded}
+							linkName="upsell-follow-expander"
+							onToggle={this.updateExpandState}
+							text={{
+								more: 'See more',
+								less: 'Less',
+							}}
+						/>
+						{isExpanded && (
+							<div>
+								<a
+									data-link-name="upsell-newsletter-link"
+									className="u-underline identity-upsell-consent-card__link"
+									href={`${config.get(
+										'page.idUrl',
+									)}/email-prefs`}
+								>
+									View all Guardian newsletters
+								</a>
+							</div>
+						)}
+					</div>
+				)}
+				<LegalTextBlock>
+					By subscribing, you confirm that you are 13 years or older.
+					The Guardian’s newsletters may include advertising and
+					messages about the Guardian’s other products and services,
+					such as Jobs and Masterclasses. To find out what personal
+					data we collect and how we use it, please visit our&nbsp;
+					<a
+						data-link-name="upsell-privacy-link"
+						className="u-underline identity-upsell-consent-card__link"
+						href="https://www.theguardian.com/info/privacy"
+					>
+						Privacy Policy.
+					</a>
+				</LegalTextBlock>
+			</div>
+		);
+	}
 }
 
 export { FollowCardList };

--- a/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/error-bar/ErrorBar.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/error-bar/ErrorBar.js
@@ -11,31 +11,31 @@
  */
 
 // @flow
-import React, { Component } from 'preact-compat';
+import React, { Component } from 'react';
 
 type ErrorBarProps = {
-    errors: string[],
-    tagName: ?string,
+	errors: string[],
+	tagName: ?string,
 };
 
 export const genericErrorStr = 'Oops! Something went wrong';
 
 export class ErrorBar extends Component<ErrorBarProps> {
-    static defaultProps = {
-        tagName: 'div',
-    };
+	static defaultProps = {
+		tagName: 'div',
+	};
 
-    render() {
-        const { errors } = this.props;
-        const TagName = this.props.tagName;
-        return (
-            <TagName aria-live="polite">
-                {errors.map(error => (
-                    <div className="form__error" role="alert">
-                        {error}
-                    </div>
-                ))}
-            </TagName>
-        );
-    }
+	render() {
+		const { errors } = this.props;
+		const TagName = this.props.tagName;
+		return (
+			<TagName aria-live="polite">
+				{errors.map((error) => (
+					<div className="form__error" role="alert">
+						{error}
+					</div>
+				))}
+			</TagName>
+		);
+	}
 }

--- a/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/header/Header.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/header/Header.js
@@ -11,34 +11,34 @@
  */
 
 // @flow
-import React from 'preact-compat';
+import React from 'react';
 import circlesLeft from './circles-left.svg';
 import circlesRight from './circles-right.svg';
 
 type HeaderProps = {
-    title: string,
-    subtitle: string,
+	title: string,
+	subtitle: string,
 };
 
 const Header = ({ title, subtitle }: HeaderProps) => (
-    <div className="identity-upsell-subheader">
-        <div className="identity-upsell-layout identity-upsell-layout--padding">
-            <header className="identity-upsell-title identity-upsell-title--hero">
-                <h1 className="identity-upsell-title__title">{title}</h1>
-                <h1 className="identity-upsell-title__subtitle">{subtitle}</h1>
-            </header>
-        </div>
-        <div className="identity-upsell-subheader__graphics">
-            <span
-                className="identity-upsell-subheader__graphic identity-upsell-subheader__graphic--circlesLeft"
-                dangerouslySetInnerHTML={{ __html: circlesLeft.markup }}
-            />
-            <span
-                className="identity-upsell-subheader__graphic identity-upsell-subheader__graphic--circlesRight"
-                dangerouslySetInnerHTML={{ __html: circlesRight.markup }}
-            />
-        </div>
-    </div>
+	<div className="identity-upsell-subheader">
+		<div className="identity-upsell-layout identity-upsell-layout--padding">
+			<header className="identity-upsell-title identity-upsell-title--hero">
+				<h1 className="identity-upsell-title__title">{title}</h1>
+				<h1 className="identity-upsell-title__subtitle">{subtitle}</h1>
+			</header>
+		</div>
+		<div className="identity-upsell-subheader__graphics">
+			<span
+				className="identity-upsell-subheader__graphic identity-upsell-subheader__graphic--circlesLeft"
+				dangerouslySetInnerHTML={{ __html: circlesLeft.markup }}
+			/>
+			<span
+				className="identity-upsell-subheader__graphic identity-upsell-subheader__graphic--circlesRight"
+				dangerouslySetInnerHTML={{ __html: circlesRight.markup }}
+			/>
+		</div>
+	</div>
 );
 
 export { Header };

--- a/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/opt-outs/OptOutsList.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/opt-outs/OptOutsList.js
@@ -11,152 +11,155 @@
  */
 
 // @flow
-import React, { Component } from 'preact-compat';
+import React, { Component } from 'react';
 import { Checkbox } from 'common/modules/identity/upsell/checkbox/Checkbox';
 import { OptoutsExpanderButton } from 'common/modules/identity/upsell/button/OptoutsExpanderButton';
 import {
-    getAllUserConsents,
-    setConsentsInApi,
+	getAllUserConsents,
+	setConsentsInApi,
 } from 'common/modules/identity/upsell/store/consents';
 import type { ConsentWithState } from 'common/modules/identity/upsell/store/types';
 import { ErrorBar, genericErrorStr } from '../error-bar/ErrorBar';
 
 export class OptOutsList extends Component<
-    {},
-    {
-        consents: ConsentWithState[],
-        isLoading: boolean,
-        hasUnsavedChanges: boolean,
-        errors: string[],
-        isExpanded: boolean,
-    }
+	{},
+	{
+		consents: ConsentWithState[],
+		isLoading: boolean,
+		hasUnsavedChanges: boolean,
+		errors: string[],
+		isExpanded: boolean,
+	},
 > {
-    constructor(props: {}) {
-        super(props);
-        this.state = {
-            isLoading: false,
-            errors: [],
-            hasUnsavedChanges: true,
-            consents: [],
-            isExpanded: false,
-        };
-    }
+	constructor(props: {}) {
+		super(props);
+		this.state = {
+			isLoading: false,
+			errors: [],
+			hasUnsavedChanges: true,
+			consents: [],
+			isExpanded: false,
+		};
+	}
 
-    componentDidMount() {
-        getAllUserConsents().then(consents => {
-            this.setState({
-                consents: consents.filter(c => c.consent.isOptOut),
-            });
-        });
-    }
+	componentDidMount() {
+		getAllUserConsents().then((consents) => {
+			this.setState({
+				consents: consents.filter((c) => c.consent.isOptOut),
+			});
+		});
+	}
 
-    onCheckboxChange = (consent: ConsentWithState) => {
-        this.setState(state => ({
-            hasUnsavedChanges: true,
-            consents: state.consents.map(original =>
-                original.uniqueId === consent.uniqueId ? consent : original
-            ),
-        }));
-    };
+	onCheckboxChange = (consent: ConsentWithState) => {
+		this.setState((state) => ({
+			hasUnsavedChanges: true,
+			consents: state.consents.map((original) =>
+				original.uniqueId === consent.uniqueId ? consent : original,
+			),
+		}));
+	};
 
-    onSubmit = (ev: Event) => {
-        ev.preventDefault();
-        this.setState({
-            isLoading: true,
-            errors: [],
-        });
-        setConsentsInApi(this.state.consents)
-            .then(() => {
-                this.setState({
-                    hasUnsavedChanges: false,
-                    isLoading: false,
-                });
-            })
-            .catch(() => {
-                this.setState({
-                    errors: [genericErrorStr],
-                    isLoading: false,
-                });
-            });
-    };
+	onSubmit = (ev: Event) => {
+		ev.preventDefault();
+		this.setState({
+			isLoading: true,
+			errors: [],
+		});
+		setConsentsInApi(this.state.consents)
+			.then(() => {
+				this.setState({
+					hasUnsavedChanges: false,
+					isLoading: false,
+				});
+			})
+			.catch(() => {
+				this.setState({
+					errors: [genericErrorStr],
+					isLoading: false,
+				});
+			});
+	};
 
-    updateExpandState = (isExpanded: boolean) => {
-        this.setState({
-            isExpanded,
-        });
-    };
+	updateExpandState = (isExpanded: boolean) => {
+		this.setState({
+			isExpanded,
+		});
+	};
 
-    render() {
-        const {
-            hasUnsavedChanges,
-            isLoading,
-            consents,
-            errors,
-            isExpanded,
-        } = this.state;
-        return (
-            <div
-                className={
-                    isExpanded
-                        ? 'identity-upsell-optouts'
-                        : 'identity-upsell-optouts identity-upsell-optouts--closed'
-                }>
-                <OptoutsExpanderButton
-                    isExpanded={isExpanded}
-                    linkName="upsell-optouts-expander"
-                    onToggle={this.updateExpandState}
-                    text="Change my preferences"
-                />
-                {isExpanded && (
-                    <div className="identity-upsell-optouts-expanded">
-                        <form onSubmit={ev => this.onSubmit(ev)}>
-                            <ul className="identity-forms-fields">
-                                <ErrorBar errors={errors} tagName="li" />
-                                <li>
-                                    {consents.map(consent => (
-                                        <Checkbox
-                                            title={consent.consent.description}
-                                            uniqueId={consent.uniqueId}
-                                            checkboxHtmlProps={{
-                                                checked: consent.hasConsented,
-                                                onChange: ev => {
-                                                    consent.setState(
-                                                        ev.currentTarget.checked
-                                                    );
-                                                    this.onCheckboxChange(
-                                                        consent
-                                                    );
-                                                },
-                                            }}
-                                        />
-                                    ))}
-                                </li>
-                                <li>
-                                    <div className="identity-upsell-button-with-proxy">
-                                        <button
-                                            data-link-name="upsell-consent : submit optouts"
-                                            type="submit"
-                                            disabled={isLoading}
-                                            className="manage-account__button manage-account__button--main">
-                                            Save preferences
-                                        </button>
-                                        {!hasUnsavedChanges && (
-                                            <span className="identity-upsell-button-with-proxy__proxy identity-upsell-button-with-proxy__proxy--success">
-                                                Changes saved
-                                            </span>
-                                        )}
-                                        {isLoading && (
-                                            <span className="identity-upsell-button-with-proxy__proxy">
-                                                Loading
-                                            </span>
-                                        )}
-                                    </div>
-                                </li>
-                            </ul>
-                        </form>
-                    </div>
-                )}
-            </div>
-        );
-    }
+	render() {
+		const {
+			hasUnsavedChanges,
+			isLoading,
+			consents,
+			errors,
+			isExpanded,
+		} = this.state;
+		return (
+			<div
+				className={
+					isExpanded
+						? 'identity-upsell-optouts'
+						: 'identity-upsell-optouts identity-upsell-optouts--closed'
+				}
+			>
+				<OptoutsExpanderButton
+					isExpanded={isExpanded}
+					linkName="upsell-optouts-expander"
+					onToggle={this.updateExpandState}
+					text="Change my preferences"
+				/>
+				{isExpanded && (
+					<div className="identity-upsell-optouts-expanded">
+						<form onSubmit={(ev) => this.onSubmit(ev)}>
+							<ul className="identity-forms-fields">
+								<ErrorBar errors={errors} tagName="li" />
+								<li>
+									{consents.map((consent) => (
+										<Checkbox
+											title={consent.consent.description}
+											uniqueId={consent.uniqueId}
+											checkboxHtmlProps={{
+												checked: consent.hasConsented,
+												onChange: (ev) => {
+													consent.setState(
+														ev.currentTarget
+															.checked,
+													);
+													this.onCheckboxChange(
+														consent,
+													);
+												},
+											}}
+										/>
+									))}
+								</li>
+								<li>
+									<div className="identity-upsell-button-with-proxy">
+										<button
+											data-link-name="upsell-consent : submit optouts"
+											type="submit"
+											disabled={isLoading}
+											className="manage-account__button manage-account__button--main"
+										>
+											Save preferences
+										</button>
+										{!hasUnsavedChanges && (
+											<span className="identity-upsell-button-with-proxy__proxy identity-upsell-button-with-proxy__proxy--success">
+												Changes saved
+											</span>
+										)}
+										{isLoading && (
+											<span className="identity-upsell-button-with-proxy__proxy">
+												Loading
+											</span>
+										)}
+									</div>
+								</li>
+							</ul>
+						</form>
+					</div>
+				)}
+			</div>
+		);
+	}
 }

--- a/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/page/ConfirmEmailPage.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/page/ConfirmEmailPage.js
@@ -12,7 +12,7 @@
 
 // @flow
 
-import React from 'preact-compat';
+import React from 'react';
 
 import { NewsLetterSignUps } from './NewsLetterSignUps';
 import { OptOuts } from './OptOuts';
@@ -20,38 +20,38 @@ import { Header } from '../header/Header';
 import { AccountCreationBlock } from '../account-creation/AccountCreationBlock';
 
 type Props = {
-    csrfToken: string,
-    accountToken: ?string,
-    email: string,
-    hasPassword: boolean,
-    hasSocialLinks: boolean,
-    isUserLoggedIn: boolean,
+	csrfToken: string,
+	accountToken: ?string,
+	email: string,
+	hasPassword: boolean,
+	hasSocialLinks: boolean,
+	isUserLoggedIn: boolean,
 };
 
 const Components = (props: Props): React.Component => {
-    let components = [<NewsLetterSignUps />, <OptOuts />];
+	let components = [<NewsLetterSignUps />, <OptOuts />];
 
-    if (!props.hasPassword && !props.hasSocialLinks && props.accountToken) {
-        components = [
-            <AccountCreationBlock
-                csrfToken={props.csrfToken}
-                accountToken={props.accountToken}
-                email={props.email}
-            />,
-            <NewsLetterSignUps />,
-            <OptOuts />,
-        ];
-    } else if (!props.isUserLoggedIn) {
-        // TODO: sign in form
-        components = [<NewsLetterSignUps />, <OptOuts />];
-    }
+	if (!props.hasPassword && !props.hasSocialLinks && props.accountToken) {
+		components = [
+			<AccountCreationBlock
+				csrfToken={props.csrfToken}
+				accountToken={props.accountToken}
+				email={props.email}
+			/>,
+			<NewsLetterSignUps />,
+			<OptOuts />,
+		];
+	} else if (!props.isUserLoggedIn) {
+		// TODO: sign in form
+		components = [<NewsLetterSignUps />, <OptOuts />];
+	}
 
-    return <div className="identity-upsell-layout">{components}</div>;
+	return <div className="identity-upsell-layout">{components}</div>;
 };
 
 export const ConfirmEmailPage = (props: Props): React.Component => (
-    <div className="identity-upsell-wrapper">
-        <Header title="Thank you!" subtitle="You’re now subscribed." />
-        <Components {...props} />
-    </div>
+	<div className="identity-upsell-wrapper">
+		<Header title="Thank you!" subtitle="You’re now subscribed." />
+		<Components {...props} />
+	</div>
 );

--- a/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/page/NewsLetterSignUps.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/page/NewsLetterSignUps.js
@@ -12,12 +12,12 @@
 
 // @flow
 
-import React from 'preact-compat';
+import React from 'react';
 import { Block } from '../block/Block';
 import { FollowCardList } from '../consent-card/FollowCardList';
 
 export const NewsLetterSignUps = (): React.Component => (
-    <Block title="Guardian favourites:">
-        <FollowCardList cutoff={2} />
-    </Block>
+	<Block title="Guardian favourites:">
+		<FollowCardList cutoff={2} />
+	</Block>
 );

--- a/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/page/OptOuts.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/page/OptOuts.js
@@ -12,18 +12,19 @@
 
 // @flow
 
-import React from 'preact-compat';
+import React from 'react';
 import { Block } from '../block/Block';
 import { OptOutsList } from '../opt-outs/OptOutsList';
 
 export const OptOuts = (): React.Component => (
-    <Block
-        halfWidth
-        sideBySideBackwards
-        title="Your marketing preferences"
-        subtext="We may contact you by telephone and post about our products and services (if you've previously given
+	<Block
+		halfWidth
+		sideBySideBackwards
+		title="Your marketing preferences"
+		subtext="We may contact you by telephone and post about our products and services (if you've previously given
         us your number and address). We may also contact you for market research purposes and use your data for
-        marketing analysis.">
-        <OptOutsList />
-    </Block>
+        marketing analysis."
+	>
+		<OptOutsList />
+	</Block>
 );

--- a/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/page/StatefulConfirmEmailPage.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/page/StatefulConfirmEmailPage.js
@@ -12,48 +12,48 @@
 
 // @flow
 
-import React from 'preact-compat';
+import React from 'react';
 import { ConfirmEmailPage } from './ConfirmEmailPage';
 import { getUserData } from '../../api';
 
 type Props = {
-    csrfToken: string,
-    accountToken: ?string,
-    email: string,
-    hasPassword: boolean,
-    hasSocialLinks: boolean,
+	csrfToken: string,
+	accountToken: ?string,
+	email: string,
+	hasPassword: boolean,
+	hasSocialLinks: boolean,
 };
 
 type State = {
-    isUserLoggedIn: boolean,
+	isUserLoggedIn: boolean,
 };
 
 const isUserLoggedIn = (): Promise<boolean> =>
-    getUserData().then(response => response.ok);
+	getUserData().then((response) => response.ok);
 
 export class StatefulConfirmEmailPage extends React.Component<Props, State> {
-    constructor(props: Props) {
-        super(props);
-        this.setState({ isUserLoggedIn: false });
-    }
+	constructor(props: Props) {
+		super(props);
+		this.setState({ isUserLoggedIn: false });
+	}
 
-    componentDidMount() {
-        // For some reason using this.setState instead of an anonymous function doesn't work?
-        isUserLoggedIn().then(status =>
-            this.setState({ isUserLoggedIn: status })
-        );
-    }
+	componentDidMount() {
+		// For some reason using this.setState instead of an anonymous function doesn't work?
+		isUserLoggedIn().then((status) =>
+			this.setState({ isUserLoggedIn: status }),
+		);
+	}
 
-    render() {
-        return (
-            <ConfirmEmailPage
-                csrfToken={this.props.csrfToken}
-                accountToken={this.props.accountToken}
-                email={this.props.email}
-                hasPassword={this.props.hasPassword}
-                hasSocialLinks={this.props.hasSocialLinks}
-                isUserLoggedIn={this.state.isUserLoggedIn}
-            />
-        );
-    }
+	render() {
+		return (
+			<ConfirmEmailPage
+				csrfToken={this.props.csrfToken}
+				accountToken={this.props.accountToken}
+				email={this.props.email}
+				hasPassword={this.props.hasPassword}
+				hasSocialLinks={this.props.hasSocialLinks}
+				isUserLoggedIn={this.state.isUserLoggedIn}
+			/>
+		);
+	}
 }

--- a/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/upsell.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/upsell.js
@@ -12,7 +12,7 @@
 
 // @flow
 import { trackNonClickInteraction } from 'common/modules/analytics/google';
-import React, { render } from 'preact-compat';
+import React, { render } from 'react';
 import fastdom from 'lib/fastdom-promise';
 import ophan from 'ophan/ng';
 import loadEnhancers from 'common/modules/identity/modules/loadEnhancers';
@@ -20,67 +20,67 @@ import { AccountCreationCompleteConsentsFlow } from 'common/modules/identity/ups
 import { StatefulConfirmEmailPage } from './page/StatefulConfirmEmailPage';
 
 const trackInteraction = (interaction: string): void => {
-    ophan.record({
-        component: 'set-password',
-        value: interaction,
-    });
-    trackNonClickInteraction(interaction);
+	ophan.record({
+		component: 'set-password',
+		value: interaction,
+	});
+	trackNonClickInteraction(interaction);
 };
 
 const bindAccountCreation = (el): void => {
-    trackInteraction('set-password : display');
-    fastdom.mutate(() => {
-        render(
-            <AccountCreationCompleteConsentsFlow
-                csrfToken={el.dataset.csrf}
-                accountToken={el.dataset.accountToken}
-                email={el.dataset.email}
-            />,
-            el
-        );
-    });
+	trackInteraction('set-password : display');
+	fastdom.mutate(() => {
+		render(
+			<AccountCreationCompleteConsentsFlow
+				csrfToken={el.dataset.csrf}
+				accountToken={el.dataset.accountToken}
+				email={el.dataset.email}
+			/>,
+			el,
+		);
+	});
 };
 
 type Prefill = {
-    csrfToken: string,
-    accountToken: ?string,
-    email: string,
-    hasPassword: boolean,
-    hasSocialLinks: boolean,
+	csrfToken: string,
+	accountToken: ?string,
+	email: string,
+	hasPassword: boolean,
+	hasSocialLinks: boolean,
 };
 
 const getPrefill = (el: HTMLElement): Prefill => ({
-    csrfToken: el.dataset.csrfToken,
-    accountToken: el.dataset.accountToken,
-    email: el.dataset.email,
-    hasPassword: el.dataset.hasPassword === 'true',
-    hasSocialLinks: el.dataset.hasSocialLinks === 'true',
+	csrfToken: el.dataset.csrfToken,
+	accountToken: el.dataset.accountToken,
+	email: el.dataset.email,
+	hasPassword: el.dataset.hasPassword === 'true',
+	hasSocialLinks: el.dataset.hasSocialLinks === 'true',
 });
 
 const bindBlockList = (el): void => {
-    fastdom
-        .measure(() => getPrefill(el))
-        .then(prefill =>
-            fastdom.mutate(() => {
-                render(
-                    <StatefulConfirmEmailPage
-                        csrfToken={prefill.csrfToken}
-                        accountToken={prefill.accountToken}
-                        email={prefill.email}
-                        hasPassword={prefill.hasPassword}
-                        hasSocialLinks={prefill.hasSocialLinks}
-                    />,
-                    el
-                );
-            })
-        );
+	fastdom
+		.measure(() => getPrefill(el))
+		.then((prefill) =>
+			fastdom.mutate(() => {
+				render(
+					<StatefulConfirmEmailPage
+						csrfToken={prefill.csrfToken}
+						accountToken={prefill.accountToken}
+						email={prefill.email}
+						hasPassword={prefill.hasPassword}
+						hasSocialLinks={prefill.hasSocialLinks}
+					/>,
+					el,
+				);
+			}),
+		);
 };
 
 const enhanceUpsell = (): void => {
-    loadEnhancers([
-        ['.js-identity-upsell-account-creation', bindAccountCreation],
-        ['.js-identity-block-list', bindBlockList],
-    ]);
+	loadEnhancers([
+		['.js-identity-upsell-account-creation', bindAccountCreation],
+		['.js-identity-block-list', bindBlockList],
+	]);
 };
 
 export { enhanceUpsell };

--- a/static/src/javascripts/bootstraps/enhanced/accessibility.js
+++ b/static/src/javascripts/bootstraps/enhanced/accessibility.js
@@ -1,103 +1,103 @@
-import React, { Component, render } from 'preact-compat';
+import React, { Component, render } from 'react';
 
 import { saveState, isOn } from 'common/modules/accessibility/main';
 
 const DOM_ID = 'js-accessibility-preferences';
 
-
 class BinaryToggle extends Component {
-    render() {
-        return (
-            <div className="form-field">
-                <div className="checkbox">
-                    <label
-                        className="label"
-                        htmlFor={`checkbox-${this.props.name}`}>
-                        <input
-                            id={`checkbox-${this.props.name}`}
-                            key={this.props.name}
-                            type="checkbox"
-                            data-link-name={this.props.name}
-                            defaultChecked={this.props.enabled}
-                            onChange={this.props.handleChange.bind(this)}
-                            // TODO damn me when I decided to implement this page
-                            // global.css includes pasteup-forms 5 which applies ugly styles
-                            // on all inputs. The proper solution is to upgrade pasteup to 6
-                            // but I prefer to leave the pleasure to someone else
-                            // The style object should be removed once we upgrade. Never probably.
-                            style={{
-                                float: 'none',
-                                margin: '3px 0.5ex',
-                            }}
-                        />
-                        {this.props.label}
-                    </label>
-                </div>
-            </div>
-        );
-    }
+	render() {
+		return (
+			<div className="form-field">
+				<div className="checkbox">
+					<label
+						className="label"
+						htmlFor={`checkbox-${this.props.name}`}
+					>
+						<input
+							id={`checkbox-${this.props.name}`}
+							key={this.props.name}
+							type="checkbox"
+							data-link-name={this.props.name}
+							defaultChecked={this.props.enabled}
+							onChange={this.props.handleChange.bind(this)}
+							// TODO damn me when I decided to implement this page
+							// global.css includes pasteup-forms 5 which applies ugly styles
+							// on all inputs. The proper solution is to upgrade pasteup to 6
+							// but I prefer to leave the pleasure to someone else
+							// The style object should be removed once we upgrade. Never probably.
+							style={{
+								float: 'none',
+								margin: '3px 0.5ex',
+							}}
+						/>
+						{this.props.label}
+					</label>
+				</div>
+			</div>
+		);
+	}
 }
 
 class Accessibility extends Component {
-    constructor() {
-        super();
-        this.state = ({
-            'flashing-elements': isOn('flashing-elements'),
-        });
-    }
+	constructor() {
+		super();
+		this.state = {
+			'flashing-elements': isOn('flashing-elements'),
+		};
+	}
 
-    toggle(key) {
-        const newState = {};
-        newState[key] = !this.state[key];
-        this.setState(newState, function() {
-            saveState(this.state);
-        });
-    }
+	toggle(key) {
+		const newState = {};
+		newState[key] = !this.state[key];
+		this.setState(newState, function () {
+			saveState(this.state);
+		});
+	}
 
-    render() {
-        return (
-            <form className="form">
-                <fieldset className="fieldset">
-                    <p key="p1">
-                        We aim to make this site accessible to a wide audience
-                        and to ensure a great experience for all users by
-                        conforming to World Wide Web Consortium accessibility
-                        guidelines (W3C&apos;s WCAG)
-                    </p>
-                    <p key="p2">
-                        However, if you are having trouble reading this website
-                        you can change the way it looks or disable some of its
-                        functionalities.
-                    </p>
-                    <BinaryToggle
-                        key="flashing-elements"
-                        name="flashing-elements"
-                        label={[
-                            <strong key="label">
-                                Allow flashing elements
-                            </strong>,
-                            this.state['flashing-elements']
-                                ? ' Untick this to disable flashing and moving elements'
-                                : ' Tick this to enable flashing or moving elements.',
-                        ]}
-                        enabled={this.state['flashing-elements']}
-                        handleChange={this.toggle.bind(
-                            this,
-                            'flashing-elements'
-                        )}
-                    />
-                </fieldset>
-            </form>
-        );
-    }
+	render() {
+		return (
+			<form className="form">
+				<fieldset className="fieldset">
+					<p key="p1">
+						We aim to make this site accessible to a wide audience
+						and to ensure a great experience for all users by
+						conforming to World Wide Web Consortium accessibility
+						guidelines (W3C&apos;s WCAG)
+					</p>
+					<p key="p2">
+						However, if you are having trouble reading this website
+						you can change the way it looks or disable some of its
+						functionalities.
+					</p>
+					<BinaryToggle
+						key="flashing-elements"
+						name="flashing-elements"
+						label={[
+							<strong key="label">
+								Allow flashing elements
+							</strong>,
+							this.state['flashing-elements']
+								? ' Untick this to disable flashing and moving elements'
+								: ' Tick this to enable flashing or moving elements.',
+						]}
+						enabled={this.state['flashing-elements']}
+						handleChange={this.toggle.bind(
+							this,
+							'flashing-elements',
+						)}
+					/>
+				</fieldset>
+			</form>
+		);
+	}
 }
 
 const init = (callback) => {
-    const el = document.getElementById(DOM_ID);
+	const el = document.getElementById(DOM_ID);
 
-    if (el) {
-        render(<Accessibility />, el, callback);
-    }
+	if (el) {
+		render(<Accessibility />, el, callback);
+	}
 };
 
 export { DOM_ID, init };

--- a/static/src/javascripts/bootstraps/enhanced/preferences.js
+++ b/static/src/javascripts/bootstraps/enhanced/preferences.js
@@ -1,103 +1,104 @@
-import React, { Component, render } from 'preact-compat';
+import React, { Component, render } from 'react';
 import {
-    getPopularFiltered,
-    deleteFromSummary,
-    showInMegaNav,
-    showInMegaNavEnable,
-    showInMegaNavEnabled,
+	getPopularFiltered,
+	deleteFromSummary,
+	showInMegaNav,
+	showInMegaNavEnable,
+	showInMegaNavEnabled,
 } from 'common/modules/onward/history';
 
 class SummaryTagsList extends Component {
-    constructor() {
-        super();
-        this.state = {
-            popular: getPopularFiltered(),
-        };
-    }
+	constructor() {
+		super();
+		this.state = {
+			popular: getPopularFiltered(),
+		};
+	}
 
-    handleRemove(tag) {
-        deleteFromSummary(tag);
-        this.setState({
-            popular: getPopularFiltered({ flush: true }),
-        });
-        showInMegaNav();
-    }
+	handleRemove(tag) {
+		deleteFromSummary(tag);
+		this.setState({
+			popular: getPopularFiltered({ flush: true }),
+		});
+		showInMegaNav();
+	}
 
-    render() {
-        const tagElements = this.state.popular.map(tag => (
-            <span
-                className="button button--small button--tag button--secondary"
-                key={tag[0]}>
-                <button
-                    onClick={this.handleRemove.bind(this, tag[0])}
-                    data-link-name={`remove | ${tag[1]}`}>
-                    X
-                </button>
-                <a href={`/${tag[0]}`}>{tag[1]}</a>
-            </span>
-        ));
+	render() {
+		const tagElements = this.state.popular.map((tag) => (
+			<span
+				className="button button--small button--tag button--secondary"
+				key={tag[0]}
+			>
+				<button
+					onClick={this.handleRemove.bind(this, tag[0])}
+					data-link-name={`remove | ${tag[1]}`}
+				>
+					X
+				</button>
+				<a href={`/${tag[0]}`}>{tag[1]}</a>
+			</span>
+		));
 
-        let helperText;
+		let helperText;
 
-        if (!tagElements.length) {
-            helperText = "(You don't have any recently visited topics.)";
-        } else {
-            helperText =
-                "Remove individual topics by clicking 'X' or switch off the functionality below. We respect your privacy and your shortcuts will never be made public.";
-        }
-        tagElements.push(<p key="helper-text">{helperText}</p>);
+		if (!tagElements.length) {
+			helperText = "(You don't have any recently visited topics.)";
+		} else {
+			helperText =
+				"Remove individual topics by clicking 'X' or switch off the functionality below. We respect your privacy and your shortcuts will never be made public.";
+		}
+		tagElements.push(<p key="helper-text">{helperText}</p>);
 
-        return <div>{tagElements}</div>;
-    }
+		return <div>{tagElements}</div>;
+	}
 }
 
 class SummaryTagsSettings extends Component {
-    constructor() {
-        super();
-        this.state = {
-            enabled: showInMegaNavEnabled(),
-        };
-    }
+	constructor() {
+		super();
+		this.state = {
+			enabled: showInMegaNavEnabled(),
+		};
+	}
 
-    handleToggle() {
-        const isEnabled = !this.state.enabled;
+	handleToggle() {
+		const isEnabled = !this.state.enabled;
 
-        this.setState({
-            enabled: isEnabled,
-        });
-        showInMegaNavEnable(isEnabled);
-    }
+		this.setState({
+			enabled: isEnabled,
+		});
+		showInMegaNavEnable(isEnabled);
+	}
 
-    render() {
-        const toggleAction = this.state.enabled ? 'OFF' : 'ON';
+	render() {
+		const toggleAction = this.state.enabled ? 'OFF' : 'ON';
 
-        return (
-            <div data-link-name="suggested links">
-                <p>
-                    These are based on the topics you visit most. You can access
-                    them at any time by opening the &quot;all sections&quot;
-                    menu.
-                </p>
-                {this.state.enabled ? <SummaryTagsList /> : null}
-                <button
-                    onClick={this.handleToggle.bind(this)}
-                    className="button button--medium button--primary"
-                    data-link-name={toggleAction}>
-                    Switch recently visited links {toggleAction}
-                </button>
-            </div>
-        );
-    }
+		return (
+			<div data-link-name="suggested links">
+				<p>
+					These are based on the topics you visit most. You can access
+					them at any time by opening the &quot;all sections&quot;
+					menu.
+				</p>
+				{this.state.enabled ? <SummaryTagsList /> : null}
+				<button
+					onClick={this.handleToggle.bind(this)}
+					className="button button--medium button--primary"
+					data-link-name={toggleAction}
+				>
+					Switch recently visited links {toggleAction}
+				</button>
+			</div>
+		);
+	}
 }
 
 const init = () => {
-    const placeholder = document.getElementById(
-        'preferences-history-tags'
-    );
+	const placeholder = document.getElementById('preferences-history-tags');
 
-    if (placeholder) {
-        render(<SummaryTagsSettings />, placeholder);
-    }
+	if (placeholder) {
+		render(<SummaryTagsSettings />, placeholder);
+	}
 };
 
 export { init };

--- a/static/src/javascripts/projects/common/modules/crosswords/anagram-helper/clue-input.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/anagram-helper/clue-input.js
@@ -1,52 +1,52 @@
-import React, { Component, findDOMNode } from 'preact-compat';
+import React, { Component, findDOMNode } from 'react';
 
 class ClueInput extends Component {
-    componentDidMount() {
-        const el = (findDOMNode(this));
+	componentDidMount() {
+		const el = findDOMNode(this);
 
-        if (el) {
-            el.focus();
-        }
-    }
+		if (el) {
+			el.focus();
+		}
+	}
 
-    componentDidUpdate() {
-        const el = (findDOMNode(this));
+	componentDidUpdate() {
+		const el = findDOMNode(this);
 
-        // focus on reset
-        if (this.props.value === '' && el) {
-            el.focus();
-        }
-    }
+		// focus on reset
+		if (this.props.value === '' && el) {
+			el.focus();
+		}
+	}
 
-    onInputChange(e) {
-        if (!(e.target instanceof HTMLInputElement)) {
-            return;
-        }
-        this.props.onChange(e.target.value.toLowerCase());
-    }
+	onInputChange(e) {
+		if (!(e.target instanceof HTMLInputElement)) {
+			return;
+		}
+		this.props.onChange(e.target.value.toLowerCase());
+	}
 
-    onKeyDown(e) {
-        const el = (findDOMNode(this));
+	onKeyDown(e) {
+		const el = findDOMNode(this);
 
-        if (e.keyCode === 13 && el) {
-            el.blur();
-            this.props.onEnter();
-        }
-    }
+		if (e.keyCode === 13 && el) {
+			el.blur();
+			this.props.onEnter();
+		}
+	}
 
-    render() {
-        return (
-            <input
-                type="text"
-                className="crossword__anagram-helper__clue-input"
-                placeholder="Enter letters"
-                maxLength={this.props.clue.length}
-                value={this.props.value}
-                onChange={this.onInputChange.bind(this)}
-                onKeyDown={this.onKeyDown.bind(this)}
-            />
-        );
-    }
+	render() {
+		return (
+			<input
+				type="text"
+				className="crossword__anagram-helper__clue-input"
+				placeholder="Enter letters"
+				maxLength={this.props.clue.length}
+				value={this.props.value}
+				onChange={this.onInputChange.bind(this)}
+				onKeyDown={this.onKeyDown.bind(this)}
+			/>
+		);
+	}
 }
 
 export { ClueInput };

--- a/static/src/javascripts/projects/common/modules/crosswords/anagram-helper/clue-preview.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/anagram-helper/clue-preview.js
@@ -1,88 +1,85 @@
-import React, { Component } from 'preact-compat';
-
+import React, { Component } from 'react';
 
 // Checks a object in the form{",":[4,7]}
-const checkIfLetterHasSeparator = (
-    locations,
-    letterIndex
-) => {
-    const spaces = locations[','];
-    const letterHasBoundary = (separators) =>
-        separators.includes(letterIndex);
+const checkIfLetterHasSeparator = (locations, letterIndex) => {
+	const spaces = locations[','];
+	const letterHasBoundary = (separators) => separators.includes(letterIndex);
 
-    if (spaces && letterHasBoundary(spaces)) {
-        return 'crossword__anagram-helper__cell crossword__anagram-helper__cell--with-space';
-    }
+	if (spaces && letterHasBoundary(spaces)) {
+		return 'crossword__anagram-helper__cell crossword__anagram-helper__cell--with-space';
+	}
 
-    const dashes = locations['-'];
-    if (dashes && letterHasBoundary(dashes)) {
-        return 'crossword__anagram-helper__cell crossword__anagram-helper__cell--with-hyphen';
-    }
+	const dashes = locations['-'];
+	if (dashes && letterHasBoundary(dashes)) {
+		return 'crossword__anagram-helper__cell crossword__anagram-helper__cell--with-hyphen';
+	}
 
-    return 'crossword__anagram-helper__cell';
+	return 'crossword__anagram-helper__cell';
 };
 
 class CluePreview extends Component {
-    /**
-     * Get the entries for the preview cells: first filter the user's input to
-     * remove anything anything that's already been entered into the grid.
-     *
-     * With that, we map over the entries, and wherever there's an empty space
-     * we insert one of the shuffled input characters.
-     *
-     * If the user hasn't yet clicked 'shuffle' (this.props.hasShuffled) just
-     * display the entries as they are, preserving any blank spaces.
-     */
-    getEntries() {
-        const unsolved = this.props.letters.filter(l => !l.entered);
+	/**
+	 * Get the entries for the preview cells: first filter the user's input to
+	 * remove anything anything that's already been entered into the grid.
+	 *
+	 * With that, we map over the entries, and wherever there's an empty space
+	 * we insert one of the shuffled input characters.
+	 *
+	 * If the user hasn't yet clicked 'shuffle' (this.props.hasShuffled) just
+	 * display the entries as they are, preserving any blank spaces.
+	 */
+	getEntries() {
+		const unsolved = this.props.letters.filter((l) => !l.entered);
 
-        return this.props.entries.map(entry => {
-            entry.solved = !!entry.value;
+		return this.props.entries.map((entry) => {
+			entry.solved = !!entry.value;
 
-            const returnVal = this.props.hasShuffled
-                ? (entry.value && entry) || unsolved.shift()
-                : entry;
+			const returnVal = this.props.hasShuffled
+				? (entry.value && entry) || unsolved.shift()
+				: entry;
 
-            return Object.assign({}, { key: entry.key }, returnVal);
-        });
-    }
+			return Object.assign({}, { key: entry.key }, returnVal);
+		});
+	}
 
-    render() {
-        const entries = this.getEntries();
+	render() {
+		const entries = this.getEntries();
 
-        return (
-            <div
-                className={`crossword__anagram-helper__clue-preview ${
-                    entries.length >= 9 ? 'long' : ''
-                }`}>
-                <div>
-                    <strong>
-                        {this.props.clue.number}{' '}
-                        <span className="crossword__anagram-helper__direction">
-                            {this.props.clue.direction}
-                        </span>
-                    </strong>{' '}
-                    {this.props.clue.clue}
-                </div>
-                {entries.map((entry, i) => {
-                    const classNames = checkIfLetterHasSeparator(
-                        this.props.clue.separatorLocations,
-                        i + 1
-                    ); // Separators are one indexed in CAPI, annoyingly
+		return (
+			<div
+				className={`crossword__anagram-helper__clue-preview ${
+					entries.length >= 9 ? 'long' : ''
+				}`}
+			>
+				<div>
+					<strong>
+						{this.props.clue.number}{' '}
+						<span className="crossword__anagram-helper__direction">
+							{this.props.clue.direction}
+						</span>
+					</strong>{' '}
+					{this.props.clue.clue}
+				</div>
+				{entries.map((entry, i) => {
+					const classNames = checkIfLetterHasSeparator(
+						this.props.clue.separatorLocations,
+						i + 1,
+					); // Separators are one indexed in CAPI, annoyingly
 
-                    return (
-                        <span
-                            className={
-                                classNames + (entry.solved ? ' has-value' : '')
-                            }
-                            key={entry.key}>
-                            {entry.value || ''}
-                        </span>
-                    );
-                })}
-            </div>
-        );
-    }
+					return (
+						<span
+							className={
+								classNames + (entry.solved ? ' has-value' : '')
+							}
+							key={entry.key}
+						>
+							{entry.value || ''}
+						</span>
+					);
+				})}
+			</div>
+		);
+	}
 }
 
 export { CluePreview };

--- a/static/src/javascripts/projects/common/modules/crosswords/anagram-helper/main.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/anagram-helper/main.js
@@ -1,8 +1,8 @@
-import React, { Component } from 'preact-compat';
+import React, { Component } from 'react';
 import { markup as closeCentralIcon } from 'svgs/icon/close-central.svg';
 import {
-    cellsForClue,
-    getAnagramClueData,
+	cellsForClue,
+	getAnagramClueData,
 } from 'common/modules/crosswords/helpers';
 import shuffle from 'lodash/shuffle';
 import { ClueInput } from './clue-input';
@@ -10,163 +10,163 @@ import { CluePreview } from './clue-preview';
 import { Ring } from './ring';
 
 class AnagramHelper extends Component {
-    constructor() {
-        super();
-        this.state = {
-            clueInput: '',
-            showInput: true,
-        };
-    }
+	constructor() {
+		super();
+		this.state = {
+			clueInput: '',
+			showInput: true,
+		};
+	}
 
-    componentWillReceiveProps(next) {
-        // reset on clue change
-        if (next.clue !== this.props.focussedEntry) {
-            this.reset();
-        }
-    }
+	componentWillReceiveProps(next) {
+		// reset on clue change
+		if (next.clue !== this.props.focussedEntry) {
+			this.reset();
+		}
+	}
 
-    onClueInput(text) {
-        if (!/\s|\d/g.test(text)) {
-            this.setState({
-                clueInput: text,
-            });
-        }
-    }
+	onClueInput(text) {
+		if (!/\s|\d/g.test(text)) {
+			this.setState({
+				clueInput: text,
+			});
+		}
+	}
 
-    /**
-     * Shuffle the letters in the user's input.
-     *
-     * First, create an array of input characters that have already been entered
-     * into the grid. Then build a new collection of letters, using the first
-     * array to flag letters that are already entered in the puzzle, and
-     * shuffle it.
-     *
-     */
-    // eslint-disable-next-line class-methods-use-this
-    shuffleWord(
-        word,
-        entries
-    ) {
-        const wordEntries = entries
-            .map(entry => entry.value.toLowerCase())
-            .filter(entry => word.includes(entry))
-            .filter(Boolean)
-            .sort();
+	/**
+	 * Shuffle the letters in the user's input.
+	 *
+	 * First, create an array of input characters that have already been entered
+	 * into the grid. Then build a new collection of letters, using the first
+	 * array to flag letters that are already entered in the puzzle, and
+	 * shuffle it.
+	 *
+	 */
+	// eslint-disable-next-line class-methods-use-this
+	shuffleWord(word, entries) {
+		const wordEntries = entries
+			.map((entry) => entry.value.toLowerCase())
+			.filter((entry) => word.includes(entry))
+			.filter(Boolean)
+			.sort();
 
-        return shuffle(
-            word
-                .trim()
-                .split('')
-                .sort()
-                .reduce(
-                    (acc, letter) => {
-                        const [head, ...tail] = acc.entries;
-                        const entered = head === letter.toLowerCase();
+		return shuffle(
+			word
+				.trim()
+				.split('')
+				.sort()
+				.reduce(
+					(acc, letter) => {
+						const [head, ...tail] = acc.entries;
+						const entered = head === letter.toLowerCase();
 
-                        return {
-                            letters: acc.letters.concat({
-                                value: letter,
-                                entered,
-                            }),
-                            entries: entered ? tail : acc.entries,
-                        };
-                    },
-                    {
-                        letters: [],
-                        entries: wordEntries,
-                    }
-                ).letters
-        );
-    }
+						return {
+							letters: acc.letters.concat({
+								value: letter,
+								entered,
+							}),
+							entries: entered ? tail : acc.entries,
+						};
+					},
+					{
+						letters: [],
+						entries: wordEntries,
+					},
+				).letters,
+		);
+	}
 
-    shuffle() {
-        if (this.canShuffle()) {
-            this.setState({
-                showInput: false,
-            });
-        }
-    }
+	shuffle() {
+		if (this.canShuffle()) {
+			this.setState({
+				showInput: false,
+			});
+		}
+	}
 
-    reset() {
-        if (this.state.clueInput) {
-            this.setState({
-                clueInput: '',
-                showInput: true,
-            });
-        }
-    }
+	reset() {
+		if (this.state.clueInput) {
+			this.setState({
+				clueInput: '',
+				showInput: true,
+			});
+		}
+	}
 
-    canShuffle() {
-        return !!this.state.clueInput && this.state.clueInput.length > 0;
-    }
+	canShuffle() {
+		return !!this.state.clueInput && this.state.clueInput.length > 0;
+	}
 
-    render() {
-        const closeIcon = {
-            __html: closeCentralIcon,
-        };
-        const clue = getAnagramClueData(
-            this.props.entries,
-            this.props.focussedEntry
-        );
-        const cells = cellsForClue(
-            this.props.entries,
-            this.props.focussedEntry
-        );
-        const entries = cells.map(coords =>
-            Object.assign({}, this.props.grid[coords.x][coords.y], {
-                key: `${coords.x},${coords.y}`,
-            })
-        );
+	render() {
+		const closeIcon = {
+			__html: closeCentralIcon,
+		};
+		const clue = getAnagramClueData(
+			this.props.entries,
+			this.props.focussedEntry,
+		);
+		const cells = cellsForClue(
+			this.props.entries,
+			this.props.focussedEntry,
+		);
+		const entries = cells.map((coords) =>
+			Object.assign({}, this.props.grid[coords.x][coords.y], {
+				key: `${coords.x},${coords.y}`,
+			}),
+		);
 
-        const letters = this.shuffleWord(this.state.clueInput, entries);
+		const letters = this.shuffleWord(this.state.clueInput, entries);
 
-        const inner = this.state.showInput ? (
-            <ClueInput
-                value={this.state.clueInput}
-                clue={clue}
-                onChange={this.onClueInput.bind(this)}
-                onEnter={this.shuffle.bind(this)}
-            />
-        ) : (
-            <Ring letters={letters} />
-        );
+		const inner = this.state.showInput ? (
+			<ClueInput
+				value={this.state.clueInput}
+				clue={clue}
+				onChange={this.onClueInput.bind(this)}
+				onEnter={this.shuffle.bind(this)}
+			/>
+		) : (
+			<Ring letters={letters} />
+		);
 
-        return (
-            <div
-                className="crossword__anagram-helper-outer"
-                data-link-name="Anagram Helper">
-                <div className="crossword__anagram-helper-inner">{inner}</div>
-                <button
-                    className="button button--large button--tertiary crossword__anagram-helper-close"
-                    onClick={this.props.close.bind(this.props.crossword)}
-                    dangerouslySetInnerHTML={closeIcon}
-                    data-link-name="Close"
-                />
-                <button
-                    className={`button button--large ${
-                        !this.state.clueInput ? 'button--tertiary' : ''
-                    }`}
-                    onClick={this.reset.bind(this)}
-                    data-link-name="Start Again">
-                    start again
-                </button>
-                <button
-                    className={`button button--large ${
-                        this.canShuffle() ? '' : 'button--tertiary'
-                    }`}
-                    onClick={this.shuffle.bind(this)}
-                    data-link-name="Shuffle">
-                    shuffle
-                </button>
-                <CluePreview
-                    clue={clue}
-                    entries={entries}
-                    letters={letters}
-                    hasShuffled={!this.state.showInput}
-                />
-            </div>
-        );
-    }
+		return (
+			<div
+				className="crossword__anagram-helper-outer"
+				data-link-name="Anagram Helper"
+			>
+				<div className="crossword__anagram-helper-inner">{inner}</div>
+				<button
+					className="button button--large button--tertiary crossword__anagram-helper-close"
+					onClick={this.props.close.bind(this.props.crossword)}
+					dangerouslySetInnerHTML={closeIcon}
+					data-link-name="Close"
+				/>
+				<button
+					className={`button button--large ${
+						!this.state.clueInput ? 'button--tertiary' : ''
+					}`}
+					onClick={this.reset.bind(this)}
+					data-link-name="Start Again"
+				>
+					start again
+				</button>
+				<button
+					className={`button button--large ${
+						this.canShuffle() ? '' : 'button--tertiary'
+					}`}
+					onClick={this.shuffle.bind(this)}
+					data-link-name="Shuffle"
+				>
+					shuffle
+				</button>
+				<CluePreview
+					clue={clue}
+					entries={entries}
+					letters={letters}
+					hasShuffled={!this.state.showInput}
+				/>
+			</div>
+		);
+	}
 }
 
 export { AnagramHelper };

--- a/static/src/javascripts/projects/common/modules/crosswords/anagram-helper/ring.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/anagram-helper/ring.js
@@ -1,44 +1,42 @@
-import React, { Component } from 'preact-compat';
+import React, { Component } from 'react';
 
-const round = x => Math.round(x * 100) / 100;
+const round = (x) => Math.round(x * 100) / 100;
 /**
  * Get coordinates for a letter as percentages.
  *
  * To get the diameter:
  *   (width of .crossword__anagram-helper-shuffler) - (2 * desired padding)
  */
-const getPosition = (
-    angle,
-    i
-) => {
-    const diameter = 40;
-    const theta = ((angle * Math.PI) / 180) * i;
+const getPosition = (angle, i) => {
+	const diameter = 40;
+	const theta = ((angle * Math.PI) / 180) * i;
 
-    return {
-        left: `${diameter + round(diameter * Math.sin(theta))}%`,
-        top: `${diameter + round(diameter * Math.cos(theta))}%`,
-    };
+	return {
+		left: `${diameter + round(diameter * Math.sin(theta))}%`,
+		top: `${diameter + round(diameter * Math.cos(theta))}%`,
+	};
 };
 
 class Ring extends Component {
-    render() {
-        const angle = 360 / this.props.letters.length;
+	render() {
+		const angle = 360 / this.props.letters.length;
 
-        return (
-            <div className="crossword__anagram-helper-shuffler">
-                {this.props.letters.map((letter, i) => (
-                    <div
-                        className={`crossword__anagram-helper-shuffler__letter ${
-                            letter.entered ? 'entered' : ''
-                        }`}
-                        style={getPosition(angle, i)}
-                        key={`${letter.value}-${i}`}>
-                        {letter.value}
-                    </div>
-                ))}
-            </div>
-        );
-    }
+		return (
+			<div className="crossword__anagram-helper-shuffler">
+				{this.props.letters.map((letter, i) => (
+					<div
+						className={`crossword__anagram-helper-shuffler__letter ${
+							letter.entered ? 'entered' : ''
+						}`}
+						style={getPosition(angle, i)}
+						key={`${letter.value}-${i}`}
+					>
+						{letter.value}
+					</div>
+				))}
+			</div>
+		);
+	}
 }
 
 export { Ring };

--- a/static/src/javascripts/projects/common/modules/crosswords/cell.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/cell.js
@@ -1,68 +1,70 @@
-import React, { Component } from 'preact-compat';
+import React, { Component } from 'react';
 import { gridSize } from 'common/modules/crosswords/helpers';
 import { constants } from 'common/modules/crosswords/constants';
 import { classNames } from 'common/modules/crosswords/classNames';
 
 class Cell extends Component {
-    onClick(event) {
-        event.preventDefault();
-        this.props.handleSelect(this.props.x, this.props.y);
-    }
+	onClick(event) {
+		event.preventDefault();
+		this.props.handleSelect(this.props.x, this.props.y);
+	}
 
-    render() {
-        const top = gridSize(this.props.y);
-        const left = gridSize(this.props.x);
+	render() {
+		const top = gridSize(this.props.y);
+		const left = gridSize(this.props.x);
 
-        let cellNumber = null;
-        if (this.props.number !== undefined) {
-            cellNumber = (
-                <text
-                    x={left + 1}
-                    y={top + constants.numberSize}
-                    key="number"
-                    className="crossword__cell-number">
-                    {this.props.number}
-                </text>
-            );
-        }
+		let cellNumber = null;
+		if (this.props.number !== undefined) {
+			cellNumber = (
+				<text
+					x={left + 1}
+					y={top + constants.numberSize}
+					key="number"
+					className="crossword__cell-number"
+				>
+					{this.props.number}
+				</text>
+			);
+		}
 
-        let cellValue = null;
-        if (this.props.value !== undefined) {
-            cellValue = (
-                <text
-                    x={left + constants.cellSize * 0.5}
-                    y={top + constants.cellSize * 0.675}
-                    key="entry"
-                    className={classNames({
-                        'crossword__cell-text': true,
-                        'crossword__cell-text--focussed': this.props.isFocussed,
-                        'crossword__cell-text--error': this.props.isError,
-                    })}
-                    textAnchor="middle">
-                    {this.props.value}
-                </text>
-            );
-        }
+		let cellValue = null;
+		if (this.props.value !== undefined) {
+			cellValue = (
+				<text
+					x={left + constants.cellSize * 0.5}
+					y={top + constants.cellSize * 0.675}
+					key="entry"
+					className={classNames({
+						'crossword__cell-text': true,
+						'crossword__cell-text--focussed': this.props.isFocussed,
+						'crossword__cell-text--error': this.props.isError,
+					})}
+					textAnchor="middle"
+				>
+					{this.props.value}
+				</text>
+			);
+		}
 
-        return (
-            <g onClick={this.onClick.bind(this)}>
-                <rect
-                    x={left}
-                    y={top}
-                    width={constants.cellSize}
-                    height={constants.cellSize}
-                    className={classNames({
-                        crossword__cell: true,
-                        'crossword__cell--focussed': this.props.isFocussed,
-                        'crossword__cell--highlighted': this.props
-                            .isHighlighted,
-                    })}
-                />
-                {cellNumber}
-                {cellValue}
-            </g>
-        );
-    }
+		return (
+			<g onClick={this.onClick.bind(this)}>
+				<rect
+					x={left}
+					y={top}
+					width={constants.cellSize}
+					height={constants.cellSize}
+					className={classNames({
+						crossword__cell: true,
+						'crossword__cell--focussed': this.props.isFocussed,
+						'crossword__cell--highlighted': this.props
+							.isHighlighted,
+					})}
+				/>
+				{cellNumber}
+				{cellValue}
+			</g>
+		);
+	}
 }
 
 export default Cell;

--- a/static/src/javascripts/projects/common/modules/crosswords/clues.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/clues.js
@@ -1,4 +1,4 @@
-import React, { Component, findDOMNode } from 'preact-compat';
+import React, { Component, findDOMNode } from 'react';
 import bean from 'bean';
 import fastdom from 'fastdom';
 import { classNames } from 'common/modules/crosswords/classNames';
@@ -6,146 +6,149 @@ import { isBreakpoint } from 'lib/detect';
 import { scrollTo } from 'lib/scroller';
 
 class Clue extends Component {
-    onClick() {
-        this.props.setReturnPosition();
-    }
+	onClick() {
+		this.props.setReturnPosition();
+	}
 
-    render() {
-        return (
-            <li>
-                <a
-                    href={`#${this.props.id}`}
-                    onClick={this.onClick.bind(this)}
-                    className={classNames({
-                        crossword__clue: true,
-                        'crossword__clue--answered': this.props.hasAnswered,
-                        'crossword__clue--selected': this.props.isSelected,
-                        'crossword__clue--display-group-order':
-                            JSON.stringify(this.props.number) !==
-                            this.props.humanNumber,
-                    })}>
-                    <div className="crossword__clue__number">
-                        {this.props.humanNumber}
-                    </div>
-                    <div
-                        className="crossword__clue__text"
-                        dangerouslySetInnerHTML={{ __html: this.props.clue }}
-                    />
-                </a>
-            </li>
-        );
-    }
+	render() {
+		return (
+			<li>
+				<a
+					href={`#${this.props.id}`}
+					onClick={this.onClick.bind(this)}
+					className={classNames({
+						crossword__clue: true,
+						'crossword__clue--answered': this.props.hasAnswered,
+						'crossword__clue--selected': this.props.isSelected,
+						'crossword__clue--display-group-order':
+							JSON.stringify(this.props.number) !==
+							this.props.humanNumber,
+					})}
+				>
+					<div className="crossword__clue__number">
+						{this.props.humanNumber}
+					</div>
+					<div
+						className="crossword__clue__text"
+						dangerouslySetInnerHTML={{ __html: this.props.clue }}
+					/>
+				</a>
+			</li>
+		);
+	}
 }
 
 class Clues extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            showGradient: true,
-        };
-    }
+	constructor(props) {
+		super(props);
+		this.state = {
+			showGradient: true,
+		};
+	}
 
-    componentDidMount() {
-        this.$cluesNode = (findDOMNode(this.clues));
+	componentDidMount() {
+		this.$cluesNode = findDOMNode(this.clues);
 
-        const height =
-            this.$cluesNode.scrollHeight - this.$cluesNode.clientHeight;
+		const height =
+			this.$cluesNode.scrollHeight - this.$cluesNode.clientHeight;
 
-        bean.on(this.$cluesNode, 'scroll', e => {
-            const showGradient = height - e.currentTarget.scrollTop > 25;
+		bean.on(this.$cluesNode, 'scroll', (e) => {
+			const showGradient = height - e.currentTarget.scrollTop > 25;
 
-            if (this.state.showGradient !== showGradient) {
-                this.setState({
-                    showGradient,
-                });
-            }
-        });
-    }
+			if (this.state.showGradient !== showGradient) {
+				this.setState({
+					showGradient,
+				});
+			}
+		});
+	}
 
-    /**
-     * Scroll clues into view when they're activated (i.e. clicked in the grid)
-     */
-    componentDidUpdate(prev) {
-        if (
-            isBreakpoint({
-                min: 'tablet',
-                max: 'leftCol',
-            }) &&
-            (this.props.focussed &&
-                (!prev.focussed || prev.focussed.id !== this.props.focussed.id))
-        ) {
-            fastdom.measure(() => {
-                this.scrollIntoView(this.props.focussed);
-            });
-        }
-    }
+	/**
+	 * Scroll clues into view when they're activated (i.e. clicked in the grid)
+	 */
+	componentDidUpdate(prev) {
+		if (
+			isBreakpoint({
+				min: 'tablet',
+				max: 'leftCol',
+			}) &&
+			this.props.focussed &&
+			(!prev.focussed || prev.focussed.id !== this.props.focussed.id)
+		) {
+			fastdom.measure(() => {
+				this.scrollIntoView(this.props.focussed);
+			});
+		}
+	}
 
-    $cluesNode;
+	$cluesNode;
 
-    scrollIntoView(clue) {
-        const buffer = 100;
-        const node = (findDOMNode(this[clue.id]));
-        const visible =
-            node.offsetTop - buffer > this.$cluesNode.scrollTop &&
-            node.offsetTop + buffer <
-                this.$cluesNode.scrollTop + this.$cluesNode.clientHeight;
+	scrollIntoView(clue) {
+		const buffer = 100;
+		const node = findDOMNode(this[clue.id]);
+		const visible =
+			node.offsetTop - buffer > this.$cluesNode.scrollTop &&
+			node.offsetTop + buffer <
+				this.$cluesNode.scrollTop + this.$cluesNode.clientHeight;
 
-        if (!visible) {
-            const offset = node.offsetTop - this.$cluesNode.clientHeight / 2;
-            scrollTo(offset, 250, 'easeOutQuad', this.$cluesNode);
-        }
-    }
+		if (!visible) {
+			const offset = node.offsetTop - this.$cluesNode.clientHeight / 2;
+			scrollTo(offset, 250, 'easeOutQuad', this.$cluesNode);
+		}
+	}
 
-    render() {
-        const headerClass = 'crossword__clues-header';
-        const cluesByDirection = direction =>
-            this.props.clues
-                .filter(clue => clue.entry.direction === direction)
-                .map(clue => (
-                    <Clue
-                        ref={clueRef => {
-                            this[clue.entry.id] = clueRef;
-                        }}
-                        id={clue.entry.id}
-                        key={clue.entry.id}
-                        number={clue.entry.number}
-                        humanNumber={clue.entry.humanNumber}
-                        clue={clue.entry.clue}
-                        hasAnswered={clue.hasAnswered}
-                        isSelected={clue.isSelected}
-                        setReturnPosition={() => {
-                            this.props.setReturnPosition(window.scrollY);
-                        }}
-                    />
-                ));
+	render() {
+		const headerClass = 'crossword__clues-header';
+		const cluesByDirection = (direction) =>
+			this.props.clues
+				.filter((clue) => clue.entry.direction === direction)
+				.map((clue) => (
+					<Clue
+						ref={(clueRef) => {
+							this[clue.entry.id] = clueRef;
+						}}
+						id={clue.entry.id}
+						key={clue.entry.id}
+						number={clue.entry.number}
+						humanNumber={clue.entry.humanNumber}
+						clue={clue.entry.clue}
+						hasAnswered={clue.hasAnswered}
+						isSelected={clue.isSelected}
+						setReturnPosition={() => {
+							this.props.setReturnPosition(window.scrollY);
+						}}
+					/>
+				));
 
-        return (
-            <div
-                className={`crossword__clues--wrapper ${
-                    this.state.showGradient ? '' : 'hide-gradient'
-                }`}>
-                <div
-                    className="crossword__clues"
-                    ref={clues => {
-                        this.clues = clues;
-                    }}>
-                    <div className="crossword__clues--across">
-                        <h3 className={headerClass}>Across</h3>
-                        <ol className="crossword__clues-list">
-                            {cluesByDirection('across')}
-                        </ol>
-                    </div>
-                    <div className="crossword__clues--down">
-                        <h3 className={headerClass}>Down</h3>
-                        <ol className="crossword__clues-list">
-                            {cluesByDirection('down')}
-                        </ol>
-                    </div>
-                </div>
-                <div className="crossword__clues__gradient" />
-            </div>
-        );
-    }
+		return (
+			<div
+				className={`crossword__clues--wrapper ${
+					this.state.showGradient ? '' : 'hide-gradient'
+				}`}
+			>
+				<div
+					className="crossword__clues"
+					ref={(clues) => {
+						this.clues = clues;
+					}}
+				>
+					<div className="crossword__clues--across">
+						<h3 className={headerClass}>Across</h3>
+						<ol className="crossword__clues-list">
+							{cluesByDirection('across')}
+						</ol>
+					</div>
+					<div className="crossword__clues--down">
+						<h3 className={headerClass}>Down</h3>
+						<ol className="crossword__clues-list">
+							{cluesByDirection('down')}
+						</ol>
+					</div>
+				</div>
+				<div className="crossword__clues__gradient" />
+			</div>
+		);
+	}
 }
 
 export { Clues };

--- a/static/src/javascripts/projects/common/modules/crosswords/confirm-button.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/confirm-button.js
@@ -1,55 +1,55 @@
-import React, { Component } from 'preact-compat';
+import React, { Component } from 'react';
 import { classNames } from 'common/modules/crosswords/classNames';
 
 const timeout = 2000;
 
 class ConfirmButton extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            confirming: false,
-        };
-    }
+	constructor(props) {
+		super(props);
+		this.state = {
+			confirming: false,
+		};
+	}
 
-    confirm() {
-        if (this.state.confirming) {
-            this.setState({
-                confirming: false,
-            });
-            this.props.onClick();
-        } else {
-            this.setState({
-                confirming: true,
-            });
-            setTimeout(() => {
-                this.setState({
-                    confirming: false,
-                });
-            }, timeout);
-        }
-    }
+	confirm() {
+		if (this.state.confirming) {
+			this.setState({
+				confirming: false,
+			});
+			this.props.onClick();
+		} else {
+			this.setState({
+				confirming: true,
+			});
+			setTimeout(() => {
+				this.setState({
+					confirming: false,
+				});
+			}, timeout);
+		}
+	}
 
-    render() {
-        const inner = this.state.confirming
-            ? `Confirm ${this.props.text.toLowerCase()}`
-            : this.props.text;
+	render() {
+		const inner = this.state.confirming
+			? `Confirm ${this.props.text.toLowerCase()}`
+			: this.props.text;
 
-        const classes = {};
-        const className = classNames(
-            ((classes[
-                'crossword__controls__button--confirm'
-            ] = this.state.confirming),
-            (classes[this.props.className] = true),
-            classes)
-        );
-        const props = {
-            'data-link-name': this.props['data-link-name'],
-            onClick: this.confirm.bind(this),
-            className,
-        };
+		const classes = {};
+		const className = classNames(
+			((classes[
+				'crossword__controls__button--confirm'
+			] = this.state.confirming),
+			(classes[this.props.className] = true),
+			classes),
+		);
+		const props = {
+			'data-link-name': this.props['data-link-name'],
+			onClick: this.confirm.bind(this),
+			className,
+		};
 
-        return <button {...props}>{inner}</button>;
-    }
+		return <button {...props}>{inner}</button>;
+	}
 }
 
 export { ConfirmButton };

--- a/static/src/javascripts/projects/common/modules/crosswords/controls.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/controls.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'preact-compat';
+import React, { Component } from 'react';
 import { ConfirmButton } from 'common/modules/crosswords/confirm-button';
 
 const buttonClassName = 'button button--primary';
@@ -6,115 +6,119 @@ const buttonCurrentClassName = 'button--crossword--current';
 const buttonGenericClassName = 'button--secondary';
 
 class Controls extends Component {
-    render() {
-        const hasSolutions = this.props.hasSolutions;
-        const hasFocus = this.props.clueInFocus;
-        const controls = {
-            clue: [],
-            grid: [],
-        };
+	render() {
+		const hasSolutions = this.props.hasSolutions;
+		const hasFocus = this.props.clueInFocus;
+		const controls = {
+			clue: [],
+			grid: [],
+		};
 
-        // GRID CONTROLS
-        controls.grid.unshift(
-            <ConfirmButton
-                className={`${buttonClassName} ${buttonGenericClassName}`}
-                onClick={this.props.crossword.onClearAll.bind(
-                    this.props.crossword
-                )}
-                key="clear"
-                data-link-name="Clear all"
-                text="Clear all"
-            />
-        );
+		// GRID CONTROLS
+		controls.grid.unshift(
+			<ConfirmButton
+				className={`${buttonClassName} ${buttonGenericClassName}`}
+				onClick={this.props.crossword.onClearAll.bind(
+					this.props.crossword,
+				)}
+				key="clear"
+				data-link-name="Clear all"
+				text="Clear all"
+			/>,
+		);
 
-        if (hasSolutions) {
-            controls.grid.unshift(
-                <ConfirmButton
-                    className={`${buttonClassName} ${buttonGenericClassName}`}
-                    onClick={this.props.crossword.onSolution.bind(
-                        this.props.crossword
-                    )}
-                    key="solution"
-                    data-link-name="Reveal all"
-                    text="Reveal all"
-                />
-            );
-            controls.grid.unshift(
-                <ConfirmButton
-                    className={`${buttonClassName} ${buttonGenericClassName}`}
-                    onClick={this.props.crossword.onCheckAll.bind(
-                        this.props.crossword
-                    )}
-                    key="checkAll"
-                    data-link-name="Check all"
-                    text="Check all"
-                />
-            );
-        }
+		if (hasSolutions) {
+			controls.grid.unshift(
+				<ConfirmButton
+					className={`${buttonClassName} ${buttonGenericClassName}`}
+					onClick={this.props.crossword.onSolution.bind(
+						this.props.crossword,
+					)}
+					key="solution"
+					data-link-name="Reveal all"
+					text="Reveal all"
+				/>,
+			);
+			controls.grid.unshift(
+				<ConfirmButton
+					className={`${buttonClassName} ${buttonGenericClassName}`}
+					onClick={this.props.crossword.onCheckAll.bind(
+						this.props.crossword,
+					)}
+					key="checkAll"
+					data-link-name="Check all"
+					text="Check all"
+				/>,
+			);
+		}
 
-        // HIGHLIGHTED CLUE CONTROLS  - published solution
-        if (hasFocus) {
-            controls.clue.unshift(
-                <button
-                    className={`${buttonClassName} ${buttonCurrentClassName}`}
-                    onClick={this.props.crossword.onClearSingle.bind(
-                        this.props.crossword
-                    )}
-                    key="clear-single"
-                    data-link-name="Clear this">
-                    Clear this
-                </button>
-            );
+		// HIGHLIGHTED CLUE CONTROLS  - published solution
+		if (hasFocus) {
+			controls.clue.unshift(
+				<button
+					className={`${buttonClassName} ${buttonCurrentClassName}`}
+					onClick={this.props.crossword.onClearSingle.bind(
+						this.props.crossword,
+					)}
+					key="clear-single"
+					data-link-name="Clear this"
+				>
+					Clear this
+				</button>,
+			);
 
-            // anagram helper
-            controls.clue.push(
-                <button
-                    className={`${buttonClassName} ${buttonCurrentClassName}`}
-                    onClick={this.props.crossword.onToggleAnagramHelper.bind(
-                        this.props.crossword
-                    )}
-                    key="anagram"
-                    data-link-name="Show anagram helper">
-                    Anagram helper
-                </button>
-            );
+			// anagram helper
+			controls.clue.push(
+				<button
+					className={`${buttonClassName} ${buttonCurrentClassName}`}
+					onClick={this.props.crossword.onToggleAnagramHelper.bind(
+						this.props.crossword,
+					)}
+					key="anagram"
+					data-link-name="Show anagram helper"
+				>
+					Anagram helper
+				</button>,
+			);
 
-            if (hasSolutions) {
-                controls.clue.unshift(
-                    <button
-                        className={`${buttonClassName} ${buttonCurrentClassName}`}
-                        onClick={this.props.crossword.onCheat.bind(
-                            this.props.crossword
-                        )}
-                        key="cheat"
-                        data-link-name="Reveal this">
-                        Reveal this
-                    </button>
-                );
-                controls.clue.unshift(
-                    <button
-                        className={`${buttonClassName} ${buttonCurrentClassName}`}
-                        onClick={this.props.crossword.onCheck.bind(
-                            this.props.crossword
-                        )}
-                        key="check"
-                        data-link-name="Check this">
-                        Check this
-                    </button>
-                );
-            }
-        }
+			if (hasSolutions) {
+				controls.clue.unshift(
+					<button
+						className={`${buttonClassName} ${buttonCurrentClassName}`}
+						onClick={this.props.crossword.onCheat.bind(
+							this.props.crossword,
+						)}
+						key="cheat"
+						data-link-name="Reveal this"
+					>
+						Reveal this
+					</button>,
+				);
+				controls.clue.unshift(
+					<button
+						className={`${buttonClassName} ${buttonCurrentClassName}`}
+						onClick={this.props.crossword.onCheck.bind(
+							this.props.crossword,
+						)}
+						key="check"
+						data-link-name="Check this"
+					>
+						Check this
+					</button>,
+				);
+			}
+		}
 
-        return (
-            <div className="crossword__controls">
-                <div className="crossword__controls__clue">{controls.clue}</div>
-                <div className="crossword__controls__grid">{controls.grid}</div>
-                <div className="crossword__controls_autosave_label">
-                    Crosswords are saved automatically
-                </div>
-            </div>
-        );
-    }
+		return (
+			<div className="crossword__controls">
+				<div className="crossword__controls__clue">{controls.clue}</div>
+				<div className="crossword__controls__grid">{controls.grid}</div>
+				<div className="crossword__controls_autosave_label">
+					Crosswords are saved automatically
+				</div>
+			</div>
+		);
+	}
 }
 
 export { Controls };

--- a/static/src/javascripts/projects/common/modules/crosswords/crossword.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/crossword.js
@@ -1,4 +1,4 @@
-import React, { Component, findDOMNode } from 'preact-compat';
+import React, { Component, findDOMNode } from 'react';
 import fastdom from 'fastdom';
 import $ from 'lib/$';
 import mediator from 'lib/mediator';
@@ -12,804 +12,804 @@ import { Controls } from 'common/modules/crosswords/controls';
 import { HiddenInput } from 'common/modules/crosswords/hidden-input';
 import { Grid } from 'common/modules/crosswords/grid';
 import {
-    buildClueMap,
-    buildGrid,
-    otherDirection,
-    entryHasCell,
-    cluesFor,
-    mapGrid,
-    getClearableCellsForClue,
-    getLastCellInClue,
-    getPreviousClueInGroup,
-    isFirstCellInClue,
-    getNextClueInGroup,
-    isLastCellInClue,
-    gridSize,
-    checkClueHasBeenAnswered,
-    buildSeparatorMap,
-    cellsForEntry,
+	buildClueMap,
+	buildGrid,
+	otherDirection,
+	entryHasCell,
+	cluesFor,
+	mapGrid,
+	getClearableCellsForClue,
+	getLastCellInClue,
+	getPreviousClueInGroup,
+	isFirstCellInClue,
+	getNextClueInGroup,
+	isLastCellInClue,
+	gridSize,
+	checkClueHasBeenAnswered,
+	buildSeparatorMap,
+	cellsForEntry,
 } from 'common/modules/crosswords/helpers';
 import { keycodes } from 'common/modules/crosswords/keycodes';
 import {
-    saveGridState,
-    loadGridState,
+	saveGridState,
+	loadGridState,
 } from 'common/modules/crosswords/persistence';
 import { classNames } from 'common/modules/crosswords/classNames';
 
-
 class Crossword extends Component {
-    constructor(props) {
-        super(props);
-        const dimensions = this.props.data.dimensions;
+	constructor(props) {
+		super(props);
+		const dimensions = this.props.data.dimensions;
 
-        this.columns = dimensions.cols;
-        this.rows = dimensions.rows;
-        this.clueMap = buildClueMap(this.props.data.entries);
+		this.columns = dimensions.cols;
+		this.rows = dimensions.rows;
+		this.clueMap = buildClueMap(this.props.data.entries);
 
-        this.state = {
-            grid: buildGrid(
-                dimensions.rows,
-                dimensions.cols,
-                this.props.data.entries,
-                loadGridState(this.props.data.id)
-            ),
-            cellInFocus: null,
-            directionOfEntry: null,
-            showAnagramHelper: false,
-        };
-    }
+		this.state = {
+			grid: buildGrid(
+				dimensions.rows,
+				dimensions.cols,
+				this.props.data.entries,
+				loadGridState(this.props.data.id),
+			),
+			cellInFocus: null,
+			directionOfEntry: null,
+			showAnagramHelper: false,
+		};
+	}
 
-    componentDidMount() {
-        // Sticky clue
-        const $stickyClueWrapper = $(findDOMNode(this.stickyClueWrapper));
-        const $grid = $(findDOMNode(this.grid));
-        const $game = $(findDOMNode(this.game));
+	componentDidMount() {
+		// Sticky clue
+		const $stickyClueWrapper = $(findDOMNode(this.stickyClueWrapper));
+		const $grid = $(findDOMNode(this.grid));
+		const $game = $(findDOMNode(this.game));
 
-        mediator.on(
-            'window:resize',
-            debounce(this.setGridHeight.bind(this), 200)
-        );
-        mediator.on(
-            'window:orientationchange',
-            debounce(this.setGridHeight.bind(this), 200)
-        );
-        this.setGridHeight();
+		mediator.on(
+			'window:resize',
+			debounce(this.setGridHeight.bind(this), 200),
+		);
+		mediator.on(
+			'window:orientationchange',
+			debounce(this.setGridHeight.bind(this), 200),
+		);
+		this.setGridHeight();
 
-        mediator.on('window:throttledScroll', () => {
-            const gridOffset = $grid.offset();
-            const gameOffset = $game.offset();
-            const stickyClueWrapperOffset = $stickyClueWrapper.offset();
-            const scrollY = window.scrollY;
+		mediator.on('window:throttledScroll', () => {
+			const gridOffset = $grid.offset();
+			const gameOffset = $game.offset();
+			const stickyClueWrapperOffset = $stickyClueWrapper.offset();
+			const scrollY = window.scrollY;
 
-            fastdom.mutate(() => {
-                // Clear previous state
-                $stickyClueWrapper
-                    .css('top', '')
-                    .css('bottom', '')
-                    .removeClass('is-fixed');
+			fastdom.mutate(() => {
+				// Clear previous state
+				$stickyClueWrapper
+					.css('top', '')
+					.css('bottom', '')
+					.removeClass('is-fixed');
 
-                const scrollYPastGame = scrollY - gameOffset.top;
+				const scrollYPastGame = scrollY - gameOffset.top;
 
-                if (scrollYPastGame >= 0) {
-                    const gridOffsetBottom = gridOffset.top + gridOffset.height;
+				if (scrollYPastGame >= 0) {
+					const gridOffsetBottom = gridOffset.top + gridOffset.height;
 
-                    if (
-                        scrollY >
-                        gridOffsetBottom - stickyClueWrapperOffset.height
-                    ) {
-                        $stickyClueWrapper.css('top', 'auto').css('bottom', 0);
-                    } else if (isIOS()) {
-                        // iOS doesn't support sticky things when the keyboard
-                        // is open, so we use absolute positioning and
-                        // programatically update the value of top
-                        $stickyClueWrapper.css('top', scrollYPastGame);
-                    } else {
-                        $stickyClueWrapper.addClass('is-fixed');
-                    }
-                }
-            });
-        });
-    }
+					if (
+						scrollY >
+						gridOffsetBottom - stickyClueWrapperOffset.height
+					) {
+						$stickyClueWrapper.css('top', 'auto').css('bottom', 0);
+					} else if (isIOS()) {
+						// iOS doesn't support sticky things when the keyboard
+						// is open, so we use absolute positioning and
+						// programatically update the value of top
+						$stickyClueWrapper.css('top', scrollYPastGame);
+					} else {
+						$stickyClueWrapper.addClass('is-fixed');
+					}
+				}
+			});
+		});
+	}
 
-    componentDidUpdate(prevProps, prevState) {
-        // return focus to active cell after exiting anagram helper
-        if (
-            !this.state.showAnagramHelper &&
-            this.state.showAnagramHelper !== prevState.showAnagramHelper
-        ) {
-            this.focusCurrentCell();
-        }
-    }
+	componentDidUpdate(prevProps, prevState) {
+		// return focus to active cell after exiting anagram helper
+		if (
+			!this.state.showAnagramHelper &&
+			this.state.showAnagramHelper !== prevState.showAnagramHelper
+		) {
+			this.focusCurrentCell();
+		}
+	}
 
-    onKeyDown(event) {
-        const cell = this.state.cellInFocus;
+	onKeyDown(event) {
+		const cell = this.state.cellInFocus;
 
-        if (event.keyCode === keycodes.tab) {
-            event.preventDefault();
-            if (event.shiftKey) {
-                this.focusPreviousClue();
-            } else {
-                this.focusNextClue();
-            }
-        } else if (!event.metaKey && !event.ctrlKey && !event.altKey) {
-            if (
-                event.keyCode === keycodes.backspace ||
-                event.keyCode === keycodes.delete
-            ) {
-                event.preventDefault();
-                if (cell) {
-                    if (this.cellIsEmpty(cell.x, cell.y)) {
-                        this.focusPrevious();
-                    } else {
-                        this.setCellValue(cell.x, cell.y, '');
-                        this.save();
-                    }
-                }
-            } else if (event.keyCode === keycodes.left) {
-                event.preventDefault();
-                this.moveFocus(-1, 0);
-            } else if (event.keyCode === keycodes.up) {
-                event.preventDefault();
-                this.moveFocus(0, -1);
-            } else if (event.keyCode === keycodes.right) {
-                event.preventDefault();
-                this.moveFocus(1, 0);
-            } else if (event.keyCode === keycodes.down) {
-                event.preventDefault();
-                this.moveFocus(0, 1);
-            }
-        }
-    }
+		if (event.keyCode === keycodes.tab) {
+			event.preventDefault();
+			if (event.shiftKey) {
+				this.focusPreviousClue();
+			} else {
+				this.focusNextClue();
+			}
+		} else if (!event.metaKey && !event.ctrlKey && !event.altKey) {
+			if (
+				event.keyCode === keycodes.backspace ||
+				event.keyCode === keycodes.delete
+			) {
+				event.preventDefault();
+				if (cell) {
+					if (this.cellIsEmpty(cell.x, cell.y)) {
+						this.focusPrevious();
+					} else {
+						this.setCellValue(cell.x, cell.y, '');
+						this.save();
+					}
+				}
+			} else if (event.keyCode === keycodes.left) {
+				event.preventDefault();
+				this.moveFocus(-1, 0);
+			} else if (event.keyCode === keycodes.up) {
+				event.preventDefault();
+				this.moveFocus(0, -1);
+			} else if (event.keyCode === keycodes.right) {
+				event.preventDefault();
+				this.moveFocus(1, 0);
+			} else if (event.keyCode === keycodes.down) {
+				event.preventDefault();
+				this.moveFocus(0, 1);
+			}
+		}
+	}
 
-    // called when cell is selected (by click or programtically focussed)
-    onSelect(x, y) {
-        const cellInFocus = this.state.cellInFocus;
-        const clue = cluesFor(this.clueMap, x, y);
-        const focussedClue = this.clueInFocus();
-        let newDirection;
+	// called when cell is selected (by click or programtically focussed)
+	onSelect(x, y) {
+		const cellInFocus = this.state.cellInFocus;
+		const clue = cluesFor(this.clueMap, x, y);
+		const focussedClue = this.clueInFocus();
+		let newDirection;
 
-        const isInsideFocussedClue = () =>
-            focussedClue ? entryHasCell(focussedClue, x, y) : false;
+		const isInsideFocussedClue = () =>
+			focussedClue ? entryHasCell(focussedClue, x, y) : false;
 
-        if (
-            cellInFocus &&
-            cellInFocus.x === x &&
-            cellInFocus.y === y &&
-            this.state.directionOfEntry
-        ) {
-            /** User has clicked again on the highlighted cell, meaning we ought to swap direction */
-            newDirection = otherDirection(this.state.directionOfEntry);
+		if (
+			cellInFocus &&
+			cellInFocus.x === x &&
+			cellInFocus.y === y &&
+			this.state.directionOfEntry
+		) {
+			/** User has clicked again on the highlighted cell, meaning we ought to swap direction */
+			newDirection = otherDirection(this.state.directionOfEntry);
 
-            if (clue[newDirection]) {
-                this.focusClue(x, y, newDirection);
-            }
-        } else if (isInsideFocussedClue() && this.state.directionOfEntry) {
-            /**
-             * If we've clicked inside the currently highlighted clue, then we ought to just shift the cursor
-             * to the new cell, not change direction or anything funny.
-             */
+			if (clue[newDirection]) {
+				this.focusClue(x, y, newDirection);
+			}
+		} else if (isInsideFocussedClue() && this.state.directionOfEntry) {
+			/**
+			 * If we've clicked inside the currently highlighted clue, then we ought to just shift the cursor
+			 * to the new cell, not change direction or anything funny.
+			 */
 
-            this.focusClue(x, y, this.state.directionOfEntry);
-        } else {
-            this.state.cellInFocus = {
-                x,
-                y,
-            };
+			this.focusClue(x, y, this.state.directionOfEntry);
+		} else {
+			this.state.cellInFocus = {
+				x,
+				y,
+			};
 
-            const isStartOfClue = (sourceClue) =>
-                !!sourceClue &&
-                sourceClue.position.x === x &&
-                sourceClue.position.y === y;
+			const isStartOfClue = (sourceClue) =>
+				!!sourceClue &&
+				sourceClue.position.x === x &&
+				sourceClue.position.y === y;
 
-            /**
-             * If the user clicks on the start of a down clue midway through an across clue, we should
-             * prefer to highlight the down clue.
-             */
-            if (!isStartOfClue(clue.across) && isStartOfClue(clue.down)) {
-                newDirection = 'down';
-            } else if (clue.across) {
-                /** Across is the default focus otherwise */
-                newDirection = 'across';
-            } else {
-                newDirection = 'down';
-            }
-            this.focusClue(x, y, newDirection);
-        }
-    }
+			/**
+			 * If the user clicks on the start of a down clue midway through an across clue, we should
+			 * prefer to highlight the down clue.
+			 */
+			if (!isStartOfClue(clue.across) && isStartOfClue(clue.down)) {
+				newDirection = 'down';
+			} else if (clue.across) {
+				/** Across is the default focus otherwise */
+				newDirection = 'across';
+			} else {
+				newDirection = 'down';
+			}
+			this.focusClue(x, y, newDirection);
+		}
+	}
 
-    onCheat() {
-        this.allHighlightedClues().forEach(clue => this.cheat(clue));
-        this.save();
-    }
+	onCheat() {
+		this.allHighlightedClues().forEach((clue) => this.cheat(clue));
+		this.save();
+	}
 
-    onCheck() {
-        // 'Check this' checks single and grouped clues
-        this.allHighlightedClues().forEach(clue => this.check(clue));
-        this.save();
-    }
+	onCheck() {
+		// 'Check this' checks single and grouped clues
+		this.allHighlightedClues().forEach((clue) => this.check(clue));
+		this.save();
+	}
 
-    onSolution() {
-        this.props.data.entries.forEach(clue => this.cheat(clue));
-        this.save();
-    }
+	onSolution() {
+		this.props.data.entries.forEach((clue) => this.cheat(clue));
+		this.save();
+	}
 
-    onCheckAll() {
-        this.props.data.entries.forEach(clue => this.check(clue));
-        this.save();
-    }
+	onCheckAll() {
+		this.props.data.entries.forEach((clue) => this.check(clue));
+		this.save();
+	}
 
-    onClearAll() {
-        this.setState({
-            grid: mapGrid(this.state.grid, cell => {
-                cell.value = '';
-                return cell;
-            }),
-        });
+	onClearAll() {
+		this.setState({
+			grid: mapGrid(this.state.grid, (cell) => {
+				cell.value = '';
+				return cell;
+			}),
+		});
 
-        this.save();
-    }
+		this.save();
+	}
 
-    onClearSingle() {
-        const clueInFocus = this.clueInFocus();
+	onClearSingle() {
+		const clueInFocus = this.clueInFocus();
 
-        if (clueInFocus) {
-            // Merge arrays of cells from all highlighted clues
-            // const cellsInFocus = _.flatten(_.map(this.allHighlightedClues(), helpers.cellsForEntry, this));
-            const cellsInFocus = getClearableCellsForClue(
-                this.state.grid,
-                this.clueMap,
-                this.props.data.entries,
-                clueInFocus
-            );
+		if (clueInFocus) {
+			// Merge arrays of cells from all highlighted clues
+			// const cellsInFocus = _.flatten(_.map(this.allHighlightedClues(), helpers.cellsForEntry, this));
+			const cellsInFocus = getClearableCellsForClue(
+				this.state.grid,
+				this.clueMap,
+				this.props.data.entries,
+				clueInFocus,
+			);
 
-            this.setState({
-                grid: mapGrid(this.state.grid, (cell, gridX, gridY) => {
-                    if (
-                        cellsInFocus.some(c => c.x === gridX && c.y === gridY)
-                    ) {
-                        cell.value = '';
-                    }
-                    return cell;
-                }),
-            });
+			this.setState({
+				grid: mapGrid(this.state.grid, (cell, gridX, gridY) => {
+					if (
+						cellsInFocus.some((c) => c.x === gridX && c.y === gridY)
+					) {
+						cell.value = '';
+					}
+					return cell;
+				}),
+			});
 
-            this.save();
-        }
-    }
+			this.save();
+		}
+	}
 
-    onToggleAnagramHelper() {
-        // only show anagram helper if a clue is active
-        if (!this.state.showAnagramHelper) {
-            if (this.clueInFocus()) {
-                this.setState({
-                    showAnagramHelper: true,
-                });
-            }
-        } else {
-            this.setState({
-                showAnagramHelper: false,
-            });
-        }
-    }
+	onToggleAnagramHelper() {
+		// only show anagram helper if a clue is active
+		if (!this.state.showAnagramHelper) {
+			if (this.clueInFocus()) {
+				this.setState({
+					showAnagramHelper: true,
+				});
+			}
+		} else {
+			this.setState({
+				showAnagramHelper: false,
+			});
+		}
+	}
 
-    onClickHiddenInput(event) {
-        const focussed = this.state.cellInFocus;
+	onClickHiddenInput(event) {
+		const focussed = this.state.cellInFocus;
 
-        if (focussed) {
-            this.onSelect(focussed.x, focussed.y);
-        }
+		if (focussed) {
+			this.onSelect(focussed.x, focussed.y);
+		}
 
-        /* We need to handle touch seperately as touching an input on iPhone does not fire the
+		/* We need to handle touch seperately as touching an input on iPhone does not fire the
          click event - listen for a touchStart and preventDefault to avoid calling onSelect twice on
          devices that fire click AND touch events. The click event doesn't fire only when the input is already focused */
-        if (event.type === 'touchstart') {
-            event.preventDefault();
-        }
-    }
-
-    setGridHeight() {
-        if (!this.$gridWrapper) {
-            this.$gridWrapper = $(findDOMNode(this.gridWrapper));
-        }
-
-        if (
-            isBreakpoint({
-                max: 'tablet',
-            })
-        ) {
-            fastdom.measure(() => {
-                // Our grid is a square, set the height of the grid wrapper
-                // to the width of the grid wrapper
-                fastdom.mutate(() => {
-                    this.$gridWrapper.css(
-                        'height',
-                        `${this.$gridWrapper.offset().width}px`
-                    );
-                });
-                this.gridHeightIsSet = true;
-            });
-        } else if (this.gridHeightIsSet) {
-            // Remove inline style if tablet and wider
-            this.$gridWrapper.attr('style', '');
-        }
-    }
-
-    setCellValue(x, y, value) {
-        this.setState({
-            grid: mapGrid(this.state.grid, (cell, gridX, gridY) => {
-                if (gridX === x && gridY === y) {
-                    cell.value = value;
-                    cell.isError = false;
-                }
-
-                return cell;
-            }),
-        });
-    }
-
-    getCellValue(x, y) {
-        return this.state.grid[x][y].value;
-    }
-
-    setReturnPosition(position) {
-        this.returnPosition = position;
-    }
-
-
-
-    insertCharacter(character) {
-        const characterUppercase = character.toUpperCase();
-        const cell = this.state.cellInFocus;
-        if (
-            /[A-Za-zÀ-ÿ0-9]/.test(characterUppercase) &&
-            characterUppercase.length === 1 &&
-            cell
-        ) {
-            this.setCellValue(cell.x, cell.y, characterUppercase);
-            this.save();
-            this.focusNext();
-        }
-    }
-
-    cellIsEmpty(x, y) {
-        return !this.getCellValue(x, y);
-    }
-
-    goToReturnPosition() {
-        if (
-            isBreakpoint({
-                max: 'mobile',
-            })
-        ) {
-            if (this.returnPosition) {
-                scrollTo(this.returnPosition, 250, 'easeOutQuad');
-            }
-            this.returnPosition = null;
-        }
-    }
-
-    indexOfClueInFocus() {
-        return this.props.data.entries.indexOf(this.clueInFocus());
-    }
-
-    focusPreviousClue() {
-        const i = this.indexOfClueInFocus();
-        const entries = this.props.data.entries;
-
-        if (i !== -1) {
-            const newClue = entries[i === 0 ? entries.length - 1 : i - 1];
-            this.focusClue(
-                newClue.position.x,
-                newClue.position.y,
-                newClue.direction
-            );
-        }
-    }
-
-    focusNextClue() {
-        const i = this.indexOfClueInFocus();
-        const entries = this.props.data.entries;
-
-        if (i !== -1) {
-            const newClue = entries[i === entries.length - 1 ? 0 : i + 1];
-            this.focusClue(
-                newClue.position.x,
-                newClue.position.y,
-                newClue.direction
-            );
-        }
-    }
-
-    moveFocus(deltaX, deltaY) {
-        const cell = this.state.cellInFocus;
-
-        if (!cell) {
-            return;
-        }
-
-        const x = cell.x + deltaX;
-        const y = cell.y + deltaY;
-        let direction = 'down';
-
-        if (
-            this.state.grid[x] &&
-            this.state.grid[x][y] &&
-            this.state.grid[x][y].isEditable
-        ) {
-            if (deltaY !== 0) {
-                direction = 'down';
-            } else if (deltaX !== 0) {
-                direction = 'across';
-            }
-            this.focusClue(x, y, direction);
-        }
-    }
-
-    isAcross() {
-        return this.state.directionOfEntry === 'across';
-    }
-
-    focusPrevious() {
-        const cell = this.state.cellInFocus;
-        const clue = this.clueInFocus();
-
-        if (cell && clue) {
-            if (isFirstCellInClue(cell, clue)) {
-                const newClue = getPreviousClueInGroup(
-                    this.props.data.entries,
-                    clue
-                );
-                if (newClue) {
-                    const newCell = getLastCellInClue(newClue);
-                    this.focusClue(newCell.x, newCell.y, newClue.direction);
-                }
-            } else if (this.isAcross()) {
-                this.moveFocus(-1, 0);
-            } else {
-                this.moveFocus(0, -1);
-            }
-        }
-    }
-
-    focusNext() {
-        const cell = this.state.cellInFocus;
-        const clue = this.clueInFocus();
-
-        if (cell && clue) {
-            if (isLastCellInClue(cell, clue)) {
-                const newClue = getNextClueInGroup(
-                    this.props.data.entries,
-                    clue
-                );
-                if (newClue) {
-                    this.focusClue(
-                        newClue.position.x,
-                        newClue.position.y,
-                        newClue.direction
-                    );
-                }
-            } else if (this.isAcross()) {
-                this.moveFocus(1, 0);
-            } else {
-                this.moveFocus(0, 1);
-            }
-        }
-    }
-
-    asPercentage(x, y) {
-        const width = gridSize(this.columns);
-        const height = gridSize(this.rows);
-
-        return {
-            x: (100 * x) / width,
-            y: (100 * y) / height,
-        };
-    }
-
-    focusHiddenInput(x, y) {
-        const wrapper = (findDOMNode(
-            this.hiddenInputComponent.wrapper
-        ));
-        const left = gridSize(x);
-        const top = gridSize(y);
-        const position = this.asPercentage(left, top);
-
-        /** This has to be done before focus to move viewport accordingly */
-        wrapper.style.left = `${position.x}%`;
-        wrapper.style.top = `${position.y}%`;
-
-        const hiddenInputNode = (findDOMNode(
-            this.hiddenInputComponent.input
-        ));
-
-        if (document.activeElement !== hiddenInputNode) {
-            hiddenInputNode.focus();
-        }
-    }
-
-    // Focus corresponding clue for a given cell
-    focusClue(x, y, direction) {
-        const clues = cluesFor(this.clueMap, x, y);
-        const clue = clues[direction];
-
-        if (clues && clue) {
-            this.focusHiddenInput(x, y);
-
-            this.setState({
-                grid: this.state.grid,
-                cellInFocus: {
-                    x,
-                    y,
-                },
-                directionOfEntry: direction,
-            });
-
-            // Side effect
-            window.history.replaceState(
-                undefined,
-                document.title,
-                `#${clue.id}`
-            );
-        }
-    }
-
-    // Focus first cell in given clue
-    focusFirstCellInClue(entry) {
-        this.focusClue(entry.position.x, entry.position.y, entry.direction);
-    }
-
-    focusCurrentCell() {
-        if (this.state.cellInFocus) {
-            this.focusHiddenInput(
-                this.state.cellInFocus.x,
-                this.state.cellInFocus.y
-            );
-        }
-    }
-
-    clueInFocus() {
-        if (this.state.cellInFocus) {
-            const cluesForCell = cluesFor(
-                this.clueMap,
-                this.state.cellInFocus.x,
-                this.state.cellInFocus.y
-            );
-
-            if (this.state.directionOfEntry) {
-                return cluesForCell[this.state.directionOfEntry];
-            }
-        }
-        return null;
-    }
-
-    allHighlightedClues() {
-        return this.props.data.entries.filter(clue =>
-            this.clueIsInFocusGroup(clue)
-        );
-    }
-
-    clueIsInFocusGroup(clue) {
-        if (this.state.cellInFocus) {
-            const cluesForCell = cluesFor(
-                this.clueMap,
-                this.state.cellInFocus.x,
-                this.state.cellInFocus.y
-            );
-
-            if (
-                this.state.directionOfEntry &&
-                cluesForCell[this.state.directionOfEntry]
-            ) {
-                return cluesForCell[this.state.directionOfEntry].group.includes(
-                    clue.id
-                );
-            }
-        }
-        return false;
-    }
-
-    cluesData() {
-        return this.props.data.entries.map(entry => {
-            const hasAnswered = checkClueHasBeenAnswered(
-                this.state.grid,
-                entry
-            );
-            return {
-                entry,
-                hasAnswered,
-                isSelected: this.clueIsInFocusGroup(entry),
-            };
-        });
-    }
-
-    save() {
-        saveGridState(this.props.data.id, this.state.grid);
-    }
-
-    cheat(entry) {
-        const cells = cellsForEntry(entry);
-
-        if (entry.solution) {
-            this.setState({
-                grid: mapGrid(this.state.grid, (cell, x, y) => {
-                    if (cells.some(c => c.x === x && c.y === y)) {
-                        const n =
-                            entry.direction === 'across'
-                                ? x - entry.position.x
-                                : y - entry.position.y;
-
-                        cell.value = entry.solution[n];
-                    }
-
-                    return cell;
-                }),
-            });
-        }
-    }
-
-    check(entry) {
-        const cells = cellsForEntry(entry);
-
-        if (entry.solution) {
-            const badCells = zip(cells, entry.solution.split(''))
-                .filter(cellAndSolution => {
-                    const coords = cellAndSolution[0];
-                    const cell = this.state.grid[coords.x][coords.y];
-                    const solution = cellAndSolution[1];
-                    return (
-                        /^[A-Z]$/.test(cell.value) && cell.value !== solution
-                    );
-                })
-                .map(cellAndSolution => cellAndSolution[0]);
-
-            this.setState({
-                grid: mapGrid(this.state.grid, (cell, gridX, gridY) => {
-                    if (
-                        badCells.some(bad => bad.x === gridX && bad.y === gridY)
-                    ) {
-                        cell.isError = true;
-                        cell.value = '';
-                    }
-
-                    return cell;
-                }),
-            });
-
-            setTimeout(() => {
-                this.setState({
-                    grid: mapGrid(this.state.grid, (cell, gridX, gridY) => {
-                        if (
-                            badCells.some(
-                                bad => bad.x === gridX && bad.y === gridY
-                            )
-                        ) {
-                            cell.isError = false;
-                            cell.value = '';
-                        }
-
-                        return cell;
-                    }),
-                });
-            }, 150);
-        }
-    }
-
-    hiddenInputValue() {
-        const cell = this.state.cellInFocus;
-
-        let currentValue;
-
-        if (cell) {
-            currentValue = this.state.grid[cell.x][cell.y].value;
-        }
-
-        return currentValue || '';
-    }
-
-    hasSolutions() {
-        return 'solution' in this.props.data.entries[0];
-    }
-
-    isHighlighted(x, y) {
-        const focused = this.clueInFocus();
-        return focused
-            ? focused.group.some(id => {
-                  const entry = this.props.data.entries.find(e => e.id === id);
-                  return entryHasCell(entry, x, y);
-              })
-            : false;
-    }
-
-    render() {
-        const focused = this.clueInFocus();
-
-        const anagramHelper = this.state.showAnagramHelper && (
-            <AnagramHelper
-                crossword={this}
-                focussedEntry={focused}
-                entries={this.props.data.entries}
-                grid={this.state.grid}
-                close={this.onToggleAnagramHelper}
-            />
-        );
-
-        const gridProps = {
-            rows: this.rows,
-            columns: this.columns,
-            cells: this.state.grid,
-            separators: buildSeparatorMap(this.props.data.entries),
-            crossword: this,
-            focussedCell: this.state.cellInFocus,
-            ref: grid => {
-                this.grid = grid;
-            },
-        };
-
-        return (
-            <div
-                className={`crossword__container crossword__container--${
-                    this.props.data.crosswordType
-                } crossword__container--react`}
-                data-link-name="Crosswords">
-                <div
-                    className="crossword__container__game"
-                    ref={game => {
-                        this.game = game;
-                    }}>
-                    <div
-                        className="crossword__sticky-clue-wrapper"
-                        ref={stickyClueWrapper => {
-                            this.stickyClueWrapper = stickyClueWrapper;
-                        }}>
-                        <div
-                            className={classNames({
-                                'crossword__sticky-clue': true,
-                                'is-hidden': !focused,
-                            })}>
-                            {focused && (
-                                <div className="crossword__sticky-clue__inner">
-                                    <div className="crossword__sticky-clue__inner__inner">
-                                        <strong>
-                                            {focused.number}{' '}
-                                            <span className="crossword__sticky-clue__direction">
-                                                {focused.direction}
-                                            </span>
-                                        </strong>{' '}
-                                        {focused.clue}
-                                    </div>
-                                </div>
-                            )}
-                        </div>
-                    </div>
-                    <div
-                        className="crossword__container__grid-wrapper"
-                        ref={gridWrapper => {
-                            this.gridWrapper = gridWrapper;
-                        }}>
-                        {Grid(gridProps)}
-                        <HiddenInput
-                            crossword={this}
-                            value={this.hiddenInputValue()}
-                            ref={hiddenInputComponent => {
-                                this.hiddenInputComponent = hiddenInputComponent;
-                            }}
-                        />
-                        {anagramHelper}
-                    </div>
-                </div>
-                <Controls
-                    hasSolutions={this.hasSolutions()}
-                    clueInFocus={focused}
-                    crossword={this}
-                />
-                <Clues
-                    clues={this.cluesData()}
-                    focussed={focused}
-                    setReturnPosition={this.setReturnPosition.bind(this)}
-                />
-            </div>
-        );
-    }
+		if (event.type === 'touchstart') {
+			event.preventDefault();
+		}
+	}
+
+	setGridHeight() {
+		if (!this.$gridWrapper) {
+			this.$gridWrapper = $(findDOMNode(this.gridWrapper));
+		}
+
+		if (
+			isBreakpoint({
+				max: 'tablet',
+			})
+		) {
+			fastdom.measure(() => {
+				// Our grid is a square, set the height of the grid wrapper
+				// to the width of the grid wrapper
+				fastdom.mutate(() => {
+					this.$gridWrapper.css(
+						'height',
+						`${this.$gridWrapper.offset().width}px`,
+					);
+				});
+				this.gridHeightIsSet = true;
+			});
+		} else if (this.gridHeightIsSet) {
+			// Remove inline style if tablet and wider
+			this.$gridWrapper.attr('style', '');
+		}
+	}
+
+	setCellValue(x, y, value) {
+		this.setState({
+			grid: mapGrid(this.state.grid, (cell, gridX, gridY) => {
+				if (gridX === x && gridY === y) {
+					cell.value = value;
+					cell.isError = false;
+				}
+
+				return cell;
+			}),
+		});
+	}
+
+	getCellValue(x, y) {
+		return this.state.grid[x][y].value;
+	}
+
+	setReturnPosition(position) {
+		this.returnPosition = position;
+	}
+
+	insertCharacter(character) {
+		const characterUppercase = character.toUpperCase();
+		const cell = this.state.cellInFocus;
+		if (
+			/[A-Za-zÀ-ÿ0-9]/.test(characterUppercase) &&
+			characterUppercase.length === 1 &&
+			cell
+		) {
+			this.setCellValue(cell.x, cell.y, characterUppercase);
+			this.save();
+			this.focusNext();
+		}
+	}
+
+	cellIsEmpty(x, y) {
+		return !this.getCellValue(x, y);
+	}
+
+	goToReturnPosition() {
+		if (
+			isBreakpoint({
+				max: 'mobile',
+			})
+		) {
+			if (this.returnPosition) {
+				scrollTo(this.returnPosition, 250, 'easeOutQuad');
+			}
+			this.returnPosition = null;
+		}
+	}
+
+	indexOfClueInFocus() {
+		return this.props.data.entries.indexOf(this.clueInFocus());
+	}
+
+	focusPreviousClue() {
+		const i = this.indexOfClueInFocus();
+		const entries = this.props.data.entries;
+
+		if (i !== -1) {
+			const newClue = entries[i === 0 ? entries.length - 1 : i - 1];
+			this.focusClue(
+				newClue.position.x,
+				newClue.position.y,
+				newClue.direction,
+			);
+		}
+	}
+
+	focusNextClue() {
+		const i = this.indexOfClueInFocus();
+		const entries = this.props.data.entries;
+
+		if (i !== -1) {
+			const newClue = entries[i === entries.length - 1 ? 0 : i + 1];
+			this.focusClue(
+				newClue.position.x,
+				newClue.position.y,
+				newClue.direction,
+			);
+		}
+	}
+
+	moveFocus(deltaX, deltaY) {
+		const cell = this.state.cellInFocus;
+
+		if (!cell) {
+			return;
+		}
+
+		const x = cell.x + deltaX;
+		const y = cell.y + deltaY;
+		let direction = 'down';
+
+		if (
+			this.state.grid[x] &&
+			this.state.grid[x][y] &&
+			this.state.grid[x][y].isEditable
+		) {
+			if (deltaY !== 0) {
+				direction = 'down';
+			} else if (deltaX !== 0) {
+				direction = 'across';
+			}
+			this.focusClue(x, y, direction);
+		}
+	}
+
+	isAcross() {
+		return this.state.directionOfEntry === 'across';
+	}
+
+	focusPrevious() {
+		const cell = this.state.cellInFocus;
+		const clue = this.clueInFocus();
+
+		if (cell && clue) {
+			if (isFirstCellInClue(cell, clue)) {
+				const newClue = getPreviousClueInGroup(
+					this.props.data.entries,
+					clue,
+				);
+				if (newClue) {
+					const newCell = getLastCellInClue(newClue);
+					this.focusClue(newCell.x, newCell.y, newClue.direction);
+				}
+			} else if (this.isAcross()) {
+				this.moveFocus(-1, 0);
+			} else {
+				this.moveFocus(0, -1);
+			}
+		}
+	}
+
+	focusNext() {
+		const cell = this.state.cellInFocus;
+		const clue = this.clueInFocus();
+
+		if (cell && clue) {
+			if (isLastCellInClue(cell, clue)) {
+				const newClue = getNextClueInGroup(
+					this.props.data.entries,
+					clue,
+				);
+				if (newClue) {
+					this.focusClue(
+						newClue.position.x,
+						newClue.position.y,
+						newClue.direction,
+					);
+				}
+			} else if (this.isAcross()) {
+				this.moveFocus(1, 0);
+			} else {
+				this.moveFocus(0, 1);
+			}
+		}
+	}
+
+	asPercentage(x, y) {
+		const width = gridSize(this.columns);
+		const height = gridSize(this.rows);
+
+		return {
+			x: (100 * x) / width,
+			y: (100 * y) / height,
+		};
+	}
+
+	focusHiddenInput(x, y) {
+		const wrapper = findDOMNode(this.hiddenInputComponent.wrapper);
+		const left = gridSize(x);
+		const top = gridSize(y);
+		const position = this.asPercentage(left, top);
+
+		/** This has to be done before focus to move viewport accordingly */
+		wrapper.style.left = `${position.x}%`;
+		wrapper.style.top = `${position.y}%`;
+
+		const hiddenInputNode = findDOMNode(this.hiddenInputComponent.input);
+
+		if (document.activeElement !== hiddenInputNode) {
+			hiddenInputNode.focus();
+		}
+	}
+
+	// Focus corresponding clue for a given cell
+	focusClue(x, y, direction) {
+		const clues = cluesFor(this.clueMap, x, y);
+		const clue = clues[direction];
+
+		if (clues && clue) {
+			this.focusHiddenInput(x, y);
+
+			this.setState({
+				grid: this.state.grid,
+				cellInFocus: {
+					x,
+					y,
+				},
+				directionOfEntry: direction,
+			});
+
+			// Side effect
+			window.history.replaceState(
+				undefined,
+				document.title,
+				`#${clue.id}`,
+			);
+		}
+	}
+
+	// Focus first cell in given clue
+	focusFirstCellInClue(entry) {
+		this.focusClue(entry.position.x, entry.position.y, entry.direction);
+	}
+
+	focusCurrentCell() {
+		if (this.state.cellInFocus) {
+			this.focusHiddenInput(
+				this.state.cellInFocus.x,
+				this.state.cellInFocus.y,
+			);
+		}
+	}
+
+	clueInFocus() {
+		if (this.state.cellInFocus) {
+			const cluesForCell = cluesFor(
+				this.clueMap,
+				this.state.cellInFocus.x,
+				this.state.cellInFocus.y,
+			);
+
+			if (this.state.directionOfEntry) {
+				return cluesForCell[this.state.directionOfEntry];
+			}
+		}
+		return null;
+	}
+
+	allHighlightedClues() {
+		return this.props.data.entries.filter((clue) =>
+			this.clueIsInFocusGroup(clue),
+		);
+	}
+
+	clueIsInFocusGroup(clue) {
+		if (this.state.cellInFocus) {
+			const cluesForCell = cluesFor(
+				this.clueMap,
+				this.state.cellInFocus.x,
+				this.state.cellInFocus.y,
+			);
+
+			if (
+				this.state.directionOfEntry &&
+				cluesForCell[this.state.directionOfEntry]
+			) {
+				return cluesForCell[this.state.directionOfEntry].group.includes(
+					clue.id,
+				);
+			}
+		}
+		return false;
+	}
+
+	cluesData() {
+		return this.props.data.entries.map((entry) => {
+			const hasAnswered = checkClueHasBeenAnswered(
+				this.state.grid,
+				entry,
+			);
+			return {
+				entry,
+				hasAnswered,
+				isSelected: this.clueIsInFocusGroup(entry),
+			};
+		});
+	}
+
+	save() {
+		saveGridState(this.props.data.id, this.state.grid);
+	}
+
+	cheat(entry) {
+		const cells = cellsForEntry(entry);
+
+		if (entry.solution) {
+			this.setState({
+				grid: mapGrid(this.state.grid, (cell, x, y) => {
+					if (cells.some((c) => c.x === x && c.y === y)) {
+						const n =
+							entry.direction === 'across'
+								? x - entry.position.x
+								: y - entry.position.y;
+
+						cell.value = entry.solution[n];
+					}
+
+					return cell;
+				}),
+			});
+		}
+	}
+
+	check(entry) {
+		const cells = cellsForEntry(entry);
+
+		if (entry.solution) {
+			const badCells = zip(cells, entry.solution.split(''))
+				.filter((cellAndSolution) => {
+					const coords = cellAndSolution[0];
+					const cell = this.state.grid[coords.x][coords.y];
+					const solution = cellAndSolution[1];
+					return (
+						/^[A-Z]$/.test(cell.value) && cell.value !== solution
+					);
+				})
+				.map((cellAndSolution) => cellAndSolution[0]);
+
+			this.setState({
+				grid: mapGrid(this.state.grid, (cell, gridX, gridY) => {
+					if (
+						badCells.some(
+							(bad) => bad.x === gridX && bad.y === gridY,
+						)
+					) {
+						cell.isError = true;
+						cell.value = '';
+					}
+
+					return cell;
+				}),
+			});
+
+			setTimeout(() => {
+				this.setState({
+					grid: mapGrid(this.state.grid, (cell, gridX, gridY) => {
+						if (
+							badCells.some(
+								(bad) => bad.x === gridX && bad.y === gridY,
+							)
+						) {
+							cell.isError = false;
+							cell.value = '';
+						}
+
+						return cell;
+					}),
+				});
+			}, 150);
+		}
+	}
+
+	hiddenInputValue() {
+		const cell = this.state.cellInFocus;
+
+		let currentValue;
+
+		if (cell) {
+			currentValue = this.state.grid[cell.x][cell.y].value;
+		}
+
+		return currentValue || '';
+	}
+
+	hasSolutions() {
+		return 'solution' in this.props.data.entries[0];
+	}
+
+	isHighlighted(x, y) {
+		const focused = this.clueInFocus();
+		return focused
+			? focused.group.some((id) => {
+					const entry = this.props.data.entries.find(
+						(e) => e.id === id,
+					);
+					return entryHasCell(entry, x, y);
+			  })
+			: false;
+	}
+
+	render() {
+		const focused = this.clueInFocus();
+
+		const anagramHelper = this.state.showAnagramHelper && (
+			<AnagramHelper
+				crossword={this}
+				focussedEntry={focused}
+				entries={this.props.data.entries}
+				grid={this.state.grid}
+				close={this.onToggleAnagramHelper}
+			/>
+		);
+
+		const gridProps = {
+			rows: this.rows,
+			columns: this.columns,
+			cells: this.state.grid,
+			separators: buildSeparatorMap(this.props.data.entries),
+			crossword: this,
+			focussedCell: this.state.cellInFocus,
+			ref: (grid) => {
+				this.grid = grid;
+			},
+		};
+
+		return (
+			<div
+				className={`crossword__container crossword__container--${this.props.data.crosswordType} crossword__container--react`}
+				data-link-name="Crosswords"
+			>
+				<div
+					className="crossword__container__game"
+					ref={(game) => {
+						this.game = game;
+					}}
+				>
+					<div
+						className="crossword__sticky-clue-wrapper"
+						ref={(stickyClueWrapper) => {
+							this.stickyClueWrapper = stickyClueWrapper;
+						}}
+					>
+						<div
+							className={classNames({
+								'crossword__sticky-clue': true,
+								'is-hidden': !focused,
+							})}
+						>
+							{focused && (
+								<div className="crossword__sticky-clue__inner">
+									<div className="crossword__sticky-clue__inner__inner">
+										<strong>
+											{focused.number}{' '}
+											<span className="crossword__sticky-clue__direction">
+												{focused.direction}
+											</span>
+										</strong>{' '}
+										{focused.clue}
+									</div>
+								</div>
+							)}
+						</div>
+					</div>
+					<div
+						className="crossword__container__grid-wrapper"
+						ref={(gridWrapper) => {
+							this.gridWrapper = gridWrapper;
+						}}
+					>
+						{Grid(gridProps)}
+						<HiddenInput
+							crossword={this}
+							value={this.hiddenInputValue()}
+							ref={(hiddenInputComponent) => {
+								this.hiddenInputComponent = hiddenInputComponent;
+							}}
+						/>
+						{anagramHelper}
+					</div>
+				</div>
+				<Controls
+					hasSolutions={this.hasSolutions()}
+					clueInFocus={focused}
+					crossword={this}
+				/>
+				<Clues
+					clues={this.cluesData()}
+					focussed={focused}
+					setReturnPosition={this.setReturnPosition.bind(this)}
+				/>
+			</div>
+		);
+	}
 }
 
 export default Crossword;

--- a/static/src/javascripts/projects/common/modules/crosswords/grid.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/grid.js
@@ -1,165 +1,151 @@
-import React from 'preact-compat';
+import React from 'react';
 import { gridSize, clueMapKey } from 'common/modules/crosswords/helpers';
 import { constants } from 'common/modules/crosswords/constants';
 import GridCell from 'common/modules/crosswords/cell';
 import { classNames } from 'common/modules/crosswords/classNames';
 
-
 // Position at end of previous cell
-const createWordSeparator = (
-    x,
-    y,
-    direction
-) => {
-    const top = gridSize(y);
-    const left = gridSize(x);
-    const borderWidth = 1;
+const createWordSeparator = (x, y, direction) => {
+	const top = gridSize(y);
+	const left = gridSize(x);
+	const borderWidth = 1;
 
-    if (direction === 'across') {
-        const width = 1;
-        return (
-            <rect
-                x={left - borderWidth - width}
-                y={top}
-                key={['sep', direction, x, y].join('_')}
-                width={width}
-                height={constants.cellSize}
-            />
-        );
-    } else if (direction === 'down') {
-        const height = 1;
-        return (
-            <rect
-                x={left}
-                y={top - borderWidth - height}
-                key={['sep', direction, x, y].join('_')}
-                width={constants.cellSize}
-                height={height}
-            />
-        );
-    }
+	if (direction === 'across') {
+		const width = 1;
+		return (
+			<rect
+				x={left - borderWidth - width}
+				y={top}
+				key={['sep', direction, x, y].join('_')}
+				width={width}
+				height={constants.cellSize}
+			/>
+		);
+	} else if (direction === 'down') {
+		const height = 1;
+		return (
+			<rect
+				x={left}
+				y={top - borderWidth - height}
+				key={['sep', direction, x, y].join('_')}
+				width={constants.cellSize}
+				height={height}
+			/>
+		);
+	}
 };
 
 // Position in-between this and previous cells
-const createHyphenSeparator = (
-    x,
-    y,
-    direction
-) => {
-    const top = gridSize(y);
-    const left = gridSize(x);
-    const borderWidth = 1;
-    let width;
-    let height;
+const createHyphenSeparator = (x, y, direction) => {
+	const top = gridSize(y);
+	const left = gridSize(x);
+	const borderWidth = 1;
+	let width;
+	let height;
 
-    if (direction === 'across') {
-        width = constants.cellSize / 4;
-        height = 1;
-        return (
-            <rect
-                x={left - borderWidth / 2 - width / 2}
-                y={top + constants.cellSize / 2 + height / 2}
-                key={['sep', direction, x, y].join('_')}
-                width={width}
-                height={height}
-            />
-        );
-    } else if (direction === 'down') {
-        width = 1;
-        height = constants.cellSize / 4;
-        return (
-            <rect
-                x={left + constants.cellSize / 2 + width / 2}
-                y={top - borderWidth / 2 - height / 2}
-                key={['sep', direction, x, y].join('_')}
-                width={width}
-                height={height}
-            />
-        );
-    }
+	if (direction === 'across') {
+		width = constants.cellSize / 4;
+		height = 1;
+		return (
+			<rect
+				x={left - borderWidth / 2 - width / 2}
+				y={top + constants.cellSize / 2 + height / 2}
+				key={['sep', direction, x, y].join('_')}
+				width={width}
+				height={height}
+			/>
+		);
+	} else if (direction === 'down') {
+		width = 1;
+		height = constants.cellSize / 4;
+		return (
+			<rect
+				x={left + constants.cellSize / 2 + width / 2}
+				y={top - borderWidth / 2 - height / 2}
+				key={['sep', direction, x, y].join('_')}
+				width={width}
+				height={height}
+			/>
+		);
+	}
 };
 
-const createSeparator = (
-    x,
-    y,
-    separatorDescription
-) => {
-    if (separatorDescription) {
-        if (separatorDescription.separator === ',') {
-            return createWordSeparator(x, y, separatorDescription.direction);
-        } else if (separatorDescription.separator === '-') {
-            return createHyphenSeparator(x, y, separatorDescription.direction);
-        }
-    }
+const createSeparator = (x, y, separatorDescription) => {
+	if (separatorDescription) {
+		if (separatorDescription.separator === ',') {
+			return createWordSeparator(x, y, separatorDescription.direction);
+		} else if (separatorDescription.separator === '-') {
+			return createHyphenSeparator(x, y, separatorDescription.direction);
+		}
+	}
 };
 
 export const Grid = (props) => {
-    const getSeparators = (x, y) =>
-        props.separators[clueMapKey(x, y)];
+	const getSeparators = (x, y) => props.separators[clueMapKey(x, y)];
 
-    const handleSelect = (x, y) =>
-        props.crossword.onSelect(x, y);
+	const handleSelect = (x, y) => props.crossword.onSelect(x, y);
 
-    const width = gridSize(props.columns);
-    const height = gridSize(props.rows);
-    const cells = [];
-    let separators = [];
+	const width = gridSize(props.columns);
+	const height = gridSize(props.rows);
+	const cells = [];
+	let separators = [];
 
-    const range = n => Array.from({ length: n }, (value, key) => key);
+	const range = (n) => Array.from({ length: n }, (value, key) => key);
 
-    // This is needed to appease ESLint (https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md#false-positives-sfc)
-    const cellsIn = props.cells;
+	// This is needed to appease ESLint (https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md#false-positives-sfc)
+	const cellsIn = props.cells;
 
-    range(props.rows).forEach(y =>
-        range(props.columns).forEach(x => {
-            const cellProps = cellsIn[x][y];
+	range(props.rows).forEach((y) =>
+		range(props.columns).forEach((x) => {
+			const cellProps = cellsIn[x][y];
 
-            if (cellProps.isEditable) {
-                const isHighlighted = props.crossword.isHighlighted(x, y);
-                cells.push(
-                    <GridCell
-                        {...Object.assign(
-                            {},
-                            cellProps,
-                            {
-                                handleSelect,
-                                x,
-                                y,
-                                key: `cell_${x}_${y}`,
-                                isHighlighted,
-                                isFocussed:
-                                    props.focussedCell &&
-                                    x === props.focussedCell.x &&
-                                    y === props.focussedCell.y,
-                            },
-                            this
-                        )}
-                    />
-                );
+			if (cellProps.isEditable) {
+				const isHighlighted = props.crossword.isHighlighted(x, y);
+				cells.push(
+					<GridCell
+						{...Object.assign(
+							{},
+							cellProps,
+							{
+								handleSelect,
+								x,
+								y,
+								key: `cell_${x}_${y}`,
+								isHighlighted,
+								isFocussed:
+									props.focussedCell &&
+									x === props.focussedCell.x &&
+									y === props.focussedCell.y,
+							},
+							this,
+						)}
+					/>,
+				);
 
-                separators = separators.concat(
-                    createSeparator(x, y, getSeparators(x, y))
-                );
-            }
-        })
-    );
+				separators = separators.concat(
+					createSeparator(x, y, getSeparators(x, y)),
+				);
+			}
+		}),
+	);
 
-    return (
-        <svg
-            viewBox={`0 0 ${width} ${height}`}
-            className={classNames({
-                crossword__grid: true,
-                'crossword__grid--focussed': !!props.focussedCell,
-            })}>
-            <rect
-                x={0}
-                y={0}
-                width={width}
-                height={height}
-                className="crossword__grid-background"
-            />
-            {cells}
-            <g className="crossword__grid__separators">{separators}</g>
-        </svg>
-    );
+	return (
+		<svg
+			viewBox={`0 0 ${width} ${height}`}
+			className={classNames({
+				crossword__grid: true,
+				'crossword__grid--focussed': !!props.focussedCell,
+			})}
+		>
+			<rect
+				x={0}
+				y={0}
+				width={width}
+				height={height}
+				className="crossword__grid-background"
+			/>
+			{cells}
+			<g className="crossword__grid__separators">{separators}</g>
+		</svg>
+	);
 };

--- a/static/src/javascripts/projects/common/modules/crosswords/hidden-input.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/hidden-input.js
@@ -1,88 +1,89 @@
-import React, { Component, findDOMNode } from 'preact-compat';
+import React, { Component, findDOMNode } from 'react';
 import bonzo from 'bonzo';
 import fastdom from 'fastdom';
 import { scrollTo } from 'lib/scroller';
 import { isBreakpoint } from 'lib/detect';
 
 class HiddenInput extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            value: this.props.value,
-        };
-    }
+	constructor(props) {
+		super(props);
+		this.state = {
+			value: this.props.value,
+		};
+	}
 
-    componentDidUpdate() {
-        if (
-            isBreakpoint({
-                max: 'mobile',
-            })
-        ) {
-            fastdom.measure(() => {
-                const offsets = bonzo(findDOMNode(this.input)).offset();
-                const clueHeight = document.getElementsByClassName(
-                    'crossword__sticky-clue'
-                )[0].offsetHeight;
+	componentDidUpdate() {
+		if (
+			isBreakpoint({
+				max: 'mobile',
+			})
+		) {
+			fastdom.measure(() => {
+				const offsets = bonzo(findDOMNode(this.input)).offset();
+				const clueHeight = document.getElementsByClassName(
+					'crossword__sticky-clue',
+				)[0].offsetHeight;
 
-                scrollTo(
-                    offsets.top - offsets.height * 1.5 - clueHeight,
-                    250,
-                    'easeOutQuad'
-                );
-            });
-        }
-    }
+				scrollTo(
+					offsets.top - offsets.height * 1.5 - clueHeight,
+					250,
+					'easeOutQuad',
+				);
+			});
+		}
+	}
 
-    onClick(event) {
-        this.props.crossword.onClickHiddenInput(event);
-    }
+	onClick(event) {
+		this.props.crossword.onClickHiddenInput(event);
+	}
 
-    onKeyDown(event) {
-        this.props.crossword.onKeyDown(event);
-    }
+	onKeyDown(event) {
+		this.props.crossword.onKeyDown(event);
+	}
 
-    onBlur(event) {
-        this.props.crossword.goToReturnPosition(event);
-    }
+	onBlur(event) {
+		this.props.crossword.goToReturnPosition(event);
+	}
 
-    touchStart(event) {
-        this.props.crossword.onClickHiddenInput(event);
-    }
+	touchStart(event) {
+		this.props.crossword.onClickHiddenInput(event);
+	}
 
-    handleChange(event) {
-        this.props.crossword.insertCharacter(event.target.value);
-        this.setState({
-            value: '',
-        });
-    }
+	handleChange(event) {
+		this.props.crossword.insertCharacter(event.target.value);
+		this.setState({
+			value: '',
+		});
+	}
 
-    render() {
-        return (
-            <div
-                className="crossword__hidden-input-wrapper"
-                ref={wrapper => {
-                    this.wrapper = wrapper;
-                }}>
-                <input
-                    type="text"
-                    className="crossword__hidden-input"
-                    maxLength="1"
-                    onClick={this.onClick.bind(this)}
-                    onChange={this.handleChange.bind(this)}
-                    onTouchStart={this.touchStart.bind(this)}
-                    onKeyDown={this.onKeyDown.bind(this)}
-                    onBlur={this.onBlur.bind(this)}
-                    value={this.state.value}
-                    autoComplete="off"
-                    spellCheck="false"
-                    autoCorrect="off"
-                    ref={input => {
-                        this.input = input;
-                    }}
-                />
-            </div>
-        );
-    }
+	render() {
+		return (
+			<div
+				className="crossword__hidden-input-wrapper"
+				ref={(wrapper) => {
+					this.wrapper = wrapper;
+				}}
+			>
+				<input
+					type="text"
+					className="crossword__hidden-input"
+					maxLength="1"
+					onClick={this.onClick.bind(this)}
+					onChange={this.handleChange.bind(this)}
+					onTouchStart={this.touchStart.bind(this)}
+					onKeyDown={this.onKeyDown.bind(this)}
+					onBlur={this.onBlur.bind(this)}
+					value={this.state.value}
+					autoComplete="off"
+					spellCheck="false"
+					autoCorrect="off"
+					ref={(input) => {
+						this.input = input;
+					}}
+				/>
+			</div>
+		);
+	}
 }
 
 export { HiddenInput };

--- a/static/src/javascripts/projects/common/modules/crosswords/main.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/main.js
@@ -1,58 +1,58 @@
-import React, { render } from 'preact-compat';
+import React, { render } from 'react';
 import bean from 'bean';
 import fastdom from 'lib/fastdom-promise';
 import $ from 'lib/$';
 import Crossword from 'common/modules/crosswords/crossword';
 
 const initCrosswords = () => {
-    fastdom
-        .measure(() => document.getElementsByClassName('js-crossword'))
-        .then(elements => {
-            Array.from(elements).forEach(element => {
-                const data = element.getAttribute('data-crossword-data');
+	fastdom
+		.measure(() => document.getElementsByClassName('js-crossword'))
+		.then((elements) => {
+			Array.from(elements).forEach((element) => {
+				const data = element.getAttribute('data-crossword-data');
 
-                if (!data) {
-                    throw new Error(
-                        'JavaScript crossword without associated data in data-crossword-data'
-                    );
-                }
+				if (!data) {
+					throw new Error(
+						'JavaScript crossword without associated data in data-crossword-data',
+					);
+				}
 
-                const crosswordComponent = render(
-                    <Crossword data={JSON.parse(data)} />,
-                    element
-                );
+				const crosswordComponent = render(
+					<Crossword data={JSON.parse(data)} />,
+					element,
+				);
 
-                const entryId = window.location.hash.replace('#', '');
-                const entry = crosswordComponent.props.data.entries.find(
-                    val => val.id === entryId
-                );
+				const entryId = window.location.hash.replace('#', '');
+				const entry = crosswordComponent.props.data.entries.find(
+					(val) => val.id === entryId,
+				);
 
-                if (entry) {
-                    crosswordComponent.focusFirstCellInClue(entry);
-                }
+				if (entry) {
+					crosswordComponent.focusFirstCellInClue(entry);
+				}
 
-                bean.on(element, 'click', $('.crossword__clue'), e => {
-                    e.preventDefault();
+				bean.on(element, 'click', $('.crossword__clue'), (e) => {
+					e.preventDefault();
 
-                    const idMatch = e.currentTarget.hash.match(/#.*/);
-                    const newEntryId = idMatch && idMatch[0].replace('#', '');
-                    const newEntry = crosswordComponent.props.data.entries.find(
-                        val => val.id === newEntryId
-                    );
-                    const focussedEntry = crosswordComponent.clueInFocus();
-                    const isNewEntry =
-                        focussedEntry && focussedEntry.id !== newEntry.id;
+					const idMatch = e.currentTarget.hash.match(/#.*/);
+					const newEntryId = idMatch && idMatch[0].replace('#', '');
+					const newEntry = crosswordComponent.props.data.entries.find(
+						(val) => val.id === newEntryId,
+					);
+					const focussedEntry = crosswordComponent.clueInFocus();
+					const isNewEntry =
+						focussedEntry && focussedEntry.id !== newEntry.id;
 
-                    // Only focus the first cell in the new clue if it's not already
-                    // focussed. When focussing a cell in a new clue, we update the
-                    // hash fragment afterwards, in which case we do not want to
-                    // reset focus to the first cell.
-                    if (newEntry && (focussedEntry ? isNewEntry : true)) {
-                        crosswordComponent.focusFirstCellInClue(newEntry);
-                    }
-                });
-            });
-        });
+					// Only focus the first cell in the new clue if it's not already
+					// focussed. When focussing a cell in a new clue, we update the
+					// hash fragment afterwards, in which case we do not want to
+					// reset focus to the first cell.
+					if (newEntry && (focussedEntry ? isNewEntry : true)) {
+						crosswordComponent.focusFirstCellInClue(newEntry);
+					}
+				});
+			});
+		});
 };
 
 export { initCrosswords };

--- a/static/src/javascripts/projects/common/modules/identity/ad-prefs.js
+++ b/static/src/javascripts/projects/common/modules/identity/ad-prefs.js
@@ -1,119 +1,119 @@
-import React, { Component, render } from 'preact-compat';
+import React, { Component, render } from 'react';
 import { FeedbackFlashBox } from 'common/modules/identity/ad-prefs/FeedbackFlashBox';
 import { ConsentBox } from 'common/modules/identity/ad-prefs/ConsentBox';
 
 import fastdom from 'lib/fastdom-promise';
 import {
-    getAdConsentState,
-    setAdConsentState,
-    getAllAdConsentsWithState,
+	getAdConsentState,
+	setAdConsentState,
+	getAllAdConsentsWithState,
 } from 'common/modules/commercial/ad-prefs.lib';
-
 
 const rootSelector = '.js-manage-account__ad-prefs';
 
 class AdPrefsWrapper extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            changesPending: false,
-            flashing: false,
-            consentsWithState: [...this.props.initialConsentsWithState],
-        };
-    }
+	constructor(props) {
+		super(props);
+		this.state = {
+			changesPending: false,
+			flashing: false,
+			consentsWithState: [...this.props.initialConsentsWithState],
+		};
+	}
 
-    onUpdate(consentId, state) {
-        const consentsWithState = [...this.state.consentsWithState];
-        const changesPending =
-            this.props.getAdConsentState(
-                consentsWithState[consentId].consent
-            ) !== state;
-        consentsWithState[consentId].state = state;
-        if (this.SubmitButtonRef) {
-            this.SubmitButtonRef.scrollIntoView(false);
-        }
-        this.setState({
-            consentsWithState,
-            changesPending,
-            flashing: false,
-        });
-    }
+	onUpdate(consentId, state) {
+		const consentsWithState = [...this.state.consentsWithState];
+		const changesPending =
+			this.props.getAdConsentState(
+				consentsWithState[consentId].consent,
+			) !== state;
+		consentsWithState[consentId].state = state;
+		if (this.SubmitButtonRef) {
+			this.SubmitButtonRef.scrollIntoView(false);
+		}
+		this.setState({
+			consentsWithState,
+			changesPending,
+			flashing: false,
+		});
+	}
 
-    onSubmit(event) {
-        event.preventDefault();
-        this.state.consentsWithState.forEach(consentWithState => {
-            if (typeof consentWithState.state === 'boolean') {
-                this.props.setAdConsentState(
-                    consentWithState.consent,
-                    consentWithState.state
-                );
-            }
-        });
-        this.setState({
-            changesPending: false,
-            flashing: true,
-        });
-    }
+	onSubmit(event) {
+		event.preventDefault();
+		this.state.consentsWithState.forEach((consentWithState) => {
+			if (typeof consentWithState.state === 'boolean') {
+				this.props.setAdConsentState(
+					consentWithState.consent,
+					consentWithState.state,
+				);
+			}
+		});
+		this.setState({
+			changesPending: false,
+			flashing: true,
+		});
+	}
 
-
-
-    render() {
-        return (
-            <form
-                className="identity-ad-prefs-manager"
-                onSubmit={ev => this.onSubmit(ev)}>
-                <div>
-                    {this.state.consentsWithState.map(
-                        (consentWithState, index) => (
-                            <ConsentBox
-                                consent={consentWithState.consent}
-                                state={consentWithState.state}
-                                key={consentWithState.consent.cookie}
-                                onUpdate={(state) => {
-                                    this.onUpdate(index, state);
-                                }}
-                            />
-                        )
-                    )}
-                </div>
-                <div
-                    className="identity-ad-prefs-manager__footer"
-                    ref={child => {
-                        this.SubmitButtonRef = child;
-                    }}>
-                    <button
-                        disabled={this.state.changesPending ? null : 'disabled'}
-                        className="manage-account__button manage-account__button--center"
-                        data-link-name="ad-prefs : submit"
-                        type="submit">
-                        Save my settings
-                    </button>
-                    <FeedbackFlashBox flashing={this.state.flashing}>
-                        Your settings have been saved.
-                    </FeedbackFlashBox>
-                </div>
-            </form>
-        );
-    }
+	render() {
+		return (
+			<form
+				className="identity-ad-prefs-manager"
+				onSubmit={(ev) => this.onSubmit(ev)}
+			>
+				<div>
+					{this.state.consentsWithState.map(
+						(consentWithState, index) => (
+							<ConsentBox
+								consent={consentWithState.consent}
+								state={consentWithState.state}
+								key={consentWithState.consent.cookie}
+								onUpdate={(state) => {
+									this.onUpdate(index, state);
+								}}
+							/>
+						),
+					)}
+				</div>
+				<div
+					className="identity-ad-prefs-manager__footer"
+					ref={(child) => {
+						this.SubmitButtonRef = child;
+					}}
+				>
+					<button
+						disabled={this.state.changesPending ? null : 'disabled'}
+						className="manage-account__button manage-account__button--center"
+						data-link-name="ad-prefs : submit"
+						type="submit"
+					>
+						Save my settings
+					</button>
+					<FeedbackFlashBox flashing={this.state.flashing}>
+						Your settings have been saved.
+					</FeedbackFlashBox>
+				</div>
+			</form>
+		);
+	}
 }
 
 const enhanceAdPrefs = () => {
-    fastdom
-        .measure(() => Array.from(document.querySelectorAll(rootSelector)))
-        .then((wrapperEls) => {
-            wrapperEls.forEach(_ => {
-                fastdom.mutate(() => {
-                    render(
-                        <AdPrefsWrapper
-                            initialConsentsWithState={getAllAdConsentsWithState()}
-                            getAdConsentState={getAdConsentState}
-                            setAdConsentState={setAdConsentState}
-                        />,
-                        _
-                    );
-                });
-            });
-        });
+	fastdom
+		.measure(() => Array.from(document.querySelectorAll(rootSelector)))
+		.then((wrapperEls) => {
+			wrapperEls.forEach((_) => {
+				fastdom.mutate(() => {
+					render(
+						<AdPrefsWrapper
+							initialConsentsWithState={getAllAdConsentsWithState()}
+							getAdConsentState={getAdConsentState}
+							setAdConsentState={setAdConsentState}
+						/>,
+						_,
+					);
+				});
+			});
+		});
 };
 
 export { enhanceAdPrefs };

--- a/static/src/javascripts/projects/common/modules/identity/ad-prefs/ConsentBox.js
+++ b/static/src/javascripts/projects/common/modules/identity/ad-prefs/ConsentBox.js
@@ -1,83 +1,81 @@
-import React, { Component } from 'preact-compat';
+import React, { Component } from 'react';
 import { getConsentWording } from './wordings';
 
-
-
 class ConsentRadioButton extends Component {
-    handleChange(event) {
-        if (event.target.checked) {
-            this.props.onToggle();
-        }
-    }
-    render() {
-        const id = `gu-ad-prefs-${this.props.value.toString()}-${
-            this.props.consent.cookie
-        }`;
-        const name = `gu-ad-prefs-${this.props.consent.cookie}`;
+	handleChange(event) {
+		if (event.target.checked) {
+			this.props.onToggle();
+		}
+	}
+	render() {
+		const id = `gu-ad-prefs-${this.props.value.toString()}-${
+			this.props.consent.cookie
+		}`;
+		const name = `gu-ad-prefs-${this.props.consent.cookie}`;
 
-        return (
-            <div className="identity-ad-prefs-input identity-ad-prefs-manager">
-                <label className="identity-ad-prefs-input__label" htmlFor={id}>
-                    <input
-                        type="radio"
-                        name={name}
-                        id={id}
-                        data-link-name={`ad-prefs - ${
-                            this.props.consent.cookie
-                        } - ${this.props.value.toString()}`}
-                        value={this.props.value.toString()}
-                        checked={this.props.checked}
-                        onChange={this.handleChange.bind(this)}
-                    />
-                    <span>{this.props.wording.title}</span>
-                </label>
-                {this.props.wording.text && (
-                    <span
-                        className="identity-ad-prefs-input__wording"
-                        dangerouslySetInnerHTML={{
-                            __html: this.props.wording.text,
-                        }}
-                    />
-                )}
-            </div>
-        );
-    }
+		return (
+			<div className="identity-ad-prefs-input identity-ad-prefs-manager">
+				<label className="identity-ad-prefs-input__label" htmlFor={id}>
+					<input
+						type="radio"
+						name={name}
+						id={id}
+						data-link-name={`ad-prefs - ${
+							this.props.consent.cookie
+						} - ${this.props.value.toString()}`}
+						value={this.props.value.toString()}
+						checked={this.props.checked}
+						onChange={this.handleChange.bind(this)}
+					/>
+					<span>{this.props.wording.title}</span>
+				</label>
+				{this.props.wording.text && (
+					<span
+						className="identity-ad-prefs-input__wording"
+						dangerouslySetInnerHTML={{
+							__html: this.props.wording.text,
+						}}
+					/>
+				)}
+			</div>
+		);
+	}
 }
 
 class ConsentBox extends Component {
-    render() {
-        const wording = getConsentWording(this.props.consent);
+	render() {
+		const wording = getConsentWording(this.props.consent);
 
-        return (
-            <fieldset>
-                <legend className="identity-title identity-title--small">
-                    {wording.question.title}
-                </legend>
-                {wording.question.text && (
-                    <div className="identity-ad-prefs-input__wording">
-                        {wording.question.text}
-                    </div>
-                )}
+		return (
+			<fieldset>
+				<legend className="identity-title identity-title--small">
+					{wording.question.title}
+				</legend>
+				{wording.question.text && (
+					<div className="identity-ad-prefs-input__wording">
+						{wording.question.text}
+					</div>
+				)}
 
-                <div className="identity-ad-prefs-options">
-                    <ConsentRadioButton
-                        value="true"
-                        wording={wording.yesCheckbox}
-                        checked={this.props.state === true}
-                        consent={this.props.consent}
-                        onToggle={() => this.props.onUpdate(true)}
-                    />
-                    <ConsentRadioButton
-                        value="false"
-                        wording={wording.noCheckbox}
-                        checked={this.props.state === false}
-                        consent={this.props.consent}
-                        onToggle={() => this.props.onUpdate(false)}
-                    />
-                </div>
-            </fieldset>
-        );
-    }
+				<div className="identity-ad-prefs-options">
+					<ConsentRadioButton
+						value="true"
+						wording={wording.yesCheckbox}
+						checked={this.props.state === true}
+						consent={this.props.consent}
+						onToggle={() => this.props.onUpdate(true)}
+					/>
+					<ConsentRadioButton
+						value="false"
+						wording={wording.noCheckbox}
+						checked={this.props.state === false}
+						consent={this.props.consent}
+						onToggle={() => this.props.onUpdate(false)}
+					/>
+				</div>
+			</fieldset>
+		);
+	}
 }
 
 export { ConsentBox };

--- a/static/src/javascripts/projects/common/modules/identity/ad-prefs/FeedbackFlashBox.js
+++ b/static/src/javascripts/projects/common/modules/identity/ad-prefs/FeedbackFlashBox.js
@@ -1,21 +1,21 @@
-import React, { Component } from 'preact-compat';
-
+import React, { Component } from 'react';
 
 class FeedbackFlashBox extends Component {
-    render() {
-        return (
-            <div
-                className={[
-                    'identity-ad-prefs-manager__flash',
-                    this.props.flashing
-                        ? 'identity-ad-prefs-manager__flash--flashing'
-                        : '',
-                ].join(' ')}
-                aria-hidden="true">
-                {this.props.children}
-            </div>
-        );
-    }
+	render() {
+		return (
+			<div
+				className={[
+					'identity-ad-prefs-manager__flash',
+					this.props.flashing
+						? 'identity-ad-prefs-manager__flash--flashing'
+						: '',
+				].join(' ')}
+				aria-hidden="true"
+			>
+				{this.props.children}
+			</div>
+		);
+	}
 }
 
 export { FeedbackFlashBox };

--- a/static/src/javascripts/projects/common/modules/identity/ad-prefs/wordings.js
+++ b/static/src/javascripts/projects/common/modules/identity/ad-prefs/wordings.js
@@ -1,60 +1,59 @@
-import React from 'preact-compat';
+import React from 'react';
 import { thirdPartyTrackingAdConsent } from 'common/modules/commercial/ad-prefs.lib';
 
-
-
-
 const ThirdPartyConsentWording = {
-    question: {
-        title: 'Set your personalised ads preferences',
-        text: (
-            <div>
-                <p>
-                    We work with{' '}
-                    <a
-                        className="u-underline"
-                        href="https://www.theguardian.com/info/cookies">
-                        advertising partners
-                    </a>{' '}
-                    (including Google and the Ozone project) to show you ads for
-                    products and services you might be interested in. You can
-                    choose whether the ads you see on our sites are personalised
-                    by selecting one of the options below.
-                </p>
-                <p>
-                    Don&apos;t worry, you can always revisit these settings by
-                    following the link on our{' '}
-                    <a
-                        className="u-underline"
-                        href="https://www.theguardian.com/info/cookies#nav4">
-                        cookies policy page.
-                    </a>
-                </p>
-            </div>
-        ),
-    },
-    yesCheckbox: {
-        title: 'I am OK with personalised ads',
-        text: `We and our advertising partners will use your data to show you ads that you might be interested in.`,
-    },
-    noCheckbox: {
-        title: 'I do not want to see personalised ads',
-        text: `We will ask our advertising partners not to show you personalised ads. Please note that you will still see advertising, but it will be less relevant.`,
-    },
+	question: {
+		title: 'Set your personalised ads preferences',
+		text: (
+			<div>
+				<p>
+					We work with{' '}
+					<a
+						className="u-underline"
+						href="https://www.theguardian.com/info/cookies"
+					>
+						advertising partners
+					</a>{' '}
+					(including Google and the Ozone project) to show you ads for
+					products and services you might be interested in. You can
+					choose whether the ads you see on our sites are personalised
+					by selecting one of the options below.
+				</p>
+				<p>
+					Don&apos;t worry, you can always revisit these settings by
+					following the link on our{' '}
+					<a
+						className="u-underline"
+						href="https://www.theguardian.com/info/cookies#nav4"
+					>
+						cookies policy page.
+					</a>
+				</p>
+			</div>
+		),
+	},
+	yesCheckbox: {
+		title: 'I am OK with personalised ads',
+		text: `We and our advertising partners will use your data to show you ads that you might be interested in.`,
+	},
+	noCheckbox: {
+		title: 'I do not want to see personalised ads',
+		text: `We will ask our advertising partners not to show you personalised ads. Please note that you will still see advertising, but it will be less relevant.`,
+	},
 };
 
 const getConsentWording = (consent) => {
-    if (consent.cookie === thirdPartyTrackingAdConsent.cookie)
-        return ThirdPartyConsentWording;
-    return {
-        question: { title: consent.label },
-        yesCheckbox: {
-            title: 'yes',
-        },
-        noCheckbox: {
-            title: 'no',
-        },
-    };
+	if (consent.cookie === thirdPartyTrackingAdConsent.cookie)
+		return ThirdPartyConsentWording;
+	return {
+		question: { title: consent.label },
+		yesCheckbox: {
+			title: 'yes',
+		},
+		noCheckbox: {
+			title: 'no',
+		},
+	};
 };
 
 export { getConsentWording };

--- a/static/src/javascripts/projects/common/modules/identity/follow.js
+++ b/static/src/javascripts/projects/common/modules/identity/follow.js
@@ -1,31 +1,31 @@
-import React, { render } from 'preact-compat';
+import React, { render } from 'react';
 import fastdom from 'lib/fastdom-promise';
 import { FollowButtonWrap } from './upsell/button/FollowButtonWrap';
 import loadEnhancers from './modules/loadEnhancers';
 
 const bindFollow = (el) => {
-    fastdom
-        .measure(() => el.querySelector('.identity-follow__button-target'))
-        .then((wrapperEl) => {
-            fastdom.mutate(() => {
-                render(
-                    <FollowButtonWrap
-                        following
-                        onFollow={() => {
-                            console.log('following');
-                        }}
-                        onUnfollow={() => {
-                            console.log('not following');
-                        }}
-                    />,
-                    wrapperEl
-                );
-            });
-        });
+	fastdom
+		.measure(() => el.querySelector('.identity-follow__button-target'))
+		.then((wrapperEl) => {
+			fastdom.mutate(() => {
+				render(
+					<FollowButtonWrap
+						following
+						onFollow={() => {
+							console.log('following');
+						}}
+						onUnfollow={() => {
+							console.log('not following');
+						}}
+					/>,
+					wrapperEl,
+				);
+			});
+		});
 };
 
 const enhanceFollow = () => {
-    loadEnhancers([['.identity-follow', bindFollow]]);
+	loadEnhancers([['.identity-follow', bindFollow]]);
 };
 
 export { enhanceFollow };

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountBenefits.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountBenefits.js
@@ -1,103 +1,101 @@
-import React from 'preact-compat';
+import React from 'react';
 import config from 'lib/config';
 
-
-
-
 const benefits = [
-    {
-        title: `Get closer to our journalism`,
-        blurb: `Choose from over 40 exclusive newsletters and updates on the variety of topics that matter to you.`,
-    },
-    {
-        title: `Join the conversation`,
-        blurb: `Get involved – post or recommend comments below an article.`,
-    },
-    {
-        title: `Take your career to the next level `,
-        blurb: `Browse a huge variety of jobs, create your jobseeker profile and receive job alerts for vacancies you want to hear about.`,
-    },
-    {
-        title: `Enjoy our free iOS and Android apps`,
-        blurb: `Save articles for later, tailor your news and get notified about topics that matter to you.`,
-    },
+	{
+		title: `Get closer to our journalism`,
+		blurb: `Choose from over 40 exclusive newsletters and updates on the variety of topics that matter to you.`,
+	},
+	{
+		title: `Join the conversation`,
+		blurb: `Get involved – post or recommend comments below an article.`,
+	},
+	{
+		title: `Take your career to the next level `,
+		blurb: `Browse a huge variety of jobs, create your jobseeker profile and receive job alerts for vacancies you want to hear about.`,
+	},
+	{
+		title: `Enjoy our free iOS and Android apps`,
+		blurb: `Save articles for later, tailor your news and get notified about topics that matter to you.`,
+	},
 ];
 
 const actionableBenefits = [
-    {
-        title: `Get closer to our journalism`,
-        blurb: `Browse over 40 curated newsletters on a variety of topics - from daily news headlines to weekly culture highlights, and diverse dedicated topics like science, documentary films and fashion. You can also sign up to receive updates about Guardian events, holidays and offers.`,
-        cta: [
-            {
-                name: `Find your favourite newsletter`,
-                link: `${config.get('page.host')}/email-newsletters`,
-            },
-        ],
-    },
-    {
-        title: `Join the conversation`,
-        blurb: `We believe in having open debate and in giving readers a voice in our journalism. With your Guardian profile, you can recommend comments added by other Guardian readers at the bottom of the articles or contribute your thoughts for other readers to see. Complete your public profile and join the debate.`,
-        cta: [
-            {
-                name: `Complete your profile`,
-                link: `${config.get('page.idUrl')}/public/edit`,
-            },
-        ],
-    },
-    {
-        title: `Download our award-winning app`,
-        blurb: `Available on iOS and Android. Sign in with your Guardian account to use exclusive features such as ‘save for later’ or mobile alerts when your favourite writers publish an article, or your football team scores.`,
-        cta: [
-            {
-                name: `Explore our apps`,
-                link: `${config.get(
-                    'page.host'
-                )}/technology/ng-interactive/2018/may/15/the-guardian-app`,
-            },
-        ],
-    },
-    {
-        title: `Take your career to the next level`,
-        blurb: `Your account allows you to set up a Guardian Jobs profile, browse a huge variety of jobs and be the first to hear about vacancies in your preferred industry.`,
-        cta: [
-            {
-                name: `Browse jobs`,
-                link: `https://jobs.theguardian.com/`,
-            },
-        ],
-    },
+	{
+		title: `Get closer to our journalism`,
+		blurb: `Browse over 40 curated newsletters on a variety of topics - from daily news headlines to weekly culture highlights, and diverse dedicated topics like science, documentary films and fashion. You can also sign up to receive updates about Guardian events, holidays and offers.`,
+		cta: [
+			{
+				name: `Find your favourite newsletter`,
+				link: `${config.get('page.host')}/email-newsletters`,
+			},
+		],
+	},
+	{
+		title: `Join the conversation`,
+		blurb: `We believe in having open debate and in giving readers a voice in our journalism. With your Guardian profile, you can recommend comments added by other Guardian readers at the bottom of the articles or contribute your thoughts for other readers to see. Complete your public profile and join the debate.`,
+		cta: [
+			{
+				name: `Complete your profile`,
+				link: `${config.get('page.idUrl')}/public/edit`,
+			},
+		],
+	},
+	{
+		title: `Download our award-winning app`,
+		blurb: `Available on iOS and Android. Sign in with your Guardian account to use exclusive features such as ‘save for later’ or mobile alerts when your favourite writers publish an article, or your football team scores.`,
+		cta: [
+			{
+				name: `Explore our apps`,
+				link: `${config.get(
+					'page.host',
+				)}/technology/ng-interactive/2018/may/15/the-guardian-app`,
+			},
+		],
+	},
+	{
+		title: `Take your career to the next level`,
+		blurb: `Your account allows you to set up a Guardian Jobs profile, browse a huge variety of jobs and be the first to hear about vacancies in your preferred industry.`,
+		cta: [
+			{
+				name: `Browse jobs`,
+				link: `https://jobs.theguardian.com/`,
+			},
+		],
+	},
 ];
 
 export const AccountActionableBenefits = () => (
-    <ul className="identity-upsell-account-creation-bullets identity-upsell-account-creation-bullets--super">
-        {actionableBenefits.map(({ title, blurb, cta }) => (
-            <li>
-                <h4 className="identity-upsell-account-creation-bullets__title">
-                    {title}
-                </h4>
-                <p>{blurb}</p>
-                {cta.map(({ name, link }) => (
-                    <a
-                        data-link-name={`benefit : ${title}`}
-                        href={link}
-                        className="manage-account__button manage-account__button--light">
-                        {name}
-                    </a>
-                ))}
-            </li>
-        ))}
-    </ul>
+	<ul className="identity-upsell-account-creation-bullets identity-upsell-account-creation-bullets--super">
+		{actionableBenefits.map(({ title, blurb, cta }) => (
+			<li>
+				<h4 className="identity-upsell-account-creation-bullets__title">
+					{title}
+				</h4>
+				<p>{blurb}</p>
+				{cta.map(({ name, link }) => (
+					<a
+						data-link-name={`benefit : ${title}`}
+						href={link}
+						className="manage-account__button manage-account__button--light"
+					>
+						{name}
+					</a>
+				))}
+			</li>
+		))}
+	</ul>
 );
 
 export const AccountBenefits = () => (
-    <ul className="identity-upsell-account-creation-bullets">
-        {benefits.map(benefit => (
-            <li>
-                <h4 className="identity-upsell-account-creation-bullets__title">
-                    {benefit.title}
-                </h4>
-                <p>{benefit.blurb}</p>
-            </li>
-        ))}
-    </ul>
+	<ul className="identity-upsell-account-creation-bullets">
+		{benefits.map((benefit) => (
+			<li>
+				<h4 className="identity-upsell-account-creation-bullets__title">
+					{benefit.title}
+				</h4>
+				<p>{benefit.blurb}</p>
+			</li>
+		))}
+	</ul>
 );

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationBlock.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationBlock.js
@@ -1,36 +1,36 @@
-import React, { Component } from 'preact-compat';
+import React, { Component } from 'react';
 import { AccountCreationForm } from './AccountCreationForm';
 import { AccountActionableBenefits, AccountBenefits } from './AccountBenefits';
 import { Block } from '../block/Block';
 
-
 class AccountCreationBlock extends Component {
-    onAccountCreated = () => {
-        this.setState({
-            hasCreatedAccount: true,
-        });
-    };
+	onAccountCreated = () => {
+		this.setState({
+			hasCreatedAccount: true,
+		});
+	};
 
-    render() {
-        return !this.state.hasCreatedAccount ? (
-            <Block
-                sideBySide
-                title="Want more from The Guardian?"
-                subtitle="Create your account now to manage your preferences and explore your free benefits.">
-                <AccountCreationForm
-                    {...this.props}
-                    onAccountCreated={this.onAccountCreated}
-                />
-                <div>
-                    <AccountBenefits />
-                </div>
-            </Block>
-        ) : (
-            <Block title="Start exploring your benefits">
-                <AccountActionableBenefits />
-            </Block>
-        );
-    }
+	render() {
+		return !this.state.hasCreatedAccount ? (
+			<Block
+				sideBySide
+				title="Want more from The Guardian?"
+				subtitle="Create your account now to manage your preferences and explore your free benefits."
+			>
+				<AccountCreationForm
+					{...this.props}
+					onAccountCreated={this.onAccountCreated}
+				/>
+				<div>
+					<AccountBenefits />
+				</div>
+			</Block>
+		) : (
+			<Block title="Start exploring your benefits">
+				<AccountActionableBenefits />
+			</Block>
+		);
+	}
 }
 
 export { AccountCreationBlock };

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationCompleteConsentsFlow.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationCompleteConsentsFlow.js
@@ -1,49 +1,48 @@
-import React, { Component } from 'preact-compat';
+import React, { Component } from 'react';
 import { AccountCreationFeatures } from './AccountCreationFeatures';
 import { AccountCreationForm } from './AccountCreationForm';
 import { AccountBenefits } from './AccountBenefits';
 
-
 class AccountCreationCompleteConsentsFlow extends Component {
-    onAccountCreated = () => {
-        this.setState({
-            hasCreatedAccount: true,
-        });
-    };
+	onAccountCreated = () => {
+		this.setState({
+			hasCreatedAccount: true,
+		});
+	};
 
-    render() {
-        return !this.state.hasCreatedAccount ? (
-            <div>
-                <hr className="manage-account-small-divider" />
-                <div className="form">
-                    <h1 className="identity-upsell-title">
-                        <h1 className="identity-upsell-title__title">
-                            Want more from The Guardian?
-                        </h1>
-                        <p className="identity-upsell-title__subtitle">
-                            Create your account now to manage your preferences
-                            and explore your free benefits.
-                        </p>
-                    </h1>
-                    <div>
-                        <AccountCreationForm
-                            {...this.props}
-                            onAccountCreated={this.onAccountCreated}
-                        />
-                    </div>
-                    <aside className="identity-upsell-account-creation-block">
-                        <hr className="manage-account-small-divider" />
-                        <AccountBenefits />
-                    </aside>
-                </div>
-            </div>
-        ) : (
-            <div>
-                <hr className="manage-account-small-divider" />
-                <AccountCreationFeatures returnUrl={this.props.returnUrl} />
-            </div>
-        );
-    }
+	render() {
+		return !this.state.hasCreatedAccount ? (
+			<div>
+				<hr className="manage-account-small-divider" />
+				<div className="form">
+					<h1 className="identity-upsell-title">
+						<h1 className="identity-upsell-title__title">
+							Want more from The Guardian?
+						</h1>
+						<p className="identity-upsell-title__subtitle">
+							Create your account now to manage your preferences
+							and explore your free benefits.
+						</p>
+					</h1>
+					<div>
+						<AccountCreationForm
+							{...this.props}
+							onAccountCreated={this.onAccountCreated}
+						/>
+					</div>
+					<aside className="identity-upsell-account-creation-block">
+						<hr className="manage-account-small-divider" />
+						<AccountBenefits />
+					</aside>
+				</div>
+			</div>
+		) : (
+			<div>
+				<hr className="manage-account-small-divider" />
+				<AccountCreationFeatures returnUrl={this.props.returnUrl} />
+			</div>
+		);
+	}
 }
 
 export { AccountCreationCompleteConsentsFlow };

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationFeatures.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationFeatures.js
@@ -1,22 +1,22 @@
-import React, { Component } from 'preact-compat';
+import React, { Component } from 'react';
 import { AccountActionableBenefits } from './AccountBenefits';
 
 export class AccountCreationFeatures extends Component {
-    render() {
-        return (
-            <div>
-                <header className="identity-upsell-title">
-                    <h1 className="identity-upsell-title__title">
-                        Your account has been created.
-                    </h1>
-                    <p className="identity-upsell-title__subtitle">
-                        Start exploring your benefits:
-                    </p>
-                </header>
-                <div className="identity-forms-message__body">
-                    <AccountActionableBenefits />
-                </div>
-            </div>
-        );
-    }
+	render() {
+		return (
+			<div>
+				<header className="identity-upsell-title">
+					<h1 className="identity-upsell-title__title">
+						Your account has been created.
+					</h1>
+					<p className="identity-upsell-title__subtitle">
+						Start exploring your benefits:
+					</p>
+				</header>
+				<div className="identity-forms-message__body">
+					<AccountActionableBenefits />
+				</div>
+			</div>
+		);
+	}
 }

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationForm.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationForm.js
@@ -1,141 +1,144 @@
-import React, { Component } from 'preact-compat';
+import React, { Component } from 'react';
 import reqwest from 'reqwest';
 import ophan from 'ophan/ng';
 import reportError from 'lib/report-error';
 import { ErrorBar, genericErrorStr } from '../error-bar/ErrorBar';
 
-
 class AccountCreationForm extends Component {
-    constructor(props) {
-        super(props);
-        this.setState({
-            errors: [],
-        });
-    }
+	constructor(props) {
+		super(props);
+		this.setState({
+			errors: [],
+		});
+	}
 
-    onSubmit = (ev) => {
-        ev.preventDefault();
-        this.setState({
-            isLoading: true,
-            errors: [],
-        });
+	onSubmit = (ev) => {
+		ev.preventDefault();
+		this.setState({
+			isLoading: true,
+			errors: [],
+		});
 
-        reqwest({
-            url: '/password/guest',
-            method: 'post',
-            data: {
-                csrfToken: this.props.csrfToken,
-                token: this.props.accountToken,
-                password: this.state.password,
-            },
-            success: () => {
-                ophan.record({
-                    component: 'set-password',
-                    value: 'set-password',
-                });
-                this.props.onAccountCreated();
-            },
-            error: response => {
-                reportError(
-                    Error(response),
-                    {
-                        feature: 'identity-create-account-upsell',
-                    },
-                    false
-                );
-                try {
-                    const apiError = JSON.parse(response.responseText)[0];
-                    this.setState({
-                        errors: [apiError.description],
-                    });
-                } catch (exception) {
-                    this.setState({ errors: [genericErrorStr] });
-                }
-            },
-            complete: () => {
-                this.setState({ isLoading: false });
-            },
-        });
-    };
+		reqwest({
+			url: '/password/guest',
+			method: 'post',
+			data: {
+				csrfToken: this.props.csrfToken,
+				token: this.props.accountToken,
+				password: this.state.password,
+			},
+			success: () => {
+				ophan.record({
+					component: 'set-password',
+					value: 'set-password',
+				});
+				this.props.onAccountCreated();
+			},
+			error: (response) => {
+				reportError(
+					Error(response),
+					{
+						feature: 'identity-create-account-upsell',
+					},
+					false,
+				);
+				try {
+					const apiError = JSON.parse(response.responseText)[0];
+					this.setState({
+						errors: [apiError.description],
+					});
+				} catch (exception) {
+					this.setState({ errors: [genericErrorStr] });
+				}
+			},
+			complete: () => {
+				this.setState({ isLoading: false });
+			},
+		});
+	};
 
-    handlePasswordChange = (ev) => {
-        if (!(ev.target instanceof HTMLInputElement)) {
-            return;
-        }
-        this.setState({ password: ev.target.value });
-    };
+	handlePasswordChange = (ev) => {
+		if (!(ev.target instanceof HTMLInputElement)) {
+			return;
+		}
+		this.setState({ password: ev.target.value });
+	};
 
-    render() {
-        const { errors, isLoading } = this.state;
-        const { email } = this.props;
-        return (
-            <form onSubmit={this.onSubmit}>
-                <ul className="identity-forms-fields">
-                    <ErrorBar tagName="li" errors={errors} />
-                    {email && (
-                        <li id="email_field" aria-hidden>
-                            <label
-                                className="identity-forms-input-wrap"
-                                htmlFor="email">
-                                <div className="identity-forms-label">
-                                    Email
-                                </div>
-                                <input
-                                    className="identity-forms-input"
-                                    type="email"
-                                    id="email"
-                                    value={email}
-                                    autoComplete="off"
-                                    autoCapitalize="off"
-                                    autoCorrect="off"
-                                    spellCheck="false"
-                                    aria-required="true"
-                                    required
-                                    disabled
-                                />
-                            </label>
-                        </li>
-                    )}
-                    <li id="password_field">
-                        <label
-                            className="identity-forms-input-wrap"
-                            htmlFor="password">
-                            <div className="identity-forms-label">Password</div>
-                            <input
-                                className="identity-forms-input"
-                                type="password"
-                                id="password"
-                                name="password"
-                                value={this.state.password}
-                                autoComplete="off"
-                                onChange={this.handlePasswordChange}
-                                autoCapitalize="off"
-                                autoCorrect="off"
-                                spellCheck="false"
-                                aria-required="true"
-                                required
-                            />
-                        </label>
-                    </li>
-                    <li>
-                        {isLoading ? (
-                            <button
-                                disabled
-                                className="manage-account__button manage-account__button--light manage-account__button--center">
-                                Hang on...
-                            </button>
-                        ) : (
-                            <button
-                                type="submit"
-                                className="manage-account__button manage-account__button--icon manage-account__button--main">
-                                Create an account
-                            </button>
-                        )}
-                    </li>
-                </ul>
-            </form>
-        );
-    }
+	render() {
+		const { errors, isLoading } = this.state;
+		const { email } = this.props;
+		return (
+			<form onSubmit={this.onSubmit}>
+				<ul className="identity-forms-fields">
+					<ErrorBar tagName="li" errors={errors} />
+					{email && (
+						<li id="email_field" aria-hidden>
+							<label
+								className="identity-forms-input-wrap"
+								htmlFor="email"
+							>
+								<div className="identity-forms-label">
+									Email
+								</div>
+								<input
+									className="identity-forms-input"
+									type="email"
+									id="email"
+									value={email}
+									autoComplete="off"
+									autoCapitalize="off"
+									autoCorrect="off"
+									spellCheck="false"
+									aria-required="true"
+									required
+									disabled
+								/>
+							</label>
+						</li>
+					)}
+					<li id="password_field">
+						<label
+							className="identity-forms-input-wrap"
+							htmlFor="password"
+						>
+							<div className="identity-forms-label">Password</div>
+							<input
+								className="identity-forms-input"
+								type="password"
+								id="password"
+								name="password"
+								value={this.state.password}
+								autoComplete="off"
+								onChange={this.handlePasswordChange}
+								autoCapitalize="off"
+								autoCorrect="off"
+								spellCheck="false"
+								aria-required="true"
+								required
+							/>
+						</label>
+					</li>
+					<li>
+						{isLoading ? (
+							<button
+								disabled
+								className="manage-account__button manage-account__button--light manage-account__button--center"
+							>
+								Hang on...
+							</button>
+						) : (
+							<button
+								type="submit"
+								className="manage-account__button manage-account__button--icon manage-account__button--main"
+							>
+								Create an account
+							</button>
+						)}
+					</li>
+				</ul>
+			</form>
+		);
+	}
 }
 
 export { AccountCreationForm };

--- a/static/src/javascripts/projects/common/modules/identity/upsell/block/Block.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/block/Block.js
@@ -1,52 +1,53 @@
-import React, { Component } from 'preact-compat';
-
+import React, { Component } from 'react';
 
 export class Block extends Component {
-    render() {
-        const {
-            title,
-            subtitle,
-            subtext,
-            children,
-            sideBySide,
-            sideBySideBackwards,
-            halfWidth,
-        } = this.props;
-        return (
-            <section
-                className={[
-                    'identity-upsell-block',
-                    sideBySide || sideBySideBackwards
-                        ? 'identity-upsell-block--side-by-side'
-                        : '',
-                    sideBySideBackwards
-                        ? 'identity-upsell-block--side-by-side identity-upsell-block--side-by-side--backwards'
-                        : '',
-                ].join(' ')}>
-                <div
-                    className={
-                        halfWidth ? 'identity-upsell-block--half-width' : ''
-                    }>
-                    <div className="identity-upsell-title">
-                        <h2 className="identity-upsell-title__title">
-                            {title}
-                        </h2>
-                        {subtitle && (
-                            <h3 className="identity-upsell-title__subtitle">
-                                {subtitle}
-                            </h3>
-                        )}
-                        {subtext && (
-                            <p className="identity-upsell-title__subtext">
-                                {subtext}
-                            </p>
-                        )}
-                    </div>
-                    <div className="identity-upsell-block__container">
-                        {children}
-                    </div>
-                </div>
-            </section>
-        );
-    }
+	render() {
+		const {
+			title,
+			subtitle,
+			subtext,
+			children,
+			sideBySide,
+			sideBySideBackwards,
+			halfWidth,
+		} = this.props;
+		return (
+			<section
+				className={[
+					'identity-upsell-block',
+					sideBySide || sideBySideBackwards
+						? 'identity-upsell-block--side-by-side'
+						: '',
+					sideBySideBackwards
+						? 'identity-upsell-block--side-by-side identity-upsell-block--side-by-side--backwards'
+						: '',
+				].join(' ')}
+			>
+				<div
+					className={
+						halfWidth ? 'identity-upsell-block--half-width' : ''
+					}
+				>
+					<div className="identity-upsell-title">
+						<h2 className="identity-upsell-title__title">
+							{title}
+						</h2>
+						{subtitle && (
+							<h3 className="identity-upsell-title__subtitle">
+								{subtitle}
+							</h3>
+						)}
+						{subtext && (
+							<p className="identity-upsell-title__subtext">
+								{subtext}
+							</p>
+						)}
+					</div>
+					<div className="identity-upsell-block__container">
+						{children}
+					</div>
+				</div>
+			</section>
+		);
+	}
 }

--- a/static/src/javascripts/projects/common/modules/identity/upsell/block/LegalTextBlock.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/block/LegalTextBlock.js
@@ -1,7 +1,7 @@
-import React from 'preact-compat';
+import React from 'react';
 
 const LegalTextBlock = ({ children }) => (
-    <div className="identity-upsell-legal-text-block">{children}</div>
+	<div className="identity-upsell-legal-text-block">{children}</div>
 );
 
 export { LegalTextBlock };

--- a/static/src/javascripts/projects/common/modules/identity/upsell/button/FollowButtonWrap.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/button/FollowButtonWrap.js
@@ -1,136 +1,138 @@
-import React, { Component } from 'preact-compat';
+import React, { Component } from 'react';
 import envelopeRemove from 'svgs/icon/envelope-remove.svg';
 import envelopeAdd from 'svgs/icon/envelope-add.svg';
 import tick from 'svgs/icon/tick.svg';
 
 const getButtonClassNames = (...modifiers) => [
-    'manage-account__button',
-    ...modifiers.map(m => `manage-account__button--${m}`),
+	'manage-account__button',
+	...modifiers.map((m) => `manage-account__button--${m}`),
 ];
 
-
-
 class FollowButtonWrap extends Component {
-    constructor(props) {
-        super(props);
-        this.setState({
-            mousedOutOnce: true,
-        });
-    }
+	constructor(props) {
+		super(props);
+		this.setState({
+			mousedOutOnce: true,
+		});
+	}
 
-    onMouseOut = () => {
-        this.setState({
-            mousedOutOnce: true,
-        });
-    };
+	onMouseOut = () => {
+		this.setState({
+			mousedOutOnce: true,
+		});
+	};
 
-    updateFollowing = (to) => {
-        if (to) {
-            this.props.onFollow();
-            this.setState({
-                mousedOutOnce: false,
-            });
-        } else {
-            this.props.onUnfollow();
-        }
-    };
+	updateFollowing = (to) => {
+		if (to) {
+			this.props.onFollow();
+			this.setState({
+				mousedOutOnce: false,
+			});
+		} else {
+			this.props.onUnfollow();
+		}
+	};
 
-    render() {
-        const { following, trackingName } = this.props;
-        const { mousedOutOnce } = this.state;
+	render() {
+		const { following, trackingName } = this.props;
+		const { mousedOutOnce } = this.state;
 
-        const followingFeedbackButton = (...classNames) => (
-            <div
-                role="alert"
-                className={[
-                    ...getButtonClassNames(
-                        'green-secondary',
-                        'center',
-                        'icon-left'
-                    ),
-                    ...classNames,
-                ].join(' ')}>
-                <span
-                    className="manage-account__button-react-icon"
-                    dangerouslySetInnerHTML={{ __html: tick.markup }}
-                />
-                Signed up
-            </div>
-        );
+		const followingFeedbackButton = (...classNames) => (
+			<div
+				role="alert"
+				className={[
+					...getButtonClassNames(
+						'green-secondary',
+						'center',
+						'icon-left',
+					),
+					...classNames,
+				].join(' ')}
+			>
+				<span
+					className="manage-account__button-react-icon"
+					dangerouslySetInnerHTML={{ __html: tick.markup }}
+				/>
+				Signed up
+			</div>
+		);
 
-        const unfollowButton = (...classNames) => (
-            <button
-                data-link-name={
-                    trackingName
-                        ? `upsell-consent : ${trackingName} : untick`
-                        : false
-                }
-                type="button"
-                className={[
-                    ...getButtonClassNames('danger', 'center', 'icon-left'),
-                    ...classNames,
-                ].join(' ')}
-                onClick={() => {
-                    this.updateFollowing(false);
-                }}>
-                <span
-                    className="manage-account__button-react-icon"
-                    dangerouslySetInnerHTML={{
-                        __html: envelopeRemove.markup,
-                    }}
-                />
-                Unsubscribe
-            </button>
-        );
+		const unfollowButton = (...classNames) => (
+			<button
+				data-link-name={
+					trackingName
+						? `upsell-consent : ${trackingName} : untick`
+						: false
+				}
+				type="button"
+				className={[
+					...getButtonClassNames('danger', 'center', 'icon-left'),
+					...classNames,
+				].join(' ')}
+				onClick={() => {
+					this.updateFollowing(false);
+				}}
+			>
+				<span
+					className="manage-account__button-react-icon"
+					dangerouslySetInnerHTML={{
+						__html: envelopeRemove.markup,
+					}}
+				/>
+				Unsubscribe
+			</button>
+		);
 
-        const followButton = () => (
-            <button
-                data-link-name={
-                    trackingName
-                        ? `upsell-consent : ${trackingName} : tick`
-                        : false
-                }
-                type="button"
-                className={getButtonClassNames('green', 'icon-left').join(' ')}
-                onClick={() => {
-                    this.updateFollowing(true);
-                }}>
-                <span
-                    className="manage-account__button-react-icon"
-                    dangerouslySetInnerHTML={{ __html: envelopeAdd.markup }}
-                />
-                Sign me up
-            </button>
-        );
+		const followButton = () => (
+			<button
+				data-link-name={
+					trackingName
+						? `upsell-consent : ${trackingName} : tick`
+						: false
+				}
+				type="button"
+				className={getButtonClassNames('green', 'icon-left').join(' ')}
+				onClick={() => {
+					this.updateFollowing(true);
+				}}
+			>
+				<span
+					className="manage-account__button-react-icon"
+					dangerouslySetInnerHTML={{ __html: envelopeAdd.markup }}
+				/>
+				Sign me up
+			</button>
+		);
 
-        return following ? (
-            <div
-                aria-live="polite"
-                className={[
-                    'identity-upsell-follow-button-wrap',
-                    mousedOutOnce
-                        ? ''
-                        : 'identity-upsell-follow-button-wrap--blocked',
-                ].join(' ')}
-                onMouseOut={() => {
-                    this.onMouseOut();
-                }}
-                onBlur={() => {
-                    this.onMouseOut();
-                }}>
-                {followingFeedbackButton(
-                    'identity-upsell-follow-button-wrap__button'
-                )}
-                {unfollowButton(
-                    'identity-upsell-follow-button-wrap__button',
-                    'identity-upsell-follow-button-wrap__button--longer',
-                    'identity-upsell-follow-button-wrap__button--hoverable'
-                )}
-            </div>
-        ) : (
-            followButton()
-        );
-    }
+		return following ? (
+			<div
+				aria-live="polite"
+				className={[
+					'identity-upsell-follow-button-wrap',
+					mousedOutOnce
+						? ''
+						: 'identity-upsell-follow-button-wrap--blocked',
+				].join(' ')}
+				onMouseOut={() => {
+					this.onMouseOut();
+				}}
+				onBlur={() => {
+					this.onMouseOut();
+				}}
+			>
+				{followingFeedbackButton(
+					'identity-upsell-follow-button-wrap__button',
+				)}
+				{unfollowButton(
+					'identity-upsell-follow-button-wrap__button',
+					'identity-upsell-follow-button-wrap__button--longer',
+					'identity-upsell-follow-button-wrap__button--hoverable',
+				)}
+			</div>
+		) : (
+			followButton()
+		);
+	}
 }
 
 export { FollowButtonWrap };

--- a/static/src/javascripts/projects/common/modules/identity/upsell/button/FollowCardExpanderButton.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/button/FollowCardExpanderButton.js
@@ -1,41 +1,36 @@
-import React from 'preact-compat';
+import React from 'react';
 import arrowDown from 'svgs/icon/arrow-down.svg';
 import arrowUp from 'svgs/icon/arrow-up.svg';
 
-
-
 const defaultExpanderButtonText = {
-    more: 'More',
-    less: 'Less',
+	more: 'More',
+	less: 'Less',
 };
 
-const FollowCardExpanderButton = ({
-    isExpanded,
-    onToggle,
-    linkName,
-    text,
-}) =>
-    isExpanded ? (
-        <button
-            data-link-name={linkName ? `${linkName} : shrink` : null}
-            className="manage-account__button manage-account__button--secondary manage-account__button--icon"
-            onClick={() => onToggle(false)}>
-            {(text || defaultExpanderButtonText).less}
-            <span
-                className="manage-account__button-react-icon"
-                dangerouslySetInnerHTML={{ __html: arrowUp.markup }}
-            />
-        </button>
-    ) : (
-        <button
-            data-link-name={linkName ? `${linkName} : expand` : null}
-            className="manage-account__button manage-account__button--secondary manage-account__button--icon"
-            onClick={() => onToggle(true)}>
-            {(text || defaultExpanderButtonText).more}
-            <span
-                className="manage-account__button-react-icon"
-                dangerouslySetInnerHTML={{ __html: arrowDown.markup }}
-            />
-        </button>
-    );
+const FollowCardExpanderButton = ({ isExpanded, onToggle, linkName, text }) =>
+	isExpanded ? (
+		<button
+			data-link-name={linkName ? `${linkName} : shrink` : null}
+			className="manage-account__button manage-account__button--secondary manage-account__button--icon"
+			onClick={() => onToggle(false)}
+		>
+			{(text || defaultExpanderButtonText).less}
+			<span
+				className="manage-account__button-react-icon"
+				dangerouslySetInnerHTML={{ __html: arrowUp.markup }}
+			/>
+		</button>
+	) : (
+		<button
+			data-link-name={linkName ? `${linkName} : expand` : null}
+			className="manage-account__button manage-account__button--secondary manage-account__button--icon"
+			onClick={() => onToggle(true)}
+		>
+			{(text || defaultExpanderButtonText).more}
+			<span
+				className="manage-account__button-react-icon"
+				dangerouslySetInnerHTML={{ __html: arrowDown.markup }}
+			/>
+		</button>
+	);
 export { FollowCardExpanderButton };

--- a/static/src/javascripts/projects/common/modules/identity/upsell/button/OptoutsExpanderButton.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/button/OptoutsExpanderButton.js
@@ -1,35 +1,31 @@
-import React from 'preact-compat';
+import React from 'react';
 import plus from 'svgs/icon/plus.svg';
 import minus from 'svgs/icon/minus.svg';
 
-
-const OptoutsExpanderButton = ({
-    isExpanded,
-    onToggle,
-    linkName,
-    text,
-}) =>
-    isExpanded ? (
-        <button
-            data-link-name={linkName ? `${linkName} : shrink` : null}
-            className="manage-account__button manage-account__button--secondary manage-account__button--icon manage-account__button--long manage-account__button--long-expanded"
-            onClick={() => onToggle(false)}>
-            {text}
-            <span
-                className="manage-account__button-react-icon"
-                dangerouslySetInnerHTML={{ __html: minus.markup }}
-            />
-        </button>
-    ) : (
-        <button
-            data-link-name={linkName ? `${linkName} : expand` : null}
-            className="manage-account__button manage-account__button--secondary manage-account__button--icon manage-account__button--long"
-            onClick={() => onToggle(true)}>
-            {text}
-            <span
-                className="manage-account__button-react-icon"
-                dangerouslySetInnerHTML={{ __html: plus.markup }}
-            />
-        </button>
-    );
+const OptoutsExpanderButton = ({ isExpanded, onToggle, linkName, text }) =>
+	isExpanded ? (
+		<button
+			data-link-name={linkName ? `${linkName} : shrink` : null}
+			className="manage-account__button manage-account__button--secondary manage-account__button--icon manage-account__button--long manage-account__button--long-expanded"
+			onClick={() => onToggle(false)}
+		>
+			{text}
+			<span
+				className="manage-account__button-react-icon"
+				dangerouslySetInnerHTML={{ __html: minus.markup }}
+			/>
+		</button>
+	) : (
+		<button
+			data-link-name={linkName ? `${linkName} : expand` : null}
+			className="manage-account__button manage-account__button--secondary manage-account__button--icon manage-account__button--long"
+			onClick={() => onToggle(true)}
+		>
+			{text}
+			<span
+				className="manage-account__button-react-icon"
+				dangerouslySetInnerHTML={{ __html: plus.markup }}
+			/>
+		</button>
+	);
 export { OptoutsExpanderButton };

--- a/static/src/javascripts/projects/common/modules/identity/upsell/checkbox/Checkbox.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/checkbox/Checkbox.js
@@ -1,20 +1,19 @@
-import React from 'preact-compat';
-
-
+import React from 'react';
 
 const Checkbox = ({ title, uniqueId, checkboxHtmlProps }) => (
-    <label
-        data-link-name={`upsell-consent : checkbox : ${uniqueId} : ${
-            checkboxHtmlProps.checked ? 'untick' : 'tick'
-        }`}
-        className="identity-upsell-checkbox"
-        htmlFor={uniqueId}>
-        <span className="identity-upsell-checkbox__title">{title}</span>
-        <input type="checkbox" id={uniqueId} {...checkboxHtmlProps} />
-        <span className="identity-upsell-checkbox__checkmark">
-            <span className="identity-upsell-checkbox__checkmark_tick" />
-        </span>
-    </label>
+	<label
+		data-link-name={`upsell-consent : checkbox : ${uniqueId} : ${
+			checkboxHtmlProps.checked ? 'untick' : 'tick'
+		}`}
+		className="identity-upsell-checkbox"
+		htmlFor={uniqueId}
+	>
+		<span className="identity-upsell-checkbox__title">{title}</span>
+		<input type="checkbox" id={uniqueId} {...checkboxHtmlProps} />
+		<span className="identity-upsell-checkbox__checkmark">
+			<span className="identity-upsell-checkbox__checkmark_tick" />
+		</span>
+	</label>
 );
 
 export { Checkbox };

--- a/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCard.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCard.js
@@ -1,30 +1,29 @@
-import React from 'preact-compat';
+import React from 'react';
 import { FollowButtonWrap } from 'common/modules/identity/upsell/button/FollowButtonWrap';
 
-
 const FollowCard = (props) => {
-    const { hasConsented } = props;
-    const { name, description } = props.consent;
-    return (
-        <div className="identity-upsell-consent-card">
-            <h1 className="identity-upsell-consent-card__title">{name}</h1>
-            <p className="identity-upsell-consent-card__description">
-                {description}
-            </p>
-            <div className="identity-upsell-consent-card__footer">
-                <FollowButtonWrap
-                    trackingName={name}
-                    following={hasConsented}
-                    onFollow={() => {
-                        props.onChange(true);
-                    }}
-                    onUnfollow={() => {
-                        props.onChange(false);
-                    }}
-                />
-            </div>
-        </div>
-    );
+	const { hasConsented } = props;
+	const { name, description } = props.consent;
+	return (
+		<div className="identity-upsell-consent-card">
+			<h1 className="identity-upsell-consent-card__title">{name}</h1>
+			<p className="identity-upsell-consent-card__description">
+				{description}
+			</p>
+			<div className="identity-upsell-consent-card__footer">
+				<FollowButtonWrap
+					trackingName={name}
+					following={hasConsented}
+					onFollow={() => {
+						props.onChange(true);
+					}}
+					onUnfollow={() => {
+						props.onChange(false);
+					}}
+				/>
+			</div>
+		</div>
+	);
 };
 
 export { FollowCard };

--- a/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCardList.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/consent-card/FollowCardList.js
@@ -1,146 +1,146 @@
-import React from 'preact-compat';
+import React from 'react';
 import config from 'lib/config';
 import { FollowCard } from 'common/modules/identity/upsell/consent-card/FollowCard';
 import {
-    setConsentsInApi,
-    getNewsletterConsent,
-    getUserConsent,
+	setConsentsInApi,
+	getNewsletterConsent,
+	getUserConsent,
 } from 'common/modules/identity/upsell/store/consents';
 import { LegalTextBlock } from 'common/modules/identity/upsell/block/LegalTextBlock';
 import { ErrorBar, genericErrorStr } from '../error-bar/ErrorBar';
 import { FollowCardExpanderButton } from '../button/FollowCardExpanderButton';
 
 const getConsents = () =>
-    Promise.all([
-        getUserConsent('supporter'),
-        getNewsletterConsent('the-long-read'),
-        getUserConsent('holidays'),
-        getNewsletterConsent('bookmarks'),
-        getUserConsent('events'),
-        getNewsletterConsent('brexit-briefing'),
-        getUserConsent('offers'),
-        getUserConsent('jobs'),
-        getNewsletterConsent('green-light'),
-        getNewsletterConsent('lab-notes'),
-    ]);
-
-
+	Promise.all([
+		getUserConsent('supporter'),
+		getNewsletterConsent('the-long-read'),
+		getUserConsent('holidays'),
+		getNewsletterConsent('bookmarks'),
+		getUserConsent('events'),
+		getNewsletterConsent('brexit-briefing'),
+		getUserConsent('offers'),
+		getUserConsent('jobs'),
+		getNewsletterConsent('green-light'),
+		getNewsletterConsent('lab-notes'),
+	]);
 
 // TODO: seperate this into a stateless component and a stateful wrapper.
 class FollowCardList extends React.Component {
-    constructor(props) {
-        super(props);
-        this.setState({
-            consents: [],
-            isLoading: true,
-            isExpanded: false,
-            errors: [],
-        });
-    }
+	constructor(props) {
+		super(props);
+		this.setState({
+			consents: [],
+			isLoading: true,
+			isExpanded: false,
+			errors: [],
+		});
+	}
 
-    componentDidMount() {
-        getConsents().then(consents =>
-            this.setState({
-                consents,
-                isLoading: false,
-            })
-        );
-    }
+	componentDidMount() {
+		getConsents().then((consents) =>
+			this.setState({
+				consents,
+				isLoading: false,
+			}),
+		);
+	}
 
-    updateConsentState(consent) {
-        this.setState(state => ({
-            errors: [],
-            consents: state.consents.map(original =>
-                original.uniqueId === consent.uniqueId ? consent : original
-            ),
-        }));
-        setConsentsInApi([consent]).catch(() => {
-            consent.flipState();
-            this.setState(state => ({
-                errors: [genericErrorStr],
-                consents: state.consents.map(original =>
-                    original.uniqueId === consent.uniqueId ? consent : original
-                ),
-            }));
-        });
-    }
+	updateConsentState(consent) {
+		this.setState((state) => ({
+			errors: [],
+			consents: state.consents.map((original) =>
+				original.uniqueId === consent.uniqueId ? consent : original,
+			),
+		}));
+		setConsentsInApi([consent]).catch(() => {
+			consent.flipState();
+			this.setState((state) => ({
+				errors: [genericErrorStr],
+				consents: state.consents.map((original) =>
+					original.uniqueId === consent.uniqueId ? consent : original,
+				),
+			}));
+		});
+	}
 
-    updateExpandState = (isExpanded) => {
-        this.setState({
-            isExpanded,
-        });
-    };
+	updateExpandState = (isExpanded) => {
+		this.setState({
+			isExpanded,
+		});
+	};
 
-    render() {
-        const { consents, isLoading, isExpanded, errors } = this.state;
-        const { cutoff } = this.props;
+	render() {
+		const { consents, isLoading, isExpanded, errors } = this.state;
+		const { cutoff } = this.props;
 
-        const displayables = isExpanded
-            ? consents
-            : [...consents].splice(0, cutoff);
+		const displayables = isExpanded
+			? consents
+			: [...consents].splice(0, cutoff);
 
-        return (
-            <div>
-                {isLoading && (
-                    <div className="identity-forms-loading u-identity-forms-padded">
-                        <div className="identity-forms-loading__spinner is-updating" />
-                    </div>
-                )}
-                <ErrorBar errors={errors} />
-                <div className="identity-upsell-consent-card-grid">
-                    {displayables.map(consent => (
-                        <FollowCard
-                            key={consent.uniqueId}
-                            consent={consent.consent}
-                            hasConsented={consent.hasConsented}
-                            onChange={hasConsented => {
-                                consent.setState(hasConsented);
-                                this.updateConsentState(consent);
-                            }}
-                        />
-                    ))}
-                </div>
-                {[...consents].splice(cutoff).length > 0 && (
-                    <div className="identity-upsell-consent-card-footer">
-                        <FollowCardExpanderButton
-                            isExpanded={isExpanded}
-                            linkName="upsell-follow-expander"
-                            onToggle={this.updateExpandState}
-                            text={{
-                                more: 'See more',
-                                less: 'Less',
-                            }}
-                        />
-                        {isExpanded && (
-                            <div>
-                                <a
-                                    data-link-name="upsell-newsletter-link"
-                                    className="u-underline identity-upsell-consent-card__link"
-                                    href={`${config.get(
-                                        'page.idUrl'
-                                    )}/email-prefs`}>
-                                    View all Guardian newsletters
-                                </a>
-                            </div>
-                        )}
-                    </div>
-                )}
-                <LegalTextBlock>
-                    By subscribing, you confirm that you are 13 years or older.
-                    The Guardian’s newsletters may include advertising and
-                    messages about the Guardian’s other products and services,
-                    such as Jobs and Masterclasses. To find out what personal
-                    data we collect and how we use it, please visit our&nbsp;
-                    <a
-                        data-link-name="upsell-privacy-link"
-                        className="u-underline identity-upsell-consent-card__link"
-                        href="https://www.theguardian.com/info/privacy">
-                        Privacy Policy.
-                    </a>
-                </LegalTextBlock>
-            </div>
-        );
-    }
+		return (
+			<div>
+				{isLoading && (
+					<div className="identity-forms-loading u-identity-forms-padded">
+						<div className="identity-forms-loading__spinner is-updating" />
+					</div>
+				)}
+				<ErrorBar errors={errors} />
+				<div className="identity-upsell-consent-card-grid">
+					{displayables.map((consent) => (
+						<FollowCard
+							key={consent.uniqueId}
+							consent={consent.consent}
+							hasConsented={consent.hasConsented}
+							onChange={(hasConsented) => {
+								consent.setState(hasConsented);
+								this.updateConsentState(consent);
+							}}
+						/>
+					))}
+				</div>
+				{[...consents].splice(cutoff).length > 0 && (
+					<div className="identity-upsell-consent-card-footer">
+						<FollowCardExpanderButton
+							isExpanded={isExpanded}
+							linkName="upsell-follow-expander"
+							onToggle={this.updateExpandState}
+							text={{
+								more: 'See more',
+								less: 'Less',
+							}}
+						/>
+						{isExpanded && (
+							<div>
+								<a
+									data-link-name="upsell-newsletter-link"
+									className="u-underline identity-upsell-consent-card__link"
+									href={`${config.get(
+										'page.idUrl',
+									)}/email-prefs`}
+								>
+									View all Guardian newsletters
+								</a>
+							</div>
+						)}
+					</div>
+				)}
+				<LegalTextBlock>
+					By subscribing, you confirm that you are 13 years or older.
+					The Guardian’s newsletters may include advertising and
+					messages about the Guardian’s other products and services,
+					such as Jobs and Masterclasses. To find out what personal
+					data we collect and how we use it, please visit our&nbsp;
+					<a
+						data-link-name="upsell-privacy-link"
+						className="u-underline identity-upsell-consent-card__link"
+						href="https://www.theguardian.com/info/privacy"
+					>
+						Privacy Policy.
+					</a>
+				</LegalTextBlock>
+			</div>
+		);
+	}
 }
 
 export { FollowCardList };

--- a/static/src/javascripts/projects/common/modules/identity/upsell/error-bar/ErrorBar.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/error-bar/ErrorBar.js
@@ -1,24 +1,23 @@
-import React, { Component } from 'preact-compat';
-
+import React, { Component } from 'react';
 
 export const genericErrorStr = 'Oops! Something went wrong';
 
 export class ErrorBar extends Component {
-    static defaultProps = {
-        tagName: 'div',
-    };
+	static defaultProps = {
+		tagName: 'div',
+	};
 
-    render() {
-        const { errors } = this.props;
-        const TagName = this.props.tagName;
-        return (
-            <TagName aria-live="polite">
-                {errors.map(error => (
-                    <div className="form__error" role="alert">
-                        {error}
-                    </div>
-                ))}
-            </TagName>
-        );
-    }
+	render() {
+		const { errors } = this.props;
+		const TagName = this.props.tagName;
+		return (
+			<TagName aria-live="polite">
+				{errors.map((error) => (
+					<div className="form__error" role="alert">
+						{error}
+					</div>
+				))}
+			</TagName>
+		);
+	}
 }

--- a/static/src/javascripts/projects/common/modules/identity/upsell/header/Header.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/header/Header.js
@@ -1,27 +1,26 @@
-import React from 'preact-compat';
+import React from 'react';
 import circlesLeft from './circles-left.svg';
 import circlesRight from './circles-right.svg';
 
-
 const Header = ({ title, subtitle }) => (
-    <div className="identity-upsell-subheader">
-        <div className="identity-upsell-layout identity-upsell-layout--padding">
-            <header className="identity-upsell-title identity-upsell-title--hero">
-                <h1 className="identity-upsell-title__title">{title}</h1>
-                <h1 className="identity-upsell-title__subtitle">{subtitle}</h1>
-            </header>
-        </div>
-        <div className="identity-upsell-subheader__graphics">
-            <span
-                className="identity-upsell-subheader__graphic identity-upsell-subheader__graphic--circlesLeft"
-                dangerouslySetInnerHTML={{ __html: circlesLeft.markup }}
-            />
-            <span
-                className="identity-upsell-subheader__graphic identity-upsell-subheader__graphic--circlesRight"
-                dangerouslySetInnerHTML={{ __html: circlesRight.markup }}
-            />
-        </div>
-    </div>
+	<div className="identity-upsell-subheader">
+		<div className="identity-upsell-layout identity-upsell-layout--padding">
+			<header className="identity-upsell-title identity-upsell-title--hero">
+				<h1 className="identity-upsell-title__title">{title}</h1>
+				<h1 className="identity-upsell-title__subtitle">{subtitle}</h1>
+			</header>
+		</div>
+		<div className="identity-upsell-subheader__graphics">
+			<span
+				className="identity-upsell-subheader__graphic identity-upsell-subheader__graphic--circlesLeft"
+				dangerouslySetInnerHTML={{ __html: circlesLeft.markup }}
+			/>
+			<span
+				className="identity-upsell-subheader__graphic identity-upsell-subheader__graphic--circlesRight"
+				dangerouslySetInnerHTML={{ __html: circlesRight.markup }}
+			/>
+		</div>
+	</div>
 );
 
 export { Header };

--- a/static/src/javascripts/projects/common/modules/identity/upsell/opt-outs/OptOutsList.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/opt-outs/OptOutsList.js
@@ -1,139 +1,142 @@
-import React, { Component } from 'preact-compat';
+import React, { Component } from 'react';
 import { Checkbox } from 'common/modules/identity/upsell/checkbox/Checkbox';
 import { OptoutsExpanderButton } from 'common/modules/identity/upsell/button/OptoutsExpanderButton';
 import {
-    getAllUserConsents,
-    setConsentsInApi,
+	getAllUserConsents,
+	setConsentsInApi,
 } from 'common/modules/identity/upsell/store/consents';
 import { ErrorBar, genericErrorStr } from '../error-bar/ErrorBar';
 
 export class OptOutsList extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            isLoading: false,
-            errors: [],
-            hasUnsavedChanges: true,
-            consents: [],
-            isExpanded: false,
-        };
-    }
+	constructor(props) {
+		super(props);
+		this.state = {
+			isLoading: false,
+			errors: [],
+			hasUnsavedChanges: true,
+			consents: [],
+			isExpanded: false,
+		};
+	}
 
-    componentDidMount() {
-        getAllUserConsents().then(consents => {
-            this.setState({
-                consents: consents.filter(c => c.consent.isOptOut),
-            });
-        });
-    }
+	componentDidMount() {
+		getAllUserConsents().then((consents) => {
+			this.setState({
+				consents: consents.filter((c) => c.consent.isOptOut),
+			});
+		});
+	}
 
-    onCheckboxChange = (consent) => {
-        this.setState(state => ({
-            hasUnsavedChanges: true,
-            consents: state.consents.map(original =>
-                original.uniqueId === consent.uniqueId ? consent : original
-            ),
-        }));
-    };
+	onCheckboxChange = (consent) => {
+		this.setState((state) => ({
+			hasUnsavedChanges: true,
+			consents: state.consents.map((original) =>
+				original.uniqueId === consent.uniqueId ? consent : original,
+			),
+		}));
+	};
 
-    onSubmit = (ev) => {
-        ev.preventDefault();
-        this.setState({
-            isLoading: true,
-            errors: [],
-        });
-        setConsentsInApi(this.state.consents)
-            .then(() => {
-                this.setState({
-                    hasUnsavedChanges: false,
-                    isLoading: false,
-                });
-            })
-            .catch(() => {
-                this.setState({
-                    errors: [genericErrorStr],
-                    isLoading: false,
-                });
-            });
-    };
+	onSubmit = (ev) => {
+		ev.preventDefault();
+		this.setState({
+			isLoading: true,
+			errors: [],
+		});
+		setConsentsInApi(this.state.consents)
+			.then(() => {
+				this.setState({
+					hasUnsavedChanges: false,
+					isLoading: false,
+				});
+			})
+			.catch(() => {
+				this.setState({
+					errors: [genericErrorStr],
+					isLoading: false,
+				});
+			});
+	};
 
-    updateExpandState = (isExpanded) => {
-        this.setState({
-            isExpanded,
-        });
-    };
+	updateExpandState = (isExpanded) => {
+		this.setState({
+			isExpanded,
+		});
+	};
 
-    render() {
-        const {
-            hasUnsavedChanges,
-            isLoading,
-            consents,
-            errors,
-            isExpanded,
-        } = this.state;
-        return (
-            <div
-                className={
-                    isExpanded
-                        ? 'identity-upsell-optouts'
-                        : 'identity-upsell-optouts identity-upsell-optouts--closed'
-                }>
-                <OptoutsExpanderButton
-                    isExpanded={isExpanded}
-                    linkName="upsell-optouts-expander"
-                    onToggle={this.updateExpandState}
-                    text="Change my preferences"
-                />
-                {isExpanded && (
-                    <div className="identity-upsell-optouts-expanded">
-                        <form onSubmit={ev => this.onSubmit(ev)}>
-                            <ul className="identity-forms-fields">
-                                <ErrorBar errors={errors} tagName="li" />
-                                <li>
-                                    {consents.map(consent => (
-                                        <Checkbox
-                                            title={consent.consent.description}
-                                            uniqueId={consent.uniqueId}
-                                            checkboxHtmlProps={{
-                                                checked: consent.hasConsented,
-                                                onChange: ev => {
-                                                    consent.setState(
-                                                        ev.currentTarget.checked
-                                                    );
-                                                    this.onCheckboxChange(
-                                                        consent
-                                                    );
-                                                },
-                                            }}
-                                        />
-                                    ))}
-                                </li>
-                                <li>
-                                    <div className="identity-upsell-button-with-proxy">
-                                        <button
-                                            data-link-name="upsell-consent : submit optouts"
-                                            type="submit"
-                                            disabled={isLoading}
-                                            className="manage-account__button manage-account__button--main">
-                                            Save preferences
-                                        </button>
-                                        {!hasUnsavedChanges && (
-                                            <span className="identity-upsell-button-with-proxy__proxy identity-upsell-button-with-proxy__proxy--success">
-                                                Changes saved
-                                            </span>
-                                        )}
-                                        {isLoading && (
-                                            <span className="identity-upsell-button-with-proxy__proxy">
-                                                Loading
-                                            </span>
-                                        )}
-                                    </div>
-                                </li>
-                            </ul>
-                        </form>
-                    </div>
-                )}
-            </div>
-        );
-    }
+	render() {
+		const {
+			hasUnsavedChanges,
+			isLoading,
+			consents,
+			errors,
+			isExpanded,
+		} = this.state;
+		return (
+			<div
+				className={
+					isExpanded
+						? 'identity-upsell-optouts'
+						: 'identity-upsell-optouts identity-upsell-optouts--closed'
+				}
+			>
+				<OptoutsExpanderButton
+					isExpanded={isExpanded}
+					linkName="upsell-optouts-expander"
+					onToggle={this.updateExpandState}
+					text="Change my preferences"
+				/>
+				{isExpanded && (
+					<div className="identity-upsell-optouts-expanded">
+						<form onSubmit={(ev) => this.onSubmit(ev)}>
+							<ul className="identity-forms-fields">
+								<ErrorBar errors={errors} tagName="li" />
+								<li>
+									{consents.map((consent) => (
+										<Checkbox
+											title={consent.consent.description}
+											uniqueId={consent.uniqueId}
+											checkboxHtmlProps={{
+												checked: consent.hasConsented,
+												onChange: (ev) => {
+													consent.setState(
+														ev.currentTarget
+															.checked,
+													);
+													this.onCheckboxChange(
+														consent,
+													);
+												},
+											}}
+										/>
+									))}
+								</li>
+								<li>
+									<div className="identity-upsell-button-with-proxy">
+										<button
+											data-link-name="upsell-consent : submit optouts"
+											type="submit"
+											disabled={isLoading}
+											className="manage-account__button manage-account__button--main"
+										>
+											Save preferences
+										</button>
+										{!hasUnsavedChanges && (
+											<span className="identity-upsell-button-with-proxy__proxy identity-upsell-button-with-proxy__proxy--success">
+												Changes saved
+											</span>
+										)}
+										{isLoading && (
+											<span className="identity-upsell-button-with-proxy__proxy">
+												Loading
+											</span>
+										)}
+									</div>
+								</li>
+							</ul>
+						</form>
+					</div>
+				)}
+			</div>
+		);
+	}
 }

--- a/static/src/javascripts/projects/common/modules/identity/upsell/page/ConfirmEmailPage.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/page/ConfirmEmailPage.js
@@ -1,35 +1,34 @@
-import React from 'preact-compat';
+import React from 'react';
 
 import { NewsLetterSignUps } from './NewsLetterSignUps';
 import { OptOuts } from './OptOuts';
 import { Header } from '../header/Header';
 import { AccountCreationBlock } from '../account-creation/AccountCreationBlock';
 
-
 const Components = (props) => {
-    let components = [<NewsLetterSignUps />, <OptOuts />];
+	let components = [<NewsLetterSignUps />, <OptOuts />];
 
-    if (!props.hasPassword && !props.hasSocialLinks && props.accountToken) {
-        components = [
-            <AccountCreationBlock
-                csrfToken={props.csrfToken}
-                accountToken={props.accountToken}
-                email={props.email}
-            />,
-            <NewsLetterSignUps />,
-            <OptOuts />,
-        ];
-    } else if (!props.isUserLoggedIn) {
-        // TODO: sign in form
-        components = [<NewsLetterSignUps />, <OptOuts />];
-    }
+	if (!props.hasPassword && !props.hasSocialLinks && props.accountToken) {
+		components = [
+			<AccountCreationBlock
+				csrfToken={props.csrfToken}
+				accountToken={props.accountToken}
+				email={props.email}
+			/>,
+			<NewsLetterSignUps />,
+			<OptOuts />,
+		];
+	} else if (!props.isUserLoggedIn) {
+		// TODO: sign in form
+		components = [<NewsLetterSignUps />, <OptOuts />];
+	}
 
-    return <div className="identity-upsell-layout">{components}</div>;
+	return <div className="identity-upsell-layout">{components}</div>;
 };
 
 export const ConfirmEmailPage = (props) => (
-    <div className="identity-upsell-wrapper">
-        <Header title="Thank you!" subtitle="You’re now subscribed." />
-        <Components {...props} />
-    </div>
+	<div className="identity-upsell-wrapper">
+		<Header title="Thank you!" subtitle="You’re now subscribed." />
+		<Components {...props} />
+	</div>
 );

--- a/static/src/javascripts/projects/common/modules/identity/upsell/page/NewsLetterSignUps.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/page/NewsLetterSignUps.js
@@ -1,9 +1,9 @@
-import React from 'preact-compat';
+import React from 'react';
 import { Block } from '../block/Block';
 import { FollowCardList } from '../consent-card/FollowCardList';
 
 export const NewsLetterSignUps = () => (
-    <Block title="Guardian favourites:">
-        <FollowCardList cutoff={2} />
-    </Block>
+	<Block title="Guardian favourites:">
+		<FollowCardList cutoff={2} />
+	</Block>
 );

--- a/static/src/javascripts/projects/common/modules/identity/upsell/page/OptOuts.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/page/OptOuts.js
@@ -1,15 +1,16 @@
-import React from 'preact-compat';
+import React from 'react';
 import { Block } from '../block/Block';
 import { OptOutsList } from '../opt-outs/OptOutsList';
 
 export const OptOuts = () => (
-    <Block
-        halfWidth
-        sideBySideBackwards
-        title="Your marketing preferences"
-        subtext="We may contact you by telephone and post about our products and services (if you've previously given
+	<Block
+		halfWidth
+		sideBySideBackwards
+		title="Your marketing preferences"
+		subtext="We may contact you by telephone and post about our products and services (if you've previously given
         us your number and address). We may also contact you for market research purposes and use your data for
-        marketing analysis.">
-        <OptOutsList />
-    </Block>
+        marketing analysis."
+	>
+		<OptOutsList />
+	</Block>
 );

--- a/static/src/javascripts/projects/common/modules/identity/upsell/page/StatefulConfirmEmailPage.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/page/StatefulConfirmEmailPage.js
@@ -1,35 +1,32 @@
-import React from 'preact-compat';
+import React from 'react';
 import { ConfirmEmailPage } from './ConfirmEmailPage';
 import { getUserData } from '../../api';
 
-
-
-const isUserLoggedIn = () =>
-    getUserData().then(response => response.ok);
+const isUserLoggedIn = () => getUserData().then((response) => response.ok);
 
 export class StatefulConfirmEmailPage extends React.Component {
-    constructor(props) {
-        super(props);
-        this.setState({ isUserLoggedIn: false });
-    }
+	constructor(props) {
+		super(props);
+		this.setState({ isUserLoggedIn: false });
+	}
 
-    componentDidMount() {
-        // For some reason using this.setState instead of an anonymous function doesn't work?
-        isUserLoggedIn().then(status =>
-            this.setState({ isUserLoggedIn: status })
-        );
-    }
+	componentDidMount() {
+		// For some reason using this.setState instead of an anonymous function doesn't work?
+		isUserLoggedIn().then((status) =>
+			this.setState({ isUserLoggedIn: status }),
+		);
+	}
 
-    render() {
-        return (
-            <ConfirmEmailPage
-                csrfToken={this.props.csrfToken}
-                accountToken={this.props.accountToken}
-                email={this.props.email}
-                hasPassword={this.props.hasPassword}
-                hasSocialLinks={this.props.hasSocialLinks}
-                isUserLoggedIn={this.state.isUserLoggedIn}
-            />
-        );
-    }
+	render() {
+		return (
+			<ConfirmEmailPage
+				csrfToken={this.props.csrfToken}
+				accountToken={this.props.accountToken}
+				email={this.props.email}
+				hasPassword={this.props.hasPassword}
+				hasSocialLinks={this.props.hasSocialLinks}
+				isUserLoggedIn={this.state.isUserLoggedIn}
+			/>
+		);
+	}
 }

--- a/static/src/javascripts/projects/common/modules/identity/upsell/upsell.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/upsell.js
@@ -1,5 +1,5 @@
 import { trackNonClickInteraction } from 'common/modules/analytics/google';
-import React, { render } from 'preact-compat';
+import React, { render } from 'react';
 import fastdom from 'lib/fastdom-promise';
 import ophan from 'ophan/ng';
 import loadEnhancers from 'common/modules/identity/modules/loadEnhancers';
@@ -7,60 +7,59 @@ import { AccountCreationCompleteConsentsFlow } from 'common/modules/identity/ups
 import { StatefulConfirmEmailPage } from './page/StatefulConfirmEmailPage';
 
 const trackInteraction = (interaction) => {
-    ophan.record({
-        component: 'set-password',
-        value: interaction,
-    });
-    trackNonClickInteraction(interaction);
+	ophan.record({
+		component: 'set-password',
+		value: interaction,
+	});
+	trackNonClickInteraction(interaction);
 };
 
 const bindAccountCreation = (el) => {
-    trackInteraction('set-password : display');
-    fastdom.mutate(() => {
-        render(
-            <AccountCreationCompleteConsentsFlow
-                csrfToken={el.dataset.csrf}
-                accountToken={el.dataset.accountToken}
-                email={el.dataset.email}
-            />,
-            el
-        );
-    });
+	trackInteraction('set-password : display');
+	fastdom.mutate(() => {
+		render(
+			<AccountCreationCompleteConsentsFlow
+				csrfToken={el.dataset.csrf}
+				accountToken={el.dataset.accountToken}
+				email={el.dataset.email}
+			/>,
+			el,
+		);
+	});
 };
 
-
 const getPrefill = (el) => ({
-    csrfToken: el.dataset.csrfToken,
-    accountToken: el.dataset.accountToken,
-    email: el.dataset.email,
-    hasPassword: el.dataset.hasPassword === 'true',
-    hasSocialLinks: el.dataset.hasSocialLinks === 'true',
+	csrfToken: el.dataset.csrfToken,
+	accountToken: el.dataset.accountToken,
+	email: el.dataset.email,
+	hasPassword: el.dataset.hasPassword === 'true',
+	hasSocialLinks: el.dataset.hasSocialLinks === 'true',
 });
 
 const bindBlockList = (el) => {
-    fastdom
-        .measure(() => getPrefill(el))
-        .then(prefill =>
-            fastdom.mutate(() => {
-                render(
-                    <StatefulConfirmEmailPage
-                        csrfToken={prefill.csrfToken}
-                        accountToken={prefill.accountToken}
-                        email={prefill.email}
-                        hasPassword={prefill.hasPassword}
-                        hasSocialLinks={prefill.hasSocialLinks}
-                    />,
-                    el
-                );
-            })
-        );
+	fastdom
+		.measure(() => getPrefill(el))
+		.then((prefill) =>
+			fastdom.mutate(() => {
+				render(
+					<StatefulConfirmEmailPage
+						csrfToken={prefill.csrfToken}
+						accountToken={prefill.accountToken}
+						email={prefill.email}
+						hasPassword={prefill.hasPassword}
+						hasSocialLinks={prefill.hasSocialLinks}
+					/>,
+					el,
+				);
+			}),
+		);
 };
 
 const enhanceUpsell = () => {
-    loadEnhancers([
-        ['.js-identity-upsell-account-creation', bindAccountCreation],
-        ['.js-identity-block-list', bindBlockList],
-    ]);
+	loadEnhancers([
+		['.js-identity-upsell-account-creation', bindAccountCreation],
+		['.js-identity-block-list', bindBlockList],
+	]);
 };
 
 export { enhanceUpsell };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,171 +3,167 @@ const CircularDependencyPlugin = require('circular-dependency-plugin');
 const webpack = require('webpack');
 
 module.exports = {
-    entry: {
-        standard: path.join(
-            __dirname,
-            'static',
-            'src',
-            'javascripts',
-            'boot.js'
-        ),
-        admin: path.join(
-            __dirname,
-            'static',
-            'src',
-            'javascripts',
-            'bootstraps',
-            'admin.js'
-        ),
-        // Old VideoJS embed
-        'videojs-embed': path.join(
-            __dirname,
-            'static',
-            'src',
-            'javascripts',
-            'bootstraps',
-            'videojs-embed.js'
-        ),
-        // Video embed with native video player enhancements
-        'video-embed': path.join(
-            __dirname,
-            'static',
-            'src',
-            'javascripts',
-            'bootstraps',
-            'video-embed.js'
-        ),
-        'youtube-embed': path.join(
-            __dirname,
-            'static',
-            'src',
-            'javascripts',
-            'bootstraps',
-            'youtube-embed.js'
-        ),
-    },
-    output: {
-        path: path.join(__dirname, 'static', 'target', 'javascripts'),
-    },
-    resolve: {
-        modules: [
-            path.join(__dirname, 'static', 'src', 'javascripts'),
-            path.join(__dirname, 'static', 'vendor', 'javascripts'),
-            'node_modules', // default location, but we're overiding above, so it needs to be explicit
-        ],
-        alias: {
-            admin: 'projects/admin',
-            common: 'projects/common',
-            facia: 'projects/facia',
-            membership: 'projects/membership',
-            commercial: 'projects/commercial',
-            journalism: 'projects/journalism',
+	entry: {
+		standard: path.join(
+			__dirname,
+			'static',
+			'src',
+			'javascripts',
+			'boot.js',
+		),
+		admin: path.join(
+			__dirname,
+			'static',
+			'src',
+			'javascripts',
+			'bootstraps',
+			'admin.js',
+		),
+		// Old VideoJS embed
+		'videojs-embed': path.join(
+			__dirname,
+			'static',
+			'src',
+			'javascripts',
+			'bootstraps',
+			'videojs-embed.js',
+		),
+		// Video embed with native video player enhancements
+		'video-embed': path.join(
+			__dirname,
+			'static',
+			'src',
+			'javascripts',
+			'bootstraps',
+			'video-embed.js',
+		),
+		'youtube-embed': path.join(
+			__dirname,
+			'static',
+			'src',
+			'javascripts',
+			'bootstraps',
+			'youtube-embed.js',
+		),
+	},
+	output: {
+		path: path.join(__dirname, 'static', 'target', 'javascripts'),
+	},
+	resolve: {
+		modules: [
+			path.join(__dirname, 'static', 'src', 'javascripts'),
+			path.join(__dirname, 'static', 'vendor', 'javascripts'),
+			'node_modules', // default location, but we're overiding above, so it needs to be explicit
+		],
+		alias: {
+			admin: 'projects/admin',
+			common: 'projects/common',
+			facia: 'projects/facia',
+			membership: 'projects/membership',
+			commercial: 'projects/commercial',
+			journalism: 'projects/journalism',
 
-            // #wp-rjs weird old aliasing from requirejs
-            videojs: 'video.js',
+			// #wp-rjs weird old aliasing from requirejs
+			videojs: 'video.js',
 
-            svgs: path.join(__dirname, 'static', 'src', 'inline-svgs'),
-            'ophan/ng': 'ophan-tracker-js',
-            'ophan/embed': 'ophan-tracker-js/build/ophan.embed',
-            lodash: 'lodash-es',
-        },
-        extensions: ['.js', '.ts', '.tsx', '.jsx'],
-        symlinks: false, // Inserted to enable linking @guardian/consent-management-platform
-    },
-    resolveLoader: {
-        modules: [
-            path.resolve(__dirname, 'dev', 'webpack-loaders'),
-            // TODO: atom-renderer's loaders are actually dependencies of frontend, not atom-renderer
-            // They should be listed as peerDependencies in atom-renderer
-            // https://github.com/guardian/atom-renderer/issues/41
-            path.resolve(
-                __dirname,
-                'node_modules',
-                '@guardian',
-                'atom-renderer',
-                'node_modules'
-            ),
-            'node_modules',
-        ],
-    },
-    module: {
-        rules: [
-            {
-                test: /\.[jt]sx?|mjs$/,
-                exclude: [
-                    {
-                        test: /node_modules/,
-                        exclude: [
-                            /@guardian\/(?!(automat-modules|automat-contributions|atom-renderer))/,
-                            /dynamic-import-polyfill/,
-                        ],
-                    },
-                    path.resolve(__dirname, 'static/vendor'),
-                ],
-                use: [
-                    {
-                        loader: 'babel-loader',
-                    },
-                    {
-                        loader: 'ts-loader',
-                        options: {
-                            transpileOnly: true,
-                        },
-                    },
-                ]
-            },
-            {
-                test: /\.svg$/,
-                exclude: /(node_modules)/,
-                loader: 'svg-loader',
-            },
-            {
-                test: /\.(html|css)$/,
-                exclude: /(node_modules)/,
-                loader: 'raw-loader',
-            },
-            {
-                include: path.resolve(__dirname, 'node_modules/preact-x'),
-                resolve: {
-                    alias: { preact: 'preact-x' },
-                },
-            },
-            // Atoms rely on locally defined variables (see atoms/vars.scss)
-            // to exhibit the same styles of the underlying platform. This
-            // module below exposes a loader that catches requests for
-            // atoms's CSS and automatically swaps in values for these variables
-            ...require('@guardian/atom-renderer/webpack/css')({
-                cssVarsPath: path.join(
-                    __dirname,
-                    'static',
-                    'src',
-                    'stylesheets',
-                    'atoms',
-                    'vars.scss'
-                ),
-            }),
-        ],
-    },
-    plugins: [
-        // Makes videosjs available to all modules in the videojs chunk.
-        // videojs plugins expect this object to be available globally,
-        // but it's sufficient to scope it at the chunk level
-        new webpack.ProvidePlugin({
-            videojs: 'videojs',
-        }),
+			svgs: path.join(__dirname, 'static', 'src', 'inline-svgs'),
+			'ophan/ng': 'ophan-tracker-js',
+			'ophan/embed': 'ophan-tracker-js/build/ophan.embed',
+			lodash: 'lodash-es',
+			react: 'preact/compat',
+			'react-dom': 'preact/compat',
+		},
+		extensions: ['.js', '.ts', '.tsx', '.jsx'],
+		symlinks: false, // Inserted to enable linking @guardian/consent-management-platform
+	},
+	resolveLoader: {
+		modules: [
+			path.resolve(__dirname, 'dev', 'webpack-loaders'),
+			// TODO: atom-renderer's loaders are actually dependencies of frontend, not atom-renderer
+			// They should be listed as peerDependencies in atom-renderer
+			// https://github.com/guardian/atom-renderer/issues/41
+			path.resolve(
+				__dirname,
+				'node_modules',
+				'@guardian',
+				'atom-renderer',
+				'node_modules',
+			),
+			'node_modules',
+		],
+	},
+	module: {
+		rules: [
+			{
+				test: /\.[jt]sx?|mjs$/,
+				exclude: [
+					{
+						test: /node_modules/,
+						exclude: [
+							/@guardian\/(?!(automat-modules|automat-contributions|atom-renderer))/,
+							/dynamic-import-polyfill/,
+						],
+					},
+					path.resolve(__dirname, 'static/vendor'),
+				],
+				use: [
+					{
+						loader: 'babel-loader',
+					},
+					{
+						loader: 'ts-loader',
+						options: {
+							transpileOnly: true,
+						},
+					},
+				],
+			},
+			{
+				test: /\.svg$/,
+				exclude: /(node_modules)/,
+				loader: 'svg-loader',
+			},
+			{
+				test: /\.(html|css)$/,
+				exclude: /(node_modules)/,
+				loader: 'raw-loader',
+			},
+			// Atoms rely on locally defined variables (see atoms/vars.scss)
+			// to exhibit the same styles of the underlying platform. This
+			// module below exposes a loader that catches requests for
+			// atoms's CSS and automatically swaps in values for these variables
+			...require('@guardian/atom-renderer/webpack/css')({
+				cssVarsPath: path.join(
+					__dirname,
+					'static',
+					'src',
+					'stylesheets',
+					'atoms',
+					'vars.scss',
+				),
+			}),
+		],
+	},
+	plugins: [
+		// Makes videosjs available to all modules in the videojs chunk.
+		// videojs plugins expect this object to be available globally,
+		// but it's sufficient to scope it at the chunk level
+		new webpack.ProvidePlugin({
+			videojs: 'videojs',
+		}),
 
-        new CircularDependencyPlugin({
-            // exclude detection of files based on a RegExp
-            exclude: /node_modules/,
-            // add errors to webpack instead of warnings
-            failOnError: true,
-        }),
+		new CircularDependencyPlugin({
+			// exclude detection of files based on a RegExp
+			exclude: /node_modules/,
+			// add errors to webpack instead of warnings
+			failOnError: true,
+		}),
 
-        new webpack.DefinePlugin({
-            'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
-        }),
-    ],
-    externals: {
-        xhr2: {},
-    },
+		new webpack.DefinePlugin({
+			'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+		}),
+	],
+	externals: {
+		xhr2: {},
+	},
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7384,12 +7384,6 @@ ignore@^5.0.5, ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
-immutability-helper@^2.7.1:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/immutability-helper/-/immutability-helper-2.9.0.tgz#04a1c646300cd3a68aa5dc1daa7758da2ca75292"
-  dependencies:
-    invariant "^2.2.0"
-
 immutable@^3:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
@@ -7522,12 +7516,6 @@ interpret@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
-
-invariant@^2.2.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
-  dependencies:
-    loose-envify "^1.0.0"
 
 invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
@@ -10809,39 +10797,15 @@ postcss@^7.0.2:
     source-map "^0.6.1"
     supports-color "^5.5.0"
 
-preact-compat@^3.18.4:
-  version "3.18.4"
-  resolved "https://registry.yarnpkg.com/preact-compat/-/preact-compat-3.18.4.tgz#fbe76ddd30356c68e3ccde608107104946f2cf8d"
-  dependencies:
-    immutability-helper "^2.7.1"
-    preact-render-to-string "^3.8.2"
-    preact-transition-group "^1.1.1"
-    prop-types "^15.6.2"
-    standalone-react-addons-pure-render-mixin "^0.1.1"
-
-preact-render-to-string@^3.8.2:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/preact-render-to-string/-/preact-render-to-string-3.8.2.tgz#bd72964d705a57da3a9e72098acaa073dd3ceff9"
-  dependencies:
-    pretty-format "^3.5.1"
-
-preact-transition-group@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/preact-transition-group/-/preact-transition-group-1.1.1.tgz#f0a49327ea515ece34ea2be864c4a7d29e5d6e10"
-
-"preact-x@npm:preact@10.3.1":
-  version "10.3.1"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.3.1.tgz#70a2cc5484ca727c992216dfc528907d240e0a05"
-  integrity sha512-CaKtEY235GtuypRRvaMxM3PNy44OzQj8BO7plXbPwF+iJzNnUufgHtqRA6NbjeWnfy+cN1dP1MFTAGxJmCiPqQ==
-
 preact@^10.4.6:
   version "10.4.6"
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.4.6.tgz#86cc43396e4bdd755726a2b4b1f0529e78067cd3"
   integrity sha512-80WJfXH53yyINig5Wza/8MD9n4lMg9G6aN00ws0ptsAaY/Fu/M7xW4zICf7OLfocVltxS30wvNQ8oIbUyZS1tw==
 
-preact@^8.2.9:
-  version "8.2.9"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.9.tgz#813ba9dd45e5d97c5ea0d6c86d375b3be711cc40"
+preact@^10.5.13:
+  version "10.5.13"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.13.tgz#85f6c9197ecd736ce8e3bec044d08fd1330fa019"
+  integrity sha512-q/vlKIGNwzTLu+jCcvywgGrt+H/1P/oIRSD6mV4ln3hmlC+Aa34C7yfPI4+5bzW8pONyVXYS7SvXosy2dKKtWQ==
 
 "prebid.js@https://github.com/guardian/Prebid.js#681fbb":
   version "3.26.0"
@@ -10895,10 +10859,6 @@ pretty-format@^26.0.0, pretty-format@^26.6.2:
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
-
-pretty-format@^3.5.1:
-  version "3.8.0"
-  resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz#bfbed56d5e9a776645f4b1ff7aa1a3ac4fa3c385"
 
 prettysize@^0.1.0:
   version "0.1.0"
@@ -11146,15 +11106,6 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@16.7.0:
-  version "16.7.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.7.0.tgz#a17b2a7ca89ee7390bc1ed5eb81783c7461748b8"
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.12.0"
-
 react-dom@^0.14.0:
   version "0.14.8"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-0.14.8.tgz#0f1c547514263f771bd31814a739e5306575069e"
@@ -11198,15 +11149,6 @@ react@^16.13.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-
-react@^16.8.3:
-  version "16.8.3"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.8.3.tgz#c6f988a2ce895375de216edcfaedd6b9a76451d9"
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.13.3"
 
 read-cache@^1.0.0:
   version "1.0.0"
@@ -11947,20 +11889,6 @@ saxes@^5.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.12.0.tgz#8ab17699939c0aedc5a196a657743c496538647b"
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-
-scheduler@^0.13.3:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.3.tgz#bed3c5850f62ea9c716a4d781f9daeb9b2a58896"
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-
 scheduler@^0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
@@ -12484,10 +12412,6 @@ stack-utils@^2.0.2:
   integrity sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==
   dependencies:
     escape-string-regexp "^2.0.0"
-
-standalone-react-addons-pure-render-mixin@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/standalone-react-addons-pure-render-mixin/-/standalone-react-addons-pure-render-mixin-0.1.1.tgz#3c7409f4c79c40de9ac72c616cf679a994f37551"
 
 static-extend@^0.1.1:
   version "0.1.2"


### PR DESCRIPTION
## What does this change?
- Remove Preact 8 (and `preact/compact`)
- Add Preact 10 (X) as dependency
- Import directly from `react` and redirect to preact 10's compact using webpack aliases

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
- Reduce bundle size
- Aligne everything to Preact-10

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
