### PR TITLE
increase mandatory gate audience to 30%

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
@@ -8,7 +8,7 @@ export const signInGateMainVariant = {
     author: 'Mahesh Makani',
     description:
         'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Main/Variant Audience.',
-    audience: 0.70,
+    audience: 0.60,
     audienceOffset: 0.0,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-mandatory.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-mandatory.js
@@ -5,8 +5,8 @@ export const signInGateMandoryTest = {
 	author: 'Peter Colley',
 	description:
 		'Compare mandatory gate (an article sigin gate without the dismiss button) with the main signin gate',
-	audience: 0.20,
-	audienceOffset: 0.70,
+	audience: 0.30,
+	audienceOffset: 0.60,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:
 		'3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss or reshown after 5 dismisses, not on help, info sections etc. exclude iOS 9 and guardian-live-australia, UK only, only users with specific CMP consents. Suppresses other banners, and appears over epics',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Increase mandatory gate audience to 30%

### Before

Audience was 20%

### After

Audience is 30%

## Why?

We want to reach 170K views of the variant by March 29


See https://github.com/guardian/dotcom-rendering/pull/2731