### PR TITLE
Showcase preview error display improvements

### DIFF
--- a/common/app/common/TrailsToShowcase.scala
+++ b/common/app/common/TrailsToShowcase.scala
@@ -103,11 +103,14 @@ object TrailsToShowcase {
   }
 
   def asSingleStoryPanel(content: PressedContent): Either[Seq[String], SingleStoryPanel] = {
-    val proposedTitle = Some(TrailsToRss.stripInvalidXMLCharacters(titleFrom(content)))
+    val trailTitle = TrailsToRss.stripInvalidXMLCharacters(titleFrom(content))
+    val proposedTitle = Some(trailTitle)
       .filter(_.nonEmpty)
       .filter(_.length <= MaxLengthForSinglePanelTitle)
       .map(Right(_))
-      .getOrElse(Left(Seq("Headline was longer than " + MaxLengthForSinglePanelTitle + " characters")))
+      .getOrElse(
+        Left(Seq(s"The headline '$trailTitle' is longer than " + MaxLengthForSinglePanelTitle + " characters")),
+      )
     val proposedWebUrl = webUrl(content).map(Right(_)).getOrElse(Left(Seq("Trail had no web url")))
     val proposedImageUrl = singleStoryImageUrlFor(content)
     val proposedBulletList =
@@ -157,11 +160,13 @@ object TrailsToShowcase {
     def makeArticlesFrom(content: Seq[PressedContent]): Either[Seq[String], Seq[RundownArticle]] = {
       val articleOutcomes = content.map { contentItem =>
         // Collect the mandatory fields for the article. If any of these are missing we can skip this item
-        val title = TrailsToRss.stripInvalidXMLCharacters(titleFrom(contentItem))
-        val proposedArticleTitle = Some(title)
+        val trailTitle = TrailsToRss.stripInvalidXMLCharacters(titleFrom(contentItem))
+        val proposedArticleTitle = Some(trailTitle)
           .filter(_.length <= MaxLengthForRundownPanelArticleTitle)
           .map(Right(_))
-          .getOrElse(Left(Seq(s"The title '$title' is too long for a rundown article")))
+          .getOrElse(
+            Left(Seq(s"The headline '$trailTitle' is longer than $MaxLengthForRundownPanelArticleTitle characters")),
+          )
         val proposedArticleImage = rundownPanelArticleImageUrlFor(contentItem)
         val proposedOverline = overlineFrom(contentItem)
 

--- a/common/app/common/TrailsToShowcase.scala
+++ b/common/app/common/TrailsToShowcase.scala
@@ -99,7 +99,7 @@ object TrailsToShowcase {
   ): (Either[Seq[String], RundownPanel], Seq[Either[Seq[String], SingleStoryPanel]]) = {
     val rundownPanelOutcome = asRundownPanel(rundownContainerTitle, rundownStoryTrails, rundownContainerId)
     val singleStoryPanelCreationOutcomes = singleStoryTrails.map(asSingleStoryPanel)
-    (rundownPanelOutcome, singleStoryPanelCreationOutcomes )
+    (rundownPanelOutcome, singleStoryPanelCreationOutcomes)
   }
 
   def asSingleStoryPanel(content: PressedContent): Either[Seq[String], SingleStoryPanel] = {
@@ -214,13 +214,13 @@ object TrailsToShowcase {
           }
         }
         .getOrElse {
-          Left(
-            articleOutcomes
-              .flatMap(_.left.toOption)
-              .flatten
-              .flatten
-              .flatten :+ "Could not make 3 valid rundown articles from rundown trails",
-          )
+          val articleProblems = articleOutcomes
+            .flatMap(_.left.toOption)
+            .flatten
+            .flatten
+            .flatten
+          // Couldn not make 3 valid articles is the most useful message to the editor so put it first
+          Left("Could not find 3 valid rundown article trails" +: articleProblems)
         }
     }
 

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -805,18 +805,31 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     outcome.left.get.contains("Could not find image bigger than the minimum required size: 640x320") shouldBe (true)
   }
 
-  "TrailToShowcase validation" should "reject rundown panels with less than 3 articles" in {
-    val content = makePressedContent(
+  "TrailToShowcase validation" should "reject rundown panels with less than 3 valid articles" in {
+    val valid = makePressedContent(
       webPublicationDate = wayBackWhen,
       lastModified = Some(lastModifiedWayBackWhen),
       trailPicture = Some(imageMedia),
+      kickerText = Some("A kicker"),
+    )
+    val notValid = makePressedContent(
+      webPublicationDate = wayBackWhen,
+      lastModified = Some(lastModifiedWayBackWhen),
+      trailPicture = Some(imageMedia),
+      kickerText = Some("A kicker"),
+      headline =
+        "Way to long Way to long Way to long Way to long Way to long Way to long Way to long Way to longWay to long Way to long",
     )
 
     val rundownPanel =
-      TrailsToShowcase.asRundownPanel("Rundown container with too few articles", Seq(content), "rundown-container-id")
+      TrailsToShowcase.asRundownPanel(
+        "Rundown container with too few articles",
+        Seq(valid, valid, notValid),
+        "rundown-container-id",
+      )
 
     rundownPanel.right.toOption should be(None)
-    rundownPanel.left.get should be(Seq("Could not make 3 valid rundown articles from rundown trails"))
+    rundownPanel.left.get.head should be("Could not find 3 valid rundown article trails")
   }
 
   "TrailToShowcase validation" should "trim rundown panels to 3 articles if too many are supplied" in {

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -759,7 +759,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     val outcome = TrailsToShowcase.asSingleStoryPanel(withLongTitle)
 
     outcome.right.toOption should be(None)
-    outcome.left.get.contains("Headline was longer than 86 characters") shouldBe (true)
+    outcome.left.get.contains(s"The headline '$longerThan86' is longer than 86 characters") shouldBe (true)
   }
 
   "TrailToShowcase validation" should "omit single panel author fields longer than 42 characters" in {
@@ -910,7 +910,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     )
 
     rundownPanel.toOption should be(None)
-    rundownPanel.left.get.contains(s"The title '$longerThan64' is too long for a rundown article") should be(true)
+    rundownPanel.left.get.contains(s"The headline '$longerThan64' is longer than 64 characters") should be(true)
   }
 
   "TrailToShowcase validation" should "reject rundown articles with images smaller than 1200x900" in {

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -245,13 +245,13 @@ trait FaciaController
   }
 
   protected def renderShowcaseFront(faciaPage: PressedPage)(implicit request: RequestHeader): RevalidatableResult = {
-    val (singleStoryPanels, maybeRundownPanel, _) = TrailsToShowcase.generatePanelsFrom(faciaPage)
+    val (rundownPanelOutcome, singleStoryPanelOutcomes) = TrailsToShowcase.generatePanelsFrom(faciaPage)
     val showcase = TrailsToShowcase(
       feedTitle = faciaPage.metadata.title,
       url = Some(faciaPage.metadata.url),
       description = faciaPage.metadata.description,
-      singleStoryPanels = singleStoryPanels,
-      maybeRundownPanel = maybeRundownPanel,
+      singleStoryPanels = singleStoryPanelOutcomes.flatMap(_.toOption),
+      maybeRundownPanel = rundownPanelOutcome.toOption,
     )
     RevalidatableResult(Ok(showcase).as("text/xml; charset=utf-8"), showcase)
   }

--- a/preview/app/controllers/FaciaDraftController.scala
+++ b/preview/app/controllers/FaciaDraftController.scala
@@ -37,8 +37,8 @@ class FaciaDraftController(
   override protected def renderShowcaseFront(
       faciaPage: PressedPage,
   )(implicit request: RequestHeader): RevalidatableResult = {
-    val (singleStoryPanels, maybeRundownPanel, problems) = TrailsToShowcase.generatePanelsFrom(faciaPage)
-    val html = views.html.showcase(singleStoryPanels, maybeRundownPanel, problems)
+    val (rundownPanelOutcomes, singleStoryPanelOutcomes) = TrailsToShowcase.generatePanelsFrom(faciaPage)
+    val html = views.html.showcase(rundownPanelOutcomes, singleStoryPanelOutcomes)
     RevalidatableResult(Ok(html), html.body)
   }
 

--- a/preview/app/views/showcase.scala.html
+++ b/preview/app/views/showcase.scala.html
@@ -1,4 +1,4 @@
-@(singleStoryPanels: Seq[common.TrailsToShowcase.SingleStoryPanel], rundownPanel: Option[common.TrailsToShowcase.RundownPanel], problems: Seq[String])
+@(rundownPanelOutcomes: Either[Seq[String], common.TrailsToShowcase.RundownPanel], singleStoryPanelOutcomes: Seq[Either[Seq[String], common.TrailsToShowcase.SingleStoryPanel]])
 <!DOCTYPE html>
 <html>
     <head>
@@ -28,6 +28,10 @@
                 padding: 10px;
                 width: 320px;
                 margin: 10px;
+            }
+
+            .errors {
+               color: red;
             }
 
             .panelTitle {
@@ -64,23 +68,22 @@
     </head>
     <body>
         <h1>Showcase</h1>
-        @if(problems.nonEmpty) {
-            <p>Problems were found with this feed:</p>
-            <ul>
-                @for(problem <- problems) {
-                    <li>@problem</li>
-                }
-            </ul>
-        } else {
-            <p>No problems found.</p>
-        }
 
         <ul>
-            @for(panel <- rundownPanel) {
+            @for(problems <- rundownPanelOutcomes.left.toOption) {
+                <li class="panel">
+                    <ul class="errors">
+                        @for(problem <- problems) {
+                        <li>@problem</li>
+                        }
+                    </ul>
+                </li>
+            }
+            @for(panel <- rundownPanelOutcomes.right.toOption) {
                 <li class="panel rundown">
                     <h2 class="panelTitle">@panel.panelTitle</h2>
                     @for((article, index) <- panel.articles.zipWithIndex) {
-                       <a href="@article.link" target="_blank"><img src="@article.imageUrl" width="160"/></a>
+                        <a href="@article.link" target="_blank"><img src="@article.imageUrl" width="160"/></a>
                         @for(overline <- article.overline) {
                             <p class="overline">@overline</p>
                         }
@@ -95,29 +98,38 @@
                 </li>
             }
 
-            @for(panel <- singleStoryPanels) {
-            <li class="panel singleStory">
-                    @for(panelTitle <- panel.panelTitle) {
-                        <h2 class="panelTitle">@panel.panelTitle</h2>
-                    }
-                <a href="@panel.link" target="_blank"><img src="@panel.imageUrl"/></a>
-
-                    @for(overline <- panel.overline) {
-                        <p class="overline">@overline</p>
-                    }
-                    <a href="@panel.link" target="_blank"><h4>@panel.title</h4></a>
-                    @for(author <- panel.author) {
-                        <p class="author">@author</p>
-                    }
-
-                    @for(bulletList <- panel.bulletList) {
-                        <ul class="bulletList">
-                            @for(bullet <- bulletList.listItems) {
-                                <li>@bullet.text</li>
+            @for(panelOutcome <- singleStoryPanelOutcomes) {
+                @for(problems <- panelOutcome.left.toOption) {
+                    <li class="panel">
+                        <ul class="errors">
+                            @for(problem <- problems) {
+                            <li>@problem</li>
                             }
                         </ul>
-                    }
-                </li>
+                    </li>
+                }
+                @for(panel <- panelOutcome.right.toOption) {
+                    <li class="panel singleStory">
+                        @for(panelTitle <- panel.panelTitle) {
+                            <h2 class="panelTitle">@panel.panelTitle</h2>
+                        }
+                        <a href="@panel.link" target="_blank"><img src="@panel.imageUrl"/></a>
+                        @for(overline <- panel.overline) {
+                            <p class="overline">@overline</p>
+                        }
+                        <a href="@panel.link" target="_blank"><h4>@panel.title</h4></a>
+                            @for(author <- panel.author) {
+                        <p class="author">@author</p>
+                        }
+                        @for(bulletList <- panel.bulletList) {
+                            <ul class="bulletList">
+                                @for(bullet <- bulletList.listItems) {
+                                <li>@bullet.text</li>
+                                }
+                            </ul>
+                        }
+                    </li>
+                }
             }
         </ul>
     </body>


### PR DESCRIPTION
## What does this change?

Render panel specific errors in the place the panel would have appeared.
Echo back over length headlines for easier identification.

Makes it easier to associate an error with a given panel.

<img width="392" alt="Screenshot 2021-09-15 at 11 05 25" src="https://user-images.githubusercontent.com/150238/133414656-4523a94e-8480-4df5-9b61-4191680063b4.png">

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->

