### PR TITLE
Auto-resize embeds using iframeMessenger

### DIFF
--- a/sport/app/football/views/wallchart/embed.scala.html
+++ b/sport/app/football/views/wallchart/embed.scala.html
@@ -12,4 +12,8 @@
             @fragments.analytics.base()(page, request, context)
         </div>
     </body>
+    <script src="https://interactive.guim.co.uk/libs/iframe-messenger/iframeMessenger.js"></script>
+    <script>
+            iframeMessenger.enableAutoResize();
+    </script>
 </html>

--- a/sport/app/football/views/wallchart/groupTablesEmbed.scala.html
+++ b/sport/app/football/views/wallchart/groupTablesEmbed.scala.html
@@ -34,4 +34,8 @@
             </div>
         </div>
     </body>
+    <script src="https://interactive.guim.co.uk/libs/iframe-messenger/iframeMessenger.js"></script>
+    <script>
+            iframeMessenger.enableAutoResize();
+    </script>
 </html>

--- a/sport/app/football/views/wallchart/spiderEmbed.scala.html
+++ b/sport/app/football/views/wallchart/spiderEmbed.scala.html
@@ -33,4 +33,8 @@
             </div>
         </div>
     </body>
+    <script src="https://interactive.guim.co.uk/libs/iframe-messenger/iframeMessenger.js"></script>
+    <script>
+            iframeMessenger.enableAutoResize();
+    </script>
 </html>

--- a/static/src/javascripts/projects/facia/modules/ui/snaps.js
+++ b/static/src/javascripts/projects/facia/modules/ui/snaps.js
@@ -17,7 +17,6 @@ const bindIframeMsgReceiverOnce = once(() => {
         const iframe = snapIframes.find(
             snapIframe => snapIframe.contentWindow === event.source
         );
-
         let message;
         if (iframe) {
             message = JSON.parse(event.data);
@@ -189,8 +188,17 @@ const initStandardSnap = (el) => {
     });
 };
 
+const getIframesFromSnap = (snap) =>
+    Array.from(snap.children).filter((e) => e.nodeName === 'IFRAME')
+
+const isInteractiveSnap = (inlinedSnap) => getIframesFromSnap(inlinedSnap).length !== 0
+
 const initInlinedSnap = (el) => {
     addCss(el);
+    if (isInteractiveSnap(el)) {
+        getIframesFromSnap(el).forEach((iframe) => snapIframes.push(iframe))
+        bindIframeMsgReceiverOnce();
+    }
     if (!isIOS) {
         mediator.on('window:throttledResize', () => {
             addCss(el, true);
@@ -218,7 +226,6 @@ const init = () => {
             );
         })
         .filter(el => el.getAttribute('data-snap-uri'));
-
     snaps.forEach(initStandardSnap);
 };
 


### PR DESCRIPTION
# What does this change?
This introduces auto-resizing for interactive atom snaps on Fronts, particularly for use with the Euros interactive embeds.

I've added the iframe messenger to the Euros embeds and also introduced handling of inline snaps that use interactive atoms/iframes on Fronts.


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No - as long as these embeds aren't used in articles.
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/9122944/118628706-c914f900-b7c4-11eb-882f-b154e5aa377d.gif
[after]: https://user-images.githubusercontent.com/9122944/118628716-cb775300-b7c4-11eb-97c8-94845dbaacc3.gif

## What is the value of this and can you measure success?
Allow these embeds to work on web fronts during Euros

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
