### PR TITLE
remove height transition for fluid ads

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -430,14 +430,6 @@
         width: 100%;
     }
 
-    &.ad-slot--commercial-component-high {
-
-        &,
-        & > .ad-slot__content > iframe {
-            transition: height 1s;
-        }
-    }
-
     &.ad-slot--liveblog-inline {
         @include mq(mobile, $until: mobileLandscape) {
             margin-left: $gs-gutter / -2;


### PR DESCRIPTION
## What does this change?

Removes the animation when an iframe loads..

cc @ashishpuliyel, @MarSavar

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

https://user-images.githubusercontent.com/76776/121372920-a5008f80-c90c-11eb-9e17-b2ebc8f19141.mp4

## What is the value of this and can you measure success?

The transition is long, and doesn’t help with CLS.

### Tested

- [ ] Locally
- [ ] On CODE (optional)
