### PR TITLE
Only upload sarif file when not on main

### DIFF
--- a/.github/workflows/snyk-node.yml
+++ b/.github/workflows/snyk-node.yml
@@ -31,6 +31,7 @@ jobs:
                   args: --org=the-guardian --project-name=${{ github.repository }} --dev=true --sarif-file-output=snyk-node.sarif
                   command: ${{ env.SNYK_COMMAND }}
             - name: Upload result to GitHub Code Scanning
+              if: github.ref != 'refs/heads/main'
               uses: github/codeql-action/upload-sarif@v1
               with:
                   sarif_file: snyk-node.sarif

--- a/.github/workflows/snyk-scala.yml
+++ b/.github/workflows/snyk-scala.yml
@@ -32,6 +32,7 @@ jobs:
 
                   command: ${{ env.SNYK_COMMAND }}
             - name: Upload result to GitHub Code Scanning
+              if: github.ref != 'refs/heads/main'
               uses: github/codeql-action/upload-sarif@v1
               with:
                   sarif_file: snyk-scala.sarif


### PR DESCRIPTION
## What does this change?
Only runs the SARIF file upload step of the Snyk github actions if not on `main` branch. This is because `snyk monitor`, which runs on `main` doesn't produce output in the same way that `snyk test` does. Without this, the upload SARIF step will fail and create email noise.
