### PR TITLE
Render html correctly for anagram helper display

### DIFF
--- a/static/src/javascripts/projects/common/modules/crosswords/anagram-helper/clue-preview.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/anagram-helper/clue-preview.js
@@ -62,7 +62,7 @@ class CluePreview extends Component {
                             {this.props.clue.direction}
                         </span>
                     </strong>{' '}
-                    {this.props.clue.clue}
+                    <span dangerouslySetInnerHTML={{ __html: this.props.clue.clue }} />
                 </div>
                 {entries.map((entry, i) => {
                     const classNames = checkIfLetterHasSeparator(


### PR DESCRIPTION
## What does this change?
Uses the correct way to render the html we get sent for each clue in the anagram helper

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
Before
![Screen Shot 2021-09-09 at 16 38 09](https://user-images.githubusercontent.com/2051501/132722554-f740b116-42db-486c-a0ea-f2c0564fa8e9.png)
After
![Screen Shot 2021-09-09 at 16 37 35](https://user-images.githubusercontent.com/2051501/132722558-3894491c-0a89-4cc9-91f4-0d2dcca2f20c.png)
