### PR TITLE
Add a few more common interactive scripts we support

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -15,21 +15,22 @@ object ArticlePageChecks {
   }
 
   def hasOnlySupportedElements(page: PageWithStoryPackage): Boolean = {
+
+    val supportedInteractiveScriptPrefixes: List[String] = List(
+      "https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js", // standard iframe wrapper boot
+      "https://open-module.appspot.com/boot.js", // script no longer exists, i.e. parity with frontend
+      "https://embed.actionbutton.co/widget/boot.js", // supported in DCR
+      "https://interactive.guim.co.uk/2017/07/booklisted/boot.js", // not supported but fallback ok
+      "https://interactive.guim.co.uk/page-enhancers/super-lists/boot.js", // broken on frontend anyway
+      "https://gdn-cdn.s3.amazonaws.com/quiz-builder/", // old quiz builder quizzes work fine
+    )
+
     def unsupportedElement(blockElement: BlockElement) =
       blockElement match {
         case InteractiveBlockElement(_, scriptUrl) =>
           scriptUrl match {
-            case Some(
-                  "https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js", // standard iframe wrapper boot
-                ) | Some(
-                  "https://open-module.appspot.com/boot.js", // script no longer exists, i.e. parity with frontend
-                ) | Some("https://embed.actionbutton.co/widget/boot.js") | // supported in DCR
-                Some("https://interactive.guim.co.uk/2017/07/booklisted/boot.js") | // not supported but fallback ok
-                Some(
-                  "https://interactive.guim.co.uk/page-enhancers/super-lists/boot.js", // broken on frontend anyway
-                ) =>
-              false
-            case _ => true
+            case Some(scriptUrl) if supportedInteractiveScriptPrefixes.exists(scriptUrl.startsWith) => false
+            case _                                                                                  => true
           }
         case _ => false
       }

--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -19,8 +19,17 @@ object ArticlePageChecks {
       blockElement match {
         case InteractiveBlockElement(_, scriptUrl) =>
           scriptUrl match {
-            case Some("https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js") => false
-            case _                                                                       => true
+            case Some(
+                  "https://interactive.guim.co.uk/embed/iframe-wrapper/0.1/boot.js", // standard iframe wrapper boot
+                ) | Some(
+                  "https://open-module.appspot.com/boot.js", // script no longer exists, i.e. parity with frontend
+                ) | Some("https://embed.actionbutton.co/widget/boot.js") | // supported in DCR
+                Some("https://interactive.guim.co.uk/2017/07/booklisted/boot.js") | // not supported but fallback ok
+                Some(
+                  "https://interactive.guim.co.uk/page-enhancers/super-lists/boot.js", // broken on frontend anyway
+                ) =>
+              false
+            case _ => true
           }
         case _ => false
       }


### PR DESCRIPTION
## What does this change?
Adds a few more commonly used interactive scripts to the list of script URLs we support. This is based on log data from the last 24 hours - I've gone through all of the scripts that were used in more than a handful of articles  and these are the ones we already support (or frontend no longer does, so we are at parity already). Comments for why we can allow each of these are in the code.

We should soon also be able to add the most commonly used script to this list: contents interactive elements - but DCR support for that is in progress.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
It means we get a bit more DCR article support, but also removes some of the noise of common interactive scripts  so it is easier to assess the remainder.