### PR TITLE
Log page targetting & fix typos

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.js
@@ -79,7 +79,7 @@ jest.mock('../../../common/modules/commercial/commercial-features', () => ({
 }));
 jest.mock('@guardian/libs', () => ({
     loadScript: jest.fn(() => Promise.resolve()),
-
+    log: jest.requireActual('@guardian/libs').log,
     storage: jest.requireActual('@guardian/libs').storage,
 }));
 jest.mock('lodash/once', () => fn => fn);

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -316,7 +316,7 @@ const rebuildPageTargeting = () => {
     // This can be removed once we get sign-off from third parties who prefer to use appNexusPageTargeting.
     page.pageAdTargeting = pageTargeting;
 
-    log('commercial', 'pageTargeting object:', pageTargeting)
+	log('commercial', 'pageTargeting object:', pageTargeting);
 
     return pageTargeting;
 }

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -20,7 +20,7 @@ import { clearPermutiveSegments, getPermutiveSegments } from './permutive';
 import { getUserSegments } from './user-ad-targeting';
 
 let myPageTargetting = {};
-let latestCmpHasInitalised;
+let latestCmpHasInitialised;
 let latestCMPState;
 const AMTGRP_STORAGE_KEY = 'gu.adManagerGroup';
 
@@ -253,7 +253,7 @@ const filterEmptyValues = (pageTargets) => {
 }
 
 const rebuildPageTargeting = () => {
-    latestCmpHasInitalised = cmp.hasInitialised();
+    latestCmpHasInitialised = cmp.hasInitialised();
     const adConsentState = getAdConsentFromState(latestCMPState);
     const ccpaState = latestCMPState.ccpa ? latestCMPState.ccpa.doNotSell : null;
     const tcfv2EventStatus = latestCMPState.tcfv2 ? latestCMPState.tcfv2.eventStatus : 'na';
@@ -324,8 +324,8 @@ const rebuildPageTargeting = () => {
 const getPageTargeting = () => {
 
     if (Object.keys(myPageTargetting).length !== 0) {
-        // If CMP was initalised since the last time myPageTargetting was built - rebuild
-        if (latestCmpHasInitalised !== cmp.hasInitialised()) {
+        // If CMP was initialised since the last time myPageTargetting was built - rebuild
+        if (latestCmpHasInitialised !== cmp.hasInitialised()) {
             myPageTargetting = rebuildPageTargeting();
         }
         return myPageTargetting;
@@ -333,7 +333,7 @@ const getPageTargeting = () => {
 
     // First call binds to onConsentChange and returns {}
     onConsentChange((state)=>{
-    // On every consent change we rebuildPageTageting
+    // On every consent change we rebuildPageTargeting
         latestCMPState = state;
         myPageTargetting = rebuildPageTargeting();
     });

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -1,5 +1,5 @@
 import { cmp, onConsentChange } from '@guardian/consent-management-platform';
-import { storage } from '@guardian/libs';
+import { log, storage } from '@guardian/libs';
 import once from 'lodash/once';
 import pick from 'lodash/pick';
 import config from '../../../../lib/config';
@@ -315,6 +315,8 @@ const rebuildPageTargeting = () => {
 
     // This can be removed once we get sign-off from third parties who prefer to use appNexusPageTargeting.
     page.pageAdTargeting = pageTargeting;
+
+    log('commercial', 'pageTargeting object:', pageTargeting)
 
     return pageTargeting;
 }


### PR DESCRIPTION
## What does this change?

Logs the page targetting to the commercial console.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshot

![log containing the page targetting object](https://user-images.githubusercontent.com/76776/118119429-59fe6580-b3bc-11eb-93a7-188b147ac2ca.png)


## What is the value of this and can you measure success?

This allows the team to quickly identify the targeting for a given page.

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
