### PR TITLE
Fix hosted video in the standalone bundle

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -160,6 +160,7 @@ const bootEnhanced = () => {
                 );
             }
 
+            // TODO: consider issues with double-loading bundles in hosted + standalone commercial (@mxdvl 2021-09-30)
             if (
                 config.get('page.contentType') === 'Audio' ||
                 config.get('page.contentType') === 'Video' ||

--- a/static/src/javascripts/projects/commercial/modules/hosted/video.ts
+++ b/static/src/javascripts/projects/commercial/modules/hosted/video.ts
@@ -1,6 +1,6 @@
 import { initHostedYoutube } from 'commercial/modules/hosted/youtube';
 
-export const initHostedVideo = (): Promise<void> => {
+export const initHostedVideo = async (): Promise<void> => {
 	const playerContainers = document.querySelectorAll<HTMLElement>(
 		'.js-hosted-youtube-video',
 	);
@@ -10,7 +10,9 @@ export const initHostedVideo = (): Promise<void> => {
 		return Promise.resolve();
 	}
 
-	return Promise.all(
+	await Promise.all(
 		Array.from(playerContainers).map((el) => initHostedYoutube(el)),
-	).then(() => void 0);
+	);
+
+	return;
 };

--- a/static/src/javascripts/projects/commercial/modules/hosted/youtube.ts
+++ b/static/src/javascripts/projects/commercial/modules/hosted/youtube.ts
@@ -37,8 +37,8 @@ const sendPercentageCompleteEvents = (
 };
 
 export const initHostedYoutube = async (el: HTMLElement): Promise<void> => {
-	const atomId = el.getAttribute('data-media-id');
-	const duration = Number(el.getAttribute('data-duration')) || null;
+	const atomId = el.dataset.mediaId;
+	const duration = Number(el.dataset.duration) || null;
 
 	if (!atomId || !duration) {
 		return;
@@ -89,6 +89,6 @@ export const initHostedYoutube = async (el: HTMLElement): Promise<void> => {
 				}
 			},
 		},
-		el.dataset.assetId as string,
+		String(el.dataset.assetId),
 	).then(() => void 0);
 };

--- a/static/src/javascripts/projects/commercial/modules/hosted/youtube.ts
+++ b/static/src/javascripts/projects/commercial/modules/hosted/youtube.ts
@@ -37,8 +37,11 @@ const sendPercentageCompleteEvents = (
 };
 
 export const initHostedYoutube = async (el: HTMLElement): Promise<void> => {
-	const atomId = el.dataset.mediaId;
-	const duration = Number(el.dataset.duration) || null;
+	// dataset is slower for a single attribute
+	// https://jsbench.me/5wku5obaj4/1
+	// @MarSavar (2021-09-29)
+	const atomId = el.getAttribute('data-media-id');
+	const duration = Number(el.getAttribute('data-duration')) || null;
 
 	if (!atomId || !duration) {
 		return;
@@ -89,6 +92,6 @@ export const initHostedYoutube = async (el: HTMLElement): Promise<void> => {
 				}
 			},
 		},
-		String(el.dataset.assetId),
+		String(el.getAttribute('data-asset-id')),
 	).then(() => void 0);
 };

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.ts
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.ts
@@ -17,10 +17,24 @@ interface WindowLocal extends Window {
 
 const scriptSrc = 'https://www.youtube.com/iframe_api';
 const promise = new Promise<void>((resolve) => {
-	if ((window as WindowLocal).YT?.Player) {
+	const localWindow = window as WindowLocal;
+
+	if (localWindow.YT?.Player) {
 		resolve();
+	} else if (localWindow.onYouTubeIframeAPIReady) {
+		// If there’s already a callback registered.
+		// This happens with the standalone commercial bundle
+
+		const previousApiLoadCallback = localWindow.onYouTubeIframeAPIReady;
+
+		localWindow.onYouTubeIframeAPIReady = () => {
+			previousApiLoadCallback();
+			resolve();
+		};
 	} else {
-		(window as WindowLocal).onYouTubeIframeAPIReady = resolve;
+		localWindow.onYouTubeIframeAPIReady = () => {
+			resolve();
+		};
 	}
 });
 


### PR DESCRIPTION
## What does this change?

For `youtube-player.ts`, adds to existing `window.onYouTubeIframeAPIReady` callback instead of replacing it.

Small changes:
- Converted a function to `async` in order to use `await`.
- Use of HTML `dataset` directly, which camelCases automatically: `.attr('data-media-id')` &rarr; `.dataset.mediaId`

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/135273549-c526ebe7-83ec-459b-8bc6-8ae181c1773e.png
[after]: https://user-images.githubusercontent.com/76776/135273518-2a9d15f0-4cce-4b9a-9a28-836e5744c7fb.png

## What is the value of this and can you measure success?

Hosted videos work for everyone!

## Checklist

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
