### PR TITLE
Interactives @ DCR - The Article Picker

### DIFF
--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -131,7 +131,7 @@ class InteractiveController(
 
   override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = {
     val requestFormat = request.getRequestFormat
-    val renderingTier = ApplicationsInteractiveRendering.getRenderingTier(path)
+    val renderingTier = InteractiveRendering.getRenderingTier(path)
     (requestFormat, renderingTier) match {
       case (AmpFormat, USElectionTracker2020AmpPage) => renderInteractivePageUSPresidentialElection2020(path)
       case (JsonFormat, _) if request.forceDCR       => renderDCRJson(path)

--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -133,10 +133,10 @@ class InteractiveController(
     val requestFormat = request.getRequestFormat
     val renderingTier = ApplicationsInteractiveRendering.getRenderingTier(path)
     (requestFormat, renderingTier) match {
-      case (AmpFormat, USElection2020AmpPage)  => renderInteractivePageUSPresidentialElection2020(path)
-      case (JsonFormat, _) if request.forceDCR => renderDCRJson(path)
-      case (HtmlFormat, DotcomRendering)       => renderDCR(path)
-      case _                                   => renderItemLegacy(path: String)
+      case (AmpFormat, USElectionTracker2020AmpPage) => renderInteractivePageUSPresidentialElection2020(path)
+      case (JsonFormat, _) if request.forceDCR       => renderDCRJson(path)
+      case (HtmlFormat, DotcomRendering)             => renderDCR(path)
+      case _                                         => renderItemLegacy(path: String)
     }
   }
 

--- a/applications/app/services/ApplicationsInteractiveRendering.scala
+++ b/applications/app/services/ApplicationsInteractiveRendering.scala
@@ -32,13 +32,16 @@ object ApplicationsInteractiveRendering {
 
   // allowListedPaths is use to jumpstart the router (which decides which between frontend and DRC does the rendering)
   val allowListedPaths = List(
-    "environment/ng-interactive/2021/feb/23/beneath-the-blue-dive-into-a-dazzling-ocean-under-threat-interactive",
+    "/education/ng-interactive/2021/mar/29/which-english-academy-trusts-have-recorded-racism-complaints",
   )
+  def ensureStartingForwardSlash(str: String): String = {
+    if (!str.startsWith("/")) ("/" + str) else str
+  }
 
   def router(path: String)(implicit request: RequestHeader): RenderingTier = {
     // This function decides which paths are sent to DCR for rendering
     // At first we use allowListedPaths
-    if (allowListedPaths.contains(path)) DotcomRendering else FrontendLegacy
+    if (allowListedPaths.contains(ensureStartingForwardSlash(path))) DotcomRendering else FrontendLegacy
   }
 
   def getRenderingTier(path: String)(implicit request: RequestHeader): RenderingTier = {

--- a/applications/app/services/ApplicationsInteractiveRendering.scala
+++ b/applications/app/services/ApplicationsInteractiveRendering.scala
@@ -5,7 +5,7 @@ import implicits.Requests._
 
 sealed trait RenderingTier
 object FrontendLegacy extends RenderingTier
-object USElection2020AmpPage extends RenderingTier
+object USElectionTracker2020AmpPage extends RenderingTier
 object DotcomRendering extends RenderingTier
 
 /*
@@ -34,7 +34,7 @@ object ApplicationsInteractiveRendering {
     val isAmp = request.host.contains("amp")
     val forceDCR = request.forceDCR
 
-    if (isSpecialElection && isAmp) USElection2020AmpPage
+    if (isSpecialElection && isAmp) USElectionTracker2020AmpPage
     else if (forceDCR) DotcomRendering
     else FrontendLegacy
   }

--- a/applications/app/services/ApplicationsInteractiveRendering.scala
+++ b/applications/app/services/ApplicationsInteractiveRendering.scala
@@ -29,13 +29,40 @@ object DotcomRendering extends RenderingTier
  */
 
 object ApplicationsInteractiveRendering {
+
+  // allowListedPaths is use to jumpstart the router (which decides which between frontend and DRC does the rendering)
+  val allowListedPaths = List(
+    "environment/ng-interactive/2021/feb/23/beneath-the-blue-dive-into-a-dazzling-ocean-under-threat-interactive",
+  )
+
+  def router(path: String)(implicit request: RequestHeader): RenderingTier = {
+    // This function decides which paths are sent to DCR for rendering
+    // At first we use allowListedPaths
+    if (allowListedPaths.contains(path)) DotcomRendering else FrontendLegacy
+  }
+
   def getRenderingTier(path: String)(implicit request: RequestHeader): RenderingTier = {
+
     val isSpecialElection = ApplicationsUSElection2020AmpPages.pathIsSpecialHanding(path)
-    val isAmp = request.host.contains("amp")
+
+    // Date   : 01st June 2021
+    // Author : Pascal
+    // Note   : We define isWeb as the opposite of isAmp because I think it leads to easier to understand code
+    //          If it turns out that somebody disagrees, let me know.
+    val isWeb = !request.host.contains("amp")
+
     val forceDCR = request.forceDCR
 
-    if (isSpecialElection && isAmp) USElectionTracker2020AmpPage
-    else if (forceDCR) DotcomRendering
-    else FrontendLegacy
+    (isSpecialElection, isWeb, forceDCR) match {
+      case (true, false, _) => USElectionTracker2020AmpPage // Election tracker on AMP
+      case (true, true, _)  => FrontendLegacy // Election tracker on web [1]
+      case (_, false, _)    => FrontendLegacy // Regular AMP [2]
+      case (_, true, true)  => DotcomRendering // WEB with forceDCR
+      case _                => router(path) // [3] Web with no forceDCR flag
+    }
+
+    // [1] We will change that in the future, but for the moment we legacy render the election tracker.
+    // [2] We will change that in the future, but for the moment we legacy render all amp pages.
+    // [3] This is were the regular routing is performed, same job as the Article Picker.
   }
 }

--- a/applications/app/services/ApplicationsInteractiveRendering.scala
+++ b/applications/app/services/ApplicationsInteractiveRendering.scala
@@ -32,7 +32,7 @@ object ApplicationsInteractiveRendering {
 
   // allowListedPaths is use to jumpstart the router (which decides which between frontend and DRC does the rendering)
   val allowListedPaths = List(
-    "/education/ng-interactive/2021/mar/29/which-english-academy-trusts-have-recorded-racism-complaints",
+    "/sport/ng-interactive/2018/dec/26/lebron-james-comments-nba-nfl-divide",
   )
   def ensureStartingForwardSlash(str: String): String = {
     if (!str.startsWith("/")) ("/" + str) else str

--- a/applications/app/services/InteractiveRendering.scala
+++ b/applications/app/services/InteractiveRendering.scala
@@ -48,24 +48,18 @@ object InteractiveRendering {
 
     val isSpecialElection = ApplicationsUSElection2020AmpPages.pathIsSpecialHanding(path)
 
-    // Date   : 01st June 2021
-    // Author : Pascal
-    // Note   : We define isWeb as the opposite of isAmp because I think it leads to easier to understand code
-    //          If it turns out that somebody disagrees, let me know.
-    val isWeb = !request.host.contains("amp")
+    val isAmp = request.host.contains("amp")
+    val isWeb = !isAmp
 
     val forceDCR = request.forceDCR
 
-    (isSpecialElection, isWeb, forceDCR) match {
-      case (true, false, _) => USElectionTracker2020AmpPage // Election tracker on AMP
-      case (true, true, _)  => FrontendLegacy // Election tracker on web [1]
-      case (_, false, _)    => FrontendLegacy // Regular AMP [2]
-      case (_, true, true)  => DotcomRendering // WEB with forceDCR
-      case _                => decideRenderingTier(path) // [3] Web with no forceDCR flag
-    }
+    if (isSpecialElection && isAmp) USElectionTracker2020AmpPage
+    else if (isSpecialElection && isWeb) FrontendLegacy // [1]
+    else if (isAmp) FrontendLegacy // [2]
+    else if (forceDCR) DotcomRendering
+    else decideRenderingTier(path)
 
     // [1] We will change that in the future, but for the moment we legacy render the election tracker.
     // [2] We will change that in the future, but for the moment we legacy render all amp pages.
-    // [3] This is were the regular routing is performed, same job as the Article Picker.
   }
 }

--- a/applications/app/services/InteractiveRendering.scala
+++ b/applications/app/services/InteractiveRendering.scala
@@ -28,7 +28,7 @@ object DotcomRendering extends RenderingTier
   We are now moving towards supporting interactives in DCR 🙂
  */
 
-object ApplicationsInteractiveRendering {
+object InteractiveRendering {
 
   // allowListedPaths is use to jumpstart the router (which decides which between frontend and DRC does the rendering)
   val allowListedPaths = List(
@@ -38,7 +38,7 @@ object ApplicationsInteractiveRendering {
     if (!str.startsWith("/")) ("/" + str) else str
   }
 
-  def router(path: String)(implicit request: RequestHeader): RenderingTier = {
+  def decideRenderingTier(path: String)(implicit request: RequestHeader): RenderingTier = {
     // This function decides which paths are sent to DCR for rendering
     // At first we use allowListedPaths
     if (allowListedPaths.contains(ensureStartingForwardSlash(path))) DotcomRendering else FrontendLegacy
@@ -61,7 +61,7 @@ object ApplicationsInteractiveRendering {
       case (true, true, _)  => FrontendLegacy // Election tracker on web [1]
       case (_, false, _)    => FrontendLegacy // Regular AMP [2]
       case (_, true, true)  => DotcomRendering // WEB with forceDCR
-      case _                => router(path) // [3] Web with no forceDCR flag
+      case _                => decideRenderingTier(path) // [3] Web with no forceDCR flag
     }
 
     // [1] We will change that in the future, but for the moment we legacy render the election tracker.


### PR DESCRIPTION
## What does this change?

This updates ApplicationsInteractiveRendering with code to allow one Interactive url to be rendered in DCR (thereby starting what we did with the Article Picker in the [article] app).

This PR keeps the same existing rendering logic: The 2000 election tracker keeps its current logic in amp and web (for the moment), the `request.forceDCR` is taken account as before, it doesn't change anything for amp (for the moment), but it change the way regular, non forced, interactives are rendered. We start with whitelisting just one URL. 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No