### PR TITLE
gitignore all vscode config files except extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,6 @@ static/riffraff
 
 static/src/stylesheets/icons/*
 
-
 # emacs temp #
 **~
 
@@ -83,9 +82,11 @@ static/src/stylesheets/pasteup/.npmrc
 # SSL certificates
 *.crt
 *.key
-.vscode/settings.json
 
 # VSCode
+.vscode/*
+!.vscode/extensions.json
 
+# Scala tooling
 .bloop
 metals.sbt


### PR DESCRIPTION
## What does this change?

Update `.gitignore` so any files in `/.vscode` are ignored except the existing `extensions.json`

Allows local vscode config files like debug launchers to exist without the risk of commiting.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [X] Locally
- [ ] On CODE (optional)
