### PR TITLE
No RR epic/banner on hosted pages

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -424,9 +424,10 @@ export const renderBanner = (response) => {
 };
 
 export const fetchAndRenderEpic = async () => {
+    const isHosted = config.get('page.isHosted');
     const page = config.get('page');
 
-    if (page.contentType === 'Article' || page.contentType === 'LiveBlog') {
+    if (page.contentType === 'Article' || page.contentType === 'LiveBlog' && !isHosted) {
         try {
             const payload = await buildEpicPayload();
 

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -427,7 +427,7 @@ export const fetchAndRenderEpic = async () => {
     const isHosted = config.get('page.isHosted');
     const page = config.get('page');
 
-    if (page.contentType === 'Article' || page.contentType === 'LiveBlog' && !isHosted) {
+    if ((page.contentType === 'Article' || page.contentType === 'LiveBlog') && !isHosted) {
         try {
             const payload = await buildEpicPayload();
 

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -33,6 +33,8 @@ import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 // See https://github.com/guardian/support-dotcom-components/blob/main/module-versions.md
 export const ModulesVersion = 'v2';
 
+const isHosted = config.get('page.isHosted');
+
 const buildKeywordTags = page => {
     const keywordIds = page.keywordIds.split(',');
     const keywords = page.keywords.split(',');
@@ -331,7 +333,7 @@ export const fetchPuzzlesData = async () => {
 export const fetchBannerData = async () => {
     const payload = await buildBannerPayload();
 
-    if (payload.targeting.shouldHideReaderRevenue || payload.targeting.isPaidContent) {
+    if (payload.targeting.shouldHideReaderRevenue || payload.targeting.isPaidContent || isHosted) {
         return Promise.resolve(null);
     }
 
@@ -424,7 +426,6 @@ export const renderBanner = (response) => {
 };
 
 export const fetchAndRenderEpic = async () => {
-    const isHosted = config.get('page.isHosted');
     const page = config.get('page');
 
     if ((page.contentType === 'Article' || page.contentType === 'LiveBlog') && !isHosted) {


### PR DESCRIPTION
On hosted pages it tries to fetch the epic but fails:
`Error importing remote epic: TypeError: e.keywordIds is undefined`

We should not try to show epics on these pages.

e.g. https://www.theguardian.com/advertiser-content/orsted/here-is-why-green-energy-is-good-for-your-business