### PR TITLE
Handle discussion IDs using Facia client instead of Frontend

### DIFF
--- a/common/app/layout/DiscussionSettings.scala
+++ b/common/app/layout/DiscussionSettings.scala
@@ -13,8 +13,6 @@ object DiscussionSettings {
     DiscussionSettings(
       faciaContent.discussion.isCommentable,
       faciaContent.discussion.isClosedForComments,
-      //TODO: this is a quick fix only - remove once we've released a fixed fapi client
       faciaContent.discussion.discussionId
-        .map(_.replaceFirst("^[a-zA-Z]+://www.theguardian.com", "")),
     )
 }

--- a/common/app/layout/DiscussionSettings.scala
+++ b/common/app/layout/DiscussionSettings.scala
@@ -13,6 +13,6 @@ object DiscussionSettings {
     DiscussionSettings(
       faciaContent.discussion.isCommentable,
       faciaContent.discussion.isClosedForComments,
-      faciaContent.discussion.discussionId
+      faciaContent.discussion.discussionId,
     )
 }

--- a/common/app/model/PressedDiscussionSettings.scala
+++ b/common/app/model/PressedDiscussionSettings.scala
@@ -16,7 +16,5 @@ object PressedDiscussionSettings {
       isClosedForComments = FaciaContentUtils.isClosedForComments(content),
       discussionId = FaciaContentUtils
         .discussionId(content)
-        //TODO: this is a quick fix only - remove once we've released a fixed fapi client
-        .map(_.replaceFirst("^[a-zA-Z]+://www.theguardian.com", "")),
     )
 }

--- a/common/app/model/PressedDiscussionSettings.scala
+++ b/common/app/model/PressedDiscussionSettings.scala
@@ -15,6 +15,6 @@ object PressedDiscussionSettings {
       isCommentable = FaciaContentUtils.isCommentable(content),
       isClosedForComments = FaciaContentUtils.isClosedForComments(content),
       discussionId = FaciaContentUtils
-        .discussionId(content)
+        .discussionId(content),
     )
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,7 +32,7 @@ object Dependencies {
   val cssParser = "net.sourceforge.cssparser" % "cssparser" % "0.9.23"
   val contentApiClient = "com.gu" %% "content-api-client" % capiVersion
   val dfpAxis = "com.google.api-ads" % "dfp-axis" % "4.12.0"
-  val faciaFapiScalaClient = "com.gu" %% "fapi-client-play26" % faciaVersion
+  val faciaFapiScalaClient = "com.gu" %% "fapi-client-play27" % faciaVersion
   val identityCookie = "com.gu.identity" %% "identity-cookie" % identityLibVersion
   val identityModel = "com.gu.identity" %% "identity-model" % identityLibVersion
   val identityAuthPlay = "com.gu.identity" %% "identity-auth-play" % identityLibVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val identityLibVersion = "3.239"
   val awsVersion = "1.11.240"
   val capiVersion = "17.10"
-  val faciaVersion = "3.2.2"
+  val faciaVersion = "3.3.0"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"
@@ -32,7 +32,7 @@ object Dependencies {
   val cssParser = "net.sourceforge.cssparser" % "cssparser" % "0.9.23"
   val contentApiClient = "com.gu" %% "content-api-client" % capiVersion
   val dfpAxis = "com.google.api-ads" % "dfp-axis" % "4.12.0"
-  val faciaFapiScalaClient = "com.gu" %% "fapi-client-play27" % faciaVersion
+  val faciaFapiScalaClient = "com.gu" %% "fapi-client-play26" % faciaVersion
   val identityCookie = "com.gu.identity" %% "identity-cookie" % identityLibVersion
   val identityModel = "com.gu.identity" %% "identity-model" % identityLibVersion
   val identityAuthPlay = "com.gu.identity" %% "identity-auth-play" % identityLibVersion


### PR DESCRIPTION
## What does this change?
Bump Scala Facia client version to v2.3.0. This version introduces a fix for the new short URL format. As a result we can remove the temporary fix introduced in #23579 .

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
