### PR TITLE
Adding the ability to serve articles in DCR with contents block enhancers

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -23,6 +23,7 @@ object ArticlePageChecks {
       "https://interactive.guim.co.uk/2017/07/booklisted/boot.js", // not supported but fallback ok
       "https://interactive.guim.co.uk/page-enhancers/super-lists/boot.js", // broken on frontend anyway
       "https://gdn-cdn.s3.amazonaws.com/quiz-builder/", // old quiz builder quizzes work fine
+      "https://uploads.guim.co.uk/2019/03/20/boot.js", //creates a contents section when included in articles
     )
 
     def unsupportedElement(blockElement: BlockElement) =


### PR DESCRIPTION
## What does this change?
Enables DCR to serve articles that contain a certain boot.js script. This script creates a contents block within the article. 
