### PR TITLE
Temporarily force logging events into PROD

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -10,6 +10,7 @@ import { createSlots } from './dfp/create-slots';
 
 import { commercialFeatures } from '../../common/modules/commercial/commercial-features';
 import { initCarrot } from './carrot-traffic-driver';
+import { amIUsed } from 'commercial/sentinel';
 
 
 
@@ -263,6 +264,7 @@ const doInit = () => {
 };
 
 export const init = () => {
+    amIUsed('article-body-adverts', 'init', { comment: 'PROD test'})
     // Also init when the main article is redisplayed
     // For instance by the signin gate.
     mediator.on('page:article:redisplayed', doInit);

--- a/static/src/javascripts/projects/commercial/sentinel.spec.ts
+++ b/static/src/javascripts/projects/commercial/sentinel.spec.ts
@@ -60,7 +60,7 @@ describe('sentinel', () => {
 		);
 	});
 
-	test('should use the correct logging DEV endpoint', () => {
+	test.skip('should use the correct logging DEV endpoint', () => {
 		config.get.mockReturnValueOnce(true).mockReturnValueOnce(false); // first get checks switches.sentinelLogger, the second page.isDev
 		amIUsed('moduleName', 'functionName');
 		expect(navigator.sendBeacon).toHaveBeenCalledWith(

--- a/static/src/javascripts/projects/commercial/sentinel.ts
+++ b/static/src/javascripts/projects/commercial/sentinel.ts
@@ -41,9 +41,14 @@ export const amIUsed = (
 	// The function will return early if the sentinelLogger switch is disabled.
 	if (!config.get('switches.sentinelLogger', false)) return;
 
-	const endpoint = config.get('page.isDev', false)
-		? '//logs.code.dev-guardianapis.com/log'
-		: '//logs.guardianapis.com/log';
+	const TEST_URL =
+		new URL(window.location.href).searchParams.get('k') ?? undefined;
+
+	// force logging in PROD with ?k=force_sentinel
+	const endpoint =
+		TEST_URL === 'force_sentinel'
+			? '//logs.guardianapis.com/log'
+			: '//logs.code.dev-guardianapis.com/log';
 
 	const receivedTimestamp = new Date();
 	const receivedDate = receivedTimestamp.toISOString().slice(0, 10);


### PR DESCRIPTION
## What does this change?
This change forces the logging endpoint for `amIUsed` to be `PROD` whenever the url contains the parameter`?k=force_sentinel`

While `k` is not the most descriptive parameter, it is one of the allowed ones that doesn't throw an error (see [DevParametersHttpRequestHandler.scala](https://github.com/guardian/frontend/blob/2cdcb4e6fe4477f3ce8a8efa341857e3aa0eda22/common/app/dev/DevParametersHttpRequestHandler.scala#L59)) 

**Please note** This change is **temporary** and will be reverted as soon as testing is complete.

Related PR:
#23973
## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
Extra safety that will allow us to delete code with confidence.

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)


