### PR TITLE
Remove remaining ESI ad call code

### DIFF
--- a/common/app/http/Filters.scala
+++ b/common/app/http/Filters.scala
@@ -16,14 +16,8 @@ import org.apache.commons.codec.digest.DigestUtils
 import scala.concurrent.{ExecutionContext, Future}
 
 class GzipperConfig() extends GzipFilterConfig {
-  // These paths are used as a whitelist that means the server's
-  // outgoing response for this request will be uncompressed.
-  val excludeFromGzip = List(
-    "/esi/ad-call",
-  )
-
   override val shouldGzip: (RequestHeader, Result) => Boolean = (request, result) => {
-    !result.header.isImage && !excludeFromGzip.contains(request.path)
+    !result.header.isImage
   }
 }
 class Gzipper(implicit val mat: Materializer) extends GzipFilter(new GzipperConfig)

--- a/common/app/templates/inlineJS/blocking/config.scala.js
+++ b/common/app/templates/inlineJS/blocking/config.scala.js
@@ -36,21 +36,14 @@ window.guardian = {
     config: @JavaScript(templates.js.javaScriptConfig(page).body)
 };
 
-// Check if a pre-made view id has been constructed through an esi.
-if (window.esi && window.esi.viewId) {
-    window.guardian.config.ophan = {
-        pageViewId: window.esi.viewId
-    };
-} else {
-    window.guardian.config.ophan = {
-        // This is duplicated from
-        // https://github.com/guardian/ophan/blob/master/tracker-js/assets/coffee/ophan/transmit.coffee
-        // Please do not change this without talking to the Ophan project first.
-        pageViewId: new Date().getTime().toString(36) + 'xxxxxxxxxxxx'.replace(/x/g, function () {
-            return Math.floor(Math.random() * 36).toString(36);
-        })
-    };
-}
+window.guardian.config.ophan = {
+    // This is duplicated from
+    // https://github.com/guardian/ophan/blob/master/tracker-js/assets/coffee/ophan/transmit.coffee
+    // Please do not change this without talking to the Ophan project first.
+    pageViewId: new Date().getTime().toString(36) + 'xxxxxxxxxxxx'.replace(/x/g, function () {
+        return Math.floor(Math.random() * 36).toString(36);
+    })
+};
 
 // http://blogs.msdn.com/b/ieinternals/archive/2010/05/13/xdomainrequest-restrictions-limitations-and-workarounds.aspx
 /*@@cc_on

--- a/diagnostics/app/views/adCall.scala.html
+++ b/diagnostics/app/views/adCall.scala.html
@@ -1,7 +1,0 @@
-@(pageViewId: String)<div class="ad-call">
-    <script>
-        window.esi = {
-            viewId: '@pageViewId'
-        };
-    </script>
-</div>

--- a/tools/__tasks__/validate-head/javascript.js
+++ b/tools/__tasks__/validate-head/javascript.js
@@ -15,7 +15,7 @@ module.exports = {
                     const errors = [];
                     const jsFiles = files.filter(
                         file =>
-                            file.endsWith('.js') ||
+                            (file.endsWith('.js') && !file.endsWith('.scala.js')) ||
                             file.endsWith('.jsx') ||
                             file.startsWith('git-hooks')
                     );


### PR DESCRIPTION
## What does this change?

Removes features introduced in #15836 to use ESI (edge side includes) to speed up ad calls.  This was mostly removed by #17685 but these bits got left behind.

Also disables the linter for `.scala.js` files since I don't think they will ever lint correctly.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
