### PR TITLE
feat: Allow Special Reports in DCR

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -104,7 +104,6 @@ object ArticlePicker {
       ("isNotLiveBlog", ArticlePageChecks.isNotLiveBlog(page)),
       ("isNotAMP", ArticlePageChecks.isNotAMP(request)),
       ("isNotInTagBlockList", ArticlePageChecks.isNotInTagBlockList(page)),
-      ("isNotSpecialReport", !DotcomRenderingUtils.isSpecialReport(page)),
       ("isNotNumberedList", ArticlePageChecks.isNotNumberedList(page)),
     )
   }
@@ -118,7 +117,6 @@ object ArticlePicker {
         "isNotLiveBlog",
         "isNotAMP",
         "isNotInTagBlockList",
-        "isNotSpecialReport",
       ),
     )
 


### PR DESCRIPTION
## What does this change?
Removes the filters preventing `SpecialReports` from being rendered by DCR

### The opinion card problem
There's still one outstanding issue where onwards cards for SpecialReports that are also comment pieces have the wrong styling. Instead of the grey background, they get the peachy one. This is both rare and minor and a fix for this is already planned so I'm inclined to go ahead with adding support (while I'm still around to look into any issues rather than later when I'm gone 😨 ). Plus, I'm just keen to see that percentage go up a bit 📈 