### PR TITLE
Chronos refactoring

### DIFF
--- a/applications/app/services/InteractivePicker.scala
+++ b/applications/app/services/InteractivePicker.scala
@@ -55,7 +55,7 @@ object InteractivePicker {
     val forceDCR = request.forceDCR
     val isMigrated = migratedPaths.contains(if (path.startsWith("/")) path else "/" + path)
     val switchOn = InteractivePickerFeature.isSwitchedOn
-    val publishedPostSwitch = dateIsPostTransition(Chronos.jodaDateTimeToJavaDateTime(datetime))
+    val publishedPostSwitch = dateIsPostTransition(Chronos.jodaDateTimeToJavaTimeDateTime(datetime))
     val isOptedInAmp = (requestFormat == AmpFormat) && isAmpOptedIn(tags)
     val isWeb = requestFormat == HtmlFormat
     val isOptOut = isOptedOut(tags)

--- a/common/app/common/Chronos.scala
+++ b/common/app/common/Chronos.scala
@@ -14,9 +14,15 @@ import java.time.format.DateTimeFormatter
 
 object Chronos {
 
+  // ------------------------------------------------
+  // Conversions from java.time to joda.time
+
   def javaLocalDateTimeToJodaDateTime(date: java.time.LocalDateTime): org.joda.time.DateTime = {
     DateTime.parse(date.toString)
   }
+
+  // ------------------------------------------------
+  // Conversions from joda.time to java.time
 
   def jodaDateTimeToJavaTimeDateTime(date: org.joda.time.DateTime): java.time.LocalDateTime = {
     LocalDateTime.ofInstant(
@@ -33,9 +39,15 @@ object Chronos {
     date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate()
   }
 
+  // ------------------------------------------------
+  // Conversions away from java.util.Date
+
   def javaUtilDateToJavaTimeLocalDateTime(date: java.util.Date): java.time.LocalDateTime = {
     date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime()
   }
+
+  // ------------------------------------------------
+  // Java Time helpers
 
   def toMilliSeconds(date: java.time.LocalDateTime): Long = {
     date.atZone(ZoneId.of("UTC")).toInstant().toEpochMilli()

--- a/common/app/common/Chronos.scala
+++ b/common/app/common/Chronos.scala
@@ -29,7 +29,7 @@ object Chronos {
     )
   }
 
-  def javaDateToJavaLocalDate(date: java.util.Date): java.time.LocalDate = {
+  def javaUtilDateToJavaTimeLocalDate(date: java.util.Date): java.time.LocalDate = {
     date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate()
   }
 

--- a/common/app/common/Chronos.scala
+++ b/common/app/common/Chronos.scala
@@ -18,7 +18,7 @@ object Chronos {
     DateTime.parse(date.toString)
   }
 
-  def jodaDateTimeToJavaDateTime(date: org.joda.time.DateTime): java.time.LocalDateTime = {
+  def jodaDateTimeToJavaTimeDateTime(date: org.joda.time.DateTime): java.time.LocalDateTime = {
     LocalDateTime.ofInstant(
       Instant.ofEpochMilli(
         date

--- a/common/app/common/Chronos.scala
+++ b/common/app/common/Chronos.scala
@@ -17,7 +17,7 @@ object Chronos {
   // ------------------------------------------------
   // Conversions from java.time to joda.time
 
-  def javaLocalDateTimeToJodaDateTime(date: java.time.LocalDateTime): org.joda.time.DateTime = {
+  def javaTimeLocalDateTimeToJodaDateTime(date: java.time.LocalDateTime): org.joda.time.DateTime = {
     DateTime.parse(date.toString)
   }
 

--- a/common/app/common/Chronos.scala
+++ b/common/app/common/Chronos.scala
@@ -33,7 +33,7 @@ object Chronos {
     date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate()
   }
 
-  def javaDateToJavaLocalDateTime(date: java.util.Date): java.time.LocalDateTime = {
+  def javaUtilDateToJavaTimeLocalDateTime(date: java.util.Date): java.time.LocalDateTime = {
     date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime()
   }
 

--- a/common/app/common/Chronos.scala
+++ b/common/app/common/Chronos.scala
@@ -14,6 +14,12 @@ import java.time.format.DateTimeFormatter
 
 object Chronos {
 
+  // The conversion functions implement the following naming logic
+  // [Type1]To[Type2]
+  // "joda" for org.joda.time.*
+  // "javaTime" for java.time.*
+  // "javaUtil" for java.util.*
+
   // ------------------------------------------------
   // Conversions from java.time to joda.time
 

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -366,7 +366,7 @@ object DotcomRenderingDataModel {
 
     val isLegacyInteractive =
       modifiedFormat.design == InteractiveDesign && content.trail.webPublicationDate
-        .isBefore(Chronos.javaLocalDateTimeToJodaDateTime(InteractiveSwitchOver.date))
+        .isBefore(Chronos.javaTimeLocalDateTimeToJodaDateTime(InteractiveSwitchOver.date))
 
     DotcomRenderingDataModel(
       author = author,

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -1065,7 +1065,8 @@ object PageElement {
           }
 
           case Some(interactive: InteractiveAtom) => {
-            val isLegacy = InteractiveSwitchOver.date.isAfter(Chronos.jodaDateTimeToJavaDateTime(webPublicationDate))
+            val isLegacy =
+              InteractiveSwitchOver.date.isAfter(Chronos.jodaDateTimeToJavaTimeDateTime(webPublicationDate))
             val encodedId = URLEncoder.encode(interactive.id, "UTF-8")
             Some(
               InteractiveAtomBlockElement(

--- a/common/test/model/MetaDataTest.scala
+++ b/common/test/model/MetaDataTest.scala
@@ -150,9 +150,9 @@ class MetaDataTest extends FlatSpec with Matchers {
 
   it should "show https Facebook og:url for content first published after our decision to start advertisng https canonical urls to Facebook" in {
     val content = contentApi(
-      publicationDate = Chronos.javaLocalDateTimeToJodaDateTime(dateAfterWeStartedAdvertistingHttpsUrlsToFacebook),
+      publicationDate = Chronos.javaTimeLocalDateTimeToJodaDateTime(dateAfterWeStartedAdvertistingHttpsUrlsToFacebook),
       firstPublicationDate =
-        Some(Chronos.javaLocalDateTimeToJodaDateTime(dateAfterWeStartedAdvertistingHttpsUrlsToFacebook)),
+        Some(Chronos.javaTimeLocalDateTimeToJodaDateTime(dateAfterWeStartedAdvertistingHttpsUrlsToFacebook)),
       webUrl = "https://www.theguardian.com/football/2021/nov/16/top-flight-team-conceded-most-goals",
     )
     val fields = Fields.make(content)
@@ -183,7 +183,7 @@ class MetaDataTest extends FlatSpec with Matchers {
 
   it should "pages with no explict first published date should continue to show http og:urls" in {
     val content = contentApi(
-      publicationDate = Chronos.javaLocalDateTimeToJodaDateTime(dateAfterWeStartedAdvertistingHttpsUrlsToFacebook),
+      publicationDate = Chronos.javaTimeLocalDateTimeToJodaDateTime(dateAfterWeStartedAdvertistingHttpsUrlsToFacebook),
       firstPublicationDate = None,
       webUrl = "https://www.theguardian.com/football/2021/nov/16/top-flight-team-conceded-most-goals",
     )

--- a/sport/app/cricket/views/fragments/cricketMatchSummary.scala.html
+++ b/sport/app/cricket/views/fragments/cricketMatchSummary.scala.html
@@ -11,7 +11,7 @@
 
     <h2 class="u-h">
         <time class="u-h" datetime="@theMatch.gameDate.format(DateTimeFormatter.ISO_DATE)" data-timestamp="@Chronos.toMilliSeconds(theMatch.gameDate)">
-        @GuDateFormatLegacy(Chronos.javaLocalDateTimeToJodaDateTime(theMatch.gameDate), "d MMM y")
+        @GuDateFormatLegacy(Chronos.javaTimeLocalDateTimeToJodaDateTime(theMatch.gameDate), "d MMM y")
         </time>
         @theMatch.competitionName, @theMatch.venueName
     </h2>


### PR DESCRIPTION
## What does this change?

Simple refactoring: Just update the name of a few functions in Chronos to add extra clarity. Notably we introduce and enforce a convention for the transition conversions functions

```
"joda" for org.joda.time.*
"javaTime" for java.time.*
"javaUtil" for java.util.*
```