### PR TITLE
Upgrade braze-components version to 2.1.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@guardian/atom-renderer": "1.2.2",
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.8",
-    "@guardian/braze-components": "^2.0.0",
+    "@guardian/braze-components": "^2.1.0",
     "@guardian/commercial-core": "^0.17.0",
     "@guardian/consent-management-platform": "^6.11.3",
     "@guardian/libs": "^1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1888,10 +1888,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/braze-components@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-2.0.0.tgz#d8cfcfb342d7a3a827a9b8906f828b15903eb048"
-  integrity sha512-708Gy8n/S4YEAgwYiPlJJzPXJJxjVM8CxGp6oYBjJpIbM4i/A5s0qDaFo3H7ZETOpGBFp7L+sfAuKi+tU0c6PA==
+"@guardian/braze-components@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-2.1.0.tgz#d878bf2d7351fd682ee8e5d588970d18a62efd8a"
+  integrity sha512-PofC9Ao2fjUhT9tQcLh5ZFy4n+AwJE2eDNd2UdKM0pnhnfhqLZV+II3wARKuVc8K+4EjDJLnNOY9UA+NbXgE2Q==
   dependencies:
     "@guardian/src-button" "3.3.0"
     "@guardian/src-foundations" "3.3.0"


### PR DESCRIPTION
## What does this change?
Upgrade the @gaurdian/braze-components dependency to version 2.1.0.

This enables better filtering of invalid cached braze messages

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes https://github.com/guardian/dotcom-rendering/pull/3043

## What is the value of this and can you measure success?
Invalid messages at the top of the braze message queue don't prevent a later valid message from rendering a braze component.

## Checklist

### Does this affect other platforms?

- [ ] AMP 
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist
N/A

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
