### PR TITLE
Change to logic dealing with comscore consent 

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/comscore.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.js
@@ -48,10 +48,17 @@ const initOnConsent = (state) => {
 export const init = () => {
     if (commercialFeatures.comscore) {
         onConsentChange(state => {
-            const canRunTcfv2 =
-                state.tcfv2 && getConsentFor('comscore', state);
-            const canRunCcpaOrAus = !!state.ccpa || !!state.aus; // always runs in CCPA and AUS
-            if (canRunTcfv2 || canRunCcpaOrAus) initOnConsent(true);
+
+            /* Rule is that comscore can run:
+                - in Tcfv2: Based on consent for comsocre
+                - in Australia: Always
+                - in CCPA: If the user hasn't chosen Do Not Sell
+            */
+            const canRunTcfv2 = state.tcfv2 && getConsentFor('comscore', state);
+            const canRunAus = !!state.aus;
+            const canRunCcpa = !!state.ccpa && !state.ccpa.doNotSell;
+
+            if (canRunTcfv2 || canRunAus || canRunCcpa) initOnConsent(true);
         });
     }
 

--- a/static/src/javascripts/projects/commercial/modules/comscore.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.spec.js
@@ -108,7 +108,7 @@ describe('comscore init', () => {
             expect(loadScript).toBeCalled();
         });
 
-        it('CCPA without consent: runs', () => {
+        it('CCPA without consent: does not run', () => {
             onConsentChange.mockImplementation(ccpaWithoutConsentMock);
             init();
             expect(loadScript).not.toBeCalled();

--- a/static/src/javascripts/projects/commercial/modules/comscore.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.spec.js
@@ -97,7 +97,7 @@ describe('comscore init', () => {
         it('CCPA without consent: runs', () => {
             onConsentChange.mockImplementation(ccpaWithoutConsentMock);
             init();
-            expect(loadScript).toBeCalled();
+            expect(loadScript).not.toBeCalled();
         });
     });
 });
@@ -117,7 +117,7 @@ describe('comscore initOnConsent', () => {
         _.initOnConsent(true);
         _.initOnConsent(true);
 
-        
+
         expect(loadScript).toBeCalledTimes(1);
     });
 });

--- a/static/src/javascripts/projects/commercial/modules/comscore.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.spec.js
@@ -44,6 +44,20 @@ const ccpaWithoutConsentMock = (callback) =>
         },
     });
 
+const AusWithoutConsentMock = (callback) =>
+    callback({
+        aus: {
+            doNotSell: true,
+        },
+    });
+
+const AusWithConsentMock = (callback) =>
+    callback({
+        aus: {
+            doNotSell: false,
+        },
+    });
+
 jest.mock('@guardian/libs', () => ({
     loadScript: jest.fn(() => Promise.resolve()),
 }));
@@ -98,6 +112,18 @@ describe('comscore init', () => {
             onConsentChange.mockImplementation(ccpaWithoutConsentMock);
             init();
             expect(loadScript).not.toBeCalled();
+        });
+
+        it('Aus without consent: runs', () => {
+            onConsentChange.mockImplementation(AusWithoutConsentMock);
+            init();
+            expect(loadScript).toBeCalled();
+        });
+
+        it('Aus with consent: runs', () => {
+            onConsentChange.mockImplementation(AusWithConsentMock);
+            init();
+            expect(loadScript).toBeCalled();
         });
     });
 });


### PR DESCRIPTION
## What does this change?
Comscore needs to be moved behind consent in CCPA.
The rules are:

- In TCFv2 areas: With consent
- In CCPA areas: with consent (opt-out means no comscore)
- In Australia: Always
- 
## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
Meet our consent obligations.

### Tested

- [x] Locally
- [ ] On CODE (optional)
