### PR TITLE
Simplify sentinel test

### DIFF
--- a/static/src/javascripts/projects/commercial/sentinel.spec.ts
+++ b/static/src/javascripts/projects/commercial/sentinel.spec.ts
@@ -1,12 +1,9 @@
-import { mocked } from 'ts-jest/utils';
-import raven_ from 'lib/raven';
+import raven from 'lib/raven';
 import config_ from '../../lib/config';
 import { amIUsed } from './sentinel';
 
-const raven = raven_;
-
 const config = config_ as {
-	get: (s: string, d: boolean) => boolean;
+	get: jest.MockedFunction<(s: string, d: boolean) => boolean>;
 };
 
 jest.mock('lib/raven', () => ({
@@ -17,25 +14,25 @@ jest.mock('../../lib/config', () => ({
 	get: jest.fn(),
 }));
 
-describe('sentinel', () => {
-	afterEach(() => {
-		jest.clearAllMocks();
-	});
+afterEach(() => {
+	jest.clearAllMocks();
+});
 
+describe('sentinel', () => {
 	test('does not send a message when switches.sentinelLogger is false', () => {
-		mocked(config.get).mockReturnValue(false);
+		config.get.mockReturnValue(false);
 		amIUsed('moduleName', 'functioName');
 		expect(raven.captureMessage).not.toHaveBeenCalled();
 	});
 
 	test('does send a message when switches.sentinelLogger is true', () => {
-		mocked(config.get).mockReturnValue(true);
+		config.get.mockReturnValue(true);
 		amIUsed('moduleName', 'functioName');
 		expect(raven.captureMessage).toHaveBeenCalledTimes(1);
 	});
 
 	test('does not attach a label when it is not present', () => {
-		mocked(config.get).mockReturnValue(true);
+		config.get.mockReturnValue(true);
 		amIUsed('moduleName', 'functionName');
 		expect(raven.captureMessage).toHaveBeenCalledWith(
 			'moduleName.functionName',
@@ -44,7 +41,7 @@ describe('sentinel', () => {
 	});
 
 	test('does attach a label when it is present', () => {
-		mocked(config.get).mockReturnValue(true);
+		config.get.mockReturnValue(true);
 		amIUsed('moduleName', 'functionName', 'label=test');
 		expect(raven.captureMessage).toHaveBeenCalledWith(
 			'moduleName.functionName.label=test',
@@ -53,7 +50,7 @@ describe('sentinel', () => {
 	});
 
 	test('does log the event at the info level', () => {
-		mocked(config.get).mockReturnValue(true);
+		config.get.mockReturnValue(true);
 		amIUsed('moduleName', 'functionName');
 		expect(raven.captureMessage).toHaveBeenCalledWith(
 			expect.any(String),
@@ -62,7 +59,7 @@ describe('sentinel', () => {
 	});
 
 	test('does use the commercial-sentinel tag', () => {
-		mocked(config.get).mockReturnValue(true);
+		config.get.mockReturnValue(true);
 		amIUsed('moduleName', 'functionName');
 		expect(raven.captureMessage).toHaveBeenCalledWith(
 			expect.any(String),


### PR DESCRIPTION
## What does this change?

Simplify mocking pattern used in `sentinel.spec.ts`

Thank you @mxdvl 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)
