### PR TITLE
Update to the latest version of ophan

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "fence": "guardian/fence#0.2.11",
     "lodash-es": "^4.17.21",
     "object-fit-videos": "^1.0.3",
-    "ophan-tracker-js": "1.3.24",
+    "ophan-tracker-js": "1.3.25",
     "preact": "^10.5.13",
     "prebid.js": "https://github.com/guardian/Prebid.js#681fbb",
     "qwery": "3.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10248,10 +10248,10 @@ openurl@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/openurl/-/openurl-1.1.1.tgz#3875b4b0ef7a52c156f0db41d4609dbb0f94b387"
 
-ophan-tracker-js@1.3.24:
-  version "1.3.24"
-  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.24.tgz#8bee64a8dfcba840d097cc816c5d7ed3e0a50dcc"
-  integrity sha512-bFm5nh12KWwy2jxMSHlnVOPNj/3YvlQiGykUqVpMqiIVIgr8GETfVaWHS3SZzZ73pk4oV8kEBphBUT6zl5IlxA==
+ophan-tracker-js@1.3.25:
+  version "1.3.25"
+  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.25.tgz#7a43b4a232d940cd68f74a82a712bd2a1ddb4b6f"
+  integrity sha512-jufAOME9FLSuzEMgWhDd6O6xoMJTv2I/GJISiOuaT0W1YVs9upP7zTeXVEPQi12NMe1ZliqFBWnqCea8gVx+2g==
 
 opn@5.3.0:
   version "5.3.0"


### PR DESCRIPTION
## What does this change?

Updating to the new version of `ophan-tracker` which removes [IP connectivity](https://github.com/guardian/ophan/pull/4110)

## Does this change need to be reproduced in dotcom-rendering ?

yes.
