### PR TITLE
remove npa from tcf from ad manager consent

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.ts
@@ -203,52 +203,6 @@ const tcfv2WithConsent = {
 	},
 };
 
-const tcfv2WithoutConsent = {
-	tcfv2: {
-		consents: {
-			'1': false,
-			'2': false,
-			'3': false,
-			'4': false,
-			'5': false,
-		},
-		vendorConsents: {
-			'5f1aada6b8e05c306c0597d7': false, // Googletag
-		},
-	},
-};
-
-// TODO: There is no null consent in the new CMP
-const tcfv2NullConsent = {
-	tcfv2: {
-		consents: {
-			'1': null,
-			'2': null,
-			'3': null,
-			'4': null,
-			'5': null,
-		},
-		vendorConsents: {
-			'5f1aada6b8e05c306c0597d7': null, // Googletag
-		},
-	},
-};
-
-const tcfv2MixedConsent = {
-	tcfv2: {
-		consents: {
-			'1': true,
-			'2': false,
-			'3': false,
-			'4': true,
-			'5': false,
-		},
-		vendorConsents: {
-			'5f1aada6b8e05c306c0597d7': true, // Googletag
-		},
-	},
-};
-
 const ausNotRejected = {
 	aus: {
 		rejectedCategories: [],
@@ -644,56 +598,6 @@ describe('DFP', () => {
 		});
 	});
 
-	describe('NPA flag is set correctly', () => {
-		it('when full TCF consent was given', async () => {
-			onConsentChange.mockImplementation(
-				(
-					callback: (val: {
-						tcfv2: TCFv2ConsentStateMockType;
-					}) => void,
-				) => callback(tcfv2WithConsent),
-			);
-			getConsentFor.mockReturnValue(true);
-			await prepareGoogletag();
-			expect(pubAds.setRequestNonPersonalizedAds).toHaveBeenCalledWith(0);
-		});
-		it('when no TCF consent preferences were specified', async () => {
-			onConsentChange.mockImplementation(
-				(
-					callback: (val: {
-						tcfv2: TCFv2ConsentStateMockType;
-					}) => void,
-				) => callback(tcfv2NullConsent),
-			);
-			getConsentFor.mockReturnValue(true);
-			await prepareGoogletag();
-			expect(pubAds.setRequestNonPersonalizedAds).toHaveBeenCalledWith(0);
-		});
-		it('when full TCF consent was denied', async () => {
-			onConsentChange.mockImplementation(
-				(
-					callback: (val: {
-						tcfv2: TCFv2ConsentStateMockType;
-					}) => void,
-				) => callback(tcfv2WithoutConsent),
-			);
-			getConsentFor.mockReturnValue(false);
-			await prepareGoogletag();
-			expect(pubAds.setRequestNonPersonalizedAds).toHaveBeenCalledWith(1);
-		});
-		it('when only partial TCF consent was given', async () => {
-			onConsentChange.mockImplementation(
-				(
-					callback: (val: {
-						tcfv2: TCFv2ConsentStateMockType;
-					}) => void,
-				) => callback(tcfv2MixedConsent),
-			);
-			getConsentFor.mockReturnValue(false);
-			await prepareGoogletag();
-			expect(pubAds.setRequestNonPersonalizedAds).toHaveBeenCalledWith(1);
-		});
-	});
 	describe('NPA flag in AUS', () => {
 		it('when AUS has not retracted advertising consent', async () => {
 			onConsentChange.mockImplementation(

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.ts
@@ -122,25 +122,28 @@ export const init = (): Promise<void> => {
 					window.googletag?.cmd.push(setPublisherProvidedId);
 				}
 			} else {
-				let npaFlag = false;
 				if (state.tcfv2) {
 					// TCFv2 mode
-					npaFlag =
-						Object.keys(state.tcfv2.consents).length === 0 ||
-						Object.values(state.tcfv2.consents).includes(false);
+					const canTarget = Object.values(state.tcfv2.consents).every(
+						Boolean,
+					);
+					if (canTarget) {
+						window.googletag?.cmd.push(setPublisherProvidedId);
+					}
+
 					canRun = getConsentFor('googletag', state);
 				} else if (state.aus) {
 					// AUS mode
 					// canRun stays true, set NPA flag if consent is retracted
-					npaFlag = !getConsentFor('googletag', state);
-				}
-				window.googletag?.cmd.push(() => {
-					window.googletag
-						?.pubads()
-						.setRequestNonPersonalizedAds(npaFlag ? 1 : 0);
-				});
-				if (!npaFlag) {
-					window.googletag?.cmd.push(setPublisherProvidedId);
+					const npaFlag = !getConsentFor('googletag', state);
+					window.googletag?.cmd.push(() => {
+						window.googletag
+							?.pubads()
+							.setRequestNonPersonalizedAds(npaFlag ? 1 : 0);
+					});
+					if (!npaFlag) {
+						window.googletag?.cmd.push(setPublisherProvidedId);
+					}
 				}
 			}
 			// Prebid will already be loaded, and window.googletag is stubbed in `commercial.js`.


### PR DESCRIPTION
## What does this change?

Remove `setRequestNonPersonalizedAds` from tcf from ad manager consent.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)
