### PR TITLE
Stop removing “Most Viewed” with portrait ads

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.ts
@@ -2,7 +2,6 @@ import { adSizes } from '@guardian/commercial-core';
 import { $$ } from '../../../../lib/$$';
 import fastdom from '../../../../lib/fastdom-promise';
 import reportError from '../../../../lib/report-error';
-import { geoMostPopular } from '../../../common/modules/onward/geo-most-popular';
 import { stickyCommentsMpu, stickyMpu } from '../sticky-mpu';
 import type { Advert } from './Advert';
 import { getAdIframe } from './get-ad-iframe';
@@ -167,27 +166,6 @@ const outOfPageCallback = (advert: Advert, event?: SlotRenderEndedEvent) => {
 };
 sizeCallbacks[adSizes.outOfPage.toString()] = outOfPageCallback;
 sizeCallbacks[adSizes.empty.toString()] = outOfPageCallback;
-
-/**
- * Portrait adverts exclude the locally-most-popular widget
- */
-// Temporary definition until 'geo-most-popular' is converted to TypeScript
-
-type WrappedElem = {
-	elem: HTMLElement | null;
-	remove: () => void;
-};
-sizeCallbacks[adSizes.portrait.toString()] = () =>
-	// remove geo most popular
-	geoMostPopular.whenRendered.then(
-		(popular: WrappedElem | undefined | null) =>
-			fastdom.mutate(() => {
-				if (popular?.elem) {
-					popular.elem.remove();
-					popular.elem = null;
-				}
-			}),
-	);
 
 /**
  * Commercial components with merch sizing get fluid-250 styling

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -321,8 +321,7 @@
   "../projects/commercial/modules/dfp/Advert.ts",
   "../projects/commercial/modules/dfp/get-ad-iframe.ts",
   "../projects/commercial/modules/dfp/render-advert-label.ts",
-  "../projects/commercial/modules/sticky-mpu.js",
-  "../projects/common/modules/onward/geo-most-popular.js"
+  "../projects/commercial/modules/sticky-mpu.js"
  ],
  "../projects/commercial/modules/dfp/track-ad-render.js": [
   "../projects/commercial/modules/dfp/wait-for-advert.ts"
@@ -612,11 +611,6 @@
   "../lib/time-utils.js",
   "../projects/common/modules/identity/api.ts"
  ],
- "../projects/common/modules/component.js": [
-  "../../../../node_modules/bean/bean.js",
-  "../../../../node_modules/bonzo/bonzo.js",
-  "../lib/fetch-json.ts"
- ],
  "../projects/common/modules/experiments/ab-constants.ts": [],
  "../projects/common/modules/experiments/ab-core.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
@@ -688,12 +682,6 @@
  ],
  "../projects/common/modules/identity/auth-component-event-params.js": [
   "../lib/url.ts"
- ],
- "../projects/common/modules/onward/geo-most-popular.js": [
-  "../../../../node_modules/lodash-es/lodash.js",
-  "../lib/fastdom-promise.js",
-  "../lib/mediator.js",
-  "../projects/common/modules/component.js"
  ],
  "../projects/common/modules/spacefinder.js": [
   "../../../../node_modules/bean/bean.js",


### PR DESCRIPTION
## What does this change?

Stop removing `geo-most-popular` when we get a portrait ad. They are rarely used, and we snip a dependency.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
