### PR TITLE
Enable all remaining atoms for DCR

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -26,16 +26,8 @@ object ArticlePageChecks {
   }
 
   def hasOnlySupportedElements(page: PageWithStoryPackage): Boolean = {
-    // See: https://github.com/guardian/dotcom-rendering/blob/master/packages/frontend/web/components/lib/ArticleRenderer.tsx
-
     def unsupportedElement(blockElement: BlockElement) =
       blockElement match {
-        case ContentAtomBlockElement(_, atomtype, _) =>
-          // ContentAtomBlockElement was expanded to include atomtype.
-          // To support an atom type, just add it to supportedAtomTypes
-          val supportedAtomTypes =
-            List("audio", "chart", "explainer", "guide", "interactive", "media", "profile", "qanda", "timeline")
-          !supportedAtomTypes.contains(atomtype)
         case InteractiveBlockElement(_, scriptUrl) =>
           scriptUrl match {
             case Some("https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js") => false
@@ -48,7 +40,6 @@ object ArticlePageChecks {
   }
 
   def hasOnlySupportedMainElements(page: PageWithStoryPackage): Boolean = {
-    // See: https://github.com/guardian/dotcom-rendering/blob/master/packages/frontend/web/components/lib/ArticleRenderer.tsx
     def unsupportedElement(blockElement: BlockElement) =
       blockElement match {
         // The majority of the remaining atoms appear to be interactive atoms, which aren't supported yet


### PR DESCRIPTION
## What does this change?
This removes any explicit exceptions for articles that contain atoms in the body from being rendered by DCR. This has been enabled by completing work on quiz atoms specifically, which are now supported but there are a few others that will be included:

- CTA, which (as far as we can tell) is only used on hosted-by content which is not rendered by the `article` app
- Review, which we can't find an example of
- Recipe, which there are no published examples of
- Commons division, which was barely used and experimental at best
- Email signups, which never got completed (and should be removed)

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)