### PR TITLE
Add interactive scripts to DCR logger

### DIFF
--- a/article/app/services/dotcomponents/DotcomponentsLogger.scala
+++ b/article/app/services/dotcomponents/DotcomponentsLogger.scala
@@ -3,9 +3,10 @@ package services.dotcomponents
 import common.GuLogging
 import common.LoggingField._
 import model.PageWithStoryPackage
+import model.liveblog.InteractiveBlockElement
 import play.api.mvc.RequestHeader
 
-import scala.util.Random
+import scala.util.{Random, Try}
 
 case class DotcomponentsLoggerFields(request: Option[RequestHeader]) {
 
@@ -47,6 +48,13 @@ case class DotcomponentsLogger(request: Option[RequestHeader]) extends GuLogging
       element <- main.elements
     } yield element.getClass.getSimpleName
 
+    val bodyInteractiveBlockScripts = for {
+      blocks <- page.article.blocks.toSeq
+      body <- blocks.body
+      interactiveElement <- body.elements if interactiveElement.isInstanceOf[InteractiveBlockElement]
+      scriptUrl <- Try(interactiveElement.asInstanceOf[InteractiveBlockElement]).toOption
+    } yield scriptUrl
+
     List(
       LogFieldString(
         "page.elements",
@@ -59,6 +67,10 @@ case class DotcomponentsLogger(request: Option[RequestHeader]) extends GuLogging
       LogFieldString(
         "page.tone",
         page.article.tags.tones.headOption.map(_.name).getOrElse(""),
+      ),
+      LogFieldString(
+        "page.bodyInteractiveElementScripts",
+        bodyInteractiveBlockScripts.distinct.mkString(", "),
       ),
     )
   }


### PR DESCRIPTION
## What does this change?
This adds a new field to the DotcomponentsLogger, which contains a csv of any interactive script URLs in the body of the article.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
We would like to know the frequency of re-use of certain scripts to determine the best approach for supporting/releasing the remaining interactive elements. Knowing what % of scripts are single-use and the frequency distribution of commonly used scripts will inform our decision making.