### PR TITLE
Prepare for DCR date refactoring

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -107,6 +107,7 @@ object DotcomRenderingDataModel {
         "pagination" -> model.pagination,
         "author" -> model.author,
         "webPublicationDate" -> model.webPublicationDate,
+        "webPublicationDateDeprecated" -> model.webPublicationDate,
         "webPublicationDateDisplay" -> model.webPublicationDateDisplay,
         "webPublicationSecondaryDateDisplay" -> model.webPublicationSecondaryDateDisplay,
         "editionLongForm" -> model.editionLongForm,


### PR DESCRIPTION
## What does this change?

Duplicates `webPublicationDate` into `webPublicationDateDeprecated` so that we can reformat the original field as part of wider DCR date refactor.

See: https://docs.google.com/document/d/1Emc0OivrVhH5-svVOiE2QLBER_wREdIxpe9G1XqMy9g/edit#. 

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

DCR PR is here: https://github.com/guardian/dotcom-rendering/pull/3223.