### PR TITLE
Add A/B test to remove sticky behaviour from navigation menu in DCR

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -24,7 +24,7 @@ trait ABTestSwitches {
     exposeClientSide = true,
   )
 
-    Switch(
+  Switch(
     ABTests,
     "ab-remove-sticky-nav",
     "Remove sticky behaviour from the navigation and subnavigation bar",

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -23,4 +23,14 @@ trait ABTestSwitches {
     sellByDate = Some(LocalDate.of(2021, 12, 1)),
     exposeClientSide = true,
   )
+
+    Switch(
+    ABTests,
+    "ab-remove-sticky-nav",
+    "Remove sticky behaviour from the navigation and subnavigation bar",
+    owners = Seq(Owner.withGithub("MarSavar")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2021, 10, 10)),
+    exposeClientSide = true,
+  )
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -30,7 +30,7 @@ trait ABTestSwitches {
     "Remove sticky behaviour from the navigation and subnavigation bar",
     owners = Seq(Owner.withGithub("MarSavar")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2021, 10, 10)),
+    sellByDate = Some(LocalDate.of(2021, 10, 8)),
     exposeClientSide = true,
   )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -4,7 +4,7 @@ import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
 
 // keep in sync with ab-tests in dotcom-rendering
-// https://github.com/guardian/dotcom-rendering/tree/main/src/web/experiments/ab-tests.ts
+// https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/experiments/ab-tests.ts
 export const concurrentTests: readonly ABTest[] = [
 	signInGateMainVariant,
 	signInGateMainControl,

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -1,5 +1,6 @@
 import type { ABTest } from '@guardian/ab-core';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
+import { removeStickyNav } from './tests/remove-sticky-nav';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
 
@@ -9,4 +10,5 @@ export const concurrentTests: readonly ABTest[] = [
 	signInGateMainVariant,
 	signInGateMainControl,
 	remoteRRHeaderLinksTest,
+	removeStickyNav,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/remove-sticky-nav.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/remove-sticky-nav.ts
@@ -2,7 +2,7 @@ import type { ABTest } from '@guardian/ab-core';
 
 export const removeStickyNav: ABTest = {
 	id: 'RemoveStickyNav',
-	start: '2021-09-10',
+	start: '2021-09-06',
 	expiry: '2021-10-10',
 	author: 'Mario Savarese',
 	description:

--- a/static/src/javascripts/projects/common/modules/experiments/tests/remove-sticky-nav.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/remove-sticky-nav.ts
@@ -3,7 +3,7 @@ import type { ABTest } from '@guardian/ab-core';
 export const removeStickyNav: ABTest = {
 	id: 'RemoveStickyNav',
 	start: '2021-09-06',
-	expiry: '2021-10-10',
+	expiry: '2021-10-08',
 	author: 'Mario Savarese',
 	description:
 		'Remove the sticky behaviour of the navigation and subnavigation bars',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/remove-sticky-nav.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/remove-sticky-nav.ts
@@ -1,0 +1,24 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const removeStickyNav: ABTest = {
+	id: 'RemoveStickyNav',
+	start: '2021-09-10',
+	expiry: '2021-10-10',
+	author: 'Mario Savarese',
+	description:
+		'Remove the sticky behaviour of the navigation and subnavigation bars',
+	audience: 0.01,
+	audienceOffset: 0,
+	successMeasure: 'Ad viewability score shows improvement.',
+	audienceCriteria: 'DCR-rendered articles',
+	showForSensitive: true,
+	variants: [
+		{
+			id: 'variant',
+			test: (): void => {
+				// debug
+			},
+		},
+	],
+	canRun: () => true,
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/remove-sticky-nav.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/remove-sticky-nav.ts
@@ -8,7 +8,7 @@ export const removeStickyNav: ABTest = {
 	description:
 		'Remove the sticky behaviour of the navigation and subnavigation bars',
 	audience: 0.01,
-	audienceOffset: 0,
+	audienceOffset: 0.5,
 	successMeasure: 'Ad viewability score shows improvement.',
 	audienceCriteria: 'DCR-rendered articles',
 	showForSensitive: true,


### PR DESCRIPTION
## What does this change?
This PR adds an AB test to remove the sticky behaviour from the navigation menu.
The test will only target DCR-rendered articles and will mimic the behaviour that currently exists in frontend.
However, it is necessary to include it in frontend as it's a client-side test.

As per video below, the navigation menu (navbar and subnav) is not sticky on frontend, meaning that the ad is more visibile. We are aiming to test the same behaviour on DCR, where the nav is currently sticky.

https://user-images.githubusercontent.com/57295823/132241915-e7d92377-6b4a-4d05-8d9d-412202eb6261.mov

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] **Yes** (separate PR incoming)

## What is the value of this and can you measure success?
The hypothesis is that removing the sticky behaviour will improve ad viewability for the top-above-nav slot, which should turn into increased revenue.

## Checklist

### Tested

- [ ] Locally
- [ ] On CODE (optional)