### PR TITLE
Interactive controller refactoring and functional upgrade

### DIFF
--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -115,7 +115,6 @@ class InteractiveController(
   override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = {
     val requestFormat = request.getRequestFormat
     val renderingTier = ApplicationsInteractiveRendering.getRenderingTier(path)
-    println((requestFormat, renderingTier))
     (requestFormat, renderingTier) match {
       case (AmpFormat, USElection2020AmpPage) => renderInteractivePageUSPresidentialElection2020(path)
       case (JsonFormat, DotcomRendering)      => Future.successful(Ok("{}").as("application/json"))

--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -122,7 +122,8 @@ class InteractiveController(
       case (AmpFormat, USElection2020AmpPage) => renderInteractivePageUSPresidentialElection2020(path)
       case (AmpFormat, DotcomRendering)       => RenderItemLegacy(path: String)
       case (HtmlFormat, _)                    => RenderItemLegacy(path: String)
-      case (JsonFormat, _)                    => Future.successful(Ok("[]").as("application/json"))
+      case (JsonFormat, DotcomRendering)      => Future.successful(Ok("[]").as("application/json"))
+      case (JsonFormat, _)                    => RenderItemLegacy(path: String)
     }
   }
 

--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -122,7 +122,7 @@ class InteractiveController(
       case (AmpFormat, USElection2020AmpPage) => renderInteractivePageUSPresidentialElection2020(path)
       case (AmpFormat, DotcomRendering)       => RenderItemLegacy(path: String)
       case (HtmlFormat, _)                    => RenderItemLegacy(path: String)
-      case (JsonFormat, DotcomRendering)      => Future.successful(Ok("[]").as("application/json"))
+      case (JsonFormat, DotcomRendering)      => Future.successful(Ok("{}").as("application/json"))
       case (JsonFormat, _)                    => RenderItemLegacy(path: String)
     }
   }

--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -117,13 +117,9 @@ class InteractiveController(
     val renderingTier = ApplicationsInteractiveRendering.getRenderingTier(path)
     println((requestFormat, renderingTier))
     (requestFormat, renderingTier) match {
-      case (EmailFormat, _)                   => RenderItemLegacy(path: String)
-      case (AmpFormat, FrontendLegacy)        => RenderItemLegacy(path: String)
       case (AmpFormat, USElection2020AmpPage) => renderInteractivePageUSPresidentialElection2020(path)
-      case (AmpFormat, DotcomRendering)       => RenderItemLegacy(path: String)
-      case (HtmlFormat, _)                    => RenderItemLegacy(path: String)
       case (JsonFormat, DotcomRendering)      => Future.successful(Ok("{}").as("application/json"))
-      case (JsonFormat, _)                    => RenderItemLegacy(path: String)
+      case _                                  => RenderItemLegacy(path: String)
     }
   }
 


### PR DESCRIPTION
## What does this change?

Another step in the interactives DCR migration. Follow up of: https://github.com/guardian/frontend/pull/23729

Here again we do not change much of what is already happening, if not posing the foundations for the `.json?dcr` functionality. To this aim we currently just return an empty JSON object. The rest is identical. 

Regular display : 

![Screenshot 2021-04-22 at 12 06 12](https://user-images.githubusercontent.com/6035518/115704360-31f28800-a363-11eb-9d46-e4e2e748f798.png)


Regular display with the currently inactive `?dcr` flag :

![Screenshot 2021-04-22 at 12 07 18](https://user-images.githubusercontent.com/6035518/115704460-4fbfed00-a363-11eb-8f7b-4bf1d35aa861.png)

`json` (legacy)

![Screenshot 2021-04-22 at 12 19 43](https://user-images.githubusercontent.com/6035518/115706044-22743e80-a365-11eb-9e26-83d4324c5da4.png)

`.json?dcr` : 

![Screenshot 2021-04-22 at 12 27 47](https://user-images.githubusercontent.com/6035518/115707043-38ceca00-a366-11eb-8f7c-25666cbaef9a.png)

And manually making sure the AMP election tracker is still there 🙂  (hardcoded AMP in the code for the screenshot) :

![Screenshot 2021-04-22 at 12 09 17](https://user-images.githubusercontent.com/6035518/115704718-9e6d8700-a363-11eb-8ef9-fb231e3f319f.png)

