### PR TITLE
Decommissioning joda.time 2/.

### DIFF
--- a/admin/app/dfp/ApiHelper.scala
+++ b/admin/app/dfp/ApiHelper.scala
@@ -2,7 +2,8 @@ package dfp
 
 import com.google.api.ads.admanager.axis.v202011._
 import common.GuLogging
-import java.time.LocalDateTime
+import org.joda.time.DateTime
+import java.time.{LocalDateTime, ZoneId}
 
 private[dfp] object ApiHelper extends GuLogging {
 
@@ -34,5 +35,13 @@ private[dfp] object ApiHelper extends GuLogging {
       gdt.getMinute,
       gdt.getSecond,
     )
+  }
+
+  def toMilliSeconds(ldt: LocalDateTime): Long = {
+    ldt.atZone(ZoneId.of("UTC")).toInstant.toEpochMilli()
+  }
+
+  def localDateTimeToDateTime(ldt: LocalDateTime): DateTime = {
+    DateTime.parse(ldt.toString)
   }
 }

--- a/admin/app/dfp/ApiHelper.scala
+++ b/admin/app/dfp/ApiHelper.scala
@@ -2,7 +2,9 @@ package dfp
 
 import com.google.api.ads.admanager.axis.v202011._
 import common.GuLogging
-import org.joda.time.{DateTime => JodaDateTime, DateTimeZone}
+import org.joda.time.{DateTimeZone, DateTime => JodaDateTime}
+
+import java.time.LocalDateTime
 
 private[dfp] object ApiHelper extends GuLogging {
 
@@ -23,4 +25,16 @@ private[dfp] object ApiHelper extends GuLogging {
 
   //noinspection IfElseToOption
   def optJavaInt(i: java.lang.Integer): Option[Int] = if (i == null) None else Some(i)
+
+  def toLocalDateTime(gdt: com.google.api.ads.admanager.axis.v202011.DateTime): LocalDateTime = {
+    val gd: com.google.api.ads.admanager.axis.v202011.Date = gdt.getDate
+    LocalDateTime.of(
+      gd.getYear,
+      gd.getMonth,
+      gd.getDay,
+      gdt.getHour,
+      gdt.getMinute,
+      gdt.getSecond,
+    )
+  }
 }

--- a/admin/app/dfp/ApiHelper.scala
+++ b/admin/app/dfp/ApiHelper.scala
@@ -2,7 +2,6 @@ package dfp
 
 import com.google.api.ads.admanager.axis.v202011._
 import common.GuLogging
-import org.joda.time.DateTime
 import java.time.{LocalDateTime, ZoneId}
 
 private[dfp] object ApiHelper extends GuLogging {
@@ -39,9 +38,5 @@ private[dfp] object ApiHelper extends GuLogging {
 
   def toMilliSeconds(ldt: LocalDateTime): Long = {
     ldt.atZone(ZoneId.of("UTC")).toInstant.toEpochMilli()
-  }
-
-  def localDateTimeToDateTime(ldt: LocalDateTime): DateTime = {
-    DateTime.parse(ldt.toString)
   }
 }

--- a/admin/app/dfp/ApiHelper.scala
+++ b/admin/app/dfp/ApiHelper.scala
@@ -2,8 +2,6 @@ package dfp
 
 import com.google.api.ads.admanager.axis.v202011._
 import common.GuLogging
-import org.joda.time.{DateTimeZone, DateTime => JodaDateTime}
-
 import java.time.LocalDateTime
 
 private[dfp] object ApiHelper extends GuLogging {

--- a/admin/app/dfp/ApiHelper.scala
+++ b/admin/app/dfp/ApiHelper.scala
@@ -7,7 +7,6 @@ import org.joda.time.{DateTime => JodaDateTime, DateTimeZone}
 private[dfp] object ApiHelper extends GuLogging {
 
   def isPageSkin(dfpLineItem: LineItem): Boolean = {
-
     def hasA1x1Pixel(placeholders: Array[CreativePlaceholder]): Boolean = {
       placeholders.exists {
         _.getCompanions.exists { companion =>
@@ -16,22 +15,8 @@ private[dfp] object ApiHelper extends GuLogging {
         }
       }
     }
-
     (dfpLineItem.getRoadblockingType == RoadblockingType.CREATIVE_SET) &&
     hasA1x1Pixel(dfpLineItem.getCreativePlaceholders)
-  }
-
-  def toJodaTime(time: DateTime): JodaDateTime = {
-    val date = time.getDate
-    new JodaDateTime(
-      date.getYear,
-      date.getMonth,
-      date.getDay,
-      time.getHour,
-      time.getMinute,
-      time.getSecond,
-      DateTimeZone.forID(time.getTimeZoneId),
-    )
   }
 
   def toSeq[A](as: Array[A]): Seq[A] = Option(as) map (_.toSeq) getOrElse Nil

--- a/admin/app/dfp/ApiHelper.scala
+++ b/admin/app/dfp/ApiHelper.scala
@@ -1,6 +1,11 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.v202011._
+import com.google.api.ads.admanager.axis.v202011.{
+  LineItem,
+  CreativePlaceholder,
+  RoadblockingType,
+  DateTime => DfpDateTime,
+}
 import common.GuLogging
 import java.time.{LocalDateTime, ZoneId}
 
@@ -24,7 +29,7 @@ private[dfp] object ApiHelper extends GuLogging {
   //noinspection IfElseToOption
   def optJavaInt(i: java.lang.Integer): Option[Int] = if (i == null) None else Some(i)
 
-  def toLocalDateTime(gdt: com.google.api.ads.admanager.axis.v202011.DateTime): LocalDateTime = {
+  def toLocalDateTime(gdt: DfpDateTime): LocalDateTime = {
     val gd: com.google.api.ads.admanager.axis.v202011.Date = gdt.getDate
     LocalDateTime.of(
       gd.getYear,

--- a/admin/app/dfp/DataMapper.scala
+++ b/admin/app/dfp/DataMapper.scala
@@ -2,7 +2,7 @@ package dfp
 
 import com.google.api.ads.admanager.axis.v202011._
 import common.dfp._
-import dfp.ApiHelper.{isPageSkin, optJavaInt, toSeq}
+import dfp.ApiHelper.{isPageSkin, optJavaInt, toSeq, toLocalDateTime}
 import java.time.LocalDateTime
 
 // These mapping functions use libraries that are only available in admin to create common DFP data models.
@@ -110,18 +110,6 @@ class DataMapper(
       val size = placeholder.size
       (size.width, size.height)
     }
-  }
-
-  def toLocalDateTime(gdt: com.google.api.ads.admanager.axis.v202011.DateTime): LocalDateTime = {
-    val gd: com.google.api.ads.admanager.axis.v202011.Date = gdt.getDate
-    LocalDateTime.of(
-      gd.getYear,
-      gd.getMonth,
-      gd.getDay,
-      gdt.getHour,
-      gdt.getMinute,
-      gdt.getSecond,
-    )
   }
 
   def toGuLineItem(session: SessionWrapper)(dfpLineItem: LineItem): GuLineItem =

--- a/admin/app/dfp/DataMapper.scala
+++ b/admin/app/dfp/DataMapper.scala
@@ -3,6 +3,7 @@ package dfp
 import com.google.api.ads.admanager.axis.v202011._
 import common.dfp._
 import dfp.ApiHelper.{isPageSkin, optJavaInt, toJodaTime, toSeq}
+import java.time.LocalDateTime
 
 // These mapping functions use libraries that are only available in admin to create common DFP data models.
 class DataMapper(
@@ -111,16 +112,28 @@ class DataMapper(
     }
   }
 
+  def toLocalDateTime(gdt: com.google.api.ads.admanager.axis.v202011.DateTime): LocalDateTime = {
+    val gd: com.google.api.ads.admanager.axis.v202011.Date = gdt.getDate
+    LocalDateTime.of(
+      gd.getYear,
+      gd.getMonth,
+      gd.getDay,
+      gdt.getHour,
+      gdt.getMinute,
+      gdt.getSecond,
+    )
+  }
+
   def toGuLineItem(session: SessionWrapper)(dfpLineItem: LineItem): GuLineItem =
     GuLineItem(
       id = dfpLineItem.getId,
       orderId = dfpLineItem.getOrderId,
       name = dfpLineItem.getName,
       lineItemType = GuLineItemType.fromDFPLineItemType(dfpLineItem.getLineItemType.getValue),
-      startTime = toJodaTime(dfpLineItem.getStartDateTime),
+      startTime = toLocalDateTime(dfpLineItem.getStartDateTime),
       endTime = {
         if (dfpLineItem.getUnlimitedEndDateTime) None
-        else Some(toJodaTime(dfpLineItem.getEndDateTime))
+        else Some(toLocalDateTime(dfpLineItem.getEndDateTime))
       },
       isPageSkin = isPageSkin(dfpLineItem),
       sponsor = customFieldService.sponsor(dfpLineItem),
@@ -130,7 +143,7 @@ class DataMapper(
       targeting = toGuTargeting(session)(dfpLineItem.getTargeting),
       status = dfpLineItem.getStatus.toString,
       costType = dfpLineItem.getCostType.toString,
-      lastModified = toJodaTime(dfpLineItem.getLastModifiedDateTime),
+      lastModified = toLocalDateTime(dfpLineItem.getLastModifiedDateTime),
     )
 
   def toGuCreativeTemplate(dfpCreativeTemplate: CreativeTemplate): GuCreativeTemplate = {

--- a/admin/app/dfp/DataMapper.scala
+++ b/admin/app/dfp/DataMapper.scala
@@ -2,7 +2,7 @@ package dfp
 
 import com.google.api.ads.admanager.axis.v202011._
 import common.dfp._
-import dfp.ApiHelper.{isPageSkin, optJavaInt, toJodaTime, toSeq}
+import dfp.ApiHelper.{isPageSkin, optJavaInt, toSeq}
 import java.time.LocalDateTime
 
 // These mapping functions use libraries that are only available in admin to create common DFP data models.

--- a/admin/app/dfp/DataMapper.scala
+++ b/admin/app/dfp/DataMapper.scala
@@ -3,7 +3,6 @@ package dfp
 import com.google.api.ads.admanager.axis.v202011._
 import common.dfp._
 import dfp.ApiHelper.{isPageSkin, optJavaInt, toSeq, toLocalDateTime}
-import java.time.LocalDateTime
 
 // These mapping functions use libraries that are only available in admin to create common DFP data models.
 class DataMapper(

--- a/admin/app/dfp/DataMapper.scala
+++ b/admin/app/dfp/DataMapper.scala
@@ -191,7 +191,7 @@ class DataMapper(
     GuCreative(
       id = dfpCreative.getId,
       name = dfpCreative.getName,
-      lastModified = toJodaTime(dfpCreative.getLastModifiedDateTime),
+      lastModified = toLocalDateTime(dfpCreative.getLastModifiedDateTime),
       args = Option(dfpCreative.getCreativeTemplateVariableValues).map(_.map(arg)).map(_.toMap).getOrElse(Map.empty),
       templateId = Some(dfpCreative.getCreativeTemplateId),
       snippet = None,

--- a/admin/app/dfp/DfpApi.scala
+++ b/admin/app/dfp/DfpApi.scala
@@ -7,8 +7,8 @@ import com.google.api.ads.admanager.axis.v202011._
 import common.GuLogging
 import common.dfp._
 import org.joda.time.DateTime
-
-import java.time.{LocalDateTime, ZoneId}
+import dfp.ApiHelper.toMilliSeconds
+import java.time.LocalDateTime
 
 case class DfpLineItems(validItems: Seq[GuLineItem], invalidItems: Seq[GuLineItem])
 
@@ -109,10 +109,6 @@ class DfpApi(dataMapper: DataMapper, dataValidation: DataValidation) extends GuL
     withDfpSession {
       _.creativeTemplates(stmtBuilder) map dataMapper.toGuCreativeTemplate filterNot (_.isForApps)
     }
-  }
-
-  def toMilliSeconds(ldt: LocalDateTime): Long = {
-    ldt.atZone(ZoneId.of("UTC")).toInstant.toEpochMilli()
   }
 
   def readTemplateCreativesModifiedSince(threshold: LocalDateTime): Seq[GuCreative] = {

--- a/admin/app/dfp/DfpApi.scala
+++ b/admin/app/dfp/DfpApi.scala
@@ -6,7 +6,6 @@ import com.google.api.ads.admanager.axis.utils.v202011.StatementBuilder
 import com.google.api.ads.admanager.axis.v202011._
 import common.GuLogging
 import common.dfp._
-import org.joda.time.DateTime
 import dfp.ApiHelper.toMilliSeconds
 import java.time.LocalDateTime
 
@@ -66,11 +65,11 @@ class DfpApi(dataMapper: DataMapper, dataValidation: DataValidation) extends GuL
     readLineItems(stmtBuilder)
   }
 
-  def readLineItemsModifiedSince(threshold: DateTime): DfpLineItems = {
+  def readLineItemsModifiedSince(threshold: LocalDateTime): DfpLineItems = {
 
     val stmtBuilder = new StatementBuilder()
       .where("lastModifiedDateTime > :threshold")
-      .withBindVariableValue("threshold", threshold.getMillis)
+      .withBindVariableValue("threshold", toMilliSeconds(threshold))
 
     readLineItems(stmtBuilder)
   }

--- a/admin/app/dfp/DfpApi.scala
+++ b/admin/app/dfp/DfpApi.scala
@@ -8,6 +8,8 @@ import common.GuLogging
 import common.dfp._
 import org.joda.time.DateTime
 
+import java.time.{LocalDateTime, ZoneId}
+
 case class DfpLineItems(validItems: Seq[GuLineItem], invalidItems: Seq[GuLineItem])
 
 class DfpApi(dataMapper: DataMapper, dataValidation: DataValidation) extends GuLogging {
@@ -109,11 +111,15 @@ class DfpApi(dataMapper: DataMapper, dataValidation: DataValidation) extends GuL
     }
   }
 
-  def readTemplateCreativesModifiedSince(threshold: DateTime): Seq[GuCreative] = {
+  def toMilliSeconds(ldt: LocalDateTime): Long = {
+    ldt.atZone(ZoneId.of("UTC")).toInstant.toEpochMilli()
+  }
+
+  def readTemplateCreativesModifiedSince(threshold: LocalDateTime): Seq[GuCreative] = {
 
     val stmtBuilder = new StatementBuilder()
       .where("lastModifiedDateTime > :threshold")
-      .withBindVariableValue("threshold", threshold.getMillis)
+      .withBindVariableValue("threshold", toMilliSeconds(threshold))
 
     withDfpSession {
       _.creatives.get(stmtBuilder) collect {

--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -2,7 +2,6 @@ package dfp
 
 import common.dfp._
 import common.GuLogging
-import dfp.ApiHelper.localDateTimeToDateTime
 import play.api.libs.json.Json.{toJson, _}
 import tools.Store
 import scala.concurrent.{ExecutionContext, Future}
@@ -59,7 +58,7 @@ class DfpDataCacheJob(
 
     val loadSummary = loadLineItems(
       fetchCachedLineItems(),
-      ldt => dfpApi.readLineItemsModifiedSince(localDateTimeToDateTime(ldt)),
+      ldt => dfpApi.readLineItemsModifiedSince(ldt),
       dfpApi.readCurrentLineItems,
     )
 

--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -5,14 +5,10 @@ import common.GuLogging
 import org.joda.time.DateTime
 import play.api.libs.json.Json.{toJson, _}
 import tools.Store
-
 import scala.concurrent.{ExecutionContext, Future}
-import java.time.LocalDateTime
 import java.time.ZoneId
-import java.util.{Date, TimeZone}
 import java.time.LocalDateTime
 import java.time.Instant
-import java.time.ZoneOffset
 
 class DfpDataCacheJob(
     adUnitAgent: AdUnitAgent,
@@ -64,7 +60,7 @@ class DfpDataCacheJob(
   }
 
   def localDateTimeToDateTime(ldt: LocalDateTime): DateTime = {
-    DateTime.parse(ldt.toString)
+    DateTime.parse(ldt.toString) // Todo: Is this correct ?
   }
 
   private def loadLineItems(): DfpDataExtractor = {
@@ -92,8 +88,7 @@ class DfpDataCacheJob(
   def report(ids: Iterable[Long]): String = if (ids.isEmpty) "None" else ids.mkString(", ")
 
   def localDateTimeToMilliseconds(ldt: LocalDateTime): Long = {
-    val timezone = ZoneId.of("UTC")
-    ldt.atZone(timezone).toInstant.toEpochMilli
+    ldt.atZone(ZoneId.of("UTC")).toInstant.toEpochMilli()
   }
 
   def loadLineItems(

--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -88,7 +88,7 @@ class DfpDataCacheJob(
 
       // Calculate the most recent modified timestamp of the existing cache items,
       // and find line items modified since that timestamp.
-      val threshold = cachedLineItems.validItems.map(_.lastModified).maxBy(x => toMilliSeconds(x))
+      val threshold = cachedLineItems.validItems.map(_.lastModified).maxBy(toMilliSeconds)
       val recentlyModified = lineItemsModifiedSince(threshold)
 
       // Update existing items with a patch of new items.

--- a/admin/app/dfp/DfpDataExtractor.scala
+++ b/admin/app/dfp/DfpDataExtractor.scala
@@ -3,6 +3,7 @@ package dfp
 import common.Edition
 import common.dfp._
 import java.time.{LocalDateTime, ZoneId}
+import dfp.ApiHelper.toMilliSeconds
 
 case class DfpDataExtractor(lineItems: Seq[GuLineItem], invalidLineItems: Seq[GuLineItem]) {
 
@@ -53,15 +54,11 @@ case class DfpDataExtractor(lineItems: Seq[GuLineItem], invalidLineItems: Seq[Gu
     }
   }
 
-  def localDateTimeToMilliseconds(ldt: LocalDateTime) = {
-    ldt.atZone(ZoneId.of("UTC")).toInstant().toEpochMilli()
-  }
-
   def dateSort(lineItems: => Seq[GuLineItem]): Seq[GuLineItem] =
     lineItems sortBy { lineItem =>
       (
-        localDateTimeToMilliseconds(lineItem.startTime),
-        lineItem.endTime.map(x => localDateTimeToMilliseconds(x)).getOrElse(0L),
+        toMilliSeconds(lineItem.startTime),
+        lineItem.endTime.map(x => toMilliSeconds(x)).getOrElse(0L),
       )
     }
 

--- a/admin/app/dfp/DfpDataExtractor.scala
+++ b/admin/app/dfp/DfpDataExtractor.scala
@@ -3,6 +3,8 @@ package dfp
 import common.Edition
 import common.dfp._
 
+import java.time.{LocalDateTime, ZoneId}
+
 case class DfpDataExtractor(lineItems: Seq[GuLineItem], invalidLineItems: Seq[GuLineItem]) {
 
   val hasValidLineItems: Boolean = lineItems.nonEmpty
@@ -52,9 +54,16 @@ case class DfpDataExtractor(lineItems: Seq[GuLineItem], invalidLineItems: Seq[Gu
     }
   }
 
+  def localDateTimeToMilliseconds(ldt: LocalDateTime) = {
+    ldt.atZone(ZoneId.of("UTC")).toInstant().toEpochMilli()
+  }
+
   def dateSort(lineItems: => Seq[GuLineItem]): Seq[GuLineItem] =
     lineItems sortBy { lineItem =>
-      (lineItem.startTime.getMillis, lineItem.endTime.map(_.getMillis).getOrElse(0L))
+      (
+        localDateTimeToMilliseconds(lineItem.startTime),
+        lineItem.endTime.map(x => localDateTimeToMilliseconds(x)).getOrElse(0L),
+      )
     }
 
   val topAboveNavSlotTakeovers: Seq[GuLineItem] = dateSort {

--- a/admin/app/dfp/DfpDataExtractor.scala
+++ b/admin/app/dfp/DfpDataExtractor.scala
@@ -58,7 +58,7 @@ case class DfpDataExtractor(lineItems: Seq[GuLineItem], invalidLineItems: Seq[Gu
     lineItems sortBy { lineItem =>
       (
         toMilliSeconds(lineItem.startTime),
-        lineItem.endTime.map(x => toMilliSeconds(x)).getOrElse(0L),
+        lineItem.endTime.map(toMilliSeconds).getOrElse(0L),
       )
     }
 

--- a/admin/app/dfp/DfpDataExtractor.scala
+++ b/admin/app/dfp/DfpDataExtractor.scala
@@ -2,7 +2,6 @@ package dfp
 
 import common.Edition
 import common.dfp._
-
 import java.time.{LocalDateTime, ZoneId}
 
 case class DfpDataExtractor(lineItems: Seq[GuLineItem], invalidLineItems: Seq[GuLineItem]) {

--- a/admin/app/dfp/DfpTemplateCreativeCacheJob.scala
+++ b/admin/app/dfp/DfpTemplateCreativeCacheJob.scala
@@ -1,10 +1,10 @@
 package dfp
 
 import common.dfp.GuCreative
-import org.joda.time.DateTime.now
 import play.api.libs.json.Json
 import tools.Store
 
+import java.time.LocalDateTime
 import scala.concurrent.{ExecutionContext, Future}
 
 class DfpTemplateCreativeCacheJob(dfpApi: DfpApi) {
@@ -12,7 +12,7 @@ class DfpTemplateCreativeCacheJob(dfpApi: DfpApi) {
   def run()(implicit executionContext: ExecutionContext): Future[Unit] =
     Future {
       val cached = Store.getDfpTemplateCreatives
-      val threshold = GuCreative.lastModified(cached) getOrElse now.minusMonths(1)
+      val threshold = GuCreative.lastModified(cached) getOrElse LocalDateTime.now().minusMonths(1)
       val recentlyModified = dfpApi.readTemplateCreativesModifiedSince(threshold)
       val merged = GuCreative.merge(cached, recentlyModified)
       Store.putDfpTemplateCreatives(Json.stringify(Json.toJson(merged)))

--- a/admin/app/dfp/DfpTemplateCreativeCacheJob.scala
+++ b/admin/app/dfp/DfpTemplateCreativeCacheJob.scala
@@ -3,7 +3,6 @@ package dfp
 import common.dfp.GuCreative
 import play.api.libs.json.Json
 import tools.Store
-
 import java.time.LocalDateTime
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/admin/app/dfp/package.scala
+++ b/admin/app/dfp/package.scala
@@ -1,21 +1,27 @@
-import org.joda.time.format.{DateTimeFormat, DateTimeFormatter}
-import org.joda.time.{DateTime, DateTimeZone}
+import org.joda.time.format.{DateTimeFormat}
+import java.text.SimpleDateFormat
+import java.time.{ZoneId, LocalDateTime}
+import java.util.TimeZone
 
 package object dfp {
 
-  private def timeFormatter: DateTimeFormatter = {
-    DateTimeFormat.forPattern("d MMM YYYY HH:mm:ss z")
+  private def timeFormatter: SimpleDateFormat = {
+    new SimpleDateFormat("d MMM YYYY HH:mm:ss z")
   }
 
-  def printLondonTime(timestamp: DateTime): String = {
-    timeFormatter.withZone(DateTimeZone.forID("Europe/London")).print(timestamp)
+  def printLondonTime(date: LocalDateTime): String = {
+    timeFormatter.setTimeZone(TimeZone.getTimeZone("Europe/London"))
+    timeFormatter.format(date)
   }
 
-  def printUniversalTime(timestamp: DateTime): String = {
-    timeFormatter.withZoneUTC().print(timestamp)
+  def printUniversalTime(date: LocalDateTime): String = {
+    timeFormatter.setTimeZone(TimeZone.getTimeZone(ZoneId.of("UTC")))
+    timeFormatter.format(date)
   }
 
-  def printDate(timestamp: DateTime): String = {
-    DateTimeFormat.forPattern("dd MMM YYYY").print(timestamp)
+  def printDate(date: LocalDateTime): String = {
+    val timeFormatter = new SimpleDateFormat("dd MMM YYYY")
+    timeFormatter.setTimeZone(TimeZone.getTimeZone("Europe/London"))
+    timeFormatter.format(date)
   }
 }

--- a/admin/app/dfp/package.scala
+++ b/admin/app/dfp/package.scala
@@ -1,4 +1,3 @@
-import org.joda.time.format.{DateTimeFormat}
 import java.text.SimpleDateFormat
 import java.time.{ZoneId, LocalDateTime}
 import java.util.TimeZone

--- a/admin/test/dfp/DfpApiValidationTest.scala
+++ b/admin/test/dfp/DfpApiValidationTest.scala
@@ -3,9 +3,10 @@ package dfp
 import concurrent.BlockingOperations
 import common.dfp.{GuAdUnit, GuLineItem, GuTargeting, Sponsorship}
 import com.google.api.ads.admanager.axis.v202011._
-import org.joda.time.DateTime
 import org.scalatest._
 import akka.actor.ActorSystem
+import java.time.LocalDateTime
+import java.time.LocalDate
 
 class DfpApiValidationTest extends FlatSpec with Matchers {
 
@@ -19,7 +20,7 @@ class DfpApiValidationTest extends FlatSpec with Matchers {
       orderId = 0L,
       name = "test line item",
       Sponsorship,
-      startTime = DateTime.now.withTimeAtStartOfDay,
+      startTime = java.time.LocalDate.now.atStartOfDay,
       endTime = None,
       isPageSkin = false,
       sponsor = None,
@@ -33,7 +34,7 @@ class DfpApiValidationTest extends FlatSpec with Matchers {
         geoTargetsExcluded = Nil,
         customTargetSets = Nil,
       ),
-      lastModified = DateTime.now.withTimeAtStartOfDay,
+      lastModified = java.time.LocalDate.now.atStartOfDay,
     )
   }
 

--- a/admin/test/dfp/DfpDataCacheJobTest.scala
+++ b/admin/test/dfp/DfpDataCacheJobTest.scala
@@ -5,6 +5,7 @@ import org.scalatest._
 import org.scalatest.mockito.MockitoSugar
 import test._
 import java.time.LocalDateTime
+import java.time.LocalDate
 
 class DfpDataCacheJobTest
     extends FlatSpec
@@ -30,7 +31,7 @@ class DfpDataCacheJobTest
       0L,
       name,
       Sponsorship,
-      startTime = java.time.LocalDate.now.atStartOfDay,
+      startTime = LocalDate.now.atStartOfDay,
       endTime = None,
       isPageSkin = false,
       sponsor = None,
@@ -44,7 +45,7 @@ class DfpDataCacheJobTest
         geoTargetsExcluded = Nil,
         customTargetSets = Nil,
       ),
-      lastModified = java.time.LocalDate.now.atStartOfDay,
+      lastModified = LocalDate.now.atStartOfDay,
     )
   }
 

--- a/admin/test/dfp/DfpDataCacheJobTest.scala
+++ b/admin/test/dfp/DfpDataCacheJobTest.scala
@@ -1,10 +1,10 @@
 package dfp
 
 import common.dfp.{GuLineItem, GuTargeting, Sponsorship}
-import org.joda.time.DateTime
 import org.scalatest._
 import org.scalatest.mockito.MockitoSugar
 import test._
+import java.time.LocalDateTime
 
 class DfpDataCacheJobTest
     extends FlatSpec
@@ -30,7 +30,7 @@ class DfpDataCacheJobTest
       0L,
       name,
       Sponsorship,
-      startTime = DateTime.now.withTimeAtStartOfDay,
+      startTime = java.time.LocalDate.now.atStartOfDay,
       endTime = None,
       isPageSkin = false,
       sponsor = None,
@@ -44,7 +44,7 @@ class DfpDataCacheJobTest
         geoTargetsExcluded = Nil,
         customTargetSets = Nil,
       ),
-      lastModified = DateTime.now.withTimeAtStartOfDay,
+      lastModified = java.time.LocalDate.now.atStartOfDay,
     )
   }
 
@@ -56,7 +56,7 @@ class DfpDataCacheJobTest
   private val allReadyOrDeliveringLineItems = DfpLineItems(Seq.empty, Seq.empty)
 
   "loadLineItems" should "dedupe line items that have changed in an unknown way" in {
-    def lineItemsModifiedSince(threshold: DateTime): DfpLineItems =
+    def lineItemsModifiedSince(threshold: LocalDateTime): DfpLineItems =
       DfpLineItems(
         validItems = Seq(
           lineItem(1, "a-fresh"),
@@ -78,7 +78,7 @@ class DfpDataCacheJobTest
   }
 
   it should "dedupe line items that have changed in a known way" in {
-    def lineItemsModifiedSince(threshold: DateTime): DfpLineItems =
+    def lineItemsModifiedSince(threshold: LocalDateTime): DfpLineItems =
       DfpLineItems(
         validItems = Seq(
           lineItem(1, "d"),
@@ -104,7 +104,7 @@ class DfpDataCacheJobTest
   }
 
   it should "omit line items whose state has changed to no longer be ready or delivering" in {
-    def lineItemsModifiedSince(threshold: DateTime): DfpLineItems =
+    def lineItemsModifiedSince(threshold: LocalDateTime): DfpLineItems =
       DfpLineItems(
         validItems = Seq(
           lineItem(1, "a", completed = true),

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -2,7 +2,6 @@ package common.dfp
 
 import common.Edition
 import common.dfp.AdSize.{leaderboardSize, responsiveSize}
-import org.joda.time.DateTime
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import java.time.{LocalDateTime, ZoneId}

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -91,9 +91,7 @@ case class CustomTarget(name: String, op: String, values: Seq[String]) {
 }
 
 object CustomTarget {
-
   implicit val customTargetFormats: Format[CustomTarget] = Json.format[CustomTarget]
-
 }
 
 case class CustomTargetSet(op: String, targets: Seq[CustomTarget]) {
@@ -113,9 +111,7 @@ case class CustomTargetSet(op: String, targets: Seq[CustomTarget]) {
 }
 
 object CustomTargetSet {
-
   implicit val customTargetSetFormats: Format[CustomTargetSet] = Json.format[CustomTargetSet]
-
 }
 
 case class GeoTarget(id: Long, parentId: Option[Int], locationType: String, name: String) {
@@ -130,9 +126,7 @@ case class GeoTarget(id: Long, parentId: Option[Int], locationType: String, name
 }
 
 object GeoTarget {
-
   implicit val geoTargetFormats: Format[GeoTarget] = Json.format[GeoTarget]
-
 }
 
 case class GuCustomField(
@@ -383,7 +377,7 @@ object GuCreativeTemplateParameter {
 case class GuCreative(
     id: Long,
     name: String,
-    lastModified: DateTime,
+    lastModified: LocalDateTime,
     args: Map[String, String],
     templateId: Option[Long],
     snippet: Option[String],
@@ -396,9 +390,9 @@ object GuCreative {
     ldt.atZone(ZoneId.of("UTC")).toInstant.toEpochMilli()
   }
 
-  def lastModified(cs: Seq[GuCreative]): Option[DateTime] = {
+  def lastModified(cs: Seq[GuCreative]): Option[LocalDateTime] = {
     if (cs.isEmpty) None
-    else Some(cs.map(_.lastModified).maxBy(_.getMillis))
+    else Some(cs.map(_.lastModified).maxBy(x => toMilliSeconds(x)))
   }
 
   def merge(old: Seq[GuCreative], recent: Seq[GuCreative]): Seq[GuCreative] = {

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -391,7 +391,7 @@ object GuCreative {
 
   def lastModified(cs: Seq[GuCreative]): Option[LocalDateTime] = {
     if (cs.isEmpty) None
-    else Some(cs.map(_.lastModified).maxBy(x => toMilliSeconds(x)))
+    else Some(cs.map(_.lastModified).maxBy(toMilliSeconds))
   }
 
   def merge(old: Seq[GuCreative], recent: Seq[GuCreative]): Seq[GuCreative] = {

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -3,17 +3,12 @@ package common.dfp
 import common.Edition
 import common.dfp.AdSize.{leaderboardSize, responsiveSize}
 import org.joda.time.DateTime
-import org.joda.time.DateTime.now
-import org.joda.time.format.ISODateTimeFormat
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
-import play.api.libs.json.JodaReads._
-
-import java.text.SimpleDateFormat
 import java.time.{LocalDateTime, ZoneId}
 import java.time.format.DateTimeFormatter
-import java.util.{Date, TimeZone}
 import scala.language.postfixOps
+import play.api.libs.json.JodaReads._
 
 sealed trait GuLineItemType {
   val asString: String
@@ -398,8 +393,7 @@ case class GuCreative(
 object GuCreative {
 
   def toMilliSeconds(ldt: LocalDateTime): Long = {
-    val timezone = ZoneId.of("UTC")
-    ldt.atZone(timezone).toInstant.toEpochMilli
+    ldt.atZone(ZoneId.of("UTC")).toInstant.toEpochMilli()
   }
 
   def lastModified(cs: Seq[GuCreative]): Option[DateTime] = {

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -236,7 +236,7 @@ case class GuLineItem(
   val now = LocalDateTime.now()
 
   val isCurrent = startTime.isBefore(now) && (endTime.isEmpty || endTime.exists(_.isAfter(now)))
-  val isExpired = endTime.exists(_.isBefore(LocalDateTime.now()))
+  val isExpired = endTime.exists(_.isBefore(now))
   val isExpiredRecently = isExpired && endTime.exists(_.isAfter(now.minusWeeks(1)))
   val isExpiringSoon = !isExpired && endTime.exists(_.isBefore(now.plusMonths(1)))
 
@@ -279,7 +279,7 @@ case class GuLineItem(
     targeting.geoTargetsIncluded.exists { geoTarget =>
       geoTarget.targetsUk || geoTarget.targetsUs || geoTarget.targetsAustralia
     } &&
-    startTime.isBefore(LocalDateTime.now().plusDays(1)) &&
+    startTime.isBefore(now.plusDays(1)) &&
     (endTime.isEmpty || endTime.exists(_.isAfter(now)))
   }
 

--- a/common/app/services/ophan/SurgingContentAgent.scala
+++ b/common/app/services/ophan/SurgingContentAgent.scala
@@ -4,12 +4,12 @@ import app.LifecycleComponent
 import com.gu.Box
 import com.gu.commercial.display.SurgeLookupService
 import common._
-import org.joda.time.DateTime
 import play.api.inject.ApplicationLifecycle
 import play.api.libs.json.{JsArray, JsValue}
 import services.OphanApi
 
 import scala.concurrent.{ExecutionContext, Future}
+import java.time.LocalDateTime
 
 object SurgingContentAgent extends SurgeLookupService with GuLogging {
 
@@ -29,7 +29,7 @@ object SurgingContentAgent extends SurgeLookupService with GuLogging {
   override def pageViewsPerMinute(pageId: String): Option[Int] = getSurging.surges.get(pageId)
 }
 
-case class SurgingContent(surges: Map[String, Int] = Map.empty, lastUpdated: DateTime = DateTime.now()) {
+case class SurgingContent(surges: Map[String, Int] = Map.empty, lastUpdated: LocalDateTime = LocalDateTime.now()) {
   lazy val sortedSurges: Seq[(String, Int)] = surges.toSeq.sortBy(_._2).reverse
 }
 

--- a/common/test/common/dfp/GuLineItemTest.scala
+++ b/common/test/common/dfp/GuLineItemTest.scala
@@ -1,9 +1,8 @@
 package common.dfp
 
 import common.dfp.AdSize.leaderboardSize
-import org.joda.time.DateTime
-import org.joda.time.DateTime.now
 import org.scalatest.{FlatSpec, Matchers}
+import java.time.LocalDateTime
 
 class GuLineItemTest extends FlatSpec with Matchers {
 
@@ -28,7 +27,7 @@ class GuLineItemTest extends FlatSpec with Matchers {
   }
 
   private def lineItem(
-      endTime: Option[DateTime] = None,
+      endTime: Option[LocalDateTime] = None,
       costType: String = "CPD",
       creativePlaceholders: Seq[GuCreativePlaceholder] = defaultCreativePlaceholders,
       targeting: GuTargeting = defaultTargeting,
@@ -38,7 +37,7 @@ class GuLineItemTest extends FlatSpec with Matchers {
       orderId = 0L,
       name = "name",
       Sponsorship,
-      startTime = now,
+      startTime = LocalDateTime.now(),
       endTime,
       isPageSkin = false,
       sponsor = None,
@@ -46,7 +45,7 @@ class GuLineItemTest extends FlatSpec with Matchers {
       costType,
       creativePlaceholders,
       targeting,
-      lastModified = now,
+      lastModified = LocalDateTime.now(),
     )
   }
 
@@ -82,6 +81,6 @@ class GuLineItemTest extends FlatSpec with Matchers {
   }
 
   it should "be false for a completed campaign" in {
-    lineItem(endTime = Some(now.minusDays(1))) should not be 'suitableForTopAboveNavSlot
+    lineItem(endTime = Some(LocalDateTime.now().minusDays(1))) should not be 'suitableForTopAboveNavSlot
   }
 }


### PR DESCRIPTION
## What does this change?

This is the second step of the ongoing effort of decommissioning `joda.time` from the frontend code. 

Two case classes have been updated:

```
case class GuCreative
case class GuLineItem
```

The rest follows. (Note that I updated `dfp/ApiHelper.scala` with helper functions)

Step1:  https://github.com/guardian/frontend/pull/23950

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No