### PR TITLE
Add codename to NxTeam

### DIFF
--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -11,7 +11,7 @@ import implicits.{Football, Requests}
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model.{Cached, Competition, Content, ContentType, TeamColours}
 import org.joda.time.DateTime
-import pa.{FootballMatch, LineUp, LineUpTeam, MatchDayTeam}
+import pa.{FootballMatch, LineUp, LineUpTeam, MatchDayTeam, TeamCodes}
 import play.api.libs.json._
 import play.api.mvc._
 import play.twirl.api.Html
@@ -66,6 +66,7 @@ case class NxPlayer(
 case class NxTeam(
     id: String,
     name: String,
+    codename: String,
     players: Seq[NxPlayer],
     score: Int,
     scorers: List[String],
@@ -114,6 +115,7 @@ object NxAnswer {
     NxTeam(
       teamV1.id,
       cleanTeamName2021(teamV1.name),
+      codename = TeamCodes.codeFor(teamV1),
       players = players,
       score = teamV1.score.getOrElse(0),
       scorers = teamV1.scorers.fold(Nil: List[String])(


### PR DESCRIPTION
## What does this change?

Currently the short name of a team is computed as the first three letters to its long name. In the case of (The) Netherlands, that could be "NET" instead of the expected "NED". In the case of North Macedonia, that would be "NOR" which is the codename for Norway. 

This change simply adds `codename` to the match match-nav API answer. The codename is determined using PA's own function.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] Yes. Once the change is live in frontend, we will update DCR which is where we generate the match reports. 

## API Update

BEFORE

<img width="502" alt="Screenshot 2021-06-28 at 12 26 24" src="https://user-images.githubusercontent.com/6035518/123630114-0bdadf80-d80d-11eb-979b-b8d022b2a16c.png">


AFTER: 

<img width="565" alt="Screenshot 2021-06-28 at 12 26 17" src="https://user-images.githubusercontent.com/6035518/123630077-ffef1d80-d80c-11eb-92e3-e685398e83db.png">



