### PR TITLE
Adds `role` to the DCR model for Interactive Atoms

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -93,13 +93,13 @@ object ArticlePageChecks {
     // See: https://github.com/guardian/dotcom-rendering/blob/master/packages/frontend/web/components/lib/ArticleRenderer.tsx
     def unsupportedElement(blockElement: BlockElement) =
       blockElement match {
-        case _: TextBlockElement                 => false
-        case _: ImageBlockElement                => false
-        case _: VideoBlockElement                => false
-        case _: GuVideoBlockElement              => false
-        case _: EmbedBlockElement                => false
+        case _: TextBlockElement                    => false
+        case _: ImageBlockElement                   => false
+        case _: VideoBlockElement                   => false
+        case _: GuVideoBlockElement                 => false
+        case _: EmbedBlockElement                   => false
         case ContentAtomBlockElement(_, "media", _) => false
-        case _                                   => true
+        case _                                      => true
       }
 
     !page.article.blocks.exists(_.main.exists(_.elements.exists(unsupportedElement)))

--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -70,7 +70,7 @@ object ArticlePageChecks {
         case _: UnknownBlockElement   => false
         case _: VideoBlockElement     => false
         case _: WitnessBlockElement   => false
-        case ContentAtomBlockElement(_, atomtype) => {
+        case ContentAtomBlockElement(_, atomtype, _) => {
           // ContentAtomBlockElement was expanded to include atomtype.
           // To support an atom type, just add it to supportedAtomTypes
           val supportedAtomTypes =
@@ -98,7 +98,7 @@ object ArticlePageChecks {
         case _: VideoBlockElement                => false
         case _: GuVideoBlockElement              => false
         case _: EmbedBlockElement                => false
-        case ContentAtomBlockElement(_, "media") => false
+        case ContentAtomBlockElement(_, "media", _) => false
         case _                                   => true
       }
 

--- a/article/app/views/fragments/email/emailArticleBody.scala.html
+++ b/article/app/views/fragments/email/emailArticleBody.scala.html
@@ -234,7 +234,7 @@
                         }
                     }
 
-                    case ContentAtomBlockElement(atomId, atomtype) => {
+                    case ContentAtomBlockElement(atomId, atomtype, role) => {
                         @page.article.content.media.find(_.id == atomId).map { atom: MediaAtom =>
                             @atom.posterImage.flatMap(EmailVideoImage.bestSrcFor).map { imageUrl =>
                                 @atom.activeAssets.headOption.map { asset =>

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -803,6 +803,12 @@ object PageElement {
         atom <- atoms.find(_.id == contentAtom.atomId)
       } yield atom
 
+    def extractRole: Option[String] =
+      for {
+        contentAtom <- element.contentAtomTypeData
+        role <- contentAtom.role
+      } yield role
+
     element.`type` match {
 
       case Text =>
@@ -1060,11 +1066,6 @@ object PageElement {
           }
 
           case Some(interactive: InteractiveAtom) => {
-            val maybeRole = for {
-              contentAtom <- element.contentAtomTypeData
-              role <- contentAtom.role
-            } yield role
-
             val encodedId = URLEncoder.encode(interactive.id, "UTF-8")
             Some(
               InteractiveAtomBlockElement(
@@ -1074,7 +1075,7 @@ object PageElement {
                 css = Some(interactive.css),
                 js = interactive.mainJS,
                 placeholderUrl = interactive.placeholderUrl,
-                role = maybeRole,
+                role = extractRole,
               ),
             )
           }

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -799,14 +799,14 @@ object PageElement {
   ): List[PageElement] = {
     def extractAtom: Option[Atom] =
       for {
-        contentAtom <- element.contentAtomTypeData
-        atom <- atoms.find(_.id == contentAtom.atomId)
+        d <- element.contentAtomTypeData
+        atom <- atoms.find(_.id == d.atomId)
       } yield atom
 
     def extractRole: Option[String] =
       for {
-        contentAtom <- element.contentAtomTypeData
-        role <- contentAtom.role
+        d <- element.contentAtomTypeData
+        role <- d.role
       } yield role
 
     element.`type` match {

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -801,7 +801,6 @@ object PageElement {
       for {
         contentAtom <- element.contentAtomTypeData
         atom <- atoms.find(_.id == contentAtom.atomId)
-        atomRole <- contentAtom.role
       } yield atom
 
     element.`type` match {
@@ -1061,6 +1060,11 @@ object PageElement {
           }
 
           case Some(interactive: InteractiveAtom) => {
+            val maybeRole = for {
+            contentAtom <- element.contentAtomTypeData
+            role <- contentAtom.role
+            } yield role
+
             val encodedId = URLEncoder.encode(interactive.id, "UTF-8")
             Some(
               InteractiveAtomBlockElement(
@@ -1070,7 +1074,7 @@ object PageElement {
                 css = Some(interactive.css),
                 js = interactive.mainJS,
                 placeholderUrl = interactive.placeholderUrl,
-                role = Some(interactive.role),
+                role = maybeRole,
               ),
             )
           }

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -797,19 +797,17 @@ object PageElement {
       overrideImage: Option[ImageElement],
       edition: Edition,
   ): List[PageElement] = {
-
-    def extractAtomWithRole(element: ApiBlockElement): Option[(Atom, Option[String])] = {
-      val role: Option[String] =
-        for {
-          d <- element.contentAtomTypeData
-          role <- d.role
-        } yield role
-
+    def extractAtom: Option[Atom] =
       for {
         d <- element.contentAtomTypeData
         atom <- atoms.find(_.id == d.atomId)
-      } yield (atom, role)
-    }
+      } yield atom
+
+    def extractRole: Option[String] =
+      for {
+        d <- element.contentAtomTypeData
+        role <- d.role
+      } yield role
 
     element.`type` match {
 
@@ -1015,9 +1013,9 @@ object PageElement {
       // 3. CalloutBlockElement
 
       case Contentatom =>
-        (extractAtomWithRole(element) match {
+        (extractAtom match {
 
-          case Some((audio: AudioAtom, _: Option[String])) => {
+          case Some(audio: AudioAtom) => {
             Some(
               AudioAtomBlockElement(
                 id = audio.id,
@@ -1031,7 +1029,7 @@ object PageElement {
             )
           }
 
-          case Some((chart: ChartAtom, _: Option[String])) => {
+          case Some(chart: ChartAtom) => {
             val encodedId = URLEncoder.encode(chart.id, "UTF-8")
             // chart.id is a uuid, so there is no real need to url-encode it but just to be safe
             Some(
@@ -1045,11 +1043,11 @@ object PageElement {
             )
           }
 
-          case Some((explainer: ExplainerAtom, _: Option[String])) => {
+          case Some(explainer: ExplainerAtom) => {
             Some(ExplainerAtomBlockElement(explainer.id, explainer.title, explainer.body))
           }
 
-          case Some((guide: GuideAtom, _: Option[String])) => {
+          case Some(guide: GuideAtom) => {
             val html = guide.data.items
               .map(item => s"${item.title.map(t => s"<p><strong>${t}</strong></p>").getOrElse("")}${item.body}")
               .mkString("")
@@ -1067,7 +1065,7 @@ object PageElement {
             )
           }
 
-          case Some((interactive: InteractiveAtom, role: Option[String])) => {
+          case Some(interactive: InteractiveAtom) => {
             val encodedId = URLEncoder.encode(interactive.id, "UTF-8")
             Some(
               InteractiveAtomBlockElement(
@@ -1077,12 +1075,12 @@ object PageElement {
                 css = Some(interactive.css),
                 js = interactive.mainJS,
                 placeholderUrl = interactive.placeholderUrl,
-                role = role,
+                role = extractRole,
               ),
             )
           }
 
-          case Some((mediaAtom: MediaAtom, _: Option[String])) => {
+          case Some(mediaAtom: MediaAtom) => {
             val imageOverride = overrideImage.map(_.images).flatMap(Video700.bestSrcFor)
             val altText = overrideImage.flatMap(_.images.allImages.headOption.flatMap(_.altText))
             mediaAtom match {
@@ -1118,7 +1116,7 @@ object PageElement {
             }
           }
 
-          case Some((profile: ProfileAtom, _: Option[String])) => {
+          case Some(profile: ProfileAtom) => {
             val html = profile.data.items
               .map(item => s"${item.title.map(t => s"<p><strong>${t}</strong></p>").getOrElse("")}${item.body}")
               .mkString("")
@@ -1136,7 +1134,7 @@ object PageElement {
             )
           }
 
-          case Some((qa: QandaAtom, _: Option[String])) => {
+          case Some(qa: QandaAtom) => {
             Some(
               QABlockElement(
                 id = qa.id,
@@ -1148,7 +1146,7 @@ object PageElement {
             )
           }
 
-          case Some((timeline: TimelineAtom, _: Option[String])) => {
+          case Some(timeline: TimelineAtom) => {
             Some(
               TimelineBlockElement(
                 id = timeline.id,
@@ -1167,7 +1165,7 @@ object PageElement {
               ),
             )
           }
-          case Some((quizAtom: QuizAtom, _: Option[String])) => {
+          case Some(quizAtom: QuizAtom) => {
             val questions = quizAtom.content.questions.map { q =>
               QuizAtomQuestion(
                 id = q.id,
@@ -1200,7 +1198,7 @@ object PageElement {
 
           // Here we capture all the atom types which are not yet supported.
           // ContentAtomBlockElement is mapped to null in the DCR source code.
-          case Some((atom, _: Option[String])) => Some(ContentAtomBlockElement(atom.id))
+          case Some(atom) => Some(ContentAtomBlockElement(atom.id))
 
           case _ => None
         }).toList

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -291,6 +291,7 @@ case class InteractiveAtomBlockElement(
     css: Option[String],
     js: Option[String],
     placeholderUrl: Option[String],
+    role: Option[String]
 ) extends PageElement
 object InteractiveAtomBlockElement {
   implicit val InteractiveAtomBlockElementWrites: Writes[InteractiveAtomBlockElement] =
@@ -800,6 +801,7 @@ object PageElement {
       for {
         contentAtom <- element.contentAtomTypeData
         atom <- atoms.find(_.id == contentAtom.atomId)
+        atomRole <- contentAtom.role
       } yield atom
 
     element.`type` match {
@@ -1068,6 +1070,7 @@ object PageElement {
                 css = Some(interactive.css),
                 js = interactive.mainJS,
                 placeholderUrl = interactive.placeholderUrl,
+                role = Some(interactive.role),
               ),
             )
           }

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -797,13 +797,14 @@ object PageElement {
       overrideImage: Option[ImageElement],
       edition: Edition,
   ): List[PageElement] = {
+
     def extractAtom: Option[Atom] =
       for {
         d <- element.contentAtomTypeData
         atom <- atoms.find(_.id == d.atomId)
       } yield atom
 
-    def extractRole: Option[String] =
+    val elementRole: Option[String] =
       for {
         d <- element.contentAtomTypeData
         role <- d.role
@@ -1075,7 +1076,7 @@ object PageElement {
                 css = Some(interactive.css),
                 js = interactive.mainJS,
                 placeholderUrl = interactive.placeholderUrl,
-                role = extractRole,
+                role = elementRole,
               ),
             )
           }

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -291,7 +291,7 @@ case class InteractiveAtomBlockElement(
     css: Option[String],
     js: Option[String],
     placeholderUrl: Option[String],
-    role: Option[String]
+    role: Option[String],
 ) extends PageElement
 object InteractiveAtomBlockElement {
   implicit val InteractiveAtomBlockElementWrites: Writes[InteractiveAtomBlockElement] =
@@ -1061,8 +1061,8 @@ object PageElement {
 
           case Some(interactive: InteractiveAtom) => {
             val maybeRole = for {
-            contentAtom <- element.contentAtomTypeData
-            role <- contentAtom.role
+              contentAtom <- element.contentAtomTypeData
+              role <- contentAtom.role
             } yield role
 
             val encodedId = URLEncoder.encode(interactive.id, "UTF-8")

--- a/common/app/model/liveblog/BlockElement.scala
+++ b/common/app/model/liveblog/BlockElement.scala
@@ -42,7 +42,6 @@ case class GuVideoBlockElement(assets: Seq[VideoAsset], imageMedia: ImageMedia, 
 case class VideoBlockElement(data: Map[String, String]) extends BlockElement
 case class EmbedBlockElement(html: Option[String], safe: Option[Boolean], alt: Option[String]) extends BlockElement
 case class ContentAtomBlockElement(atomId: String, atomtype: String, role: Option[String]) extends BlockElement
-case class InteractiveBlockElement(html: Option[String]) extends BlockElement
 case class CommentBlockElement(html: Option[String]) extends BlockElement
 case class TableBlockElement(html: Option[String]) extends BlockElement
 case class WitnessBlockElement(html: Option[String]) extends BlockElement
@@ -51,7 +50,6 @@ case class InstagramBlockElement(html: Option[String]) extends BlockElement
 case class VineBlockElement(html: Option[String]) extends BlockElement
 case class MapBlockElement(html: Option[String]) extends BlockElement
 case class UnknownBlockElement(html: Option[String]) extends BlockElement
-
 case class InteractiveBlockElement(html: Option[String], scriptUrl: Option[String] = None) extends BlockElement
 
 case class MembershipBlockElement(

--- a/common/app/model/liveblog/BlockElement.scala
+++ b/common/app/model/liveblog/BlockElement.scala
@@ -156,7 +156,7 @@ object BlockElement {
 
       case Embed => element.embedTypeData.map(d => EmbedBlockElement(d.html, d.safeEmbedCode, d.alt))
 
-      case Contentatom => element.contentAtomTypeData.map(d => ContentAtomBlockElement(d.atomId, d.atomType, Some(d.role)))
+      case Contentatom => element.contentAtomTypeData.map(d => ContentAtomBlockElement(d.atomId, d.atomType, d.role))
 
       case Pullquote       => element.pullquoteTypeData.map(d => PullquoteBlockElement(d.html))
       case Interactive     => element.interactiveTypeData.map(d => InteractiveBlockElement(d.html, d.scriptUrl))

--- a/common/app/model/liveblog/BlockElement.scala
+++ b/common/app/model/liveblog/BlockElement.scala
@@ -41,7 +41,8 @@ case class GuVideoBlockElement(assets: Seq[VideoAsset], imageMedia: ImageMedia, 
     extends BlockElement
 case class VideoBlockElement(data: Map[String, String]) extends BlockElement
 case class EmbedBlockElement(html: Option[String], safe: Option[Boolean], alt: Option[String]) extends BlockElement
-case class ContentAtomBlockElement(atomId: String, atomtype: String) extends BlockElement
+case class ContentAtomBlockElement(atomId: String, atomtype: String, role: Option[String]) extends BlockElement
+case class InteractiveBlockElement(html: Option[String]) extends BlockElement
 case class CommentBlockElement(html: Option[String]) extends BlockElement
 case class TableBlockElement(html: Option[String]) extends BlockElement
 case class WitnessBlockElement(html: Option[String]) extends BlockElement
@@ -155,7 +156,7 @@ object BlockElement {
 
       case Embed => element.embedTypeData.map(d => EmbedBlockElement(d.html, d.safeEmbedCode, d.alt))
 
-      case Contentatom => element.contentAtomTypeData.map(d => ContentAtomBlockElement(d.atomId, d.atomType))
+      case Contentatom => element.contentAtomTypeData.map(d => ContentAtomBlockElement(d.atomId, d.atomType, Some(d.role)))
 
       case Pullquote       => element.pullquoteTypeData.map(d => PullquoteBlockElement(d.html))
       case Interactive     => element.interactiveTypeData.map(d => InteractiveBlockElement(d.html, d.scriptUrl))


### PR DESCRIPTION
## What does this change?

We are now getting role through CAPI and need to add it to the DCR model so we can correctly position interactive atoms.

![image](https://user-images.githubusercontent.com/638051/111167087-a84bdf80-8598-11eb-811a-371f703c9669.png)


## Does this change need to be reproduced in dotcom-rendering ?

- [x] Yes (please indicate your plans for DCR Implementation)

Implementation TBC.

