### PR TITLE
Interactive switchover - re-enable CAPI error handling

### DIFF
--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -84,12 +84,6 @@ class InteractiveController(
     result recover convertApiExceptions
   }
 
-  private def lookup(
-      path: String,
-  )(implicit request: RequestHeader): Future[Either[(InteractivePage, Blocks), Result]] = {
-    itemResponseToModel(lookupItemResponse(path: String))
-  }
-
   private def render(model: InteractivePage)(implicit request: RequestHeader) = {
     val htmlResponse = () => InteractiveHtmlPage.html(model)
     val jsonResponse = () => views.html.fragments.interactiveBody(model)

--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -151,7 +151,7 @@ class InteractiveController(
     if (USElection2020AmpPages.pathIsSpecialHanding(path) && requestFormat == AmpFormat) {
       renderInteractivePageUSPresidentialElection2020(path)
     } else {
-      lookupItemResponse(path).flatMap { itemResponse =>
+      val res = lookupItemResponse(path).flatMap { itemResponse =>
         itemResponseToInteractivePickerInputData(itemResponse) match {
           case Some((datetime, tags)) => {
             val renderingTier = InteractivePicker.getRenderingTier(path, datetime, tags)
@@ -165,6 +165,8 @@ class InteractiveController(
           case None => renderItemLegacy(itemResponse)
         }
       }
+
+      res.recover(convertApiExceptionsWithoutEither)
     }
   }
 


### PR DESCRIPTION
A quick fix to reinstate CAPI error recovery for interactives - removed accidentally in the DCR switchover code.

We should really refactor the entire controller as it's very difficult to read, but will do that in a separate PR.