### PR TITLE
Remove switch and experiment now anniversary is over

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -444,16 +444,6 @@ trait FeatureSwitches {
     exposeClientSide = true,
   )
 
-  val AnniversaryArticleHeader = Switch(
-    SwitchGroup.Feature,
-    "anniversary-article-header",
-    "Enables the anniversary interactive atom in DCR",
-    owners = Seq(Owner.withGithub("gtrufitt")),
-    safeState = Off,
-    sellByDate = new LocalDate(2022, 5, 11),
-    exposeClientSide = true,
-  )
-
   val AnniversaryLogoHeader = Switch(
     SwitchGroup.Feature,
     "anniversary-header-svg",

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -9,7 +9,6 @@ import conf.switches.SwitchGroup.Commercial
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
     LiveblogRendering,
-    HideAnniversaryAtom,
   )
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -22,14 +21,4 @@ object LiveblogRendering
       owners = Seq(Owner.withGithub("shtukas")),
       sellByDate = new LocalDate(2021, 8, 2),
       participationGroup = Perc0A,
-    )
-
-object HideAnniversaryAtom
-    extends Experiment(
-      name = "hide-anniversary-atom",
-      description =
-        "Controls the visibility of the the Anniversary interactive atom on articles. If OPTED IN, will NOT show banner.",
-      owners = Seq(Owner.withGithub("gtrufitt")),
-      sellByDate = new LocalDate(2022, 5, 11),
-      participationGroup = Perc0D,
     )


### PR DESCRIPTION
## What does this change?
The anniversary is over, we no longer need the experiment and switch that were used in DCR.