### PR TITLE
convert `$` to native JS

### DIFF
--- a/static/src/javascripts/projects/commercial/adblock-ask.spec.ts
+++ b/static/src/javascripts/projects/commercial/adblock-ask.spec.ts
@@ -1,0 +1,42 @@
+import { pageShouldHideReaderRevenue } from 'common/modules/commercial/contributions-utilities';
+import { shouldHideSupportMessaging } from 'common/modules/commercial/user-features';
+import config from '../../lib/config';
+import { _ } from './adblock-ask';
+
+const { params, canShow } = _;
+
+jest.mock('../common/modules/commercial/contributions-utilities');
+jest.mock('../common/modules/commercial/user-features');
+jest.mock('../../lib/config', () => ({
+	get: jest.fn(),
+}));
+jest.mock('ophan/ng', () => null);
+jest.mock('lib/raven');
+
+describe('adblock-ask', () => {
+	it('has the correct URL params', () => {
+		expect(params.toString()).toBe(
+			'acquisitionData=%7B%22componentType%22%3A%22ACQUISITIONS_OTHER%22%2C%22source%22%3A%22GUARDIAN_WEB%22%2C%22campaignCode%22%3A%22shady_pie_open_2019%22%2C%22componentId%22%3A%22shady_pie_open_2019%22%7D&INTCMP=shady_pie_open_2019',
+		);
+	});
+
+	it('should show if possible', () => {
+		(config.get as jest.Mock).mockReturnValue(false); // 'page.hasShowcaseMainElement'
+		(pageShouldHideReaderRevenue as jest.Mock).mockReturnValue(false);
+		(shouldHideSupportMessaging as jest.Mock).mockReturnValue(false);
+
+		expect(canShow()).toBe(true);
+	});
+
+	it.each([
+		['page.hasShowcaseMainElement', true, false, false],
+		['pageShouldHideReaderRevenue', false, true, false],
+		['shouldHideSupportMessaging', false, false, true],
+	])('should not show if is %s is true', (_, a, b, c) => {
+		(config.get as jest.Mock).mockReturnValue(a); // 'page.hasShowcaseMainElement'
+		(pageShouldHideReaderRevenue as jest.Mock).mockReturnValue(b);
+		(shouldHideSupportMessaging as jest.Mock).mockReturnValue(c);
+
+		expect(canShow()).toBe(false);
+	});
+});

--- a/static/src/javascripts/projects/commercial/adblock-ask.ts
+++ b/static/src/javascripts/projects/commercial/adblock-ask.ts
@@ -26,7 +26,7 @@ const askHtml = `
 </div>
 `;
 
-const canShow = () =>
+const canShow = (): boolean =>
 	!shouldHideSupportMessaging() &&
 	!pageShouldHideReaderRevenue() &&
 	!config.get('page.hasShowcaseMainElement');
@@ -42,4 +42,9 @@ export const initAdblockAsk = (): Promise<void> => {
 				slot.insertAdjacentHTML('beforeend', askHtml);
 			});
 		});
+};
+
+export const _ = {
+	params,
+	canShow,
 };

--- a/static/src/javascripts/projects/commercial/adblock-ask.ts
+++ b/static/src/javascripts/projects/commercial/adblock-ask.ts
@@ -4,7 +4,19 @@ import { pageShouldHideReaderRevenue } from '../common/modules/commercial/contri
 import { supportSubscribeDigitalURL } from '../common/modules/commercial/support-utilities';
 import { shouldHideSupportMessaging } from '../common/modules/commercial/user-features';
 
-const supportUrl = `${supportSubscribeDigitalURL()}?acquisitionData=%7B%22componentType%22%3A%22ACQUISITIONS_OTHER%22%2C%22source%22%3A%22GUARDIAN_WEB%22%2C%22campaignCode%22%3A%22shady_pie_open_2019%22%2C%22componentId%22%3A%22shady_pie_open_2019%22%7D&INTCMP=shady_pie_open_2019`;
+const params = new URLSearchParams();
+params.set(
+	'acquisitionData',
+	JSON.stringify({
+		componentType: 'ACQUISITIONS_OTHER',
+		source: 'GUARDIAN_WEB',
+		campaignCode: 'shady_pie_open_2019',
+		componentId: 'shady_pie_open_2019',
+	}),
+);
+params.set('INTCMP', 'shady_pie_open_2019');
+
+const supportUrl = `${supportSubscribeDigitalURL()}?${params.toString()}`;
 
 const askHtml = `
 <div class="contributions__adblock">

--- a/static/src/javascripts/projects/commercial/adblock-ask.ts
+++ b/static/src/javascripts/projects/commercial/adblock-ask.ts
@@ -6,9 +6,7 @@ import { shouldHideSupportMessaging } from '../common/modules/commercial/user-fe
 
 const supportUrl = `${supportSubscribeDigitalURL()}?acquisitionData=%7B%22componentType%22%3A%22ACQUISITIONS_OTHER%22%2C%22source%22%3A%22GUARDIAN_WEB%22%2C%22campaignCode%22%3A%22shady_pie_open_2019%22%2C%22componentId%22%3A%22shady_pie_open_2019%22%7D&INTCMP=shady_pie_open_2019`;
 
-const askHtml = document.createElement('a');
-askHtml.classList.add('contributions__adblock');
-askHtml.innerHTML = `
+const askHtml = `
 <div class="contributions__adblock">
     <a href="${supportUrl}">
         <img src="https://uploads.guim.co.uk/2020/10/02/Digisubs_MPU_c1_my_opt.png" width="300" alt="" />
@@ -29,7 +27,7 @@ export const initAdblockAsk = (): Promise<void> => {
 		.then((slot) => {
 			if (!slot) return;
 			return fastdom.mutate(() => {
-				slot.append(askHtml);
+				slot.insertAdjacentHTML('beforeend', askHtml);
 			});
 		});
 };

--- a/static/src/javascripts/projects/commercial/adblock-ask.ts
+++ b/static/src/javascripts/projects/commercial/adblock-ask.ts
@@ -1,4 +1,3 @@
-import $ from 'lib/$';
 import config from '../../lib/config';
 import fastdom from '../../lib/fastdom-promise';
 import { pageShouldHideReaderRevenue } from '../common/modules/commercial/contributions-utilities';
@@ -7,7 +6,9 @@ import { shouldHideSupportMessaging } from '../common/modules/commercial/user-fe
 
 const supportUrl = `${supportSubscribeDigitalURL()}?acquisitionData=%7B%22componentType%22%3A%22ACQUISITIONS_OTHER%22%2C%22source%22%3A%22GUARDIAN_WEB%22%2C%22campaignCode%22%3A%22shady_pie_open_2019%22%2C%22componentId%22%3A%22shady_pie_open_2019%22%7D&INTCMP=shady_pie_open_2019`;
 
-const askHtml = `
+const askHtml = document.createElement('a');
+askHtml.classList.add('contributions__adblock');
+askHtml.innerHTML = `
 <div class="contributions__adblock">
     <a href="${supportUrl}">
         <img src="https://uploads.guim.co.uk/2020/10/02/Digisubs_MPU_c1_my_opt.png" width="300" alt="" />
@@ -23,16 +24,12 @@ const canShow = () =>
 export const initAdblockAsk = (): Promise<void> => {
 	if (!canShow()) return Promise.resolve();
 
-	return (
-		fastdom
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-return -- TODO: fix it
-			.measure(() => $('.js-aside-slot-container'))
-			.then((slot) => {
-				if (!slot) return;
-				return fastdom.mutate(() => {
-					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call -- TODO: fix it
-					slot.append(askHtml);
-				});
-			})
-	);
+	return fastdom
+		.measure(() => document.querySelector('.js-aside-slot-container'))
+		.then((slot) => {
+			if (!slot) return;
+			return fastdom.mutate(() => {
+				slot.append(askHtml);
+			});
+		});
 };


### PR DESCRIPTION
## What does this change?

Implements a native Javascript implementation of `$`, which treats the HTML as such and does not insert it as text.

Follow-up on #24049 and proper implementation of f7a6cbd529ee4ad5a843535d8a1f0b036adaa3e1.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Less reliance on `$`.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)


### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
