### PR TITLE
Replace flatten and is empty lodash with native JS

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
@@ -38,7 +38,13 @@ const getSizeOpts = (sizesByBreakpoint) => {
     const sizeMapping = buildSizeMapping(sizesByBreakpoint);
     // as we're using sizeMapping, pull out all the ad sizes, as an array of arrays
 
-    const flattenSizeMappings = sizeMapping.map(size => size[1]).reduce((a, b) => [...a, ...b], [])
+    const flattenSizeMappings = sizeMapping.map(size => size[1]).reduce((a, b) => {
+        if (!b.length) {
+            return [...a, b];
+        }
+        return [...a, ...b]
+    }, []);
+
     const sizes = uniqBy(
         flattenSizeMappings,
         size => `${size[0]}-${size[1]}`

--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
@@ -1,4 +1,3 @@
-import flatten from 'lodash/flatten';
 import once from 'lodash/once';
 import uniqBy from 'lodash/uniqBy';
 import config from '../../../../lib/config';
@@ -38,8 +37,10 @@ const buildSizeMapping = (sizes) => {
 const getSizeOpts = (sizesByBreakpoint) => {
     const sizeMapping = buildSizeMapping(sizesByBreakpoint);
     // as we're using sizeMapping, pull out all the ad sizes, as an array of arrays
+
+    const flattenSizeMappings = sizeMapping.map(size => size[1]).reduce((a, b) => [...a, ...b], [])
     const sizes = uniqBy(
-        flatten(sizeMapping.map(size => size[1])),
+        flattenSizeMappings,
         size => `${size[0]}-${size[1]}`
     );
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.spec.js
@@ -1,0 +1,52 @@
+import { defineSlot } from './define-slot';
+
+beforeEach(() => {
+    const pubAds = {
+        setTargeting: jest.fn(),
+    };
+
+    const sizeMapping = {
+        sizes: [],
+        addSize: jest.fn(function(width, sizes) {
+            this.sizes.unshift([width, sizes]);
+        }),
+        build: jest.fn(function() {
+            const tmp = this.sizes;
+            this.sizes = [];
+            return tmp;
+        }),
+    };
+
+    window.googletag = {
+        defineSlot: jest.fn(() => window.googletag),
+        defineSizeMapping: jest.fn(() => window.googletag),
+        addService: jest.fn(() => window.googletag),
+        setTargeting: jest.fn(),
+        pubads() {
+            return pubAds;
+        },
+        sizeMapping() {
+            return sizeMapping;
+        },
+    };
+});
+
+describe('Define Slot', () => {
+    it('should call defineSlot with correct params', () => {
+        const slotDiv = document.createElement("div");
+        slotDiv.id = "dfp-ad--top-above-nav";
+        slotDiv.setAttribute('data-tablet', '1,1|2,2|728,90|88,71|fluid');
+        slotDiv.setAttribute('data-desktop', '1,1|2,2|728,90|940,230|900,250|970,250|88,71|fluid');
+
+        const topAboveNavSizes = {
+            tablet: [[1, 1], [2, 2], [728, 90], [88, 71], "fluid"],
+            desktop: [[1, 1], [2, 2], [728, 90], [940, 230], [900, 250], [970, 250], [88, 71], "fluid"]
+        };
+
+        defineSlot(slotDiv, topAboveNavSizes);
+
+        expect(window.googletag.defineSlot).toHaveBeenCalledWith( undefined, [
+            [1, 1], [2, 2], [728, 90], [940, 230], [900, 250], [970, 250], [88, 71], "fluid"],
+            "dfp-ad--top-above-nav");
+    });
+});

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.js
@@ -1,4 +1,3 @@
-import isEmpty from 'lodash/isEmpty';
 import config from '../../../../../lib/config';
 import { pbTestNameMap } from '../../../../../lib/url';
 import {
@@ -224,7 +223,7 @@ const getOzoneTargeting = () => {
 };
 
 // Is pbtest being used?
-const isPbTestOn = () => !isEmpty(pbTestNameMap());
+const isPbTestOn = () => Object.keys(pbTestNameMap()).length > 0;
 // Helper for conditions
 const inPbTestOr = liveClause => isPbTestOn() || liveClause;
 


### PR DESCRIPTION
## What does this change?

First PR for replacing lodash functions 

Replaces `lodash/flatten` and
`lodash/isEmpty` with native JS

## Performance results

### flatten
lhttps://jsbench.me/sckmuq8pk7/3
https://jsbench.me/sckmuq8pk7/2

### isEmpty
Lodash 55% slower than native
https://jsbench.me/vdkmuqbiqd/1 


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
