### PR TITLE
Add commercial metric event for blocked ads

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.ts
+++ b/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.ts
@@ -59,9 +59,6 @@ const maybeRefreshBlockedSlotOnce: ConfiantCallback = (
 
 				advert.slot.setTargeting('confiant', String(blockingType));
 
-				setForceSendMetrics(true);
-				captureCommercialMetrics();
-
 				if (shouldRefresh()) {
 					refreshAdvert(advert);
 

--- a/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.ts
+++ b/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.ts
@@ -46,10 +46,7 @@ const maybeRefreshBlockedSlotOnce: ConfiantCallback = (
 	// don’t run the logic if the ad is only screened
 	if (!isBlocked || !blockedSlotPath) return;
 
-	// refresh the blocked slot to get new ad
 	const advert = getAdvertById(blockedSlotPath);
-
-	// check if the slot exists
 	if (!advert) throw new Error(`No slot found for ${blockedSlotPath}`);
 
 	const eventTimer = new EventTimer();
@@ -60,6 +57,7 @@ const maybeRefreshBlockedSlotOnce: ConfiantCallback = (
 
 	advert.slot.setTargeting('confiant', String(blockingType));
 
+	// refresh the blocked slot to get new ad, if it hasn’t been refreshed yet
 	if (shouldRefresh() && !confiantRefreshedSlots.includes(blockedSlotPath)) {
 		refreshAdvert(advert);
 

--- a/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.ts
+++ b/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.ts
@@ -43,31 +43,28 @@ const maybeRefreshBlockedSlotOnce: ConfiantCallback = (
 		},
 	);
 
-	// check if ad is blocked
-	if (isBlocked && !!blockedSlotPath) {
-		// check if the slot hasn’t already been refreshed
-		if (confiantRefreshedSlots.includes(blockedSlotPath)) return;
+	// don’t run the logic if the ad is only screened
+	if (!isBlocked || !blockedSlotPath) return;
 
-		// refresh the blocked slot to get new ad
-		const advert = getAdvertById(blockedSlotPath);
+	// refresh the blocked slot to get new ad
+	const advert = getAdvertById(blockedSlotPath);
 
-		// check if the slot exists
-		if (!advert) throw new Error(`No slot found for ${blockedSlotPath}`);
+	// check if the slot exists
+	if (!advert) throw new Error(`No slot found for ${blockedSlotPath}`);
 
-		const eventTimer = new EventTimer();
-		eventTimer.mark(`${stripDfpAdPrefixFrom(advert.id)}-blockedByConfiant`);
+	const eventTimer = new EventTimer();
+	eventTimer.mark(`${stripDfpAdPrefixFrom(advert.id)}-blockedByConfiant`);
 
-		setForceSendMetrics(true);
-		captureCommercialMetrics();
+	setForceSendMetrics(true);
+	captureCommercialMetrics();
 
-		advert.slot.setTargeting('confiant', String(blockingType));
+	advert.slot.setTargeting('confiant', String(blockingType));
 
-		if (shouldRefresh()) {
-			refreshAdvert(advert);
+	if (shouldRefresh() && !confiantRefreshedSlots.includes(blockedSlotPath)) {
+		refreshAdvert(advert);
 
-			// mark it as refreshed so it won’t refresh multiple time
-			confiantRefreshedSlots.push(blockedSlotPath);
-		}
+		// mark it as refreshed so it won’t refresh multiple time
+		confiantRefreshedSlots.push(blockedSlotPath);
 	}
 };
 

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -72,10 +72,12 @@
  ],
  "../projects/commercial/modules/ad-sizes.js": [],
  "../projects/commercial/modules/ad-verification/prepare-ad-verification.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../projects/commercial/commercial-metrics.ts",
   "../projects/commercial/modules/dfp/get-advert-by-id.ts",
   "../projects/commercial/modules/dfp/load-advert.js",
+  "../projects/commercial/modules/header-bidding/utils.ts",
   "../projects/common/modules/analytics/forceSendMetrics.ts",
   "../projects/common/modules/experiments/ab.ts",
   "../projects/common/modules/experiments/tests/refresh-confiant-blocked-ads.ts"


### PR DESCRIPTION
## What does this change?

Adds an `EventTimer` mark when an ad is blocked by Confiant.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

![image](https://user-images.githubusercontent.com/76776/134331806-a0dc77f2-1b8f-4f6c-b43a-73c67ac8ea8c.png)

## What is the value of this and can you measure success?

This will allow us to know which page views have had an ad blocked by Confiant. We can gather meaningful insight from the the A/B test introduced in #24176 

## Checklist


### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [X] Locally (add `#confiantDevMode` to your URL)
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
