### PR TITLE
Update crossword focussed clue to render correctly

### DIFF
--- a/static/src/javascripts/projects/common/modules/crosswords/crossword.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/crossword.js
@@ -775,7 +775,7 @@ class Crossword extends Component {
                                                 {focused.direction}
                                             </span>
                                         </strong>{' '}
-                                        {focused.clue}
+                                        <span dangerouslySetInnerHTML={{ __html: focused.clue }} />
                                     </div>
                                 </div>
                             )}

--- a/static/src/javascripts/projects/common/modules/crosswords/crossword.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/crossword.js
@@ -772,9 +772,9 @@ class Crossword extends Component {
                                         <strong>
                                             {focused.number}{' '}
                                             <span className="crossword__sticky-clue__direction">
-                                                {focused.direction}
+                                                {focused.direction}{' '}
                                             </span>
-                                        </strong>{' '}
+                                        </strong>
                                         <span dangerouslySetInnerHTML={{ __html: focused.clue }} />
                                     </div>
                                 </div>


### PR DESCRIPTION
## What does this change?
The display of the focussed clue(shown at below-desktop breakpoints) did not use dangerouslySetInnerHtml and therefore was rendering the full html string from the clue.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
Before
<img width="713" alt="Screen Shot 2021-09-08 at 20 01 25" src="https://user-images.githubusercontent.com/2051501/132569644-32ca1dfa-ea31-4ced-8ab0-b7b3dbf85e35.png">
After
<img width="713" alt="Screen Shot 2021-09-08 at 20 00 41" src="https://user-images.githubusercontent.com/2051501/132569639-5a265e84-7fe4-438e-aa6d-bc528a92533a.png">


