### PR TITLE
Create individual group table endpoint

### DIFF
--- a/sport/app/football/controllers/WallchartController.scala
+++ b/sport/app/football/controllers/WallchartController.scala
@@ -92,23 +92,19 @@ class WallchartController(
             .stagesFromCompetition(competition, KnockoutSpider.orderings)
 
           val groupStages = competitionStages.collectFirst { case stage: Groups => stage }
-
-          groupStages match {
-            case None => NotFound
-            case Some(group) => {
-              group.groupTables.find(x => x._1.roundNumber == groupId) match {
-                case None => NotFound
-                case Some(table) => {
+          groupStages.map {
+            group => {
+              group.groupTables.find(x => x._1.roundNumber == groupId).map {
+                table => {
                   Cached(60) {
                     RevalidatableResult.Ok(
                       football.views.html.wallchart.groupTableEmbed(page, competition, group, table),
                     )
                   }
                 }
-              }
-
+              }.getOrElse(NotFound)
             }
-          }
+          }.getOrElse(NotFound)
         }
         .getOrElse(NotFound)
     }

--- a/sport/app/football/controllers/WallchartController.scala
+++ b/sport/app/football/controllers/WallchartController.scala
@@ -99,7 +99,7 @@ class WallchartController(
                 {
                   Cached(60) {
                     RevalidatableResult.Ok(
-                      football.views.html.wallchart.groupTableEmbed(page, competition, group, table),
+                      football.views.html.wallchart.groupTableEmbed(page, competition, table),
                     )
                   }
                 }

--- a/sport/app/football/views/wallchart/groupTableEmbed.scala.html
+++ b/sport/app/football/views/wallchart/groupTableEmbed.scala.html
@@ -1,6 +1,5 @@
 @import implicits.Football._
 @import pa._
-@import views.support.`package`.Seq2zipWithRowInfo
 
 @(page: model.Page, competition: model.Competition, groupStage: football.model.Groups, groupTable: (Round, Seq[LeagueTableEntry]))(implicit request: RequestHeader, context: model.ApplicationContext)
 
@@ -16,16 +15,6 @@
                         striped = true,
                         withCrests = true
                     )
-                </div>
-                <div class="football-group__matches">
-                @{matches.matchesGroupedByDateAndCompetition.zipWithRowInfo.map { case ((date, competitionMatches), info) =>
-                    competitionMatches.map { case (competition, matches) =>
-                        football.views.html.matchList.matchesList(matches, competition, date,
-                            linkToCompetition = false,
-                            heading = if(info.isFirst) Option(("Fixtures and results", None)) else None
-                        )
-                    }
-                }}
                 </div>
             }
         </div>
@@ -50,11 +39,6 @@
                         <div class="container">
                             <div class="facia-container__inner">
                                 <div class="container__border hide-on-mobile"></div>
-                                <div class="fc-container__header">
-                                    <h3 class="container__title">
-                                        <span class="container__title__label u-text-hyphenate">@groupTable._1.name</span>
-                                    </h3>
-                                </div>
                                 <div class="container__body">
                                     <div data-link-name="@competition.fullName groups">
                                         <ul class="football-groups u-unstyled u-cf">

--- a/sport/app/football/views/wallchart/groupTableEmbed.scala.html
+++ b/sport/app/football/views/wallchart/groupTableEmbed.scala.html
@@ -1,0 +1,75 @@
+@import implicits.Football._
+@import pa._
+@import views.support.`package`.Seq2zipWithRowInfo
+
+@(page: model.Page, competition: model.Competition, groupStage: football.model.Groups, groupTable: (Round, Seq[LeagueTableEntry]))(implicit request: RequestHeader, context: model.ApplicationContext)
+
+@footballGroup(round: Round, leagueTableEntries: Seq[LeagueTableEntry]) = {
+@defining(groupStage.matchesList(competition, round)) { matches =>
+    <li class="football-group football-group-embed">
+        <div class="football-group__container football-group__container-embed table--hide-from-importance-3">
+            @round.name.map{ name =>
+                <div class="football-group__table">
+                    @football.views.html.tablesList.tableView(competition, model.Group(round, leagueTableEntries),
+                        heading = round.name,
+                        headingLink = groupTag(competition.id, round),
+                        striped = true,
+                        withCrests = true
+                    )
+                </div>
+                <div class="football-group__matches">
+                @{matches.matchesGroupedByDateAndCompetition.zipWithRowInfo.map { case ((date, competitionMatches), info) =>
+                    competitionMatches.map { case (competition, matches) =>
+                        football.views.html.matchList.matchesList(matches, competition, date,
+                            linkToCompetition = false,
+                            heading = if(info.isFirst) Option(("Fixtures and results", None)) else None
+                        )
+                    }
+                }}
+                </div>
+            }
+        </div>
+    </li>
+}
+}
+
+
+
+<!DOCTYPE html>
+
+<html class="js-off is-not-modern id--signed-out" lang="en-GB">
+    <head>
+        <meta name="robots" content="noindex, nofollow" />
+        @fragments.head(Some("football"), Html(""))(page, request, context)
+        <script>guardian.config.page.isFootballWorldCup2014 = true;</script>
+        </head>
+    <body id="top" itemscope itemtype="http://schema.org/WebPage">
+        <div id="js-context" class="football-wallchart-embed">
+            <div class="l-side-margins wc-overview">
+                    <div class="facia-container facia-container--layout-content">
+                        <div class="container">
+                            <div class="facia-container__inner">
+                                <div class="container__border hide-on-mobile"></div>
+                                <div class="fc-container__header">
+                                    <h3 class="container__title">
+                                        <span class="container__title__label u-text-hyphenate">@groupTable._1.name</span>
+                                    </h3>
+                                </div>
+                                <div class="container__body">
+                                    <div data-link-name="@competition.fullName groups">
+                                        <ul class="football-groups u-unstyled u-cf">
+                                            @footballGroup(groupTable._1, groupTable._2)
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                @fragments.analytics.base()(page, request, context)
+            </div>
+        </div>
+    </body>
+</html>
+
+
+

--- a/sport/app/football/views/wallchart/groupTableEmbed.scala.html
+++ b/sport/app/football/views/wallchart/groupTableEmbed.scala.html
@@ -1,59 +1,25 @@
 @import implicits.Football._
 @import pa._
 
-@(page: model.Page, competition: model.Competition, groupStage: football.model.Groups, groupTable: (Round, Seq[LeagueTableEntry]))(implicit request: RequestHeader, context: model.ApplicationContext)
+@(page: model.Page, competition: model.Competition, groupTable: (Round, Seq[LeagueTableEntry]))(implicit request: RequestHeader, context: model.ApplicationContext)
 
-@footballGroup(round: Round, leagueTableEntries: Seq[LeagueTableEntry]) = {
-@defining(groupStage.matchesList(competition, round)) { matches =>
-    <li class="football-group football-group-embed">
-        <div class="football-group__container football-group__container-embed table--hide-from-importance-3">
-            @round.name.map{ name =>
-                <div class="football-group__table">
-                    @football.views.html.tablesList.tableView(competition, model.Group(round, leagueTableEntries),
-                        heading = round.name,
-                        headingLink = groupTag(competition.id, round),
-                        striped = true,
-                        withCrests = true
-                    )
-                </div>
-            }
-        </div>
-    </li>
-}
-}
+@round=@{groupTable._1}
+@leagueTableEntries=@{groupTable._2}
 
-
-
-<!DOCTYPE html>
-
-<html class="js-off is-not-modern id--signed-out" lang="en-GB">
-    <head>
-        <meta name="robots" content="noindex, nofollow" />
-        @fragments.head(Some("football"), Html(""))(page, request, context)
-        <script>guardian.config.page.isFootballWorldCup2014 = true;</script>
-        </head>
-    <body id="top" itemscope itemtype="http://schema.org/WebPage">
-        <div id="js-context" class="football-wallchart-embed">
-            <div class="l-side-margins wc-overview">
-                    <div class="facia-container facia-container--layout-content">
-                        <div class="container">
-                            <div class="facia-container__inner">
-                                <div class="container__border hide-on-mobile"></div>
-                                <div class="container__body">
-                                    <div data-link-name="@competition.fullName groups">
-                                        <ul class="football-groups u-unstyled u-cf">
-                                            @footballGroup(groupTable._1, groupTable._2)
-                                        </ul>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                @fragments.analytics.base()(page, request, context)
+<div class="football-group football-group-embed">
+    <div class="football-group__container football-group__container-embed table--hide-from-importance-3">
+        @round.name.map{ name =>
+            <div class="football-group__table">
+                @football.views.html.tablesList.tableView(competition, model.Group(round, leagueTableEntries),
+                    heading = round.name,
+                    headingLink = groupTag(competition.id, round),
+                    striped = true,
+                    withCrests = true
+                )
             </div>
-        </div>
-    </body>
-</html>
+        }
+    </div>
+</div>
 
 
 

--- a/sport/conf/routes
+++ b/sport/conf/routes
@@ -57,6 +57,7 @@ GET        /football/:team/fixtures-and-results-container                    foo
 
 GET        /football/:competitionTag/overview/embed                          football.controllers.WallchartController.renderWallchartEmbed(competitionTag)
 GET        /football/:competitionTag/groups/embed                            football.controllers.WallchartController.renderGroupTablesEmbed(competitionTag)
+GET        /football/:competitionTag/groups/:groupId/embed                   football.controllers.WallchartController.renderIndividualGroupTableEmbed(competitionTag, groupId)
 GET        /football/:competitionTag/spider/embed                            football.controllers.WallchartController.renderSpiderEmbed(competitionTag)
 GET        /football/:competitionTag/overview                                football.controllers.WallchartController.renderWallchart(competitionTag)
 GET        /football/:competitionTag/wallchart.json                          football.controllers.WallchartController.renderWallchartJson(competitionTag)

--- a/static/src/stylesheets/module/football/_overview.scss
+++ b/static/src/stylesheets/module/football/_overview.scss
@@ -321,6 +321,34 @@
         display: none;
     }
 }
+.football-groups {
+    .football-group-embed {
+        @include mq($from: tablet) {
+            width: 100%;
+        }
+
+        .football-group__matches {
+            @include mq($from: tablet) {
+                border-top: 0; // style, colour, width
+            }
+        }
+    }
+}
+
+.football-group__container-embed {
+    @include mq($from: tablet) {
+        display: flex;
+        margin-bottom: 0;
+        .football-group__matches {
+            flex: 2 1 auto;
+        }
+
+        .football-group__table {
+            flex: 1 1 auto;
+        }
+    }
+}
+
 
 /* ==========================================================================
    Knockout chart (Desktop only)


### PR DESCRIPTION
## What does this change?
We need to be able to provide individual group tables for the Euro
atoms. We've introduced here a new endpoint that provides a single group
table.

Changes:
- New endpoint and associated controller method
- New twirl template for single group table
- New styling for individual group tables

Co-authored-by: Marjan Kalanaki <marjan.kalanaki@guardian.co.uk>

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

### Desktop/Tablet
![image](https://user-images.githubusercontent.com/9122944/118846239-6f93f380-b8c4-11eb-9ecc-18bd7eb8a888.png)

### Mobile

![image](https://user-images.githubusercontent.com/9122944/118846270-76226b00-b8c4-11eb-94dc-69b9a653ab29.png)

## What is the value of this and can you measure success?
Allows fixed height atoms for Euros

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [x] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
