### PR TITLE
Remove qwery from commercial code

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-aside-adverts.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/article-aside-adverts.spec.js
@@ -1,4 +1,3 @@
-import qwery from 'qwery';
 import fakeConfig from '../../../lib/config';
 import fakeMediator from '../../../lib/mediator';
 import fastdom from '../../../lib/fastdom-promise';
@@ -45,7 +44,7 @@ describe('Standard Article Aside Adverts', () => {
 
     it('should exist', () => {
         expect(init).toBeDefined();
-        expect(qwery('.ad-slot').length).toBe(1);
+        expect(document.querySelectorAll('.ad-slot').length).toBe(1);
     });
 
     it('should resolve immediately if the secondary column does not exist', done => {
@@ -101,7 +100,7 @@ describe('Immersive Article Aside Adverts', () => {
 
     it('should have correct test elements', () => {
         expect(
-            qwery('.js-content-main-column .element--immersive').length
+            document.querySelectorAll('.js-content-main-column .element--immersive').length
         ).toBe(2);
     });
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
@@ -1,4 +1,3 @@
-import qwery from 'qwery';
 import { dfpEnv } from './dfp-env';
 import { Advert } from './Advert';
 import { queueAdvert } from './queue-advert';
@@ -35,7 +34,7 @@ const fillAdvertSlots = () => {
             config.get('isDotcomRendering', false) &&
             getBreakpoint() === 'mobile'
         // Get all ad slots
-        const adverts = qwery(dfpEnv.adSlotSelector)
+        const adverts = Array.from(document.querySelectorAll(dfpEnv.adSlotSelector))
             .filter(adSlot => !(adSlot.id in dfpEnv.advertIds))
             // TODO: find cleaner workaround
             // we need to not init top-above-nav on mobile view in DCR

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.js
@@ -3,7 +3,6 @@ import {
     onConsentChange,
 } from '@guardian/consent-management-platform';
 import { loadScript, storage } from '@guardian/libs';
-import qwery from 'qwery';
 import config from '../../../../lib/config';
 import fastdom from '../../../../lib/fastdom-promise';
 import raven from '../../../../lib/raven';

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.js
@@ -1,4 +1,3 @@
-import qwery from 'qwery';
 import config from '../../../../lib/config';
 import reportError from '../../../../lib/report-error';
 import fastdom from '../../../../lib/fastdom-promise';
@@ -187,8 +186,7 @@ sizeCallbacks[adSizes.merchandising] = addFluid250([
 ]);
 
 const addContentClass = adSlotNode => {
-    const adSlotContent = qwery('> div:not(.ad-slot__label)', adSlotNode);
-
+    const adSlotContent = Array.from(adSlotNode.querySelectorAll('div:not(.ad-slot__label)'));
     if (adSlotContent.length) {
         fastdom.mutate(() => {
             adSlotContent[0].classList.add('ad-slot__content');

--- a/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
@@ -1,7 +1,6 @@
 import bonzo from 'bonzo';
 import fastdom from 'fastdom';
 import throttle from 'lodash/throttle';
-import qwery from 'qwery';
 import $ from '../../../../lib/$';
 import config from '../../../../lib/config';
 import { getBreakpoint, hasTouchScreen } from '../../../../lib/detect';
@@ -40,17 +39,14 @@ class HostedGallery {
         this.$images = $('.js-hosted-gallery-image', this.$imagesContainer);
         this.$progress = $('.js-hosted-gallery-progress', this.$galleryEl);
         this.$border = $('.js-hosted-gallery-rotating-border', this.$progress);
-        this.prevBtn = qwery('.inline-arrow-up', this.$progress)[0];
-        this.nextBtn = qwery('.inline-arrow-down', this.$progress)[0];
-        this.infoBtn = qwery(
-            '.js-gallery-caption-button',
-            this.$captionContainer
-        )[0];
+        this.prevBtn = this.$progress[0].querySelector('.inline-arrow-up');
+        this.nextBtn = this.$progress[0].querySelector('.inline-arrow-down');
+        this.infoBtn = this.$captionContainer[0].querySelector('.js-gallery-caption-button');
         this.$counter = $('.js-hosted-gallery-image-count', this.$progress);
         this.$ctaFloat = $('.js-hosted-gallery-cta', this.$galleryEl)[0];
         this.$ojFloat = $('.js-hosted-gallery-oj', this.$galleryEl)[0];
         this.$meta = $('.js-hosted-gallery-meta', this.$galleryEl)[0];
-        this.ojClose = qwery('.js-hosted-gallery-oj-close', this.$ojFloat)[0];
+        this.ojClose = this.$ojFloat.querySelector('.js-hosted-gallery-oj-close');
 
         if (this.$galleryEl.length) {
             this.resize = this.trigger.bind(this, 'resize');
@@ -532,7 +528,7 @@ HostedGallery.prototype.states = {
 };
 
 export const init = () => {
-    if (qwery('.js-hosted-gallery-container').length) {
+    if (document.querySelectorAll('.js-hosted-gallery-container').length) {
         return loadCssPromise.then(() => {
             let res;
             const galleryHash = window.location.hash;

--- a/static/src/javascripts/projects/commercial/modules/hosted/onward-journey-carousel.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/onward-journey-carousel.js
@@ -1,4 +1,3 @@
-import qwery from 'qwery';
 import fastdom from 'fastdom';
 import $ from '../../../../lib/$';
 
@@ -60,7 +59,7 @@ class HostedCarousel {
 }
 
 export const initHostedCarousel = () => {
-    if (qwery('.js-carousel-pages').length) {
+    if (document.querySelectorAll('.js-carousel-pages').length) {
         new HostedCarousel().bindButtons();
     }
     return Promise.resolve();

--- a/static/src/javascripts/projects/commercial/modules/paid-containers.js
+++ b/static/src/javascripts/projects/commercial/modules/paid-containers.js
@@ -1,4 +1,3 @@
-import qwery from 'qwery';
 import bean from 'bean';
 import fastdom from 'fastdom';
 
@@ -24,7 +23,7 @@ const onOpenClick = (event) => {
 };
 
 const paidContainers = () => {
-    const showMores = qwery('.dumathoin-more > summary');
+    const showMores = Array.from(document.querySelectorAll('.dumathoin-more > summary'));
     bean.on(document, 'click', showMores, onOpenClick);
     bean.on(document, 'click', showMores, onKeyPress(onOpenClick));
 


### PR DESCRIPTION
## What does this change?

Removes use of the [qwery](https://github.com/ded/qwery) library from the commercial bundle.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Reduced bundle size, faster start up time, less reliance on very old libraries, help future migration

### Tested

- [ ] Locally
- [ ] On CODE (optional)

