### PR TITLE
Add instruction to the admin tool about how to unpress an interactive article

### DIFF
--- a/admin/app/views/pressInteractive.scala.html
+++ b/admin/app/views/pressInteractive.scala.html
@@ -45,6 +45,15 @@
         <br>
         <div id="server-message">No pressing in progress</div>
     </div>
+  <br>
+  <br>
+    <h2>Un-press an interactive</h2>
+    <br>
+    <ul>
+        <li>
+            Un-pressing is not currently an automated process. Please contact the dotcom team if you need to un-press an individual interactive.
+        </li>
+    </ul>
     <script>
         const btn = document.getElementById('interactiveUrlBtn');
 

--- a/admin/app/views/pressInteractive.scala.html
+++ b/admin/app/views/pressInteractive.scala.html
@@ -9,7 +9,7 @@
             This will <strong>only</strong> work as expected for interactive articles.
         </li>
         <li>
-            This tool will only press interactive articles. To serve the pressed articles to readers, please contact the dotcom team.
+            This tool will only press interactive articles. To serve the pressed articles to readers, please contact the dotcom team (dotcom.platform@@theguardian.com).
         </li>
         <li>
             Please provide full URLs like <strong>https://www.theguardian.com/something/ng-interactive/something</strong>
@@ -51,7 +51,7 @@
     <br>
     <ul>
         <li>
-            Un-pressing is not currently an automated process. Please contact the dotcom team if you need to un-press an individual interactive.
+            Un-pressing is not currently an automated process. Please contact the dotcom team (dotcom.platform@@theguardian.com) if you need to un-press an individual interactive.
         </li>
     </ul>
     <script>


### PR DESCRIPTION
## What does this change?
For now, the process for un-pressing an interactive article is not automated. Given we're holding a list of interactive URLs in config (and looking at this list to determine whether we show pressed content), anyone wishing to un-press an interactive will need to request dotcom's support.

This change adds a note to the admin tool to help people who may be trying to un-press an interactive.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/45561419/135124865-882c4950-000c-403c-a7a6-b1e5175bf8aa.png
[after]: https://user-images.githubusercontent.com/45561419/135839887-d7e4fd33-b420-40cb-8635-6c0b2c9fc694.png



## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

