### PR TITLE
Use better defaults in Chronos

### DIFF
--- a/common/app/common/Chronos.scala
+++ b/common/app/common/Chronos.scala
@@ -37,7 +37,7 @@ object Chronos {
           .toInstant()
           .getMillis,
       ),
-      ZoneId.systemDefault,
+      ZoneId.of("UTC"),
     )
   }
 
@@ -49,7 +49,7 @@ object Chronos {
           .toInstant()
           .getMillis,
       ),
-      ZoneId.systemDefault,
+      ZoneId.of("UTC"),
     )
   }
 
@@ -57,14 +57,14 @@ object Chronos {
   // Conversions away from java.util.Date
 
   def javaUtilDateToJavaTimeLocalDate(date: java.util.Date): java.time.LocalDate = {
-    date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate()
+    date.toInstant().atZone(ZoneId.of("UTC")).toLocalDate()
   }
 
   // ------------------------------------------------
   // Conversions away from java.util.Date
 
   def javaUtilDateToJavaTimeLocalDateTime(date: java.util.Date): java.time.LocalDateTime = {
-    date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime()
+    date.toInstant().atZone(ZoneId.of("UTC")).toLocalDateTime()
   }
 
   // ------------------------------------------------


### PR DESCRIPTION
## What does this change?

The use of `ZoneId.systemDefault` is not currently causing problems, but Step 11 of the ongoing joda.time decomposition (a work currently in progress) has highlighted that it causes unreliable date conversions when converting across large timezones. This change defaults to `ZoneId.of("UTC")`, which fixes the problem. 
