### PR TITLE
CodeBlockElement

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -1312,9 +1312,8 @@ object PageElement {
       case Code => {
         (for {
           data <- element.codeTypeData
-          html = data.html
         } yield {
-          CodeBlockElement(html, true)
+          CodeBlockElement(data.html, true)
         }).toList
       }
 


### PR DESCRIPTION
## What does this change?

This finish the implementation /  generation of `CodeBlockElement` to be used in DCR

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] Yes, but not directly because of this change. The schema in DCR needs to be updated independently.  