### PR TITLE
Filter out unsafe content (vid.me)

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -14,6 +14,7 @@ import play.api.mvc._
 import renderers.DotcomRenderingService
 import services.CAPILookup
 import services.dotcomponents.{ArticlePicker, _}
+import utils.UnsafeContent
 import views.support._
 
 import scala.concurrent.Future
@@ -133,7 +134,16 @@ class ArticleController(
     val supportedContent: Option[ContentType] = response.content.filter(isSupported).map(Content(_))
     val blocks = response.content.flatMap(_.blocks).getOrElse(Blocks())
 
+    // Hack to error if body unsafe
+    val isUnsafe = (for {
+      content <- response.content
+      fields <- content.fields
+    } yield UnsafeContent.isVidme(fields.body.getOrElse(""))).getOrElse(false)
+
     ModelOrResult(supportedContent, response) match {
+      case _ if isUnsafe =>
+        log.error(s"Unsafe content found for path: ${request.path}")
+        Right(NoCache(play.api.mvc.Results.InternalServerError("Unsafe content error (500)")))
       case Left(article: Article) => Left((ArticlePage(article, StoryPackages(article.metadata.id, response)), blocks))
       case Right(r)               => Right(r)
       case _                      => Right(NotFound)

--- a/article/app/utils/UnsafeContent.scala
+++ b/article/app/utils/UnsafeContent.scala
@@ -1,0 +1,9 @@
+package utils
+
+import common.GuLogging
+
+object UnsafeContent extends GuLogging {
+  def isVidme(content: String): Boolean = {
+    content.contains("vid.me") // todo make case insensitive
+  }
+}

--- a/article/test/utils/UnsafeContentTest.scala
+++ b/article/test/utils/UnsafeContentTest.scala
@@ -1,0 +1,18 @@
+package utils
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class UnsafeContentTest extends FlatSpec with Matchers {
+
+  "Unsafe content" should "return false if vid.me URL not found" in {
+    val input = "Some content with vid..me in it."
+    val got = UnsafeContent.isVidme(input)
+    got shouldBe false
+  }
+
+  "Unsafe content" should "return true if vid.me URL found" in {
+    val input = "Some content with vid.me in it."
+    val got = UnsafeContent.isVidme(input)
+    got shouldBe true
+  }
+}


### PR DESCRIPTION
A hacky fix to remove some unsafe content. Note:

* we are logging cases to gauge impact
* will not work for non-articles/liveblogs (e.g. R2 pressed content)

We'll look into a better fix once this goes live.

POST-MERGE UPDATE (Author @OllysCoding):

This fix was introduced as a mitigation step for the vid.me (NSFW link) incident which took place on the 23/07/2021. In this case the domain for short-urls of a site (vidme.com) had been acquired by an adult content website and redirected. This fix was introduced as part of a department wide effort to avoid any situation where we might be unintentionally linking users to this content.

The code should be cleaned up at a later date - but the methods introduced of 'removing unsafe content' could be a useful model going forward if similar issues crop up.

Any time a page is blocked due to unsafe content, it will be logged, these logs for PROD can be checked here: https://logs.gutools.co.uk/goto/803c29ec88a865d06d2af3536c833fef

