### PR TITLE
Add `ref` and `refViewId` to `POST /email`

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/newsletters.js
+++ b/static/src/javascripts/bootstraps/enhanced/newsletters.js
@@ -67,9 +67,15 @@ const submitForm = (
     const csrfToken = encodeURIComponent(
         $('input[name="csrfToken"]', form).val()
     );
+    const ref = encodeURIComponent(
+        window.location.href
+    );
+    const refViewId = encodeURIComponent(
+        config.get('ophan.pageViewId')
+    );
     const formQueryString = `${
         inputs.email
-    }=${email}&csrfToken=${csrfToken}&listName=${listName}&${
+    }=${email}&csrfToken=${csrfToken}&listName=${listName}&ref=${ref}&refViewId=${refViewId}${
         inputs.dummy
     }=${dummyEmail}`;
 


### PR DESCRIPTION
## What does this change?
This adds 2 parameters to the POST request made by https://www.theguardian.com/email-newsletters when a reader subscribes to a newsletter

## Why?
Because we want to be able to understand the place from where a reader initiated their subscription request. We allow people to subscribe to newsletters from multiple locations but because we don't carry this source information through the confirmation chain we lose this knowledge and don't know which pages are more effective vs. others.

## Why is this PR a draft?
Because I still need to open a PR on Identity so that I'm confident that these params will be received okay

## What about all the other places this request is made from?
This change will need to be propagated throughout. This PR is step one. Once we're happy the data is flowing correctly end to end we can push the change out over a wider surface.