### PR TITLE
Enable braze for all logged in users

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -49,9 +49,8 @@ const hasRequiredConsents = () =>
     });
 
 const canShowPreChecks = ({
-    userIsGuSupporter,
     pageConfig,
-}) => Boolean(userIsGuSupporter && !pageConfig.isPaidContent);
+}) => Boolean(!pageConfig.isPaidContent);
 
 let message;
 
@@ -200,7 +199,6 @@ const canShow = async () => {
     }
 
     if (!canShowPreChecks({
-        userIsGuSupporter: shouldNotBeShownSupportMessaging(),
         pageConfig: config.get('page'),
     })) {
         // Currently all active web canvases in Braze target existing supporters,

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -48,9 +48,6 @@ const hasRequiredConsents = () =>
         })
     });
 
-const canShowPreChecks = ({
-    pageConfig,
-}) => Boolean(!pageConfig.isPaidContent);
 
 let message;
 
@@ -198,13 +195,8 @@ const canShow = async () => {
         return false;
     }
 
-    if (!canShowPreChecks({
-        pageConfig: config.get('page'),
-    })) {
-        // Currently all active web canvases in Braze target existing supporters,
-        // subscribers or otherwise those with a Guardian product. We can use the
-        // value of `shouldNotBeShownSupportMessaging` to identify these users,
-        // limiting the number of requests we need to initialise Braze on the page:
+    // Don't load Braze SDK for paid content
+    if (config.get('page').isPaidContent) {
         return false;
     }
 
@@ -313,5 +305,4 @@ export {
     brazeBanner,
     brazeVendorId,
     hasRequiredConsents,
-    canShowPreChecks,
 }

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.spec.js
@@ -19,21 +19,10 @@ afterEach(() => {
 });
 
 describe('canShowPreChecks', () => {
-    describe('when not a supporter', () => {
-        it('returns false', () => {
-            const result = canShowPreChecks({
-                userIsGuSupporter: false,
-                pageConfig: {isPaidContent: false},
-            })
-
-            expect(result).toBe(false);
-        });
-    });
 
     describe('when viewing paid content', () => {
         it('returns false', () => {
             const result = canShowPreChecks({
-                userIsGuSupporter: true,
                 pageConfig: {isPaidContent: true},
             })
 
@@ -44,7 +33,6 @@ describe('canShowPreChecks', () => {
     describe('when all checks pass', () => {
         it('returns true', () => {
             const result = canShowPreChecks({
-                userIsGuSupporter: true,
                 pageConfig: {isPaidContent: false},
             })
 

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.spec.js
@@ -1,6 +1,5 @@
 import {
     brazeVendorId,
-    canShowPreChecks,
     hasRequiredConsents,
 } from './brazeBanner';
 
@@ -16,30 +15,6 @@ jest.mock('@guardian/consent-management-platform', () => ({
 
 afterEach(() => {
     mockOnConsentChangeResult = undefined;
-});
-
-describe('canShowPreChecks', () => {
-
-    describe('when viewing paid content', () => {
-        it('returns false', () => {
-            const result = canShowPreChecks({
-                pageConfig: {isPaidContent: true},
-            })
-
-            expect(result).toBe(false);
-        });
-    });
-
-    describe('when all checks pass', () => {
-        it('returns true', () => {
-            const result = canShowPreChecks({
-                pageConfig: {isPaidContent: false},
-            })
-
-            expect(result).toBe(true);
-
-        })
-    })
 });
 
 describe('hasRequiredConsents', () => {


### PR DESCRIPTION
## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes https://github.com/guardian/dotcom-rendering/pull/3081

## What is the value of this and can you measure success?
It will enable marketing to use Braze to show messages to all logged in users, to allow acquisition campaigns, not just retention / upsell.

## Checklist

### Does this affect other platforms?
No

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

- [x] No. Braze will remain not loaded if the page is paid content.
- [ ] Yes 

### Does this change break ad-free?
- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?
- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [x] Locally
- [ ] On CODE (optional)
