### PR TITLE
Decommissioning joda.time 1/.

### DIFF
--- a/admin/app/controllers/admin/ReaderRevenueAdminController.scala
+++ b/admin/app/controllers/admin/ReaderRevenueAdminController.scala
@@ -4,7 +4,7 @@ import com.gu.googleauth.UserIdentity
 import common.{ImplicitControllerExecutionContext, GuLogging}
 import model.{ApplicationContext, NoCache}
 import model.readerRevenue._
-import org.joda.time.DateTime
+import java.time.Instant
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc._
 import services.S3
@@ -48,7 +48,7 @@ class ReaderRevenueAdminController(wsClient: WSClient, val controllerComponents:
         ) { region: ReaderRevenueRegion =>
           val requester: String =
             UserIdentity.fromRequest(request) map (_.fullName) getOrElse "unknown user (dev-build?)"
-          val millisSinceEpoch = DateTime.now.getMillis()
+          val millisSinceEpoch = Instant.now().toEpochMilli()
           val jsonLog: JsValue = Json.toJson(BannerDeploy(millisSinceEpoch))
           val message =
             s"${bannerType.name} banner in ${region.name} redeploy by $requester at ${millisSinceEpoch.toString}}"

--- a/admin/app/services/Fastly.scala
+++ b/admin/app/services/Fastly.scala
@@ -3,7 +3,7 @@ package services
 import common.GuLogging
 import conf.AdminConfiguration.fastly
 import com.amazonaws.services.cloudwatch.model.{Dimension, MetricDatum}
-import org.joda.time.DateTime
+import java.util.Date
 import play.api.libs.ws.WSClient
 import play.api.libs.json.{JsValue, Json}
 
@@ -19,7 +19,7 @@ case class FastlyStatistic(service: String, region: String, timestamp: Long, nam
       new Dimension().withName("service").withValue(service),
       new Dimension().withName("region").withValue(region),
     )
-    .withTimestamp(new DateTime(timestamp).toDate)
+    .withTimestamp(new Date(timestamp))
     .withValue(value.toDouble)
 }
 


### PR DESCRIPTION
## What does this change?

This is the first of a series of PR to decommission `joda.time` from the frontend code. Here we perform the two following operations

```
    -   .withTimestamp(new DateTime(timestamp).toDate)
    +   .withTimestamp(new Date(timestamp))
```

and 

```
    - val millisSinceEpoch = DateTime.now.getMillis()
    + val millisSinceEpoch = Instant.now().toEpochMilli()
```
In Fastly.scala and ReaderRevenueAdminController.scala. 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No