### PR TITLE
Decommission joda.time Step 8 attempt 3

### DIFF
--- a/common/app/common/Chronos.scala
+++ b/common/app/common/Chronos.scala
@@ -1,0 +1,38 @@
+package common
+
+import org.joda.time.DateTime
+
+import java.time.format.DateTimeFormatter
+import java.time.ZoneId
+
+// Introduced in August 2021 by Pascal to help and support the migration from joda.time to java.time
+// Contains both helper functions implementing patterns emerging during the migration as well as more permanent
+// functions.
+
+// DO NOT attempt to simplify, until otherwise specified, the signatures of the functions.
+// The arguments are verbose type to help with reading and understanding. This will be simplified in due course.
+
+object Chronos {
+
+  def toJodaDateTime(date: java.time.LocalDateTime): org.joda.time.DateTime = {
+    DateTime.parse(date.toString)
+  }
+
+  def jodaDateToLocalDate(date: java.util.Date): java.time.LocalDate = {
+    date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate()
+  }
+
+  def jodaDateToLocalDateTime(date: java.util.Date): java.time.LocalDateTime = {
+    date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime()
+  }
+
+  def toMilliSeconds(date: java.time.LocalDateTime): Long = {
+    date.atZone(ZoneId.of("UTC")).toInstant().toEpochMilli()
+  }
+
+  def dateFormatter(pattern: String, timeZoneId: ZoneId): DateTimeFormatter = {
+    val format = DateTimeFormatter.ofPattern(pattern)
+    format.withZone(timeZoneId)
+    format
+  }
+}

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -173,6 +173,7 @@ object `package` {
 }
 
 object GuDateFormatLegacy {
+
   def apply(date: DateTime, pattern: String, tzOverride: Option[DateTimeZone] = None)(implicit
       request: RequestHeader,
   ): String = {

--- a/sport/app/cricket/conf/context.scala
+++ b/sport/app/cricket/conf/context.scala
@@ -3,7 +3,8 @@ package cricket.conf
 import app.LifecycleComponent
 import common.{AkkaAsync, JobScheduler}
 import jobs.CricketStatsJob
-import org.joda.time.LocalDate
+
+import java.time.LocalDate
 import play.api.inject.ApplicationLifecycle
 
 import scala.concurrent.duration._

--- a/sport/app/cricket/feed/cricketModel.scala
+++ b/sport/app/cricket/feed/cricketModel.scala
@@ -1,6 +1,6 @@
 package cricketModel
 
-import org.joda.time.DateTime
+import java.time.LocalDateTime
 
 case class Match(
     teams: List[Team],
@@ -8,7 +8,7 @@ case class Match(
     competitionName: String,
     venueName: String,
     result: String,
-    gameDate: DateTime,
+    gameDate: LocalDateTime,
     officials: List[String],
     matchId: String,
 ) {

--- a/sport/app/cricket/feed/cricketPaDeserialisation.scala
+++ b/sport/app/cricket/feed/cricketPaDeserialisation.scala
@@ -1,10 +1,15 @@
 package conf.cricketPa
 
+import common.Chronos
+
 import xml.{NodeSeq, XML}
 import scala.language.postfixOps
-import org.joda.time.format.DateTimeFormat
-import org.joda.time.DateTime
+import java.time
+import java.text.SimpleDateFormat
 import cricketModel._
+
+import java.time.{LocalDate, LocalDateTime, ZoneId}
+import java.util.{Date, TimeZone}
 
 object Parser {
 
@@ -31,14 +36,14 @@ object Parser {
       competitionName: String,
       venueName: String,
       result: String,
-      gameDate: DateTime,
+      gameDate: LocalDateTime,
       officials: List[String],
   )
 
   private object Date {
-    private val dateTimeParser = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss")
-
-    def apply(dateTime: String): DateTime = dateTimeParser.parseDateTime(dateTime)
+    private val dateTimePattern = "yyyy-MM-dd'T'HH:mm:ss"
+    private val dateTimeParser = Chronos.dateFormatter(dateTimePattern, TimeZone.getTimeZone("Europe/London").toZoneId)
+    def apply(dateTime: String): LocalDateTime = LocalDateTime.parse(dateTime, dateTimeParser)
   }
 
   private def inningsDescription(inningsOrder: Int, battingTeam: String): String = {

--- a/sport/app/cricket/feed/cricketPaFeed.scala
+++ b/sport/app/cricket/feed/cricketPaFeed.scala
@@ -2,19 +2,21 @@ package conf.cricketPa
 
 import akka.actor.ActorSystem
 import akka.stream.Materializer
+import common.Chronos
 import common.GuLogging
 import cricket.feed.CricketThrottler
-import org.joda.time.{DateTime, LocalDate}
-import org.joda.time.format.{DateTimeFormat, DateTimeFormatter}
+
+import java.time.{LocalDate, ZoneId}
 import play.api.libs.ws.WSClient
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.xml.XML
+import java.util.TimeZone
 
 case class CricketFeedException(message: String) extends RuntimeException(message)
 
 object PaFeed {
-  val dateFormat: DateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd")
+  val dateFormat = Chronos.dateFormatter("yyyy-MM-dd", ZoneId.of("UTC"))
 }
 
 class PaFeed(wsClient: WSClient, actorSystem: ActorSystem, materializer: Materializer) extends GuLogging {
@@ -77,8 +79,8 @@ class PaFeed(wsClient: WSClient, actorSystem: ActorSystem, materializer: Materia
     credentials
       .map(header =>
         throttler.throttle { () =>
-          val start = PaFeed.dateFormat.print(startDate)
-          val end = PaFeed.dateFormat.print(endDate)
+          val start = PaFeed.dateFormat.format(startDate)
+          val end = PaFeed.dateFormat.format(endDate)
           val endpoint = s"$paEndpoint/team/${team.paId}/$matchType"
 
           wsClient

--- a/sport/app/cricket/jobs/CricketStatsJob.scala
+++ b/sport/app/cricket/jobs/CricketStatsJob.scala
@@ -2,18 +2,15 @@ package jobs
 
 import com.gu.Box
 import common.GuLogging
+import common.Chronos
 import conf.cricketPa.{CricketFeedException, CricketTeam, CricketTeams, PaFeed}
 import cricketModel.Match
-import org.joda.time.{DateTimeZone, Days, LocalDate}
-import org.joda.time.format.DateTimeFormat
-
-import scala.concurrent.{ExecutionContext, Future}
+import java.time.{Duration, LocalDate}
+import scala.concurrent.ExecutionContext
 
 class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
 
   private val cricketStatsAgents = CricketTeams.teams.map(Team => (Team, Box[Map[String, Match]](Map.empty)))
-
-  private val dateFormatUTC = DateTimeFormat.forPattern("yyyy/MMM/dd").withZone(DateTimeZone.UTC)
 
   def getMatch(team: CricketTeam, date: String): Option[Match] =
     cricketStatsAgents
@@ -22,11 +19,11 @@ class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
 
   def findMatch(team: CricketTeam, date: String): Option[Match] = {
     val dateFormat = PaFeed.dateFormat
-    val requestDate = dateFormat.parseLocalDate(date)
+    val requestDate: LocalDate = LocalDate.parse(date, dateFormat)
 
     val matchObjects = for {
       day <- 0 until 6 // normally test matches are 5 days but we have seen at least 6 days in practice
-      date <- Some(dateFormat.print(requestDate.minusDays(day)))
+      date <- Some(dateFormat.format(requestDate.minusDays(day)))
     } yield {
       getMatch(team, date)
     }
@@ -41,7 +38,7 @@ class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
         val loadedMatches = agent().values
           .filter(cricketMatch =>
             // Omit any recent match within the last 5 days, to account for test matches.
-            Days.daysBetween(cricketMatch.gameDate.toLocalDate, LocalDate.now).getDays > 5,
+            Duration.between(cricketMatch.gameDate, LocalDate.now).toDays() > 5,
           )
           .map(_.matchId)
           .toSeq
@@ -56,7 +53,7 @@ class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
               paFeed
                 .getMatch(matchId)
                 .map { matchData =>
-                  val date = PaFeed.dateFormat.print(matchData.gameDate)
+                  val date = PaFeed.dateFormat.format(matchData.gameDate)
                   log.info(s"Updating cricket match: ${matchData.homeTeam.name} v ${matchData.awayTeam.name}, $date")
                   agent.send(_ + (date -> matchData))
                 }

--- a/sport/app/cricket/views/fragments/cricketMatchSummary.scala.html
+++ b/sport/app/cricket/views/fragments/cricketMatchSummary.scala.html
@@ -1,12 +1,17 @@
-@(theMatch: cricketModel.Match, matchUrl: String)(implicit request: RequestHeader)
+@import java.time.format.DateTimeFormatter
+@import java.time.ZoneId
 @import common.LinkTo
+@import common.Chronos
 @import views.support.GuDateFormatLegacy
+
+
+@(theMatch: cricketModel.Match, matchUrl: String)(implicit request: RequestHeader)
 
 <div class="sport-summary sport-summary--cricket" itemscope itemtype="http://schema.org/SportsEvent">
 
     <h2 class="u-h">
-        <time class="u-h" datetime="@theMatch.gameDate.toString("yyyy-MM-dd'T'HH:mm:ss'Z'")" data-timestamp="@theMatch.gameDate.getMillis">
-        @GuDateFormatLegacy(theMatch.gameDate, "d MMM y")
+        <time class="u-h" datetime="@theMatch.gameDate.format(DateTimeFormatter.ISO_DATE)" data-timestamp="@Chronos.toMilliSeconds(theMatch.gameDate)">
+        @GuDateFormatLegacy(Chronos.toJodaDateTime(theMatch.gameDate), "d MMM y")
         </time>
         @theMatch.competitionName, @theMatch.venueName
     </h2>


### PR DESCRIPTION
This reverts commit d4ac3c397d705a5c29dc3bf625c7878b08e3d69a.

## What does this change?

This is the same at Step 8 attempt 2 ( https://github.com/guardian/frontend/pull/24107 ). Investigation shows that the date migration wasn't actually the cause of the momentary loss of live score widget on the liveblog.  This was established simply by running again the change in production and observing that the widget and the end point that supports it were just fine (see PR comments).
