### PR TITLE
Support for AU targeted containers

### DIFF
--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -8,7 +8,7 @@ import com.gu.facia.client.models.{
   USWestCoastTerritory,
   AUVictoriaTerritory,
   AUQueenslandTerritory,
-  AUNewSouthWalesTerritory
+  AUNewSouthWalesTerritory,
 }
 import conf.Configuration
 import play.api.mvc.RequestHeader
@@ -37,7 +37,7 @@ trait Requests {
     TerritoryHeader(USWestCoastTerritory, USWestCoastTerritory.id),
     TerritoryHeader(AUVictoriaTerritory, AUVictoriaTerritory.id),
     TerritoryHeader(AUQueenslandTerritory, AUQueenslandTerritory.id),
-    TerritoryHeader(AUNewSouthWalesTerritory, AUNewSouthWalesTerritory.id)
+    TerritoryHeader(AUNewSouthWalesTerritory, AUNewSouthWalesTerritory.id),
   )
 
   implicit class RichRequestHeader(r: RequestHeader) {

--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -6,6 +6,9 @@ import com.gu.facia.client.models.{
   TargetedTerritory,
   USEastCoastTerritory,
   USWestCoastTerritory,
+  AUVictoriaTerritory,
+  AUQueenslandTerritory,
+  AUNewSouthWalesTerritory
 }
 import conf.Configuration
 import play.api.mvc.RequestHeader
@@ -28,10 +31,13 @@ trait Requests {
   val EMAIL_JSON_SUFFIX = ".emailjson"
   val EMAIL_TXT_SUFFIX = ".emailtxt"
   val territoryHeaders: List[TerritoryHeader] = List(
-    TerritoryHeader(EU27Territory, "EU-27"),
-    TerritoryHeader(NZTerritory, "NZ"),
-    TerritoryHeader(USEastCoastTerritory, "US-East-Coast"),
-    TerritoryHeader(USWestCoastTerritory, "US-West-Coast"),
+    TerritoryHeader(EU27Territory, EU27Territory.id),
+    TerritoryHeader(NZTerritory, NZTerritory.id),
+    TerritoryHeader(USEastCoastTerritory, USEastCoastTerritory.id),
+    TerritoryHeader(USWestCoastTerritory, USWestCoastTerritory.id),
+    TerritoryHeader(AUVictoriaTerritory, AUVictoriaTerritory.id),
+    TerritoryHeader(AUQueenslandTerritory, AUQueenslandTerritory.id),
+    TerritoryHeader(AUNewSouthWalesTerritory, AUNewSouthWalesTerritory.id)
   )
 
   implicit class RichRequestHeader(r: RequestHeader) {

--- a/facia/app/utils/TargetedCollections.scala
+++ b/facia/app/utils/TargetedCollections.scala
@@ -8,7 +8,7 @@ import com.gu.facia.client.models.{
   USWestCoastTerritory,
   AUVictoriaTerritory,
   AUQueenslandTerritory,
-  AUNewSouthWalesTerritory
+  AUNewSouthWalesTerritory,
 }
 import model.PressedPage
 import model.facia.PressedCollection
@@ -29,7 +29,7 @@ object TargetedCollections {
     USWestCoastTerritory -> "US West Coast",
     AUVictoriaTerritory -> "Australia - Victoria",
     AUQueenslandTerritory -> "Australia - Queensland",
-    AUNewSouthWalesTerritory -> "Australia - New South Wales"
+    AUNewSouthWalesTerritory -> "Australia - New South Wales",
   )
 
   def markDisplayName(collection: PressedCollection): PressedCollection = {

--- a/facia/app/utils/TargetedCollections.scala
+++ b/facia/app/utils/TargetedCollections.scala
@@ -6,6 +6,9 @@ import com.gu.facia.client.models.{
   TargetedTerritory,
   USEastCoastTerritory,
   USWestCoastTerritory,
+  AUVictoria,
+  AUQueensland,
+  AUNewSouthWales
 }
 import model.PressedPage
 import model.facia.PressedCollection
@@ -24,6 +27,9 @@ object TargetedCollections {
     EU27Territory -> "EU-27 Countries",
     USEastCoastTerritory -> "US East Coast",
     USWestCoastTerritory -> "US West Coast",
+    AUVictoria -> "Australia - Victoria",
+    AUQueensland -> "Australia - Queensland",
+    AUNewSouthWales -> "Australia - New South Wales"
   )
 
   def markDisplayName(collection: PressedCollection): PressedCollection = {

--- a/facia/app/utils/TargetedCollections.scala
+++ b/facia/app/utils/TargetedCollections.scala
@@ -6,9 +6,9 @@ import com.gu.facia.client.models.{
   TargetedTerritory,
   USEastCoastTerritory,
   USWestCoastTerritory,
-  AUVictoria,
-  AUQueensland,
-  AUNewSouthWales
+  AUVictoriaTerritory,
+  AUQueenslandTerritory,
+  AUNewSouthWalesTerritory
 }
 import model.PressedPage
 import model.facia.PressedCollection
@@ -27,9 +27,9 @@ object TargetedCollections {
     EU27Territory -> "EU-27 Countries",
     USEastCoastTerritory -> "US East Coast",
     USWestCoastTerritory -> "US West Coast",
-    AUVictoria -> "Australia - Victoria",
-    AUQueensland -> "Australia - Queensland",
-    AUNewSouthWales -> "Australia - New South Wales"
+    AUVictoriaTerritory -> "Australia - Victoria",
+    AUQueenslandTerritory -> "Australia - Queensland",
+    AUNewSouthWalesTerritory -> "Australia - New South Wales"
   )
 
   def markDisplayName(collection: PressedCollection): PressedCollection = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val identityLibVersion = "3.240-C4"
   val awsVersion = "1.11.240"
   val capiVersion = "17.22"
-  val faciaVersion = "3.3.6"
+  val faciaVersion = "3.3.8"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"


### PR DESCRIPTION
## What does this change?

The fronts tool allows editors to target containers at specific geographic regions.  We currently support targeting US West Coast, EU27 and New Zealand.  This change will allow frontend to parse new values of the `X-GU-Territory` header for Queensland, Victoria and New South Wales.  

The header is added by Fastly based on location of the end user's IP address, and there is a PR open on fastly-edge-cache to start sending the new values - https://github.com/guardian/fastly-edge-cache/pull/926.

NB- this header only splits the cache for pages that contain a geo-targeted container, so while adding 3 new values will reduce our cache performance it will only be for a tiny number of pages.

See also:
https://github.com/guardian/fastly-edge-cache/pull/926
https://github.com/guardian/mobile-apps-api/pull/1755
https://github.com/guardian/fastly-edge-cache/pull/926
https://github.com/guardian/facia-tool/pull/1387
https://github.com/guardian/facia-scala-client/pull/254

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
