### PR TITLE
Showcase single stories are sources from all collections named "Singl…

### DIFF
--- a/common/app/common/TrailsToShowcase.scala
+++ b/common/app/common/TrailsToShowcase.scala
@@ -95,16 +95,15 @@ object TrailsToShowcase {
       asRundownPanel(collection.curated, collection.id, collection.lastUpdated)
     }
 
-    val maybeSingleStoriesCollection = faciaPage.collections.find(_.displayName == SingleStoriesCollectionName)
-    val singleStoryPanelsOutcome = maybeSingleStoriesCollection
-      .map { collection =>
-        collection.curated.map(asSingleStoryPanel)
-      }
-      .getOrElse {
-        Seq(
-          Left(Seq(s"Could not find the '$SingleStoriesCollectionName' collection to build single story panels from")),
-        )
-      }
+    val singleStoryCollections = faciaPage.collections.filter(_.displayName.trim.startsWith(SingleStoriesCollectionName))
+    val singleStoryPanelsOutcome = if (singleStoryCollections.nonEmpty) {
+      // Attempt to map all trails from all single story collections to panels
+      singleStoryCollections.flatMap(_.curated).map(asSingleStoryPanel)
+    } else {
+      Seq(
+        Left(Seq(s"Could not find the '$SingleStoriesCollectionName' collection to build single story panels from")),
+      )
+    }
 
     (rundownPanelOutcome, singleStoryPanelsOutcome)
   }

--- a/common/app/common/TrailsToShowcase.scala
+++ b/common/app/common/TrailsToShowcase.scala
@@ -95,7 +95,8 @@ object TrailsToShowcase {
       asRundownPanel(collection.curated, collection.id, collection.lastUpdated)
     }
 
-    val singleStoryCollections = faciaPage.collections.filter(_.displayName.trim.startsWith(SingleStoriesCollectionName))
+    val singleStoryCollections =
+      faciaPage.collections.filter(_.displayName.trim.startsWith(SingleStoriesCollectionName))
     val singleStoryPanelsOutcome = if (singleStoryCollections.nonEmpty) {
       // Attempt to map all trails from all single story collections to panels
       singleStoryCollections.flatMap(_.curated).map(asSingleStoryPanel)


### PR DESCRIPTION
…e Stories*".

Allows feed contents to be split across multiple collections to make feed capacity additions a none code change.

## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
