### PR TITLE
Add support for Membership, Vine and most Main elements

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -54,12 +54,14 @@ object ArticlePageChecks {
     // See: https://github.com/guardian/dotcom-rendering/blob/master/packages/frontend/web/components/lib/ArticleRenderer.tsx
     def unsupportedElement(blockElement: BlockElement) =
       blockElement match {
+        // This has never been used but we know we don't yet support them due to a required CAPI update
+        case _: CodeBlockElement => true
         // There is currently an issue with showcase layout for these
         case _: InteractiveBlockElement => true
         // The majority of the remaining atoms appear to be interactive atoms, which aren't supported yet
         case ContentAtomBlockElement(_, atomtype, _) if atomtype != "media" => true
         // Everything else should be supported, but there are some element types that don't
-        // get use in main media, for which there are no guarantees
+        // get used in main media, for which there are no guarantees
         case _ => false
       }
 


### PR DESCRIPTION
## What does this change?
The main change here is to indicate support for MembershipBlockElement, VineBlockElement and most remaining main-media elements (all except interactive and most atoms). It also seems overdue to explicitly list the elements we don't support, rather than the ones we do - so I've also made the default in the case statements that we do support them in DCR.

In terms of adding support for these elements here is the justification:

**Membership** - we have deprecated and simply do not render in DCR
**Vine** - is supported and looks ok in all examples I checked (ignoring problems with the service/embed itself which we don't control)
**Main media** - we have been given an exhaustive list of main media elements in CAPI from 2010 onwards. Apart from ones that were already supported there was:
- Audio - e.g. soundcloud embeds, which render fine in DCR
- Tweet - examples checked
- Witness - examples checked
- Map - example checked (there's only one)
- Vine - example checked (there's only one)
- Instagram - examples checked
- Interactive - excluded for now and card added to backlog
- Atoms apart from media - excluded for now and card added to backlog (mostly interactives)

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)