### PR TITLE
Check whether hosted modules are loaded in DCR

### DIFF
--- a/static/src/javascripts/bootstraps/commercial.dcr.js
+++ b/static/src/javascripts/bootstraps/commercial.dcr.js
@@ -29,6 +29,7 @@ import { init as initRedplanet } from 'commercial/modules/dfp/redplanet';
 import { init as initCommercialMetrics } from 'commercial/commercial-metrics';
 import { refresh as refreshUserFeatures } from 'common/modules/commercial/user-features';
 import { EventTimer } from '@guardian/commercial-core';
+import { amIUsed } from 'commercial/sentinel';
 
 const commercialModules = [
 	['cm-setAdTestCookie', setAdTestCookie],
@@ -64,6 +65,7 @@ if (!commercialFeatures.adFree) {
 
 const loadHostedBundle = () => {
 	if (config.get('page.isHosted')) {
+        amIUsed('commercial.dcr.js', 'loadHostedBundle', { isHosted: 'true'})
 		return new Promise((resolve) => {
 			require.ensure(
 				[],


### PR DESCRIPTION
## What does this change?
This PR adds `amIUsed` to `commercial.dcr.js` to check if hosted modules are ever loaded in DCR.
If not, we can just get rid of them.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
Hosted pages are served by Frontend so there's no need to include them in DCR.

## Checklist

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [x] Locally
- [ ] On CODE (optional)
