### PR TITLE
Update riff-raff plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -213,10 +213,6 @@ val main = root()
     rss,
   )
   .settings(
-    riffRaffBuildIdentifier := System
-      .getenv()
-      .getOrDefault("BUILD_NUMBER", "0")
-      .replaceAll("\"", ""),
     riffRaffUploadArtifactBucket := Some(
       System.getenv().getOrDefault("RIFF_RAFF_ARTIFACT_BUCKET", "aws-frontend-teamcity"),
     ),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -29,7 +29,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.1")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.3")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.0.0")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
 


### PR DESCRIPTION
## What does this change?

This PR updates the riff-raff sbt plugin to the latest version, 1.0.0 &rarr; **1.1.9**.

~Should fix commit url in riff-raff.~ Deprecated config was removed from `build.sbt`

Note, this brings the following warnings:
```log
~/code/frontend/build.sbt:24: warning: object Play in package sbt is deprecated (since 2.7.0): Use PlayWeb instead for a web project.
      filters,
      ^
~/code/frontend/build.sbt:38: warning: object Play in package sbt is deprecated (since 2.7.0): Use PlayWeb instead for a web project.
      ws,
      ^
~/code/frontend/build.sbt:54: warning: object Play in package sbt is deprecated (since 2.7.0): Use PlayWeb instead for a web project.
      jodaForms,
      ^
~/code/frontend/build.sbt:146: warning: object Play in package sbt is deprecated (since 2.7.0): Use PlayWeb instead for a web project.
      filters,
      ^
```

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [X] Locally
- [X] On CODE (optional)