### PR TITLE
Add Euro 2020 to top of tables page

### DIFF
--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -27,6 +27,7 @@ class LeagueTableController(
 
   // Competitions must be added to this list to show up at /football/tables
   val tableOrder: Seq[String] = Seq(
+    "Euro 2020",
     "World Cup 2022 qualifying",
     "Premier League",
     "Bundesliga",

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -181,6 +181,16 @@ object CompetitionsProvider {
       startDate = Some(LocalDate.of(2018, 6, 1)),
     ),
     Competition(
+      "750",
+      "/football/euro-2020",
+      "Euro 2020",
+      "Euro 2020",
+      "Internationals",
+      showInTeamsList = true,
+      tableDividers = List(2),
+      startDate = Some(LocalDate.of(2019, 11, 30)),
+    ),
+    Competition(
       "701",
       "/football/world-cup-2022-qualifiers",
       "World Cup 2022 qualifying",
@@ -312,16 +322,6 @@ object CompetitionsProvider {
       "European",
     ),
     Competition("333", "/football/womens-fa-cup", "Women's FA Cup", "Women's FA Cup", "English"),
-    Competition(
-      "750",
-      "/football/euro-2020",
-      "Euro 2020",
-      "Euro 2020",
-      "Internationals",
-      showInTeamsList = true,
-      tableDividers = List(2),
-      startDate = Some(LocalDate.of(2019, 11, 30)),
-    ),
   )
 }
 


### PR DESCRIPTION
## What does this change?
Adds Euro 2020 to the `tableOrder` so that it appears on /football/tables and is selectable from the dropdown there. Speaking of the dropdown, the order they appear there is based on `Competitions` ordering, so I've moved Euro 2020 above the other internationals.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
![image](https://user-images.githubusercontent.com/8754692/121676058-13c81f00-caac-11eb-95f9-0be6509d97dc.png)
![image](https://user-images.githubusercontent.com/8754692/121676097-25a9c200-caac-11eb-97b9-4a83b7d1f517.png)

## What is the value of this and can you measure success?
Better visibility of the most important competition right now.