### PR TITLE
Declare `config`’s method types

### DIFF
--- a/static/src/javascripts/lib/config.d.ts
+++ b/static/src/javascripts/lib/config.d.ts
@@ -1,0 +1,20 @@
+declare const get: <T>(path: string, defaultValue?: T) => T;
+declare const set: (path: string, defaultValue?: unknown) => void;
+declare const hasTone: (s: string) => boolean;
+declare const hasSeries: (s: string) => boolean;
+declare const referenceOfType: (name: string) => string;
+declare const referencesOfType: (name: string) => string[];
+declare const webPublicationDateAsUrlPart: () => string | null;
+declare const dateFromSlug: () => string | null;
+
+// eslint-disable-next-line import/no-default-export -- it’s a declaration
+export default {
+	get,
+	set,
+	hasTone,
+	hasSeries,
+	referenceOfType,
+	referencesOfType,
+	webPublicationDateAsUrlPart,
+	dateFromSlug,
+};

--- a/static/src/javascripts/lib/config.d.ts
+++ b/static/src/javascripts/lib/config.d.ts
@@ -1,4 +1,5 @@
-declare const get: <T>(path: string, defaultValue?: T) => T;
+declare function get<T>(path: string): T | undefined;
+declare function get<T>(path: string, defaultValue: T): T;
 declare const set: (path: string, defaultValue?: unknown) => void;
 declare const hasTone: (s: string) => boolean;
 declare const hasSeries: (s: string) => boolean;

--- a/static/src/javascripts/lib/fetch-json.ts
+++ b/static/src/javascripts/lib/fetch-json.ts
@@ -1,9 +1,4 @@
-import config_ from './config';
-
-// This is really a hacky workaround ⚠️
-const config = config_ as {
-	get: (s: string, d?: string) => string;
-};
+import config from './config';
 
 /**
  * Check that path is a path-absolute-URL string as described in https://url.spec.whatwg.org/#path-absolute-url-string
@@ -22,7 +17,7 @@ const fetchJson = async (
 
 	let path = resource;
 	if (isPathAbsoluteURL(path)) {
-		path = config.get('page.ajaxUrl', '') + resource;
+		path = config.get<string>('page.ajaxUrl', '') + resource;
 		init.mode = 'cors';
 	}
 

--- a/static/src/javascripts/projects/commercial/modules/article-aside-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-aside-adverts.ts
@@ -1,13 +1,9 @@
 import { $$ } from '../../../lib/$$';
-import config_ from '../../../lib/config';
+import config from '../../../lib/config';
 import fastdom from '../../../lib/fastdom-promise';
 import mediator from '../../../lib/mediator';
 
 const minArticleHeight = 1300;
-
-const config = config_ as {
-	get: (s: string, b?: boolean) => string;
-};
 
 const getAllowedSizesForImmersive = (availableSpace: number) => {
 	// filter ad slot sizes based on the available height
@@ -72,7 +68,7 @@ export const init = (): Promise<void | boolean> => {
 		})
 		.then(([mainColHeight, immersiveOffset]) => {
 			// we do all the adjustments server-side if the page has a ShowcaseMainElement!
-			if (config.get('page.hasShowcaseMainElement', false)) {
+			if (config.get<boolean>('page.hasShowcaseMainElement', false)) {
 				return adSlotsWithinRightCol[0];
 			}
 			// immersive articles may have an image that overlaps the aside ad so we need to remove

--- a/static/src/javascripts/projects/commercial/modules/carrot-traffic-driver.ts
+++ b/static/src/javascripts/projects/commercial/modules/carrot-traffic-driver.ts
@@ -1,16 +1,10 @@
-import config_ from '../../../lib/config';
+import config from '../../../lib/config';
 import { getBreakpoint } from '../../../lib/detect';
 import fastdom from '../../../lib/fastdom-promise';
 import { spaceFiller } from '../../common/modules/article/space-filler';
 import { commercialFeatures } from '../../common/modules/commercial/commercial-features';
 import { addSlot } from './dfp/add-slot';
 import { createSlots } from './dfp/create-slots';
-
-// This is really a hacky workaround ⚠️
-// TODO convert config.js to TypeScript
-const config = config_ as {
-	get: (s: string, d?: unknown) => unknown;
-};
 
 // TODO Typescript Spacefinder
 type RuleSpacing = {

--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.ts
@@ -1,5 +1,5 @@
 import { adSizes } from '@guardian/commercial-core';
-import config_ from '../../../lib/config';
+import config from '../../../lib/config';
 import { getBreakpoint } from '../../../lib/detect';
 import fastdom from '../../../lib/fastdom-promise';
 import mediator from '../../../lib/mediator';
@@ -10,11 +10,6 @@ import type { Advert } from './dfp/Advert';
 import { createSlots } from './dfp/create-slots';
 import { getAdvertById } from './dfp/get-advert-by-id';
 import { refreshAdvert } from './dfp/load-advert';
-
-// This is really a hacky workaround ⚠️
-const config = config_ as {
-	get: (s: string, d?: string) => string;
-};
 
 const createCommentSlots = (canBeDmpu: boolean): HTMLElement[] => {
 	const sizes = canBeDmpu

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
@@ -254,7 +254,7 @@ const initialise = (window: Window, framework = 'tcfv2'): void => {
 
 	window.pbjs.setConfig(pbjsConfig);
 
-	if (config.get('switches.prebidAnalytics', false)) {
+	if (config.get<boolean>('switches.prebidAnalytics', false)) {
 		window.pbjs.enableAnalytics([
 			{
 				provider: 'gu',
@@ -270,7 +270,7 @@ const initialise = (window: Window, framework = 'tcfv2'): void => {
 	// allows dynamic assignment.
 	window.pbjs.bidderSettings = {};
 
-	if (config.get('switches.prebidXaxis', false)) {
+	if (config.get<boolean>('switches.prebidXaxis', false)) {
 		window.pbjs.bidderSettings.xhb = {
 			adserverTargeting: [
 				{
@@ -287,7 +287,7 @@ const initialise = (window: Window, framework = 'tcfv2'): void => {
 		};
 	}
 
-	if (config.get('switches.prebidImproveDigital', false)) {
+	if (config.get<boolean>('switches.prebidImproveDigital', false)) {
 		// Add placement ID for Improve Digital, reading from the bid response
 		const REGEX_PID = new RegExp(/placement_id=\\?"(\d+)\\?"/);
 		window.pbjs.bidderSettings.improvedigital = {

--- a/static/src/javascripts/projects/commercial/sentinel.spec.ts
+++ b/static/src/javascripts/projects/commercial/sentinel.spec.ts
@@ -1,13 +1,11 @@
-import config_ from '../../lib/config';
+import config from '../../lib/config';
 import type { amIUsed as amIUsed_, SentinelLoggingEvent } from './sentinel';
 
 const { amIUsed }: { amIUsed: typeof amIUsed_ } = jest.requireActual(
 	'./sentinel',
 );
 
-const config = (config_ as unknown) as {
-	get: jest.MockedFunction<(s: string, d: boolean) => boolean>;
-};
+jest.mock('../../lib/config');
 
 const CODE_ENDPOINT = '//logs.code.dev-guardianapis.com/log';
 const PROD_ENDPOINT = '//logs.guardianapis.com/log';
@@ -30,19 +28,21 @@ afterEach(() => {
 
 describe('sentinel', () => {
 	test('should not send an event when switches.sentinelLogger is false', () => {
-		config.get.mockReturnValue(false);
+		(config.get as jest.Mock).mockReturnValue(false);
 		amIUsed('moduleName', 'functionName');
 		expect(navigator.sendBeacon).not.toHaveBeenCalled();
 	});
 
 	test('should send an event when switches.sentinelLogger is true', () => {
-		config.get.mockReturnValue(true);
+		(config.get as jest.Mock).mockReturnValue(true);
 		amIUsed('moduleName', 'functionName');
 		expect(navigator.sendBeacon).toHaveBeenCalledTimes(1);
 	});
 
 	test('should use the correct logging CODE endpoint', () => {
-		config.get.mockReturnValueOnce(true).mockReturnValueOnce(true); // first get checks switches.sentinelLogger, the second page.isDev
+		(config.get as jest.Mock)
+			.mockReturnValueOnce(true) // for `switches.sentinelLogger`
+			.mockReturnValueOnce(true); // for `page.isDev`
 		amIUsed('moduleName', 'functionName');
 		expect(navigator.sendBeacon).toHaveBeenCalledWith(
 			CODE_ENDPOINT,
@@ -51,7 +51,9 @@ describe('sentinel', () => {
 	});
 
 	test('should use the correct logging DEV endpoint', () => {
-		config.get.mockReturnValueOnce(true).mockReturnValueOnce(false); // first get checks switches.sentinelLogger, the second page.isDev
+		(config.get as jest.Mock)
+			.mockReturnValueOnce(true) // for `switches.sentinelLogger`
+			.mockReturnValueOnce(false); // for `page.isDev`
 		amIUsed('moduleName', 'functionName');
 		expect(navigator.sendBeacon).toHaveBeenCalledWith(
 			PROD_ENDPOINT,
@@ -60,7 +62,7 @@ describe('sentinel', () => {
 	});
 
 	test('should not attach any extra properties if the property parameter is not passed', () => {
-		config.get.mockReturnValue(true);
+		(config.get as jest.Mock).mockReturnValue(true);
 		amIUsed('moduleName', 'functionName');
 		expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
 			[
@@ -78,7 +80,7 @@ describe('sentinel', () => {
 	});
 
 	test('should attach extra properties if they are passed as a parameter', () => {
-		config.get.mockReturnValue(true);
+		(config.get as jest.Mock).mockReturnValue(true);
 		amIUsed('moduleName', 'functionName', { comment: 'test' });
 		expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
 			[
@@ -97,7 +99,7 @@ describe('sentinel', () => {
 	});
 
 	test('should chain optional parameters to the properties array', () => {
-		config.get.mockReturnValue(true);
+		(config.get as jest.Mock).mockReturnValue(true);
 		amIUsed('moduleName', 'functionName', {
 			conditionA: 'true',
 			conditionB: 'false',
@@ -120,7 +122,7 @@ describe('sentinel', () => {
 	});
 
 	test('should correctly assign commercial.sentinel as a label', () => {
-		config.get.mockReturnValue(true);
+		(config.get as jest.Mock).mockReturnValue(true);
 		amIUsed('moduleName', 'functionName');
 		expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
 			[

--- a/static/src/javascripts/projects/commercial/sentinel.ts
+++ b/static/src/javascripts/projects/commercial/sentinel.ts
@@ -32,9 +32,9 @@ export const amIUsed = (
 	>,
 ): void => {
 	// The function will return early if the sentinelLogger switch is disabled.
-	if (!config.get('switches.sentinelLogger', false)) return;
+	if (!config.get<boolean>('switches.sentinelLogger', false)) return;
 
-	const endpoint = config.get('page.isDev', false)
+	const endpoint = config.get<boolean>('page.isDev', false)
 		? '//logs.code.dev-guardianapis.com/log'
 		: '//logs.guardianapis.com/log';
 

--- a/static/src/javascripts/projects/common/modules/avatar/api.ts
+++ b/static/src/javascripts/projects/common/modules/avatar/api.ts
@@ -1,12 +1,7 @@
-import config_ from 'lib/config';
+import config from 'lib/config';
 
-// This is really a hacky workaround ⚠️
-const config = config_ as {
-	get: (s: string) => string;
-};
-
-const apiUrl = `${config.get('page.avatarApiUrl')}/v1`;
-const staticUrl = `${config.get('page.avatarImagesUrl')}/user`;
+const apiUrl = `${config.get<string>('page.avatarApiUrl')}/v1`;
+const staticUrl = `${config.get<string>('page.avatarImagesUrl')}/user`;
 
 const request = (
 	method: string,

--- a/static/src/javascripts/projects/common/modules/avatar/api.ts
+++ b/static/src/javascripts/projects/common/modules/avatar/api.ts
@@ -1,7 +1,7 @@
 import config from 'lib/config';
 
-const apiUrl = `${config.get<string>('page.avatarApiUrl')}/v1`;
-const staticUrl = `${config.get<string>('page.avatarImagesUrl')}/user`;
+const apiUrl = `${config.get<string>('page.avatarApiUrl', '')}/v1`;
+const staticUrl = `${config.get<string>('page.avatarImagesUrl', '')}/user`;
 
 const request = (
 	method: string,

--- a/static/src/javascripts/projects/common/modules/avatar/api.ts
+++ b/static/src/javascripts/projects/common/modules/avatar/api.ts
@@ -1,7 +1,7 @@
 import config from 'lib/config';
 
-const apiUrl = `${config.get<string>('page.avatarApiUrl', '')}/v1`;
-const staticUrl = `${config.get<string>('page.avatarImagesUrl', '')}/user`;
+const apiUrl = `${config.get<string>('page.avatarApiUrl', '/AVATAR_API_URL_NOT_FOUND')}/v1`;
+const staticUrl = `${config.get<string>('page.avatarImagesUrl', '/AVATAR_IMAGES_URL_NOT_FOUND')}/user`;
 
 const request = (
 	method: string,

--- a/static/src/javascripts/projects/common/modules/avatar/api.ts
+++ b/static/src/javascripts/projects/common/modules/avatar/api.ts
@@ -1,7 +1,13 @@
 import config from 'lib/config';
 
-const apiUrl = `${config.get<string>('page.avatarApiUrl', '/AVATAR_API_URL_NOT_FOUND')}/v1`;
-const staticUrl = `${config.get<string>('page.avatarImagesUrl', '/AVATAR_IMAGES_URL_NOT_FOUND')}/user`;
+const apiUrl = `${config.get<string>(
+	'page.avatarApiUrl',
+	'/AVATAR_API_URL_NOT_FOUND',
+)}/v1`;
+const staticUrl = `${config.get<string>(
+	'page.avatarImagesUrl',
+	'/AVATAR_IMAGES_URL_NOT_FOUND',
+)}/user`;
 
 const request = (
 	method: string,

--- a/static/src/javascripts/projects/common/modules/discussion/api.ts
+++ b/static/src/javascripts/projects/common/modules/discussion/api.ts
@@ -46,8 +46,7 @@ export const send = (
 	data?: Comment | AbuseReport,
 ): Promise<CommentResponse> => {
 	if (config.get('switches.enableDiscussionSwitch')) {
-		const apiUrl = config.get<string>('page.discussionApiUrl');
-		if (!apiUrl) return Promise.reject();
+		const apiUrl = config.get<string>('page.discussionApiUrl', '/DISCUSSION_API_URL_NOT_FOUND');
 		const url = apiUrl + endpoint;
 
 		// https://github.com/guardian/discussion-rendering/blob/1e8a7c7fa0b6a4273497111f0dab30f479a107bf/src/lib/api.tsx#L140

--- a/static/src/javascripts/projects/common/modules/discussion/api.ts
+++ b/static/src/javascripts/projects/common/modules/discussion/api.ts
@@ -46,7 +46,10 @@ export const send = (
 	data?: Comment | AbuseReport,
 ): Promise<CommentResponse> => {
 	if (config.get('switches.enableDiscussionSwitch')) {
-		const apiUrl = config.get<string>('page.discussionApiUrl', '/DISCUSSION_API_URL_NOT_FOUND');
+		const apiUrl = config.get<string>(
+			'page.discussionApiUrl',
+			'/DISCUSSION_API_URL_NOT_FOUND',
+		);
 		const url = apiUrl + endpoint;
 
 		// https://github.com/guardian/discussion-rendering/blob/1e8a7c7fa0b6a4273497111f0dab30f479a107bf/src/lib/api.tsx#L140

--- a/static/src/javascripts/projects/common/modules/discussion/api.ts
+++ b/static/src/javascripts/projects/common/modules/discussion/api.ts
@@ -1,9 +1,4 @@
-import config_ from 'lib/config';
-
-// This is really a hacky workaround ⚠️
-const config = config_ as {
-	get: (s: string) => string;
-};
+import config from 'lib/config';
 
 /**
  * This information is partly inspired by the API in discussion-rendering
@@ -37,8 +32,11 @@ const defaultInitParams: RequestInit = {
 	mode: 'cors',
 	credentials: 'include',
 	headers: {
-		'D2-X-UID': config.get('page.discussionD2Uid'),
-		'GU-Client': config.get('page.discussionApiClientHeader'),
+		'D2-X-UID': config.get<string>('page.discussionD2Uid', 'NONE_FOUND'),
+		'GU-Client': config.get<string>(
+			'page.discussionApiClientHeader',
+			'NONE_FOUND',
+		),
 	},
 };
 
@@ -48,7 +46,9 @@ export const send = (
 	data?: Comment | AbuseReport,
 ): Promise<CommentResponse> => {
 	if (config.get('switches.enableDiscussionSwitch')) {
-		const url = config.get('page.discussionApiUrl') + endpoint;
+		const apiUrl = config.get<string>('page.discussionApiUrl');
+		if (!apiUrl) return Promise.reject();
+		const url = apiUrl + endpoint;
 
 		// https://github.com/guardian/discussion-rendering/blob/1e8a7c7fa0b6a4273497111f0dab30f479a107bf/src/lib/api.tsx#L140
 		if (method === 'POST') {

--- a/static/src/javascripts/projects/common/modules/experiments/ab-core.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-core.ts
@@ -4,17 +4,12 @@ import {
 	getMvtValue,
 } from 'common/modules/analytics/mvt-cookie';
 import { logAutomatEvent } from 'common/modules/experiments/automatLog';
-import config_ from 'lib/config';
+import config from 'lib/config';
 import { isExpired } from 'lib/time-utils';
 import { NOT_IN_TEST } from './ab-constants';
 import { getVariantFromLocalStorage } from './ab-local-storage';
 import { getIgnoreCanRunFromUrl, getVariantFromUrl } from './ab-url';
 import { isTestSwitchedOn } from './ab-utils';
-
-// This is really a hacky workaround ⚠️
-const config = config_ as {
-	get: (s: string, d?: string) => string | boolean;
-};
 
 // We only take account of a variant's canRun function if it's defined.
 // If it's not, assume the variant can be run.

--- a/static/src/javascripts/projects/common/modules/experiments/ab-ophan.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-ophan.ts
@@ -1,13 +1,8 @@
 import type { ABTest, Runnable, Variant } from '@guardian/ab-core';
 import ophan from 'ophan/ng';
-import config_ from '../../../../lib/config';
+import config from '../../../../lib/config';
 import { noop } from '../../../../lib/noop';
 import reportError from '../../../../lib/report-error';
-
-// This is really a hacky workaround ⚠️
-const config = config_ as {
-	get: (s: string, d?: string) => string;
-};
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- generics don’t play nice
 type BooleanFunction = (...args: any[]) => boolean;
@@ -88,7 +83,7 @@ export const buildOphanPayload = (
 ): OphanABPayload => {
 	try {
 		const log: OphanABPayload = {};
-		const serverSideTests = Object.keys(config.get('tests')).filter(
+		const serverSideTests = Object.keys(config.get('tests', {})).filter(
 			(test) => !!config.get(`tests.${test}`),
 		);
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab-utils.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-utils.ts
@@ -5,13 +5,8 @@ import type {
 	Variant,
 } from '@guardian/ab-core';
 import { fromPairs, toPairs } from 'lodash-es';
-import config_ from '../../../../lib/config';
+import config from '../../../../lib/config';
 import { NOT_IN_TEST, notInTestVariant } from './ab-constants';
-
-// This is really a hacky workaround ⚠️
-const config = config_ as {
-	get: <T>(s: string, d?: T) => T;
-};
 
 export const testSwitchExists = (testId: string): boolean =>
 	config.get<boolean | string>(`switches.ab${testId}`, 'NOT_FOUND') !==

--- a/static/src/javascripts/projects/common/modules/identity/api.ts
+++ b/static/src/javascripts/projects/common/modules/identity/api.ts
@@ -87,8 +87,14 @@ const cookieName = 'GU_U';
 const signOutCookieName = 'GU_SO';
 const fbCheckKey = 'gu.id.nextFbCheck';
 
-const idApiRoot = config.get<string>('page.idApiUrl', '/ID_API_ROOT_URL_NOT_FOUND');
-const profileRoot = config.get<string>('page.idUrl', '/PROFILE_ROOT_ID_URL_NOT_FOUND');
+const idApiRoot = config.get<string>(
+	'page.idApiUrl',
+	'/ID_API_ROOT_URL_NOT_FOUND',
+);
+const profileRoot = config.get<string>(
+	'page.idUrl',
+	'/PROFILE_ROOT_ID_URL_NOT_FOUND',
+);
 mediator.emit('module:identity:api:loaded');
 
 export const decodeBase64 = (str: string): string =>
@@ -338,13 +344,13 @@ export const getSubscribedNewsletters = (): Promise<string[]> => {
 
 	type NewslettersResponse =
 		| {
-			result?: {
-				globalSubscriptionStatus?: string;
-				htmlPreference?: string;
-				subscriptions?: Subscriptions[];
-				status?: 'ok' | string;
-			};
-		}
+				result?: {
+					globalSubscriptionStatus?: string;
+					htmlPreference?: string;
+					subscriptions?: Subscriptions[];
+					status?: 'ok' | string;
+				};
+		  }
 		| undefined;
 
 	return (fetchJson(url, {

--- a/static/src/javascripts/projects/common/modules/identity/api.ts
+++ b/static/src/javascripts/projects/common/modules/identity/api.ts
@@ -87,8 +87,8 @@ const cookieName = 'GU_U';
 const signOutCookieName = 'GU_SO';
 const fbCheckKey = 'gu.id.nextFbCheck';
 
-const idApiRoot = config.get<string>('page.idApiUrl');
-const profileRoot = config.get<string>('page.idUrl');
+const idApiRoot = config.get<string>('page.idApiUrl', '/ID_API_ROOT_URL_NOT_FOUND');
+const profileRoot = config.get<string>('page.idUrl', '/PROFILE_ROOT_ID_URL_NOT_FOUND');
 mediator.emit('module:identity:api:loaded');
 
 export const decodeBase64 = (str: string): string =>
@@ -131,7 +131,6 @@ export const getUserFromCookie = (): IdentityUserFromCache => {
 };
 
 export const updateNewsletter = (newsletter: Newsletter): Promise<void> => {
-	if (!idApiRoot) return Promise.reject();
 	const url = `${idApiRoot}/users/me/newsletters`;
 	return fetch(url, {
 		method: 'PATCH',
@@ -163,7 +162,7 @@ export const isUserLoggedIn = (): boolean => getUserFromCookie() !== null;
 
 export const getUserFromApi = mergeCalls(
 	(mergingCallback: (u: IdentityUser | null) => void) => {
-		if (isUserLoggedIn() && idApiRoot) {
+		if (isUserLoggedIn()) {
 			const url = `${idApiRoot}/user/me`;
 			void (fetchJson(url, {
 				mode: 'cors',
@@ -190,10 +189,9 @@ export const reset = (): void => {
 export const getCookie = (): string | null =>
 	getCookieByName(cookieName) as string | null;
 
-export const getUrl = (): string => profileRoot ?? ''; // TODO: is there a default value?
+export const getUrl = (): string => profileRoot;
 
 export const getUserFromApiWithRefreshedCookie = (): Promise<unknown> => {
-	if (!idApiRoot) return Promise.reject();
 	const endpoint = `${idApiRoot}/user/me?refreshCookie=true`;
 	return fetch(endpoint, {
 		mode: 'cors',
@@ -255,7 +253,6 @@ export const shouldAutoSigninInUser = (): boolean => {
 };
 
 export const getUserEmailSignUps = (): Promise<unknown> => {
-	if (!idApiRoot) return Promise.reject();
 	const user = getUserFromCookie();
 
 	if (user) {
@@ -272,7 +269,6 @@ export const getUserEmailSignUps = (): Promise<unknown> => {
 };
 
 export const sendValidationEmail = (): unknown => {
-	if (!(idApiRoot && profileRoot)) return Promise.reject();
 	const defaultReturnEndpoint = '/email-prefs';
 	const endpoint = `${idApiRoot}/user/send-validation-email`;
 
@@ -295,7 +291,6 @@ export const sendValidationEmail = (): unknown => {
 };
 
 export const updateUsername = (username: string): unknown => {
-	if (!idApiRoot) return Promise.reject();
 	const endpoint = `${idApiRoot}/user/me`;
 	const data = {
 		publicFields: {
@@ -314,7 +309,6 @@ export const updateUsername = (username: string): unknown => {
 };
 
 export const getAllConsents = (): Promise<unknown> => {
-	if (!idApiRoot) return Promise.reject();
 	const endpoint = '/consents';
 	const url = idApiRoot + endpoint;
 	return fetchJson(url, {
@@ -325,7 +319,6 @@ export const getAllConsents = (): Promise<unknown> => {
 };
 
 export const getAllNewsletters = (): Promise<unknown> => {
-	if (!idApiRoot) return Promise.reject();
 	const endpoint = '/newsletters';
 	const url = idApiRoot + endpoint;
 	return fetchJson(url, {
@@ -336,7 +329,6 @@ export const getAllNewsletters = (): Promise<unknown> => {
 };
 
 export const getSubscribedNewsletters = (): Promise<string[]> => {
-	if (!idApiRoot) return Promise.resolve([]);
 	const endpoint = '/users/me/newsletters';
 	const url = idApiRoot + endpoint;
 
@@ -346,13 +338,13 @@ export const getSubscribedNewsletters = (): Promise<string[]> => {
 
 	type NewslettersResponse =
 		| {
-				result?: {
-					globalSubscriptionStatus?: string;
-					htmlPreference?: string;
-					subscriptions?: Subscriptions[];
-					status?: 'ok' | string;
-				};
-		  }
+			result?: {
+				globalSubscriptionStatus?: string;
+				htmlPreference?: string;
+				subscriptions?: Subscriptions[];
+				status?: 'ok' | string;
+			};
+		}
 		| undefined;
 
 	return (fetchJson(url, {
@@ -370,9 +362,8 @@ export const getSubscribedNewsletters = (): Promise<string[]> => {
 		.catch(() => []);
 };
 
-export const setConsent = (consents: SettableConsent): Promise<void> => {
-	if (!idApiRoot) return Promise.reject();
-	return fetch(`${idApiRoot}/users/me/consents`, {
+export const setConsent = (consents: SettableConsent): Promise<void> =>
+	fetch(`${idApiRoot}/users/me/consents`, {
 		method: 'PATCH',
 		credentials: 'include',
 		mode: 'cors',
@@ -381,13 +372,10 @@ export const setConsent = (consents: SettableConsent): Promise<void> => {
 		if (resp.ok) return Promise.resolve();
 		return Promise.reject();
 	});
-};
 
-export const getUserData = (): Promise<unknown> => {
-	if (!idApiRoot) return Promise.reject();
-	return fetchJson(`${idApiRoot}/user/me`, {
+export const getUserData = (): Promise<unknown> =>
+	fetchJson(`${idApiRoot}/user/me`, {
 		method: 'GET',
 		mode: 'cors',
 		credentials: 'include',
 	});
-};

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -3,6 +3,7 @@
   "../../../../node_modules/csstype/index.d.ts"
  ],
  "../lib/a9-apstag.js": [],
+ "../lib/config.d.ts": [],
  "../lib/config.js": [],
  "../lib/cookies.js": [
   "../lib/config.js",
@@ -18,7 +19,7 @@
   "../../../../node_modules/fastdom/fastdom.js"
  ],
  "../lib/fetch-json.ts": [
-  "../lib/config.js"
+  "../lib/config.d.ts"
  ],
  "../lib/fsm.ts": [
   "../lib/noop.ts"
@@ -26,7 +27,7 @@
  "../lib/geolocation.ts": [
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../lib/config.js",
+  "../lib/config.d.ts",
   "../lib/cookies.js",
   "../lib/report-error.js"
  ],
@@ -84,7 +85,7 @@
  ],
  "../projects/commercial/modules/article-aside-adverts.ts": [
   "../lib/$$.ts",
-  "../lib/config.js",
+  "../lib/config.d.ts",
   "../lib/fastdom-promise.js",
   "../lib/mediator.js"
  ],
@@ -102,7 +103,7 @@
   "../projects/common/modules/commercial/commercial-features.js"
  ],
  "../projects/commercial/modules/carrot-traffic-driver.ts": [
-  "../lib/config.js",
+  "../lib/config.d.ts",
   "../lib/detect.js",
   "../lib/fastdom-promise.js",
   "../projects/commercial/modules/dfp/add-slot.ts",
@@ -112,7 +113,7 @@
  ],
  "../projects/commercial/modules/comment-adverts.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../lib/config.js",
+  "../lib/config.d.ts",
   "../lib/detect.js",
   "../lib/fastdom-promise.js",
   "../lib/mediator.js",
@@ -161,7 +162,7 @@
   "../lib/url.ts"
  ],
  "../projects/commercial/modules/dfp/dfp-env.ts": [
-  "../lib/config.js",
+  "../lib/config.d.ts",
   "../lib/url.ts",
   "../projects/commercial/modules/dfp/Advert.ts"
  ],
@@ -218,7 +219,7 @@
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@types/lodash-es/index.d.ts",
-  "../lib/config.js",
+  "../lib/config.d.ts",
   "../lib/mediator.js",
   "../lib/report-error.js",
   "../lib/user-timing.js",
@@ -250,7 +251,7 @@
  "../projects/commercial/modules/dfp/prepare-googletag.ts": [
   "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../lib/config.js",
+  "../lib/config.d.ts",
   "../lib/raven.js",
   "../projects/commercial/modules/ad-free-slot-remove.ts",
   "../projects/commercial/modules/dfp/fill-advert-slots.ts",
@@ -345,7 +346,7 @@
  ],
  "../projects/commercial/modules/header-bidding/prebid/bid-config.ts": [
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../lib/config.js",
+  "../lib/config.d.ts",
   "../lib/url.ts",
   "../projects/commercial/modules/header-bidding/prebid/appnexus.js",
   "../projects/commercial/modules/header-bidding/utils.ts",
@@ -355,7 +356,7 @@
  "../projects/commercial/modules/header-bidding/prebid/prebid.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../lib/config.js",
+  "../lib/config.d.ts",
   "../projects/commercial/modules/dfp/Advert.ts",
   "../projects/commercial/modules/dfp/dfp-env.ts",
   "../projects/commercial/modules/dfp/get-advert-by-id.ts",
@@ -368,13 +369,13 @@
  "../projects/commercial/modules/header-bidding/prebid/price-config.ts": [],
  "../projects/commercial/modules/header-bidding/prebid/pubmatic.js": [],
  "../projects/commercial/modules/header-bidding/slot-config.ts": [
-  "../lib/config.js",
+  "../lib/config.d.ts",
   "../projects/commercial/modules/dfp/Advert.ts",
   "../projects/commercial/modules/header-bidding/utils.ts"
  ],
  "../projects/commercial/modules/header-bidding/utils.ts": [
   "../../../../node_modules/@types/lodash-es/index.d.ts",
-  "../lib/config.js",
+  "../lib/config.d.ts",
   "../lib/detect.js",
   "../lib/url.ts",
   "../projects/common/modules/commercial/geo-utils.js"
@@ -558,7 +559,7 @@
   "../../../../node_modules/@guardian/consent-management-platform/dist/types/tcfv2/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../../../../node_modules/fastdom/fastdom.d.ts",
-  "../lib/config.js",
+  "../lib/config.d.ts",
   "../lib/url.ts",
   "../projects/common/modules/commercial/build-page-targeting.js",
   "../projects/common/modules/commercial/commercial-features.js",
@@ -620,7 +621,7 @@
  "../projects/common/modules/experiments/ab-constants.ts": [],
  "../projects/common/modules/experiments/ab-core.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
-  "../lib/config.js",
+  "../lib/config.d.ts",
   "../lib/time-utils.js",
   "../projects/common/modules/analytics/mvt-cookie.js",
   "../projects/common/modules/experiments/ab-constants.ts",
@@ -637,7 +638,7 @@
  ],
  "../projects/common/modules/experiments/ab-ophan.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
-  "../lib/config.js",
+  "../lib/config.d.ts",
   "../lib/noop.ts",
   "../lib/report-error.js"
  ],
@@ -655,7 +656,7 @@
  "../projects/common/modules/experiments/ab-utils.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
   "../../../../node_modules/@types/lodash-es/index.d.ts",
-  "../lib/config.js",
+  "../lib/config.d.ts",
   "../projects/common/modules/experiments/ab-constants.ts"
  ],
  "../projects/common/modules/experiments/ab.ts": [
@@ -678,7 +679,7 @@
  "../projects/common/modules/experiments/tests/sign-in-gate-main-variant.js": [],
  "../projects/common/modules/identity/api.ts": [
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../lib/config.js",
+  "../lib/config.d.ts",
   "../lib/cookies.js",
   "../lib/fetch-json.ts",
   "../lib/mediator.js",


### PR DESCRIPTION
## What does this change?

Use typescript Declaration files to get some type hints for the config methods.

Implement those changes in TS files.

Question for @guardian/identity: are these defaults sensible? What should happen when these config values are undefined?

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)


## What is the value of this and can you measure success?

No more workarounds needed in typescript files. Caught some actual bugs.

## Checklist

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
