### PR TITLE
Add uni guide tag to Interactive Picker

### DIFF
--- a/applications/app/services/InteractivePicker.scala
+++ b/applications/app/services/InteractivePicker.scala
@@ -32,7 +32,8 @@ object InteractivePicker {
       "tone/cartoons",
       "profile/david-squires",
       "tone/documentaries",
-      "tone/resource", // university guides, e.g. https://www.theguardian.com/education/2009/may/10/universityguide-bath-spa-uni
+      "education/universityguide",
+      "tone/resource",
     )
 
     tags.exists(tag => supported.contains(tag.id))


### PR DESCRIPTION
Some of these articles don't have tone/resource so adding this to
ensure all are migrated. E.g.

https://www.theguardian.com/education/ng-interactive/2020/sep/05/the-best-uk-universities-2021-league-table
