### PR TITLE
java 11 migration - update ami recipe

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -56,5 +56,5 @@ deployments:
       cloudFormationStackName: frontend
       amiParametersToTags:
         AMI:
-          Recipe: frontend-base-ARM
+          Recipe: frontend-base-ARM-java11
           AmigoStage: PROD


### PR DESCRIPTION
## What does this change?
This change updates the AMI recipe used for frontend. The ec2 instances will boot with java 11. The updated recipe can be found here: https://amigo.gutools.co.uk/recipes/frontend-base-ARM-java11

This change depends on: https://github.com/guardian/platform/pull/1459

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
When this change has been deployed the frontend apps will be deployed onto servers running java 11. This should give us performance improvements (to be quantified after deployment to prod) - we'll be measuring latency and cpu utlisation.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist
N/A

### Tested

- [x] Locally
- [x] On CODE (optional)

