### PR TITLE
Add sentinel checks to `hide.js` and `hide-element.js`

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/hide-element.js
+++ b/static/src/javascripts/projects/commercial/modules/hide-element.js
@@ -1,4 +1,7 @@
+import { amIUsed } from 'commercial/sentinel';
 import fastdom from '../../../lib/fastdom-promise';
 
-export const hideElement =(element) =>
+export const hideElement = (element) => {
+    amIUsed('hide-element', 'hideElement')
     fastdom.mutate(() => element.classList.add('u-h'));
+}

--- a/static/src/javascripts/projects/commercial/modules/hide-element.js
+++ b/static/src/javascripts/projects/commercial/modules/hide-element.js
@@ -3,5 +3,5 @@ import fastdom from '../../../lib/fastdom-promise';
 
 export const hideElement = (element) => {
     amIUsed('hide-element', 'hideElement')
-    fastdom.mutate(() => element.classList.add('u-h'));
+    return fastdom.mutate(() => element.classList.add('u-h'));
 }

--- a/static/src/javascripts/projects/commercial/modules/messenger/hide.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/hide.js
@@ -1,11 +1,16 @@
+import { amIUsed } from 'commercial/sentinel';
 import { hideElement } from '../hide-element';
 
 const init = (register) => {
+    amIUsed('hide', 'init');
     register('hide', (specs, ret, iframe) => {
+        amIUsed('hide', 'init', { nested_function_name: 'register' });
         if (iframe) {
+            amIUsed('hide', 'init', { nested_function_name: 'register', iframe: 'truthy' });
             const adSlot = iframe.closest('.js-ad-slot');
 
             if (adSlot) {
+                amIUsed('hide', 'init', { nested_function_name: 'register', adSlot: 'truthy' });
                 return hideElement(adSlot);
             }
         }


### PR DESCRIPTION
## What does this change?
Added `amIUsed` sentinel checks to functions in the following modules:

- `hide.js`
- `hide-element.js`

 as we are not sure where this code runs at the moment.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
Hopefully we will be able to see some useful reports in BigQuery.

Related PR: 
- https://github.com/guardian/frontend/pull/23973
