### PR TITLE
Add feature switch for the new puzzles banner

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -443,4 +443,14 @@ trait FeatureSwitches {
     sellByDate = new LocalDate(2021, 8, 3),
     exposeClientSide = true,
   )
+
+  val puzzlesBanner = Switch(
+    SwitchGroup.Feature,
+    "puzzles-banner",
+    "Enables the puzzles banner on puzzles pages",
+    owners = Seq(Owner.withGithub("i-hardy")),
+    safeState = Off,
+    sellByDate = new LocalDate(2022, 3, 31),
+    exposeClientSide = true,
+  )
 }

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -305,7 +305,7 @@ export const fetchPuzzlesData = async () => {
     const page = config.get('page');
     const payload = await buildBannerPayload();
     const forcePuzzlesBannerTest = isInVariantSynchronous(puzzlesBanner, 'variant');
-    const isPuzzlesBannerSwitchOn = config.get('switches.puzzlesBanner');
+    const isPuzzlesBannerSwitchOn = config.get('switches.puzzlesBanner', false);
     const userShouldSeeBanner = forcePuzzlesBannerTest || isPuzzlesBannerSwitchOn;
     const isPuzzlesPage = page.section === 'crosswords' || page.series === 'Sudoku';
 

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -224,9 +224,10 @@ const getStickyBottomBanner = (payload) => {
     });
 };
 
-const getPuzzlesBanner = () => {
+const getPuzzlesBanner = (payload) => {
     const isProd = config.get('page.isProd');
     const URL = isProd ? 'https://contributions.guardianapis.com/puzzles' : 'https://contributions.code.dev-guardianapis.com/puzzles?';
+    const json = JSON.stringify(payload);
 
     const forcedVariant = getForcedVariant('banner');
     const queryString = forcedVariant ? `?force=${forcedVariant}` : '';
@@ -234,6 +235,7 @@ const getPuzzlesBanner = () => {
     return fetchJson(`${URL}${queryString}`, {
         method: 'post',
         headers: { 'Content-Type': 'application/json' },
+        body: json,
     });
 }
 
@@ -303,14 +305,16 @@ export const fetchPuzzlesData = async () => {
     const page = config.get('page');
     const payload = await buildBannerPayload();
     const forcePuzzlesBannerTest = isInVariantSynchronous(puzzlesBanner, 'variant');
+    const isPuzzlesBannerSwitchOn = config.get('switches.puzzlesBanner');
+    const userShouldSeeBanner = forcePuzzlesBannerTest || isPuzzlesBannerSwitchOn;
     const isPuzzlesPage = page.section === 'crosswords' || page.series === 'Sudoku';
 
     if (payload.targeting.shouldHideReaderRevenue || payload.targeting.isPaidContent) {
         return null;
     }
 
-    if (forcePuzzlesBannerTest && isPuzzlesPage) {
-        return getPuzzlesBanner().then(json => {
+    if (userShouldSeeBanner && isPuzzlesPage) {
+        return getPuzzlesBanner(payload).then(json => {
             if (!json.data) {
                 return null;
             }


### PR DESCRIPTION
## What does this change?
This adds a feature switch to control the puzzles banner in addition to the 0% A/B test. It also ensures the usual banner payload including tracking information for Ophan is passed when the puzzles banner is requested.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

The necessary DCR work will be included in the work to enable the new banner on DCR.

## What is the value of this and can you measure success?

The 0% A/B test has allowed us to test the banner internally, but a feature switch is more suitable for the eventual launch as we intend to launch to everyone at once.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [x] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [x] Locally
- [ ] On CODE (optional)
