### PR TITLE
Remove gifting property from DCR Navigation model

### DIFF
--- a/common/app/navigation/DCRNavigation.scala
+++ b/common/app/navigation/DCRNavigation.scala
@@ -8,7 +8,6 @@ case class ReaderRevenueLink(
     contribute: String,
     subscribe: String,
     support: String,
-    gifting: String,
     supporter: String,
 )
 
@@ -31,7 +30,6 @@ object ReaderRevenueLinks {
     getReaderRevenueUrl(SupportContribute, Header),
     getReaderRevenueUrl(SupportSubscribe, Header),
     getReaderRevenueUrl(Support, Header),
-    getReaderRevenueUrl(SupportGifting, Header),
     getReaderRevenueUrl(SupporterCTA, Header),
   )
 
@@ -39,7 +37,6 @@ object ReaderRevenueLinks {
     getReaderRevenueUrl(SupportContribute, Footer),
     getReaderRevenueUrl(SupportSubscribe, Footer),
     getReaderRevenueUrl(Support, Footer),
-    getReaderRevenueUrl(SupportGifting, Footer),
     getReaderRevenueUrl(SupporterCTA, Footer)
   )
 
@@ -47,7 +44,6 @@ object ReaderRevenueLinks {
     getReaderRevenueUrl(SupportContribute, SideMenu),
     getReaderRevenueUrl(SupportSubscribe, SideMenu),
     getReaderRevenueUrl(Support, SideMenu),
-    getReaderRevenueUrl(SupportGifting, SideMenu),
     getReaderRevenueUrl(SupporterCTA, SideMenu),
   )
 
@@ -55,7 +51,6 @@ object ReaderRevenueLinks {
     getReaderRevenueUrl(SupportContribute, AmpHeader),
     getReaderRevenueUrl(SupportSubscribe, AmpHeader),
     getReaderRevenueUrl(Support, AmpHeader),
-    getReaderRevenueUrl(SupportGifting, AmpHeader),
     getReaderRevenueUrl(SupporterCTA, AmpHeader),
   )
 
@@ -63,7 +58,6 @@ object ReaderRevenueLinks {
     getReaderRevenueUrl(SupportContribute, AmpFooter),
     getReaderRevenueUrl(SupportSubscribe, AmpFooter),
     getReaderRevenueUrl(Support, AmpFooter),
-    getReaderRevenueUrl(SupportGifting, AmpFooter),
     getReaderRevenueUrl(SupporterCTA, AmpFooter),
   )
 


### PR DESCRIPTION
## What does this change?

The recently merged PR https://github.com/guardian/dotcom-rendering/pull/2737 updated `dotcom-rendering` so the `gifting` property in the DCR Navigation Model sent from `frontend` is now optional. This means we can now remove it from the DCR Navigation Model in `frontend` without impacting `dotcom-rendering`. Which is what this PR does.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] Yes

Once we've removed this from this gifting property in `frontend` we can update `dotcom-rendering` and completely remove `gifting` from the model it expects `frontend` to send it.