### PR TITLE
Add `display:initial` to `ad-slot__label.hidden` so it is not overridden

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -73,6 +73,7 @@
     }
 
     &.hidden {
+        display: initial;
         visibility: hidden;
     }
 }


### PR DESCRIPTION
## What does this change?

External ad labels that sit outside the ad slot are toggled by the use of `ad-slot__label.hidden` and `ad-slot__label.visible`.

However it is possible for rogue global CSS rules like `.hidden { display: none }` to remove the element from the page flow and subsequently get removed by `remove-slots.ts`.

This is currently the case on the UK front which has global CSS being applied from the coronavirus container.

This adds `display:initial` to `ad-slot__label.hidden` so that it has higher specificity.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)
