### PR TITLE
AB test for remote RR header links

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -44,4 +44,3 @@ trait ABTestSwitches {
     exposeClientSide = true,
   )
 }
-

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -33,4 +33,15 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2021, 5, 3),
     exposeClientSide = true,
   )
+
+  Switch(
+    ABTests,
+    "ab-remote-rr-header-links-test",
+    "Test serving remote header",
+    owners = Seq(Owner.withGithub("tomrf1")),
+    safeState = Off,
+    sellByDate = new LocalDate(2021, 6, 1),
+    exposeClientSide = true,
+  )
 }
+

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -1,9 +1,11 @@
 import { signInGateMainVariant } from 'common/modules/experiments/tests/sign-in-gate-main-variant';
 import { signInGateMainControl } from 'common/modules/experiments/tests/sign-in-gate-main-control';
 import { puzzlesBanner } from 'common/modules/experiments/tests/puzzles-banner';
+import { remoteRRHeaderLinksTest } from 'common/modules/experiments/tests/remote-header-test';
 
 export const concurrentTests = [
     signInGateMainVariant,
     signInGateMainControl,
-    puzzlesBanner
+    puzzlesBanner,
+    remoteRRHeaderLinksTest,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/remote-header-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/remote-header-test.js
@@ -1,0 +1,28 @@
+export const remoteRRHeaderLinksTest = {
+    id: 'RemoteRRHeaderLinksTest',
+    start: '2021-04-15',
+    expiry: '2021-12-01',
+    author: 'Tom Forbes',
+    description:
+        'Use the dotcom-components service for serving the Reader Revenue header links',
+    audience: 0.1,
+    audienceOffset: 0.9,
+    successMeasure: 'AV is not worse',
+    audienceCriteria:
+        'all pageviews',
+    dataLinkNames: 'RRHeaderLinks',
+    idealOutcome:
+        'AV is not worse',
+    showForSensitive: true,
+    canRun: () => true,
+    variants: [
+        {
+            id: 'control',
+            test: () => {},
+        },
+        {
+            id: 'remote',
+            test: () => {},
+        },
+    ],
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/remote-header-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/remote-header-test.js
@@ -5,8 +5,8 @@ export const remoteRRHeaderLinksTest = {
     author: 'Tom Forbes',
     description:
         'Use the dotcom-components service for serving the Reader Revenue header links',
-    audience: 0.1,
-    audienceOffset: 0.9,
+    audience: 1,
+    audienceOffset: 0,
     successMeasure: 'AV is not worse',
     audienceCriteria:
         'all pageviews',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/remote-header-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/remote-header-test.js
@@ -1,5 +1,5 @@
 export const remoteRRHeaderLinksTest = {
-    id: 'RemoteRRHeaderLinksTest',
+    id: 'RemoteRrHeaderLinksTest',
     start: '2021-04-15',
     expiry: '2021-12-01',
     author: 'Tom Forbes',


### PR DESCRIPTION
This is a DCR-only test, see:
https://github.com/guardian/dotcom-rendering/pull/2838