### PR TITLE
Force sending core web vitals data for users in pre-defined set of server-side AB tests

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -35,16 +35,13 @@ const jsonData: CoreWebVitalsPayload = {
  * Equivalent dotcom-rendering functionality is here: https://git.io/JBRIt
  */
 export const coreVitals = (): void => {
-	// If the current user is part of a server-side AB test
-	// then we always want to sample their core web vitals data.
-	const userInTest =
-		window.guardian.config.tests &&
-		Object.values(window.guardian.config.tests).includes('variant');
-
-	// Otherwise, only send core web vitals data for 1% of users.
+	// By default, sample 1% of users
 	const inSample = Math.random() < 1 / 100;
 
-	if (!userInTest && !shouldCaptureMetrics() && !inSample) {
+	// Unless we are forcing metrics for this user
+	const captureMetrics = shouldCaptureMetrics();
+
+	if (!captureMetrics && !inSample) {
 		return;
 	}
 

--- a/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
@@ -4,7 +4,7 @@ import { commercialPartner } from '../experiments/tests/commercial-partner';
 import { improveSkins } from '../experiments/tests/improve-skins';
 
 const defaultClientSideTests: ABTest[] = [commercialPartner, improveSkins];
-const serverSideTests: String[] = [
+const serverSideTests: string[] = [
 	'topAboveNavHeight150Variant',
 	'topAboveNavHeight200Variant',
 	'topAboveNavHeight250Variant',

--- a/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
@@ -3,16 +3,30 @@ import { getSynchronousTestsToRun } from '../experiments/ab';
 import { commercialPartner } from '../experiments/tests/commercial-partner';
 import { improveSkins } from '../experiments/tests/improve-skins';
 
-const defaultTests: ABTest[] = [commercialPartner, improveSkins];
+const defaultClientSideTests: ABTest[] = [commercialPartner, improveSkins];
+const serverSideTests: String[] = [
+	'topAboveNavHeight150Variant',
+	'topAboveNavHeight200Variant',
+	'topAboveNavHeight250Variant',
+];
+
 /**
  * Function to check wether metrics should be captured for the current page
  * @param tests - optional array of ABTest to check against, default to above.
- * @returns true if the user is in a test
+ * @returns true if the user is in a one of a set of client or server-side tests
+ * for which we want to always capture metrics.
  */
-const shouldCaptureMetrics = (tests = defaultTests): boolean => {
-	return getSynchronousTestsToRun().some((test) =>
+const shouldCaptureMetrics = (tests = defaultClientSideTests): boolean => {
+	const userInClientSideTest = getSynchronousTestsToRun().some((test) =>
 		tests.map((t) => t.id).includes(test.id),
 	);
+
+	const userInServerSideTest =
+		window.guardian.config.tests !== undefined &&
+		Object.keys(window.guardian.config.tests).some((test) =>
+			serverSideTests.includes(test),
+		);
+	return userInClientSideTest || userInServerSideTest;
 };
 
 export { shouldCaptureMetrics };


### PR DESCRIPTION
## What does this change?
Force sending core web vital and commercial metrics only for users in a hardcoded list of server side tests, rather than for users in any server side test.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

## Screenshots
N/A

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist
N/A

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
