### PR TITLE
Google PPID update

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
@@ -31,6 +31,7 @@ jest.mock('../../../../lib/raven');
 jest.mock('../../../common/modules/identity/api', () => ({
     isUserLoggedIn: () => true,
     getUserFromCookie: jest.fn(),
+    getUserFromApi: jest.fn(),
     getUrl: jest.fn(),
 }));
 jest.mock('ophan/ng', () => null);

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -10,7 +10,7 @@ import raven from '../../../../lib/raven';
 import sha1 from '../../../../lib/sha1';
 import { getPageTargeting } from '../../../common/modules/commercial/build-page-targeting';
 import { commercialFeatures } from '../../../common/modules/commercial/commercial-features';
-import { getUserFromCookie } from '../../../common/modules/identity/api';
+import { getUserFromApi, getUserFromCookie } from '../../../common/modules/identity/api';
 import { adFreeSlotRemove } from '../ad-free-slot-remove';
 import { init as initMessenger } from '../messenger';
 import { init as background } from '../messenger/background';
@@ -84,11 +84,14 @@ const removeAdSlots = () => {
 };
 
 const setPublisherProvidedId = () => {
-    const user = getUserFromCookie();
-    if (user) {
-        const hashedId = sha1.hash(user.id);
-        window.googletag.pubads().setPublisherProvidedId(hashedId);
-    }
+	// Also known as PPID
+	getUserFromApi((user) => {
+		if (user && user.privateFields && user.privateFields.googleTagId) {
+			window.googletag
+				.pubads()
+				.setPublisherProvidedId(user.privateFields.googleTagId);
+		}
+	});
 };
 
 export const init = () => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -7,7 +7,6 @@ import qwery from 'qwery';
 import config from '../../../../lib/config';
 import fastdom from '../../../../lib/fastdom-promise';
 import raven from '../../../../lib/raven';
-import sha1 from '../../../../lib/sha1';
 import { getPageTargeting } from '../../../common/modules/commercial/build-page-targeting';
 import { commercialFeatures } from '../../../common/modules/commercial/commercial-features';
 import { getUserFromApi, getUserFromCookie } from '../../../common/modules/identity/api';


### PR DESCRIPTION
## What does this change?

Update Google’s Publisher Provided ID (PPID) to the new value available from `idapi`.

We ensured that using `getUserFromApi()` did not result in an extra network call, thanks to `async-call-merger.js`.


[`async-call-merger.js`]: https://github.com/guardian/frontend/blob/3c0a7a6389d0a1e9ae2e68de8def48912a0c713f/static/src/javascripts/projects/common/modules/async-call-merger.js

<details>
<summary>Notes for subsequent PRs</summary>

Because we set this id on every page load, we investigated caching this value locally, similarly to what was previously done with `adData` user segments. The way that this is done is by checking that a weak hash of the `id` matches what’s stored in local storage—the logic is `id % 9999`. It’s worth noting that this logic has been [virtually untouched for 8 years `userAdTargeting.js`][userAdTargeting.js]. Checking this against the user id in the cookie seems a little brittle.


- Do we still need the `user.adData` field? I’ve only seen an empty array with the three users I have. I ran `localStorage['gu.ads.userSegmentsData']` in the console.
- How long should we cache this value for? This is currently saved for a single day, but we should maybe think about extending this
- This data is not purged when a user logs out, and never has. Only if a different user signs-in does the data get destroyed.
- What is the benefit of the user hash saved in localStorage?
- There is a [`async-call-merger.js`][] method that ensures all calls to `getUserFromApi` result in a single network call. Is this enough of an optimisation to let this happen on every page?


[userAdTargeting.js]: https://github.com/guardian/frontend/blob/1a8405163349bd5e4262277cf41994221c822b3e/common/app/assets/javascripts/modules/adverts/userAdTargeting.js

</details>

## What is the value of this and can you measure success?

The previous implementation was using a weak hash—`id %9999`—which could lead to user identification by third parties.

## Checklist

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [X] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
