### PR TITLE
Use sensible defaults for throttled cricket actor

### DIFF
--- a/sport/app/cricket/feed/CricketThrottler.scala
+++ b/sport/app/cricket/feed/CricketThrottler.scala
@@ -2,6 +2,7 @@ package cricket.feed
 
 import java.util.concurrent.TimeUnit
 import akka.NotUsed
+import akka.actor.Status.{Failure, Success}
 import akka.actor.{Actor, ActorRef, ActorSystem, Props}
 import akka.pattern.{ask, pipe}
 import akka.stream.scaladsl.{Sink, Source}
@@ -19,8 +20,8 @@ class CricketThrottlerActor()(implicit materializer: Materializer) extends Actor
 
   private case class TaskWithSender[+T](sender: ActorRef, task: () => Future[T])
 
-  val completionMatcher: PartialFunction[Any, CompletionStrategy] = { case e => CompletionStrategy.immediately }
-  val failureMatcher: PartialFunction[Any, Throwable] = { case e => new Throwable() }
+  val completionMatcher: PartialFunction[Any, CompletionStrategy] = { case Success => CompletionStrategy.draining }
+  val failureMatcher: PartialFunction[Any, Throwable] = { case Failure(t) => t }
 
   val throttler: ActorRef = Source
     .actorRef[CricketThrottledTask[Nothing]](
@@ -30,7 +31,7 @@ class CricketThrottlerActor()(implicit materializer: Materializer) extends Actor
       overflowStrategy = OverflowStrategy.dropNew,
     )
     .throttle(1, 500.millisecond, 1, ThrottleMode.Shaping)
-    .to(Sink.actorRef(self, NotUsed, failureMatcher))
+    .to(Sink.actorRef(self, NotUsed, _ => ()))
     .run()
 
   override def receive: PartialFunction[Any, Unit] = {

--- a/sport/app/cricket/feed/CricketThrottler.scala
+++ b/sport/app/cricket/feed/CricketThrottler.scala
@@ -31,7 +31,7 @@ class CricketThrottlerActor()(implicit materializer: Materializer) extends Actor
       overflowStrategy = OverflowStrategy.dropNew,
     )
     .throttle(1, 500.millisecond, 1, ThrottleMode.Shaping)
-    .to(Sink.actorRef(self, NotUsed, _ => ()))
+    .to(Sink.actorRef(self, NotUsed, t => Failure(t)))
     .run()
 
   override def receive: PartialFunction[Any, Unit] = {


### PR DESCRIPTION
## What does this change?
This addresses an issue with fetching cricket match data from PA. 

We were observing logs that indicated an actor was not responding to messages: `Ask timed out on [Actor[akka://application/user/$a#-1466781103]] after [120000 ms]. Message of type [cricket.feed.CricketThrottledTask]. A typical reason for `AskTimeoutException` is that the recipient actor didn't send a reply.`

On closer inspection, this appears to be because we are using `PartialFunction`s for the `failureMatcher` and `completionMatcher`  of the throttling actor, where the partial function is actually total (i.e. always matches). This means that whatever message is sent to the actor, it will either complete or fail the stream immediately (whichever matcher is used first). To resolve that I've just used some typical defaults (match a status message of `Failure` for failures and `Success` for success), which is similar to defaults used by akka internally (on deprecated methods we shouldn't use).

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
This should bring back cricket live scoreboards on the site because match data will be cached successfully again.

### Tested

- [x] Locally
- [x] On CODE (optional)
