### PR TITLE
Decommission cookie GU_geo_continent

### DIFF
--- a/static/src/javascripts.flow.archive/projects/common/modules/commercial/reader-revenue-dev-utils.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/commercial/reader-revenue-dev-utils.js
@@ -109,7 +109,6 @@ const showMeTheBanner = (asExistingSupporter: boolean = false): void => {
 };
 
 const showMeTheDoubleBanner = (asExistingSupporter: boolean = false): void => {
-    addCookie('GU_geo_continent', 'EU');
     showMeTheBanner(asExistingSupporter);
 };
 

--- a/static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js
+++ b/static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js
@@ -92,7 +92,6 @@ const showMeTheBanner = (asExistingSupporter = false) => {
 };
 
 const showMeTheDoubleBanner = (asExistingSupporter = false) => {
-    addCookie('GU_geo_continent', 'EU');
     showMeTheBanner(asExistingSupporter);
 };
 


### PR DESCRIPTION
## What does this change?

We decommission the GU_geo_continent cookie which is no longer used. (The motivation for doing it now is that its existence is therefore no longer essential, and stands between us and PECR compliance.)