### PR TITLE
Fix commercial type warnings

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.spec.ts
@@ -10,6 +10,12 @@ import type { Advert } from './dfp/Advert';
 import { getAdvertById as getAdvertById_ } from './dfp/get-advert-by-id';
 import { refreshAdvert as refreshAdvert_ } from './dfp/load-advert';
 
+// Mock advert type by overwriting slot property with only one function for defining size mapping
+// This avoids having to set the rest of the slot properties that are unnecessary for the tests
+type MockAdvert = Omit<Advert, 'slot'> & {
+	slot: { defineSizeMapping: (asm: SizeMapping[]) => googletag.Slot };
+};
+
 // Workaround to fix issue where dataset is missing from jsdom, and solve the
 // 'cannot set property [...] which has only a getter' TypeError
 Object.defineProperty(HTMLElement.prototype, 'dataset', {
@@ -75,7 +81,7 @@ const generateInnerHtmlWithAdSlot = () => {
             </div>`;
 };
 
-const createTestAdvert = (testAdvert: Partial<Advert>): Advert =>
+const createTestAdvert = (testAdvert: Partial<MockAdvert>): Advert =>
 	({ ...testAdvert } as Advert);
 
 const getElement = (selector: string): Element =>

--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.ts
@@ -71,10 +71,7 @@ const containsDMPU = (ad: Advert): boolean =>
 const maybeUpgradeSlot = (ad: Advert, adSlot: Element): Advert => {
 	if (!containsDMPU(ad)) {
 		ad.sizes.desktop.push([300, 600], [160, 600]);
-		const defineSizeMappingFunction = ad.slot.defineSizeMapping as (
-			asm: SizeMapping[],
-		) => Slot;
-		defineSizeMappingFunction([[[0, 0], ad.sizes.desktop]]);
+		ad.slot.defineSizeMapping([[[0, 0], ad.sizes.desktop]]);
 		void fastdom.mutate(() => {
 			adSlot.setAttribute(
 				'data-desktop',

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -15,12 +15,6 @@ type Timings = {
 	lazyWaitComplete: number | null;
 };
 
-// Temporary definition until './define-slot' is converted to TypeScript
-type SlotDefinition = {
-	slot: Record<string, any>;
-	slotReady: Promise<void>;
-};
-
 /** A breakpoint can have various sizes assigned to it. You can assign either on
  * set of sizes or multiple.
  *
@@ -50,7 +44,7 @@ class Advert {
 	node: HTMLElement;
 	sizes: AdSizes;
 	size: AdSize | null = null;
-	slot: Record<string, unknown>;
+	slot: googletag.Slot;
 	isEmpty: boolean | null = null;
 	isLoading = false;
 	isRendering = false;
@@ -77,7 +71,7 @@ class Advert {
 
 	constructor(adSlotNode: HTMLElement) {
 		const sizes = getAdBreakpointSizes(adSlotNode);
-		const slotDefinition = defineSlot(adSlotNode, sizes) as SlotDefinition;
+		const slotDefinition = defineSlot(adSlotNode, sizes);
 
 		this.id = adSlotNode.id;
 		this.node = adSlotNode;

--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.ts
@@ -153,7 +153,7 @@ jest.mock('@guardian/libs', () => {
 		storage: jest.requireActual('@guardian/libs').storage,
 	};
 });
-jest.mock('lodash/once', () => (fn: <T>() => T) => fn);
+jest.mock('lodash/once', () => <T>(fn: () => T) => fn);
 jest.mock('./refresh-on-resize', () => ({
 	refreshOnResize: jest.fn(),
 }));

--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.ts
@@ -15,14 +15,12 @@ import { init as prepareGoogletag } from './prepare-googletag';
 
 // Note: this does not appear to be typed in @guardian/consent-management-platform
 type AUSRejectedMockType = {
-	aus: {
-		rejectedCategories:
-			| Array<{
-					_id: string;
-					name: string;
-			  }>
-			| never[];
-	};
+	rejectedCategories:
+		| Array<{
+				_id: string;
+				name: string;
+		  }>
+		| never[];
 };
 
 declare global {
@@ -59,19 +57,17 @@ const config = _config as {
 };
 
 interface TCFv2ConsentStateMockType {
-	tcfv2: {
-		consents: Record<string, boolean | null>;
-		vendorConsents: Record<string, boolean | null>;
-	};
+	consents: Record<string, boolean | null>;
+	vendorConsents: Record<string, boolean | null>;
 }
 
 const onConsentChange = onConsentChange_ as jest.MockedFunction<
 	(
 		fn: (
 			arg0:
-				| TCFv2ConsentStateMockType
+				| { tcfv2: TCFv2ConsentStateMockType }
 				| { ccpa: CCPAConsentState }
-				| AUSRejectedMockType,
+				| { aus: AUSRejectedMockType },
 		) => void,
 	) => void
 >;
@@ -211,7 +207,7 @@ const tcfv2WithConsent = {
 			'5f1aada6b8e05c306c0597d7': true, // Googletag
 		},
 	},
-} as TCFv2ConsentStateMockType;
+};
 
 const tcfv2WithoutConsent = {
 	tcfv2: {
@@ -226,7 +222,7 @@ const tcfv2WithoutConsent = {
 			'5f1aada6b8e05c306c0597d7': false, // Googletag
 		},
 	},
-} as TCFv2ConsentStateMockType;
+};
 
 // TODO: There is no null consent in the new CMP
 const tcfv2NullConsent = {
@@ -242,7 +238,7 @@ const tcfv2NullConsent = {
 			'5f1aada6b8e05c306c0597d7': null, // Googletag
 		},
 	},
-} as TCFv2ConsentStateMockType;
+};
 
 const tcfv2MixedConsent = {
 	tcfv2: {
@@ -257,7 +253,7 @@ const tcfv2MixedConsent = {
 			'5f1aada6b8e05c306c0597d7': true, // Googletag
 		},
 	},
-} as TCFv2ConsentStateMockType;
+};
 
 const ausNotRejected = {
 	aus: {
@@ -637,8 +633,11 @@ describe('DFP', () => {
 	describe('keyword targeting', () => {
 		it('should send page level keywords', async () => {
 			onConsentChange.mockImplementation(
-				(callback: (val: TCFv2ConsentStateMockType) => void) =>
-					callback(tcfv2WithConsent),
+				(
+					callback: (val: {
+						tcfv2: TCFv2ConsentStateMockType;
+					}) => void,
+				) => callback(tcfv2WithConsent),
 			);
 			getConsentFor.mockReturnValue(true);
 			await prepareGoogletag();
@@ -652,8 +651,11 @@ describe('DFP', () => {
 	describe('NPA flag is set correctly', () => {
 		it('when full TCF consent was given', async () => {
 			onConsentChange.mockImplementation(
-				(callback: (val: TCFv2ConsentStateMockType) => void) =>
-					callback(tcfv2WithConsent),
+				(
+					callback: (val: {
+						tcfv2: TCFv2ConsentStateMockType;
+					}) => void,
+				) => callback(tcfv2WithConsent),
 			);
 			getConsentFor.mockReturnValue(true);
 			await prepareGoogletag();
@@ -661,8 +663,11 @@ describe('DFP', () => {
 		});
 		it('when no TCF consent preferences were specified', async () => {
 			onConsentChange.mockImplementation(
-				(callback: (val: TCFv2ConsentStateMockType) => void) =>
-					callback(tcfv2NullConsent),
+				(
+					callback: (val: {
+						tcfv2: TCFv2ConsentStateMockType;
+					}) => void,
+				) => callback(tcfv2NullConsent),
 			);
 			getConsentFor.mockReturnValue(true);
 			await prepareGoogletag();
@@ -670,8 +675,11 @@ describe('DFP', () => {
 		});
 		it('when full TCF consent was denied', async () => {
 			onConsentChange.mockImplementation(
-				(callback: (val: TCFv2ConsentStateMockType) => void) =>
-					callback(tcfv2WithoutConsent),
+				(
+					callback: (val: {
+						tcfv2: TCFv2ConsentStateMockType;
+					}) => void,
+				) => callback(tcfv2WithoutConsent),
 			);
 			getConsentFor.mockReturnValue(false);
 			await prepareGoogletag();
@@ -679,8 +687,11 @@ describe('DFP', () => {
 		});
 		it('when only partial TCF consent was given', async () => {
 			onConsentChange.mockImplementation(
-				(callback: (val: TCFv2ConsentStateMockType) => void) =>
-					callback(tcfv2MixedConsent),
+				(
+					callback: (val: {
+						tcfv2: TCFv2ConsentStateMockType;
+					}) => void,
+				) => callback(tcfv2MixedConsent),
 			);
 			getConsentFor.mockReturnValue(false);
 			await prepareGoogletag();
@@ -690,7 +701,7 @@ describe('DFP', () => {
 	describe('NPA flag in AUS', () => {
 		it('when AUS has not retracted advertising consent', async () => {
 			onConsentChange.mockImplementation(
-				(callback: (val: AUSRejectedMockType) => void) =>
+				(callback: (val: { aus: AUSRejectedMockType }) => void) =>
 					callback(ausNotRejected),
 			);
 			getConsentFor.mockReturnValue(true);
@@ -699,7 +710,7 @@ describe('DFP', () => {
 		});
 		it('when AUS has retracted advertising consent', async () => {
 			onConsentChange.mockImplementation(
-				(callback: (val: AUSRejectedMockType) => void) =>
+				(callback: (val: { aus: AUSRejectedMockType }) => void) =>
 					callback(ausRejected),
 			);
 			getConsentFor.mockReturnValue(false);

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.ts
@@ -51,11 +51,15 @@ const setDfpListeners = (): void => {
 	if (!pubads) return;
 	pubads.addEventListener(
 		'slotRenderEnded',
-		raven.wrap(onSlotRender) as (arg0: any) => void,
+		raven.wrap(onSlotRender) as (
+			event: googletag.events.SlotRenderEndedEvent,
+		) => void,
 	);
 	pubads.addEventListener(
 		'slotOnload',
-		raven.wrap(onSlotLoad) as (arg0: any) => void,
+		raven.wrap(onSlotLoad) as (
+			event: googletag.events.SlotOnloadEvent,
+		) => void,
 	);
 
 	pubads.addEventListener('impressionViewable', onSlotViewableFunction());
@@ -72,7 +76,7 @@ const setPageTargeting = (): void => {
 	const pubads = window.googletag?.pubads();
 	if (!pubads) return;
 	// because commercialFeatures may export itself as {} in the event of an exception during construction
-	const targeting = getPageTargeting() as Record<string, any>;
+	const targeting = getPageTargeting() as Record<string, string | string[]>;
 	Object.keys(targeting).forEach((key) => {
 		pubads.setTargeting(key, targeting[key]);
 	});
@@ -144,7 +148,7 @@ export const init = (): Promise<void> => {
 			if (canRun) {
 				void loadScript(
 					(config as {
-						get: (arg: string, defaultValue: any) => string;
+						get: (arg: string, defaultValue: string) => string;
 					}).get(
 						'libs.googletag',
 						'//www.googletagservices.com/tag/js/gpt.js',

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.ts
@@ -18,7 +18,10 @@ import { renderAdvertLabel } from './render-advert-label';
  *
  */
 
-type Callback = {
+/**
+ * Types of events that are returned when executing a size change callback
+ */
+type CallbackEvent = {
 	event: {
 		slot: {
 			getOutOfPage: () => unknown;
@@ -28,7 +31,7 @@ type Callback = {
 
 const addClassIfHasClass = (newClassNames: string[]) =>
 	function hasClass(classNames: string[]) {
-		return function onAdvertRendered(_: Callback, advert: Advert) {
+		return function onAdvertRendered(_: CallbackEvent, advert: Advert) {
 			if (
 				classNames.some((className) =>
 					advert.node.classList.contains(className),
@@ -62,7 +65,7 @@ const removeStyleFromAdIframe = (
 
 const sizeCallbacks: Record<
 	string,
-	undefined | ((arg0: Callback, arg1: Advert) => Promise<void>)
+	undefined | ((arg0: CallbackEvent, arg1: Advert) => Promise<void>)
 > = {};
 
 /**
@@ -71,7 +74,7 @@ const sizeCallbacks: Record<
  * CSS transitions when expanding/collapsing various native style formats.
  */
 sizeCallbacks[adSizes.fluid.toString()] = (
-	renderSlotEvent: Callback,
+	renderSlotEvent: CallbackEvent,
 	advert: Advert,
 ) =>
 	addFluid(['ad-slot'])(renderSlotEvent, advert).then(() =>
@@ -82,7 +85,7 @@ sizeCallbacks[adSizes.fluid.toString()] = (
  * Trigger sticky scrolling for MPUs in the right-hand article column
  */
 sizeCallbacks[adSizes.mpu.toString()] = (
-	_: Callback,
+	_: CallbackEvent,
 	advert: Advert,
 ): Promise<void> =>
 	fastdom.measure(() => {
@@ -100,7 +103,10 @@ sizeCallbacks[adSizes.mpu.toString()] = (
 /**
  * Resolve the stickyMpu.whenRendered promise
  */
-sizeCallbacks[adSizes.halfPage.toString()] = (_: Callback, advert: Advert) =>
+sizeCallbacks[adSizes.halfPage.toString()] = (
+	_: CallbackEvent,
+	advert: Advert,
+) =>
 	fastdom.measure(() => {
 		if (advert.node.classList.contains('ad-slot--right')) {
 			stickyMpu(advert.node);
@@ -111,7 +117,10 @@ sizeCallbacks[adSizes.halfPage.toString()] = (_: Callback, advert: Advert) =>
 		void fastdom.mutate(() => advert.updateExtraSlotClasses());
 	});
 
-sizeCallbacks[adSizes.skyscraper.toString()] = (_: Callback, advert: Advert) =>
+sizeCallbacks[adSizes.skyscraper.toString()] = (
+	_: CallbackEvent,
+	advert: Advert,
+) =>
 	fastdom.measure(() => {
 		if (advert.node.classList.contains('ad-slot--right')) {
 			stickyMpu(advert.node);
@@ -124,13 +133,13 @@ sizeCallbacks[adSizes.skyscraper.toString()] = (_: Callback, advert: Advert) =>
 		);
 	});
 
-sizeCallbacks[adSizes.video.toString()] = (_: Callback, advert: Advert) =>
+sizeCallbacks[adSizes.video.toString()] = (_: CallbackEvent, advert: Advert) =>
 	fastdom.mutate(() => {
 		advert.updateExtraSlotClasses('u-h');
 	});
 
 sizeCallbacks[adSizes.outstreamDesktop.toString()] = (
-	_: Callback,
+	_: CallbackEvent,
 	advert: Advert,
 ) =>
 	fastdom.mutate(() => {
@@ -138,7 +147,7 @@ sizeCallbacks[adSizes.outstreamDesktop.toString()] = (
 	});
 
 sizeCallbacks[adSizes.outstreamGoogleDesktop.toString()] = (
-	_: Callback,
+	_: CallbackEvent,
 	advert: Advert,
 ) =>
 	fastdom.mutate(() => {
@@ -146,14 +155,17 @@ sizeCallbacks[adSizes.outstreamGoogleDesktop.toString()] = (
 	});
 
 sizeCallbacks[adSizes.outstreamMobile.toString()] = (
-	_: Callback,
+	_: CallbackEvent,
 	advert: Advert,
 ) =>
 	fastdom.mutate(() => {
 		advert.updateExtraSlotClasses('ad-slot--outstream');
 	});
 
-sizeCallbacks[adSizes.googleCard.toString()] = (_: Callback, advert: Advert) =>
+sizeCallbacks[adSizes.googleCard.toString()] = (
+	_: CallbackEvent,
+	advert: Advert,
+) =>
 	fastdom.mutate(() => {
 		advert.updateExtraSlotClasses('ad-slot--gc');
 	});
@@ -162,7 +174,7 @@ sizeCallbacks[adSizes.googleCard.toString()] = (_: Callback, advert: Advert) =>
  * Out of page adverts - creatives that aren't directly shown on the page - need to be hidden,
  * and their containers closed up.
  */
-const outOfPageCallback = ({ event }: Callback, advert: Advert) => {
+const outOfPageCallback = ({ event }: CallbackEvent, advert: Advert) => {
 	if (!event.slot.getOutOfPage()) {
 		const parent = advert.node.parentNode as HTMLElement;
 		return fastdom.mutate(() => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.ts
@@ -21,17 +21,10 @@ import { renderAdvertLabel } from './render-advert-label';
 /**
  * Types of events that are returned when executing a size change callback
  */
-type CallbackEvent = {
-	event: {
-		slot: {
-			getOutOfPage: () => unknown;
-		};
-	};
-};
 
 const addClassIfHasClass = (newClassNames: string[]) =>
 	function hasClass(classNames: string[]) {
-		return function onAdvertRendered(_: CallbackEvent, advert: Advert) {
+		return function onAdvertRendered(advert: Advert) {
 			if (
 				classNames.some((className) =>
 					advert.node.classList.contains(className),
@@ -65,7 +58,7 @@ const removeStyleFromAdIframe = (
 
 const sizeCallbacks: Record<
 	string,
-	undefined | ((arg0: CallbackEvent, arg1: Advert) => Promise<void>)
+	undefined | ((arg0: Advert, arg1?: SlotRenderEndedEvent) => Promise<void>)
 > = {};
 
 /**
@@ -73,21 +66,15 @@ const sizeCallbacks: Record<
  * The vertical-align property found on DFP iframes affects the smoothness of
  * CSS transitions when expanding/collapsing various native style formats.
  */
-sizeCallbacks[adSizes.fluid.toString()] = (
-	renderSlotEvent: CallbackEvent,
-	advert: Advert,
-) =>
-	addFluid(['ad-slot'])(renderSlotEvent, advert).then(() =>
+sizeCallbacks[adSizes.fluid.toString()] = (advert: Advert) =>
+	addFluid(['ad-slot'])(advert).then(() =>
 		removeStyleFromAdIframe(advert, 'vertical-align'),
 	);
 
 /**
  * Trigger sticky scrolling for MPUs in the right-hand article column
  */
-sizeCallbacks[adSizes.mpu.toString()] = (
-	_: CallbackEvent,
-	advert: Advert,
-): Promise<void> =>
+sizeCallbacks[adSizes.mpu.toString()] = (advert: Advert): Promise<void> =>
 	fastdom.measure(() => {
 		if (advert.node.classList.contains('js-sticky-mpu')) {
 			if (advert.node.classList.contains('ad-slot--right')) {
@@ -103,10 +90,7 @@ sizeCallbacks[adSizes.mpu.toString()] = (
 /**
  * Resolve the stickyMpu.whenRendered promise
  */
-sizeCallbacks[adSizes.halfPage.toString()] = (
-	_: CallbackEvent,
-	advert: Advert,
-) =>
+sizeCallbacks[adSizes.halfPage.toString()] = (advert: Advert) =>
 	fastdom.measure(() => {
 		if (advert.node.classList.contains('ad-slot--right')) {
 			stickyMpu(advert.node);
@@ -117,10 +101,7 @@ sizeCallbacks[adSizes.halfPage.toString()] = (
 		void fastdom.mutate(() => advert.updateExtraSlotClasses());
 	});
 
-sizeCallbacks[adSizes.skyscraper.toString()] = (
-	_: CallbackEvent,
-	advert: Advert,
-) =>
+sizeCallbacks[adSizes.skyscraper.toString()] = (advert: Advert) =>
 	fastdom.measure(() => {
 		if (advert.node.classList.contains('ad-slot--right')) {
 			stickyMpu(advert.node);
@@ -133,39 +114,27 @@ sizeCallbacks[adSizes.skyscraper.toString()] = (
 		);
 	});
 
-sizeCallbacks[adSizes.video.toString()] = (_: CallbackEvent, advert: Advert) =>
+sizeCallbacks[adSizes.video.toString()] = (advert: Advert) =>
 	fastdom.mutate(() => {
 		advert.updateExtraSlotClasses('u-h');
 	});
 
-sizeCallbacks[adSizes.outstreamDesktop.toString()] = (
-	_: CallbackEvent,
-	advert: Advert,
-) =>
+sizeCallbacks[adSizes.outstreamDesktop.toString()] = (advert: Advert) =>
 	fastdom.mutate(() => {
 		advert.updateExtraSlotClasses('ad-slot--outstream');
 	});
 
-sizeCallbacks[adSizes.outstreamGoogleDesktop.toString()] = (
-	_: CallbackEvent,
-	advert: Advert,
-) =>
+sizeCallbacks[adSizes.outstreamGoogleDesktop.toString()] = (advert: Advert) =>
 	fastdom.mutate(() => {
 		advert.updateExtraSlotClasses('ad-slot--outstream');
 	});
 
-sizeCallbacks[adSizes.outstreamMobile.toString()] = (
-	_: CallbackEvent,
-	advert: Advert,
-) =>
+sizeCallbacks[adSizes.outstreamMobile.toString()] = (advert: Advert) =>
 	fastdom.mutate(() => {
 		advert.updateExtraSlotClasses('ad-slot--outstream');
 	});
 
-sizeCallbacks[adSizes.googleCard.toString()] = (
-	_: CallbackEvent,
-	advert: Advert,
-) =>
+sizeCallbacks[adSizes.googleCard.toString()] = (advert: Advert) =>
 	fastdom.mutate(() => {
 		advert.updateExtraSlotClasses('ad-slot--gc');
 	});
@@ -174,8 +143,8 @@ sizeCallbacks[adSizes.googleCard.toString()] = (
  * Out of page adverts - creatives that aren't directly shown on the page - need to be hidden,
  * and their containers closed up.
  */
-const outOfPageCallback = ({ event }: CallbackEvent, advert: Advert) => {
-	if (!event.slot.getOutOfPage()) {
+const outOfPageCallback = (advert: Advert, event?: SlotRenderEndedEvent) => {
+	if (!event?.slot.getOutOfPage()) {
 		const parent = advert.node.parentNode as HTMLElement;
 		return fastdom.mutate(() => {
 			advert.node.classList.add('ad-slot--collapse');
@@ -238,7 +207,7 @@ const addContentClass = (adSlotNode: HTMLElement) => {
  */
 export const renderAdvert = (
 	advert: Advert,
-	slotRenderEndedEvent: Event,
+	slotRenderEndedEvent: SlotRenderEndedEvent,
 ): Promise<boolean> => {
 	addContentClass(advert.node);
 
@@ -259,10 +228,10 @@ export const renderAdvert = (
 					 * */
 					advert.hasPrebidSize = false;
 
+					const sizeCallback = sizeCallbacks[size];
 					return Promise.resolve(
-						sizeCallbacks[size]
-							? // @ts-expect-error - We check if sizeCallbacks[size] is truthy above
-							  sizeCallbacks[size](slotRenderEndedEvent, advert)
+						sizeCallback !== undefined
+							? sizeCallback(advert, slotRenderEndedEvent)
 							: fastdom.mutate(() => {
 									advert.updateExtraSlotClasses();
 							  }),

--- a/static/src/javascripts/projects/commercial/types.d.ts
+++ b/static/src/javascripts/projects/commercial/types.d.ts
@@ -46,6 +46,7 @@ type Slot = {
 	getAdUnitPath: GetString;
 	getAttributeKeys: GetStrings;
 	getCategoryExclusions: GetStrings;
+	getOutOfPage: () => boolean;
 	getResponseInformation: GetResponseInformation;
 	getSlotElementId: GetString;
 	getTargeting: GetTargeting;


### PR DESCRIPTION
## What does this change?

Fix warnings related to use of `any` types in the commercial frontend.


## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Removing use of any types helps catch more type errors at compile time.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [X] Locally
- [ ] On CODE (optional)