### PR TITLE
Update Ophan Tracker-JS for removed `kruxId`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "fence": "guardian/fence#0.2.11",
     "lodash-es": "^4.17.21",
     "object-fit-videos": "^1.0.3",
-    "ophan-tracker-js": "1.3.25",
+    "ophan-tracker-js": "1.3.27",
     "preact": "^10.5.13",
     "prebid.js": "https://github.com/guardian/Prebid.js#a6d34e7",
     "qwery": "3.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10141,10 +10141,10 @@ openurl@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/openurl/-/openurl-1.1.1.tgz#3875b4b0ef7a52c156f0db41d4609dbb0f94b387"
 
-ophan-tracker-js@1.3.25:
-  version "1.3.25"
-  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.25.tgz#7a43b4a232d940cd68f74a82a712bd2a1ddb4b6f"
-  integrity sha512-jufAOME9FLSuzEMgWhDd6O6xoMJTv2I/GJISiOuaT0W1YVs9upP7zTeXVEPQi12NMe1ZliqFBWnqCea8gVx+2g==
+ophan-tracker-js@1.3.27:
+  version "1.3.27"
+  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.27.tgz#a9913e3cc49ba39b712578659150acf202b6b8c1"
+  integrity sha512-0UXITRMb5tNJhYQzu6tDFsBLFqltYVAbbAqe4m9iVNyX8pV1xCTx+z6rA4MeM4vZEmf1yV+ERUzfEYfrCGyCOQ==
 
 opn@5.3.0:
   version "5.3.0"


### PR DESCRIPTION
Upgrading Ophan Tracker-JS as part of followup for the following PRs:

- https://github.com/guardian/ophan/pull/4216
- https://github.com/guardian/ophan/pull/4221

This will ensure frontend uses the latest, KruxId-free version of the script. Removing Krux Ids has been part of a broader effort by @shtukas and the rest of the Transparency and Consent team to ensure Krux Ids are no longer collected and passed downstream - especially to the data lake. 

A corresponding PR for dotcom-rendering is pending at https://github.com/guardian/dotcom-rendering/pull/3240.

**Further reading and context:**

- https://github.com/guardian/ophan/issues/3628
- https://github.com/guardian/android-news-app/pull/6942