### PR TITLE
Avoid sorting unless necessary

### DIFF
--- a/sport/app/football/containers/FixturesAndResults.scala
+++ b/sport/app/football/containers/FixturesAndResults.scala
@@ -50,7 +50,7 @@ class FixturesAndResults(competitions: Competitions) extends Football {
       teamId <- TeamMap.findTeamIdByUrlName(tagId)
       teamName <- teamNameBuilder.withId(teamId)
     } yield {
-      val relevantMatches = competitions.matches
+      val relevantMatches = competitions.sortedMatches
         .filter({ theMatch =>
           theMatch.homeTeam.id == teamId || theMatch.awayTeam.id == teamId
         })

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -97,7 +97,9 @@ trait Competitions extends implicits.Football {
       .find(m => m.hasTeam(team1) && m.hasTeam(team2))
   }
 
-  def matches: Seq[FootballMatch] = competitions.flatMap(_.matches).sortByDate
+  def sortedMatches: Seq[FootballMatch] = matches.sortByDate
+
+  def matches: Seq[FootballMatch] = competitions.flatMap(_.matches)
 
 }
 


### PR DESCRIPTION
In local profiling, over 20% of CPU time responding to match-nav requests was sorting matches. But actually, we don't need to sort at all for find operations (where only a single result is required).

![Screenshot 2021-05-05 at 17 20 28](https://user-images.githubusercontent.com/858402/117269414-279ab880-ae50-11eb-8d14-cc24717a6a1e.png)

Note, this is unlikely to be the root cause of recent perf issues with football, but it still seems like a quick and meaningful win.