### PR TITLE
Add `navigator.sendBeacon`polyfill

### DIFF
--- a/static/src/javascripts/polyfill.io
+++ b/static/src/javascripts/polyfill.io
@@ -1,1 +1,1 @@
-https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,fetch&flags=gated&callback=guardianPolyfilled&unknown=polyfill&clearCache=5
+https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,fetch,navigator.sendBeacon&flags=gated&callback=guardianPolyfilled&unknown=polyfill&clearCache=5


### PR DESCRIPTION
## What does this change?

We’re using it to capture metrics. As of today, [support is only 96%][caniuse]. We currently use this API in:

- [`sentinel` ](https://github.com/guardian/frontend/blob/8212b2a393b99503159b97fd3e1eded60e06c8c1/static/src/javascripts/projects/commercial/sentinel.ts#L64)
- `commercial-metrics` via **`@guardian/commercial-core`**’s [`sendCommercialMetrics`](https://github.com/guardian/commercial-core/blob/2d736b61956f2aba978e35190e20cd72e6ac2028/src/sendCommercialMetrics.ts#L58)

[caniuse]: https://caniuse.com/beacon

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes TBC

## What is the value of this and can you measure success?

We can capture commercial metrics for Internet Explorer!

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
