### PR TITLE
Retrieve newsletters using newsletter agent on complete consents flow

### DIFF
--- a/common/app/services/newsletters/NewsletterSignupAgent.scala
+++ b/common/app/services/newsletters/NewsletterSignupAgent.scala
@@ -86,6 +86,14 @@ class NewsletterSignupAgent(newsletterApi: NewsletterApi) extends GuLogging {
     }
   }
 
+  def getNewsletters(): Either[String, List[NewsletterResponse]] = {
+    newslettersAgent.get() match {
+      case Left(err) => Left(err)
+      case Right(newsletters) =>
+        Right(newsletters)
+    }
+  }
+
   def refresh()(implicit ec: ExecutionContext): Unit = {
     refreshNewsletters()
     refreshGroupedNewsletters()

--- a/common/app/services/newsletters/NewsletterSignupAgent.scala
+++ b/common/app/services/newsletters/NewsletterSignupAgent.scala
@@ -78,21 +78,9 @@ class NewsletterSignupAgent(newsletterApi: NewsletterApi) extends GuLogging {
 
   }
 
-  def getGroupedNewsletters(): Either[String, GroupedNewslettersResponse] = {
-    groupedNewslettersAgent.get() match {
-      case Left(err) => Left(err)
-      case Right(groupedNewsletters) =>
-        Right(groupedNewsletters)
-    }
-  }
+  def getGroupedNewsletters(): Either[String, GroupedNewslettersResponse] = groupedNewslettersAgent.get()
 
-  def getNewsletters(): Either[String, List[NewsletterResponse]] = {
-    newslettersAgent.get() match {
-      case Left(err) => Left(err)
-      case Right(newsletters) =>
-        Right(newsletters)
-    }
-  }
+  def getNewsletters(): Either[String, List[NewsletterResponse]] = newslettersAgent.get()
 
   def refresh()(implicit ec: ExecutionContext): Unit = {
     refreshNewsletters()

--- a/identity/app/controllers/editprofile/EditProfileController.scala
+++ b/identity/app/controllers/editprofile/EditProfileController.scala
@@ -8,6 +8,7 @@ import model._
 import play.api.http.HttpConfiguration
 import play.api.mvc._
 import play.filters.csrf.{CSRFAddToken, CSRFCheck}
+import services.newsletters.NewsletterSignupAgent
 import services.{IdRequestParser, IdentityUrlBuilder, ReturnUrlVerifier, _}
 
 class EditProfileController(
@@ -20,6 +21,7 @@ class EditProfileController(
     override val returnUrlVerifier: ReturnUrlVerifier,
     override val newsletterService: NewsletterService,
     override val signinService: PlaySigninService,
+    override val newsletterSignupAgent: NewsletterSignupAgent,
     override implicit val profileFormsMapping: ProfileFormsMapping,
     override implicit val context: ApplicationContext,
     val httpConfiguration: HttpConfiguration,

--- a/identity/app/views/completeConsents.scala.html
+++ b/identity/app/views/completeConsents.scala.html
@@ -1,6 +1,6 @@
 @import services.EmailPrefsData
 
-@import com.gu.identity.model.EmailNewsletter
+@import services.newsletters.NewsletterResponse
 @(
     idRequest: services.IdentityRequest,
     idUrlBuilder: services.IdentityUrlBuilder,
@@ -8,7 +8,7 @@
     email: String,
     emailPrefsForm: Form[EmailPrefsData],
     emailSubscriptions: List[String],
-    availableLists: List[EmailNewsletter],
+    availableLists: List[NewsletterResponse],
 )(implicit request: RequestHeader, messages: play.api.i18n.Messages)
 
 @import common.LinkTo

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -12,7 +12,7 @@
 @import controllers.editprofile.ProfileForms
 @import _root_.utils.ConsentsJourneyType._
 
-@import com.gu.identity.model.EmailNewsletter
+@import services.newsletters.NewsletterResponse
 @(
     user: com.gu.identity.model.User,
     forms: ProfileForms,
@@ -22,7 +22,7 @@
     idUrlBuilder: services.IdentityUrlBuilder,
     emailPrefsForm: Form[EmailPrefsData],
     emailSubscriptions: List[String],
-    availableLists: List[EmailNewsletter],
+    availableLists: List[NewsletterResponse],
     consentHint: Option[String] = None,
     skin: Option[String] = None)(implicit request: RequestHeader, messages: play.api.i18n.Messages, context: model.ApplicationContext)
 

--- a/identity/app/views/fragments/emailListCategories.scala.html
+++ b/identity/app/views/fragments/emailListCategories.scala.html
@@ -1,16 +1,16 @@
 @import _root_.form.IdFormHelpers.nonInputFields
-@import _root_.com.gu.identity.model.EmailNewsletter
 @import services.EmailPrefsData
 @import views.support.`package`.Seq2zipWithRowInfo
+@import services.newsletters.NewsletterResponse
 
 @(
     emailPrefsForm: Form[EmailPrefsData],
-    availableLists: List[EmailNewsletter],
+    availableLists: List[NewsletterResponse],
     emailSubscriptions: List[String],
     startsOpen: Boolean = false
 )(implicit request: RequestHeader, messages: play.api.i18n.Messages)
 
-@emailListCategoryList(theme: String, newsletters: List[EmailNewsletter], isActive: Boolean) = {
+@emailListCategoryList(theme: String, newsletters: List[NewsletterResponse], isActive: Boolean) = {
     @fragments.dropdown(theme.capitalize, modifier = Some("email-subscription"), isActive = isActive, isAnimated = true) {
         <div class="manage-account__switches manage-account__switches--single-column">
             <ul>

--- a/identity/app/views/fragments/newsletterSwitch.scala.html
+++ b/identity/app/views/fragments/newsletterSwitch.scala.html
@@ -1,19 +1,19 @@
-@import com.gu.identity.model.EmailNewsletter
 @import common.LinkTo
 @import _root_.form.IdFormHelpers.nonInputFields
 @import views.support.fragment.Switch._
+@import services.newsletters.NewsletterResponse
 
 @* Editorial Newsletter switch/checkbox *@
 
 @(
     emailPrefsForm: Form[_],
     emailSubscriptions: List[String],
-    newsletter: EmailNewsletter,
+    newsletter: NewsletterResponse,
     unchecked: Boolean = false,
     skin: Option[String] = None
 )(implicit handler: views.html.helper.FieldConstructor, messages: play.api.i18n.Messages, request: RequestHeader)
 
-@buildFooter(newsletter: EmailNewsletter) = {
+@buildFooter(newsletter: NewsletterResponse) = {
     <div class="manage-account__switch-footer-tidbit">
         @fragments.inlineSvg("clock", "icon", List("inline-icon--light-grey"))
         @newsletter.frequency
@@ -33,7 +33,7 @@
     if (unchecked)
         None
     else {
-        Some(newsletter.subscribedTo(emailSubscriptions).toString)
+        Some(emailSubscriptions.contains(newsletter.listId.toString).toString)
     }
 }
 
@@ -56,5 +56,5 @@
     extraFields = Nil,
     footer = Some(buildFooter(newsletter)),
     skin = skin,
-    newsletterIdentityName = Some(newsletter.identityName)
+    newsletterIdentityName = Some(newsletter.id)
 )(nonInputFields, messages)

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -2,11 +2,12 @@
 
 @import com.gu.identity.model.User
 @import com.gu.identity.model.EmailNewsletter
+@import services.newsletters.NewsletterResponse
 @(
     page: model.Page,
     emailPrefsForm: Form[EmailPrefsData],
     emailSubscriptions: List[String],
-    availableLists: List[EmailNewsletter],
+    availableLists: List[NewsletterResponse],
     idRequest: services.IdentityRequest,
     idUrlBuilder: services.IdentityUrlBuilder)(implicit request: RequestHeader, messages: play.api.i18n.Messages)
 

--- a/identity/app/views/profile/privacyForm.scala.html
+++ b/identity/app/views/profile/privacyForm.scala.html
@@ -6,15 +6,15 @@
 @import services.EmailPrefsData
 @import views.support.fragment.Switch._
 @import views.support.fragment.ConsentChannel._
+@import services.newsletters.NewsletterResponse
 
-@import com.gu.identity.model.EmailNewsletter
 @(idUrlBuilder: services.IdentityUrlBuilder,
   idRequest: services.IdentityRequest,
   user: com.gu.identity.model.User,
   privacyForm: Form[_root_.form.PrivacyFormData],
   emailPrefsForm: Form[EmailPrefsData],
   emailSubscriptions: List[String],
-  availableLists: List[EmailNewsletter],
+  availableLists: List[NewsletterResponse],
   consentsUpdated: Boolean = false,
   consentHint: Option[String] = None
 )(implicit request: RequestHeader, messages: play.api.i18n.Messages)

--- a/identity/test/controllers/ConsentsJourneyControllerTest.scala
+++ b/identity/test/controllers/ConsentsJourneyControllerTest.scala
@@ -19,6 +19,7 @@ import _root_.play.api.http.HttpConfiguration
 import _root_.play.api.mvc._
 import _root_.play.api.test.Helpers._
 import services._
+import services.newsletters.NewsletterSignupAgent
 import test._
 
 import scala.concurrent.Future
@@ -46,6 +47,7 @@ import scala.concurrent.Future
     val returnUrlVerifier = mock[ReturnUrlVerifier]
     val newsletterService = spy(new NewsletterService(api, idRequestParser, idUrlBuilder))
     val httpConfiguration = HttpConfiguration.createWithDefaults()
+    val newsletterSignupAgent = mock[NewsletterSignupAgent]
 
     val userId: String = "123"
     val user = User("test@example.com", userId, statusFields = StatusFields(userEmailValidated = Some(true)))
@@ -79,6 +81,7 @@ import scala.concurrent.Future
     when(api.userEmails(anyString(), any[TrackingData])) thenReturn Future.successful(
       Right(Subscriber("Text", List(EmailList("37")), "subscribed")),
     )
+    when(newsletterSignupAgent.getNewsletters()) thenReturn Right(Nil)
 
     lazy val controller = new EditProfileController(
       idUrlBuilder,
@@ -90,6 +93,7 @@ import scala.concurrent.Future
       returnUrlVerifier,
       newsletterService,
       signinService,
+      newsletterSignupAgent,
       profileFormsMapping,
       testApplicationContext,
       httpConfiguration,

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -23,7 +23,9 @@ import _root_.play.api.mvc._
 import _root_.play.api.test.FakeRequest
 import _root_.play.api.test.Helpers._
 import services._
+import services.newsletters.NewsletterSignupAgent
 import test._
+
 import scala.concurrent.Future
 
 //TODO test form validation and population of form fields.
@@ -50,6 +52,7 @@ import scala.concurrent.Future
     val returnUrlVerifier = mock[ReturnUrlVerifier]
     val newsletterService = spy(new NewsletterService(api, idRequestParser, idUrlBuilder))
     val httpConfiguration = HttpConfiguration.createWithDefaults()
+    val newsletterSignupAgent = mock[NewsletterSignupAgent]
 
     val userId: String = "123"
     val user = User("test@example.com", userId, statusFields = StatusFields(userEmailValidated = Some(true)))
@@ -76,6 +79,7 @@ import scala.concurrent.Future
     when(idRequestParser.apply(MockitoMatchers.any[RequestHeader])) thenReturn idRequest
     when(idRequest.trackingData) thenReturn trackingData
     when(idRequest.returnUrl) thenReturn None
+    when(newsletterSignupAgent.getNewsletters()) thenReturn Right(Nil)
 
     when(api.userEmails(MockitoMatchers.anyString(), MockitoMatchers.any[TrackingData])) thenReturn Future.successful(
       Right(Subscriber("Text", List(EmailList("37")), "subscribed")),
@@ -91,6 +95,7 @@ import scala.concurrent.Future
       returnUrlVerifier,
       newsletterService,
       signinService,
+      newsletterSignupAgent,
       profileFormsMapping,
       testApplicationContext,
       httpConfiguration,


### PR DESCRIPTION
## What does this change?

Retrieve newsletters using newsletter agent on complete consents flow
This means we don't need to release the Identity library on newsletter changes

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

We don't have to release the Identity library on newsletter changes. The agent fetches the list of newsletters from the Identity library

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
Test in CODE before releasing
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
