### PR TITLE
Use PascalCase for the name of TheRuralNetwork email banner

### DIFF
--- a/common/app/model/EmailAddons.scala
+++ b/common/app/model/EmailAddons.scala
@@ -442,7 +442,7 @@ case object Documentaries extends FrontEmailMetadata {
 }
 
 case object TheRuralNetwork extends FrontEmailMetadata {
-  val name = "The rural network"
+  val name = "The Rural Network"
   override val banner = Some("rural-network.png")
 }
 


### PR DESCRIPTION
Use PascalCase for the name of TheRuralNetwork email banner in case that solves our display problem
