### PR TITLE
Add role (missing) to Spotify element for DCR

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -470,6 +470,7 @@ case class SpotifyBlockElement(
     isThirdPartyTracking: Boolean,
     source: Option[String],
     sourceDomain: Option[String],
+    role: Role,
 ) extends PageElement
     with ThirdPartyEmbeddedContent
 object SpotifyBlockElement {
@@ -1511,6 +1512,7 @@ object PageElement {
         thirdPartyTracking,
         d.source,
         d.sourceDomain,
+        Role(d.role),
       )
     }
   }


### PR DESCRIPTION
For: https://trello.com/c/slkvULVz/188-weighting-of-embed-is-not-being-respected-in-dcr.

cc @DavidLawes 