### PR TITLE
Remove unused and potentially conflicting code

### DIFF
--- a/sport/app/football/views/support.scala
+++ b/sport/app/football/views/support.scala
@@ -4,14 +4,6 @@ import pa.{LineUpPlayer, Team}
 import common.GuLogging
 import play.twirl.api.Html
 
-object ShortName {
-
-  val names = Map("44" -> "Wolves")
-
-  def apply(team: Team): String = names.getOrElse(team.id, team.name)
-
-}
-
 object MatchStatus extends GuLogging {
 
   // This is the list of possible statuses from the docs


### PR DESCRIPTION
## What does this change?

This removes some unused and potentially conflicting/misleading code. The correct way to decide a team short name is as done here: https://github.com/guardian/frontend/pull/23958/files

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
