### PR TITLE
Drop support for lookup user by Vanity URL

### DIFF
--- a/identity/app/controllers/PublicProfileController.scala
+++ b/identity/app/controllers/PublicProfileController.scala
@@ -3,6 +3,7 @@ package controllers
 import clients.DiscussionProfile
 import com.gu.identity.model.User
 import common.ImplicitControllerExecutionContext
+import idapiclient.responses.Error
 import idapiclient.{IdApiClient, Response}
 import model.Cached.RevalidatableResult
 import model.{ApplicationContext, Cached, IdentityPage}
@@ -29,7 +30,8 @@ class PublicProfileController(
     findProfileDataAndRender(
       "/user/" + vanityUrl,
       activityType,
-      identityApiClient.userFromVanityUrl(vanityUrl),
+      // IDAPI no longer supports lookup by Vanity URL. We return not found profile pages instead
+      Future.successful(Left(List(Error("Not Found", "Not Found", 404)))),
     )
 
   def renderProfileFromId(id: String, activityType: String): Action[AnyContent] =

--- a/identity/app/idapiclient/IdApiClient.scala
+++ b/identity/app/idapiclient/IdApiClient.scala
@@ -67,14 +67,6 @@ class IdApiClient(idJsonBodyParser: IdApiJsonBodyParser, conf: IdConfig, httpCli
     response map extractUser
   }
 
-  def userFromVanityUrl(vanityUrl: String, auth: Auth = Anonymous): Future[Response[User]] = {
-    val apiPath = urlJoin("user", "vanityurl", vanityUrl)
-    val params = buildParams(Some(auth))
-    val headers = buildHeaders(Some(auth))
-    val response = httpClient.GET(apiUrl(apiPath), None, params, headers)
-    response map extractUser
-  }
-
   def userFromQueryParam(param: String, field: String, auth: Auth = Anonymous): Future[Response[User]] = {
     val apiPath = s"/user?${field}=${param}"
     val params = buildParams(Some(auth))

--- a/identity/test/controllers/PublicProfileControllerTest.scala
+++ b/identity/test/controllers/PublicProfileControllerTest.scala
@@ -36,7 +36,6 @@ class PublicProfileControllerTest
     publicFields = PublicFields(
       displayName = Some("John Smith"),
       username = Some("John Smith"),
-      vanityUrl = Some(vanityUrl),
     ),
     dates = UserDates(
       accountCreatedDate = Some(new DateTime().minusDays(7)),
@@ -50,7 +49,6 @@ class PublicProfileControllerTest
     publicFields = PublicFields(
       displayName = Some("John Smith"),
       username = Some("John Smith"),
-      vanityUrl = Some(vanityUrl),
     ),
     dates = UserDates(
       accountCreatedDate = Some(new DateTime().minusDays(7)),
@@ -111,10 +109,6 @@ class PublicProfileControllerTest
   }
 
   "Given renderProfileFromVanityUrl is called" - Fake {
-    when(api.userFromVanityUrl(MockitoMatchers.anyString, MockitoMatchers.any[Auth])) thenReturn Future.successful(
-      Left(Nil),
-    )
-    when(api.userFromVanityUrl(vanityUrl)) thenReturn Future.successful(Right(user))
     when(discussionApi.findDiscussionUserFilterCommented(userId)) thenReturn Future.successful(Some(discussionProfile))
 
     "with valid user Id who has commented" - {
@@ -124,12 +118,8 @@ class PublicProfileControllerTest
         status(result) should be(200)
       }
 
-      val content = contentAsString(result)
-      "then rendered profile should include username" in {
-        content should include(user.publicFields.username.get)
-      }
-      "then rendered profile should include account creation date" in {
-        content should include(s"Registered on ${user.dates.accountCreatedDate.get.toString("d MMM yyyy")}")
+      "then rendered profile should display no comments found since vanity URLs are no longer supported in IDAPI" in {
+        contentAsString(result) should include("No comments found for user")
       }
     }
 

--- a/identity/test/idapiclient/IdApiTest.scala
+++ b/identity/test/idapiclient/IdApiTest.scala
@@ -79,7 +79,6 @@ class IdApiTest
       |        "publicFields": {
       |            "username": "testUsername",
       |            "displayName": "testUsername",
-      |            "vanityUrl": "testVanityUrl",
       |            "usernameLowerCase": "testusername"
       |        },
       |        "statusFields": {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Remove lookup by user vanity URLs.  When navigating to these pages users will see 'no comments for user'. Lookup by user ID is still supported (used by profile links on discussion)


## Why?

Currently, Vanity URLs are not being added to new accounts or on user updates. Vanity URLs are not referenced by discussion links (Identity IDs are used instead). Only around 35 successful vanityUrl lookups are made to Identity per day (via Dotcom Identity frontend). See https://github.com/guardian/identity/pull/1908