### PR TITLE
Do not count duplicate article views

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -29,7 +29,6 @@ import {
     logHistory,
     logSummary,
     showInMegaNav,
-    incrementDailyArticleCount,
     incrementWeeklyArticleCount,
 } from 'common/modules/onward/history';
 import { initAccessibilityPreferences } from 'common/modules/ui/accessibility-prefs';
@@ -174,7 +173,6 @@ const updateArticleCounts = async () => {
     const hasConsentedToArticleCounts = await getArticleCountConsent();
 
     if (page && hasConsentedToArticleCounts) {
-        incrementDailyArticleCount(page);
         incrementWeeklyArticleCount(page);
     }
 };

--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -474,8 +474,7 @@ const showInMegaNavEnable = (bool) => {
     saveSummary(summary);
 };
 
-// Returns true if the article has already been viewed this week
-const updateCountForArticleThisWeek = (pageId) => {
+const articleHasBeenViewedThisWeek = (pageId) => {
     const articleCounts = storage.local.get(storageKeyForArticleCountsThisWeek);
     if (articleCounts && articleCounts.week === startOfThisWeek) {
         const currentCount = articleCounts.articles[pageId] || 0;
@@ -502,8 +501,7 @@ const updateCountForArticleThisWeek = (pageId) => {
 
 const incrementWeeklyArticleCount = (pageConfig) => {
     if (!pageConfig.isFront && !getCookie(ARTICLES_VIEWED_OPT_OUT_COOKIE.name)) {
-        const hasBeenViewedThisWeek = updateCountForArticleThisWeek(pageConfig.pageId);
-        console.log('hasBeenViewedThisWeek', hasBeenViewedThisWeek)
+        const hasBeenViewedThisWeek = articleHasBeenViewedThisWeek(pageConfig.pageId);
 
         if (!hasBeenViewedThisWeek) {
             const weeklyArticleCount =

--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -475,30 +475,6 @@ const showInMegaNavEnable = (bool) => {
     saveSummary(summary);
 };
 
-const incrementDailyArticleCount = (pageConfig) => {
-    if (!pageConfig.isFront && !getCookie(ARTICLES_VIEWED_OPT_OUT_COOKIE.name)) {
-        const dailyCount = storage.local.get(storageKeyDailyArticleCount) || [];
-
-        if (dailyCount[0] && dailyCount[0].day && dailyCount[0].day === today) {
-            dailyCount[0].count += 1;
-        } else {
-            // New day
-            dailyCount.unshift({ day: today, count: 1 });
-
-            // Remove any days older than 60
-            const cutOff = today - 60;
-            const firstOldDayIndex = dailyCount.findIndex(
-                c => c.day && c.day < cutOff
-            );
-            if (firstOldDayIndex > 0) {
-                dailyCount.splice(firstOldDayIndex);
-            }
-        }
-
-        storage.local.set(storageKeyDailyArticleCount, dailyCount);
-    }
-};
-
 const incrementWeeklyArticleCount = (pageConfig) => {
     if (!pageConfig.isFront && !getCookie(ARTICLES_VIEWED_OPT_OUT_COOKIE.name)) {
         const weeklyArticleCount =
@@ -574,7 +550,6 @@ export {
     reset,
     seriesSummary,
     mostViewedSeries,
-    incrementDailyArticleCount,
     incrementWeeklyArticleCount,
     getArticleViewCountForDays,
     getArticleViewCountForWeeks,

--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -487,7 +487,7 @@ const articleHasBeenViewedThisWeek = (pageId) => {
             },
         });
 
-        return !!currentCount;
+        return currentCount > 0;
     } else {
         // It's a new week
         storage.local.set(storageKeyForArticleCountsThisWeek, {

--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -68,7 +68,6 @@ const forgetUniquesAfter = 10;
 const historySize = 50;
 const storageKeyHistory = 'gu.history';
 const storageKeySummary = 'gu.history.summary';
-const storageKeyDailyArticleCount = 'gu.history.dailyArticleCount'; // Array containing an article count for each day
 const storageKeyWeeklyArticleCount = 'gu.history.weeklyArticleCount';
 const storageKeyForArticleCountsThisWeek = 'gu.history.articleCountsThisWeek';
 
@@ -346,7 +345,6 @@ const reset = () => {
     summaryCache = undefined;
     storage.local.remove(storageKeyHistory);
     storage.local.remove(storageKeySummary);
-    storage.local.remove(storageKeyDailyArticleCount);
 };
 
 const logHistory = (pageConfig) => {
@@ -538,21 +536,6 @@ const incrementWeeklyArticleCount = (pageConfig) => {
     }
 };
 
-const getArticleViewCountForDays = (days) => {
-    const dailyCount = storage.local.get(storageKeyDailyArticleCount) || [];
-    const cutOff = today - days;
-
-    const firstOldDayIndex = dailyCount.findIndex(
-        c => c.day && c.day <= cutOff
-    );
-    const dailyCountWindow =
-        firstOldDayIndex >= 0
-            ? dailyCount.slice(0, firstOldDayIndex)
-            : dailyCount;
-
-    return dailyCountWindow.reduce((acc, current) => current.count + acc, 0);
-};
-
 const getArticleViewCountForWeeks = (weeks) => {
     const weeklyCount = storage.local.get(storageKeyWeeklyArticleCount) || [];
     const cutOff = startOfThisWeek - weeks * 7;
@@ -583,10 +566,8 @@ export {
     seriesSummary,
     mostViewedSeries,
     incrementWeeklyArticleCount,
-    getArticleViewCountForDays,
     getArticleViewCountForWeeks,
     getMondayFromDate,
-    storageKeyDailyArticleCount,
     storageKeyWeeklyArticleCount,
 };
 

--- a/static/src/javascripts/projects/common/modules/onward/history.spec.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.spec.js
@@ -444,4 +444,32 @@ describe('history', () => {
 
         expect(getArticleViewCountForWeeks(1)).toEqual(1);
     });
+
+    it('increments the weekly article count if not a duplicate article', () => {
+        const counts = [{ week: startOfThisWeek, count: 1 }];
+        storageStub.local.set('gu.history.weeklyArticleCount', counts);
+        storageStub.local.set('gu.history.articleCountsThisWeek', {
+            week: startOfThisWeek,
+            articles: { someOtherArticle: 1 },
+        });
+        getCookie.mockReturnValue(new Date().getTime().toString());
+
+        incrementWeeklyArticleCount(pageConfig);
+
+        expect(getArticleViewCountForWeeks(1)).toEqual(1);
+    });
+
+    it('does not increment the weekly article count if duplicate article', () => {
+        const counts = [{ week: startOfThisWeek, count: 1 }];
+        storageStub.local.set('gu.history.weeklyArticleCount', counts);
+        storageStub.local.set('gu.history.articleCountsThisWeek', {
+            week: startOfThisWeek,
+            articles: { [pageConfig.pageId]: 1 },
+        });
+        getCookie.mockReturnValue(new Date().getTime().toString());
+
+        incrementWeeklyArticleCount(pageConfig);
+
+        expect(getArticleViewCountForWeeks(1)).toEqual(1);
+    });
 });

--- a/static/src/javascripts/projects/common/modules/onward/history.spec.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.spec.js
@@ -11,7 +11,6 @@ import {
     mostViewedSeries,
     getArticleViewCountForDays,
     _,
-    incrementDailyArticleCount,
     getMondayFromDate,
     getArticleViewCountForWeeks,
     incrementWeeklyArticleCount,
@@ -393,35 +392,6 @@ describe('history', () => {
         storageStub.local.set('gu.history.dailyArticleCount', counts);
 
         expect(getArticleViewCountForDays(2)).toEqual(2);
-    });
-
-    it('increments the daily article count', () => {
-        const counts = [{ day: today, count: 1 }];
-        storageStub.local.set('gu.history.dailyArticleCount', counts);
-
-        incrementDailyArticleCount(pageConfig);
-
-        expect(getArticleViewCountForDays(1)).toEqual(2);
-    });
-
-    it('increments the yearly article count', () => {
-        const counts = [{ day: today, count: 1 }];
-        storageStub.local.set('gu.history.dailyArticleCount', counts);
-
-        incrementDailyArticleCount(pageConfig);
-
-        expect(getArticleViewCountForDays(1)).toEqual(2);
-    });
-
-    it('removes old daily history while incrementing the article count', () => {
-        const counts = [{ day: today - 70, count: 9 }];
-        storageStub.local.set('gu.history.dailyArticleCount', counts);
-
-        incrementDailyArticleCount(pageConfig);
-
-        expect(storageStub.local.get('gu.history.dailyArticleCount')).toEqual([
-            { day: today, count: 1 },
-        ]);
     });
 
     // weeklyArticleCountB tests

--- a/static/src/javascripts/projects/common/modules/onward/history.spec.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.spec.js
@@ -9,7 +9,6 @@ import {
     reset,
     seriesSummary,
     mostViewedSeries,
-    getArticleViewCountForDays,
     _,
     getMondayFromDate,
     getArticleViewCountForWeeks,
@@ -87,7 +86,6 @@ const lessVisited = {
 describe('history', () => {
     let mockContains;
     let mockSummary;
-    let mockDailyArticleCount;
     let mockWeeklyArticleCount;
 
     beforeEach(() => {
@@ -98,8 +96,6 @@ describe('history', () => {
                 return mockContains;
             } else if (key === 'gu.history.summary') {
                 return mockSummary;
-            } else if (key === 'gu.history.dailyArticleCount') {
-                return mockDailyArticleCount;
             } else if (key === 'gu.history.weeklyArticleCount') {
                 return mockWeeklyArticleCount;
             }
@@ -110,8 +106,6 @@ describe('history', () => {
                 mockContains = data;
             } else if (key === 'gu.history.summary') {
                 mockSummary = data;
-            } else if (key === 'gu.history.dailyArticleCount') {
-                mockDailyArticleCount = data;
             } else if (key === 'gu.history.weeklyArticleCount') {
                 mockWeeklyArticleCount = data;
             }
@@ -377,21 +371,6 @@ describe('history', () => {
 
         expect(getContributors().length).toEqual(1);
         expect(getContributors()[0][0]).toEqual('Finbarr Saunders');
-    });
-
-    // dailyArticleCount tests
-    it('gets article count for today only', () => {
-        const counts = [{ day: today, count: 1 }, { day: today - 1, count: 1 }];
-        storageStub.local.set('gu.history.dailyArticleCount', counts);
-
-        expect(getArticleViewCountForDays(1)).toEqual(1);
-    });
-
-    it('gets article count for 2 days', () => {
-        const counts = [{ day: today, count: 1 }, { day: today - 1, count: 1 }];
-        storageStub.local.set('gu.history.dailyArticleCount', counts);
-
-        expect(getArticleViewCountForDays(2)).toEqual(2);
     });
 
     // weeklyArticleCountB tests


### PR DESCRIPTION
Currently we record an article count per week for 52 weeks in the `weeklyArticleCount` local storage item.
This is used by the epic/banner.

This PR ensures we do not count the same article more than once in the last week. 
It does this by introducing a new item, `articlesThisWeek`. The count for the current week in `weeklyArticleCount` is only incremented if the article does not exist in `articlesThisWeek`.
Note - for a time users may see some cached pages with the old logic. This is ok, it just means the current week's count will be a mixture of old and new style counting.

I've also deleted everything to do with the old daily article count, which we haven't used for a long time.

TODO - 

- [ ] make the same change in DCR.
- [ ] clear `articlesThisWeek` in SDC when a user opts out