### PR TITLE
Short URLs redirect using webUrl field from CAPI

### DIFF
--- a/applications/app/controllers/ShortUrlsController.scala
+++ b/applications/app/controllers/ShortUrlsController.scala
@@ -29,9 +29,9 @@ class ShortUrlsController(
       .getResponse(contentApiClient.item(shortUrl))
       .map { response =>
         response.content
-          .map(_.id)
-          .map { id =>
-            Redirect(LinkTo(s"/$id"), queryString = queryString, status = MOVED_PERMANENTLY)
+          .map(_.webUrl)
+          .map { url =>
+            Redirect(LinkTo(url), queryString = queryString, status = MOVED_PERMANENTLY)
           }
           .getOrElse(NotFound)
       }


### PR DESCRIPTION
## What does this change?
As part of the "Evolving URLs" project, frontend needs to start consistently using the `webUrl` field from CAPI as the source of redirect location. The ID field is no longer the latest location for an item. This updates one place where we weren't already doing that: short URL redirects.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)