### PR TITLE
Collapse top-above-nav container: top-banner-ad-container

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.ts
@@ -148,6 +148,15 @@ const outOfPageCallback = (advert: Advert, event?: SlotRenderEndedEvent) => {
 		const parent = advert.node.parentNode as HTMLElement;
 		return fastdom.mutate(() => {
 			advert.node.classList.add('ad-slot--collapse');
+			// Special case for top-above-nav which has a container with its own height
+			if (advert.id.includes('top-above-nav')) {
+				const adContainer = advert.node.closest<HTMLElement>(
+					'.top-banner-ad-container',
+				);
+				if (adContainer) {
+					adContainer.style.display = 'none';
+				}
+			}
 			// if in a slice, add the 'no mpu' class
 			if (parent.classList.contains('fc-slice__item--mpu-candidate')) {
 				parent.classList.add('fc-slice__item--no-mpu');


### PR DESCRIPTION
## What does this change?

Collapses the new container `top-banner-ad-container` of `top-above-nav` when a 1x1 (out of page) or a 2x2 (empty) slot is detected. 

This is because `top-banner-ad-container` has its own height as of [#24133](https://github.com/guardian/frontend/pull/24133).

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [ ] Locally
- [x] On CODE (optional)