### PR TITLE
Update Ophan Tracker-JS for Attention-Time unskew

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "fence": "guardian/fence#0.2.11",
     "lodash-es": "^4.17.21",
     "object-fit-videos": "^1.0.3",
-    "ophan-tracker-js": "1.3.23",
+    "ophan-tracker-js": "1.3.24",
     "preact": "^10.5.13",
     "prebid.js": "https://github.com/guardian/Prebid.js#681fbb",
     "qwery": "3.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10137,10 +10137,10 @@ openurl@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/openurl/-/openurl-1.1.1.tgz#3875b4b0ef7a52c156f0db41d4609dbb0f94b387"
 
-ophan-tracker-js@1.3.23:
-  version "1.3.23"
-  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.23.tgz#e63ca951370b98f265ba654ec4c0db86c15cd822"
-  integrity sha512-MfNMDKUJ0uv9tq3j2B2ISjht8EPs73No8r0NH+H9D3ExrHi8wL9SlPcuVC/Ma2vI7quibduko2RzzuhvAX3BIQ==
+ophan-tracker-js@1.3.24:
+  version "1.3.24"
+  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.24.tgz#8bee64a8dfcba840d097cc816c5d7ed3e0a50dcc"
+  integrity sha512-bFm5nh12KWwy2jxMSHlnVOPNj/3YvlQiGykUqVpMqiIVIgr8GETfVaWHS3SZzZ73pk4oV8kEBphBUT6zl5IlxA==
 
 opn@5.3.0:
   version "5.3.0"


### PR DESCRIPTION
## What does this change?

This upgrade of Ophan's Tracker JS contains two updates:

* https://github.com/guardian/ophan/pull/4063 - work towards removing a possible source of Attention Time metric bias, that is likely to have caused [Attention Times of zero seconds to have been relatively over-reported for dotcom-rendering](https://trello.com/c/Vomnrhwe/39-pageview-underreporting-of-attention-time-on-dcr) (DCR).
* https://github.com/guardian/ophan/pull/4065 - gather stats on browser support for the `performance.now()` API, as a potential way to avoid _negative_ attention times being reported by browsers undergoing clock-skew.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (PR https://github.com/guardian/dotcom-rendering/pull/2717)

## Screenshots

https://user-images.githubusercontent.com/52038/111487583-65bd0b00-8730-11eb-8c99-eb39450112da.mov

## What is the value of this and can you measure success?

Ultimately, we hope for the [reported median Attention Time for DCR](https://tableau.gnmremote.com/#/views/Dotcomrendering/Topline?:iid=1) to move up to match that of pages served by the legacy system.

![image](https://user-images.githubusercontent.com/52038/111656179-31b21a80-8802-11eb-861a-5b5ba2af491f.png)

This PR is only groundwork for that, and should not visibly affect attention-time. The positive change will come when https://github.com/guardian/ophan/pull/4064 is merged in Ophan - but the new version of the Ophan Tracker JS library must be in use first.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)


### Tested

- [x] Locally
- [ ] On CODE (optional)


