### PR TITLE
Add Tokyo Paralympic games link to UK / US / AU sport navs

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -112,7 +112,7 @@ private object NavLinks {
     ),
   )
   val soccer = football.copy(title = "Soccer")
-
+  val paralympics = NavLink("Tokyo 2020 Paralympic Games", "/sport/tokyo-paralympic-games-2020")
   val cricket = NavLink("Cricket", "/sport/cricket")
   val cycling = NavLink("Cycling", "/sport/cycling")
   val rugbyUnion = NavLink("Rugby union", "/sport/rugby-union")
@@ -363,6 +363,7 @@ private object NavLinks {
     longTitle = Some("Sport home"),
     iconName = Some("home"),
     List(
+      paralympics,
       football,
       cricket,
       rugbyUnion,

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -379,6 +379,7 @@ private object NavLinks {
   )
   val auSportPillar = ukSportPillar.copy(
     children = List(
+      paralympics,
       football,
       AFL,
       NRL,
@@ -392,6 +393,7 @@ private object NavLinks {
   )
   val usSportPillar = ukSportPillar.copy(
     children = List(
+      paralympics,
       soccer,
       NFL,
       tennis,

--- a/docs/01-start-here/01-installation-steps.md
+++ b/docs/01-start-here/01-installation-steps.md
@@ -95,6 +95,8 @@ $ sdk current java
 Using java version 11.0.11.hs-adpt
 $ java -version
 openjdk version "11.0.11" 2021-04-20
+$ sdk use java 11.0.11.hs-adpt
+Using java version 11.0.11.hs-adpt in this shell.
 ```
 
 ### Node.js

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,6 +58,7 @@
 ## [Features and components](06-features-and-components/)
 - [SteadyPage JS utility](06-features-and-components/01-steadypage-js-utility.md)
 - [How are trail pictures picked in Frontend?](06-features-and-components/02-trail-images.md)
+- [theguardian.com/font-loader](06-features-and-components/03-font-loader-route.md)
 
 ## [Performance](07-performance/)
 - [Performance reading list](07-performance/01-performance-reading.md)


### PR DESCRIPTION
## What does this change?
This adds a link to the Tokyo Paralympic games in the UK, US and AU sport navs.

I also made a change in the installation steps doc because I had a fiddly time updating java, and I thought future users might be save some trouble from the lines I've added.

The change to the README is an automatically generated one. I believe this is probably an update generated by a previous change.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
### UK sport nav
![Screen Shot 2021-08-23 at 17 21 57](https://user-images.githubusercontent.com/16781258/130482655-0caa85f4-9472-4bbe-97c3-1d84a6dface9.png)

### US sport nav
![Screen Shot 2021-08-24 at 11 32 51](https://user-images.githubusercontent.com/16781258/130602058-23cf5669-d850-4677-83ab-d8ff224e7aaf.png)

### AUS sport nav
![Screen Shot 2021-08-24 at 11 33 06](https://user-images.githubusercontent.com/16781258/130602128-8f2c5874-d9e7-4530-9df3-696e61142b7a.png)


### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [x] Locally
- [ ] On CODE (optional)

