### PR TITLE
Serve the standalone commercial bundle to 51%

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -39,8 +39,8 @@ object StandaloneCommercialBundle
       name = "standalone-commercial-bundle",
       description = "Serve a standalone commercial bundle to a subset of users",
       owners = Seq(Owner.withGithub("mxdvl")),
-      sellByDate = LocalDate.of(2021, 10, 1),
-      participationGroup = Perc5A,
+      sellByDate = LocalDate.of(2021, 10, 15),
+      participationGroup = Perc50,
     )
 
 object StandaloneCommercialBundleTracking
@@ -48,7 +48,7 @@ object StandaloneCommercialBundleTracking
       name = "standalone-commercial-bundle-tracking",
       description = "Track performance metrics for the standalone commercial bundle",
       owners = Seq(Owner.withGithub("mxdvl")),
-      sellByDate = LocalDate.of(2021, 10, 1),
+      sellByDate = LocalDate.of(2021, 10, 15),
       participationGroup = Perc1A,
     )
 

--- a/docs/05-commercial/03-commercial-javascript.md
+++ b/docs/05-commercial/03-commercial-javascript.md
@@ -1,4 +1,30 @@
-# Commercial javascript
+# Commercial javascript (standalone)
+The standalone commercial bundle is a new webpack JavaScript bundle
+that contains all of The Guardian’s commercial business logic.
+
+In frontend, commercial logic is intertwined with the rest of the JS code,
+being loaded as one of the “bootstraps” in [boot.js][frontend]. This means
+chunks and conditional loading is all handled by Webpack.
+
+With the introduction of `dotcom-rendering`, commercial scripts needed to to be
+executed in different contexts, and a new remote bundle was introduced:
+`webpack.config.dcr.js`. The standalone bundle uses the same behaviour in every
+context, being loaded via a `<script>` tag injection.
+
+The standalone bundle has the added benefits of caching when switching between
+rendering contexts.
+
+- Commercial scripts are loaded via the following bundle: [`standalone.commercial.ts`][]
+- There is a separate webpack config for this bundle : [`webpack.config.commercial.js`][]
+- The commercial bundle is executed in both [frontend] and [dotcom-rendering][]
+- The commercial bundle loads only if the commercial switch is ON.
+
+[`standalone.commercial.ts`]: /static/src/javascripts/bootstraps/standalone.commercial.ts
+[frontend]: https://github.com/guardian/frontend/blob/ad8f6734/static/src/javascripts/boot.js#L94
+[dotcom-rendering]: https://github.com/guardian/dotcom-rendering/blob/c114bc93/dotcom-rendering/src/web/server/document.tsx#L255
+[`webpack.config.commercial.js`]: /webpack.config.commercial.js
+
+# Commercial javascript (legacy)
 * Commercial scripts run under their own bundle, with the root script /bootstraps/commercial.js
 * The commercial bundle only runs if the browser passes the `isModernBrowser` check (i.e. not IE8)
 * We interface with Doubleclick for Publishers using the `dfp-api.js` module. Most advertising on The Guardian involves a roundtrip to DFP somehow.

--- a/docs/05-commercial/03-commercial-javascript.md
+++ b/docs/05-commercial/03-commercial-javascript.md
@@ -29,7 +29,7 @@ The next step is for this bundle to move entirely out of frontend and into
 
 The team responsible for the commercial logic is @guardian/commercial-dev.
 
-# Commercial javascript (legacy)
+## Commercial javascript (legacy)
 * Commercial scripts run under their own bundle, with the root script /bootstraps/commercial.js
 * The commercial bundle only runs if the browser passes the `isModernBrowser` check (i.e. not IE8)
 * We interface with Doubleclick for Publishers using the `dfp-api.js` module. Most advertising on The Guardian involves a roundtrip to DFP somehow.

--- a/docs/05-commercial/03-commercial-javascript.md
+++ b/docs/05-commercial/03-commercial-javascript.md
@@ -1,4 +1,4 @@
-# Commercial javascript (standalone)
+# Standalone Commercial Bundle
 The standalone commercial bundle is a new webpack JavaScript bundle
 that contains all of The Guardian’s commercial business logic.
 
@@ -23,6 +23,11 @@ rendering contexts.
 [frontend]: https://github.com/guardian/frontend/blob/ad8f6734/static/src/javascripts/boot.js#L94
 [dotcom-rendering]: https://github.com/guardian/dotcom-rendering/blob/c114bc93/dotcom-rendering/src/web/server/document.tsx#L255
 [`webpack.config.commercial.js`]: /webpack.config.commercial.js
+
+The next step is for this bundle to move entirely out of frontend and into
+[@guardian/commercial-core](https://github.com/guardian/commercial-core).
+
+The team responsible for the commercial logic is @guardian/commercial-dev.
 
 # Commercial javascript (legacy)
 * Commercial scripts run under their own bundle, with the root script /bootstraps/commercial.js

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,7 +53,7 @@
 ## [Commercial](05-commercial/)
 - [⚠️ Moved to https://github.com/guardian/commercial-core/blob/3a8c75e619c2e4ac2d731d251f5bf186f7af89dd/docs/GAM-Advertising.md ⚠️](05-commercial/01-DFP-Advertising.md)
 - [Integration of commercial components](05-commercial/02-commercial-components.md)
-- [Commercial javascript (standalone)](05-commercial/03-commercial-javascript.md)
+- [Standalone Commercial Bundle](05-commercial/03-commercial-javascript.md)
 
 ## [Features and components](06-features-and-components/)
 - [SteadyPage JS utility](06-features-and-components/01-steadypage-js-utility.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,7 +53,7 @@
 ## [Commercial](05-commercial/)
 - [⚠️ Moved to https://github.com/guardian/commercial-core/blob/3a8c75e619c2e4ac2d731d251f5bf186f7af89dd/docs/GAM-Advertising.md ⚠️](05-commercial/01-DFP-Advertising.md)
 - [Integration of commercial components](05-commercial/02-commercial-components.md)
-- [Commercial javascript](05-commercial/03-commercial-javascript.md)
+- [Commercial javascript (standalone)](05-commercial/03-commercial-javascript.md)
 
 ## [Features and components](06-features-and-components/)
 - [SteadyPage JS utility](06-features-and-components/01-steadypage-js-utility.md)


### PR DESCRIPTION
## What does this change?

Extend and expand the standalone bundle experiment to 51% of all users.

Up from 6% in #24140. Depends on #24232 for a fix.

[Report any found issues here](https://docs.google.com/spreadsheets/d/125NUpNmKEW9gyqpfxfqK1-dDXkKy1P1tbxRbXNLv5xg/edit?pli=1#gid=0)

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No – this will automatically trickle
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Another step towards the new standalone commercial bundle, with its own internal logic and clear contract.

> The standalone commercial bundle is a new webpack JavaScript bundle that contains all of The Guardian’s commercial business logic.
>
> In frontend, commercial logic is deeply intertwined with the rest of the JS code, being loaded as one of the “bootstraps”. This meant that chunks and conditional loading was all handled by Webpack. Once `dotcom-rendering` was introduced, there was a need for the commercial logic to be executed in a different context, and a new remote bundle was introduced. The standalone bundle is continuation of this behaviour, where the commercial bundle is imported similarly in `frontend` as it is in `dotcom-rendering`: via a `<script>` tag injection.
> 
> The standalone bundle also means that when navigating between fronts and articles, we can reuse the same cached file.

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [X] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
