### PR TITLE
Add Journal to theguardian sub nav

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -168,6 +168,7 @@ private object NavLinks {
     children = List(
       NavLink("Obituaries", "/tone/obituaries"),
       NavLink("G2", "/theguardian/g2"),
+      NavLink("Journal", "/theguardian/journal"),
       NavLink("Weekend", "/theguardian/weekend"),
       NavLink("The Guide", "/theguardian/theguide"),
       NavLink("Saturday review", "/theguardian/guardianreview"),


### PR DESCRIPTION
## What does this change?

Adds theguardian/journal to the subnav of /theguardian

## Does this change need to be reproduced in dotcom-rendering ?

- [x] Yes Automatically

## Screenshots

| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/638051/115401142-fbd9ca80-a1e1-11eb-88c8-5be81ba75c39.png) | ![image](https://user-images.githubusercontent.com/638051/115401208-10b65e00-a1e2-11eb-93f1-068dc8785b63.png)|

![image](https://user-images.githubusercontent.com/638051/115401260-1e6be380-a1e2-11eb-81f9-24838c7070fd.png)


Tested locally.