### PR TITLE
Use correct action for snyk monitor on Scala code

### DIFF
--- a/.github/workflows/snyk-scala.yml
+++ b/.github/workflows/snyk-scala.yml
@@ -33,7 +33,7 @@ jobs:
 
             - name: Run Snyk monitor to update snyk.io
               if: github.ref == 'refs/heads/main'
-              uses: snyk/actions/node@0.3.0
+              uses: snyk/actions/scala@0.3.0
               continue-on-error: true # To make sure that SARIF upload gets called
               env:
                   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## What does this change?
Uses correct action for the `snyk monitor` step of the Github action. Previously it was trying to use the `Node` action instead
