### PR TITLE
Merchandising high section switch

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -287,6 +287,16 @@ trait CommercialSwitches {
     sellByDate = never,
     exposeClientSide = true,
   )
+
+  val MerchandisingHighSection: Switch = Switch(
+    group = Commercial,
+    name = "merchandising-high-section",
+    description = "Move merchandising high section one section lower",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = false,
+  )
 }
 
 trait PrebidSwitches {

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -2,9 +2,9 @@ package views.support
 
 import java.net.URI
 import java.util.regex.{Matcher, Pattern}
-
 import com.gu.contentatom.renderer.ArticleConfiguration
-import common.{Edition, LinkTo, GuLogging}
+import common.editions.Uk
+import common.{Edition, GuLogging, LinkTo}
 import conf.Configuration.affiliateLinks._
 import conf.Configuration.site.host
 import conf.switches.Switches
@@ -821,8 +821,9 @@ case class CommercialMPUForFronts()(implicit val request: RequestHeader) extends
   }
 }
 
-case class CommercialComponentHigh(isPaidContent: Boolean, isNetworkFront: Boolean, hasPageSkin: Boolean)(implicit
-    val request: RequestHeader,
+case class CommercialComponentHigh(isPaidContent: Boolean, isNetworkFront: Boolean, hasPageSkin: Boolean)(
+    implicit val edition: Edition,
+    implicit val request: RequestHeader,
 ) extends HtmlCleaner {
 
   override def clean(document: Document): Document = {
@@ -834,7 +835,13 @@ case class CommercialComponentHigh(isPaidContent: Boolean, isNetworkFront: Boole
     if (containers.length >= minContainers) {
 
       val containerIndex = if (containers.length >= 4) {
-        if (isNetworkFront) 3 else 2
+        if (isNetworkFront) {
+          if (MerchandisingHighSection.isSwitchedOn && edition.id.equals(Uk.id)) {
+            4
+          } else {
+            3
+          }
+        } else 2
       } else 0
 
       val adSlotHtml = views.html.fragments.commercial.commercialComponentHigh(isPaidContent, hasPageSkin)


### PR DESCRIPTION
## What does this change?

Add a new switch that moves the merchandising high section lower on a UK front, to coincide with an ad campaign.

> As part of a specific advertising campaign there is a desire, for 24 hours to re-arrange the network front so the merchandising-high.fc-container is one section lower.
(The idea is the coronavirus content sits together while the ad runs in an expanded double width slot)

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [X] Locally
- [X] On CODE (optional)

## Screenshots

Before (switch off):

<img width="651" alt="Screenshot 2021-04-12 at 15 13 23" src="https://user-images.githubusercontent.com/7014230/114412929-7765c700-9ba5-11eb-91f0-891c2202bec7.png">

After (switch on): 

<img width="651" alt="Screenshot 2021-04-12 at 15 14 11" src="https://user-images.githubusercontent.com/7014230/114412954-7d5ba800-9ba5-11eb-891a-5f8afa9ab71b.png">



