### PR TITLE
Fix alignment of Paid Content sections on fronts

### DIFF
--- a/static/src/stylesheets/module/commercial/_labs.scss
+++ b/static/src/stylesheets/module/commercial/_labs.scss
@@ -255,7 +255,7 @@
             }
         }
         
-        @include mq(leftCol) {
+        @include mq(wide) {
             padding: $gs-baseline 0;
         }
     }

--- a/static/src/stylesheets/module/commercial/_labs.scss
+++ b/static/src/stylesheets/module/commercial/_labs.scss
@@ -58,7 +58,8 @@
 
     @include mq(leftCol) {
         padding: $gs-baseline $gs-gutter / 5 * 2;
-        width: 160px;
+        // Extra 1px to line up with borders on sections above / below
+        width: 160px + $gs-gutter / 2 + 1px;
     }
 
     @include mq(tablet, desktop) {
@@ -67,7 +68,8 @@
 
     @include mq(wide) {
         padding: $gs-baseline $gs-gutter;
-        width: 240px;
+        // Extra 1px to line up with borders on sections above / below
+        width: 240px + $gs-gutter / 2 + 1px;
     }
 
     .button {
@@ -114,20 +116,18 @@
 
     @include mq(mobileLandscape) {
         box-sizing: border-box;
-        max-width: gs-span(8) + ($gs-gutter * 2);
     }
     @include mq(tablet) {
-        max-width: gs-span(9) + ($gs-gutter * 2);
         padding-bottom: $gs-baseline;
-    }
-    @include mq(desktop) {
-        max-width: gs-span(12) + ($gs-gutter * 2);
     }
     @include mq(leftCol) {
         flex: 1;
     }
     @include mq($until: tablet) {
         margin: auto;
+    }
+    @include mq(wide) {
+        margin-right: $gs-gutter + 70px + 1px;
     }
 }
 
@@ -184,7 +184,7 @@
     }
 
     .dumathoin__row {
-        padding: $gs-baseline / 2 0;
+        padding: $gs-baseline / 2 $gs-gutter / 2;
         display: flex;
 
         > * {
@@ -223,8 +223,6 @@
         }
 
         @include mq(tablet) {
-            padding: $gs-baseline $gs-gutter / 2;
-
             > * + * {
                 position: relative;
 
@@ -256,7 +254,10 @@
                 }
             }
         }
-
+        
+        @include mq(leftCol) {
+            padding: $gs-baseline 0;
+        }
     }
 
     .dumathoin__row--wrap {


### PR DESCRIPTION

## What does this change?

Adjust the width of headers in "Paid Content" sections so they align with sections above and below on fronts.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before](https://user-images.githubusercontent.com/8000415/130481961-5f50cdfa-c414-457f-8dcd-190b0d93c70e.png) | ![after](https://user-images.githubusercontent.com/8000415/130482010-57b547af-a966-4421-9ff9-eaa97ac6c09d.png) |

## What is the value of this and can you measure success?

The value is that this container lines up more appropriately with the content above and below it on the front page.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No - it only affects the "Paid Content" container on fronts
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)
