### PR TITLE
Revert "Add `display:initial` to `ad-slot__label.hidden` so it is not overridden"

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -73,7 +73,6 @@
     }
 
     &.hidden {
-        display: initial;
         visibility: hidden;
     }
 }


### PR DESCRIPTION
Reverts guardian/frontend#24070

Coronavirus global scope CSS has been fixed