### PR TITLE
Restores Intellij sbt import and run unit tests

### DIFF
--- a/applications/app/AppLoader.scala
+++ b/applications/app/AppLoader.scala
@@ -1,10 +1,10 @@
 import akka.actor.ActorSystem
 import app.{FrontendApplicationLoader, FrontendComponents}
-import assets.DiscussionExternalAssetsLifecycle
 import com.softwaremill.macwire._
 import common.dfp.DfpAgentLifecycle
 import common.{ApplicationMetrics, CloudWatchMetricsLifecycle, ContentApiMetrics, EmailSubsciptionMetrics}
 import _root_.commercial.targeting.TargetingLifecycle
+import common.Assets.DiscussionExternalAssetsLifecycle
 import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
 import conf.CachedHealthCheckLifeCycle
 import conf.switches.SwitchboardLifecycle
@@ -23,7 +23,7 @@ import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import services._
 import router.Routes
-import services.newsletters.{NewsletterSignupLifecycle, NewsletterSignupAgent, NewsletterApi}
+import services.newsletters.{NewsletterApi, NewsletterSignupAgent, NewsletterSignupLifecycle}
 
 import scala.concurrent.ExecutionContext
 

--- a/article/app/AppLoader.scala
+++ b/article/app/AppLoader.scala
@@ -1,8 +1,8 @@
 import _root_.commercial.targeting.TargetingLifecycle
 import akka.actor.ActorSystem
 import app.{FrontendApplicationLoader, FrontendComponents}
-import assets.DiscussionExternalAssetsLifecycle
 import com.softwaremill.macwire._
+import common.Assets.DiscussionExternalAssetsLifecycle
 import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
 import common._
 import common.dfp.DfpAgentLifecycle

--- a/common/app/common/Assets/DiscussionAssets.scala
+++ b/common/app/common/Assets/DiscussionAssets.scala
@@ -1,15 +1,14 @@
-package assets
-
-import java.net.URI
+package common.Assets
 
 import app.LifecycleComponent
 import com.gu.Box
-import common.{GuardianConfiguration, JobScheduler, GuLogging}
+import common.{GuLogging, GuardianConfiguration, JobScheduler}
 import conf.switches.Switches
 import play.api.libs.ws.{WSClient, WSResponse}
 
-import scala.concurrent.{ExecutionContext, Future}
+import java.net.URI
 import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
 /**

--- a/common/app/common/Assets/assets.scala
+++ b/common/app/common/Assets/assets.scala
@@ -1,16 +1,15 @@
 package common.Assets
 
-import java.nio.charset.Charset
-
 import common.{GuLogging, RelativePathEscaper}
 import conf.Configuration
+import html.HtmlPageHelpers.{ContentCSSFile, FaciaCSSFile, RichLinksCSSFile}
 import model.ApplicationContext
 import org.apache.commons.io.IOUtils
-import play.api.libs.json._
 import play.api.Mode
-import html.HtmlPageHelpers.{ContentCSSFile, FaciaCSSFile, RichLinksCSSFile}
+import play.api.libs.json._
 import play.api.mvc.RequestHeader
 
+import java.nio.charset.Charset
 import scala.collection.concurrent.{TrieMap, Map => ConcurrentMap}
 import scala.util.{Failure, Success, Try}
 

--- a/common/app/conf/application.scala
+++ b/common/app/conf/application.scala
@@ -1,9 +1,12 @@
 package conf
 
+import common.Assets.DiscussionAssetsMap
+
 object Configuration extends common.GuardianConfiguration
 object Static extends common.Assets.Assets(Configuration.assets.path, "assets/assets.map")
+
 object DiscussionAsset {
   def apply(assetName: String): String = {
-    assets.DiscussionAssetsMap.getURL(assetName)
+    DiscussionAssetsMap.getURL(assetName)
   }
 }

--- a/common/test/common/Assets/AssetsTest.scala
+++ b/common/test/common/Assets/AssetsTest.scala
@@ -1,7 +1,6 @@
 package common.Assets
 
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers
+import org.scalatest.{FlatSpec, Matchers}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 
 class AssetsTest extends FlatSpec with Matchers with GuiceOneAppPerSuite {

--- a/dev-build/app/AppLoader.scala
+++ b/dev-build/app/AppLoader.scala
@@ -1,5 +1,4 @@
 import app.{FrontendApplicationLoader, FrontendComponents, LifecycleComponent}
-import assets.DiscussionExternalAssetsLifecycle
 import business.StocksDataLifecycle
 import com.softwaremill.macwire._
 import common.DiagnosticsLifecycle
@@ -30,8 +29,9 @@ import rugby.controllers.RugbyControllers
 import services._
 import _root_.commercial.targeting.TargetingLifecycle
 import akka.actor.ActorSystem
+import common.Assets.DiscussionExternalAssetsLifecycle
 import concurrent.BlockingOperations
-import services.newsletters.{NewsletterSignupLifecycle, NewsletterSignupAgent, NewsletterApi}
+import services.newsletters.{NewsletterApi, NewsletterSignupAgent, NewsletterSignupLifecycle}
 import play.api.OptionalDevContext
 
 class AppLoader extends FrontendApplicationLoader {


### PR DESCRIPTION
## What does this change?

Resolves 'is already defined as a class' errors when building with Intellij.

<img width="1649" alt="Screenshot 2021-07-19 at 17 27 08" src="https://user-images.githubusercontent.com/150238/126203842-0391ba32-ef63-4f57-b1d7-5c43b14f8441.png">

Rightly or wrongly Intellij is less tolerant of overlapping package name spaces and file locations than vanilla sbt builds.

- Move common.Assets down into a package folder to a match Intellij's expected layout. 

- Move common Discussion assets to common.Assets package as they are imported into several projects and can be called 'common'.

Hopefully this helps new starters on this project, avoiding the 'what did I do wrong?' moment.



This all naive file moving; if there is any Play framework magic related to this packages then this could cause problems.
The effected classes seem to be magic free url generation helpers.


Tested by deploying to CODE.
Didn't notice anything completely broken.

Checked a page which had discussion and comments before and after deploy and it retained it's comment count and content:
https://m.code.dev-theguardian.com/commentisfree/2015/may/27/catholic-church-ireland-vatican-gay-marriage


## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->

