### PR TITLE
Don't use DCR for Labs articles

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -83,6 +83,8 @@ object ArticlePageChecks {
 
   def isNotOpinion(page: PageWithStoryPackage): Boolean = !page.item.tags.isComment
 
+  def isNotPaidContent(page: PageWithStoryPackage): Boolean = !page.article.tags.isPaidContent
+
 }
 
 object ArticlePicker {
@@ -103,6 +105,7 @@ object ArticlePicker {
       ("isNotAGallery", ArticlePageChecks.isNotAGallery(page)),
       ("isNotLiveBlog", ArticlePageChecks.isNotLiveBlog(page)),
       ("isNotAMP", ArticlePageChecks.isNotAMP(request)),
+      ("isNotPaidContent", ArticlePageChecks.isNotPaidContent(page)),
       ("isNotInTagBlockList", ArticlePageChecks.isNotInTagBlockList(page)),
       ("isNotNumberedList", ArticlePageChecks.isNotNumberedList(page)),
     )
@@ -117,6 +120,7 @@ object ArticlePicker {
         "isNotLiveBlog",
         "isNotAMP",
         "isNotInTagBlockList",
+        "isNotPaidContent",
       ),
     )
 


### PR DESCRIPTION
## What does this change?
This reverts https://github.com/guardian/frontend/pull/23735/

We noticed a few minor issues after releasing this change that - whilst not serious -by reverting we have more time to deal with them