### PR TITLE
Hardcode football subdomain to allow basic cross-platform smart match redirects

### DIFF
--- a/sport/app/football/model/TeamMap.scala
+++ b/sport/app/football/model/TeamMap.scala
@@ -158,6 +158,9 @@ object MatchUrl {
 
   def smartUrl(theMatch: FootballMatch): Option[String] = {
     if (Football.hoursTillMatch(theMatch) > 72) None
-    else Some(s"/football/match-redirect/${theMatch.id}")
+    // We are trialling using the football subdomain for smart match redirects
+    // This is because they will still work on web (with an extra redirect), but
+    // importantly they will not be intercepted by apps and so work there too (via a webview)
+    else Some(s"https://football.theguardian.com/match-redirect/${theMatch.id}")
   }
 }


### PR DESCRIPTION
## What does this change?
This switches to a hardcoded domain for smart match redirect URLs so that they (semi) work when visited via the  apps. The reason we are doing this is because a number of football components are going to be shared between app and web, so we need match links that work on both. This is proving a little tricky in a short space of time because we don't currently have the exact match-report/min-by-min link available, all we have is a redirect URL that sends you to the correct destination as appropriate. That is fine, but doesn't work on app because the native layer does not understand such URLs. Without the time to build this feature into the apps (and while we work on a different solution) this change will act as a fallback, where at least the links will open in a webview if visited from apps.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
Cross-platform match links work (better). The downside is that quite a few places will now have football.theguardian.com links even though not strictly necessary. This means slightly worse URL UX for users and an extra hop.