### PR TITLE
Remove qwery from component

### DIFF
--- a/static/src/javascripts/projects/common/modules/component.js
+++ b/static/src/javascripts/projects/common/modules/component.js
@@ -3,7 +3,6 @@
 import bean from 'bean';
 import bonzo from 'bonzo';
 import { fetchJson } from '../../../lib/fetch-json';
-import qwery from 'qwery';
 
 class ComponentError {
     constructor(message) {
@@ -237,7 +236,9 @@ class Component {
             return this.elems[elemName];
         }
 
-        const elem = qwery(this.getClass(elemName), this.elem)[0];
+        const selector = this.getClass(elemName);
+        // const elem = qwery(selector, this.elem)[0];
+        const elem = selector ? this.elem.querySelectorAll(selector)[0] : this.elem && this.elem.children[0];
 
         if (elem && this.elems) {
             this.elems[elemName] = elem;
@@ -255,7 +256,8 @@ class Component {
             className = (this.classes && this.classes[elemName]) || '';
         }
 
-        return (sansDot ? '' : '.') + className;
+        const selector = (sansDot ? '' : '.') + className;
+        return selector === '' || selector === '.' ? undefined : selector;
     }
 
     setState(state, elemName) {

--- a/static/src/javascripts/projects/common/modules/component.js
+++ b/static/src/javascripts/projects/common/modules/component.js
@@ -237,8 +237,14 @@ class Component {
         }
 
         const selector = this.getClass(elemName);
-        // const elem = qwery(selector, this.elem)[0];
-        const elem = selector ? this.elem.querySelectorAll(selector)[0] : this.elem && this.elem.children[0];
+        // Previously we used the qwery library to select elements from the DOM.
+        // The method signature of qwery is: `qwery(selector, context)`
+        // The previous code was: `const elem = qwery(selector, this.elem)[0];`
+        // qwery has a quirk in that it accepts invalid selectors and
+        // returns the children of context node (i.e. this.elem).
+        // We kept this behaviour to maintain backwards compatibility
+        const elem = selector ?
+            this.elem.querySelectorAll(selector)[0] : this.elem && this.elem.children[0];
 
         if (elem && this.elems) {
             this.elems[elemName] = elem;
@@ -257,6 +263,7 @@ class Component {
         }
 
         const selector = (sansDot ? '' : '.') + className;
+        // An invalid selector is returned as undefined
         return selector === '' || selector === '.' ? undefined : selector;
     }
 

--- a/static/src/javascripts/projects/common/modules/component.js
+++ b/static/src/javascripts/projects/common/modules/component.js
@@ -237,14 +237,17 @@ class Component {
         }
 
         const selector = this.getClass(elemName);
-        // Previously we used the qwery library to select elements from the DOM.
+        // Previously we used the qwery library to select elements from the DOM
         // The method signature of qwery is: `qwery(selector, context)`
+        // qwery defaults context to document
+        const context = this.elem ?? document;
         // The previous code was: `const elem = qwery(selector, this.elem)[0];`
-        // qwery has a quirk in that it accepts invalid selectors and
-        // returns the children of context node (i.e. this.elem).
-        // We kept this behaviour to maintain backwards compatibility
+        // qwery has a quirk in the case of an invalid selector it returns
+        // the children of the context node (i.e. this.elem)
+        // querySelectorAll will however throw an exception
+        // We kept the qwery behaviour to maintain backwards compatibility
         const elem = selector ?
-            this.elem.querySelectorAll(selector)[0] : this.elem && this.elem.children[0];
+            context.querySelectorAll(selector)[0] : context.children[0];
 
         if (elem && this.elems) {
             this.elems[elemName] = elem;

--- a/static/src/javascripts/projects/common/modules/component.spec.js
+++ b/static/src/javascripts/projects/common/modules/component.spec.js
@@ -190,8 +190,8 @@ describe('Component', () => {
             expect(component.getClass('element', true)).toBe(
                 'my-element-class'
             );
-            expect(component.getClass('element-2')).toBeDefined();
-            expect(component.getClass('element-2', true)).not.toBe('.');
+            expect(component.getClass('element-2')).toBeUndefined();
+            expect(component.getClass('element-2', true)).toBeUndefined();
         });
     });
 

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -608,7 +608,6 @@
  "../projects/common/modules/component.js": [
   "../../../../node_modules/bean/bean.js",
   "../../../../node_modules/bonzo/bonzo.js",
-  "../../../../node_modules/qwery/qwery.js",
   "../lib/fetch-json.ts"
  ],
  "../projects/common/modules/experiments/ab-constants.ts": [],


### PR DESCRIPTION
## What does this change?

Remove unmaintained library `qwery` from `modules/component`

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [x] On CODE (optional)
