### PR TITLE
Make full group embed endpoint atom compatible

### DIFF
--- a/sport/app/football/views/wallchart/groupTablesEmbed.scala.html
+++ b/sport/app/football/views/wallchart/groupTablesEmbed.scala.html
@@ -1,37 +1,8 @@
 @(page: model.Page, competition: model.Competition, competitionStages: List[football.model.Groups], next: Option[pa.FootballMatch])(implicit request: RequestHeader, context: model.ApplicationContext)
-<!DOCTYPE html>
 
-<html class="js-off is-not-modern id--signed-out" lang="en-GB">
-    <head>
-        <meta name="robots" content="noindex, nofollow" />
-        @fragments.head(Some("football"), Html(""))(page, request, context)
-        <script>guardian.config.page.isFootballWorldCup2014 = true;</script>
-        </head>
-    <body id="top" itemscope itemtype="http://schema.org/WebPage">
-        <div id="js-context" class="football-wallchart-embed">
-            <div class="l-side-margins wc-overview">
-                @competitionStages.map { groupStage =>
-                    <div class="facia-container facia-container--layout-content">
-                        <div class="container">
-                            <div class="facia-container__inner">
-                                <div class="container__border hide-on-mobile"></div>
-                                <div class="fc-container__header">
-                                    <h3 class="container__title">
-                                        <span class="container__title__label u-text-hyphenate">Groups</span>
-                                    </h3>
-                                </div>
-                                <div class="container__body">
-                                    <div data-link-name="@competition.fullName groups">
-                                    @football.views.html.wallchart.groups(competition, groupStage)
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+@competitionStages.map { groupStage =>
+    <div data-link-name="@competition.fullName groups">
+    @football.views.html.wallchart.groups(competition, groupStage)
+    </div>
+}
 
-                }
-                @fragments.analytics.base()(page, request, context)
-            </div>
-        </div>
-    </body>
-</html>


### PR DESCRIPTION
## What does this change?
We need to make this endpoint compatible with the architecture of the atoms that will use it. We do this by removing the HTML needed to render this as a page and instead simply return a HTML snippet. All CSS will be bundled in the atom itself.


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
### Frontend
![image](https://user-images.githubusercontent.com/9122944/119801915-04ef4300-bed6-11eb-877a-cf99423d7580.png)


### Atom
![image](https://user-images.githubusercontent.com/9122944/119801838-f3a63680-bed5-11eb-809e-28ced4420ebe.png)

## What is the value of this and can you measure success?
Allows full group endpoint to be used as an atom.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
