### PR TITLE
 Update RR links to support new header test 

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -23,6 +23,7 @@ import {
 } from './contributions-utilities';
 import {
     ARTICLES_VIEWED_OPT_OUT_COOKIE,
+    getLastOneOffContributionTimestamp,
     getLastOneOffContributionDate,
     isRecurringContributor,
     shouldHideSupportMessaging,
@@ -130,7 +131,7 @@ const buildEpicPayload = async () => {
         showSupportMessaging: !shouldHideSupportMessaging(),
         isRecurringContributor: isRecurringContributor(),
         lastOneOffContributionDate:
-            getLastOneOffContributionDate() || undefined,
+            getLastOneOffContributionTimestamp() || undefined,
         mvtId: getMvtValue(),
         countryCode,
         epicViewLog: getViewLog(),
@@ -162,6 +163,7 @@ const buildHeaderLinksPayload = () => {
             countryCode,
             modulesVersion: ModulesVersion,
             mvtId: getMvtValue(),
+            lastOneOffContributionDate: getLastOneOffContributionDate() || undefined,
         },
     };
 }

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -180,7 +180,7 @@ const isPayingMember = () =>
     isUserLoggedIn() && getCookie(PAYING_MEMBER_COOKIE) !== 'false';
 
 // Expects milliseconds since epoch
-const getSupportFrontendOneOffContributionDate = () => {
+const getSupportFrontendOneOffContributionTimestamp = () => {
     const supportFrontendCookie = getCookie(
         SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE
     );
@@ -194,7 +194,7 @@ const getSupportFrontendOneOffContributionDate = () => {
 };
 
 // Expects YYYY-MM-DD format
-const getAttributesOneOffContributionDate = () => {
+const getAttributesOneOffContributionTimestamp = () => {
     const attributesCookie = getCookie(ONE_OFF_CONTRIBUTION_DATE_COOKIE);
 
     if (attributesCookie) {
@@ -207,9 +207,24 @@ const getAttributesOneOffContributionDate = () => {
 
 // number returned is Epoch time in milliseconds.
 // null value signifies no last contribution date.
-const getLastOneOffContributionDate = () =>
-    getSupportFrontendOneOffContributionDate() ||
-    getAttributesOneOffContributionDate();
+const getLastOneOffContributionTimestamp = () =>
+    getSupportFrontendOneOffContributionTimestamp() ||
+    getAttributesOneOffContributionTimestamp();
+
+const getLastOneOffContributionDate = () => {
+	const timestamp = getLastOneOffContributionTimestamp();
+
+	if (timestamp === null) {
+		return null;
+	}
+
+	const date = new Date(timestamp);
+	const year = date.getFullYear();
+	const month = (date.getMonth() + 1).toString().padStart(2, '0');
+	const day = date.getDate().toString().padStart(2, '0');
+
+	return `${year}-${month}-${day}`;
+}
 
 const getLastRecurringContributionDate = () => {
     // Check for cookies, ensure that cookies parse, and ensure parsed results are integers
@@ -236,7 +251,7 @@ const getLastRecurringContributionDate = () => {
 };
 
 const getDaysSinceLastOneOffContribution = () => {
-    const lastContributionDate = getLastOneOffContributionDate();
+    const lastContributionDate = getLastOneOffContributionTimestamp();
     if (lastContributionDate === null) {
         return null;
     }
@@ -336,6 +351,7 @@ export {
     shouldHideSupportMessaging,
     refresh,
     deleteOldData,
+    getLastOneOffContributionTimestamp,
     getLastOneOffContributionDate,
     getLastRecurringContributionDate,
     getDaysSinceLastOneOffContribution,

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -9,7 +9,7 @@ import {
     isRecurringContributor,
     accountDataUpdateWarning,
     isDigitalSubscriber,
-    getLastOneOffContributionDate,
+    getLastOneOffContributionTimestamp,
     getDaysSinceLastOneOffContribution,
     isRecentOneOffContributor,
     shouldNotBeShownSupportMessaging,
@@ -455,24 +455,24 @@ describe('getting the last one-off contribution date of a user', () => {
     const contributionDateTimeEpoch = Date.parse(contributionDate);
 
     it("returns null if the user hasn't previously contributed", () => {
-        expect(getLastOneOffContributionDate()).toBe(null);
+        expect(getLastOneOffContributionTimestamp()).toBe(null);
     });
 
     it('return the correct date if the user support-frontend contribution cookie is set', () => {
         setSupportFrontendOneOffContributionCookie(
             contributionDateTimeEpoch.toString()
         );
-        expect(getLastOneOffContributionDate()).toBe(contributionDateTimeEpoch);
+        expect(getLastOneOffContributionTimestamp()).toBe(contributionDateTimeEpoch);
     });
 
     it('returns null if the cookie has been set with an invalid value', () => {
         setSupportFrontendOneOffContributionCookie('invalid value');
-        expect(getLastOneOffContributionDate()).toBe(null);
+        expect(getLastOneOffContributionTimestamp()).toBe(null);
     });
 
     it('returns the correct date if cookie from attributes is set', () => {
         setAttributesOneOffContributionCookie(contributionDate.toString());
-        expect(getLastOneOffContributionDate()).toBe(contributionDateTimeEpoch);
+        expect(getLastOneOffContributionTimestamp()).toBe(contributionDateTimeEpoch);
     });
 });
 

--- a/static/src/javascripts/projects/common/modules/navigation/membership.js
+++ b/static/src/javascripts/projects/common/modules/navigation/membership.js
@@ -1,7 +1,7 @@
 import {
     isPayingMember,
     accountDataUpdateWarning,
-    getLastOneOffContributionDate,
+    getLastOneOffContributionTimestamp,
     getLastRecurringContributionDate,
 } from 'common/modules/commercial/user-features';
 import fastdom from 'lib/fastdom-promise';
@@ -144,7 +144,7 @@ export const membershipBanner = {
 };
 
 export const initMembership = () => {
-    const lastOneOff = getLastOneOffContributionDate();
+    const lastOneOff = getLastOneOffContributionTimestamp();
     const lastRecurring = getLastRecurringContributionDate();
 
     if (lastOneOff) {

--- a/static/src/stylesheets/layout/nav/_cta-bar.scss
+++ b/static/src/stylesheets/layout/nav/_cta-bar.scss
@@ -1,18 +1,15 @@
 .new-header__cta-bar {
-    position: absolute;
-    top: 30px;
-    left: $gs-gutter / 2;
-
-    @include mq(mobileMedium) {
-        top: 37px;
-    }
+    padding-top: 33px;
+    padding-left: 10px;
+    max-width: 310px;
 
     @include mq(mobileLandscape) {
-        left: $gs-gutter;
+        padding-left: $gs-gutter;
     }
 
     @include mq(tablet) {
-        top: 0;
+        padding-top: 4px;
+        padding-bottom: 20px;
     }
 
     @include mq(desktop) {


### PR DESCRIPTION
## What does this change?
Send last one off contribution date to SDC for our "support again" header test. The corresponding DCR PR is: https://github.com/guardian/dotcom-rendering/pull/3091/files#diff-5021052c4003acf93b233ffc9614f5baab19911581b166f4318997430c36330eR110-R115

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [x] Locally
- [ ] On CODE (optional)