### PR TITLE
Use LocalMessageCache instead of InMemoryCache

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -18,7 +18,7 @@ import {
     setHasCurrentBrazeUser,
 } from './hasCurrentBrazeUser';
 import { measureTiming } from './measure-timing';
-import { BrazeMessages, InMemoryCache, LocalMessageCache } from '@guardian/braze-components/logic'
+import { BrazeMessages, LocalMessageCache } from '@guardian/braze-components/logic'
 
 const brazeVendorId = '5ed8c49c4b8ce4571c7ad801';
 
@@ -128,7 +128,7 @@ const getMessageFromBraze = async (apiKey, brazeUuid) => {
     appboy.initialize(apiKey, SDK_OPTIONS);
 
     const errorHandler = (error) => { reportError(error, {}, false) };
-    const brazeMessages = new BrazeMessages(appboy, InMemoryCache, errorHandler);
+    const brazeMessages = new BrazeMessages(appboy, LocalMessageCache, errorHandler);
 
     setHasCurrentBrazeUser();
     appboy.changeUser(brazeUuid);


### PR DESCRIPTION
## What does this change?
We will start using the `LocalMessageCache` for Braze messages. This was required because the Braze Epic will often not be seen by users (as it's at the end of the article) and we will need a mechanism to persist the message beyond a single page/session.

I've tested the delivery of messages locally.

### Before
Braze messages uses the `InMemoryCache`

### After
Braze messages use the local storage-based `LocalMessageCache`.

### Why?
To support the Braze Epic and also to show Braze banners on a subsequent page if they did not display before the time limit specified by the platform.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes the PR can be found [here](https://github.com/guardian/dotcom-rendering/pull/2846)).

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
