### PR TITLE
Add optional chaining to avoid console error

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.ts
@@ -80,8 +80,8 @@ const setPageTargeting = (): void => {
 
 const setPublisherProvidedId = (): void => {
 	// Also known as PPID
-	getUserFromApi((user: IdentityUser) => {
-		if (user.privateFields.googleTagId) {
+	getUserFromApi((user: IdentityUser | null) => {
+		if (user?.privateFields.googleTagId) {
 			window.googletag
 				?.pubads()
 				.setPublisherProvidedId(user.privateFields.googleTagId);


### PR DESCRIPTION
## What does this change?

Quick fix to [previous PR](https://github.com/guardian/frontend/pull/23747/files#r625742754) to address console error caused by accessing property on null value

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)


### Tested

- [x] Locally
- [ ] On CODE (optional)


