### PR TITLE
Adopt CAPI date naming conventions for DCR data model

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -22,7 +22,7 @@ import model.{
   PageWithStoryPackage,
 }
 import navigation._
-import org.joda.time.DateTime
+import org.joda.time.{DateTime, DateTimeZone}
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
 import views.support.{AffiliateLinksCleaner, CamelCase, ContentLayout, JavaScriptPage}
@@ -42,9 +42,11 @@ case class DotcomRenderingDataModel(
     blocks: List[Block],
     pagination: Option[Pagination],
     author: Author,
-    webPublicationDate: String,
+    webPublicationDate: DateTime,
+    webPublicationDateDeprecated: String,
+    lastModifiedDate: DateTime,
     webPublicationDateDisplay: String, // TODO remove
-    webPublicationSecondaryDateDisplay: String,
+    webPublicationSecondaryDateDisplay: String, // TODO remove
     editionLongForm: String,
     editionId: String,
     pageId: String,
@@ -106,8 +108,9 @@ object DotcomRenderingDataModel {
         "blocks" -> model.blocks,
         "pagination" -> model.pagination,
         "author" -> model.author,
-        "webPublicationDate" -> model.webPublicationDate,
-        "webPublicationDateDeprecated" -> model.webPublicationDate,
+        "webPublicationDate" -> model.webPublicationDate.withZone(DateTimeZone.UTC).toString,
+        "lastModifiedDate" -> model.lastModifiedDate.withZone(DateTimeZone.UTC).toString,
+        "webPublicationDateDeprecated" -> model.webPublicationDateDeprecated,
         "webPublicationDateDisplay" -> model.webPublicationDateDisplay,
         "webPublicationSecondaryDateDisplay" -> model.webPublicationSecondaryDateDisplay,
         "editionLongForm" -> model.editionLongForm,
@@ -393,6 +396,7 @@ object DotcomRenderingDataModel {
       isLegacyInteractive = isLegacyInteractive,
       isSpecialReport = DotcomRenderingUtils.isSpecialReport(page),
       keyEvents = keyEventsDCR.toList,
+      lastModifiedDate = content.fields.lastModified,
       linkedData = linkedData,
       main = content.fields.main,
       mainMediaElements = mainMediaElements,
@@ -421,7 +425,8 @@ object DotcomRenderingDataModel {
       trailText = TextCleaner.sanitiseLinks(edition)(content.trail.fields.trailText.getOrElse("")),
       twitterData = page.getTwitterProperties,
       version = 3,
-      webPublicationDate = content.trail.webPublicationDate.toString,
+      webPublicationDate = content.trail.webPublicationDate,
+      webPublicationDateDeprecated = content.trail.webPublicationDate.toString,
       webPublicationDateDisplay =
         GUDateTimeFormatNew.formatDateTimeForDisplay(content.trail.webPublicationDate, request),
       webPublicationSecondaryDateDisplay = DotcomRenderingUtils.secondaryDateString(content, request),

--- a/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
@@ -42,15 +42,18 @@ object Tag {
 case class Block(
     id: String,
     elements: List[PageElement],
-    blockCreatedOn: Option[Long],
-    blockCreatedOnDisplay: Option[String],
-    blockLastUpdated: Option[Long],
-    blockLastUpdatedDisplay: Option[String],
-    blockFirstPublished: Option[Long],
-    blockFirstPublishedDisplay: Option[String],
+    createdDate: Option[String],
+    firstPublishedDate: Option[String],
+    lastModifiedDate: Option[String],
+    blockCreatedOn: Option[Long], // TODO remove
+    blockCreatedOnDisplay: Option[String], // TODO remove
+    blockLastUpdated: Option[Long], // TODO remove
+    blockLastUpdatedDisplay: Option[String], // TODO remove
+    blockFirstPublished: Option[Long], // TODO remove
+    blockFirstPublishedDisplay: Option[String], // TODO remove
     title: Option[String],
-    primaryDateLine: String,
-    secondaryDateLine: String,
+    primaryDateLine: String, // TODO remove
+    secondaryDateLine: String, // TODO remove
 )
 
 object Block {
@@ -99,6 +102,9 @@ object Block {
         campaigns,
         calloutsUrl,
       ),
+      createdDate = block.createdDate.map(_.iso8601),
+      firstPublishedDate = block.firstPublishedDate.map(_.iso8601),
+      lastModifiedDate = block.lastModifiedDate.map(_.iso8601),
       blockCreatedOn = blockCreatedOn,
       blockCreatedOnDisplay = blockCreatedOnDisplay,
       blockLastUpdated = blockLastUpdated,


### PR DESCRIPTION
## What does this change?

Adopt CAPI date naming conventions for DCR data model

Old fields have been marked for removal - possible once DCR has been updated to use the new fields.

For more, see: https://trello.com/c/Nim3sRdU/248-better-dcr-date-handling.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

Yes, we will switch to the new fields once live and we can then remove the old ones in Frontend.