### PR TITLE
Remove `reqwest` from Identity

### DIFF
--- a/docs/02-architecture/03-libraries-we-use.md
+++ b/docs/02-architecture/03-libraries-we-use.md
@@ -10,9 +10,6 @@ https://github.com/ded/bonzo
 Bean - an events library for components
 https://github.com/fat/bean
 
-Reqwest - an Ajax library
-https://github.com/ded/reqwest
-
 ## back end
 Play - the application server
 https://playframework.com/

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "raven-js": "^3.19.1",
     "react": "^16.8.3",
     "react-dom": "16.7.0",
-    "reqwest": "2.0.5",
     "video.js": "~5.3",
     "videojs-contrib-ads": "3.1.3",
     "videojs-embed": "guardian/videojs-embed#v0.3.3",

--- a/static/src/javascripts/projects/common/modules/identity/consents.js
+++ b/static/src/javascripts/projects/common/modules/identity/consents.js
@@ -1,4 +1,3 @@
-import reqwest from 'reqwest';
 import fastdom from 'lib/fastdom-promise';
 import config from 'lib/config';
 import loadEnhancers from './modules/loadEnhancers';
@@ -59,11 +58,11 @@ const getInputFields = (labelEl) =>
 
 const unsubscribeFromAll = (buttonEl) => {
     buttonEl.classList.add(isLoadingClassName);
-    return reqwest({
-        url: `${config.get('page.idApiUrl')}/remove/consent/all`,
+    const url = `${config.get('page.idApiUrl')}/remove/consent/all`;
+    return fetch(url, {
         method: 'POST',
-        withCredentials: true,
-        crossOrigin: true,
+        credentials: 'include',
+        mode: 'cors',
     });
 };
 

--- a/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationForm.js
+++ b/static/src/javascripts/projects/common/modules/identity/upsell/account-creation/AccountCreationForm.js
@@ -28,7 +28,7 @@ class AccountCreationForm extends Component {
         data.append('password', this.state.password);
 
         fetch(url, {
-            method: 'post',
+            method: 'POST',
             headers: {
                 "content-type": "application/x-www-form-urlencoded",
             },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11727,11 +11727,6 @@ requires-port@1.x.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
-reqwest@2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/reqwest/-/reqwest-2.0.5.tgz#00fb15ac4918c419ca82b43f24c78882e66039a1"
-  integrity sha1-APsVrEkYxBnKgrQ/JMeIguZgOaE=
-
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"


### PR DESCRIPTION
## What does this change?

Removes the last remnants of `qwery`, which live in Identity. Uses native `fetch` instead.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Modernise code, reduce unnecessary dependencies, ship less JS to users.

@coldlink and I paired on this.

## Checklist

### Tested

- [X] Locally
- [X] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
