### PR TITLE
Showcase panel publication date is set on pubDate field

### DIFF
--- a/common/app/common/TrailsToShowcase.scala
+++ b/common/app/common/TrailsToShowcase.scala
@@ -1,8 +1,8 @@
 package common
 
+import com.sun.syndication.feed.module.Module
 import com.sun.syndication.feed.module.mediarss.MediaEntryModuleImpl
 import com.sun.syndication.feed.module.mediarss.types.{MediaContent, Metadata, UrlReference}
-import com.sun.syndication.feed.module.{DCModule, Module}
 import com.sun.syndication.feed.synd._
 import com.sun.syndication.io.SyndFeedOutput
 import common.TrailsToRss.image
@@ -495,10 +495,11 @@ object TrailsToShowcase {
       description: Option[String],
       entries: Seq[SyndEntry],
   ): SyndFeed = {
-    // Create a Rome feed of our entries
+    val feedTitle = title.map(t => s"$t | The Guardian").getOrElse("The Guardian")
+
+    // Feed
     val feed = new SyndFeedImpl
     feed.setFeedType("rss_2.0")
-    val feedTitle = title.map(t => s"$t | The Guardian").getOrElse("The Guardian")
     feed.setTitle(feedTitle)
     feed.setDescription(
       description.getOrElse("Latest news and features from theguardian.com, the world's leading liberal voice"),
@@ -585,8 +586,6 @@ object TrailsToShowcase {
       bylinePretendingToBePerson.setEmail(byline)
       entry.setAuthors(Seq(bylinePretendingToBePerson).asJava)
     }
-
-    removeDCModule(entry)
     entry
   }
 
@@ -601,8 +600,6 @@ object TrailsToShowcase {
     gModule.setPanelTitle(Some(rundownPanel.panelTitle))
     gModule.setArticleGroup(Some(asGArticleGroup(rundownPanel.articleGroup)))
     addModuleTo(entry, gModule)
-
-    removeDCModule(entry)
     entry
   }
 
@@ -622,7 +619,7 @@ object TrailsToShowcase {
     GArticleGroup(role = articleGroup.role, articles = articleGroup.articles.map(asGArticle))
   }
 
-  private def setEntryDates(panel: Panel, entry: SyndEntryImpl): Unit = {
+  private def setEntryDates(panel: Panel, entry: SyndEntryImpl) = {
     def atomDatesModuleFor(updated: Option[DateTime]): RssAtomModuleImpl = {
       val atomModule = new RssAtomModuleImpl
       atomModule.setUpdated(updated)
@@ -634,16 +631,6 @@ object TrailsToShowcase {
       entry.setPublishedDate(published.toDate)
     }
     addModuleTo(entry, atomDatesModuleFor(panel.updated))
-  }
-
-  private def removeDCModule(entry: SyndEntryImpl): Unit = {
-    // Showcase does not expect the dc entries for publication date included by Rome.
-    // We should remove this module from out entries to avoid validation warning
-    val modules = entry.getModules.asScala.filter {
-      case _: DCModule => false
-      case _           => true
-    }
-    entry.setModules(modules.asJava)
   }
 
   trait Panel {

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -173,7 +173,8 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       "Kicker",
     )
 
-    (singleStoryPanel \ "published").filter(_.prefix == "atom").text should be("2021-03-02T12:30:01Z")
+    // Check date fields
+    (singleStoryPanel \ "pubDate").text should be("Tue, 02 Mar 2021 12:30:01 GMT")
     (singleStoryPanel \ "updated").filter(_.prefix == "atom").text should be("2021-03-02T13:30:01Z")
 
     val singleStoryPanelMedia = (singleStoryPanel \ "content").filter(_.prefix == "media")
@@ -198,7 +199,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
 
     (rundownPanel \ "panel_title").filter(_.prefix == "g").head.text should be("My rundown panel title")
 
-    (rundownPanel \ "published").filter(_.prefix == "atom").text should be("2021-03-02T12:30:01Z")
+    (rundownPanel \ "pubDate").text should be("Tue, 02 Mar 2021 12:30:01 GMT")
     (rundownPanel \ "updated").filter(_.prefix == "atom").text should be("2021-03-02T13:30:01Z")
 
     val rundownPanelMedia = (rundownPanel \ "content").filter(_.prefix == "media")
@@ -224,8 +225,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     )
     (rundownArticle \ "author").text should be("Trail byline")
 
-    (rundownArticle \ "published").filter(_.prefix == "atom").text should be("2021-03-02T12:30:01Z")
-    (rundownArticle \ "published").filter(_.prefix == "atom").text should be("2021-03-02T12:30:01Z")
+    (rundownArticle \ "pubDate").text should be("Tue, 02 Mar 2021 12:30:01 GMT")
     (rundownArticle \ "updated").filter(_.prefix == "atom").text should be("2021-03-02T13:30:01Z")
     (rundownArticle \ "content").filter(_.prefix == "media").head.attribute("url").get.head.text should be(
       "http://localhost/trail.jpg",
@@ -402,8 +402,8 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     gModule.getOverline should be(Some("A kicker"))
     gModule.getArticleGroup.nonEmpty should be(true)
 
+    entry.getPublishedDate should be(wayBackWhen.toDate)
     val rssAtomModule = entry.getModule(RssAtomModule.URI).asInstanceOf[RssAtomModule]
-    rssAtomModule.getPublished should be(Some(wayBackWhen))
     rssAtomModule.getUpdated should be(Some(lastModifiedWayBackWhen))
 
     val mediaModule = entry.getModule("http://search.yahoo.com/mrss/").asInstanceOf[MediaEntryModule]
@@ -728,6 +728,10 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
 
     val entry = TrailsToShowcase.asSyndEntry(rundownPanel)
 
+    entry.getPublishedDate should be(wayBackWhen.toDate)
+    val rssAtomModule = entry.getModule(RssAtomModule.URI).asInstanceOf[RssAtomModule]
+    rssAtomModule.getUpdated should be(Some(lastModifiedWayBackWhen))
+
     // Rundown panels have no image of their own
     val mediaModule = entry.getModule("http://search.yahoo.com/mrss/").asInstanceOf[MediaEntryModule]
     mediaModule should be(null)
@@ -738,6 +742,11 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     val articleGroup = gModule.getArticleGroup.get
     articleGroup.role should be("RUNDOWN")
     articleGroup.articles.size should be(3)
+
+    val article = articleGroup.articles.head
+    article.title should be("My headline")
+    article.published should be(wayBackWhen)
+    article.updated should be(lastModifiedWayBackWhen)
   }
 
   "TrailToShowcase" should "strip all markup from rundown text elements" in {


### PR DESCRIPTION
## What does this change?

Showcase Item published date moves from `atom:published` field to `pubDate` field.

This differs from the docs but is what the validator and support recommend. 
Also more in line with normal RSS feeds.

Gives a harmless unknown field warning for dc:publicationDate field; DC Module is quite tightly coupled to item publication date in Rome so not as simple as removing the DCModule from the items.



## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
