### PR TITLE
Allow the dcr flag on local

### DIFF
--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -53,6 +53,7 @@ class DevParametersHttpRequestHandler(
     "pbjs_debug", // set to `true` to enable prebid debugging,
     "amzn_debug_mode", // set to `1` to enable A9 debugging
     "force-braze-message", // JSON encoded representation of "extras" data from Braze
+    "dcr",
   )
 
   val commercialParams = Seq(


### PR DESCRIPTION
## What does this change?

We are currently thinking messing about with query parameters ( see open PR: https://github.com/guardian/frontend/pull/23802 ), but for the moment @liywjl pointed out that we still need to be able to `dcr=false` on local. This makes it happen.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No