### PR TITLE
Ramping up the click-to-view ab test to 50% of users

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -39,5 +39,5 @@ object ClickToView
       description = "Click to provide consent before seeing embedded content",
       owners = Seq(Owner.withGithub("frj")),
       sellByDate = new LocalDate(2021, 5, 6),
-      participationGroup = Perc20A,
+      participationGroup = Perc50,
     )


### PR DESCRIPTION
<img width="633" alt="Screenshot 2021-03-24 at 14 30 36" src="https://user-images.githubusercontent.com/289928/114368009-e840bb00-9b74-11eb-85b6-37f2146da45d.png">

## What does this change?

This will increase the proportion of users for who the click to view embedded content overlay is enabled from 20% to 50% of users.

For more details about the click to view overlay see the following PRs:

https://github.com/guardian/dotcom-rendering/pull/2408
https://github.com/guardian/frontend/pull/23534
https://github.com/guardian/frontend/pull/23519

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

The component this AB test enables is implemented in DCR.

## What is the value of this and can you measure success?

Component and click tracking is enabled for the click to view component, see:

https://github.com/guardian/dotcom-rendering/pull/2698

The performance of the component can be measured by querying the data lake.

For more details see:

https://docs.google.com/document/d/1-jvghAlEhSfi5GvjhVPyOmTaeOrBbM2o7E93TCrcFHE/edit#heading=h.le9paspao2c

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
