### PR TITLE
[ROTA] reorder football tables

### DIFF
--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -27,8 +27,6 @@ class LeagueTableController(
 
   // Competitions must be added to this list to show up at /football/tables
   val tableOrder: Seq[String] = Seq(
-    "Euro 2020",
-    "World Cup 2022 qualifying",
     "Premier League",
     "Bundesliga",
     "Serie A",
@@ -51,8 +49,8 @@ class LeagueTableController(
     "Community Shield",
     "Scottish Cup",
     "Scottish League Cup",
-    "Nations League",
     "Women's FA Cup",
+    "World Cup 2022 qualifying",
   )
 
   def sortedCompetitions: Seq[Competition] =


### PR DESCRIPTION
## What does this change?
As per ROTA request this reorders the football tables:
- Euro 2020 removed
- World cup qualifying moved to bottom
- Nations League removed

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]:https://user-images.githubusercontent.com/45561419/128147062-e49d2b8e-ef38-4a33-8e44-aed66a2a509a.png

[after]: https://user-images.githubusercontent.com/45561419/128147420-c556044a-2b5a-49d7-b548-708e3ddd2d6b.png

