### PR TITLE
Change top-above-nav ad slot background colour to light grey

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -90,7 +90,7 @@
         display: none !important;
     }
 
-    background-color: $brightness-100;
+    background-color: $brightness-97;
     border-bottom: 1px solid $brightness-86;
 
     min-height: 250px + 24px;
@@ -159,32 +159,26 @@
     display: block;
 
     &.ad-slot--fabric {
-        > .ad-slot__label {
-            box-sizing: content-box;
-            // Copying stuff from _mixins.scss because I don't want to
-            // use @extend and no, I am not modifying the markup
-            margin-left: $gs-gutter / 2;
-            margin-right: $gs-gutter / 2;
 
-            @include mq(mobileLandscape) {
-                margin-left: $gs-gutter;
-                margin-right: $gs-gutter;
-            }
-            @include mq(containerWidestMobile) {
-                margin-left: auto;
-                margin-right: auto;
-                width: $mobile-max-container-width;
-            }
-            @include mq(tablet) {
-                padding-left: $gs-gutter;
-                padding-right: $gs-gutter;
-            }
-            @each $breakpoint, $container-width in $breakpoints {
-                @include mq($breakpoint) {
-                    width: $container-width;
-                }
-            }
+        position: relative;
+        margin: auto;
+
+        @include mq($from: tablet) {
+            max-width: 740px;
         }
+
+        @include mq($from: desktop) {
+            max-width: 980px;
+        }
+
+        @include mq($from: leftCol) {
+            max-width: 1140px;
+        }
+
+        @include mq($from: wide) {
+            max-width: 1300px;
+        }
+
     }
 
     &.ad-slot--fluid {

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -159,26 +159,32 @@
     display: block;
 
     &.ad-slot--fabric {
+        > .ad-slot__label {
+            box-sizing: content-box;
+            // Copying stuff from _mixins.scss because I don't want to
+            // use @extend and no, I am not modifying the markup
+            margin-left: $gs-gutter / 2;
+            margin-right: $gs-gutter / 2;
 
-        position: relative;
-        margin: auto;
-
-        @include mq($from: tablet) {
-            max-width: 740px;
+            @include mq(mobileLandscape) {
+                margin-left: $gs-gutter;
+                margin-right: $gs-gutter;
+            }
+            @include mq(containerWidestMobile) {
+                margin-left: auto;
+                margin-right: auto;
+                width: $mobile-max-container-width;
+            }
+            @include mq(tablet) {
+                padding-left: $gs-gutter;
+                padding-right: $gs-gutter;
+            }
+            @each $breakpoint, $container-width in $breakpoints {
+                @include mq($breakpoint) {
+                    width: $container-width;
+                }
+            }
         }
-
-        @include mq($from: desktop) {
-            max-width: 980px;
-        }
-
-        @include mq($from: leftCol) {
-            max-width: 1140px;
-        }
-
-        @include mq($from: wide) {
-            max-width: 1300px;
-        }
-
     }
 
     &.ad-slot--fluid {


### PR DESCRIPTION
## What does this change?
Since we recently rolled out a change to increase the space reserved for the top-above-nav ad slot to 250px, the large white space looks a bit jarring.
This PR changes the background colour to a light shade of grey to make it clear that the slot is separate from any editorial content (this may or may not have been influenced by the New York Times!)
The change has been discussed with @zeek01 and @HarryFischer

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes: https://github.com/guardian/dotcom-rendering/pull/3452

## Screenshots
Before

![image](https://user-images.githubusercontent.com/57295823/134337119-6296d802-4331-4729-93aa-11001738faa7.png)

After

![image](https://user-images.githubusercontent.com/57295823/134337392-ecdde5a2-0d79-47d9-bfea-5deb9db48e6f.png)

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)