### PR TITLE
Add Prebid.js logging events

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "object-fit-videos": "^1.0.3",
     "ophan-tracker-js": "1.3.25",
     "preact": "^10.5.13",
-    "prebid.js": "https://github.com/guardian/Prebid.js#e005fa316",
+    "prebid.js": "https://github.com/guardian/Prebid.js#f509be01",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10882,10 +10882,11 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.13.tgz#85f6c9197ecd736ce8e3bec044d08fd1330fa019"
   integrity sha512-q/vlKIGNwzTLu+jCcvywgGrt+H/1P/oIRSD6mV4ln3hmlC+Aa34C7yfPI4+5bzW8pONyVXYS7SvXosy2dKKtWQ==
 
-"prebid.js@https://github.com/guardian/Prebid.js#e005fa316":
+"prebid.js@https://github.com/guardian/Prebid.js#f509be01":
   version "4.37.0"
-  resolved "https://github.com/guardian/Prebid.js#e005fa3169d48e81d5ded851e0f9d22f22e98ace"
+  resolved "https://github.com/guardian/Prebid.js#f509be01e0b57871978612afdc5b2186ac640e85"
   dependencies:
+    "@guardian/libs" "^1.7.1"
     babel-plugin-transform-object-assign "^6.22.0"
     core-js "^3.0.0"
     core-js-pure "^3.6.5"


### PR DESCRIPTION
## What does this change?

Enables Prebid.js analytics logging into the console. Currently, these events can be seen using the network tools, but having them easily accessible for developers subscribed the the 'commercial' logs will now be easy.

Based off https://github.com/guardian/Prebid.js/pull/113

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/117478777-900b9780-af2d-11eb-8497-1cf628cdd60c.png

[after]: https://user-images.githubusercontent.com/76776/117478690-7bc79a80-af2d-11eb-8701-8f02c981cba4.png

## What is the value of this and can you measure success?

This will allow the team to more easily debug Prebid, using the `@guardian/libs` logger.

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
