### PR TITLE
Ensure that hide button is clickable

### DIFF
--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -74,6 +74,10 @@ $block-height: 58px; // Note: duplicated from _item.scss
 }
 
 .fc-container--story-package {
+    
+    .fc-container__header {
+        z-index: 1;   
+    }
 
     .fc-container__body {
         position: relative;


### PR DESCRIPTION
## What does this change?

The hide button was not clickable on desktop breakpoint because the body was higher in the stack order, adding a simple `z-index` to the header for story packages nudges it above so that the hide link is clickable.

## BEfore

![2021-06-28 12 36 46](https://user-images.githubusercontent.com/638051/123630856-f1edcc80-d80d-11eb-9bb4-9242491133d0.gif)

## After

![2021-06-28 12 37 35](https://user-images.githubusercontent.com/638051/123630879-f87c4400-d80d-11eb-81a6-cf9fcd46b5af.gif)
