### PR TITLE
Update Identity Libraries Dependency Version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.239-C2"
+  val identityLibVersion = "3.239-C3"
   val awsVersion = "1.11.240"
   val capiVersion = "17.21"
   val faciaVersion = "3.3.6"


### PR DESCRIPTION
## What does this change?

- Bumps the Identity library to `3.239-C3` which is the [detached branch](https://github.com/guardian/identity/pull/1875) used to add newsletters/consents to older versions of play.
- This version updates the models used on the old newsletters flow at `/complete-consents` to update the newsletters.
