### PR TITLE
Remove cleaning of ads from pressed interactives

### DIFF
--- a/common/app/pagepresser/InteractiveImmersiveHtmlCleaner.scala
+++ b/common/app/pagepresser/InteractiveImmersiveHtmlCleaner.scala
@@ -22,15 +22,6 @@ object InteractiveImmersiveHtmlCleaner extends HtmlCleaner {
   }
 
   def clean(document: Document, convertToHttps: Boolean, now: LocalDateTime): Document = {
-    partialUniversalClean(document)
-    removeReaderRevenueCallouts(document)
-    removeEmailSignup(document)
-    removeByTagName(document, "noscript")
-    if (convertToHttps) secureDocument(document)
-    addExtraCopyToDocument(document, now)
-  }
-
-  def partialUniversalClean(document: Document): Document = {
     removeByClass(document, "top-search-box")
     removeByClass(document, "share-links")
     removeByClass(document, "user-details")
@@ -40,6 +31,11 @@ object InteractiveImmersiveHtmlCleaner extends HtmlCleaner {
     repairStaticLinks(document)
     repairStaticSources(document)
     deComboLinks(document)
+    removeReaderRevenueCallouts(document)
+    removeEmailSignup(document)
+    removeByTagName(document, "noscript")
+    if (convertToHttps) secureDocument(document)
+    addExtraCopyToDocument(document, now)
   }
 
   def hideReaderRevenue(document: Document): Document = {

--- a/common/app/pagepresser/InteractiveImmersiveHtmlCleaner.scala
+++ b/common/app/pagepresser/InteractiveImmersiveHtmlCleaner.scala
@@ -22,8 +22,7 @@ object InteractiveImmersiveHtmlCleaner extends HtmlCleaner {
   }
 
   def clean(document: Document, convertToHttps: Boolean, now: LocalDateTime): Document = {
-    universalClean(document)
-    removeTopBannerAds(document)
+    partialUniversalClean(document)
     removeReaderRevenueCallouts(document)
     removeEmailSignup(document)
     removeByTagName(document, "noscript")
@@ -31,8 +30,16 @@ object InteractiveImmersiveHtmlCleaner extends HtmlCleaner {
     addExtraCopyToDocument(document, now)
   }
 
-  def removeTopBannerAds(document: Document): Document = {
-    removeByClass(document, "top-banner-ad-container js-top-banner")
+  def partialUniversalClean(document: Document): Document = {
+    removeByClass(document, "top-search-box")
+    removeByClass(document, "share-links")
+    removeByClass(document, "user-details")
+    removeByClass(document, "initially-off")
+    removeByClass(document, "comment-count")
+    replaceLinks(document)
+    repairStaticLinks(document)
+    repairStaticSources(document)
+    deComboLinks(document)
   }
 
   def hideReaderRevenue(document: Document): Document = {

--- a/common/test/common/HtmlCleanerTest.scala
+++ b/common/test/common/HtmlCleanerTest.scala
@@ -23,20 +23,7 @@ class InteractiveImmersiveHtmlCleanerTest extends FlatSpec with Matchers {
     InteractiveImmersiveHtmlCleaner.canClean(doc) should be(true)
   }
 
-  "Cleaned interactive immersives" should "have top banner ads removed" in {
-    val doc = Jsoup.parse("""<html>
-              |<body>
-              |<div id="bannerandheader">
-              |<div class="top-banner-ad-container js-top-banner"></div>
-              |</div>
-              |</body>
-              |</html>""".stripMargin)
-
-    val cleanedDoc = InteractiveImmersiveHtmlCleaner.removeTopBannerAds(doc)
-    cleanedDoc.getElementsByClass("top-banner-ad-container").isEmpty should be(true)
-  }
-
-  it should "set page config to hide reader revenue" in {
+  "Cleaned interactive immersives" should "set page config to hide reader revenue" in {
     val doc = Jsoup.parse("""<html>
               |<head>
               |</head>


### PR DESCRIPTION
## What does this change?
Previously the cleaning of pressed interactives removed ads from the page. After conversations with Visuals and Commercial we reverse this decision.

Pressed & cleaned interactives will now have ads included.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/45561419/135239490-d9ec5276-801f-489f-943a-cf1df0de85eb.png

[after]: https://user-images.githubusercontent.com/45561419/135239525-1cc6679a-9df9-497a-8e5c-c3a24221cfff.png

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
