### PR TITLE
Showcase Related Articles panels

### DIFF
--- a/common/app/common/ShowcaseRSSModules.scala
+++ b/common/app/common/ShowcaseRSSModules.scala
@@ -68,21 +68,21 @@ trait GModule extends com.sun.syndication.feed.module.Module with Serializable w
 
   def setOverline(overline: Option[String])
 
-  def getArticleGroup: Option[ArticleGroup]
+  def getArticleGroup: Option[GArticleGroup]
 
-  def setArticleGroup(articleGroup: Option[ArticleGroup])
+  def setArticleGroup(articleGroup: Option[GArticleGroup])
 
-  def getBulletList: Option[BulletList]
+  def getBulletList: Option[GBulletList]
 
-  def setBulletList(bulletList: Option[BulletList])
+  def setBulletList(bulletList: Option[GBulletList])
 }
 
 class GModuleImpl() extends GModule {
   private var panel: Option[String] = None
   private var panelTitle: Option[String] = None
   private var overline: Option[String] = None
-  private var articleGroup: Option[ArticleGroup] = None
-  private var bulletList: Option[BulletList] = None
+  private var articleGroup: Option[GArticleGroup] = None
+  private var bulletList: Option[GBulletList] = None
 
   override def getPanel: Option[String] = panel
 
@@ -96,13 +96,13 @@ class GModuleImpl() extends GModule {
 
   override def setOverline(overline: Option[String]): Unit = this.overline = overline
 
-  override def getArticleGroup: Option[ArticleGroup] = articleGroup
+  override def getArticleGroup: Option[GArticleGroup] = articleGroup
 
-  override def setArticleGroup(articleGroup: Option[ArticleGroup]): Unit = this.articleGroup = articleGroup
+  override def setArticleGroup(articleGroup: Option[GArticleGroup]): Unit = this.articleGroup = articleGroup
 
-  override def getBulletList: Option[BulletList] = bulletList
+  override def getBulletList: Option[GBulletList] = bulletList
 
-  override def setBulletList(bulletList: Option[BulletList]): Unit = this.bulletList = bulletList
+  override def setBulletList(bulletList: Option[GBulletList]): Unit = this.bulletList = bulletList
 
   override def getInterface: Class[_] = classOf[GModule]
 
@@ -138,11 +138,14 @@ case class GArticle(
     mediaContent: Option[MediaContent],
 )
 
-case class ArticleGroup(role: Option[String], articles: Seq[GArticle])
+case class GArticleGroup(
+    role: String,
+    articles: Seq[GArticle],
+)
 
-case class BulletList(listItems: Seq[BulletListItem])
+case class GBulletList(listItems: Seq[GBulletListItem])
 
-case class BulletListItem(text: String)
+case class GBulletListItem(text: String)
 
 class RssAtomModuleGenerator extends ModuleGenerator {
 
@@ -202,10 +205,9 @@ class GModuleGenerator extends ModuleGenerator {
         // Article group element needs article group and role
         for {
           articleGroup <- gModule.getArticleGroup
-          role <- articleGroup.role
         } yield {
           val articleGroupElement = new org.jdom.Element("article_group", NS)
-          articleGroupElement.setAttribute("role", role)
+          articleGroupElement.setAttribute("role", articleGroup.role)
 
           articleGroup.articles.foreach { article =>
             // Slightly regrettable but limited duplication with the main rss entry generation

--- a/common/app/common/TrailsToShowcase.scala
+++ b/common/app/common/TrailsToShowcase.scala
@@ -573,6 +573,7 @@ object TrailsToShowcase {
       published: Option[DateTime],
       updated: Option[DateTime],
       panelTitle: Option[String],
+      summary: Option[String] = None,
   ) extends Panel {
     val `type`: String = SingleStory
     def guid: String = link

--- a/common/app/common/TrailsToShowcase.scala
+++ b/common/app/common/TrailsToShowcase.scala
@@ -15,7 +15,6 @@ import play.api.mvc.RequestHeader
 import java.io.StringWriter
 import java.util.Date
 import scala.collection.JavaConverters._
-import scala.collection.immutable
 import scala.collection.immutable.WrappedString
 
 object TrailsToShowcase {
@@ -106,6 +105,13 @@ object TrailsToShowcase {
   }
 
   def asSingleStoryPanel(content: PressedContent): Either[Seq[String], SingleStoryPanel] = {
+    val proposedTitle = titleOfLengthFrom(MaxLengthForSinglePanelTitle, content)
+    val proposedPanelTitle = panelTitleFrom(content)
+    val proposedWebUrl = webUrl(content).map(Right(_)).getOrElse(Left(Seq("Trail had no web url")))
+    val proposedImageUrl = singleStoryImageUrlFor(content)
+
+    // TODO Something like if supporting content is available then this is a Related Articles panel
+    // Otherwise attempt to process it as a bulllet list panel.
     // Can we access supporting content / sublinks from pressed trails?
     val supportingContent: Seq[PressedContent] = content match {
       case curatedContent: CuratedContent =>
@@ -120,10 +126,6 @@ object TrailsToShowcase {
       val image = singleStoryImageUrlFor(content)
       println("Supporting content image: " + image)
     }
-    val proposedTitle = titleOfLengthFrom(MaxLengthForSinglePanelTitle, content)
-    val proposedPanelTitle = panelTitleFrom(content)
-    val proposedWebUrl = webUrl(content).map(Right(_)).getOrElse(Left(Seq("Trail had no web url")))
-    val proposedImageUrl = singleStoryImageUrlFor(content)
     val proposedBulletList =
       content.card.trailText.map(extractBulletsFrom).getOrElse(Left(Seq("No trail text available")))
 

--- a/common/app/common/TrailsToShowcase.scala
+++ b/common/app/common/TrailsToShowcase.scala
@@ -6,7 +6,7 @@ import com.sun.syndication.feed.module.mediarss.types.{MediaContent, Metadata, U
 import com.sun.syndication.feed.synd._
 import com.sun.syndication.io.SyndFeedOutput
 import common.TrailsToRss.image
-import model.pressed.{PressedContent, Replace}
+import model.pressed.{CuratedContent, PressedContent, Replace}
 import model.{ImageAsset, PressedPage}
 import org.joda.time.DateTime
 import org.jsoup.Jsoup
@@ -15,6 +15,7 @@ import play.api.mvc.RequestHeader
 import java.io.StringWriter
 import java.util.Date
 import scala.collection.JavaConverters._
+import scala.collection.immutable
 import scala.collection.immutable.WrappedString
 
 object TrailsToShowcase {
@@ -105,6 +106,20 @@ object TrailsToShowcase {
   }
 
   def asSingleStoryPanel(content: PressedContent): Either[Seq[String], SingleStoryPanel] = {
+    // Can we access supporting content / sublinks from pressed trails?
+    val supportingContent: Seq[PressedContent] = content match {
+      case curatedContent: CuratedContent =>
+        curatedContent.supportingContent // TODO showcase always deals in curated content so we can push this matching up
+      case _ => Seq.empty
+    }
+    println("Found supporting content on pressed content: " + supportingContent.length)
+    supportingContent.foreach { content =>
+      // Can we find a headline, webUrl and image on the supporting content?
+      println("Supporting content: " + content.header.headline + ", " + content.header.url)
+      // Needs an image Minimum 640 px wide, 320 px high.
+      val image = singleStoryImageUrlFor(content)
+      println("Supporting content image: " + image)
+    }
     val proposedTitle = titleOfLengthFrom(MaxLengthForSinglePanelTitle, content)
     val proposedPanelTitle = panelTitleFrom(content)
     val proposedWebUrl = webUrl(content).map(Right(_)).getOrElse(Left(Seq("Trail had no web url")))

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -422,17 +422,20 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       webPublicationDate = wayBackWhen,
       lastModified = Some(lastModifiedWayBackWhen),
       trailPicture = Some(imageMedia),
-      trailText = Some(twoEncodedBulletItems),
+      trailText = Some("On a related article panel the trail text should become the panel description"),
       supportingContent = Seq(subLink, subLink),
     )
 
-    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(withSupportingContent)
+    val outcome = TrailsToShowcase.asSingleStoryPanel(withSupportingContent)
 
-    singleStoryPanel.left.toOption.isEmpty should be(true)
-    singleStoryPanel.right.get.articleGroup.nonEmpty shouldBe (true)
-    singleStoryPanel.right.get.articleGroup.get.role shouldBe ("RELATED_CONTENT")
-    singleStoryPanel.right.get.articleGroup.get.articles.size shouldBe (2)
-    singleStoryPanel.right.get.articleGroup.get.articles.head.title shouldBe ("A sublink")
+    outcome.left.toOption.isEmpty should be(true)
+    val singleStoryRelatedArticlesPanel = outcome.right.get
+    singleStoryRelatedArticlesPanel.articleGroup.nonEmpty shouldBe (true)
+    singleStoryRelatedArticlesPanel.articleGroup.get.role shouldBe ("RELATED_CONTENT")
+    singleStoryRelatedArticlesPanel.articleGroup.get.articles.size shouldBe (2)
+    singleStoryRelatedArticlesPanel.articleGroup.get.articles.head.title shouldBe ("A sublink")
+
+    singleStoryRelatedArticlesPanel.summary shouldBe(Some("On a related article panel the trail text should become the panel description"))
   }
 
   "TrailToShowcase" can "encode single story panel bullet lists from trailtext lines" in {

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -1184,11 +1184,12 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     rundownPanel.articleGroup.articles.forall(_.overline.isEmpty) should be(true)
   }
 
-  "TrailToShowcase validation" should "omit authors from rundown panel articles if author has not been set on all articles" in {
+  "TrailToShowcase validation" should "reject rundown panel articles if author been set on some but not all articles" in {
     val withAuthor = makePressedContent(
       webPublicationDate = wayBackWhen,
       lastModified = Some(lastModifiedWayBackWhen),
       trailPicture = Some(imageMedia),
+      headline = "Panel title | headline",
       byline = Some("An author"),
     )
     val withoutAuthor = makePressedContent(
@@ -1197,10 +1198,11 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       trailPicture = Some(imageMedia),
     )
 
-    val rundownPanel = TrailsToShowcase
+    val outcome = TrailsToShowcase
       .asRundownPanel(Seq(withAuthor, withAuthor, withoutAuthor), "rundown-container-id")
 
-    rundownPanel.toOption should be(None)
+    outcome.right.toOption should be(None)
+    outcome.left.get.contains("Rundown trails need to have all Kickers or all Bylines") should be(true)
   }
 
   "TrailToShowcase validation" should "choose kickers over authors" in {

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -377,12 +377,16 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       headline = "My panel title | My unique headline",
       byline = Some("Trail byline"),
       kickerText = Some("A kicker"),
-      trailText = Some(twoEncodedBulletItems),
+      trailText = Some("Trailtext"),
       supportingContent = Seq(sublink, sublink),
     )
     val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(curatedContent).toOption.get
 
     val entry = TrailsToShowcase.asSyndEntry(singleStoryPanel)
+
+    entry.getTitle should be("My unique headline")
+    entry.getDescription.getValue should be("Trailtext")
+
     // Showcase's use of the RSS author tag is slightly off spec; they use it to pass free text where the standard is expecting an email address
     // We use a person with an email address to get the free form byline through Rome and onto the author tag
     // See https://github.com/rometools/rome/blob/001d1cca5448817a031e3746f417519652ede4e9/rome/src/main/java/com/rometools/rome/feed/synd/impl/ConverterForRSS094.java#L139
@@ -435,7 +439,9 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     singleStoryRelatedArticlesPanel.articleGroup.get.articles.size shouldBe (2)
     singleStoryRelatedArticlesPanel.articleGroup.get.articles.head.title shouldBe ("A sublink")
 
-    singleStoryRelatedArticlesPanel.summary shouldBe(Some("On a related article panel the trail text should become the panel description"))
+    singleStoryRelatedArticlesPanel.summary shouldBe (Some(
+      "On a related article panel the trail text should become the panel description",
+    ))
   }
 
   "TrailToShowcase" can "encode single story panel bullet lists from trailtext lines" in {
@@ -476,8 +482,9 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       trailText = Some(bulletEncodedTrailText),
     )
 
-    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(bulletedContent).toOption.get
+    val outcome = TrailsToShowcase.asSingleStoryPanel(bulletedContent)
 
+    val singleStoryPanel = outcome.toOption.get
     val bulletList = singleStoryPanel.bulletList.get
     val bulletListItems = bulletList.listItems
     bulletListItems.size should be(2)

--- a/preview/app/views/showcase.scala.html
+++ b/preview/app/views/showcase.scala.html
@@ -45,7 +45,7 @@
                 object-fit: cover;
              }
 
-            .rundown img {
+            .articleGroup img {
                 margin-left: auto;
                 border-radius: 5px;
                 object-fit: cover;
@@ -82,19 +82,7 @@
             @for(panel <- rundownPanelOutcomes.right.toOption) {
                 <li class="panel rundown">
                     <h2 class="panelTitle">@panel.panelTitle</h2>
-                    @for((article, index) <- panel.articles.zipWithIndex) {
-                        <a href="@article.link" target="_blank"><img src="@article.imageUrl" width="160"/></a>
-                        @for(overline <- article.overline) {
-                            <p class="overline">@overline</p>
-                        }
-                        <a href="@article.link" target="_blank"><h4>@article.title</h4></a>
-                        @for(author <- article.author) {
-                            <p class="author">@author</p>
-                        }
-                        @if(index + 1 < panel.articles.size) {
-                            <hr/>
-                        }
-                    }
+                    @showcase_articlegroup(panel.articleGroup)
                 </li>
             }
 
@@ -127,6 +115,9 @@
                                 <li>@bullet.text</li>
                                 }
                             </ul>
+                        }
+                        @for(relatedArticles <- panel.articleGroup) {
+                            @showcase_articlegroup(relatedArticles)
                         }
                     </li>
                 }

--- a/preview/app/views/showcase.scala.html
+++ b/preview/app/views/showcase.scala.html
@@ -109,6 +109,9 @@
                             @for(author <- panel.author) {
                         <p class="author">@author</p>
                         }
+                        @for(summary <- panel.summary) {
+                            <p>@summary</p>
+                        }
                         @for(bulletList <- panel.bulletList) {
                             <ul class="bulletList">
                                 @for(bullet <- bulletList.listItems) {

--- a/preview/app/views/showcase_articlegroup.scala.html
+++ b/preview/app/views/showcase_articlegroup.scala.html
@@ -1,0 +1,18 @@
+@(articleGroup: common.TrailsToShowcase.ArticleGroup)
+@defining(articleGroup.articles) { articles =>
+    <div class="articleGroup">
+        @for((article, index) <- articles.zipWithIndex) {
+            <a href="@article.link" target="_blank"><img src="@article.imageUrl" width="160"/></a>
+            @for(overline <- article.overline) {
+                <p class="overline">@overline</p>
+            }
+            <a href="@article.link" target="_blank"><h4>@article.title</h4></a>
+            @for(author <- article.author) {
+                <p class="author">@author</p>
+            }
+            @if(index + 1 < articles.size) {
+                <hr/>
+            }
+        }
+    </div>
+}


### PR DESCRIPTION
## What does this change?

Adds support for Related Article style single story Showcase panels.

If a Showcase single story trail has sublinks then it should be rendered as a Showcase Related Articles panel and validated using the rules for a Related Articles panel.

If there are no sublinks then it should be rendered as a Bullet panel and validated using those rule.

Introducing a second panel type has clarified our understanding of the Showcase model so there are some refactorings and Article Groups in particular.

<img width="377" alt="Screenshot 2021-09-22 at 11 47 11" src="https://user-images.githubusercontent.com/150238/134330459-afdeffac-3bdd-4bf4-b518-3760770c811e.png">

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->

