### PR TITLE
Fix fetch calls to IDAPI

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/api.ts
+++ b/static/src/javascripts/projects/common/modules/identity/api.ts
@@ -198,14 +198,11 @@ export const getCookie = (): string | null =>
 export const getUrl = (): string => profileRoot;
 
 export const getUserFromApiWithRefreshedCookie = (): Promise<unknown> => {
-	const endpoint = `${idApiRoot}/user/me`;
-	const data = new URLSearchParams();
-	data.append('refreshCookie', 'true');
+	const endpoint = `${idApiRoot}/user/me?refreshCookie=true`;
 
 	return fetch(endpoint, {
 		mode: 'cors',
 		credentials: 'include',
-		body: data.toString(),
 	}).then((resp) => resp.json());
 };
 
@@ -288,14 +285,13 @@ export const sendValidationEmail = (): unknown => {
 		  decodeURIComponent(getUrlVars()?.returnUrl)
 		: profileRoot + defaultReturnEndpoint;
 
-	const data = new URLSearchParams();
-	data.append('method', 'post');
-	data.append('returnUrl', returnUrl);
+	const params = new URLSearchParams();
+	params.append('returnUrl', returnUrl);
 
-	const request = fetch(endpoint, {
+	const request = fetch(`${endpoint}?${params.toString()}`, {
 		mode: 'cors',
 		credentials: 'include',
-		body: data.toString(),
+		method: 'POST',
 	});
 
 	return request;


### PR DESCRIPTION
## What does this change?

Fix errors thrown by fetch introduced in https://github.com/guardian/frontend/commit/9aa8ca8650c52d0792ee9e06c7c60394f4f043bf

User sessions stopped getting refreshed on 12th April

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

User SC_GU_U cookies get refreshed if they are a month old. If they are not refreshed, after 3 months users have to login again. 

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
