### PR TITLE
Extend ImproveSkins AB test duration by two weeks

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -34,13 +34,14 @@ trait ABTestSwitches {
     exposeClientSide = true,
   )
 
+  // tests/improve-skins.ts
   Switch(
     ABTests,
     "ab-improve-skins",
     "Serve Improve page skins via Prebid and measure performance",
     owners = Seq(Owner.withGithub("mxdvl")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2021, 7, 20)),
+    sellByDate = Some(LocalDate.of(2021, 8, 3)),
     exposeClientSide = true,
   )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/improve-skins.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/improve-skins.ts
@@ -3,7 +3,7 @@ import type { ABTest } from '@guardian/ab-core';
 export const improveSkins: ABTest = {
 	id: 'ImproveSkins',
 	start: '2021-07-09',
-	expiry: '2021-07-20',
+	expiry: '2021-08-03',
 	author: 'Max Duval (@mxdvl)',
 	description: 'Serve Improve page skins via Prebid and measure performance',
 	audience: 0,


### PR DESCRIPTION
## What does this change?

This change extends the duration of the ImproveSkins AB tests by two weeks by changing the expiry date from 20/7/2021 to 3/8/2021.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)