### PR TITLE
update au environment nav links

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -51,6 +51,9 @@ private object NavLinks {
   val wildlife = NavLink("Wildlife", "/environment/wildlife")
   val energy = NavLink("Energy", "/environment/energy")
   val pollution = NavLink("Pollution", "/environment/pollution")
+  val biodiversity = NavLink("Biodiversity", "/environment/biodiversity")
+  val oceans = NavLink("Oceans", "/environment/oceans")
+  val greatBarrierReef = NavLink("Great Barrier Reef", "/environment/great-barrier-reef")
   val property = NavLink("Property", "/money/property")
   val pensions = NavLink("Pensions", "/money/pensions")
   val savings = NavLink("Savings", "/money/savings")
@@ -72,7 +75,7 @@ private object NavLinks {
   )
   val ukEnvironment =
     NavLink("Environment", "/environment", children = List(climateChange, wildlife, energy, pollution))
-  val auEnvironment = ukEnvironment.copy(children = List(globalDevelopment, ourWideBrownLand))
+  val auEnvironment = ukEnvironment.copy(children = List(climateChange, energy, wildlife, biodiversity, oceans, pollution, greatBarrierReef))
   val usEnvironment = ukEnvironment.copy(children = List(climateChange, wildlife, energy, pollution, greenLight))
   val money = NavLink("Money", "/money", children = List(property, pensions, savings, borrowing, careers))
   val ukBusiness = NavLink(

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -75,7 +75,9 @@ private object NavLinks {
   )
   val ukEnvironment =
     NavLink("Environment", "/environment", children = List(climateChange, wildlife, energy, pollution))
-  val auEnvironment = ukEnvironment.copy(children = List(climateChange, energy, wildlife, biodiversity, oceans, pollution, greatBarrierReef))
+  val auEnvironment = ukEnvironment.copy(children =
+    List(climateChange, energy, wildlife, biodiversity, oceans, pollution, greatBarrierReef),
+  )
   val usEnvironment = ukEnvironment.copy(children = List(climateChange, wildlife, energy, pollution, greenLight))
   val money = NavLink("Money", "/money", children = List(property, pensions, savings, borrowing, careers))
   val ukBusiness = NavLink(


### PR DESCRIPTION
## What does this change?

This updates the environment subnav links for the Australia edition. This change was requested by CP.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/45561419/128344993-c9373160-ad80-4d81-9a4e-1a0a8edd1754.png

[after]: https://user-images.githubusercontent.com/45561419/128345043-62b391c1-b4b1-4296-bb28-e2780cb19e70.png


## What is the value of this and can you measure success?

This change was requested by CP who gave specific instructions about what links should appear in the subnav. Change is a success if these requirements are met, see here for reference: https://trello.com/c/2idj4i2w

## Checklist

### Does this affect other platforms?

Apps have replicated this change.


### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

N/A

### Tested

- [ ] Locally
- [x] On CODE (optional)
