### PR TITLE
Move ./sbt-tc to ./scripts/ci

### DIFF
--- a/scripts/ci
+++ b/scripts/ci
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Main Continuous Integration Script
+
 # Explicitly clean sbt targets to prevent cross-branch conflicts
 ./sbt clean
 


### PR DESCRIPTION
## What does this change?

Move `./sbt-tc` to `./scripts/ci` as per recommendations ( https://github.com/guardian/recommendations/blob/master/continuous-integration.md ). 

Note that TC has been updated to gracefully handle the transition.

<img width="685" alt="Screenshot 2021-05-20 at 15 17 44" src="https://user-images.githubusercontent.com/6035518/118997819-d8d93c80-b980-11eb-8094-93316b24583c.png">

