### PR TITLE
Refactoring and dcroptout

### DIFF
--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -162,10 +162,10 @@ class InteractiveController(
           case Some((datetime, tags)) => {
             val renderingTier = InteractivePicker.getRenderingTier(path, datetime, tags)
             (requestFormat, renderingTier) match {
-              case (AmpFormat, DotcomRendering)        => renderDCRAmp(itemResponse)
-              case (JsonFormat, _) if request.forceDCR => renderDCRJson(itemResponse)
-              case (HtmlFormat, DotcomRendering)       => renderDCR(itemResponse)
-              case _                                   => renderItemLegacy(itemResponse)
+              case (AmpFormat, DotcomRendering)  => renderDCRAmp(itemResponse)
+              case (JsonFormat, DotcomRendering) => renderDCRJson(itemResponse)
+              case (HtmlFormat, DotcomRendering) => renderDCR(itemResponse)
+              case _                             => renderItemLegacy(itemResponse)
             }
           }
           case None => renderItemLegacy(itemResponse)

--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -149,6 +149,11 @@ class InteractiveController(
 
   override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = {
     val requestFormat = request.getRequestFormat
+    /*
+       Calling lookupItemResponse(path) on an election tracker path, 404 in CAPI, the atom is retrived using the atom Id.
+       This is the reason why we need to process those paths before performing the logic for the Interactive Picker
+       (ie: before calling the CAPI response and extracting the input parameters for `getRenderingTier`)
+     */
     if (USElection2020AmpPages.pathIsSpecialHanding(path) && requestFormat == AmpFormat) {
       renderInteractivePageUSPresidentialElection2020(path)
     } else {
@@ -157,11 +162,10 @@ class InteractiveController(
           case Some((datetime, tags)) => {
             val renderingTier = InteractivePicker.getRenderingTier(path, datetime, tags)
             (requestFormat, renderingTier) match {
-              case (AmpFormat, USElectionTracker2020AmpPage) => renderInteractivePageUSPresidentialElection2020(path)
-              case (AmpFormat, DotcomRendering)              => renderDCRAmp(itemResponse)
-              case (JsonFormat, _) if request.forceDCR       => renderDCRJson(itemResponse)
-              case (HtmlFormat, DotcomRendering)             => renderDCR(itemResponse)
-              case _                                         => renderItemLegacy(itemResponse)
+              case (AmpFormat, DotcomRendering)        => renderDCRAmp(itemResponse)
+              case (JsonFormat, _) if request.forceDCR => renderDCRJson(itemResponse)
+              case (HtmlFormat, DotcomRendering)       => renderDCR(itemResponse)
+              case _                                   => renderItemLegacy(itemResponse)
             }
           }
           case None => renderItemLegacy(itemResponse)

--- a/applications/app/services/InteractivePicker.scala
+++ b/applications/app/services/InteractivePicker.scala
@@ -27,21 +27,18 @@ object InteractivePicker {
   }
 
   def isOptedOut(tags: List[Tag]): Boolean = {
-    tags.exists(t => t.id == "tracking/platformfunctional/dcrblacklist")
+    tags.exists(t => t.id == "tracking/platformfunctional/dcroptout")
   }
 
   def getRenderingTier(path: String, datetime: DateTime, tags: List[Tag])(implicit
       request: RequestHeader,
   ): RenderingTier = {
-    val isSpecialElection = USElection2020AmpPages.pathIsSpecialHanding(path)
-    val isAmp = request.host.contains("amp")
     val forceDCR = request.forceDCR
     val isMigrated = migratedPaths.contains(if (path.startsWith("/")) path else "/" + path)
     val switchOn = InteractivePickerFeature.isSwitchedOn
     val publishedPostSwitch = dateIsPostTransition(datetime)
 
-    if (isSpecialElection && isAmp) USElectionTracker2020AmpPage
-    else if (forceDCR || isMigrated) DotcomRendering
+    if (forceDCR || isMigrated) DotcomRendering
     else if (switchOn && !isOptedOut(tags) && publishedPostSwitch) DotcomRendering
     else FrontendLegacy
   }


### PR DESCRIPTION
## What does this change?

This is a the follow up of this fix ( https://github.com/guardian/frontend/pull/23939 ). We perform code cleaning/simplification and add a comment for the future.

We also use the newly created `tracking/platformfunctional/dcroptout` ( thanks @nicl  )

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No