### PR TITLE
Log referer on user profile request

### DIFF
--- a/identity/app/controllers/PublicProfileController.scala
+++ b/identity/app/controllers/PublicProfileController.scala
@@ -41,6 +41,8 @@ class PublicProfileController(
       futureUser: => Future[Response[User]],
   ): Action[AnyContent] =
     Action.async { implicit request =>
+      logger.info(s"PublicProfileController findProfileDataAndRender URI is ${request.uri} - Referer is ${request.headers.get("Referer")}")
+
       futureUser.flatMap {
         case Left(errors) =>
           logger.info(s"public profile page returned errors ${errors.toString()}")

--- a/identity/app/controllers/PublicProfileController.scala
+++ b/identity/app/controllers/PublicProfileController.scala
@@ -41,7 +41,9 @@ class PublicProfileController(
       futureUser: => Future[Response[User]],
   ): Action[AnyContent] =
     Action.async { implicit request =>
-      logger.info(s"PublicProfileController findProfileDataAndRender URI is ${request.uri} - Referer is ${request.headers.get("Referer")}")
+      logger.info(
+        s"PublicProfileController findProfileDataAndRender URI is ${request.uri} - Referer is ${request.headers.get("Referer")}",
+      )
 
       futureUser.flatMap {
         case Left(errors) =>


### PR DESCRIPTION
## What does this change?

Log referer header on user profile request

We want to check which pages are linking to vanity profile URLs. We are considering removing vanity URLs or replacing them with username. 

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
