### PR TITLE
Force Core Web Vitals reporting (really)

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -2,7 +2,7 @@ import { getCookie, log } from '@guardian/libs';
 import type { ReportHandler } from 'web-vitals';
 import { getCLS, getFCP, getFID, getLCP, getTTFB } from 'web-vitals';
 import reportError from 'lib/report-error';
-import { forceSendMetrics, setForceSendMetrics } from './forceSendMetrics';
+import { forceSendMetrics } from './forceSendMetrics';
 import { shouldCaptureMetrics } from './shouldCaptureMetrics';
 
 type CoreWebVitalsPayload = {

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -1,14 +1,13 @@
-import { getCookie } from '@guardian/libs';
+import { getCookie, log } from '@guardian/libs';
+import type { ReportHandler } from 'web-vitals';
 import { getCLS, getFCP, getFID, getLCP, getTTFB } from 'web-vitals';
 import reportError from 'lib/report-error';
-import { forceSendMetrics } from './forceSendMetrics';
+import { forceSendMetrics, setForceSendMetrics } from './forceSendMetrics';
 import { shouldCaptureMetrics } from './shouldCaptureMetrics';
 
 type CoreWebVitalsPayload = {
 	page_view_id: string | null;
-	received_timestamp: string | null;
 	browser_id: string | null;
-	received_date: string;
 	fid: null | number;
 	cls: null | number;
 	lcp: null | number;
@@ -16,20 +15,20 @@ type CoreWebVitalsPayload = {
 	ttfb: null | number;
 };
 
-const timestamp = new Date();
-const date = new Date().toISOString().slice(0, 10);
-
 const jsonData: CoreWebVitalsPayload = {
-	browser_id: null,
-	page_view_id: null,
-	received_timestamp: timestamp.toISOString(),
-	received_date: date,
+	browser_id:
+		window.guardian.config.ophan.browserId ??
+		getCookie({ name: 'bwid', shouldMemoize: true }),
+	page_view_id: window.guardian.ophan.pageViewId,
 	fid: null,
 	cls: null,
 	lcp: null,
 	fcp: null,
 	ttfb: null,
 };
+
+// Needed when we start using version 2
+// let hasFCPBeenSent = false;
 
 // By default, sample 1% of users
 const userInSample = Math.random() < 1 / 100;
@@ -39,109 +38,97 @@ const captureMetrics = shouldCaptureMetrics();
 // or we are force sending for this page view for some other reason with forceSendMetrics.
 
 /**
+ * Restrict a number to 9 digits
+ */
+const nineDigitPrecision = (value: number) => {
+	return Math.round(value * 1_000_000) / 1_000_000;
+};
+
+const sendData = () => {
+	const endpoint =
+		window.location.hostname === 'm.code.dev-theguardian.com' ||
+		window.location.hostname === 'localhost' ||
+		window.location.hostname === 'preview.gutools.co.uk'
+			? 'https://performance-events.code.dev-guardianapis.com/core-web-vitals'
+			: 'https://performance-events.guardianapis.com/core-web-vitals';
+
+	fetch(endpoint, {
+		method: 'POST',
+		mode: 'no-cors',
+		cache: 'no-cache',
+		headers: {
+			'Content-Type': 'application/json',
+		},
+		referrerPolicy: 'no-referrer',
+		body: JSON.stringify(jsonData),
+	})
+		.then(() => {
+			log('dotcom', 'Successfully recorded Core Web Vitals');
+		})
+		.catch((error) => {
+			reportError(error, 'core-web-vitals');
+		});
+};
+
+const onReport: ReportHandler = (metric) => {
+	switch (metric.name) {
+		case 'FCP':
+			// Browser support: Chromium, Firefox, Safari Technology Preview
+			jsonData.fcp = nineDigitPrecision(metric.value);
+			break;
+		case 'CLS':
+			// Browser support: Chromium,
+			jsonData.cls = nineDigitPrecision(metric.value);
+			break;
+		case 'LCP':
+			// Browser support: Chromium
+			jsonData.lcp = nineDigitPrecision(metric.value);
+			break;
+		case 'FID':
+			// Browser support: Chromium, Firefox, Safari, Internet Explorer (with the polyfill)
+			jsonData.fid = nineDigitPrecision(metric.value);
+			break;
+		case 'TTFB':
+			// Browser support: Chromium, Firefox, Safari, Internet Explorer
+			jsonData.ttfb = nineDigitPrecision(metric.value);
+			break;
+	}
+
+	/*
+		--> The logic below is only needed for Version 2 of Google's Core Web Vitals<--
+		As of Version 2.0, CLS values should only be sent if FCP has been sent
+		https://github.com/GoogleChrome/web-vitals/blob/main/CHANGELOG.md#v200-2021-06-01
+	if (jsonToSend.name === 'CLS' && hasFCPBeenSent) {
+		if (jsonData.cls !== null) {
+			sendData();
+		}
+	} else {
+		sendData();
+		if (jsonToSend.name === 'FCP') {
+			hasFCPBeenSent = true;
+		}
+	} */
+
+	if (captureMetrics || userInSample || forceSendMetrics) {
+		log('dotcom', 'About to send Core Web Vitals', jsonData);
+
+		// We will send all data whenever any update.
+		// This means `null` values will appear in the lake and need handling
+		sendData();
+	} else {
+		log('dotcom', 'Won’t send Core Web Vitals');
+	}
+};
+
+/**
  * Calls functions of web-vitals library to collect core web vitals data, registering callbacks which
  * send it to the data lake for a sample of page views.
  * Equivalent dotcom-rendering functionality is here: https://git.io/JBRIt
  */
 export const coreVitals = (): void => {
-	type CoreVitalsArgs = {
-		name: string;
-		value: number;
-	};
-
-	// Needed when we start using version 2
-	// let hasFCPBeenSent = false;
-
-	const nineDigitPrecision = (value: number) => {
-		// The math functions are to make sure the length of number is <= 9
-		return Math.round(value * 1_000_000) / 1_000_000;
-	};
-
-	const jsonToSend = ({ name, value }: CoreVitalsArgs): void => {
-		if (!captureMetrics && !userInSample && !forceSendMetrics) {
-			return;
-		}
-
-		switch (name) {
-			case 'FCP':
-				jsonData.fcp = nineDigitPrecision(value);
-				break;
-			case 'CLS':
-				jsonData.cls = nineDigitPrecision(value);
-				break;
-			case 'LCP':
-				jsonData.lcp = nineDigitPrecision(value);
-				break;
-			case 'FID':
-				jsonData.fid = nineDigitPrecision(value);
-				break;
-			case 'TTFB':
-				jsonData.ttfb = nineDigitPrecision(value);
-				break;
-		}
-
-		jsonData.page_view_id = window.guardian.ophan.pageViewId;
-		// 'window.guardian.config.ophan' does not exist here, so the fallback below might be the solution we go with
-		// jsonData.browser_id = window.guardian.config.ophan.browserId;
-
-		// Fallback to check for browser ID
-		if (getCookie({ name: 'bwid' })) {
-			jsonData.browser_id = getCookie({ name: 'bwid' });
-		}
-
-		const endpoint =
-			window.location.hostname === 'm.code.dev-theguardian.com' ||
-			window.location.hostname === 'localhost' ||
-			window.location.hostname === 'preview.gutools.co.uk'
-				? 'https://performance-events.code.dev-guardianapis.com/core-web-vitals'
-				: 'https://performance-events.guardianapis.com/core-web-vitals';
-
-		const sendData = () => {
-			fetch(endpoint, {
-				method: 'POST',
-				mode: 'cors',
-				cache: 'no-cache',
-				credentials: 'same-origin',
-				headers: {
-					'Content-Type': 'application/json',
-				},
-				redirect: 'follow',
-				referrerPolicy: 'no-referrer',
-				body: JSON.stringify(jsonData),
-			}).catch((error) => reportError(error, 'core-web-vitals'));
-		};
-
-		// Browser support
-		// getCLS(): Chromium,
-		// getFCP(): Chromium, Firefox, Safari Technology Preview
-		// getFID(): Chromium, Firefox, Safari, Internet Explorer (with the polyfill)
-		// getLCP(): Chromium
-		// getTTFB(): Chromium, Firefox, Safari, Internet Explorer
-
-		// We will send all data whenever any update. This means `null` values will appear in the lake
-		// and need handling.
-
-		/*
-		    --> The logic below is only needed for Version 2 of Google's Core Web Vitals<--
-		    As of Version 2.0, CLS values should only be sent if FCP has been sent
-	        https://github.com/GoogleChrome/web-vitals/blob/main/CHANGELOG.md#v200-2021-06-01
-		if (jsonToSend.name === 'CLS' && hasFCPBeenSent) {
-			if (jsonData.cls !== null) {
-				sendData();
-			}
-		} else {
-			sendData();
-			if (jsonToSend.name === 'FCP') {
-				hasFCPBeenSent = true;
-			}
-		} */
-
-		sendData();
-	};
-
-	getCLS(jsonToSend, false);
-	getFID(jsonToSend);
-	getLCP(jsonToSend);
-	getFCP(jsonToSend);
-	getTTFB(jsonToSend);
+	getCLS(onReport, false);
+	getFID(onReport);
+	getLCP(onReport);
+	getFCP(onReport);
+	getTTFB(onReport);
 };

--- a/static/src/javascripts/projects/common/modules/analytics/forceSendMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/forceSendMetrics.ts
@@ -1,4 +1,4 @@
-export let forceSendMetrics = false;
+export let forceSendMetrics = window.location.hash === '#forceSendMetrics';
 
 export const setForceSendMetrics = (val: boolean): void => {
 	forceSendMetrics = val;

--- a/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
@@ -11,8 +11,8 @@ const serverSideTests: string[] = [
 
 /**
  * Function to check wether metrics should be captured for the current page
- * @param tests - optional array of ABTest to check against, default to above.
- * @returns true if the user is in a one of a set of client or server-side tests
+ * @param tests - optional array of ABTest to check against.
+ * @returns {boolean} whether the user is in a one of a set of client or server-side tests
  * for which we want to always capture metrics.
  */
 const shouldCaptureMetrics = (tests = defaultClientSideTests): boolean => {


### PR DESCRIPTION
## What does this change?

Refactors the `coreVitals.ts` module, extracting callbacks out of the main exported function.

Now, the check against `captureMetrics || userInSample || forceSendMetrics` only prevents sending the data, but allows the assignments. Before this, metrics would only be partially captured in #24077.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes, but first it will go into `@guardian/libs`!

## What is the value of this and can you measure success?

More metrics when forced after page load.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Tested

- [X] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
