### PR TITLE
feat: Allow labs articles in DCR

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -83,8 +83,6 @@ object ArticlePageChecks {
 
   def isNotOpinion(page: PageWithStoryPackage): Boolean = !page.item.tags.isComment
 
-  def isNotPaidContent(page: PageWithStoryPackage): Boolean = !page.article.tags.isPaidContent
-
 }
 
 object ArticlePicker {
@@ -105,7 +103,6 @@ object ArticlePicker {
       ("isNotAGallery", ArticlePageChecks.isNotAGallery(page)),
       ("isNotLiveBlog", ArticlePageChecks.isNotLiveBlog(page)),
       ("isNotAMP", ArticlePageChecks.isNotAMP(request)),
-      ("isNotPaidContent", ArticlePageChecks.isNotPaidContent(page)),
       ("isNotInTagBlockList", ArticlePageChecks.isNotInTagBlockList(page)),
       ("isNotSpecialReport", !DotcomRenderingUtils.isSpecialReport(page)),
       ("isNotNumberedList", ArticlePageChecks.isNotNumberedList(page)),
@@ -122,7 +119,6 @@ object ArticlePicker {
         "isNotAMP",
         "isNotInTagBlockList",
         "isNotSpecialReport",
-        "isNotPaidContent",
       ),
     )
 


### PR DESCRIPTION
## What does this change?
Removes the restrictions from`ArticlePicker` to allow paid for ccontent to be displayed in DCR.

Depends on https://github.com/guardian/dotcom-rendering/pull/2905