### PR TITLE
Catch and handle rich link CAPI errors

### DIFF
--- a/onward/app/controllers/RichLinkController.scala
+++ b/onward/app/controllers/RichLinkController.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import common.`package`.convertApiExceptionsWithoutEither
 import common.{Edition, GuLogging, ImplicitControllerExecutionContext, JsonComponent}
 import contentapi.ContentApiClient
 import implicits.Requests
@@ -20,7 +21,7 @@ class RichLinkController(contentApiClient: ContentApiClient, controllerComponent
     with Requests {
   def render(path: String): Action[AnyContent] =
     Action.async { implicit request =>
-      contentType(path) map {
+      val resp = contentType(path) map {
         case Some(content) if request.forceDCR =>
           val richLink = RichLink(
             tags =
@@ -41,6 +42,8 @@ class RichLinkController(contentApiClient: ContentApiClient, controllerComponent
         case Some(content) => renderContent(richLinkHtml(content), richLinkBodyHtml(content))
         case None          => NotFound
       }
+
+      resp.recover(convertApiExceptionsWithoutEither)
     }
 
   private def contentType(path: String)(implicit request: RequestHeader): Future[Option[ContentType]] = {


### PR DESCRIPTION
## What does this change?

Recover from rich link CAPI errors rather than a noisy 500. This also makes it easier to see issues in the logs.

Before (an uncaught exception/500):

![Screenshot 2021-05-28 at 09 57 45](https://user-images.githubusercontent.com/858402/119959158-a2f91100-bf9b-11eb-9be1-1519379d394b.png)

After (404, blank response, with a nice logging message as appropriate - see https://github.com/guardian/frontend/blob/main/common/app/common/package.scala#L42 for how it handles things here):

![Screenshot 2021-05-28 at 09 58 07](https://user-images.githubusercontent.com/858402/119959198-ae4c3c80-bf9b-11eb-843e-0346ef320812.png)
