### PR TITLE
Add a large capacity collection to hold live Showcase panels

### DIFF
--- a/common/app/layout/slices/FixedContainers.scala
+++ b/common/app/layout/slices/FixedContainers.scala
@@ -52,7 +52,7 @@ object FixedContainers {
     ("fixed/medium/fast-XII", fixedMediumFastXII),
     ("fixed/large/slow-XIV", slices(ThreeQuarterQuarter, QuarterQuarterQuarterQuarter, Ql2Ql2Ql2Ql2)),
     ("fixed/thrasher", thrasher),
-    ("fixed/showcase-single-stories", showcaseSingleStories),
+    ("fixed/showcase", showcaseSingleStories),
   ) ++ (if (Configuration.faciatool.showTestContainers)
           Map(
             (

--- a/common/app/layout/slices/FixedContainers.scala
+++ b/common/app/layout/slices/FixedContainers.scala
@@ -1,7 +1,6 @@
 package layout.slices
 
 import conf.Configuration
-import model.pressed.PressedContent
 
 object FixedContainers {
   import ContainerDefinition.{ofSlices => slices}
@@ -36,6 +35,8 @@ object FixedContainers {
 
   val thrasher = slices(Fluid).copy(customCssClasses = Set("fc-container--thrasher", "flashing-image"))
 
+  val showcaseSingleStories = slices(ShowcaseSingleStories)
+
   val all: Map[String, ContainerDefinition] = Map(
     ("fixed/small/slow-I", slices(FullMedia75)),
     ("fixed/small/slow-III", slices(HalfQQ)),
@@ -51,6 +52,7 @@ object FixedContainers {
     ("fixed/medium/fast-XII", fixedMediumFastXII),
     ("fixed/large/slow-XIV", slices(ThreeQuarterQuarter, QuarterQuarterQuarterQuarter, Ql2Ql2Ql2Ql2)),
     ("fixed/thrasher", thrasher),
+    ("fixed/showcase-single-stories", showcaseSingleStories),
   ) ++ (if (Configuration.faciatool.showTestContainers)
           Map(
             (

--- a/common/app/layout/slices/Slice.scala
+++ b/common/app/layout/slices/Slice.scala
@@ -94,6 +94,24 @@ case object QuarterQuarterQlQl extends Slice {
   )
 }
 
+// Large single column collection hold all currently live Showcase single stories; not intended to be render as HTML
+case object ShowcaseSingleStories extends Slice {
+  val layout = SliceLayout(
+    cssClassName = "q-q-q-ql",
+    columns = Seq(
+      Rows(
+        colSpan = 1,
+        columns = 1,
+        rows = 30,
+        ItemClasses(
+          mobile = ListItem,
+          tablet = ListItem,
+        ),
+      ),
+    ),
+  )
+}
+
 /* .________.________.________.________.
  * |########|########|########|________|
  * |########|########|########|________|


### PR DESCRIPTION
## What does this change?

New layout with 30 item capacity. Not going to be HTML rendered; only to be used on Showcase priority fronts.

Tests ok in CODE.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
