### PR TITLE
Remove the import `import play.sbt.Play.autoImport._`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 import com.gu.riffraff.artifact.RiffRaffArtifact.autoImport._
-import play.sbt.Play.autoImport._
 import play.sbt.routes.RoutesKeys
 import com.typesafe.sbt.web.SbtWeb.autoImport._
 import com.gu.Dependencies._


### PR DESCRIPTION
Remove the import `import play.sbt.Play.autoImport._` which is causing deprecation warnings (see below) and duplicates the other existing import `import com.typesafe.sbt.web.SbtWeb.autoImport._`.

Warnings:
<img width="1140" alt="Screenshot 2021-04-19 at 14 44 33" src="https://user-images.githubusercontent.com/6035518/115246523-de432d00-a11d-11eb-9f9a-c675d1114b33.png">



