### PR TITLE
Change Crossword Select value if it is weekend

### DIFF
--- a/applications/app/crosswords/CrosswordPage.scala
+++ b/applications/app/crosswords/CrosswordPage.scala
@@ -65,7 +65,7 @@ class CrosswordSearchPage extends StandalonePage {
     "weekend",
   )
 
-  def isWeekend(crossType: String): String = {
+  def queryParameter(crossType: String): String = {
     if (crossType == "weekend") "weekend-crossword" else crossType
   }
 

--- a/applications/app/crosswords/CrosswordPage.scala
+++ b/applications/app/crosswords/CrosswordPage.scala
@@ -65,6 +65,22 @@ class CrosswordSearchPage extends StandalonePage {
     "weekend",
   )
 
+  val crossword: Seq[String] = Seq(
+    "quick",
+    "cryptic",
+    "prize",
+    "quiptic",
+    "genius",
+    "speedy",
+    "everyman",
+    "azed",
+    "weekend",
+  )
+
+  def decideIfWeekend(crossType: String): String = {
+    if (crossType == "weekend") "weekend-crossword" else crossType
+  }
+
   val setters: Seq[String] = Seq(
     "Anto",
     "Arachne",

--- a/applications/app/crosswords/CrosswordPage.scala
+++ b/applications/app/crosswords/CrosswordPage.scala
@@ -65,19 +65,7 @@ class CrosswordSearchPage extends StandalonePage {
     "weekend",
   )
 
-  val crossword: Seq[String] = Seq(
-    "quick",
-    "cryptic",
-    "prize",
-    "quiptic",
-    "genius",
-    "speedy",
-    "everyman",
-    "azed",
-    "weekend",
-  )
-
-  def decideIfWeekend(crossType: String): String = {
+  def isWeekend(crossType: String): String = {
     if (crossType == "weekend") "weekend-crossword" else crossType
   }
 

--- a/applications/app/views/fragments/crosswords/crosswordSearchForm.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordSearchForm.scala.html
@@ -14,7 +14,7 @@
                         <label class="label" for="crossword_type">Type</label>
                         <select id="crossword_type" name="crossword_type">
                             @page.crosswordTypes.map { crosswordType =>
-                                <option value="@page.isWeekend(crosswordType)">@crosswordType</option>
+                                <option value="@page.queryParameter(crosswordType)">@crosswordType</option>
                             }
                         </select>
                     </li>

--- a/applications/app/views/fragments/crosswords/crosswordSearchForm.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordSearchForm.scala.html
@@ -14,7 +14,7 @@
                         <label class="label" for="crossword_type">Type</label>
                         <select id="crossword_type" name="crossword_type">
                             @page.crosswordTypes.map { crosswordType =>
-                                <option value="@crosswordType">@crosswordType</option>
+                                <option value="@page.decideIfWeekend(crosswordType)">@crosswordType</option>
                             }
                         </select>
                     </li>

--- a/applications/app/views/fragments/crosswords/crosswordSearchForm.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordSearchForm.scala.html
@@ -14,7 +14,7 @@
                         <label class="label" for="crossword_type">Type</label>
                         <select id="crossword_type" name="crossword_type">
                             @page.crosswordTypes.map { crosswordType =>
-                                <option value="@page.decideIfWeekend(crosswordType)">@crosswordType</option>
+                                <option value="@page.isWeekend(crosswordType)">@crosswordType</option>
                             }
                         </select>
                     </li>


### PR DESCRIPTION
## What does this change?

Previously, selecting weekend in crossword search created an incorrect URL:

Incorrect
https://www.theguardian.com/crosswords/search?crossword_type=**weekend**&setter=&month=04&year=2021

Correct:
https://www.theguardian.com/crosswords/search?crossword_type=**weekend-crossword**&setter=&month=04&year=2021


## Does this change need to be reproduced in dotcom-rendering ?

- [X] No

## Screenshots:

### Before:

![Before crossword fix](https://user-images.githubusercontent.com/35331926/116528979-57881000-a8d4-11eb-8e60-a6999697aea2.gif)


### After:
![After crossword fix](https://user-images.githubusercontent.com/35331926/116529021-6242a500-a8d4-11eb-8294-ca46dee8eba8.gif)


