### PR TITLE
Remove qwery from fill-advert-slots.js

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
@@ -18,44 +18,44 @@ import config from '../../../../lib/config';
 //  liveblog-adverts
 //  high-merch
 const fillAdvertSlots = () => {
-    // This module has the following strict dependencies. These dependencies must be
-    // fulfilled before fillAdvertSlots can execute reliably. The bootstrap (commercial.js)
-    // initiates these dependencies, to speed up the init process. Bootstrap also captures the module performance.
-    const dependencies = [
-        setupPrebidOnce(),
-        removeDisabledSlots(),
-    ];
+	// This module has the following strict dependencies. These dependencies must be
+	// fulfilled before fillAdvertSlots can execute reliably. The bootstrap (commercial.js)
+	// initiates these dependencies, to speed up the init process. Bootstrap also captures the module performance.
+	const dependencies = [setupPrebidOnce(), removeDisabledSlots()];
 
-    return Promise.all(dependencies).then(() => {
-        // Quit if ad-free
-        if (commercialFeatures.adFree) {
-            return Promise.resolve();
-        }
-        const isDCRMobile =
-            config.get('isDotcomRendering', false) &&
-            getBreakpoint() === 'mobile'
-        // Get all ad slots
-        const adverts = qwery(dfpEnv.adSlotSelector)
-            .filter(adSlot => !(adSlot.id in dfpEnv.advertIds))
-            // TODO: find cleaner workaround
-            // we need to not init top-above-nav on mobile view in DCR
-            // as the DOM element needs to be removed and replaced to be inline
-            // refer to: 3562dc07-78e9-4507-b922-78b979d4c5cb
-            .filter(adSlot => !(isDCRMobile && adSlot.id === 'dfp-ad--top-above-nav'))
-            .map(adSlot => new Advert(adSlot));
-        const currentLength = dfpEnv.adverts.length;
-        dfpEnv.adverts = dfpEnv.adverts.concat(adverts);
-        adverts.forEach((advert, index) => {
-            dfpEnv.advertIds[advert.id] = currentLength + index;
-        });
-        adverts.forEach(queueAdvert);
+	return Promise.all(dependencies).then(() => {
+		// Quit if ad-free
+		if (commercialFeatures.adFree) {
+			return Promise.resolve();
+		}
+		const isDCRMobile =
+			config.get('isDotcomRendering', false) &&
+			getBreakpoint() === 'mobile';
+		// Get all ad slots
+		const adverts = [...document.querySelectorAll(dfpEnv.adSlotSelector)]
+			.filter((adSlot) => !(adSlot.id in dfpEnv.advertIds))
+			// TODO: find cleaner workaround
+			// we need to not init top-above-nav on mobile view in DCR
+			// as the DOM element needs to be removed and replaced to be inline
+			// refer to: 3562dc07-78e9-4507-b922-78b979d4c5cb
+			.filter(
+				(adSlot) =>
+					!(isDCRMobile && adSlot.id === 'dfp-ad--top-above-nav'),
+			)
+			.map((adSlot) => new Advert(adSlot));
+		const currentLength = dfpEnv.adverts.length;
+		dfpEnv.adverts = dfpEnv.adverts.concat(adverts);
+		adverts.forEach((advert, index) => {
+			dfpEnv.advertIds[advert.id] = currentLength + index;
+		});
+		adverts.forEach(queueAdvert);
 
-        if (dfpEnv.shouldLazyLoad()) {
-            displayLazyAds();
-        } else {
-            displayAds();
-        }
-    });
+		if (dfpEnv.shouldLazyLoad()) {
+			displayLazyAds();
+		} else {
+			displayAds();
+		}
+	});
 };
 
 export { fillAdvertSlots };

--- a/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.js
@@ -18,44 +18,44 @@ import config from '../../../../lib/config';
 //  liveblog-adverts
 //  high-merch
 const fillAdvertSlots = () => {
-	// This module has the following strict dependencies. These dependencies must be
-	// fulfilled before fillAdvertSlots can execute reliably. The bootstrap (commercial.js)
-	// initiates these dependencies, to speed up the init process. Bootstrap also captures the module performance.
-	const dependencies = [setupPrebidOnce(), removeDisabledSlots()];
+    // This module has the following strict dependencies. These dependencies must be
+    // fulfilled before fillAdvertSlots can execute reliably. The bootstrap (commercial.js)
+    // initiates these dependencies, to speed up the init process. Bootstrap also captures the module performance.
+    const dependencies = [
+        setupPrebidOnce(),
+        removeDisabledSlots(),
+    ];
 
-	return Promise.all(dependencies).then(() => {
-		// Quit if ad-free
-		if (commercialFeatures.adFree) {
-			return Promise.resolve();
-		}
-		const isDCRMobile =
-			config.get('isDotcomRendering', false) &&
-			getBreakpoint() === 'mobile';
-		// Get all ad slots
-		const adverts = [...document.querySelectorAll(dfpEnv.adSlotSelector)]
-			.filter((adSlot) => !(adSlot.id in dfpEnv.advertIds))
-			// TODO: find cleaner workaround
-			// we need to not init top-above-nav on mobile view in DCR
-			// as the DOM element needs to be removed and replaced to be inline
-			// refer to: 3562dc07-78e9-4507-b922-78b979d4c5cb
-			.filter(
-				(adSlot) =>
-					!(isDCRMobile && adSlot.id === 'dfp-ad--top-above-nav'),
-			)
-			.map((adSlot) => new Advert(adSlot));
-		const currentLength = dfpEnv.adverts.length;
-		dfpEnv.adverts = dfpEnv.adverts.concat(adverts);
-		adverts.forEach((advert, index) => {
-			dfpEnv.advertIds[advert.id] = currentLength + index;
-		});
-		adverts.forEach(queueAdvert);
+    return Promise.all(dependencies).then(() => {
+        // Quit if ad-free
+        if (commercialFeatures.adFree) {
+            return Promise.resolve();
+        }
+        const isDCRMobile =
+            config.get('isDotcomRendering', false) &&
+            getBreakpoint() === 'mobile'
+        // Get all ad slots
+        const adverts = [...document.querySelectorAll(dfpEnv.adSlotSelector)]
+            .filter(adSlot => !(adSlot.id in dfpEnv.advertIds))
+            // TODO: find cleaner workaround
+            // we need to not init top-above-nav on mobile view in DCR
+            // as the DOM element needs to be removed and replaced to be inline
+            // refer to: 3562dc07-78e9-4507-b922-78b979d4c5cb
+            .filter(adSlot => !(isDCRMobile && adSlot.id === 'dfp-ad--top-above-nav'))
+            .map(adSlot => new Advert(adSlot));
+        const currentLength = dfpEnv.adverts.length;
+        dfpEnv.adverts = dfpEnv.adverts.concat(adverts);
+        adverts.forEach((advert, index) => {
+            dfpEnv.advertIds[advert.id] = currentLength + index;
+        });
+        adverts.forEach(queueAdvert);
 
-		if (dfpEnv.shouldLazyLoad()) {
-			displayLazyAds();
-		} else {
-			displayAds();
-		}
-	});
+        if (dfpEnv.shouldLazyLoad()) {
+            displayLazyAds();
+        } else {
+            displayAds();
+        }
+    });
 };
 
 export { fillAdvertSlots };


### PR DESCRIPTION
## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Part of https://github.com/guardian/frontend/pull/23740

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
