### PR TITLE
Preview Showcase fronts

### DIFF
--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -513,6 +513,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
 
     val rundownPanel = TrailsToShowcase
       .asRundownPanel("Rundown container name", Seq(trail, anotherTrail, anotherTrail), "rundown-container-id")
+      .right
       .get
 
     rundownPanel.`type` should be("RUNDOWN")
@@ -553,6 +554,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       )
     val rundownPanel = TrailsToShowcase
       .asRundownPanel("Rundown container name", Seq(trail, anotherTrail, anotherTrail), "rundown-container-id")
+      .right
       .get
 
     val entry = TrailsToShowcase.asSyndEntry(rundownPanel)
@@ -579,6 +581,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
 
     val rundownPanel = TrailsToShowcase
       .asRundownPanel("Rundown container name", Seq(withByline, withByline, withByline), "rundown-container-id")
+      .right
       .get
 
     val firstItemInArticleGroup = rundownPanel.articles.head
@@ -595,6 +598,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
 
     val rundownPanel = TrailsToShowcase
       .asRundownPanel("Rundown container name", Seq(withKicker, withKicker, withKicker), "rundown-container-id")
+      .right
       .get
 
     val firstItemInArticleGroup = rundownPanel.articles.head
@@ -616,6 +620,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
         Seq(withAuthorAndKicker, withAuthorAndKicker, withAuthorAndKicker),
         "rundown-container-id",
       )
+      .right
       .get
 
     val firstItemInArticleGroup = rundownPanel.articles.head
@@ -645,6 +650,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
         Seq(withAuthorAndKicker, withAuthorAndKicker, withMissingKicker),
         "rundown-container-id",
       )
+      .right
       .get
 
     rundownPanel.articles.forall(_.author.nonEmpty) should be(true)
@@ -669,7 +675,8 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     val rundownPanel = TrailsToShowcase
       .asRundownPanel("Rundown container name", Seq(withKicker, withKicker, withAuthor), "rundown-container-id")
 
-    rundownPanel should be(None)
+    rundownPanel.right.toOption should be(None)
+    rundownPanel.left.get should be(Seq("Rundown trails need to all have Kickers or Bylines"))
   }
 
   "TrailToShowcase" can "rundown panels articles should prefer replaced images over content trail image" in {
@@ -684,6 +691,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
 
     val rundownPanel = TrailsToShowcase
       .asRundownPanel("Rundown contained", Seq(withReplacedImage, withReplacedImage, withReplacedImage), "rundown-id")
+      .right
       .get
 
     rundownPanel.articles.head.imageUrl shouldBe Some("http://localhost/replaced-image.jpg")
@@ -698,6 +706,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
 
     val rundownPanel = TrailsToShowcase
       .asRundownPanel("Rundown container name", Seq(content, content, content), "rundown-container-id")
+      .right
       .get
 
     rundownPanel.articles.head.updated shouldBe (wayBackWhen)
@@ -810,7 +819,8 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     val rundownPanel =
       TrailsToShowcase.asRundownPanel("Rundown container with too few articles", Seq(content), "rundown-container-id")
 
-    rundownPanel should be(None)
+    rundownPanel.right.toOption should be(None)
+    rundownPanel.left.get should be(Seq("Could not make 3 valid rundown articles from rundown trails"))
   }
 
   "TrailToShowcase validation" should "trim rundown panels to 3 articles if too many are supplied" in {
@@ -827,6 +837,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
         Seq(content, content, content, content),
         "rundown-container-id",
       )
+      .right
       .get
 
     rundownPanel.articles.size should be(3)
@@ -846,7 +857,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
 
     val rundownPanel = TrailsToShowcase.asRundownPanel(longerThan74, Seq(trail, anotherTrail), "rundown-container-id")
 
-    rundownPanel should be(None)
+    rundownPanel.toOption should be(None)
   }
 
   "TrailToShowcase validation" should "omit rundown panel articles g:overlines longer than 30 characters" in {
@@ -867,7 +878,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
         "rundown-container-id",
       )
 
-    rundownPanel should be(None)
+    rundownPanel.toOption should be(None)
   }
 
   "TrailToShowcase validation" should "reject rundown panel articles with titles longer than 64 characters" in {
@@ -887,7 +898,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       "rundown-container-id",
     )
 
-    rundownPanel should be(None)
+    rundownPanel.toOption should be(None)
   }
 
   "TrailToShowcase validation" should "reject rundown panels containing articles with images smaller than 1200x900" in {
@@ -904,7 +915,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
         "rundown-container-id",
       )
 
-    rundownPanel should be(None)
+    rundownPanel.toOption should be(None)
   }
 
   "TrailToShowcase validation" should "omit kickers from rundown panels if kicker is not set on all articles" in {
@@ -928,6 +939,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
         Seq(withKicker, withKicker, withoutKicker),
         "rundown-container-id",
       )
+      .right
       .get
 
     rundownPanel.articles.size should be(3)
@@ -954,7 +966,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
         "rundown-container-id",
       )
 
-    rundownPanel should be(None)
+    rundownPanel.toOption should be(None)
   }
 
   "TrailToShowcase validation" should "choose kickers over authors" in {
@@ -972,6 +984,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
         Seq(withAuthorAndKicker, withAuthorAndKicker, withAuthorAndKicker),
         "rundown-container-id",
       )
+      .right
       .get
 
     rundownPanel.articles.size should be(3)

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -726,7 +726,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     outcome.right.get.panelTitle should be(None)
   }
 
-  "TrailToShowcase validation" should "omit single panel g:overlines longer than 30 characters" in {
+  "TrailToShowcase validation" should "reject single panel g:overlines longer than 30 characters" in {
     val longerThan30 = "This sentence is way longer than 30 characters and should be omitted"
     longerThan30.size > 30 should be(true)
 
@@ -740,8 +740,8 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
 
     val outcome = TrailsToShowcase.asSingleStoryPanel(content)
 
-    outcome.right.get.overline should be(None)
-    // outcome.left.get.contains("Kicker was too long annd was omitted") shouldBe(true)
+    outcome.right.toOption should be(None)
+    outcome.left.get.contains(s"Kicker text '${longerThan30}' is too long") shouldBe (true)
   }
 
   "TrailToShowcase validation" should "reject single panels with titles longer than 86 characters" in {
@@ -914,7 +914,9 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       )
 
     rundownPanel.toOption should be(None)
-    rundownPanel.left.get.contains("Could not find image bigger than the minimum required size: 1200x900") should be(true)
+    rundownPanel.left.get.contains("Could not find image bigger than the minimum required size: 1200x900") should be(
+      true,
+    )
   }
 
   "TrailToShowcase validation" should "omit kickers from rundown panels if kicker is not set on all articles" in {

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -420,9 +420,10 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       trailText = Some(bulletEncodedTrailText),
     )
 
-    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(bulletedContent).toOption
+    val outcome = TrailsToShowcase.asSingleStoryPanel(bulletedContent)
 
-    singleStoryPanel should be(None)
+    outcome.right.toOption should be(None)
+    outcome.left.get.contains("Trail text is not formatted as a bullet list") shouldBe (true)
   }
 
   "TrailToShowcase" should "trim single story bullets to 3 at most" in {
@@ -780,7 +781,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
 
     outcome.right.toOption should be(None)
     println("SSS: " + outcome.left.get)
-    outcome.left.get.contains("Single story panel had no image") shouldBe (true)
+    outcome.left.get.contains("No image available") shouldBe (true)
   }
 
   "TrailToShowcase validation" should "reject single panels with images smaller than 640x320" in {
@@ -793,7 +794,9 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     val outcome = TrailsToShowcase.asSingleStoryPanel(withTooSmallImage)
 
     outcome.right.toOption should be(None)
-    outcome.left.get.contains("Single story panel did not have an image bigger than 640x320") shouldBe (true)
+    val value1: Seq[String] = outcome.left.get
+    println(value1)
+    outcome.left.get.contains("No image bigger than the minimum required size: 640x320") shouldBe (true)
   }
 
   "TrailToShowcase validation" should "reject rundown panels with less than 3 articles" in {

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -933,7 +933,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     rundownPanel.articles.forall(_.overline.isEmpty) should be(true)
   }
 
-  "TrailToShowcase validation" should "omit authors from rundown panel articles of author has not been set on all articles" in {
+  "TrailToShowcase validation" should "omit authors from rundown panel articles if author has not been set on all articles" in {
     val withAuthor = makePressedContent(
       webPublicationDate = wayBackWhen,
       lastModified = Some(lastModifiedWayBackWhen),

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -465,19 +465,6 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     singleStoryPanels.size should be(0)
   }
 
-  "TrailToShowcase" should "offer an explaination when rejecting single story panels" in {
-    val bulletedContent = makePressedContent(
-      webPublicationDate = wayBackWhen,
-      lastModified = Some(lastModifiedWayBackWhen),
-      trailPicture = Some(imageMedia),
-      trailText = Some("Not properly bullet encoded"),
-    )
-
-    val panelCreationOutcome = TrailsToShowcase.asSingleStoryPanel(bulletedContent)
-
-    panelCreationOutcome.left.toOption should be(Some("Something went wrong"))
-  }
-
   "TrailToShowcase" can "single story panels should prefer replaced images over content trail image" in {
     val curatedContent = makePressedContent(
       webPublicationDate = wayBackWhen,
@@ -723,9 +710,9 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       trailText = Some("- A bullet"),
     )
 
-    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(content).toOption.get
+    val outcome = TrailsToShowcase.asSingleStoryPanel(content)
 
-    singleStoryPanel.panelTitle should be(None)
+    outcome.right.get.panelTitle should be(None)
   }
 
   "TrailToShowcase validation" should "omit single panel g:overlines longer than 30 characters" in {
@@ -740,9 +727,10 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       trailText = Some("- A bullet"),
     )
 
-    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(content).toOption.get
+    val outcome = TrailsToShowcase.asSingleStoryPanel(content)
 
-    singleStoryPanel.overline should be(None)
+    outcome.right.get.overline should be(None)
+    // outcome.left.get.contains("Kicker was too long annd was omitted") shouldBe(true)
   }
 
   "TrailToShowcase validation" should "reject single panels with titles longer than 86 characters" in {
@@ -757,9 +745,11 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       headline = longerThan86,
     )
 
-    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(withLongTitle).toOption
+    val outcome = TrailsToShowcase.asSingleStoryPanel(withLongTitle)
 
-    singleStoryPanel should be(None)
+    outcome.right.toOption should be(None)
+    println(outcome.left.get)
+    outcome.left.get.contains("Headline was longer than 86 characters") shouldBe (true)
   }
 
   "TrailToShowcase validation" should "omit single panel author fields longer than 42 characters" in {
@@ -774,9 +764,10 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       trailText = Some("- A bullet"),
     )
 
-    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(withLongByline).toOption.get
+    val outcome = TrailsToShowcase.asSingleStoryPanel(withLongByline)
 
-    singleStoryPanel.author should be(None)
+    outcome.right.get.author should be(None)
+    // outcome.left.get.contains("Author was too long and was dropped") shouldBe(true)
   }
 
   "TrailToShowcase validation" should "reject single panels with no image" in {
@@ -785,9 +776,11 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       lastModified = Some(lastModifiedWayBackWhen),
     )
 
-    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(withNoImage).toOption
+    val outcome = TrailsToShowcase.asSingleStoryPanel(withNoImage)
 
-    singleStoryPanel should be(None)
+    outcome.right.toOption should be(None)
+    println("SSS: " + outcome.left.get)
+    outcome.left.get.contains("Single story panel had no image") shouldBe (true)
   }
 
   "TrailToShowcase validation" should "reject single panels with images smaller than 640x320" in {
@@ -797,9 +790,10 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       trailPicture = Some(smallImageMedia),
     )
 
-    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(withTooSmallImage).toOption
+    val outcome = TrailsToShowcase.asSingleStoryPanel(withTooSmallImage)
 
-    singleStoryPanel should be(None)
+    outcome.right.toOption should be(None)
+    outcome.left.get.contains("Single story panel did not have an image bigger than 640x320") shouldBe (true)
   }
 
   "TrailToShowcase validation" should "reject rundown panels with less than 3 articles" in {

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -75,7 +75,8 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       )
 
     val rss = XML.loadString(
-      TrailsToShowcase(Option("foo"), singleStoryTrails, Seq.empty, "Rundown panel name", "rundown-panel-id")(request),
+      TrailsToShowcase
+        .fromTrails(Option("foo"), singleStoryTrails, Seq.empty, "Rundown panel name", "rundown-panel-id")(request),
     )
 
     rss.getNamespace("g") should be("http://schemas.google.com/pcn/2020")
@@ -90,7 +91,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     )
 
     val rss = XML.loadString(
-      TrailsToShowcase(
+      TrailsToShowcase.fromTrails(
         Option("foo"),
         Seq.empty,
         Seq(content, content, content),
@@ -136,7 +137,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     val rundownTrails = Seq(rundownArticleContent, rundownArticleContent, rundownArticleContent)
 
     val rss = XML.loadString(
-      TrailsToShowcase(
+      TrailsToShowcase.fromTrails(
         Option("foo"),
         singleStoryTrails,
         rundownTrails,
@@ -232,7 +233,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     val rundownTrails = Seq(withKicker, withKicker, withKicker)
 
     val rss = XML.loadString(
-      TrailsToShowcase(
+      TrailsToShowcase.fromTrails(
         Option("foo"),
         Seq.empty,
         rundownTrails,
@@ -264,7 +265,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     )
 
     val rss = XML.loadString(
-      TrailsToShowcase(
+      TrailsToShowcase.fromTrails(
         Option("foo"),
         Seq(withByline),
         Seq.empty,
@@ -283,7 +284,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     val singleStoryTrails =
       Seq(makePressedContent(webPublicationDate = wayBackWhen, trailPicture = Some(imageMedia)))
 
-    val rss = XML.loadString(TrailsToShowcase(Option("foo"), singleStoryTrails, Seq.empty, "", "")(request))
+    val rss = XML.loadString(TrailsToShowcase.fromTrails(Option("foo"), singleStoryTrails, Seq.empty, "", "")(request))
 
     val rundownPanels = (rss \ "channel" \ "item").filter(ofRundownPanelType)
     rundownPanels.size should be(0)
@@ -460,7 +461,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
         ),
       )
 
-    val rss = XML.loadString(TrailsToShowcase(Option("foo"), singleStoryTrails, Seq.empty, "", "")(request))
+    val rss = XML.loadString(TrailsToShowcase.fromTrails(Option("foo"), singleStoryTrails, Seq.empty, "", "")(request))
 
     val singleStoryPanels = (rss \ "channel" \ "item").filter(ofSingleStoryPanelType)
     singleStoryPanels.size should be(0)

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -759,7 +759,6 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     val outcome = TrailsToShowcase.asSingleStoryPanel(withLongTitle)
 
     outcome.right.toOption should be(None)
-    println(outcome.left.get)
     outcome.left.get.contains("Headline was longer than 86 characters") shouldBe (true)
   }
 
@@ -790,7 +789,6 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     val outcome = TrailsToShowcase.asSingleStoryPanel(withNoImage)
 
     outcome.right.toOption should be(None)
-    println("SSS: " + outcome.left.get)
     outcome.left.get.contains("No image available") shouldBe (true)
   }
 
@@ -804,8 +802,6 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     val outcome = TrailsToShowcase.asSingleStoryPanel(withTooSmallImage)
 
     outcome.right.toOption should be(None)
-    val value1: Seq[String] = outcome.left.get
-    println(value1)
     outcome.left.get.contains("No image bigger than the minimum required size: 640x320") shouldBe (true)
   }
 
@@ -857,7 +853,8 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
 
     val rundownPanel = TrailsToShowcase.asRundownPanel(longerThan74, Seq(trail, anotherTrail), "rundown-container-id")
 
-    rundownPanel.toOption should be(None)
+    rundownPanel.toOption shouldBe (None)
+    rundownPanel.left.get.contains("Rundown panel title is too long") shouldBe (true)
   }
 
   "TrailToShowcase validation" should "omit rundown panel articles g:overlines longer than 30 characters" in {
@@ -899,6 +896,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     )
 
     rundownPanel.toOption should be(None)
+    rundownPanel.left.get.contains(s"The title '$longerThan64' is too long for a rundown article") should be(true)
   }
 
   "TrailToShowcase validation" should "reject rundown panels containing articles with images smaller than 1200x900" in {

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -300,7 +300,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       trailText = Some("- A bullet"),
     )
 
-    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(curatedContent).get
+    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(curatedContent).toOption.get
     singleStoryPanel.title should be("My unique headline")
 
     singleStoryPanel.link should be(
@@ -330,7 +330,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       kickerText = Some("A Kicker"),
       trailText = Some("- A bullet"),
     )
-    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(curatedContent).get
+    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(curatedContent).toOption.get
 
     val entry = TrailsToShowcase.asSyndEntry(singleStoryPanel)
 
@@ -373,7 +373,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       trailText = Some(bulletEncodedTrailText),
     )
 
-    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(bulletedContent).get
+    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(bulletedContent).toOption.get
 
     val bulletList = singleStoryPanel.bulletList.get
     bulletList.listItems.size should be(3)
@@ -396,7 +396,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       trailText = Some(bulletEncodedTrailText),
     )
 
-    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(bulletedContent).get
+    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(bulletedContent).toOption.get
 
     val bulletList = singleStoryPanel.bulletList.get
     val bulletListItems = bulletList.listItems
@@ -420,7 +420,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       trailText = Some(bulletEncodedTrailText),
     )
 
-    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(bulletedContent)
+    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(bulletedContent).toOption
 
     singleStoryPanel should be(None)
   }
@@ -441,7 +441,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       trailText = Some(bulletEncodedTrailText),
     )
 
-    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(bulletedContent).get
+    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(bulletedContent).toOption.get
 
     val bulletList = singleStoryPanel.bulletList.get
     val bulletListItems = bulletList.listItems
@@ -465,6 +465,19 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     singleStoryPanels.size should be(0)
   }
 
+  "TrailToShowcase" should "offer an explaination when rejecting single story panels" in {
+    val bulletedContent = makePressedContent(
+      webPublicationDate = wayBackWhen,
+      lastModified = Some(lastModifiedWayBackWhen),
+      trailPicture = Some(imageMedia),
+      trailText = Some("Not properly bullet encoded"),
+    )
+
+    val panelCreationOutcome = TrailsToShowcase.asSingleStoryPanel(bulletedContent)
+
+    panelCreationOutcome.left.toOption should be(Some("Something went wrong"))
+  }
+
   "TrailToShowcase" can "single story panels should prefer replaced images over content trail image" in {
     val curatedContent = makePressedContent(
       webPublicationDate = wayBackWhen,
@@ -477,7 +490,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       trailText = Some("- A bullet"),
     )
 
-    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(curatedContent).get
+    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(curatedContent).toOption.get
 
     singleStoryPanel.imageUrl should be("http://localhost/replaced-image.jpg")
   }
@@ -489,7 +502,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       trailText = Some("- A bullet"),
     )
 
-    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(curatedContent).get
+    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(curatedContent).toOption.get
 
     singleStoryPanel.updated should be(Some(wayBackWhen))
   }
@@ -710,7 +723,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       trailText = Some("- A bullet"),
     )
 
-    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(content).get
+    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(content).toOption.get
 
     singleStoryPanel.panelTitle should be(None)
   }
@@ -727,7 +740,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       trailText = Some("- A bullet"),
     )
 
-    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(content).get
+    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(content).toOption.get
 
     singleStoryPanel.overline should be(None)
   }
@@ -744,7 +757,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       headline = longerThan86,
     )
 
-    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(withLongTitle)
+    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(withLongTitle).toOption
 
     singleStoryPanel should be(None)
   }
@@ -761,7 +774,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       trailText = Some("- A bullet"),
     )
 
-    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(withLongByline).get
+    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(withLongByline).toOption.get
 
     singleStoryPanel.author should be(None)
   }
@@ -772,7 +785,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       lastModified = Some(lastModifiedWayBackWhen),
     )
 
-    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(withNoImage)
+    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(withNoImage).toOption
 
     singleStoryPanel should be(None)
   }
@@ -784,7 +797,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       trailPicture = Some(smallImageMedia),
     )
 
-    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(withTooSmallImage)
+    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(withTooSmallImage).toOption
 
     singleStoryPanel should be(None)
   }

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -802,7 +802,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     val outcome = TrailsToShowcase.asSingleStoryPanel(withTooSmallImage)
 
     outcome.right.toOption should be(None)
-    outcome.left.get.contains("No image bigger than the minimum required size: 640x320") shouldBe (true)
+    outcome.left.get.contains("Could not find image bigger than the minimum required size: 640x320") shouldBe (true)
   }
 
   "TrailToShowcase validation" should "reject rundown panels with less than 3 articles" in {
@@ -899,7 +899,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     rundownPanel.left.get.contains(s"The title '$longerThan64' is too long for a rundown article") should be(true)
   }
 
-  "TrailToShowcase validation" should "reject rundown panels containing articles with images smaller than 1200x900" in {
+  "TrailToShowcase validation" should "reject rundown articles with images smaller than 1200x900" in {
     val withTooSmallImage = makePressedContent(
       webPublicationDate = wayBackWhen,
       lastModified = Some(lastModifiedWayBackWhen),
@@ -914,6 +914,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       )
 
     rundownPanel.toOption should be(None)
+    rundownPanel.left.get.contains("Could not find image bigger than the minimum required size: 1200x900") should be(true)
   }
 
   "TrailToShowcase validation" should "omit kickers from rundown panels if kicker is not set on all articles" in {

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -777,7 +777,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     val outcome = TrailsToShowcase.asSingleStoryPanel(withLongByline)
 
     outcome.right.get.author should be(None)
-    // outcome.left.get.contains("Author was too long and was dropped") shouldBe(true)
+    //outcome.left.get.contains("Author was too long and was dropped") shouldBe(true)
   }
 
   "TrailToShowcase validation" should "reject single panels with no image" in {
@@ -857,7 +857,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     rundownPanel.left.get.contains("Rundown panel title is too long") shouldBe (true)
   }
 
-  "TrailToShowcase validation" should "omit rundown panel articles g:overlines longer than 30 characters" in {
+  "TrailToShowcase validation" should "reject rundown panel article kickers longer than 30 characters" in {
     val longerThan30 = "This kicker is way longer than 30 characters and should be omitted"
     longerThan30.length > 30 should be(true)
 
@@ -876,6 +876,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       )
 
     rundownPanel.toOption should be(None)
+    rundownPanel.left.get.contains(s"Kicker text '${longerThan30}' is too long") should be(true)
   }
 
   "TrailToShowcase validation" should "reject rundown panel articles with titles longer than 64 characters" in {

--- a/preview/app/controllers/FaciaDraftController.scala
+++ b/preview/app/controllers/FaciaDraftController.scala
@@ -46,7 +46,7 @@ class FaciaDraftController(
             val singleStoryPanelCreationOutcomes =
               singleStoriesCollection.curated.map(TrailsToShowcase.asSingleStoryPanel)
             val singleStoryPanels = singleStoryPanelCreationOutcomes.flatMap(_.toOption)
-            val problems = singleStoryPanelCreationOutcomes.flatMap(_.left.toOption)
+            val problems = singleStoryPanelCreationOutcomes.flatMap(_.left.toOption).flatten
 
             val rundownPanel = TrailsToShowcase.asRundownPanel(
               rundownStoriesCollection.displayName,

--- a/preview/app/controllers/FaciaDraftController.scala
+++ b/preview/app/controllers/FaciaDraftController.scala
@@ -43,13 +43,18 @@ class FaciaDraftController(
             singleStoriesCollection <- faciaPage.collections.find(_.displayName == "Standalone")
             rundownStoriesCollection <- faciaPage.collections.find(_.displayName == "Rundown")
           } yield {
-            val singleStoryPanels = singleStoriesCollection.curated.flatMap(TrailsToShowcase.asSingleStoryPanel)
+            val singleStoryPanelCreationOutcomes =
+              singleStoriesCollection.curated.map(TrailsToShowcase.asSingleStoryPanel)
+            val singleStoryPanels = singleStoryPanelCreationOutcomes.flatMap(_.toOption)
+            val problems = singleStoryPanelCreationOutcomes.flatMap(_.left.toOption)
+
             val rundownPanel = TrailsToShowcase.asRundownPanel(
               rundownStoriesCollection.displayName,
               rundownStoriesCollection.curated,
               rundownStoriesCollection.id,
             )
-            Ok(views.html.showcase(singleStoryPanels, rundownPanel))
+
+            Ok(views.html.showcase(singleStoryPanels, rundownPanel, problems))
 
           }).getOrElse {
             // Not a Showcase front

--- a/preview/app/views/showcase.scala.html
+++ b/preview/app/views/showcase.scala.html
@@ -1,4 +1,4 @@
-@(singleStoryPanels: Seq[common.TrailsToShowcase.SingleStoryPanel], rundownPanel: Option[common.TrailsToShowcase.RundownPanel])
+@(singleStoryPanels: Seq[common.TrailsToShowcase.SingleStoryPanel], rundownPanel: Option[common.TrailsToShowcase.RundownPanel], problems: Seq[String])
 <!DOCTYPE html>
 <html>
     <head>
@@ -64,6 +64,17 @@
     </head>
     <body>
         <h1>Showcase</h1>
+        @if(problems.nonEmpty) {
+            <p>Problems were found with this feed:</p>
+            <ul>
+                @for(problem <- problems) {
+                    <li>@problem</li>
+                }
+            </ul>
+        } else {
+            <p>No problems found.</p>
+        }
+
         <ul>
             @for(panel <- rundownPanel) {
                 <li class="panel rundown">

--- a/preview/app/views/showcase.scala.html
+++ b/preview/app/views/showcase.scala.html
@@ -1,0 +1,113 @@
+@(singleStoryPanels: Seq[common.TrailsToShowcase.SingleStoryPanel], rundownPanel: Option[common.TrailsToShowcase.RundownPanel])
+<!DOCTYPE html>
+<html>
+    <head>
+        <style>
+            body {
+                font-family: 'Guardian Egyptian Text', Georgia, serif;
+                margin-top: 10%;
+                margin-left: 20%;
+                margin-right: 20%;
+                background: white;
+                color: rgb(51, 51, 51);
+            }
+
+            h1 {
+                font-weight: bold;
+            }
+
+            a, a:visited {
+                color: #005689;
+                text-decoration: none;
+            }
+            .panel {
+                border-radius: 8px;
+                overflow: hidden;
+                moz-border-radius: 8px;
+                border: 1px solid #dadce0;
+                padding: 10px;
+                width: 320px;
+                margin: 10px;
+            }
+
+            .panelTitle {
+                background-color: rgb(255, 229, 0);
+             }
+
+             .singleStory img {
+                width: 310px;
+                margin-left: auto;
+                border-radius: 5px;
+                object-fit: cover;
+             }
+
+            .rundown img {
+                margin-left: auto;
+                border-radius: 5px;
+                object-fit: cover;
+                width: 93px;
+                height: 70px;
+                float: right;
+            }
+
+            .overline {
+                font-size: 11px;
+                text-transform: uppercase;
+                color: rgb(95, 99, 104);
+            }
+
+            .author {
+                font-size: 12px;
+                color: rgb(95, 99, 104);
+            }
+        </style>
+    </head>
+    <body>
+        <h1>Showcase</h1>
+        <ul>
+            @for(panel <- rundownPanel) {
+                <li class="panel rundown">
+                    <h2 class="panelTitle">@panel.panelTitle</h2>
+                    @for((article, index) <- panel.articles.zipWithIndex) {
+                       <a href="@article.link" target="_blank"><img src="@article.imageUrl" width="160"/></a>
+                        @for(overline <- article.overline) {
+                            <p class="overline">@overline</p>
+                        }
+                        <a href="@article.link" target="_blank"><h4>@article.title</h4></a>
+                        @for(author <- article.author) {
+                            <p class="author">@author</p>
+                        }
+                        @if(index + 1 < panel.articles.size) {
+                            <hr/>
+                        }
+                    }
+                </li>
+            }
+
+            @for(panel <- singleStoryPanels) {
+            <li class="panel singleStory">
+                    @for(panelTitle <- panel.panelTitle) {
+                        <h2 class="panelTitle">@panel.panelTitle</h2>
+                    }
+                <a href="@panel.link" target="_blank"><img src="@panel.imageUrl"/></a>
+
+                    @for(overline <- panel.overline) {
+                        <p class="overline">@overline</p>
+                    }
+                    <a href="@panel.link" target="_blank"><h4>@panel.title</h4></a>
+                    @for(author <- panel.author) {
+                        <p class="author">@author</p>
+                    }
+
+                    @for(bulletList <- panel.bulletList) {
+                        <ul class="bulletList">
+                            @for(bullet <- bulletList.listItems) {
+                                <li>@bullet.text</li>
+                            }
+                        </ul>
+                    }
+                </li>
+            }
+        </ul>
+    </body>
+</html>


### PR DESCRIPTION
## What does this change?

Allows editors to preview a Showcase feed generated from a Showcase Front.
Explains any validation errors on the preview page so that Editors can understand why panels are not rendering.

Change Trail to Showcase Panel code to pass error up rather than silently dropping invalid panels.
Identify Showcase fronts be the pressed fronts priority field.

<img width="841" alt="Screenshot 2021-09-13 at 12 11 55" src="https://user-images.githubusercontent.com/150238/133073941-6700a861-0f86-494b-baad-ca74bbe4a0df.png">



## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
