### PR TITLE
Remove "Editor" from crosswords subnav

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -191,7 +191,6 @@ private object NavLinks {
     "/crosswords",
     children = List(
       NavLink("Blog", "/crosswords/crossword-blog"),
-      NavLink("Editor", "/crosswords/series/crossword-editor-update"),
       NavLink("Quick", "/crosswords/series/quick"),
       NavLink("Cryptic", "/crosswords/series/cryptic"),
       NavLink("Prize", "/crosswords/series/prize"),


### PR DESCRIPTION
## What does this change?
As requested by CP, this removes Editor from the crosswords subnav, which is no longer an active series of crosswords.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No (flows through)
- [ ] Yes (please indicate your plans for DCR Implementation)