### PR TITLE
Rundown collection last updated time contributes to Showcase rundown panel updated time

### DIFF
--- a/common/app/common/TrailsToShowcase.scala
+++ b/common/app/common/TrailsToShowcase.scala
@@ -68,9 +68,9 @@ object TrailsToShowcase {
       rundownContainerId: String,
       url: Option[String] = None,
       description: Option[String] = None,
-      collectionLastUpdate: Option[DateTime] = None,
+      collectionLastUpdated: Option[DateTime] = None,
   )(implicit request: RequestHeader): String = {
-    val rundownPanelOutcome = asRundownPanel(rundownTrails, rundownContainerId, collectionLastUpdate)
+    val rundownPanelOutcome = asRundownPanel(rundownTrails, rundownContainerId, collectionLastUpdated)
     val singleStoryPanelOutcomes = singleTrails.map(asSingleStoryPanel)
 
     val maybeRundownPanel = rundownPanelOutcome.toOption

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -673,7 +673,11 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     val collectionLastUpdated = Some(DateTime.now)
 
     val recentlyEditedRundownPanelMadeWithUnchangingContent = TrailsToShowcase
-      .asRundownPanel(Seq(unchangingContent, unchangingContent, unchangingContent), "rundown-container-id", collectionLastUpdated)
+      .asRundownPanel(
+        Seq(unchangingContent, unchangingContent, unchangingContent),
+        "rundown-container-id",
+        collectionLastUpdated,
+      )
       .right
       .get
 

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -650,7 +650,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     singleStoryPanel.imageUrl should be("http://localhost/replaced-image.jpg")
   }
 
-  "TrailToShowcase" can "should default single panel last updated to web publication date if no last updated value is available" in {
+  "TrailToShowcase" can "should default single panel last updated to content web publication date if no contet last updated value is available" in {
     val curatedContent = makePressedContent(
       webPublicationDate = wayBackWhen,
       trailPicture = Some(imageMedia),
@@ -660,6 +660,37 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(curatedContent).toOption.get
 
     singleStoryPanel.updated should be(wayBackWhen)
+  }
+
+  "TrailToShowcase" can "should consider collection last updated when deciding single story panel updated time" in {
+    val curatedContent = makePressedContent(
+      webPublicationDate = wayBackWhen,
+      trailPicture = Some(imageMedia),
+      trailText = Some(twoEncodedBulletItems),
+    )
+    val collectionLastUpdated = Some(DateTime.now)
+
+    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(curatedContent, collectionLastUpdated).toOption.get
+
+    singleStoryPanel.updated should be(collectionLastUpdated)
+  }
+
+  "TrailToShowcase" can "should consider collection last updated when deciding panel updated time" in {
+    val unchangingContent = makePressedContent(
+      webPublicationDate = wayBackWhen,
+      trailPicture = Some(imageMedia),
+      trailText = Some(twoEncodedBulletItems),
+      headline = "Panel title | Headline",
+      kickerText = Some("A kicker"),
+    )
+    val collectionLastUpdated = Some(DateTime.now)
+
+    val recentlyEditedRundownPanelMadeWithUnchangingContent = TrailsToShowcase
+      .asRundownPanel(Seq(unchangingContent, unchangingContent, unchangingContent), "rundown-container-id", collectionLastUpdated)
+      .right
+      .get
+
+    recentlyEditedRundownPanelMadeWithUnchangingContent.updated should be(collectionLastUpdated)
   }
 
   "TrailToShowcase" can "create Rundown panels from a group of trails" in {
@@ -970,7 +1001,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     rundownPanel.articleGroup.articles.head.imageUrl shouldBe Some("http://localhost/replaced-image.jpg")
   }
 
-  "TrailToShowcase" can "should default rundown items updated publication date if no last updated value is available" in {
+  "TrailToShowcase" can "should default rundown articles updated to content publication date if no last updated value is available" in {
     val content = makePressedContent(
       webPublicationDate = wayBackWhen,
       trailPicture = Some(imageMedia),

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -670,13 +670,13 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       headline = "Panel title | Headline",
       kickerText = Some("A kicker"),
     )
-    val collectionLastUpdated = Some(DateTime.now)
+    val collectionLastUpdated = DateTime.now
 
     val recentlyEditedRundownPanelMadeWithUnchangingContent = TrailsToShowcase
       .asRundownPanel(
         Seq(unchangingContent, unchangingContent, unchangingContent),
         "rundown-container-id",
-        collectionLastUpdated,
+        Some(collectionLastUpdated),
       )
       .right
       .get

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -662,19 +662,6 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     singleStoryPanel.updated should be(wayBackWhen)
   }
 
-  "TrailToShowcase" can "should consider collection last updated when deciding single story panel updated time" in {
-    val curatedContent = makePressedContent(
-      webPublicationDate = wayBackWhen,
-      trailPicture = Some(imageMedia),
-      trailText = Some(twoEncodedBulletItems),
-    )
-    val collectionLastUpdated = Some(DateTime.now)
-
-    val singleStoryPanel = TrailsToShowcase.asSingleStoryPanel(curatedContent, collectionLastUpdated).toOption.get
-
-    singleStoryPanel.updated should be(collectionLastUpdated)
-  }
-
   "TrailToShowcase" can "should consider collection last updated when deciding panel updated time" in {
     val unchangingContent = makePressedContent(
       webPublicationDate = wayBackWhen,

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -650,7 +650,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     singleStoryPanel.imageUrl should be("http://localhost/replaced-image.jpg")
   }
 
-  "TrailToShowcase" can "should default single panel last updated to content web publication date if no contet last updated value is available" in {
+  "TrailToShowcase" can "should default single panel last updated to content web publication date if no content last updated value is available" in {
     val curatedContent = makePressedContent(
       webPublicationDate = wayBackWhen,
       trailPicture = Some(imageMedia),


### PR DESCRIPTION
## What does this change?

The Showcase Rundown panel is constantly recycled and updated with new content rather than been created anew each time. 
This means the panel updated field could be particularly important for this panel and should try to react to has many update sources as possible.

Specially changes to the rundown collection could signal an update even if none of the content involved as been updated.

The maximum of each Card's updated time would be better and applicable single story panels as well but this data does not appear to be available from Facia.

The Facia API responses do not appear to contain a per trail last updated field.
There is `frontPublicationDate` but this does not appear to react to actions like editing the trail headline.


## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
