### PR TITLE
Showcase Panel titles support pipe characters

### DIFF
--- a/common/app/common/TrailsToShowcase.scala
+++ b/common/app/common/TrailsToShowcase.scala
@@ -447,12 +447,12 @@ object TrailsToShowcase {
     val trailTitle = TrailsToRss.stripInvalidXMLCharacters(content.header.headline)
     // Look for panel title delimiter
     val pipeDelimited = trailTitle.split(PanelTitleInHeadlineDelimiter).toSeq
-    pipeDelimited.length match {
-      case 1 => (None, stripHtml(trailTitle))
-      case _ =>
-        val right = pipeDelimited.last
-        val left = pipeDelimited.dropRight(1)
-        (Some(stripHtml(left.mkString(PanelTitleInHeadlineDelimiter.toString))), stripHtml(right))
+    if (pipeDelimited.length == 1) {
+      (None, stripHtml(trailTitle))
+    } else {
+      val right = pipeDelimited.last
+      val left = pipeDelimited.dropRight(1)
+      (Some(stripHtml(left.mkString(PanelTitleInHeadlineDelimiter.toString))), stripHtml(right))
     }
   }
 

--- a/common/app/common/TrailsToShowcase.scala
+++ b/common/app/common/TrailsToShowcase.scala
@@ -40,7 +40,7 @@ object TrailsToShowcase {
   private val MaxRelatedArticlesPanelSummaryLength = 82
 
   // Panel titles can encoded with a pipe delimiter in the trail headline.
-  private val PanelTitleInHeadlineDelimiter = "\\|"
+  private val PanelTitleInHeadlineDelimiter = '|'
 
   // Bullet list items are delimited with a hyphen
   private val BulletTrailPrefix = "-"
@@ -449,7 +449,10 @@ object TrailsToShowcase {
     val pipeDelimited = trailTitle.split(PanelTitleInHeadlineDelimiter).toSeq
     pipeDelimited.length match {
       case 1 => (None, stripHtml(trailTitle))
-      case _ => (Some(stripHtml(pipeDelimited.head)), stripHtml(pipeDelimited.drop(1).mkString))
+      case _ =>
+        val right = pipeDelimited.last
+        val left = pipeDelimited.dropRight(1)
+        (Some(stripHtml(left.mkString(PanelTitleInHeadlineDelimiter.toString))), stripHtml(right))
     }
   }
 
@@ -609,7 +612,7 @@ object TrailsToShowcase {
     entry
   }
 
-  def asGArticleGroup(articleGroup: ArticleGroup) = {
+  private def asGArticleGroup(articleGroup: ArticleGroup): GArticleGroup = {
     def asGArticle(article: Article): GArticle = {
       GArticle(
         article.guid,

--- a/common/app/common/TrailsToShowcase.scala
+++ b/common/app/common/TrailsToShowcase.scala
@@ -450,8 +450,8 @@ object TrailsToShowcase {
     if (pipeDelimited.length == 1) {
       (None, stripHtml(trailTitle))
     } else {
-      val right = pipeDelimited.last
       val left = pipeDelimited.dropRight(1)
+      val right = pipeDelimited.last
       (Some(stripHtml(left.mkString(PanelTitleInHeadlineDelimiter.toString))), stripHtml(right))
     }
   }

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -793,7 +793,8 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       lastModified = Some(lastModifiedWayBackWhen),
       kickerText = Some("A Kicker"),
       trailPicture = Some(imageMedia),
-      headline = "Evening briefing | Tuesday 28 September | PM meets with Liberal MPs worried Coalition will appease Nats ",
+      headline =
+        "Evening briefing | Tuesday 28 September | PM meets with Liberal MPs worried Coalition will appease Nats ",
     )
     val anotherTrail =
       makePressedContent(
@@ -807,9 +808,10 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       .asRundownPanel(Seq(firstTrail, anotherTrail, anotherTrail), "rundown-container-id")
 
     outcome.right.get.panelTitle should be("Evening briefing | Tuesday 28 September")
-    outcome.right.get.articleGroup.articles.head.title should be("PM meets with Liberal MPs worried Coalition will appease Nats")
+    outcome.right.get.articleGroup.articles.head.title should be(
+      "PM meets with Liberal MPs worried Coalition will appease Nats",
+    )
   }
-
 
   "TrailToShowcase" should "reject rundown panels with missing panel title" in {
     val firstTrail = makePressedContent(

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -787,6 +787,30 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     outcome.right.get.articleGroup.articles.head.title should be("My headline")
   }
 
+  "TrailToShowcase" should "allow panel titles with pipes in them" in {
+    val firstTrail = makePressedContent(
+      webPublicationDate = wayBackWhen,
+      lastModified = Some(lastModifiedWayBackWhen),
+      kickerText = Some("A Kicker"),
+      trailPicture = Some(imageMedia),
+      headline = "Evening briefing | Tuesday 28 September | PM meets with Liberal MPs worried Coalition will appease Nats ",
+    )
+    val anotherTrail =
+      makePressedContent(
+        webPublicationDate = wayBackWhen,
+        lastModified = Some(lastModifiedWayBackWhen),
+        trailPicture = Some(imageMedia),
+        kickerText = Some("Another Kicker"),
+      )
+
+    val outcome = TrailsToShowcase
+      .asRundownPanel(Seq(firstTrail, anotherTrail, anotherTrail), "rundown-container-id")
+
+    outcome.right.get.panelTitle should be("Evening briefing | Tuesday 28 September")
+    outcome.right.get.articleGroup.articles.head.title should be("PM meets with Liberal MPs worried Coalition will appease Nats")
+  }
+
+
   "TrailToShowcase" should "reject rundown panels with missing panel title" in {
     val firstTrail = makePressedContent(
       webPublicationDate = wayBackWhen,


### PR DESCRIPTION
## What does this change?

Showcase Panel titles often include the pipe character

Which is our delimiter; take from the left rather than the right as pipes -cough- never appear in headlines.

Could have moved to a more exotic delimiter but this feels elegant and is not a breaking change which needs to be coordinated with the editors.



## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
