### PR TITLE
Adding licensing link to brand extensions

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -228,6 +228,7 @@ private object NavLinks {
   val ukPatrons = NavLink("Patrons", "https://patrons.theguardian.com/?INTCMP=header_patrons")
   val guardianLive = NavLink("Live events", "https://membership.theguardian.com/events?INTCMP=live_uk_header_dropdown")
   val guardianPuzzlesApp = NavLink("Guardian Puzzles app", s"https://puzzles.theguardian.com/download")
+  val guardianLicensing = NavLink("Guardian content licensing site", s"https://licensing.theguardian.com/")
   val jobsRecruiter = NavLink(
     "Hire with Guardian Jobs",
     "https://recruiters.theguardian.com/?utm_source=gdnwb&utm_medium=navbar&utm_campaign=Guardian_Navbar_Recruiters&CMP_TU=trdmkt&CMP_BUNIT=jobs",
@@ -584,23 +585,27 @@ private object NavLinks {
     printShop,
     ukPatrons,
     guardianPuzzlesApp,
+    guardianLicensing,
   )
   val auBrandExtensions = List(
     auEvents,
     digitalNewspaperArchive,
     guardianPuzzlesApp,
     auWeekend,
+    guardianLicensing,
   )
   val usBrandExtensions = List(
     jobs.copy(url = jobs.url + "?INTCMP=jobs_us_web_newheader_dropdown"),
     digitalNewspaperArchive,
     guardianPuzzlesApp,
+    guardianLicensing,
   )
   val intBrandExtensions = List(
     jobs.copy(url = jobs.url + "?INTCMP=jobs_int_web_newheader_dropdown"),
     holidays.copy(url = holidays.url + "?INTCMP=holidays_int_web_newheader"),
     digitalNewspaperArchive,
     guardianPuzzlesApp,
+    guardianLicensing,
   )
 
   // Tertiary Navigation


### PR DESCRIPTION
## What does this change?
In order to promote our licensing site, the rights team requested the addition of a link within our brand extensions menu on the main site.
Before
<img width="671" alt="Screen Shot 2021-09-28 at 18 14 47" src="https://user-images.githubusercontent.com/2051501/135134688-4001089f-958b-4032-b64b-2603e5777c99.png">

After
<img width="671" alt="Screen Shot 2021-09-28 at 18 14 31" src="https://user-images.githubusercontent.com/2051501/135134676-4b8763b8-7b74-4533-a65b-852837962848.png">
 