### PR TITLE
Shorten team names that are too large to fit on the spider

### DIFF
--- a/sport/app/football/model/model.scala
+++ b/sport/app/football/model/model.scala
@@ -175,6 +175,12 @@ object CompetitionDisplayHelpers {
       .replace("Holland", "Netherlands")
   }
 
+  def cleanTeamNameSpider(teamName: String): String = {
+    teamName
+      .replace("Czech Republic", "Czech Rep.")
+      .replace("Holland", "Netherlands")
+  }
+
   def cleanTeamCode(teamCode: String): String = {
     teamCode
       .replace("JAP", "JPN")

--- a/sport/app/football/views/wallchart/knockoutMatch.scala.html
+++ b/sport/app/football/views/wallchart/knockoutMatch.scala.html
@@ -3,7 +3,7 @@
 
 @import implicits.Football._
 @import conf.Configuration
-@import model.CompetitionDisplayHelpers.cleanTeamName
+@import model.CompetitionDisplayHelpers.cleanTeamNameSpider
 
 <div class="football-match" id="football-match-@fm.id">
     <div class="football-match__container">
@@ -11,7 +11,7 @@
             @if(!fm.homeTeam.isGhostTeam){
                 <img class="team-crest knockout--crest" alt="" src="@Configuration.staticSport.path/football/crests/120/@{fm.homeTeam.id}.png" />
             }
-            @cleanTeamName(fm.homeTeam.knockoutName)
+            @cleanTeamNameSpider(fm.homeTeam.knockoutName)
             @if(fm.hasStarted){
                 <span class="football-match__score">@fm.homeTeam.score</span>
             }
@@ -38,7 +38,7 @@
             @if(!fm.awayTeam.isGhostTeam){
                 <img class="team-crest knockout--crest" alt="" src="@Configuration.staticSport.path/football/crests/120/@{fm.awayTeam.id}.png" />
             }
-            @cleanTeamName(fm.awayTeam.knockoutName)
+            @cleanTeamNameSpider(fm.awayTeam.knockoutName)
             @if(fm.hasStarted){
                 <span class="football-match__score">@fm.awayTeam.score</span>
             }


### PR DESCRIPTION
## What does this change?

Replaces team names that are too long to fit on the spider with shortened alternatives

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:-->
before:
![image](https://user-images.githubusercontent.com/9575458/123625833-15ae1400-d808-11eb-8b0a-191eaef8db28.png)
after:
![image](https://user-images.githubusercontent.com/9575458/123625906-26f72080-d808-11eb-88d9-14c1dcbbf33c.png)


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
