### PR TITLE
Mobbing 30 Jul 2021

### DIFF
--- a/static/src/javascripts/bootstraps/commercial.ts
+++ b/static/src/javascripts/bootstraps/commercial.ts
@@ -59,6 +59,7 @@ if (!commercialFeatures.adFree) {
 	);
 }
 
+// TODO (cm):  make the hosted bundle separate
 const loadHostedBundle = (): Promise<void> => {
 	if (window.guardian.config.page.isHosted) {
 		return new Promise((resolve) => {

--- a/static/src/javascripts/projects/commercial/mob/session-01.md
+++ b/static/src/javascripts/projects/commercial/mob/session-01.md
@@ -1,0 +1,31 @@
+# Let’s mob!
+## 30 Jul 30 2021
+
+Present today
+- @chrislomaxjones
+- @MarSavar
+- @mxdvl
+- @zekehuntergreen
+- @arelra
+
+## Purpose
+
+- Add comments straight in the code
+- Find candidates for `amIUsed` and start tracking usage.
+- Make link to historic PRs to understand decisions
+
+## Discoveries
+
+The reason there are two commercial modules folders is because one isn’t loaded
+if the `commercial` switch is off. This seems like a very premature optimisation
+for a rare event. Commercial logic should always be loaded, and only use the
+switch logic to prevent initialising further code.
+
+## Actions taken
+
+We will identify all the common/commercial/*.(ts|js) files use outside of the
+commercial bundle, and identified this as comments in the code.
+
+## Next steps
+
+- Create cards from above?

--- a/static/src/javascripts/projects/commercial/mob/session-01.md
+++ b/static/src/javascripts/projects/commercial/mob/session-01.md
@@ -26,6 +26,8 @@ switch logic to prevent initialising further code.
 We will identify all the common/commercial/*.(ts|js) files use outside of the
 commercial bundle, and identified this as comments in the code.
 
+### https://github.com/guardian/frontend/pull/24047
+
 ## Next steps
 
 - Create cards from above?

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -1,6 +1,11 @@
 import { addReferrerData } from './acquisitions-ophan';
 import { addCountryGroupToSupportLink } from './support-utilities';
 
+/*
+ * Where is this file used outside the commercial bundle?
+ * /static/src/javascripts/bootstraps/enhanced/main.js
+ */
+
 // Currently the only acquisition components on the site are
 // from the Mother Load campaign and the Wide Brown Land campaign.
 // Work needs to be done so we don't have to hard code what campaigns are running.

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
@@ -2,6 +2,19 @@ import ophan from 'ophan/ng';
 import config from '../../../../lib/config';
 import { constructQuery as constructURLQuery } from '../../../../lib/url';
 
+
+/*
+ * Inside the bundle:
+ * - static/src/javascripts/projects/commercial/modules/brazeBanner.js
+ *
+ * Where is this file used outside the commercial bundle?
+ * - static/src/javascripts/bootstraps/enhanced/common.js
+ * - static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+ * - static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+ * - static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+ * - static/src/javascripts/projects/common/modules/navigation/membership.js
+ */
+
 export const submitComponentEvent = (componentEvent) => {
     ophan.record({ componentEvent });
 };

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-view-log.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-view-log.js
@@ -1,5 +1,11 @@
 import { storage } from '@guardian/libs';
 
+/*
+ * Outside the bundle:
+ * - /static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+ * - /static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js
+ */
+
 const viewKey = 'gu.contributions.views';
 const viewLog = storage.local.get(viewKey) || [];
 

--- a/static/src/javascripts/projects/common/modules/commercial/ad-free-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ad-free-banner.js
@@ -3,6 +3,11 @@ import config from '../../../../lib/config';
 import { hasUserAcknowledgedBanner, Message } from '../ui/message';
 import { isAdFreeUser } from './user-features';
 
+/*
+ * Where is this file used outside the commercial bundle?
+ * - /static/src/javascripts/bootstraps/enhanced/common.js
+ */
+
 const messageCode = 'ad-free-banner';
 const image = config.get('images.acquisitions.ad-free', '');
 

--- a/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.js
@@ -1,7 +1,12 @@
 import { addCookie, getCookie } from '../../../../lib/cookies';
 import { onConsentSet } from '../analytics/send-privacy-prefs';
 
-
+/*
+ * Where is this file used outside the commercial bundle?
+ * - static/src/javascripts/bootstraps/enhanced/common.js
+ * - static/src/javascripts/projects/common/modules/identity/ad-prefs.js
+ * - static/src/javascripts/projects/common/modules/identity/ad-prefs/wordings.js
+ */
 
 const cookieExpiryDate = 30 * 18;
 

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -19,6 +19,20 @@ import { commercialFeatures } from './commercial-features';
 import { clearPermutiveSegments, getPermutiveSegments } from './permutive';
 import { getUserSegments } from './user-ad-targeting';
 
+/*
+ * Inside:
+ * - static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.ts
+ * - static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
+ * - static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.js
+ * - static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.ts
+ *
+ * Outside:
+ * - static/src/javascripts/projects/common/modules/atoms/youtube-player.ts
+ *
+ * - static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+ */
+
+
 let myPageTargetting = {};
 let latestCmpHasInitialised;
 let latestCMPState;

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
@@ -4,6 +4,16 @@ import { isAdFreeUser } from './user-features';
 import { isUserLoggedIn } from '../identity/api';
 import userPrefs from '../user-prefs';
 
+/*
+ * This file is used outside of the commercial bundle:
+ * - static/src/javascripts/projects/common/modules/article/rich-links.js
+ * - static/src/javascripts/projects/common/modules/atoms/youtube-player.ts
+ * - static/src/javascripts/projects/common/modules/onward/related.js
+ * 
+ * It’s also used by common/commercial:
+ * - build-page-targetting
+ */
+
 // Having a constructor means we can easily re-instantiate the object in a test
 class CommercialFeatures {
 
@@ -44,7 +54,7 @@ class CommercialFeatures {
         ].includes(config.get('page.pageId', ''));
 
         // Feature switches
-        this.adFree = !!forceAdFree || isAdFreeUser();
+        this.adFree = forceAdFree || isAdFreeUser();
 
         this.dfpAdvertising =
             forceAds ||

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-liveblog-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-liveblog-utilities.js
@@ -1,6 +1,11 @@
 import { mountDynamic } from '@guardian/automat-modules';
 import $ from '../../../../lib/$';
 
+/**
+ * Where is this used outside of the commercial bundle?
+ * - /static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+ */
+
 const getBlockToInsertEpicAfter = () => {
     const blocks = document.getElementsByClassName('block');
     const epicsAlreadyOnPage = document.getElementsByClassName('is-epic');

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -31,6 +31,15 @@ import {
 import { puzzlesBanner } from 'common/modules/experiments/tests/puzzles-banner';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 
+/*
+ * This module is used outside of the commercial bundle:
+ * - static/src/javascripts/bootstraps/enhanced/common.js
+ * - static/src/javascripts/bootstraps/enhanced/main.js
+ * - static/src/javascripts/projects/common/modules/commercial/puzzles-banner.js
+ * - static/src/javascripts/projects/common/modules/commercial/reader-revenue-banner.js
+ */
+
+
 // See https://github.com/guardian/support-dotcom-components/blob/main/module-versions.md
 export const ModulesVersion = 'v2';
 

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -4,6 +4,18 @@ import { elementInView } from '../../../../lib/element-inview';
 import { submitInsertEvent, submitViewEvent } from './acquisitions-ophan';
 import { logView } from './acquisitions-view-log';
 
+/*
+ * Inside the bundle:
+ * - static/src/javascripts/projects/commercial/adblock-ask.ts
+ *
+ * Where is this file used outside the commercial bundle?
+ * - static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+ * - static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js
+ *
+ */
+
+
+
 const getVisitCount = () => parseInt(storage.local.getRaw('gu.alreadyVisited'), 10) || 0;
 
 const pageShouldHideReaderRevenue = () =>

--- a/static/src/javascripts/projects/common/modules/commercial/geo-utils.js
+++ b/static/src/javascripts/projects/common/modules/commercial/geo-utils.js
@@ -7,6 +7,27 @@ const currentGeoLocation = (() => {
     return geo;
 });
 
+/*
+ * Inside the bundle:
+ * - static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
+ * - static/src/javascripts/projects/commercial/modules/dfp/redplanet.spec.js
+ * - static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.js
+ * - static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.spec.js
+ * - static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.spec.ts
+ * - static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.ts
+ * - static/src/javascripts/projects/commercial/modules/header-bidding/utils.spec.js
+ * - static/src/javascripts/projects/commercial/modules/header-bidding/utils.ts
+ * - static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide-legacy.js
+ * - static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide.js
+ *
+ * Where is this file used outside the commercial bundle?
+ * - static/src/javascripts/lib/getPrivacyFramework.js
+ * - static/src/javascripts/projects/common/modules/commercial/geo-utils.spec.js
+ *
+ */
+
+
+
 export const isInUk = () => currentGeoLocation() === 'GB';
 
 export const isInUsa = () => currentGeoLocation() === 'US';

--- a/static/src/javascripts/projects/common/modules/commercial/permutive.js
+++ b/static/src/javascripts/projects/common/modules/commercial/permutive.js
@@ -1,5 +1,19 @@
 import { storage } from '@guardian/libs';
 
+/*
+ * Inside the bundle:
+ * [None]
+ *
+ * Where is this file used outside the commercial bundle?
+ * - static/src/javascripts/projects/common/modules/atoms/youtube-player.ts
+ *
+ * - static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+ * - static/src/javascripts/projects/common/modules/commercial/permutive.spec.js
+ *
+ */
+
+
+
 const PERMUTIVE_KEY = `_papns`;
 const PERMUTIVE_PFP_KEY = `_pdfps`;
 

--- a/static/src/javascripts/projects/common/modules/commercial/puzzles-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/puzzles-banner.js
@@ -1,6 +1,14 @@
 import reportError from 'lib/report-error';
 import { fetchPuzzlesData, renderBanner } from './contributions-service';
 
+/*
+ * Where is this file used outside the commercial bundle?
+ * - /static/src/javascripts/bootstraps/enhanced/common.js
+ *
+ * inside bundle
+ * - /static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+ */
+
 const messageCode = 'puzzles-banner';
 
 let data = null;

--- a/static/src/javascripts/projects/common/modules/commercial/reader-revenue-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/reader-revenue-banner.js
@@ -2,6 +2,14 @@ import config from 'lib/config';
 import reportError from 'lib/report-error';
 import { fetchBannerData, renderBanner } from './contributions-service';
 
+/*
+ * Inside the bundle:
+ *
+ * Where is this file used outside the commercial bundle?
+ * - static/src/javascripts/bootstraps/enhanced/common.js
+ *
+ */
+
 const messageCode = 'reader-revenue-banner';
 
 let data = null;

--- a/static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js
+++ b/static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js
@@ -19,6 +19,14 @@ import {
     readerRevenueRelevantCookies,
 } from './user-features';
 
+/*
+ * Inside the bundle:
+ *
+ * Where is this file used outside the commercial bundle?
+ * - static/src/javascripts/bootstraps/enhanced/common.js
+ *
+ */
+
 const lastClosedAtKey = 'engagementBannerLastClosedAt';
 const minArticlesBeforeShowingBanner = 2;
 

--- a/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
@@ -3,6 +3,20 @@ import {
     getCountryCode,
 } from '../../../../lib/geolocation';
 
+/*
+ * Inside the bundle:
+ * - static/src/javascripts/projects/commercial/adblock-ask.ts
+ *
+ * Where is this file used outside the commercial bundle?
+ * - static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+ * - static/src/javascripts/projects/common/modules/commercial/support-utilities.spec.js
+ *
+ * - static/src/javascripts/projects/journalism/modules/audio-series-add-contributions.js
+ *
+ */
+
+
+
 const addCountryGroupToSupportLink = (rawUrl) => {
     const countryCode = getCountryCode();
     if (countryCode) {

--- a/static/src/javascripts/projects/common/modules/commercial/user-ad-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-ad-targeting.js
@@ -1,6 +1,19 @@
 import { storage } from '@guardian/libs';
 import { getUserFromCookie, getUserFromApi } from '../identity/api';
 
+/*
+ * Inside the bundle:
+ * - static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+ * - static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+ * - static/src/javascripts/projects/common/modules/commercial/user-ad-targeting.spec.js
+ *
+ * Where is this file used outside the commercial bundle?
+ * - static/src/javascripts/bootstraps/enhanced/common.js
+ *
+ */
+
+
+
 const userSegmentsKey = 'gu.ads.userSegmentsData';
 
 const getUserSegments = (adConsentState) => {

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -4,6 +4,33 @@ import { fetchJson } from '../../../../lib/fetch-json';
 import { isUserLoggedIn } from '../identity/api';
 import { dateDiffDays } from '../../../../lib/time-utils';
 
+/*
+ * Inside the bundle:
+ * - static/src/javascripts/bootstraps/commercial.dcr.ts
+ * - static/src/javascripts/projects/commercial/adblock-ask.ts
+ * - static/src/javascripts/projects/commercial/modules/brazeBanner.js
+ *
+ * Where is this file used outside the commercial bundle?
+ * - static/src/javascripts/bootstraps/enhanced/common.js
+ * - static/src/javascripts/bootstraps/enhanced/membership.js
+ * - static/src/javascripts/projects/atoms/services.js
+ * - static/src/javascripts/projects/common/modules/audio/index.js
+ *
+ * - static/src/javascripts/projects/common/modules/commercial/ad-free-banner.js
+ * - static/src/javascripts/projects/common/modules/commercial/commercial-features.js
+ * - static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.js
+ * - static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+ * - static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js
+ * - static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+ *
+ * - static/src/javascripts/projects/common/modules/navigation/membership.js
+ * - static/src/javascripts/projects/common/modules/navigation/supporter-cta.js
+ * - static/src/javascripts/projects/common/modules/onward/history.js
+ * - static/src/javascripts/projects/facia/modules/ui/container-show-more.js
+ */
+
+
+
 // Persistence keys
 const USER_FEATURES_EXPIRY_COOKIE = 'gu_user_features_expiry';
 const PAYING_MEMBER_COOKIE = 'gu_paying_member';

--- a/webpack.config.dcr.js
+++ b/webpack.config.dcr.js
@@ -22,6 +22,7 @@ module.exports = webpackMerge.smart(config, {
     resolve: {
         alias: {
             "ophan/ng": path.join(__dirname, 'static', 'src', 'javascripts', 'bootstraps', 'commercial-ophan.dcr.js'),
+            // TODO: Add similar logic for `@guardian/consent-management-platform`
         },
     },
 });


### PR DESCRIPTION
> This is branched of #24044, so there is a bit more than expected.

# Let’s mob!
## 30 Jul 30 2021

Present today
- @chrislomaxjones
- @MarSavar
- @mxdvl
- @zekehuntergreen
- @arelra

## Purpose

- Add comments straight in the code
- Find candidates for `amIUsed` and start tracking usage.
- Make link to historic PRs to understand decisions

## Discoveries

The reason there are two commercial modules folders is because one isn’t loaded
if the `commercial` switch is off. This seems like a very premature optimisation
for a rare event. Commercial logic should always be loaded, and only use the
switch logic to prevent initialising further code.

## Actions taken

We will identify all the common/commercial/*.(ts|js) files use outside of the
commercial bundle, and identified this as comments in the code.

## Next steps

- Create cards from above?
