### PR TITLE
Disable scroll test for now as flaky

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/messenger/scroll.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/scroll.spec.js
@@ -14,7 +14,8 @@ jest.mock('../../../../lib/detect', () => ({
     getViewport: jest.fn(),
 }));
 
-describe('Cross-frame messenger: scroll', () => {
+// TODO either remove or resolve flakiness of these tests.
+describe.skip('Cross-frame messenger: scroll', () => {
     let iframe1 = {};
     let iframe2 = {};
     let onScroll = () => Promise.resolve();


### PR DESCRIPTION
Disable scroll commercial tests temporarily as flaky.

![Screenshot 2021-05-27 at 09 22 05](https://user-images.githubusercontent.com/858402/119791802-108a3c00-becd-11eb-922b-a8f3c09dd78b.png)

`main` and feature branches are intermittently failing because of this.