### PR TITLE
Introduce the ?dcr flag at the interactive controller

### DIFF
--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -106,7 +106,7 @@ class InteractiveController(
 
   override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = {
     ApplicationsInteractiveRendering.getRenderingTier(path) match {
-      case Regular => {
+      case FrontendLegacy => {
         lookup(path) map {
           case Left(model)  => render(model)
           case Right(other) => RenderOtherStatus(other)

--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -105,7 +105,6 @@ class InteractiveController(
   override def canRender(i: ItemResponse): Boolean = i.content.exists(_.isInteractive)
 
   override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = {
-    // See comment id: DF38D2B4-614D for why we have two rendering.
     ApplicationsInteractiveRendering.getRenderingTier(path) match {
       case Regular => {
         lookup(path) map {
@@ -114,6 +113,13 @@ class InteractiveController(
         }
       }
       case USElection2020AmpPage => renderInteractivePageUSPresidentialElection2020(path)
+      case DotcomRendering => {
+        // On purpose reproduce Regular [work in progress]
+        lookup(path) map {
+          case Left(model)  => render(model)
+          case Right(other) => RenderOtherStatus(other)
+        }
+      }
     }
   }
 
@@ -122,7 +128,7 @@ class InteractiveController(
 
   def renderInteractivePageUSPresidentialElection2020(path: String): Future[Result] = {
     /*
-      This version retrieve the AMP version directly but rely on an predefined map between paths and amp page ids
+      This version retrieve the AMP version directly but rely on a predefined map between paths and amp page ids
      */
     val capiLookupString = ApplicationsUSElection2020AmpPages.pathToAmpAtomId(path)
     val response: Future[ItemResponse] = lookupWithoutModelConvertion(capiLookupString)

--- a/applications/app/services/ApplicationsInteractiveRendering.scala
+++ b/applications/app/services/ApplicationsInteractiveRendering.scala
@@ -4,7 +4,7 @@ import play.api.mvc.RequestHeader
 import implicits.Requests._
 
 sealed trait RenderingTier
-object Regular extends RenderingTier
+object FrontendLegacy extends RenderingTier
 object USElection2020AmpPage extends RenderingTier
 object DotcomRendering extends RenderingTier
 
@@ -36,6 +36,6 @@ object ApplicationsInteractiveRendering {
 
     if (isSpecialElection && isAmp) USElection2020AmpPage
     else if (forceDCR) DotcomRendering
-    else Regular
+    else FrontendLegacy
   }
 }

--- a/applications/app/services/ApplicationsInteractiveRendering.scala
+++ b/applications/app/services/ApplicationsInteractiveRendering.scala
@@ -33,10 +33,9 @@ object ApplicationsInteractiveRendering {
     val isSpecialElection = ApplicationsUSElection2020AmpPages.pathIsSpecialHanding(path)
     val isAmp = request.host.contains("amp")
     val forceDCR = request.forceDCR
-    (isSpecialElection, isAmp, forceDCR) match {
-      case (true, true, _)  => USElection2020AmpPage
-      case (_, false, true) => DotcomRendering
-      case _                => Regular
-    }
+
+    if (isSpecialElection && isAmp) USElection2020AmpPage
+    else if (forceDCR) DotcomRendering
+    else Regular
   }
 }

--- a/applications/app/services/ApplicationsInteractiveRendering.scala
+++ b/applications/app/services/ApplicationsInteractiveRendering.scala
@@ -1,15 +1,16 @@
 package services
 
 import play.api.mvc.RequestHeader
+import implicits.Requests._
 
 sealed trait RenderingTier
 object Regular extends RenderingTier
 object USElection2020AmpPage extends RenderingTier
+object DotcomRendering extends RenderingTier
 
 /*
-  Author: Pascal
   Date: 21st Jan 2020
-  CommentID: DF38D2B4-614D
+  Author: Pascal
 
   This object was introduced in late 2020, to handle the routing between regular rendering of interactives
   versus the code that had been written to handle the US Presidential Election Tracker amp page.
@@ -18,13 +19,24 @@ object USElection2020AmpPage extends RenderingTier
   1. Implement the support for it in DCR, or
   2. Implement support for it directly in the [applications] app, using the AMP page already present in CAPI.
 
-  The former wold have taken too long so we went for the latter.
+  The former would have taken too long so we went for the latter.
+
+  ----------------
+  Author: Pascal
+  Date: 21st April 2021
+
+  We are now moving towards supporting interactives in DCR 🙂
  */
 
 object ApplicationsInteractiveRendering {
   def getRenderingTier(path: String)(implicit request: RequestHeader): RenderingTier = {
     val isSpecialElection = ApplicationsUSElection2020AmpPages.pathIsSpecialHanding(path)
     val isAmp = request.host.contains("amp")
-    if (isSpecialElection && isAmp) USElection2020AmpPage else Regular
+    val forceDCR = request.forceDCR
+    (isSpecialElection, isAmp, forceDCR) match {
+      case (true, true, _)  => USElection2020AmpPage
+      case (_, false, true) => DotcomRendering
+      case _                => Regular
+    }
   }
 }


### PR DESCRIPTION
## What does this change?

This is the first of a series of PRs that are going to bring us to using DCR for rendering interactives, and here we simply adds  `DotcomRendering` to the list of `RenderingTier`s for the interactive controller and links it to the `?dcr` flag. There is no other change for the moment.

This obviously builds on the preliminary work we had done few months ago for the 2020 Election Tracker, and one of the outcomes of the work we start today is to eventually decommission `USElection2020AmpPage` as a special case.
