### PR TITLE
DCR interactives immersives live

### DIFF
--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -115,7 +115,7 @@ class InteractiveController(
         case Left((page, blocks)) => {
           val tags = page.interactive.tags.tags
           val date = page.interactive.trail.webPublicationDate
-          val tier = InteractivePicker.getRenderingTier(requestFormat, path, date, tags)
+          val tier = InteractivePicker.getRenderingTier(page.interactive, requestFormat)
 
           (requestFormat, tier) match {
             case (AmpFormat, DotcomRendering)  => renderAmp(page, blocks)

--- a/applications/app/services/InteractivePicker.scala
+++ b/applications/app/services/InteractivePicker.scala
@@ -44,8 +44,10 @@ object InteractivePicker {
 
   // Immersives tend to work fairly well in DCR as they don't rely on modifying
   // existing page markup.
-  def isImmersive(format: Option[ContentFormat]): Boolean = {
-    format.exists(_.display == ImmersiveDisplay)
+  def isSupportedImmersive(interactive: Interactive): Boolean = {
+    val supportedTagIds = Set("tone/documentaries")
+    val isSupportedTag = interactive.tags.tags.exists(tag => supportedTagIds.contains(tag.id))
+    interactive.metadata.format.exists(_.display == ImmersiveDisplay) && isSupportedTag
   }
 
   def getRenderingTier(interactive: Interactive, requestFormat: RequestFormat)(implicit
@@ -61,7 +63,7 @@ object InteractivePicker {
       !isOptedOut(tags) && (
         dateIsPostTransition(interactive.trail.webPublicationDate) ||
         isCartoon(tags) ||
-        isImmersive(interactive.metadata.format) ||
+        isSupportedImmersive(interactive) ||
         isAmpOptedIn(requestFormat, tags) ||
         isAllowList(interactive.metadata.id)
       )


### PR DESCRIPTION
## What does this change?

**Update:  only switches documentary immersive interactives live for now as there are outstanding issues with other immersives to fix.**

Follow on from https://github.com/guardian/frontend/pull/23976 which should go live very soon.

Defaults immersive interactives to DCR.

Refactor is for picker logic clarity as it's grown a bit more complicated now. And to comment some of the bits to explain the thinking as we migrate.