### PR TITLE
Filter away SubMetaLinks with empty titles

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -506,7 +506,9 @@ object DotcomRenderingUtils {
       sectionLabel = Localisation(article.content.sectionLabelName)(request), // String
       sectionUrl = article.content.sectionLabelLink, // String
       sectionName = article.metadata.section.map(_.value), // Option[String]
-      subMetaSectionLinks = article.content.submetaLinks.sectionLabels.map(SubMetaLink.apply), // List[SubMetaLink]
+      subMetaSectionLinks = article.content.submetaLinks.sectionLabels
+        .map(SubMetaLink.apply)
+        .filter(_.title.trim.nonEmpty), // List[SubMetaLink]
       subMetaKeywordLinks = article.content.submetaLinks.keywords.map(SubMetaLink.apply), // List[SubMetaLink]
       shouldHideAds = article.content.shouldHideAdverts, // Boolean
       isAdFreeUser = views.support.Commercial.isAdFree(request), // Boolean


### PR DESCRIPTION
## What does this change?

This Filter away SubMetaLinks with empty titles from the DCR data object. 

Before: 

<img width="378" alt="before" src="https://user-images.githubusercontent.com/6035518/114145507-63ecfe80-990e-11eb-97b7-11025fd23b7b.png">

<img width="316" alt="before" src="https://user-images.githubusercontent.com/6035518/114147113-4456d580-9910-11eb-8dfb-71a3d29e3e39.png">


After:

<img width="357" alt="after" src="https://user-images.githubusercontent.com/6035518/114145525-68b1b280-990e-11eb-9852-73676456e0e8.png">

<img width="318" alt="after" src="https://user-images.githubusercontent.com/6035518/114147131-491b8980-9910-11eb-9622-ebc717b0f672.png">

----------------------------

This replaces the DCR solution ( https://github.com/guardian/dotcom-rendering/pull/2815 ).
