### PR TITLE
Prebid: include `rtdModule`

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "object-fit-videos": "^1.0.3",
     "ophan-tracker-js": "1.3.25",
     "preact": "^10.5.13",
-    "prebid.js": "https://github.com/guardian/Prebid.js#67ebc672",
+    "prebid.js": "https://github.com/guardian/Prebid.js#213328cc",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10887,9 +10887,9 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.13.tgz#85f6c9197ecd736ce8e3bec044d08fd1330fa019"
   integrity sha512-q/vlKIGNwzTLu+jCcvywgGrt+H/1P/oIRSD6mV4ln3hmlC+Aa34C7yfPI4+5bzW8pONyVXYS7SvXosy2dKKtWQ==
 
-"prebid.js@https://github.com/guardian/Prebid.js#67ebc672":
+"prebid.js@https://github.com/guardian/Prebid.js#213328cc":
   version "4.38.0"
-  resolved "https://github.com/guardian/Prebid.js#67ebc6728637fdb35f7164184ea853b488ffc2b6"
+  resolved "https://github.com/guardian/Prebid.js#213328cc342b8c745f87122fe47daa5770734cf5"
   dependencies:
     "@guardian/libs" "^1.7.1"
     babel-plugin-transform-object-assign "^6.22.0"


### PR DESCRIPTION
## What does this change?

Bumps the version of Prebid to one which includes `rtdModule`.

Follow-up and fix for #23789. 

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
