### PR TITLE
Edit Nav for Euro2020

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -92,10 +92,13 @@ private object NavLinks {
 
   /* SPORT */
 
+  val Euro2020 = NavLink("Euro 2020", "/football/euro-2020")
+
   val football = NavLink(
     "Football",
     "/football",
     children = List(
+      Euro2020,
       NavLink("Live scores", "/football/live", Some("football/live")),
       NavLink("Tables", "/football/tables", Some("football/tables")),
       NavLink("Fixtures", "/football/fixtures", Some("football/fixtures")),
@@ -355,6 +358,7 @@ private object NavLinks {
     longTitle = Some("Sport home"),
     iconName = Some("home"),
     List(
+      Euro2020,
       football,
       cricket,
       rugbyUnion,
@@ -394,6 +398,7 @@ private object NavLinks {
   )
   val intSportPillar = ukSportPillar.copy(
     children = List(
+      Euro2020,
       football,
       cricket,
       rugbyUnion,


### PR DESCRIPTION
## What does this change?

Add `NavLink("Euro 2020", "/football/euro-2020")` to the Sport front in `UK` and `Int` as well as on the `/football` front.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No


Better file views than the Github diffs

<img width="669" alt="Screenshot 2021-06-04 at 16 39 05" src="https://user-images.githubusercontent.com/6035518/120827711-a1a78580-c553-11eb-8b31-136dbd150ef4.png">

<img width="350" alt="Screenshot 2021-06-04 at 16 39 26" src="https://user-images.githubusercontent.com/6035518/120827733-a66c3980-c553-11eb-98b8-d51591c0c266.png">

<img width="392" alt="Screenshot 2021-06-04 at 16 39 34" src="https://user-images.githubusercontent.com/6035518/120827749-aa985700-c553-11eb-8050-9288546a6fa2.png">

