### PR TITLE
Add format type data to rich links

### DIFF
--- a/onward/app/controllers/RichLinkController.scala
+++ b/onward/app/controllers/RichLinkController.scala
@@ -1,9 +1,9 @@
 package controllers
 
-import common.{Edition, ImplicitControllerExecutionContext, JsonComponent, GuLogging}
+import common.{Edition, GuLogging, ImplicitControllerExecutionContext, JsonComponent}
 import contentapi.ContentApiClient
 import implicits.Requests
-import model.{ApplicationContext, Cached, Content, ContentType}
+import model.{ApplicationContext, Cached, Content, ContentFormat, ContentType}
 import models.dotcomponents.{OnwardsUtils, RichLink, RichLinkTag}
 import play.api.mvc.{Action, AnyContent, ControllerComponents, RequestHeader}
 import play.twirl.api.Html
@@ -35,6 +35,7 @@ class RichLinkController(contentApiClient: ContentApiClient, controllerComponent
               .flatMap(_.properties.contributorLargeImagePath.map(ImgSrc(_, RichLinkContributor))),
             url = content.metadata.url,
             pillar = OnwardsUtils.determinePillar(content.metadata.pillar),
+            format = content.metadata.format.getOrElse(ContentFormat.defaultContentFormat),
           )
           Cached(900)(JsonComponent(richLink)(request, RichLink.writes))
         case Some(content) => renderContent(richLinkHtml(content), richLinkBodyHtml(content))

--- a/onward/app/models/dotcomponents/DotcomponentsOnwardsModels.scala
+++ b/onward/app/models/dotcomponents/DotcomponentsOnwardsModels.scala
@@ -1,7 +1,7 @@
 package models.dotcomponents
 
-import com.gu.contentapi.client.utils.{DesignType}
-import model.{DotcomContentType, Pillar}
+import com.gu.contentapi.client.utils.DesignType
+import model.{ContentFormat, DotcomContentType, Pillar}
 import play.api.libs.json.Json
 
 // duplicated in dotcomponentsdatamodel
@@ -26,6 +26,7 @@ case class RichLink(
     contributorImage: Option[String],
     url: String,
     pillar: String,
+    format: ContentFormat,
 )
 
 object RichLink {


### PR DESCRIPTION
## What does this change?
Adds the format type information from the CAPI client to the Rich link
data object. This is needed for DCR to use this information with rich
links.

See also: #23577 and #23593

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation) https://github.com/guardian/dotcom-rendering/pull/2634

## Screenshots
![image](https://user-images.githubusercontent.com/9122944/112458479-bf3ac080-8d54-11eb-9d25-3ab9832bacaa.png)

## What is the value of this and can you measure success?
Allows DCR integration of Format 

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
