### PR TITLE
Ensure interactive block element script URLs secure

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -1238,7 +1238,9 @@ object PageElement {
           .toList
       case Interactive =>
         element.interactiveTypeData
-          .map(d => InteractiveBlockElement(d.iframeUrl, d.alt, d.scriptUrl, d.role, d.isMandatory, d.caption))
+          .map(d =>
+            InteractiveBlockElement(d.iframeUrl, d.alt, d.scriptUrl.map(ensureHTTPS), d.role, d.isMandatory, d.caption),
+          )
           .toList
       case Table => element.tableTypeData.map(d => TableBlockElement(d.html, Role(d.role), d.isMandatory)).toList
       case Witness => {
@@ -1314,6 +1316,14 @@ object PageElement {
       case EnumUnknownElementType(f) => List(UnknownBlockElement(None))
       case _                         => Nil
     }
+  }
+
+  private[this] def ensureHTTPS(url: String): String = {
+    val http = "http://"
+
+    if (url.startsWith(http)) {
+      "https://" + url.stripPrefix(http)
+    } else url
   }
 
   private def makeWitnessAssets(element: ApiBlockElement): Seq[WitnessBlockElementAssetsElement] = {


### PR DESCRIPTION
## What does this change?

We are seeing failing cases in DCR caused by our Content Security
Policy blocking insecure scripts. Frontend uses the body field here
which is switched to HTTPs upstream (CAPI?) somewhere.

cc @DavidLawes 