### PR TITLE
Saturday magazine - Removing the discontinued sections and updating correct supplement link

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -175,9 +175,7 @@ private object NavLinks {
       NavLink("Obituaries", "/tone/obituaries"),
       NavLink("G2", "/theguardian/g2"),
       NavLink("Journal", "/theguardian/journal"),
-      NavLink("Weekend", "/theguardian/weekend"),
-      NavLink("The Guide", "/theguardian/theguide"),
-      NavLink("Saturday review", "/theguardian/guardianreview"),
+      NavLink("Saturday", "/theguardian/saturday"),
     ),
   )
   val insideTheGuardian = NavLink("Inside the Guardian", "https://www.theguardian.com/membership")


### PR DESCRIPTION
## What does this change?
Updates the subnav links on https://www.theguardian.com/theguardian

Before
<img width="651" alt="Screen Shot 2021-09-28 at 17 50 34" src="https://user-images.githubusercontent.com/2051501/135131185-9ac67268-dafc-467b-97dc-2455d15f63f5.png">


After
<img width="571" alt="Screen Shot 2021-09-28 at 17 50 19" src="https://user-images.githubusercontent.com/2051501/135131197-a39c2ed6-c7be-4eab-8383-d20567456e70.png">

