### PR TITLE
Signify support for labs content in ArticlePicker

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -43,8 +43,6 @@ object ArticlePageChecks {
 
   def isNotAMP(request: RequestHeader): Boolean = !request.isAmp
 
-  def isNotPaidContent(page: PageWithStoryPackage): Boolean = !page.article.tags.isPaidContent
-
 }
 
 object ArticlePicker {
@@ -64,7 +62,6 @@ object ArticlePicker {
       ("isNotAGallery", ArticlePageChecks.isNotAGallery(page)),
       ("isNotLiveBlog", ArticlePageChecks.isNotLiveBlog(page)),
       ("isNotAMP", ArticlePageChecks.isNotAMP(request)),
-      ("isNotPaidContent", ArticlePageChecks.isNotPaidContent(page)),
       ("isNotInTagBlockList", ArticlePageChecks.isNotInTagBlockList(page)),
     )
   }


### PR DESCRIPTION
## What does this change?
Re-adds support for labs content to DCR, by removing that check from the `ArticlePicker`. Planning to launch this 24/6 AM (tomorrow morning). The Labs team have previewed the changes and are happy for this to be released.

N.B. There's still some labs content that won't be supported because it contains custom interactive elements

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
Gets paid content onto DCR, where we know there are UX/perf benefits plus moves us closer to full DCR support for articles and removing rendering from frontend. The design has also been refreshed!
