### PR TITLE
associate tokyo badge with paraolympics url

### DIFF
--- a/common/app/model/Badges.scala
+++ b/common/app/model/Badges.scala
@@ -99,6 +99,8 @@ object Badges {
     Badge("football/euro-2020", Static("images/badges/euro-2020.svg"))
   val tokyo2020 =
     Badge("sport/olympic-games-2020", Static("images/badges/tokyo-2020.svg"))
+  val paraolympics2020 =
+    Badge("sport/paralympic-games-2020", Static("images/badges/tokyo-2020.svg"))
 
   val allBadges = Seq(
     newArrivals,
@@ -146,6 +148,7 @@ object Badges {
     anniversary200,
     euro2020,
     tokyo2020,
+    paraolympics2020,
   )
 
   def badgeFor(c: ContentType): Option[Badge] = {


### PR DESCRIPTION
## What does this change?
Associates series (https://www.theguardian.com/uk/sport/paralympic-games-2020) with Tokyo2020 badge

## Does this change need to be reproduced in dotcom-rendering ?

- [X ] No
- [ ] Yes (please indicate your plans for DCR Implementation)
