### PR TITLE
Always add Confiant targeting

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.spec.ts
@@ -1,4 +1,3 @@
-import { Advert } from '../dfp/Advert';
 import { _ } from './prepare-ad-verification';
 
 jest.mock('../../../../lib/raven');
@@ -38,12 +37,7 @@ jest.mock('../dfp/load-advert', () => ({
 const mockVariantSynchronous = jest.fn<boolean, unknown[]>();
 const mockLog = jest.fn<void, unknown[]>();
 
-const {
-	init,
-	maybeRefreshBlockedSlotOnce,
-	shouldRefresh,
-	getRefreshedSlots,
-} = _;
+const { init, maybeRefreshBlockedSlotOnce, shouldRefresh } = _;
 
 let scriptLoadShouldFail = false;
 

--- a/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.ts
+++ b/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.ts
@@ -43,7 +43,6 @@ const maybeRefreshBlockedSlotOnce: ConfiantCallback = (
 
 	// check if ad is blocked and haven't refreshed the slot yet.
 	if (
-		shouldRefresh() &&
 		isBlocked &&
 		!!blockedSlotPath &&
 		!confiantRefreshedSlots.includes(blockedSlotPath)
@@ -56,12 +55,19 @@ const maybeRefreshBlockedSlotOnce: ConfiantCallback = (
 			if (blockedSlotPath === currentSlot.getSlotElementId()) {
 				// refresh the blocked slot to get new ad
 				const advert = getAdvertById(blockedSlotPath);
-				if (advert) {
-					advert.slot.setTargeting('confiant', String(blockingType));
+				if (!advert) return;
+
+				advert.slot.setTargeting('confiant', String(blockingType));
+
+				setForceSendMetrics(true);
+				captureCommercialMetrics();
+
+				if (shouldRefresh()) {
 					refreshAdvert(advert);
+
+					// mark it as refreshed so it won't refresh multiple time
+					confiantRefreshedSlots.push(blockedSlotPath);
 				}
-				// mark it as refreshed so it won't refresh multiple time
-				confiantRefreshedSlots.push(blockedSlotPath);
 			}
 		});
 	}
@@ -92,5 +98,5 @@ export const _ = {
 	init,
 	maybeRefreshBlockedSlotOnce,
 	shouldRefresh,
-	confiantRefreshedSlots,
+	getRefreshedSlots: (): string[] => confiantRefreshedSlots,
 };

--- a/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.ts
+++ b/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.ts
@@ -98,5 +98,5 @@ export const _ = {
 	init,
 	maybeRefreshBlockedSlotOnce,
 	shouldRefresh,
-	getRefreshedSlots: (): string[] => confiantRefreshedSlots,
+	confiantRefreshedSlots,
 };


### PR DESCRIPTION
## What does this change?

Ads `confiant` key-value targetting regardless of wether we’ll refresh.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

There’s no other way to tell an ad was blocked, so it’s hard to compare the control and variant groups.

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
