### PR TITLE
Set modulesVersion in requests to dotcom-components

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -30,6 +30,9 @@ import {
 import { puzzlesBanner } from 'common/modules/experiments/tests/puzzles-banner';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 
+// See https://github.com/guardian/support-dotcom-components/blob/main/module-versions.md
+export const ModulesVersion = 'v1';
+
 const buildKeywordTags = page => {
     const keywordIds = page.keywordIds.split(',');
     const keywords = page.keywords.split(',');
@@ -131,7 +134,8 @@ const buildEpicPayload = async () => {
         countryCode,
         epicViewLog: getViewLog(),
         weeklyArticleHistory: getWeeklyArticleHistory(),
-        hasOptedOutOfArticleCount: !(await getArticleCountConsent())
+        hasOptedOutOfArticleCount: !(await getArticleCountConsent()),
+        modulesVersion: ModulesVersion,
     };
 
     return {
@@ -180,7 +184,8 @@ const buildBannerPayload = async () => {
         mvtId: getMvtValue(),
         countryCode: geolocationGetSync(),
         weeklyArticleHistory: getWeeklyArticleHistory(),
-        hasOptedOutOfArticleCount: !(await getArticleCountConsent())
+        hasOptedOutOfArticleCount: !(await getArticleCountConsent()),
+        modulesVersion: ModulesVersion,
     };
 
     return {


### PR DESCRIPTION
We now have versioning on the modules served by dotcom-components.
This change ensures that v1 is requested by frontend pages.
This will ensure backwards-compatibility when we do the upgrade to v2.

See [here](https://github.com/guardian/support-dotcom-components#module-versions)

[PR for v2 modules](https://github.com/guardian/support-dotcom-components/pull/361)

Epic request:
![Screen Shot 2021-04-08 at 09 01 34](https://user-images.githubusercontent.com/1513454/113990161-16f32480-9849-11eb-8764-386b1f18c497.png)

Banner request:
![Screen Shot 2021-04-08 at 09 01 45](https://user-images.githubusercontent.com/1513454/113990152-15296100-9849-11eb-8ebe-b86e690c82a3.png)
