### PR TITLE
Bump ai.x-play-json-extensions version to 0.42.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"
   val playJsonVersion = "2.6.3"
-  val playJsonExtensionsVersion = "0.10.0"
+  val playJsonExtensionsVersion = "0.42.0"
   val guBox = "com.gu" %% "box" % "0.1.0"
   val apacheCommonsLang = "org.apache.commons" % "commons-lang3" % "3.11"
   val awsCore = "com.amazonaws" % "aws-java-sdk-core" % awsVersion


### PR DESCRIPTION
## What does this change?

Bump ai.x-play-json-extensions version to 0.42.0.

This will avoid using a 4 year old library for a more modern version, but also might help with generating a slightly less wild dependency tree (relevant for another work).