### PR TITLE
Log caching-related headers

### DIFF
--- a/common/app/common/RequestLogger.scala
+++ b/common/app/common/RequestLogger.scala
@@ -23,6 +23,7 @@ case class RequestLoggerFields(request: Option[RequestHeader], response: Option[
       "Fastly-FF",
       "Fastly-SSL",
       "Fastly-Digest",
+      "Accept-Encoding", // TODO remove if seen after 2021/09/03
     )
     val allHeadersFields = request
       .map {
@@ -52,6 +53,7 @@ case class RequestLoggerFields(request: Option[RequestHeader], response: Option[
         List[LogField](
           "resp.status" -> r.header.status,
           "resp.dotcomponents" -> r.header.headers.get("X-GU-Dotcomponents").isDefined,
+          "resp.Vary" -> r.header.headers.get("Vary").getOrElse(""), // TODO remove if seen after 2021/09/03
         )
       }
       .getOrElse(Nil)

--- a/common/app/http/Filters.scala
+++ b/common/app/http/Filters.scala
@@ -121,8 +121,7 @@ class PanicSheddingFilter(implicit val mat: Materializer, executionContext: Exec
 }
 
 object Filters {
-  // NOTE - order is important here, Gzipper AFTER JsonVaryHeaders
-  // which effectively means "JsonVaryHeaders goes around Gzipper"
+  // NOTE: filters are executed in *reverse* order, and the order is important.
   def common(implicit
       materializer: Materializer,
       applicationContext: ApplicationContext,


### PR DESCRIPTION
Logs:

* Vary response header
* Accept-Encoding request header

The former directly splits the cache. The latter helps us understand the range of values here (as we split the cache on this header for every request).

This is temporary to enable better understanding of our cache splitting and will be removed either later today or early next week.
