### PR TITLE
Fix AC on fronts

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -173,7 +173,7 @@ const updateArticleCounts = async () => {
     const page = config.get('page');
     const hasConsentedToArticleCounts = await getArticleCountConsent();
 
-    if (page && hasConsentedToArticleCounts) {
+    if (page && !page.isFront && hasConsentedToArticleCounts) {
         incrementDailyArticleCount(page);
         incrementWeeklyArticleCount(storage.local, page.pageId);
     }


### PR DESCRIPTION
This was a regression from the change to use automat for article count https://github.com/guardian/frontend/pull/24080
It should exclude fronts
