### PR TITLE
AdBlock Ask temp rollback.

### DIFF
--- a/static/src/javascripts/projects/commercial/adblock-ask.ts
+++ b/static/src/javascripts/projects/commercial/adblock-ask.ts
@@ -1,3 +1,4 @@
+import $ from 'lib/$';
 import config from '../../lib/config';
 import fastdom from '../../lib/fastdom-promise';
 import { pageShouldHideReaderRevenue } from '../common/modules/commercial/contributions-utilities';
@@ -22,12 +23,16 @@ const canShow = () =>
 export const initAdblockAsk = (): Promise<void> => {
 	if (!canShow()) return Promise.resolve();
 
-	return fastdom
-		.measure(() => document.querySelector('.js-aside-slot-container'))
-		.then((slot) => {
-			if (!slot) return;
-			return fastdom.mutate(() => {
-				slot.append(askHtml);
-			});
-		});
+	return (
+		fastdom
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-return -- TODO: fix it
+			.measure(() => $('.js-aside-slot-container'))
+			.then((slot) => {
+				if (!slot) return;
+				return fastdom.mutate(() => {
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call -- TODO: fix it
+					slot.append(askHtml);
+				});
+			})
+	);
 };


### PR DESCRIPTION
## What does this change?

Reinstate `$` so it inserts html directly. Otherwise, the HTML is rendered as text. See screenshot below.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/127834593-1687e78b-e849-4ee3-8685-27e03c27a0d4.png
[after]: https://user-images.githubusercontent.com/76776/127834761-a03f7371-13ec-4be5-8a19-9ad1379d5a19.png

Proper HTML:

![image](https://user-images.githubusercontent.com/76776/127834986-de3dcd3c-d55f-44c0-8d41-d80f867a6b0d.png)


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
