### PR TITLE
Remove Paralympics from Sport Nav

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -112,7 +112,6 @@ private object NavLinks {
     ),
   )
   val soccer = football.copy(title = "Soccer")
-  val paralympics = NavLink("Tokyo 2020 Paralympics", "/sport/paralympic-games-2020")
   val cricket = NavLink("Cricket", "/sport/cricket")
   val cycling = NavLink("Cycling", "/sport/cycling")
   val rugbyUnion = NavLink("Rugby union", "/sport/rugby-union")
@@ -365,7 +364,6 @@ private object NavLinks {
     longTitle = Some("Sport home"),
     iconName = Some("home"),
     List(
-      paralympics,
       football,
       cricket,
       rugbyUnion,
@@ -381,7 +379,6 @@ private object NavLinks {
   )
   val auSportPillar = ukSportPillar.copy(
     children = List(
-      paralympics,
       football,
       AFL,
       NRL,
@@ -395,7 +392,6 @@ private object NavLinks {
   )
   val usSportPillar = ukSportPillar.copy(
     children = List(
-      paralympics,
       soccer,
       NFL,
       tennis,


### PR DESCRIPTION
## What does this change?

Removes the Tokyo Paralympic games from the sports nav.

## Screenshots

Before:
![Screenshot 2021-09-06 at 13 15 19](https://user-images.githubusercontent.com/35331926/132216380-ecb9a248-2dfd-4f19-b9a2-54ce9b50a8de.png)

After (locally run)
![Screenshot 2021-09-06 at 13 14 55](https://user-images.githubusercontent.com/35331926/132216331-26abd0a8-8c32-45d4-85c9-36ac6e4a04b5.png)



### Tested

- [x] Locally
- [ ] On CODE (optional)

