### PR TITLE
Add a 0% Experiment for Anniversary Atom

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -10,6 +10,7 @@ object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
     ClickToView,
     LiveblogRendering,
+    HideAnniversaryAtom,
   )
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -22,6 +23,16 @@ object LiveblogRendering
       owners = Seq(Owner.withGithub("shtukas")),
       sellByDate = new LocalDate(2021, 8, 2),
       participationGroup = Perc0A,
+    )
+
+object HideAnniversaryAtom
+    extends Experiment(
+      name = "hide-anniversary-atom",
+      description =
+        "Controls the visibility of the the Anniversary interactive atom on articles. If OPTED IN, will NOT show banner.",
+      owners = Seq(Owner.withGithub("gtrufitt")),
+      sellByDate = new LocalDate(2021, 5, 19),
+      participationGroup = Perc0B,
     )
 
 object NewsletterEmbedDesign


### PR DESCRIPTION
## What does this change?

Adding a 0% server-side A/B test for the Anniversary atom. The purpose of this is to opt people into this test and *not* show the Anniversary atom to users that are *in* the test. 

This is a slight abuse of the A/B test system but gives us a nicer UX for users (being able to remove the atom at the top of articles) while not having to further cache split.