### PR TITLE
Switch hide anniversary atom experiment to use 0 % slot D

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -33,7 +33,7 @@ object HideAnniversaryAtom
         "Controls the visibility of the the Anniversary interactive atom on articles. If OPTED IN, will NOT show banner.",
       owners = Seq(Owner.withGithub("gtrufitt")),
       sellByDate = new LocalDate(2021, 5, 19),
-      participationGroup = Perc0B,
+      participationGroup = Perc0D,
     )
 
 object AnniversaryAtom


### PR DESCRIPTION
## What does this change?

Moves the anniversary atom to slot D to make sure that those that were accidentally opted-in to B will see the atom.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes https://github.com/guardian/dotcom-rendering/pull/2939
