### PR TITLE
Add linting to Typescript workflow

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -28,5 +28,5 @@ jobs:
             uses: bahmutov/npm-install@v1
 
           - name: Lint files
-            run: yarn lint
+            run: yarn eslint static/src/javascripts --ext=ts,tsx
 

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -17,3 +17,16 @@ jobs:
 
             - name: Check typescript
               run: yarn tsc
+    lint:
+        name: Linting
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v2
+          - uses: guardian/actions-setup-node@main
+
+          - name: Install dependencies
+            uses: bahmutov/npm-install@v1
+
+          - name: Lint files
+            run: yarn lint
+

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -14,19 +14,10 @@ jobs:
 
             - name: Install
               run: yarn
+              
+            - name: Lint files
+              run: yarn eslint static/src/javascripts --ext=ts,tsx
 
             - name: Check typescript
               run: yarn tsc
-    lint:
-        name: Linting
-        runs-on: ubuntu-latest
-        steps:
-          - uses: actions/checkout@v2
-          - uses: guardian/actions-setup-node@main
-
-          - name: Install dependencies
-            uses: bahmutov/npm-install@v1
-
-          - name: Lint files
-            run: yarn eslint static/src/javascripts --ext=ts,tsx
 


### PR DESCRIPTION
## What does this change?

Adds a linting step to the Typescript workflow. This will highlights in the files tab where issues are present. Accompanying #23853 

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Knowing linting is wrong before the TeamCity build fails.