### PR TITLE
Use section to look up all Ipsos tags

### DIFF
--- a/common/app/model/IpsosTags.scala
+++ b/common/app/model/IpsosTags.scala
@@ -2,7 +2,7 @@ package model
 
 object IpsosTags {
 
-  val tags = Map(
+  private val guardianToIpsosTagMapping = Map(
     "uk" -> "uk",
     "us" -> "us",
     "au" -> "au",
@@ -117,7 +117,7 @@ object IpsosTags {
 
   // Default to top level `guardian` tag if key is not found
   def getScriptTag(id: String): String = {
-    tags.getOrElse(id, "guardian")
+    guardianToIpsosTagMapping.getOrElse(id, "guardian")
   }
 
 }

--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -5,11 +5,9 @@ import common.Edition
 import common.Maps.RichMap
 import common.commercial.EditionAdTargeting._
 import conf.Configuration.environment
-import model.IpsosTags.{getScriptTag}
 import conf.{Configuration, DiscussionAsset}
 import model._
 import play.api.libs.json._
-import model.IpsosTags.{getScriptTag}
 import play.api.mvc.RequestHeader
 
 object JavaScriptPage {
@@ -65,8 +63,6 @@ object JavaScriptPage {
       case _                 => Map()
     }
 
-    val ipsos = if (page.metadata.isFront) getScriptTag(page.metadata.id) else getScriptTag(page.metadata.sectionId)
-
     javascriptConfig ++ config ++ commercialMetaData ++ journalismMetaData ++ Map(
       ("edition", JsString(edition.id)),
       ("ajaxUrl", JsString(Configuration.ajax.url)),
@@ -84,7 +80,7 @@ object JavaScriptPage {
       ("cardStyle", JsString(cardStyle)),
       ("discussionFrontendUrl", JsString(DiscussionAsset("discussion-frontend.preact.iife"))),
       ("brazeApiKey", JsString(Configuration.braze.apiKey)),
-      ("ipsosTag", JsString(ipsos)),
+      ("ipsosTag", JsString(IpsosTags.getScriptTag(page.metadata.sectionId))),
     )
   }
 }


### PR DESCRIPTION
## What does this change?
We were notified a few weeks ago that (at least some) tag pages were not being correctly "tagged" for Ipsos Iris. At the time, on closer inspection, I spotted this was because tag pages were considered as "Fronts" in the lookup of Ipsos tag via Guardian tag.  I don't believe this was the intention originally and tag pages should use their section to determine the correct Ipsos tag. _However_ curated fronts (e.g. /uk) also appear to have a section ID that we could equally use in the lookup, so I think we can use that universally.

This is a just a draft that someone else could pick up. Things I think still need to happen:
- Write some tests
- Manually test some articles, curated fronts, tag pages (and other areas of the site?)

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
