### PR TITLE
Correct a bug in GUDateTimeFormatNew

### DIFF
--- a/common/app/model/DatesAndTimes.scala
+++ b/common/app/model/DatesAndTimes.scala
@@ -1,7 +1,6 @@
 package model
 
 import java.text.DecimalFormat
-
 import common.Edition
 import org.joda.time.{DateTime, DateTimeZone, LocalDate}
 import org.joda.time.format.DateTimeFormat
@@ -106,7 +105,8 @@ object GUDateTimeFormatNew {
     date.toString(DateTimeFormat.forPattern("E d MMM yyyy HH.mm").withZone(timezone)) + " " + timeZoneString
   }
   def formatDateForDisplay(date: DateTime, request: RequestHeader): String = {
-    date.toString("E d MMM yyyy")
+    val timezone = Edition(request).timezone
+    date.toString(DateTimeFormat.forPattern("E d MMM yyyy").withZone(timezone))
   }
   def formatTimeForDisplay(date: DateTime, request: RequestHeader): String = {
     val edition = Edition(request)


### PR DESCRIPTION
## What does this change?

This adds timezone information to `GUDateTimeFormatNew.formatDateForDisplay`. 

This was causing a problem by which some datetimes would be rendered with an incorrect date (because the date fragment of the datetime would be computed using a different timezone than the time fragment of the datetime). 

Example: with 

```
datetime = "2021-04-29T23:00:18Z"
```

We have 

```
datetime.date + " " + datetime.time.withTimeZone("BSD") == "2021-04-29 00:00:18 BSD" 
(
    eg: BST midnight on the day before, because the computer 
    may have implicitly datetime.date.withTimeZone("UTC")
)
```

Whereas we want 

```
datetime.date.withTimeZone("BSD") + " " + datetime.time.withTimeZone("BSD") == "2021-04-30 00:00:18 BST"
```
