### PR TITLE
Fix for appboy declaration in maybeWipeUserData

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -161,7 +161,7 @@ const maybeWipeUserData = async (apiKey, brazeUuid, consent) => {
 
     if (userHasLoggedOut || userHasRemovedConsent) {
         try {
-            appboy = await import(/* webpackChunkName: "braze-web-sdk-core" */ '@braze/web-sdk-core');
+            const appboy = await import(/* webpackChunkName: "braze-web-sdk-core" */ '@braze/web-sdk-core');
             appboy.initialize(apiKey, SDK_OPTIONS);
             appboy.wipeData();
 


### PR DESCRIPTION
## What does this change?
This fixes the `appboy` declaration in `maybeWipeUserData` - which may be causing problems with `appboy` in production.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)
