### PR TITLE
Only set ad Manager Group if consented

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -229,6 +229,11 @@ const getAdConsentFromState = (state) => {
     return false;
 }
 
+const getAdManagerGroup = (consented = true) => {
+	if (!consented) return null;
+	return storage.local.getRaw(AMTGRP_STORAGE_KEY) || createAdManagerGroup()
+}
+
 const createAdManagerGroup = () => {
     // users are assigned to groups 1-12
     const group = String(Math.floor(Math.random() * 12) + 1);
@@ -257,11 +262,11 @@ const rebuildPageTargeting = () => {
     const ccpaState = latestCMPState.ccpa ? latestCMPState.ccpa.doNotSell : null;
     const tcfv2EventStatus = latestCMPState.tcfv2 ? latestCMPState.tcfv2.eventStatus : 'na';
     const page = config.get('page');
+    const amtgrp = latestCMPState.tcfv2
+		? getAdManagerGroup(adConsentState)
+		: getAdManagerGroup(true);
     // personalised ads targeting
     if (adConsentState === false) clearPermutiveSegments();
-	const amtgrp = adConsentState
-		? storage.local.getRaw(AMTGRP_STORAGE_KEY) || createAdManagerGroup()
-		: null;
     // flowlint-next-line sketchy-null-bool:off
     const paTargeting = { pa: adConsentState ? 't' : 'f' };
     const adFreeTargeting = commercialFeatures.adFree ? { af: 't' } : {};

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -264,7 +264,7 @@ const rebuildPageTargeting = () => {
     const page = config.get('page');
     const amtgrp = latestCMPState.tcfv2
 		? getAdManagerGroup(adConsentState)
-		: getAdManagerGroup(true);
+		: getAdManagerGroup();
     // personalised ads targeting
     if (adConsentState === false) clearPermutiveSegments();
     // flowlint-next-line sketchy-null-bool:off

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -259,13 +259,16 @@ const rebuildPageTargeting = () => {
     const page = config.get('page');
     // personalised ads targeting
     if (adConsentState === false) clearPermutiveSegments();
+	const amtgrp = adConsentState
+		? storage.local.getRaw(AMTGRP_STORAGE_KEY) || createAdManagerGroup()
+		: null;
     // flowlint-next-line sketchy-null-bool:off
     const paTargeting = { pa: adConsentState ? 't' : 'f' };
     const adFreeTargeting = commercialFeatures.adFree ? { af: 't' } : {};
     const pageTargets = Object.assign(
         {
             ab: abParam(),
-            amtgrp: storage.local.getRaw(AMTGRP_STORAGE_KEY) || createAdManagerGroup(),
+            amtgrp,
             at: getCookie('adtest') || undefined,
             bp: findBreakpoint(),
             cc: getCountryCode(),


### PR DESCRIPTION
## What does this change?

Does not set an ad manager group if we don’t have consent for personalised advertising.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

This `localStorage` item is no longer set prior to a consent signal being received.

## Checklist

### Tested

- [X] Locally
- [ ] On CODE (optional)
