### PR TITLE
Fix RR banners

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -360,7 +360,10 @@ export const renderBanner = (response) => {
             return fastdom.mutate(() => {
                 const container = document.createElement('div');
                 container.classList.add('site-message--banner');
-                container.classList.add('remote-banner', isPuzzlesBanner ? 'remote-banner--puzzles' : '');
+                container.classList.add('remote-banner');
+                if (isPuzzlesBanner) {
+                    container.classList.add('remote-banner--puzzles');
+                }
 
                 if (document.body) {
                     document.body.insertAdjacentElement('beforeend', container);


### PR DESCRIPTION
This is preventing banners from rendering because `classList.add` throws an exception if you give it an empty string


The error is:
`Error importing remote banner: SyntaxError: An invalid or illegal string was specified`