### PR TITLE
interactive-librarian/read-clean-write

### DIFF
--- a/admin/app/controllers/admin/InteractiveLibrarianController.scala
+++ b/admin/app/controllers/admin/InteractiveLibrarianController.scala
@@ -6,6 +6,8 @@ import play.api.libs.ws.WSClient
 import play.api.mvc._
 import services.dotcomrendering.InteractiveLibrarian
 
+import scala.concurrent.Future
+
 class InteractiveLibrarianController(
     wsClient: WSClient,
     akkaAsync: AkkaAsync,
@@ -20,6 +22,12 @@ class InteractiveLibrarianController(
       InteractiveLibrarian.pressLiveContents(wsClient, path).map { message =>
         Ok(message)
       }
+    }
+  }
+
+  def readCleanWrite(path: String): Action[AnyContent] = {
+    Action.async { implicit request =>
+      Future.successful(Ok("Pascal [1437]"))
     }
   }
 }

--- a/admin/app/controllers/admin/InteractiveLibrarianController.scala
+++ b/admin/app/controllers/admin/InteractiveLibrarianController.scala
@@ -27,7 +27,8 @@ class InteractiveLibrarianController(
 
   def readCleanWrite(path: String): Action[AnyContent] = {
     Action.async { implicit request =>
-      Future.successful(Ok("Pascal [1437]"))
+      val status = InteractiveLibrarian.readCleanWrite(path)
+      Future.successful(Ok(status.toString()))
     }
   }
 }

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -48,6 +48,7 @@ POST        /ajax/clear                                                         
 
 # Interactive Pressing
 POST        /interactive-librarian/live-presser/*path                                               controllers.admin.InteractiveLibrarianController.liveContentsPress(path: String)
+POST        /interactive-librarian/read-clean-write/*path                                           controllers.admin.InteractiveLibrarianController.readCleanWrite(path: String)
 
 # Development endpoints
 GET         /dev/switchboard                                                                        controllers.admin.SwitchboardController.renderSwitchboard()

--- a/common/app/http/GoogleAuthFilters.scala
+++ b/common/app/http/GoogleAuthFilters.scala
@@ -26,17 +26,18 @@ object GoogleAuthFilters {
     // Author: Pascal
 
     // Condition [1], below, was added in July 2021, as part of posing the ground for the interactive migration.
-    // It should be removed when the Interactives migration is complete, meaning when we no longer need the route
+    // It should be removed when the Interactives migration is complete, meaning when we no longer need the routes
     // POST /interactive-librarian/live-presser/*path
+    // POST /interactive-librarian/read-clean-write/*path
     // in [admin].
     // Note that a slightly better solution would have been to set up a new entry in AdminFilters's FilterExemptions
-    // But they do not interpret wildcards, as a consequence the next best solution is to add a migration specific
+    // but they do not interpret wildcards. As a consequence the next best solution is to add a migration specific
     // clause to doNotAuthenticate
 
     private def doNotAuthenticate(request: RequestHeader) =
       context.environment.mode == Mode.Test ||
         request.path.startsWith(loginUrl.path) ||
-        request.path.startsWith("/interactive-librarian/live-presser/") || // Condition [1]
+        request.path.startsWith("/interactive-librarian/") || // Condition [1]
         exemptions.exists(exemption => request.path.startsWith(exemption.path))
 
     def apply(nextFilter: (RequestHeader) => Future[Result])(request: RequestHeader): Future[Result] = {

--- a/common/app/services/dotcomrendering/InteractiveLibrarian.scala
+++ b/common/app/services/dotcomrendering/InteractiveLibrarian.scala
@@ -121,6 +121,13 @@ object InteractiveLibrarian extends GuLogging {
     }
   }
 
+  def readCleanWrite(path: String): (Boolean, String) = {
+    // The first component of the return value says whether the operation completed successfully,
+    // in the negative case the string indicates what happened.
+
+    (false, "not implemented")
+  }
+
   def getDocumentFromS3(path: String): Option[String] = {
     val s3path = s"www.theguardian.com/${path}"
     retrieveCleanedDocumentFromS3(s3path)

--- a/common/app/services/dotcomrendering/InteractiveLibrarian.scala
+++ b/common/app/services/dotcomrendering/InteractiveLibrarian.scala
@@ -122,10 +122,14 @@ object InteractiveLibrarian extends GuLogging {
   }
 
   def readCleanWrite(path: String): (Boolean, String) = {
+
     // The first component of the return value says whether the operation completed successfully,
     // in the negative case the string indicates what happened.
 
-    (false, "not implemented")
+    val s3path = s"www.theguardian.com/${path}"
+    retrieveOriginalDocumentFromS3(s3path).fold(
+      (false, s"could not retrieve the original document at ${s3path}"),
+    )(document => commitCleanedDocumentToS3(s3path, cleanOriginalDocument(document)))
   }
 
   def getDocumentFromS3(path: String): Option[String] = {


### PR DESCRIPTION
## What does this change?

This PR is the follow up of https://github.com/guardian/frontend/pull/23968 . Part of the ongoing efforts of pausing the foundations for the long term use of the Interactive Librarian and the code required for a one time migration. 

In this case we introduce the [admin] endpoint to take an original document from "aws-frontend-archive-code-originals" or "aws-frontend-archive-originals" and puts the cleaned version into "aws-frontend-archive-code" or "aws-frontend-archive". 

Note that for the moment the cleaning operation is still the identity function. See next PRs.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No