### PR TITLE
Remove unused switch

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -8,7 +8,6 @@ import conf.switches.SwitchGroup.Commercial
 
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
-    ClickToView,
     LiveblogRendering,
     HideAnniversaryAtom,
   )
@@ -42,13 +41,4 @@ object NewsletterEmbedDesign
       owners = Seq(Owner.withGithub("buck06191")),
       sellByDate = new LocalDate(2020, 11, 30),
       participationGroup = Perc20A,
-    )
-
-object ClickToView
-    extends Experiment(
-      name = "click-to-view",
-      description = "Click to provide consent before seeing embedded content",
-      owners = Seq(Owner.withGithub("frj")),
-      sellByDate = new LocalDate(2021, 5, 6),
-      participationGroup = Perc50,
     )


### PR DESCRIPTION
## What does this change?

Remove un-used expiring switch `click-to-view`.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No

