### PR TITLE
Bump @guardian/braze-components to v1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@guardian/atom-renderer": "1.2.2",
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.7",
-    "@guardian/braze-components": "1.0.1",
+    "@guardian/braze-components": "1.1.0",
     "@guardian/commercial-core": "^0.16.3",
     "@guardian/consent-management-platform": "^6.11.3",
     "@guardian/libs": "^1.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1868,10 +1868,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/braze-components@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-1.0.1.tgz#427364b25c1288a1845c7ad49009a8f32efc7f01"
-  integrity sha512-mF63OjWy1YbQnC4nQlGhB8fPcwlgf8ed6YAr5NiyJ4S1QQow5vU/2gw6halI1a79UjmDIM6GNk21kJ1ZrK89Rg==
+"@guardian/braze-components@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-1.1.0.tgz#d5ac3e5152d23bb6006880b52cb71efd1a9efb76"
+  integrity sha512-YVfqckgIeF2Txqs6Z4QnXgFYhRP/nOLOJAWPaOt+msnxqr9MPysjcCHFoJ2iEPjnwRNibszJUx9ONsN3mx9spA==
   dependencies:
     "@guardian/src-button" "2.7.1"
     "@guardian/src-foundations" "2.7.1"


### PR DESCRIPTION
## What does this change?
Bumps @guardian/braze-components to [v1.1.0 ](https://github.com/guardian/braze-components/releases/tag/v1.1.0)

## Why?
In order to support the Braze Epic & `LocalMessageCache` with additional error logs.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes - [PR here](https://github.com/guardian/dotcom-rendering/pull/2885).

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
