### PR TITLE
Identity | Sign In Gate | Setup switch for Australia mandatory test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -23,4 +23,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2021, 12, 1),
     exposeClientSide = true,
   )
+
+  Switch(
+    ABTests,
+    "ab-sign-in-gate-aus-mandatory",
+    "Mandatory sign in gate to users in australia split test",
+    owners = Seq(Owner.withGithub("coldlink")),
+    safeState = Off,
+    sellByDate = new LocalDate(2021, 12, 1),
+    exposeClientSide = true,
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.js
@@ -2,10 +2,12 @@ import { signInGateMainVariant } from 'common/modules/experiments/tests/sign-in-
 import { signInGateMainControl } from 'common/modules/experiments/tests/sign-in-gate-main-control';
 import { puzzlesBanner } from 'common/modules/experiments/tests/puzzles-banner';
 import { remoteRRHeaderLinksTest } from 'common/modules/experiments/tests/remote-header-test';
+import { signInGateAusMandatory } from 'common/modules/experiments/tests/sign-in-gate-aus-mandatory';
 
 export const concurrentTests = [
     signInGateMainVariant,
     signInGateMainControl,
+    signInGateAusMandatory,
     puzzlesBanner,
     remoteRRHeaderLinksTest,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-aus-mandatory.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-aus-mandatory.js
@@ -5,8 +5,8 @@ export const signInGateAusMandatory = {
 	author: 'Mahesh Makani',
 	description:
 		'Compare mandatory gate (an article sigin gate without the dismiss button) with the main signin gate for australia only',
-	audience: 0.05,
-	audienceOffset: 0.85,
+	audience: 0.01,
+	audienceOffset: 0.89,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:
 		'3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss or reshown after 5 dismisses, not on help, info sections etc. exclude iOS 9 and guardian-live-australia, AUS only, only users with specific CMP consents. Suppresses other banners, and appears over epics',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-aus-mandatory.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-aus-mandatory.js
@@ -1,0 +1,28 @@
+export const signInGateAusMandatory = {
+	id: 'SignInGateAusMandatory',
+	start: '2020-06-07',
+	expiry: '2021-12-01',
+	author: 'Mahesh Makani',
+	description:
+		'Compare mandatory gate (an article sigin gate without the dismiss button) with the main signin gate for australia only',
+	audience: 0.2,
+	audienceOffset: 0.7,
+	successMeasure: 'Users sign in or create a Guardian account',
+	audienceCriteria:
+		'3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss or reshown after 5 dismisses, not on help, info sections etc. exclude iOS 9 and guardian-live-australia, AUS only, only users with specific CMP consents. Suppresses other banners, and appears over epics',
+	dataLinkNames: 'SignInGateAusMandatory',
+	idealOutcome:
+		'We believe that a mandatory sign in gate will increase sign in conversion by 30% vs a dismissable sign in gate.',
+	showForSensitive: false,
+	canRun: () => true,
+	variants: [
+		{
+			id: 'aus-mandatory-gate-control',
+			test: () => {},
+		},
+		{
+			id: 'aus-mandatory-gate-variant',
+			test: () => {},
+		},
+	],
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-aus-mandatory.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-aus-mandatory.js
@@ -5,8 +5,8 @@ export const signInGateAusMandatory = {
 	author: 'Mahesh Makani',
 	description:
 		'Compare mandatory gate (an article sigin gate without the dismiss button) with the main signin gate for australia only',
-	audience: 0.2,
-	audienceOffset: 0.7,
+	audience: 0.05,
+	audienceOffset: 0.85,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:
 		'3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss or reshown after 5 dismisses, not on help, info sections etc. exclude iOS 9 and guardian-live-australia, AUS only, only users with specific CMP consents. Suppresses other banners, and appears over epics',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
@@ -8,7 +8,7 @@ export const signInGateMainVariant = {
     author: 'Mahesh Makani',
     description:
         'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Main/Variant Audience.',
-    audience: 0.7,
+    audience: 0.85,
     audienceOffset: 0.0,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
@@ -8,7 +8,7 @@ export const signInGateMainVariant = {
     author: 'Mahesh Makani',
     description:
         'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Main/Variant Audience.',
-    audience: 0.9,
+    audience: 0.7,
     audienceOffset: 0.0,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
@@ -8,7 +8,7 @@ export const signInGateMainVariant = {
     author: 'Mahesh Makani',
     description:
         'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Main/Variant Audience.',
-    audience: 0.85,
+    audience: 0.89,
     audienceOffset: 0.0,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:


### PR DESCRIPTION
## What does this change?

Adds the test definition and switch and changes for the Sign In Gate Aus Mandatory test in DCR. See the DCR PR for more information.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

https://github.com/guardian/dotcom-rendering/pull/3087

## Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
