### PR TITLE
RSS item guid is the item webUrl

### DIFF
--- a/common/app/common/TrailsToRss.scala
+++ b/common/app/common/TrailsToRss.scala
@@ -134,9 +134,6 @@ object TrailsToRss extends implicits.Collections {
       val entry = new SyndEntryImpl
       entry.setTitle(stripInvalidXMLCharacters(trail.fields.linkText))
       entry.setLink(trail.metadata.webUrl)
-      /* set http intentionally to not break existing guid */
-      entry.setUri("http://www.theguardian.com/" + trail.metadata.id)
-
       entry.setDescription(description)
       entry.setCategories(categories)
       entry.setModules(new java.util.ArrayList((mediaModules ++ Seq(dc)).asJava))

--- a/common/test/common/TrailsToRssTest.scala
+++ b/common/test/common/TrailsToRssTest.scala
@@ -52,7 +52,7 @@ class TrailsToRssTest extends FlatSpec with Matchers with GuiceOneAppPerSuite {
     val rss = XML.loadString(TrailsToRss(Option("foo"), trails)(request))
     val item =  (rss \ "channel" \ "item").head
     (item \ "link").text should be ("https://www.theguardian.com/a")
-    (item \ "guid").text should be ("http://www.theguardian.com/a")
+    (item \ "guid").text should be ("http://www.theguardian.com/a") // TODO this is not been applied to press page feeds
   }
 
   "TrailsToRss" should "produce a item description from each trail made up of the standfirst, an intro extracted from the first 2 paragraphs of the body and a read more prompt" in {

--- a/common/test/common/TrailsToRssTest.scala
+++ b/common/test/common/TrailsToRssTest.scala
@@ -50,9 +50,9 @@ class TrailsToRssTest extends FlatSpec with Matchers with GuiceOneAppPerSuite {
 
   "TrailsToRss" should "use webUrl as item guid" in {
     val rss = XML.loadString(TrailsToRss(Option("foo"), content)(request))
-    val item =  (rss \ "channel" \ "item").head
-    (item \ "link").text should be ("https://www.theguardian.com/a")
-    (item \ "guid").text should be ("https://www.theguardian.com/a")
+    val item = (rss \ "channel" \ "item").head
+    (item \ "link").text should be("https://www.theguardian.com/a")
+    (item \ "guid").text should be("https://www.theguardian.com/a")
   }
 
   "TrailsToRss" should "produce a item description from each trail made up of the standfirst, an intro extracted from the first 2 paragraphs of the body and a read more prompt" in {
@@ -68,7 +68,12 @@ class TrailsToRssTest extends FlatSpec with Matchers with GuiceOneAppPerSuite {
       scala.io.Source.fromFile(getClass.getClassLoader.getResource("liveblog-standfirst.html").getFile).mkString
     val liveblogBody =
       scala.io.Source.fromFile(getClass.getClassLoader.getResource("liveblog-body.html").getFile).mkString
-    val trail = testContent("a", "https://www.theguardian.com/a", standfirst = Some(liveblogStandfirst), body = Some(liveblogBody))
+    val trail = testContent(
+      "a",
+      "https://www.theguardian.com/a",
+      standfirst = Some(liveblogStandfirst),
+      body = Some(liveblogBody),
+    )
     val liveblogTrails = Seq(trail)
 
     val rss = XML.loadString(TrailsToRss(Option("foo"), liveblogTrails)(request))

--- a/common/test/common/TrailsToRssTest.scala
+++ b/common/test/common/TrailsToRssTest.scala
@@ -49,7 +49,7 @@ class TrailsToRssTest extends FlatSpec with Matchers with GuiceOneAppPerSuite {
   }
 
   "TrailsToRss" should "use link as the item guid as thats what we did for pressed fronts for along time" in {
-    val rss = XML.loadString(TrailsToRss(Option("foo"), content)(request))
+    val rss = XML.loadString(TrailsToRss(Option("foo"), trails)(request))
     val item =  (rss \ "channel" \ "item").head
     (item \ "link").text should be ("https://www.theguardian.com/a")
     (item \ "guid").text should be ("http://www.theguardian.com/a")

--- a/common/test/common/TrailsToRssTest.scala
+++ b/common/test/common/TrailsToRssTest.scala
@@ -48,18 +48,18 @@ class TrailsToRssTest extends FlatSpec with Matchers with GuiceOneAppPerSuite {
     (rss \ "channel" \ "item").size should be(2)
   }
 
-  "TrailsToRss" should "use link as the item guid as thats what we did for pressed fronts for along time" in {
-    val rss = XML.loadString(TrailsToRss(Option("foo"), trails)(request))
+  "TrailsToRss" should "use webUrl as item guid" in {
+    val rss = XML.loadString(TrailsToRss(Option("foo"), content)(request))
     val item =  (rss \ "channel" \ "item").head
     (item \ "link").text should be ("https://www.theguardian.com/a")
-    (item \ "guid").text should be ("http://www.theguardian.com/a") // TODO this is not been applied to press page feeds
+    (item \ "guid").text should be ("https://www.theguardian.com/a")
   }
 
   "TrailsToRss" should "produce a item description from each trail made up of the standfirst, an intro extracted from the first 2 paragraphs of the body and a read more prompt" in {
     val rss = XML.loadString(TrailsToRss(Option("foo"), content)(request))
     val firstTrailDescription = (rss \ "channel" \ "item" \ "description").head.text
     firstTrailDescription should be(
-      "The standfist<p>Paragraph 1</p><p>Paragraph 2</p> <a href=\"\">Continue reading...</a>",
+      "The standfist<p>Paragraph 1</p><p>Paragraph 2</p> <a href=\"https://www.theguardian.com/a\">Continue reading...</a>",
     )
   }
 


### PR DESCRIPTION
## What does this change?

Use the item webUrl is the RSS item guid for automatic tag feeds.
This makes tag feeds consistent with what has been happening for pressed fronts.

Currently in live:

Pressed front - https://www.theguardian.com/uk/rss
```
<item>
 <link>https://www.theguardian.com/politics/2021/aug/30/couple-divided-by-irish-border-because-of-post-brexit-rules</link>
 <guid>https://www.theguardian.com/politics/2021/aug/30/couple-divided-by-irish-border-because-of-post-brexit-rules</guid>
```

Tag front - https://www.theguardian.com/uk/ukcrime/rss
```
<item>
 <link>https://www.theguardian.com/uk-news/2021/aug/25/kevin-young-obituary</link>
 <guid isPermaLink="false">http://www.theguardian.com/uk-news/2021/aug/25/kevin-young-obituary</guid>
```

We could go either way to make these consistant but matching the pressed page format would favour the more prominent feeds.



No test coverage for the fromPressFront method which I'm guessing is because PressedPages are hard to setup. 
Showcase has todo that and we'll try to provided a fixture for that when we merge that work.


## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

Single format of guid across all RSS feeds.


## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
