### PR TITLE
Temporary fix for bonzai page skin - do not display the top banner ad container

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -603,3 +603,11 @@
 .ad-slot--collapse {
     display: none;
 }
+
+/**
+ * Hides the top-above-nav ad-slot container when a
+ * Bonzai TrueSkin (Australian 3rd Party page skin) is shown
+ */
+.bz-custom-container ~ #bannerandheader > .top-banner-ad-container {
+    display: none;
+}


### PR DESCRIPTION
## What does this change?

Hides the top-above-nav ad-slot container when a Bonzai TrueSkin (Australian 3rd Party page skin) is shown

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/7014230/132022963-09e7b374-5aa7-4297-a72d-61573c855e7f.png)

