### PR TITLE
Expand Main Element support to interactive atoms

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -40,14 +40,16 @@ object ArticlePageChecks {
   }
 
   def hasOnlySupportedMainElements(page: PageWithStoryPackage): Boolean = {
-    def unsupportedElement(blockElement: BlockElement) =
+
+    def unsupportedElement(blockElement: BlockElement) = {
       blockElement match {
         // The majority of the remaining atoms appear to be interactive atoms, which aren't supported yet
-        case ContentAtomBlockElement(_, atomtype, _) if atomtype != "media" => true
+        case ContentAtomBlockElement(_, atomtype, _) if !List("media", "interactive").contains(atomtype) => true
         // Everything else should be supported, but there are some element types that don't
         // get used in main media, for which there are no guarantees
         case _ => false
       }
+    }
 
     !page.article.blocks.exists(_.main.exists(_.elements.exists(unsupportedElement)))
   }


### PR DESCRIPTION
## What does this change?

Expand Main Element support to interactive atoms.
Backend follow up of: https://github.com/guardian/dotcom-rendering/pull/3077 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] Yes Actually already done.

![Screenshot 2021-06-04 at 14 31 42](https://user-images.githubusercontent.com/6035518/120809092-a7946b00-c541-11eb-9a63-7b6c41f39b47.png)
