### PR TITLE
Serve pressed interactives

### DIFF
--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -142,11 +142,7 @@ class InteractiveController(
     if (isUSElectionAMP) { // A special-cased AMP page for various US Election (2020) interactive pages.
       renderUSElectionAMPPage(path)
     } else if (canShowPressed) {
-      val result = InteractiveLibrarian.getDocumentFromS3(path) match {
-        case Some(document) => servePressedPage(path)
-        case None           => NotFound(s"Could not retrieve stored document at www.theguardian.com/${path}")
-      }
-      Future.successful(result)
+      Future.successful(servePressedPage(path))
     } else {
       val res = for {
         resp <- lookupItemResponse(path)

--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -19,9 +19,8 @@ import services.{CAPILookup, USElection2020AmpPages, _}
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import experiments.{ActiveExperiments, ShowPressedInteractives}
+import experiments.ShowPressedInteractives
 import services.dotcomrendering.PressedInteractives.isPressed
-import services.dotcomrendering.InteractiveLibrarian
 
 class InteractiveController(
     contentApiClient: ContentApiClient,
@@ -136,8 +135,6 @@ class InteractiveController(
         case Right(result) => Future.successful(result)
       }
     }
-
-    log.info(s"Serving interactive, path=$path, canShowPressed=${canShowPressed}")
 
     if (isUSElectionAMP) { // A special-cased AMP page for various US Election (2020) interactive pages.
       renderUSElectionAMPPage(path)

--- a/applications/test/InteractiveControllerTest.scala
+++ b/applications/test/InteractiveControllerTest.scala
@@ -50,9 +50,9 @@ import conf.Configuration.interactive.cdnPath
   }
 
   "Interactive serve pressed page" should "return expected headers and path" in {
-    val pressedPage = interactiveController.servePressedPage(url)(TestRequest(url))
+    val result = interactiveController.servePressedPage(url)(TestRequest(url))
 
-    pressedPage.header.headers.getOrElse("X-Accel-Redirect", "No header") should be(
+    header("X-Accel-Redirect", result).head should be(
       s"/s3-archive/www.theguardian.com/$url",
     )
   }

--- a/applications/test/InteractiveControllerTest.scala
+++ b/applications/test/InteractiveControllerTest.scala
@@ -49,4 +49,11 @@ import conf.Configuration.interactive.cdnPath
     )
   }
 
+  "Interactive serve pressed page" should "return expected headers and path" in {
+    val pressedPage = interactiveController.servePressedPage(url)(TestRequest(url))
+
+    pressedPage.header.headers.getOrElse("X-Accel-Redirect", "No header") should be(
+      s"/s3-archive/www.theguardian.com/$url",
+    )
+  }
 }

--- a/applications/test/package.scala
+++ b/applications/test/package.scala
@@ -3,7 +3,7 @@ package test
 import java.util.{List => JList}
 
 import org.scalatest.Suites
-import services.{FacebookGraphApiTest, IndexPageTest, NewspaperControllerTest}
+import services.{FacebookGraphApiTest, IndexPageTest, NewspaperControllerTest, InteractivePickerTest}
 
 import collection.JavaConverters._
 
@@ -42,6 +42,7 @@ class ApplicationsTestSuite
       new NewspaperControllerTest,
       new IndexPageTest,
       new FacebookGraphApiTest,
+      new InteractivePickerTest,
     )
     with SingleServerSuite {
   override lazy val port: Int = 19003

--- a/applications/test/services/InteractivePickerTest.scala
+++ b/applications/test/services/InteractivePickerTest.scala
@@ -1,0 +1,35 @@
+package services
+
+import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
+import test.{ConfiguredTestSuite, TestRequest}
+import implicits.HtmlFormat
+import play.api.test.Helpers._
+import experiments.ShowPressedInteractives
+
+import java.time.LocalDateTime
+
+@DoNotDiscover class InteractivePickerTest extends FlatSpec with Matchers {
+  val path = "lifeandstyle/ng-interactive/2016/mar/12/stephen-collins-cats-cartoon"
+  object MockPressedInteractives {
+    private[this] val interactives = Set[String](path)
+    def isPressed(path: String): Boolean = interactives.contains(path)
+  }
+  val date = LocalDateTime.now
+
+  "Interactive Picker get rendering tier" should "return InteractiveLegacy if pressed and not amp and part of experiment" in {
+    conf.switches.Switches.ServerSideExperiments.switchOn
+    ShowPressedInteractives.switch.switchOn()
+
+    val testRequest = TestRequest(path)
+      .withHeaders(
+        ShowPressedInteractives.participationGroup.headerName -> "variant",
+      )
+    val tags = List()
+    val requestFormat = HtmlFormat
+    val tier = InteractivePicker.getRenderingTier(requestFormat, path, date, tags, MockPressedInteractives.isPressed)(
+      testRequest,
+    )
+
+    tier should be(InteractiveLegacy)
+  }
+}

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -7,7 +7,7 @@ import java.time.LocalDate
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
     LiveblogRendering,
-    PressedInteractives,
+    ShowPressedInteractives,
     StandaloneCommercialBundle,
     StandaloneCommercialBundleTracking,
     RemoveStickyNav,
@@ -25,7 +25,7 @@ object LiveblogRendering
       participationGroup = Perc0A,
     )
 
-object PressedInteractives
+object ShowPressedInteractives
     extends Experiment(
       name = "interactive-librarian",
       description = "The pressed interactives experiment",

--- a/common/app/services/dotcomrendering/PressedInteractives.scala
+++ b/common/app/services/dotcomrendering/PressedInteractives.scala
@@ -8,7 +8,7 @@ object PressedInteractives {
   // - remove this file entirely
   // - update the InteractiveController to show pressed pages based on presence of the tag
   // - update the press+clean functionality to automate tagging as part of this process
-  private[this] val interactives = Set(
+  private[this] val interactives = Set[String](
   )
 
   def isPressed(path: String): Boolean = interactives.contains(path)

--- a/common/app/services/dotcomrendering/PressedInteractives.scala
+++ b/common/app/services/dotcomrendering/PressedInteractives.scala
@@ -9,7 +9,6 @@ object PressedInteractives {
   // - update the InteractiveController to show pressed pages based on presence of the tag
   // - update the press+clean functionality to automate tagging as part of this process
   private[this] val interactives = Set(
-    "world/ng-interactive/2020/apr/08/coronavirus-100-days-that-changed-the-world",
   )
 
   def isPressed(path: String): Boolean = interactives.contains(path)

--- a/common/app/services/dotcomrendering/PressedInteractives.scala
+++ b/common/app/services/dotcomrendering/PressedInteractives.scala
@@ -1,0 +1,16 @@
+package services.dotcomrendering
+
+object PressedInteractives {
+  // Temporarily retain a list of pressed interactives that Visuals agree to show to readers
+  // Ed Tools are supporting us in how to batch/programmatically add tags to pressed articles.
+  // When we can tag pressed articles (tracking/dcroptout) then we will:
+  // - tag all articles that appear in this list
+  // - remove this file entirely
+  // - update the InteractiveController to show pressed pages based on presence of the tag
+  // - update the press+clean functionality to automate tagging as part of this process
+  private[this] val interactives = Set(
+    "world/ng-interactive/2020/apr/08/coronavirus-100-days-that-changed-the-world",
+  )
+
+  def isPressed(path: String): Boolean = interactives.contains(path)
+}

--- a/docs/03-dev-howtos/14-override-default-configuration.md
+++ b/docs/03-dev-howtos/14-override-default-configuration.md
@@ -19,7 +19,9 @@ Tired of pointing your `facia.stage` at `CODE`?  Have you ever longed to change 
           facia.stage=CODE
         }
 
-3. Restart the app you're working on
+3. If overriding switches, control what you want turned on in file switches-yournamehere.properties. Upload your file to the S3 frontend store bucket (aws-frontend-store/DEV/config).
+
+4. Restart the app you're working on
 
 ## Notes
 


### PR DESCRIPTION
## What does this change?
This change allows us to serve pressed interactives to readers. Pressed interactives will only be served to readers if:
- the interactive-librarian  experiment is switched on
- the interactive path is defined in Set `interactives`

At the time of committing it is not possible to batch tag pressed interactives or programmatically add a tracking tag. While this solution is being worked on, we will keep a list of pressed interactives that Visuals have agreed to show to readers. When we have the ability to add tags to pressed interactives our solution will change. For now we also retain the experiment in the controller to enable us to quickly hide pressed content in the event of unexpected errors.

When we can tag pressed articles (tracking/dcroptout) then we will:
- tag all articles that are hardcoded in the frontend codebase
- remove file PressedInteractives entirely
- update the InteractiveController to show pressed pages based on presence of the tag
- update the press+clean functionality to automate tagging as part of this process

Some notes:
- Using the X-Accel-Redirect header redirects all requests to the s3 bucket defined here: https://github.com/guardian/platform/blob/main/router/files/router.conf#L677. This means that, if testing in non-Prod the files from the prod bucket will be served. This caused me a bit of confusion so thought I'd highlight this.
- I've updated the docs to add a little note about how to set switch overrides in DEV, hope my notes make sense.
- During testing in DEV and CODE I noticed some kind of race condition between the config loading and the interactive being served, meaning that on the first request of an interactive the relevant switch config appeared `off`, despite being turned `on` in the remote config. The result was that an unpressed page was displayed. During subsequent requests I could see the switch config appearing `on` - as expected. The issue I couldn't work out was that `ActiveExperiments.isParticipating(ShowPressedInteractives)` was consistently returning `false`, despite the underlying evaluations returning `true` (the switch itself was on and the server side experiment was switched on). Given my intention is to remove the switch altogether when we have confidence in the pressed pages being displayed to readers in PROD, I decided not to get too hung up on this point... Happy to try and think more about it though if this all sounds too implausible!


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
<img width="1092" alt="Screenshot 2021-09-21 at 15 54 38" src="https://user-images.githubusercontent.com/45561419/134202716-4abacaf0-ec6e-4c67-82cd-9fd991f69cbc.png">


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
