### PR TITLE
Experiment: hide top above nav slot when ad blocker is enabled

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -69,4 +69,3 @@ object HideTopAboveNavWhenAdBlockerEnabled
       sellByDate = LocalDate.of(2021, 11, 1),
       participationGroup = Perc0C,
     )
-

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -11,6 +11,7 @@ object ActiveExperiments extends ExperimentsDefinition {
     StandaloneCommercialBundle,
     StandaloneCommercialBundleTracking,
     RemoveStickyNav,
+    HideTopAboveNavWhenAdBlockerEnabled,
   )
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -60,3 +60,13 @@ object RemoveStickyNav
       sellByDate = LocalDate.of(2021, 10, 8),
       participationGroup = Perc1B,
     )
+
+object HideTopAboveNavWhenAdBlockerEnabled
+    extends Experiment(
+      name = "hide-top-above-nav-when-ad-blocker-enabled",
+      description = "Hides top-above-nav ad slot when we detect that the user has an ad blocker enabled",
+      owners = Seq(Owner.withGithub("zekehuntergreen")),
+      sellByDate = LocalDate.of(2021, 11, 1),
+      participationGroup = Perc0C,
+    )
+

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -60,17 +60,35 @@ const go = () => {
         cmp.init({ pubData, country: await getLocale() });
 
         // 2. once standard is done, next is commercial
-        if (process.env.NODE_ENV !== 'production') {
-            window.guardian.adBlockers.onDetect.push(isInUse => {
-                const needsMessage =
-                    isInUse && window.console && window.console.warn;
-                const message =
-                    'Do you have an adblocker enabled? Commercial features might fail to run, or throw exceptions.';
-                if (needsMessage) {
-                    window.console.warn(message);
-                }
-            });
-        }
+		// Handle ad blockers
+		window.guardian.adBlockers.onDetect.push((adblockInUse) => {
+			if (!adblockInUse) return;
+
+			// For the moment we'll hide the top-above-nav slot if we detect that the user has ad blockers enabled
+			// in order to avoid showing them a large blank space.
+			// TODO improve shady pie to make better use of the slot.
+			if (
+				config.get(
+					'tests.hideTopAboveNavWhenAdBlockerEnabledVariant',
+					false,
+				) === 'variant'
+			) {
+				console.log('Hiding top-above-nav slot');
+				document.querySelector(
+					'.top-banner-ad-container',
+				).style.display = 'none';
+			}
+
+			if (process.env.NODE_ENV !== 'production') {
+				const needsMessage =
+					adblockInUse && window.console && window.console.warn;
+				const message =
+					'Do you have an adblocker enabled? Commercial features might fail to run, or throw exceptions.';
+				if (needsMessage) {
+					window.console.warn(message);
+				}
+			}
+		});
 
         const fakeBootCommercial = { bootCommercial: () => {} }
 		const useStandaloneBundle =


### PR DESCRIPTION
## What does this change?
At the moment in production, users with [some browser, ad blocker combinations](https://docs.google.com/spreadsheets/d/18n2N5p8ARA4R2ySfe2-bvocCuvJjApdtbMu9fa1Ol8k/edit?usp=sharing) see a top-above-nav ad slot where the ad is blocked and the slot appears as a blank, white space. In order to improve this user experience, we'd like to hide the slot for all users who we detect are using ad blockers.
The above ad-blocking behaviour can't be reproduced in frontend CODE or locally, so we're testing the change that hides the ad slot in production by putting it behind a zero-percent test.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After (user in variant group of experiment)     |
|-------------|------------|
|  ![Screenshot 2021-09-15 at 12 12 40](https://user-images.githubusercontent.com/17057932/133423388-ed8652e6-0fff-40af-9dd8-fdc0556ae50e.png) | ![Screenshot 2021-09-15 at 12 12 52](https://user-images.githubusercontent.com/17057932/133423419-a5abb4c4-6486-4ef0-9108-b3a47f4d4e89.png) |

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?
If we're happy with the experience of users with ad blockers in the experiment variant group, we can roll out the change to everyone and improve the user experience of readers with ad blockers.


## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
