### PR TITLE
Force send core web vital data for Improve/Collective skin

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
@@ -10,6 +10,7 @@ import { stripDfpAdPrefixFrom } from '../utils';
 import { bids } from './bid-config';
 import { priceGranularity } from './price-config';
 import { pubmatic } from './pubmatic';
+import { setForceSendMetrics } from '../../../../common/modules/analytics/coreVitals';
 
 type CmpApi = 'iab' | 'static';
 // https://docs.prebid.org/dev-docs/modules/consentManagement.html
@@ -330,7 +331,14 @@ const initialise = (window: Window, framework = 'tcfv2'): void => {
 		 * */
 		advert.hasPrebidSize = true;
 
-		if (data.bidderCode === 'improvedigital') captureCommercialMetrics();
+		/**
+		 * If improve skin has won auction, toggle force send metrics on.
+		 * TODO remove after improve skin release.
+		 * */
+		if (data.bidderCode === 'improvedigital') {
+			setForceSendMetrics(true);
+			captureCommercialMetrics();
+		}
 	});
 };
 

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
@@ -3,7 +3,7 @@ import { isString, log } from '@guardian/libs';
 import { captureCommercialMetrics } from 'commercial/commercial-metrics';
 import type { Advert } from 'commercial/modules/dfp/Advert';
 import config from '../../../../../lib/config';
-import { setForceSendMetrics } from '../../../../common/modules/analytics/coreVitals';
+import { setForceSendMetrics } from '../../../../common/modules/analytics/forceSendMetrics';
 import { dfpEnv } from '../../dfp/dfp-env';
 import { getAdvertById } from '../../dfp/get-advert-by-id';
 import { getHeaderBiddingAdSlots } from '../slot-config';

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
@@ -3,6 +3,7 @@ import { isString, log } from '@guardian/libs';
 import { captureCommercialMetrics } from 'commercial/commercial-metrics';
 import type { Advert } from 'commercial/modules/dfp/Advert';
 import config from '../../../../../lib/config';
+import { setForceSendMetrics } from '../../../../common/modules/analytics/coreVitals';
 import { dfpEnv } from '../../dfp/dfp-env';
 import { getAdvertById } from '../../dfp/get-advert-by-id';
 import { getHeaderBiddingAdSlots } from '../slot-config';
@@ -10,7 +11,6 @@ import { stripDfpAdPrefixFrom } from '../utils';
 import { bids } from './bid-config';
 import { priceGranularity } from './price-config';
 import { pubmatic } from './pubmatic';
-import { setForceSendMetrics } from '../../../../common/modules/analytics/coreVitals';
 
 type CmpApi = 'iab' | 'static';
 // https://docs.prebid.org/dev-docs/modules/consentManagement.html

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -32,8 +32,15 @@ const jsonData: CoreWebVitalsPayload = {
 
 // By default, sample 1% of users
 const userInSample = Math.random() < 1 / 100;
-// Unless we are forcing metrics for this user
+// unless we are forcing metrics for this user because they are participating in an AB test
+// for which we need to capture all metrics
 const captureMetrics = shouldCaptureMetrics();
+// or we are force sending for this page view for some other reason.
+var forceSendMetrics = false;
+
+export const setForceSendMetrics = (val: boolean): void => {
+	forceSendMetrics = val;
+};
 
 /**
  * Calls functions of web-vitals library to collect core web vitals data, registering callbacks which
@@ -55,7 +62,7 @@ export const coreVitals = (): void => {
 	};
 
 	const jsonToSend = ({ name, value }: CoreVitalsArgs): void => {
-		if (!captureMetrics && !userInSample) {
+		if (!captureMetrics && !userInSample && !forceSendMetrics) {
 			return;
 		}
 

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -30,21 +30,17 @@ const jsonData: CoreWebVitalsPayload = {
 	ttfb: null,
 };
 
+// By default, sample 1% of users
+const userInSample = Math.random() < 1 / 100;
+// Unless we are forcing metrics for this user
+const captureMetrics = shouldCaptureMetrics();
+
 /**
- * Sends core web vitals data for a sample of page views to the data lake.
+ * Calls functions of web-vitals library to collect core web vitals data, registering callbacks which
+ * send it to the data lake for a sample of page views.
  * Equivalent dotcom-rendering functionality is here: https://git.io/JBRIt
  */
 export const coreVitals = (): void => {
-	// By default, sample 1% of users
-	const inSample = Math.random() < 1 / 100;
-
-	// Unless we are forcing metrics for this user
-	const captureMetrics = shouldCaptureMetrics();
-
-	if (!captureMetrics && !inSample) {
-		return;
-	}
-
 	type CoreVitalsArgs = {
 		name: string;
 		value: number;
@@ -59,6 +55,10 @@ export const coreVitals = (): void => {
 	};
 
 	const jsonToSend = ({ name, value }: CoreVitalsArgs): void => {
+		if (!captureMetrics && !userInSample) {
+			return;
+		}
+
 		switch (name) {
 			case 'FCP':
 				jsonData.fcp = nineDigitPrecision(value);

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -36,7 +36,7 @@ const userInSample = Math.random() < 1 / 100;
 // for which we need to capture all metrics
 const captureMetrics = shouldCaptureMetrics();
 // or we are force sending for this page view for some other reason.
-var forceSendMetrics = false;
+let forceSendMetrics = false;
 
 export const setForceSendMetrics = (val: boolean): void => {
 	forceSendMetrics = val;

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -1,6 +1,7 @@
 import { getCookie } from '@guardian/libs';
 import { getCLS, getFCP, getFID, getLCP, getTTFB } from 'web-vitals';
 import reportError from 'lib/report-error';
+import { forceSendMetrics } from './forceSendMetrics';
 import { shouldCaptureMetrics } from './shouldCaptureMetrics';
 
 type CoreWebVitalsPayload = {
@@ -35,12 +36,7 @@ const userInSample = Math.random() < 1 / 100;
 // unless we are forcing metrics for this user because they are participating in an AB test
 // for which we need to capture all metrics
 const captureMetrics = shouldCaptureMetrics();
-// or we are force sending for this page view for some other reason.
-let forceSendMetrics = false;
-
-export const setForceSendMetrics = (val: boolean): void => {
-	forceSendMetrics = val;
-};
+// or we are force sending for this page view for some other reason with forceSendMetrics.
 
 /**
  * Calls functions of web-vitals library to collect core web vitals data, registering callbacks which

--- a/static/src/javascripts/projects/common/modules/analytics/forceSendMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/forceSendMetrics.ts
@@ -1,0 +1,5 @@
+export let forceSendMetrics = false;
+
+export const setForceSendMetrics = (val: boolean): void => {
+	forceSendMetrics = val;
+};


### PR DESCRIPTION
## What does this change?
- Change sampling logic of core web vitals collection so that CWV data is always collected, but only sent to the lake for a sample of pageviews.
- Introduce a toggle, `forceSendMetrics` and setter function which is used when prebid auction is over to force sending CWV data if the Improve Digital has won. (The skin won't necessarily be shown but we are alright with collecting too much data).


## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes, we'll reimplement the same changes [here](https://git.io/JBRIt).

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
