### PR TITLE
Make Advert.ts compatible with IE11

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -137,6 +137,7 @@ class Advert {
 			this.extraNodeClasses,
 			newClasses,
 		);
+		// IE11 does not support multiple arguments to classList.add/remove so do these one-by-ones
 		classesToRemove.forEach((cls) => this.node.classList.remove(cls));
 		newClasses.forEach((cls) => this.node.classList.add(cls));
 		this.extraNodeClasses = newClasses;

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -137,8 +137,8 @@ class Advert {
 			this.extraNodeClasses,
 			newClasses,
 		);
-		this.node.classList.remove(...classesToRemove);
-		this.node.classList.add(...newClasses);
+		classesToRemove.forEach((cls) => this.node.classList.remove(cls));
+		newClasses.forEach((cls) => this.node.classList.add(cls));
 		this.extraNodeClasses = newClasses;
 	}
 }


### PR DESCRIPTION
## What does this change?

Add/remove classes one by one since IE11 does not support multiple arguments to classList.add/remove

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)

