### PR TITLE
Bump @guardian/braze-message-components to v1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@guardian/atom-renderer": "1.2.2",
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.7",
-    "@guardian/braze-components": "^0.0.20",
+    "@guardian/braze-components": "1.0.1",
     "@guardian/commercial-core": "^0.16.3",
     "@guardian/consent-management-platform": "^6.11.3",
     "@guardian/libs": "^1.7.1",

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -83,8 +83,7 @@ const getMessageFromUrlFragment = () => {
             );
 
             try {
-                const dataFromBraze = JSON.parse(decodeURIComponent(value));
-
+                const dataFromBraze = JSON.parse(decodeURIComponent(forcedMessage));
                 return {
                     extras: dataFromBraze,
                 };

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -265,7 +265,7 @@ const show = () => Promise.all([
             document.body.appendChild(container);
         }
 
-        const Component = brazeModule.BrazeMessage
+        const Component = brazeModule.BrazeMessageComponent
 
         // IE does not support shadow DOM, so instead we just render
         if (!container.attachShadow) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1868,10 +1868,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/braze-components@^0.0.20":
-  version "0.0.20"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-0.0.20.tgz#6e63a93a598eefa1ebd80c643be0a3087b3fa839"
-  integrity sha512-3KWR9Td2KxvEZ3NDa56aPeyNJ2hFYD5K50IepSB1BxVpICxX1UAYF1CvP8yPashDon4rI/T8VcPiaSw16reyJA==
+"@guardian/braze-components@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-1.0.1.tgz#427364b25c1288a1845c7ad49009a8f32efc7f01"
+  integrity sha512-mF63OjWy1YbQnC4nQlGhB8fPcwlgf8ed6YAr5NiyJ4S1QQow5vU/2gw6halI1a79UjmDIM6GNk21kJ1ZrK89Rg==
   dependencies:
     "@guardian/src-button" "2.7.1"
     "@guardian/src-foundations" "2.7.1"


### PR DESCRIPTION
## What does this change?

Bumps @guardian/braze-components to v1.0.1. This includes a change to the interface for accessing components, from `brazeMessage` to `brazeMessageComponent`.

Also included is a fix to `force-braze-message`.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes - a PR is underway for DCR to [use the package](https://github.com/guardian/dotcom-rendering/pull/2763).

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
