### PR TITLE
Adding Tokyo 2020 to sports navs

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -92,13 +92,12 @@ private object NavLinks {
 
   /* SPORT */
 
-  val Euro2020 = NavLink("Euro 2020", "/football/euro-2020")
+  val Tokyo2020 = NavLink("Tokyo 2020", "/sport/olympic-games-2020")
 
   val football = NavLink(
     "Football",
     "/football",
     children = List(
-      Euro2020,
       NavLink("Live scores", "/football/live", Some("football/live")),
       NavLink("Tables", "/football/tables", Some("football/tables")),
       NavLink("Fixtures", "/football/fixtures", Some("football/fixtures")),
@@ -358,7 +357,7 @@ private object NavLinks {
     longTitle = Some("Sport home"),
     iconName = Some("home"),
     List(
-      Euro2020,
+      Tokyo2020,
       football,
       cricket,
       rugbyUnion,
@@ -374,6 +373,7 @@ private object NavLinks {
   )
   val auSportPillar = ukSportPillar.copy(
     children = List(
+      Tokyo2020,
       football,
       AFL,
       NRL,
@@ -387,6 +387,7 @@ private object NavLinks {
   )
   val usSportPillar = ukSportPillar.copy(
     children = List(
+      Tokyo2020,
       soccer,
       NFL,
       tennis,
@@ -398,7 +399,7 @@ private object NavLinks {
   )
   val intSportPillar = ukSportPillar.copy(
     children = List(
-      Euro2020,
+      Tokyo2020,
       football,
       cricket,
       rugbyUnion,


### PR DESCRIPTION
## What does this change?
Adds links to the olympics coverage on each of our editionalised sport homepages.