### PR TITLE
Do not show RR header links on galleries

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -499,6 +499,10 @@ export const fetchAndRenderHeaderLinks = async () => {
         return;
     }
 
+    if (config.get('page.contentType') === 'Gallery') {
+        return;
+    }
+
     try {
         const response = await getHeaderLinks(requestData);
         if (!response.data) {


### PR DESCRIPTION
the header is very small

Before:
![hidden_cta](https://user-images.githubusercontent.com/1513454/124477702-39d79b00-dd9c-11eb-8f7b-cb25ce95f347.png)
