### PR TITLE
Design tweaks to anniversary logo

### DIFF
--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -8,6 +8,8 @@
 @import conf.switches.Switches.{IdentityProfileNavigationSwitch, SearchSwitch, AnniversaryLogoHeader}
 @import experiments.{ActiveExperiments, AnniversaryAtom}
 
+@shouldShowLogo = @{AnniversaryLogoHeader.isSwitchedOn && ActiveExperiments.isParticipating(AnniversaryAtom)}
+
 @defining(NavMenu(page, Edition(request))) { navMenu: NavMenu =>
     <header class="@RenderClasses(Map(
         "new-header--slim" -> page.metadata.hasSlimHeader
@@ -20,7 +22,9 @@
             aria-label="Guardian sections">
 
             <a href="@LinkTo {/}"
-            class="new-header__logo"
+            class="@{if(shouldShowLogo) {"new-header__logo news-header__logo-anniversary"} else {
+              "new-header__logo"
+            }}"
             data-link-name="nav2 : logo">
 
                 <span class="u-h">The Guardian - Back to home</span>
@@ -28,7 +32,7 @@
                 @if(page.metadata.hasSlimHeader) {
                     @fragments.inlineSvg("the-guardian-roundel", "logo")
                 } else {
-                    @if(AnniversaryLogoHeader.isSwitchedOn && ActiveExperiments.isParticipating(AnniversaryAtom)) {
+                    @if(shouldShowLogo) {
                         @fragments.inlineSvg("guardian-anniversary-logo", "logo")
                     } else {
                         @fragments.inlineSvg("the-guardian-logo", "logo")

--- a/static/src/stylesheets/layout/nav/_new-header.scss
+++ b/static/src/stylesheets/layout/nav/_new-header.scss
@@ -146,6 +146,21 @@ from scrolling */
     }
 }
 
+.news-header__logo-anniversary {
+    @include mq($until: mobileMedium) {
+        margin-top: 19px;
+    }
+
+    @include mq(mobileMedium) {
+        margin-top: 14px;
+    }
+
+    @include mq(desktop) {
+        margin-top: 10px;
+    }
+
+}
+
 .inline-the-guardian-roundel__svg {
     height: $veggie-burger;
     width: $veggie-burger;


### PR DESCRIPTION
## What does this change?
Align bottom of logo title with the CTA on mobile devices

- Tidies up logic around adding new class in Twirl template
- Uses new class to set `margin-top` at specific breakpoints.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)
PR to follow

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/9122944/116270253-d7986380-a776-11eb-9f81-87d22e5241f8.png
[after]: https://user-images.githubusercontent.com/9122944/116269938-91db9b00-a776-11eb-9696-1448dba3a942.png



## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
