### PR TITLE
Add type annotation to Youtube iFrames on hosted advertiser pages

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/hosted/video.ts
+++ b/static/src/javascripts/projects/commercial/modules/hosted/video.ts
@@ -1,7 +1,9 @@
 import { initHostedYoutube } from 'commercial/modules/hosted/youtube';
 
 export const initHostedVideo = (): Promise<void> => {
-	const youtubeIframe = document.querySelectorAll('.js-hosted-youtube-video');
+	const youtubeIframe: NodeListOf<HTMLElement> = document.querySelectorAll(
+		'.js-hosted-youtube-video',
+	);
 
 	if (!youtubeIframe.length) {
 		// Halt execution if there are no video containers on the page.


### PR DESCRIPTION
## What does this change?

 `hosted/youtube.js`'s `initHostedYoutube` expects an argument of type `HTMLElement`.
`hosted/video.ts` was calling the above function on an array whose members were of type `Element`.

The type mismatch was causing the error in the screenshot below. This PR adds a type annotation, which stops the compiler from complaining.

**Error screenshot**:
![image](https://user-images.githubusercontent.com/57295823/127857485-fc26a674-cc56-4206-b1a1-8c5a95082595.png)
