### PR TITLE
Enable numbered lists on DCR

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -73,8 +73,6 @@ object ArticlePageChecks {
     !page.item.tags.tags.exists(t => tagsBlockList(t.id))
   }
 
-  def isNotNumberedList(page: PageWithStoryPackage): Boolean = !page.item.isNumberedList
-
   def isNotAGallery(page: PageWithStoryPackage): Boolean = !page.item.tags.isGallery
 
   def isNotLiveBlog(page: PageWithStoryPackage): Boolean = !page.item.tags.isLiveBlog
@@ -107,7 +105,6 @@ object ArticlePicker {
       ("isNotAMP", ArticlePageChecks.isNotAMP(request)),
       ("isNotPaidContent", ArticlePageChecks.isNotPaidContent(page)),
       ("isNotInTagBlockList", ArticlePageChecks.isNotInTagBlockList(page)),
-      ("isNotNumberedList", ArticlePageChecks.isNotNumberedList(page)),
     )
   }
 


### PR DESCRIPTION
## What does this change?

Removes check for numbered lists for DCR.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)


## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
