### PR TITLE
Correct bug in SubMetaLinks.make

### DIFF
--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -693,12 +693,7 @@ object SubMetaLinks {
     val sectionLabels = List(sectionLink, secondaryLink).flatten
     val keywordSubMetaLinks = tags.keywords
       .filterNot(_.isSectionTag)
-      .filter(k => {
-        sectionLabelName match {
-          case Some(name) => k.name != name
-          case None       => false
-        }
-      })
+      .filterNot(k => sectionLabelName.exists(name => k.name == name))
       .filterNot(t => blogOrSeriesTag.exists(s => s.id == t.id))
       .take(6)
       .map(tag => SubMetaLink(tag.metadata.url, makeKeywordName(tag, tags.keywords), Some(s"keyword: ${tag.id}")))

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -693,7 +693,12 @@ object SubMetaLinks {
     val sectionLabels = List(sectionLink, secondaryLink).flatten
     val keywordSubMetaLinks = tags.keywords
       .filterNot(_.isSectionTag)
-      .filterNot(_.name == sectionLabelName)
+      .filter(k => {
+        sectionLabelName match {
+          case Some(name) => k.name == name
+          case None       => false
+        }
+      })
       .filterNot(t => blogOrSeriesTag.exists(s => s.id == t.id))
       .take(6)
       .map(tag => SubMetaLink(tag.metadata.url, makeKeywordName(tag, tags.keywords), Some(s"keyword: ${tag.id}")))

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -695,7 +695,7 @@ object SubMetaLinks {
       .filterNot(_.isSectionTag)
       .filter(k => {
         sectionLabelName match {
-          case Some(name) => k.name == name
+          case Some(name) => k.name != name
           case None       => false
         }
       })

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -676,7 +676,10 @@ object SubMetaLinks {
       sectionLabelName: Option[String],
   ): SubMetaLinks = {
     val sectionLink: Option[SubMetaLink] = if (!(isImmersive && tags.isArticle)) {
-      sectionLabelName.map(name => SubMetaLink(s"/$sectionLabelLink", name, Some("article section")))
+      for {
+        link <- sectionLabelLink
+        name <- sectionLabelName
+      } yield SubMetaLink(s"/$link", name, Some("article section"))
     } else None
 
     val secondaryLink = if (blogOrSeriesTag.isDefined) {


### PR DESCRIPTION
## What does this change?

This corrects a very interesting bug in `SubMetaLinks.make`. 

`sectionLabelLink` are `Option[String]` and were manipulated as `String` in a string interpolation, and the compiler didn't notice because of automatic casting. Unfortunately this caused "Some" (the standard way defined options are rendered as strings) to appear in an URL. Bad.

BEFORE:

<img width="491" alt="Screenshot 2021-04-14 at 13 26 16" src="https://user-images.githubusercontent.com/6035518/114712629-334eff80-9d28-11eb-9428-f9705db36d4b.png">


AFTER:

<img width="434" alt="Screenshot 2021-04-14 at 13 43 07" src="https://user-images.githubusercontent.com/6035518/114712644-3944e080-9d28-11eb-9a26-71d6b5f572af.png">


ALSO:

<img width="671" alt="Screenshot 2021-04-14 at 14 07 23" src="https://user-images.githubusercontent.com/6035518/114715996-8a0a0880-9d2b-11eb-807a-ade6757d2a45.png">


