### PR TITLE
Migrating build.sbt and ProjectSettings to slash syntax

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ import com.gu.ProjectSettings._
 
 val common = library("common")
   .settings(
-    javaOptions in Test += "-Dconfig.file=common/conf/test.conf",
+    Test / javaOptions += "-Dconfig.file=common/conf/test.conf",
     libraryDependencies ++= Seq(
       guBox,
       apacheCommonsLang,
@@ -59,7 +59,7 @@ val common = library("common")
     ) ++ jackson,
   )
   .settings(
-    mappings in TestAssets ~= filterAssets,
+    TestAssets / mappings ~= filterAssets,
   )
 
 val commonWithTests = withTests(common)
@@ -172,7 +172,7 @@ val dev = application("dev-build")
   )
   .settings(
     RoutesKeys.routesImport += "bindables._",
-    javaOptions in Runtime += "-Dconfig.file=dev-build/conf/dev-build.application.conf",
+    Runtime / javaOptions += "-Dconfig.file=dev-build/conf/dev-build.application.conf",
   )
 
 val preview = application("preview")
@@ -219,20 +219,20 @@ val main = root()
     ),
     riffRaffManifestProjectName := s"dotcom:all",
     riffRaffArtifactResources := Seq(
-      (packageBin in Universal in admin).value -> s"${(name in admin).value}/${(packageBin in Universal in admin).value.getName}",
-      (packageBin in Universal in applications).value -> s"${(name in applications).value}/${(packageBin in Universal in applications).value.getName}",
-      (packageBin in Universal in archive).value -> s"${(name in archive).value}/${(packageBin in Universal in archive).value.getName}",
-      (packageBin in Universal in article).value -> s"${(name in article).value}/${(packageBin in Universal in article).value.getName}",
-      (packageBin in Universal in commercial).value -> s"${(name in commercial).value}/${(packageBin in Universal in commercial).value.getName}",
-      (packageBin in Universal in diagnostics).value -> s"${(name in diagnostics).value}/${(packageBin in Universal in diagnostics).value.getName}",
-      (packageBin in Universal in discussion).value -> s"${(name in discussion).value}/${(packageBin in Universal in discussion).value.getName}",
-      (packageBin in Universal in identity).value -> s"${(name in identity).value}/${(packageBin in Universal in identity).value.getName}",
-      (packageBin in Universal in facia).value -> s"${(name in facia).value}/${(packageBin in Universal in facia).value.getName}",
-      (packageBin in Universal in faciaPress).value -> s"${(name in faciaPress).value}/${(packageBin in Universal in faciaPress).value.getName}",
-      (packageBin in Universal in onward).value -> s"${(name in onward).value}/${(packageBin in Universal in onward).value.getName}",
-      (packageBin in Universal in preview).value -> s"${(name in preview).value}/${(packageBin in Universal in preview).value.getName}",
-      (packageBin in Universal in rss).value -> s"${(name in rss).value}/${(packageBin in Universal in rss).value.getName}",
-      (packageBin in Universal in sport).value -> s"${(name in sport).value}/${(packageBin in Universal in sport).value.getName}",
+      (admin / Universal / packageBin).value -> s"${(admin / name).value}/${(admin / Universal / packageBin).value.getName}",
+      (applications / Universal / packageBin).value -> s"${(applications / name).value}/${(applications / Universal / packageBin).value.getName}",
+      (archive / Universal / packageBin).value -> s"${(archive / name).value}/${(archive / Universal / packageBin).value.getName}",
+      (article / Universal / packageBin).value -> s"${(article / name).value}/${(article / Universal / packageBin).value.getName}",
+      (commercial / Universal / packageBin).value -> s"${(commercial / name).value}/${(commercial / Universal / packageBin).value.getName}",
+      (diagnostics / Universal / packageBin).value -> s"${(diagnostics / name).value}/${(diagnostics / Universal / packageBin).value.getName}",
+      (discussion / Universal / packageBin).value -> s"${(discussion / name).value}/${(discussion / Universal / packageBin).value.getName}",
+      (identity / Universal / packageBin).value -> s"${(identity / name).value}/${(identity / Universal / packageBin).value.getName}",
+      (facia / Universal / packageBin).value -> s"${(facia / name).value}/${(facia / Universal / packageBin).value.getName}",
+      (faciaPress / Universal / packageBin).value -> s"${(faciaPress / name).value}/${(faciaPress / Universal / packageBin).value.getName}",
+      (onward / Universal / packageBin).value -> s"${(onward / name).value}/${(onward / Universal / packageBin).value.getName}",
+      (preview / Universal / packageBin).value -> s"${(preview / name).value}/${(preview / Universal / packageBin).value.getName}",
+      (rss / Universal / packageBin).value -> s"${(rss / name).value}/${(rss / Universal / packageBin).value.getName}",
+      (sport / Universal / packageBin).value -> s"${(sport / name).value}/${(sport / Universal / packageBin).value.getName}",
       baseDirectory.value / "riff-raff.yaml" -> "riff-raff.yaml",
     ),
   )

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -29,9 +29,9 @@ object ProjectSettings {
       "-feature",
       "-Xfatal-warnings",
     ),
-    publishArtifact in (Compile, packageDoc) := false,
-    sources in (Compile, doc) := Seq.empty,
-    doc in Compile := target.map(_ / "none").value,
+    Compile / packageDoc / publishArtifact := false,
+    Compile / doc / sources := Seq.empty,
+    Compile / doc := target.map(_ / "none").value,
     scalaVersion := "2.12.13",
     initialize := {
       val _ = initialize.value
@@ -64,24 +64,24 @@ object ProjectSettings {
 
   val frontendTestSettings = Seq(
     // Use ScalaTest https://groups.google.com/d/topic/play-framework/rZBfNoGtC0M/discussion
-    testOptions in Test := Nil,
+    Test / testOptions := Nil,
     concurrentRestrictions in Global := List(Tags.limit(Tags.Test, 4)),
     // Copy unit test resources https://groups.google.com/d/topic/play-framework/XD3X6R-s5Mc/discussion
-    unmanagedClasspath in Test += (baseDirectory map { bd => Attributed.blank(bd / "test") }).value,
+    Test / unmanagedClasspath += (baseDirectory map { bd => Attributed.blank(bd / "test") }).value,
     libraryDependencies ++= Seq(
       scalaTest,
       scalaTestPlus,
       mockito,
     ),
     // These settings are needed for forking, which in turn is needed for concurrent restrictions.
-    javaOptions in Test += "-DAPP_SECRET=this_is_not_a_real_secret_just_for_tests",
-    javaOptions in Test += "-Xmx2048M",
-    javaOptions in Test += "-XX:+UseConcMarkSweepGC",
-    javaOptions in Test += "-XX:ReservedCodeCacheSize=128m",
-    baseDirectory in Test := file("."),
+    Test / javaOptions += "-DAPP_SECRET=this_is_not_a_real_secret_just_for_tests",
+    Test / javaOptions += "-Xmx2048M",
+    Test / javaOptions += "-XX:+UseConcMarkSweepGC",
+    Test / javaOptions += "-XX:ReservedCodeCacheSize=128m",
+    Test / baseDirectory := file("."),
     // Set testResultLogger back to the default, fixes an issue with `sbt-teamcity-logger`
     //   See: https://github.com/JetBrains/sbt-tc-logger/issues/9
-    testResultLogger in (Test, test) := TestResultLogger.Default,
+    Test / test / testResultLogger := TestResultLogger.Default,
   )
 
   val testAll = taskKey[Unit]("test all aggregate projects")
@@ -91,7 +91,7 @@ object ProjectSettings {
 
   def frontendRootSettings: Seq[Def.Setting[Task[Unit]]] =
     List(
-      testAll := (test in Test)
+      testAll := (Test / test)
         .all(ScopeFilter(inAggregates(ThisProject, includeRoot = false)))
         .value,
       upload := riffRaffUpload.in(LocalRootProject).value,


### PR DESCRIPTION
## What does this change?

Recently noticed that we had a bunch of deprecation warnings of the form 

```
frontend/build.sbt:9: warning: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
    javaOptions in Test += "-Dconfig.file=common/conf/test.conf",
                ^
```
This update the code as per instructions in https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No