### PR TITLE
Stop braze auto collectiving device data

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -108,6 +108,7 @@ const SDK_OPTIONS = {
     baseUrl: 'https://sdk.fra-01.braze.eu/api/v3',
     sessionTimeoutInSeconds: 1,
     minimumIntervalBetweenTriggerActionsInSeconds: 0,
+    devicePropertyAllowlist: [],
 };
 
 const getMessageFromBraze = async (apiKey, brazeUuid) => {


### PR DESCRIPTION
## What does this change?
Stops Braze collecting user data listed here https://www.braze.com/docs/developer_guide/platform_integration_guides/web/cookies_and_storage/#device-properties
We don't want to collect this data automatically as it is often wrong
A  lot of this data we don't need to collect at all.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes
PR for DCR change here: https://github.com/guardian/dotcom-rendering/pull/2998

## What is the value of this and can you measure success?


## Checklist

### Does this affect other platforms?

No

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [ ] Locally
- [x] On CODE (optional)
