### PR TITLE
Add Prebid targeting `hb_pid`

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
@@ -67,14 +67,14 @@ const initialise = (window, framework = 'tcfv2') => {
 		}
 	};
 
-    const pbjsConfig = Object.assign(
-        {},
-        {
-            bidderTimeout,
-            priceGranularity,
-            userSync,
-        },
-    );
+	const pbjsConfig = Object.assign(
+		{},
+		{
+			bidderTimeout,
+			priceGranularity,
+			userSync,
+		},
+	);
 
     if(config.get('switches.consentManagement', false)) {
         pbjsConfig.consentManagement = consentManagement()
@@ -134,6 +134,22 @@ const initialise = (window, framework = 'tcfv2') => {
                 return bidCpm * 1.05;
             }
         };
+    }
+
+    // Add placement ID for Improve Digital, reading from the bid response
+    const REGEX_PID = new RegExp(/placement_id=\\?\"(\d+)\\?\"/)
+    window.pbjs.bidderSettings.improvedigital = {
+        adserverTargeting: [
+            {
+                key: 'hb_pid',
+                val(bidResponse) {
+                    const matches = REGEX_PID.exec(bidResponse.ad);
+                    const pid = matches && matches[1];
+                    log('commercial', 'Improve Digital Bid', {pid, matches, bidResponse})
+                    return pid ?? '';
+                }
+            }
+        ]
     }
 
     // Adjust slot size when prebid ad loads

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
@@ -149,7 +149,8 @@ const initialise = (window, framework = 'tcfv2') => {
                         return pid ?? null;
                     }
                 }
-            ]
+            ],
+            suppressEmptyKeys: true,
         }
     }
 

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
@@ -136,20 +136,21 @@ const initialise = (window, framework = 'tcfv2') => {
         };
     }
 
-    // Add placement ID for Improve Digital, reading from the bid response
-    const REGEX_PID = new RegExp(/placement_id=\\?\"(\d+)\\?\"/)
-    window.pbjs.bidderSettings.improvedigital = {
-        adserverTargeting: [
-            {
-                key: 'hb_pid',
-                val(bidResponse) {
-                    const matches = REGEX_PID.exec(bidResponse.ad);
-                    const pid = matches && matches[1];
-                    log('commercial', 'Improve Digital Bid', {pid, matches, bidResponse})
-                    return pid ?? '';
+    if(config.get('switches.prebidImproveDigital', false)) {
+        // Add placement ID for Improve Digital, reading from the bid response
+        const REGEX_PID = new RegExp(/placement_id=\\?\"(\d+)\\?\"/)
+        window.pbjs.bidderSettings.improvedigital = {
+            adserverTargeting: [
+                {
+                    key: 'hb_pid',
+                    val(bidResponse) {
+                        const matches = REGEX_PID.exec(bidResponse.ad);
+                        const pid = matches && matches[1];
+                        return pid ?? '';
+                    }
                 }
-            }
-        ]
+            ]
+        }
     }
 
     // Adjust slot size when prebid ad loads

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.js
@@ -146,7 +146,7 @@ const initialise = (window, framework = 'tcfv2') => {
                     val(bidResponse) {
                         const matches = REGEX_PID.exec(bidResponse.ad);
                         const pid = matches && matches[1];
-                        return pid ?? '';
+                        return pid ?? null;
                     }
                 }
             ]

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.spec.js
@@ -157,11 +157,31 @@ describe('initialise', () => {
         );
     });
 
-    test('should generate correct bidder settings when Xaxis off', () => {
-        config.set('switches.prebidXaxis', false);
-        prebid.initialise(window);
-        expect(window.pbjs.bidderSettings).toEqual({});
-    });
+    describe('bidderSettings', () => {
+
+        beforeEach(() => {
+            config.set('switches.prebidXaxis', false);
+            config.set('switches.prebidImproveDigital', false);
+        })
+
+        test('should generate correct bidder settings when bidder switches are off', () => {
+            prebid.initialise(window);
+            expect(window.pbjs.bidderSettings).toEqual({});
+        });
+
+        test('should generate correct bidder settings when Xaxis is on', () => {
+            config.set('switches.prebidXaxis', true);
+            prebid.initialise(window);
+            expect(window.pbjs.bidderSettings).toHaveProperty('xhb');
+        });
+
+        test('should generate correct bidder settings when Improve Digital is on', () => {
+            config.set('switches.prebidImproveDigital', true);
+            prebid.initialise(window);
+            expect(window.pbjs.bidderSettings).toHaveProperty('improvedigital');
+        });
+
+    })
 
     test('should generate correct Prebid config when user-sync off', () => {
         config.set('switches.prebidUserSync', false);


### PR DESCRIPTION
## What does this change?

This allows for targeting against the _placement id_ (pid) for `improvedigital`, which is especially useful for Collective skins.

Prebid allows to send custom targeting keys for a bidder by via [bidderSettings]. We set `window.pbjs.bidderSettings.[bidderCode]`, where `[bidderCode] = improvedigital`. The custom targerting key is **`hb_pid`** for “**H**eader **B**idding **P**lacement **ID**”. The custom value executes a [regular expression check][regexp] against the `ad` record of the response object, which contain a `placement_id` attribute near the end of the string.

This also improves and adds tests specific to `pbjs.bidderSettings`.

[bidderSettings]: https://docs.prebid.org/dev-docs/publisher-api-reference/bidderSettings.html
[regexp]: https://regex101.com/r/XDtigp/3

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

![image](https://user-images.githubusercontent.com/76776/126618691-3cf76b69-a3c8-4499-9c54-b3ab13de4ab7.png)

## What is the value of this and can you measure success?

We can target a specific placement id in Google Ad Manager. Confirmed via CODE and Spencer in Commercial that the values come through on a test page.

## Checklist

### Tested

- [X] Locally
- [X] On CODE (optional)
