### PR TITLE
Collapse ad slot descriptive class

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
@@ -11,8 +11,9 @@ const shouldRenderLabel = (adSlotNode: HTMLElement) =>
 		adSlotNode.classList.contains('ad-slot--fluid') ||
 		adSlotNode.classList.contains('ad-slot--frame') ||
 		adSlotNode.classList.contains('ad-slot--gc') ||
-		// u-h class is set for out-of-page ads i.e. 1x1 and 2x2 ads
+		// u-h and ad-slot-collapse class is set for out-of-page ads i.e. 1x1 and 2x2 ads
 		adSlotNode.classList.contains('u-h') ||
+		adSlotNode.classList.contains('ad-slot--collapse') ||
 		adSlotNode.getAttribute('data-label') === 'false' ||
 		adSlotNode.getElementsByClassName('ad-slot__label').length
 	);

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
@@ -11,8 +11,8 @@ const shouldRenderLabel = (adSlotNode: HTMLElement) =>
 		adSlotNode.classList.contains('ad-slot--fluid') ||
 		adSlotNode.classList.contains('ad-slot--frame') ||
 		adSlotNode.classList.contains('ad-slot--gc') ||
-		// u-h and ad-slot-collapse class is set for out-of-page ads i.e. 1x1 and 2x2 ads
 		adSlotNode.classList.contains('u-h') ||
+		// set for out-of-page (1x1) and empty (2x2) ads
 		adSlotNode.classList.contains('ad-slot--collapse') ||
 		adSlotNode.getAttribute('data-label') === 'false' ||
 		adSlotNode.getElementsByClassName('ad-slot__label').length

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.ts
@@ -179,7 +179,6 @@ const outOfPageCallback = (
 	if (!event.slot.getOutOfPage()) {
 		const parent = advert.node.parentNode as HTMLElement;
 		return fastdom.mutate(() => {
-			advert.node.classList.add('u-h');
 			advert.node.classList.add('ad-slot--collapse');
 			// if in a slice, add the 'no mpu' class
 			if (parent.classList.contains('fc-slice__item--mpu-candidate')) {

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.ts
@@ -180,6 +180,7 @@ const outOfPageCallback = (
 		const parent = advert.node.parentNode as HTMLElement;
 		return fastdom.mutate(() => {
 			advert.node.classList.add('u-h');
+			advert.node.classList.add('ad-slot--collapse');
 			// if in a slice, add the 'no mpu' class
 			if (parent.classList.contains('fc-slice__item--mpu-candidate')) {
 				parent.classList.add('fc-slice__item--no-mpu');

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -593,3 +593,7 @@
     stroke-width: 2;
     text-align: center;
 }
+
+.ad-slot--collapse {
+    display: none;
+}


### PR DESCRIPTION
## What does this change?

This change improves the naming and behaviour of the CSS used to collapse "excluded" ad slots.

For excluded ads the commercial client side code adds a CSS class to the ad slot to make the slot collapse.

The current class is the `u-h` class [here](https://github.com/guardian/frontend/blob/d3de6c7e28bae2d4bc55da8f1efb59be466969a2/static/src/javascripts/projects/commercial/modules/dfp/render-advert.ts#L181).

The [u-h class](https://github.com/guardian/frontend/blob/5b970cd7308175cfc1bcae2d4fb8c06ee13c5fa0/static/src/stylesheets/_mixins.scss#L73) collapses the slot by setting the ad slot to be 1x1 and positioning it off screen.

Given the comment on u-h _"Hide content visually, still readable by screen readers"_ I think this is potential misuse of this class and the naming is not very descriptive.

The new class is `ad-slot--collapse` and it will instead use `display: none` to collapse the ad slot.

This class will be recognised on DCR in another PR.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes https://github.com/guardian/dotcom-rendering/pull/3059



### Tested

- [x] Locally
- [x] On CODE (optional)
