### PR TITLE
Interactive atom cleaning for DCR

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -164,6 +164,7 @@ object DotcomRenderingUtils {
           calloutsUrl,
           article.elements.thumbnail,
           edition,
+          article.trail.webPublicationDate,
         ),
       )
       .filter(PageElement.isSupported)

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -21,9 +21,11 @@ import http.ResultWithPreconnectPreload
 import http.HttpPreconnections
 
 import java.net.ConnectException
+import java.util.concurrent.TimeoutException
 
-// Introduced as CAPI error handling elsewhere would smother a regular ConnectException.
+// Introduced as CAPI error handling elsewhere would smother these otherwise
 case class DCRLocalConnectException(message: String) extends ConnectException(message)
+case class DCRTimeoutException(message: String) extends TimeoutException(message)
 
 class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload {
 
@@ -62,7 +64,8 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
               |To get started with dotcom-rendering, see:
               |
               |    https://github.com/guardian/dotcom-rendering""".stripMargin
-          Future.failed(new DCRLocalConnectException(msg))
+          Future.failed(DCRLocalConnectException(msg))
+        case t: TimeoutException => Future.failed(DCRTimeoutException(t.getMessage))
       })
     }
 


### PR DESCRIPTION
## What does this change?

Frontend performs some basic HTML cleanup for interactive atoms. In DCR we replicated this (https://github.com/guardian/dotcom-rendering/pull/3070) but it is very slow and causing timeouts. This PR moves this back into Frontend for DCR requests.

Running things locally, the cleaning step for a large interactive atom (https://www.theguardian.com/education/ng-interactive/2018/may/29/university-guide-2019-league-table-for-computer-science-information) goes from ~2s to ~50ms.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

See DCR PR here: https://github.com/guardian/dotcom-rendering/pull/3278.