### PR TITLE
Temporarily force documentaries into DCR

### DIFF
--- a/applications/app/services/InteractivePicker.scala
+++ b/applications/app/services/InteractivePicker.scala
@@ -53,11 +53,15 @@ object InteractivePicker {
     val switchOn = InteractivePickerFeature.isSwitchedOn
     val publishedPostSwitch = dateIsPostTransition(datetime)
     val isOptedInAmp = (requestFormat == AmpFormat) && isAmpOptedIn(tags)
-    val isWebNotOptedOut = (requestFormat == HtmlFormat) && !isOptedOut(tags)
+    val isWeb = requestFormat == HtmlFormat
+    val isOptOut = isOptedOut(tags)
+
+    // Temporarily force documentaries into DCR while Composer doesn't allow easy removal of opt-out tag.
+    val isDocumentary = tags.exists(tag => tag.id == "tone/documentaries")
 
     if (forceDCR || isMigrated || isOptedInAmp) DotcomRendering
-    else if (switchOn && publishedPostSwitch && isWebNotOptedOut) DotcomRendering
-    else if (switchOn && isSupported(tags) && isWebNotOptedOut) DotcomRendering
+    else if (switchOn && publishedPostSwitch && isWeb && !isOptOut) DotcomRendering
+    else if (switchOn && isSupported(tags) && isWeb && (!isOptOut || isDocumentary)) DotcomRendering
     else FrontendLegacy
   }
 }


### PR DESCRIPTION
Most documentaries are already switched over, but some have the
opt-out tag. Unfortunately, removing this tag is pretty difficult
at the moment. Composer are changing things to make this easier but
in the meantime we can ignore the tag for documentaries.

Note, this is important as documentaries share the same rendering
code so the DCR-specific fixes that are live are resulting in visual
issues (albeit minor) on the opted out ones that are still served by
Frontend.
