### PR TITLE
Remove scoping keys deprecation warning (migrate to slash syntax)

### DIFF
--- a/identity/build.sbt
+++ b/identity/build.sbt
@@ -1,2 +1,2 @@
 PlayKeys.playDefaultPort := 9009
-testOptions in Test += Tests.Argument("-oF")
+Test / testOptions += Tests.Argument("-oF")

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -56,7 +56,7 @@ object ProjectSettings {
       Resolver.sonatypeRepo("releases"),
       "Spy" at "https://files.couchbase.com/maven2/",
     ),
-    evictionWarningOptions in update := EvictionWarningOptions.default
+    update / evictionWarningOptions := EvictionWarningOptions.default
       .withWarnTransitiveEvictions(false)
       .withWarnDirectEvictions(false)
       .withWarnScalaVersionEviction(false),
@@ -94,7 +94,7 @@ object ProjectSettings {
       testAll := (Test / test)
         .all(ScopeFilter(inAggregates(ThisProject, includeRoot = false)))
         .value,
-      upload := riffRaffUpload.in(LocalRootProject).value,
+      upload := (LocalRootProject / riffRaffUpload).value,
       testThenUpload := Def
         .taskDyn({
           testAll.result.value match {
@@ -126,7 +126,7 @@ object ProjectSettings {
       .settings(frontendTestSettings)
       .settings(VersionInfo.projectSettings)
       .settings(libraryDependencies ++= Seq(macwire, commonsIo))
-      .settings(packageName in Universal := applicationName)
+      .settings(Universal / packageName := applicationName)
   }
 
   def library(applicationName: String): Project = {


### PR DESCRIPTION
## What does this change?

Remove scoping keys deprecation warning (migrate to slash syntax) ( see instructions here: https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash ). Similar update than the one I had made here: https://github.com/guardian/frontend/pull/23886
