### PR TITLE
Apply the correct order to Euro 2020 for correct spider

### DIFF
--- a/sport/app/football/model/CompetitionStages.scala
+++ b/sport/app/football/model/CompetitionStages.scala
@@ -160,18 +160,18 @@ object KnockoutSpider {
     ),
     // Euro 2020
     "750" -> List(
-      ZonedDateTime.of(2021, 6, 26, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 37
-      ZonedDateTime.of(2021, 6, 26, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 38
-      ZonedDateTime.of(2021, 6, 27, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 39
       ZonedDateTime.of(2021, 6, 27, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 40
-      ZonedDateTime.of(2021, 6, 28, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 41
+      ZonedDateTime.of(2021, 6, 26, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 38
       ZonedDateTime.of(2021, 6, 28, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 42
-      ZonedDateTime.of(2021, 6, 29, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 43
+      ZonedDateTime.of(2021, 6, 28, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 41
       ZonedDateTime.of(2021, 6, 29, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 44
-      ZonedDateTime.of(2021, 7, 2, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Final  // Match 45
+      ZonedDateTime.of(2021, 6, 29, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 43
+      ZonedDateTime.of(2021, 6, 27, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 39
+      ZonedDateTime.of(2021, 6, 26, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 37
       ZonedDateTime.of(2021, 7, 2, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Final  // Match 46
-      ZonedDateTime.of(2021, 7, 3, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Final  // Match 47
+      ZonedDateTime.of(2021, 7, 2, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Final  // Match 45
       ZonedDateTime.of(2021, 7, 3, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Final  // Match 48
+      ZonedDateTime.of(2021, 7, 3, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Final  // Match 47
       ZonedDateTime.of(2021, 7, 6, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Semi-Final     // Match 49
       ZonedDateTime.of(2021, 7, 7, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Semi-Final     // Match 50
       ZonedDateTime.of(2021, 7, 11, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Final         // Match 51

--- a/sport/app/football/model/CompetitionStages.scala
+++ b/sport/app/football/model/CompetitionStages.scala
@@ -119,6 +119,12 @@ case class KnockoutSpider(
 object KnockoutSpider {
   // Pay attention to the timezone for the orderings
   // If the dates of the matches don't line up with the ordering dates, the ordering will be ignored.
+
+  /*
+    How to find the line ordering ?
+    To avoid the same drama every two or so years, see this PR: https://github.com/guardian/frontend/pull/23929
+   */
+
   val orderings: Map[String, List[ZonedDateTime]] = Map(
     // world cup 2018
     "700" -> List(


### PR DESCRIPTION
## What does this change?

Apply the correct order to Euro 2020 for correct spider

Ok, so every `n` years (with `n` approximatively equal to 2) we go through the same problem of trying to figure out how to display the spider correctly. Unfortunately there isn't a general, all encompassing, answer to this question. It's more an art than a science, but to avoid to stare at the code and the web page next time, and waiting for the brain cells to fire in the right order, here is how to think about it.

In this case I used the (assumed correct) BBC spider, stolen from here ( https://downloads.bbci.co.uk/euro2020/wallchartfinal.pdf ), and reproduced here in case that link dies.

<img width="1535" alt="Screenshot 2021-06-21 at 15 18 01" src="https://user-images.githubusercontent.com/6035518/122778316-ce260600-d2a4-11eb-9ba5-1bb0f596b5ee.png">

The spider is a tree, but it has an order to it. Let's move from the root (the finals to the "top left" of the BBC spider).  

The root / finals is Match 51. The "left", match is Match 49. 

Match 49 is 

<img width="236" alt="Screenshot 2021-06-21 at 15 27 54" src="https://user-images.githubusercontent.com/6035518/122778886-4987b780-d2a5-11eb-8edc-ea8b369e7a35.png">

The first / top match child of Match 49 is Match 46.

Match 46 is 

<img width="221" alt="Screenshot 2021-06-21 at 15 29 02" src="https://user-images.githubusercontent.com/6035518/122779040-6e7c2a80-d2a5-11eb-98b6-3805e353b7d8.png">

Match 46 is made of Match 40 and Match 38, which are leaves of the tree. Interestingly at this point we have identified the two first lines of the Scala spider code:

<img width="1436" alt="Screenshot 2021-06-21 at 15 30 46" src="https://user-images.githubusercontent.com/6035518/122779375-b4d18980-d2a5-11eb-8dfb-f66bc747ce8a.png">

Now, let's go back to Match 49, the next child is Match 45, which is made of 42 and 41. This gives you the next two lines of the Scala code

<img width="1489" alt="Screenshot 2021-06-21 at 15 32 21" src="https://user-images.githubusercontent.com/6035518/122779593-ecd8cc80-d2a5-11eb-9604-bc6a1f37364d.png">

And so on... 

You map the BBC matches to specific lines in the Scala code (each BBC match number corresponds to a unique Scala line, since there are no two lines with the same datetime for match start because no two matches start at the same time), and then the (admittedly arbitrary) Left/Right, Top/Down way I chose to read the BBC spider, gives me a natural ordering of the leaves of the BBC spider, that then corresponds to the ordering of your Scala code. At which point the Guardian spider "looks like", meaning has fundamentally the same shape, as the BBC one. 

Q: But then, if I had used the Wikipedia spider ? Would I have a different ordering of the Scala lines ?
A: Totally yes! And then the Guardian spider would look like (have the same logic) as the Wikipedia one. 

RESULT:

<img width="992" alt="Screenshot 2021-06-21 at 15 14 49" src="https://user-images.githubusercontent.com/6035518/122781566-d9c6fc00-d2a7-11eb-8dde-5b3c2689c0de.png">


<img width="989" alt="Screenshot 2021-06-21 at 15 05 15" src="https://user-images.githubusercontent.com/6035518/122781579-de8bb000-d2a7-11eb-9f85-55efafbb1410.png">
