### PR TITLE
Roll out the Standalone Commercial Bundle 📦 to 6%

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -38,5 +38,14 @@ object StandaloneCommercialBundle
       description = "Serve a standalone commercial bundle to a subset of users",
       owners = Seq(Owner.withGithub("mxdvl")),
       sellByDate = LocalDate.of(2021, 10, 1),
-      participationGroup = Perc0E,
+      participationGroup = Perc5A,
+    )
+
+object StandaloneCommercialBundleTracking
+    extends Experiment(
+      name = "standalone-commercial-bundle-tracking",
+      description = "Track performance metrics for the standalone commercial bundle",
+      owners = Seq(Owner.withGithub("mxdvl")),
+      sellByDate = LocalDate.of(2021, 10, 1),
+      participationGroup = Perc1A,
     )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -9,6 +9,7 @@ object ActiveExperiments extends ExperimentsDefinition {
     LiveblogRendering,
     InteractiveLibrarianExp,
     StandaloneCommercialBundle,
+    StandaloneCommercialBundleTracking,
   )
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -8,7 +8,7 @@ import common.commercial.EditionCommercialProperties
 import common.{Edition, Localisation, RichRequestHeader}
 import conf.Configuration
 import conf.switches.Switches
-import experiments.{ActiveExperiments, StandaloneCommercialBundle}
+import experiments.ActiveExperiments
 import model.dotcomrendering.pageElements.{PageElement, TextCleaner}
 import model.{
   ArticleDateTimes,

--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -10,7 +10,7 @@ import conf.{Configuration, DiscussionAsset}
 import model._
 import play.api.libs.json._
 import model.IpsosTags.getScriptTag
-import experiments.{ActiveExperiments, StandaloneCommercialBundle}
+import experiments.{ActiveExperiments, StandaloneCommercialBundle, StandaloneCommercialBundleTracking}
 import model.dotcomrendering.DotcomRenderingUtils.assetURL
 import play.api.mvc.RequestHeader
 
@@ -70,7 +70,10 @@ object JavaScriptPage {
     val ipsos = if (page.metadata.isFront) getScriptTag(page.metadata.id) else getScriptTag(page.metadata.sectionId)
 
     val commercialBundleUrl: Map[String, JsString] =
-      if (ActiveExperiments.isParticipating(StandaloneCommercialBundle)(request))
+      if (
+        ActiveExperiments.isParticipating(StandaloneCommercialBundle)(request)
+        || ActiveExperiments.isParticipating(StandaloneCommercialBundleTracking)(request)
+      )
         Map("commercialBundleUrl" -> JsString(assetURL("javascripts/commercial/graun.standalone.commercial.js")))
       else
         Map("commercialBundleUrl" -> JsString(assetURL("javascripts/graun.commercial.dcr.js")))

--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -5,7 +5,6 @@ import common.Edition
 import common.Maps.RichMap
 import common.commercial.EditionAdTargeting._
 import conf.Configuration.environment
-import model.IpsosTags.getScriptTag
 import conf.{Configuration, DiscussionAsset}
 import model._
 import play.api.libs.json._

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -73,9 +73,13 @@ const go = () => {
         }
 
         const fakeBootCommercial = { bootCommercial: () => {} }
-        const useStandaloneBundle =
+		const useStandaloneBundle =
 			config.get('tests.standaloneCommercialBundleVariant', false) ===
-			'variant';
+				'variant' ||
+			config.get(
+				'tests.standaloneCommercialBundleTrackingVariant',
+				false,
+			) === 'variant';
 		const commercialBundle = () =>
 			useStandaloneBundle
 				? loadScript(

--- a/static/src/javascripts/bootstraps/standalone.commercial.ts
+++ b/static/src/javascripts/bootstraps/standalone.commercial.ts
@@ -177,9 +177,7 @@ const bootCommercial = async (): Promise<void> => {
 				},
 			],
 		],
-		{
-			feature: 'commercial',
-		},
+		tags,
 	);
 
 	// Stub the command queue

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -61,6 +61,7 @@ const sendData = () => {
 		},
 		referrerPolicy: 'no-referrer',
 		body: JSON.stringify(jsonData),
+		keepalive: true,
 	})
 		.then(() => {
 			log('dotcom', 'Successfully recorded Core Web Vitals');

--- a/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
@@ -2,7 +2,9 @@ import type { ABTest } from '@guardian/ab-core';
 import { getSynchronousTestsToRun } from '../experiments/ab';
 
 const defaultClientSideTests: ABTest[] = [];
-const serverSideTests: string[] = [];
+const serverSideTests: ServerSideABTest[] = [
+	'standaloneCommercialBundleTrackingVariant',
+];
 
 /**
  * Function to check wether metrics should be captured for the current page
@@ -18,7 +20,7 @@ const shouldCaptureMetrics = (tests = defaultClientSideTests): boolean => {
 	const userInServerSideTest =
 		window.guardian.config.tests !== undefined &&
 		Object.keys(window.guardian.config.tests).some((test) =>
-			serverSideTests.includes(test),
+			serverSideTests.includes(test as ServerSideABTest),
 		);
 	return userInClientSideTest || userInServerSideTest;
 };

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -1,3 +1,5 @@
+type ServerSideABTest = `${string}${'Variant' | 'Control'}`;
+
 declare const twttr: {
 	widgets?: {
 		load?: (arg0: Element | null | undefined) => void;
@@ -64,7 +66,7 @@ interface Config {
 	};
 	page: PageConfig;
 	switches: Record<string, boolean | undefined>;
-	tests?: Record<string, 'control' | 'variant'>;
+	tests?: Record<ServerSideABTest, 'control' | 'variant'>;
 	isDotcomRendering: boolean;
 }
 

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -685,7 +685,6 @@
  "../projects/common/modules/spacefinder.js": [
   "../../../../node_modules/bean/bean.js",
   "../../../../node_modules/lodash-es/lodash.js",
-  "../../../../node_modules/qwery/qwery.js",
   "../lib/fastdom-promise.js",
   "../lib/mediator.js"
  ],


### PR DESCRIPTION
## What does this change?

Roll out the standalone commercial bundle introduced in #24058 to 5% + 1% of users.

- 5% to reach a wider audience and hopefully catch more raven errors
- 1% to capture performance metrics, which will hopefully be better than the baseline.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes (it will be automatic)

## What is the value of this and can you measure success?

This is the next step in extracting the commercial code from `frontend`. Success would be a significantly equivalent or better performance for these users.

## Checklist

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
