### PR TITLE
Remove hardcoding of isPreview in JS config for DCR

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -308,7 +308,8 @@ object DotcomRenderingDataModel {
     )
 
     val combinedConfig: JsObject = {
-      val jsPageConfig: Map[String, JsValue] = JavaScriptPage.getMap(page, Edition(request), false, request)
+      val jsPageConfig: Map[String, JsValue] =
+        JavaScriptPage.getMap(page, Edition(request), pageType.isPreview, request)
       Json.toJsObject(config).deepMerge(JsObject(jsPageConfig))
     }
 


### PR DESCRIPTION
## What does this change?
This removes the hardcoding of the config value `isPreview` for passing through to DCR. This probably wasn't used so far because we typically don't vary behaviour clientside based on whether the content is preview, but we have a request to start doing so. Note that there is already another place where `isPreview` gets passed to DCR, which can probably already be used safely, but this will remove any confusion hopefully.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

Before:
![image](https://user-images.githubusercontent.com/8754692/118989569-0b336b80-b97a-11eb-8063-3821993231d4.png)

After:
![image](https://user-images.githubusercontent.com/8754692/118989457-f6ef6e80-b979-11eb-8946-31956e8528dd.png)