### PR TITLE
Add World Cup Qualifying as a competition

### DIFF
--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -34,7 +34,7 @@ class LeagueTableController(
     "Ligue 1",
     "Women's Super League",
     "Champions League",
-    "Euro 2020 qualifying",
+    "World Cup 2022 qualifying",
     "Europa League",
     "Carabao Cup",
     "International friendlies",

--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -27,6 +27,7 @@ class LeagueTableController(
 
   // Competitions must be added to this list to show up at /football/tables
   val tableOrder: Seq[String] = Seq(
+    "World Cup 2022 qualifying",
     "Premier League",
     "Bundesliga",
     "Serie A",
@@ -34,7 +35,6 @@ class LeagueTableController(
     "Ligue 1",
     "Women's Super League",
     "Champions League",
-    "World Cup 2022 qualifying",
     "Europa League",
     "Carabao Cup",
     "International friendlies",

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -168,6 +168,13 @@ object CompetitionsProvider {
     ),
     Competition("751", "/football/euro-2020-qualifiers", "Euro 2020 qualifying", "Euro 2020 qual.", "Internationals"),
     Competition(
+      "701",
+      "/football/world-cup-2022-qualifiers",
+      "World Cup 2022 qualifying",
+      "World Cup 2022 qual.",
+      "Internationals",
+    ),
+    Competition(
       "510",
       "/football/uefa-europa-league",
       "Europa League",

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -166,7 +166,6 @@ object CompetitionsProvider {
       "European",
       tableDividers = List(2, 6, 21),
     ),
-    Competition("751", "/football/euro-2020-qualifiers", "Euro 2020 qualifying", "Euro 2020 qual.", "Internationals"),
     Competition(
       "701",
       "/football/world-cup-2022-qualifiers",


### PR DESCRIPTION
## What does this change?
Adds World Cup Qualifiers as a competition so that the fixtures are picked up on the fixtures page and the tables appear on the tables page! We already have a tag for the qualifiers, so I used the tag name as the path of the URL.

We could probably get rid of the Euro 2020/21 qualifiers now, but awaiting confirmation of that from CP/sport desk.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
![image](https://user-images.githubusercontent.com/8754692/111764923-aab18080-889b-11eb-9d54-d17abb478059.png)
