### PR TITLE
Refactor to cleanTeamNameNextGenApi

### DIFF
--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -15,7 +15,7 @@ import pa.{FootballMatch, LineUp, LineUpTeam, MatchDayTeam, TeamCodes}
 import play.api.libs.json._
 import play.api.mvc._
 import play.twirl.api.Html
-import model.CompetitionDisplayHelpers.cleanTeamName2021
+import model.CompetitionDisplayHelpers.cleanTeamNameNextGenApi
 
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
@@ -114,7 +114,7 @@ object NxAnswer {
     val players = makePlayers(teamV2)
     NxTeam(
       teamV1.id,
-      cleanTeamName2021(teamV1.name),
+      cleanTeamNameNextGenApi(teamV1.name),
       codename = TeamCodes.codeFor(teamV1),
       players = players,
       score = teamV1.score.getOrElse(0),

--- a/sport/app/football/model/model.scala
+++ b/sport/app/football/model/model.scala
@@ -164,12 +164,7 @@ object CompetitionDisplayHelpers {
       .replace("Holland", "The Netherlands")
   }
 
-  // This function has specifically raised for the 2021 Euros after some clarification.
-  // "We're happy with "Netherlands" as a label, like the keyword for football and also the news one you can see here:
-  // https://www.theguardian.com/world/2021/jun/11/princess-amalia-heir-to-dutch-throne-waives-right-to-yearly-income"
-  // - Philip Cornwall, 16/6/21
-  // I don't know if this is permanent going forward hence the separate function.
-  def cleanTeamName2021(teamName: String): String = {
+  def cleanTeamNameNextGenApi(teamName: String): String = {
     teamName
       .replace("Ladies", "")
       .replace("Holland", "Netherlands")


### PR DESCRIPTION
## What does this change?

This renames `cleanTeamName2021`, into `cleanTeamNameNextGenApi`, because the existing name is a bit surprising. 

With that change it is now clear that we have three substitutions functions: 

- `cleanTeamName` used in the legacy html views,
- `cleanTeamNameNextGenApi` used for the frontend api json answers.
- `cleanTeamNameSpider` used for the spider (due to spider specific layout constraints).

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)
