### PR TITLE
Lodash native flattenDeep

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -158,9 +158,18 @@ const getUrlKeywords = (pageId) => {
     return [];
 };
 
-const flattenDeep = (arr) => Array.isArray(arr)
-    ? arr.reduce( (a, b) => a.concat(flattenDeep(b)) , [])
-    : [arr]
+const flattenDeep = arr => {
+    let flattened = [];
+    for (const a of arr) {
+        if (Array.isArray(a)) {
+            flattened = [...flattened, ...a];
+            flattened = [...flattenDeep(flattened)]
+        } else {
+            flattened.push(a);
+        }
+    }
+    return flattened;
+}
 
 const formatAppNexusTargeting = (obj) =>
     flattenDeep(

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -160,7 +160,6 @@ const getUrlKeywords = (pageId) => {
 
 const formatAppNexusTargeting = (obj) => {
     const asKeyValues = Object.keys(obj)
-        .filter((key) => obj[key] !== '' && obj[key] !== null)
         .map((key) => {
             const value = obj[key];
             return Array.isArray(value)

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -158,30 +158,19 @@ const getUrlKeywords = (pageId) => {
     return [];
 };
 
-const flattenDeep = arr => {
-    let flattened = [];
-    for (const a of arr) {
-        if (Array.isArray(a)) {
-            flattened = [...flattened, ...a];
-            flattened = [...flattenDeep(flattened)]
-        } else {
-            flattened.push(a);
-        }
-    }
-    return flattened;
-}
+const formatAppNexusTargeting = (obj) => {
+    const asKeyValues = Object.keys(obj)
+        .filter((key) => obj[key] !== '' && obj[key] !== null)
+        .map((key) => {
+            const value = obj[key];
+            return Array.isArray(value)
+                ? value.map(nestedValue => `${key}=${nestedValue}`)
+                : `${key}=${value}`;
+        });
 
-const formatAppNexusTargeting = (obj) =>
-    flattenDeep(
-        Object.keys(obj)
-            .filter((key) => obj[key] !== '' && obj[key] !== null)
-            .map((key) => {
-                const value = obj[key];
-                return Array.isArray(value)
-                    ? value.map(nestedValue => `${key}=${nestedValue}`)
-                    : `${key}=${value}`;
-            })
-    ).join(',');
+    const flattenDeep = Array.prototype.concat.apply([], asKeyValues);
+    return flattenDeep.join(',');
+}
 
 const buildAppNexusTargetingObject = once(
     (pageTargeting) =>

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -1,6 +1,5 @@
 import { cmp, onConsentChange } from '@guardian/consent-management-platform';
 import { storage } from '@guardian/libs';
-import flattenDeep from 'lodash/flattenDeep';
 import once from 'lodash/once';
 import pick from 'lodash/pick';
 import pickBy from 'lodash/pickBy';
@@ -158,6 +157,10 @@ const getUrlKeywords = (pageId) => {
     }
     return [];
 };
+
+const flattenDeep = (arr) => Array.isArray(arr)
+    ? arr.reduce( (a, b) => a.concat(flattenDeep(b)) , [])
+    : [arr]
 
 const formatAppNexusTargeting = (obj) =>
     flattenDeep(

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -376,6 +376,15 @@ describe('Build Page Targeting', () => {
             getBreakpoint.mockReturnValue('wide');
             expect(getPageTargeting().bp).toEqual('desktop');
         });
+
+
+        it('should set appNexusPageTargeting as flatten string', () => {
+            getBreakpoint.mockReturnValue('desktop');
+            getPageTargeting();
+            expect(config.get('page').appNexusPageTargeting).toEqual(
+                "sens=f,pt1=/football/series/footballweekly,pt2=us,pt3=video,pt4=ng,pt5=prince-charles-letters,pt5=uk/uk,pt5=prince-charles,pt6=5,pt7=desktop,pt9=seg1,seg2|presetOphanPageViewId|gabrielle-chan|news|"
+            );
+        });
     });
 
     describe('Build Page Targeting (ad-free)', () => {


### PR DESCRIPTION
## What does this change?
Replaces flattenDeep with native JS

Performance results shows native version is slower at runtime but we think the overall improvement in bundle size will speed up its execution time

### Performance results

~40% slower than lodash
https://jsbench.me/8gkmxhh8wf/2

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
