### PR TITLE
Ensure tag linker only links first tag in para

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/TextCleaner.scala
+++ b/common/app/model/dotcomrendering/pageElements/TextCleaner.scala
@@ -102,8 +102,8 @@ object TagLinker {
       val keyword = keywords.find(tag => el.html.contains(tag.name))
 
       keyword.map(tag => {
-        def mapper(tag: Tag)(m: Match) = Some(m.group("start") + link(tag, edition) + m.group("end"))
-        val updatedHtml = keywordRegex(tag.name).replaceSomeIn(el.html, mapper(tag))
+        // $1 and $3 here are 'start' and 'end' regex match groups.
+        val updatedHtml = keywordRegex(tag.name).replaceFirstIn(el.html, "$1" + link(tag, edition) + "$3")
         (TextBlockElement(updatedHtml), terms + tag.name)
       }) getOrElse (el, terms)
     } else {

--- a/common/test/model/dotcomrendering/pageElements/TextCleanerTest.scala
+++ b/common/test/model/dotcomrendering/pageElements/TextCleanerTest.scala
@@ -67,7 +67,43 @@ class TextCleanerTest extends FlatSpec with Matchers {
     })
   }
 
-  "tagLinks" should "link only first occurrence of a tag" in {
+  "tagLinks" should "link only first occurrence of a tag within paragraph" in {
+    val elements = List(
+      TextBlockElement("Champions League first. Champions League second."),
+    )
+
+    val want = List(
+      TextBlockElement(
+        s"""<a href="${host}/championsleague" data-component="auto-linked-tag">Champions League</a> first. Champions League second.""",
+      ),
+    )
+
+    val tag = Tag(
+      TagProperties.make(
+        ApiTag(
+          id = "championsleague",
+          `type` = Keyword,
+          sectionId = Some("football"),
+          webTitle = "Champions League",
+          webUrl = "/football/championsleague",
+          apiUrl = "example",
+        ),
+      ),
+      None,
+      None,
+    )
+
+    val got = TextCleaner.tagLinks(
+      els = elements,
+      tags = Tags(List(tag)),
+      showInRelated = true,
+      edition = editions.Uk,
+    )
+
+    got shouldBe want
+  }
+
+  "tagLinks" should "link only first occurrence of a tag across multiple paragraphs" in {
     val elements = List(
       TextBlockElement("Champions League first"),
       TextBlockElement("Champions League repeat"),


### PR DESCRIPTION
## What does this change?

Fixes a bug where we would (auto) link the same tag multiple times within a para.