### PR TITLE
increase US mandatory gate audience to 25%

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
@@ -8,7 +8,7 @@ export const signInGateMainVariant = {
     author: 'Mahesh Makani',
     description:
         'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Main/Variant Audience.',
-    audience: 0.89,
+    audience: 0.65,
     audienceOffset: 0.0,
     successMeasure: 'Users sign in or create a Guardian account',
     audienceCriteria:

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-us-mandatory.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-us-mandatory.js
@@ -5,8 +5,8 @@ export const signInGateUsMandatory = {
 	author: 'Identity Team',
 	description:
         'Compare mandatory gate (an article sigin gate without the dismiss button) with the main signin gate for US only',
-    audience: 0.01,
-	audienceOffset: 0.89,
+    audience: 0.25,
+	audienceOffset: 0.65,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:
         '3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss or reshown after 5 dismisses, not on help, info sections etc. exclude iOS 9 and guardian-live, US only, only users with specific CMP consents. Suppresses other banners, and appears over epics',


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Increase US mandatory signin gate audience to 25%. This eats into the main variant audience. The mandatory gate variant is same as main variant, but without the dismiss button.

## Why?

We want more users to see mandatory variant


See https://github.com/guardian/dotcom-rendering/pull/3157