### PR TITLE
Carrot ad DCR (quickfix)

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/carrot-traffic-driver.js
+++ b/static/src/javascripts/projects/commercial/modules/carrot-traffic-driver.js
@@ -5,8 +5,13 @@ import { commercialFeatures } from '../../common/modules/commercial/commercial-f
 import { spaceFiller } from '../../common/modules/article/space-filler';
 import { getBreakpoint } from '../../../lib/detect';
 
+const isDotcomRendering = config.get('isDotcomRendering', false);
+const bodySelector = isDotcomRendering
+	? '.article-body-commercial-selector'
+	: '.js-article__body';
+
 const defaultRules = {
-    bodySelector: '.js-article__body',
+    bodySelector,
     slotSelector: ' > p',
     minAbove: 500,
     minBelow: 400,
@@ -51,7 +56,7 @@ const defaultRules = {
 
 // desktop(980) and tablet(740)
 const desktopRules = {
-    bodySelector: '.js-article__body',
+    bodySelector,
     slotSelector: ' > p',
     minAbove: 500,
     minBelow: 400,
@@ -100,7 +105,7 @@ const desktopRules = {
 
 // mobile(320) and above
 const mobileRules = {
-    bodySelector: '.js-article__body',
+    bodySelector,
     slotSelector: ' > p',
     minAbove: 500,
     minBelow: 400,

--- a/static/src/javascripts/projects/commercial/modules/carrot-traffic-driver.js
+++ b/static/src/javascripts/projects/commercial/modules/carrot-traffic-driver.js
@@ -4,6 +4,7 @@ import { createSlots } from './dfp/create-slots';
 import { commercialFeatures } from '../../common/modules/commercial/commercial-features';
 import { spaceFiller } from '../../common/modules/article/space-filler';
 import { getBreakpoint } from '../../../lib/detect';
+import config from '../../../lib/config';
 
 const isDotcomRendering = config.get('isDotcomRendering', false);
 const bodySelector = isDotcomRendering

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.ts
@@ -31,6 +31,7 @@ const addClassIfHasClass = (newClassNames: string[]) =>
 					newClassNames.forEach((className) => {
 						advert.node.classList.add(className);
 					});
+					const allClasses: DOMTokenList = advert.node.classList;
 					// Add fluid styles from _adslot.scss
 					// mark: 9473ae05-a901-4a8d-a51d-1b9c894d6e1f
 					// Temporary typing until config.js is converted to TypeScript
@@ -39,6 +40,7 @@ const addClassIfHasClass = (newClassNames: string[]) =>
 					}).get('isDotcomRendering', false);
 					if (
 						isDotcomRendering &&
+						!allClasses.contains('ad-slot--carrot') &&
 						newClassNames.includes('ad-slot--fluid')
 					) {
 						advert.node.style.minHeight = '250px';
@@ -46,9 +48,8 @@ const addClassIfHasClass = (newClassNames: string[]) =>
 						advert.node.style.padding = '0';
 						advert.node.style.margin = '0';
 						if (
-							!newClassNames.includes('ad-slot--im') &&
-							!newClassNames.includes('ad-slot--carrot') &&
-							!newClassNames.includes('ad-slot--offset-right')
+							!allClasses.contains('ad-slot--im') &&
+							!allClasses.contains('ad-slot--offset-right')
 						)
 							advert.node.style.width = '100%';
 					}

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -450,6 +450,8 @@
     }
 }
 
+// See implementation on DCR
+// mark: dca5c7dd-dda4-4922-9317-a55a3789fe4c
 .ad-slot--carrot {
     min-height: 0px;
     padding: 0;


### PR DESCRIPTION
## What does this change?

Fixes the styling and selector for carrot ads in DCR.

Proper fix coming in #23866

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes https://github.com/guardian/dotcom-rendering/pull/3060

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |


[before]: https://user-images.githubusercontent.com/76776/120459768-7e6bb300-c366-11eb-9161-6a1629f1d0ec.png
[after]: https://user-images.githubusercontent.com/76776/120459707-6a27b600-c366-11eb-9996-95d3ab6e905d.png

## What is the value of this and can you measure success?

## Checklist

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
