### PR TITLE
Update amp-iframe.html

### DIFF
--- a/static/vendor/data/amp-iframe.html
+++ b/static/vendor/data/amp-iframe.html
@@ -1,7 +1,7 @@
 <html>
 	<body>
 		<iframe
-			src="https://cdn.jsdelivr.net/npm/prebid-universal-creative@latest/dist/load-cookie-with-consent.html"
+			src="https://acdn.adnxs.com/prebid/amp/user-sync/load-cookie-with-consent.html"
 			height="0"
 			width="0"
 		></iframe>


### PR DESCRIPTION
## What does this change?

JSDeliver only serves javascript, so the iframe wasn’t parsed as HTML.


## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

User sync should now work.

## Checklist

### Does this affect other platforms?

- [X] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)