### PR TITLE
Extend confiant AB test switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -30,7 +30,7 @@ trait ABTestSwitches {
     "Check whether refreshing blocked ads lead to revenue uplift",
     owners = Seq(Owner.withGithub("mxdvl")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2021, 10, 1)),
+    sellByDate = Some(LocalDate.of(2021, 10, 15)),
     exposeClientSide = true,
   )
 }


### PR DESCRIPTION
## What does this change?

Extend the sell by date of:
- `ab-refresh-confiant-blocked-ads` switch to 15th October 2021.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Prevent switches tests of the form `should be deleted once expired` from failing.

### Tested

- [ ] Locally
- [ ] On CODE (optional)