### PR TITLE
remove qwery from geo-most-popular

### DIFF
--- a/static/src/javascripts/projects/common/modules/onward/geo-most-popular.js
+++ b/static/src/javascripts/projects/common/modules/onward/geo-most-popular.js
@@ -2,7 +2,6 @@
  Module: geo-most-popular.js
  Description: Shows popular trails for a given country.
  */
-import qwery from 'qwery';
 import fastdom from 'lib/fastdom-promise';
 import { Component } from 'common/modules/component';
 import mediator from 'lib/mediator';
@@ -39,7 +38,7 @@ const showMostPopularThreshold = 1500;
 const fetchMostPopular = (articleBodyHeight) => {
     if (articleBodyHeight > showMostPopularThreshold) {
         new GeoMostPopular().fetch(
-            qwery('.js-components-container'),
+            document.querySelectorAll('.js-components-container'),
             'rightHtml'
         );
     }


### PR DESCRIPTION
## What does this change?

Remove qwery from `geo-most-popular`

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [ ] Locally
- [x] On CODE (optional)
