### PR TITLE
Always collect core web vitals data for user in variant group of AB test

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -37,7 +37,7 @@ export const coreVitals = (): void => {
 		Object.values(window.guardian.config.tests).includes('variant');
 
 	// Otherwise, only send core web vitals data for 1% of users.
-	const inSample = Math.floor(Math.random() * 100) == 1;
+	const inSample = Math.random() < 1 / 100;
 
 	if (!userInTest && !inSample) {
 		return;

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -29,6 +29,10 @@ const jsonData: CoreWebVitalsPayload = {
 	ttfb: null,
 };
 
+/**
+* Sends core web vitals data for a sample of page views to the data lake.
+* Equivalent dotcom-rendering functionality is here: https://git.io/JBRIt
+*/
 export const coreVitals = (): void => {
 	// If the current user is part of a server-side AB test
 	// then we always want to sample their core web vitals data.

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -30,8 +30,16 @@ const jsonData: CoreWebVitalsPayload = {
 };
 
 export const coreVitals = (): void => {
-	const inSample = Math.floor(Math.random() * 100);
-	if (inSample != 1) {
+	// If the current user is part of a server-side AB test
+	// then we always want to sample their core web vitals data.
+	const userInTest =
+		window.guardian.config.tests &&
+		Object.values(window.guardian.config.tests).includes('variant');
+
+	// Otherwise, only send core web vitals data for 1% of users.
+	const inSample = Math.floor(Math.random() * 100) == 1;
+
+	if (!userInTest && !inSample) {
 		return;
 	}
 

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -30,9 +30,9 @@ const jsonData: CoreWebVitalsPayload = {
 };
 
 /**
-* Sends core web vitals data for a sample of page views to the data lake.
-* Equivalent dotcom-rendering functionality is here: https://git.io/JBRIt
-*/
+ * Sends core web vitals data for a sample of page views to the data lake.
+ * Equivalent dotcom-rendering functionality is here: https://git.io/JBRIt
+ */
 export const coreVitals = (): void => {
 	// If the current user is part of a server-side AB test
 	// then we always want to sample their core web vitals data.

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -65,10 +65,7 @@ interface CommercialPageConfig {
 interface Config {
 	page: PageConfig;
 	switches: Record<string, boolean | undefined>;
-	tests?: {
-		testName: string;
-		groupName: string;
-	};
+	tests?: Record<string, 'control' | 'variant'>;
 }
 
 interface PageConfig extends CommercialPageConfig {

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -65,6 +65,10 @@ interface CommercialPageConfig {
 interface Config {
 	page: PageConfig;
 	switches: Record<string, boolean | undefined>;
+	tests?: {
+		testName: string;
+		groupName: string;
+	};
 }
 
 interface PageConfig extends CommercialPageConfig {


### PR DESCRIPTION
## What does this change?
Before the change, we collect core web vitals data for 1% of users.
After the change we always collect the data if the user is in the variant group of a server-side AB test, otherwise fall back to 1% sampling.

## Does this change need to be reproduced in dotcom-rendering ?
We are accepting the fact that after this change, the behavior around collection of core web vitals in frontend and DCR will be different.
The equivalent change would need to be made [here](https://github.com/guardian/dotcom-rendering/blob/dc6ab694db8a9b52285e0d30552e120f98012b67/src/web/browser/coreVitals/coreVitals.ts#L31) but isn't possible because server-side AB test groups aren't exposed to DCR. 

## Screenshots
N/A

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?
Often we need to determine whether or not the groups in an AB test have an impact on core web vitals. When the AB test is run on a very small group, say a 1% of all users, the current sampling rate of 1% means that gathering an appropriate volume of data takes a very long time. This change solves the problem by ignoring the sampling rate for users participating in a test.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
