### PR TITLE
Identity | Sign In Gate | Update Sign In Gate Copy

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-control.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-control.js
@@ -13,7 +13,7 @@ export const signInGateMainControl = {
     successMeasure: 'N/A - User does not see gate, only to compare to variant.',
     audienceCriteria:
         '3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
-    ophanComponentId: 'main_control_3',
+    ophanComponentId: 'main_control_4',
     dataLinkNames: 'SignInGateMain',
     idealOutcome:
         'Increase the number of users signed in whilst running at a reasonable scale',
@@ -21,7 +21,7 @@ export const signInGateMainControl = {
     canRun: () => true,
     variants: [
         {
-            id: 'main-control-3',
+            id: 'main-control-4',
             test: () => {},
         },
     ],

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
@@ -13,7 +13,7 @@ export const signInGateMainVariant = {
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:
         '3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
-    ophanComponentId: 'main_variant_3',
+    ophanComponentId: 'main_variant_4',
     dataLinkNames: 'SignInGateMain',
     idealOutcome:
         'Increase the number of users signed in whilst running at a reasonable scale',
@@ -21,7 +21,7 @@ export const signInGateMainVariant = {
     canRun: () => true,
     variants: [
         {
-            id: 'main-variant-3',
+            id: 'main-variant-4',
             test: () => {},
         },
     ],

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/sign-in-gate.spec.js
@@ -12,7 +12,7 @@ jest.mock('common/modules/experiments/ab', () => ({
             id: 'SignInGateMainVariant', // Update for each new test
             dataLinkNames: 'SignInGateMain', // Update for each new test
             variantToRun: {
-                id: 'main-variant-3', // Update for each new test
+                id: 'main-variant-4', // Update for each new test
             },
             ophanComponentId: 'main_test',
         },

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/main-variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/design/main-variant.js
@@ -20,19 +20,16 @@ const htmlTemplate = ({ signInUrl, guUrl }) => `
 <div class="signin-gate">
     <div class="signin-gate__content--var">
         <div class="signin-gate__header--var">
-            <h1 class="signin-gate__header--text--var">Register for free and <br>continue reading</h1>
+            <h1 class="signin-gate__header--text--var">You need to register to keep reading</h1>
         </div>
         <div class="signin-gate__benefits--var signin-gate__margin-top--var">
             <p class="signin-gate__benefits--text--var">
-                It’s important to say this is not a step towards a paywall
+                It’s still free to read - this is not a paywall
             </p>
         </div>
         <div class="signin-gate__paragraph--var">
             <p class="signin-gate__paragraph--text--var">
-               Registering is a free and simple way to help us sustain our independent Guardian journalism.
-            </p>
-            <p class="signin-gate__paragraph--text--var">
-               When you register with us we are able to improve our news experience for you and for others. You will always be able to control your own <a id="js-signin-gate__privacy" class="signin-gate__link--var">privacy settings</a>. Thank you.
+                We’re committed to keeping our quality reporting open. By registering and providing us with insight into your preferences, you’re helping us to engage with you more deeply, and that allows us to keep our journalism free for all. You’ll always be able to control your own <a id="js-signin-gate__privacy" class="signin-gate__link--var">privacy settings</a>.
             </p>
         </div>
         <div class="signin-gate__buttons">

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/main/control.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/main/control.js
@@ -11,7 +11,7 @@ import {
 } from '../../helper';
 
 // define the variant name here
-const variant = 'main-control-3';
+const variant = 'main-control-4';
 
 // method which returns a boolean determining if this variant can be shown on the current pageview
 const canShow = (name = '') => {

--- a/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/main/variant.js
+++ b/static/src/javascripts/projects/common/modules/identity/sign-in-gate/variants/main/variant.js
@@ -14,7 +14,7 @@ import {
 import { designShow } from '../design/main-variant';
 
 // define the variant name here
-const variant = 'main-variant-3';
+const variant = 'main-variant-4';
 
 // method which returns a boolean determining if this variant can be shown on the current pageview
 const canShow = (name = '') => {

--- a/static/src/stylesheets/module/identity/_sign-in-gate.scss
+++ b/static/src/stylesheets/module/identity/_sign-in-gate.scss
@@ -2,9 +2,6 @@
 .signin-gate {
     clear: left;
     margin-bottom: $gs-baseline * 2;
-    @include mq(tablet) {
-        padding: ($gs-baseline * 2) 0;
-    }
     @include mq(desktop) {
         min-height: 600px;
     }
@@ -107,10 +104,10 @@
         height: 100%;
 
         /* "transparent" only works here because == rgba(0,0,0,0) */
-        background-image: linear-gradient(0deg, $brightness-100, 70%, rgba(255, 255, 255, 0));
+        background-image: linear-gradient(0deg, $brightness-100, 10%, rgba(255, 255, 255, 0));
 
         &.signin-gate__first-paragraph-overlay--comment {
-            background-image: linear-gradient(0deg, $opinion-faded, 70%, rgba(255, 255, 255, 0));
+            background-image: linear-gradient(0deg, $opinion-faded, 10%, rgba(255, 255, 255, 0));
         }
     }
 }
@@ -324,15 +321,6 @@
     padding-bottom: $gs-baseline * 3;
     padding-top: $gs-baseline * 1;
     position: relative;
-}
-
-// VARIANT DESIGN - article gradient overlay changes // vii-variant
-
-.signin-gate__content--var {
-    padding-top: $gs-baseline * 3;
-    @include mq(tablet) {
-        padding-top: $gs-baseline * 3;
-    }
 }
 
 .overlay--var {


### PR DESCRIPTION
## What does this change?

Update the copy of the main variant of the sign in gate to the winner of https://github.com/guardian/dotcom-rendering/pull/2622 and launch a new test in the form of main-variant-4 and main-control-4

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

See: https://github.com/guardian/dotcom-rendering/pull/2874

## Screenshots
![m code dev-theguardian com_technology_2015_may_14_google-right-to-be-forgotten-academics-letter_dcr=false(Laptop with HiDPI screen)](https://user-images.githubusercontent.com/13315440/115207469-898abc80-a0f3-11eb-80c7-bbda8030c137.png)

![m code dev-theguardian com_technology_2015_may_14_google-right-to-be-forgotten-academics-letter_dcr=false(iPhone 6_7_8)](https://user-images.githubusercontent.com/13315440/115207476-8b548000-a0f3-11eb-84bf-0a85c68a0c19.png)

## Tested

- [x] Locally
- [x] On CODE (optional)
