### PR TITLE
Remove decommissioned switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -26,16 +26,6 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-sticky-nav-test",
-    "Tests sticky nav behaviour",
-    owners = Seq(Owner.withGithub("nicl")),
-    safeState = Off,
-    sellByDate = new LocalDate(2021, 5, 31),
-    exposeClientSide = true,
-  )
-
-  Switch(
-    ABTests,
     "ab-remote-rr-header-links-test",
     "Test serving remote header",
     owners = Seq(Owner.withGithub("tomrf1")),


### PR DESCRIPTION
## What does this change?

Remove decommissioned `ab-sticky-nav-test` switch.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No

