### PR TITLE
Exclude most banners in preview

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -282,8 +282,14 @@ const initPublicApi = () => {
 };
 
 const initialiseBanner = () => {
+    const isPreview = config.get('page.isPreview', false)
     // ordered by priority
-    const bannerList = [
+    // in preview we don't want to show most banners as they are an unnecessary interruption
+    // however braze banner does use preview for testing
+    const bannerList = isPreview ? [
+        cmpBannerCandidate,
+        brazeBanner,
+    ] : [
         cmpBannerCandidate,
         signInGate,
         membershipBanner,


### PR DESCRIPTION
## What does this change?
This prevents all banners from showing on `preview` apart from the CMP and Braze. For CMP, we may be able to remove it, but it requires more thinking first. For Braze, it should not appear for editorial users, but the preview environment is useful for testing, so it is kept for now.

## Does this change need to be reproduced in dotcom-rendering ?
Already done

## What is the value of this and can you measure success?
Reduces interruption for tools users of viewer/preview, who will not typically be interested in seeing banners.