### PR TITLE
Introduce sbt-tc

### DIFF
--- a/sbt-tc
+++ b/sbt-tc
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Explicitly clean sbt targets to prevent cross-branch conflicts
+./sbt clean
+
+echo "##teamcity[progressMessage 'sbt compile assets scalafmtCheckAll test riffRaffUpload']"
+
+export JDK_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
+export JAVA_HOME=${JDK_HOME}
+
+echo "********** Java version **********"
+${JAVA_HOME}/bin/java -version
+echo "**********************************"
+
+cat /dev/null | ${JDK_HOME}/bin/java \
+    -Xmx6144M \
+    -XX:ReservedCodeCacheSize=128m \
+    -Dsbt.log.noformat=true \
+    -XX:+UseParallelGC \
+    -DAPP_SECRET="fake_secret" \
+    -Duser.timezone=Australia/Sydney \
+    -jar ./bin/sbt-launch.jar compile assets scalafmtCheckAll test riffRaffUpload
+
+SBT_EXIT=$?
+
+if [ $SBT_EXIT == "0" ]; then
+    exit 0
+else
+    exit 1
+fi


### PR DESCRIPTION
## What does this change?

This PR introduces a script to run the sbt build as a command line step in TC. 

Until now we have relied on Team City's sbt runner for the Scala code. This causes two problems:

1. It makes upgrading the SBT version difficult see ( https://github.com/guardian/frontend/pull/23524 ) and ( https://github.com/guardian/frontend/commit/06ebb2429f8f7d10e5144e6e117f5bc0812fb682 )

2. There is value in having a version controlled sbt run which we can update/improve/test per branch without disturbing other users by temporarily breaking their build process. 

The next step after this one will be the upgrade of sbt, and then we might redesign a bit our entire TC build to have all of it under versioned script the way some Tools already do. 

<img width="1186" alt="Screenshot 2021-05-12 at 08 51 09" src="https://user-images.githubusercontent.com/6035518/117939104-a8016380-b2ff-11eb-9af0-ef3594a6cbe3.png">

To give justice where it's due, note that we took inspiration from:

1. https://github.com/guardian/flexible-content/blob/2716e3d6c7b5f284061af63cc7412aac947731c9/scripts/ci.sh
2. https://github.com/guardian/flexible-content/blob/2716e3d6c7b5f284061af63cc7412aac947731c9/sbt-tc

although in our case, since we are only doing the sbt build for the moment and not yet the node steps we only need one script. 
