### PR TITLE
Clarify `amIUsed` JSdoc and test description

### DIFF
--- a/static/src/javascripts/projects/commercial/sentinel.spec.ts
+++ b/static/src/javascripts/projects/commercial/sentinel.spec.ts
@@ -106,7 +106,7 @@ describe('sentinel', () => {
 		]);
 	});
 
-	test('should convert parameter values to strings', () => {
+	test('should chain optional parameters to the properties array', () => {
 		config.get.mockReturnValue(true);
 		amIUsed('moduleName', 'functionName', {
 			conditionA: 'true',

--- a/static/src/javascripts/projects/commercial/sentinel.ts
+++ b/static/src/javascripts/projects/commercial/sentinel.ts
@@ -28,7 +28,7 @@ type RestrictedKeys = 'module_name' | 'function_name' | 'URL';
  * logged into the `fastly_logging` table within the `logging` dataset.
  * @param moduleName the name of the JS/TS module (e.g. `article-body-adverts`)
  * @param functionName the name of the function within the module (e.g. `init`)
- * @param parameters an optional object to add function-specific information (e.g. `{ conditionA: true, conditionB: false }`)
+ * @param parameters an optional object to add function-specific information (e.g. `{ conditionA: 'true', conditionB: 'false' }`)
  * @returns void.
  */
 export const amIUsed = (


### PR DESCRIPTION
## What does this change?
Changed the JSdoc of `amIUsed` and clarified a test description, since the optional parameter can only take strings as values. 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)


## What is the value of this and can you measure success?
Comments in the code should describe what the logic does. 