### PR TITLE
fix `EventTimer` usage

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.ts
+++ b/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.ts
@@ -49,7 +49,7 @@ const maybeRefreshBlockedSlotOnce: ConfiantCallback = (
 	const advert = getAdvertById(blockedSlotPath);
 	if (!advert) throw new Error(`No slot found for ${blockedSlotPath}`);
 
-	const eventTimer = new EventTimer();
+	const eventTimer = EventTimer.get();
 	eventTimer.mark(`${stripDfpAdPrefixFrom(advert.id)}-blockedByConfiant`);
 
 	setForceSendMetrics(true);


### PR DESCRIPTION
## What does this change?

Uses the `EventTimer` properly.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
