### PR TITLE
Decommission joda.time (8) 

### DIFF
--- a/common/app/common/Chronos.scala
+++ b/common/app/common/Chronos.scala
@@ -2,7 +2,9 @@ package common
 
 import org.joda.time.DateTime
 
+import java.text.SimpleDateFormat
 import java.time.ZoneId
+import java.util.TimeZone
 
 object Chronos {
 
@@ -10,15 +12,25 @@ object Chronos {
   // Contains both helper functions implementing patterns emerging during the migration as well as more permanent
   // functions.
 
-  // Do not attempt to simplify, until otherwise specified, the signatures of the functions.
+  // DO NOT attempt to simplify, until otherwise specified, the signatures of the functions.
   // The arguments are verbose type to help with reading and understanding. This will be simplified in due course.
+
+  def toDateTime(date: java.time.LocalDateTime): org.joda.time.DateTime = {
+    DateTime.parse(date.toString)
+  }
 
   def toLocalDate(date: java.util.Date): java.time.LocalDate = {
     date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate()
   }
 
-  def toDateTime(date: java.time.LocalDateTime): org.joda.time.DateTime = {
-    DateTime.parse(date.toString)
+  def toLocalDateTime(date: java.util.Date): java.time.LocalDateTime = {
+    date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime()
+  }
+
+  def dateFormatter(pattern: String, timezone: TimeZone): SimpleDateFormat = {
+    val dateTimeParser = new SimpleDateFormat(pattern)
+    dateTimeParser.setTimeZone(timezone)
+    dateTimeParser
   }
 
 }

--- a/common/app/common/Chronos.scala
+++ b/common/app/common/Chronos.scala
@@ -1,7 +1,8 @@
-package utils
+package common
+
+import org.joda.time.DateTime
 
 import java.time.ZoneId
-import java.util
 
 object Chronos {
 
@@ -14,6 +15,10 @@ object Chronos {
 
   def toLocalDate(date: java.util.Date): java.time.LocalDate = {
     date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate()
+  }
+
+  def toDateTime(date: java.time.LocalDateTime): org.joda.time.DateTime = {
+    DateTime.parse(date.toString)
   }
 
 }

--- a/common/app/common/Chronos.scala
+++ b/common/app/common/Chronos.scala
@@ -27,6 +27,10 @@ object Chronos {
     date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime()
   }
 
+  def toMilliSeconds(date: java.time.LocalDateTime): Long = {
+    date.atZone(ZoneId.of("UTC")).toInstant().toEpochMilli()
+  }
+
   def dateFormatter(pattern: String, timezone: TimeZone): SimpleDateFormat = {
     val dateTimeParser = new SimpleDateFormat(pattern)
     dateTimeParser.setTimeZone(timezone)

--- a/common/app/common/Chronos.scala
+++ b/common/app/common/Chronos.scala
@@ -6,14 +6,14 @@ import java.text.SimpleDateFormat
 import java.time.ZoneId
 import java.util.TimeZone
 
+// Introduced in August 2021 by Pascal to help and support the migration from joda.time to java.time
+// Contains both helper functions implementing patterns emerging during the migration as well as more permanent
+// functions.
+
+// DO NOT attempt to simplify, until otherwise specified, the signatures of the functions.
+// The arguments are verbose type to help with reading and understanding. This will be simplified in due course.
+
 object Chronos {
-
-  // Introduced in August 2021 by Pascal to help and support the migration from joda.time to java.time
-  // Contains both helper functions implementing patterns emerging during the migration as well as more permanent
-  // functions.
-
-  // DO NOT attempt to simplify, until otherwise specified, the signatures of the functions.
-  // The arguments are verbose type to help with reading and understanding. This will be simplified in due course.
 
   def toDateTime(date: java.time.LocalDateTime): org.joda.time.DateTime = {
     DateTime.parse(date.toString)

--- a/common/app/utils/Chronos.scala
+++ b/common/app/utils/Chronos.scala
@@ -1,0 +1,19 @@
+package utils
+
+import java.time.ZoneId
+import java.util
+
+object Chronos {
+
+  // Introduced in August 2021 by Pascal to help and support the migration from joda.time to java.time
+  // Contains both helper functions implementing patterns emerging during the migration as well as more permanent
+  // functions.
+
+  // Do not attempt to simplify, until otherwise specified, the signatures of the functions.
+  // The arguments are verbose type to help with reading and understanding. This will be simplified in due course.
+
+  def toLocalDate(date: java.util.Date): java.time.LocalDate = {
+    date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate()
+  }
+
+}

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -174,12 +174,6 @@ object `package` {
 
 object GuDateFormatLegacy {
 
-  def apply2(date: java.time.LocalDateTime, pattern: String, tzOverride: Option[DateTimeZone] = None)(implicit
-      request: RequestHeader,
-  ): String = {
-    apply(DateTime.parse(date.toString), Edition(request), pattern, tzOverride)
-  }
-
   def apply(date: DateTime, pattern: String, tzOverride: Option[DateTimeZone] = None)(implicit
       request: RequestHeader,
   ): String = {

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -173,6 +173,13 @@ object `package` {
 }
 
 object GuDateFormatLegacy {
+
+  def apply2(date: java.time.LocalDateTime, pattern: String, tzOverride: Option[DateTimeZone] = None)(implicit
+      request: RequestHeader,
+  ): String = {
+    apply(DateTime.parse(date.toString), Edition(request), pattern, tzOverride)
+  }
+
   def apply(date: DateTime, pattern: String, tzOverride: Option[DateTimeZone] = None)(implicit
       request: RequestHeader,
   ): String = {

--- a/sport/app/cricket/conf/context.scala
+++ b/sport/app/cricket/conf/context.scala
@@ -4,7 +4,7 @@ import app.LifecycleComponent
 import common.{AkkaAsync, JobScheduler}
 import jobs.CricketStatsJob
 
-import java.time.{LocalDate, LocalDateTime}
+import java.time.{LocalDate}
 import play.api.inject.ApplicationLifecycle
 
 import scala.concurrent.duration._

--- a/sport/app/cricket/conf/context.scala
+++ b/sport/app/cricket/conf/context.scala
@@ -4,7 +4,7 @@ import app.LifecycleComponent
 import common.{AkkaAsync, JobScheduler}
 import jobs.CricketStatsJob
 
-import java.time.{LocalDate}
+import java.time.LocalDate
 import play.api.inject.ApplicationLifecycle
 
 import scala.concurrent.duration._

--- a/sport/app/cricket/conf/context.scala
+++ b/sport/app/cricket/conf/context.scala
@@ -3,7 +3,8 @@ package cricket.conf
 import app.LifecycleComponent
 import common.{AkkaAsync, JobScheduler}
 import jobs.CricketStatsJob
-import org.joda.time.LocalDate
+
+import java.time.{LocalDate, LocalDateTime}
 import play.api.inject.ApplicationLifecycle
 
 import scala.concurrent.duration._

--- a/sport/app/cricket/feed/cricketModel.scala
+++ b/sport/app/cricket/feed/cricketModel.scala
@@ -1,6 +1,6 @@
 package cricketModel
 
-import org.joda.time.DateTime
+import java.time.LocalDateTime
 
 case class Match(
     teams: List[Team],
@@ -8,7 +8,7 @@ case class Match(
     competitionName: String,
     venueName: String,
     result: String,
-    gameDate: DateTime,
+    gameDate: LocalDateTime,
     officials: List[String],
     matchId: String,
 ) {

--- a/sport/app/cricket/feed/cricketPaDeserialisation.scala
+++ b/sport/app/cricket/feed/cricketPaDeserialisation.scala
@@ -1,5 +1,7 @@
 package conf.cricketPa
 
+import common.Chronos
+
 import xml.{NodeSeq, XML}
 import scala.language.postfixOps
 import java.time
@@ -39,12 +41,9 @@ object Parser {
   )
 
   private object Date {
-    def toLocalDate(date: Date): LocalDateTime = date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime()
-
-    private val dateTimeParser = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss")
-    dateTimeParser.setTimeZone(TimeZone.getTimeZone("Europe/London"))
-
-    def apply(dateTime: String): LocalDateTime = toLocalDate(dateTimeParser.parse(dateTime))
+    private val dateTimePattern = "yyyy-MM-dd'T'HH:mm:ss"
+    private val dateTimeParser = Chronos.dateFormatter(dateTimePattern, TimeZone.getTimeZone("Europe/London"))
+    def apply(dateTime: String): LocalDateTime = Chronos.toLocalDateTime(dateTimeParser.parse(dateTime))
   }
 
   private def inningsDescription(inningsOrder: Int, battingTeam: String): String = {

--- a/sport/app/cricket/feed/cricketPaDeserialisation.scala
+++ b/sport/app/cricket/feed/cricketPaDeserialisation.scala
@@ -2,9 +2,12 @@ package conf.cricketPa
 
 import xml.{NodeSeq, XML}
 import scala.language.postfixOps
-import org.joda.time.format.DateTimeFormat
-import org.joda.time.DateTime
+import java.time
+import java.text.SimpleDateFormat
 import cricketModel._
+
+import java.time.{LocalDate, LocalDateTime, ZoneId}
+import java.util.{Date, TimeZone}
 
 object Parser {
 
@@ -31,14 +34,17 @@ object Parser {
       competitionName: String,
       venueName: String,
       result: String,
-      gameDate: DateTime,
+      gameDate: LocalDateTime,
       officials: List[String],
   )
 
   private object Date {
-    private val dateTimeParser = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss")
+    def toLocalDate(date: Date): LocalDateTime = date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime()
 
-    def apply(dateTime: String): DateTime = dateTimeParser.parseDateTime(dateTime)
+    private val dateTimeParser = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss")
+    dateTimeParser.setTimeZone(TimeZone.getTimeZone("Europe/London"))
+
+    def apply(dateTime: String): LocalDateTime = toLocalDate(dateTimeParser.parse(dateTime))
   }
 
   private def inningsDescription(inningsOrder: Int, battingTeam: String): String = {

--- a/sport/app/cricket/feed/cricketPaFeed.scala
+++ b/sport/app/cricket/feed/cricketPaFeed.scala
@@ -15,7 +15,7 @@ import java.text.SimpleDateFormat
 case class CricketFeedException(message: String) extends RuntimeException(message)
 
 object PaFeed {
-  val dateFormat = new SimpleDateFormat("yyyy-MM-dd")
+  val dateFormat = new SimpleDateFormat("yyyy-MM-dd") // Note that there is an implicit timezone assumption here
 }
 
 class PaFeed(wsClient: WSClient, actorSystem: ActorSystem, materializer: Materializer) extends GuLogging {

--- a/sport/app/cricket/feed/cricketPaFeed.scala
+++ b/sport/app/cricket/feed/cricketPaFeed.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.Materializer
 import common.GuLogging
 import cricket.feed.CricketThrottler
-import org.joda.time.{DateTime, LocalDate}
+import java.time.LocalDate
 import play.api.libs.ws.WSClient
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -78,8 +78,8 @@ class PaFeed(wsClient: WSClient, actorSystem: ActorSystem, materializer: Materia
     credentials
       .map(header =>
         throttler.throttle { () =>
-          val start = PaFeed.dateFormat.print(startDate)
-          val end = PaFeed.dateFormat.print(endDate)
+          val start = PaFeed.dateFormat.format(startDate)
+          val end = PaFeed.dateFormat.format(endDate)
           val endpoint = s"$paEndpoint/team/${team.paId}/$matchType"
 
           wsClient

--- a/sport/app/cricket/feed/cricketPaFeed.scala
+++ b/sport/app/cricket/feed/cricketPaFeed.scala
@@ -5,16 +5,17 @@ import akka.stream.Materializer
 import common.GuLogging
 import cricket.feed.CricketThrottler
 import org.joda.time.{DateTime, LocalDate}
-import org.joda.time.format.{DateTimeFormat, DateTimeFormatter}
 import play.api.libs.ws.WSClient
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.xml.XML
 
+import java.text.SimpleDateFormat
+
 case class CricketFeedException(message: String) extends RuntimeException(message)
 
 object PaFeed {
-  val dateFormat: DateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd")
+  val dateFormat = new SimpleDateFormat("yyyy-MM-dd")
 }
 
 class PaFeed(wsClient: WSClient, actorSystem: ActorSystem, materializer: Materializer) extends GuLogging {

--- a/sport/app/cricket/feed/cricketPaFeed.scala
+++ b/sport/app/cricket/feed/cricketPaFeed.scala
@@ -2,6 +2,7 @@ package conf.cricketPa
 
 import akka.actor.ActorSystem
 import akka.stream.Materializer
+import common.Chronos
 import common.GuLogging
 import cricket.feed.CricketThrottler
 
@@ -10,14 +11,12 @@ import play.api.libs.ws.WSClient
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.xml.XML
-import java.text.SimpleDateFormat
 import java.util.TimeZone
 
 case class CricketFeedException(message: String) extends RuntimeException(message)
 
 object PaFeed {
-  val dateFormat = new SimpleDateFormat("yyyy-MM-dd")
-  dateFormat.setTimeZone(TimeZone.getTimeZone(ZoneId.of("UTC")))
+  val dateFormat = Chronos.dateFormatter("yyyy-MM-dd", TimeZone.getTimeZone(ZoneId.of("UTC")))
 }
 
 class PaFeed(wsClient: WSClient, actorSystem: ActorSystem, materializer: Materializer) extends GuLogging {

--- a/sport/app/cricket/feed/cricketPaFeed.scala
+++ b/sport/app/cricket/feed/cricketPaFeed.scala
@@ -4,18 +4,20 @@ import akka.actor.ActorSystem
 import akka.stream.Materializer
 import common.GuLogging
 import cricket.feed.CricketThrottler
-import java.time.LocalDate
+
+import java.time.{LocalDate, ZoneId}
 import play.api.libs.ws.WSClient
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.xml.XML
-
 import java.text.SimpleDateFormat
+import java.util.TimeZone
 
 case class CricketFeedException(message: String) extends RuntimeException(message)
 
 object PaFeed {
-  val dateFormat = new SimpleDateFormat("yyyy-MM-dd") // Note that there is an implicit timezone assumption here
+  val dateFormat = new SimpleDateFormat("yyyy-MM-dd")
+  dateFormat.setTimeZone(TimeZone.getTimeZone(ZoneId.of("UTC")))
 }
 
 class PaFeed(wsClient: WSClient, actorSystem: ActorSystem, materializer: Materializer) extends GuLogging {

--- a/sport/app/cricket/jobs/CricketStatsJob.scala
+++ b/sport/app/cricket/jobs/CricketStatsJob.scala
@@ -56,7 +56,7 @@ class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
         val loadedMatches = agent().values
           .filter(cricketMatch =>
             // Omit any recent match within the last 5 days, to account for test matches.
-            Duration.between(dateTimeToLocalDateTime(cricketMatch.gameDate), LocalDate.now).toDays() > 5,
+            Duration.between(cricketMatch.gameDate, LocalDate.now).toDays() > 5,
           )
           .map(_.matchId)
           .toSeq

--- a/sport/app/cricket/jobs/CricketStatsJob.scala
+++ b/sport/app/cricket/jobs/CricketStatsJob.scala
@@ -4,12 +4,11 @@ import com.gu.Box
 import common.GuLogging
 import conf.cricketPa.{CricketFeedException, CricketTeam, CricketTeams, PaFeed}
 import cricketModel.Match
-import org.joda.time.DateTime
 
-import java.time.{Duration, Instant, LocalDate, LocalDateTime, ZoneId}
+import java.time.{Duration, LocalDate}
 import java.text.SimpleDateFormat
-import java.util.{Date, TimeZone}
-import scala.concurrent.{ExecutionContext, Future}
+import java.util.{TimeZone}
+import scala.concurrent.{ExecutionContext}
 
 import utils.Chronos
 
@@ -19,17 +18,6 @@ class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
 
   private val dateFormatUTC = new SimpleDateFormat("yyyy/MMM/dd")
   dateFormatUTC.setTimeZone(TimeZone.getTimeZone("Europe/London"))
-
-  private def dateTimeToLocalDateTime(date: DateTime): LocalDateTime = {
-    LocalDateTime.ofInstant(
-      Instant.ofEpochMilli(
-        date
-          .toInstant()
-          .getMillis,
-      ),
-      ZoneId.systemDefault,
-    )
-  }
 
   def getMatch(team: CricketTeam, date: String): Option[Match] =
     cricketStatsAgents

--- a/sport/app/cricket/jobs/CricketStatsJob.scala
+++ b/sport/app/cricket/jobs/CricketStatsJob.scala
@@ -11,6 +11,8 @@ import java.text.SimpleDateFormat
 import java.util.{Date, TimeZone}
 import scala.concurrent.{ExecutionContext, Future}
 
+import utils.Chronos
+
 class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
 
   private val cricketStatsAgents = CricketTeams.teams.map(Team => (Team, Box[Map[String, Match]](Map.empty)))
@@ -18,7 +20,6 @@ class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
   private val dateFormatUTC = new SimpleDateFormat("yyyy/MMM/dd")
   dateFormatUTC.setTimeZone(TimeZone.getTimeZone("Europe/London"))
 
-  private def toLocalDate(date: Date): LocalDate = date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate()
   private def dateTimeToLocalDateTime(date: DateTime): LocalDateTime = {
     LocalDateTime.ofInstant(
       Instant.ofEpochMilli(
@@ -41,7 +42,7 @@ class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
 
     val matchObjects = for {
       day <- 0 until 6 // normally test matches are 5 days but we have seen at least 6 days in practice
-      date <- Some(dateFormat.format(toLocalDate(requestDate).minusDays(day)))
+      date <- Some(dateFormat.format(Chronos.toLocalDate(requestDate).minusDays(day)))
     } yield {
       getMatch(team, date)
     }

--- a/sport/app/cricket/jobs/CricketStatsJob.scala
+++ b/sport/app/cricket/jobs/CricketStatsJob.scala
@@ -15,8 +15,7 @@ class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
 
   private val cricketStatsAgents = CricketTeams.teams.map(Team => (Team, Box[Map[String, Match]](Map.empty)))
 
-  private val dateFormatUTC = new SimpleDateFormat("yyyy/MMM/dd")
-  dateFormatUTC.setTimeZone(TimeZone.getTimeZone("Europe/London"))
+  private val dateFormatUTC = Chronos.dateFormatter("yyyy/MMM/dd", TimeZone.getTimeZone("Europe/London"))
 
   def getMatch(team: CricketTeam, date: String): Option[Match] =
     cricketStatsAgents

--- a/sport/app/cricket/jobs/CricketStatsJob.scala
+++ b/sport/app/cricket/jobs/CricketStatsJob.scala
@@ -5,17 +5,12 @@ import common.GuLogging
 import common.Chronos
 import conf.cricketPa.{CricketFeedException, CricketTeam, CricketTeams, PaFeed}
 import cricketModel.Match
-
 import java.time.{Duration, LocalDate}
-import java.text.SimpleDateFormat
-import java.util.{TimeZone}
-import scala.concurrent.{ExecutionContext}
+import scala.concurrent.ExecutionContext
 
 class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
 
   private val cricketStatsAgents = CricketTeams.teams.map(Team => (Team, Box[Map[String, Match]](Map.empty)))
-
-  private val dateFormatUTC = Chronos.dateFormatter("yyyy/MMM/dd", TimeZone.getTimeZone("Europe/London"))
 
   def getMatch(team: CricketTeam, date: String): Option[Match] =
     cricketStatsAgents

--- a/sport/app/cricket/jobs/CricketStatsJob.scala
+++ b/sport/app/cricket/jobs/CricketStatsJob.scala
@@ -2,6 +2,7 @@ package jobs
 
 import com.gu.Box
 import common.GuLogging
+import common.Chronos
 import conf.cricketPa.{CricketFeedException, CricketTeam, CricketTeams, PaFeed}
 import cricketModel.Match
 
@@ -9,8 +10,6 @@ import java.time.{Duration, LocalDate}
 import java.text.SimpleDateFormat
 import java.util.{TimeZone}
 import scala.concurrent.{ExecutionContext}
-
-import utils.Chronos
 
 class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
 

--- a/sport/app/cricket/views/fragments/cricketMatchSummary.scala.html
+++ b/sport/app/cricket/views/fragments/cricketMatchSummary.scala.html
@@ -1,3 +1,5 @@
+@import java.time.format.DateTimeFormatter
+@import java.time.ZoneId
 @(theMatch: cricketModel.Match, matchUrl: String)(implicit request: RequestHeader)
 @import common.LinkTo
 @import views.support.GuDateFormatLegacy
@@ -5,8 +7,8 @@
 <div class="sport-summary sport-summary--cricket" itemscope itemtype="http://schema.org/SportsEvent">
 
     <h2 class="u-h">
-        <time class="u-h" datetime="@theMatch.gameDate.toString("yyyy-MM-dd'T'HH:mm:ss'Z'")" data-timestamp="@theMatch.gameDate.getMillis">
-        @GuDateFormatLegacy(theMatch.gameDate, "d MMM y")
+        <time class="u-h" datetime="@theMatch.gameDate.format(DateTimeFormatter.ISO_DATE)" data-timestamp="@theMatch.gameDate.atZone(ZoneId.of("UTC")).toInstant().toEpochMilli()">
+        @GuDateFormatLegacy.apply2(theMatch.gameDate, "d MMM y")
         </time>
         @theMatch.competitionName, @theMatch.venueName
     </h2>

--- a/sport/app/cricket/views/fragments/cricketMatchSummary.scala.html
+++ b/sport/app/cricket/views/fragments/cricketMatchSummary.scala.html
@@ -10,7 +10,7 @@
 <div class="sport-summary sport-summary--cricket" itemscope itemtype="http://schema.org/SportsEvent">
 
     <h2 class="u-h">
-        <time class="u-h" datetime="@theMatch.gameDate.format(DateTimeFormatter.ISO_DATE)" data-timestamp="@theMatch.gameDate.atZone(ZoneId.of("UTC")).toInstant().toEpochMilli()">
+        <time class="u-h" datetime="@theMatch.gameDate.format(DateTimeFormatter.ISO_DATE)" data-timestamp="@Chronos.toMilliSeconds(theMatch.gameDate)">
         @GuDateFormatLegacy(Chronos.toDateTime(theMatch.gameDate), "d MMM y")
         </time>
         @theMatch.competitionName, @theMatch.venueName

--- a/sport/app/cricket/views/fragments/cricketMatchSummary.scala.html
+++ b/sport/app/cricket/views/fragments/cricketMatchSummary.scala.html
@@ -1,14 +1,17 @@
 @import java.time.format.DateTimeFormatter
 @import java.time.ZoneId
-@(theMatch: cricketModel.Match, matchUrl: String)(implicit request: RequestHeader)
 @import common.LinkTo
+@import common.Chronos
 @import views.support.GuDateFormatLegacy
+
+
+@(theMatch: cricketModel.Match, matchUrl: String)(implicit request: RequestHeader)
 
 <div class="sport-summary sport-summary--cricket" itemscope itemtype="http://schema.org/SportsEvent">
 
     <h2 class="u-h">
         <time class="u-h" datetime="@theMatch.gameDate.format(DateTimeFormatter.ISO_DATE)" data-timestamp="@theMatch.gameDate.atZone(ZoneId.of("UTC")).toInstant().toEpochMilli()">
-        @GuDateFormatLegacy.apply2(theMatch.gameDate, "d MMM y")
+        @GuDateFormatLegacy(Chronos.toDateTime(theMatch.gameDate), "d MMM y")
         </time>
         @theMatch.competitionName, @theMatch.venueName
     </h2>


### PR DESCRIPTION
## What does this change?

Step 8 of the going project of decommissioning joda.time from frontend.

Previous step: https://github.com/guardian/frontend/pull/24007

In this step we focus on migrating Cricket dates. Note that we also also introduce [common] utils.Chronos, which is going to contain helper functions that encapsulate patterns that are now emerging. As indicated in the code comment (the fully path specified arguments of the functions are a feature!)

