### PR TITLE
Create `analytics/shouldCaptureMetrics` and use it

### DIFF
--- a/static/src/javascripts/projects/commercial/commercial-metrics.ts
+++ b/static/src/javascripts/projects/commercial/commercial-metrics.ts
@@ -14,18 +14,20 @@ const sendMetrics = (): void => {
 	logged = sendCommercialMetrics(pageViewId, browserId, isDev);
 };
 
+const shouldForceMetrics = (): boolean => {
+	const testsToForceMetricsFor: ABTest[] = [commercialPartner, improveSkins];
+	return getSynchronousTestsToRun().some((test) =>
+		testsToForceMetricsFor.map((t) => t.id).includes(test.id),
+	);
+};
+
 const init = (): Promise<void> => {
 	if (!window.guardian.config.switches.commercialMetrics)
 		return Promise.resolve();
 
-	const testsToForceMetricsFor: ABTest[] = [commercialPartner, improveSkins];
-
 	const userIsInSamplingGroup = Math.random() <= 0.01;
-	const shouldForceMetrics = getSynchronousTestsToRun().some((test) =>
-		testsToForceMetricsFor.map((t) => t.id).includes(test.id),
-	);
 
-	if (isDev || shouldForceMetrics || userIsInSamplingGroup) {
+	if (isDev || shouldForceMetrics() || userIsInSamplingGroup) {
 		document.addEventListener('visibilitychange', sendMetrics);
 	}
 
@@ -40,4 +42,8 @@ const captureCommercialMetrics = (): void => {
 	document.addEventListener('visibilitychange', sendMetrics);
 };
 
-export { init, captureCommercialMetrics };
+export {
+	init,
+	captureCommercialMetrics,
+	shouldForceMetrics as shouldForceCommercialMetrics,
+};

--- a/static/src/javascripts/projects/commercial/commercial-metrics.ts
+++ b/static/src/javascripts/projects/commercial/commercial-metrics.ts
@@ -1,8 +1,5 @@
-import type { ABTest } from '@guardian/ab-core';
 import { sendCommercialMetrics } from '@guardian/commercial-core';
-import { getSynchronousTestsToRun } from 'common/modules/experiments/ab';
-import { commercialPartner } from 'common/modules/experiments/tests/commercial-partner';
-import { improveSkins } from '../common/modules/experiments/tests/improve-skins';
+import { shouldCaptureMetrics } from 'common/modules/analytics/shouldCaptureMetrics';
 
 const { isDev } = window.guardian.config.page;
 const { pageViewId } = window.guardian.ophan;
@@ -14,20 +11,13 @@ const sendMetrics = (): void => {
 	logged = sendCommercialMetrics(pageViewId, browserId, isDev);
 };
 
-const shouldForceMetrics = (): boolean => {
-	const testsToForceMetricsFor: ABTest[] = [commercialPartner, improveSkins];
-	return getSynchronousTestsToRun().some((test) =>
-		testsToForceMetricsFor.map((t) => t.id).includes(test.id),
-	);
-};
-
 const init = (): Promise<void> => {
 	if (!window.guardian.config.switches.commercialMetrics)
 		return Promise.resolve();
 
 	const userIsInSamplingGroup = Math.random() <= 0.01;
 
-	if (isDev || shouldForceMetrics() || userIsInSamplingGroup) {
+	if (isDev || shouldCaptureMetrics() || userIsInSamplingGroup) {
 		document.addEventListener('visibilitychange', sendMetrics);
 	}
 
@@ -42,8 +32,4 @@ const captureCommercialMetrics = (): void => {
 	document.addEventListener('visibilitychange', sendMetrics);
 };
 
-export {
-	init,
-	captureCommercialMetrics,
-	shouldForceMetrics as shouldForceCommercialMetrics,
-};
+export { init, captureCommercialMetrics };

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -1,6 +1,7 @@
 import { getCookie } from '@guardian/libs';
 import { getCLS, getFCP, getFID, getLCP, getTTFB } from 'web-vitals';
 import reportError from 'lib/report-error';
+import { shouldForceCommercialMetrics } from '../../../commercial/commercial-metrics';
 
 type CoreWebVitalsPayload = {
 	page_view_id: string | null;
@@ -43,7 +44,7 @@ export const coreVitals = (): void => {
 	// Otherwise, only send core web vitals data for 1% of users.
 	const inSample = Math.random() < 1 / 100;
 
-	if (!userInTest && !inSample) {
+	if (!userInTest && !shouldForceCommercialMetrics() && !inSample) {
 		return;
 	}
 

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -1,7 +1,7 @@
 import { getCookie } from '@guardian/libs';
 import { getCLS, getFCP, getFID, getLCP, getTTFB } from 'web-vitals';
 import reportError from 'lib/report-error';
-import { shouldForceCommercialMetrics } from '../../../commercial/commercial-metrics';
+import { shouldCaptureMetrics } from './shouldCaptureMetrics';
 
 type CoreWebVitalsPayload = {
 	page_view_id: string | null;
@@ -44,7 +44,7 @@ export const coreVitals = (): void => {
 	// Otherwise, only send core web vitals data for 1% of users.
 	const inSample = Math.random() < 1 / 100;
 
-	if (!userInTest && !shouldForceCommercialMetrics() && !inSample) {
+	if (!userInTest && !shouldCaptureMetrics() && !inSample) {
 		return;
 	}
 

--- a/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
@@ -1,0 +1,18 @@
+import type { ABTest } from '@guardian/ab-core';
+import { getSynchronousTestsToRun } from '../experiments/ab';
+import { commercialPartner } from '../experiments/tests/commercial-partner';
+import { improveSkins } from '../experiments/tests/improve-skins';
+
+const defaultTests: ABTest[] = [commercialPartner, improveSkins];
+/**
+ * Function to check wether metrics should be captured for the current page
+ * @param tests - optional array of ABTest to check against, default to above.
+ * @returns true if the user is in a test
+ */
+const shouldCaptureMetrics = (tests = defaultTests): boolean => {
+	return getSynchronousTestsToRun().some((test) =>
+		tests.map((t) => t.id).includes(test.id),
+	);
+};
+
+export { shouldCaptureMetrics };


### PR DESCRIPTION
## What does this change?

Extract `shouldCaptureMetrics` as a function and use it for both `commercial-metrics` and `coreVitals`.
This function can take an optional array of `ABTest`s and if the user is in any of them, it will return true.

There is a [default set][] of metrics which would force capture. Currently, it’s:
- `improveSkins`
- `commercialPartner`

[default set]: https://github.com/guardian/frontend/pull/24066/files#diff-0b7d74d7ccd325508bcc23d690d71cb9930fd14d603af716d557e7ec94ed29c1R6

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes **TBC!**

## What is the value of this and can you measure success?

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
