### PR TITLE
Use @guardian/braze-components for message cache & message brokering logic

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -253,17 +253,17 @@ const show = () => Promise.all([
         if (!container.attachShadow) {
             render(
                 <Component
-                    componentName={ messageConfig.extras.componentName}
+                    componentName={ message.extras.componentName}
                     logButtonClickWithBraze={(buttonId) => {
                         if (appboy) {
                             const thisButton = new appboy.InAppMessageButton(`Button ${buttonId}`,null,null,null,null,null,buttonId)
                             appboy.logInAppMessageButtonClick(
-                                thisButton, messageConfig
+                                thisButton, message
                             );
                         }
                     }}
                     submitComponentEvent={submitComponentEvent}
-                    brazeMessageProps={messageConfig.extras}
+                    brazeMessageProps={message.extras}
                 />
             , container);
         } else {
@@ -278,17 +278,17 @@ const show = () => Promise.all([
             const cached = (
                 <CacheProvider value={emotionCache}>
                     <Component
-                        componentName={ messageConfig.extras.componentName}
+                        componentName={ message.extras.componentName}
                         logButtonClickWithBraze={(buttonId) => {
                             if (appboy) {
                                 const thisButton = new appboy.InAppMessageButton(`Button ${buttonId}`,null,null,null,null,null,buttonId)
                                 appboy.logInAppMessageButtonClick(
-                                    thisButton, messageConfig
+                                    thisButton, message
                                 );
                             }
                         }}
                         submitComponentEvent={submitComponentEvent}
-                        brazeMessageProps={messageConfig.extras}
+                        brazeMessageProps={message.extras}
                     />
                 </CacheProvider>
             );

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -86,6 +86,8 @@ const getMessageFromUrlFragment = () => {
                 const dataFromBraze = JSON.parse(decodeURIComponent(forcedMessage));
                 return {
                     extras: dataFromBraze,
+                    logImpression: () => {},
+                    logButtonClick: () => {}
                 };
             } catch (e) {
                 // Parsing failed. Log a message and fall through.
@@ -255,12 +257,7 @@ const show = () => Promise.all([
                 <Component
                     componentName={ message.extras.componentName}
                     logButtonClickWithBraze={(buttonId) => {
-                        if (appboy) {
-                            const thisButton = new appboy.InAppMessageButton(`Button ${buttonId}`,null,null,null,null,null,buttonId)
-                            appboy.logInAppMessageButtonClick(
-                                thisButton, message
-                            );
-                        }
+                        message.logButtonClick(buttonId)
                     }}
                     submitComponentEvent={submitComponentEvent}
                     brazeMessageProps={message.extras}
@@ -280,12 +277,7 @@ const show = () => Promise.all([
                     <Component
                         componentName={ message.extras.componentName}
                         logButtonClickWithBraze={(buttonId) => {
-                            if (appboy) {
-                                const thisButton = new appboy.InAppMessageButton(`Button ${buttonId}`,null,null,null,null,null,buttonId)
-                                appboy.logInAppMessageButtonClick(
-                                    thisButton, message
-                                );
-                            }
+                            message.logButtonClick(buttonId)
                         }}
                         submitComponentEvent={submitComponentEvent}
                         brazeMessageProps={message.extras}

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -197,7 +197,7 @@ const canShow = async () => {
 
     const [brazeUuid, hasGivenConsent] = await Promise.all([getBrazeUuid(), hasRequiredConsents()]);
 
-    await maybeWipeUserData(apiKey, brazeUuid);
+    await maybeWipeUserData(apiKey, brazeUuid, hasGivenConsent);
 
     if (!(brazeUuid && hasGivenConsent)) {
         return false;

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -154,11 +154,12 @@ const getMessageFromBraze = async (apiKey, brazeUuid) => {
     return canShowPromise
 };
 
-const maybeWipeUserData = async (apiKey, brazeUuid) => {
+const maybeWipeUserData = async (apiKey, brazeUuid, consent) => {
     const userHasLoggedOut = !brazeUuid && hasCurrentBrazeUser();
-    const slotNames = ['Banner','EndOfArticle']
+    const userHasRemovedConsent = !consent && hasCurrentBrazeUser();
+    const slotNames = ['Banner','EndOfArticle'];
 
-    if (userHasLoggedOut) {
+    if (userHasLoggedOut || userHasRemovedConsent) {
         try {
             appboy = await import(/* webpackChunkName: "braze-web-sdk-core" */ '@braze/web-sdk-core');
             appboy.initialize(apiKey, SDK_OPTIONS);


### PR DESCRIPTION
## What does this change?
This PR moves to using `BrazeMessages` and `LocalMessageCache` from the @guardian/braze-components NPM package. 

Before:
- We use Frontend-specific logic for rendering a Braze banner.

After: 
- We use shared logic on both DCR and Frontend for rendering banners.
- We add a LocalMessageCache that will enable us (in a future PR) to retain messages if they cannot show on the first page they are received (e.g. due to exceeding timeout set by the platform)
- We also start actively wiping user data when they remove consent

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes - PR available [here](https://github.com/guardian/dotcom-rendering/tree/tw-use-npm-package-for-braze-logic)

## What is the value of this and can you measure success?

Makes development of Braze messages easier by making failed dependencies clearer.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
