### PR TITLE
Remove pressing live R2 page

### DIFF
--- a/admin/app/services/R2PagePressNotifier.scala
+++ b/admin/app/services/R2PagePressNotifier.scala
@@ -12,7 +12,7 @@ object R2PagePressNotifier extends GuLogging {
   def enqueue(akkaAsync: AkkaAsync)(message: R2PressMessage)(implicit executionContext: ExecutionContext): String = {
     try {
       R2PressNotification.sendWithoutSubject(akkaAsync)(Json.toJson[R2PressMessage](message).toString())
-      val msg = s"Queued for pressing: ${message.url} (from preserved source: ${message.fromPreservedSrc})"
+      val msg = s"Queued for pressing: ${message.url}."
       log.info(msg)
       msg
     } catch {

--- a/admin/app/views/pressR2.scala.html
+++ b/admin/app/views/pressR2.scala.html
@@ -5,6 +5,7 @@
     <form action="/press/r2" method="POST" class="form-horizontal redirect-form">
         <fieldset>
             <legend>Press (archive) an individual page</legend>
+            <p>Note, as the code for R2 is not running anymore, re-pressing is only possible for pages that we already have a static copy of - i.e. pages that have already been pressed.</p>
             <div class="form-group">
                 <label for="r2url" class="control-label col-sm-1">R2 URL:</label>
                 <div class="col-sm-6">
@@ -15,12 +16,6 @@
                 <label for="is-takedown" class="control-label col-sm-1">Takedown:</label>
                 <div class="col-sm-6">
                     <input type="checkbox" class="form-control" id="is-takedown" name="is-takedown"/>
-                </div>
-            </div>
-            <div class="form-group">
-                <label for="is-from-preserved-source" class="control-label col-sm-1">From preserved src:</label>
-                <div class="col-sm-6">
-                    <input type="checkbox" class="form-control" id="is-from-preserved-source" name="is-from-preserved-source" checked/>
                 </div>
             </div>
             <div class="form-group">
@@ -53,6 +48,7 @@
     <form action="/press/r2/batchupload" method="POST" class="form-horizontal redirect-form" enctype="multipart/form-data">
         <fieldset>
             <legend>Press a batch of pages from a file of urls</legend>
+            <p>Note, as the code for R2 is not running anymore, re-pressing is only possible for pages that we already have a static copy of - i.e. pages that have already been pressed.</p>
             <div class="form-group">
                 <label for="r2urlfile" class="control-label col-sm-1">File:</label>
                 <div class="col-sm-6">
@@ -63,12 +59,6 @@
                 <label for="is-takedown" class="control-label col-sm-1">Takedown:</label>
                 <div class="col-sm-6">
                     <input id="is-takedown" name="is-takedown" type="checkbox"/>
-                </div>
-            </div>
-            <div class="form-group">
-                <label for="is-from-preserved-source" class="control-label col-sm-1">From preserved src:</label>
-                <div class="col-sm-6">
-                    <input type="checkbox" class="form-control" id="is-from-preserved-source" name="is-from-preserved-source" checked/>
                 </div>
             </div>
             <div class="form-group">

--- a/common/app/implicits/R2PressNotification.scala
+++ b/common/app/implicits/R2PressNotification.scala
@@ -7,7 +7,6 @@ import model.R2PressMessage
 trait R2PressNotification {
   implicit val pressMessageFormatter: Format[R2PressMessage] = (
     (__ \ "url").format[String] and
-      (__ \ "fromPreservedSrc").format[Boolean] and
       (__ \ "convertToHttps").format[Boolean]
   )(R2PressMessage.apply, unlift(R2PressMessage.unapply))
 }

--- a/common/app/model/R2PressMessage.scala
+++ b/common/app/model/R2PressMessage.scala
@@ -1,3 +1,3 @@
 package model
 
-case class R2PressMessage(url: String, fromPreservedSrc: Boolean, convertToHttps: Boolean)
+case class R2PressMessage(url: String, convertToHttps: Boolean)


### PR DESCRIPTION
R2 is no longer running so pressing from live is not possible anymore.

It is still possible to press from source (which is when you press an already-pressed page).

cc @DavidLawes 

![Screenshot 2021-10-04 at 17 33 49](https://user-images.githubusercontent.com/858402/135889543-54734edf-da8b-4433-85c6-b3c9cdb0efac.png)

