### PR TITLE
Upgrade to prebid `5.15.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "object-fit-videos": "^1.0.3",
     "ophan-tracker-js": "1.3.28",
     "preact": "^10.5.13",
-    "prebid.js": "https://github.com/guardian/Prebid.js#a6d34e7",
+    "prebid.js": "https://github.com/guardian/Prebid.js#5b7d7b2a",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.spec.ts
@@ -102,7 +102,6 @@ describe('initialise', () => {
 			s2sConfig: {
 				adapter: 'prebidServer',
 				adapterOptions: {},
-				enabled: false,
 				maxBids: 1,
 				syncUrlModifier: {},
 				timeout: 1000,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1927,7 +1927,7 @@
   resolved "https://registry.yarnpkg.com/@guardian/eslint-config/-/eslint-config-0.5.0.tgz#ece14ec90b372932c7bf01992fc6d8ce58f7f26e"
   integrity sha512-THJn0wg7i9YjSVM9ofobsJgS+WH9ybrZH1+0CXLAebp0T53RGtgZUkek82mDg1h3DidsM+f7HSZqoQyrCbPzPw==
 
-"@guardian/libs@^1", "@guardian/libs@^1.7.1":
+"@guardian/libs@^1":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-1.8.1.tgz#22bccd66be7c5bf70cd5bbb1bf7700d94610ccb7"
   integrity sha512-Q/JPLhNeYa5XhDPJhw/1+fbZmszopvovWW8I7dGEuFPGWeNUmXAbW8J3kzuonDu7l9/tuFZg8jljbKHZlrFx0A==
@@ -4845,10 +4845,10 @@ core-js-pure@^3.0.0:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.8.2.tgz#286f885c0dac1cdcd6d78397392abc25ddeca225"
   integrity sha512-v6zfIQqL/pzTVAbZvYUozsxNfxcFb6Ks3ZfEbuneJl3FW9Jb8F6vLWB6f+qTmAu72msUdyb84V8d/yBFf7FNnw==
 
-core-js-pure@^3.6.5:
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.5.tgz#c79e75f5e38dbc85a662d91eea52b8256d53b813"
-  integrity sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
+core-js-pure@^3.13.0:
+  version "3.18.1"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.18.1.tgz#097d34d24484be45cea700a448d1e74622646c80"
+  integrity sha512-kmW/k8MaSuqpvA1xm2l3TVlBuvW+XBkcaOroFUpO3D4lsTGQWBTb/tBDCf/PNkkPLrwgrkQRIYNPB0CeqGJWGQ==
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -4862,10 +4862,10 @@ core-js@^2.5.3:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
 
-core-js@^3.0.0:
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
-  integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
+core-js@^3.13.0:
+  version "3.18.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.18.1.tgz#289d4be2ce0085d40fc1244c0b1a54c00454622f"
+  integrity sha512-vJlUi/7YdlCZeL6fXvWNaLUPh/id12WXj3MbkMw5uOyF0PfWPBNOCNbs53YqgrvtujLNlt9JQpruyIKkUZ+PKA==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -9022,10 +9022,6 @@ jsdom@^16.4.0:
     ws "^7.2.3"
     xml-name-validator "^3.0.0"
 
-jsencrypt@^3.0.0-rc.1:
-  version "3.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/jsencrypt/-/jsencrypt-3.0.0-rc.1.tgz#0e0a4744ba43cc557fb5cf62fe8646bceb561b1c"
-
 jsesc@^2.5.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.1.tgz#e421a2a8e20d6b0819df28908f782526b96dd1fe"
@@ -11255,21 +11251,20 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.13.tgz#85f6c9197ecd736ce8e3bec044d08fd1330fa019"
   integrity sha512-q/vlKIGNwzTLu+jCcvywgGrt+H/1P/oIRSD6mV4ln3hmlC+Aa34C7yfPI4+5bzW8pONyVXYS7SvXosy2dKKtWQ==
 
-"prebid.js@https://github.com/guardian/Prebid.js#a6d34e7":
-  version "4.38.0"
-  resolved "https://github.com/guardian/Prebid.js#a6d34e7e53da978bf4da4adaa98368f24d39faea"
+"prebid.js@https://github.com/guardian/Prebid.js#5b7d7b2a":
+  version "5.15.0"
+  resolved "https://github.com/guardian/Prebid.js#5b7d7b2aeb799ef1e9d43d388a662457c8bdbc1f"
   dependencies:
-    "@guardian/libs" "^1.7.1"
+    "@guardian/libs" "^3.1.0"
     babel-plugin-transform-object-assign "^6.22.0"
-    core-js "^3.0.0"
-    core-js-pure "^3.6.5"
+    core-js "^3.13.0"
+    core-js-pure "^3.13.0"
     criteo-direct-rsa-validate "^1.1.0"
     crypto-js "^3.3.0"
     dlv "1.1.3"
     dset "2.1.0"
     express "^4.15.4"
     fun-hooks "^0.9.9"
-    jsencrypt "^3.0.0-rc.1"
     just-clone "^1.0.2"
     live-connect-js "2.0.0"
 


### PR DESCRIPTION
## What does this change?

Upgrades prebid.js to `5.15.0`

Associated PR: https://github.com/guardian/Prebid.js/pull/120

One spec failed because the prebid config object has changed slightly. It no longer contains `enabled: false`. To fix this, I just removed `enabled: false` from the expectation. I don't think this is cause for concern as `enabled` is optional anyway and defaults to `false`, as outlined in the docs:

https://docs.prebid.org/dev-docs/bidders/prebidServer (scroll down to "Configuration options" table)

I have tested this locally and on CODE and everything appears to work fine. Example prebid events from CODE:

![Screenshot 2021-09-30 at 14 43 52](https://user-images.githubusercontent.com/7423751/135467552-e25b6090-4f11-4262-8a3c-1ace05aad3c8.png)


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Prebid.js is kept nice and up-to-date.

### Tested

- [x] Locally
- [x] On CODE (optional)