### PR TITLE
Roll out Prebid with Permutive to 100% of audience

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -10,7 +10,6 @@ object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
     LiveblogRendering,
     HideAnniversaryAtom,
-    PrebidWithPermutive,
   )
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -42,13 +41,4 @@ object NewsletterEmbedDesign
       owners = Seq(Owner.withGithub("buck06191")),
       sellByDate = new LocalDate(2020, 11, 30),
       participationGroup = Perc20A,
-    )
-
-object PrebidWithPermutive
-    extends Experiment(
-      name = "prebid-with-permutive",
-      description = "Enables permutive real-time config for Prebid.js",
-      owners = group(Commercial),
-      sellByDate = new LocalDate(2021, 6, 1),
-      participationGroup = Perc0B,
     )

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "object-fit-videos": "^1.0.3",
     "ophan-tracker-js": "1.3.25",
     "preact": "^10.5.13",
-    "prebid.js": "https://github.com/guardian/Prebid.js#213328cc",
+    "prebid.js": "https://github.com/guardian/Prebid.js#a6d34e7",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/permutive-test.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/permutive-test.ts
@@ -1,9 +1,0 @@
-import config_ from '../../../../../lib/config';
-
-// This is really a hacky workaround ⚠️
-const config = config_ as {
-	get: (s: string, d?: string) => string;
-};
-
-export const isInPrebidPermutiveTest = (): boolean =>
-	config.get('tests.prebidWithPermutiveVariant', '') === 'variant';

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
@@ -6,7 +6,6 @@ import { priceGranularity } from './price-config';
 import { getAdvertById } from '../../dfp/get-advert-by-id';
 import { stripDfpAdPrefixFrom } from '../utils';
 import { EventTimer } from '@guardian/commercial-core';
-import { isInPrebidPermutiveTest } from './permutive-test';
 import { pubmatic } from './pubmatic';
 
 const bidderTimeout = 1500;
@@ -79,7 +78,7 @@ const initialise = (window, framework = 'tcfv2') => {
         pbjsConfig.consentManagement = consentManagement()
     }
 
-    if (config.get('switches.permutive', false) && isInPrebidPermutiveTest()) {
+    if (config.get('switches.permutive', false)) {
 		pbjsConfig.realTimeData = {
 			dataProviders: [
 				{

--- a/yarn.lock
+++ b/yarn.lock
@@ -10887,9 +10887,9 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.13.tgz#85f6c9197ecd736ce8e3bec044d08fd1330fa019"
   integrity sha512-q/vlKIGNwzTLu+jCcvywgGrt+H/1P/oIRSD6mV4ln3hmlC+Aa34C7yfPI4+5bzW8pONyVXYS7SvXosy2dKKtWQ==
 
-"prebid.js@https://github.com/guardian/Prebid.js#213328cc":
+"prebid.js@https://github.com/guardian/Prebid.js#a6d34e7":
   version "4.38.0"
-  resolved "https://github.com/guardian/Prebid.js#213328cc342b8c745f87122fe47daa5770734cf5"
+  resolved "https://github.com/guardian/Prebid.js#a6d34e7e53da978bf4da4adaa98368f24d39faea"
   dependencies:
     "@guardian/libs" "^1.7.1"
     babel-plugin-transform-object-assign "^6.22.0"


### PR DESCRIPTION
## What does this change?

Implements the Permutive changes in Prebid to 100% of the audience.

Follow-up on #23789, #23810 and #23811.
Relies on https://github.com/guardian/Prebid.js/pull/117.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Better header bidding, more revenue from advertising partners.

## Checklist

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Tested

- [X] Locally
- [ ] On CODE (optional)