### PR TITLE
Remove qwery from commercial hosted gallery

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
@@ -1,7 +1,6 @@
 import bonzo from 'bonzo';
 import fastdom from 'fastdom';
 import throttle from 'lodash/throttle';
-import qwery from 'qwery';
 import $ from '../../../../lib/$';
 import config from '../../../../lib/config';
 import { getBreakpoint, hasTouchScreen } from '../../../../lib/detect';
@@ -40,17 +39,14 @@ class HostedGallery {
         this.$images = $('.js-hosted-gallery-image', this.$imagesContainer);
         this.$progress = $('.js-hosted-gallery-progress', this.$galleryEl);
         this.$border = $('.js-hosted-gallery-rotating-border', this.$progress);
-        this.prevBtn = qwery('.inline-arrow-up', this.$progress)[0];
-        this.nextBtn = qwery('.inline-arrow-down', this.$progress)[0];
-        this.infoBtn = qwery(
-            '.js-gallery-caption-button',
-            this.$captionContainer
-        )[0];
+        this.prevBtn = this.$progress.get(0).querySelector('.inline-arrow-up');
+        this.nextBtn = this.$progress.get(0).querySelector('.inline-arrow-down');
+        this.infoBtn = this.$captionContainer.get(0).querySelector('.js-gallery-caption-button');
         this.$counter = $('.js-hosted-gallery-image-count', this.$progress);
         this.$ctaFloat = $('.js-hosted-gallery-cta', this.$galleryEl)[0];
         this.$ojFloat = $('.js-hosted-gallery-oj', this.$galleryEl)[0];
         this.$meta = $('.js-hosted-gallery-meta', this.$galleryEl)[0];
-        this.ojClose = qwery('.js-hosted-gallery-oj-close', this.$ojFloat)[0];
+        this.ojClose = this.$ojFloat.querySelector('.js-hosted-gallery-oj-close');
 
         if (this.$galleryEl.length) {
             this.resize = this.trigger.bind(this, 'resize');
@@ -532,7 +528,7 @@ HostedGallery.prototype.states = {
 };
 
 export const init = () => {
-    if (qwery('.js-hosted-gallery-container').length) {
+    if (document.querySelectorAll('.js-hosted-gallery-container').length) {
         return loadCssPromise.then(() => {
             let res;
             const galleryHash = window.location.hash;

--- a/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
@@ -256,10 +256,10 @@ class HostedGallery {
         const imageSize = getFrame(imgRatio);
 
         fastdom.mutate(() => {
-            $sizer.style.width =  imageSize.width;
-            $sizer.style.height =  imageSize.height;
-            $sizer.style.top =  imageSize.topBottom;
-            $sizer.style.left =  imageSize.leftRight;
+            $sizer.style.setProperty('width', imageSize.width);
+            $sizer.style.setProperty('height', imageSize.height);
+            $sizer.style.setProperty('top', imageSize.topBottom);
+            $sizer.style.setProperty('left', imageSize.leftRight);
             if (imgIndex === ctaIndex) {
                 $ctaFloat.style.setProperty('bottom', ctaSize.topBottom);
             }
@@ -280,17 +280,10 @@ class HostedGallery {
         const galleryEl = this.$imagesContainer;
         const $meta = this.$meta;
 
-        galleryEl.style.webkitTransitionDuration = `${duration}ms`;
-        galleryEl.style.mozTransitionDuration = `${duration}ms`;
-        galleryEl.style.msTransitionDuration = `${duration}ms`;
-        galleryEl.style.transitionDuration = `${duration}ms`;
-        galleryEl.style.webkitTransform = `translate(${px +
-            offset}px,0) translateZ(0)`;
-        galleryEl.style.mozTransform = `translate(${px + offset}px,0)`;
-        galleryEl.style.msTransform = `translate(${px + offset}px,0)`;
-        galleryEl.style.transform = `translate(${px +
-            offset}px,0) translateZ(0)`;
         fastdom.mutate(() => {
+            galleryEl.style.setProperty('transition-duration', `${duration}ms`);
+            galleryEl.style.setProperty('transform', `translate(${px +
+                offset}px,0) translateZ(0)`);
             $meta.style.setProperty('opacity', offset !== 0 ? 0 : 1);
         });
     }
@@ -314,7 +307,6 @@ class HostedGallery {
             });
 
             this.$border.style.setProperty('transform', `rotate(${deg}deg)`);
-            this.$border.style.setProperty('-webkit-transform', `rotate(${deg}deg)`);
 
             this.toggleClass(
                 this.$galleryEl,
@@ -396,15 +388,15 @@ class HostedGallery {
         this.swipeContainerWidth = imageWidth;
         fastdom.mutate(() => {
             if ($header) {
-                $header.style.width = imageWidth;
+                $header.style.setProperty('width', imageWidth);
             }
             if ($footer) {
-                $footer.style.margin = `0 ${leftRight}`;
-                $footer.style.width = 'auto';
+                $footer.style.setProperty('margin', `0 ${leftRight}`);
+                $footer.style.setProperty('width', 'auto');
             }
             if ($gallery) {
-                $galleryFrame.style.left = leftRight;
-                $galleryFrame.style.right = leftRight;
+                $galleryFrame.style.setProperty('left', leftRight);
+                $galleryFrame.style.setProperty('right', leftRight);
             }
             that.loadSurroundingImages(that.index, that.$images.length);
         });

--- a/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
@@ -124,7 +124,7 @@ class HostedGallery {
         let ox;
         let dx;
         const updateTime = 20;
-        this.$imagesContainer.css('width', `${this.$images.length}00%`);
+        this.$imagesContainer.style.setProperty('width', `${this.$images.length}00%`);
 
         this.$galleryEl.addEventListener('touchstart', e => {
             threshold = this.swipeContainerWidth * this.swipeThreshold;
@@ -361,7 +361,7 @@ class HostedGallery {
             (() => {
                 this.loadSurroundingImages(this.index, this.$images.length);
                 if (this.useSwipe) {
-                    this.swipeContainerWidth = this.$galleryFrame.dim().width;
+                    this.swipeContainerWidth = this.$galleryFrame.offsetWidth;
                     this.translateContent(this.index, 0, 0);
                 }
                 this.setPageWidth();

--- a/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
@@ -1,4 +1,3 @@
-import bonzo from 'bonzo';
 import fastdom from 'fastdom';
 import throttle from 'lodash/throttle';
 import { $$ } from '../../../../lib/$$';
@@ -83,6 +82,14 @@ class HostedGallery {
 
     toggleOj() {
         this.$ojFloat.classList.toggle('minimise-oj');
+    }
+
+    toggleClass(el, className, opt_condition) {
+        if (el) {
+              typeof opt_condition !== 'undefined' ?
+                opt_condition ? el.classList.add(className) : el.classList.remove(className) :
+                el.toggleClass(className);
+        }
     }
 
     initScroll() {
@@ -255,22 +262,16 @@ class HostedGallery {
             $sizer.style.top =  imageSize.topBottom;
             $sizer.style.left =  imageSize.leftRight;
             if (imgIndex === ctaIndex) {
-                bonzo($ctaFloat).css('bottom', ctaSize.topBottom);
+                $ctaFloat.style.setProperty('bottom', ctaSize.topBottom);
             }
             if (imgIndex === $images.length - 1) {
-                bonzo($ojFloat).css('bottom', ctaSize.topBottom);
+                $ojFloat.style.setProperty('bottom', ctaSize.topBottom);
             }
             if (imgIndex === $images.length - 1) {
-                bonzo($ojFloat).css(
-                    'padding-bottom',
-                    ctaSize.topBottom > 40 || width > tabletSize ? 0 : 40
-                );
+                $ojFloat.style.setProperty('padding-bottom', ctaSize.topBottom > 40 || width > tabletSize ? 0 : 40);
             }
             if (imgIndex === 0) {
-                bonzo($meta).css(
-                    'padding-bottom',
-                    imageSize.topBottom > 40 || width > tabletSize ? 20 : 40
-                );
+                $meta.style.setProperty('padding-bottom', imageSize.topBottom > 40 || width > tabletSize ? 20 : 40);
             }
         });
     }
@@ -291,7 +292,7 @@ class HostedGallery {
         galleryEl.style.transform = `translate(${px +
             offset}px,0) translateZ(0)`;
         fastdom.mutate(() => {
-            bonzo($meta).css('opacity', offset !== 0 ? 0 : 1);
+            $meta.style.setProperty('opacity', offset !== 0 ? 0 : 1);
         });
     }
 
@@ -310,27 +311,31 @@ class HostedGallery {
         fastdom.mutate(() => {
             this.$images.forEach((image, index) => {
                 const opacity = ((progress - index + 1) * 16) / 11 - 0.0625;
-                bonzo(image).css('opacity', Math.min(Math.max(opacity, 0), 1));
+                image.style.setProperty('opacity', Math.min(Math.max(opacity, 0), 1));
             });
 
-            bonzo(this.$border).css('transform', `rotate(${deg}deg)`);
-            bonzo(this.$border).css('-webkit-transform', `rotate(${deg}deg)`);
+            this.$border.style.setProperty('transform', `rotate(${deg}deg)`);
+            this.$border.style.setProperty('-webkit-transform', `rotate(${deg}deg)`);
 
-            bonzo(this.$galleryEl).toggleClass(
+            this.toggleClass(
+                this.$galleryEl,
                 'show-cta',
                 progress <= ctaIndex && progress >= ctaIndex - 0.25
             );
-            bonzo(this.$galleryEl).toggleClass(
+
+            this.toggleClass(
+                this.$galleryEl,
                 'show-oj',
                 progress >= length - 1.25
             );
 
-            bonzo(this.$progress).toggleClass(
+            this.toggleClass(
+                this.$progress,
                 'first-half',
                 fractionProgress && fractionProgress < 0.5
             );
 
-            bonzo(this.$meta).css('opacity', progress !== 0 ? 0 : 1);
+            this.$meta.style.setProperty('opacity', progress !== 0 ? 0 : 1);
         });
 
         if (newIndex && newIndex !== this.index) {
@@ -346,7 +351,7 @@ class HostedGallery {
         const length = this.$images.length;
         const scrollHeight = scrollEl.scrollHeight;
         fastdom.mutate(() => {
-            bonzo(scrollEl).scrollTop(((index - 1) * scrollHeight) / length);
+            scrollEl.scrollTop = ((index - 1) * scrollHeight) / length;
         });
     }
 
@@ -455,20 +460,23 @@ HostedGallery.prototype.states = {
             // load prev/current/next
             this.loadSurroundingImages(this.index, this.$images.length);
             this.$captions.forEach((caption, index) => {
-                bonzo(caption).toggleClass(
+                this.toggleClass(
+                    caption,
                     'current-caption',
                     that.index === index + 1
                 );
             });
-            bonzo(this.$counter).html(`${this.index}/${this.$images.length}`);
+            this.$counter.textContent = `${this.index}/${this.$images.length}`;
 
             if (this.useSwipe) {
                 this.translateContent(this.index, 0, 100);
-                bonzo(this.$galleryEl).toggleClass(
+                this.toggleClass(
+                    this.$galleryEl,
                     'show-oj',
                     this.index === this.$images.length
                 );
-                bonzo(this.$galleryEl).toggleClass(
+                this.toggleClass(
+                    this.$galleryEl,
                     'show-cta',
                     this.index === HostedGallery.ctaIndex() + 1
                 );

--- a/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
@@ -1,7 +1,7 @@
 import bonzo from 'bonzo';
 import fastdom from 'fastdom';
 import throttle from 'lodash/throttle';
-import $ from '../../../../lib/$';
+import { $$ } from '../../../../lib/$$';
 import config from '../../../../lib/config';
 import { getBreakpoint, hasTouchScreen } from '../../../../lib/detect';
 import FiniteStateMachine from '../../../../lib/fsm';
@@ -23,32 +23,27 @@ class HostedGallery {
         this.imageRatios = [];
 
         // ELEMENT BINDINGS
-        this.$galleryEl = $('.js-hosted-gallery-container');
-        this.$galleryFrame = $('.js-hosted-gallery-frame');
-        this.$header = $('.js-hosted-headerwrap');
-        this.$imagesContainer = $('.js-hosted-gallery-images', this.$galleryEl);
-        this.$captionContainer = $('.js-gallery-caption-bar');
-        this.$captions = $(
-            '.js-hosted-gallery-caption',
-            this.$captionContainer
-        );
-        this.$scrollEl = $(
-            '.js-hosted-gallery-scroll-container',
-            this.$galleryEl
-        );
-        this.$images = $('.js-hosted-gallery-image', this.$imagesContainer);
-        this.$progress = $('.js-hosted-gallery-progress', this.$galleryEl);
-        this.$border = $('.js-hosted-gallery-rotating-border', this.$progress);
-        this.prevBtn = this.$progress.get(0).querySelector('.inline-arrow-up');
-        this.nextBtn = this.$progress.get(0).querySelector('.inline-arrow-down');
-        this.infoBtn = this.$captionContainer.get(0).querySelector('.js-gallery-caption-button');
-        this.$counter = $('.js-hosted-gallery-image-count', this.$progress);
-        this.$ctaFloat = $('.js-hosted-gallery-cta', this.$galleryEl)[0];
-        this.$ojFloat = $('.js-hosted-gallery-oj', this.$galleryEl)[0];
-        this.$meta = $('.js-hosted-gallery-meta', this.$galleryEl)[0];
+        this.$galleryEl = $$('.js-hosted-gallery-container').get(0);
+        this.$galleryFrame = $$('.js-hosted-gallery-frame').get(0);
+        this.$header = $$('.js-hosted-headerwrap').get(0);
+        this.$imagesContainer = $$('.js-hosted-gallery-images', this.$galleryEl).get(0);
+        this.$captionContainer = $$('.js-gallery-caption-bar').get(0);
+        this.$captions = $$('.js-hosted-gallery-caption', this.$captionContainer).get();
+        this.$scrollEl = $$('.js-hosted-gallery-scroll-container', this.$galleryEl).get(0);
+
+        this.$images = $$('.js-hosted-gallery-image', this.$imagesContainer).get();
+        this.$progress = $$('.js-hosted-gallery-progress', this.$galleryEl).get(0);
+        this.$border = $$('.js-hosted-gallery-rotating-border', this.$progress).get(0);
+        this.prevBtn = this.$progress.querySelector('.inline-arrow-up');
+        this.nextBtn = this.$progress.querySelector('.inline-arrow-down');
+        this.infoBtn = this.$captionContainer.querySelector('.js-gallery-caption-button');
+        this.$counter = $$('.js-hosted-gallery-image-count', this.$progress).get(0);
+        this.$ctaFloat = $$('.js-hosted-gallery-cta', this.$galleryEl).get(0);
+        this.$ojFloat = $$('.js-hosted-gallery-oj', this.$galleryEl).get(0);
+        this.$meta = $$('.js-hosted-gallery-meta', this.$galleryEl).get(0);
         this.ojClose = this.$ojFloat.querySelector('.js-hosted-gallery-oj-close');
 
-        if (this.$galleryEl.length) {
+        if (this.$galleryEl) {
             this.resize = this.trigger.bind(this, 'resize');
             mediator.on('window:throttledResize', this.resize);
 
@@ -77,17 +72,17 @@ class HostedGallery {
             this.setPageWidth();
 
             if (this.useSwipe) {
-                this.$galleryEl.addClass('use-swipe');
+                this.$galleryEl.classList.add('use-swipe');
                 this.initSwipe();
             } else {
-                this.$galleryEl.addClass('use-scroll');
+                this.$galleryEl.classList.add('use-scroll');
                 this.initScroll();
             }
         }
     }
 
     toggleOj() {
-        bonzo(this.$ojFloat).toggleClass('minimise-oj');
+        this.$ojFloat.classList.toggle('minimise-oj');
     }
 
     initScroll() {
@@ -112,7 +107,7 @@ class HostedGallery {
             }
         });
 
-        this.$scrollEl[0].addEventListener(
+        this.$scrollEl.addEventListener(
             'scroll',
             throttle(this.fadeContent.bind(this), 20)
         );
@@ -125,7 +120,7 @@ class HostedGallery {
         const updateTime = 20;
         this.$imagesContainer.css('width', `${this.$images.length}00%`);
 
-        this.$galleryEl[0].addEventListener('touchstart', e => {
+        this.$galleryEl.addEventListener('touchstart', e => {
             threshold = this.swipeContainerWidth * this.swipeThreshold;
             ox = e.touches[0].pageX;
             dx = 0;
@@ -140,14 +135,14 @@ class HostedGallery {
             this.translateContent(this.index, dx, updateTime);
         };
 
-        this.$galleryEl[0].addEventListener(
+        this.$galleryEl.addEventListener(
             'touchmove',
             throttle(touchMove, updateTime, {
                 trailing: false,
             })
         );
 
-        this.$galleryEl[0].addEventListener('touchend', () => {
+        this.$galleryEl.addEventListener('touchend', () => {
             let direction;
             if (Math.abs(dx) > threshold) {
                 direction = dx > threshold ? 1 : -1;
@@ -197,7 +192,7 @@ class HostedGallery {
         const setSize = ($image, imageIndex) => {
             if (!that.imageRatios[imageIndex]) {
                 that.imageRatios[imageIndex] =
-                    $image[0].naturalWidth / $image[0].naturalHeight;
+                    $image.naturalWidth / $image.naturalHeight;
             }
             that.resizeImage.call(that, imageIndex);
         };
@@ -205,9 +200,9 @@ class HostedGallery {
         [0, 1, 2]
             .map(i => (index + i === 0 ? count - 1 : (index - 1 + i) % count))
             .forEach(function(i) {
-                $img = $('img', this.$images[i]);
-                if (!$img[0].complete) {
-                    $img[0].addEventListener(
+                $img = this.$images[i].querySelector('img');
+                if (!$img.complete) {
+                    $img.addEventListener(
                         'load',
                         setSize.bind(this, $img, i)
                     );
@@ -218,7 +213,7 @@ class HostedGallery {
     }
 
     resizeImage(imgIndex) {
-        const $galleryFrame = this.$galleryFrame[0];
+        const $galleryFrame = this.$galleryFrame;
         const width = $galleryFrame.clientWidth;
         const height = $galleryFrame.clientHeight;
 
@@ -247,7 +242,7 @@ class HostedGallery {
         const $ojFloat = this.$ojFloat;
         const $meta = this.$meta;
         const $images = this.$images;
-        const $sizer = $('.js-hosted-gallery-image-sizer', $imageDiv);
+        const $sizer = $$('.js-hosted-gallery-image-sizer', $imageDiv).get(0);
         const imgRatio = this.imageRatios[imgIndex];
         const ctaSize = getFrame(0);
         const ctaIndex = HostedGallery.ctaIndex();
@@ -255,10 +250,10 @@ class HostedGallery {
         const imageSize = getFrame(imgRatio);
 
         fastdom.mutate(() => {
-            $sizer.css('width', imageSize.width);
-            $sizer.css('height', imageSize.height);
-            $sizer.css('top', imageSize.topBottom);
-            $sizer.css('left', imageSize.leftRight);
+            $sizer.style.width =  imageSize.width;
+            $sizer.style.height =  imageSize.height;
+            $sizer.style.top =  imageSize.topBottom;
+            $sizer.style.left =  imageSize.leftRight;
             if (imgIndex === ctaIndex) {
                 bonzo($ctaFloat).css('bottom', ctaSize.topBottom);
             }
@@ -282,7 +277,7 @@ class HostedGallery {
 
     translateContent(imgIndex, offset, duration) {
         const px = -1 * (imgIndex - 1) * this.swipeContainerWidth;
-        const galleryEl = this.$imagesContainer[0];
+        const galleryEl = this.$imagesContainer;
         const $meta = this.$meta;
 
         galleryEl.style.webkitTransitionDuration = `${duration}ms`;
@@ -313,7 +308,7 @@ class HostedGallery {
         const newIndex = Math.round(progress + 0.75);
         const ctaIndex = HostedGallery.ctaIndex() || -1;
         fastdom.mutate(() => {
-            this.$images.each((image, index) => {
+            this.$images.forEach((image, index) => {
                 const opacity = ((progress - index + 1) * 16) / 11 - 0.0625;
                 bonzo(image).css('opacity', Math.min(Math.max(opacity, 0), 1));
             });
@@ -349,9 +344,9 @@ class HostedGallery {
     scrollTo(index) {
         const scrollEl = this.$scrollEl;
         const length = this.$images.length;
-        const scrollHeight = scrollEl[0].scrollHeight;
+        const scrollHeight = scrollEl.scrollHeight;
         fastdom.mutate(() => {
-            scrollEl.scrollTop(((index - 1) * scrollHeight) / length);
+            bonzo(scrollEl).scrollTop(((index - 1) * scrollHeight) / length);
         });
     }
 
@@ -379,8 +374,8 @@ class HostedGallery {
     }
 
     setPageWidth() {
-        const $imagesContainer = this.$imagesContainer[0];
-        const $gallery = this.$galleryEl[0];
+        const $imagesContainer = this.$imagesContainer;
+        const $gallery = this.$galleryEl;
         const width = $gallery.clientWidth;
         const height = $imagesContainer.clientHeight;
         const $header = this.$header;
@@ -396,11 +391,17 @@ class HostedGallery {
         }
         this.swipeContainerWidth = imageWidth;
         fastdom.mutate(() => {
-            $header.css('width', imageWidth);
-            $footer.css('margin', `0 ${leftRight}`);
-            $footer.css('width', 'auto');
-            $galleryFrame.css('left', leftRight);
-            $galleryFrame.css('right', leftRight);
+            if ($header) {
+                $header.style.width = imageWidth;
+            }
+            if ($footer) {
+                $footer.style.margin = `0 ${leftRight}`;
+                $footer.style.width = 'auto';
+            }
+            if ($gallery) {
+                $galleryFrame.style.left = leftRight;
+                $galleryFrame.style.right = leftRight;
+            }
             that.loadSurroundingImages(that.index, that.$images.length);
         });
     }
@@ -453,7 +454,7 @@ HostedGallery.prototype.states = {
 
             // load prev/current/next
             this.loadSurroundingImages(this.index, this.$images.length);
-            this.$captions.each((caption, index) => {
+            this.$captions.forEach((caption, index) => {
                 bonzo(caption).toggleClass(
                     'current-caption',
                     that.index === index + 1
@@ -508,17 +509,17 @@ HostedGallery.prototype.states = {
                 this.reloadState = true;
             },
             'toggle-info': function() {
-                this.$captionContainer.toggleClass(
+                this.$captionContainer.classList.toggle(
                     'hosted-gallery--show-caption'
                 );
             },
             'hide-info': function() {
-                this.$captionContainer.removeClass(
+                this.$captionContainer.classList.remove(
                     'hosted-gallery--show-caption'
                 );
             },
             'show-info': function() {
-                this.$captionContainer.addClass('hosted-gallery--show-caption');
+                this.$captionContainer.classList.add('hosted-gallery--show-caption');
             },
             resize() {
                 this.onResize();

--- a/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
@@ -1,6 +1,5 @@
 import fastdom from 'fastdom';
 import throttle from 'lodash/throttle';
-import { $$ } from '../../../../lib/$$';
 import config from '../../../../lib/config';
 import { getBreakpoint, hasTouchScreen } from '../../../../lib/detect';
 import FiniteStateMachine from '../../../../lib/fsm';
@@ -22,24 +21,24 @@ class HostedGallery {
         this.imageRatios = [];
 
         // ELEMENT BINDINGS
-        this.$galleryEl = $$('.js-hosted-gallery-container').get(0);
-        this.$galleryFrame = $$('.js-hosted-gallery-frame').get(0);
-        this.$header = $$('.js-hosted-headerwrap').get(0);
-        this.$imagesContainer = $$('.js-hosted-gallery-images', this.$galleryEl).get(0);
-        this.$captionContainer = $$('.js-gallery-caption-bar').get(0);
-        this.$captions = $$('.js-hosted-gallery-caption', this.$captionContainer).get();
-        this.$scrollEl = $$('.js-hosted-gallery-scroll-container', this.$galleryEl).get(0);
+        this.$galleryEl = document.querySelector('.js-hosted-gallery-container');
+        this.$galleryFrame = document.querySelector('.js-hosted-gallery-frame');
+        this.$header = document.querySelector('.js-hosted-headerwrap');
+        this.$imagesContainer = this.$galleryEl.querySelector('.js-hosted-gallery-images');
+        this.$captionContainer = document.querySelector('.js-gallery-caption-bar');
+        this.$captions = [...this.$captionContainer.querySelectorAll('.js-hosted-gallery-caption')];
+        this.$scrollEl = this.$galleryEl.querySelector('.js-hosted-gallery-scroll-container');
 
-        this.$images = $$('.js-hosted-gallery-image', this.$imagesContainer).get();
-        this.$progress = $$('.js-hosted-gallery-progress', this.$galleryEl).get(0);
-        this.$border = $$('.js-hosted-gallery-rotating-border', this.$progress).get(0);
+        this.$images = [...this.$imagesContainer.querySelectorAll('.js-hosted-gallery-image')];
+        this.$progress = this.$galleryEl.querySelector('.js-hosted-gallery-progress');
+        this.$border = this.$progress.querySelector('.js-hosted-gallery-rotating-border');
         this.prevBtn = this.$progress.querySelector('.inline-arrow-up');
         this.nextBtn = this.$progress.querySelector('.inline-arrow-down');
         this.infoBtn = this.$captionContainer.querySelector('.js-gallery-caption-button');
-        this.$counter = $$('.js-hosted-gallery-image-count', this.$progress).get(0);
-        this.$ctaFloat = $$('.js-hosted-gallery-cta', this.$galleryEl).get(0);
-        this.$ojFloat = $$('.js-hosted-gallery-oj', this.$galleryEl).get(0);
-        this.$meta = $$('.js-hosted-gallery-meta', this.$galleryEl).get(0);
+        this.$counter = this.$progress.querySelector('.js-hosted-gallery-image-count');
+        this.$ctaFloat = this.$galleryEl.querySelector('.js-hosted-gallery-cta');
+        this.$ojFloat = this.$galleryEl.querySelector('.js-hosted-gallery-oj');
+        this.$meta = this.$galleryEl.querySelector('.js-hosted-gallery-meta');
         this.ojClose = this.$ojFloat.querySelector('.js-hosted-gallery-oj-close');
 
         if (this.$galleryEl) {
@@ -249,7 +248,7 @@ class HostedGallery {
         const $ojFloat = this.$ojFloat;
         const $meta = this.$meta;
         const $images = this.$images;
-        const $sizer = $$('.js-hosted-gallery-image-sizer', $imageDiv).get(0);
+        const $sizer = $imageDiv.querySelector('.js-hosted-gallery-image-sizer');
         const imgRatio = this.imageRatios[imgIndex];
         const ctaSize = getFrame(0);
         const ctaIndex = HostedGallery.ctaIndex();


### PR DESCRIPTION
## What does this change?

For commercial hosted gallery:

- remove qwery
- remove $
- remove bonzo 
- remove $$ (superfluous once bonzo removed)

I decided not to convert this to TS as its a very large file with a lot of dependencies and dynamic binding to unravel.

The reward / effort required would be small for something we will probably replace in future.

Part of #23740

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)
