### PR TITLE
Remove related links component remover from the presser cleaner because it was removing the byline from the datablog

### DIFF
--- a/admin/app/pagepresser/HtmlCleaner.scala
+++ b/admin/app/pagepresser/HtmlCleaner.scala
@@ -20,7 +20,7 @@ abstract class HtmlCleaner extends GuLogging {
     removeAds(document)
     removeByClass(document, "top-search-box")
     removeByClass(document, "share-links")
-    removeRelatedComponent(document)
+    //removeRelatedComponent(document) This removes the byline on datablog pieces, but may be needed elsewhere
     removeByClass(document, "user-details")
     removeByClass(document, "initially-off")
     removeByClass(document, "comment-count")

--- a/admin/test/pagepresser/HtmlCleanerTest.scala
+++ b/admin/test/pagepresser/HtmlCleanerTest.scala
@@ -21,21 +21,23 @@ import scala.io.Source
     actualResult.html().replace(" ", "") should be(expectedDoc.html().replace(" ", ""))
   }
 
-  it should "remove related links component" in {
-    val originalSource = Source.fromInputStream(
-      getClass.getClassLoader.getResourceAsStream("pagepresser/r2/pageWithRelatedComponent.html"),
-    )
-    val originalDoc = Jsoup.parse(originalSource.mkString)
+  // This removes the byline from datablog, I'm leaving this commented as it
+  // could be needed for some content- and represents the state of the pressed archive.
+  // it should "remove related links component" in {
+  //   val originalSource = Source.fromInputStream(
+  //     getClass.getClassLoader.getResourceAsStream("pagepresser/r2/pageWithRelatedComponent.html"),
+  //   )
+  //   val originalDoc = Jsoup.parse(originalSource.mkString)
 
-    val expectedCleanedDocFromSource = Source.fromInputStream(
-      getClass.getClassLoader.getResourceAsStream("pagepresser/r2/pageWithRelatedComponentRemoved.html"),
-    )
-    val expectedDoc = Jsoup.parse(expectedCleanedDocFromSource.mkString)
+  //   val expectedCleanedDocFromSource = Source.fromInputStream(
+  //     getClass.getClassLoader.getResourceAsStream("pagepresser/r2/pageWithRelatedComponentRemoved.html"),
+  //   )
+  //   val expectedDoc = Jsoup.parse(expectedCleanedDocFromSource.mkString)
 
-    val actualResult = SimpleHtmlCleaner.removeRelatedComponent(originalDoc)
+  //   val actualResult = SimpleHtmlCleaner.removeRelatedComponent(originalDoc)
 
-    actualResult.html().replace(" ", "") should be(expectedDoc.html().replace(" ", ""))
-  }
+  //   actualResult.html().replace(" ", "") should be(expectedDoc.html().replace(" ", ""))
+  // }
 
   it should "change links to protocol relative urls to satisfy http and https requests" in {
     val html =


### PR DESCRIPTION
## What does this change?
https://www.theguardian.com/news/datablog/2011/jun/22/global-top-foods-list-by-country
https://www.theguardian.com/news/datablog/2009/sep/21/afghanistan-troop-numbers-nato-data
don't show a publication date or byline as they're in the related links component 

this may be a bug with r2 or an incorrect convention in the datablog, but it's a long way in the past now and there's no way to tell.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?
show bylines on pressed datablog pages if we re-press them

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)
- [X] THE ARCHIVE!

There is probably a good reason we wanted to get rid of this component on press.

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

Probably not.

### Does this change break ad-free?

No.

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)
- [X] How does one test the presser?

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
