### PR TITLE
Implement Snyk Github Actions

### DIFF
--- a/.github/workflows/snyk-node.yml
+++ b/.github/workflows/snyk-node.yml
@@ -1,7 +1,7 @@
 # This action runs every day at 6 AM and on every push
 # If the branch it's running on is main then it will run snyk monitor (reports vulnerabilities to snyk.io)
 # Otherwise it will run snyk test
-name: Snyk
+name: Snyk - Node
 
 on:
     schedule:

--- a/.github/workflows/snyk-node.yml
+++ b/.github/workflows/snyk-node.yml
@@ -24,9 +24,14 @@ jobs:
 
             - name: Run Snyk to check for vulnerabilities
               uses: snyk/actions/node@0.3.0
+              continue-on-error: true # To make sure that SARIF upload gets called
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
               with:
-                  args: --org=the-guardian --project-name=${{ github.repository }} --dev=true
+                  args: --org=the-guardian --project-name=${{ github.repository }} --dev=true --sarif-file-output=snyk-node.sarif
                   command: ${{ env.SNYK_COMMAND }}
+            - name: Upload result to GitHub Code Scanning
+              uses: github/codeql-action/upload-sarif@v1
+              with:
+                  sarif_file: snyk-node.sarif
 

--- a/.github/workflows/snyk-node.yml
+++ b/.github/workflows/snyk-node.yml
@@ -1,0 +1,32 @@
+# This action runs every day at 6 AM and on every push
+# If the branch it's running on is main then it will run snyk monitor (reports vulnerabilities to snyk.io)
+# Otherwise it will run snyk test
+name: Snyk
+
+on:
+    schedule:
+        - cron: "0 6 * * *"
+    push:
+    workflow_dispatch:
+
+jobs:
+    security:
+        runs-on: ubuntu-latest
+        env:
+            SNYK_COMMAND: test
+        steps:
+            - name: Checkout branch
+              uses: actions/checkout@v2
+
+            - name: Set command to monitor
+              if: github.ref == 'refs/heads/main'
+              run: echo "SNYK_COMMAND=monitor" >> $GITHUB_ENV
+
+            - name: Run Snyk to check for vulnerabilities
+              uses: snyk/actions/node@0.3.0
+              env:
+                  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+              with:
+                  args: --org=the-guardian --project-name=${{ github.repository }} --dev=true
+                  command: ${{ env.SNYK_COMMAND }}
+

--- a/.github/workflows/snyk-scala.yml
+++ b/.github/workflows/snyk-scala.yml
@@ -24,8 +24,14 @@ jobs:
 
             - name: Run Snyk to check for vulnerabilities
               uses: snyk/actions/scala@0.3.0
+              continue-on-error: true # To make sure that SARIF upload gets called
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
               with:
-                  args: --org=the-guardian --project-name=${{ github.repository }}
+                  args: --org=the-guardian --project-name=${{ github.repository }} --file=build.sbt --sarif-file-output=snyk-scala.sarif
+
                   command: ${{ env.SNYK_COMMAND }}
+            - name: Upload result to GitHub Code Scanning
+              uses: github/codeql-action/upload-sarif@v1
+              with:
+                  sarif_file: snyk-scala.sarif

--- a/.github/workflows/snyk-scala.yml
+++ b/.github/workflows/snyk-scala.yml
@@ -1,7 +1,7 @@
 # This action runs every day at 6 AM and on every push
 # If the branch it's running on is main then it will run snyk monitor (reports vulnerabilities to snyk.io)
 # Otherwise it will run snyk test
-name: Snyk
+name: Snyk - Scala
 
 on:
     schedule:

--- a/.github/workflows/snyk-scala.yml
+++ b/.github/workflows/snyk-scala.yml
@@ -1,0 +1,31 @@
+# This action runs every day at 6 AM and on every push
+# If the branch it's running on is main then it will run snyk monitor (reports vulnerabilities to snyk.io)
+# Otherwise it will run snyk test
+name: Snyk
+
+on:
+    schedule:
+        - cron: '0 6 * * *'
+    push:
+    workflow_dispatch:
+
+jobs:
+    security:
+        runs-on: ubuntu-latest
+        env:
+            SNYK_COMMAND: test
+        steps:
+            - name: Checkout branch
+              uses: actions/checkout@v2
+
+            - name: Set command to monitor
+              if: github.ref == 'refs/heads/main'
+              run: echo "SNYK_COMMAND=monitor" >> $GITHUB_ENV
+
+            - name: Run Snyk to check for vulnerabilities
+              uses: snyk/actions/scala@0.3.0
+              env:
+                  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+              with:
+                  args: --org=the-guardian --project-name=${{ github.repository }}
+                  command: ${{ env.SNYK_COMMAND }}


### PR DESCRIPTION
We want/need Snyk on our repos and projects, but there are a number of
drawbacks to using the existing Github integration, namely that it can
block deployments due to vulnerabilities unrelated to the code changes
in place.

The alternative introduced here is to use the Github Action instead.
This doesn't block anything, the config is version controlled and it
still gives devs the relevant info.

