### PR TITLE
Do not reserve space for `top-above-nav` on mobile

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -82,6 +82,13 @@
  */
 
 .top-banner-ad-container {
+
+    // Don’t show below tablet
+    // On mobile, top-above-nav is inline
+    @include mq($until: tablet) {
+        display: none !important;
+    }
+
     background-color: $brightness-100;
     border-bottom: 1px solid $brightness-86;
 

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -85,6 +85,7 @@
 
     // Don’t show below tablet
     // On mobile, top-above-nav is inline
+    // See also .ad-slot--top-banner-ad-desktop
     @include mq($until: tablet) {
         display: none !important;
     }


### PR DESCRIPTION
## What does this change?

Hide `top-above-nav` for mobile below tablet. Previously, the styling was on its children: `.ad-slot--top-banner-ad-desktop`

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/131652871-f72f094e-5901-4a88-b2da-bbd6954acd06.png
[after]: https://user-images.githubusercontent.com/76776/131652881-9fd1a5de-ec6e-4177-9880-dd0457fe5f35.png


## What is the value of this and can you measure success?

Large unused space on mobile is gone! Follow-up on #24037

## Checklist

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
