### PR TITLE
Change "The Netherlands" to "Netherlands"

### DIFF
--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -15,7 +15,7 @@ import pa.{FootballMatch, LineUp, LineUpTeam, MatchDayTeam}
 import play.api.libs.json._
 import play.api.mvc._
 import play.twirl.api.Html
-import model.CompetitionDisplayHelpers.cleanTeamName
+import model.CompetitionDisplayHelpers.cleanTeamName2021
 
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
@@ -113,7 +113,7 @@ object NxAnswer {
     val players = makePlayers(teamV2)
     NxTeam(
       teamV1.id,
-      cleanTeamName(teamV1.name),
+      cleanTeamName2021(teamV1.name),
       players = players,
       score = teamV1.score.getOrElse(0),
       scorers = teamV1.scorers.fold(Nil: List[String])(

--- a/sport/app/football/model/model.scala
+++ b/sport/app/football/model/model.scala
@@ -164,6 +164,17 @@ object CompetitionDisplayHelpers {
       .replace("Holland", "The Netherlands")
   }
 
+  // This function has specifically raised for the 2021 Euros after some clarification.
+  // "We're happy with "Netherlands" as a label, like the keyword for football and also the news one you can see here:
+  // https://www.theguardian.com/world/2021/jun/11/princess-amalia-heir-to-dutch-throne-waives-right-to-yearly-income"
+  // - Philip Cornwall, 16/6/21
+  // I don't know if this is permanent going forward hence the separate function.
+  def cleanTeamName2021(teamName: String): String = {
+    teamName
+      .replace("Ladies", "")
+      .replace("Holland", "Netherlands")
+  }
+
   def cleanTeamCode(teamCode: String): String = {
     teamCode
       .replace("JAP", "JPN")


### PR DESCRIPTION
## What does this change?

The decision has been made to use `Netherlands` instead of `The Netherlands`.

As commented in the code, a new function has been made for this change in case we want to switch back.

## Screenshots

**Before**

<img width="281" alt="Screenshot 2021-06-14 at 16 37 38" src="https://user-images.githubusercontent.com/35331926/122243271-e6201300-cebb-11eb-90db-0a8aae19c8c5.png">

**After**

<img width="283" alt="Screenshot 2021-06-16 at 15 56 36" src="https://user-images.githubusercontent.com/35331926/122243365-f637f280-cebb-11eb-8606-88c4abc4920d.png">


### Tested

- [x] Locally
- [ ] On CODE (optional)


