### PR TITLE
Core Vitals for front end

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "videojs-ima": "googleads/videojs-ima#0.3.0",
     "videojs-persistvolume": "guardian/videojs-persistvolume#0.1.4",
     "videojs-playlist": "guardian/videojs-playlist#0.1.4",
-    "web-vitals": "^0.2.4",
+    "web-vitals": "^1.1.1",
     "wolfy87-eventemitter": "~5.2.4"
   },
   "devDependencies": {

--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -56,7 +56,7 @@ const bootEnhanced = () => {
             },
         ],
 
-        ['core-vitals', initCoreVitals],
+        ['core-web-vitals', initCoreVitals],
 
         ['enrich-acquisition-links', initAcquisitionsLinkEnrichment],
 

--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -11,7 +11,7 @@ import { trackPerformance } from 'common/modules/analytics/google';
 import { init as geolocationInit } from 'lib/geolocation';
 import { init as initAcquisitionsLinkEnrichment } from 'common/modules/commercial/acquisitions-link-enrichment';
 import { fetchAndRenderEpic, fetchAndRenderHeaderLinks } from "common/modules/commercial/contributions-service";
-import { init as initCoreVitals } from 'common/modules/analytics/coreVitals';
+import { coreVitals } from 'common/modules/analytics/coreVitals';
 
 const bootEnhanced = () => {
     const bootstrapContext = (featureName, bootstrap) => {
@@ -56,7 +56,7 @@ const bootEnhanced = () => {
             },
         ],
 
-        ['core-web-vitals', initCoreVitals],
+        ['core-web-vitals', coreVitals],
 
         ['enrich-acquisition-links', initAcquisitionsLinkEnrichment],
 

--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -11,6 +11,7 @@ import { trackPerformance } from 'common/modules/analytics/google';
 import { init as geolocationInit } from 'lib/geolocation';
 import { init as initAcquisitionsLinkEnrichment } from 'common/modules/commercial/acquisitions-link-enrichment';
 import { fetchAndRenderEpic, fetchAndRenderHeaderLinks } from "common/modules/commercial/contributions-service";
+import { init as initCoreVitals } from 'common/modules/analytics/coreVitals';
 
 const bootEnhanced = () => {
     const bootstrapContext = (featureName, bootstrap) => {
@@ -54,6 +55,8 @@ const bootEnhanced = () => {
                 ]);
             },
         ],
+
+        ['core-vitals', initCoreVitals],
 
         ['enrich-acquisition-links', initAcquisitionsLinkEnrichment],
 

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -1,5 +1,5 @@
+import { getCookie } from '@guardian/libs';
 import { getCLS, getFCP, getFID, getLCP, getTTFB } from 'web-vitals';
-import { cookies } from '@guardian/libs';
 
 export const init = () => {
 	coreVitals();
@@ -73,8 +73,8 @@ const coreVitals = (): void => {
 
 		// Fallback to check for browser ID
 		// eslint-disable-prefer-optional-chain @typescript-eslint/prefer-optional-chain
-		if (cookies.GetCookie('bwid')) {
-			jsonData.browser_id = cookies.GetCookie('bwid');
+		if (getCookie({ name: 'bwid' })) {
+			jsonData.browser_id = getCookie({ name: 'bwid' });
 		}
 
 		const endpoint =
@@ -105,7 +105,7 @@ const coreVitals = (): void => {
 			redirect: 'follow',
 			referrerPolicy: 'no-referrer', // no-referrer, *no-referrer-w
 			body: JSON.stringify(jsonData),
-		}).catch(() => {});
+		}).catch((error) => console.log(error));
 	};
 
 	getCLS(jsonToSend, false);

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -112,7 +112,7 @@ const coreVitals = (): void => {
 		    As of Version 2.0, CLS values should only be sent if FCP has been sent
 	        https://github.com/GoogleChrome/web-vitals/blob/main/CHANGELOG.md#v200-2021-06-01
 		if (jsonToSend.name === 'CLS' && hasFCPBeenSent) {
-			if (jsonData.cls !== null && jsonData.cls > 0) {
+			if (jsonData.cls !== null) {
 				sendData();
 			}
 		} else {

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -76,7 +76,8 @@ const coreVitals = (): void => {
 		}
 
 		const endpoint =
-			window.location.hostname === 'm.code.dev-theguardian.com' ||
+			window.location.hostname ===
+				'm.code.dev-theguardian.com/science/grrlscientist/2012/aug/07/3?dcr=false' ||
 			window.location.hostname === 'localhost' ||
 			window.location.hostname === 'preview.gutools.co.uk'
 				? 'https://performance-events.code.dev-guardianapis.com/core-web-vitals'

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -82,6 +82,21 @@ const coreVitals = (): void => {
 				? 'https://performance-events.code.dev-guardianapis.com/core-web-vitals'
 				: 'https://performance-events.guardianapis.com/core-web-vitals';
 
+		const sendData = () => {
+			fetch(endpoint, {
+				method: 'POST', // *GET, POST, PUT, DELETE, etc.
+				mode: 'cors', // no-cors, *cors, same-origin
+				cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
+				credentials: 'same-origin', // include, *same-origin, omit
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				redirect: 'follow',
+				referrerPolicy: 'no-referrer', // no-referrer, *no-referrer-w
+				body: JSON.stringify(jsonData),
+			}).catch((error) => console.log(error));
+		};
+
 		// Browser support
 		// getCLS(): Chromium,
 		// getFCP(): Chromium, Firefox, Safari Technology Preview
@@ -96,19 +111,10 @@ const coreVitals = (): void => {
 		// https://github.com/GoogleChrome/web-vitals/blob/main/CHANGELOG.md#v200-2021-06-01
 		if (jsonToSend.name === 'FCP') {
 			if (jsonData.fcp !== null && jsonData.fcp > 0) {
-				fetch(endpoint, {
-					method: 'POST', // *GET, POST, PUT, DELETE, etc.
-					mode: 'cors', // no-cors, *cors, same-origin
-					cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
-					credentials: 'same-origin', // include, *same-origin, omit
-					headers: {
-						'Content-Type': 'application/json',
-					},
-					redirect: 'follow',
-					referrerPolicy: 'no-referrer', // no-referrer, *no-referrer-w
-					body: JSON.stringify(jsonData),
-				}).catch((error) => console.log(error));
+				sendData();
 			}
+		} else {
+			sendData();
 		}
 	};
 

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -74,8 +74,7 @@ const coreVitals = (): void => {
 			jsonData.browser_id = getCookie('bwid');
 		}
 
-		const endpoint =
-			window.location.hostname === 'm.code.dev-theguardian.com' ||
+		const endpoint = window.location.hostname === 'm.code.dev-theguardian.com' ||
 			window.location.hostname === 'localhost' ||
 			window.location.hostname === 'preview.gutools.co.uk'
 				? 'http://performance-events.code.dev-guardianapis.com/core-web-vitals'

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -1,6 +1,6 @@
 import { getCookie } from '@guardian/libs';
 import { getCLS, getFCP, getFID, getLCP, getTTFB } from 'web-vitals';
-import reportError from "lib/report-error";
+import reportError from 'lib/report-error';
 
 type CoreWebVitalsPayload = {
 	page_view_id: string | null;

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -113,7 +113,7 @@ const coreVitals = (): void => {
 			if (jsonData.fcp !== null && jsonData.fcp > 0) {
 				sendData();
 			}
-		} else {
+		} else if (jsonToSend.name !== 'CLS') {
 			sendData();
 		}
 	};

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -1,10 +1,6 @@
 import { getCookie } from '@guardian/libs';
 import { getCLS, getFCP, getFID, getLCP, getTTFB } from 'web-vitals';
 
-export const init = () => {
-	coreVitals();
-};
-
 type CoreWebVitalsPayload = {
 	page_view_id: string | null;
 	received_timestamp: string | null;
@@ -32,7 +28,12 @@ const jsonData: CoreWebVitalsPayload = {
 	ttfb: null,
 };
 
-const coreVitals = (): void => {
+export const coreVitals = (): void => {
+	const inSample = Math.floor(Math.random() * 100);
+	if (inSample != 1) {
+		return;
+	}
+
 	type CoreVitalsArgs = {
 		name: string;
 		value: number;

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -64,20 +64,24 @@ const coreVitals = (): void => {
 
 		// Some browser ID's are not caputured (and if they have no cookie there won't be one)
 		// but there are occassions of reoccuring users without a browser ID being sent.
+		// eslint/no-unnecessary-condition
+		/* eslint/prefer-optional-chain */
 		if (window.guardian && window.guardian.ophan) {
 			jsonData.page_view_id = window.guardian.ophan.pageViewId;
 			// jsonData.browser_id = window.guardian.config.ophan.browserId;
 		}
 
 		// Fallback to check for browser ID
+		/* eslint/prefer-optional-chain */
 		if (getCookie('bwid')) {
 			jsonData.browser_id = getCookie('bwid');
 		}
 
-		const endpoint = window.location.hostname === 'm.code.dev-theguardian.com' ||
+		const endpoint =
+			window.location.hostname === 'm.code.dev-theguardian.com' ||
 			window.location.hostname === 'localhost' ||
 			window.location.hostname === 'preview.gutools.co.uk'
-				? 'http://performance-events.code.dev-guardianapis.com/core-web-vitals'
+				? 'https://performance-events.code.dev-guardianapis.com/core-web-vitals'
 				: 'https://performance-events.guardianapis.com/core-web-vitals';
 
 		// Browser support
@@ -89,7 +93,7 @@ const coreVitals = (): void => {
 
 		// We will send all data whenever any update. This means `null` values will appear in the lake
 		// and need handling.
-
+		/* eslint/no-empty-function */
 		fetch(endpoint, {
 			method: 'POST', // *GET, POST, PUT, DELETE, etc.
 			mode: 'cors', // no-cors, *cors, same-origin

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -1,5 +1,5 @@
 import { getCLS, getFCP, getFID, getLCP, getTTFB } from 'web-vitals';
-import { getCookie } from 'lib/cookies';
+import { cookies } from '@guardian/libs';
 
 export const init = () => {
 	coreVitals();
@@ -64,17 +64,17 @@ const coreVitals = (): void => {
 
 		// Some browser ID's are not caputured (and if they have no cookie there won't be one)
 		// but there are occassions of reoccuring users without a browser ID being sent.
-		// eslint/no-unnecessary-condition
-		// eslint/prefer-optional-chain
-		if (window.guardian && window.guardian.ophan) {
+		// eslint-disable-no-unnecessary-condition @typescript-eslint/no-unnecessary-condition
+		// eslint-disable-prefer-optional-chain @typescript-eslint/prefer-optional-chain
+		if (window.guardian.ophan) {
 			jsonData.page_view_id = window.guardian.ophan.pageViewId;
 			// jsonData.browser_id = window.guardian.config.ophan.browserId;
 		}
 
 		// Fallback to check for browser ID
-		// eslint/prefer-optional-chain
-		if (getCookie('bwid')) {
-			jsonData.browser_id = getCookie('bwid');
+		// eslint-disable-prefer-optional-chain @typescript-eslint/prefer-optional-chain
+		if (cookies.GetCookie('bwid')) {
+			jsonData.browser_id = cookies.GetCookie('bwid');
 		}
 
 		const endpoint =
@@ -93,7 +93,7 @@ const coreVitals = (): void => {
 
 		// We will send all data whenever any update. This means `null` values will appear in the lake
 		// and need handling.
-		// eslint/no-empty-function
+		// eslint-disable-no-empty-function @typescript-eslint/no-empty-function
 		fetch(endpoint, {
 			method: 'POST', // *GET, POST, PUT, DELETE, etc.
 			mode: 'cors', // no-cors, *cors, same-origin

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -1,4 +1,4 @@
-import { getCLS, getFID, getLCP, getFCP, getTTFB } from 'web-vitals';
+import { getCLS, getFID, getFCP, getLCP, getTTFB } from 'web-vitals';
 import { getCookie } from 'lib/cookies';
 
 export const init = () => {

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -1,11 +1,9 @@
 import { getCLS, getFID, getLCP, getFCP, getTTFB } from 'web-vitals';
 import { getCookie } from 'lib/cookies';
 
-
 export const init = () => {
     coreVitals();
 };
-
 
 type CoreWebVitalsPayload = {
     page_view_id: string | null;
@@ -113,6 +111,7 @@ const coreVitals = (): void => {
     getFCP(jsonToSend);
     getTTFB(jsonToSend);
 };
+
 
 
 

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -62,8 +62,6 @@ const coreVitals = (): void => {
 				break;
 		}
 
-		// Some browser ID's are not caputured (and if they have no cookie there won't be one)
-		// but there are occassions of reoccuring users without a browser ID being sent.
 		// eslint-disable-no-unnecessary-condition @typescript-eslint/no-unnecessary-condition
 		// eslint-disable-prefer-optional-chain @typescript-eslint/prefer-optional-chain
 		if (window.guardian.ophan) {
@@ -93,19 +91,25 @@ const coreVitals = (): void => {
 
 		// We will send all data whenever any update. This means `null` values will appear in the lake
 		// and need handling.
-		// eslint-disable-no-empty-function @typescript-eslint/no-empty-function
-		fetch(endpoint, {
-			method: 'POST', // *GET, POST, PUT, DELETE, etc.
-			mode: 'cors', // no-cors, *cors, same-origin
-			cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
-			credentials: 'same-origin', // include, *same-origin, omit
-			headers: {
-				'Content-Type': 'application/json',
-			},
-			redirect: 'follow',
-			referrerPolicy: 'no-referrer', // no-referrer, *no-referrer-w
-			body: JSON.stringify(jsonData),
-		}).catch((error) => console.log(error));
+
+		// As of Version 2.0, CLS values should only be sent when FCP is sent
+		// https://github.com/GoogleChrome/web-vitals/blob/main/CHANGELOG.md#v200-2021-06-01
+		if (jsonToSend.name === 'FCP') {
+			if (jsonData.fcp !== null && jsonData.fcp > 0) {
+				fetch(endpoint, {
+					method: 'POST', // *GET, POST, PUT, DELETE, etc.
+					mode: 'cors', // no-cors, *cors, same-origin
+					cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
+					credentials: 'same-origin', // include, *same-origin, omit
+					headers: {
+						'Content-Type': 'application/json',
+					},
+					redirect: 'follow',
+					referrerPolicy: 'no-referrer', // no-referrer, *no-referrer-w
+					body: JSON.stringify(jsonData),
+				}).catch((error) => console.log(error));
+			}
+		}
 	};
 
 	getCLS(jsonToSend, false);

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -1,5 +1,6 @@
 import { getCookie } from '@guardian/libs';
 import { getCLS, getFCP, getFID, getLCP, getTTFB } from 'web-vitals';
+import reportError from "lib/report-error";
 
 type CoreWebVitalsPayload = {
 	page_view_id: string | null;
@@ -96,7 +97,7 @@ export const coreVitals = (): void => {
 				redirect: 'follow',
 				referrerPolicy: 'no-referrer',
 				body: JSON.stringify(jsonData),
-			}).catch((error) => console.log(error));
+			}).catch((error) => reportError(error, 'core-web-vitals'));
 		};
 
 		// Browser support

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -76,8 +76,7 @@ const coreVitals = (): void => {
 		}
 
 		const endpoint =
-			window.location.hostname ===
-				'm.code.dev-theguardian.com/science/grrlscientist/2012/aug/07/3?dcr=false' ||
+			window.location.hostname === 'm.code.dev-theguardian.com' ||
 			window.location.hostname === 'localhost' ||
 			window.location.hostname === 'preview.gutools.co.uk'
 				? 'https://performance-events.code.dev-guardianapis.com/core-web-vitals'

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -1,0 +1,118 @@
+import { getCLS, getFID, getLCP, getFCP, getTTFB } from 'web-vitals';
+import { getCookie } from 'lib/cookies';
+
+
+export const init = () => {
+    coreVitals();
+};
+
+
+type CoreWebVitalsPayload = {
+    page_view_id: string | null;
+    received_timestamp: string | null;
+    browser_id: string | null;
+    received_date: string;
+    fid: null | number;
+    cls: null | number;
+    lcp: null | number;
+    fcp: null | number;
+    ttfb: null | number;
+};
+
+const timestamp = new Date();
+const date = new Date().toISOString().slice(0, 10);
+
+const jsonData: CoreWebVitalsPayload = {
+    browser_id: null,
+    page_view_id: null,
+    received_timestamp: timestamp.toISOString(),
+    received_date: date,
+    fid: null,
+    cls: null,
+    lcp: null,
+    fcp: null,
+    ttfb: null,
+};
+
+const coreVitals = (): void => {
+    type CoreVitalsArgs = {
+        name: string;
+        value: number;
+    };
+
+    const nineDigitPrecision = (value: number) => {
+        // The math functions are to make sure the length of number is <= 9
+        return Math.round(value * 1_000_000) / 1_000_000;
+    };
+
+    const jsonToSend = ({ name, value }: CoreVitalsArgs): void => {
+        switch (name) {
+            case 'FCP':
+                jsonData.fcp = nineDigitPrecision(value);
+                break;
+            case 'CLS':
+                jsonData.cls = nineDigitPrecision(value);
+                break;
+            case 'LCP':
+                jsonData.lcp = nineDigitPrecision(value);
+                break;
+            case 'FID':
+                jsonData.fid = nineDigitPrecision(value);
+                break;
+            case 'TTFB':
+                jsonData.ttfb = nineDigitPrecision(value);
+                break;
+        }
+
+        // Some browser ID's are not caputured (and if they have no cookie there won't be one)
+        // but there are occassions of reoccuring users without a browser ID being sent.
+        if (window.guardian && window.guardian.ophan) {
+            jsonData.page_view_id = window.guardian.ophan.pageViewId;
+            // jsonData.browser_id = window.guardian.config.ophan.browserId;
+        }
+
+        // Fallback to check for browser ID
+        if (getCookie('bwid')) {
+            jsonData.browser_id = getCookie('bwid');
+        }
+
+        const endpoint =
+            window.location.hostname === 'm.code.dev-theguardian.com' ||
+            window.location.hostname === 'localhost' ||
+            window.location.hostname === 'preview.gutools.co.uk'
+                ? 'http://performance-events.code.dev-guardianapis.com/core-web-vitals'
+                : 'https://performance-events.guardianapis.com/core-web-vitals';
+
+        // Browser support
+        // getCLS(): Chromium,
+        // getFCP(): Chromium, Firefox, Safari Technology Preview
+        // getFID(): Chromium, Firefox, Safari, Internet Explorer (with the polyfill)
+        // getLCP(): Chromium
+        // getTTFB(): Chromium, Firefox, Safari, Internet Explorer
+
+        // We will send all data whenever any update. This means `null` values will appear in the lake
+        // and need handling.
+
+        fetch(endpoint, {
+            method: 'POST', // *GET, POST, PUT, DELETE, etc.
+            mode: 'cors', // no-cors, *cors, same-origin
+            cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
+            credentials: 'same-origin', // include, *same-origin, omit
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            redirect: 'follow',
+            referrerPolicy: 'no-referrer', // no-referrer, *no-referrer-w
+            body: JSON.stringify(jsonData),
+        }).catch(() => {});
+    };
+
+    getCLS(jsonToSend, false);
+    getFID(jsonToSend);
+    getLCP(jsonToSend);
+    getFCP(jsonToSend);
+    getTTFB(jsonToSend);
+};
+
+
+

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -64,15 +64,12 @@ const coreVitals = (): void => {
 				break;
 		}
 
-		// eslint-disable-no-unnecessary-condition @typescript-eslint/no-unnecessary-condition
-		// eslint-disable-prefer-optional-chain @typescript-eslint/prefer-optional-chain
 		if (window.guardian.ophan) {
 			jsonData.page_view_id = window.guardian.ophan.pageViewId;
 			// jsonData.browser_id = window.guardian.config.ophan.browserId;
 		}
 
 		// Fallback to check for browser ID
-		// eslint-disable-prefer-optional-chain @typescript-eslint/prefer-optional-chain
 		if (getCookie({ name: 'bwid' })) {
 			jsonData.browser_id = getCookie({ name: 'bwid' });
 		}

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -38,6 +38,8 @@ const coreVitals = (): void => {
 		value: number;
 	};
 
+	let hasFCPBeenSent = false;
+
 	const nineDigitPrecision = (value: number) => {
 		// The math functions are to make sure the length of number is <= 9
 		return Math.round(value * 1_000_000) / 1_000_000;
@@ -107,13 +109,14 @@ const coreVitals = (): void => {
 		// We will send all data whenever any update. This means `null` values will appear in the lake
 		// and need handling.
 
-		// As of Version 2.0, CLS values should only be sent when FCP is sent
+		// As of Version 2.0, CLS values should only be sent if FCP has been sent
 		// https://github.com/GoogleChrome/web-vitals/blob/main/CHANGELOG.md#v200-2021-06-01
-		if (jsonToSend.name === 'FCP') {
-			if (jsonData.fcp !== null && jsonData.fcp > 0) {
+		if (jsonToSend.name === 'CLS' && !hasFCPBeenSent) {
+			if (jsonData.cls !== null && jsonData.cls > 0) {
 				sendData();
+				hasFCPBeenSent = true;
 			}
-		} else if (jsonToSend.name !== 'CLS') {
+		} else {
 			sendData();
 		}
 	};

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -67,6 +67,7 @@ const coreVitals = (): void => {
 
 		if (window.guardian.ophan) {
 			jsonData.page_view_id = window.guardian.ophan.pageViewId;
+			// 'window.guardian.config.ophan' does not exist here, so the fallback below might be the solution we go with
 			// jsonData.browser_id = window.guardian.config.ophan.browserId;
 		}
 
@@ -84,15 +85,15 @@ const coreVitals = (): void => {
 
 		const sendData = () => {
 			fetch(endpoint, {
-				method: 'POST', // *GET, POST, PUT, DELETE, etc.
-				mode: 'cors', // no-cors, *cors, same-origin
-				cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
-				credentials: 'same-origin', // include, *same-origin, omit
+				method: 'POST',
+				mode: 'cors',
+				cache: 'no-cache',
+				credentials: 'same-origin',
 				headers: {
 					'Content-Type': 'application/json',
 				},
 				redirect: 'follow',
-				referrerPolicy: 'no-referrer', // no-referrer, *no-referrer-w
+				referrerPolicy: 'no-referrer',
 				body: JSON.stringify(jsonData),
 			}).catch((error) => console.log(error));
 		};

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -1,117 +1,113 @@
-import { getCLS, getFID, getFCP, getLCP, getTTFB } from 'web-vitals';
+import { getCLS, getFCP, getFID, getLCP, getTTFB } from 'web-vitals';
 import { getCookie } from 'lib/cookies';
 
 export const init = () => {
-    coreVitals();
+	coreVitals();
 };
 
 type CoreWebVitalsPayload = {
-    page_view_id: string | null;
-    received_timestamp: string | null;
-    browser_id: string | null;
-    received_date: string;
-    fid: null | number;
-    cls: null | number;
-    lcp: null | number;
-    fcp: null | number;
-    ttfb: null | number;
+	page_view_id: string | null;
+	received_timestamp: string | null;
+	browser_id: string | null;
+	received_date: string;
+	fid: null | number;
+	cls: null | number;
+	lcp: null | number;
+	fcp: null | number;
+	ttfb: null | number;
 };
 
 const timestamp = new Date();
 const date = new Date().toISOString().slice(0, 10);
 
 const jsonData: CoreWebVitalsPayload = {
-    browser_id: null,
-    page_view_id: null,
-    received_timestamp: timestamp.toISOString(),
-    received_date: date,
-    fid: null,
-    cls: null,
-    lcp: null,
-    fcp: null,
-    ttfb: null,
+	browser_id: null,
+	page_view_id: null,
+	received_timestamp: timestamp.toISOString(),
+	received_date: date,
+	fid: null,
+	cls: null,
+	lcp: null,
+	fcp: null,
+	ttfb: null,
 };
 
 const coreVitals = (): void => {
-    type CoreVitalsArgs = {
-        name: string;
-        value: number;
-    };
+	type CoreVitalsArgs = {
+		name: string;
+		value: number;
+	};
 
-    const nineDigitPrecision = (value: number) => {
-        // The math functions are to make sure the length of number is <= 9
-        return Math.round(value * 1_000_000) / 1_000_000;
-    };
+	const nineDigitPrecision = (value: number) => {
+		// The math functions are to make sure the length of number is <= 9
+		return Math.round(value * 1_000_000) / 1_000_000;
+	};
 
-    const jsonToSend = ({ name, value }: CoreVitalsArgs): void => {
-        switch (name) {
-            case 'FCP':
-                jsonData.fcp = nineDigitPrecision(value);
-                break;
-            case 'CLS':
-                jsonData.cls = nineDigitPrecision(value);
-                break;
-            case 'LCP':
-                jsonData.lcp = nineDigitPrecision(value);
-                break;
-            case 'FID':
-                jsonData.fid = nineDigitPrecision(value);
-                break;
-            case 'TTFB':
-                jsonData.ttfb = nineDigitPrecision(value);
-                break;
-        }
+	const jsonToSend = ({ name, value }: CoreVitalsArgs): void => {
+		switch (name) {
+			case 'FCP':
+				jsonData.fcp = nineDigitPrecision(value);
+				break;
+			case 'CLS':
+				jsonData.cls = nineDigitPrecision(value);
+				break;
+			case 'LCP':
+				jsonData.lcp = nineDigitPrecision(value);
+				break;
+			case 'FID':
+				jsonData.fid = nineDigitPrecision(value);
+				break;
+			case 'TTFB':
+				jsonData.ttfb = nineDigitPrecision(value);
+				break;
+		}
 
-        // Some browser ID's are not caputured (and if they have no cookie there won't be one)
-        // but there are occassions of reoccuring users without a browser ID being sent.
-        if (window.guardian && window.guardian.ophan) {
-            jsonData.page_view_id = window.guardian.ophan.pageViewId;
-            // jsonData.browser_id = window.guardian.config.ophan.browserId;
-        }
+		// Some browser ID's are not caputured (and if they have no cookie there won't be one)
+		// but there are occassions of reoccuring users without a browser ID being sent.
+		if (window.guardian && window.guardian.ophan) {
+			jsonData.page_view_id = window.guardian.ophan.pageViewId;
+			// jsonData.browser_id = window.guardian.config.ophan.browserId;
+		}
 
-        // Fallback to check for browser ID
-        if (getCookie('bwid')) {
-            jsonData.browser_id = getCookie('bwid');
-        }
+		// Fallback to check for browser ID
+		if (getCookie('bwid')) {
+			jsonData.browser_id = getCookie('bwid');
+		}
 
-        const endpoint =
-            window.location.hostname === 'm.code.dev-theguardian.com' ||
-            window.location.hostname === 'localhost' ||
-            window.location.hostname === 'preview.gutools.co.uk'
-                ? 'http://performance-events.code.dev-guardianapis.com/core-web-vitals'
-                : 'https://performance-events.guardianapis.com/core-web-vitals';
+		const endpoint =
+			window.location.hostname === 'm.code.dev-theguardian.com' ||
+			window.location.hostname === 'localhost' ||
+			window.location.hostname === 'preview.gutools.co.uk'
+				? 'http://performance-events.code.dev-guardianapis.com/core-web-vitals'
+				: 'https://performance-events.guardianapis.com/core-web-vitals';
 
-        // Browser support
-        // getCLS(): Chromium,
-        // getFCP(): Chromium, Firefox, Safari Technology Preview
-        // getFID(): Chromium, Firefox, Safari, Internet Explorer (with the polyfill)
-        // getLCP(): Chromium
-        // getTTFB(): Chromium, Firefox, Safari, Internet Explorer
+		// Browser support
+		// getCLS(): Chromium,
+		// getFCP(): Chromium, Firefox, Safari Technology Preview
+		// getFID(): Chromium, Firefox, Safari, Internet Explorer (with the polyfill)
+		// getLCP(): Chromium
+		// getTTFB(): Chromium, Firefox, Safari, Internet Explorer
 
-        // We will send all data whenever any update. This means `null` values will appear in the lake
-        // and need handling.
+		// We will send all data whenever any update. This means `null` values will appear in the lake
+		// and need handling.
 
-        fetch(endpoint, {
-            method: 'POST', // *GET, POST, PUT, DELETE, etc.
-            mode: 'cors', // no-cors, *cors, same-origin
-            cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
-            credentials: 'same-origin', // include, *same-origin, omit
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            redirect: 'follow',
-            referrerPolicy: 'no-referrer', // no-referrer, *no-referrer-w
-            body: JSON.stringify(jsonData),
-        }).catch(() => {});
-    };
+		fetch(endpoint, {
+			method: 'POST', // *GET, POST, PUT, DELETE, etc.
+			mode: 'cors', // no-cors, *cors, same-origin
+			cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
+			credentials: 'same-origin', // include, *same-origin, omit
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			redirect: 'follow',
+			referrerPolicy: 'no-referrer', // no-referrer, *no-referrer-w
+			body: JSON.stringify(jsonData),
+		}).catch(() => {});
+	};
 
-    getCLS(jsonToSend, false);
-    getFID(jsonToSend);
-    getLCP(jsonToSend);
-    getFCP(jsonToSend);
-    getTTFB(jsonToSend);
+	getCLS(jsonToSend, false);
+	getFID(jsonToSend);
+	getLCP(jsonToSend);
+	getFCP(jsonToSend);
+	getTTFB(jsonToSend);
 };
-
-
-
-

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -108,13 +108,15 @@ const coreVitals = (): void => {
 
 		// As of Version 2.0, CLS values should only be sent if FCP has been sent
 		// https://github.com/GoogleChrome/web-vitals/blob/main/CHANGELOG.md#v200-2021-06-01
-		if (jsonToSend.name === 'CLS' && !hasFCPBeenSent) {
+		if (jsonToSend.name === 'CLS' && hasFCPBeenSent) {
 			if (jsonData.cls !== null && jsonData.cls > 0) {
 				sendData();
-				hasFCPBeenSent = true;
 			}
 		} else {
 			sendData();
+			if (jsonToSend.name === 'FCP') {
+				hasFCPBeenSent = true;
+			}
 		}
 	};
 

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -65,14 +65,14 @@ const coreVitals = (): void => {
 		// Some browser ID's are not caputured (and if they have no cookie there won't be one)
 		// but there are occassions of reoccuring users without a browser ID being sent.
 		// eslint/no-unnecessary-condition
-		/* eslint/prefer-optional-chain */
+		// eslint/prefer-optional-chain
 		if (window.guardian && window.guardian.ophan) {
 			jsonData.page_view_id = window.guardian.ophan.pageViewId;
 			// jsonData.browser_id = window.guardian.config.ophan.browserId;
 		}
 
 		// Fallback to check for browser ID
-		/* eslint/prefer-optional-chain */
+		// eslint/prefer-optional-chain
 		if (getCookie('bwid')) {
 			jsonData.browser_id = getCookie('bwid');
 		}
@@ -93,7 +93,7 @@ const coreVitals = (): void => {
 
 		// We will send all data whenever any update. This means `null` values will appear in the lake
 		// and need handling.
-		/* eslint/no-empty-function */
+		// eslint/no-empty-function
 		fetch(endpoint, {
 			method: 'POST', // *GET, POST, PUT, DELETE, etc.
 			mode: 'cors', // no-cors, *cors, same-origin

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -38,7 +38,8 @@ const coreVitals = (): void => {
 		value: number;
 	};
 
-	let hasFCPBeenSent = false;
+	// Needed when we start using version 2
+	// let hasFCPBeenSent = false;
 
 	const nineDigitPrecision = (value: number) => {
 		// The math functions are to make sure the length of number is <= 9
@@ -106,8 +107,10 @@ const coreVitals = (): void => {
 		// We will send all data whenever any update. This means `null` values will appear in the lake
 		// and need handling.
 
-		// As of Version 2.0, CLS values should only be sent if FCP has been sent
-		// https://github.com/GoogleChrome/web-vitals/blob/main/CHANGELOG.md#v200-2021-06-01
+		/*
+		    --> The logic below is only needed for Version 2 of Google's Core Web Vitals<--
+		    As of Version 2.0, CLS values should only be sent if FCP has been sent
+	        https://github.com/GoogleChrome/web-vitals/blob/main/CHANGELOG.md#v200-2021-06-01
 		if (jsonToSend.name === 'CLS' && hasFCPBeenSent) {
 			if (jsonData.cls !== null && jsonData.cls > 0) {
 				sendData();
@@ -117,7 +120,9 @@ const coreVitals = (): void => {
 			if (jsonToSend.name === 'FCP') {
 				hasFCPBeenSent = true;
 			}
-		}
+		} */
+
+		sendData();
 	};
 
 	getCLS(jsonToSend, false);

--- a/yarn.lock
+++ b/yarn.lock
@@ -13545,10 +13545,10 @@ watchpack@^1.7.4:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.0"
 
-web-vitals@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-0.2.4.tgz#ec3df43c834a207fd7cdefd732b2987896e08511"
-  integrity sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg==
+web-vitals@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-1.1.2.tgz#06535308168986096239aa84716e68b4c6ae6d1c"
+  integrity sha512-PFMKIY+bRSXlMxVAQ+m2aw9c/ioUYfDgrYot0YUa+/xa0sakubWhSDyxAKwzymvXVdF4CZI71g06W+mqhzu6ig==
 
 webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
## What does this change?

This adds Google's Core Web Vitals to frontend so we can draw comparisons with DCR. It also increases the Web-Vitals library to match DCR (before we switch to version 2).

## Does this change need to be reproduced in dotcom-rendering ?

I've already implemented it.

## Screenshots

<img width="562" alt="Screenshot 2021-06-03 at 11 53 37" src="https://user-images.githubusercontent.com/35331926/120636634-c1608000-c465-11eb-8892-5fcfc07e39cd.png">

## What is the value of this and can you measure success?

Success is accurate data being sent to the data lake.

### Tested

- [X] Locally
- [x] On CODE (optional)

Data lake from CODE test
 
<img width="814" alt="Screenshot 2021-06-07 at 10 51 08" src="https://user-images.githubusercontent.com/35331926/120997664-4ce85280-c77f-11eb-893d-ee48922a4f43.png">
