### PR TITLE
Move to url fragment for force-braze-message

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -70,16 +70,17 @@ const getMessageFromUrlFragment = () => {
         const key = 'force-braze-message';
 
         const hashString = window.location.hash;
-		const forcedMessage = hashString.slice(
-			hashString.indexOf(`${key}=`) + key.length + 1,
-			hashString.length,
-		);
 
-        if (forcedMessage) {
+        if (hashString.includes(key)) {
             if (!FORCE_BRAZE_ALLOWLIST.includes(window.location.hostname)) {
                 console.log(`${key} is not supported on this domain`)
                 return null;
             }
+
+            const forcedMessage = hashString.slice(
+                hashString.indexOf(`${key}=`) + key.length + 1,
+                hashString.length,
+            );
 
             try {
                 const dataFromBraze = JSON.parse(decodeURIComponent(value));

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -62,30 +62,38 @@ const FORCE_BRAZE_ALLOWLIST = [
     'm.thegulocal.com',
 ];
 
-const getMessageFromQueryString = () => {
-    const qsArg = 'force-braze-message';
+const getMessageFromUrlFragment = () => {
+    if (window.location.hash){
+        // This is intended for use on development domains for preview purposes.
+		// It won't run in PROD.
 
-    const params = getUrlVars();
-    const value = params[qsArg];
+        const key = 'force-braze-message';
 
-    if (value) {
-        if (!FORCE_BRAZE_ALLOWLIST.includes(window.location.hostname)) {
-            console.log(`${qsArg} is not supported on this domain`)
-            return null;
-        }
+        const hashString = window.location.hash;
+		const forcedMessage = hashString.slice(
+			hashString.indexOf(`${key}=`) + key.length + 1,
+			hashString.length,
+		);
 
-        try {
-            const dataFromBraze = JSON.parse(value);
+        if (forcedMessage) {
+            if (!FORCE_BRAZE_ALLOWLIST.includes(window.location.hostname)) {
+                console.log(`${key} is not supported on this domain`)
+                return null;
+            }
 
-            return {
-                extras: dataFromBraze,
-            };
-        } catch (e) {
-            // Parsing failed. Log a message and fall through.
-            console.log(
-                `There was an error with ${qsArg}:`,
-                e.message,
-            );
+            try {
+                const dataFromBraze = JSON.parse(decodeURIComponent(value));
+
+                return {
+                    extras: dataFromBraze,
+                };
+            } catch (e) {
+                // Parsing failed. Log a message and fall through.
+                console.log(
+                    `There was an error with ${key}:`,
+                    e.message,
+                );
+            }
         }
     }
 
@@ -192,7 +200,7 @@ const canShow = async () => {
     const bannerTiming = measureTiming('braze-banner');
     bannerTiming.start();
 
-    const forcedBrazeMessage = getMessageFromQueryString();
+    const forcedBrazeMessage = getMessageFromUrlFragment();
     if (forcedBrazeMessage) {
         messageConfig = forcedBrazeMessage;
         return true;


### PR DESCRIPTION
## What does this change?

Moves `force-braze-message` to use the URL fragment rather than query strings because the new Epic exceeded the 1024 character limit set for query strings.

This is PR is shorter than DCRs because we only deliver BrazeBanners on Frontend - not Epics - so we only need to force Braze messages in one place. However, we still need to use a consistent mechanism across both platforms (URL fragments rather than query strings).

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes - PR is [here](https://github.com/guardian/dotcom-rendering/pull/2778)

## What is the value of this and can you measure success?

DCR needs to move to a hash-based solution in order to support forcing the Braze epic.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
