### PR TITLE
Add Anniversary atom

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -11,6 +11,7 @@ object ActiveExperiments extends ExperimentsDefinition {
     ClickToView,
     LiveblogRendering,
     HideAnniversaryAtom,
+    AnniversaryAtom,
   )
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -33,6 +34,15 @@ object HideAnniversaryAtom
       owners = Seq(Owner.withGithub("gtrufitt")),
       sellByDate = new LocalDate(2021, 5, 19),
       participationGroup = Perc0B,
+    )
+
+object AnniversaryAtom
+    extends Experiment(
+      name = "anniversary-atom",
+      description = "Allows opting into the anniversary atom for testing on prod",
+      owners = Seq(Owner.withGithub("gtrufitt")),
+      sellByDate = new LocalDate(2021, 5, 19),
+      participationGroup = Perc0C,
     )
 
 object NewsletterEmbedDesign


### PR DESCRIPTION
## What does this change?

I need a way for people to opt into the anniversary atom on PROD, so need a second serverside switch.

- AnniversaryAtom - 0% opt in to see the atom before rolling out to users
- HideAnniversaryAtom - opt in to hide the atom (will opt users in on first page view, so they're only shown atom once)