### PR TITLE
Add tests to advert utility functions

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.spec.ts
@@ -1,6 +1,6 @@
 import { _, Advert } from './Advert';
 
-const { filterClasses } = _;
+const { filterClasses, createSizeMapping, getAdBreakpointSizes } = _;
 
 jest.mock('../../../../lib/raven');
 jest.mock('ophan/ng', () => null);
@@ -93,5 +93,65 @@ describe('Advert', () => {
 		const ad = new Advert(slot);
 		expect(ad).toBeDefined();
 		expect(googleSlot.setSafeFrameConfig).not.toBeCalled();
+	});
+});
+
+describe('createSizeMapping', () => {
+	it('one size', () => {
+		expect(createSizeMapping('300,50')).toEqual([[300, 50]]);
+	});
+	it('multiple sizes', () => {
+		expect(createSizeMapping('300,50|320,50')).toEqual([
+			[300, 50],
+			[320, 50],
+		]);
+		expect(createSizeMapping('300,50|320,50|fluid')).toEqual([
+			[300, 50],
+			[320, 50],
+			'fluid',
+		]);
+	});
+});
+
+describe('getAdBreakpointSizes', () => {
+	it('none', () => {
+		const advertNode = document.createElement('div', {});
+		advertNode.setAttribute('data-name', 'name');
+		advertNode.setAttribute('data-something', 'something-else');
+		expect(getAdBreakpointSizes(advertNode)).toEqual({});
+	});
+
+	it('one breakpoint, one size', () => {
+		const advertNode = document.createElement('div', {});
+		advertNode.setAttribute('data-mobile', '300,50');
+		expect(getAdBreakpointSizes(advertNode)).toEqual({
+			mobile: [[300, 50]],
+		});
+	});
+
+	it('one breakpoint, multi-size', () => {
+		const advertNode = document.createElement('div', {});
+		advertNode.setAttribute('data-mobile', '300,50|320,50');
+		expect(getAdBreakpointSizes(advertNode)).toEqual({
+			mobile: [
+				[300, 50],
+				[320, 50],
+			],
+		});
+	});
+
+	it('multiple breakpoints, multi-size', () => {
+		const advertNode = document.createElement('div', {});
+		advertNode.setAttribute('data-mobile', '300,50|320,50');
+		advertNode.setAttribute('data-phablet', '200,200');
+		advertNode.setAttribute('data-desktop', '250,250|fluid');
+		expect(getAdBreakpointSizes(advertNode)).toEqual({
+			mobile: [
+				[300, 50],
+				[320, 50],
+			],
+			phablet: [[200, 200]],
+			desktop: [[250, 250], 'fluid'],
+		});
 	});
 });

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -28,6 +28,11 @@ const createSizeMapping = (attr: string): AdSize[] =>
 			size === 'fluid' ? 'fluid' : size.split(',').map(Number),
 		);
 
+/** Extract the ad sizes from the breakpoint data attributes of an ad slot
+ *
+ * @param advertNode The ad slot HTML element that contains the breakpoint attributes
+ * @returns A mapping from the breakpoints supported by the slot to an array of ad sizes
+ */
 const getAdBreakpointSizes = (advertNode: HTMLElement): AdSizes =>
 	breakpoints.reduce<Record<string, AdSize[]>>((sizes, breakpoint) => {
 		const data = advertNode.getAttribute(

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -142,4 +142,6 @@ export { Advert };
 
 export const _ = {
 	filterClasses: Advert.filterClasses,
+	createSizeMapping,
+	getAdBreakpointSizes,
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/breakpoint-name-to-attribute.test.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/breakpoint-name-to-attribute.test.ts
@@ -1,0 +1,16 @@
+import { breakpointNameToAttribute } from './breakpoint-name-to-attribute';
+
+describe('breakpointNameToAttribute', () => {
+	it.each([
+		['mobile', 'mobile'],
+		['mobileMedium', 'mobile-medium'],
+		['mobileLandscape', 'mobile-landscape'],
+		['phablet', 'phablet'],
+		['tablet', 'tablet'],
+		['desktop', 'desktop'],
+		['leftCol', 'left-col'],
+		['wide', 'wide'],
+	])('breakpoint %s is attribute %s', (breakpoint, attribute) => {
+		expect(breakpointNameToAttribute(breakpoint)).toEqual(attribute);
+	});
+});

--- a/static/src/javascripts/projects/commercial/modules/dfp/breakpoint-name-to-attribute.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/breakpoint-name-to-attribute.ts
@@ -1,5 +1,10 @@
+// Regex to match a lowercase letter followed by an uppercase letter
 const regex = /([a-z])([A-Z])/g;
 
+/** Convert a breakpoint name to a form suitable for use as an attribute
+ *
+ * e.g. `mobileLandscape` => `mobile-landscape`
+ */
 const breakpointNameToAttribute = (breakpointName: string): string =>
 	breakpointName.replace(regex, '$1-$2').toLowerCase();
 


### PR DESCRIPTION
## What does this change?

- Add tests to utility functions `createSizeMapping`, `getAdBreakpointSizes`.
- Add tests for `breakpointNameToAttribute`.
- Additional TS doc comments.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

- A few more tests!
- A little more documentation!

### Tested

- [X] Locally
- [ ] On CODE (optional)