### PR TITLE
Introduce football.model.GuTeamCodes

### DIFF
--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -6,7 +6,7 @@ import conf.Configuration
 import contentapi.ContentApiClient
 import feed.CompetitionsService
 import football.datetime.DateHelpers
-import football.model.FootballMatchTrail
+import football.model.{FootballMatchTrail, GuTeamCodes}
 import implicits.{Football, Requests}
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model.{Cached, Competition, Content, ContentType, TeamColours}
@@ -113,7 +113,7 @@ object NxAnswer {
     NxTeam(
       teamV1.id,
       cleanTeamNameNextGenApi(teamV1.name),
-      codename = TeamCodes.codeFor(teamV1),
+      codename = GuTeamCodes.codeFor(teamV1),
       players = players,
       score = teamV1.score.getOrElse(0),
       scorers = teamV1.scorers.fold(Nil: List[String])(

--- a/sport/app/football/model/GuTeamCode.scala
+++ b/sport/app/football/model/GuTeamCode.scala
@@ -1,0 +1,9 @@
+package football.model
+
+import pa._
+
+object GuTeamCodes {
+  def codeFor(team: FootballTeam): String = {
+    TeamCodes.codeFor(team)
+  }
+}

--- a/sport/app/football/model/GuTeamCode.scala
+++ b/sport/app/football/model/GuTeamCode.scala
@@ -4,6 +4,20 @@ import pa._
 
 object GuTeamCodes {
   def codeFor(team: FootballTeam): String = {
-    TeamCodes.codeFor(team)
+
+    // Date: June 2021
+    // Author: Pascal
+
+    // Introducing this function to patches pa.TeamCodes.codeFor in order to replace the currently PA incorrect
+    // short code for North Macedonia. PA's current library says "MAC", but the correct value is "MKD".
+    // This is a temporary fix. The, better, long term fix is to upgrade the PA library (and check that the new library
+    // come with the correct value for North Macedonia), at which point this object should be removed.
+
+    val code = TeamCodes.codeFor(team)
+    if (code == "MAC") {
+      "MKD"
+    } else {
+      code
+    }
   }
 }

--- a/sport/app/football/views/fragments/matchSummary.scala.html
+++ b/sport/app/football/views/fragments/matchSummary.scala.html
@@ -5,6 +5,7 @@
 @import views.support.RenderClasses
 @import conf.Configuration
 @import model.CompetitionDisplayHelpers.cleanTeamName
+@import football.model.GuTeamCodes
 
 @(theMatch: FootballMatch, competition: Option[Competition] = None, responsive: Boolean = false, link: Boolean = false)(implicit request: RequestHeader)
 
@@ -24,7 +25,7 @@
 
     <div class="match-summary__teams">
         <div class="match-summary__team match-summary__team--home">
-            <h2 class="team__name" data-abbr="@pa.TeamCodes.codeFor(homeTeam)">
+            <h2 class="team__name" data-abbr="@GuTeamCodes.codeFor(homeTeam)">
                 @cleanTeamName(homeTeam.name)
             </h2>
 
@@ -43,7 +44,7 @@
         </div>
 
         <div class="match-summary__team match-summary__team--away">
-            <h2 class="team__name" data-abbr="@pa.TeamCodes.codeFor(awayTeam)">
+            <h2 class="team__name" data-abbr="@GuTeamCodes.codeFor(awayTeam)">
                 @cleanTeamName(awayTeam.name)
             </h2>
 

--- a/sport/app/football/views/matchList/matchesList.scala.html
+++ b/sport/app/football/views/matchList/matchesList.scala.html
@@ -1,4 +1,5 @@
 @import java.time.format.DateTimeFormatter
+@import football.model.GuTeamCodes
 @(matchesList: List[pa.FootballMatch],
     competition: model.Competition,
     date: java.time.LocalDate,
@@ -53,14 +54,14 @@
                 <td class="football-match__teams table-column--main">
                     <a @(theMatch.smartUrl.map(url => s"href=${LinkTo(url)}").getOrElse("")) class="u-unstyled football-teams u-cf" data-link-name="match-redirect">
                         <div class="football-match__team football-match__team--home football-team">
-                            <div class="football-team__name team-name" data-abbr="@pa.TeamCodes.codeFor(theMatch.homeTeam)">
+                            <div class="football-team__name team-name" data-abbr="@GuTeamCodes.codeFor(theMatch.homeTeam)">
                                 <span class="team-name__long">@cleanTeamName(theMatch.homeTeam.name)</span>
                             </div>
                             <div class="football-team__score">@theMatch.homeTeam.score</div>
                         </div>
 
                         <div class="football-match__team football-match__team--away football-team">
-                            <div class="football-team__name team-name" data-abbr="@pa.TeamCodes.codeFor(theMatch.awayTeam)">
+                            <div class="football-team__name team-name" data-abbr="@GuTeamCodes.codeFor(theMatch.awayTeam)">
                                 <span class="team-name__long">@cleanTeamName(theMatch.awayTeam.name)</span>
                             </div>
                             <div class="football-team__score">@theMatch.awayTeam.score</div>

--- a/sport/app/football/views/matchStats/matchStatsComponent.scala.html
+++ b/sport/app/football/views/matchStats/matchStatsComponent.scala.html
@@ -5,6 +5,7 @@
 @import pa.LineUpPlayer
 @import model.CompetitionDisplayHelpers.{cleanTeamName, cleanTeamCode}
 
+@import football.model.GuTeamCodes
 @(page: MatchPage)(implicit request: RequestHeader)
 
 @team(players: Seq[LineUpPlayer]) = {
@@ -47,8 +48,8 @@
                        data-chart-show-values="true">
                     <thead hidden>
                         <tr>
-                            <th>@cleanTeamCode(pa.TeamCodes.codeFor(away))</th>
-                            <th>@cleanTeamCode(pa.TeamCodes.codeFor(home))</th>
+                            <th>@cleanTeamCode(GuTeamCodes.codeFor(away))</th>
+                            <th>@cleanTeamCode(GuTeamCodes.codeFor(home))</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/sport/app/football/views/tablesList/tableView.scala.html
+++ b/sport/app/football/views/tablesList/tableView.scala.html
@@ -4,6 +4,7 @@
 @import views.support.`package`.Seq2zipWithRowInfo
 @import model.CompetitionDisplayHelpers.cleanTeamName
 
+@import football.model.GuTeamCodes
 @(competition: Competition, group: Group,
     heading: Option[String] = None,
     headingLink: Option[String] = None,
@@ -41,7 +42,7 @@
                         "table-row--divider" -> competition.tableDividers.contains(entry.team.rank-1)))">
                     <td class="table-column--sub">@entry.team.rank</td>
                     <td class="table-column--main">
-                        <span class="team-name" data-abbr="@pa.TeamCodes.codeFor(entry.team)">
+                        <span class="team-name" data-abbr="@GuTeamCodes.codeFor(entry.team)">
                             <img class="team-crest" alt="" src="@Configuration.staticSport.path/football/crests/60/@{entry.team.id}.png" />
                             @TeamUrl(entry.team).map{ url =>
                                 <a href="@TeamUrl(entry.team)" data-link-name="View team" class="team-name__long">


### PR DESCRIPTION
## What does this change?

Introduce a function to patch `pa.TeamCodes.codeFor` in order to replace the currently PA incorrect short code for North Macedonia. PA's current library says "MAC", but the correct value is "MKD". This is a temporary fix. The, better, long term fix is to upgrade the PA library (and check that the new library come with the correct value for North Macedonia), at which point this object should be removed. We have a card for that.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No


BEFORE:

<img width="1342" alt="Screenshot 2021-07-07 at 11 09 56" src="https://user-images.githubusercontent.com/6035518/124742413-96f65c80-df14-11eb-9ef0-0ede2ea2dd6c.png">

AFTER:

<img width="1157" alt="Screenshot 2021-07-07 at 11 12 50" src="https://user-images.githubusercontent.com/6035518/124742432-a07fc480-df14-11eb-928d-cf4034b8aa35.png">

