### PR TITLE
Upgrade @guardian/braze-components to 3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@guardian/atom-renderer": "1.2.2",
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.8",
-    "@guardian/braze-components": "^2.1.0",
+    "@guardian/braze-components": "^3.1.0",
     "@guardian/commercial-core": "^0.19.1",
     "@guardian/consent-management-platform": "6.11.5",
     "@guardian/libs": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@guardian/atom-renderer": "1.2.2",
     "@guardian/automat-contributions": "^0.3.6",
     "@guardian/automat-modules": "^0.3.8",
-    "@guardian/braze-components": "^3.1.0",
+    "@guardian/braze-components": "^3.2.0",
     "@guardian/commercial-core": "^0.19.1",
     "@guardian/consent-management-platform": "6.11.5",
     "@guardian/libs": "^2.8.0",

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -222,7 +222,7 @@ const show = () => Promise.all([
     import('react-dom'),
     import('@emotion/react'),
     import('@emotion/cache'),
-    import(/* webpackChunkName: "guardian-braze-components" */ '@guardian/braze-components')
+    import(/* webpackChunkName: "guardian-braze-components-banner" */ '@guardian/braze-components/banner')
 ]).then((props) => {
     const [{ render }, { CacheProvider }, { default: createCache }, brazeModule] = props;
     const container = document.createElement('div');
@@ -233,7 +233,7 @@ const show = () => Promise.all([
             document.body.appendChild(container);
         }
 
-        const Component = brazeModule.BrazeMessageComponent
+        const Component = brazeModule.BrazeBannerComponent
 
         // IE does not support shadow DOM, so instead we just render
         if (!container.attachShadow) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1893,10 +1893,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/braze-components@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-3.1.0.tgz#ef0f57df148c88cf3396843fc5d35fef4955f698"
-  integrity sha512-qdEBLZvU9JooEAsOyNg3ywOuhpvy2ARTD23fAoyREVNncf9DJDBUWWigf1iI71RM/rT0pGJcKZiQqYn4zQQw1g==
+"@guardian/braze-components@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-3.2.0.tgz#f24117252a516bd7b1e39fe952a55d935646f746"
+  integrity sha512-NY5K/BoV0MAzEOpUUajUM91RPxHT7OeLzUuqHluZp7gIKtmfZKglrebct0ALQSsrORCTVbT3PTBtK9svI01jRQ==
   dependencies:
     "@guardian/src-button" "3.3.0"
     "@guardian/src-foundations" "3.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1893,10 +1893,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/braze-components@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-2.1.0.tgz#d878bf2d7351fd682ee8e5d588970d18a62efd8a"
-  integrity sha512-PofC9Ao2fjUhT9tQcLh5ZFy4n+AwJE2eDNd2UdKM0pnhnfhqLZV+II3wARKuVc8K+4EjDJLnNOY9UA+NbXgE2Q==
+"@guardian/braze-components@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-3.1.0.tgz#ef0f57df148c88cf3396843fc5d35fef4955f698"
+  integrity sha512-qdEBLZvU9JooEAsOyNg3ywOuhpvy2ARTD23fAoyREVNncf9DJDBUWWigf1iI71RM/rT0pGJcKZiQqYn4zQQw1g==
   dependencies:
     "@guardian/src-button" "3.3.0"
     "@guardian/src-foundations" "3.3.0"


### PR DESCRIPTION
## What does this change?

This PR upgrades the version of `@guardian/braze-components` used by frontend to 3.2.0. The interface has slightly changes in this new release. We can import _only_ banners from the /banners entry point of the package which will keep the size of the lazy import down. The factory components have also been split out so we use `BrazeBannerComponent` instead of `BrazeMessageComponent`.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation) guardian/dotcom-rendering#3209

## Screenshots

![Screenshot 2021-07-28 at 17 14 54](https://user-images.githubusercontent.com/379839/127358666-0992966f-5e8c-4603-bc9c-c21ee765c1a5.png)


<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
