### PR TITLE
Add image block selector to spacefinder

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -94,6 +94,10 @@ const addDesktopInlineAds = (isInline1) => {
                 minAbove: 500,
                 minBelow: 0,
             },
+            ' figure.element--image-block': {
+                minAbove: 0,
+                minBelow: 0,
+            },
         },
         filter: filterNearbyCandidates(adSizes.mpu.height),
     };


### PR DESCRIPTION
## What does this change?
Add selector to space finder

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

This specifically is meant to solve an issue arising from the new DOM structure on DCR


## Screenshots
### Current issue on DCR
![image](https://user-images.githubusercontent.com/8831403/117477969-864a5a00-af56-11eb-96f4-ee8cbbc45787.png)

## What is the value of this and can you measure success?

## Checklist

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->

## Related  PR
https://github.com/guardian/dotcom-rendering/pull/2975