### PR TITLE
Fix `ajax.js` error

### DIFF
--- a/static/src/javascripts/lib/ajax.js
+++ b/static/src/javascripts/lib/ajax.js
@@ -25,6 +25,7 @@ const ajax = (params) => {
         credentials: options.withCredentials ? 'include' : undefined,
     }
 
+    // Ensure no “empty object” gets passed on GET or HEAD requests.
     if (['GET', 'HEAD'].includes(`${method}`.toUpperCase())) delete init.body;
 
     const r = fetch(url, init);

--- a/static/src/javascripts/lib/ajax.js
+++ b/static/src/javascripts/lib/ajax.js
@@ -14,7 +14,6 @@ const ajax = (params) => {
 
     const { url } = options;
     const headers = { ...options.headers };
-    if(options.headers !== undefined) headers.append( options.headers );
     if(options.contentType !== undefined)
         headers['Content-Type'] = options.contentType;
 

--- a/static/src/javascripts/lib/ajax.js
+++ b/static/src/javascripts/lib/ajax.js
@@ -12,7 +12,7 @@ const ajax = (params) => {
         options.crossOrigin = true;
     }
 
-    const { url } = options;
+    const { url, method } = options;
     const headers = { ...options.headers };
     if(options.contentType !== undefined)
         headers['Content-Type'] = options.contentType;
@@ -24,6 +24,8 @@ const ajax = (params) => {
         body: options.data ? JSON.stringify(options.data) : undefined,
         credentials: options.withCredentials ? 'include' : undefined,
     }
+
+    if (['GET', 'HEAD'].includes(`${method}`.toUpperCase())) delete init.body;
 
     const r = fetch(url, init);
 


### PR DESCRIPTION
## What does this change?

Fixes an outstanding bit of code flagged by @buck06191, which prevented the comments from loading on non-DCR articles.

### Tested

- [X] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
