### PR TITLE
Showcase panel titles

### DIFF
--- a/common/app/common/TrailsToShowcase.scala
+++ b/common/app/common/TrailsToShowcase.scala
@@ -210,7 +210,7 @@ object TrailsToShowcase {
             .flatten
             .flatten
             .flatten
-          // Couldn not make 3 valid articles is the most useful message to the editor so put it first
+          // Could not make 3 valid articles is the most useful message to the editor so put it first
           Left("Could not find 3 valid rundown article trails" +: articleProblems)
         }
     }
@@ -323,25 +323,21 @@ object TrailsToShowcase {
 
   private def titleOfLengthFrom(length: Int, content: PressedContent): Either[Seq[String], String] = {
     val (_, title) = inferPanelTitleAndTitleFrom(content)
-    Some(title)
-      .filter(_.nonEmpty)
-      .filter(_.length <= length)
-      .map(Right(_))
-      .getOrElse(
-        Left(Seq(s"The headline '$title' is longer than " + length + " characters")),
-      )
+    Right(title)
+      .filterOrElse(_.nonEmpty, Seq("Heading is empty"))
+      .filterOrElse(_.length <= length, Seq(s"The headline '$title' is longer than " + length + " characters"))
   }
 
   private def panelTitleFrom(content: PressedContent): Either[Seq[String], Option[String]] = {
     val (maybePanelTitle, _) = inferPanelTitleAndTitleFrom(content)
     maybePanelTitle
       .map { panelTitle =>
-        maybePanelTitle
-          .filter(_.length <= MaxLengthForPanelTitle)
-          .map(validPanelTitle => Right(Some(validPanelTitle)))
-          .getOrElse {
-            Left(Seq(s"The panel title '$panelTitle' is longer than " + MaxLengthForPanelTitle + " characters"))
-          }
+        Right(Some(panelTitle))
+          .filterOrElse(_ => panelTitle.nonEmpty, Seq(s"Panel title in headline '${content.header.headline}' is empty"))
+          .filterOrElse(
+            _ => panelTitle.length <= MaxLengthForPanelTitle,
+            Seq(s"The panel title '$panelTitle' is longer than " + MaxLengthForPanelTitle + " characters"),
+          )
       }
       .getOrElse {
         Right(None)
@@ -352,12 +348,12 @@ object TrailsToShowcase {
     val (maybePanelTitle, _) = inferPanelTitleAndTitleFrom(content)
     maybePanelTitle
       .map { panelTitle =>
-        maybePanelTitle
-          .filter(_.length <= MaxLengthForPanelTitle)
-          .map(validPanelTitle => Right(validPanelTitle))
-          .getOrElse {
-            Left(Seq(s"The panel title '$panelTitle' is longer than " + MaxLengthForPanelTitle + " characters"))
-          }
+        Right(panelTitle)
+          .filterOrElse(_ => panelTitle.nonEmpty, Seq(s"Panel title in headline '${content.header.headline}' is empty"))
+          .filterOrElse(
+            _ => panelTitle.length <= MaxLengthForPanelTitle,
+            Seq(s"The panel title '$panelTitle' is longer than " + MaxLengthForPanelTitle + " characters"),
+          )
       }
       .getOrElse {
         Left(Seq(s"Could not find a panel title in the first trail headline '${content.header.headline}'"))

--- a/common/app/common/TrailsToShowcase.scala
+++ b/common/app/common/TrailsToShowcase.scala
@@ -218,7 +218,7 @@ object TrailsToShowcase {
     }
 
     // Collect mandatory fields. If any of these is missing we can yield None
-    val proposedPanelTitle: Either[Seq[String], String] = {
+    val proposedPanelTitle = {
       content.headOption
         .map { firstTrail =>
           mandatoryPanelTitleFrom(firstTrail)

--- a/common/app/common/TrailsToShowcase.scala
+++ b/common/app/common/TrailsToShowcase.scala
@@ -366,11 +366,10 @@ object TrailsToShowcase {
     val trailTitle = TrailsToRss.stripInvalidXMLCharacters(content.header.headline)
     // Look for panel title delimiter
     val pipeDelimited = trailTitle.split(PanelTitleInHeadlineDelimiter).toSeq
-    val (maybePanelTitle, title) = pipeDelimited.length match {
+    pipeDelimited.length match {
       case 1 => (None, stripHtml(trailTitle))
       case _ => (Some(stripHtml(pipeDelimited.head)), stripHtml(pipeDelimited.drop(1).mkString))
     }
-    (maybePanelTitle, title)
   }
 
   private def bylineFrom(content: PressedContent): Option[String] = {

--- a/common/app/common/TrailsToShowcase.scala
+++ b/common/app/common/TrailsToShowcase.scala
@@ -59,14 +59,14 @@ object TrailsToShowcase {
 
   def fromTrails(
       feedTitle: Option[String],
-      singleStories: Seq[PressedContent],
-      rundownStories: Seq[PressedContent],
+      singleTrails: Seq[PressedContent],
+      rundownTrails: Seq[PressedContent],
       rundownContainerId: String,
       url: Option[String] = None,
       description: Option[String] = None,
   )(implicit request: RequestHeader): String = {
-    val rundownPanelOutcome = asRundownPanel(rundownStories, rundownContainerId)
-    val singleStoryPanelOutcomes = singleStories.map(asSingleStoryPanel)
+    val rundownPanelOutcome = asRundownPanel(rundownTrails, rundownContainerId)
+    val singleStoryPanelOutcomes = singleTrails.map(asSingleStoryPanel)
 
     val maybeRundownPanel = rundownPanelOutcome.toOption
     val singleStoryPanels = singleStoryPanelOutcomes.flatMap(_.toOption)

--- a/common/app/common/TrailsToShowcase.scala
+++ b/common/app/common/TrailsToShowcase.scala
@@ -406,11 +406,9 @@ object TrailsToShowcase {
     val bulletListItemsToUse =
       validBulletTexts.map(BulletListItem).take(MaxBulletsAllowed) // 3 is the maximum permitted number of bullets
 
-    if (bulletListItemsToUse.nonEmpty) {
-      Right(BulletList(bulletListItemsToUse))
-    } else {
-      Left(Seq("Trail text is not formatted as a bullet list"))
-    }
+    Right(BulletList(bulletListItemsToUse))
+      .filterOrElse(_.listItems.nonEmpty, Seq("Trail text is not formatted as a bullet list"))
+      .filterOrElse(_.listItems.size >= 2, Seq("Need at least 2 valid bullet list items"))
   }
 
   private def syndFeedOf(

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -64,13 +64,20 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
   val wayBackWhen = new DateTime(2021, 3, 2, 12, 30, 1)
   val lastModifiedWayBackWhen = wayBackWhen.plusHours(1)
 
+  val twoEncodedBulletItems =
+    """
+      | - Bullet 1
+      |
+      |-Bullet 2
+      |""".stripMargin
+
   "TrailsToShowcase" should "set module namespaces in feed header" in {
     val singleStoryTrails =
       Seq(
         makePressedContent(
           webPublicationDate = wayBackWhen,
           trailPicture = Some(imageMedia),
-          trailText = Some("- A bullet"),
+          trailText = Some(twoEncodedBulletItems),
         ),
       )
 
@@ -262,7 +269,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       webPublicationDate = wayBackWhen,
       lastModified = Some(lastModifiedWayBackWhen),
       trailPicture = Some(imageMedia),
-      trailText = Some(" - Bullet"),
+      trailText = Some(twoEncodedBulletItems),
       byline = Some("I showed up on the author tag right?"),
     )
 
@@ -299,9 +306,10 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       headline = "My unique headline",
       byline = Some("Trail byline"),
       kickerText = Some("A Kicker"),
-      trailText = Some("- A bullet"),
+      trailText = Some(twoEncodedBulletItems),
     )
 
+    println(TrailsToShowcase.asSingleStoryPanel(curatedContent).left.get)
     val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(curatedContent).toOption.get
     singleStoryPanel.title should be("My unique headline")
 
@@ -426,6 +434,26 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
 
     outcome.right.toOption should be(None)
     outcome.left.get.contains("Trail text is not formatted as a bullet list") shouldBe (true)
+  }
+
+  "TrailToShowcase" should "reject bullet lists with less than 2 items" in {
+    // Showcase specifies 2 or 3 items
+    val bulletEncodedTrailText =
+      """
+          | - 1 bullet item is not going to be enough
+          |""".stripMargin
+
+    val bulletedContent = makePressedContent(
+      webPublicationDate = wayBackWhen,
+      lastModified = Some(lastModifiedWayBackWhen),
+      trailPicture = Some(imageMedia),
+      trailText = Some(bulletEncodedTrailText),
+    )
+
+    val outcome = TrailsToShowcase.asSingleStoryPanel(bulletedContent)
+
+    outcome.right.toOption should be(None)
+    outcome.left.get.contains("Need at least 2 valid bullet list items") shouldBe (true)
   }
 
   "TrailToShowcase" should "trim single story bullets to 3 at most" in {
@@ -768,7 +796,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       webPublicationDate = wayBackWhen,
       lastModified = Some(lastModifiedWayBackWhen),
       trailPicture = Some(imageMedia),
-      trailText = Some("- A bullet"),
+      trailText = Some(twoEncodedBulletItems),
       headline = "Meteoric rise | US Open winner could become Britain’s first billion-dollar sport star",
     )
 
@@ -823,7 +851,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       lastModified = Some(lastModifiedWayBackWhen),
       trailPicture = Some(imageMedia),
       byline = Some(longerThan42),
-      trailText = Some("- A bullet"),
+      trailText = Some(twoEncodedBulletItems),
     )
 
     val outcome = TrailsToShowcase.asSingleStoryPanel(withLongByline)


### PR DESCRIPTION
## What does this change?

Allows Showcase panel titles to be encoded using a pipe delimit in the headline of the first trail in the rundown collection or optional in each single story trail.

ie.
```
My Panel Title | My headline 
```

This may move to a Fronts editor controlled field on the pressed content one day.

<img width="392" alt="Screenshot 2021-09-15 at 16 26 35" src="https://user-images.githubusercontent.com/150238/133586881-24d1deaa-7a63-4155-aa67-da0be5b34494.png">


## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
