### PR TITLE
Add SP domain as preconnect link to the head of the page

### DIFF
--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -6,7 +6,7 @@
 @import model.Page
 @import views.support.{SeoThumbnail, StripHtmlTags}
 @import conf.switches.Switches.{ComscoreSwitch, SmartAppBanner}
-@import play.api.Mode.Dev
+@import play.api.Mode.{Dev, Prod}
 
 <meta charset="utf-8">
 @page.metadata.description.map { description =>
@@ -30,7 +30,9 @@
 <link rel="preconnect" href="@Configuration.assets.path" />
 <link rel="preconnect" href="@Configuration.images.host" />
 <link rel="preconnect" href="//interactive.guim.co.uk" />
-
+@if(context.environment.mode == Prod){
+    <link rel="preconnect" href="https://sourcepoint.theguardian.com" />
+}
 
 @if(ComscoreSwitch.isSwitchedOn) {
     <link rel="dns-prefetch" href="//sb.scorecardresearch.com" />


### PR DESCRIPTION
## What does this change?

Add SP domain as preconnect link to the page head in order to reduce the queue time of requests to SP


**Note** Testing this on CODE it didn't remove the 560ms queued time but I think is worth testing it in PROD as well.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation) Equivalent PR in DCR coming up
DCR PR: https://github.com/guardian/dotcom-rendering/pull/2735

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?
Why know we will definitely call this domain's URL for all SP requests in all regions. This should allow establish an early connection with this domain and will speed up the page load.



### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
