### PR TITLE
At Contributor Bio to DCR Model

### DIFF
--- a/applications/app/model/InteractivesDotcomRenderingDataObject.scala
+++ b/applications/app/model/InteractivesDotcomRenderingDataObject.scala
@@ -131,6 +131,7 @@ object InteractivesDotcomRenderingDataObject {
       blocks = List(),
       pagination = None,
       author = author,
+      contributorBio = Some("Contributor Bio"),
       webPublicationDate = "2021-04-22T14:11:12.000Z",
       webPublicationDateDisplay = "Thu 22 Apr 2021 15.11 BST",
       webPublicationSecondaryDateDisplay = "First published on Thu 22 Apr 2021 11.00 BST",

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -21,6 +21,7 @@ case class DotcomRenderingDataModel(
     blocks: List[Block],
     pagination: Option[Pagination],
     author: Author,
+    contributorBio: Option[String],
     webPublicationDate: String,
     webPublicationDateDisplay: String, // TODO remove
     webPublicationSecondaryDateDisplay: String,
@@ -115,6 +116,7 @@ object DotcomRenderingDataModel {
         "blocks" -> model.blocks,
         "pagination" -> model.pagination,
         "author" -> model.author,
+        "contributorBio" -> model.contributorBio,
         "webPublicationDate" -> model.webPublicationDate,
         "webPublicationDateDisplay" -> model.webPublicationDateDisplay,
         "webPublicationSecondaryDateDisplay" -> model.webPublicationSecondaryDateDisplay,

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -491,6 +491,7 @@ object DotcomRenderingUtils {
       blocks = bodyBlocks,
       pagination = pagination,
       author = author,
+      contributorBio = article.content.contributorBio,
       webPublicationDate = article.trail.webPublicationDate.toString,
       webPublicationDateDisplay =
         GUDateTimeFormatNew.formatDateTimeForDisplay(article.trail.webPublicationDate, request),


### PR DESCRIPTION
## What does this change?

Adds the Contributor bio to the model to be used in DCR.

At the moment `contributorBio` is provided via `flatmap` in [content](https://github.com/guardian/frontend/blob/9216bf1f26b56dc28d838d422e13b8cfc1e765ed/common/app/model/content.scala#L414) which produces an `Option[Array[Char]]` wheres we would like a string, changing this directly to map will most likely break other things so this bit is still a work in progress.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes 


### Tested

- [X] Locally
- [ ] On CODE (optional)


