### PR TITLE
Decommissioning joda.time 5/.

### DIFF
--- a/admin/app/jobs/AnalyticsSanityCheckJob.scala
+++ b/admin/app/jobs/AnalyticsSanityCheckJob.scala
@@ -60,11 +60,11 @@ class AnalyticsSanityCheckJob(ophanApi: OphanApi) extends GuLogging {
   }
 
   private def ophanViews()(implicit executionContext: ExecutionContext): Future[Long] = {
-    val fifteenMinsAgo: Long = LocalDateTime.now().minusMinutes(15).atZone(ZoneId.of("UTC")).toInstant().toEpochMilli()
+    val instant: Long = LocalDateTime.now().minusMinutes(15).atZone(ZoneId.of("UTC")).toInstant().toEpochMilli()
     ophanApi.getBreakdown("next-gen", hours = 1).map { json =>
       (json \\ "data").flatMap { line =>
         val recent = line.asInstanceOf[play.api.libs.json.JsArray].value.filter { entry =>
-          (entry \ "dateTime").as[Long] > fifteenMinsAgo
+          (entry \ "dateTime").as[Long] > instant
         }
         recent.map(r => (r \ "count").as[Long])
       }.sum

--- a/admin/app/jobs/AnalyticsSanityCheckJob.scala
+++ b/admin/app/jobs/AnalyticsSanityCheckJob.scala
@@ -1,12 +1,12 @@
 package jobs
 
 import java.util.concurrent.atomic.AtomicLong
-
 import com.amazonaws.services.cloudwatch.model.{GetMetricStatisticsResult, StandardUnit}
 import common.GuLogging
 import metrics.GaugeMetric
 import model.diagnostics.CloudWatch
-import org.joda.time.DateTime
+
+import java.time.{LocalDateTime, ZoneId}
 import services.{CloudWatchStats, OphanApi}
 
 import scala.collection.JavaConverters._
@@ -60,11 +60,11 @@ class AnalyticsSanityCheckJob(ophanApi: OphanApi) extends GuLogging {
   }
 
   private def ophanViews()(implicit executionContext: ExecutionContext): Future[Long] = {
-    val now = new DateTime().minusMinutes(15).getMillis
+    val fifteenMinsAgo: Long = LocalDateTime.now().minusMinutes(15).atZone(ZoneId.of("UTC")).toInstant().toEpochMilli()
     ophanApi.getBreakdown("next-gen", hours = 1).map { json =>
       (json \\ "data").flatMap { line =>
         val recent = line.asInstanceOf[play.api.libs.json.JsArray].value.filter { entry =>
-          (entry \ "dateTime").as[Long] > now
+          (entry \ "dateTime").as[Long] > fifteenMinsAgo
         }
         recent.map(r => (r \ "count").as[Long])
       }.sum


### PR DESCRIPTION
## What does this change?

Step 5 of the going project of decommissioning `joda.time` from frontend.

Previous step: https://github.com/guardian/frontend/pull/23965