### PR TITLE
Remove unused ad-block images

### DIFF
--- a/common/app/templates/javaScriptConfig.scala.js
+++ b/common/app/templates/javaScriptConfig.scala.js
@@ -22,11 +22,6 @@
             }
         },
         "images": {
-            "commercial": {
-                "ab-icon": "@Static("images/commercial/ab-icon.png")",
-                "abp-icon": "@Static("images/commercial/abp-icon.png")",
-                "abp-whitelist-instruction-chrome": "@Static("images/commercial/ad-block-instructions-chrome.png")"
-            },
             "acquisitions": {
                 "payment-methods": "@Static("images/acquisitions/payment-methods.png")",
                 "payment-methods-us": "@Static("images/acquisitions/payment-methods-us.png")",


### PR DESCRIPTION
## What does this change?

Remove deprecated config objects, gone since #14643.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

“Delete the obsolete” -@rtyley 

## Checklist

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
