### PR TITLE
Facebook https urls

### DIFF
--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -130,7 +130,7 @@ final case class Fields(
 
 object MetaData {
 
-  val StartDateForHttpsFacebookUrls: OffsetDateTime = OffsetDateTime.of(2021, 9, 3, 12, 0, 0, 0, ZoneOffset.UTC)
+  val StartDateForHttpsFacebookUrls: OffsetDateTime = OffsetDateTime.of(2021, 9, 6, 16, 0, 0, 0, ZoneOffset.UTC)
 
   def make(
       id: String,

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -130,7 +130,7 @@ final case class Fields(
 
 object MetaData {
 
-  val StartDateForHttpsFacebookUrls: OffsetDateTime = OffsetDateTime.of(2021, 9, 6, 16, 0, 0, 0, ZoneOffset.UTC)
+  val StartDateForHttpsFacebookUrls: OffsetDateTime = OffsetDateTime.of(2021, 9, 6, 13, 0, 0, 0, ZoneOffset.UTC)
 
   def make(
       id: String,

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -22,10 +22,11 @@ import play.api.libs.json.JodaWrites.JodaDateTimeWrites
 import play.api.libs.functional.syntax._
 import play.api.mvc.RequestHeader
 import navigation.GuardianFoundationHelper
-import org.joda.time.DateTimeZone
 
 import scala.util.matching.Regex
 import utils.ShortUrls
+
+import java.time.{OffsetDateTime, ZoneId, ZoneOffset}
 
 object Commercial {
 
@@ -129,7 +130,7 @@ final case class Fields(
 
 object MetaData {
 
-  val StartDateForHttpsFacebookUrls: DateTime = new DateTime(2021, 9, 3, 12, 0, 0).withZone(DateTimeZone.UTC)
+  val StartDateForHttpsFacebookUrls: OffsetDateTime = OffsetDateTime.of(2021, 9, 3, 12, 0, 0, 0, ZoneOffset.UTC)
 
   def make(
       id: String,
@@ -392,7 +393,8 @@ final case class MetaData(
       // When we migrated to https in 2016 we kept all og:urls as http to preserve engagement counts.
       // In 2021 at Facebook's request we began advertising https urls for newly published content
       // Any page which was able to supply a known first publication date with it's page meta data can benefit from this.
-      firstPublished.isAfter(MetaData.StartDateForHttpsFacebookUrls)
+      val firstPublishedLocalDateTime = firstPublished.date.toInstant.atZone(ZoneId.systemDefault()).toLocalDateTime
+      firstPublishedLocalDateTime.isAfter(MetaData.StartDateForHttpsFacebookUrls.toLocalDateTime)
     }
 
     val webUrlToAdvertise = if (shouldAdvertiseHttpsUrlToFacebook) {

--- a/common/test/model/MetaDataTest.scala
+++ b/common/test/model/MetaDataTest.scala
@@ -39,22 +39,11 @@ class MetaDataTest extends FlatSpec with Matchers {
     references = Nil,
   )
 
-  val ukWeatherTag = ApiTag(
-    id = "uk/weather",
-    `type` = TagType.Keyword,
-    webTitle = "",
-    sectionId = None,
-    sectionName = None,
-    webUrl = "",
-    apiUrl = "apiurl",
-    references = Nil,
-  )
-
   val cutoffDate = new DateTime("2017-07-03T12:00:00.000Z")
   val dateBeforeCutoff = new DateTime("2017-07-02T12:00:00.000Z")
   val dateAfterCutoff = new DateTime("2017-07-04T12:00:00.000Z")
   val dateBeforeHttpsMigration = new DateTime("2013-07-02T12:00:00.000Z")
-  val dateAfterWeStartedAdvertistingHttpsUrlsToFacebook = new DateTime("2021-11-02T12:00:00.000Z")
+  val dateAfterWeStartedAdvertistingHttpsUrlsToFacebook = MetaData.StartDateForHttpsFacebookUrls.plusWeeks(2)
 
   private def contentApi(
       shouldHideReaderRevenue: Option[Boolean] = None,
@@ -162,7 +151,6 @@ class MetaDataTest extends FlatSpec with Matchers {
       publicationDate = dateAfterWeStartedAdvertistingHttpsUrlsToFacebook,
       firstPublicationDate = Some(dateAfterWeStartedAdvertistingHttpsUrlsToFacebook),
       webUrl = "https://www.theguardian.com/football/2021/nov/16/top-flight-team-conceded-most-goals",
-      tag = ukWeatherTag,
     )
     val fields = Fields.make(content)
     val metaData = MetaData.make(fields, content)
@@ -179,7 +167,6 @@ class MetaDataTest extends FlatSpec with Matchers {
       publicationDate = dateBeforeHttpsMigration,
       firstPublicationDate = Some(dateBeforeHttpsMigration),
       webUrl = "https://www.theguardian.com/football/2013/jan/16/top-flight-team-conceded-most-goals",
-      tag = ukWeatherTag,
     )
     val fields = Fields.make(content)
     val metaData = MetaData.make(fields, content)
@@ -196,7 +183,6 @@ class MetaDataTest extends FlatSpec with Matchers {
       publicationDate = dateAfterWeStartedAdvertistingHttpsUrlsToFacebook,
       firstPublicationDate = None,
       webUrl = "https://www.theguardian.com/football/2021/nov/16/top-flight-team-conceded-most-goals",
-      tag = ukWeatherTag,
     )
     val fields = Fields.make(content)
     val metaData = MetaData.make(fields, content)

--- a/common/test/model/MetaDataTest.scala
+++ b/common/test/model/MetaDataTest.scala
@@ -6,6 +6,7 @@ import com.gu.contentapi.client.utils.CapiModelEnrichment.RichOffsetDateTime
 import implicits.Dates.jodaToJavaInstant
 import org.scalatest.{FlatSpec, Matchers}
 import org.joda.time.DateTime
+import common.Chronos
 
 class MetaDataTest extends FlatSpec with Matchers {
 
@@ -43,7 +44,8 @@ class MetaDataTest extends FlatSpec with Matchers {
   val dateBeforeCutoff = new DateTime("2017-07-02T12:00:00.000Z")
   val dateAfterCutoff = new DateTime("2017-07-04T12:00:00.000Z")
   val dateBeforeHttpsMigration = new DateTime("2013-07-02T12:00:00.000Z")
-  val dateAfterWeStartedAdvertistingHttpsUrlsToFacebook = MetaData.StartDateForHttpsFacebookUrls.plusWeeks(2)
+  val dateAfterWeStartedAdvertistingHttpsUrlsToFacebook =
+    MetaData.StartDateForHttpsFacebookUrls.plusWeeks(2).toLocalDateTime
 
   private def contentApi(
       shouldHideReaderRevenue: Option[Boolean] = None,
@@ -148,8 +150,9 @@ class MetaDataTest extends FlatSpec with Matchers {
 
   it should "show https Facebook og:url for content first published after our decision to start advertisng https canonical urls to Facebook" in {
     val content = contentApi(
-      publicationDate = dateAfterWeStartedAdvertistingHttpsUrlsToFacebook,
-      firstPublicationDate = Some(dateAfterWeStartedAdvertistingHttpsUrlsToFacebook),
+      publicationDate = Chronos.javaLocalDateTimeToJodaDateTime(dateAfterWeStartedAdvertistingHttpsUrlsToFacebook),
+      firstPublicationDate =
+        Some(Chronos.javaLocalDateTimeToJodaDateTime(dateAfterWeStartedAdvertistingHttpsUrlsToFacebook)),
       webUrl = "https://www.theguardian.com/football/2021/nov/16/top-flight-team-conceded-most-goals",
     )
     val fields = Fields.make(content)
@@ -180,7 +183,7 @@ class MetaDataTest extends FlatSpec with Matchers {
 
   it should "pages with no explict first published date should continue to show http og:urls" in {
     val content = contentApi(
-      publicationDate = dateAfterWeStartedAdvertistingHttpsUrlsToFacebook,
+      publicationDate = Chronos.javaLocalDateTimeToJodaDateTime(dateAfterWeStartedAdvertistingHttpsUrlsToFacebook),
       firstPublicationDate = None,
       webUrl = "https://www.theguardian.com/football/2021/nov/16/top-flight-team-conceded-most-goals",
     )


### PR DESCRIPTION
## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
