### PR TITLE
Decommissioning joda.time 4/.

### DIFF
--- a/admin/app/views/email/expiringSwitches.scala.html
+++ b/admin/app/views/email/expiringSwitches.scala.html
@@ -8,7 +8,7 @@
         <div>
             <strong>@{switch.name}</strong>
             - @showOwners(switch.owners)
-            @if(showExpirationDate) { - <span style="color:grey;font-style: italic;">expires @{switch.sellByDate.get.toString("E dd MMM")} at 23:59 (London time)</span>}
+            @if(showExpirationDate) { - <span style="color:grey;font-style: italic;">@{Switch.expiryAsUserFriendlyString(switch)}</span>}
         </div>
         <div>@{switch.description}</div>
     </li>

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -1,7 +1,7 @@
 package conf.switches
 
 import conf.switches.SwitchGroup.ABTests
-import org.joda.time.LocalDate
+import java.time.LocalDate
 
 trait ABTestSwitches {
   Switch(
@@ -10,7 +10,7 @@ trait ABTestSwitches {
     "Control audience for the sign in gate to 9% audience. Will never see the sign in gate.",
     owners = Seq(Owner.withGithub("coldlink")),
     safeState = Off,
-    sellByDate = new LocalDate(2021, 12, 1),
+    sellByDate = Some(LocalDate.of(2021, 12, 1)),
     exposeClientSide = true,
   )
 
@@ -20,7 +20,7 @@ trait ABTestSwitches {
     "Show sign in gate to 90% of users on 3rd article view, variant/full audience",
     owners = Seq(Owner.withGithub("coldlink")),
     safeState = Off,
-    sellByDate = new LocalDate(2021, 12, 1),
+    sellByDate = Some(LocalDate.of(2021, 12, 1)),
     exposeClientSide = true,
   )
 
@@ -30,7 +30,7 @@ trait ABTestSwitches {
     "Mandatory sign in gate to users in US split test",
     owners = Seq(Owner.withGithub("quarpt")),
     safeState = Off,
-    sellByDate = new LocalDate(2021, 12, 1),
+    sellByDate = Some(LocalDate.of(2021, 12, 1)),
     exposeClientSide = true,
   )
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -1,7 +1,7 @@
 package conf.switches
 
 import conf.switches.Expiry.never
-import org.joda.time.LocalDate
+import java.time.LocalDate
 import conf.switches.Owner.group
 import conf.switches.SwitchGroup.Commercial
 
@@ -440,7 +440,7 @@ trait FeatureSwitches {
     "Enables the puzzles banner on puzzles pages",
     owners = Seq(Owner.withGithub("i-hardy")),
     safeState = Off,
-    sellByDate = new LocalDate(2022, 3, 31),
+    sellByDate = LocalDate.of(2022, 3, 31),
     exposeClientSide = true,
   )
 
@@ -450,7 +450,7 @@ trait FeatureSwitches {
     "Enables the anniversary logo SVG in the header",
     owners = Seq(Owner.withGithub("buck06191")),
     safeState = Off,
-    sellByDate = new LocalDate(2022, 5, 11),
+    sellByDate = LocalDate.of(2022, 5, 11),
     exposeClientSide = true,
   )
 
@@ -460,7 +460,7 @@ trait FeatureSwitches {
     "Enables a Euro 2020 version of the banner on the fiver email",
     owners = Seq(Owner.withGithub("jfsoul")),
     safeState = Off,
-    sellByDate = new LocalDate(2021, 7, 20),
+    sellByDate = LocalDate.of(2021, 7, 20),
     exposeClientSide = false,
   )
 
@@ -470,7 +470,7 @@ trait FeatureSwitches {
     "Activate the Interactive Picker (routing interactives between frontend and DCR)",
     owners = Seq(Owner.withName("Pascal")),
     safeState = Off,
-    sellByDate = new LocalDate(2021, 9, 30),
+    sellByDate = LocalDate.of(2021, 9, 30),
     exposeClientSide = false,
   )
 }

--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -1,7 +1,7 @@
 package conf.switches
 
 import conf.switches.Expiry.never
-import org.joda.time.LocalDate
+import java.time.LocalDate
 
 trait PerformanceSwitches {
 
@@ -183,7 +183,7 @@ trait PerformanceSwitches {
     "If switched on, explicitly request lazy loading of images on supporting browsers.",
     owners = Seq(Owner.withGithub("nicl")),
     safeState = On,
-    sellByDate = new LocalDate(2029, 9, 3),
+    sellByDate = LocalDate.of(2029, 9, 3),
     exposeClientSide = false,
   )
 }

--- a/common/app/experiments/Experiment.scala
+++ b/common/app/experiments/Experiment.scala
@@ -2,7 +2,7 @@ package experiments
 
 import conf.switches.{Owner, Switch, SwitchGroup}
 import conf.switches.Switches.ServerSideExperiments
-import org.joda.time.LocalDate
+import java.time.LocalDate
 import play.api.mvc.RequestHeader
 
 abstract case class Experiment(

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -1,10 +1,8 @@
 package experiments
 
-import conf.switches.{Owner, SwitchGroup}
+import conf.switches.Owner
 import experiments.ParticipationGroups._
-import org.joda.time.LocalDate
-import conf.switches.Owner.group
-import conf.switches.SwitchGroup.Commercial
+import java.time.LocalDate
 
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
@@ -19,7 +17,7 @@ object LiveblogRendering
       name = "liveblog-rendering",
       description = "Use DCR for liveblogs",
       owners = Seq(Owner.withGithub("shtukas")),
-      sellByDate = new LocalDate(2021, 11, 30),
+      sellByDate = LocalDate.of(2021, 11, 30),
       participationGroup = Perc0A,
     )
 
@@ -28,6 +26,6 @@ object InteractiveLibrarian
       name = "interactive-librarian",
       description = "Private experiment to develop archiving backup for Interactives",
       owners = Seq(Owner.withGithub("shtukas")),
-      sellByDate = new LocalDate(2021, 8, 31),
+      sellByDate = LocalDate.of(2021, 8, 31),
       participationGroup = Perc0B,
     )

--- a/common/test/common/ExperimentsTest.scala
+++ b/common/test/common/ExperimentsTest.scala
@@ -1,7 +1,7 @@
 package experiments
 
 import conf.switches.Owner
-import org.joda.time.LocalDate
+import java.time.LocalDate
 import org.scalatest.{FlatSpec, Matchers}
 import test.TestRequest
 import ParticipationGroups._
@@ -111,7 +111,7 @@ class ExperimentsTest extends FlatSpec with Matchers {
           "experiment0",
           "an experiment",
           Seq(Owner.withName("Fake owner")),
-          new LocalDate(2100, 1, 1),
+          LocalDate.of(2100, 1, 1),
           participationGroup = Perc0A,
         )
     object experiment1
@@ -119,7 +119,7 @@ class ExperimentsTest extends FlatSpec with Matchers {
           "experiment1",
           "another experiment",
           Seq(Owner.withName("Fake owner")),
-          new LocalDate(2100, 1, 1),
+          LocalDate.of(2100, 1, 1),
           participationGroup = Perc1A,
         )
     object experiment2
@@ -127,7 +127,7 @@ class ExperimentsTest extends FlatSpec with Matchers {
           "experiment2",
           "still another experiment",
           Seq(Owner.withName("Fake owner")),
-          new LocalDate(2100, 1, 1),
+          LocalDate.of(2100, 1, 1),
           participationGroup = Perc1B,
         )
     object experimentWithTruePriorCondition
@@ -135,7 +135,7 @@ class ExperimentsTest extends FlatSpec with Matchers {
           "experiment-with-true-prior-condition",
           "an experiment",
           Seq(Owner.withName("Fake owner")),
-          new LocalDate(2100, 1, 1),
+          LocalDate.of(2100, 1, 1),
           participationGroup = Perc1C,
         ) {
       override def priorCondition(implicit request: RequestHeader): Boolean = true
@@ -145,7 +145,7 @@ class ExperimentsTest extends FlatSpec with Matchers {
           "experiment-with-false-prior-condition",
           "an experiment",
           Seq(Owner.withName("Fake owner")),
-          new LocalDate(2100, 1, 1),
+          LocalDate.of(2100, 1, 1),
           participationGroup = Perc1D,
         ) {
       override def priorCondition(implicit request: RequestHeader): Boolean = false
@@ -155,7 +155,7 @@ class ExperimentsTest extends FlatSpec with Matchers {
           "experiment-with-extra-header",
           "an experiment",
           Seq(Owner.withName("Fake owner")),
-          new LocalDate(2100, 1, 1),
+          LocalDate.of(2100, 1, 1),
           participationGroup = Perc1E,
         ) {
       override val extraHeader: Option[ExperimentHeader] = Some(ExperimentHeader("extraCond", "true"))

--- a/common/test/conf/switches/SwitchesTest.scala
+++ b/common/test/conf/switches/SwitchesTest.scala
@@ -1,7 +1,7 @@
 package conf.switches
 
-import org.joda.time.DateTimeConstants.{SATURDAY, SUNDAY}
-import org.joda.time.LocalDate
+import java.time.DayOfWeek.{SATURDAY, SUNDAY}
+import java.time.LocalDate
 import org.scalatest.{AppendedClues, FlatSpec, Matchers}
 
 class SwitchesTest extends FlatSpec with Matchers with AppendedClues {
@@ -15,7 +15,7 @@ class SwitchesTest extends FlatSpec with Matchers with AppendedClues {
   private val testSwitchGroup = new SwitchGroup("category")
 
   private val switchExpiryDate = {
-    val today = new LocalDate()
+    val today = LocalDate.now()
     if (today.getDayOfWeek == SATURDAY) today.plusDays(2)
     else if (today.getDayOfWeek == SUNDAY) today.plusDays(1)
     else today
@@ -28,7 +28,7 @@ class SwitchesTest extends FlatSpec with Matchers with AppendedClues {
       "exciting switch",
       owners = Seq(Owner.withGithub("FakeOwner")),
       safeState = Off,
-      sellByDate = switchExpiryDate,
+      sellByDate = Some(switchExpiryDate),
       exposeClientSide = true,
     )
 


### PR DESCRIPTION
## What does this change?

Step 4 of the going project of decommissioning `joda.time` from frontend. 

Notes :

1. the refactoring in `expiringSwitches.scala.html`, because `switch.sellByDate.get.toString` is inherently dangerous since `switch.sellByDate` is an option (would not cause any problem in the current code due to `if(showExpirationDate)`, but still a potential problem).

2. `Days.daysBetween` needs arguments which support the `SECONDS` unit, which explain the `.atStartOfDay()` conversion to a `LocalDateTime`.

3. `Switch`'s `sellByDate` is an option, I can't event explain why `sellByDate = switchExpiryDate` didn't fail before.

Previous step: https://github.com/guardian/frontend/pull/23964