### PR TITLE
Render cartoon interactives on DCR

### DIFF
--- a/applications/app/services/InteractivePicker.scala
+++ b/applications/app/services/InteractivePicker.scala
@@ -27,6 +27,16 @@ object InteractivePicker {
     date.isAfter(InteractiveSwitchOver.date)
   }
 
+  def isCartoon(tags: List[Tag]): Boolean = {
+    tags.exists(t => t.id == "tone/cartoons")
+  }
+
+  def isSupported(tags: List[Tag]): Boolean = {
+    // This will be expanded more as we support more interactives
+    if (isCartoon((tags)))  true
+    else false
+  }
+
   def isOptedOut(tags: List[Tag]): Boolean = {
     tags.exists(t => t.id == "tracking/platformfunctional/dcroptout")
   }
@@ -47,6 +57,7 @@ object InteractivePicker {
 
     if (forceDCR || isMigrated || isOptedInAmp) DotcomRendering
     else if (switchOn && publishedPostSwitch && isWebNotOptedOut) DotcomRendering
+    else if (switchOn && isSupported(tags)) DotcomRendering
     else FrontendLegacy
   }
 }

--- a/applications/app/services/InteractivePicker.scala
+++ b/applications/app/services/InteractivePicker.scala
@@ -28,7 +28,8 @@ object InteractivePicker {
   }
 
   def isCartoon(tags: List[Tag]): Boolean = {
-    tags.exists(t => t.id == "tone/cartoons")
+    def isCartoonTagId(tag: Tag) = List("tone/cartoons", "profile/david-squires").contains(tag.id)
+    tags.exists(isCartoonTagId _)
   }
 
   def isSupported(tags: List[Tag]): Boolean = {

--- a/applications/app/services/InteractivePicker.scala
+++ b/applications/app/services/InteractivePicker.scala
@@ -33,8 +33,7 @@ object InteractivePicker {
 
   def isSupported(tags: List[Tag]): Boolean = {
     // This will be expanded more as we support more interactives
-    if (isCartoon((tags))) true
-    else false
+    isCartoon(tags)
   }
 
   def isOptedOut(tags: List[Tag]): Boolean = {
@@ -57,7 +56,7 @@ object InteractivePicker {
 
     if (forceDCR || isMigrated || isOptedInAmp) DotcomRendering
     else if (switchOn && publishedPostSwitch && isWebNotOptedOut) DotcomRendering
-    else if (switchOn && isSupported(tags)) DotcomRendering
+    else if (switchOn && isSupported(tags) && isWebNotOptedOut) DotcomRendering
     else FrontendLegacy
   }
 }

--- a/applications/app/services/InteractivePicker.scala
+++ b/applications/app/services/InteractivePicker.scala
@@ -33,7 +33,7 @@ object InteractivePicker {
 
   def isSupported(tags: List[Tag]): Boolean = {
     // This will be expanded more as we support more interactives
-    if (isCartoon((tags)))  true
+    if (isCartoon((tags))) true
     else false
   }
 

--- a/applications/app/services/InteractivePicker.scala
+++ b/applications/app/services/InteractivePicker.scala
@@ -28,8 +28,8 @@ object InteractivePicker {
   }
 
   def isCartoon(tags: List[Tag]): Boolean = {
-    def isCartoonTag(tag: Tag) = List("tone/cartoons", "profile/david-squires").contains(tag.id)
-    tags.exists(isCartoonTag)
+    val cartoonTagIds = Set("tone/cartoons", "profile/david-squires")
+    tags.exists(tag => cartoonTagIds.contains(tag.id))
   }
 
   def isSupported(tags: List[Tag]): Boolean = {

--- a/applications/app/services/InteractivePicker.scala
+++ b/applications/app/services/InteractivePicker.scala
@@ -29,7 +29,7 @@ object InteractivePicker {
 
   def isCartoon(tags: List[Tag]): Boolean = {
     def isCartoonTagId(tag: Tag) = List("tone/cartoons", "profile/david-squires").contains(tag.id)
-    tags.exists(isCartoonTagId _)
+    tags.exists(isCartoonTagId)
   }
 
   def isSupported(tags: List[Tag]): Boolean = {

--- a/applications/app/services/InteractivePicker.scala
+++ b/applications/app/services/InteractivePicker.scala
@@ -28,8 +28,8 @@ object InteractivePicker {
   }
 
   def isCartoon(tags: List[Tag]): Boolean = {
-    def isCartoonTagId(tag: Tag) = List("tone/cartoons", "profile/david-squires").contains(tag.id)
-    tags.exists(isCartoonTagId)
+    def isCartoonTag(tag: Tag) = List("tone/cartoons", "profile/david-squires").contains(tag.id)
+    tags.exists(isCartoonTag)
   }
 
   def isSupported(tags: List[Tag]): Boolean = {


### PR DESCRIPTION
## What does this change?

- Expand InteractivePicker to allow for new checks on whether an interactive is supported
- Check if the article is a cartoon and if so allow it to be rendered on DCR

Credit to Scala mob programming group 'Wheatley' :D 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
