### PR TITLE
Refactor to use more idiomatic Scala

### DIFF
--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -693,8 +693,8 @@ object SubMetaLinks {
     val sectionLabels = List(sectionLink, secondaryLink).flatten
     val keywordSubMetaLinks = tags.keywords
       .filterNot(_.isSectionTag)
-      .filterNot(k => sectionLabelName.exists(name => k.name == name))
-      .filterNot(t => blogOrSeriesTag.exists(s => s.id == t.id))
+      .filterNot(k => sectionLabelName.contains(k.name))
+      .filterNot(t => blogOrSeriesTag.map(_.id).contains(t.id))
       .take(6)
       .map(tag => SubMetaLink(tag.metadata.url, makeKeywordName(tag, tags.keywords), Some(s"keyword: ${tag.id}")))
 


### PR DESCRIPTION
## What does this change?

This is a small refactoring to use a more idiomatic Scala when doing simple Option introspection. For testing that an option is defined and contains a given element, using `.contains` is better than `.exists`, this later having a more complex signature leading to harder comprehension. (Noticed when doing this https://github.com/guardian/frontend/pull/23706 yesterday.)

