### PR TITLE
Add `performance.now` to `polyfill.io` bundle

### DIFF
--- a/static/src/javascripts/polyfill.io
+++ b/static/src/javascripts/polyfill.io
@@ -1,1 +1,1 @@
-https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,fetch,navigator.sendBeacon&flags=gated&callback=guardianPolyfilled&unknown=polyfill&clearCache=5
+https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,fetch,navigator.sendBeacon,performance.now&flags=gated&callback=guardianPolyfilled&unknown=polyfill&clearCache=5


### PR DESCRIPTION
## What does this change?

Adds `performance.now` to the `polyfill.io` bundle.

[Some older browsers don't support the User Timing API](https://caniuse.com/user-timing). Mostly we guard against this case by checking if `window.performance` is `undefined` before calling methods on it, but we discovered one instance where this wasn't happening and we believe this to be the cause of a number of Sentry errors. Adding a polyfill for older browsers feels like the right approach so we don't always need to worry about guards.

[1]: https://caniuse.com/user-timing

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

PR here: https://github.com/guardian/dotcom-rendering/pull/3463

## What is the value of this and can you measure success?

A reduction in the number of [sentry errors](https://sentry.io/organizations/the-guardian/issues/?project=35463&query=is%3Aunresolved++window.performance&sort=date&statsPeriod=14d) tagged with:

`window.performance.<SOMETHING> is not a function`

## Checklist

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Tested

- [x] Locally
- [ ] On CODE (optional)
