### PR TITLE
Add sentinel to `article-body-adverts` and `next-video-autoplay`

### DIFF
--- a/dev/jest.setupTestFrameworkScriptFile.js
+++ b/dev/jest.setupTestFrameworkScriptFile.js
@@ -1,9 +1,10 @@
 // Polyfill test environment (done by polyfill.io in production)
 require('core-js');
 
-jest.mock('../static/src/javascripts/projects/commercial/sentinel', () => {
-    amIUsed: jest.fn();
-});
+jest.mock('../static/src/javascripts/projects/commercial/sentinel', () => ({
+    amIUsed: jest.fn()
+}));
+
 
 // Stub global Guardian config
 // eslint-disable-next-line id-denylist -- this is on purpose

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -10,6 +10,7 @@ import { createSlots } from './dfp/create-slots';
 
 import { commercialFeatures } from '../../common/modules/commercial/commercial-features';
 import { initCarrot } from './carrot-traffic-driver';
+import { amIUsed } from 'commercial/sentinel';
 
 
 
@@ -263,6 +264,7 @@ const doInit = () => {
 };
 
 export const init = () => {
+    amIUsed('article-body-adverts','init')
     // Also init when the main article is redisplayed
     // For instance by the signin gate.
     mediator.on('page:article:redisplayed', doInit);

--- a/static/src/javascripts/projects/commercial/modules/hosted/next-video-autoplay.ts
+++ b/static/src/javascripts/projects/commercial/modules/hosted/next-video-autoplay.ts
@@ -69,6 +69,7 @@ const canAutoplay = (): boolean => !!($hostedNext && nextVideoPage);
 
 const init = (): Promise<void> =>
 	load().then(() => {
+		amIUsed('next-video-autoplay', 'init');
 		$hostedNext = document.querySelector('.js-hosted-next-autoplay');
 		$timer = document.querySelector('.js-autoplay-timer');
 		nextVideoPage = $timer?.dataset.nextPage;


### PR DESCRIPTION
## What does this change?
This change introduces `amIUsed` to the `init` method of two modules:

`article-body-adverts`
`next-video-autoplay`

This was done to make sure `amIUsed` events are correctly logged into Sentry, as the expecation is that `init` functions should be called much more frequently. Once we've ascertained that logging is working as intended, this change can safely be reverted (so as to avoid being overwhelmed by logs) and we can start using `amIUsed` in the codebase with much more confidence.

Reversion PR: #23893 

## What is sentinel?
See #23878 
