### PR TITLE
Remove hidden hide toggle on dynamic containers

### DIFF
--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -101,10 +101,6 @@ $block-height: 58px; // Note: duplicated from _item.scss
         }
     }
 
-    .fc-container__toggle {
-        display: none;
-    }
-
     .fc-container__header__title {
         padding-left: calc((#{$gs-baseline} / 2) - 2px);
         margin-bottom: $gs-baseline / 2;


### PR DESCRIPTION
## What does this change?

Dynamo hiding was previously unavailable but the usage of Dynamos has 'evolved' and both users and editors have requested it's added again.

### Before

![image](https://user-images.githubusercontent.com/638051/122051292-57889480-cddc-11eb-8017-434f0669bc20.png)

### After

![2021-06-15 13 18 34](https://user-images.githubusercontent.com/638051/122051315-5d7e7580-cddc-11eb-8338-35c7b49883ee.gif)

- Existing functionality. 
- Doesn't need replicating in DCR.
