### PR TITLE
Include series tag in epic request

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -44,6 +44,11 @@ const buildKeywordTags = page => {
         title: keywords[idx],
     }));
 };
+const buildSeriesTag = page => ({
+    id: page.seriesId,
+    type: 'Series',
+    title: page.series,
+});
 
 const epicEl = () => {
     const target = document.querySelector(
@@ -126,7 +131,7 @@ const buildEpicPayload = async () => {
         isMinuteArticle: config.hasTone('Minute'),
         isPaidContent: page.isPaidContent,
         isSensitive: page.isSensitive,
-        tags: buildKeywordTags(page),
+        tags: buildKeywordTags(page).concat([buildSeriesTag(page)]),
         showSupportMessaging: !shouldHideSupportMessaging(),
         isRecurringContributor: isRecurringContributor(),
         lastOneOffContributionDate:


### PR DESCRIPTION
currently we only use keyword tags for targeting, but we need the series tag on the page.
See https://github.com/guardian/frontend/blob/e82610d0559c0bd431c1960c684e3a4a027dc170/common/app/model/content.scala#L299

Note - dcr sends all tags


Tested in CODE, here are the tags sent in a request from a liveblog:
![Screen Shot 2021-10-04 at 14 31 31](https://user-images.githubusercontent.com/1513454/135860414-305d9f6d-bad2-43ea-ae50-95d0ed72e2d5.png)
