### PR TITLE
make VS Code play nice with Typescript

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,9 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[*.ts]
+indent_style = tab
+
 [*.scala]
 indent_size = 2
 


### PR DESCRIPTION
## What does this change?

Align `.editorconfig` with linting rules for better DevX.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No

### Tested

- [X] Locally
