### PR TITLE
Decommission joda.time Step 8 part 4

### DIFF
--- a/sport/app/cricket/jobs/CricketStatsJob.scala
+++ b/sport/app/cricket/jobs/CricketStatsJob.scala
@@ -5,7 +5,8 @@ import common.GuLogging
 import common.Chronos
 import conf.cricketPa.{CricketFeedException, CricketTeam, CricketTeams, PaFeed}
 import cricketModel.Match
-import java.time.{Duration, LocalDate}
+
+import java.time.{Duration, LocalDate, LocalDateTime}
 import scala.concurrent.ExecutionContext
 
 class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
@@ -38,7 +39,7 @@ class CricketStatsJob(paFeed: PaFeed) extends GuLogging {
         val loadedMatches = agent().values
           .filter(cricketMatch =>
             // Omit any recent match within the last 5 days, to account for test matches.
-            Duration.between(cricketMatch.gameDate, LocalDate.now).toDays() > 5,
+            Duration.between(cricketMatch.gameDate, LocalDateTime.now).toDays() > 5,
           )
           .map(_.matchId)
           .toSeq


### PR DESCRIPTION
## What does this change?

Fix a problem in the Cricket scores agent. The `Duration.between` function cannot work on a `LocalDate` because (as per documentation) the arguments have to implement the SECONDS unit.

This might fix the refresh problem we have been having

<img width="695" alt="Screenshot 2021-08-26 at 17 34 32" src="https://user-images.githubusercontent.com/6035518/131001700-d3f1eec3-760c-46ed-ba76-6849494bcc8c.png">

