### PR TITLE
Switch to ARM Amigo recipe

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -56,5 +56,5 @@ deployments:
       cloudFormationStackName: frontend
       amiParametersToTags:
         AMI:
-          Recipe: frontend-base
+          Recipe: frontend-base-ARM
           AmigoStage: PROD


### PR DESCRIPTION
Note, PROD is already running this (but hardcoded) following the recent Graviton switch. This allows things to be dynamic again.

See original switch to Graviton PR here: https://github.com/guardian/platform/pull/1439.