### PR TITLE
Add switch to Prebid permutive segments

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -341,6 +341,16 @@ trait PrebidSwitches {
     exposeClientSide = true,
   )
 
+  val PrebidPermutiveAudience = Switch(
+    Commercial,
+    "prebid-permutive-audience",
+    "Enable Permutive’s Audience Connector to run with Prebid",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
+
   val prebidSonobi: Switch = Switch(
     group = CommercialPrebid,
     name = "prebid-sonobi",

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
@@ -41,29 +41,29 @@ const initialise = (window, framework = 'tcfv2') => {
           }
         : { syncEnabled: false };
 
-		const consentManagement = () => {
-			switch (framework) {
-				case 'aus':
-				case 'ccpa':
-					// https://docs.prebid.org/dev-docs/modules/consentManagementUsp.html
-					return {
-						usp: {
-							cmpApi: 'iab',
-							timeout: 1500,
-						},
-					};
-				case 'tcfv2':
-				default:
-					// https://docs.prebid.org/dev-docs/modules/consentManagement.html
-					return {
-						gdpr: {
-							cmpApi: 'iab',
-							timeout: 200,
-							defaultGdprScope: true,
-						},
-					};
-			}
-		};
+	const consentManagement = () => {
+		switch (framework) {
+			case 'aus':
+			case 'ccpa':
+				// https://docs.prebid.org/dev-docs/modules/consentManagementUsp.html
+				return {
+					usp: {
+						cmpApi: 'iab',
+						timeout: 1500,
+					},
+				};
+			case 'tcfv2':
+			default:
+				// https://docs.prebid.org/dev-docs/modules/consentManagement.html
+				return {
+					gdpr: {
+						cmpApi: 'iab',
+						timeout: 200,
+						defaultGdprScope: true,
+					},
+				};
+		}
+	};
 
     const pbjsConfig = Object.assign(
         {},
@@ -78,7 +78,10 @@ const initialise = (window, framework = 'tcfv2') => {
         pbjsConfig.consentManagement = consentManagement()
     }
 
-    if (config.get('switches.permutive', false)) {
+    if (
+		config.get('switches.permutive', false) &&
+		config.get('switches.prebidPermutiveAudience', false)
+	) {
 		pbjsConfig.realTimeData = {
 			dataProviders: [
 				{


### PR DESCRIPTION
## What does this change?

Add a switch + tests for Permutive Audience Connector in Prebid.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
