### PR TITLE
Adfree users should not have page skin classes added to body

### DIFF
--- a/common/app/html/HtmlPage.scala
+++ b/common/app/html/HtmlPage.scala
@@ -41,8 +41,11 @@ object HtmlPageHelpers {
       applicationContext: ApplicationContext,
   ): Map[String, Boolean] = {
     val edition = Edition(request)
+    val showAds =
+      Commercial.shouldShowAds(page) && !model.Page.getContent(page).exists(_.tags.isTheMinuteArticle) && !Commercial
+        .isAdFree(request)
     Map(
-      ("has-page-skin", page.metadata.hasPageSkin(request)),
+      ("has-page-skin", page.metadata.hasPageSkin(request) && showAds),
       ("has-membership-access-requirement", page.metadata.requiresMembershipAccess),
       ("childrens-books-site", page.metadata.sectionId == "childrens-books-site"),
     )

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -31,7 +31,7 @@
     <body
         id="top"
         class="@RenderClasses(Map(
-            ("has-page-skin", page.metadata.hasPageSkin(request)),
+            ("has-page-skin", page.metadata.hasPageSkin(request) && showAdverts),
             ("has-membership-access-requirement", page.metadata.requiresMembershipAccess),
             ("childrens-books-site", page.metadata.sectionId == "childrens-books-site"),
             ("has-super-sticky-banner", false),


### PR DESCRIPTION
## What does this change?

For 'ad free' users when viewing a front with an active page skin, they experience a noticeable jump in the page width.

This is because:

1. The `has-page-skin` class is added to `body` by each Frontend scala template ([for example](https://github.com/guardian/frontend/blob/37efbc8d62a118f9842a64eb17909adbcb55d8e7/common/app/views/main.scala.html#L34)) when `page.metadata.hasPageSkin(request) == true` . This then renders the page at a reduced width.
2. [ad-free-slot-remove](https://github.com/guardian/frontend/blob/5b970cd7308175cfc1bcae2d4fb8c06ee13c5fa0/static/src/javascripts/projects/commercial/modules/ad-free-slot-remove.ts#L40-L45) removes the `has-page-skin` class at runtime for ad free users causing the jump to normal width.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

### Before

Courtesy of @HarryFischer 

https://user-images.githubusercontent.com/7014230/130226511-a5431b29-3393-4fb9-b775-3893312d80d0.mov

### Tested

- [ ] Locally
- [x] On CODE (optional)
