### PR TITLE
Remove sentinel test from `article-body-adverts` and `next-video-autoplay`

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -10,7 +10,6 @@ import { createSlots } from './dfp/create-slots';
 
 import { commercialFeatures } from '../../common/modules/commercial/commercial-features';
 import { initCarrot } from './carrot-traffic-driver';
-import { amIUsed } from 'commercial/sentinel';
 
 
 
@@ -264,7 +263,6 @@ const doInit = () => {
 };
 
 export const init = () => {
-    amIUsed('article-body-adverts','init')
     // Also init when the main article is redisplayed
     // For instance by the signin gate.
     mediator.on('page:article:redisplayed', doInit);

--- a/static/src/javascripts/projects/commercial/modules/hosted/next-video-autoplay.ts
+++ b/static/src/javascripts/projects/commercial/modules/hosted/next-video-autoplay.ts
@@ -69,7 +69,6 @@ const canAutoplay = (): boolean => !!($hostedNext && nextVideoPage);
 
 const init = (): Promise<void> =>
 	load().then(() => {
-		amIUsed('next-video-autoplay', 'init');
 		$hostedNext = document.querySelector('.js-hosted-next-autoplay');
 		$timer = document.querySelector('.js-autoplay-timer');
 		nextVideoPage = $timer?.dataset.nextPage;


### PR DESCRIPTION
## What does this change?
This change removes the `amIUsed` sentinel logging from the `init` functions of the following modules:

- `article-body-adverts`
- `next-video-autoplay`

This PR is a fix for #23893, which was supposed to address this but didn't.

## What is Sentinel?
See #23878