### PR TITLE
enable atom type interactive in article picker

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -74,7 +74,7 @@ object ArticlePageChecks {
           // ContentAtomBlockElement was expanded to include atomtype.
           // To support an atom type, just add it to supportedAtomTypes
           val supportedAtomTypes =
-            List("audio", "chart", "explainer", "guide", "media", "profile", "qanda", "timeline")
+            List("audio", "chart", "explainer", "guide", "interactive", "media", "profile", "qanda", "timeline")
           !supportedAtomTypes.contains(atomtype)
         }
         case InteractiveBlockElement(_, scriptUrl) => {


### PR DESCRIPTION
## What does this change?
Enable atom type `interactive` in article picker, thereby allowing `InteractiveAtomBlockElement` in DCR.