### PR TITLE
Expose header bidding switches

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -268,14 +268,14 @@ trait CommercialSwitches {
     exposeClientSide = true,
   )
 
-  val a9Switch: Switch = Switch(
+  val a9HeaderBidding: Switch = Switch(
     group = CommercialPrebid,
     name = "a9-header-bidding",
     description = "Turn on A9 header bidding",
     owners = group(Commercial),
     safeState = Off,
     sellByDate = never,
-    exposeClientSide = false,
+    exposeClientSide = true,
   )
 
   val redplanetForAUSSwitch: Switch = Switch(
@@ -311,14 +311,14 @@ trait CommercialSwitches {
 
 trait PrebidSwitches {
 
-  val prebidSwitch: Switch = Switch(
+  val prebidHeaderBidding: Switch = Switch(
     group = CommercialPrebid,
     name = "prebid-header-bidding",
     description = "Turn on Prebid header bidding (takes priority over Sonobi)",
     owners = group(Commercial),
     safeState = Off,
     sellByDate = never,
-    exposeClientSide = false,
+    exposeClientSide = true,
   )
 
   val prebidAnalytics: Switch = Switch(

--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -5,8 +5,8 @@ import common.Edition
 import common.Maps.RichMap
 import common.commercial.EditionAdTargeting._
 import conf.Configuration.environment
-import conf.switches.Switches.prebidSwitch
-import conf.switches.Switches.a9Switch
+import conf.switches.Switches.prebidHeaderBidding
+import conf.switches.Switches.a9HeaderBidding
 import model.IpsosTags.{getScriptTag}
 import conf.{Configuration, DiscussionAsset}
 import model._
@@ -56,8 +56,8 @@ object JavaScriptPage {
       "pbIndexSites" -> Json.toJson(metaData.commercial.flatMap(_.prebidIndexSites).getOrElse(Set.empty)),
       "hbImpl" -> JsObject(
         Seq(
-          "prebid" -> JsBoolean(prebidSwitch.isSwitchedOn),
-          "a9" -> JsBoolean(a9Switch.isSwitchedOn),
+          "prebid" -> JsBoolean(prebidHeaderBidding.isSwitchedOn),
+          "a9" -> JsBoolean(a9HeaderBidding.isSwitchedOn),
         ),
       ),
       "isSensitive" -> JsBoolean(page.metadata.sensitive),


### PR DESCRIPTION
## What does this change?

Expose both switches used to determine header bidding implementation to the client. We also rename them so their switch names match the names supplied in the switch (except in camelCase).

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No - DCR currently doesn't use these switches
- [ ] Yes

## What is the value of this and can you measure success?

Currently header bidding related switches aren't exposed to the client and their on/off state is surfaced via the `hbImpl` object in the page config. Instead of doing this we should remove the config property and expose the switches directly. 

This is the first step in no longer use hbImpl in the page config, by exposing the switches to the client but not removing the config. The next step will be to remove the config from DCR ([this PR](https://github.com/guardian/dotcom-rendering/pull/3136)) and then from frontend.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)