### PR TITLE
Stop setting repermissioned field on Identity

### DIFF
--- a/identity/app/controllers/editprofile/ConsentsJourney.scala
+++ b/identity/app/controllers/editprofile/ConsentsJourney.scala
@@ -75,7 +75,7 @@ trait ConsentsJourney extends EditProfileControllerComponents {
     displayConsentComplete(ConsentJourneyPageDefault, None, guestPasswordForm)
 
   /** POST /complete-consents */
-  def submitRepermissionedFlag: Action[AnyContent] =
+  def completeConsents: Action[AnyContent] =
     csrfCheck {
       consentAuthWithIdapiUserAction.async { implicit request =>
         val returnUrlForm = Form(single("returnUrl" -> nonEmptyText))
@@ -90,17 +90,16 @@ trait ConsentsJourney extends EditProfileControllerComponents {
                 request.user.id,
                 UserUpdateDTO(
                   consents = Some(newConsents),
-                  statusFields = Some(StatusFields(hasRepermissioned = Some(true))),
                 ),
                 request.user.auth,
               )
               .map {
                 case Left(idapiErrors) =>
-                  logger.error(s"Failed to set hasRepermissioned flag for user ${request.user.id}: $idapiErrors")
+                  logger.error(s"Failed to set save user consents ${request.user.id}: $idapiErrors")
                   InternalServerError(Json.toJson(idapiErrors))
 
                 case Right(updatedUser) =>
-                  logger.info(s"Successfully set hasRepermissioned flag for user ${request.user.id}")
+                  logger.info(s"Successfully set consents for user ${request.user.id}")
                   Redirect(
                     s"${routes.EditProfileController.displayConsentComplete().url}",
                     Map("returnUrl" -> Seq(returnUrl)),

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -151,7 +151,6 @@
 @displayJourney = {
     <div class="
         identity-consent-journey
-        @{if (!user.statusFields.hasRepermissioned.getOrElse(false)){"identity-consent-journey--with-alert"}}
         @{skin.map(s => s"identity-consent-journey--$s" )}
         u-h
     " data-journey="@journey" data-component="identity-consent-journey-@journey">

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -44,7 +44,7 @@ GET         /email-prefs                            controllers.editprofile.Edit
 ########################################################################################################################
 GET         /consents/thank-you                     controllers.editprofile.EditProfileController.displayConsentsJourneyThankYou
 
-POST        /complete-consents                      controllers.editprofile.EditProfileController.submitRepermissionedFlag
+POST        /complete-consents                      controllers.editprofile.EditProfileController.completeConsents
 GET         /complete-consents                      controllers.editprofile.EditProfileController.displayConsentComplete()
 ########################################################################################################################
 

--- a/identity/test/actions/AuthenticatedActionsTest.scala
+++ b/identity/test/actions/AuthenticatedActionsTest.scala
@@ -40,7 +40,7 @@ class AuthenticatedActionsTest
     val user = User(
       "",
       "test@example.com",
-      statusFields = new StatusFields(userEmailValidated = Some(true), hasRepermissioned = Some(true)),
+      statusFields = new StatusFields(userEmailValidated = Some(true)),
     )
     val newsletterService: NewsletterService = mock[NewsletterService]
     val rpCookie = mock[ScGuRp]

--- a/identity/test/controllers/ConsentsJourneyControllerTest.scala
+++ b/identity/test/controllers/ConsentsJourneyControllerTest.scala
@@ -102,26 +102,20 @@ import scala.concurrent.Future
 
     "using any journey" should {
 
-      "set a repermission flag on submit" in new ConsentsJourneyFixture {
-        val updatedUser = user.copy(
-          statusFields = StatusFields(hasRepermissioned = Some(true)),
-        )
-
+      "update Identity user on submit" in new ConsentsJourneyFixture {
         val fakeRequest = FakeCSRFRequest(csrfAddToken)
           .withFormUrlEncodedBody(
             "returnUrl" -> returnUrlVerifier.defaultReturnUrl,
           )
 
         when(api.saveUser(any[String], any[UserUpdateDTO], any[Auth]))
-          .thenReturn(Future.successful(Right(updatedUser)))
+          .thenReturn(Future.successful(Right(user)))
 
-        val result = controller.submitRepermissionedFlag.apply(fakeRequest)
+        val result = controller.completeConsents.apply(fakeRequest)
         status(result) should be(303)
 
         val userUpdateCapture = ArgumentCaptor.forClass(classOf[UserUpdateDTO])
         verify(api).saveUser(MockitoMatchers.eq(userId), userUpdateCapture.capture(), MockitoMatchers.eq(testAuth))
-        val userUpdate = userUpdateCapture.getValue
-        userUpdate.statusFields.get.hasRepermissioned should equal(Some(true))
       }
 
     }

--- a/static/src/javascripts/projects/common/modules/identity/api.ts
+++ b/static/src/javascripts/projects/common/modules/identity/api.ts
@@ -54,7 +54,6 @@ export type IdentityUser = {
 	};
 	statusFields: {
 		userEmailValidated: boolean;
-		hasRepermissioned: boolean;
 	};
 	privateFields: {
 		brazeUuid: string;


### PR DESCRIPTION

## What does this change?

Stop setting repermissioned field on Identity - we are removing this field

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

We are removing this field before migrating to OKTA. See https://github.com/guardian/identity/pull/1904

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
