### PR TITLE
Remove 'items' from guide atom object for DCR

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -236,18 +236,12 @@ object GenericAtomBlockElement {
   implicit val GenericAtomBlockElementWrites: Writes[GenericAtomBlockElement] = Json.writes[GenericAtomBlockElement]
 }
 
-case class GuideAtomBlockElementItem(title: Option[String], body: String)
-object GuideAtomBlockElementItem {
-  implicit val GuideAtomBlockElementItemWrites: Writes[GuideAtomBlockElementItem] =
-    Json.writes[GuideAtomBlockElementItem]
-}
 case class GuideAtomBlockElement(
     id: String,
     label: String,
     title: String,
     img: Option[String],
     html: String,
-    items: List[GuideAtomBlockElementItem],
     credit: String,
 ) extends PageElement
 object GuideAtomBlockElement {
@@ -1053,7 +1047,6 @@ object PageElement {
             val html = guide.data.items
               .map(item => s"${item.title.map(t => s"<p><strong>${t}</strong></p>").getOrElse("")}${item.body}")
               .mkString("")
-            val items = guide.data.items.toList.map(item => GuideAtomBlockElementItem(item.title, item.body))
             Some(
               GuideAtomBlockElement(
                 id = guide.id,
@@ -1061,7 +1054,6 @@ object PageElement {
                 title = guide.atom.title.getOrElse(""),
                 img = guide.image.flatMap(ImgSrc.getAmpImageUrl),
                 html = html,
-                items = items,
                 credit = guide.credit.getOrElse(""),
               ),
             )


### PR DESCRIPTION
## What does this change?

This change removes the items element from the guide atom as it is redundant data for DCR.

`items` are passed as a field as part of the guide atom object down to DCR, however the DCR atom element only uses the `html` field ([see here](https://github.com/guardian/atoms-rendering/blob/main/src/GuideAtom.tsx)). 

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes - DCR PR will follow up removing 'items' from the model. We cannot update DCR until after this PR is in production as DCR runs fixture tests which pull from prod data. There is no impact on DCR as `items` is an optional parameter in the interface.

## What is the value of this and can you measure success?

Remove unused JSON fields in the DCR endpoint to reduce clutter and keep code clean & up-to-date.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
