### PR TITLE
Remove old AB test

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -33,12 +33,3 @@ object HideAnniversaryAtom
       sellByDate = new LocalDate(2022, 5, 11),
       participationGroup = Perc0D,
     )
-
-object NewsletterEmbedDesign
-    extends Experiment(
-      name = "new-newsletter-embed-designs",
-      description = "New newsletter signup embeds for discoverability OKR",
-      owners = Seq(Owner.withGithub("buck06191")),
-      sellByDate = new LocalDate(2020, 11, 30),
-      participationGroup = Perc20A,
-    )

--- a/common/app/views/emailSubscriptionSuccessResult.scala.html
+++ b/common/app/views/emailSubscriptionSuccessResult.scala.html
@@ -1,19 +1,9 @@
-@import com.gu.identity.model.EmailNewsletter
-@import experiments.{ActiveExperiments, NewsletterEmbedDesign}
+
 @import services.newsletters.NewsletterResponse
 @(page: model.Page, emailNewsletter: NewsletterResponse, listName: String)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @electionNewsletters = @{List("minute-us", "us-morning-newsletter", "today-us", "green-light")}
 
 @emailEmbed(page) {
-    @if(ActiveExperiments.isParticipating(NewsletterEmbedDesign) && electionNewsletters.contains(listName)) {
-        @fragments.email.signup.result.emailResultNewDesign(
-            listName,
-            emailNewsletter,
-            fragments.email.signup.result.emailSuccess(emailNewsletter.emailEmbed)
-        )
-    } else {
-        @fragments.email.signup.result.emailSuccess(emailNewsletter.emailEmbed)
-    }
-
+    @fragments.email.signup.result.emailSuccess(emailNewsletter.emailEmbed)
 }


### PR DESCRIPTION
## What does this change?
Removes an old, expired AB test for the Newsletter embeds design test.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
Code health

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
