### PR TITLE
java 11 migration - update ci script

### DIFF
--- a/scripts/ci
+++ b/scripts/ci
@@ -7,7 +7,7 @@
 
 echo "##teamcity[progressMessage 'sbt compile assets scalafmtCheckAll test riffRaffUpload']"
 
-export JDK_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
+export JDK_HOME=${JDK_11}
 export JAVA_HOME=${JDK_HOME}
 
 echo "********** Java version **********"


### PR DESCRIPTION
## What does this change?
As part of the migration to java 11 it would be good if the build steps also use java 11. The teamcity build is controlled via the ci script. The ci script referenced a hardcoded location of java 8 (this pointed to the java home path on the teamcity box). To update to java 11:
- create an environment variable (I did this via the teamcity console for the frontend project - see below)
- point the environment variable to a pre-existing value (location of java 11 on teamcity box)
- reference the env var in the ci script

<img width="1767" alt="Screenshot 2021-08-04 at 16 37 57" src="https://user-images.githubusercontent.com/45561419/128210567-07f9faf8-de8f-4387-bca6-908057797fd2.png">

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
This change ensures the build steps use the intended java version. In team city build logs we can see the intended java version being used for the compilation:

```
[15:25:46][Step 7/9] sbt compile assets scalafmtCheckAll test riffRaffUpload
[15:25:46][Step 7/9] ********** Java version **********
[15:25:47][Step 7/9] openjdk version "11.0.12" 2021-07-20 LTS
[15:25:47][Step 7/9] OpenJDK Runtime Environment Corretto-11.0.12.7.1 (build 11.0.12+7-LTS)
[15:25:47][Step 7/9] OpenJDK 64-Bit Server VM Corretto-11.0.12.7.1 (build 11.0.12+7-LTS, mixed mode)
[15:25:47][Step 7/9] **********************************
```

When a build has been compiled using java 11, validate that the deploy is also successful.

## Checklist

### Does this affect other platforms?
N/A

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist
N/A

### Tested

I validated a successful build on teamcity

