### PR TITLE
US mandatory gate switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -24,4 +24,13 @@ trait ABTestSwitches {
     exposeClientSide = true,
   )
 
+  Switch(
+    ABTests,
+    "ab-sign-in-gate-us-mandatory",
+    "Mandatory sign in gate to users in US split test",
+    owners = Seq(Owner.withGithub("quarpt")),
+    safeState = Off,
+    sellByDate = new LocalDate(2021, 12, 1),
+    exposeClientSide = true,
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -2,10 +2,12 @@ import { puzzlesBanner } from 'common/modules/experiments/tests/puzzles-banner';
 import { remoteRRHeaderLinksTest } from 'common/modules/experiments/tests/remote-header-test';
 import { signInGateMainControl } from 'common/modules/experiments/tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from 'common/modules/experiments/tests/sign-in-gate-main-variant';
+import { signInGateUsMandatory } from 'common/modules/experiments/tests/sign-in-gate-us-mandatory';
 
 export const concurrentTests: readonly ABTest[] = [
 	signInGateMainVariant,
 	signInGateMainControl,
+	signInGateUsMandatory,
 	puzzlesBanner,
 	remoteRRHeaderLinksTest,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
@@ -8,7 +8,7 @@ export const signInGateMainVariant = {
     author: 'Mahesh Makani',
     description:
         'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Main/Variant Audience.',
-    audience: 0.9,
+    audience: 0.89,
     audienceOffset: 0.0,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-us-mandatory.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-us-mandatory.js
@@ -1,0 +1,28 @@
+export const signInGateUsMandatory = {
+	id: 'SignInGateUsMandatory',
+	start: '2020-06-28',
+	expiry: '2021-12-01',
+	author: 'Identity Team',
+	description:
+        'Compare mandatory gate (an article sigin gate without the dismiss button) with the main signin gate for US only',
+    audience: 0.01,
+	audienceOffset: 0.89,
+	successMeasure: 'Users sign in or create a Guardian account',
+	audienceCriteria:
+        '3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss or reshown after 5 dismisses, not on help, info sections etc. exclude iOS 9 and guardian-live, US only, only users with specific CMP consents. Suppresses other banners, and appears over epics',
+    dataLinkNames: 'SignInGateUsMandatory',
+	idealOutcome:
+		'We believe that a mandatory sign in gate will increase sign in conversion by 30% vs a dismissable sign in gate.',
+	showForSensitive: false,
+	canRun: () => true,
+	variants: [
+		{
+			id: 'us-mandatory-gate-control',
+			test: () => {},
+		},
+		{
+			id: 'us-mandatory-gate-variant',
+			test: () => {},
+		},
+	],
+};


### PR DESCRIPTION
## What does this change?

Add switch for US mandatory signin gate. We are rolling out a mandatory signin gate for US readers.

I've set the base branch as remove-aus-mandatory-gate to make the diff more realistic. https://github.com/guardian/frontend/pull/23935 needs to be merged to main first. Afterwards, merge this PR against main

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

Testing the affect of mandatory signin gate for US viewers

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
