### PR TITLE
Enhancing richlink JSON with 'imageAsset' data (for DCR, downstream)

### DIFF
--- a/onward/app/controllers/RichLinkController.scala
+++ b/onward/app/controllers/RichLinkController.scala
@@ -4,7 +4,7 @@ import common.`package`.convertApiExceptionsWithoutEither
 import common.{Edition, GuLogging, ImplicitControllerExecutionContext, JsonComponent}
 import contentapi.ContentApiClient
 import implicits.Requests
-import model.{ApplicationContext, Cached, Content, ContentFormat, ContentType}
+import model.{ApplicationContext, Cached, Content, ContentFormat, ContentType, ImageAsset}
 import models.dotcomponents.{OnwardsUtils, RichLink, RichLinkTag}
 import play.api.mvc.{Action, AnyContent, ControllerComponents, RequestHeader}
 import play.twirl.api.Html
@@ -28,6 +28,7 @@ class RichLinkController(contentApiClient: ContentApiClient, controllerComponent
               content.tags.tags.map(t => RichLinkTag(t.properties.id, t.properties.tagType, t.properties.webTitle)),
             cardStyle = content.content.cardStyle.toneString,
             thumbnailUrl = content.trail.trailPicture.flatMap(tp => Item460.bestSrcFor(tp)),
+            imageAsset = content.trail.trailPicture.flatMap(tp => Item460.bestFor(tp)),
             headline = content.trail.headline,
             contentType = content.metadata.contentType,
             starRating = content.content.starRating,

--- a/onward/app/models/dotcomponents/DotcomponentsOnwardsModels.scala
+++ b/onward/app/models/dotcomponents/DotcomponentsOnwardsModels.scala
@@ -1,7 +1,7 @@
 package models.dotcomponents
 
 import com.gu.contentapi.client.utils.DesignType
-import model.{ContentFormat, DotcomContentType, Pillar}
+import model.{ContentFormat, DotcomContentType, Pillar, ImageAsset}
 import play.api.libs.json.Json
 
 // duplicated in dotcomponentsdatamodel
@@ -19,6 +19,7 @@ case class RichLink(
     tags: List[RichLinkTag],
     cardStyle: String,
     thumbnailUrl: Option[String],
+    imageAsset: Option[ImageAsset],
     headline: String,
     contentType: Option[DotcomContentType],
     starRating: Option[Int],


### PR DESCRIPTION
## What does this change?
Adding the 'imageasset' data to the richlink endpoint, to be consumed by DCR

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes (please indicate your plans for DCR Implementation)

Not "reproduced" as such, but the next PR from me there will be the continuation of this work.

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->
<img width="822" alt="Screenshot at Jun 29 12-32-17" src="https://user-images.githubusercontent.com/3300789/123790609-70ae3c80-d8d6-11eb-91cf-ed4ba18b2597.png">


## What is the value of this and can you measure success?
Will improve our core web vitals- hopefully by a measurable amount (a point or two?)

## Checklist

### Does this affect other platforms?
N/A

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->
N/A
- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
