### PR TITLE
Remove Ophan tracking levels of `performance.now` browser support

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "fence": "guardian/fence#0.2.11",
     "lodash-es": "^4.17.21",
     "object-fit-videos": "^1.0.3",
-    "ophan-tracker-js": "1.3.27",
+    "ophan-tracker-js": "1.3.28",
     "preact": "^10.5.13",
     "prebid.js": "https://github.com/guardian/Prebid.js#a6d34e7",
     "qwery": "3.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10559,10 +10559,10 @@ openurl@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/openurl/-/openurl-1.1.1.tgz#3875b4b0ef7a52c156f0db41d4609dbb0f94b387"
 
-ophan-tracker-js@1.3.27:
-  version "1.3.27"
-  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.27.tgz#a9913e3cc49ba39b712578659150acf202b6b8c1"
-  integrity sha512-0UXITRMb5tNJhYQzu6tDFsBLFqltYVAbbAqe4m9iVNyX8pV1xCTx+z6rA4MeM4vZEmf1yV+ERUzfEYfrCGyCOQ==
+ophan-tracker-js@1.3.28:
+  version "1.3.28"
+  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.28.tgz#52d24a03a507dc491b0c27f2ded51b1ad44bae8b"
+  integrity sha512-1azFLoS1MS1mUX3+LN/MR0tkYqJd+PHByf5AkHsfoNxKz0O+G5L92x7AGdTfPvNiQZ0BCO1qhMoLyRo1OgNMSA==
 
 opn@5.3.0:
   version "5.3.0"


### PR DESCRIPTION
## What does this change?

This updated version of the Ophan Tracker-JS library no longer tracks `performance.now` browser support:

https://www.npmjs.com/package/ophan-tracker-js/v/1.3.28

The tracking has been in place for about half a year (introduced to Frontend with https://github.com/guardian/frontend/pull/23612) and has allowed us on the Ophan team to establish that only 0.007% of pageviews are from browsers that _don't_ support the `performance.now` API - having got that, we don't need Ophan's Tracker-JS to track this anymore.

Also, DCR have recently introduced a `performance.now` polyfill (https://github.com/guardian/dotcom-rendering/pull/3463) that would mean we would no longer be accurately tracking _native_ browser support.

See also:

* https://github.com/guardian/ophan/pull/4065
* https://github.com/guardian/ophan/pull/4277


## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

https://github.com/guardian/dotcom-rendering/pull/3486
