### PR TITLE
Pick all Permutive segments in Prebid

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/pubmatic.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/pubmatic.js
@@ -10,7 +10,11 @@ export const pubmatic = function (bid, data, acEnabled, utils, defaultFn) {
 
 		// add all user segments
 		try {
-			segments = JSON.parse(localStorage._psegs || '[]');
+            const psegs = JSON.parse(localStorage._psegs || '[]').map(String);
+            const ppam = JSON.parse(localStorage._ppam || '[]');
+            const pcrprs = JSON.parse(localStorage._pcrprs || '[]');
+
+            segments = [...psegs, ...ppam, ...pcrprs];
 		} catch (e) {}
 
 		// add AC specific segments (these would typically go to a separate key-value, but not sure if we can have 2 lists of segments here?)


### PR DESCRIPTION
## What does this change?

Updates the config as suggested by David Reischer @dreischer.

Follow-up on #23810 and #23789 

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

More precise segments.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
