### PR TITLE
Add security docs and allow checking of dev dependencies

### DIFF
--- a/.github/workflows/snyk-node.yml
+++ b/.github/workflows/snyk-node.yml
@@ -1,19 +1,17 @@
 # This action runs every day at 6 AM and on every push
 # If the branch it's running on is main then it will run snyk monitor (reports vulnerabilities to snyk.io)
 # Otherwise it will run snyk test
-name: Snyk - Node
+name: Snyk
 
 on:
     schedule:
-        - cron: "0 6 * * *"
+        - cron: '0 6 * * *'
     push:
     workflow_dispatch:
 
 jobs:
     security:
         runs-on: ubuntu-latest
-        env:
-            SNYK_COMMAND: test
         steps:
             - name: Checkout branch
               uses: actions/checkout@v2
@@ -28,11 +26,19 @@ jobs:
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
               with:
-                  args: --org=the-guardian --project-name=${{ github.repository }} --dev=true --sarif-file-output=snyk-node.sarif
-                  command: ${{ env.SNYK_COMMAND }}
+                  args: --org=the-guardian --project-name=${{ github.repository }} --dev=true --prune-repeated-subdependencies --sarif-file-output=snyk-node.sarif
+                  command: test
             - name: Upload result to GitHub Code Scanning
-              if: github.ref != 'refs/heads/main'
               uses: github/codeql-action/upload-sarif@v1
               with:
                   sarif_file: snyk-node.sarif
 
+            - name: Run Snyk monitor to update snyk.io
+              if: github.ref == 'refs/heads/main'
+              uses: snyk/actions/node@0.3.0
+              continue-on-error: true # To make sure that SARIF upload gets called
+              env:
+                  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+              with:
+                  args: --org=the-guardian --project-name=${{ github.repository }} --dev=true --prune-repeated-subdependencies
+                  command: monitor

--- a/.github/workflows/snyk-scala.yml
+++ b/.github/workflows/snyk-scala.yml
@@ -12,15 +12,9 @@ on:
 jobs:
     security:
         runs-on: ubuntu-latest
-        env:
-            SNYK_COMMAND: test
         steps:
             - name: Checkout branch
               uses: actions/checkout@v2
-
-            - name: Set command to monitor
-              if: github.ref == 'refs/heads/main'
-              run: echo "SNYK_COMMAND=monitor" >> $GITHUB_ENV
 
             - name: Run Snyk to check for vulnerabilities
               uses: snyk/actions/scala@0.3.0
@@ -30,9 +24,19 @@ jobs:
               with:
                   args: --org=the-guardian --project-name=${{ github.repository }} --file=build.sbt --sarif-file-output=snyk-scala.sarif
 
-                  command: ${{ env.SNYK_COMMAND }}
+                  command: test
             - name: Upload result to GitHub Code Scanning
               if: github.ref != 'refs/heads/main'
               uses: github/codeql-action/upload-sarif@v1
               with:
                   sarif_file: snyk-scala.sarif
+
+            - name: Run Snyk monitor to update snyk.io
+              if: github.ref == 'refs/heads/main'
+              uses: snyk/actions/node@0.3.0
+              continue-on-error: true # To make sure that SARIF upload gets called
+              env:
+                  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+              with:
+                  args: --org=the-guardian --project-name=${{ github.repository }} --file=build.sbt
+                  command: monitor

--- a/docs/04-quality/04-security.md
+++ b/docs/04-quality/04-security.md
@@ -1,0 +1,7 @@
+# Security
+
+[General security advice can be found in the `guardian/recommendations` repo](https://github.com/guardian/recommendations/blob/master/security.md)
+## Snyk Code Scanning
+There's a Github action set up on the repository to scan for vulnerabilities. This is set to "continue on error" and so will show a green tick regardless. In order to check the vulnerabilities we can use the Github code scanning feature in the security tab and this will list all vulnerabilities for a given branch etc. You should use this if adding/removing/updating packages to see if there are any vulnerabilities.
+
+There are two Snyk actions - one for Scala code and one for Javascript. The Scala one takes a bit longer, so be patient with it before panicking.

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,7 @@
 - [Browsers support](04-quality/01-browser-support.md)
 - [Browser support principles](04-quality/02-browser-support-principles.md)
 - [Accessibility](04-quality/03-accessibility.md)
+- [Security](04-quality/04-security.md)
 
 ## [Commercial](05-commercial/)
 - [⚠️ Moved to https://github.com/guardian/commercial-core/blob/3a8c75e619c2e4ac2d731d251f5bf186f7af89dd/docs/GAM-Advertising.md ⚠️](05-commercial/01-DFP-Advertising.md)
@@ -61,8 +62,6 @@
 
 ## [Performance](07-performance/)
 - [Performance reading list](07-performance/01-performance-reading.md)
-
-## [Design](08-design/)
 
 ## [Archives](99-archives/)
 - [Recipe for Breton crêpes](99-archives/crepes.md)


### PR DESCRIPTION
## What does this change?
- Adds Security docs  with a current focus around the new Snyk Github actions. 
- Run GH Action on `main` and upload results to code scanning.
- Handle dev dependencies in Node action by pruning repeated sub dependencies.