### PR TITLE
Remove Tokyo2020/Olympics from nav on all editions

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -99,8 +99,6 @@ private object NavLinks {
 
   /* SPORT */
 
-  val Tokyo2020 = NavLink("Tokyo 2020", "/sport/olympic-games-2020")
-
   val football = NavLink(
     "Football",
     "/football",
@@ -365,7 +363,6 @@ private object NavLinks {
     longTitle = Some("Sport home"),
     iconName = Some("home"),
     List(
-      Tokyo2020,
       football,
       cricket,
       rugbyUnion,
@@ -381,7 +378,6 @@ private object NavLinks {
   )
   val auSportPillar = ukSportPillar.copy(
     children = List(
-      Tokyo2020,
       football,
       AFL,
       NRL,
@@ -395,7 +391,6 @@ private object NavLinks {
   )
   val usSportPillar = ukSportPillar.copy(
     children = List(
-      Tokyo2020,
       soccer,
       NFL,
       tennis,
@@ -407,7 +402,6 @@ private object NavLinks {
   )
   val intSportPillar = ukSportPillar.copy(
     children = List(
-      Tokyo2020,
       football,
       cricket,
       rugbyUnion,


### PR DESCRIPTION
## What does this change?

Removes Tokyo 2020 from navbar

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

Before: 

![image](https://user-images.githubusercontent.com/9575458/128853754-4c63ab20-7fd6-4fde-8efb-2f05e58ed5cf.png)


After:

![image](https://user-images.githubusercontent.com/9575458/128853733-6ef77cce-f76d-43df-af8b-1f3f1c460426.png)


## What is the value of this and can you measure success?

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
