### PR TITLE
Improve Crossword Printout Style

### DIFF
--- a/static/src/stylesheets/print.scss
+++ b/static/src/stylesheets/print.scss
@@ -279,9 +279,3 @@ $logoHeight: 110px;
     font-size: 13px;
     text-align: left;
 }
-
-@media print {
-    crossword__clues--wrapper {
-        height: 60rem !important;
-    }
-}

--- a/static/src/stylesheets/print.scss
+++ b/static/src/stylesheets/print.scss
@@ -169,14 +169,16 @@ $logoHeight: 110px;
     // ironically browsers don't widely support it.
     @supports (zoom: 100%) {
         .content__head {
-            margin-top: $logoHeight * .5 !important;
+            margin-top: 75px !important;
+            margin-right: 25px !important;
         }
 
         &.content--article:before {
             display: block;
             zoom: 50%;
-            width: $logoWidth * .5 !important;
             height: $logoHeight * .5 !important;
+            padding-right: 64px;
+            padding-top: 35px;
         }
     }
 }
@@ -195,6 +197,9 @@ $logoHeight: 110px;
     // Clearfix
     overflow: hidden;
     width: auto !important;
+    padding-top: 30px !important;
+    padding-bottom: 25px !important;
+
 }
 
 .crossword__container__grid-wrapper {
@@ -273,4 +278,10 @@ $logoHeight: 110px;
 .crossword__instructions {
     font-size: 13px;
     text-align: left;
+}
+
+@media print {
+    crossword__clues--wrapper {
+        height: 60rem !important;
+    }
 }


### PR DESCRIPTION
## What does this change?

Moves the Guardian logo and text further onto the page to look neater when printing. Also adds spacing to the grid so it's usable.

## Screenshots
Before:

![Screenshot 2021-06-10 at 12 33 51](https://user-images.githubusercontent.com/35331926/121518409-59231880-c9e8-11eb-965d-ad384ead52a1.png)

After:

<img width="560" alt="Screenshot 2021-06-10 at 12 34 37" src="https://user-images.githubusercontent.com/35331926/121518441-63ddad80-c9e8-11eb-9b89-01124f09bf9d.png">


### Tested

- [x] Locally
- [ ] On CODE (optional)
