### PR TITLE
Add sentinel logger to all functions in `next-video-autoplay`

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/hosted/next-video-autoplay.ts
+++ b/static/src/javascripts/projects/commercial/modules/hosted/next-video-autoplay.ts
@@ -9,6 +9,7 @@ let $timer: HTMLElement | null;
 let nextVideoPage: string | undefined;
 
 const cancelAutoplay = () => {
+	amIUsed('next-video-autoplay', 'cancelAutoplay');
 	fastdom.mutate(() => {
 		$hostedNext?.classList.add('hosted-slide-out');
 	});
@@ -16,6 +17,7 @@ const cancelAutoplay = () => {
 };
 
 const cancelAutoplayMobile = () => {
+	amIUsed('next-video-autoplay', 'cancelAutoplayMobile');
 	fastdom.mutate(() => {
 		$hostedNext?.classList.add('u-h');
 	});
@@ -44,6 +46,7 @@ const triggerAutoplay = (
 };
 
 const triggerEndSlate = (): void => {
+	amIUsed('next-video-autoplay', 'triggerEndSlate');
 	fastdom.mutate(() => {
 		$hostedNext?.classList.add('js-autoplay-start');
 	});
@@ -55,25 +58,30 @@ const triggerEndSlate = (): void => {
 };
 
 const addCancelListener = (): void => {
+	amIUsed('next-video-autoplay', 'addCancelListener');
 	const element = document.querySelector('.js-autoplay-cancel');
 	element?.addEventListener('click', () => {
 		cancelAutoplay();
 	});
 };
 
-const canAutoplay = (): boolean => !!($hostedNext && nextVideoPage);
+const canAutoplay = (): boolean => {
+	amIUsed('next-video-autoplay', 'canAutoplay');
+	return !!($hostedNext && nextVideoPage);
+};
 
 /*
     This module appears to setup autoplay for guardian-hosted commercial videos (i.e. not Youtube) - couldn't find any examples of this
 */
 
-const init = (): Promise<void> =>
-	load().then(() => {
+const init = (): Promise<void> => {
+	amIUsed('next-video-autoplay', 'init');
+	return load().then(() => {
 		$hostedNext = document.querySelector('.js-hosted-next-autoplay');
 		$timer = document.querySelector('.js-autoplay-timer');
 		nextVideoPage = $timer?.dataset.nextPage;
 	});
-
+};
 export {
 	init,
 	canAutoplay,


### PR DESCRIPTION
## What does this change?
Added `amIUsed` to all functions in `next-video-autoplay`. 

PR #23885 introduced `amIUsed` to `triggerAutoplay`. We haven't received any reports in a month so it is likely that this module can be deleted. However, to be extra sure that we're not deleting code that is actually being run, this PR adds an extra safety check that will hopefully prove that we can delete this module, if we don't receive any logs for a few days.

## Does this change need to be reproduced in dotcom-rendering ?
- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
Smaller bundle.

## Checklist

### Tested

- [x] Locally (made sure the `init` function isn't called on obvious pages such as [this one]( https://www.theguardian.com/technology/video/2021/apr/29/europes-first-fully-3d-printed-house-gets-its-first-tenants-video) so we don't get inundated by logs)
- [ ] On CODE (optional)


<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
