### PR TITLE
Stop sending metrics for `improvedigital`

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
@@ -1,9 +1,7 @@
 import { EventTimer } from '@guardian/commercial-core';
 import { isString, log } from '@guardian/libs';
-import { captureCommercialMetrics } from 'commercial/commercial-metrics';
 import type { Advert } from 'commercial/modules/dfp/Advert';
 import config from '../../../../../lib/config';
-import { setForceSendMetrics } from '../../../../common/modules/analytics/forceSendMetrics';
 import { dfpEnv } from '../../dfp/dfp-env';
 import { getAdvertById } from '../../dfp/get-advert-by-id';
 import { getHeaderBiddingAdSlots } from '../slot-config';
@@ -330,15 +328,6 @@ const initialise = (window: Window, framework = 'tcfv2'): void => {
 		 * set here when adjusting the slot size.
 		 * */
 		advert.hasPrebidSize = true;
-
-		/**
-		 * If improve skin has won auction, toggle force send metrics on.
-		 * TODO remove after improve skin release.
-		 * */
-		if (data.bidderCode === 'improvedigital') {
-			setForceSendMetrics(true);
-			captureCommercialMetrics();
-		}
 	});
 };
 

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -350,7 +350,6 @@
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/config.js",
-  "../projects/commercial/commercial-metrics.ts",
   "../projects/commercial/modules/dfp/Advert.ts",
   "../projects/commercial/modules/dfp/dfp-env.ts",
   "../projects/commercial/modules/dfp/get-advert-by-id.ts",
@@ -358,8 +357,7 @@
   "../projects/commercial/modules/header-bidding/prebid/price-config.ts",
   "../projects/commercial/modules/header-bidding/prebid/pubmatic.js",
   "../projects/commercial/modules/header-bidding/slot-config.ts",
-  "../projects/commercial/modules/header-bidding/utils.ts",
-  "../projects/common/modules/analytics/forceSendMetrics.ts"
+  "../projects/commercial/modules/header-bidding/utils.ts"
  ],
  "../projects/commercial/modules/header-bidding/prebid/price-config.ts": [],
  "../projects/commercial/modules/header-bidding/prebid/pubmatic.js": [],


### PR DESCRIPTION
## What does this change?

Stop sending metrics when we get a winning bid from `improvedigital`.
This capture was introduced in #24077.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

We collected enough data as part of the collective test.

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
