### PR TITLE
Add container following palette styles to first container selector

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_containers.scss
+++ b/static/src/stylesheets/module/facia-garnett/_containers.scss
@@ -1,5 +1,6 @@
 @import 'container--video';
 
+.fc-container--first#palette-styles-new-do-not-delete + .fc-container, 
 .fc-container--first {
     margin-top: 0;
     padding-top: 0;


### PR DESCRIPTION
## What does this change?

There is a first container selector added to the first container (woah), but the first container on some fronts is the invisible palette thrasher. Adding this selector means that we apply the first-container styles to the sibling of that thrasher container specifically if it is the first-container.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No

## Screenshots


### Before

![Screen Shot 2021-05-10 at 16 00 55](https://user-images.githubusercontent.com/638051/117683689-39f85780-b1ac-11eb-8366-4fc8b51acc1c.png)

### After

![image](https://user-images.githubusercontent.com/638051/117684110-978ca400-b1ac-11eb-8d6d-d79f9fdfc724.png)
