### PR TITLE
Make checking the source of videos case insensitive

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -1610,8 +1610,8 @@ object PageElement {
       url = data.url.getOrElse(originalUrl)
       thirdPartyTracking = containsThirdPartyTracking(element.tracking)
     } yield {
-      source match {
-        case "YouTube" =>
+      source.toLowerCase match {
+        case "youtube" =>
           VideoYoutubeBlockElement(
             caption,
             url,
@@ -1624,7 +1624,7 @@ object PageElement {
             data.source,
             data.sourceDomain,
           )
-        case "Vimeo" =>
+        case "vimeo" =>
           VideoVimeoBlockElement(
             caption,
             url,
@@ -1637,7 +1637,7 @@ object PageElement {
             data.source,
             data.sourceDomain,
           )
-        case "Facebook" =>
+        case "facebook" =>
           VideoFacebookBlockElement(
             caption,
             url,


### PR DESCRIPTION
## What does this change?
Makes checking of video sources from composer/CAPI case insensitive as a short-term fix for an issue caused by a change in the casing of "YouTube" coming from the tools. 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)