### PR TITLE
Tidy up Braze logout code

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -157,7 +157,6 @@ const getMessageFromBraze = async (apiKey, brazeUuid) => {
 const maybeWipeUserData = async (apiKey, brazeUuid, consent) => {
     const userHasLoggedOut = !brazeUuid && hasCurrentBrazeUser();
     const userHasRemovedConsent = !consent && hasCurrentBrazeUser();
-    const slotNames = ['Banner','EndOfArticle'];
 
     if (userHasLoggedOut || userHasRemovedConsent) {
         try {
@@ -165,16 +164,9 @@ const maybeWipeUserData = async (apiKey, brazeUuid, consent) => {
             appboy.initialize(apiKey, SDK_OPTIONS);
             appboy.wipeData();
 
-            // DCR has an implementation of LocalMessageCache but Frontend does not
-            // We should still wipe the cache from Frontend if the user logs out
-            const localStorageKeyBase = 'gu.brazeMessageCache'
-            slotNames.forEach(slotName => {
-                const key = `${localStorageKeyBase}.${slotName}`
-                storage.local.remove(key);
-            })
+            LocalMessageCache.clear();
 
             clearHasCurrentBrazeUser();
-            LocalMessageCache.clear();
         } catch(error) {
             reportError(error, {}, false);
         }


### PR DESCRIPTION
## What does this change?

Previously we had some code in here to manually clear out any cached Braze messages on logout (from when DCR was using LocalMessageCache but frontend wasn't). Now we're calling LocalMessageCache.clear there's no need for the manual localstorage clearing.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

The duplicated logic this PR removes could be confusing for future developers.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
