### PR TITLE
Assign commercial switches to correct groups

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -352,9 +352,9 @@ trait PrebidSwitches {
   )
 
   val PrebidPermutiveAudience = Switch(
-    Commercial,
-    "prebid-permutive-audience",
-    "Enable Permutive’s Audience Connector to run with Prebid",
+    group = CommercialPrebid,
+    name = "prebid-permutive-audience",
+    description = "Enable Permutive’s Audience Connector to run with Prebid",
     owners = group(Commercial),
     safeState = Off,
     sellByDate = never,
@@ -502,7 +502,7 @@ trait PrebidSwitches {
   )
 
   val mobileStickyPrebid: Switch = Switch(
-    group = Commercial,
+    group = CommercialPrebid,
     name = "mobile-sticky-prebid",
     description = "Include Mobile Sticky leaderboard banner in Prebid",
     owners = group(Commercial),


### PR DESCRIPTION
## What does this change?

from Commercial to CommercialPrebid

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

## Checklist

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
