### PR TITLE
Repair the election tracker

### DIFF
--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -149,19 +149,23 @@ class InteractiveController(
 
   override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = {
     val requestFormat = request.getRequestFormat
-    lookupItemResponse(path).flatMap { itemResponse =>
-      itemResponseToInteractivePickerInputData(itemResponse) match {
-        case Some((datetime, tags)) => {
-          val renderingTier = InteractivePicker.getRenderingTier(path, datetime, tags)
-          (requestFormat, renderingTier) match {
-            case (AmpFormat, USElectionTracker2020AmpPage) => renderInteractivePageUSPresidentialElection2020(path)
-            case (AmpFormat, DotcomRendering)              => renderDCRAmp(itemResponse)
-            case (JsonFormat, _) if request.forceDCR       => renderDCRJson(itemResponse)
-            case (HtmlFormat, DotcomRendering)             => renderDCR(itemResponse)
-            case _                                         => renderItemLegacy(itemResponse)
+    if (USElection2020AmpPages.pathIsSpecialHanding(path) && requestFormat == AmpFormat) {
+      renderInteractivePageUSPresidentialElection2020(path)
+    } else {
+      lookupItemResponse(path).flatMap { itemResponse =>
+        itemResponseToInteractivePickerInputData(itemResponse) match {
+          case Some((datetime, tags)) => {
+            val renderingTier = InteractivePicker.getRenderingTier(path, datetime, tags)
+            (requestFormat, renderingTier) match {
+              case (AmpFormat, USElectionTracker2020AmpPage) => renderInteractivePageUSPresidentialElection2020(path)
+              case (AmpFormat, DotcomRendering)              => renderDCRAmp(itemResponse)
+              case (JsonFormat, _) if request.forceDCR       => renderDCRJson(itemResponse)
+              case (HtmlFormat, DotcomRendering)             => renderDCR(itemResponse)
+              case _                                         => renderItemLegacy(itemResponse)
+            }
           }
+          case None => renderItemLegacy(itemResponse)
         }
-        case None => renderItemLegacy(itemResponse)
       }
     }
   }

--- a/identity/app/controllers/PublicProfileController.scala
+++ b/identity/app/controllers/PublicProfileController.scala
@@ -3,6 +3,7 @@ package controllers
 import clients.DiscussionProfile
 import com.gu.identity.model.User
 import common.ImplicitControllerExecutionContext
+import idapiclient.responses.Error
 import idapiclient.{IdApiClient, Response}
 import model.Cached.RevalidatableResult
 import model.{ApplicationContext, Cached, IdentityPage}
@@ -29,7 +30,8 @@ class PublicProfileController(
     findProfileDataAndRender(
       "/user/" + vanityUrl,
       activityType,
-      identityApiClient.userFromVanityUrl(vanityUrl),
+      // IDAPI no longer supports lookup by Vanity URL. We return not found profile pages instead
+      Future.successful(Left(List(Error("Not Found", "Not Found", 404)))),
     )
 
   def renderProfileFromId(id: String, activityType: String): Action[AnyContent] =

--- a/identity/app/idapiclient/IdApiClient.scala
+++ b/identity/app/idapiclient/IdApiClient.scala
@@ -67,14 +67,6 @@ class IdApiClient(idJsonBodyParser: IdApiJsonBodyParser, conf: IdConfig, httpCli
     response map extractUser
   }
 
-  def userFromVanityUrl(vanityUrl: String, auth: Auth = Anonymous): Future[Response[User]] = {
-    val apiPath = urlJoin("user", "vanityurl", vanityUrl)
-    val params = buildParams(Some(auth))
-    val headers = buildHeaders(Some(auth))
-    val response = httpClient.GET(apiUrl(apiPath), None, params, headers)
-    response map extractUser
-  }
-
   def userFromQueryParam(param: String, field: String, auth: Auth = Anonymous): Future[Response[User]] = {
     val apiPath = s"/user?${field}=${param}"
     val params = buildParams(Some(auth))

--- a/identity/test/controllers/PublicProfileControllerTest.scala
+++ b/identity/test/controllers/PublicProfileControllerTest.scala
@@ -36,7 +36,6 @@ class PublicProfileControllerTest
     publicFields = PublicFields(
       displayName = Some("John Smith"),
       username = Some("John Smith"),
-      vanityUrl = Some(vanityUrl),
     ),
     dates = UserDates(
       accountCreatedDate = Some(new DateTime().minusDays(7)),
@@ -50,7 +49,6 @@ class PublicProfileControllerTest
     publicFields = PublicFields(
       displayName = Some("John Smith"),
       username = Some("John Smith"),
-      vanityUrl = Some(vanityUrl),
     ),
     dates = UserDates(
       accountCreatedDate = Some(new DateTime().minusDays(7)),
@@ -111,10 +109,6 @@ class PublicProfileControllerTest
   }
 
   "Given renderProfileFromVanityUrl is called" - Fake {
-    when(api.userFromVanityUrl(MockitoMatchers.anyString, MockitoMatchers.any[Auth])) thenReturn Future.successful(
-      Left(Nil),
-    )
-    when(api.userFromVanityUrl(vanityUrl)) thenReturn Future.successful(Right(user))
     when(discussionApi.findDiscussionUserFilterCommented(userId)) thenReturn Future.successful(Some(discussionProfile))
 
     "with valid user Id who has commented" - {
@@ -124,12 +118,8 @@ class PublicProfileControllerTest
         status(result) should be(200)
       }
 
-      val content = contentAsString(result)
-      "then rendered profile should include username" in {
-        content should include(user.publicFields.username.get)
-      }
-      "then rendered profile should include account creation date" in {
-        content should include(s"Registered on ${user.dates.accountCreatedDate.get.toString("d MMM yyyy")}")
+      "then rendered profile should display no comments found since vanity URLs are no longer supported in IDAPI" in {
+        contentAsString(result) should include("No comments found for user")
       }
     }
 

--- a/identity/test/idapiclient/IdApiTest.scala
+++ b/identity/test/idapiclient/IdApiTest.scala
@@ -79,7 +79,6 @@ class IdApiTest
       |        "publicFields": {
       |            "username": "testUsername",
       |            "displayName": "testUsername",
-      |            "vanityUrl": "testVanityUrl",
       |            "usernameLowerCase": "testusername"
       |        },
       |        "statusFields": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.8",
     "@guardian/braze-components": "^2.1.0",
-    "@guardian/commercial-core": "^0.19.0",
+    "@guardian/commercial-core": "^0.19.1",
     "@guardian/consent-management-platform": "^6.11.3",
     "@guardian/libs": "^1.8.0",
     "@guardian/shimport": "^1.0.2",

--- a/sport/app/football/model/CompetitionStages.scala
+++ b/sport/app/football/model/CompetitionStages.scala
@@ -119,6 +119,12 @@ case class KnockoutSpider(
 object KnockoutSpider {
   // Pay attention to the timezone for the orderings
   // If the dates of the matches don't line up with the ordering dates, the ordering will be ignored.
+
+  /*
+    How to find the line ordering ?
+    To avoid the same drama every two or so years, see this PR: https://github.com/guardian/frontend/pull/23929
+   */
+
   val orderings: Map[String, List[ZonedDateTime]] = Map(
     // world cup 2018
     "700" -> List(
@@ -160,18 +166,18 @@ object KnockoutSpider {
     ),
     // Euro 2020
     "750" -> List(
-      ZonedDateTime.of(2021, 6, 26, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 37
-      ZonedDateTime.of(2021, 6, 26, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 38
-      ZonedDateTime.of(2021, 6, 27, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 39
       ZonedDateTime.of(2021, 6, 27, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 40
-      ZonedDateTime.of(2021, 6, 28, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 41
+      ZonedDateTime.of(2021, 6, 26, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 38
       ZonedDateTime.of(2021, 6, 28, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 42
-      ZonedDateTime.of(2021, 6, 29, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 43
+      ZonedDateTime.of(2021, 6, 28, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 41
       ZonedDateTime.of(2021, 6, 29, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 44
-      ZonedDateTime.of(2021, 7, 2, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Final  // Match 45
+      ZonedDateTime.of(2021, 6, 29, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 43
+      ZonedDateTime.of(2021, 6, 27, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 39
+      ZonedDateTime.of(2021, 6, 26, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Round of 16   // Match 37
       ZonedDateTime.of(2021, 7, 2, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Final  // Match 46
-      ZonedDateTime.of(2021, 7, 3, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Final  // Match 47
+      ZonedDateTime.of(2021, 7, 2, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Final  // Match 45
       ZonedDateTime.of(2021, 7, 3, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Final  // Match 48
+      ZonedDateTime.of(2021, 7, 3, 17, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter Final  // Match 47
       ZonedDateTime.of(2021, 7, 6, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Semi-Final     // Match 49
       ZonedDateTime.of(2021, 7, 7, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Semi-Final     // Match 50
       ZonedDateTime.of(2021, 7, 11, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Final         // Match 51

--- a/yarn.lock
+++ b/yarn.lock
@@ -1897,10 +1897,10 @@
     "@guardian/src-foundations" "3.3.0"
     "@guardian/src-icons" "3.3.0"
 
-"@guardian/commercial-core@^0.19.0":
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.19.0.tgz#aa3a1db0f7bb45a3e7ab4e94b3457206277ff1b8"
-  integrity sha512-K91YUAXnLAvaJtak55glUeVv81/RRTPLDkgFzc5FH0mMl1jeY0myC5kyZIID6dxTb3PpNbHmQIvy4c5syF2ixw==
+"@guardian/commercial-core@^0.19.1":
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.19.1.tgz#48740ad167ba1e0f85e2711901a1ed1471d7abf2"
+  integrity sha512-Aa/rTBPvduJxbqgOU9NvorqV+4VDvTyEJCZxuG7clocO+1shvlkjx32egIxVfot0Fd/i5c76+hHkv02PcifEVg==
 
 "@guardian/consent-management-platform@^6.11.3":
   version "6.11.3"


### PR DESCRIPTION
## What does this change?

This fixes a problem I introduced few mins ago when I merged this : https://github.com/guardian/frontend/pull/23871  

Turns out that the election tracker URL itself doesn't have a CAPI answer [1]. This change puts it outside the CAPI answer processing. I will make another PR to clean up a bit more, since we no longer need

```
case (AmpFormat, USElectionTracker2020AmpPage)
```

[1] This fails: https://content.guardianapis.com/us-news/ng-interactive/2020/nov/17/us-election-results-2020-joe-biden-won-donald-trump-presidential-electoral-college-votes?[REMOVED]&api-key=[REMOVED]

[2] The tracker is here: https://content.guardianapis.com/atom/interactive/interactives/2020/11/us-election/prod/amp-page?[REMOVED]&api-key=[REMOVED]