### PR TITLE
Showcase fronts never render as HTML

### DIFF
--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -395,7 +395,6 @@ GET            /$publication<(theguardian|theobserver)>/$year<\d\d\d\d>/$month<\
 GET            /                                                                                                                 controllers.FaciaController.rootEditionRedirect()
 GET            /$path<(lifeandstyle/love-and-sex|lifeandstyle/home-and-garden|world/asia|business/companies|football)>           controllers.FaciaController.renderFrontPressSpecial(path)
 GET            /rss                                                                                                              controllers.FaciaController.renderRootFrontRss()
-GET            /*path/showcase                                                                                                   controllers.FaciaController.renderFrontShowcase(path)
 GET            /$path<(uk|au|us|international)(/(culture|sport|commentisfree|business|money|travel|rss))?>                       controllers.FaciaController.renderFrontPress(path)
 GET            /$path<email/.*>                                                                                                  controllers.FaciaController.renderFrontPress(path)
 GET            /*path/lite.json                                                                                                  controllers.FaciaController.renderFrontJsonLite(path)

--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -35,7 +35,6 @@ GET        /most-relevant-container/*path.json                                  
 GET        /*path/show-more/*id.json                                                controllers.FaciaController.renderShowMore(path, id)
 GET        /rss                                                                     controllers.FaciaController.renderRootFrontRss()
 GET        /*path/rss                                                               controllers.FaciaController.renderFrontRss(path)
-GET        /*path/showcase                                                          controllers.FaciaController.renderFrontShowcase(path)
 GET        /*path/lite.json                                                         controllers.FaciaController.renderFrontJsonLite(path)
 GET        /*path.emailjson                                                         controllers.FaciaController.renderFrontJson(path)
 GET        /*path.emailtxt                                                          controllers.FaciaController.renderFrontJson(path)

--- a/preview/conf/routes
+++ b/preview/conf/routes
@@ -135,7 +135,6 @@ GET        /$path<(culture|sport|commentisfree|business|money|rss)>             
 GET        /$path<(\w\w)(/[\w\d-]+)?>/rss                                                      controllers.FaciaDraftController.renderFrontRss(path)
 GET        /$path<.+>/lite.json                                                                controllers.FaciaDraftController.renderFrontJsonLite(path)
 GET        /$path<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>.json                                       controllers.FaciaDraftController.renderFrontJson(path)
-GET        /*path/showcase                                                                     controllers.FaciaDraftController.renderFrontShowcase(path)
 
 GET        /container/*id.json                                                                 controllers.FaciaDraftController.renderContainerJson(id)
 


### PR DESCRIPTION
Showcase surrenders it's /showcase prefix and instead presents itself as an alternative rendering of the front's canonical path.

Deals with the problem if ghost HTML renderings of the Showcase fronts and gives a cleaner integration with preview.

## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
