### PR TITLE
Mock up data object that passes DCR validation for interactive

### DIFF
--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -11,7 +11,7 @@ import play.api.mvc._
 import views.support.RenderOtherStatus
 import conf.Configuration.interactive.cdnPath
 import model.content.InteractiveAtom
-import model.dotcomrendering.PageType
+import model.dotcomrendering.{DotcomRenderingDataModel, PageType}
 import org.apache.commons.lang.StringEscapeUtils
 import pages.InteractiveHtmlPage
 import renderers.DotcomRenderingService
@@ -117,8 +117,12 @@ class InteractiveController(
     val renderingTier = ApplicationsInteractiveRendering.getRenderingTier(path)
     (requestFormat, renderingTier) match {
       case (AmpFormat, USElection2020AmpPage) => renderInteractivePageUSPresidentialElection2020(path)
-      case (JsonFormat, DotcomRendering)      => Future.successful(Ok("{}").as("application/json"))
-      case _                                  => RenderItemLegacy(path: String)
+      case (JsonFormat, DotcomRendering) => {
+        val data = InteractivesDotcomRenderingDataObject.makeDataObject()
+        val dataJson = DotcomRenderingDataModel.toJson(data)
+        Future.successful(Ok(dataJson).as("application/json"))
+      }
+      case _ => RenderItemLegacy(path: String)
     }
   }
 

--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -115,7 +115,6 @@ class InteractiveController(
   override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = {
     val requestFormat = request.getRequestFormat
     val renderingTier = ApplicationsInteractiveRendering.getRenderingTier(path)
-    println((requestFormat, renderingTier))
     (requestFormat, renderingTier) match {
       case (EmailFormat, _)                   => RenderItemLegacy(path: String)
       case (AmpFormat, FrontendLegacy)        => RenderItemLegacy(path: String)

--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -118,7 +118,7 @@ class InteractiveController(
     (requestFormat, renderingTier) match {
       case (AmpFormat, USElection2020AmpPage) => renderInteractivePageUSPresidentialElection2020(path)
       case (JsonFormat, DotcomRendering) => {
-        val data = InteractivesDotcomRenderingDataObject.makeDataObject()
+        val data = InteractivesDotcomRenderingDataObject.mockDataObject()
         val dataJson = DotcomRenderingDataModel.toJson(data)
         Future.successful(Ok(dataJson))
       }

--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -120,7 +120,7 @@ class InteractiveController(
       case (JsonFormat, DotcomRendering) => {
         val data = InteractivesDotcomRenderingDataObject.makeDataObject()
         val dataJson = DotcomRenderingDataModel.toJson(data)
-        Future.successful(Ok(dataJson).as("application/json"))
+        Future.successful(Ok(dataJson))
       }
       case _ => RenderItemLegacy(path: String)
     }

--- a/applications/app/model/InteractivesDotcomRenderingDataObject.scala
+++ b/applications/app/model/InteractivesDotcomRenderingDataObject.scala
@@ -1,0 +1,136 @@
+package model
+
+import com.gu.contentapi.client.utils.format.{ArticleDesign, NewsPillar, StandardDisplay}
+import common.{Edition, Localisation}
+import conf.Configuration
+import model.dotcomrendering.DotcomRenderingUtils.{designTypeAsString, findPillar, makeMatchUrl}
+import model.dotcomrendering.pageElements.TextCleaner
+import model.dotcomrendering.{Author, DotcomRenderingDataModel, DotcomRenderingUtils, PageFooter, PageType}
+import navigation.{FooterLinks, Nav, NavLink, ReaderRevenueLink, ReaderRevenueLinks, Subnav}
+import views.support.ContentLayout
+import play.api.libs.json
+import play.api.libs.json._
+import play.api.mvc.RequestHeader
+
+object InteractivesDotcomRenderingDataObject {
+
+  def makeDataObject()(implicit request: RequestHeader): DotcomRenderingDataModel = {
+
+    val author = Author(Some("author byline"), Some("author twitterHandle"))
+    val config: json.JsObject = Json.obj("name" -> "Something")
+    val pageType = PageType(
+      hasShowcaseMainElement = false,
+      isFront = false,
+      isLiveblog = false,
+      isMinuteArticle = false,
+      isPaidContent = false,
+      isPreview = false,
+      isSensitive = false,
+    )
+
+    val readerRevenueLinks = ReaderRevenueLinks(
+      header = ReaderRevenueLink(
+        contribute = "contribute",
+        subscribe = "subscribe",
+        support = "support",
+        supporter = "supporter",
+      ),
+      footer = ReaderRevenueLink(
+        contribute = "contribute",
+        subscribe = "subscribe",
+        support = "support",
+        supporter = "supporter",
+      ),
+      sideMenu = ReaderRevenueLink(
+        contribute = "contribute",
+        subscribe = "subscribe",
+        support = "support",
+        supporter = "supporter",
+      ),
+      ampHeader = ReaderRevenueLink(
+        contribute = "contribute",
+        subscribe = "subscribe",
+        support = "support",
+        supporter = "supporter",
+      ),
+      ampFooter = ReaderRevenueLink(
+        contribute = "contribute",
+        subscribe = "subscribe",
+        support = "support",
+        supporter = "supporter",
+      ),
+    )
+
+    val nav = Nav(
+      currentUrl = "currentUrl",
+      pillars = List(),
+      otherLinks = List(),
+      brandExtensions = List(),
+      currentNavLinkTitle = None,
+      currentPillarTitle = None,
+      subNavSections = None,
+      readerRevenueLinks = readerRevenueLinks,
+    )
+
+    val pageFooter: PageFooter = PageFooter(
+      FooterLinks.getFooterByEdition(Edition(request)),
+    )
+
+    DotcomRenderingDataModel(
+      version = 3, // Int
+      headline = "headline",
+      standfirst = "standfirst",
+      webTitle = "webTitle",
+      mainMediaElements = List(),
+      main = "main",
+      keyEvents = List(),
+      blocks = List(),
+      pagination = None,
+      author = author,
+      webPublicationDate = "2021-04-22T14:11:12.000Z",
+      webPublicationDateDisplay = "Thu 22 Apr 2021 15.11 BST",
+      webPublicationSecondaryDateDisplay = "First published on Thu 22 Apr 2021 11.00 BST",
+      editionLongForm = "UK edition",
+      editionId = "UK",
+      pageId = "pageId",
+      format = ContentFormat(ArticleDesign, NewsPillar, StandardDisplay),
+      designType = "designType",
+      tags = List(),
+      pillar = "pillar",
+      isImmersive = false,
+      sectionLabel = "sectionLabel",
+      sectionUrl = "sectionUrl",
+      sectionName = None,
+      subMetaSectionLinks = List(),
+      subMetaKeywordLinks = List(),
+      shouldHideAds = true,
+      isAdFreeUser = false,
+      webURL = "webURL",
+      linkedData = List(),
+      openGraphData = Map(),
+      twitterData = Map(),
+      config = config,
+      guardianBaseURL = "https://www.theguardian.com",
+      contentType = "contentType",
+      hasRelated = false,
+      hasStoryPackage = false,
+      beaconURL = "//phar.gu-web.net",
+      isCommentable = false,
+      commercialProperties = Map(),
+      pageType = pageType,
+      starRating = None,
+      trailText = "trailText",
+      nav = nav,
+      showBottomSocialButtons = false,
+      pageFooter = pageFooter,
+      publication = "publication",
+      shouldHideReaderRevenue = true,
+      slotMachineFlags = "",
+      contributionsServiceUrl = "https://contributions.guardianapis.com",
+      badge = None,
+      matchUrl = None,
+      isSpecialReport = false,
+    )
+  }
+
+}

--- a/applications/app/model/InteractivesDotcomRenderingDataObject.scala
+++ b/applications/app/model/InteractivesDotcomRenderingDataObject.scala
@@ -1,6 +1,9 @@
 package model
 
+import com.gu.commercial.branding.Branding
+import com.gu.commercial.display.AdTargetParam
 import com.gu.contentapi.client.utils.format.{ArticleDesign, NewsPillar, StandardDisplay}
+import common.commercial.EditionCommercialProperties
 import common.{Edition, Localisation}
 import conf.Configuration
 import model.dotcomrendering.DotcomRenderingUtils.{designTypeAsString, findPillar, makeMatchUrl}
@@ -17,7 +20,40 @@ object InteractivesDotcomRenderingDataObject {
   def makeDataObject()(implicit request: RequestHeader): DotcomRenderingDataModel = {
 
     val author = Author(Some("author byline"), Some("author twitterHandle"))
-    val config: json.JsObject = Json.obj("name" -> "Something")
+    val config: json.JsObject = Json.obj(
+      "abTests" -> Json.obj(),
+      "adUnit" -> "/59666047/theguardian.com/news/article/ng",
+      "ajaxUrl" -> "https://api.nextgen.guardianapps.co.uk",
+      "ampIframeUrl" -> "https://assets.guim.co.uk/data/vendor/8aef390c60b12c2d4425870583ed8245/amp-iframe.html",
+      "commercialBundleUrl" -> "https://assets.guim.co.uk/javascripts/1ac3825c94468946aa8d/graun.commercial.dcr.js",
+      "contentType" -> "Article",
+      "dcrSentryDsn" -> "https://1937ab71c8804b2b8438178dfdd6468f@sentry.io/1377847",
+      "dfpAccountId" -> "59666047",
+      "discussionApiClientHeader" -> "nextgen",
+      "discussionApiUrl" -> "https://discussion.theguardian.com/discussion-api",
+      "discussionD2Uid" -> "zHoBy6HNKsk",
+      "edition" -> "UK",
+      "frontendAssetsFullURL" -> "https://assets.guim.co.uk/",
+      "googletagUrl" -> "//securepubads.g.doubleclick.net/tag/js/gpt.js",
+      "hbImpl" -> Json.obj(),
+      "idApiUrl" -> "https://idapi.theguardian.com",
+      "isLive" -> false,
+      "isLiveBlog" -> false,
+      "isPhotoEssay" -> false,
+      "isSensitive" -> false,
+      "keywordIds" -> "",
+      "pageId" -> "news/2021/apr/26/iran-sentences-nazanin-zaghari-ratcliffe-to-further-one-year-jail-term",
+      "revisionNumber" -> "DEV",
+      "section" -> "news",
+      "sentryHost" -> "app.getsentry.com/35463",
+      "sentryPublicApiKey" -> "344003a8d11c41d8800fbad8383fdc50",
+      "sharedAdTargeting" -> Json.obj(),
+      "shortUrlId" -> "/p/h7pht",
+      "showRelatedContent" -> true,
+      "stage" -> "PROD",
+      "switches" -> Json.obj(),
+      "videoDuration" -> 0,
+    )
     val pageType = PageType(
       hasShowcaseMainElement = false,
       isFront = false,
@@ -76,6 +112,14 @@ object InteractivesDotcomRenderingDataObject {
       FooterLinks.getFooterByEdition(Edition(request)),
     )
 
+    val commercialProperties =
+      Map(
+        "AU" -> EditionCommercialProperties(None, Set()),
+        "INT" -> EditionCommercialProperties(None, Set()),
+        "UK" -> EditionCommercialProperties(None, Set()),
+        "US" -> EditionCommercialProperties(None, Set()),
+      )
+
     DotcomRenderingDataModel(
       version = 3, // Int
       headline = "headline",
@@ -96,7 +140,7 @@ object InteractivesDotcomRenderingDataObject {
       format = ContentFormat(ArticleDesign, NewsPillar, StandardDisplay),
       designType = "designType",
       tags = List(),
-      pillar = "pillar",
+      pillar = "news",
       isImmersive = false,
       sectionLabel = "sectionLabel",
       sectionUrl = "sectionUrl",
@@ -116,7 +160,7 @@ object InteractivesDotcomRenderingDataObject {
       hasStoryPackage = false,
       beaconURL = "//phar.gu-web.net",
       isCommentable = false,
-      commercialProperties = Map(),
+      commercialProperties = commercialProperties,
       pageType = pageType,
       starRating = None,
       trailText = "trailText",

--- a/applications/app/model/InteractivesDotcomRenderingDataObject.scala
+++ b/applications/app/model/InteractivesDotcomRenderingDataObject.scala
@@ -17,7 +17,7 @@ import play.api.mvc.RequestHeader
 
 object InteractivesDotcomRenderingDataObject {
 
-  def makeDataObject()(implicit request: RequestHeader): DotcomRenderingDataModel = {
+  def mockDataObject()(implicit request: RequestHeader): DotcomRenderingDataModel = {
 
     val author = Author(Some("author byline"), Some("author twitterHandle"))
     val config: json.JsObject = Json.obj(


### PR DESCRIPTION
## What does this change?

This is a continuation of our work of enabling DCR rendering of interactive pages. Here we give a constant mock up data object that passes DCR validation. This will allow the DCR part of that work to start. The next steps from here will be to pass an interactive model to `makeDataObject` and populate the fields accurately. 

Interestingly this PR show the "minimal" object that DCR accepts as valid. DCR has data requirements that are not encapsulated in the Scala data type definition of `DotcomRenderingDataModel`. We have always known that was the case, but it's nice to know what the minimal object is. 

The following picture shows the standard DCR server querying an interactive URL with `.json?dcr`. This PR simply makes that possible in prod to let other people reproduce it for DCR development.  

```
http://localhost:3030/Article?url=http://localhost:9000/books/ng-interactive/2021/mar/05/this-months-best-paperbacks-michelle-obama-jan-morris-and-more
```

![Screenshot 2021-04-27 at 15 26 22](https://user-images.githubusercontent.com/6035518/116258552-f5f96180-a76c-11eb-9cb0-684a940b3d15.png)

Note that this does not at all provide the `?dcr` version of an interactive. (A departure from the fact that for article `?dcr` and `.json?dcr` evolved together) 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No