### PR TITLE
Order page targeting properties to make it easier to compare to DCR

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -264,41 +264,41 @@ const rebuildPageTargeting = () => {
     const adFreeTargeting = commercialFeatures.adFree ? { af: 't' } : {};
     const pageTargets = Object.assign(
         {
-            sens: page.isSensitive ? 't' : 'f',
-            permutive: getPermutiveSegments(),
-            pv: config.get('ophan.pageViewId'),
-            bp: findBreakpoint(),
-            at: getCookie('adtest') || undefined,
-            si: isUserLoggedIn() ? 't' : 'f',
-            gdncrm: getUserSegments(adConsentState),
             ab: abParam(),
-            ref: getReferrer(),
-            ms: formatTarget(page.source),
-            fr: getVisitedValue(),
-            // round video duration up to nearest 30 multiple
-            vl: page.videoDuration
-                ? (Math.ceil(page.videoDuration / 30.0) * 30).toString()
-                : undefined,
+            amtgrp: storage.local.getRaw(AMTGRP_STORAGE_KEY) || createAdManagerGroup(),
+            at: getCookie('adtest') || undefined,
+            bp: findBreakpoint(),
             cc: getCountryCode(),
-            s: page.section, // for reference in a macro, so cannot be extracted from ad unit
-            rp: config.get('isDotcomRendering', false)
-                ? 'dotcom-rendering'
-                : 'dotcom-platform', // rendering platform
+            cmp_interaction: tcfv2EventStatus || 'na',
+            consent_tcfv2: getTcfv2ConsentValue(adConsentState),
+            // Indicates whether the page is DCR eligible. This happens when the page
+            // was DCR eligible and was actually rendered by DCR or
+            // was DCR eligible but rendered by frontend for a user not in the DotcomRendering experiment
             dcre:
                 config.get('isDotcomRendering', false) ||
                 config.get('page.dcrCouldRender', false)
                     ? 't'
                     : 'f',
-            // Indicates whether the page is DCR eligible. This happens when the page
-            // was DCR eligible and was actually rendered by DCR or
-            // was DCR eligible but rendered by frontend for a user not in the DotcomRendering experiment
+            fr: getVisitedValue(),
+            gdncrm: getUserSegments(adConsentState),
             inskin: inskinTargetting(),
+            ms: formatTarget(page.source),
+            permutive: getPermutiveSegments(),
+            pv: config.get('ophan.pageViewId'),
+            // round video duration up to nearest 30 multiple
+            rdp: getRdpValue(ccpaState),
+            ref: getReferrer(),
+            rp: config.get('isDotcomRendering', false)
+                ? 'dotcom-rendering'
+                : 'dotcom-platform', // rendering platform
+            s: page.section, // for reference in a macro, so cannot be extracted from ad unit
+            sens: page.isSensitive ? 't' : 'f',
+            si: isUserLoggedIn() ? 't' : 'f',
             skinsize: skinsizeTargetting(),
             urlkw: getUrlKeywords(page.pageId),
-            rdp: getRdpValue(ccpaState),
-            consent_tcfv2: getTcfv2ConsentValue(adConsentState),
-            cmp_interaction: tcfv2EventStatus || 'na',
-            amtgrp: storage.local.getRaw(AMTGRP_STORAGE_KEY) || createAdManagerGroup(),
+            vl: page.videoDuration
+                ? (Math.ceil(page.videoDuration / 30.0) * 30).toString()
+                : undefined,
         },
         page.sharedAdTargeting,
         paTargeting,

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -271,9 +271,9 @@ const rebuildPageTargeting = () => {
             cc: getCountryCode(),
             cmp_interaction: tcfv2EventStatus || 'na',
             consent_tcfv2: getTcfv2ConsentValue(adConsentState),
-            // Indicates whether the page is DCR eligible. This happens when the page
-            // was DCR eligible and was actually rendered by DCR or
-            // was DCR eligible but rendered by frontend for a user not in the DotcomRendering experiment
+            // dcre: DCR eligible
+            // when the page is DCR eligible and was rendered by DCR or
+            // when the page is DCR eligible but rendered by frontend for a user not in the DotcomRendering experiment
             dcre:
                 config.get('isDotcomRendering', false) ||
                 config.get('page.dcrCouldRender', false)
@@ -285,17 +285,21 @@ const rebuildPageTargeting = () => {
             ms: formatTarget(page.source),
             permutive: getPermutiveSegments(),
             pv: config.get('ophan.pageViewId'),
-            // round video duration up to nearest 30 multiple
             rdp: getRdpValue(ccpaState),
             ref: getReferrer(),
+            // rp: rendering platform
             rp: config.get('isDotcomRendering', false)
                 ? 'dotcom-rendering'
-                : 'dotcom-platform', // rendering platform
-            s: page.section, // for reference in a macro, so cannot be extracted from ad unit
+                : 'dotcom-platform',
+            // s: section
+            // for reference in a macro, so cannot be extracted from ad unit
+            s: page.section,
             sens: page.isSensitive ? 't' : 'f',
             si: isUserLoggedIn() ? 't' : 'f',
             skinsize: skinsizeTargetting(),
             urlkw: getUrlKeywords(page.pageId),
+            // vl: video length
+            // round video duration up to nearest 30 multiple
             vl: page.videoDuration
                 ? (Math.ceil(page.videoDuration / 30.0) * 30).toString()
                 : undefined,


### PR DESCRIPTION
## What does this change?

Order page targeting properties to make it easier to compare to DCR

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

