### PR TITLE
Identity | Sign In Gate | Aus Mandatory Test increase audience

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-aus-mandatory.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-aus-mandatory.js
@@ -5,8 +5,8 @@ export const signInGateAusMandatory = {
 	author: 'Mahesh Makani',
 	description:
 		'Compare mandatory gate (an article sigin gate without the dismiss button) with the main signin gate for australia only',
-	audience: 0.01,
-	audienceOffset: 0.89,
+	audience: 0.25,
+	audienceOffset: 0.65,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:
 		'3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss or reshown after 5 dismisses, not on help, info sections etc. exclude iOS 9 and guardian-live-australia, AUS only, only users with specific CMP consents. Suppresses other banners, and appears over epics',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
@@ -8,7 +8,7 @@ export const signInGateMainVariant = {
     author: 'Mahesh Makani',
     description:
         'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Main/Variant Audience.',
-    audience: 0.89,
+    audience: 0.65,
     audienceOffset: 0.0,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:


### PR DESCRIPTION
## What does this change?
- After running at 1% audience for the last two days to make sure that the reporting is working correctly, this PR increases the AB test audience to 25% after confirming with the analyst and sponsors.

## Why?
- To reach our target of 41k browsers in Australia seeing the mandatory gate