### PR TITLE
Remove lodash/pickBy

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -2,7 +2,6 @@ import { cmp, onConsentChange } from '@guardian/consent-management-platform';
 import { storage } from '@guardian/libs';
 import once from 'lodash/once';
 import pick from 'lodash/pick';
-import pickBy from 'lodash/pickBy';
 import config from '../../../../lib/config';
 import { getCookie } from '../../../../lib/cookies';
 import {
@@ -238,6 +237,21 @@ const createAdManagerGroup = () => {
     return group;
 }
 
+const filterEmptyValues = (pageTargets) => {
+    const filtered = {};
+    for (const key in pageTargets) {
+        const value = pageTargets[key];
+        if (!value) {
+            continue;
+        }
+        if (Array.isArray(value) && value.length === 0) {
+            continue;
+        }
+        filtered[key] = value;
+    }
+    return filtered;
+}
+
 const rebuildPageTargeting = () => {
     latestCmpHasInitalised = cmp.hasInitialised();
     const adConsentState = getAdConsentFromState(latestCMPState);
@@ -294,12 +308,7 @@ const rebuildPageTargeting = () => {
     );
 
     // filter out empty values
-    const pageTargeting = pickBy(pageTargets, target => {
-        if (Array.isArray(target)) {
-            return target.length > 0;
-        }
-        return target;
-    });
+    const pageTargeting = filterEmptyValues(pageTargets);
 
     // third-parties wish to access our page targeting, before the googletag script is loaded.
     page.appNexusPageTargeting = buildAppNexusTargeting(pageTargeting);

--- a/static/src/javascripts/projects/common/modules/onward/breaking-news.js
+++ b/static/src/javascripts/projects/common/modules/onward/breaking-news.js
@@ -9,7 +9,6 @@ import reportError from 'lib/report-error';
 import { storage } from '@guardian/libs';
 import template from 'lodash/template';
 import flattenDeep from 'lodash/flattenDeep';
-import pickBy from 'lodash/pickBy';
 import { isWithinSeconds } from 'common/modules/ui/relativedates';
 import { inlineSvg } from 'common/views/svgs';
 import alertHtml from 'common/views/breaking-news.html';
@@ -100,9 +99,14 @@ const pruneKnownAlertIDs = (alerts) => {
 
     // then remove all known alert ids that are not
     // in the current breaking news alerts
-    knownAlertIDs = pickBy(knownAlertIDs, (state, id) =>
-        alerts.some(alert => alert.id === id)
-    );
+    const filteredKnownAlertIDs = {};
+    for (const id in knownAlertIDs) {
+        if (alerts.some(alert => alert.id === id)) {
+        	filteredKnownAlertIDs[id] = knownAlertIDs[id];
+        }
+    }
+
+    knownAlertIDs = filteredKnownAlertIDs;
 
     storeKnownAlertIDs();
 


### PR DESCRIPTION
## What does this change?

Replace use of `lodash/pickBy` with native implementation in order to reduce bundle size.

Native implementations performance checked (caveats about micro-benchmarking aside):

`build-page-targetting`: https://jsbench.me/4okmxq9618 ~10x faster than lodash
`breaking-news`: https://jsbench.me/a5kmxqbecc/1 ~6.7x faster than lodash

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

**Value**

Helps to reduces bundle size, parse time, thread blocking time and TTI.

Helps to increase performance.

**Measure**

~2Kb saving on bundle. Gzip ~0.5Kb.

### Tested

- [X] Locally
- [ ] On CODE (optional)
