### PR TITLE
Fix paralympics link

### DIFF
--- a/common/app/model/Badges.scala
+++ b/common/app/model/Badges.scala
@@ -101,6 +101,8 @@ object Badges {
     Badge("sport/olympic-games-2020", Static("images/badges/tokyo-2020.svg"))
   val paralympics2020 =
     Badge("sport/tokyo-paralympic-games-2020", Static("images/badges/tokyo-2020.svg"))
+  val tokyoparalympics2020 =
+    Badge("sport/tokyo-paralympic-games-2020", Static("images/badges/tokyo-2020.svg"))
 
   val allBadges = Seq(
     newArrivals,
@@ -149,6 +151,7 @@ object Badges {
     euro2020,
     tokyo2020,
     paralympics2020,
+    tokyoparalympics2020,
   )
 
   def badgeFor(c: ContentType): Option[Badge] = {

--- a/common/app/model/Badges.scala
+++ b/common/app/model/Badges.scala
@@ -100,9 +100,9 @@ object Badges {
   val tokyo2020 =
     Badge("sport/olympic-games-2020", Static("images/badges/tokyo-2020.svg"))
   val paralympics2020 =
-    Badge("sport/tokyo-paralympic-games-2020", Static("images/badges/tokyo-2020.svg"))
+    Badge("sport/paralympic-games-2020", Static("images/badges/tokyo-2020.svg"))
   val tokyoparalympics2020 =
-    Badge("sport/tokyo-paralympic-games-2020", Static("images/badges/tokyo-2020.svg"))
+    Badge("sport/paralympic-games-2020", Static("images/badges/tokyo-2020.svg"))
 
   val allBadges = Seq(
     newArrivals,

--- a/common/app/model/Badges.scala
+++ b/common/app/model/Badges.scala
@@ -100,8 +100,6 @@ object Badges {
   val tokyo2020 =
     Badge("sport/olympic-games-2020", Static("images/badges/tokyo-2020.svg"))
   val paralympics2020 =
-    Badge("sport/paralympic-games-2020", Static("images/badges/tokyo-2020.svg"))
-  val tokyoparalympics2020 =
     Badge("sport/tokyo-paralympic-games-2020", Static("images/badges/tokyo-2020.svg"))
 
   val allBadges = Seq(
@@ -151,7 +149,6 @@ object Badges {
     euro2020,
     tokyo2020,
     paralympics2020,
-    tokyoparalympics2020,
   )
 
   def badgeFor(c: ContentType): Option[Badge] = {

--- a/common/app/model/Badges.scala
+++ b/common/app/model/Badges.scala
@@ -102,7 +102,7 @@ object Badges {
   val paralympics2020 =
     Badge("sport/paralympic-games-2020", Static("images/badges/tokyo-2020.svg"))
   val tokyoparalympics2020 =
-    Badge("sport/paralympic-games-2020", Static("images/badges/tokyo-2020.svg"))
+    Badge("sport/tokyo-paralympic-games-2020", Static("images/badges/tokyo-2020.svg"))
 
   val allBadges = Seq(
     newArrivals,

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -112,7 +112,7 @@ private object NavLinks {
     ),
   )
   val soccer = football.copy(title = "Soccer")
-  val paralympics = NavLink("Tokyo 2020 Paralympic Games", "/sport/tokyo-paralympic-games-2020")
+  val paralympics = NavLink("Tokyo 2020 Paralympics", "/sport/paralympic-games-2020")
   val cricket = NavLink("Cricket", "/sport/cricket")
   val cycling = NavLink("Cycling", "/sport/cycling")
   val rugbyUnion = NavLink("Rugby union", "/sport/rugby-union")


### PR DESCRIPTION
## What does this change?
The link to the paralympics front was incorrect. The error was introduced in this PR: https://github.com/guardian/frontend/pull/24113 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
