### PR TITLE
Revert "Merge pull request #24203 from guardian/ph-20210914-2055-joda-time-step-11

### DIFF
--- a/applications/app/controllers/AllIndexController.scala
+++ b/applications/app/controllers/AllIndexController.scala
@@ -2,15 +2,13 @@ package controllers
 
 import com.gu.contentapi.client.model.ContentApiError
 import common.Edition.defaultEdition
-import common.{Chronos, Edition, GuLogging, ImplicitControllerExecutionContext}
+import common.{Edition, ImplicitControllerExecutionContext, GuLogging}
 import contentapi.{ContentApiClient, SectionsLookUp}
 import implicits.{Dates, ItemResponses}
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model._
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.{DateTime, DateTimeZone}
-
-import java.time.ZoneId
 import pages.AllIndexHtmlPage
 import play.api.mvc._
 import services.{ConfigAgent, IndexPage, IndexPageItem}
@@ -105,7 +103,7 @@ class AllIndexController(
                 val today = DateTime.now
                 val nextPage =
                   if (reqDate.sameDay(today)) None else Some(s"/$path/${urlFormat(reqDate.plusDays(1))}/altdate")
-                val model = index.copy(contents = contentOnRequestedDate, tzOverride = Some(ZoneId.of("UTC")))
+                val model = index.copy(contents = contentOnRequestedDate, tzOverride = Some(DateTimeZone.UTC))
 
                 Cached(300)(
                   RevalidatableResult.Ok(
@@ -152,7 +150,7 @@ class AllIndexController(
               page = Section.make(section),
               contents = item.results.getOrElse(Nil).map(IndexPageItem(_)),
               Tags(Nil),
-              Chronos.jodaDateTimeToJavaTimeDateTime(date),
+              date,
               tzOverride = None,
             ),
           )
@@ -163,7 +161,7 @@ class AllIndexController(
                 page = tag,
                 contents = item.results.getOrElse(Nil).map(IndexPageItem(_)),
                 Tags(List(tag)),
-                Chronos.jodaDateTimeToJavaTimeDateTime(date),
+                date,
                 tzOverride = None,
               )
             }

--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import com.gu.contentapi.client.model.v1.{Crossword, ItemResponse, Content => ApiContent, Section => ApiSection}
-import common.{Edition, GuLogging, ImplicitControllerExecutionContext}
+import common.{Edition, ImplicitControllerExecutionContext, GuLogging}
 import conf.Static
 import contentapi.ContentApiClient
 import pages.{CrosswordHtmlPage, IndexHtmlPage, PrintableCrosswordHtmlPage}
@@ -15,14 +15,13 @@ import crosswords.{
 }
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model._
-import org.joda.time.LocalDate
+import org.joda.time.{DateTime, LocalDate}
 import play.api.data.Forms._
 import play.api.data._
 import play.api.mvc.{Action, RequestHeader, Result, _}
 import services.{IndexPage, IndexPageItem}
 import html.HtmlPageHelpers.ContentCSSFile
 
-import java.time.LocalDateTime
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
@@ -206,7 +205,7 @@ class CrosswordSearchController(
                     page = section,
                     contents = results.map(IndexPageItem(_)),
                     tags = Tags(Nil),
-                    date = LocalDateTime.now(),
+                    date = DateTime.now,
                     tzOverride = None,
                   )
 

--- a/applications/app/controllers/LatestIndexController.scala
+++ b/applications/app/controllers/LatestIndexController.scala
@@ -5,10 +5,10 @@ import contentapi.ContentApiClient
 import contentapi.Paths
 import model.Cached.WithoutRevalidationResult
 import model._
+import org.joda.time.DateTime
 import play.api.mvc._
 import services.{IndexPage, IndexPageItem}
 
-import java.time.LocalDateTime
 import scala.concurrent.Future
 
 class LatestIndexController(contentApiClient: ContentApiClient, val controllerComponents: ControllerComponents)
@@ -82,7 +82,7 @@ class LatestIndexController(contentApiClient: ContentApiClient, val controllerCo
               page = Section.make(section),
               contents = item.results.getOrElse(Nil).map(IndexPageItem(_)),
               tags = Tags(Nil),
-              date = LocalDateTime.now(),
+              date = DateTime.now,
               tzOverride = None,
             ),
           )
@@ -92,7 +92,7 @@ class LatestIndexController(contentApiClient: ContentApiClient, val controllerCo
                 page = Tag.make(tag),
                 contents = item.results.getOrElse(Nil).map(IndexPageItem(_)),
                 tags = Tags(Nil),
-                date = LocalDateTime.now(),
+                date = DateTime.now,
                 tzOverride = None,
               ),
             ),

--- a/applications/app/views/all.scala.html
+++ b/applications/app/views/all.scala.html
@@ -1,7 +1,6 @@
 @import layout.{ContainerDisplayConfig, ContainerLayout}
 @import model.pressed.CollectionConfig
 @import services.IndexPage
-@import common.Chronos.javaTimeLocalDateTimeToJodaDateTime
 
 @(index: IndexPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
@@ -15,7 +14,7 @@
                 index.faciaTrails
             ),
             0,
-            javaTimeLocalDateTimeToJodaDateTime(index.date),
+            index.date,
             index.page.metadata,
             index.previousAndNext,
             index.tzOverride

--- a/applications/test/AllIndexControllerTest.scala
+++ b/applications/test/AllIndexControllerTest.scala
@@ -52,7 +52,6 @@ import play.api.test.Helpers._
       todayMonthEx.findFirstIn(browser.pageSource()).nonEmpty should be(true)
       todayYearEx.findFirstIn(browser.pageSource()).nonEmpty should be(true)
     }
-
   }
 
   lazy val sectionsLookUp = new SectionsLookUp(testContentApiClient)

--- a/article/app/model/structuredData/BlogPosting.scala
+++ b/article/app/model/structuredData/BlogPosting.scala
@@ -1,31 +1,29 @@
 package model.structuredData
 
-import common.{Chronos, LinkTo}
+import common.LinkTo
 import model.Article
 import model.liveblog.BodyBlock
-
-import java.time.LocalDateTime
+import org.joda.time.DateTime
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.RequestHeader
 import views.support.GuDateFormatLegacy
 
 object BlogPosting {
 
-  def zulu(date: LocalDateTime)(implicit request: RequestHeader): String =
-    GuDateFormatLegacy(Chronos.javaTimeLocalDateTimeToJodaDateTime(date), "yyyy-MM-dd'T'HH:mm:ssZ")
+  def zulu(date: DateTime)(implicit request: RequestHeader): String = GuDateFormatLegacy(date, "yyyy-MM-dd'T'HH:mm:ssZ")
 
   def apply(blog: Article, block: BodyBlock)(implicit request: RequestHeader): JsValue = {
 
     def blockFirstPublishedDate(block: BodyBlock) =
       block.firstPublishedDate match {
-        case Some(date) => zulu(Chronos.jodaDateTimeToJavaTimeDateTime(date))
-        case None       => zulu(Chronos.jodaDateTimeToJavaTimeDateTime(blog.trail.webPublicationDate))
+        case Some(date) => zulu(date)
+        case None       => zulu(blog.trail.webPublicationDate)
       }
 
     def blockLastModifiedDate(block: BodyBlock) =
       block.lastModifiedDate match {
-        case Some(date) => zulu(Chronos.jodaDateTimeToJavaTimeDateTime(date))
-        case None       => zulu(Chronos.jodaDateTimeToJavaTimeDateTime(blog.content.fields.lastModified))
+        case Some(date) => zulu(date)
+        case None       => zulu(blog.content.fields.lastModified)
       }
 
     def blockBody(block: BodyBlock): String = {

--- a/common/app/layout/FaciaCardTimestamp.scala
+++ b/common/app/layout/FaciaCardTimestamp.scala
@@ -19,5 +19,5 @@ case object DateTimestamp extends FaciaCardTimestamp {
 
 case object TimeTimestamp extends FaciaCardTimestamp {
   override val javaScriptUpdate: Boolean = false
-  override val formatString: String = "h:mm a"
+  override val formatString: String = "h:mm aa"
 }

--- a/common/app/services/IndexPage.scala
+++ b/common/app/services/IndexPage.scala
@@ -10,8 +10,7 @@ import layout._
 import model._
 import model.meta.{ItemList, ListItem}
 import model.pressed._
-import java.time.LocalDateTime
-import java.time.ZoneId
+import org.joda.time.{DateTime, DateTimeZone}
 import play.api.mvc.RequestHeader
 import slices.{Container, ContainerDefinition, Fixed, FixedContainers}
 import views.support.PreviousAndNext
@@ -31,8 +30,8 @@ object IndexPage {
       page: Page,
       contents: Seq[IndexPageItem],
       tags: Tags,
-      date: LocalDateTime,
-      tzOverride: Option[ZoneId],
+      date: DateTime,
+      tzOverride: Option[DateTimeZone],
   ): IndexPage = {
     IndexPage(page, contents, tags, date, tzOverride, commercial = Commercial.empty)
   }
@@ -215,8 +214,8 @@ case class IndexPage(
     page: Page,
     contents: Seq[IndexPageItem],
     tags: Tags,
-    date: LocalDateTime,
-    tzOverride: Option[ZoneId],
+    date: DateTime,
+    tzOverride: Option[DateTimeZone],
     commercial: Commercial,
     previousAndNext: Option[PreviousAndNext] = None,
 ) extends StandalonePage {

--- a/common/app/services/repositories.scala
+++ b/common/app/services/repositories.scala
@@ -8,7 +8,6 @@ import contentapi.{ContentApiClient, QueryDefaults, SectionTagLookUp, SectionsLo
 import implicits.Collections
 import model._
 import org.joda.time.DateTime
-import java.time.LocalDateTime
 import play.api.mvc.{RequestHeader, Result => PlayResult}
 
 import scala.concurrent.Future
@@ -83,7 +82,7 @@ trait Index extends ConciergeRepository with Collections {
             val tag2 = findTag(head.item, secondTag)
             if (tag1.isDefined && tag2.isDefined) {
               val page = TagCombiner(s"$leftSide+$rightSide", tag1.get, tag2.get, pagination(response))
-              Left(IndexPage(page, contents = trails, tags = Tags(Nil), date = LocalDateTime.now(), tzOverride = None))
+              Left(IndexPage(page, contents = trails, tags = Tags(Nil), date = DateTime.now, tzOverride = None))
             } else {
               Right(NotFound)
             }
@@ -196,7 +195,7 @@ trait Index extends ConciergeRepository with Collections {
       page = section,
       contents = trails,
       tags = Tags(Nil),
-      date = LocalDateTime.now(),
+      date = DateTime.now,
       tzOverride = None,
       commercial = commercial,
     )
@@ -222,7 +221,7 @@ trait Index extends ConciergeRepository with Collections {
     val allTrails = (leadContent ++ editorsPicks ++ latest).distinctBy(_.item.metadata.id)
 
     tag map { tag =>
-      IndexPage(page = tag, contents = allTrails, tags = Tags(List(tag)), date = LocalDateTime.now(), tzOverride = None)
+      IndexPage(page = tag, contents = allTrails, tags = Tags(List(tag)), date = DateTime.now, tzOverride = None)
     }
   }
 

--- a/common/app/views/fragments/containers/facia_cards/date.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/date.scala.html
@@ -1,4 +1,4 @@
-@(date: org.joda.time.DateTime, tzOverride: Option[java.time.ZoneId] = None)(implicit requestHeader: RequestHeader)
+@(date: org.joda.time.DateTime, tzOverride: Option[org.joda.time.DateTimeZone] = None)(implicit requestHeader: RequestHeader)
 
 @import views.support.GuDateFormatLegacy
 

--- a/common/app/views/fragments/containers/index.scala.html
+++ b/common/app/views/fragments/containers/index.scala.html
@@ -6,9 +6,8 @@
 @import views.html.fragments.containers.facia_cards.{date, slice}
 @import views.support.{GetClasses, PreviousAndNext}
 @import implicits.Requests._
-@import java.time.ZoneId
 
-@(trails: Seq[PressedContent], containerLayout: ContainerLayout, containerIndex: Int, actualDate: DateTime, page: MetaData, nav: Option[PreviousAndNext], tzOverride: Option[ZoneId] = None)(implicit request: RequestHeader, config: CollectionConfig)
+@(trails: Seq[PressedContent], containerLayout: ContainerLayout, containerIndex: Int, actualDate: DateTime, page: MetaData, nav: Option[PreviousAndNext], tzOverride: Option[DateTimeZone] = None)(implicit request: RequestHeader, config: CollectionConfig)
 
 @* TODO Consolidate this with the master container template to get rid of repetition *@
 

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -2,12 +2,13 @@ package views.support
 
 import java.text.DecimalFormat
 import java.util.Locale
+
 import common._
 import model.Cached.WithoutRevalidationResult
 import model._
 import model.pressed.PressedContent
 import org.apache.commons.lang.StringEscapeUtils
-import org.joda.time.format.DateTimeFormat
+import org.joda.time.format.{DateTimeFormat, ISODateTimeFormat}
 import org.joda.time.{DateTime, DateTimeZone, LocalDate}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
@@ -18,8 +19,6 @@ import play.api.mvc.{RequestHeader, Result}
 import play.twirl.api.Html
 import layout.slices.ContainerDefinition
 
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
 import scala.collection.JavaConverters._
 
 /**
@@ -175,19 +174,18 @@ object `package` {
 
 object GuDateFormatLegacy {
 
-  def apply(date: DateTime, pattern: String, tzOverride: Option[ZoneId] = None)(implicit
+  def apply(date: DateTime, pattern: String, tzOverride: Option[DateTimeZone] = None)(implicit
       request: RequestHeader,
   ): String = {
     apply(date, Edition(request), pattern, tzOverride)
   }
 
-  def apply(date: DateTime, edition: Edition, pattern: String, tzOverride: Option[ZoneId]): String = {
+  def apply(date: DateTime, edition: Edition, pattern: String, tzOverride: Option[DateTimeZone]): String = {
     val timeZone = tzOverride match {
       case Some(tz) => tz
-      case _        => ZoneId.of(edition.timezone.toString) // Converting a (joda) DateTimeZone into a (java.time) ZoneId
+      case _        => edition.timezone
     }
-    val formatter = Chronos.dateFormatter(pattern, timeZone)
-    Chronos.jodaDateTimeToJavaTimeDateTime(date).format(formatter)
+    date.toString(DateTimeFormat.forPattern(pattern).withZone(timeZone))
   }
 
   def apply(date: LocalDate, pattern: String)(implicit request: RequestHeader): String =

--- a/common/test/services/IndexPageTest.scala
+++ b/common/test/services/IndexPageTest.scala
@@ -5,7 +5,6 @@ import common.editions.Uk
 import model.{Section, Tags}
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
-import java.time.LocalDateTime
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 import layout.slices.Fixed
@@ -36,7 +35,7 @@ import scala.concurrent.Future
             page = Section.make(section),
             contents = item.results.getOrElse(Nil).map(IndexPageItem(_)),
             tags = Tags(Nil),
-            date = LocalDateTime.now(),
+            date = DateTime.now,
             tzOverride = None,
           ),
         )
@@ -52,12 +51,14 @@ import scala.concurrent.Future
       case Some(page) =>
         val front = IndexPage.makeFront(page, edition)
         front.containers should not be empty
+
         val firstContainer = front.containers.head
         val formatter = DateTimeFormat.forPattern("d MMMM yyyy")
         val parsedDate = formatter.parseDateTime(firstContainer.displayName.get)
         parsedDate shouldBe a[DateTime]
         firstContainer.container.isInstanceOf[Fixed] should be(true)
         firstContainer.index should be(0)
+
         firstContainer.items should not be empty
     }
   }


### PR DESCRIPTION
This reverts commit f3935ac926cf1f7c4fa80924b4168d8ecf44b878

Trying to rule this out as the cause of the current liveblog timestamp problem.