### PR TITLE
Add wikidata Guardian entry in sameAs similar to NYT

### DIFF
--- a/common/app/model/meta/LinkedData.scala
+++ b/common/app/model/meta/LinkedData.scala
@@ -22,6 +22,7 @@ case class Guardian(
       "https://www.facebook.com/theguardian",
       "https://twitter.com/guardian",
       "https://www.youtube.com/user/TheGuardian",
+      "https://www.wikidata.org/wiki/Q11148",
     ),
 ) extends LinkedData("Organization")
 

--- a/common/test/metadata/MetaDataMatcher.scala
+++ b/common/test/metadata/MetaDataMatcher.scala
@@ -28,7 +28,7 @@ object MetaDataMatcher extends Matchers {
 
     val socialNetworks = (organisation \ "sameAs").as[List[String]]
 
-    socialNetworks.size should be(3)
+    socialNetworks.size should be(4)
   }
 
   def ensureWebPage(result: Future[Result], articleUrl: String) {


### PR DESCRIPTION
## What does this change?

Improve [Google Knowledge Graph](https://en.wikipedia.org/wiki/Google_Knowledge_Graph) by linking our website with the wikidata entry in a similar way than the New York Times.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes 

## Screenshots


## What is the value of this and can you measure success?

Improving user experience when they search about the guardian.

**Example from NYT**
 <img width="531" alt="Screenshot 2021-03-15 at 09 21 29" src="https://user-images.githubusercontent.com/615085/112142187-2aa65600-8bce-11eb-823a-7f02ba286632.png">
**Example from The Guardian**
<img width="509" alt="Screenshot 2021-03-15 at 09 21 49" src="https://user-images.githubusercontent.com/615085/112142205-2da14680-8bce-11eb-9ffc-2ffc3deaa788.png">

I have made other changes in this area, as this change alone will not fix it.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
