### PR TITLE
Anniversary Atom and Logo: Remove anniversaryAtom test switch

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -11,7 +11,6 @@ object ActiveExperiments extends ExperimentsDefinition {
     ClickToView,
     LiveblogRendering,
     HideAnniversaryAtom,
-    AnniversaryAtom,
   )
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -34,15 +33,6 @@ object HideAnniversaryAtom
       owners = Seq(Owner.withGithub("gtrufitt")),
       sellByDate = new LocalDate(2022, 5, 11),
       participationGroup = Perc0D,
-    )
-
-object AnniversaryAtom
-    extends Experiment(
-      name = "anniversary-atom",
-      description = "Allows opting into the anniversary atom for testing on prod",
-      owners = Seq(Owner.withGithub("gtrufitt")),
-      sellByDate = new LocalDate(2022, 5, 11),
-      participationGroup = Perc0C,
     )
 
 object NewsletterEmbedDesign

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -6,9 +6,6 @@
 @import navigation.UrlHelpers.{getJobUrl, Header, getReaderRevenueUrl}
 @import navigation.ReaderRevenueSite.{Support, SupportSubscribe, SupportContribute, SupporterCTA}
 @import conf.switches.Switches.{IdentityProfileNavigationSwitch, SearchSwitch, AnniversaryLogoHeader}
-@import experiments.{ActiveExperiments, AnniversaryAtom}
-
-@shouldShowLogo = @{AnniversaryLogoHeader.isSwitchedOn && ActiveExperiments.isParticipating(AnniversaryAtom)}
 
 @defining(NavMenu(page, Edition(request))) { navMenu: NavMenu =>
     <header class="@RenderClasses(Map(
@@ -22,7 +19,7 @@
             aria-label="Guardian sections">
 
             <a href="@LinkTo {/}"
-            class="@{if(shouldShowLogo) {"new-header__logo news-header__logo-anniversary"} else {
+            class="@{if(AnniversaryLogoHeader.isSwitchedOn) {"new-header__logo news-header__logo-anniversary"} else {
               "new-header__logo"
             }}"
             data-link-name="nav2 : logo">
@@ -32,7 +29,7 @@
                 @if(page.metadata.hasSlimHeader) {
                     @fragments.inlineSvg("the-guardian-roundel", "logo")
                 } else {
-                    @if(shouldShowLogo) {
+                    @if(AnniversaryLogoHeader.isSwitchedOn) {
                         @fragments.inlineSvg("guardian-anniversary-logo", "logo")
                     } else {
                         @fragments.inlineSvg("the-guardian-logo", "logo")


### PR DESCRIPTION
## What does this change?

Removes the 0% A/B switch used for testing the anniversary atom and logo. Removes the check from the view for the logo.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes https://github.com/guardian/dotcom-rendering/pull/2956#pullrequestreview-651008729
