### PR TITLE
Prebid add permutive

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -45,10 +45,10 @@ object NewsletterEmbedDesign
     )
 
 object PrebidWithPermutive
-  extends Experiment(
-    name = "prebid-with-permutive",
-    description = "Enables permutive real-time config for Prebid.js",
-    owners = group(Commercial),
-    sellByDate = new LocalDate(2021, 6, 1),
-    participationGroup = Perc0B,
-  )
+    extends Experiment(
+      name = "prebid-with-permutive",
+      description = "Enables permutive real-time config for Prebid.js",
+      owners = group(Commercial),
+      sellByDate = new LocalDate(2021, 6, 1),
+      participationGroup = Perc0B,
+    )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -42,3 +42,12 @@ object NewsletterEmbedDesign
       sellByDate = new LocalDate(2020, 11, 30),
       participationGroup = Perc20A,
     )
+
+object PrebidWithPermutive
+  extends Experiment(
+    name = "prebid-permutive",
+    description = "Enables permutive real-time config for Prebid.js",
+    owners = Seq(Owner.group("commercial")),
+    sellByDate = new LocalDate(2021, 6, 1),
+    participationGroup = Perc0B,
+  )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -10,6 +10,7 @@ object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
     LiveblogRendering,
     HideAnniversaryAtom,
+    PrebidWithPermutive,
   )
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -45,9 +46,9 @@ object NewsletterEmbedDesign
 
 object PrebidWithPermutive
   extends Experiment(
-    name = "prebid-permutive",
+    name = "prebid-with-permutive",
     description = "Enables permutive real-time config for Prebid.js",
-    owners = Seq(Owner.group("commercial")),
+    owners = group(Commercial),
     sellByDate = new LocalDate(2021, 6, 1),
     participationGroup = Perc0B,
   )

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "object-fit-videos": "^1.0.3",
     "ophan-tracker-js": "1.3.25",
     "preact": "^10.5.13",
-    "prebid.js": "https://github.com/guardian/Prebid.js#f509be01",
+    "prebid.js": "https://github.com/guardian/Prebid.js#67ebc672",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/permutive-test.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/permutive-test.ts
@@ -5,15 +5,5 @@ const config = config_ as {
 	get: (s: string, d?: string) => string;
 };
 
-let isInTest: boolean | undefined;
-
-const isInServerSideTest = (): boolean =>
-	config.get('tests.prebidWithPermutiveVariant') === 'variant';
-
-export const isInPrebidPermutiveTest = (): boolean => {
-	if (isInTest === undefined) {
-		isInTest = isInServerSideTest();
-	}
-
-	return isInTest;
-};
+export const isInPrebidPermutiveTest = (): boolean =>
+	config.get('tests.prebidWithPermutiveVariant', '') === 'variant';

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/permutive-test.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/permutive-test.ts
@@ -1,0 +1,19 @@
+import config_ from '../../../../../lib/config';
+
+// This is really a hacky workaround ⚠️
+const config = config_ as {
+	get: (s: string, d?: string) => string;
+};
+
+let isInTest: boolean | undefined;
+
+const isInServerSideTest = (): boolean =>
+	config.get('tests.prebidWithPermutiveVariant') === 'variant';
+
+export const isInPrebidPermutiveTest = (): boolean => {
+	if (isInTest === undefined) {
+		isInTest = isInServerSideTest();
+	}
+
+	return isInTest;
+};

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
@@ -77,6 +77,19 @@ const initialise = (window, framework = 'tcfv2') => {
         pbjsConfig.consentManagement = consentManagement()
     }
 
+    if(config.get("switches.permutive", false)) {
+        pbjsConfig.realTimeData = {
+            auctionDelay: 50,
+            dataProviders: [{
+              name: 'permutive',
+              waitForIt: true,
+              params: {
+                acBidders: ['appnexus', 'rubicon', 'ozone']
+              }
+            }]
+          }
+    }
+
     window.pbjs.setConfig(pbjsConfig);
 
     if (config.get('switches.prebidAnalytics', false)) {

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
@@ -87,13 +87,7 @@ const initialise = (window, framework = 'tcfv2') => {
 					params: {
 						acBidders: ['appnexus', 'ozone', 'pubmatic', 'trustx'],
 						overwrites: {
-							pubmatic: pubmatic(
-								bid,
-								data,
-								acEnabled,
-								utils,
-								defaultFn,
-							),
+							pubmatic,
 						},
 					},
 				},

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
@@ -7,6 +7,7 @@ import { getAdvertById } from '../../dfp/get-advert-by-id';
 import { stripDfpAdPrefixFrom } from '../utils';
 import { EventTimer } from '@guardian/commercial-core';
 import { isInPrebidPermutiveTest } from './permutive-test';
+import { pubmatic } from './pubmatic';
 
 const bidderTimeout = 1500;
 
@@ -86,48 +87,13 @@ const initialise = (window, framework = 'tcfv2') => {
 					params: {
 						acBidders: ['appnexus', 'ozone', 'pubmatic', 'trustx'],
 						overwrites: {
-							pubmatic: function (
+							pubmatic: pubmatic(
 								bid,
 								data,
 								acEnabled,
 								utils,
 								defaultFn,
-							) {
-								if (defaultFn) {
-									// keep this to move to default function once supported
-									// by RTD submodule
-									bid = defaultFn(bid, data, acEnabled);
-								} else if (
-									acEnabled &&
-									data.ac &&
-									data.ac.length > 0
-								) {
-									const dpName = 'permutive.com';
-									var seg = [];
-									data.ac.forEach(function (item, index) {
-										seg.push({
-											id: item,
-										});
-									});
-									const newData = [
-										{
-											name: dpName,
-											segment: seg,
-										},
-									];
-									pbjs.setBidderConfig({
-										// Note this will replace existing bidder FPD config till merge is supported.
-										bidders: ['pubmatic'],
-										config: {
-											ortb2: {
-												user: {
-													data: newData,
-												},
-											},
-										},
-									});
-								}
-							},
+							),
 						},
 					},
 				},

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
@@ -84,7 +84,7 @@ const initialise = (window, framework = 'tcfv2') => {
 				{
 					name: 'permutive',
 					params: {
-						acBidders: ['appnexus', 'pubmatic', 'trustx'],
+						acBidders: ['appnexus', 'ozone', 'pubmatic', 'trustx'],
 						overwrites: {
 							pubmatic: function (
 								bid,

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
@@ -84,7 +84,7 @@ const initialise = (window, framework = 'tcfv2') => {
               name: 'permutive',
               waitForIt: true,
               params: {
-                acBidders: ['appnexus', 'rubicon', 'ozone']
+                acBidders: ['appnexus', 'ozone', 'trustx']
               }
             }]
           }

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
@@ -6,6 +6,7 @@ import { priceGranularity } from './price-config';
 import { getAdvertById } from '../../dfp/get-advert-by-id';
 import { stripDfpAdPrefixFrom } from '../utils';
 import { EventTimer } from '@guardian/commercial-core';
+import { isInPrebidPermutiveTest } from './permutive-test';
 
 const bidderTimeout = 1500;
 
@@ -77,7 +78,7 @@ const initialise = (window, framework = 'tcfv2') => {
         pbjsConfig.consentManagement = consentManagement()
     }
 
-    if(config.get("switches.permutive", false)) {
+    if(config.get("switches.permutive", false) && isInPrebidPermutiveTest()) {
         pbjsConfig.realTimeData = {
             auctionDelay: 50,
             dataProviders: [{

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/pubmatic.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/pubmatic.js
@@ -1,3 +1,6 @@
+// Pubmatic custom override script
+// from gist.github.com/abhinavsinha001/de46bd4ac4f02d98eb50c1f4f995545e
+
 export const pubmatic = function (bid, data, acEnabled, utils, defaultFn) {
 	if (defaultFn) {
 		// keep this to move to default function once supported by RTD submodule

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/pubmatic.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/pubmatic.js
@@ -1,0 +1,39 @@
+export const pubmatic = function (bid, data, acEnabled, utils, defaultFn) {
+	if (defaultFn) {
+		// keep this to move to default function once supported by RTD submodule
+		bid = defaultFn(bid, data, acEnabled);
+	} else {
+		let segments = [];
+
+		// add all user segments
+		try {
+			segments = JSON.parse(localStorage._psegs || '[]');
+		} catch (e) {}
+
+		// add AC specific segments (these would typically go to a separate key-value, but not sure if we can have 2 lists of segments here?)
+		if (acEnabled && data.ac && data.ac.length > 0) {
+			segments = segments.concat(data.ac);
+		}
+
+		segments = segments.map(function (seg) {
+			return { id: seg };
+		});
+
+		pbjs.setBidderConfig({
+			// Note this will replace existing bidder FPD config till merge is supported.
+			bidders: ['pubmatic'],
+			config: {
+				ortb2: {
+					user: {
+						data: [
+							{
+								name: 'permutive.com',
+								segment: segments,
+							},
+						],
+					},
+				},
+			},
+		});
+	}
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1900,6 +1900,11 @@
   resolved "https://registry.yarnpkg.com/@guardian/eslint-config/-/eslint-config-0.5.0.tgz#ece14ec90b372932c7bf01992fc6d8ce58f7f26e"
   integrity sha512-THJn0wg7i9YjSVM9ofobsJgS+WH9ybrZH1+0CXLAebp0T53RGtgZUkek82mDg1h3DidsM+f7HSZqoQyrCbPzPw==
 
+"@guardian/libs@^1.7.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-1.8.1.tgz#22bccd66be7c5bf70cd5bbb1bf7700d94610ccb7"
+  integrity sha512-Q/JPLhNeYa5XhDPJhw/1+fbZmszopvovWW8I7dGEuFPGWeNUmXAbW8J3kzuonDu7l9/tuFZg8jljbKHZlrFx0A==
+
 "@guardian/libs@^1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-1.8.0.tgz#ceed9e4fcccc5561493d886ae1a307c03a356e27"
@@ -5427,10 +5432,10 @@ domutils@^2.4.3:
     domelementtype "^2.2.0"
     domhandler "^4.2.0"
 
-dset@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/dset/-/dset-2.0.1.tgz#a15fff3d1e4d60ac0c95634625cbd5441a76deb1"
-  integrity sha512-nI29OZMRYq36hOcifB6HTjajNAAiBKSXsyWZrq+VniusseuP2OpNlTiYgsaNRSGvpyq5Wjbc2gQLyBdTyWqhnQ==
+dset@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/dset/-/dset-2.1.0.tgz#cd1e99e55cf32366d8f144f906c42f7fb3bf431e"
+  integrity sha512-hlQYwNEdW7Qf8zxysy+yN1E8C/SxRst3Z9n+IvXOR35D9bPVwNHhnL8ZBeoZjvinuGrlvGg6pAMDwhmjqFDgjA==
 
 duplexer2@^0.1.2:
   version "0.1.4"
@@ -10882,9 +10887,9 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.13.tgz#85f6c9197ecd736ce8e3bec044d08fd1330fa019"
   integrity sha512-q/vlKIGNwzTLu+jCcvywgGrt+H/1P/oIRSD6mV4ln3hmlC+Aa34C7yfPI4+5bzW8pONyVXYS7SvXosy2dKKtWQ==
 
-"prebid.js@https://github.com/guardian/Prebid.js#f509be01":
-  version "4.37.0"
-  resolved "https://github.com/guardian/Prebid.js#f509be01e0b57871978612afdc5b2186ac640e85"
+"prebid.js@https://github.com/guardian/Prebid.js#67ebc672":
+  version "4.38.0"
+  resolved "https://github.com/guardian/Prebid.js#67ebc6728637fdb35f7164184ea853b488ffc2b6"
   dependencies:
     "@guardian/libs" "^1.7.1"
     babel-plugin-transform-object-assign "^6.22.0"
@@ -10893,7 +10898,7 @@ preact@^10.5.13:
     criteo-direct-rsa-validate "^1.1.0"
     crypto-js "^3.3.0"
     dlv "1.1.3"
-    dset "2.0.1"
+    dset "2.1.0"
     express "^4.15.4"
     fun-hooks "^0.9.9"
     jsencrypt "^3.0.0-rc.1"


### PR DESCRIPTION
## What does this change?

This changes is behind a [0% server-side test](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md#write-a-server-side-test), which requires users to opt-in.

Adds a real-time config (RTC) to Prebid for enabling Permutive segments to be sent to advertising partners. We're currently passing this data to GAM–provided we have user consent–but had to use workarounds for Prebid. This enables a [first-party Permutive module, `permutiveRtdProvider`](https://github.com/prebid/Prebid.js/blob/master/modules/permutiveRtdProvider.md).

Permutive is a third-party service that assigns "segments" to a browser, which helps advertisers target their ads in a more personalised manner.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Better personalised adds with Xandr/Appnexus, Pubmatic, Ozone and TrustX.

### Tested

- [x] Locally
- [X] On CODE

#### How to test?

- Opt-in the 0% test: www.theguardian.com/opt/in/prebid-with-permutive
- check the Prebid config by running `window.pbjs.getConfig('realTimeData')`
- It should be defined and contain a `dataProvider` with name `permutive`.