### PR TITLE
Add support to force DCR rendering of AMP interactives

### DIFF
--- a/applications/app/services/InteractiveRendering.scala
+++ b/applications/app/services/InteractiveRendering.scala
@@ -4,9 +4,8 @@ import play.api.mvc.RequestHeader
 import implicits.Requests._
 
 sealed trait RenderingTier
-object FrontendLegacy extends RenderingTier
-object USElectionTracker2020AmpPage extends RenderingTier
 object DotcomRendering extends RenderingTier
+object FrontendLegacy extends RenderingTier
 
 /*
   Date: 21st Jan 2020
@@ -27,39 +26,22 @@ object DotcomRendering extends RenderingTier
 
   We are now moving towards supporting interactives in DCR 🙂
  */
+object USElectionTracker2020AmpPage extends RenderingTier
 
 object InteractiveRendering {
 
-  // allowListedPaths is use to jumpstart the router (which decides which between frontend and DRC does the rendering)
-  val allowListedPaths = List(
+  val migratedPaths = List(
     "/sport/ng-interactive/2018/dec/26/lebron-james-comments-nba-nfl-divide",
   )
-  def ensureStartingForwardSlash(str: String): String = {
-    if (!str.startsWith("/")) ("/" + str) else str
-  }
-
-  def decideRenderingTier(path: String)(implicit request: RequestHeader): RenderingTier = {
-    // This function decides which paths are sent to DCR for rendering
-    // At first we use allowListedPaths
-    if (allowListedPaths.contains(ensureStartingForwardSlash(path))) DotcomRendering else FrontendLegacy
-  }
 
   def getRenderingTier(path: String)(implicit request: RequestHeader): RenderingTier = {
-
     val isSpecialElection = ApplicationsUSElection2020AmpPages.pathIsSpecialHanding(path)
-
     val isAmp = request.host.contains("amp")
-    val isWeb = !isAmp
-
     val forceDCR = request.forceDCR
+    val isMigrated = migratedPaths.contains(if (path.startsWith("/")) path else "/" + path)
 
-    if (isSpecialElection && isAmp) USElectionTracker2020AmpPage
-    else if (isSpecialElection && isWeb) FrontendLegacy // [1]
-    else if (isAmp) FrontendLegacy // [2]
-    else if (forceDCR) DotcomRendering
-    else decideRenderingTier(path)
-
-    // [1] We will change that in the future, but for the moment we legacy render the election tracker.
-    // [2] We will change that in the future, but for the moment we legacy render all amp pages.
+    if (forceDCR || isMigrated) DotcomRendering
+    else if (isSpecialElection && isAmp) USElectionTracker2020AmpPage
+    else FrontendLegacy
   }
 }

--- a/applications/app/services/InteractiveRendering.scala
+++ b/applications/app/services/InteractiveRendering.scala
@@ -7,25 +7,6 @@ sealed trait RenderingTier
 object DotcomRendering extends RenderingTier
 object FrontendLegacy extends RenderingTier
 
-/*
-  Date: 21st Jan 2020
-  Author: Pascal
-
-  This object was introduced in late 2020, to handle the routing between regular rendering of interactives
-  versus the code that had been written to handle the US Presidential Election Tracker amp page.
-
-  The tracker (an ng-interactive) didn't have a AMP page and there were two ways to provide one to it.
-  1. Implement the support for it in DCR, or
-  2. Implement support for it directly in the [applications] app, using the AMP page already present in CAPI.
-
-  The former would have taken too long so we went for the latter.
-
-  ----------------
-  Author: Pascal
-  Date: 21st April 2021
-
-  We are now moving towards supporting interactives in DCR 🙂
- */
 object USElectionTracker2020AmpPage extends RenderingTier
 
 object InteractiveRendering {

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -150,8 +150,7 @@ class GuardianConfiguration extends GuLogging {
   }
 
   object rendering {
-    lazy val renderingEndpoint = configuration.getMandatoryStringProperty("rendering.endpoint")
-    lazy val AMPArticleEndpoint = configuration.getMandatoryStringProperty("rendering.AMPArticleEndpoint")
+    lazy val baseURL = configuration.getMandatoryStringProperty("rendering.baseURL")
     lazy val sentryHost = configuration.getMandatoryStringProperty("rendering.sentryHost")
     lazy val sentryPublicApiKey = configuration.getMandatoryStringProperty("rendering.sentryPublicApiKey")
     lazy val timeout = 2.seconds

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -39,7 +39,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       page: Page,
   )(implicit request: RequestHeader): Future[Result] = {
 
-    def doGet() = {
+    def doPost() = {
       val resp = ws
         .url(endpoint)
         .withRequestTimeout(Configuration.rendering.timeout)
@@ -83,9 +83,9 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     }
 
     if (CircuitBreakerSwitch.isSwitchedOn) {
-      circuitBreaker.withCircuitBreaker(doGet()).map(handler)
+      circuitBreaker.withCircuitBreaker(doPost()).map(handler)
     } else {
-      doGet().map(handler)
+      doPost().map(handler)
     }
   }
 
@@ -102,7 +102,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     }
     val json = DotcomRenderingDataModel.toJson(dataModel)
 
-    get(ws, json, Configuration.rendering.AMPArticleEndpoint, page)
+    get(ws, json, Configuration.rendering.baseURL + "/AMPArticle", page)
   }
 
   def getArticle(
@@ -114,7 +114,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
 
     val dataModel = DotcomRenderingDataModel.forArticle(page, blocks, request, pageType)
     val json = DotcomRenderingDataModel.toJson(dataModel)
-    get(ws, json, Configuration.rendering.renderingEndpoint, page)
+    get(ws, json, Configuration.rendering.baseURL + "/Article", page)
   }
 
   def getInteractive(
@@ -126,7 +126,19 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
 
     val dataModel = DotcomRenderingDataModel.forInteractive(page, blocks, request, pageType)
     val json = DotcomRenderingDataModel.toJson(dataModel)
-    get(ws, json, Configuration.rendering.renderingEndpoint, page)
+    get(ws, json, Configuration.rendering.baseURL + "/Interactive", page)
+  }
+
+  def getAMPInteractive(
+      ws: WSClient,
+      page: InteractivePage,
+      blocks: Blocks,
+      pageType: PageType,
+  )(implicit request: RequestHeader): Future[Result] = {
+
+    val dataModel = DotcomRenderingDataModel.forInteractive(page, blocks, request, pageType)
+    val json = DotcomRenderingDataModel.toJson(dataModel)
+    get(ws, json, Configuration.rendering.baseURL + "/AMPInteractive", page)
   }
 
 }


### PR DESCRIPTION
## What does this change?

- Adds support for rendering interactives AMP pages on DCR 
- Refactor `DotcomRenderingService` to use baseURL from configuration & hardcoded paths (this makes it easier to expand endpoints in the future)
- Refactor `InteractiveRendering` to simply rendering tier logic

> Note: Before merging this PR it is necessary that the AWS parameter story is updated with the new `rendering.baseURL` parameter (update: now done for PROD/CODE/DEV, but could be double checked as part of the PR approval)

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [x] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
