### PR TITLE
!!DO NOT MERGE!! prototype JSON endpoint

### DIFF
--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -169,6 +169,16 @@ object CompetitionsProvider {
       tableDividers = List(2, 6, 21),
     ),
     Competition(
+      "700",
+      "/football/world-cup-2018",
+      "World Cup 2018",
+      "World Cup 2018",
+      "Internationals",
+      showInTeamsList = true,
+      tableDividers = List(2),
+      startDate = Some(LocalDate.of(2018, 6, 1)),
+    ),
+    Competition(
       "701",
       "/football/world-cup-2022-qualifiers",
       "World Cup 2022 qualifying",

--- a/sport/app/football/model/CompetitionStages.scala
+++ b/sport/app/football/model/CompetitionStages.scala
@@ -6,7 +6,7 @@ import java.time.{ZoneId, ZonedDateTime}
 import model.Competition
 import pa._
 import implicits.Football._
-
+import play.api.libs.json.{Json, Writes}
 import scala.util.Try
 
 sealed trait CompetitionStageLike {

--- a/sport/app/football/model/WallchartJson.scala
+++ b/sport/app/football/model/WallchartJson.scala
@@ -1,0 +1,45 @@
+package football.model
+
+import model.Competition
+import play.api.libs.json.{Json, Writes}
+import pa.{FootballMatch, LeagueStats, LeagueTableEntry, LeagueTeam, MatchDayTeam, Round, Stage, Venue}
+
+case class WallchartJson(
+    competition: Competition,
+    competitionStages: List[CompetitionStageLike],
+    next: Option[FootballMatch],
+)
+
+object WallchartJson {
+  implicit val roundWrites: Writes[Round] = Json.writes[Round]
+  implicit val stageWrites: Writes[Stage] = Json.writes[Stage]
+  implicit val matchDayTeamWrites: Writes[MatchDayTeam] = Json.writes[MatchDayTeam]
+  implicit val venueWrites: Writes[Venue] = Json.writes[Venue]
+  implicit val footballWrites = new Writes[FootballMatch] {
+    def writes(footballMatch: FootballMatch) =
+      Json.obj(
+        "id" -> footballMatch.id,
+        "date" -> footballMatch.date,
+        "stage" -> footballMatch.stage,
+        "round" -> footballMatch.round,
+        "leg" -> footballMatch.leg,
+        "homeTeam" -> footballMatch.homeTeam,
+        "awayTeam" -> footballMatch.awayTeam,
+        "venue" -> footballMatch.venue,
+        "comments" -> footballMatch.comments,
+      )
+  }
+
+  implicit val competitionStageLikeWrites = new Writes[CompetitionStageLike] {
+    def writes(competitionStageLike: CompetitionStageLike) =
+      Json.obj(
+        "matches" -> competitionStageLike.matches,
+      )
+  }
+  implicit val leagueStatsWrites: Writes[LeagueStats] = Json.writes[LeagueStats]
+  implicit val leagueTeamWrites: Writes[LeagueTeam] = Json.writes[LeagueTeam]
+  implicit val leagueTableEntryWrites: Writes[LeagueTableEntry] = Json.writes[LeagueTableEntry]
+  implicit val competitionWrites: Writes[Competition] = Json.writes[Competition]
+
+  implicit val wallChartJsonWrites: Writes[WallchartJson] = Json.writes[WallchartJson]
+}

--- a/sport/app/football/model/model.scala
+++ b/sport/app/football/model/model.scala
@@ -3,6 +3,7 @@ package model
 import pa._
 import pa.LeagueTableEntry
 import pa.MatchDayTeam
+import play.api.libs.json.{Json, Writes}
 import java.awt.Color
 import java.time.LocalDate
 

--- a/sport/conf/routes
+++ b/sport/conf/routes
@@ -55,6 +55,8 @@ GET        /football/:team/fixtures-and-results-container                       
 GET        /football/:competitionTag/overview/embed                                            football.controllers.WallchartController.renderWallchartEmbed(competitionTag)
 GET        /football/:competitionTag/overview                                                  football.controllers.WallchartController.renderWallchart(competitionTag)
 GET        /football/:competitionTag/wallchart.json                                            football.controllers.WallchartController.renderWallchartJson(competitionTag)
+GET        /football/:competitionTag/wallchartApi.json                                         football.controllers.WallchartController.getWallChartApiJson(competitionTag)
+
 
 GET        /football/api/match-nav/:year/:month/:day/:home/:away.json                          football.controllers.MoreOnMatchController.matchNavJson(year, month, day, home, away)
 GET        /football/api/match-nav/:year/:month/:day/:home/:away                               football.controllers.MoreOnMatchController.matchNav(year, month, day, home, away)


### PR DESCRIPTION
## What does this change?
Prototype the JSON endpoint for Wallchart/Spider data.

A lot of the additions are to allow serialisation of `pa` library data to JSON and this should really be done in that library.

You can check against `http://localhost:9000/football/world-cup-2022-qualifiers/wallchartApi.json` when running `sport` locally.

_Note: I don't think the competition used in the example URL above is compatible with having a knockout spider so shouldn't be used as the source of all truth_


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
