### PR TITLE
Setup Prebid bidder timeout AB test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -34,4 +34,14 @@ trait ABTestSwitches {
     sellByDate = Some(LocalDate.of(2021, 10, 20)),
     exposeClientSide = true,
   )
+
+  Switch(
+    ABTests,
+    "ab-prebid-timeout",
+    "Vary length of prebid timeout",
+    owners = Seq(Owner.withGithub("chrislomaxjones")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2021, 10, 22)),
+    exposeClientSide = true,
+  )
 }

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
@@ -1,7 +1,9 @@
 import { EventTimer } from '@guardian/commercial-core';
 import { isString, log } from '@guardian/libs';
 import type { Advert } from 'commercial/modules/dfp/Advert';
+import { prebidTimeout } from 'common/modules/experiments/tests/prebid-timeout';
 import config from '../../../../../lib/config';
+import { isInVariantSynchronous } from '../../../../common/modules/experiments/ab';
 import { dfpEnv } from '../../dfp/dfp-env';
 import { getAdvertById } from '../../dfp/get-advert-by-id';
 import { getHeaderBiddingAdSlots } from '../slot-config';
@@ -155,7 +157,25 @@ declare global {
 	}
 }
 
-const bidderTimeout = 1500;
+/**
+ * Retrieve the bidder timeout from AB test variant
+ */
+const getBidderTimeoutFromABTest = (): number => {
+	// The default bidder timeout to use if not part of an AB test
+	const defaultBidderTimeout = 1500;
+
+	// Find the possible bidder timeout from variants of AB test
+	// Note these timeout values HAVE to match those in defined in the test variants
+	const bidderTimeout = [500, 1500, 4000].find((timeout) =>
+		isInVariantSynchronous(prebidTimeout, `variant${timeout}`),
+	);
+
+	return bidderTimeout ?? defaultBidderTimeout;
+};
+
+const bidderTimeout = getBidderTimeoutFromABTest();
+
+log('commercial', `Using a prebid timeout of ${bidderTimeout}ms`);
 
 class PrebidAdUnit {
 	code: string | null | undefined;

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
@@ -52,6 +52,7 @@ type UserSync =
 
 type PbjsConfig = {
 	bidderTimeout: number;
+	timeoutBuffer?: number;
 	priceGranularity: typeof priceGranularity;
 	userSync: UserSync;
 	consentManagement?: ConsentManagement;
@@ -173,6 +174,16 @@ const getBidderTimeoutFromABTest = (): number => {
 	return bidderTimeout ?? defaultBidderTimeout;
 };
 
+/**
+ * Prebid supports an additional timeout buffer to account for noisiness in
+ * timing JavaScript on the page. This value is passed to the Prebid config
+ * and is adjustable via this constant
+ */
+const timeoutBuffer = 400;
+
+/**
+ * The amount of time reserved for the auction
+ */
 const bidderTimeout = getBidderTimeoutFromABTest();
 
 log('commercial', `Using a prebid timeout of ${bidderTimeout}ms`);
@@ -244,6 +255,7 @@ const initialise = (window: Window, framework = 'tcfv2'): void => {
 		{},
 		{
 			bidderTimeout,
+			timeoutBuffer,
 			priceGranularity,
 			userSync,
 		},

--- a/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
@@ -1,7 +1,8 @@
 import type { ABTest } from '@guardian/ab-core';
 import { getSynchronousTestsToRun } from '../experiments/ab';
+import { prebidTimeout } from '../experiments/tests/prebid-timeout';
 
-const defaultClientSideTests: ABTest[] = [];
+const defaultClientSideTests: ABTest[] = [prebidTimeout];
 const serverSideTests: ServerSideABTest[] = [
 	'standaloneCommercialBundleTrackingVariant',
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -1,4 +1,5 @@
 import type { ABTest } from '@guardian/ab-core';
+import { prebidTimeout } from './tests/prebid-timeout';
 import { refreshConfiantBlockedAds } from './tests/refresh-confiant-blocked-ads';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
@@ -11,4 +12,5 @@ export const concurrentTests: readonly ABTest[] = [
 	signInGateMainControl,
 	remoteRRHeaderLinksTest,
 	refreshConfiantBlockedAds,
+	prebidTimeout,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/prebid-timeout.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/prebid-timeout.ts
@@ -1,0 +1,22 @@
+import type { ABTest } from '@guardian/ab-core';
+import { noop } from '../../../../../lib/noop';
+
+export const prebidTimeout: ABTest = {
+	id: 'PrebidTimeout',
+	author: 'Chris Jones (@chrislomaxjones)',
+	start: '2021-10-6',
+	expiry: '2021-10-22',
+	audience: 0.03,
+	audienceOffset: 0,
+	audienceCriteria: 'All users',
+	description:
+		'Vary the length of the prebid timeout beyond which we stop accepting bids. See if varying this timeout leads to any changes in commercial timing metrics',
+	successMeasure:
+		'Varying the length of the prebid timeout has an effect on commercial timing metrics',
+	variants: [
+		{ id: 'variant500', test: noop },
+		{ id: 'variant1500', test: noop },
+		{ id: 'variant4000', test: noop },
+	],
+	canRun: () => true,
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/prebid-timeout.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/prebid-timeout.ts
@@ -6,7 +6,7 @@ export const prebidTimeout: ABTest = {
 	author: 'Chris Jones (@chrislomaxjones)',
 	start: '2021-10-6',
 	expiry: '2021-10-22',
-	audience: 0.03,
+	audience: 3 / 100,
 	audienceOffset: 0,
 	audienceCriteria: 'All users',
 	description:

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -360,7 +360,9 @@
   "../projects/commercial/modules/header-bidding/prebid/price-config.ts",
   "../projects/commercial/modules/header-bidding/prebid/pubmatic.js",
   "../projects/commercial/modules/header-bidding/slot-config.ts",
-  "../projects/commercial/modules/header-bidding/utils.ts"
+  "../projects/commercial/modules/header-bidding/utils.ts",
+  "../projects/common/modules/experiments/ab.ts",
+  "../projects/common/modules/experiments/tests/prebid-timeout.ts"
  ],
  "../projects/commercial/modules/header-bidding/prebid/price-config.ts": [],
  "../projects/commercial/modules/header-bidding/prebid/pubmatic.js": [],
@@ -544,7 +546,8 @@
  ],
  "../projects/common/modules/analytics/shouldCaptureMetrics.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
-  "../projects/common/modules/experiments/ab.ts"
+  "../projects/common/modules/experiments/ab.ts",
+  "../projects/common/modules/experiments/tests/prebid-timeout.ts"
  ],
  "../projects/common/modules/article/space-filler.js": [
   "../lib/fastdom-promise.js",
@@ -635,6 +638,7 @@
  ],
  "../projects/common/modules/experiments/ab-tests.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
+  "../projects/common/modules/experiments/tests/prebid-timeout.ts",
   "../projects/common/modules/experiments/tests/refresh-confiant-blocked-ads.ts",
   "../projects/common/modules/experiments/tests/remote-header-test.js",
   "../projects/common/modules/experiments/tests/sign-in-gate-main-control.js",
@@ -661,6 +665,10 @@
   "../projects/common/modules/experiments/ab-utils.ts"
  ],
  "../projects/common/modules/experiments/automatLog.ts": [],
+ "../projects/common/modules/experiments/tests/prebid-timeout.ts": [
+  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
+  "../lib/noop.ts"
+ ],
  "../projects/common/modules/experiments/tests/refresh-confiant-blocked-ads.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
   "../lib/noop.ts"


### PR DESCRIPTION
## What does this change?

Add a client side multi-variant test to determine if varying the Prebid bidder timeout results in any effect on commercial timing metrics (specifically first ad on page, duration of Prebid and top-above-nav on page), the number impressions and the revenue per page.

The experiment involves varying the auction timeout, defined as the time Prebid allows for coordinating a header bidding auction. This table summarises the variants and corresponding Prebid timeouts:

| group       | prebid timeout |
|-------------|----------------|
| variant500  | 500ms          |
| variant1500 | 1500ms         |
| variant4000 | 4000ms         |

We include each group as:
- 500ms: A very short timeout that will hopefully have a measurable impact on the amount of bidders that are able to return a response in time.
- 1500ms: The current Prebid timeout we use.
- 4000ms: A much longer timeout that is the Prebid default. This should allow a much larger number of bidders to respond, hopefully having an impact on the metrics we measure

Prebid includes an additional 400ms (by default) buffer timeout to account for noisiness in competing JavaScript on the page. This has been explicitly passed to the Prebid config and is fixed across all variant groups. More information is included in the [prebid documentation](https://docs.prebid.org/features/timeouts.html).

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Seeing whether adjusting the Prebid timeout has an impact on performance, impressions or revenue will be useful in setting  the timeout at a specific value in the future. Success will be measured by analysis of the results of the experiment.

### Tested

- [X] Locally
- [ ] On CODE (optional)
