### PR TITLE
Remove top padding from fronts top container on smaller desktop screens

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_container.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container.scss
@@ -442,12 +442,6 @@ $header-image-size-desktop: 100px;
     @include mq($until: leftCol) {
         clear: left;
     }
-
-    .fc-container--will-have-toggle &, .fc-container--has-toggle & {
-        @include mq(leftCol, wide) {
-            padding-top: gs-height(1);
-        }
-    }
 }
 
 .fc-container__body--is-hidden {


### PR DESCRIPTION
## What does this change?
Removes top padding from fronts top container on smaller desktop screens
It appears when viewport's width is between ~1140 and ~1300 

**NOTE**: I will need help from @guardian/guardian-frontend-team  with testing edge cases as I don't know why it was there in the first place

**Update**: Removing the padding in all containers also removes the Hide link, so we should only remove it for the first container as it doesn't come with a Hide link

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before]<img width="1209" alt="Screenshot 2021-04-14 at 18 03 49" src="https://user-images.githubusercontent.com/51630004/114737371-9ef89300-9d4f-11eb-83d1-6763771242fc.png"> | ![after]<img width="1192" alt="Screenshot 2021-04-14 at 18 43 36" src="https://user-images.githubusercontent.com/51630004/114739414-85f0e180-9d51-11eb-99aa-50938ac5285b.png">

## What is the value of this and can you measure success?
will give a better look and feel.

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
