### PR TITLE
Centre Ads in `top-abov-nav`

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -85,6 +85,12 @@
     background-color: $brightness-100;
     border-bottom: 1px solid $brightness-86;
 
+    min-height: 250px + 24px;
+    padding-bottom: $gs-row-height / 2;
+    display: flex;
+    flex-wrap: wrap;
+    align-content: center;
+
     // Needed for compatibility with IE11/Edge.
     top: 0;
 
@@ -134,15 +140,15 @@
 .ad-slot--crossword-banner,
 .ad-slot--top-banner-ad-desktop {
     margin: 0 auto;
-    min-height: 250px;
-    padding-bottom: $gs-row-height / 2;
+    min-height: 90px;
+    padding-bottom: 0;
 
     @include mq($until: tablet) {
         display: none;
     }
 
     text-align: left;
-    display: table;
+    display: block;
 
     &.ad-slot--fabric {
         > .ad-slot__label {


### PR DESCRIPTION
## What does this change?

Allows top-above nav to be centred, including the ad slot label.

This moves the styling to the parent element, and uses `block` and `flex`. Previously, `table` was used–see #19412. We introduced the 250px height in #24095.

This needs to be monitored closely as it may have unforseen impacts.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes &rarr; https://github.com/guardian/dotcom-rendering/pull/3353

## What is the value of this and can you measure success?

Better visibility, more balanced layout.

### Screenshot comparison

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/131529388-5b8aceff-e4fd-461e-ae8e-ee73b3bbe714.png
[after]: https://user-images.githubusercontent.com/76776/131529505-1ea8f61d-9941-4deb-9bf9-d778a025325b.png


## Checklist

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
