### PR TITLE
Use `lodash-es` explicitely in the commercial bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
     "testEnvironment": "jest-environment-jsdom-global",
     "testURL": "http://testurl.theguardian.com",
     "transformIgnorePatterns": [
-      "/node_modules/(?!@guardian/)"
+      "/node_modules/(?!(@guardian|lodash-es)/)"
     ]
   },
   "scripts": {

--- a/static/src/javascripts/lib/url.ts
+++ b/static/src/javascripts/lib/url.ts
@@ -1,4 +1,4 @@
-import memoize from 'lodash/memoize';
+import { memoize } from 'lodash-es';
 import { hasPushStateSupport } from './detect';
 
 // TODO: typescript detect.js

--- a/static/src/javascripts/projects/commercial/modules/ad-free-slot-remove.ts
+++ b/static/src/javascripts/projects/commercial/modules/ad-free-slot-remove.ts
@@ -1,4 +1,4 @@
-import once from 'lodash/once';
+import { once } from 'lodash-es';
 import { $$ } from '../../../lib/$$';
 import fastdom from '../../../lib/fastdom-promise';
 import { commercialFeatures } from '../../common/modules/commercial/commercial-features';

--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
@@ -1,4 +1,4 @@
-import once from 'lodash/once';
+import { once } from 'lodash-es';
 import config from '../../../../lib/config';
 import { breakpoints } from '../../../../lib/detect';
 import { getUrlVars } from '../../../../lib/url';

--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.ts
@@ -158,7 +158,7 @@ jest.mock('@guardian/libs', () => {
 		storage: jest.requireActual('@guardian/libs').storage,
 	};
 });
-jest.mock('lodash/once', () => <T>(fn: () => T) => fn);
+jest.mock('lodash-es/once', () => <T>(fn: (...args: unknown[]) => T) => fn);
 jest.mock('./refresh-on-resize', () => ({
 	refreshOnResize: jest.fn(),
 }));

--- a/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.js
@@ -1,4 +1,4 @@
-import once from 'lodash/once';
+import { once } from 'lodash-es';
 import { dfpEnv } from './dfp-env';
 import { getAdvertById } from './get-advert-by-id';
 import { loadAdvert, refreshAdvert } from './load-advert';

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.js
@@ -1,4 +1,4 @@
-import once from 'lodash/once';
+import { once } from 'lodash-es';
 import mediator from '../../../../lib/mediator';
 import reportError from '../../../../lib/report-error';
 import { dfpEnv } from './dfp-env';

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-a9.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-a9.js
@@ -2,7 +2,7 @@ import {
     getConsentFor,
     onConsentChange,
 } from '@guardian/consent-management-platform';
-import once from 'lodash/once';
+import { once } from 'lodash-es';
 import config from '../../../../lib/config';
 import { isGoogleProxy } from '../../../../lib/detect';
 import { commercialFeatures } from '../../../common/modules/commercial/commercial-features';

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
@@ -2,7 +2,7 @@ import {
     getConsentFor,
     onConsentChange,
 } from '@guardian/consent-management-platform';
-import once from 'lodash/once';
+import { once } from 'lodash-es';
 import config from '../../../../lib/config';
 import { isGoogleProxy } from '../../../../lib/detect';
 import { getPageTargeting } from '../../../common/modules/commercial/build-page-targeting';

--- a/static/src/javascripts/projects/commercial/modules/dfp/wait-for-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/wait-for-advert.js
@@ -1,4 +1,4 @@
-import memoize from 'lodash/memoize';
+import { memoize } from 'lodash-es';
 import { getAdvertById } from './get-advert-by-id';
 
 export const waitForAdvert = memoize(

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/utils.spec.js
@@ -29,7 +29,7 @@ const getBreakpoint = getBreakpoint_;
 const isBreakpoint = isBreakpoint_;
 const isInVariantSynchronous = isInVariantSynchronous_;
 
-jest.mock('lodash/once', () => a => a);
+jest.mock('lodash-es/once', () => fn => fn);
 
 jest.mock('../../../../lib/geolocation', () => ({
     getCountryCode: jest.fn(() => 'GB'),

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/utils.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/utils.ts
@@ -1,4 +1,4 @@
-import once from 'lodash/once';
+import { once } from 'lodash-es';
 import config from '../../../../lib/config';
 import { getBreakpoint, isBreakpoint } from '../../../../lib/detect';
 import { pbTestNameMap } from '../../../../lib/url';

--- a/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
@@ -1,5 +1,5 @@
 import fastdom from 'fastdom';
-import throttle from 'lodash/throttle';
+import { throttle } from 'lodash-es';
 import config from '../../../../lib/config';
 import { getBreakpoint, hasTouchScreen } from '../../../../lib/detect';
 import FiniteStateMachine from '../../../../lib/fsm';

--- a/static/src/javascripts/projects/commercial/modules/remove-slots.ts
+++ b/static/src/javascripts/projects/commercial/modules/remove-slots.ts
@@ -1,4 +1,4 @@
-import once from 'lodash/once';
+import { once } from 'lodash-es';
 import fastdom from '../../../lib/fastdom-promise';
 import { dfpEnv } from './dfp/dfp-env';
 

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -1,7 +1,6 @@
 import { cmp, onConsentChange } from '@guardian/consent-management-platform';
 import { log, storage } from '@guardian/libs';
-import once from 'lodash/once';
-import pick from 'lodash/pick';
+import { once, pick } from 'lodash-es';
 import config from '../../../../lib/config';
 import { getCookie } from '../../../../lib/cookies';
 import {

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -54,7 +54,8 @@ jest.mock('./user-ad-targeting', () => ({
 jest.mock('../experiments/ab', () => ({
     getSynchronousParticipations: jest.fn(),
 }));
-jest.mock('lodash/once', () => fn => fn);
+jest.mock('lodash-es/once', () => fn => fn);
+jest.mock('lodash-es/memoize', () => fn => fn);
 jest.mock('./commercial-features', () => ({
     commercialFeatures() {},
 }));

--- a/static/src/javascripts/projects/common/modules/experiments/ab-utils.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-utils.ts
@@ -4,8 +4,7 @@ import type {
 	Runnable,
 	Variant,
 } from '@guardian/ab-core';
-import fromPairs from 'lodash/fromPairs';
-import toPairs from 'lodash/toPairs';
+import { fromPairs, toPairs } from 'lodash-es';
 import config_ from '../../../../lib/config';
 import { NOT_IN_TEST, notInTestVariant } from './ab-constants';
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab.spec.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.spec.ts
@@ -34,7 +34,7 @@ jest.mock('common/modules/experiments/ab-ophan', () => ({
 	trackABTests: emptyFunction,
 	buildOphanPayload: emptyFunction,
 }));
-jest.mock('lodash/memoize', () => (f: (...args: unknown[]) => unknown) => f);
+jest.mock('lodash-es/memoize', () => (f: (...args: unknown[]) => unknown) => f);
 
 const cfg: DeepPartial<Config> = window.guardian.config;
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab.spec.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.spec.ts
@@ -34,7 +34,7 @@ jest.mock('common/modules/experiments/ab-ophan', () => ({
 	trackABTests: emptyFunction,
 	buildOphanPayload: emptyFunction,
 }));
-jest.mock('lodash-es/memoize', () => (f: (...args: unknown[]) => unknown) => f);
+jest.mock('lodash-es/memoize', () => <T>(f: (...args: unknown[]) => T) => f);
 
 const cfg: DeepPartial<Config> = window.guardian.config;
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.ts
@@ -1,5 +1,5 @@
 import type { ABTest, Participations, Runnable } from '@guardian/ab-core';
-import memoize from 'lodash/memoize';
+import { memoize } from 'lodash-es';
 import { allRunnableTests } from './ab-core';
 import {
 	getParticipationsFromLocalStorage,

--- a/static/src/javascripts/projects/common/modules/onward/geo-most-popular.js
+++ b/static/src/javascripts/projects/common/modules/onward/geo-most-popular.js
@@ -5,7 +5,7 @@
 import fastdom from '../../../../lib/fastdom-promise';
 import { Component } from '../component';
 import mediator from '../../../../lib/mediator';
-import once from 'lodash/once';
+import { once } from 'lodash-es';
 
 const promise = new Promise((resolve, reject) => {
     mediator.on('modules:onward:geo-most-popular:ready', resolve);

--- a/static/src/javascripts/projects/common/modules/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/spacefinder.js
@@ -4,7 +4,7 @@ import qwery from 'qwery';
 import bean from 'bean';
 import fastdom from '../../../lib/fastdom-promise';
 import mediator from '../../../lib/mediator';
-import memoize from 'lodash/memoize';
+import { memoize } from 'lodash-es';
 
 
 

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -648,14 +648,13 @@
  ],
  "../projects/common/modules/experiments/ab-utils.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
-  "../../../../node_modules/@types/lodash/fromPairs.d.ts",
-  "../../../../node_modules/@types/lodash/toPairs.d.ts",
+  "../../../../node_modules/@types/lodash-es/index.d.ts",
   "../lib/config.js",
   "../projects/common/modules/experiments/ab-constants.ts"
  ],
  "../projects/common/modules/experiments/ab.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
-  "../../../../node_modules/@types/lodash/memoize.d.ts",
+  "../../../../node_modules/@types/lodash-es/index.d.ts",
   "../projects/common/modules/experiments/ab-core.ts",
   "../projects/common/modules/experiments/ab-local-storage.ts",
   "../projects/common/modules/experiments/ab-ophan.ts",

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -52,7 +52,7 @@
  ],
  "../lib/time-utils.js": [],
  "../lib/url.ts": [
-  "../../../../node_modules/@types/lodash/memoize.d.ts",
+  "../../../../node_modules/@types/lodash-es/index.d.ts",
   "../lib/detect.js"
  ],
  "../lib/user-timing.js": [
@@ -64,7 +64,7 @@
   "../projects/common/modules/analytics/shouldCaptureMetrics.ts"
  ],
  "../projects/commercial/modules/ad-free-slot-remove.ts": [
-  "../../../../node_modules/@types/lodash/once.d.ts",
+  "../../../../node_modules/@types/lodash-es/index.d.ts",
   "../lib/$$.ts",
   "../lib/fastdom-promise.js",
   "../projects/commercial/modules/dfp/dfp-env.ts",
@@ -149,7 +149,7 @@
   "../projects/commercial/modules/ad-sizes.js"
  ],
  "../projects/commercial/modules/dfp/define-slot.js": [
-  "../../../../node_modules/lodash-es/once.js",
+  "../../../../node_modules/lodash-es/lodash.js",
   "../lib/config.js",
   "../lib/detect.js",
   "../lib/url.ts"
@@ -191,7 +191,7 @@
   "../projects/commercial/modules/dfp/dfp-env.ts"
  ],
  "../projects/commercial/modules/dfp/lazy-load.js": [
-  "../../../../node_modules/lodash-es/once.js",
+  "../../../../node_modules/lodash-es/lodash.js",
   "../projects/commercial/modules/dfp/dfp-env.ts",
   "../projects/commercial/modules/dfp/get-advert-by-id.ts",
   "../projects/commercial/modules/dfp/load-advert.js"
@@ -208,7 +208,7 @@
   "../projects/commercial/modules/messenger/post-message.js"
  ],
  "../projects/commercial/modules/dfp/on-slot-render.js": [
-  "../../../../node_modules/lodash-es/once.js",
+  "../../../../node_modules/lodash-es/lodash.js",
   "../lib/config.js",
   "../lib/mediator.js",
   "../lib/report-error.js",
@@ -230,7 +230,7 @@
  ],
  "../projects/commercial/modules/dfp/prepare-a9.js": [
   "../../../../node_modules/@guardian/consent-management-platform/dist/index.js",
-  "../../../../node_modules/lodash-es/once.js",
+  "../../../../node_modules/lodash-es/lodash.js",
   "../lib/a9-apstag.js",
   "../lib/config.js",
   "../lib/detect.js",
@@ -274,7 +274,7 @@
  ],
  "../projects/commercial/modules/dfp/prepare-prebid.js": [
   "../../../../node_modules/@guardian/consent-management-platform/dist/index.js",
-  "../../../../node_modules/lodash-es/once.js",
+  "../../../../node_modules/lodash-es/lodash.js",
   "../../../../node_modules/prebid.js/build/dist/prebid.js",
   "../lib/config.js",
   "../lib/detect.js",
@@ -319,7 +319,7 @@
   "../projects/commercial/modules/dfp/wait-for-advert.js"
  ],
  "../projects/commercial/modules/dfp/wait-for-advert.js": [
-  "../../../../node_modules/lodash-es/memoize.js",
+  "../../../../node_modules/lodash-es/lodash.js",
   "../projects/commercial/modules/dfp/get-advert-by-id.ts"
  ],
  "../projects/commercial/modules/header-bidding/a9/a9.js": [
@@ -365,7 +365,7 @@
   "../projects/commercial/modules/header-bidding/utils.ts"
  ],
  "../projects/commercial/modules/header-bidding/utils.ts": [
-  "../../../../node_modules/@types/lodash/once.d.ts",
+  "../../../../node_modules/@types/lodash-es/index.d.ts",
   "../lib/config.js",
   "../lib/detect.js",
   "../lib/url.ts",
@@ -382,7 +382,7 @@
  ],
  "../projects/commercial/modules/hosted/gallery.js": [
   "../../../../node_modules/fastdom/fastdom.js",
-  "../../../../node_modules/lodash-es/throttle.js",
+  "../../../../node_modules/lodash-es/lodash.js",
   "../lib/config.js",
   "../lib/detect.js",
   "../lib/fsm.js",
@@ -479,7 +479,7 @@
   "../projects/common/modules/ui/sticky.js"
  ],
  "../projects/commercial/modules/remove-slots.ts": [
-  "../../../../node_modules/@types/lodash/once.d.ts",
+  "../../../../node_modules/@types/lodash-es/index.d.ts",
   "../lib/fastdom-promise.js",
   "../projects/commercial/modules/dfp/dfp-env.ts"
  ],
@@ -567,8 +567,7 @@
  "../projects/common/modules/commercial/build-page-targeting.js": [
   "../../../../node_modules/@guardian/consent-management-platform/dist/index.js",
   "../../../../node_modules/@guardian/libs/dist/cjs/index.js",
-  "../../../../node_modules/lodash-es/once.js",
-  "../../../../node_modules/lodash-es/pick.js",
+  "../../../../node_modules/lodash-es/lodash.js",
   "../lib/config.js",
   "../lib/cookies.js",
   "../lib/detect.js",
@@ -685,14 +684,14 @@
   "../lib/url.ts"
  ],
  "../projects/common/modules/onward/geo-most-popular.js": [
-  "../../../../node_modules/lodash-es/once.js",
+  "../../../../node_modules/lodash-es/lodash.js",
   "../lib/fastdom-promise.js",
   "../lib/mediator.js",
   "../projects/common/modules/component.js"
  ],
  "../projects/common/modules/spacefinder.js": [
   "../../../../node_modules/bean/bean.js",
-  "../../../../node_modules/lodash-es/memoize.js",
+  "../../../../node_modules/lodash-es/lodash.js",
   "../../../../node_modules/qwery/qwery.js",
   "../lib/fastdom-promise.js",
   "../lib/mediator.js"

--- a/webpack.config.commercial.js
+++ b/webpack.config.commercial.js
@@ -3,8 +3,8 @@ const webpackMerge = require('webpack-merge');
 const config = require('./webpack.config.js');
 
 const standaloneEntry = 'commercial-standalone';
-if(Object.keys(config.entry).includes(standaloneEntry))
-    throw new Error(`Conflicting entry name: ${standaloneEntry}`)
+if (Object.keys(config.entry).includes(standaloneEntry))
+	throw new Error(`Conflicting entry name: ${standaloneEntry}`);
 
 // override JS entry points
 config.entry = {
@@ -20,14 +20,14 @@ config.entry = {
 
 module.exports = webpackMerge.smart(config, {
 	output: {
-        /**
-         * To prevent clashes with the main bundle, the JSONP loading function
-         * needs to be assigned a unique name.
-         *
-         * Typical errors were “Cannot read property `call` of undefined”
-         *
-         * **Wepback 4 only.** Renamed in Wepback 5 `chunkLoadingGlobal`
-         */
+		/**
+		 * To prevent clashes with the main bundle, the JSONP loading function
+		 * needs to be assigned a unique name.
+		 *
+		 * Typical errors were “Cannot read property `call` of undefined”
+		 *
+		 * **Wepback 4 only.** Renamed in Wepback 5 `chunkLoadingGlobal`
+		 */
 		jsonpFunction: 'commercialJsonp',
 		path: path.join(
 			__dirname,
@@ -36,5 +36,10 @@ module.exports = webpackMerge.smart(config, {
 			'javascripts',
 			'commercial',
 		),
+	},
+	resolve: {
+		alias: {
+			lodash: 'lodash',
+		},
 	},
 });


### PR DESCRIPTION
## What does this change?

Follow-up on #23594.

Remove the `lodash` → `lodash-es` alias from the commercial standalone bundle webpack config.
This means projects in commercial use `lodash-es` explicitly.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Less magic, more explicit imports.

## Checklist

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
