### PR TITLE
Add TypeScript noEmit compilation to validate step

### DIFF
--- a/tools/__tasks__/validate/index.js
+++ b/tools/__tasks__/validate/index.js
@@ -2,6 +2,7 @@ module.exports = {
     description: 'Lint assets',
     task: [
         require('./javascript'),
+        require('./typescript'),
         require('./sass'),
         require('./check-for-disallowed-strings'),
     ],

--- a/tools/__tasks__/validate/typescript.js
+++ b/tools/__tasks__/validate/typescript.js
@@ -1,5 +1,4 @@
 const chalk = require('chalk');
-const config = '--quiet --color';
 
 const error = ctx => {
     ctx.messages.push(
@@ -13,21 +12,11 @@ const error = ctx => {
 };
 
 module.exports = {
-    description: 'Lint JS',
+    description: 'Compile TS',
     task: [
         {
-            description: 'Static',
-            task: `eslint static/src/javascripts --ext=ts,tsx,js ${config}`,
-            onError: error,
-        },
-        {
-            description: 'Tools etc.',
-            task: `eslint tools ${config}`,
-            onError: error,
-        },
-        {
-            description: 'Git hooks',
-            task: `eslint git-hooks/* ${config}`,
+            description: 'Compile',
+            task: `tsc --noEmit`,
             onError: error,
         },
     ],


### PR DESCRIPTION
## What does this change?

Adds TypeScript compilation to the `validate` step.

Helps to get earlier feedback without having to rely on an IDE or the TeamCity build.

---

An aside on `pre-push`:

I looked at adding TS validation to the `pre-push` hook which calls `validate-head/index`.

The `validate-head/` scripts get committed files and passes each file as an argument to the executables (`eslint`, `sass-lint` etc).

However this conflicts with how `tsc` works as `tsc` does not accept file(s) to compile  _in combination_ with a `tsconfig.json` file:

https://github.com/microsoft/TypeScript/issues/27379

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [X] Locally
- [ ] On CODE (optional)
