### PR TITLE
Hide top above nav slot when ad blocker is enabled

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -11,7 +11,6 @@ object ActiveExperiments extends ExperimentsDefinition {
     StandaloneCommercialBundle,
     StandaloneCommercialBundleTracking,
     RemoveStickyNav,
-    HideTopAboveNavWhenAdBlockerEnabled,
   )
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -60,13 +59,4 @@ object RemoveStickyNav
       owners = Seq(Owner.withGithub("MarSavar")),
       sellByDate = LocalDate.of(2021, 10, 8),
       participationGroup = Perc1B,
-    )
-
-object HideTopAboveNavWhenAdBlockerEnabled
-    extends Experiment(
-      name = "hide-top-above-nav-when-ad-blocker-enabled",
-      description = "Hides top-above-nav ad slot when we detect that the user has an ad blocker enabled",
-      owners = Seq(Owner.withGithub("zekehuntergreen")),
-      sellByDate = LocalDate.of(2021, 11, 1),
-      participationGroup = Perc0C,
     )

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -67,17 +67,8 @@ const go = () => {
 			// For the moment we'll hide the top-above-nav slot if we detect that the user has ad blockers enabled
 			// in order to avoid showing them a large blank space.
 			// TODO improve shady pie to make better use of the slot.
-			if (
-				config.get(
-					'tests.hideTopAboveNavWhenAdBlockerEnabledVariant',
-					false,
-				) === 'variant'
-			) {
-				console.log('Hiding top-above-nav slot');
-				document.querySelector(
-					'.top-banner-ad-container',
-				).style.display = 'none';
-			}
+			document.querySelector('.top-banner-ad-container').style.display =
+				'none';
 
 			if (process.env.NODE_ENV !== 'production') {
 				const needsMessage =


### PR DESCRIPTION
## What does this change?
Roll out changes from #24172 to all users.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After (user in variant group of experiment)     |
|-------------|------------|
|  ![Screenshot 2021-09-15 at 12 12 40](https://user-images.githubusercontent.com/17057932/133423388-ed8652e6-0fff-40af-9dd8-fdc0556ae50e.png) | ![Screenshot 2021-09-15 at 12 12 52](https://user-images.githubusercontent.com/17057932/133423419-a5abb4c4-6486-4ef0-9108-b3a47f4d4e89.png) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?
At the moment in production, users with [some browser, ad blocker combinations](https://docs.google.com/spreadsheets/d/18n2N5p8ARA4R2ySfe2-bvocCuvJjApdtbMu9fa1Ol8k/edit?usp=sharing) see a top-above-nav ad slot where the ad is blocked and the slot appears as a blank, white space. In order to improve this user experience, we'd like to hide the slot for all users who we detect are using ad blockers.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
