### PR TITLE
Add a hack to turn 200 badge white on media pages

### DIFF
--- a/static/src/stylesheets/module/_badging.scss
+++ b/static/src/stylesheets/module/_badging.scss
@@ -20,3 +20,8 @@
         height: 54px;
     }
 }
+
+// GT: Temporary fix to turn the black badge to white, we need a more perm fix (probably using Format...)
+.content--media a[href*='series/guardian-200'] .badge-slot__img {
+    filter: brightness(0) invert(1);
+}


### PR DESCRIPTION
## What does this change?

Switches media logo to white on media pages for 200 anniversary badge

Before (it is all black)

![image](https://user-images.githubusercontent.com/638051/117113172-01a6e280-ad82-11eb-93e3-51049b4bfc3e.png)

After

![image](https://user-images.githubusercontent.com/638051/117112822-8a714e80-ad81-11eb-8fc1-ef635aae2912.png)


## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
