### PR TITLE
Fix: no empty URL in `fetch-json` for fully qualified resource

### DIFF
--- a/static/src/javascripts/lib/fetch-json.spec.js
+++ b/static/src/javascripts/lib/fetch-json.spec.js
@@ -9,7 +9,7 @@ const fetchSpy = require('lib/fetch');
 
 describe('Fetch JSON util', () => {
 	beforeAll(() => {
-		config.set('page.ajaxUrl', 'foo');
+		config.set('page.ajaxUrl', 'ajax.url/');
 	});
 
 	it('returns a promise which rejects on network errors', (done) => {
@@ -84,4 +84,23 @@ describe('Fetch JSON util', () => {
 			.then(done)
 			.catch(done.fail);
 	});
+
+    it('handles fully qualified URLs', (done) => {
+        fetchSpy.mockReturnValueOnce(
+            Promise.resolve({
+                ok: true,
+                json() {
+                    return Promise.resolve({})
+                }
+            })
+        )
+
+        const url = 'https://example.com';
+        fetchJson(url).then((response) => {
+            expect(response).toEqual({});
+            expect(fetchSpy).toHaveBeenLastCalledWith(url, {})
+        }).then(done)
+        .catch(done.fail)
+
+    })
 });

--- a/static/src/javascripts/lib/fetch-json.ts
+++ b/static/src/javascripts/lib/fetch-json.ts
@@ -15,6 +15,7 @@ const fetchJson = async (
 
 	let path = resource;
 	if (!RegExp('^(https?:)?//').exec(resource)) {
+		// If `resource` is not relative url
 		path = String(config.get('page.ajaxUrl', '')) + resource;
 		init.mode = 'cors';
 		init.credentials = 'include';

--- a/static/src/javascripts/lib/fetch-json.ts
+++ b/static/src/javascripts/lib/fetch-json.ts
@@ -13,12 +13,13 @@ const fetchJson = async (
 	if (typeof resource !== 'string')
 		throw new Error('First argument should be of type `string`');
 
-	let path = '';
+	let path = resource;
 	if (!RegExp('^(https?:)?//').exec(resource)) {
 		path = String(config.get('page.ajaxUrl', '')) + resource;
 		init.mode = 'cors';
 		init.credentials = 'include';
 	}
+
 	const resp = (await fetch(path, init)) as Response;
 	if (resp.ok) {
 		switch (resp.status) {


### PR DESCRIPTION
## What does this change?

Fixes requests using `fetch-json` that are passing a fully qualified URL in `resource`.

Flagged by @i-hardy – currently breaking reader revenue components

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
