### PR TITLE
Revert forced logging of commercial sentinel events into the PROD table

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -264,7 +264,6 @@ const doInit = () => {
 };
 
 export const init = () => {
-    amIUsed('article-body-adverts', 'init', { comment: 'PROD test'})
     // Also init when the main article is redisplayed
     // For instance by the signin gate.
     mediator.on('page:article:redisplayed', doInit);

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -10,7 +10,6 @@ import { createSlots } from './dfp/create-slots';
 
 import { commercialFeatures } from '../../common/modules/commercial/commercial-features';
 import { initCarrot } from './carrot-traffic-driver';
-import { amIUsed } from 'commercial/sentinel';
 
 
 

--- a/static/src/javascripts/projects/commercial/sentinel.spec.ts
+++ b/static/src/javascripts/projects/commercial/sentinel.spec.ts
@@ -60,7 +60,7 @@ describe('sentinel', () => {
 		);
 	});
 
-	test.skip('should use the correct logging DEV endpoint', () => {
+	test('should use the correct logging DEV endpoint', () => {
 		config.get.mockReturnValueOnce(true).mockReturnValueOnce(false); // first get checks switches.sentinelLogger, the second page.isDev
 		amIUsed('moduleName', 'functionName');
 		expect(navigator.sendBeacon).toHaveBeenCalledWith(

--- a/static/src/javascripts/projects/commercial/sentinel.ts
+++ b/static/src/javascripts/projects/commercial/sentinel.ts
@@ -41,14 +41,9 @@ export const amIUsed = (
 	// The function will return early if the sentinelLogger switch is disabled.
 	if (!config.get('switches.sentinelLogger', false)) return;
 
-	const TEST_URL =
-		new URL(window.location.href).searchParams.get('k') ?? undefined;
-
-	// force logging in PROD with ?k=force_sentinel
-	const endpoint =
-		TEST_URL === 'force_sentinel'
-			? '//logs.guardianapis.com/log'
-			: '//logs.code.dev-guardianapis.com/log';
+	const endpoint = config.get('page.isDev', false)
+		? '//logs.code.dev-guardianapis.com/log'
+		: '//logs.guardianapis.com/log';
 
 	const receivedTimestamp = new Date();
 	const receivedDate = receivedTimestamp.toISOString().slice(0, 10);


### PR DESCRIPTION
## What does this change?
### This PR reverts #23980.
Testing has shown that `amIUsed` correctly logs events into the `fastly_logging` table within `datatech-platform-prod` as expected.
Tests were run on liveblogs, fronts, and DCR-rendered articles.

## Screenshots
**Query**
![image](https://user-images.githubusercontent.com/57295823/124499125-664be100-ddb5-11eb-90b6-12396dc62ccf.png)

**Result**
![image](https://user-images.githubusercontent.com/57295823/124499041-44eaf500-ddb5-11eb-91ca-d9d43683e469.png)

## Checklist

### Tested

- [ ] Locally
- [ ] On CODE (optional)
- [x] Live

