### PR TITLE
Enable CodeBlockElements in Article Picker

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -30,7 +30,6 @@ object ArticlePageChecks {
 
     def unsupportedElement(blockElement: BlockElement) =
       blockElement match {
-        case _: CodeBlockElement                     => true
         case ContentAtomBlockElement(_, atomtype, _) =>
           // ContentAtomBlockElement was expanded to include atomtype.
           // To support an atom type, just add it to supportedAtomTypes
@@ -52,8 +51,6 @@ object ArticlePageChecks {
     // See: https://github.com/guardian/dotcom-rendering/blob/master/packages/frontend/web/components/lib/ArticleRenderer.tsx
     def unsupportedElement(blockElement: BlockElement) =
       blockElement match {
-        // This has never been used but we know we don't yet support them due to a required CAPI update
-        case _: CodeBlockElement => true
         // The majority of the remaining atoms appear to be interactive atoms, which aren't supported yet
         case ContentAtomBlockElement(_, atomtype, _) if atomtype != "media" => true
         // Everything else should be supported, but there are some element types that don't


### PR DESCRIPTION
## What does this change?

This enable `CodeBlockElement` in article picker.

## Does this change need to be reproduced in dotcom-rendering ?

This required a few PRs: (frontend: https://github.com/guardian/frontend/pull/23814 , https://github.com/guardian/frontend/pull/23815 ), ( dcr: https://github.com/guardian/dotcom-rendering/pull/2999 , https://github.com/guardian/dotcom-rendering/pull/3002 , https://github.com/guardian/dotcom-rendering/pull/3005 , https://github.com/guardian/dotcom-rendering/pull/3009 ).

<img width="1111" alt="Screenshot 2021-05-19 at 13 52 49" src="https://user-images.githubusercontent.com/6035518/118815837-85e08600-b8a9-11eb-9ea7-e1eb419da7a9.png">

