### PR TITLE
Enforce Prettier on commercial JS

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -14,10 +14,12 @@ jobs:
 
             - name: Install
               run: yarn
-              
+
             - name: Lint files
               run: yarn eslint static/src/javascripts --ext=ts,tsx
 
             - name: Check typescript
               run: yarn tsc
 
+            - name: Check commercial JS is formatted with Prettier
+              run: yarn prettier -c static/src/javascripts/**/commercial/**/*.js

--- a/makefile
+++ b/makefile
@@ -130,6 +130,9 @@ commercial: install
 commercial-compile: install # PRIVATE
 	@./tools/task-runner/runner commercial/compile
 
+commercial-validate: install # PRIVATE
+	@./tools/task-runner/runner commercial/validate
+
 commercial-graph: install # PRIVATE
 	@./tools/task-runner/runner commercial/graph --verbose
 

--- a/static/src/javascripts/projects/commercial/modules/article-aside-adverts.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/article-aside-adverts.spec.js
@@ -7,33 +7,33 @@ import { init } from './article-aside-adverts';
 // https://www.theguardian.com/saving-for-a-sunny-day-with-nsandi/2021/apr/20/its-incredibly-liberating-what-saving-for-a-piano-taught-me-about-my-finances
 
 jest.mock('../../common/modules/commercial/commercial-features', () => ({
-    commercialFeatures: {
-        articleAsideAdverts: true,
-    },
+	commercialFeatures: {
+		articleAsideAdverts: true,
+	},
 }));
 
 const fastdomMeasureSpy = jest.spyOn(fastdom, 'measure');
 
 const sharedBeforeEach = (domSnippet) => () => {
-    jest.resetAllMocks();
-    fakeMediator.removeAllListeners();
-    fakeConfig.page.isImmersive = false;
-    fakeConfig.page.hasShowcaseMainElement = false;
+	jest.resetAllMocks();
+	fakeMediator.removeAllListeners();
+	fakeConfig.page.isImmersive = false;
+	fakeConfig.page.hasShowcaseMainElement = false;
 
-    if (document.body) {
-        document.body.innerHTML = domSnippet;
-    }
-    expect.hasAssertions();
+	if (document.body) {
+		document.body.innerHTML = domSnippet;
+	}
+	expect.hasAssertions();
 };
 
 const sharedAfterEach = () => {
-    if (document.body) {
-        document.body.innerHTML = '';
-    }
+	if (document.body) {
+		document.body.innerHTML = '';
+	}
 };
 
 describe('Standard Article Aside Adverts', () => {
-    const domSnippet = `
+	const domSnippet = `
         <div class="js-content-main-column"></div>
         <div class="content__secondary-column js-secondary-column">
             <div class="aside-slot-container js-aside-slot-container">
@@ -42,52 +42,52 @@ describe('Standard Article Aside Adverts', () => {
         </div>
     `;
 
-    beforeEach(sharedBeforeEach(domSnippet));
-    afterEach(sharedAfterEach);
+	beforeEach(sharedBeforeEach(domSnippet));
+	afterEach(sharedAfterEach);
 
-    it('should exist', () => {
-        expect(init).toBeDefined();
-        expect(document.querySelectorAll('.ad-slot').length).toBe(1);
-    });
+	it('should exist', () => {
+		expect(init).toBeDefined();
+		expect(document.querySelectorAll('.ad-slot').length).toBe(1);
+	});
 
-    it('should resolve immediately if the secondary column does not exist', done => {
-        if (document.body) {
-            document.body.innerHTML = `<div class="js-content-main-column"></div>`;
-        }
+	it('should resolve immediately if the secondary column does not exist', (done) => {
+		if (document.body) {
+			document.body.innerHTML = `<div class="js-content-main-column"></div>`;
+		}
 
-        init().then(resolve => {
-            expect(resolve).toBe(false);
-            done();
-        });
-    });
+		init().then((resolve) => {
+			expect(resolve).toBe(false);
+			done();
+		});
+	});
 
-    it('should have the correct size mappings and classes', done => {
-        fastdomMeasureSpy.mockReturnValue(Promise.resolve([2000, 0]));
-        fakeMediator.once('page:defaultcommercial:right', adSlot => {
-            expect(adSlot.classList).toContain('js-sticky-mpu');
-            expect(adSlot.getAttribute('data-mobile')).toBe(
-                '1,1|2,2|300,250|300,274|300,600|fluid'
-            );
-            done();
-        });
-        init();
-    });
+	it('should have the correct size mappings and classes', (done) => {
+		fastdomMeasureSpy.mockReturnValue(Promise.resolve([2000, 0]));
+		fakeMediator.once('page:defaultcommercial:right', (adSlot) => {
+			expect(adSlot.classList).toContain('js-sticky-mpu');
+			expect(adSlot.getAttribute('data-mobile')).toBe(
+				'1,1|2,2|300,250|300,274|300,600|fluid',
+			);
+			done();
+		});
+		init();
+	});
 
-    it('should mutate the ad slot in short articles', done => {
-        fastdomMeasureSpy.mockReturnValue(Promise.resolve([10, 0]));
-        fakeMediator.once('page:defaultcommercial:right', adSlot => {
-            expect(adSlot.classList).not.toContain('js-sticky-mpu');
-            expect(adSlot.getAttribute('data-mobile')).toBe(
-                '1,1|2,2|300,250|300,274|fluid'
-            );
-            done();
-        });
-        init();
-    });
+	it('should mutate the ad slot in short articles', (done) => {
+		fastdomMeasureSpy.mockReturnValue(Promise.resolve([10, 0]));
+		fakeMediator.once('page:defaultcommercial:right', (adSlot) => {
+			expect(adSlot.classList).not.toContain('js-sticky-mpu');
+			expect(adSlot.getAttribute('data-mobile')).toBe(
+				'1,1|2,2|300,250|300,274|fluid',
+			);
+			done();
+		});
+		init();
+	});
 });
 
 describe('Immersive Article Aside Adverts', () => {
-    const domSnippet = `
+	const domSnippet = `
         <div class="js-content-main-column">
             <figure class="element element--immersive"></figure>
             <figure class="element element--immersive"></figure>
@@ -98,54 +98,56 @@ describe('Immersive Article Aside Adverts', () => {
             </div>
         </div>
     `;
-    beforeEach(sharedBeforeEach(domSnippet));
-    afterEach(sharedAfterEach);
+	beforeEach(sharedBeforeEach(domSnippet));
+	afterEach(sharedAfterEach);
 
-    it('should have correct test elements', () => {
-        expect(
-            document.querySelectorAll('.js-content-main-column .element--immersive').length
-        ).toBe(2);
-    });
+	it('should have correct test elements', () => {
+		expect(
+			document.querySelectorAll(
+				'.js-content-main-column .element--immersive',
+			).length,
+		).toBe(2);
+	});
 
-    it('should remove sticky and return all slot sizes when there is enough space', done => {
-        fastdomMeasureSpy.mockReturnValueOnce(Promise.resolve([900001, 10000]));
-        fakeConfig.page.isImmersive = true;
+	it('should remove sticky and return all slot sizes when there is enough space', (done) => {
+		fastdomMeasureSpy.mockReturnValueOnce(Promise.resolve([900001, 10000]));
+		fakeConfig.page.isImmersive = true;
 
-        fakeMediator.once('page:defaultcommercial:right', adSlot => {
-            expect(adSlot.classList).not.toContain('js-sticky-mpu');
-            const sizes = adSlot.getAttribute('data-mobile').split('|');
-            expect(sizes).toContain('1,1');
-            expect(sizes).toContain('2,2');
-            expect(sizes).toContain('300,250');
-            expect(sizes).toContain('300,274');
-            expect(sizes).toContain('300,600');
-            expect(sizes).toContain('fluid');
-            done();
-        });
-        init();
-    });
+		fakeMediator.once('page:defaultcommercial:right', (adSlot) => {
+			expect(adSlot.classList).not.toContain('js-sticky-mpu');
+			const sizes = adSlot.getAttribute('data-mobile').split('|');
+			expect(sizes).toContain('1,1');
+			expect(sizes).toContain('2,2');
+			expect(sizes).toContain('300,250');
+			expect(sizes).toContain('300,274');
+			expect(sizes).toContain('300,600');
+			expect(sizes).toContain('fluid');
+			done();
+		});
+		init();
+	});
 
-    it('should remove sticky and return sizes that will fit when there is limited space', done => {
-        fastdomMeasureSpy.mockReturnValueOnce(Promise.resolve([900002, 260]));
-        fakeConfig.page.isImmersive = true;
+	it('should remove sticky and return sizes that will fit when there is limited space', (done) => {
+		fastdomMeasureSpy.mockReturnValueOnce(Promise.resolve([900002, 260]));
+		fakeConfig.page.isImmersive = true;
 
-        fakeMediator.once('page:defaultcommercial:right', adSlot => {
-            expect(adSlot.classList).not.toContain('js-sticky-mpu');
-            const sizes = adSlot.getAttribute('data-mobile').split('|');
-            expect(sizes).toContain('1,1');
-            expect(sizes).toContain('2,2');
-            expect(sizes).toContain('300,250');
-            expect(sizes).not.toContain('300,274');
-            expect(sizes).not.toContain('300,600');
-            expect(sizes).not.toContain('fluid');
-            done();
-        });
-        init();
-    });
+		fakeMediator.once('page:defaultcommercial:right', (adSlot) => {
+			expect(adSlot.classList).not.toContain('js-sticky-mpu');
+			const sizes = adSlot.getAttribute('data-mobile').split('|');
+			expect(sizes).toContain('1,1');
+			expect(sizes).toContain('2,2');
+			expect(sizes).toContain('300,250');
+			expect(sizes).not.toContain('300,274');
+			expect(sizes).not.toContain('300,600');
+			expect(sizes).not.toContain('fluid');
+			done();
+		});
+		init();
+	});
 });
 
 describe('Immersive Article (no immersive elements) Aside Adverts', () => {
-    const domSnippet = `
+	const domSnippet = `
         <div class="js-content-main-column"></div>
         <div class="content__secondary-column js-secondary-column">
             <div class="aside-slot-container js-aside-slot-container">
@@ -153,20 +155,20 @@ describe('Immersive Article (no immersive elements) Aside Adverts', () => {
             </div>
         </div>
     `;
-    beforeEach(sharedBeforeEach(domSnippet));
-    afterEach(sharedAfterEach);
+	beforeEach(sharedBeforeEach(domSnippet));
+	afterEach(sharedAfterEach);
 
-    it('should have the correct size mappings and classes (leaves it untouched)', done => {
-        fastdomMeasureSpy.mockReturnValue(Promise.resolve([900000, 0]));
-        fakeConfig.page.isImmersive = true;
+	it('should have the correct size mappings and classes (leaves it untouched)', (done) => {
+		fastdomMeasureSpy.mockReturnValue(Promise.resolve([900000, 0]));
+		fakeConfig.page.isImmersive = true;
 
-        fakeMediator.once('page:defaultcommercial:right', adSlot => {
-            expect(adSlot.classList).toContain('js-sticky-mpu');
-            expect(adSlot.getAttribute('data-mobile')).toBe(
-                '1,1|2,2|300,250|300,274|300,600|fluid'
-            );
-            done();
-        });
-        init();
-    });
+		fakeMediator.once('page:defaultcommercial:right', (adSlot) => {
+			expect(adSlot.classList).toContain('js-sticky-mpu');
+			expect(adSlot.getAttribute('data-mobile')).toBe(
+				'1,1|2,2|300,250|300,274|300,600|fluid',
+			);
+			done();
+		});
+		init();
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -11,262 +11,254 @@ import { createSlots } from './dfp/create-slots';
 import { commercialFeatures } from '../../common/modules/commercial/commercial-features';
 import { initCarrot } from './carrot-traffic-driver';
 
-
-
 const isPaidContent = config.get('page.isPaidContent', false);
 
 const adSlotClassSelectorSizes = {
-    minAbove: 500,
-    minBelow: 500,
+	minAbove: 500,
+	minBelow: 500,
 };
 
-const insertAdAtPara = (
-    para,
-    name,
-    type,
-    classes,
-    sizes
-) => {
-    const ads = createSlots(type, {
-        name,
-        classes,
-        sizes,
-    });
+const insertAdAtPara = (para, name, type, classes, sizes) => {
+	const ads = createSlots(type, {
+		name,
+		classes,
+		sizes,
+	});
 
-    return fastdom
-        .mutate(() =>
-            ads.forEach(ad => {
-                if (para.parentNode) {
-                    para.parentNode.insertBefore(ad, para);
-                }
-            })
-        )
-        .then(() => {
-            const shouldForceDisplay = ['im', 'carrot'].includes(name);
-            // Only add the first ad (the DFP one) to GTP
-            addSlot(ads[0], shouldForceDisplay);
-        });
+	return fastdom
+		.mutate(() =>
+			ads.forEach((ad) => {
+				if (para.parentNode) {
+					para.parentNode.insertBefore(ad, para);
+				}
+			}),
+		)
+		.then(() => {
+			const shouldForceDisplay = ['im', 'carrot'].includes(name);
+			// Only add the first ad (the DFP one) to GTP
+			addSlot(ads[0], shouldForceDisplay);
+		});
 };
 
 let previousAllowedCandidate;
 
 // this facilitates a second filtering, now taking into account the candidates' position/size relative to the other candidates
-const filterNearbyCandidates = (maximumAdHeight) => (
-    candidate
-) => {
-    if (
-        !previousAllowedCandidate ||
-        Math.abs(candidate.top - previousAllowedCandidate.top) -
-            maximumAdHeight >=
-            adSlotClassSelectorSizes.minBelow
-    ) {
-        previousAllowedCandidate = candidate;
-        return true;
-    }
-    return false;
+const filterNearbyCandidates = (maximumAdHeight) => (candidate) => {
+	if (
+		!previousAllowedCandidate ||
+		Math.abs(candidate.top - previousAllowedCandidate.top) -
+			maximumAdHeight >=
+			adSlotClassSelectorSizes.minBelow
+	) {
+		previousAllowedCandidate = candidate;
+		return true;
+	}
+	return false;
 };
 
 const isDotcomRendering = config.get('isDotcomRendering', false);
-const articleBodySelector = isDotcomRendering ? '.article-body-commercial-selector' : '.js-article__body';
+const articleBodySelector = isDotcomRendering
+	? '.article-body-commercial-selector'
+	: '.js-article__body';
 
 const addDesktopInlineAds = (isInline1) => {
-    const isImmersive = config.get('page.isImmersive');
-    const defaultRules = {
-        bodySelector: articleBodySelector,
-        slotSelector: ' > p',
-        minAbove: isImmersive ? 700 : 300,
-        minBelow: isDotcomRendering ? 300 : 700,
-        selectors: {
-            ' > h2': {
-                minAbove: 5,
-                minBelow: 190,
-            },
-            ' .ad-slot': adSlotClassSelectorSizes,
-            ' > :not(p):not(h2):not(.ad-slot)': {
-                minAbove: 35,
-                minBelow: 400,
-            },
-            ' figure.element--immersive': {
-                minAbove: 0,
-                minBelow: 600,
-            },
-            ' figure.element--supporting': {
-                minAbove: 500,
-                minBelow: 0,
-            },
-        },
-        filter: filterNearbyCandidates(adSizes.mpu.height),
-    };
+	const isImmersive = config.get('page.isImmersive');
+	const defaultRules = {
+		bodySelector: articleBodySelector,
+		slotSelector: ' > p',
+		minAbove: isImmersive ? 700 : 300,
+		minBelow: isDotcomRendering ? 300 : 700,
+		selectors: {
+			' > h2': {
+				minAbove: 5,
+				minBelow: 190,
+			},
+			' .ad-slot': adSlotClassSelectorSizes,
+			' > :not(p):not(h2):not(.ad-slot)': {
+				minAbove: 35,
+				minBelow: 400,
+			},
+			' figure.element--immersive': {
+				minAbove: 0,
+				minBelow: 600,
+			},
+			' figure.element--supporting': {
+				minAbove: 500,
+				minBelow: 0,
+			},
+		},
+		filter: filterNearbyCandidates(adSizes.mpu.height),
+	};
 
-    // For any other inline
-    const relaxedRules = {
-        bodySelector: articleBodySelector,
-        slotSelector: ' > p',
-        minAbove: isPaidContent ? 1600 : 1000,
-        minBelow: isDotcomRendering ? 300 : 800,
-        selectors: {
-            ' .ad-slot': adSlotClassSelectorSizes,
-            ' figure.element--immersive': {
-                minAbove: 0,
-                minBelow: 600,
-            },
-            ' [data-spacefinder-ignore="numbered-list-title"]': {
+	// For any other inline
+	const relaxedRules = {
+		bodySelector: articleBodySelector,
+		slotSelector: ' > p',
+		minAbove: isPaidContent ? 1600 : 1000,
+		minBelow: isDotcomRendering ? 300 : 800,
+		selectors: {
+			' .ad-slot': adSlotClassSelectorSizes,
+			' figure.element--immersive': {
+				minAbove: 0,
+				minBelow: 600,
+			},
+			' [data-spacefinder-ignore="numbered-list-title"]': {
 				minAbove: 25,
 				minBelow: 0,
 			},
-        },
-        filter: filterNearbyCandidates(adSizes.halfPage.height),
-    };
+		},
+		filter: filterNearbyCandidates(adSizes.halfPage.height),
+	};
 
-    const rules = isInline1 ? defaultRules : relaxedRules;
+	const rules = isInline1 ? defaultRules : relaxedRules;
 
-    const insertAds = (paras) => {
-        const slots = paras
-            .slice(0, isInline1 ? 1 : paras.length)
-            .map((para, i) => {
-                const inlineId = i + (isInline1 ? 1 : 2);
+	const insertAds = (paras) => {
+		const slots = paras
+			.slice(0, isInline1 ? 1 : paras.length)
+			.map((para, i) => {
+				const inlineId = i + (isInline1 ? 1 : 2);
 
-                return insertAdAtPara(
-                    para,
-                    `inline${inlineId}`,
-                    'inline',
-                    `inline${isInline1 ? '' : ' offset-right'}`,
-                    isInline1
-                        ? null
-                        : { desktop: [adSizes.halfPage, adSizes.skyscraper] }
-                );
-            });
+				return insertAdAtPara(
+					para,
+					`inline${inlineId}`,
+					'inline',
+					`inline${isInline1 ? '' : ' offset-right'}`,
+					isInline1
+						? null
+						: { desktop: [adSizes.halfPage, adSizes.skyscraper] },
+				);
+			});
 
-        return Promise.all(slots).then(() => slots.length);
-    };
+		return Promise.all(slots).then(() => slots.length);
+	};
 
-    return spaceFiller.fillSpace(rules, insertAds, {
-        waitForImages: true,
-        waitForLinks: true,
-        waitForInteractives: true,
-    });
+	return spaceFiller.fillSpace(rules, insertAds, {
+		waitForImages: true,
+		waitForLinks: true,
+		waitForInteractives: true,
+	});
 };
 
 const addMobileInlineAds = () => {
-    const rules = {
-        bodySelector: articleBodySelector,
-        slotSelector: ' > p',
-        minAbove: 200,
-        minBelow: 200,
-        selectors: {
-            ' > h2': {
-                minAbove: 100,
-                minBelow: 250,
-            },
-            ' .ad-slot': adSlotClassSelectorSizes,
-            ' > :not(p):not(h2):not(.ad-slot)': {
-                minAbove: 35,
-                minBelow: 200,
-            },
-            fromBottom: true,
-        },
-        filter: filterNearbyCandidates(adSizes.mpu.height),
-    };
+	const rules = {
+		bodySelector: articleBodySelector,
+		slotSelector: ' > p',
+		minAbove: 200,
+		minBelow: 200,
+		selectors: {
+			' > h2': {
+				minAbove: 100,
+				minBelow: 250,
+			},
+			' .ad-slot': adSlotClassSelectorSizes,
+			' > :not(p):not(h2):not(.ad-slot)': {
+				minAbove: 35,
+				minBelow: 200,
+			},
+			fromBottom: true,
+		},
+		filter: filterNearbyCandidates(adSizes.mpu.height),
+	};
 
-    const insertAds = (paras) => {
-        const slots = paras.map((para, i) =>
-            insertAdAtPara(
-                para,
-                i === 0 ? 'top-above-nav' : `inline${i}`,
-                i === 0 ? 'top-above-nav' : 'inline',
-                'inline'
-            )
-        );
+	const insertAds = (paras) => {
+		const slots = paras.map((para, i) =>
+			insertAdAtPara(
+				para,
+				i === 0 ? 'top-above-nav' : `inline${i}`,
+				i === 0 ? 'top-above-nav' : 'inline',
+				'inline',
+			),
+		);
 
-        return Promise.all(slots).then(() => slots.length);
-    };
+		return Promise.all(slots).then(() => slots.length);
+	};
 
-    // This just returns whatever is passed in the second argument
-    return spaceFiller.fillSpace(rules, insertAds, {
-        waitForImages: true,
-        waitForLinks: true,
-        waitForInteractives: true,
-    });
+	// This just returns whatever is passed in the second argument
+	return spaceFiller.fillSpace(rules, insertAds, {
+		waitForImages: true,
+		waitForLinks: true,
+		waitForInteractives: true,
+	});
 };
 
 const addInlineAds = () => {
-    const isMobile = isBreakpoint({
-        max: 'mobileLandscape',
-    });
+	const isMobile = isBreakpoint({
+		max: 'mobileLandscape',
+	});
 
-    if (isMobile) {
-        return addMobileInlineAds();
-    }
-    if (isPaidContent) {
-        return addDesktopInlineAds(false);
-    }
-    return addDesktopInlineAds(true).then(() => addDesktopInlineAds(false));
+	if (isMobile) {
+		return addMobileInlineAds();
+	}
+	if (isPaidContent) {
+		return addDesktopInlineAds(false);
+	}
+	return addDesktopInlineAds(true).then(() => addDesktopInlineAds(false));
 };
 
 const attemptToAddInlineMerchAd = () => {
-    const rules = {
-        bodySelector: articleBodySelector,
-        slotSelector: ' > p',
-        minAbove: 300,
-        minBelow: 0,
-        selectors: {
-            ' > .merch': {
-                minAbove: 0,
-                minBelow: 0,
-            },
-            ' > header': {
-                minAbove: isBreakpoint({
-                    max: 'tablet',
-                })
-                    ? 300
-                    : 700,
-                minBelow: 0,
-            },
-            ' > h2': {
-                minAbove: 100,
-                minBelow: 250,
-            },
-            ' .ad-slot': adSlotClassSelectorSizes,
-            ' > :not(p):not(h2):not(.ad-slot)': {
-                minAbove: 200,
-                minBelow: 400,
-            },
-        },
-    };
+	const rules = {
+		bodySelector: articleBodySelector,
+		slotSelector: ' > p',
+		minAbove: 300,
+		minBelow: 0,
+		selectors: {
+			' > .merch': {
+				minAbove: 0,
+				minBelow: 0,
+			},
+			' > header': {
+				minAbove: isBreakpoint({
+					max: 'tablet',
+				})
+					? 300
+					: 700,
+				minBelow: 0,
+			},
+			' > h2': {
+				minAbove: 100,
+				minBelow: 250,
+			},
+			' .ad-slot': adSlotClassSelectorSizes,
+			' > :not(p):not(h2):not(.ad-slot)': {
+				minAbove: 200,
+				minBelow: 400,
+			},
+		},
+	};
 
-    return spaceFiller.fillSpace(
-        rules,
-        paras => insertAdAtPara(paras[0], 'im', 'im').then(() => true),
-        {
-            waitForImages: true,
-            waitForLinks: true,
-            waitForInteractives: true,
-        }
-    );
+	return spaceFiller.fillSpace(
+		rules,
+		(paras) => insertAdAtPara(paras[0], 'im', 'im').then(() => true),
+		{
+			waitForImages: true,
+			waitForLinks: true,
+			waitForInteractives: true,
+		},
+	);
 };
 
 const doInit = () => {
-    if (!commercialFeatures.articleBodyAdverts) {
-        return Promise.resolve(false);
-    }
+	if (!commercialFeatures.articleBodyAdverts) {
+		return Promise.resolve(false);
+	}
 
-    const im = config.get('page.hasInlineMerchandise')
-        ? attemptToAddInlineMerchAd()
-        : Promise.resolve(false);
-    im.then((inlineMerchAdded) =>
-        inlineMerchAdded ? trackAdRender('dfp-ad--im') : Promise.resolve()
-    )
-        .then(addInlineAds)
-        .then(initCarrot);
+	const im = config.get('page.hasInlineMerchandise')
+		? attemptToAddInlineMerchAd()
+		: Promise.resolve(false);
+	im.then((inlineMerchAdded) =>
+		inlineMerchAdded ? trackAdRender('dfp-ad--im') : Promise.resolve(),
+	)
+		.then(addInlineAds)
+		.then(initCarrot);
 
-    return im;
+	return im;
 };
 
 export const init = () => {
-    // Also init when the main article is redisplayed
-    // For instance by the signin gate.
-    mediator.on('page:article:redisplayed', doInit);
-    // DCR doesn't have mediator, so listen for CustomEvent
-    document.addEventListener('dcr:page:article:redisplayed', doInit);
-    return doInit();
+	// Also init when the main article is redisplayed
+	// For instance by the signin gate.
+	mediator.on('page:article:redisplayed', doInit);
+	// DCR doesn't have mediator, so listen for CustomEvent
+	document.addEventListener('dcr:page:article:redisplayed', doInit);
+	return doInit();
 };

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.spec.js
@@ -3,9 +3,9 @@ import config from '../../../lib/config';
 import { spaceFiller } from '../../common/modules/article/space-filler';
 import { commercialFeatures } from '../../common/modules/commercial/commercial-features';
 import {
-    getViewport as getViewport_,
-    getBreakpoint as getBreakpoint_,
-    isBreakpoint as isBreakpoint_,
+	getViewport as getViewport_,
+	getBreakpoint as getBreakpoint_,
+	isBreakpoint as isBreakpoint_,
 } from '../../../lib/detect';
 
 const getViewport = getViewport_;
@@ -13,59 +13,59 @@ const getBreakpoint = getBreakpoint_;
 const isBreakpoint = isBreakpoint_;
 
 jest.mock('./dfp/track-ad-render', () => (id) => {
-    const ads = {
-        'dfp-ad--im': true,
-    };
-    return Promise.resolve(ads[id]);
+	const ads = {
+		'dfp-ad--im': true,
+	};
+	return Promise.resolve(ads[id]);
 });
 jest.mock('./dfp/add-slot', () => ({
-    addSlot: jest.fn(),
+	addSlot: jest.fn(),
 }));
 jest.mock('../../common/modules/commercial/commercial-features', () => ({
-    commercialFeatures: {},
+	commercialFeatures: {},
 }));
 jest.mock('../../common/modules/article/space-filler', () => ({
-    spaceFiller: {
-        fillSpace: jest.fn(),
-    },
+	spaceFiller: {
+		fillSpace: jest.fn(),
+	},
 }));
 jest.mock('../../../lib/detect', () => ({
-    isBreakpoint: jest.fn(),
-    getBreakpoint: jest.fn(),
-    getViewport: jest.fn(),
+	isBreakpoint: jest.fn(),
+	getBreakpoint: jest.fn(),
+	getViewport: jest.fn(),
 }));
 jest.mock('../../../lib/config', () => ({ page: {}, get: () => false }));
 jest.mock('../../common/modules/experiments/ab', () => ({
-    isInVariantSynchronous: () => false,
+	isInVariantSynchronous: () => false,
 }));
 
-const spaceFillerStub = (spaceFiller.fillSpace);
+const spaceFillerStub = spaceFiller.fillSpace;
 
 describe('Article Body Adverts', () => {
-    beforeEach(() => {
-        jest.resetAllMocks();
-        commercialFeatures.articleBodyAdverts = true;
-        spaceFillerStub.mockImplementation(() => Promise.resolve(2));
-        getViewport.mockReturnValue({ height: 1300 });
-        expect.hasAssertions();
-    });
+	beforeEach(() => {
+		jest.resetAllMocks();
+		commercialFeatures.articleBodyAdverts = true;
+		spaceFillerStub.mockImplementation(() => Promise.resolve(2));
+		getViewport.mockReturnValue({ height: 1300 });
+		expect.hasAssertions();
+	});
 
-    it('should exist', () => {
-        expect(init).toBeDefined();
-    });
+	it('should exist', () => {
+		expect(init).toBeDefined();
+	});
 
-    it('should exit if commercial feature disabled', () => {
-        commercialFeatures.articleBodyAdverts = false;
-        return init().then(() => {
-            expect(spaceFillerStub).not.toHaveBeenCalled();
-        });
-    });
+	it('should exit if commercial feature disabled', () => {
+		commercialFeatures.articleBodyAdverts = false;
+		return init().then(() => {
+			expect(spaceFillerStub).not.toHaveBeenCalled();
+		});
+	});
 
-    describe('When merchandising components enabled', () => {
-        beforeEach(() => {
-            getBreakpoint.mockReturnValue('mobile');
-            isBreakpoint.mockReturnValue(true);
-            config.page.hasInlineMerchandise = true;
-        });
-    });
+	describe('When merchandising components enabled', () => {
+		beforeEach(() => {
+			getBreakpoint.mockReturnValue('mobile');
+			isBreakpoint.mockReturnValue(true);
+			config.page.hasInlineMerchandise = true;
+		});
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.js
@@ -8,301 +8,325 @@ import config from '../../../lib/config';
 import reportError from '../../../lib/report-error';
 import { getUrlVars } from '../../../lib/url';
 import {
-    submitComponentEvent,
-    submitViewEvent,
+	submitComponentEvent,
+	submitViewEvent,
 } from '../../common/modules/commercial/acquisitions-ophan';
 import { getUserFromApi } from '../../common/modules/identity/api';
 import {
-    clearHasCurrentBrazeUser,
-    hasCurrentBrazeUser,
-    setHasCurrentBrazeUser,
+	clearHasCurrentBrazeUser,
+	hasCurrentBrazeUser,
+	setHasCurrentBrazeUser,
 } from './hasCurrentBrazeUser';
 import { measureTiming } from './measure-timing';
-import { BrazeMessages, LocalMessageCache } from '@guardian/braze-components/logic'
+import {
+	BrazeMessages,
+	LocalMessageCache,
+} from '@guardian/braze-components/logic';
 
 const brazeVendorId = '5ed8c49c4b8ce4571c7ad801';
 
 const getBrazeUuid = () =>
-    new Promise((resolve) => {
-        getUserFromApi(user => {
-            if (user && user.privateFields && user.privateFields.brazeUuid) {
-                resolve(user.privateFields.brazeUuid);
-            } else {
-                resolve();
-            }
-        })
-    });
+	new Promise((resolve) => {
+		getUserFromApi((user) => {
+			if (user && user.privateFields && user.privateFields.brazeUuid) {
+				resolve(user.privateFields.brazeUuid);
+			} else {
+				resolve();
+			}
+		});
+	});
 
 const hasRequiredConsents = () =>
-    new Promise((resolve) => {
-        onConsentChange(({ tcfv2, ccpa, aus }) => {
-            if (tcfv2) {
-                resolve(tcfv2.vendorConsents[brazeVendorId]);
-            } else if (ccpa) {
-                resolve(!ccpa.doNotSell);
-            } else if (aus) {
-                resolve(aus.personalisedAdvertising);
-            } else {
-                resolve(false);
-            }
-        })
-    });
-
+	new Promise((resolve) => {
+		onConsentChange(({ tcfv2, ccpa, aus }) => {
+			if (tcfv2) {
+				resolve(tcfv2.vendorConsents[brazeVendorId]);
+			} else if (ccpa) {
+				resolve(!ccpa.doNotSell);
+			} else if (aus) {
+				resolve(aus.personalisedAdvertising);
+			} else {
+				resolve(false);
+			}
+		});
+	});
 
 let message;
 
 const FORCE_BRAZE_ALLOWLIST = [
-    'preview.gutools.co.uk',
-    'preview.code.dev-gutools.co.uk',
-    'localhost',
-    'm.thegulocal.com',
+	'preview.gutools.co.uk',
+	'preview.code.dev-gutools.co.uk',
+	'localhost',
+	'm.thegulocal.com',
 ];
 
 const getMessageFromUrlFragment = () => {
-    if (window.location.hash){
-        // This is intended for use on development domains for preview purposes.
+	if (window.location.hash) {
+		// This is intended for use on development domains for preview purposes.
 		// It won't run in PROD.
 
-        const key = 'force-braze-message';
+		const key = 'force-braze-message';
 
-        const hashString = window.location.hash;
+		const hashString = window.location.hash;
 
-        if (hashString.includes(key)) {
-            if (!FORCE_BRAZE_ALLOWLIST.includes(window.location.hostname)) {
-                console.log(`${key} is not supported on this domain`)
-                return null;
-            }
+		if (hashString.includes(key)) {
+			if (!FORCE_BRAZE_ALLOWLIST.includes(window.location.hostname)) {
+				console.log(`${key} is not supported on this domain`);
+				return null;
+			}
 
-            const forcedMessage = hashString.slice(
-                hashString.indexOf(`${key}=`) + key.length + 1,
-                hashString.length,
-            );
+			const forcedMessage = hashString.slice(
+				hashString.indexOf(`${key}=`) + key.length + 1,
+				hashString.length,
+			);
 
-            try {
-                const dataFromBraze = JSON.parse(decodeURIComponent(forcedMessage));
-                return {
-                    extras: dataFromBraze,
-                    logImpression: () => {},
-                    logButtonClick: () => {}
-                };
-            } catch (e) {
-                // Parsing failed. Log a message and fall through.
-                console.log(
-                    `There was an error with ${key}:`,
-                    e.message,
-                );
-            }
-        }
-    }
+			try {
+				const dataFromBraze = JSON.parse(
+					decodeURIComponent(forcedMessage),
+				);
+				return {
+					extras: dataFromBraze,
+					logImpression: () => {},
+					logButtonClick: () => {},
+				};
+			} catch (e) {
+				// Parsing failed. Log a message and fall through.
+				console.log(`There was an error with ${key}:`, e.message);
+			}
+		}
+	}
 
-    return null;
+	return null;
 };
 
 const SDK_OPTIONS = {
-    enableLogging: false,
-    noCookies: true,
-    baseUrl: 'https://sdk.fra-01.braze.eu/api/v3',
-    sessionTimeoutInSeconds: 1,
-    minimumIntervalBetweenTriggerActionsInSeconds: 0,
-    devicePropertyAllowlist: [],
+	enableLogging: false,
+	noCookies: true,
+	baseUrl: 'https://sdk.fra-01.braze.eu/api/v3',
+	sessionTimeoutInSeconds: 1,
+	minimumIntervalBetweenTriggerActionsInSeconds: 0,
+	devicePropertyAllowlist: [],
 };
 
 const getMessageFromBraze = async (apiKey, brazeUuid) => {
-    const sdkLoadTiming = measureTiming('braze-sdk-load');
-    sdkLoadTiming.start();
+	const sdkLoadTiming = measureTiming('braze-sdk-load');
+	sdkLoadTiming.start();
 
-    const appboy = await import(/* webpackChunkName: "braze-web-sdk-core" */ '@braze/web-sdk-core');
+	const appboy = await import(
+		/* webpackChunkName: "braze-web-sdk-core" */ '@braze/web-sdk-core'
+	);
 
-    const sdkLoadTimeTaken = sdkLoadTiming.end();
-    ophan.record({
-        component: 'braze-sdk-load-timing',
-        value: sdkLoadTimeTaken,
-    });
+	const sdkLoadTimeTaken = sdkLoadTiming.end();
+	ophan.record({
+		component: 'braze-sdk-load-timing',
+		value: sdkLoadTimeTaken,
+	});
 
-    const appboyTiming = measureTiming('braze-appboy');
-    appboyTiming.start();
+	const appboyTiming = measureTiming('braze-appboy');
+	appboyTiming.start();
 
-    appboy.initialize(apiKey, SDK_OPTIONS);
+	appboy.initialize(apiKey, SDK_OPTIONS);
 
-    const errorHandler = (error) => { reportError(error, {}, false) };
-    const brazeMessages = new BrazeMessages(appboy, LocalMessageCache, errorHandler);
+	const errorHandler = (error) => {
+		reportError(error, {}, false);
+	};
+	const brazeMessages = new BrazeMessages(
+		appboy,
+		LocalMessageCache,
+		errorHandler,
+	);
 
-    setHasCurrentBrazeUser();
-    appboy.changeUser(brazeUuid);
-    appboy.openSession();
+	setHasCurrentBrazeUser();
+	appboy.changeUser(brazeUuid);
+	appboy.openSession();
 
-    const canShowPromise = brazeMessages.getMessageForBanner().then((m) => {
-        message = m;
-        return true;
-    });
+	const canShowPromise = brazeMessages.getMessageForBanner().then((m) => {
+		message = m;
+		return true;
+	});
 
-    canShowPromise.then(() => {
-        const appboyTimeTaken = appboyTiming.end();
+	canShowPromise
+		.then(() => {
+			const appboyTimeTaken = appboyTiming.end();
 
-        ophan.record({
-            component: 'braze-appboy-timing',
-            value: appboyTimeTaken,
-        });
-    }).catch(() => {
-        appboyTiming.clear()
-        console.log("Appboy Timing failed.");
-    });
+			ophan.record({
+				component: 'braze-appboy-timing',
+				value: appboyTimeTaken,
+			});
+		})
+		.catch(() => {
+			appboyTiming.clear();
+			console.log('Appboy Timing failed.');
+		});
 
-    return canShowPromise
+	return canShowPromise;
 };
 
 const maybeWipeUserData = async (apiKey, brazeUuid, consent) => {
-    const userHasLoggedOut = !brazeUuid && hasCurrentBrazeUser();
-    const userHasRemovedConsent = !consent && hasCurrentBrazeUser();
+	const userHasLoggedOut = !brazeUuid && hasCurrentBrazeUser();
+	const userHasRemovedConsent = !consent && hasCurrentBrazeUser();
 
-    if (userHasLoggedOut || userHasRemovedConsent) {
-        try {
-            const appboy = await import(/* webpackChunkName: "braze-web-sdk-core" */ '@braze/web-sdk-core');
-            appboy.initialize(apiKey, SDK_OPTIONS);
-            appboy.wipeData();
+	if (userHasLoggedOut || userHasRemovedConsent) {
+		try {
+			const appboy = await import(
+				/* webpackChunkName: "braze-web-sdk-core" */ '@braze/web-sdk-core'
+			);
+			appboy.initialize(apiKey, SDK_OPTIONS);
+			appboy.wipeData();
 
-            LocalMessageCache.clear();
+			LocalMessageCache.clear();
 
-            clearHasCurrentBrazeUser();
-        } catch(error) {
-            reportError(error, {}, false);
-        }
-    }
-}
+			clearHasCurrentBrazeUser();
+		} catch (error) {
+			reportError(error, {}, false);
+		}
+	}
+};
 
 const canShow = async () => {
-    const bannerTiming = measureTiming('braze-banner');
-    bannerTiming.start();
+	const bannerTiming = measureTiming('braze-banner');
+	bannerTiming.start();
 
-    const forcedBrazeMessage = getMessageFromUrlFragment();
-    if (forcedBrazeMessage) {
-        message = forcedBrazeMessage;
-        return true;
-    }
+	const forcedBrazeMessage = getMessageFromUrlFragment();
+	if (forcedBrazeMessage) {
+		message = forcedBrazeMessage;
+		return true;
+	}
 
-    const brazeSwitch = config.get('switches.brazeSwitch');
-    const apiKey = config.get('page.brazeApiKey');
-    const isBrazeConfigured = brazeSwitch && apiKey;
-    if (!isBrazeConfigured) {
-        return false;
-    }
+	const brazeSwitch = config.get('switches.brazeSwitch');
+	const apiKey = config.get('page.brazeApiKey');
+	const isBrazeConfigured = brazeSwitch && apiKey;
+	if (!isBrazeConfigured) {
+		return false;
+	}
 
-    const [brazeUuid, hasGivenConsent] = await Promise.all([getBrazeUuid(), hasRequiredConsents()]);
+	const [brazeUuid, hasGivenConsent] = await Promise.all([
+		getBrazeUuid(),
+		hasRequiredConsents(),
+	]);
 
-    await maybeWipeUserData(apiKey, brazeUuid, hasGivenConsent);
+	await maybeWipeUserData(apiKey, brazeUuid, hasGivenConsent);
 
-    if (!(brazeUuid && hasGivenConsent)) {
-        return false;
-    }
+	if (!(brazeUuid && hasGivenConsent)) {
+		return false;
+	}
 
-    // Don't load Braze SDK for paid content
-    if (config.get('page').isPaidContent) {
-        return false;
-    }
+	// Don't load Braze SDK for paid content
+	if (config.get('page').isPaidContent) {
+		return false;
+	}
 
-    try {
-        const result = await getMessageFromBraze(apiKey, brazeUuid)
-        const timeTaken = bannerTiming.end();
+	try {
+		const result = await getMessageFromBraze(apiKey, brazeUuid);
+		const timeTaken = bannerTiming.end();
 
-        if (timeTaken) {
-            ophan.record({
-                component: 'braze-banner-timing',
-                value: timeTaken,
-            });
-        }
+		if (timeTaken) {
+			ophan.record({
+				component: 'braze-banner-timing',
+				value: timeTaken,
+			});
+		}
 
-        return result;
-    } catch (e) {
-        bannerTiming.clear()
-        return false;
-    }
+		return result;
+	} catch (e) {
+		bannerTiming.clear();
+		return false;
+	}
 };
 
-const show = () => Promise.all([
-    import('react-dom'),
-    import('@emotion/react'),
-    import('@emotion/cache'),
-    import(/* webpackChunkName: "guardian-braze-components-banner" */ '@guardian/braze-components/banner')
-]).then((props) => {
-    const [{ render }, { CacheProvider }, { default: createCache }, brazeModule] = props;
-    const container = document.createElement('div');
-        container.classList.add('site-message--banner');
+const show = () =>
+	Promise.all([
+		import('react-dom'),
+		import('@emotion/react'),
+		import('@emotion/cache'),
+		import(
+			/* webpackChunkName: "guardian-braze-components-banner" */ '@guardian/braze-components/banner'
+		),
+	])
+		.then((props) => {
+			const [
+				{ render },
+				{ CacheProvider },
+				{ default: createCache },
+				brazeModule,
+			] = props;
+			const container = document.createElement('div');
+			container.classList.add('site-message--banner');
 
-        // The condition here is to keep flow happy
-        if (document.body) {
-            document.body.appendChild(container);
-        }
+			// The condition here is to keep flow happy
+			if (document.body) {
+				document.body.appendChild(container);
+			}
 
-        const Component = brazeModule.BrazeBannerComponent
+			const Component = brazeModule.BrazeBannerComponent;
 
-        // IE does not support shadow DOM, so instead we just render
-        if (!container.attachShadow) {
-            render(
-                <Component
-                    componentName={ message.extras.componentName}
-                    logButtonClickWithBraze={(buttonId) => {
-                        message.logButtonClick(buttonId)
-                    }}
-                    submitComponentEvent={submitComponentEvent}
-                    brazeMessageProps={message.extras}
-                />
-            , container);
-        } else {
-            const shadowRoot = container.attachShadow({ mode: 'open' });
-            const inner = shadowRoot.appendChild(document.createElement('div'));
-            const renderContainer = inner.appendChild(
-                document.createElement('div'),
-            );
+			// IE does not support shadow DOM, so instead we just render
+			if (!container.attachShadow) {
+				render(
+					<Component
+						componentName={message.extras.componentName}
+						logButtonClickWithBraze={(buttonId) => {
+							message.logButtonClick(buttonId);
+						}}
+						submitComponentEvent={submitComponentEvent}
+						brazeMessageProps={message.extras}
+					/>,
+					container,
+				);
+			} else {
+				const shadowRoot = container.attachShadow({ mode: 'open' });
+				const inner = shadowRoot.appendChild(
+					document.createElement('div'),
+				);
+				const renderContainer = inner.appendChild(
+					document.createElement('div'),
+				);
 
-            const emotionCache = createCache({ key: 'site-message', container: inner });
+				const emotionCache = createCache({
+					key: 'site-message',
+					container: inner,
+				});
 
-            const cached = (
-                <CacheProvider value={emotionCache}>
-                    <Component
-                        componentName={ message.extras.componentName}
-                        logButtonClickWithBraze={(buttonId) => {
-                            message.logButtonClick(buttonId)
-                        }}
-                        submitComponentEvent={submitComponentEvent}
-                        brazeMessageProps={message.extras}
-                    />
-                </CacheProvider>
-            );
+				const cached = (
+					<CacheProvider value={emotionCache}>
+						<Component
+							componentName={message.extras.componentName}
+							logButtonClickWithBraze={(buttonId) => {
+								message.logButtonClick(buttonId);
+							}}
+							submitComponentEvent={submitComponentEvent}
+							brazeMessageProps={message.extras}
+						/>
+					</CacheProvider>
+				);
 
-            render(
-                cached,
-                renderContainer
-            );
-        }
+				render(cached, renderContainer);
+			}
 
-        // Log the impression with Braze
-        message.logImpression();
+			// Log the impression with Braze
+			message.logImpression();
 
-        // Log the impression with Ophan
-        submitViewEvent({
-            component: {
-                componentType: 'RETENTION_ENGAGEMENT_BANNER',
-                id: message.extras.componentName,
-            },
-        });
+			// Log the impression with Ophan
+			submitViewEvent({
+				component: {
+					componentType: 'RETENTION_ENGAGEMENT_BANNER',
+					id: message.extras.componentName,
+				},
+			});
 
-        return true;
-    })
-    .catch((error) => {
-        const msg = `Error with remote Braze component: ${error}`;
-        reportError(new Error(msg), {}, false);
+			return true;
+		})
+		.catch((error) => {
+			const msg = `Error with remote Braze component: ${error}`;
+			reportError(new Error(msg), {}, false);
 
-        return false;
-    });
+			return false;
+		});
 
 const brazeBanner = {
-    id: 'brazeBanner',
-    show,
-    canShow,
+	id: 'brazeBanner',
+	show,
+	canShow,
 };
 
-export {
-    brazeBanner,
-    brazeVendorId,
-    hasRequiredConsents,
-}
+export { brazeBanner, brazeVendorId, hasRequiredConsents };

--- a/static/src/javascripts/projects/commercial/modules/brazeBanner.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/brazeBanner.spec.js
@@ -1,72 +1,69 @@
-import {
-    brazeVendorId,
-    hasRequiredConsents,
-} from './brazeBanner';
+import { brazeVendorId, hasRequiredConsents } from './brazeBanner';
 
 jest.mock('../../../lib/raven');
 jest.mock('ophan/ng', () => null);
 
 let mockOnConsentChangeResult;
 jest.mock('@guardian/consent-management-platform', () => ({
-    onConsentChange: callback => {
-        callback(mockOnConsentChangeResult);
-    }
+	onConsentChange: (callback) => {
+		callback(mockOnConsentChangeResult);
+	},
 }));
 
 afterEach(() => {
-    mockOnConsentChangeResult = undefined;
+	mockOnConsentChangeResult = undefined;
 });
 
 describe('hasRequiredConsents', () => {
-    describe('when the user is covered by tcfv2 and consent is given', () => {
-        it('returns a promise which resolves with true', async () => {
-            mockOnConsentChangeResult = {
-                tcfv2: {
-                    vendorConsents: {
-                        [brazeVendorId]: true,
-                    },
-                }
-            }
+	describe('when the user is covered by tcfv2 and consent is given', () => {
+		it('returns a promise which resolves with true', async () => {
+			mockOnConsentChangeResult = {
+				tcfv2: {
+					vendorConsents: {
+						[brazeVendorId]: true,
+					},
+				},
+			};
 
-            await expect(hasRequiredConsents()).resolves.toBe(true);
-        });
-    });
+			await expect(hasRequiredConsents()).resolves.toBe(true);
+		});
+	});
 
-    describe('when the user is covered by tcfv2 and consent is not given', () => {
-        it('returns a promise which resolves with false', async () => {
-            mockOnConsentChangeResult = {
-                tcfv2: {
-                    vendorConsents: {
-                        [brazeVendorId]: false,
-                    },
-                }
-            }
+	describe('when the user is covered by tcfv2 and consent is not given', () => {
+		it('returns a promise which resolves with false', async () => {
+			mockOnConsentChangeResult = {
+				tcfv2: {
+					vendorConsents: {
+						[brazeVendorId]: false,
+					},
+				},
+			};
 
-            await expect(hasRequiredConsents()).resolves.toBe(false);
-        })
-    });
+			await expect(hasRequiredConsents()).resolves.toBe(false);
+		});
+	});
 
-    describe('when the user is covered by ccpa and consent is given', () => {
-        it('returns a promise which resolves with true', async () => {
-            mockOnConsentChangeResult = {
-                ccpa: {
-                    doNotSell: false,
-                }
-            }
+	describe('when the user is covered by ccpa and consent is given', () => {
+		it('returns a promise which resolves with true', async () => {
+			mockOnConsentChangeResult = {
+				ccpa: {
+					doNotSell: false,
+				},
+			};
 
-            await expect(hasRequiredConsents()).resolves.toBe(true);
-        })
-    });
+			await expect(hasRequiredConsents()).resolves.toBe(true);
+		});
+	});
 
-    describe('when the user is covered by ccpa and consent is not given', () => {
-        it('returns a promise which resolves with false', async () => {
-            mockOnConsentChangeResult = {
-                ccpa: {
-                    doNotSell: true,
-                }
-            }
+	describe('when the user is covered by ccpa and consent is not given', () => {
+		it('returns a promise which resolves with false', async () => {
+			mockOnConsentChangeResult = {
+				ccpa: {
+					doNotSell: true,
+				},
+			};
 
-            await expect(hasRequiredConsents()).resolves.toBe(false);
-        })
-    });
+			await expect(hasRequiredConsents()).resolves.toBe(false);
+		});
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/comscore.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.js
@@ -1,6 +1,6 @@
 import {
-    getConsentFor,
-    onConsentChange,
+	getConsentFor,
+	onConsentChange,
 } from '@guardian/consent-management-platform';
 import { loadScript } from '@guardian/libs';
 import config from '../../../lib/config';
@@ -12,66 +12,62 @@ const comscoreC2 = '6035250';
 
 let initialised = false;
 
-const getGlobals = (
-    consentState,
-    keywords
-) => {
-    const globals = {
-        c1: comscoreC1,
-        c2: comscoreC2,
-        cs_ucfr: consentState ? '1' : '0',
-    };
+const getGlobals = (consentState, keywords) => {
+	const globals = {
+		c1: comscoreC1,
+		c2: comscoreC2,
+		cs_ucfr: consentState ? '1' : '0',
+	};
 
-    if (keywords !== 'Network Front') {
-        globals.comscorekw = keywords;
-    }
+	if (keywords !== 'Network Front') {
+		globals.comscorekw = keywords;
+	}
 
-    return globals;
+	return globals;
 };
 
 const initOnConsent = (state) => {
-    if (!initialised) {
-        // eslint-disable-next-line no-underscore-dangle
-        window._comscore = window._comscore || [];
+	if (!initialised) {
+		// eslint-disable-next-line no-underscore-dangle
+		window._comscore = window._comscore || [];
 
-        // eslint-disable-next-line no-underscore-dangle
-        window._comscore.push(
-            getGlobals(!!state, config.get('page.keywords', ''))
-        );
+		// eslint-disable-next-line no-underscore-dangle
+		window._comscore.push(
+			getGlobals(!!state, config.get('page.keywords', '')),
+		);
 
-        loadScript(comscoreSrc, { id: 'comscore', async: true });
+		loadScript(comscoreSrc, { id: 'comscore', async: true });
 
-        initialised = true;
-    }
+		initialised = true;
+	}
 };
 
 export const init = () => {
-    if (commercialFeatures.comscore) {
-        onConsentChange(state => {
-
-            /* Rule is that comscore can run:
+	if (commercialFeatures.comscore) {
+		onConsentChange((state) => {
+			/* Rule is that comscore can run:
                 - in Tcfv2: Based on consent for comsocre
                 - in Australia: Always
                 - in CCPA: If the user hasn't chosen Do Not Sell
             */
-            const canRunTcfv2 = state.tcfv2 && getConsentFor('comscore', state);
-            const canRunAus = !!state.aus;
-            const canRunCcpa = !!state.ccpa && !state.ccpa.doNotSell;
+			const canRunTcfv2 = state.tcfv2 && getConsentFor('comscore', state);
+			const canRunAus = !!state.aus;
+			const canRunCcpa = !!state.ccpa && !state.ccpa.doNotSell;
 
-            if (canRunTcfv2 || canRunAus || canRunCcpa) initOnConsent(true);
-        });
-    }
+			if (canRunTcfv2 || canRunAus || canRunCcpa) initOnConsent(true);
+		});
+	}
 
-    return Promise.resolve();
+	return Promise.resolve();
 };
 
 export const _ = {
-    getGlobals,
-    initOnConsent,
-    resetInit: () => {
-        initialised = false;
-    },
-    comscoreSrc,
-    comscoreC1,
-    comscoreC2,
+	getGlobals,
+	initOnConsent,
+	resetInit: () => {
+		initialised = false;
+	},
+	comscoreSrc,
+	comscoreC1,
+	comscoreC2,
 };

--- a/static/src/javascripts/projects/commercial/modules/comscore.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.spec.js
@@ -1,14 +1,14 @@
 import { loadScript } from '@guardian/libs';
 import {
-    onConsentChange as onConsentChange_,
-    getConsentFor as getConsentFor_,
+	onConsentChange as onConsentChange_,
+	getConsentFor as getConsentFor_,
 } from '@guardian/consent-management-platform';
 import { commercialFeatures } from '../../common/modules/commercial/commercial-features';
 import { init, _ } from './comscore';
 
 jest.mock('@guardian/consent-management-platform', () => ({
-    onConsentChange: jest.fn(),
-    getConsentFor: jest.fn()
+	onConsentChange: jest.fn(),
+	getConsentFor: jest.fn(),
 }));
 
 const onConsentChange = onConsentChange_;
@@ -16,175 +16,174 @@ const getConsentFor = getConsentFor_;
 const SOURCEPOINT_ID = '5efefe25b8e05c06542b2a77';
 
 const tcfv2WithConsentMock = (callback) =>
-    callback({
-        tcfv2: {
-            vendorConsents: {
-                [SOURCEPOINT_ID]: true,
-            },
-        },
-    });
+	callback({
+		tcfv2: {
+			vendorConsents: {
+				[SOURCEPOINT_ID]: true,
+			},
+		},
+	});
 const tcfv2WithoutConsentMock = (callback) =>
-    callback({
-        tcfv2: {
-            vendorConsents: {
-                [SOURCEPOINT_ID]: false,
-            },
-        },
-    });
+	callback({
+		tcfv2: {
+			vendorConsents: {
+				[SOURCEPOINT_ID]: false,
+			},
+		},
+	});
 const ccpaWithConsentMock = (callback) =>
-    callback({
-        ccpa: {
-            doNotSell: false,
-        },
-    });
+	callback({
+		ccpa: {
+			doNotSell: false,
+		},
+	});
 const ccpaWithoutConsentMock = (callback) =>
-    callback({
-        ccpa: {
-            doNotSell: true,
-        },
-    });
+	callback({
+		ccpa: {
+			doNotSell: true,
+		},
+	});
 
 const AusWithoutConsentMock = (callback) =>
-    callback({
-        aus: {
-            doNotSell: true,
-        },
-    });
+	callback({
+		aus: {
+			doNotSell: true,
+		},
+	});
 
 const AusWithConsentMock = (callback) =>
-    callback({
-        aus: {
-            doNotSell: false,
-        },
-    });
+	callback({
+		aus: {
+			doNotSell: false,
+		},
+	});
 
 jest.mock('@guardian/libs', () => ({
-    loadScript: jest.fn(() => Promise.resolve()),
+	loadScript: jest.fn(() => Promise.resolve()),
 }));
 
 jest.mock('../../common/modules/commercial/commercial-features', () => ({
-    commercialFeatures: {
-        comscore: true,
-    },
+	commercialFeatures: {
+		comscore: true,
+	},
 }));
 
 describe('comscore init', () => {
-    it('should do nothing if the comscore is disabled in commercial features', () => {
-        commercialFeatures.comscore = false;
-        init();
+	it('should do nothing if the comscore is disabled in commercial features', () => {
+		commercialFeatures.comscore = false;
+		init();
 
-        expect(onConsentChange).not.toBeCalled();
-    });
+		expect(onConsentChange).not.toBeCalled();
+	});
 
-    it('should register a callback with onConsentChange if enabled in commercial features', () => {
-        commercialFeatures.comscore = true;
-        init();
+	it('should register a callback with onConsentChange if enabled in commercial features', () => {
+		commercialFeatures.comscore = true;
+		init();
 
-        expect(onConsentChange).toBeCalled();
-    });
+		expect(onConsentChange).toBeCalled();
+	});
 
-    describe('Framework consent: running on consent', () => {
-        beforeEach(() => {
-            jest.resetAllMocks();
-            _.resetInit();
-        });
+	describe('Framework consent: running on consent', () => {
+		beforeEach(() => {
+			jest.resetAllMocks();
+			_.resetInit();
+		});
 
-        it('TCFv2 with consent: runs', () => {
-            onConsentChange.mockImplementation(tcfv2WithConsentMock);
-            getConsentFor.mockReturnValue(true);
-            init();
-            expect(loadScript).toBeCalled();
-        });
+		it('TCFv2 with consent: runs', () => {
+			onConsentChange.mockImplementation(tcfv2WithConsentMock);
+			getConsentFor.mockReturnValue(true);
+			init();
+			expect(loadScript).toBeCalled();
+		});
 
-        it('TCFv2 without consent: does not run', () => {
-            onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
-            getConsentFor.mockReturnValue(false);
-            init();
-            expect(loadScript).not.toBeCalled();
-        });
-        it('CCPA with consent: runs', () => {
-            onConsentChange.mockImplementation(ccpaWithConsentMock);
-            init();
-            expect(loadScript).toBeCalled();
-        });
+		it('TCFv2 without consent: does not run', () => {
+			onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
+			getConsentFor.mockReturnValue(false);
+			init();
+			expect(loadScript).not.toBeCalled();
+		});
+		it('CCPA with consent: runs', () => {
+			onConsentChange.mockImplementation(ccpaWithConsentMock);
+			init();
+			expect(loadScript).toBeCalled();
+		});
 
-        it('CCPA without consent: does not run', () => {
-            onConsentChange.mockImplementation(ccpaWithoutConsentMock);
-            init();
-            expect(loadScript).not.toBeCalled();
-        });
+		it('CCPA without consent: does not run', () => {
+			onConsentChange.mockImplementation(ccpaWithoutConsentMock);
+			init();
+			expect(loadScript).not.toBeCalled();
+		});
 
-        it('Aus without consent: runs', () => {
-            onConsentChange.mockImplementation(AusWithoutConsentMock);
-            init();
-            expect(loadScript).toBeCalled();
-        });
+		it('Aus without consent: runs', () => {
+			onConsentChange.mockImplementation(AusWithoutConsentMock);
+			init();
+			expect(loadScript).toBeCalled();
+		});
 
-        it('Aus with consent: runs', () => {
-            onConsentChange.mockImplementation(AusWithConsentMock);
-            init();
-            expect(loadScript).toBeCalled();
-        });
-    });
+		it('Aus with consent: runs', () => {
+			onConsentChange.mockImplementation(AusWithConsentMock);
+			init();
+			expect(loadScript).toBeCalled();
+		});
+	});
 });
 
 describe('comscore initOnConsent', () => {
-    it('should call loadScript with the expected parameters', () => {
-        _.initOnConsent(true);
+	it('should call loadScript with the expected parameters', () => {
+		_.initOnConsent(true);
 
-        expect(loadScript).toBeCalledWith(_.comscoreSrc, {
-            id: 'comscore',
-            async: true,
-        });
-    });
+		expect(loadScript).toBeCalledWith(_.comscoreSrc, {
+			id: 'comscore',
+			async: true,
+		});
+	});
 
-    it('should call loadScript exactly once regardless of how many times it runs', () => {
-        _.initOnConsent(true);
-        _.initOnConsent(true);
-        _.initOnConsent(true);
+	it('should call loadScript exactly once regardless of how many times it runs', () => {
+		_.initOnConsent(true);
+		_.initOnConsent(true);
+		_.initOnConsent(true);
 
-
-        expect(loadScript).toBeCalledTimes(1);
-    });
+		expect(loadScript).toBeCalledTimes(1);
+	});
 });
 
 describe('comscore getGlobals', () => {
-    it('return an object with the c1 and c2 properties correctly set when called with "Network Front" as keywords', () => {
-        const expectedGlobals = { c1: _.comscoreC1, c2: _.comscoreC2 };
-        expect(_.getGlobals(true, 'Network Front')).toMatchObject(
-            expectedGlobals
-        );
-    });
+	it('return an object with the c1 and c2 properties correctly set when called with "Network Front" as keywords', () => {
+		const expectedGlobals = { c1: _.comscoreC1, c2: _.comscoreC2 };
+		expect(_.getGlobals(true, 'Network Front')).toMatchObject(
+			expectedGlobals,
+		);
+	});
 
-    it('return an object with the c1 and c2 properties correctly set when called with non-"Network Front" as keywords', () => {
-        const expectedGlobals = { c1: _.comscoreC1, c2: _.comscoreC2 };
-        expect(_.getGlobals(true, '')).toMatchObject(expectedGlobals);
-    });
+	it('return an object with the c1 and c2 properties correctly set when called with non-"Network Front" as keywords', () => {
+		const expectedGlobals = { c1: _.comscoreC1, c2: _.comscoreC2 };
+		expect(_.getGlobals(true, '')).toMatchObject(expectedGlobals);
+	});
 
-    it('returns an object with no comscorekw variable set when called with "Network Front" as keywords', () => {
-        const comscoreGlobals = Object.keys(
-            _.getGlobals(true, 'Network Front')
-        );
-        expect(comscoreGlobals).not.toContain('comscorekw');
-    });
+	it('returns an object with no comscorekw variable set when called with "Network Front" as keywords', () => {
+		const comscoreGlobals = Object.keys(
+			_.getGlobals(true, 'Network Front'),
+		);
+		expect(comscoreGlobals).not.toContain('comscorekw');
+	});
 
-    it('returns an object with the correct comscorekw variable set when called with "Network Front" as keywords', () => {
-        const keywords = 'These are the best keywords. The greatest!';
+	it('returns an object with the correct comscorekw variable set when called with "Network Front" as keywords', () => {
+		const keywords = 'These are the best keywords. The greatest!';
 
-        expect(_.getGlobals(true, keywords)).toMatchObject({
-            comscorekw: keywords,
-        });
-    });
+		expect(_.getGlobals(true, keywords)).toMatchObject({
+			comscorekw: keywords,
+		});
+	});
 
-    it('returns an object with the correct cs_ucfr variable set when calleed with consent sate as true', () => {
-        expect(_.getGlobals(true, '')).toMatchObject({
-            cs_ucfr: '1',
-        });
-    });
+	it('returns an object with the correct cs_ucfr variable set when calleed with consent sate as true', () => {
+		expect(_.getGlobals(true, '')).toMatchObject({
+			cs_ucfr: '1',
+		});
+	});
 
-    it('returns an object with the correct cs_ucfr variable set when calleed with consent sate as false', () => {
-        expect(_.getGlobals(false, '')).toMatchObject({
-            cs_ucfr: '0',
-        });
-    });
+	it('returns an object with the correct cs_ucfr variable set when calleed with consent sate as false', () => {
+		expect(_.getGlobals(false, '')).toMatchObject({
+			cs_ucfr: '0',
+		});
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slots.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slots.js
@@ -2,36 +2,36 @@ import config from '../../../../lib/config';
 import { adSizes } from '@guardian/commercial-core';
 
 const inlineDefinition = {
-    sizeMappings: {
-        mobile: [
-            adSizes.outOfPage,
-            adSizes.empty,
-            adSizes.outstreamMobile,
-            adSizes.mpu,
-            adSizes.googleCard,
-            adSizes.fluid,
-        ],
-        phablet: [
-            adSizes.outOfPage,
-            adSizes.empty,
-            adSizes.outstreamMobile,
-            adSizes.mpu,
-            adSizes.googleCard,
-            adSizes.outstreamDesktop,
-            adSizes.outstreamGoogleDesktop,
-            adSizes.fluid,
-        ],
-        desktop: [
-            adSizes.outOfPage,
-            adSizes.empty,
-            adSizes.mpu,
-            adSizes.googleCard,
-            adSizes.video,
-            adSizes.outstreamDesktop,
-            adSizes.outstreamGoogleDesktop,
-            adSizes.fluid,
-        ],
-    },
+	sizeMappings: {
+		mobile: [
+			adSizes.outOfPage,
+			adSizes.empty,
+			adSizes.outstreamMobile,
+			adSizes.mpu,
+			adSizes.googleCard,
+			adSizes.fluid,
+		],
+		phablet: [
+			adSizes.outOfPage,
+			adSizes.empty,
+			adSizes.outstreamMobile,
+			adSizes.mpu,
+			adSizes.googleCard,
+			adSizes.outstreamDesktop,
+			adSizes.outstreamGoogleDesktop,
+			adSizes.fluid,
+		],
+		desktop: [
+			adSizes.outOfPage,
+			adSizes.empty,
+			adSizes.mpu,
+			adSizes.googleCard,
+			adSizes.video,
+			adSizes.outstreamDesktop,
+			adSizes.outstreamGoogleDesktop,
+			adSizes.fluid,
+		],
+	},
 };
 
 /*
@@ -46,91 +46,91 @@ const inlineDefinition = {
  */
 
 const adSlotDefinitions = {
-    im: {
-        label: false,
-        refresh: false,
-        sizeMappings: {
-            mobile: [
-                adSizes.outOfPage,
-                adSizes.empty,
-                adSizes.inlineMerchandising,
-                adSizes.fluid,
-            ],
-        },
-    },
-    'high-merch': {
-        label: false,
-        refresh: false,
-        name: 'merchandising-high',
-        sizeMappings: {
-            mobile: [
-                adSizes.outOfPage,
-                adSizes.empty,
-                adSizes.merchandisingHigh,
-                adSizes.fluid,
-            ],
-        },
-    },
-    'high-merch-lucky': {
-        label: false,
-        refresh: false,
-        name: 'merchandising-high-lucky',
-        sizeMappings: {
-            mobile: [adSizes.outOfPage, adSizes.empty, adSizes.fluid],
-        },
-    },
-    'high-merch-paid': {
-        label: false,
-        refresh: false,
-        name: 'merchandising-high',
-        sizeMappings: {
-            mobile: [
-                adSizes.outOfPage,
-                adSizes.empty,
-                adSizes.merchandisingHighAdFeature,
-                adSizes.fluid,
-            ],
-        },
-    },
-    inline: inlineDefinition,
-    mostpop: inlineDefinition,
-    comments: inlineDefinition,
-    'top-above-nav': {
-        sizeMappings: {
-            mobile: [
-                adSizes.outOfPage,
-                adSizes.empty,
-                adSizes.fabric,
-                adSizes.outstreamMobile,
-                adSizes.mpu,
-                adSizes.fluid,
-            ],
-        },
-    },
-    carrot: {
-        label: false,
-        refresh: false,
-        name: 'carrot',
-        sizeMappings: {
-            mobile: [adSizes.fluid],
-        },
-    },
-    epic: {
-        label: false,
-        refresh: false,
-        name: 'epic',
-        sizeMappings: {
-            mobile: [adSizes.fluid],
-        },
-    },
-    'mobile-sticky': {
-        label: true,
-        refresh: true,
-        name: 'mobile-sticky',
-        sizeMappings: {
-            mobile: [adSizes.mobilesticky],
-        },
-    },
+	im: {
+		label: false,
+		refresh: false,
+		sizeMappings: {
+			mobile: [
+				adSizes.outOfPage,
+				adSizes.empty,
+				adSizes.inlineMerchandising,
+				adSizes.fluid,
+			],
+		},
+	},
+	'high-merch': {
+		label: false,
+		refresh: false,
+		name: 'merchandising-high',
+		sizeMappings: {
+			mobile: [
+				adSizes.outOfPage,
+				adSizes.empty,
+				adSizes.merchandisingHigh,
+				adSizes.fluid,
+			],
+		},
+	},
+	'high-merch-lucky': {
+		label: false,
+		refresh: false,
+		name: 'merchandising-high-lucky',
+		sizeMappings: {
+			mobile: [adSizes.outOfPage, adSizes.empty, adSizes.fluid],
+		},
+	},
+	'high-merch-paid': {
+		label: false,
+		refresh: false,
+		name: 'merchandising-high',
+		sizeMappings: {
+			mobile: [
+				adSizes.outOfPage,
+				adSizes.empty,
+				adSizes.merchandisingHighAdFeature,
+				adSizes.fluid,
+			],
+		},
+	},
+	inline: inlineDefinition,
+	mostpop: inlineDefinition,
+	comments: inlineDefinition,
+	'top-above-nav': {
+		sizeMappings: {
+			mobile: [
+				adSizes.outOfPage,
+				adSizes.empty,
+				adSizes.fabric,
+				adSizes.outstreamMobile,
+				adSizes.mpu,
+				adSizes.fluid,
+			],
+		},
+	},
+	carrot: {
+		label: false,
+		refresh: false,
+		name: 'carrot',
+		sizeMappings: {
+			mobile: [adSizes.fluid],
+		},
+	},
+	epic: {
+		label: false,
+		refresh: false,
+		name: 'epic',
+		sizeMappings: {
+			mobile: [adSizes.fluid],
+		},
+	},
+	'mobile-sticky': {
+		label: true,
+		refresh: true,
+		name: 'mobile-sticky',
+		sizeMappings: {
+			mobile: [adSizes.mobilesticky],
+		},
+	},
 };
 
 /*
@@ -144,87 +144,83 @@ const adSlotDefinitions = {
   use addSlot from add-slot.js
 */
 
-const createAdSlotElements = (
-    name,
-    attrs,
-    classes
-) => {
-    const adSlots = [];
+const createAdSlotElements = (name, attrs, classes) => {
+	const adSlots = [];
 
-    const id = `dfp-ad--${name}`;
+	const id = `dfp-ad--${name}`;
 
-    // 3562dc07-78e9-4507-b922-78b979d4c5cb
-    if (config.get('isDotcomRendering', false) && name === 'top-above-nav') {
-        // This is to prevent a problem that appeared with DCR.
-        // We are simply making sure that if we are about to
-        // introduce dfp-ad--top-above-nav then there isn't already one.
-        const node = document.getElementById(id);
-        if (node && node.parentNode) {
-            const pnode = node.parentNode;
-            console.log(`warning: cleaning up dom node id: dfp-ad--${name}`);
-            pnode.removeChild(node);
-        }
-    }
+	// 3562dc07-78e9-4507-b922-78b979d4c5cb
+	if (config.get('isDotcomRendering', false) && name === 'top-above-nav') {
+		// This is to prevent a problem that appeared with DCR.
+		// We are simply making sure that if we are about to
+		// introduce dfp-ad--top-above-nav then there isn't already one.
+		const node = document.getElementById(id);
+		if (node && node.parentNode) {
+			const pnode = node.parentNode;
+			console.log(`warning: cleaning up dom node id: dfp-ad--${name}`);
+			pnode.removeChild(node);
+		}
+	}
 
-    // The 'main' adSlot
-    const adSlot = document.createElement('div');
-    adSlot.id = id;
-    adSlot.className = `js-ad-slot ad-slot ${classes.join(' ')}`;
-    adSlot.setAttribute('data-link-name', `ad slot ${name}`);
-    adSlot.setAttribute('data-name', name);
-    adSlot.setAttribute('aria-hidden', 'true');
-    Object.keys(attrs).forEach(attr => {
-        adSlot.setAttribute(attr, attrs[attr]);
-    });
+	// The 'main' adSlot
+	const adSlot = document.createElement('div');
+	adSlot.id = id;
+	adSlot.className = `js-ad-slot ad-slot ${classes.join(' ')}`;
+	adSlot.setAttribute('data-link-name', `ad slot ${name}`);
+	adSlot.setAttribute('data-name', name);
+	adSlot.setAttribute('aria-hidden', 'true');
+	Object.keys(attrs).forEach((attr) => {
+		adSlot.setAttribute(attr, attrs[attr]);
+	});
 
-    adSlots.push(adSlot);
+	adSlots.push(adSlot);
 
-    return adSlots;
+	return adSlots;
 };
 
 export const createSlots = (type, options = {}) => {
-    const attributes = {};
-    const definition = adSlotDefinitions[type];
-    const slotName = options.name || definition.name || type;
-    const classes = options.classes
-        ? options.classes.split(' ').map(cn => `ad-slot--${cn}`)
-        : [];
+	const attributes = {};
+	const definition = adSlotDefinitions[type];
+	const slotName = options.name || definition.name || type;
+	const classes = options.classes
+		? options.classes.split(' ').map((cn) => `ad-slot--${cn}`)
+		: [];
 
-    const sizes = Object.assign({}, definition.sizeMappings);
+	const sizes = Object.assign({}, definition.sizeMappings);
 
-    if (options.sizes) {
-        Object.keys(options.sizes).forEach(size => {
-            if (sizes[size]) {
-                sizes[size] = sizes[size].concat(options.sizes[size]);
-            } else {
-                sizes[size] = options.sizes[size];
-            }
-        });
-    }
+	if (options.sizes) {
+		Object.keys(options.sizes).forEach((size) => {
+			if (sizes[size]) {
+				sizes[size] = sizes[size].concat(options.sizes[size]);
+			} else {
+				sizes[size] = options.sizes[size];
+			}
+		});
+	}
 
-    Object.keys(sizes).forEach(size => {
-        sizes[size] = sizes[size].join('|');
-    });
+	Object.keys(sizes).forEach((size) => {
+		sizes[size] = sizes[size].join('|');
+	});
 
-    Object.assign(attributes, sizes);
+	Object.assign(attributes, sizes);
 
-    if (definition.label === false) {
-        attributes.label = 'false';
-    }
+	if (definition.label === false) {
+		attributes.label = 'false';
+	}
 
-    if (definition.refresh === false) {
-        attributes.refresh = 'false';
-    }
+	if (definition.refresh === false) {
+		attributes.refresh = 'false';
+	}
 
-    classes.push(`ad-slot--${slotName}`);
+	classes.push(`ad-slot--${slotName}`);
 
-    return createAdSlotElements(
-        slotName,
-        Object.keys(attributes).reduce(
-            (result, key) =>
-                Object.assign({}, result, { [`data-${key}`]: attributes[key] }),
-            {}
-        ),
-        classes
-    );
+	return createAdSlotElements(
+		slotName,
+		Object.keys(attributes).reduce(
+			(result, key) =>
+				Object.assign({}, result, { [`data-${key}`]: attributes[key] }),
+			{},
+		),
+		classes,
+	);
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
@@ -4,12 +4,11 @@ import { breakpoints } from '../../../../lib/detect';
 import { getUrlVars } from '../../../../lib/url';
 
 const adUnit = once(() => {
-    const urlVars = getUrlVars();
-    return urlVars['ad-unit']
-        ? `/${config.get('page.dfpAccountId')}/${urlVars['ad-unit']}`
-        : config.get('page.adUnit');
+	const urlVars = getUrlVars();
+	return urlVars['ad-unit']
+		? `/${config.get('page.dfpAccountId')}/${urlVars['ad-unit']}`
+		: config.get('page.adUnit');
 });
-
 
 /**
  * Builds and assigns the correct size map for a slot based on the breakpoints
@@ -22,87 +21,93 @@ const adUnit = once(() => {
  *
  */
 const buildSizeMapping = (sizes) => {
-    const mapping = window.googletag.sizeMapping();
+	const mapping = window.googletag.sizeMapping();
 
-    breakpoints
-        .filter(_ => _.name in sizes)
-        .forEach(_ => {
-            mapping.addSize([_.width, 0], sizes[_.name]);
-        });
+	breakpoints
+		.filter((_) => _.name in sizes)
+		.forEach((_) => {
+			mapping.addSize([_.width, 0], sizes[_.name]);
+		});
 
-    return mapping.build();
+	return mapping.build();
 };
 
 const getSizeOpts = (sizesByBreakpoint) => {
-    const sizeMapping = buildSizeMapping(sizesByBreakpoint);
-    // as we're using sizeMapping, pull out all the ad sizes, as an array of arrays
-    const flattenSizeMappings = sizeMapping.map(size => size[1]).reduce((acc, current) => {
-        if (!current.length) {
-            return [...acc, current];
-        }
-        return [...acc, ...current]
-    }, []);
+	const sizeMapping = buildSizeMapping(sizesByBreakpoint);
+	// as we're using sizeMapping, pull out all the ad sizes, as an array of arrays
+	const flattenSizeMappings = sizeMapping
+		.map((size) => size[1])
+		.reduce((acc, current) => {
+			if (!current.length) {
+				return [...acc, current];
+			}
+			return [...acc, ...current];
+		}, []);
 
-    let sizes = [];
-    flattenSizeMappings.forEach(arr => {
-        if (!sizes.some(size => `${size[0]}-${size[1]}` === `${arr[0]}-${arr[1]}` )) {
-            sizes.push(arr);
-        }
-    });
+	let sizes = [];
+	flattenSizeMappings.forEach((arr) => {
+		if (
+			!sizes.some(
+				(size) => `${size[0]}-${size[1]}` === `${arr[0]}-${arr[1]}`,
+			)
+		) {
+			sizes.push(arr);
+		}
+	});
 
-    return {
-        sizeMapping,
-        sizes,
-    };
+	return {
+		sizeMapping,
+		sizes,
+	};
 };
 
 const adomikClassify = () => {
-    const rand = Math.random();
+	const rand = Math.random();
 
-    switch (true) {
-        case rand < 0.09:
-            return `ad_ex${Math.floor(100 * rand)}`;
-        case rand < 0.1:
-            return 'ad_bc';
-        default:
-            return 'ad_opt';
-    }
+	switch (true) {
+		case rand < 0.09:
+			return `ad_ex${Math.floor(100 * rand)}`;
+		case rand < 0.1:
+			return 'ad_bc';
+		default:
+			return 'ad_opt';
+	}
 };
 
 const isEligibleForOutstream = (slotTarget) =>
-    typeof slotTarget === 'string' &&
-    (slotTarget === 'inline1' || slotTarget === 'top-above-nav');
+	typeof slotTarget === 'string' &&
+	(slotTarget === 'inline1' || slotTarget === 'top-above-nav');
 
 const allowSafeFrameToExpand = (slot) => {
-    slot.setSafeFrameConfig({
-        allowOverlayExpansion: false,
-        allowPushExpansion: true,
-        sandbox: true,
-    });
-    return slot;
+	slot.setSafeFrameConfig({
+		allowOverlayExpansion: false,
+		allowPushExpansion: true,
+		sandbox: true,
+	});
+	return slot;
 };
 
 const defineSlot = (adSlotNode, sizes) => {
-    const slotTarget = adSlotNode.getAttribute('data-name');
-    const sizeOpts = getSizeOpts(sizes);
-    const id = adSlotNode.id;
-    let slot;
-    let slotReady = Promise.resolve();
+	const slotTarget = adSlotNode.getAttribute('data-name');
+	const sizeOpts = getSizeOpts(sizes);
+	const id = adSlotNode.id;
+	let slot;
+	let slotReady = Promise.resolve();
 
-    if (adSlotNode.getAttribute('data-out-of-page')) {
-        slot = window.googletag
-            .defineOutOfPageSlot(adUnit(), id)
-            .defineSizeMapping(sizeOpts.sizeMapping);
-    } else {
-        slot = window.googletag
-            .defineSlot(adUnit(), sizeOpts.sizes, id)
-            .defineSizeMapping(sizeOpts.sizeMapping);
-        if (isEligibleForOutstream(slotTarget)) {
-            allowSafeFrameToExpand(slot);
-        }
-    }
+	if (adSlotNode.getAttribute('data-out-of-page')) {
+		slot = window.googletag
+			.defineOutOfPageSlot(adUnit(), id)
+			.defineSizeMapping(sizeOpts.sizeMapping);
+	} else {
+		slot = window.googletag
+			.defineSlot(adUnit(), sizeOpts.sizes, id)
+			.defineSizeMapping(sizeOpts.sizeMapping);
+		if (isEligibleForOutstream(slotTarget)) {
+			allowSafeFrameToExpand(slot);
+		}
+	}
 
-    /*
+	/*
         For each ad slot defined, we request information from IAS, based
         on slot name, ad unit and sizes. We then add this targeting to the
         slot prior to requesting it from DFP.
@@ -113,114 +118,112 @@ const defineSlot = (adSlotNode, sizes) => {
 
         To see debugging output from IAS add the URL param `&iasdebug=true` to the page URL
      */
-    if (config.get('switches.iasAdTargeting', false)) {
+	if (config.get('switches.iasAdTargeting', false)) {
+		// this should all have been instantiated by commercial/modules/third-party-tags/ias.js
+		window.__iasPET = window.__iasPET || {};
+		const iasPET = window.__iasPET;
 
-        // this should all have been instantiated by commercial/modules/third-party-tags/ias.js
-        window.__iasPET = window.__iasPET || {};
-        const iasPET = window.__iasPET;
+		iasPET.queue = iasPET.queue || [];
+		iasPET.pubId = '10249';
 
+		// IAS Optimization Targeting
+		const iasPETSlots = [
+			{
+				adSlotId: id,
+				size: slot
+					.getSizes()
+					.filter((size) => size !== 'fluid')
+					.map((size) => [size.getWidth(), size.getHeight()]),
+				adUnitPath: adUnit(), // why do we have this method and not just slot.getAdUnitPath()?
+			},
+		];
 
-        iasPET.queue = iasPET.queue || [];
-        iasPET.pubId = '10249';
+		// this is stored so that the timeout can be cancelled in the event of IAS not timing out
+		let timeoutId;
 
-        // IAS Optimization Targeting
-        const iasPETSlots = [
-            {
-                adSlotId: id,
-                size: slot
-                    .getSizes()
-                    .filter(size => size !== 'fluid')
-                    .map(size => [size.getWidth(), size.getHeight()]),
-                adUnitPath: adUnit(), // why do we have this method and not just slot.getAdUnitPath()?
-            },
-        ];
+		// this is resolved by either the iasTimeout or iasDataCallback, defined below
+		let loadedResolve;
+		const iasDataPromise = new Promise((resolve) => {
+			loadedResolve = resolve;
+		});
 
-        // this is stored so that the timeout can be cancelled in the event of IAS not timing out
-        let timeoutId;
+		const iasDataCallback = (targetingJSON) => {
+			clearTimeout(timeoutId);
 
-        // this is resolved by either the iasTimeout or iasDataCallback, defined below
-        let loadedResolve;
-        const iasDataPromise = new Promise(resolve => {
-            loadedResolve = resolve;
-        });
-
-        const iasDataCallback = targetingJSON => {
-            clearTimeout(timeoutId);
-
-            /*  There is a name-clash with the `fr` targeting returned by IAS
+			/*  There is a name-clash with the `fr` targeting returned by IAS
                 and the `fr` paramater we already use for frequency. Therefore
                 we apply the targeting to the slot ourselves and rename the IAS
                 fr parameter to `fra` (given that, here, it relates to fraud).
             */
-            const targeting = JSON.parse(targetingJSON);
+			const targeting = JSON.parse(targetingJSON);
 
-            // brand safety is on a page level
-            Object.keys(targeting.brandSafety).forEach(key =>
-                window.googletag
-                    .pubads()
-                    .setTargeting(key, targeting.brandSafety[key])
-            );
-            if (targeting.fr) {
-                window.googletag.pubads().setTargeting('fra', targeting.fr);
-            }
-            if (targeting.custom && targeting.custom['ias-kw']) {
-                window.googletag
-                    .pubads()
-                    .setTargeting('ias-kw', targeting.custom['ias-kw']);
-            }
+			// brand safety is on a page level
+			Object.keys(targeting.brandSafety).forEach((key) =>
+				window.googletag
+					.pubads()
+					.setTargeting(key, targeting.brandSafety[key]),
+			);
+			if (targeting.fr) {
+				window.googletag.pubads().setTargeting('fra', targeting.fr);
+			}
+			if (targeting.custom && targeting.custom['ias-kw']) {
+				window.googletag
+					.pubads()
+					.setTargeting('ias-kw', targeting.custom['ias-kw']);
+			}
 
-            // viewability targeting is on a slot level
-            const ignoredKeys = ['pub'];
-            Object.keys(targeting.slots[id])
-                .filter(x => !ignoredKeys.includes(x))
-                .forEach(key =>
-                    slot.setTargeting(key, targeting.slots[id][key])
-                );
+			// viewability targeting is on a slot level
+			const ignoredKeys = ['pub'];
+			Object.keys(targeting.slots[id])
+				.filter((x) => !ignoredKeys.includes(x))
+				.forEach((key) =>
+					slot.setTargeting(key, targeting.slots[id][key]),
+				);
 
-            loadedResolve();
-        };
+			loadedResolve();
+		};
 
-        iasPET.queue.push({
-            adSlots: iasPETSlots,
-            dataHandler: iasDataCallback,
-        });
+		iasPET.queue.push({
+			adSlots: iasPETSlots,
+			dataHandler: iasDataCallback,
+		});
 
-        const iasTimeoutDuration = 1000;
+		const iasTimeoutDuration = 1000;
 
-        const iasTimeout = () =>
-            new Promise(resolve => {
-                timeoutId = setTimeout(resolve, iasTimeoutDuration);
-            });
+		const iasTimeout = () =>
+			new Promise((resolve) => {
+				timeoutId = setTimeout(resolve, iasTimeoutDuration);
+			});
 
-        slotReady = Promise.race([iasTimeout(), iasDataPromise]);
-    }
-    const isBn = config.get('page.isbn');
+		slotReady = Promise.race([iasTimeout(), iasDataPromise]);
+	}
+	const isBn = config.get('page.isbn');
 
-    if (slotTarget === 'im' && isBn) {
-        slot.setTargeting('isbn', isBn);
-    }
+	if (slotTarget === 'im' && isBn) {
+		slot.setTargeting('isbn', isBn);
+	}
 
-    const fabricKeyValues = new Map([
-        ['top-above-nav', 'fabric1'],
-        ['merchandising-high', 'fabric2'],
-        ['merchandising', 'fabric3'],
-    ]);
+	const fabricKeyValues = new Map([
+		['top-above-nav', 'fabric1'],
+		['merchandising-high', 'fabric2'],
+		['merchandising', 'fabric3'],
+	]);
 
-    if (fabricKeyValues.has(slotTarget)) {
-        slot.setTargeting('slot-fabric', fabricKeyValues.get(slotTarget));
-    }
+	if (fabricKeyValues.has(slotTarget)) {
+		slot.setTargeting('slot-fabric', fabricKeyValues.get(slotTarget));
+	}
 
-    if (config.get('switches.adomik')) {
-        slot.setTargeting('ad_group', adomikClassify());
-        slot.setTargeting('ad_h', new Date().getUTCHours().toString());
-    }
+	if (config.get('switches.adomik')) {
+		slot.setTargeting('ad_group', adomikClassify());
+		slot.setTargeting('ad_h', new Date().getUTCHours().toString());
+	}
 
-    slot.addService(window.googletag.pubads()).setTargeting('slot', slotTarget);
+	slot.addService(window.googletag.pubads()).setTargeting('slot', slotTarget);
 
-    return {
-        slot,
-        slotReady,
-    };
+	return {
+		slot,
+		slotReady,
+	};
 };
 
 export { defineSlot };

--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.spec.js
@@ -1,52 +1,75 @@
 import { defineSlot } from './define-slot';
 
 beforeEach(() => {
-    const pubAds = {
-        setTargeting: jest.fn(),
-    };
+	const pubAds = {
+		setTargeting: jest.fn(),
+	};
 
-    const sizeMapping = {
-        sizes: [],
-        addSize: jest.fn(function(width, sizes) {
-            this.sizes.unshift([width, sizes]);
-        }),
-        build: jest.fn(function() {
-            const tmp = this.sizes;
-            this.sizes = [];
-            return tmp;
-        }),
-    };
+	const sizeMapping = {
+		sizes: [],
+		addSize: jest.fn(function (width, sizes) {
+			this.sizes.unshift([width, sizes]);
+		}),
+		build: jest.fn(function () {
+			const tmp = this.sizes;
+			this.sizes = [];
+			return tmp;
+		}),
+	};
 
-    window.googletag = {
-        defineSlot: jest.fn(() => window.googletag),
-        defineSizeMapping: jest.fn(() => window.googletag),
-        addService: jest.fn(() => window.googletag),
-        setTargeting: jest.fn(),
-        pubads() {
-            return pubAds;
-        },
-        sizeMapping() {
-            return sizeMapping;
-        },
-    };
+	window.googletag = {
+		defineSlot: jest.fn(() => window.googletag),
+		defineSizeMapping: jest.fn(() => window.googletag),
+		addService: jest.fn(() => window.googletag),
+		setTargeting: jest.fn(),
+		pubads() {
+			return pubAds;
+		},
+		sizeMapping() {
+			return sizeMapping;
+		},
+	};
 });
 
 describe('Define Slot', () => {
-    it('should call defineSlot with correct params', () => {
-        const slotDiv = document.createElement("div");
-        slotDiv.id = "dfp-ad--top-above-nav";
-        slotDiv.setAttribute('data-tablet', '1,1|2,2|728,90|88,71|fluid');
-        slotDiv.setAttribute('data-desktop', '1,1|2,2|728,90|940,230|900,250|970,250|88,71|fluid');
+	it('should call defineSlot with correct params', () => {
+		const slotDiv = document.createElement('div');
+		slotDiv.id = 'dfp-ad--top-above-nav';
+		slotDiv.setAttribute('data-tablet', '1,1|2,2|728,90|88,71|fluid');
+		slotDiv.setAttribute(
+			'data-desktop',
+			'1,1|2,2|728,90|940,230|900,250|970,250|88,71|fluid',
+		);
 
-        const topAboveNavSizes = {
-            tablet: [[1, 1], [2, 2], [728, 90], [88, 71], "fluid"],
-            desktop: [[1, 1], [2, 2], [728, 90], [940, 230], [900, 250], [970, 250], [88, 71], "fluid"]
-        };
+		const topAboveNavSizes = {
+			tablet: [[1, 1], [2, 2], [728, 90], [88, 71], 'fluid'],
+			desktop: [
+				[1, 1],
+				[2, 2],
+				[728, 90],
+				[940, 230],
+				[900, 250],
+				[970, 250],
+				[88, 71],
+				'fluid',
+			],
+		};
 
-        defineSlot(slotDiv, topAboveNavSizes);
+		defineSlot(slotDiv, topAboveNavSizes);
 
-        expect(window.googletag.defineSlot).toHaveBeenCalledWith( undefined, [
-            [1, 1], [2, 2], [728, 90], [940, 230], [900, 250], [970, 250], [88, 71], "fluid"],
-            "dfp-ad--top-above-nav");
-    });
+		expect(window.googletag.defineSlot).toHaveBeenCalledWith(
+			undefined,
+			[
+				[1, 1],
+				[2, 2],
+				[728, 90],
+				[940, 230],
+				[900, 250],
+				[970, 250],
+				[88, 71],
+				'fluid',
+			],
+			'dfp-ad--top-above-nav',
+		);
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.js
@@ -4,47 +4,44 @@ import { getAdvertById } from './get-advert-by-id';
 import { loadAdvert, refreshAdvert } from './load-advert';
 
 const displayAd = (advertId) => {
-    const advert = getAdvertById(advertId);
-    if (advert) {
-        if (advert.isRendered) {
-            refreshAdvert(advert);
-        } else {
-            loadAdvert(advert);
-        }
-    }
+	const advert = getAdvertById(advertId);
+	if (advert) {
+		if (advert.isRendered) {
+			refreshAdvert(advert);
+		} else {
+			loadAdvert(advert);
+		}
+	}
 };
 
-const onIntersect = (
-    entries,
-    observer
-) => {
-    const advertIds = [];
+const onIntersect = (entries, observer) => {
+	const advertIds = [];
 
-    entries
-        .filter(entry => !('isIntersecting' in entry) || entry.isIntersecting)
-        .forEach(entry => {
-            observer.unobserve(entry.target);
-            displayAd(entry.target.id);
-            advertIds.push(entry.target.id);
-        });
+	entries
+		.filter((entry) => !('isIntersecting' in entry) || entry.isIntersecting)
+		.forEach((entry) => {
+			observer.unobserve(entry.target);
+			displayAd(entry.target.id);
+			advertIds.push(entry.target.id);
+		});
 
-    dfpEnv.advertsToLoad = dfpEnv.advertsToLoad.filter(
-        advert => advertIds.indexOf(advert.id) < 0
-    );
+	dfpEnv.advertsToLoad = dfpEnv.advertsToLoad.filter(
+		(advert) => advertIds.indexOf(advert.id) < 0,
+	);
 };
 
 const getObserver = once(() =>
-    Promise.resolve(
-        new window.IntersectionObserver(onIntersect, {
-            rootMargin: '200px 0px',
-        })
-    )
+	Promise.resolve(
+		new window.IntersectionObserver(onIntersect, {
+			rootMargin: '200px 0px',
+		}),
+	),
 );
 
 export const enableLazyLoad = (advert) => {
-    if (dfpEnv.lazyLoadObserve) {
-        getObserver().then(observer => observer.observe(advert.node));
-    } else {
-        displayAd(advert.id);
-    }
+	if (dfpEnv.lazyLoadObserve) {
+		getObserver().then((observer) => observer.observe(advert.node));
+	} else {
+		displayAd(advert.id);
+	}
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.spec.js
@@ -4,69 +4,67 @@ import { loadAdvert } from './load-advert';
 import { dfpEnv } from './dfp-env';
 
 jest.mock('../../../common/modules/experiments/ab', () => ({
-    isInVariantSynchronous: jest.fn(),
+	isInVariantSynchronous: jest.fn(),
 }));
 
 jest.mock('../../../../lib/config', () => ({
-    get: jest.fn(() => false),
+	get: jest.fn(() => false),
 }));
 
-jest.mock('./Advert', () =>
-    jest.fn(() => ({ advert: jest.fn() }))
-);
+jest.mock('./Advert', () => jest.fn(() => ({ advert: jest.fn() })));
 
 jest.mock('./get-advert-by-id', () => ({
-    getAdvertById: jest.fn(),
+	getAdvertById: jest.fn(),
 }));
 
 jest.mock('./load-advert', () => ({
-    refreshAdvert: jest.fn(),
-    loadAdvert: jest.fn(),
+	refreshAdvert: jest.fn(),
+	loadAdvert: jest.fn(),
 }));
 
 const getAdvertById = getAdvertById_;
 
 describe('enableLazyLoad', () => {
-    const windowIntersectionObserver = window.IntersectionObserver;
+	const windowIntersectionObserver = window.IntersectionObserver;
 
-    const testAdvert = {
-        id: 'test-advert',
-        sizes: { desktop: [[300, 250]] },
-        isRendered: false,
-    };
+	const testAdvert = {
+		id: 'test-advert',
+		sizes: { desktop: [[300, 250]] },
+		isRendered: false,
+	};
 
-    beforeEach(() => {
-        jest.resetAllMocks();
-        window.IntersectionObserver = jest.fn(() => ({
-            observe: jest.fn(),
-        }));
+	beforeEach(() => {
+		jest.resetAllMocks();
+		window.IntersectionObserver = jest.fn(() => ({
+			observe: jest.fn(),
+		}));
 
-        expect.hasAssertions();
-    });
+		expect.hasAssertions();
+	});
 
-    afterAll(() => {
-        window.IntersectionObserver = windowIntersectionObserver;
-    });
+	afterAll(() => {
+		window.IntersectionObserver = windowIntersectionObserver;
+	});
 
-    test('JSDOM and Jest should not have an intersectionObserver', () => {
-        // META TEST! Are the assumptions about Jest and JSDOM correct?
-        expect(windowIntersectionObserver).toBe(undefined);
-    });
+	test('JSDOM and Jest should not have an intersectionObserver', () => {
+		// META TEST! Are the assumptions about Jest and JSDOM correct?
+		expect(windowIntersectionObserver).toBe(undefined);
+	});
 
-    it('should create an observer if lazyLoadObserve is true', () => {
-        dfpEnv.lazyLoadObserve = true;
-        enableLazyLoad(testAdvert);
-        expect(loadAdvert).not.toHaveBeenCalled();
-        expect(window.IntersectionObserver.mock.calls[0][1]).toEqual({
-            rootMargin: '200px 0px',
-        });
-    });
+	it('should create an observer if lazyLoadObserve is true', () => {
+		dfpEnv.lazyLoadObserve = true;
+		enableLazyLoad(testAdvert);
+		expect(loadAdvert).not.toHaveBeenCalled();
+		expect(window.IntersectionObserver.mock.calls[0][1]).toEqual({
+			rootMargin: '200px 0px',
+		});
+	});
 
-    it('should still display the adverts if lazyLoadObserve is false', () => {
-        dfpEnv.lazyLoadObserve = false;
-        getAdvertById.mockReturnValue(testAdvert);
-        enableLazyLoad(testAdvert);
-        expect(getAdvertById.mock.calls).toEqual([['test-advert']]);
-        expect(loadAdvert).toHaveBeenCalledWith(testAdvert);
-    });
+	it('should still display the adverts if lazyLoadObserve is false', () => {
+		dfpEnv.lazyLoadObserve = false;
+		getAdvertById.mockReturnValue(testAdvert);
+		enableLazyLoad(testAdvert);
+		expect(getAdvertById.mock.calls).toEqual([['test-advert']]);
+		expect(loadAdvert).toHaveBeenCalledWith(testAdvert);
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/dfp/load-advert.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/load-advert.js
@@ -2,77 +2,77 @@ import { prebid } from '../header-bidding/prebid/prebid';
 import { markTime } from '../../../../lib/user-timing';
 import a9 from '../header-bidding/a9/a9';
 import { stripDfpAdPrefixFrom } from '../header-bidding/utils';
-import { EventTimer } from "@guardian/commercial-core";
+import { EventTimer } from '@guardian/commercial-core';
 
 const forcedSlotSize = (advert, hbSlot) => {
-    // We only fiddle with top-above-nav hbSlot(s)
-    if (hbSlot.key !== 'top-above-nav') {
-        return [hbSlot];
-    }
-    // For top-above-nav slots, we force the refreshed
-    // to be the same size as the first display
-    if (hbSlot.sizes.length === 1) {
-        // No point forcing a size, as there is already only one
-        // possible (mobile/tablet). See prebid/slot-config.js
-        return [hbSlot];
-    }
+	// We only fiddle with top-above-nav hbSlot(s)
+	if (hbSlot.key !== 'top-above-nav') {
+		return [hbSlot];
+	}
+	// For top-above-nav slots, we force the refreshed
+	// to be the same size as the first display
+	if (hbSlot.sizes.length === 1) {
+		// No point forcing a size, as there is already only one
+		// possible (mobile/tablet). See prebid/slot-config.js
+		return [hbSlot];
+	}
 
-    if (Array.isArray(advert.size)) {
-        return [
-            Object.assign({}, hbSlot, {
-                sizes: [[advert.size[0], advert.size[1]]],
-            }),
-        ];
-    }
-    // No point having this hbSlot, as advert.size is not an array
-    return [];
+	if (Array.isArray(advert.size)) {
+		return [
+			Object.assign({}, hbSlot, {
+				sizes: [[advert.size[0], advert.size[1]]],
+			}),
+		];
+	}
+	// No point having this hbSlot, as advert.size is not an array
+	return [];
 };
 
 const eventTimer = EventTimer.get();
 
 export const loadAdvert = (advert) => {
-    const adName = stripDfpAdPrefixFrom(advert.id);
-    advert.whenSlotReady
-        .catch(() => {
-            // The display needs to be called, even in the event of an error.
-        })
-        .then(() => {
-            markTime(`Commercial: Slot Ready: ${advert.id}`);
-            eventTimer.trigger('slotReady', adName);
-            advert.startLoading();
-            return Promise.all([
-                prebid.requestBids(advert),
-                a9.requestBids(advert),
-            ]);
-        })
-        .then(() => {
-            eventTimer.trigger('slotInitialised', adName);
-            window.googletag.display(advert.id);
-        });
+	const adName = stripDfpAdPrefixFrom(advert.id);
+	advert.whenSlotReady
+		.catch(() => {
+			// The display needs to be called, even in the event of an error.
+		})
+		.then(() => {
+			markTime(`Commercial: Slot Ready: ${advert.id}`);
+			eventTimer.trigger('slotReady', adName);
+			advert.startLoading();
+			return Promise.all([
+				prebid.requestBids(advert),
+				a9.requestBids(advert),
+			]);
+		})
+		.then(() => {
+			eventTimer.trigger('slotInitialised', adName);
+			window.googletag.display(advert.id);
+		});
 };
 
 export const refreshAdvert = (advert) => {
-    // advert.size contains the effective size being displayed prior to refreshing
-    advert.whenSlotReady
-        .then(() => {
-            const prebidPromise = prebid.requestBids(advert, prebidSlot =>
-                forcedSlotSize(advert, prebidSlot)
-            );
+	// advert.size contains the effective size being displayed prior to refreshing
+	advert.whenSlotReady
+		.then(() => {
+			const prebidPromise = prebid.requestBids(advert, (prebidSlot) =>
+				forcedSlotSize(advert, prebidSlot),
+			);
 
-            const a9Promise = a9.requestBids(advert, a9Slot =>
-                forcedSlotSize(advert, a9Slot)
-            );
-            return Promise.all([prebidPromise, a9Promise]);
-        })
-        .then(() => {
-            advert.slot.setTargeting('refreshed', 'true');
-            if (advert.id === 'dfp-ad--top-above-nav') {
-                // force the slot sizes to be the same as advert.size (current)
-                // only when advert.size is an array (forget 'fluid' and other specials)
-                if (Array.isArray(advert.size)) {
-                    advert.slot.defineSizeMapping([[[0, 0], [advert.size]]]);
-                }
-            }
-            window.googletag.pubads().refresh([advert.slot]);
-        });
+			const a9Promise = a9.requestBids(advert, (a9Slot) =>
+				forcedSlotSize(advert, a9Slot),
+			);
+			return Promise.all([prebidPromise, a9Promise]);
+		})
+		.then(() => {
+			advert.slot.setTargeting('refreshed', 'true');
+			if (advert.id === 'dfp-ad--top-above-nav') {
+				// force the slot sizes to be the same as advert.size (current)
+				// only when advert.size is an array (forget 'fluid' and other specials)
+				if (Array.isArray(advert.size)) {
+					advert.slot.defineSizeMapping([[[0, 0], [advert.size]]]);
+				}
+			}
+			window.googletag.pubads().refresh([advert.slot]);
+		});
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-load.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-load.js
@@ -12,21 +12,21 @@ const host = `${window.location.protocol}//${window.location.host}`;
      we resort to sending it as a token of welcome :)
 */
 export const onSlotLoad = (event) => {
-    const advert = getAdvertById(event.slot.getSlotElementId());
-    if (!advert) {
-        return;
-    }
+	const advert = getAdvertById(event.slot.getSlotElementId());
+	if (!advert) {
+		return;
+	}
 
-    const iframe = advert.node.getElementsByTagName('iframe')[0];
-    if (!iframe) {
-        console.log("No iFrame found for slot", advert.id,  advert.slot)
-        return;
-    }
-    postMessage(
-        {
-            id: iframe.id,
-            host,
-        },
-        iframe.contentWindow,
-    );
+	const iframe = advert.node.getElementsByTagName('iframe')[0];
+	if (!iframe) {
+		console.log('No iFrame found for slot', advert.id, advert.slot);
+		return;
+	}
+	postMessage(
+		{
+			id: iframe.id,
+			host,
+		},
+		iframe.contentWindow,
+	);
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.js
@@ -3,36 +3,36 @@ import { getAdvertById } from './get-advert-by-id';
 import { enableLazyLoad } from './lazy-load';
 
 const setSlotAdRefresh = (event) => {
-    const advert = getAdvertById(event.slot.getSlotElementId());
-    const viewabilityThresholdMs = 30000; // 30 seconds refresh
+	const advert = getAdvertById(event.slot.getSlotElementId());
+	const viewabilityThresholdMs = 30000; // 30 seconds refresh
 
-    if (advert && advert.shouldRefresh) {
-        const onDocumentVisible = () => {
-            if (!document.hidden) {
-                document.removeEventListener(
-                    'visibilitychange',
-                    onDocumentVisible
-                );
-                enableLazyLoad(advert);
-            }
-        };
+	if (advert && advert.shouldRefresh) {
+		const onDocumentVisible = () => {
+			if (!document.hidden) {
+				document.removeEventListener(
+					'visibilitychange',
+					onDocumentVisible,
+				);
+				enableLazyLoad(advert);
+			}
+		};
 
-        setTimeout(() => {
-            // During the elapsed time, a 'disable-refresh' message may have been posted.
-            // Check the flag again.
-            if (!advert.shouldRefresh) {
-                return;
-            }
-            if (document.hidden) {
-                document.addEventListener(
-                    'visibilitychange',
-                    onDocumentVisible
-                );
-            } else {
-                enableLazyLoad(advert);
-            }
-        }, viewabilityThresholdMs);
-    }
+		setTimeout(() => {
+			// During the elapsed time, a 'disable-refresh' message may have been posted.
+			// Check the flag again.
+			if (!advert.shouldRefresh) {
+				return;
+			}
+			if (document.hidden) {
+				document.addEventListener(
+					'visibilitychange',
+					onDocumentVisible,
+				);
+			} else {
+				enableLazyLoad(advert);
+			}
+		}, viewabilityThresholdMs);
+	}
 };
 
 /*
@@ -43,12 +43,12 @@ const setSlotAdRefresh = (event) => {
 
  */
 export const onSlotViewableFunction = () => {
-    const queryParams = getUrlVars();
+	const queryParams = getUrlVars();
 
-    if (queryParams.adrefresh !== 'false') {
-        return setSlotAdRefresh;
-    }
+	if (queryParams.adrefresh !== 'false') {
+		return setSlotAdRefresh;
+	}
 
-    // Nothing to do. Return an empty callback
-    return () => {};
+	// Nothing to do. Return an empty callback
+	return () => {};
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-visibility-changed.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-visibility-changed.js
@@ -1,24 +1,22 @@
 import { storage } from '@guardian/libs';
 import { getAdvertById } from './get-advert-by-id';
 
-export const onSlotVisibilityChanged = (
-    event
-) => {
-    if (storage.session.isAvailable()) {
-        const advert = getAdvertById(event.slot.getSlotElementId());
+export const onSlotVisibilityChanged = (event) => {
+	if (storage.session.isAvailable()) {
+		const advert = getAdvertById(event.slot.getSlotElementId());
 
-        if (advert && advert.maxViewPercentage < event.inViewPercentage) {
-            // Check the inViewPercentage has crossed the 90% threshold.
-            if (advert.maxViewPercentage <= 90 && event.inViewPercentage > 90) {
-                const highVisibilitySlots =
-                storage.session.get('gu.commercial.slotVisibility') || 0;
-                storage.session.set(
-                    'gu.commercial.slotVisibility',
-                    highVisibilitySlots + 1
-                );
-            }
+		if (advert && advert.maxViewPercentage < event.inViewPercentage) {
+			// Check the inViewPercentage has crossed the 90% threshold.
+			if (advert.maxViewPercentage <= 90 && event.inViewPercentage > 90) {
+				const highVisibilitySlots =
+					storage.session.get('gu.commercial.slotVisibility') || 0;
+				storage.session.set(
+					'gu.commercial.slotVisibility',
+					highVisibilitySlots + 1,
+				);
+			}
 
-            advert.maxViewPercentage = event.inViewPercentage;
-        }
-    }
+			advert.maxViewPercentage = event.inViewPercentage;
+		}
+	}
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-a9.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-a9.js
@@ -1,6 +1,6 @@
 import {
-    getConsentFor,
-    onConsentChange,
+	getConsentFor,
+	onConsentChange,
 } from '@guardian/consent-management-platform';
 import { once } from 'lodash-es';
 import config from '../../../../lib/config';
@@ -11,42 +11,44 @@ import { shouldIncludeOnlyA9 } from '../header-bidding/utils';
 import { dfpEnv } from './dfp-env';
 
 const setupA9 = () => {
-    // There are two articles that InfoSec would like to avoid loading scripts on
-    if (commercialFeatures.isSecureContact) {
-        return Promise.resolve();
-    }
+	// There are two articles that InfoSec would like to avoid loading scripts on
+	if (commercialFeatures.isSecureContact) {
+		return Promise.resolve();
+	}
 
-    let moduleLoadResult = Promise.resolve();
-    if (
-        shouldIncludeOnlyA9 ||
-        (dfpEnv.hbImpl.a9 &&
-            commercialFeatures.dfpAdvertising &&
-            !commercialFeatures.adFree &&
-            !config.get('page.hasPageSkin') &&
-            !isGoogleProxy())
-    ) {
-        moduleLoadResult = import(/* webpackChunkName: "a9" */ '../../../../lib/a9-apstag.js').then(() => {
-            a9.initialise();
+	let moduleLoadResult = Promise.resolve();
+	if (
+		shouldIncludeOnlyA9 ||
+		(dfpEnv.hbImpl.a9 &&
+			commercialFeatures.dfpAdvertising &&
+			!commercialFeatures.adFree &&
+			!config.get('page.hasPageSkin') &&
+			!isGoogleProxy())
+	) {
+		moduleLoadResult = import(
+			/* webpackChunkName: "a9" */ '../../../../lib/a9-apstag.js'
+		).then(() => {
+			a9.initialise();
 
-            return Promise.resolve();
-        });
-    }
+			return Promise.resolve();
+		});
+	}
 
-    return moduleLoadResult;
+	return moduleLoadResult;
 };
 
 const setupA9Once = once(setupA9);
 
 export const init = () => {
-    onConsentChange(state => {
-        if (getConsentFor('a9', state)) {
-            setupA9Once();
-        }
-    });
+	onConsentChange((state) => {
+		if (getConsentFor('a9', state)) {
+			setupA9Once();
+		}
+	});
 
-    return Promise.resolve();
+	return Promise.resolve();
 };
 
 export const _ = {
-    setupA9,
+	setupA9,
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-a9.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-a9.spec.js
@@ -10,147 +10,146 @@ const { setupA9 } = _;
 jest.mock('../../../common/modules/commercial/geo-utils');
 
 jest.mock('../../../common/modules/commercial/commercial-features', () => ({
-    commercialFeatures: {},
+	commercialFeatures: {},
 }));
 
 jest.mock('../header-bidding/a9/a9', () => ({
-    initialise: jest.fn(),
+	initialise: jest.fn(),
 }));
 
 jest.mock('./Advert', () =>
-    jest.fn().mockImplementation(() => ({ advert: jest.fn() }))
+	jest.fn().mockImplementation(() => ({ advert: jest.fn() })),
 );
 
 jest.mock('../../../../lib/a9-apstag', () => jest.fn());
 
 jest.mock('../../../common/modules/commercial/build-page-targeting', () => ({
-    buildPageTargeting: jest.fn(),
+	buildPageTargeting: jest.fn(),
 }));
 
 jest.mock('../header-bidding/prebid/bid-config', () => ({
-    isInVariant: jest.fn(),
+	isInVariant: jest.fn(),
 }));
 
 jest.mock('../header-bidding/utils', () => ({
-    isInUsRegion: () => true,
+	isInUsRegion: () => true,
 }));
 
 jest.mock('@guardian/consent-management-platform', () => ({
-    onConsentChange: jest.fn(),
-    getConsentFor: jest.fn()
+	onConsentChange: jest.fn(),
+	getConsentFor: jest.fn(),
 }));
 
-
 jest.mock('@guardian/libs', () => ({
-    loadScript: () => Promise.resolve(),
+	loadScript: () => Promise.resolve(),
 }));
 
 const fakeUserAgent = (userAgent) => {
-    const userAgentObject = {};
-    userAgentObject.get = () => userAgent;
-    userAgentObject.configurable = true;
-    Object.defineProperty(navigator, 'userAgent', userAgentObject);
+	const userAgentObject = {};
+	userAgentObject.get = () => userAgent;
+	userAgentObject.configurable = true;
+	Object.defineProperty(navigator, 'userAgent', userAgentObject);
 };
 
 describe('init', () => {
-    const originalUA = navigator.userAgent;
+	const originalUA = navigator.userAgent;
 
-    beforeEach(() => {
-        jest.clearAllMocks();
-        fakeUserAgent(originalUA);
-    });
+	beforeEach(() => {
+		jest.clearAllMocks();
+		fakeUserAgent(originalUA);
+	});
 
-    afterAll(() => {
-        jest.clearAllMocks();
-    });
+	afterAll(() => {
+		jest.clearAllMocks();
+	});
 
-    it('should initialise A9 when A9 switch is ON and advertising is on and ad-free is off', async () => {
-        dfpEnv.hbImpl = { a9: true, prebid: false };
-        commercialFeatures.dfpAdvertising = true;
-        commercialFeatures.adFree = false;
-        await setupA9();
-        expect(a9.initialise).toBeCalled();
-    });
+	it('should initialise A9 when A9 switch is ON and advertising is on and ad-free is off', async () => {
+		dfpEnv.hbImpl = { a9: true, prebid: false };
+		commercialFeatures.dfpAdvertising = true;
+		commercialFeatures.adFree = false;
+		await setupA9();
+		expect(a9.initialise).toBeCalled();
+	});
 
-    it('should initialise A9 when both prebid and a9 switches are ON and advertising is on and ad-free is off', async () => {
-        dfpEnv.hbImpl = { a9: true, prebid: true };
-        commercialFeatures.dfpAdvertising = true;
-        commercialFeatures.adFree = false;
-        await setupA9();
-        expect(a9.initialise).toBeCalled();
-    });
+	it('should initialise A9 when both prebid and a9 switches are ON and advertising is on and ad-free is off', async () => {
+		dfpEnv.hbImpl = { a9: true, prebid: true };
+		commercialFeatures.dfpAdvertising = true;
+		commercialFeatures.adFree = false;
+		await setupA9();
+		expect(a9.initialise).toBeCalled();
+	});
 
-    it('should not initialise A9 when useragent is Google Web Preview', async () => {
-        fakeUserAgent('Google Web Preview');
-        await setupA9();
-        expect(a9.initialise).not.toBeCalled();
-    });
+	it('should not initialise A9 when useragent is Google Web Preview', async () => {
+		fakeUserAgent('Google Web Preview');
+		await setupA9();
+		expect(a9.initialise).not.toBeCalled();
+	});
 
-    it('should not initialise A9 when no external demand', async () => {
-        dfpEnv.hbImpl = { a9: false, prebid: false };
-        await setupA9();
-        expect(a9.initialise).not.toBeCalled();
-    });
+	it('should not initialise A9 when no external demand', async () => {
+		dfpEnv.hbImpl = { a9: false, prebid: false };
+		await setupA9();
+		expect(a9.initialise).not.toBeCalled();
+	});
 
-    it('should not initialise a9 when advertising is switched off', async () => {
-        dfpEnv.hbImpl = { a9: true, prebid: false };
-        commercialFeatures.dfpAdvertising = false;
-        commercialFeatures.adFree = false;
-        await setupA9();
-        expect(a9.initialise).not.toBeCalled();
-    });
+	it('should not initialise a9 when advertising is switched off', async () => {
+		dfpEnv.hbImpl = { a9: true, prebid: false };
+		commercialFeatures.dfpAdvertising = false;
+		commercialFeatures.adFree = false;
+		await setupA9();
+		expect(a9.initialise).not.toBeCalled();
+	});
 
-    it('should not initialise a9 when ad-free is on', async () => {
-        dfpEnv.hbImpl = { a9: true, prebid: false };
-        commercialFeatures.dfpAdvertising = true;
-        commercialFeatures.adFree = true;
-        await setupA9();
-        expect(a9.initialise).not.toBeCalled();
-    });
+	it('should not initialise a9 when ad-free is on', async () => {
+		dfpEnv.hbImpl = { a9: true, prebid: false };
+		commercialFeatures.dfpAdvertising = true;
+		commercialFeatures.adFree = true;
+		await setupA9();
+		expect(a9.initialise).not.toBeCalled();
+	});
 
-    it('should not initialise a9 when the page has a pageskin', async () => {
-        dfpEnv.hbImpl = { a9: true, prebid: false };
-        commercialFeatures.dfpAdvertising = true;
-        commercialFeatures.adFree = false;
-        config.set('page.hasPageSkin', true);
-        await setupA9();
-        expect(a9.initialise).not.toBeCalled();
-    });
+	it('should not initialise a9 when the page has a pageskin', async () => {
+		dfpEnv.hbImpl = { a9: true, prebid: false };
+		commercialFeatures.dfpAdvertising = true;
+		commercialFeatures.adFree = false;
+		config.set('page.hasPageSkin', true);
+		await setupA9();
+		expect(a9.initialise).not.toBeCalled();
+	});
 
-    it('should initialise a9 when the page has no pageskin', async () => {
-        dfpEnv.hbImpl = { a9: true, prebid: false };
-        commercialFeatures.dfpAdvertising = true;
-        commercialFeatures.adFree = false;
-        config.set('page.hasPageSkin', false);
-        await setupA9();
-        expect(a9.initialise).toBeCalled();
-    });
+	it('should initialise a9 when the page has no pageskin', async () => {
+		dfpEnv.hbImpl = { a9: true, prebid: false };
+		commercialFeatures.dfpAdvertising = true;
+		commercialFeatures.adFree = false;
+		config.set('page.hasPageSkin', false);
+		await setupA9();
+		expect(a9.initialise).toBeCalled();
+	});
 
-    it('should not initialise a9 on the secure contact pages', async () => {
-        dfpEnv.hbImpl = { a9: true, prebid: false };
-        commercialFeatures.dfpAdvertising = true;
-        commercialFeatures.adFree = false;
-        commercialFeatures.isSecureContact = true;
-        await setupA9();
-        expect(a9.initialise).not.toBeCalled();
-    });
+	it('should not initialise a9 on the secure contact pages', async () => {
+		dfpEnv.hbImpl = { a9: true, prebid: false };
+		commercialFeatures.dfpAdvertising = true;
+		commercialFeatures.adFree = false;
+		commercialFeatures.isSecureContact = true;
+		await setupA9();
+		expect(a9.initialise).not.toBeCalled();
+	});
 
-    it('isGoogleWebPreview should return false with no navigator or useragent', () => {
-        expect(isGoogleProxy()).toBe(false);
-    });
+	it('isGoogleWebPreview should return false with no navigator or useragent', () => {
+		expect(isGoogleProxy()).toBe(false);
+	});
 
-    it('isGoogleWebPreview should return false with no navigator or useragent', () => {
-        fakeUserAgent('Firefox');
-        expect(isGoogleProxy()).toBe(false);
-    });
+	it('isGoogleWebPreview should return false with no navigator or useragent', () => {
+		fakeUserAgent('Firefox');
+		expect(isGoogleProxy()).toBe(false);
+	});
 
-    it('isGoogleWebPreview should return true with Google Web Preview useragent', () => {
-        fakeUserAgent('Google Web Preview');
-        expect(isGoogleProxy()).toBe(true);
-    });
+	it('isGoogleWebPreview should return true with Google Web Preview useragent', () => {
+		fakeUserAgent('Google Web Preview');
+		expect(isGoogleProxy()).toBe(true);
+	});
 
-    it('isGoogleWebPreview should return true with Google Web Preview useragent', () => {
-        fakeUserAgent('googleweblight');
-        expect(isGoogleProxy()).toBe(true);
-    });
+	it('isGoogleWebPreview should return true with Google Web Preview useragent', () => {
+		fakeUserAgent('googleweblight');
+		expect(isGoogleProxy()).toBe(true);
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-permutive.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-permutive.js
@@ -1,200 +1,190 @@
 import config from '../../../../lib/config';
 import reportError from '../../../../lib/report-error';
 
-
-
 const isEmpty = (value) =>
-    value === '' ||
-    value === null ||
-    typeof value === 'undefined' ||
-    (Array.isArray(value) && value.length === 0) ||
-    (typeof value === 'object' && Object.keys(value).length === 0);
+	value === '' ||
+	value === null ||
+	typeof value === 'undefined' ||
+	(Array.isArray(value) && value.length === 0) ||
+	(typeof value === 'object' && Object.keys(value).length === 0);
 
-const removeEmpty =(payload) => {
-    Object.keys(payload).forEach(key => {
-        if (typeof payload[key] === 'object' && payload[key] !== null) {
-            removeEmpty(payload[key]);
-        }
-        if (isEmpty(payload[key])) {
-            delete payload[key];
-        }
-    });
-    return payload;
+const removeEmpty = (payload) => {
+	Object.keys(payload).forEach((key) => {
+		if (typeof payload[key] === 'object' && payload[key] !== null) {
+			removeEmpty(payload[key]);
+		}
+		if (isEmpty(payload[key])) {
+			delete payload[key];
+		}
+	});
+	return payload;
 };
 
-const generatePayload = (
-    permutiveConfig = { page: {}, user: {} }
-) => {
-    const { page, user } = permutiveConfig;
-    const {
-        isPaidContent,
-        pageId,
-        headline,
-        contentType,
-        section,
-        author,
-        keywords,
-        webPublicationDate,
-        series,
-        edition,
-        toneIds,
-    } = page;
+const generatePayload = (permutiveConfig = { page: {}, user: {} }) => {
+	const { page, user } = permutiveConfig;
+	const {
+		isPaidContent,
+		pageId,
+		headline,
+		contentType,
+		section,
+		author,
+		keywords,
+		webPublicationDate,
+		series,
+		edition,
+		toneIds,
+	} = page;
 
-    const safeAuthors = (author && typeof author === 'string'
-        ? author.split(',')
-        : []
-    ).map(str => str.trim());
-    const safeKeywords = (keywords && typeof keywords === 'string'
-        ? keywords.split(',')
-        : []
-    ).map(str => str.trim());
-    const safePublishedAt =
-        webPublicationDate && typeof webPublicationDate === 'number'
-            ? new Date(webPublicationDate).toISOString()
-            : '';
-    const safeToneIds = (toneIds && typeof toneIds === 'string'
-        ? toneIds.split(',')
-        : []
-    ).map(str => str.trim());
-    const cleanPayload = removeEmpty({
-        content: {
-            premium: isPaidContent,
-            id: pageId,
-            title: headline,
-            type: contentType,
-            section,
-            authors: safeAuthors,
-            keywords: safeKeywords,
-            publishedAt: safePublishedAt,
-            series,
-            tone: safeToneIds,
-        },
-        user: {
-            edition,
-            identity: isEmpty(user) ? false : !isEmpty(user.id),
-        },
-    });
+	const safeAuthors = (author && typeof author === 'string'
+		? author.split(',')
+		: []
+	).map((str) => str.trim());
+	const safeKeywords = (keywords && typeof keywords === 'string'
+		? keywords.split(',')
+		: []
+	).map((str) => str.trim());
+	const safePublishedAt =
+		webPublicationDate && typeof webPublicationDate === 'number'
+			? new Date(webPublicationDate).toISOString()
+			: '';
+	const safeToneIds = (toneIds && typeof toneIds === 'string'
+		? toneIds.split(',')
+		: []
+	).map((str) => str.trim());
+	const cleanPayload = removeEmpty({
+		content: {
+			premium: isPaidContent,
+			id: pageId,
+			title: headline,
+			type: contentType,
+			section,
+			authors: safeAuthors,
+			keywords: safeKeywords,
+			publishedAt: safePublishedAt,
+			series,
+			tone: safeToneIds,
+		},
+		user: {
+			edition,
+			identity: isEmpty(user) ? false : !isEmpty(user.id),
+		},
+	});
 
-    return cleanPayload;
+	return cleanPayload;
 };
 
-const generatePermutiveIdentities = (
-    pageConfig = {}
-) => {
-    if (
-        typeof pageConfig.ophan === 'object' &&
-        typeof pageConfig.ophan.browserId === 'string' &&
-        pageConfig.ophan.browserId.length > 0
-    ) {
-        return [{ tag: 'ophan', id: pageConfig.ophan.browserId }];
-    }
-    return [];
+const generatePermutiveIdentities = (pageConfig = {}) => {
+	if (
+		typeof pageConfig.ophan === 'object' &&
+		typeof pageConfig.ophan.browserId === 'string' &&
+		pageConfig.ophan.browserId.length > 0
+	) {
+		return [{ tag: 'ophan', id: pageConfig.ophan.browserId }];
+	}
+	return [];
 };
 
-const runPermutive = (
-    pageConfig = {},
-    permutiveGlobal,
-    logger
-) => {
-    try {
-        if (!permutiveGlobal || !permutiveGlobal.addon) {
-            throw new Error('Global Permutive setup error');
-        }
+const runPermutive = (pageConfig = {}, permutiveGlobal, logger) => {
+	try {
+		if (!permutiveGlobal || !permutiveGlobal.addon) {
+			throw new Error('Global Permutive setup error');
+		}
 
-        const permutiveIdentities = generatePermutiveIdentities(pageConfig);
-        if (permutiveIdentities.length > 0) {
-            permutiveGlobal.identify(permutiveIdentities);
-        }
+		const permutiveIdentities = generatePermutiveIdentities(pageConfig);
+		if (permutiveIdentities.length > 0) {
+			permutiveGlobal.identify(permutiveIdentities);
+		}
 
-        const payload = generatePayload(pageConfig);
-        permutiveGlobal.addon('web', {
-            page: payload,
-        });
-    } catch (err) {
-        logger(err, { feature: 'commercial' }, false);
-    }
+		const payload = generatePayload(pageConfig);
+		permutiveGlobal.addon('web', {
+			page: payload,
+		});
+	} catch (err) {
+		logger(err, { feature: 'commercial' }, false);
+	}
 };
 
 /* eslint-disable */
 export const initPermutive = () =>
-    new Promise(resolve => {
-        // From here until we re-enable eslint is the Permutive code
-        // that we received from them.
-        // Please do not change unless you've consulted with Permutive
-        // and confirmed the change is safe.
-        (function(n, e, o, r, i) {
-            if (!e) {
-                (e = e || {}),
-                    (window.permutive = e),
-                    (e.q = []),
-                    (e.config = i || {}),
-                    (e.config.projectId = o),
-                    (e.config.apiKey = r),
-                    (e.config.environment =
-                        e.config.environment || 'production');
-                for (
-                    let t = [
-                            'addon',
-                            'identify',
-                            'track',
-                            'trigger',
-                            'query',
-                            'segment',
-                            'segments',
-                            'ready',
-                            'on',
-                            'once',
-                            'user',
-                            'consent',
-                        ],
-                        c = 0;
-                    c < t.length;
-                    c++
-                ) {
-                    const f = t[c];
-                    e[f] = (function(n) {
-                        return function() {
-                            const o = Array.prototype.slice.call(arguments, 0);
-                            e.q.push({ functionName: n, arguments: o });
-                        };
-                    })(f);
-                }
-            }
-        })(
-            document,
-            window.permutive,
-            'd6691a17-6fdb-4d26-85d6-b3dd27f55f08',
-            '359ba275-5edd-4756-84f8-21a24369ce0b',
-            {}
-        );
-        (window.googletag = window.googletag || {}),
-            (window.googletag.cmd = window.googletag.cmd || []),
-            window.googletag.cmd.push(() => {
-                if (
-                    window.googletag.pubads().getTargeting('permutive')
-                        .length === 0
-                ) {
-                    const g = window.localStorage.getItem('_pdfps');
-                    window.googletag
-                        .pubads()
-                        .setTargeting('permutive', g ? JSON.parse(g) : []);
-                }
-            });
-        /* eslint-enable */
-        const permutiveConfig = {
-            user: config.get('user', {}),
-            page: config.get('page', {}),
-            ophan: config.get('ophan', {}),
-        };
-        runPermutive(permutiveConfig, window.permutive, reportError);
+	new Promise((resolve) => {
+		// From here until we re-enable eslint is the Permutive code
+		// that we received from them.
+		// Please do not change unless you've consulted with Permutive
+		// and confirmed the change is safe.
+		(function (n, e, o, r, i) {
+			if (!e) {
+				(e = e || {}),
+					(window.permutive = e),
+					(e.q = []),
+					(e.config = i || {}),
+					(e.config.projectId = o),
+					(e.config.apiKey = r),
+					(e.config.environment =
+						e.config.environment || 'production');
+				for (
+					let t = [
+							'addon',
+							'identify',
+							'track',
+							'trigger',
+							'query',
+							'segment',
+							'segments',
+							'ready',
+							'on',
+							'once',
+							'user',
+							'consent',
+						],
+						c = 0;
+					c < t.length;
+					c++
+				) {
+					const f = t[c];
+					e[f] = (function (n) {
+						return function () {
+							const o = Array.prototype.slice.call(arguments, 0);
+							e.q.push({ functionName: n, arguments: o });
+						};
+					})(f);
+				}
+			}
+		})(
+			document,
+			window.permutive,
+			'd6691a17-6fdb-4d26-85d6-b3dd27f55f08',
+			'359ba275-5edd-4756-84f8-21a24369ce0b',
+			{},
+		);
+		(window.googletag = window.googletag || {}),
+			(window.googletag.cmd = window.googletag.cmd || []),
+			window.googletag.cmd.push(() => {
+				if (
+					window.googletag.pubads().getTargeting('permutive')
+						.length === 0
+				) {
+					const g = window.localStorage.getItem('_pdfps');
+					window.googletag
+						.pubads()
+						.setTargeting('permutive', g ? JSON.parse(g) : []);
+				}
+			});
+		/* eslint-enable */
+		const permutiveConfig = {
+			user: config.get('user', {}),
+			page: config.get('page', {}),
+			ophan: config.get('ophan', {}),
+		};
+		runPermutive(permutiveConfig, window.permutive, reportError);
 
-        return resolve();
-    });
+		return resolve();
+	});
 
 export const _ = {
-    isEmpty,
-    removeEmpty,
-    generatePayload,
-    generatePermutiveIdentities,
-    runPermutive,
+	isEmpty,
+	removeEmpty,
+	generatePayload,
+	generatePermutiveIdentities,
+	runPermutive,
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-permutive.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-permutive.spec.js
@@ -3,328 +3,334 @@ import { _ } from './prepare-permutive';
 jest.mock('../../../../lib/raven');
 
 describe('Generating Permutive payload utils', () => {
-    describe('isEmpty', () => {
-        it('returns true for empty values', () => {
-            const emptyValues = ['', undefined, null, [], {}];
-            expect(true).toBe(true);
-            emptyValues.forEach(emptyValue =>
-                expect(_.isEmpty(emptyValue)).toBe(true)
-            );
-        });
+	describe('isEmpty', () => {
+		it('returns true for empty values', () => {
+			const emptyValues = ['', undefined, null, [], {}];
+			expect(true).toBe(true);
+			emptyValues.forEach((emptyValue) =>
+				expect(_.isEmpty(emptyValue)).toBe(true),
+			);
+		});
 
-        it('returns false for non empty values', () => {
-            const values = [
-                'word',
-                -1,
-                0,
-                42,
-                2.35,
-                ['word'],
-                { word: true },
-                true,
-                false,
-            ];
-            values.forEach(value => expect(_.isEmpty(value)).toBe(false));
-        });
-    });
-    describe('removeEmpty', () => {
-        it('returns a clean object without empty fields', () => {
-            const emptyPayload = {
-                content: {
-                    pageId: '',
-                    keywords: [],
-                    webPublicationDate: null,
-                    series: undefined,
-                    empty: {},
-                },
-                user: {},
-            };
+		it('returns false for non empty values', () => {
+			const values = [
+				'word',
+				-1,
+				0,
+				42,
+				2.35,
+				['word'],
+				{ word: true },
+				true,
+				false,
+			];
+			values.forEach((value) => expect(_.isEmpty(value)).toBe(false));
+		});
+	});
+	describe('removeEmpty', () => {
+		it('returns a clean object without empty fields', () => {
+			const emptyPayload = {
+				content: {
+					pageId: '',
+					keywords: [],
+					webPublicationDate: null,
+					series: undefined,
+					empty: {},
+				},
+				user: {},
+			};
 
-            const filledPayload = {
-                content: {
-                    premium: false,
-                    id: 'Some Id',
-                    title: 'Title',
-                    type: 'Article',
-                    authors: ['The Author'],
-                },
-            };
-            expect(
-                _.removeEmpty({
-                    content: {
-                        ...emptyPayload.content,
-                        ...filledPayload.content,
-                    },
-                })
-            ).toEqual({ ...filledPayload });
-        });
-    });
-    describe('generatePayload', () => {
-        it('safely removes invalid authors or keywords', () => {
-            const invalidValues = [undefined, null, '', {}, []];
-            const expected = { user: { identity: false } };
-            invalidValues.forEach(invalid =>
-                expect(
-                    _.generatePayload({
-                        page: { author: invalid, keywords: invalid },
-                    })
-                ).toEqual(expected)
-            );
-        });
-        it('splits authors and keywords to an array correctly', () => {
-            const valid = {
-                page: {
-                    author: 'author1,author2',
-                    keywords: 'environment,travel',
-                },
-            };
+			const filledPayload = {
+				content: {
+					premium: false,
+					id: 'Some Id',
+					title: 'Title',
+					type: 'Article',
+					authors: ['The Author'],
+				},
+			};
+			expect(
+				_.removeEmpty({
+					content: {
+						...emptyPayload.content,
+						...filledPayload.content,
+					},
+				}),
+			).toEqual({ ...filledPayload });
+		});
+	});
+	describe('generatePayload', () => {
+		it('safely removes invalid authors or keywords', () => {
+			const invalidValues = [undefined, null, '', {}, []];
+			const expected = { user: { identity: false } };
+			invalidValues.forEach((invalid) =>
+				expect(
+					_.generatePayload({
+						page: { author: invalid, keywords: invalid },
+					}),
+				).toEqual(expected),
+			);
+		});
+		it('splits authors and keywords to an array correctly', () => {
+			const valid = {
+				page: {
+					author: 'author1,author2',
+					keywords: 'environment,travel',
+				},
+			};
 
-            const expected = {
-                content: {
-                    authors: ['author1', 'author2'],
-                    keywords: ['environment', 'travel'],
-                },
-                user: {
-                    identity: false,
-                },
-            };
-            expect(_.generatePayload(valid)).toEqual(expected);
-        });
-        it('splits authors and keywords to an array correctly and trims whitespace', () => {
-            const valid = {
-                page: {
-                    author: 'author1, author2',
-                    keywords: 'environment , travel',
-                },
-            };
+			const expected = {
+				content: {
+					authors: ['author1', 'author2'],
+					keywords: ['environment', 'travel'],
+				},
+				user: {
+					identity: false,
+				},
+			};
+			expect(_.generatePayload(valid)).toEqual(expected);
+		});
+		it('splits authors and keywords to an array correctly and trims whitespace', () => {
+			const valid = {
+				page: {
+					author: 'author1, author2',
+					keywords: 'environment , travel',
+				},
+			};
 
-            const expected = {
-                content: {
-                    authors: ['author1', 'author2'],
-                    keywords: ['environment', 'travel'],
-                },
-                user: {
-                    identity: false,
-                },
-            };
-            expect(_.generatePayload(valid)).toEqual(expected);
-        });
-        it('removes invalid date', () => {
-            const invalidDates = ['bad date', '', null, undefined, [], {}];
-            const expected = { user: { identity: false } };
-            invalidDates.forEach(invalid => {
-                expect(
-                    _.generatePayload({ page: { webPublicationDate: invalid } })
-                ).toEqual(expected);
-            });
-        });
-        it('generates payload with valid ISO date', () => {
-            const validConfig = { page: { webPublicationDate: 1575037372000 } };
-            const expected = {
-                content: { publishedAt: '2019-11-29T14:22:52.000Z' },
-                user: { identity: false },
-            };
-            expect(_.generatePayload(validConfig)).toEqual(expected);
-        });
-        it('generates valid payload for `content` sub schema', () => {
-            const config1 = {
-                page: {
-                    isPaidContent: false,
-                    pageId: '',
-                    contentType: 'Network Front',
-                    section: 'uk',
-                },
-            };
-            const expected1 = {
-                content: {
-                    premium: false,
-                    type: 'Network Front',
-                    section: 'uk',
-                },
-                user: {
-                    identity: false,
-                },
-            };
-            const config2 = {
-                page: {
-                    pageId: 'world/2019/nov/29',
-                    headline: 'Headline',
-                    contentType: 'Article',
-                    section: 'world',
-                    author: 'author1',
-                    keywords: 'world/nato,World news,France',
-                    webPublicationDate: 1575048268000,
-                    series: 'politics series',
-                },
-            };
-            const expected2 = {
-                content: {
-                    id: 'world/2019/nov/29',
-                    title: 'Headline',
-                    type: 'Article',
-                    section: 'world',
-                    authors: ['author1'],
-                    keywords: ['world/nato', 'World news', 'France'],
-                    publishedAt: '2019-11-29T17:24:28.000Z',
-                    series: 'politics series',
-                },
-                user: {
-                    identity: false,
-                },
-            };
-            const config3 = {
-                page: {
-                    pageId: 'the-abcs-of-recruiting-teachers-remotely/2020/may/01/',
-                    headline: 'Teacher training',
-                    contentType: 'Article',
-                    section: 'the-abcs-of-recruiting-teachers-remotely',
-                    author: 'Ross Morrison McGill',
-                    keywords: 'The ABCs of recruiting teachers remotely',
-                    webPublicationDate: 1588334970000,
-                    tones: 'Advertisement Features', // ignored
-                    toneIds: 'tone/advertisement-features,tone/minutebyminute',
-                    edition: 'UK',
-                },
-            };
-            const expected3 = {
-                content: {
-                    id: 'the-abcs-of-recruiting-teachers-remotely/2020/may/01/',
-                    title: 'Teacher training',
-                    type: 'Article',
-                    section: 'the-abcs-of-recruiting-teachers-remotely',
-                    authors: ['Ross Morrison McGill'],
-                    keywords: ['The ABCs of recruiting teachers remotely'],
-                    publishedAt: '2020-05-01T12:09:30.000Z',
-                    tone: ['tone/advertisement-features', 'tone/minutebyminute'],
-                },
-                user: {
-                    edition: 'UK',
-                    identity: false,
-                },
-            };
+			const expected = {
+				content: {
+					authors: ['author1', 'author2'],
+					keywords: ['environment', 'travel'],
+				},
+				user: {
+					identity: false,
+				},
+			};
+			expect(_.generatePayload(valid)).toEqual(expected);
+		});
+		it('removes invalid date', () => {
+			const invalidDates = ['bad date', '', null, undefined, [], {}];
+			const expected = { user: { identity: false } };
+			invalidDates.forEach((invalid) => {
+				expect(
+					_.generatePayload({
+						page: { webPublicationDate: invalid },
+					}),
+				).toEqual(expected);
+			});
+		});
+		it('generates payload with valid ISO date', () => {
+			const validConfig = { page: { webPublicationDate: 1575037372000 } };
+			const expected = {
+				content: { publishedAt: '2019-11-29T14:22:52.000Z' },
+				user: { identity: false },
+			};
+			expect(_.generatePayload(validConfig)).toEqual(expected);
+		});
+		it('generates valid payload for `content` sub schema', () => {
+			const config1 = {
+				page: {
+					isPaidContent: false,
+					pageId: '',
+					contentType: 'Network Front',
+					section: 'uk',
+				},
+			};
+			const expected1 = {
+				content: {
+					premium: false,
+					type: 'Network Front',
+					section: 'uk',
+				},
+				user: {
+					identity: false,
+				},
+			};
+			const config2 = {
+				page: {
+					pageId: 'world/2019/nov/29',
+					headline: 'Headline',
+					contentType: 'Article',
+					section: 'world',
+					author: 'author1',
+					keywords: 'world/nato,World news,France',
+					webPublicationDate: 1575048268000,
+					series: 'politics series',
+				},
+			};
+			const expected2 = {
+				content: {
+					id: 'world/2019/nov/29',
+					title: 'Headline',
+					type: 'Article',
+					section: 'world',
+					authors: ['author1'],
+					keywords: ['world/nato', 'World news', 'France'],
+					publishedAt: '2019-11-29T17:24:28.000Z',
+					series: 'politics series',
+				},
+				user: {
+					identity: false,
+				},
+			};
+			const config3 = {
+				page: {
+					pageId:
+						'the-abcs-of-recruiting-teachers-remotely/2020/may/01/',
+					headline: 'Teacher training',
+					contentType: 'Article',
+					section: 'the-abcs-of-recruiting-teachers-remotely',
+					author: 'Ross Morrison McGill',
+					keywords: 'The ABCs of recruiting teachers remotely',
+					webPublicationDate: 1588334970000,
+					tones: 'Advertisement Features', // ignored
+					toneIds: 'tone/advertisement-features,tone/minutebyminute',
+					edition: 'UK',
+				},
+			};
+			const expected3 = {
+				content: {
+					id: 'the-abcs-of-recruiting-teachers-remotely/2020/may/01/',
+					title: 'Teacher training',
+					type: 'Article',
+					section: 'the-abcs-of-recruiting-teachers-remotely',
+					authors: ['Ross Morrison McGill'],
+					keywords: ['The ABCs of recruiting teachers remotely'],
+					publishedAt: '2020-05-01T12:09:30.000Z',
+					tone: [
+						'tone/advertisement-features',
+						'tone/minutebyminute',
+					],
+				},
+				user: {
+					edition: 'UK',
+					identity: false,
+				},
+			};
 
-            expect(_.generatePayload(config1)).toEqual(expected1);
-            expect(_.generatePayload(config2)).toEqual(expected2);
-            expect(_.generatePayload(config3)).toEqual(expected3);
-        });
-        it('generates valid payload for `user` sub schema', () => {
-            const config1 = { page: {}, user: {} };
-            const expected1 = {
-                user: {
-                    identity: false,
-                },
-            };
-            const config2 = {
-                page: {
-                    edition: 'UK',
-                },
-            };
-            const expected2 = {
-                user: {
-                    identity: false,
-                    edition: 'UK',
-                },
-            };
-            const config3 = {
-                page: {},
-                user: {
-                    id: 42,
-                },
-            };
-            const expected3 = {
-                user: {
-                    identity: true,
-                },
-            };
-            expect(_.generatePayload(config1)).toEqual(expected1);
-            expect(_.generatePayload(config2)).toEqual(expected2);
-            expect(_.generatePayload(config3)).toEqual(expected3);
-        });
-    });
-    describe('generatePermutiveIdentities', () => {
-        it('returns array containing ophan-tagged id if browser ID is present', () => {
-            expect(
-                _.generatePermutiveIdentities({
-                    ophan: { browserId: 'abc123' },
-                })
-            ).toEqual([{ tag: 'ophan', id: 'abc123' }]);
-        });
-        it('returns an empty array if there is no browser ID present', () => {
-            expect(
-                _.generatePermutiveIdentities({ ophan: { pageViewId: 'pvid' } })
-            ).toEqual([]);
-        });
-        it('returns an empty array if an empty browser ID is present', () => {
-            expect(
-                _.generatePermutiveIdentities({ ophan: { browserId: '' } })
-            ).toEqual([]);
-        });
-        it('returns an empty array if ophan config object is completely missing', () => {
-            expect(_.generatePermutiveIdentities({})).toEqual([]);
-        });
-    });
-    describe('runPermutive', () => {
-        const validConfigForPayload = { page: { section: 'uk' } };
+			expect(_.generatePayload(config1)).toEqual(expected1);
+			expect(_.generatePayload(config2)).toEqual(expected2);
+			expect(_.generatePayload(config3)).toEqual(expected3);
+		});
+		it('generates valid payload for `user` sub schema', () => {
+			const config1 = { page: {}, user: {} };
+			const expected1 = {
+				user: {
+					identity: false,
+				},
+			};
+			const config2 = {
+				page: {
+					edition: 'UK',
+				},
+			};
+			const expected2 = {
+				user: {
+					identity: false,
+					edition: 'UK',
+				},
+			};
+			const config3 = {
+				page: {},
+				user: {
+					id: 42,
+				},
+			};
+			const expected3 = {
+				user: {
+					identity: true,
+				},
+			};
+			expect(_.generatePayload(config1)).toEqual(expected1);
+			expect(_.generatePayload(config2)).toEqual(expected2);
+			expect(_.generatePayload(config3)).toEqual(expected3);
+		});
+	});
+	describe('generatePermutiveIdentities', () => {
+		it('returns array containing ophan-tagged id if browser ID is present', () => {
+			expect(
+				_.generatePermutiveIdentities({
+					ophan: { browserId: 'abc123' },
+				}),
+			).toEqual([{ tag: 'ophan', id: 'abc123' }]);
+		});
+		it('returns an empty array if there is no browser ID present', () => {
+			expect(
+				_.generatePermutiveIdentities({
+					ophan: { pageViewId: 'pvid' },
+				}),
+			).toEqual([]);
+		});
+		it('returns an empty array if an empty browser ID is present', () => {
+			expect(
+				_.generatePermutiveIdentities({ ophan: { browserId: '' } }),
+			).toEqual([]);
+		});
+		it('returns an empty array if ophan config object is completely missing', () => {
+			expect(_.generatePermutiveIdentities({})).toEqual([]);
+		});
+	});
+	describe('runPermutive', () => {
+		const validConfigForPayload = { page: { section: 'uk' } };
 
-        it('catches errors and calls the logger correctly when no global permutive', () => {
-            const logger = jest.fn();
-            _.runPermutive({}, undefined, logger);
-            const err = logger.mock.calls[0][0];
-            expect(err).toBeInstanceOf(Error);
-            expect(err.message).toBe('Global Permutive setup error');
-        });
-        it('calls the permutive addon method with the correct payload', () => {
-            const mockPermutive = { addon: jest.fn(), identify: jest.fn() };
-            const logger = jest.fn();
+		it('catches errors and calls the logger correctly when no global permutive', () => {
+			const logger = jest.fn();
+			_.runPermutive({}, undefined, logger);
+			const err = logger.mock.calls[0][0];
+			expect(err).toBeInstanceOf(Error);
+			expect(err.message).toBe('Global Permutive setup error');
+		});
+		it('calls the permutive addon method with the correct payload', () => {
+			const mockPermutive = { addon: jest.fn(), identify: jest.fn() };
+			const logger = jest.fn();
 
-            _.runPermutive(validConfigForPayload, mockPermutive, logger);
-            expect(mockPermutive.addon).toHaveBeenCalledWith('web', {
-                page: { content: { section: 'uk' }, user: { identity: false } },
-            });
-            expect(logger).not.toHaveBeenCalled();
-        });
-        it("calls permutive's identify method, passing the ophan browser ID", () => {
-            const mockPermutive = { addon: jest.fn(), identify: jest.fn() };
-            const logger = jest.fn();
-            const bwid = '1234567890abcdef';
-            const config = {
-                ophan: { browserId: bwid },
-                ...validConfigForPayload,
-            };
+			_.runPermutive(validConfigForPayload, mockPermutive, logger);
+			expect(mockPermutive.addon).toHaveBeenCalledWith('web', {
+				page: { content: { section: 'uk' }, user: { identity: false } },
+			});
+			expect(logger).not.toHaveBeenCalled();
+		});
+		it("calls permutive's identify method, passing the ophan browser ID", () => {
+			const mockPermutive = { addon: jest.fn(), identify: jest.fn() };
+			const logger = jest.fn();
+			const bwid = '1234567890abcdef';
+			const config = {
+				ophan: { browserId: bwid },
+				...validConfigForPayload,
+			};
 
-            _.runPermutive(config, mockPermutive, logger);
-            expect(mockPermutive.identify).toHaveBeenCalledWith([
-                { tag: 'ophan', id: bwid },
-            ]);
-            expect(logger).not.toHaveBeenCalled();
-        });
-        it("calls permutive's identify before it calls addon, if the browser ID is present", () => {
-            const mockPermutive = { addon: jest.fn(), identify: jest.fn() };
-            const logger = jest.fn();
-            const bwid = '1234567890abcdef';
-            const config = {
-                ophan: { browserId: bwid },
-                ...validConfigForPayload,
-            };
+			_.runPermutive(config, mockPermutive, logger);
+			expect(mockPermutive.identify).toHaveBeenCalledWith([
+				{ tag: 'ophan', id: bwid },
+			]);
+			expect(logger).not.toHaveBeenCalled();
+		});
+		it("calls permutive's identify before it calls addon, if the browser ID is present", () => {
+			const mockPermutive = { addon: jest.fn(), identify: jest.fn() };
+			const logger = jest.fn();
+			const bwid = '1234567890abcdef';
+			const config = {
+				ophan: { browserId: bwid },
+				...validConfigForPayload,
+			};
 
-            _.runPermutive(config, mockPermutive, logger);
-            const [
-                identifyCallOrder,
-                
-            ] = mockPermutive.identify.mock.invocationCallOrder;
-            const [
-                addonCallOrder,
-                
-            ] = mockPermutive.addon.mock.invocationCallOrder;
-            expect(identifyCallOrder).toBeLessThan(addonCallOrder);
-        });
-        it('does not call the identify method if no browser ID is present', () => {
-            const mockPermutive = { addon: jest.fn(), identify: jest.fn() };
-            const logger = jest.fn();
+			_.runPermutive(config, mockPermutive, logger);
+			const [
+				identifyCallOrder,
+			] = mockPermutive.identify.mock.invocationCallOrder;
+			const [
+				addonCallOrder,
+			] = mockPermutive.addon.mock.invocationCallOrder;
+			expect(identifyCallOrder).toBeLessThan(addonCallOrder);
+		});
+		it('does not call the identify method if no browser ID is present', () => {
+			const mockPermutive = { addon: jest.fn(), identify: jest.fn() };
+			const logger = jest.fn();
 
-            _.runPermutive(validConfigForPayload, mockPermutive, logger);
-            expect(mockPermutive.identify).not.toHaveBeenCalled();
-            expect(logger).not.toHaveBeenCalled();
-        });
-    });
+			_.runPermutive(validConfigForPayload, mockPermutive, logger);
+			expect(mockPermutive.identify).not.toHaveBeenCalled();
+			expect(logger).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.js
@@ -1,6 +1,6 @@
 import {
-    getConsentFor,
-    onConsentChange,
+	getConsentFor,
+	onConsentChange,
 } from '@guardian/consent-management-platform';
 import { once } from 'lodash-es';
 import config from '../../../../lib/config';
@@ -12,45 +12,45 @@ import { shouldIncludeOnlyA9 } from '../header-bidding/utils';
 import { dfpEnv } from './dfp-env';
 
 const loadPrebid = (framework) => {
-    if (
-        dfpEnv.hbImpl.prebid &&
-        commercialFeatures.dfpAdvertising &&
-        !commercialFeatures.adFree &&
-        !config.get('page.hasPageSkin') &&
-        !isGoogleProxy() &&
-        !shouldIncludeOnlyA9
-    ) {
-        import(/* webpackChunkName: "Prebid.js" */ 'prebid.js/build/dist/prebid').then(
-            () => {
-                getPageTargeting();
-                prebid.initialise(window, framework);
-            }
-        );
-    }
+	if (
+		dfpEnv.hbImpl.prebid &&
+		commercialFeatures.dfpAdvertising &&
+		!commercialFeatures.adFree &&
+		!config.get('page.hasPageSkin') &&
+		!isGoogleProxy() &&
+		!shouldIncludeOnlyA9
+	) {
+		import(
+			/* webpackChunkName: "Prebid.js" */ 'prebid.js/build/dist/prebid'
+		).then(() => {
+			getPageTargeting();
+			prebid.initialise(window, framework);
+		});
+	}
 };
 
 const setupPrebid = () => {
-    onConsentChange(state => {
-        const canRun = getConsentFor('prebid', state);
-        if (canRun) {
-            let framework;
-            if(state.tcfv2) framework = 'tcfv2';
-            if(state.ccpa) framework = 'ccpa';
-            if(state.aus) framework = 'aus';
-            loadPrebid(framework);
-        }
-    });
+	onConsentChange((state) => {
+		const canRun = getConsentFor('prebid', state);
+		if (canRun) {
+			let framework;
+			if (state.tcfv2) framework = 'tcfv2';
+			if (state.ccpa) framework = 'ccpa';
+			if (state.aus) framework = 'aus';
+			loadPrebid(framework);
+		}
+	});
 
-    return Promise.resolve();
+	return Promise.resolve();
 };
 
 export const setupPrebidOnce = once(setupPrebid);
 
 export const init = () => {
-    setupPrebidOnce();
-    return Promise.resolve();
+	setupPrebidOnce();
+	return Promise.resolve();
 };
 
 export const _ = {
-    setupPrebid,
+	setupPrebid,
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.js
@@ -1,6 +1,6 @@
 import {
-    getConsentFor as getConsentFor_,
-    onConsentChange as onConsentChange_,
+	getConsentFor as getConsentFor_,
+	onConsentChange as onConsentChange_,
 } from '@guardian/consent-management-platform';
 import config from '../../../../lib/config';
 import { isGoogleProxy } from '../../../../lib/detect';
@@ -14,7 +14,7 @@ const onConsentChange = onConsentChange_;
 const getConsentFor = getConsentFor_;
 
 jest.mock('../../../common/modules/commercial/commercial-features', () => ({
-    commercialFeatures: {},
+	commercialFeatures: {},
 }));
 
 jest.mock('../header-bidding/prebid/prebid', () => ({
@@ -24,209 +24,209 @@ jest.mock('../header-bidding/prebid/prebid', () => ({
 }));
 
 jest.mock('./Advert', () =>
-    jest.fn().mockImplementation(() => ({ advert: jest.fn() }))
+	jest.fn().mockImplementation(() => ({ advert: jest.fn() })),
 );
 
 jest.mock('../../../common/modules/commercial/build-page-targeting', () => ({
-    getPageTargeting: jest.fn(),
+	getPageTargeting: jest.fn(),
 }));
 
 jest.mock('../header-bidding/prebid/bid-config', () => ({
-    isInVariant: jest.fn(),
+	isInVariant: jest.fn(),
 }));
 
 jest.mock('../header-bidding/utils', () => ({
-    shouldIncludeOnlyA9: false,
+	shouldIncludeOnlyA9: false,
 }));
 
 jest.mock('@guardian/consent-management-platform', () => ({
-    onConsentChange: jest.fn(),
-    getConsentFor: jest.fn(),
+	onConsentChange: jest.fn(),
+	getConsentFor: jest.fn(),
 }));
 
 const tcfv2WithConsentMock = (callback) =>
-    callback({
-        tcfv2: { vendorConsents: { '5f22bfd82a6b6c1afd1181a9': true } },
-    });
+	callback({
+		tcfv2: { vendorConsents: { '5f22bfd82a6b6c1afd1181a9': true } },
+	});
 
 const tcfv2WithoutConsentMock = (callback) =>
-    callback({
-        tcfv2: { vendorConsents: { '5f22bfd82a6b6c1afd1181a9': false } },
-    });
+	callback({
+		tcfv2: { vendorConsents: { '5f22bfd82a6b6c1afd1181a9': false } },
+	});
 
 const ccpaWithConsentMock = (callback) =>
-    callback({ ccpa: { doNotSell: false } });
+	callback({ ccpa: { doNotSell: false } });
 
 const ccpaWithoutConsentMock = (callback) =>
-    callback({ ccpa: { doNotSell: true } });
+	callback({ ccpa: { doNotSell: true } });
 
 const ausWithConsentMock = (callback) =>
-    callback({ aus: { rejectedCategories: [] } });
+	callback({ aus: { rejectedCategories: [] } });
 
 const ausWithoutConsentMock = (callback) =>
-    callback({
-        aus: {
-            rejectedCategories: [
-                { _id: '5f859c3420e4ec3e476c7006', name: 'Advertising' },
-            ],
-        },
-    });
+	callback({
+		aus: {
+			rejectedCategories: [
+				{ _id: '5f859c3420e4ec3e476c7006', name: 'Advertising' },
+			],
+		},
+	});
 
 const fakeUserAgent = (userAgent) => {
-    const userAgentObject = {};
-    userAgentObject.get = () => userAgent;
-    userAgentObject.configurable = true;
-    Object.defineProperty(navigator, 'userAgent', userAgentObject);
+	const userAgentObject = {};
+	userAgentObject.get = () => userAgent;
+	userAgentObject.configurable = true;
+	Object.defineProperty(navigator, 'userAgent', userAgentObject);
 };
 
 describe('init', () => {
-    const originalUA = navigator.userAgent;
+	const originalUA = navigator.userAgent;
 
-    beforeEach(() => {
-        jest.clearAllMocks();
-        fakeUserAgent(originalUA);
-    });
+	beforeEach(() => {
+		jest.clearAllMocks();
+		fakeUserAgent(originalUA);
+	});
 
-    afterAll(() => {
-        jest.clearAllMocks();
-    });
+	afterAll(() => {
+		jest.clearAllMocks();
+	});
 
-    it('should initialise Prebid when Prebid switch is ON and advertising is on and ad-free is off', async () => {
-        dfpEnv.hbImpl = { prebid: true, a9: false };
-        commercialFeatures.dfpAdvertising = true;
-        commercialFeatures.adFree = false;
-        onConsentChange.mockImplementation(tcfv2WithConsentMock);
-        getConsentFor.mockReturnValue(true);
-        await setupPrebid();
-        expect(prebid.initialise).toBeCalled();
-    });
+	it('should initialise Prebid when Prebid switch is ON and advertising is on and ad-free is off', async () => {
+		dfpEnv.hbImpl = { prebid: true, a9: false };
+		commercialFeatures.dfpAdvertising = true;
+		commercialFeatures.adFree = false;
+		onConsentChange.mockImplementation(tcfv2WithConsentMock);
+		getConsentFor.mockReturnValue(true);
+		await setupPrebid();
+		expect(prebid.initialise).toBeCalled();
+	});
 
-    it('should not initialise Prebid when useragent is Google Web Preview', async () => {
-        dfpEnv.hbImpl = { prebid: true, a9: false };
-        commercialFeatures.dfpAdvertising = true;
-        commercialFeatures.adFree = false;
-        fakeUserAgent('Google Web Preview');
-        await setupPrebid();
-        expect(prebid.initialise).not.toBeCalled();
-    });
+	it('should not initialise Prebid when useragent is Google Web Preview', async () => {
+		dfpEnv.hbImpl = { prebid: true, a9: false };
+		commercialFeatures.dfpAdvertising = true;
+		commercialFeatures.adFree = false;
+		fakeUserAgent('Google Web Preview');
+		await setupPrebid();
+		expect(prebid.initialise).not.toBeCalled();
+	});
 
-    it('should not initialise Prebid when no header bidding switches are on', async () => {
-        commercialFeatures.dfpAdvertising = true;
-        commercialFeatures.adFree = false;
-        dfpEnv.hbImpl = { prebid: false, a9: false };
-        await setupPrebid();
-        expect(prebid.initialise).not.toBeCalled();
-    });
+	it('should not initialise Prebid when no header bidding switches are on', async () => {
+		commercialFeatures.dfpAdvertising = true;
+		commercialFeatures.adFree = false;
+		dfpEnv.hbImpl = { prebid: false, a9: false };
+		await setupPrebid();
+		expect(prebid.initialise).not.toBeCalled();
+	});
 
-    it('should not initialise Prebid when advertising is switched off', async () => {
-        dfpEnv.hbImpl = { prebid: true, a9: false };
-        commercialFeatures.dfpAdvertising = false;
-        commercialFeatures.adFree = false;
-        await setupPrebid();
-        expect(prebid.initialise).not.toBeCalled();
-    });
+	it('should not initialise Prebid when advertising is switched off', async () => {
+		dfpEnv.hbImpl = { prebid: true, a9: false };
+		commercialFeatures.dfpAdvertising = false;
+		commercialFeatures.adFree = false;
+		await setupPrebid();
+		expect(prebid.initialise).not.toBeCalled();
+	});
 
-    it('should not initialise Prebid when ad-free is on', async () => {
-        dfpEnv.hbImpl = { prebid: true, a9: false };
-        commercialFeatures.dfpAdvertising = true;
-        commercialFeatures.adFree = true;
-        await setupPrebid();
-        expect(prebid.initialise).not.toBeCalled();
-    });
+	it('should not initialise Prebid when ad-free is on', async () => {
+		dfpEnv.hbImpl = { prebid: true, a9: false };
+		commercialFeatures.dfpAdvertising = true;
+		commercialFeatures.adFree = true;
+		await setupPrebid();
+		expect(prebid.initialise).not.toBeCalled();
+	});
 
-    it('should not initialise Prebid when the page has a pageskin', async () => {
-        dfpEnv.hbImpl = { prebid: true, a9: false };
-        commercialFeatures.dfpAdvertising = true;
-        commercialFeatures.adFree = false;
-        config.set('page.hasPageSkin', true);
-        await setupPrebid();
-        expect(prebid.initialise).not.toBeCalled();
-    });
+	it('should not initialise Prebid when the page has a pageskin', async () => {
+		dfpEnv.hbImpl = { prebid: true, a9: false };
+		commercialFeatures.dfpAdvertising = true;
+		commercialFeatures.adFree = false;
+		config.set('page.hasPageSkin', true);
+		await setupPrebid();
+		expect(prebid.initialise).not.toBeCalled();
+	});
 
-    it('should initialise Prebid when the page has no pageskin', async () => {
-        dfpEnv.hbImpl = { prebid: true, a9: false };
-        commercialFeatures.dfpAdvertising = true;
-        commercialFeatures.adFree = false;
-        config.set('page.hasPageSkin', false);
-        await setupPrebid();
-        expect(prebid.initialise).toBeCalled();
-    });
-    it('should initialise Prebid if TCFv2 consent with correct Sourcepoint Id is true ', async () => {
-        dfpEnv.hbImpl = { prebid: true, a9: false };
-        commercialFeatures.dfpAdvertising = true;
-        commercialFeatures.adFree = false;
-        onConsentChange.mockImplementation(tcfv2WithConsentMock);
-        getConsentFor.mockReturnValue(true);
-        await setupPrebid();
-        expect(prebid.initialise).toBeCalled();
-    });
+	it('should initialise Prebid when the page has no pageskin', async () => {
+		dfpEnv.hbImpl = { prebid: true, a9: false };
+		commercialFeatures.dfpAdvertising = true;
+		commercialFeatures.adFree = false;
+		config.set('page.hasPageSkin', false);
+		await setupPrebid();
+		expect(prebid.initialise).toBeCalled();
+	});
+	it('should initialise Prebid if TCFv2 consent with correct Sourcepoint Id is true ', async () => {
+		dfpEnv.hbImpl = { prebid: true, a9: false };
+		commercialFeatures.dfpAdvertising = true;
+		commercialFeatures.adFree = false;
+		onConsentChange.mockImplementation(tcfv2WithConsentMock);
+		getConsentFor.mockReturnValue(true);
+		await setupPrebid();
+		expect(prebid.initialise).toBeCalled();
+	});
 
-    it('should not initialise Prebid if TCFv2 consent with correct Sourcepoint Id is false', async () => {
-        dfpEnv.hbImpl = { prebid: true, a9: false };
-        commercialFeatures.dfpAdvertising = true;
-        commercialFeatures.adFree = false;
-        onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
-        getConsentFor.mockReturnValue(false);
-        await setupPrebid();
-        expect(prebid.initialise).not.toBeCalled();
-    });
+	it('should not initialise Prebid if TCFv2 consent with correct Sourcepoint Id is false', async () => {
+		dfpEnv.hbImpl = { prebid: true, a9: false };
+		commercialFeatures.dfpAdvertising = true;
+		commercialFeatures.adFree = false;
+		onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
+		getConsentFor.mockReturnValue(false);
+		await setupPrebid();
+		expect(prebid.initialise).not.toBeCalled();
+	});
 
-    it('should initialise Prebid in CCPA if doNotSell is false', async () => {
-        dfpEnv.hbImpl = { prebid: true, a9: false };
-        commercialFeatures.dfpAdvertising = true;
-        commercialFeatures.adFree = false;
-        onConsentChange.mockImplementation(ccpaWithConsentMock);
-        getConsentFor.mockReturnValue(true); // TODO: Why do we need to mock this?
-        await setupPrebid();
-        expect(prebid.initialise).toBeCalled();
-    });
+	it('should initialise Prebid in CCPA if doNotSell is false', async () => {
+		dfpEnv.hbImpl = { prebid: true, a9: false };
+		commercialFeatures.dfpAdvertising = true;
+		commercialFeatures.adFree = false;
+		onConsentChange.mockImplementation(ccpaWithConsentMock);
+		getConsentFor.mockReturnValue(true); // TODO: Why do we need to mock this?
+		await setupPrebid();
+		expect(prebid.initialise).toBeCalled();
+	});
 
-    it('should not initialise Prebid in CCPA if doNotSell is true', async () => {
-        dfpEnv.hbImpl = { prebid: true, a9: false };
-        commercialFeatures.dfpAdvertising = true;
-        commercialFeatures.adFree = false;
-        onConsentChange.mockImplementation(ccpaWithoutConsentMock);
-        getConsentFor.mockReturnValue(false);
-        await setupPrebid();
-        expect(prebid.initialise).not.toBeCalled();
-    });
+	it('should not initialise Prebid in CCPA if doNotSell is true', async () => {
+		dfpEnv.hbImpl = { prebid: true, a9: false };
+		commercialFeatures.dfpAdvertising = true;
+		commercialFeatures.adFree = false;
+		onConsentChange.mockImplementation(ccpaWithoutConsentMock);
+		getConsentFor.mockReturnValue(false);
+		await setupPrebid();
+		expect(prebid.initialise).not.toBeCalled();
+	});
 
-    it('should initialise Prebid in AUS if Advertising is not rejected', async () => {
-        dfpEnv.hbImpl = { prebid: true, a9: false };
-        commercialFeatures.dfpAdvertising = true;
-        commercialFeatures.adFree = false;
-        onConsentChange.mockImplementation(ausWithConsentMock);
-        getConsentFor.mockReturnValue(true);
-        await setupPrebid();
-        expect(prebid.initialise).toBeCalled();
-    });
+	it('should initialise Prebid in AUS if Advertising is not rejected', async () => {
+		dfpEnv.hbImpl = { prebid: true, a9: false };
+		commercialFeatures.dfpAdvertising = true;
+		commercialFeatures.adFree = false;
+		onConsentChange.mockImplementation(ausWithConsentMock);
+		getConsentFor.mockReturnValue(true);
+		await setupPrebid();
+		expect(prebid.initialise).toBeCalled();
+	});
 
-    it('should not initialise Prebid in AUS if Advertising is rejected', async () => {
-        dfpEnv.hbImpl = { prebid: true, a9: false };
-        commercialFeatures.dfpAdvertising = true;
-        commercialFeatures.adFree = false;
-        onConsentChange.mockImplementation(ausWithoutConsentMock);
-        getConsentFor.mockReturnValue(false);
-        await setupPrebid();
-        expect(prebid.initialise).not.toBeCalled();
-    });
+	it('should not initialise Prebid in AUS if Advertising is rejected', async () => {
+		dfpEnv.hbImpl = { prebid: true, a9: false };
+		commercialFeatures.dfpAdvertising = true;
+		commercialFeatures.adFree = false;
+		onConsentChange.mockImplementation(ausWithoutConsentMock);
+		getConsentFor.mockReturnValue(false);
+		await setupPrebid();
+		expect(prebid.initialise).not.toBeCalled();
+	});
 
-    it('isGoogleWebPreview should return false with no navigator or useragent', () => {
-        expect(isGoogleProxy()).toBe(false);
-    });
+	it('isGoogleWebPreview should return false with no navigator or useragent', () => {
+		expect(isGoogleProxy()).toBe(false);
+	});
 
-    it('isGoogleWebPreview should return false with no navigator or useragent', () => {
-        fakeUserAgent('Firefox');
-        expect(isGoogleProxy()).toBe(false);
-    });
+	it('isGoogleWebPreview should return false with no navigator or useragent', () => {
+		fakeUserAgent('Firefox');
+		expect(isGoogleProxy()).toBe(false);
+	});
 
-    it('isGoogleWebPreview should return true with Google Web Preview useragent', () => {
-        fakeUserAgent('Google Web Preview');
-        expect(isGoogleProxy()).toBe(true);
-    });
+	it('isGoogleWebPreview should return true with Google Web Preview useragent', () => {
+		fakeUserAgent('Google Web Preview');
+		expect(isGoogleProxy()).toBe(true);
+	});
 
-    it('isGoogleWebPreview should return true with Google Web Preview useragent', () => {
-        fakeUserAgent('googleweblight');
-        expect(isGoogleProxy()).toBe(true);
-    });
+	it('isGoogleWebPreview should return true with Google Web Preview useragent', () => {
+		fakeUserAgent('googleweblight');
+		expect(isGoogleProxy()).toBe(true);
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
@@ -1,6 +1,6 @@
 import {
-    getConsentFor,
-    onConsentChange,
+	getConsentFor,
+	onConsentChange,
 } from '@guardian/consent-management-platform';
 import config from '../../../../lib/config';
 import { commercialFeatures } from '../../../common/modules/commercial/commercial-features';
@@ -9,55 +9,57 @@ import { isInAuOrNz } from '../../../common/modules/commercial/geo-utils';
 let initialised = false;
 
 const initialise = () => {
-    // Initialise Launchpad Tracker
-    window.launchpad('newTracker', 'launchpad', 'lpx.qantas.com', {
-        discoverRootDomain: true,
-        appId: 'the-guardian',
-    });
+	// Initialise Launchpad Tracker
+	window.launchpad('newTracker', 'launchpad', 'lpx.qantas.com', {
+		discoverRootDomain: true,
+		appId: 'the-guardian',
+	});
 
-    // Track Page Views
-    window.launchpad('trackUnstructEvent', {
-        schema: 'iglu:com.qantas.launchpad/hierarchy/jsonschema/1-0-0',
-        data: {
-            u1: 'theguardian.com',
-            u2: config.get('page.section'),
-            u3: config.get('page.sectionName'),
-            u4: config.get('page.contentType'),
-            uid: config.get('ophan', {}).browserId,
-        },
-    });
+	// Track Page Views
+	window.launchpad('trackUnstructEvent', {
+		schema: 'iglu:com.qantas.launchpad/hierarchy/jsonschema/1-0-0',
+		data: {
+			u1: 'theguardian.com',
+			u2: config.get('page.section'),
+			u3: config.get('page.sectionName'),
+			u4: config.get('page.contentType'),
+			uid: config.get('ophan', {}).browserId,
+		},
+	});
 };
 
 const setupRedplanet = () => {
-    onConsentChange((state) => {
-        // CCPA only runs in the US and tcfv2 outside Aus
-        // Redplanet only runs in Australia
-        // so this should never happen
-        if (!state.aus) {
-            throw new Error(
-                `Error running Redplanet without AUS consent. It should only run in Australia on AUS mode`
-            );
-        }
-        const canRun = getConsentFor('redplanet', state);
+	onConsentChange((state) => {
+		// CCPA only runs in the US and tcfv2 outside Aus
+		// Redplanet only runs in Australia
+		// so this should never happen
+		if (!state.aus) {
+			throw new Error(
+				`Error running Redplanet without AUS consent. It should only run in Australia on AUS mode`,
+			);
+		}
+		const canRun = getConsentFor('redplanet', state);
 
-        if (!initialised && canRun) {
-            initialised = true;
-            return import(/* webpackChunkName: "redplanet" */ '../../../../lib/launchpad.js').then(() => {
-                initialise();
-                return Promise.resolve();
-            });
-        }
-    });
-    return Promise.resolve();
+		if (!initialised && canRun) {
+			initialised = true;
+			return import(
+				/* webpackChunkName: "redplanet" */ '../../../../lib/launchpad.js'
+			).then(() => {
+				initialise();
+				return Promise.resolve();
+			});
+		}
+	});
+	return Promise.resolve();
 };
 
 export const init = () => {
-    if (commercialFeatures.launchpad && isInAuOrNz()) {
-        return setupRedplanet();
-    }
-    return Promise.resolve();
+	if (commercialFeatures.launchpad && isInAuOrNz()) {
+		return setupRedplanet();
+	}
+	return Promise.resolve();
 };
 
 export const resetModule = () => {
-    initialised = false;
+	initialised = false;
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.spec.js
@@ -1,6 +1,6 @@
 import {
-    getConsentFor as getConsentFor_,
-    onConsentChange as onConsentChange_,
+	getConsentFor as getConsentFor_,
+	onConsentChange as onConsentChange_,
 } from '@guardian/consent-management-platform';
 import config from '../../../../lib/config';
 import { commercialFeatures } from '../../../common/modules/commercial/commercial-features';
@@ -11,154 +11,154 @@ jest.mock('lib/raven');
 const isInAuOrNz = isInAuOrNz_;
 
 const AusWithConsentMock = (callback) =>
-    callback({
-        aus: { personalisedAdvertising: true },
-    });
+	callback({
+		aus: { personalisedAdvertising: true },
+	});
 
 const AusWithoutConsentMock = (callback) =>
-    callback({
-        aus: { personalisedAdvertising: true },
-    });
+	callback({
+		aus: { personalisedAdvertising: true },
+	});
 
 const onConsentChange = onConsentChange_;
 
 jest.mock('../../../common/modules/commercial/commercial-features', () => ({
-    commercialFeatures: {},
+	commercialFeatures: {},
 }));
 
 jest.mock('./Advert', () =>
-    jest.fn().mockImplementation(() => ({ advert: jest.fn() }))
+	jest.fn().mockImplementation(() => ({ advert: jest.fn() })),
 );
 
 jest.mock('../../../common/modules/commercial/geo-utils');
 
 jest.mock('../../../common/modules/experiments/ab', () => ({
-    isInVariantSynchronous: jest.fn(),
+	isInVariantSynchronous: jest.fn(),
 }));
 
 jest.mock('../../../../lib/cookies', () => ({
-    getCookie: jest.fn(),
+	getCookie: jest.fn(),
 }));
 
 jest.mock('../../../../lib/launchpad', () => jest.fn());
 
 jest.mock('../../../common/modules/commercial/build-page-targeting', () => ({
-    buildPageTargeting: jest.fn(),
+	buildPageTargeting: jest.fn(),
 }));
 
 jest.mock('@guardian/libs', () => ({
-    loadScript: () => Promise.resolve(),
+	loadScript: () => Promise.resolve(),
 }));
 
 jest.mock('@guardian/consent-management-platform', () => ({
-    onConsentChange: jest.fn(),
-    getConsentFor: jest.fn()
+	onConsentChange: jest.fn(),
+	getConsentFor: jest.fn(),
 }));
 
 jest.mock('../../../common/modules/experiments/ab', () => ({
-    isInVariantSynchronous: jest.fn(),
+	isInVariantSynchronous: jest.fn(),
 }));
 
 const CcpaWithConsentMock = (callback) =>
-    callback({ ccpa: { doNotSell: false } });
+	callback({ ccpa: { doNotSell: false } });
 
 const getConsentFor = getConsentFor_;
 
 window.launchpad = jest.fn().mockImplementationOnce(() => jest.fn());
 
 describe('init', () => {
-    beforeEach(() => {
-        jest.clearAllMocks();
-        resetModule();
-    });
+	beforeEach(() => {
+		jest.clearAllMocks();
+		resetModule();
+	});
 
-    afterAll(() => {
-        jest.clearAllMocks();
-    });
+	afterAll(() => {
+		jest.clearAllMocks();
+	});
 
-    it('should initialise redplanet when all conditions are true with right params', async () => {
-        commercialFeatures.launchpad = true;
-        isInAuOrNz.mockReturnValue(true);
-        config.set('ophan.browserId', '123');
-        config.set('page.section', 'uk');
-        config.set('page.sectionName', 'Politics');
-        config.set('page.contentType', 'Article');
-        onConsentChange.mockImplementation(AusWithConsentMock);
-        getConsentFor.mockReturnValue(true);
+	it('should initialise redplanet when all conditions are true with right params', async () => {
+		commercialFeatures.launchpad = true;
+		isInAuOrNz.mockReturnValue(true);
+		config.set('ophan.browserId', '123');
+		config.set('page.section', 'uk');
+		config.set('page.sectionName', 'Politics');
+		config.set('page.contentType', 'Article');
+		onConsentChange.mockImplementation(AusWithConsentMock);
+		getConsentFor.mockReturnValue(true);
 
-        await init();
+		await init();
 
-        const expectedNewTrackerCall = [
-            'newTracker',
-            'launchpad',
-            'lpx.qantas.com',
-            {
-                appId: 'the-guardian',
-                discoverRootDomain: true,
-            },
-        ];
-        const expectedTrackUnstructEventCall = [
-            'trackUnstructEvent',
-            {
-                schema: 'iglu:com.qantas.launchpad/hierarchy/jsonschema/1-0-0',
-                data: {
-                    u1: 'theguardian.com',
-                    u2: 'uk',
-                    u3: 'Politics',
-                    u4: 'Article',
-                    uid: '123',
-                },
-            },
-        ];
-        expect(window.launchpad.mock.calls).toEqual([
-            expectedNewTrackerCall,
-            expectedTrackUnstructEventCall,
-        ]);
-    });
+		const expectedNewTrackerCall = [
+			'newTracker',
+			'launchpad',
+			'lpx.qantas.com',
+			{
+				appId: 'the-guardian',
+				discoverRootDomain: true,
+			},
+		];
+		const expectedTrackUnstructEventCall = [
+			'trackUnstructEvent',
+			{
+				schema: 'iglu:com.qantas.launchpad/hierarchy/jsonschema/1-0-0',
+				data: {
+					u1: 'theguardian.com',
+					u2: 'uk',
+					u3: 'Politics',
+					u4: 'Article',
+					uid: '123',
+				},
+			},
+		];
+		expect(window.launchpad.mock.calls).toEqual([
+			expectedNewTrackerCall,
+			expectedTrackUnstructEventCall,
+		]);
+	});
 
-    it('should initialise redplanet when TCFv2 consent has been given', async () => {
-        commercialFeatures.launchpad = true;
-        isInAuOrNz.mockReturnValue(true);
-        onConsentChange.mockImplementation(AusWithConsentMock);
-        getConsentFor.mockReturnValue(true);
-        await init();
-        expect(window.launchpad).toBeCalled();
-    });
+	it('should initialise redplanet when TCFv2 consent has been given', async () => {
+		commercialFeatures.launchpad = true;
+		isInAuOrNz.mockReturnValue(true);
+		onConsentChange.mockImplementation(AusWithConsentMock);
+		getConsentFor.mockReturnValue(true);
+		await init();
+		expect(window.launchpad).toBeCalled();
+	});
 
-    it('should not initialise redplanet when TCFv2 consent has not been given', async () => {
-        commercialFeatures.launchpad = true;
-        isInAuOrNz.mockReturnValue(true);
-        onConsentChange.mockImplementation(AusWithoutConsentMock);
-        getConsentFor.mockReturnValue(false);
-        await init();
-        expect(window.launchpad).not.toBeCalled();
-    });
+	it('should not initialise redplanet when TCFv2 consent has not been given', async () => {
+		commercialFeatures.launchpad = true;
+		isInAuOrNz.mockReturnValue(true);
+		onConsentChange.mockImplementation(AusWithoutConsentMock);
+		getConsentFor.mockReturnValue(false);
+		await init();
+		expect(window.launchpad).not.toBeCalled();
+	});
 
-    it('should throw an error when on CCPA mode', async () => {
-        commercialFeatures.launchpad = true;
-        isInAuOrNz.mockReturnValue(true);
-        onConsentChange.mockImplementation(CcpaWithConsentMock);
-        getConsentFor.mockReturnValue(true);
-        expect(await init).toThrow(
-            `Error running Redplanet without AUS consent. It should only run in Australia on AUS mode`
-        );
-    });
+	it('should throw an error when on CCPA mode', async () => {
+		commercialFeatures.launchpad = true;
+		isInAuOrNz.mockReturnValue(true);
+		onConsentChange.mockImplementation(CcpaWithConsentMock);
+		getConsentFor.mockReturnValue(true);
+		expect(await init).toThrow(
+			`Error running Redplanet without AUS consent. It should only run in Australia on AUS mode`,
+		);
+	});
 
-    it('should not initialise redplanet when launchpad conditions are false', async () => {
-        commercialFeatures.launchpad = false;
-        isInAuOrNz.mockReturnValue(true);
-        onConsentChange.mockImplementation(AusWithConsentMock);
-        getConsentFor.mockReturnValue(true);
-        await init();
-        expect(window.launchpad).not.toBeCalled();
-    });
+	it('should not initialise redplanet when launchpad conditions are false', async () => {
+		commercialFeatures.launchpad = false;
+		isInAuOrNz.mockReturnValue(true);
+		onConsentChange.mockImplementation(AusWithConsentMock);
+		getConsentFor.mockReturnValue(true);
+		await init();
+		expect(window.launchpad).not.toBeCalled();
+	});
 
-    it('should not initialise redplanet when user not in AUS regions', async () => {
-        commercialFeatures.launchpad = true;
-        isInAuOrNz.mockReturnValue(false);
-        onConsentChange.mockImplementation(AusWithConsentMock);
-        getConsentFor.mockReturnValue(true);
-        await init();
-        expect(window.launchpad).not.toBeCalled();
-    });
+	it('should not initialise redplanet when user not in AUS regions', async () => {
+		commercialFeatures.launchpad = true;
+		isInAuOrNz.mockReturnValue(false);
+		onConsentChange.mockImplementation(AusWithConsentMock);
+		getConsentFor.mockReturnValue(true);
+		await init();
+		expect(window.launchpad).not.toBeCalled();
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/dfp/refresh-on-resize.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/refresh-on-resize.js
@@ -8,48 +8,48 @@ import { refreshAdvert } from './load-advert';
 const hasBreakpointChanged = hasCrossedBreakpoint(true);
 
 /* breakpointNames: array<string>. List of breakpoint names */
-const breakpointNames = breakpoints.map(_ => _.name);
+const breakpointNames = breakpoints.map((_) => _.name);
 
 // TODO: reset advert flags
 const refresh = (currentBreakpoint, previousBreakpoint) => {
-    const getBreakpointIndex = (breakpoint, slotBreakpoints) => {
-        const validBreakpointNames = breakpointNames
-            .slice(0, breakpointNames.indexOf(breakpoint) + 1)
-            .map(breakpointNameToAttribute);
-        return Math.max(
-            ...slotBreakpoints.map(_ => validBreakpointNames.lastIndexOf(_))
-        );
-    };
+	const getBreakpointIndex = (breakpoint, slotBreakpoints) => {
+		const validBreakpointNames = breakpointNames
+			.slice(0, breakpointNames.indexOf(breakpoint) + 1)
+			.map(breakpointNameToAttribute);
+		return Math.max(
+			...slotBreakpoints.map((_) => validBreakpointNames.lastIndexOf(_)),
+		);
+	};
 
-    const shouldRefresh = advert => {
-        // get the slot breakpoints
-        const slotBreakpoints = Object.keys(advert.sizes);
-        // find the currently matching breakpoint
-        const currentSlotBreakpoint = getBreakpointIndex(
-            currentBreakpoint,
-            slotBreakpoints
-        );
-        // find the previously matching breakpoint
-        const previousSlotBreakpoint = getBreakpointIndex(
-            previousBreakpoint,
-            slotBreakpoints
-        );
-        return (
-            currentSlotBreakpoint !== -1 &&
-            currentSlotBreakpoint !== previousSlotBreakpoint
-        );
-    };
+	const shouldRefresh = (advert) => {
+		// get the slot breakpoints
+		const slotBreakpoints = Object.keys(advert.sizes);
+		// find the currently matching breakpoint
+		const currentSlotBreakpoint = getBreakpointIndex(
+			currentBreakpoint,
+			slotBreakpoints,
+		);
+		// find the previously matching breakpoint
+		const previousSlotBreakpoint = getBreakpointIndex(
+			previousBreakpoint,
+			slotBreakpoints,
+		);
+		return (
+			currentSlotBreakpoint !== -1 &&
+			currentSlotBreakpoint !== previousSlotBreakpoint
+		);
+	};
 
-    // only refresh if the slot needs to
-    const advertsToRefresh = dfpEnv.advertsToRefresh.filter(shouldRefresh);
-    advertsToRefresh.forEach(refreshAdvert);
+	// only refresh if the slot needs to
+	const advertsToRefresh = dfpEnv.advertsToRefresh.filter(shouldRefresh);
+	advertsToRefresh.forEach(refreshAdvert);
 };
 
 const windowResize = () => {
-    // refresh on resize
-    hasBreakpointChanged(refresh);
+	// refresh on resize
+	hasBreakpointChanged(refresh);
 };
 
 export const refreshOnResize = () => {
-    mediator.on('window:throttledResize', windowResize);
+	mediator.on('window:throttledResize', windowResize);
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/track-ad-render.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/track-ad-render.js
@@ -1,4 +1,4 @@
 import { waitForAdvert } from './wait-for-advert';
 
 export const trackAdRender = (id) =>
-    waitForAdvert(id).then(_ => _.whenRendered);
+	waitForAdvert(id).then((_) => _.whenRendered);

--- a/static/src/javascripts/projects/commercial/modules/hasCurrentBrazeUser.js
+++ b/static/src/javascripts/projects/commercial/modules/hasCurrentBrazeUser.js
@@ -3,15 +3,15 @@ const KEY = 'gu.brazeUserSet';
 const hasCurrentBrazeUser = () => localStorage.getItem(KEY) === 'true';
 
 const setHasCurrentBrazeUser = () => {
-    localStorage.setItem(KEY, 'true');
-}
+	localStorage.setItem(KEY, 'true');
+};
 
 const clearHasCurrentBrazeUser = () => {
-    localStorage.removeItem(KEY);
-}
+	localStorage.removeItem(KEY);
+};
 
 export {
-    hasCurrentBrazeUser,
-    setHasCurrentBrazeUser,
-    clearHasCurrentBrazeUser,
-}
+	hasCurrentBrazeUser,
+	setHasCurrentBrazeUser,
+	clearHasCurrentBrazeUser,
+};

--- a/static/src/javascripts/projects/commercial/modules/hasCurrentBrazeUser.test.js
+++ b/static/src/javascripts/projects/commercial/modules/hasCurrentBrazeUser.test.js
@@ -1,32 +1,32 @@
 import {
-    clearHasCurrentBrazeUser,
-    hasCurrentBrazeUser,
-    setHasCurrentBrazeUser,
+	clearHasCurrentBrazeUser,
+	hasCurrentBrazeUser,
+	setHasCurrentBrazeUser,
 } from './hasCurrentBrazeUser';
 
 beforeEach(clearHasCurrentBrazeUser);
 
 describe('hasCurrentBrazeUser', () => {
-    it('hasCurrentBrazeUser returns false when not set', () => {
-        const got = hasCurrentBrazeUser();
+	it('hasCurrentBrazeUser returns false when not set', () => {
+		const got = hasCurrentBrazeUser();
 
-        expect(got).toEqual(false);
-    });
+		expect(got).toEqual(false);
+	});
 
-    it('hasCurrentBrazeUser returns true when set', () => {
-        setHasCurrentBrazeUser();
+	it('hasCurrentBrazeUser returns true when set', () => {
+		setHasCurrentBrazeUser();
 
-        const got = hasCurrentBrazeUser();
+		const got = hasCurrentBrazeUser();
 
-        expect(got).toEqual(true);
-    });
+		expect(got).toEqual(true);
+	});
 
-    it('clearHasCurrentBrazeUser unsets the value', () => {
-        setHasCurrentBrazeUser();
-        clearHasCurrentBrazeUser();
+	it('clearHasCurrentBrazeUser unsets the value', () => {
+		setHasCurrentBrazeUser();
+		clearHasCurrentBrazeUser();
 
-        const got = hasCurrentBrazeUser();
+		const got = hasCurrentBrazeUser();
 
-        expect(got).toEqual(false);
-    });
+		expect(got).toEqual(false);
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.spec.js
@@ -1,67 +1,71 @@
 import {
-    getConsentFor as getConsentFor_,
-    onConsentChange as onConsentChange_,
+	getConsentFor as getConsentFor_,
+	onConsentChange as onConsentChange_,
 } from '@guardian/consent-management-platform';
 import a9, { _ } from './a9';
 
 const onConsentChange = onConsentChange_;
 
 const tcfv2WithConsentMock = (callback) =>
-    callback({
-        tcfv2: { vendorConsents: { '5edf9a821dc4e95986b66df4': true } },
-    });
+	callback({
+		tcfv2: { vendorConsents: { '5edf9a821dc4e95986b66df4': true } },
+	});
 
 const CcpaWithConsentMock = (callback) =>
-    callback({ ccpa: { doNotSell: false } });
+	callback({ ccpa: { doNotSell: false } });
 
 const getConsentFor = getConsentFor_;
 
 jest.mock('../../../../../lib/raven');
 jest.mock('../../dfp/Advert', () =>
-    jest.fn().mockImplementation(() => ({ advert: jest.fn() }))
+	jest.fn().mockImplementation(() => ({ advert: jest.fn() })),
 );
 
 jest.mock('../slot-config', () => ({
-    slots: jest
-        .fn()
-        .mockImplementation(() => [
-            { key: 'top-above-nav', sizes: [[970, 250], [728, 90]] },
-        ]),
+	slots: jest.fn().mockImplementation(() => [
+		{
+			key: 'top-above-nav',
+			sizes: [
+				[970, 250],
+				[728, 90],
+			],
+		},
+	]),
 }));
 
 jest.mock('@guardian/consent-management-platform', () => ({
-    onConsentChange: jest.fn(),
-    getConsentFor: jest.fn()
+	onConsentChange: jest.fn(),
+	getConsentFor: jest.fn(),
 }));
 
 beforeEach(async () => {
-    jest.resetModules();
-    _.resetModule();
-    window.apstag = {
-        init: jest.fn(),
-        fetchBids: jest.fn().mockImplementation(() => Promise.resolve([])),
-        setDisplayBids: jest.fn(),
-    };
+	jest.resetModules();
+	_.resetModule();
+	window.apstag = {
+		init: jest.fn(),
+		fetchBids: jest.fn().mockImplementation(() => Promise.resolve([])),
+		setDisplayBids: jest.fn(),
+	};
 });
 
 afterAll(() => {
-    jest.resetAllMocks();
+	jest.resetAllMocks();
 });
 
 describe('initialise', () => {
-    it('should generate initialise A9 library when TCFv2 consent has been given', () => {
-        onConsentChange.mockImplementation(tcfv2WithConsentMock);
-        getConsentFor.mockReturnValue(true);
-        a9.initialise();
-        expect(window.apstag).toBeDefined();
-        expect(window.apstag.init).toHaveBeenCalled();
-    });
+	it('should generate initialise A9 library when TCFv2 consent has been given', () => {
+		onConsentChange.mockImplementation(tcfv2WithConsentMock);
+		getConsentFor.mockReturnValue(true);
+		a9.initialise();
+		expect(window.apstag).toBeDefined();
+		expect(window.apstag.init).toHaveBeenCalled();
+	});
 
-    it('should generate initialise A9 library when CCPA consent has been given', () => {
-        onConsentChange.mockImplementation(CcpaWithConsentMock);
-        getConsentFor.mockReturnValue(true);
-        a9.initialise();
-        expect(window.apstag).toBeDefined();
-        expect(window.apstag.init).toHaveBeenCalled();
-    });
+	it('should generate initialise A9 library when CCPA consent has been given', () => {
+		onConsentChange.mockImplementation(CcpaWithConsentMock);
+		getConsentFor.mockReturnValue(true);
+		a9.initialise();
+		expect(window.apstag).toBeDefined();
+		expect(window.apstag.init).toHaveBeenCalled();
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.js
@@ -1,124 +1,124 @@
 import config from '../../../../../lib/config';
 import {
-    getPageTargeting,
-    buildAppNexusTargetingObject,
+	getPageTargeting,
+	buildAppNexusTargetingObject,
 } from '../../../../common/modules/commercial/build-page-targeting';
 
 import {
-    isInUsOrCa,
-    isInAuOrNz,
+	isInUsOrCa,
+	isInAuOrNz,
 } from '../../../../common/modules/commercial/geo-utils';
 
 import {
-    getLargestSize,
-    containsLeaderboard,
-    containsLeaderboardOrBillboard,
-    containsMpu,
-    containsMpuOrDmpu,
-    getBreakpointKey,
+	getLargestSize,
+	containsLeaderboard,
+	containsLeaderboardOrBillboard,
+	containsMpu,
+	containsMpuOrDmpu,
+	getBreakpointKey,
 } from '../utils';
 
-const getAppNexusInvCode = sizes => {
-    const device = getBreakpointKey() === 'M' ? 'M' : 'D';
-    // section is optional and makes it through to the config object as an empty string... OTL
-    const sectionName =
-        config.get('page.section', '') ||
-        config.get('page.sectionName', '').replace(/ /g, '-');
+const getAppNexusInvCode = (sizes) => {
+	const device = getBreakpointKey() === 'M' ? 'M' : 'D';
+	// section is optional and makes it through to the config object as an empty string... OTL
+	const sectionName =
+		config.get('page.section', '') ||
+		config.get('page.sectionName', '').replace(/ /g, '-');
 
-    const slotSize = getLargestSize(sizes);
-    if (slotSize) {
-        return `${device}${sectionName.toLowerCase()}${slotSize.join('x')}`;
-    }
+	const slotSize = getLargestSize(sizes);
+	if (slotSize) {
+		return `${device}${sectionName.toLowerCase()}${slotSize.join('x')}`;
+	}
 };
 
-export const getAppNexusPlacementId = sizes => {
-    const defaultPlacementId = '13915593';
-    if (isInUsOrCa() || isInAuOrNz()) {
-        return defaultPlacementId;
-    }
-    switch (getBreakpointKey()) {
-        case 'D':
-            if (containsMpuOrDmpu(sizes)) {
-                return '13366606';
-            }
-            if (containsLeaderboardOrBillboard(sizes)) {
-                return '13366615';
-            }
-            return defaultPlacementId;
-        case 'M':
-            if (containsMpu(sizes)) {
-                return '13366904';
-            }
-            return defaultPlacementId;
-        case 'T':
-            if (containsMpu(sizes)) {
-                return '13366913';
-            }
-            if (containsLeaderboard(sizes)) {
-                return '13366916';
-            }
-            return defaultPlacementId;
-        default:
-            return defaultPlacementId;
-    }
+export const getAppNexusPlacementId = (sizes) => {
+	const defaultPlacementId = '13915593';
+	if (isInUsOrCa() || isInAuOrNz()) {
+		return defaultPlacementId;
+	}
+	switch (getBreakpointKey()) {
+		case 'D':
+			if (containsMpuOrDmpu(sizes)) {
+				return '13366606';
+			}
+			if (containsLeaderboardOrBillboard(sizes)) {
+				return '13366615';
+			}
+			return defaultPlacementId;
+		case 'M':
+			if (containsMpu(sizes)) {
+				return '13366904';
+			}
+			return defaultPlacementId;
+		case 'T':
+			if (containsMpu(sizes)) {
+				return '13366913';
+			}
+			if (containsLeaderboard(sizes)) {
+				return '13366916';
+			}
+			return defaultPlacementId;
+		default:
+			return defaultPlacementId;
+	}
 };
 
-export const getAppNexusDirectPlacementId = sizes => {
-    if (isInAuOrNz()) {
-        return '11016434';
-    }
+export const getAppNexusDirectPlacementId = (sizes) => {
+	if (isInAuOrNz()) {
+		return '11016434';
+	}
 
-    const defaultPlacementId = '9251752';
-    switch (getBreakpointKey()) {
-        case 'D':
-            if (containsMpuOrDmpu(sizes)) {
-                return '9251752';
-            }
-            if (containsLeaderboardOrBillboard(sizes)) {
-                return '9926678';
-            }
-            return defaultPlacementId;
-        case 'M':
-            if (containsMpu(sizes)) {
-                return '4298191';
-            }
-            return defaultPlacementId;
-        case 'T':
-            if (containsMpu(sizes)) {
-                return '4371641';
-            }
-            if (containsLeaderboard(sizes)) {
-                return '4371640';
-            }
-            return defaultPlacementId;
-        default:
-            return defaultPlacementId;
-    }
+	const defaultPlacementId = '9251752';
+	switch (getBreakpointKey()) {
+		case 'D':
+			if (containsMpuOrDmpu(sizes)) {
+				return '9251752';
+			}
+			if (containsLeaderboardOrBillboard(sizes)) {
+				return '9926678';
+			}
+			return defaultPlacementId;
+		case 'M':
+			if (containsMpu(sizes)) {
+				return '4298191';
+			}
+			return defaultPlacementId;
+		case 'T':
+			if (containsMpu(sizes)) {
+				return '4371641';
+			}
+			if (containsLeaderboard(sizes)) {
+				return '4371640';
+			}
+			return defaultPlacementId;
+		default:
+			return defaultPlacementId;
+	}
 };
 
-export const getAppNexusDirectBidParams = sizes => {
-    if (isInAuOrNz() && config.get('switches.prebidAppnexusInvcode')) {
-        const invCode = getAppNexusInvCode(sizes);
-        // flowlint sketchy-null-string:warn
-        if (invCode) {
-            return {
-                invCode,
-                member: '7012',
-                keywords: {
-                    invc: [invCode],
-                    ...buildAppNexusTargetingObject(getPageTargeting()),
-                },
-            };
-        }
-    }
-    return {
-        placementId: getAppNexusDirectPlacementId(sizes),
-        keywords: buildAppNexusTargetingObject(getPageTargeting()),
-    };
+export const getAppNexusDirectBidParams = (sizes) => {
+	if (isInAuOrNz() && config.get('switches.prebidAppnexusInvcode')) {
+		const invCode = getAppNexusInvCode(sizes);
+		// flowlint sketchy-null-string:warn
+		if (invCode) {
+			return {
+				invCode,
+				member: '7012',
+				keywords: {
+					invc: [invCode],
+					...buildAppNexusTargetingObject(getPageTargeting()),
+				},
+			};
+		}
+	}
+	return {
+		placementId: getAppNexusDirectPlacementId(sizes),
+		keywords: buildAppNexusTargetingObject(getPageTargeting()),
+	};
 };
 
 export const _ = {
-    getAppNexusPlacementId,
-    getAppNexusInvCode,
-    getAppNexusDirectPlacementId,
+	getAppNexusPlacementId,
+	getAppNexusInvCode,
+	getAppNexusDirectPlacementId,
 };

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.spec.js
@@ -1,48 +1,48 @@
 import config from '../../../../../lib/config';
 import {
-    isInUsOrCa as isInUsOrCa_,
-    isInAuOrNz as isInAuOrNz_,
+	isInUsOrCa as isInUsOrCa_,
+	isInAuOrNz as isInAuOrNz_,
 } from '../../../../common/modules/commercial/geo-utils';
 import { _, getAppNexusDirectBidParams } from './appnexus';
 import { getBreakpointKey as getBreakpointKey_ } from '../utils';
 
 jest.mock('../../../../common/modules/commercial/build-page-targeting', () => ({
-    buildAppNexusTargeting: () => 'someTestAppNexusTargeting',
-    buildAppNexusTargetingObject: () => ({
-        url: 'gu.com',
-        sens: 'f',
-        edition: 'UK',
-    }),
-    getPageTargeting: () => 'pageTargeting',
+	buildAppNexusTargeting: () => 'someTestAppNexusTargeting',
+	buildAppNexusTargetingObject: () => ({
+		url: 'gu.com',
+		sens: 'f',
+		edition: 'UK',
+	}),
+	getPageTargeting: () => 'pageTargeting',
 }));
 
 jest.mock('../utils', () => {
-    const original = jest.requireActual('../utils');
-    return {
-        ...original,
-        getBreakpointKey: jest.fn(),
-    };
+	const original = jest.requireActual('../utils');
+	return {
+		...original,
+		getBreakpointKey: jest.fn(),
+	};
 });
 
 jest.mock('../../../../common/modules/commercial/geo-utils', () => ({
-    isInAuOrNz: jest.fn(),
-    isInUsOrCa: jest.fn(),
+	isInAuOrNz: jest.fn(),
+	isInUsOrCa: jest.fn(),
 }));
 
 jest.mock('../../../../../lib/cookies', () => ({
-    getCookie: jest.fn(),
+	getCookie: jest.fn(),
 }));
 
 jest.mock('../../../../common/modules/experiments/ab', () => ({
-    isInVariantSynchronous: jest.fn(
-        (testId, variantId) => variantId === 'variant'
-    ),
+	isInVariantSynchronous: jest.fn(
+		(testId, variantId) => variantId === 'variant',
+	),
 }));
 
 const {
-    getAppNexusPlacementId,
-    getAppNexusInvCode,
-    getAppNexusDirectPlacementId,
+	getAppNexusPlacementId,
+	getAppNexusInvCode,
+	getAppNexusDirectPlacementId,
 } = _;
 
 const getBreakpointKey = getBreakpointKey_;
@@ -51,214 +51,214 @@ const isInUsOrCa = isInUsOrCa_;
 
 /* eslint-disable guardian-frontend/no-direct-access-config */
 const resetConfig = () => {
-    config.set('switches.prebidAppnexus', true);
-    config.set('switches.prebidAppnexusInvcode', false);
-    config.set('ophan', { pageViewId: 'pvid' });
-    config.set('page.contentType', 'Article');
-    config.set('page.section', 'Magic');
-    config.set('page.sectionName', 'More Magic');
-    config.set('page.edition', 'UK');
+	config.set('switches.prebidAppnexus', true);
+	config.set('switches.prebidAppnexusInvcode', false);
+	config.set('ophan', { pageViewId: 'pvid' });
+	config.set('page.contentType', 'Article');
+	config.set('page.section', 'Magic');
+	config.set('page.sectionName', 'More Magic');
+	config.set('page.edition', 'UK');
 };
 
 describe('getAppNexusInvCode', () => {
-    beforeEach(() => {
-        resetConfig();
-    });
+	beforeEach(() => {
+		resetConfig();
+	});
 
-    afterEach(() => {
-        jest.resetAllMocks();
-        resetConfig();
-    });
+	afterEach(() => {
+		jest.resetAllMocks();
+		resetConfig();
+	});
 
-    test('should return the magic strings for mobile breakpoints', () => {
-        getBreakpointKey.mockReturnValue('M');
-        const invCodes = [
-            [[300, 250]],
-            [[300, 600]],
-            [[970, 250]],
-            [[728, 90]],
-        ].map(getAppNexusInvCode);
+	test('should return the magic strings for mobile breakpoints', () => {
+		getBreakpointKey.mockReturnValue('M');
+		const invCodes = [
+			[[300, 250]],
+			[[300, 600]],
+			[[970, 250]],
+			[[728, 90]],
+		].map(getAppNexusInvCode);
 
-        expect(invCodes).toEqual([
-            'Mmagic300x250',
-            'Mmagic300x600',
-            'Mmagic970x250',
-            'Mmagic728x90',
-        ]);
-    });
+		expect(invCodes).toEqual([
+			'Mmagic300x250',
+			'Mmagic300x600',
+			'Mmagic970x250',
+			'Mmagic728x90',
+		]);
+	});
 
-    test('should return the magic strings for other breakpoints', () => {
-        getBreakpointKey.mockReturnValueOnce('T');
-        getBreakpointKey.mockReturnValueOnce('D');
-        const invCodes = [
-            [[300, 250]],
-            [[300, 600]],
-            [[970, 250]],
-            [[728, 90]],
-        ].map(getAppNexusInvCode);
-        expect(invCodes).toEqual([
-            'Dmagic300x250',
-            'Dmagic300x600',
-            'Dmagic970x250',
-            'Dmagic728x90',
-        ]);
-    });
+	test('should return the magic strings for other breakpoints', () => {
+		getBreakpointKey.mockReturnValueOnce('T');
+		getBreakpointKey.mockReturnValueOnce('D');
+		const invCodes = [
+			[[300, 250]],
+			[[300, 600]],
+			[[970, 250]],
+			[[728, 90]],
+		].map(getAppNexusInvCode);
+		expect(invCodes).toEqual([
+			'Dmagic300x250',
+			'Dmagic300x600',
+			'Dmagic970x250',
+			'Dmagic728x90',
+		]);
+	});
 
-    test('should use sectionName, replacing whitespace with hyphens, when section is an empty string', () => {
-        config.set('page.section', '');
-        expect(getAppNexusInvCode([[300, 250]])).toEqual('Dmore-magic300x250');
-    });
+	test('should use sectionName, replacing whitespace with hyphens, when section is an empty string', () => {
+		config.set('page.section', '');
+		expect(getAppNexusInvCode([[300, 250]])).toEqual('Dmore-magic300x250');
+	});
 });
 
 describe('getAppNexusDirectPlacementId', () => {
-    beforeEach(() => {
-        resetConfig();
-    });
+	beforeEach(() => {
+		resetConfig();
+	});
 
-    afterEach(() => {
-        jest.resetAllMocks();
-        resetConfig();
-    });
+	afterEach(() => {
+		jest.resetAllMocks();
+		resetConfig();
+	});
 
-    const prebidSizes = [
-        [[300, 250]],
-        [[300, 600]],
-        [[970, 250]],
-        [[728, 90]],
-        [[1, 2]],
-    ];
+	const prebidSizes = [
+		[[300, 250]],
+		[[300, 600]],
+		[[970, 250]],
+		[[728, 90]],
+		[[1, 2]],
+	];
 
-    test('should return the expected values when in AU region and desktop device', () => {
-        isInAuOrNz.mockReturnValue(true);
-        expect(
-            prebidSizes.map(size => getAppNexusDirectPlacementId(size))
-        ).toEqual(['11016434', '11016434', '11016434', '11016434', '11016434']);
-    });
+	test('should return the expected values when in AU region and desktop device', () => {
+		isInAuOrNz.mockReturnValue(true);
+		expect(
+			prebidSizes.map((size) => getAppNexusDirectPlacementId(size)),
+		).toEqual(['11016434', '11016434', '11016434', '11016434', '11016434']);
+	});
 
-    test('should return the expected values for ROW when on desktop device', () => {
-        isInAuOrNz.mockReturnValue(false);
-        getBreakpointKey.mockReturnValue('D');
-        expect(
-            prebidSizes.map(size => getAppNexusDirectPlacementId(size))
-        ).toEqual(['9251752', '9251752', '9926678', '9926678', '9251752']);
-    });
+	test('should return the expected values for ROW when on desktop device', () => {
+		isInAuOrNz.mockReturnValue(false);
+		getBreakpointKey.mockReturnValue('D');
+		expect(
+			prebidSizes.map((size) => getAppNexusDirectPlacementId(size)),
+		).toEqual(['9251752', '9251752', '9926678', '9926678', '9251752']);
+	});
 
-    test('should return the expected values for ROW when on tablet device', () => {
-        getBreakpointKey.mockReturnValue('T');
-        isInAuOrNz.mockReturnValue(false);
-        expect(
-            prebidSizes.map(size => getAppNexusDirectPlacementId(size))
-        ).toEqual(['4371641', '9251752', '9251752', '4371640', '9251752']);
-    });
+	test('should return the expected values for ROW when on tablet device', () => {
+		getBreakpointKey.mockReturnValue('T');
+		isInAuOrNz.mockReturnValue(false);
+		expect(
+			prebidSizes.map((size) => getAppNexusDirectPlacementId(size)),
+		).toEqual(['4371641', '9251752', '9251752', '4371640', '9251752']);
+	});
 });
 
 describe('getAppNexusPlacementId', () => {
-    beforeEach(() => {
-        resetConfig();
-        isInAuOrNz.mockReturnValue(false);
-        isInUsOrCa.mockReturnValue(false);
-    });
+	beforeEach(() => {
+		resetConfig();
+		isInAuOrNz.mockReturnValue(false);
+		isInUsOrCa.mockReturnValue(false);
+	});
 
-    afterEach(() => {
-        jest.resetAllMocks();
-        resetConfig();
-    });
+	afterEach(() => {
+		jest.resetAllMocks();
+		resetConfig();
+	});
 
-    const generateTestIds = () => {
-        const prebidSizes = [
-            [[300, 250]],
-            [[300, 600]],
-            [[970, 250]],
-            [[728, 90]],
-            [[1, 2]],
-        ];
-        return prebidSizes.map(getAppNexusPlacementId);
-    };
+	const generateTestIds = () => {
+		const prebidSizes = [
+			[[300, 250]],
+			[[300, 600]],
+			[[970, 250]],
+			[[728, 90]],
+			[[1, 2]],
+		];
+		return prebidSizes.map(getAppNexusPlacementId);
+	};
 
-    test('should return the expected values when on desktop device', () => {
-        getBreakpointKey.mockReturnValue('D');
-        expect(generateTestIds()).toEqual([
-            '13366606',
-            '13366606',
-            '13366615',
-            '13366615',
-            '13915593',
-        ]);
-    });
+	test('should return the expected values when on desktop device', () => {
+		getBreakpointKey.mockReturnValue('D');
+		expect(generateTestIds()).toEqual([
+			'13366606',
+			'13366606',
+			'13366615',
+			'13366615',
+			'13915593',
+		]);
+	});
 
-    test('should return the expected values when on tablet device', () => {
-        getBreakpointKey.mockReturnValue('T');
-        expect(generateTestIds()).toEqual([
-            '13366913',
-            '13915593',
-            '13915593',
-            '13366916',
-            '13915593',
-        ]);
-    });
+	test('should return the expected values when on tablet device', () => {
+		getBreakpointKey.mockReturnValue('T');
+		expect(generateTestIds()).toEqual([
+			'13366913',
+			'13915593',
+			'13915593',
+			'13366916',
+			'13915593',
+		]);
+	});
 
-    test('should return the expected values when on mobile device', () => {
-        getBreakpointKey.mockReturnValue('M');
-        expect(generateTestIds()).toEqual([
-            '13366904',
-            '13915593',
-            '13915593',
-            '13915593',
-            '13915593',
-        ]);
-    });
+	test('should return the expected values when on mobile device', () => {
+		getBreakpointKey.mockReturnValue('M');
+		expect(generateTestIds()).toEqual([
+			'13366904',
+			'13915593',
+			'13915593',
+			'13915593',
+			'13915593',
+		]);
+	});
 
-    test('should return the default value if in US or AU regions', () => {
-        getBreakpointKey.mockReturnValue('D');
-        isInAuOrNz.mockReturnValueOnce(true);
-        isInUsOrCa.mockReturnValueOnce(true);
-        expect(getAppNexusPlacementId([[300, 250]])).toEqual('13915593');
-        expect(getAppNexusPlacementId([[970, 250]])).toEqual('13915593');
-        expect(getAppNexusPlacementId([[1, 2]])).toEqual('13915593');
-    });
+	test('should return the default value if in US or AU regions', () => {
+		getBreakpointKey.mockReturnValue('D');
+		isInAuOrNz.mockReturnValueOnce(true);
+		isInUsOrCa.mockReturnValueOnce(true);
+		expect(getAppNexusPlacementId([[300, 250]])).toEqual('13915593');
+		expect(getAppNexusPlacementId([[970, 250]])).toEqual('13915593');
+		expect(getAppNexusPlacementId([[1, 2]])).toEqual('13915593');
+	});
 });
 
 describe('getAppNexusDirectBidParams', () => {
-    beforeEach(() => {
-        resetConfig();
-    });
+	beforeEach(() => {
+		resetConfig();
+	});
 
-    afterEach(() => {
-        jest.resetAllMocks();
-        resetConfig();
-    });
+	afterEach(() => {
+		jest.resetAllMocks();
+		resetConfig();
+	});
 
-    test('should include placementId for AU region when invCode switch is off', () => {
-        getBreakpointKey.mockReturnValue('M');
-        isInAuOrNz.mockReturnValue(true);
-        expect(getAppNexusDirectBidParams([[300, 250]])).toEqual({
-            keywords: { edition: 'UK', sens: 'f', url: 'gu.com' },
-            placementId: '11016434',
-        });
-    });
+	test('should include placementId for AU region when invCode switch is off', () => {
+		getBreakpointKey.mockReturnValue('M');
+		isInAuOrNz.mockReturnValue(true);
+		expect(getAppNexusDirectBidParams([[300, 250]])).toEqual({
+			keywords: { edition: 'UK', sens: 'f', url: 'gu.com' },
+			placementId: '11016434',
+		});
+	});
 
-    test('should exclude placementId for AU region when including member and invCode', () => {
-        config.set('switches.prebidAppnexusInvcode', true);
-        getBreakpointKey.mockReturnValue('M');
-        isInAuOrNz.mockReturnValueOnce(true);
-        expect(getAppNexusDirectBidParams([[300, 250]])).toEqual({
-            keywords: {
-                edition: 'UK',
-                sens: 'f',
-                url: 'gu.com',
-                invc: ['Mmagic300x250'],
-            },
-            member: '7012',
-            invCode: 'Mmagic300x250',
-        });
-    });
+	test('should exclude placementId for AU region when including member and invCode', () => {
+		config.set('switches.prebidAppnexusInvcode', true);
+		getBreakpointKey.mockReturnValue('M');
+		isInAuOrNz.mockReturnValueOnce(true);
+		expect(getAppNexusDirectBidParams([[300, 250]])).toEqual({
+			keywords: {
+				edition: 'UK',
+				sens: 'f',
+				url: 'gu.com',
+				invc: ['Mmagic300x250'],
+			},
+			member: '7012',
+			invCode: 'Mmagic300x250',
+		});
+	});
 
-    test('should include placementId and not include invCode if outside AU region', () => {
-        config.set('switches.prebidAppnexusInvcode', true);
-        getBreakpointKey.mockReturnValue('M');
-        expect(getAppNexusDirectBidParams([[300, 250]])).toEqual({
-            keywords: { edition: 'UK', sens: 'f', url: 'gu.com' },
-            placementId: '4298191',
-        });
-    });
+	test('should include placementId and not include invCode if outside AU region', () => {
+		config.set('switches.prebidAppnexusInvcode', true);
+		getBreakpointKey.mockReturnValue('M');
+		expect(getAppNexusDirectBidParams([[300, 250]])).toEqual({
+			keywords: { edition: 'UK', sens: 'f', url: 'gu.com' },
+			placementId: '4298191',
+		});
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/pubmatic.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/pubmatic.js
@@ -10,11 +10,11 @@ export const pubmatic = function (bid, data, acEnabled, utils, defaultFn) {
 
 		// add all user segments
 		try {
-            const psegs = JSON.parse(localStorage._psegs || '[]').map(String);
-            const ppam = JSON.parse(localStorage._ppam || '[]');
-            const pcrprs = JSON.parse(localStorage._pcrprs || '[]');
+			const psegs = JSON.parse(localStorage._psegs || '[]').map(String);
+			const ppam = JSON.parse(localStorage._ppam || '[]');
+			const pcrprs = JSON.parse(localStorage._pcrprs || '[]');
 
-            segments = [...psegs, ...ppam, ...pcrprs];
+			segments = [...psegs, ...ppam, ...pcrprs];
 		} catch (e) {}
 
 		// add AC specific segments (these would typically go to a separate key-value, but not sure if we can have 2 lists of segments here?)

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.spec.js
@@ -3,8 +3,8 @@ import { Advert } from '../dfp/Advert';
 
 import { getHeaderBiddingAdSlots, _ } from './slot-config';
 import {
-    getBreakpointKey as getBreakpointKey_,
-    shouldIncludeMobileSticky as shouldIncludeMobileSticky_,
+	getBreakpointKey as getBreakpointKey_,
+	shouldIncludeMobileSticky as shouldIncludeMobileSticky_,
 } from './utils';
 
 jest.mock('lib/raven');
@@ -15,248 +15,270 @@ const getBreakpointKey = getBreakpointKey_;
 const shouldIncludeMobileSticky = shouldIncludeMobileSticky_;
 
 jest.mock('./utils', () => {
-
-    const original = jest.requireActual('./utils');
-    return {
-        ...original,
-        getBreakpointKey: jest.fn(),
-        shouldIncludeMobileSticky: jest.fn(),
-    };
+	const original = jest.requireActual('./utils');
+	return {
+		...original,
+		getBreakpointKey: jest.fn(),
+		shouldIncludeMobileSticky: jest.fn(),
+	};
 });
 
 jest.mock('../../../common/modules/experiments/ab', () => ({
-    isInVariantSynchronous: jest.fn(
-        (testId, variantId) => variantId === 'variant'
-    ),
+	isInVariantSynchronous: jest.fn(
+		(testId, variantId) => variantId === 'variant',
+	),
 }));
 
 jest.mock('../../../../lib/detect', () => ({
-    hasCrossedBreakpoint: jest.fn(),
-    isBreakpoint: jest.fn(),
-    getBreakpoint: jest.fn(),
-    getViewport: jest.fn(),
-    hasPushStateSupport: jest.fn(),
-    breakpoints: [],
+	hasCrossedBreakpoint: jest.fn(),
+	isBreakpoint: jest.fn(),
+	getBreakpoint: jest.fn(),
+	getViewport: jest.fn(),
+	hasPushStateSupport: jest.fn(),
+	breakpoints: [],
 }));
 
 jest.mock('../../../../lib/cookies', () => ({
-    getCookie: jest.fn(),
+	getCookie: jest.fn(),
 }));
 
 const slotPrototype = {
-    fake: 'slot',
-    defineSizeMapping: () => slotPrototype,
-    addService: () => slotPrototype,
-    setTargeting: () => slotPrototype,
+	fake: 'slot',
+	defineSizeMapping: () => slotPrototype,
+	addService: () => slotPrototype,
+	setTargeting: () => slotPrototype,
 };
 
 // Mock window.googletag
 window.googletag = {
-    sizeMapping: () => ({
-        build: () => [],
-    }),
-    defineSlot: () => ({ ...slotPrototype }),
-    pubads: () => ({}),
+	sizeMapping: () => ({
+		build: () => [],
+	}),
+	defineSlot: () => ({ ...slotPrototype }),
+	pubads: () => ({}),
 };
 
-const buildAdvert = id => {
-    const elt = document.createElement('div');
-    elt.setAttribute('id', id);
-    return new Advert(elt);
+const buildAdvert = (id) => {
+	const elt = document.createElement('div');
+	elt.setAttribute('id', id);
+	return new Advert(elt);
 };
 
 /* eslint-disable guardian-frontend/no-direct-access-config */
 describe('getSlots', () => {
-    beforeEach(() => {
-        config.set('switches.extendedMostPopular', true);
-    });
+	beforeEach(() => {
+		config.set('switches.extendedMostPopular', true);
+	});
 
-    afterEach(() => {
-        jest.resetAllMocks();
-    });
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
 
-    test('should return the correct slots at breakpoint M without mobile sticky', () => {
-        shouldIncludeMobileSticky.mockReturnValue(false);
-        getBreakpointKey.mockReturnValue('M');
-        expect(getSlots('Article')).toEqual([
-            {
-                key: 'right',
-                sizes: [[300, 600], [300, 250]],
-            },
-            {
-                key: 'inline1',
-                sizes: [[300, 250]],
-            },
-            {
-                key: 'top-above-nav',
-                sizes: [[300, 250]],
-            },
-            {
-                key: 'inline',
-                sizes: [[300, 250]],
-            },
-            {
-                key: 'mostpop',
-                sizes: [[300, 250]],
-            },
-        ]);
-    });
+	test('should return the correct slots at breakpoint M without mobile sticky', () => {
+		shouldIncludeMobileSticky.mockReturnValue(false);
+		getBreakpointKey.mockReturnValue('M');
+		expect(getSlots('Article')).toEqual([
+			{
+				key: 'right',
+				sizes: [
+					[300, 600],
+					[300, 250],
+				],
+			},
+			{
+				key: 'inline1',
+				sizes: [[300, 250]],
+			},
+			{
+				key: 'top-above-nav',
+				sizes: [[300, 250]],
+			},
+			{
+				key: 'inline',
+				sizes: [[300, 250]],
+			},
+			{
+				key: 'mostpop',
+				sizes: [[300, 250]],
+			},
+		]);
+	});
 
-    test('should return the correct slots at breakpoint M for US including mobile sticky slot', () => {
-        getBreakpointKey.mockReturnValue('M');
-        config.set('switches.mobileStickyPrebid', true);
-        shouldIncludeMobileSticky.mockReturnValue(true);
-        expect(getSlots('Article')).toEqual([
-            {
-                key: 'right',
-                sizes: [[300, 600], [300, 250]],
-            },
-            {
-                key: 'inline1',
-                sizes: [[300, 250]],
-            },
-            {
-                key: 'top-above-nav',
-                sizes: [[300, 250]],
-            },
-            {
-                key: 'inline',
-                sizes: [[300, 250]],
-            },
-            {
-                key: 'mostpop',
-                sizes: [[300, 250]],
-            },
-            {
-                key: 'mobile-sticky',
-                sizes: [[320, 50]],
-            },
-        ]);
-    });
+	test('should return the correct slots at breakpoint M for US including mobile sticky slot', () => {
+		getBreakpointKey.mockReturnValue('M');
+		config.set('switches.mobileStickyPrebid', true);
+		shouldIncludeMobileSticky.mockReturnValue(true);
+		expect(getSlots('Article')).toEqual([
+			{
+				key: 'right',
+				sizes: [
+					[300, 600],
+					[300, 250],
+				],
+			},
+			{
+				key: 'inline1',
+				sizes: [[300, 250]],
+			},
+			{
+				key: 'top-above-nav',
+				sizes: [[300, 250]],
+			},
+			{
+				key: 'inline',
+				sizes: [[300, 250]],
+			},
+			{
+				key: 'mostpop',
+				sizes: [[300, 250]],
+			},
+			{
+				key: 'mobile-sticky',
+				sizes: [[320, 50]],
+			},
+		]);
+	});
 
-    test('should return the correct slots at breakpoint T', () => {
-        getBreakpointKey.mockReturnValue('T');
-        expect(getSlots('Article')).toEqual([
-            {
-                key: 'right',
-                sizes: [[300, 600], [300, 250]],
-            },
-            {
-                key: 'inline1',
-                sizes: [[300, 250]],
-            },
-            {
-                key: 'top-above-nav',
-                sizes: [[728, 90]],
-            },
-            {
-                key: 'inline',
-                sizes: [[300, 250]],
-            },
-            {
-                key: 'mostpop',
-                sizes: [[300, 600], [300, 250], [728, 90]],
-            },
-        ]);
-    });
+	test('should return the correct slots at breakpoint T', () => {
+		getBreakpointKey.mockReturnValue('T');
+		expect(getSlots('Article')).toEqual([
+			{
+				key: 'right',
+				sizes: [
+					[300, 600],
+					[300, 250],
+				],
+			},
+			{
+				key: 'inline1',
+				sizes: [[300, 250]],
+			},
+			{
+				key: 'top-above-nav',
+				sizes: [[728, 90]],
+			},
+			{
+				key: 'inline',
+				sizes: [[300, 250]],
+			},
+			{
+				key: 'mostpop',
+				sizes: [
+					[300, 600],
+					[300, 250],
+					[728, 90],
+				],
+			},
+		]);
+	});
 
-    test('should return the correct slots at breakpoint D on article pages', () => {
-        getBreakpointKey.mockReturnValue('D');
-        const desktopSlots = getSlots('Article');
-        expect(desktopSlots).toContainEqual({
-            key: 'inline',
-            sizes: [[160, 600], [300, 600], [300, 250]],
-        });
-        expect(desktopSlots).not.toContainEqual({
-            key: 'inline',
-            sizes: [[300, 250]],
-        });
-    });
+	test('should return the correct slots at breakpoint D on article pages', () => {
+		getBreakpointKey.mockReturnValue('D');
+		const desktopSlots = getSlots('Article');
+		expect(desktopSlots).toContainEqual({
+			key: 'inline',
+			sizes: [
+				[160, 600],
+				[300, 600],
+				[300, 250],
+			],
+		});
+		expect(desktopSlots).not.toContainEqual({
+			key: 'inline',
+			sizes: [[300, 250]],
+		});
+	});
 
-    test('should return the correct slots at breakpoint T on crossword pages', () => {
-        getBreakpointKey.mockReturnValue('T');
-        const tabletSlots = getSlots('Crossword');
-        expect(tabletSlots).toContainEqual({
-            key: 'inline1',
-            sizes: [[728, 90]],
-        });
-    });
+	test('should return the correct slots at breakpoint T on crossword pages', () => {
+		getBreakpointKey.mockReturnValue('T');
+		const tabletSlots = getSlots('Crossword');
+		expect(tabletSlots).toContainEqual({
+			key: 'inline1',
+			sizes: [[728, 90]],
+		});
+	});
 
-    test('should return the correct slots at breakpoint D on other pages', () => {
-        getBreakpointKey.mockReturnValue('D');
-        const desktopSlots = getSlots('');
-        expect(desktopSlots).toContainEqual({
-            key: 'inline',
-            sizes: [[300, 250]],
-        });
-        expect(desktopSlots).not.toContainEqual({
-            key: 'inline',
-            sizes: [[300, 600], [300, 250]],
-        });
-    });
+	test('should return the correct slots at breakpoint D on other pages', () => {
+		getBreakpointKey.mockReturnValue('D');
+		const desktopSlots = getSlots('');
+		expect(desktopSlots).toContainEqual({
+			key: 'inline',
+			sizes: [[300, 250]],
+		});
+		expect(desktopSlots).not.toContainEqual({
+			key: 'inline',
+			sizes: [
+				[300, 600],
+				[300, 250],
+			],
+		});
+	});
 });
 
 describe('getPrebidAdSlots', () => {
-    afterEach(() => {
-        jest.resetAllMocks();
-    });
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
 
-    test('should return the correct top-above-nav slot at breakpoint D', () => {
-        getBreakpointKey.mockReturnValue('D');
-        expect(getHeaderBiddingAdSlots(buildAdvert('top-above-nav'))).toEqual([
-            {
-                key: 'top-above-nav',
-                sizes: [[970, 250], [728, 90]],
-            },
-        ]);
-    });
+	test('should return the correct top-above-nav slot at breakpoint D', () => {
+		getBreakpointKey.mockReturnValue('D');
+		expect(getHeaderBiddingAdSlots(buildAdvert('top-above-nav'))).toEqual([
+			{
+				key: 'top-above-nav',
+				sizes: [
+					[970, 250],
+					[728, 90],
+				],
+			},
+		]);
+	});
 
-    test('should return the correct interactive banner slot at breakpoint D', () => {
-        getBreakpointKey.mockReturnValue('D');
-        const dfpAdvert = buildAdvert('dfp-ad--1');
-        dfpAdvert.node.setAttribute(
-            'class',
-            'js-ad-slot ad-slot ad-slot--banner-ad ad-slot--banner-ad-desktop ad-slot--rendered'
-        );
+	test('should return the correct interactive banner slot at breakpoint D', () => {
+		getBreakpointKey.mockReturnValue('D');
+		const dfpAdvert = buildAdvert('dfp-ad--1');
+		dfpAdvert.node.setAttribute(
+			'class',
+			'js-ad-slot ad-slot ad-slot--banner-ad ad-slot--banner-ad-desktop ad-slot--rendered',
+		);
 
-        const slotReturned = getHeaderBiddingAdSlots(dfpAdvert)[0];
-        expect(slotReturned).toBeDefined();
-        expect(slotReturned).toMatchObject({
-            key: 'banner',
-        });
-    });
+		const slotReturned = getHeaderBiddingAdSlots(dfpAdvert)[0];
+		expect(slotReturned).toBeDefined();
+		expect(slotReturned).toMatchObject({
+			key: 'banner',
+		});
+	});
 
-    test('should return the correct top-above-nav slot at breakpoint T', () => {
-        getBreakpointKey.mockReturnValue('T');
-        expect(getHeaderBiddingAdSlots(buildAdvert('top-above-nav'))).toEqual([
-            {
-                key: 'top-above-nav',
-                sizes: [[728, 90]],
-            },
-        ]);
-    });
+	test('should return the correct top-above-nav slot at breakpoint T', () => {
+		getBreakpointKey.mockReturnValue('T');
+		expect(getHeaderBiddingAdSlots(buildAdvert('top-above-nav'))).toEqual([
+			{
+				key: 'top-above-nav',
+				sizes: [[728, 90]],
+			},
+		]);
+	});
 
-    test('should return the correct top-above-nav slot at breakpoint M', () => {
-        getBreakpointKey.mockReturnValue('M');
-        expect(getHeaderBiddingAdSlots(buildAdvert('top-above-nav'))).toEqual([
-            {
-                key: 'top-above-nav',
-                sizes: [[300, 250]],
-            },
-        ]);
-    });
+	test('should return the correct top-above-nav slot at breakpoint M', () => {
+		getBreakpointKey.mockReturnValue('M');
+		expect(getHeaderBiddingAdSlots(buildAdvert('top-above-nav'))).toEqual([
+			{
+				key: 'top-above-nav',
+				sizes: [[300, 250]],
+			},
+		]);
+	});
 
-    test('should return the correct mobile-sticky slot at breakpoint M', () => {
-        getBreakpointKey.mockReturnValue('M');
-        config.set('switches.mobileStickyPrebid', true);
-        shouldIncludeMobileSticky.mockReturnValue(true);
-        expect(
-            getHeaderBiddingAdSlots(buildAdvert('dfp-ad-mobile-sticky'))
-        ).toEqual([
-            {
-                key: 'mobile-sticky',
-                sizes: [[320, 50]],
-            },
-        ]);
-    });
+	test('should return the correct mobile-sticky slot at breakpoint M', () => {
+		getBreakpointKey.mockReturnValue('M');
+		config.set('switches.mobileStickyPrebid', true);
+		shouldIncludeMobileSticky.mockReturnValue(true);
+		expect(
+			getHeaderBiddingAdSlots(buildAdvert('dfp-ad-mobile-sticky')),
+		).toEqual([
+			{
+				key: 'mobile-sticky',
+				sizes: [[320, 50]],
+			},
+		]);
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/utils.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/utils.spec.js
@@ -1,337 +1,354 @@
 import { _ } from 'common/modules/commercial/geo-utils';
 import config from '../../../../lib/config';
 import {
-    getBreakpoint as getBreakpoint_,
-    isBreakpoint as isBreakpoint_,
+	getBreakpoint as getBreakpoint_,
+	isBreakpoint as isBreakpoint_,
 } from '../../../../lib/detect';
 import { getCountryCode as getCountryCode_ } from 'lib/geolocation';
 
 import {
-    getBreakpointKey,
-    getLargestSize,
-    removeFalseyValues,
-    shouldIncludeAdYouLike,
-    shouldIncludeAppNexus,
-    shouldIncludeImproveDigital,
-    shouldIncludeMobileSticky,
-    shouldIncludeOpenx,
-    shouldIncludeSonobi,
-    shouldIncludeTrustX,
-    shouldIncludeXaxis,
-    stripDfpAdPrefixFrom,
-    stripMobileSuffix,
-    stripTrailingNumbersAbove1,
+	getBreakpointKey,
+	getLargestSize,
+	removeFalseyValues,
+	shouldIncludeAdYouLike,
+	shouldIncludeAppNexus,
+	shouldIncludeImproveDigital,
+	shouldIncludeMobileSticky,
+	shouldIncludeOpenx,
+	shouldIncludeSonobi,
+	shouldIncludeTrustX,
+	shouldIncludeXaxis,
+	stripDfpAdPrefixFrom,
+	stripMobileSuffix,
+	stripTrailingNumbersAbove1,
 } from './utils';
-import {isInVariantSynchronous as isInVariantSynchronous_} from "common/modules/experiments/ab";
+import { isInVariantSynchronous as isInVariantSynchronous_ } from 'common/modules/experiments/ab';
 
 const getCountryCode = getCountryCode_;
 const getBreakpoint = getBreakpoint_;
 const isBreakpoint = isBreakpoint_;
 const isInVariantSynchronous = isInVariantSynchronous_;
 
-jest.mock('lodash-es/once', () => fn => fn);
+jest.mock('lodash-es/once', () => (fn) => fn);
 
 jest.mock('../../../../lib/geolocation', () => ({
-    getCountryCode: jest.fn(() => 'GB'),
+	getCountryCode: jest.fn(() => 'GB'),
 }));
 
 jest.mock('common/modules/experiments/ab', () => ({
-    isInVariantSynchronous: jest.fn(),
+	isInVariantSynchronous: jest.fn(),
 }));
 
 jest.mock('../../../../lib/detect', () => ({
-    getBreakpoint: jest.fn(() => 'mobile'),
-    hasPushStateSupport: jest.fn(() => true),
-    isBreakpoint: jest.fn(),
+	getBreakpoint: jest.fn(() => 'mobile'),
+	hasPushStateSupport: jest.fn(() => true),
+	isBreakpoint: jest.fn(),
 }));
 
 jest.mock('../../../common/modules/experiments/ab-tests');
 
 /* eslint-disable guardian-frontend/no-direct-access-config */
 const resetConfig = () => {
-    config.set('switches.prebidAppnexus', true);
-    config.set('switches.prebidAppnexusInvcode', false);
-    config.set('switches.prebidOpenx', true);
-    config.set('switches.prebidImproveDigital', true);
-    config.set('switches.prebidIndexExchange', true);
-    config.set('switches.prebidSonobi', true);
-    config.set('switches.prebidTrustx', true);
-    config.set('switches.prebidXaxis', true);
-    config.set('switches.prebidAdYouLike', true);
-    config.set('page.contentType', 'Article');
-    config.set('page.section', 'Magic');
-    config.set('page.edition', 'UK');
-    config.set('page.isDev', false);
+	config.set('switches.prebidAppnexus', true);
+	config.set('switches.prebidAppnexusInvcode', false);
+	config.set('switches.prebidOpenx', true);
+	config.set('switches.prebidImproveDigital', true);
+	config.set('switches.prebidIndexExchange', true);
+	config.set('switches.prebidSonobi', true);
+	config.set('switches.prebidTrustx', true);
+	config.set('switches.prebidXaxis', true);
+	config.set('switches.prebidAdYouLike', true);
+	config.set('page.contentType', 'Article');
+	config.set('page.section', 'Magic');
+	config.set('page.edition', 'UK');
+	config.set('page.isDev', false);
 };
 
 describe('Utils', () => {
-    beforeEach(() => {
-        jest.resetAllMocks();
-        _.resetModule();
-        resetConfig();
-    });
+	beforeEach(() => {
+		jest.resetAllMocks();
+		_.resetModule();
+		resetConfig();
+	});
 
-    test('stripPrefix correctly strips valid cases', () => {
-        const validStrips = [
-            ['dfp-ad--slot', 'slot'],
-            ['slot', 'slot'],
-            ['dfp-ad--', ''],
-        ];
+	test('stripPrefix correctly strips valid cases', () => {
+		const validStrips = [
+			['dfp-ad--slot', 'slot'],
+			['slot', 'slot'],
+			['dfp-ad--', ''],
+		];
 
-        validStrips.forEach(([stringToStrip, result]) => {
-            expect(stripDfpAdPrefixFrom(stringToStrip)).toEqual(result);
-        });
-    });
+		validStrips.forEach(([stringToStrip, result]) => {
+			expect(stripDfpAdPrefixFrom(stringToStrip)).toEqual(result);
+		});
+	});
 
-    test('stripPrefix correctly behaves in invalid case', () => {
-        expect(stripDfpAdPrefixFrom(' dfp-ad--slot')).toEqual(' dfp-ad--slot');
-    });
+	test('stripPrefix correctly behaves in invalid case', () => {
+		expect(stripDfpAdPrefixFrom(' dfp-ad--slot')).toEqual(' dfp-ad--slot');
+	});
 
-    test('getLargestSize should return only one and the largest size', () => {
-        expect(getLargestSize([[300, 250]])).toEqual([300, 250]);
-        expect(getLargestSize([[300, 250], [300, 600]])).toEqual([300, 600]);
-        expect(getLargestSize([[970, 250], [728, 80]])).toEqual([970, 250]);
-    });
+	test('getLargestSize should return only one and the largest size', () => {
+		expect(getLargestSize([[300, 250]])).toEqual([300, 250]);
+		expect(
+			getLargestSize([
+				[300, 250],
+				[300, 600],
+			]),
+		).toEqual([300, 600]);
+		expect(
+			getLargestSize([
+				[970, 250],
+				[728, 80],
+			]),
+		).toEqual([970, 250]);
+	});
 
-    test('getLargestSize should return null if no sizes exist', () => {
-        expect(getLargestSize([])).toEqual(null);
-    });
+	test('getLargestSize should return null if no sizes exist', () => {
+		expect(getLargestSize([])).toEqual(null);
+	});
 
-    test('getBreakpointKey should find the correct key', () => {
-        const breakpoints = ['mobile', 'phablet', 'tablet', 'desktop', 'wide'];
-        const results = [];
-        for (let i = 0; i < breakpoints.length; i += 1) {
-            getBreakpoint.mockReturnValueOnce(breakpoints[i]);
-            results.push(getBreakpointKey());
-        }
-        expect(results).toEqual(['M', 'T', 'T', 'D', 'D']);
-    });
+	test('getBreakpointKey should find the correct key', () => {
+		const breakpoints = ['mobile', 'phablet', 'tablet', 'desktop', 'wide'];
+		const results = [];
+		for (let i = 0; i < breakpoints.length; i += 1) {
+			getBreakpoint.mockReturnValueOnce(breakpoints[i]);
+			results.push(getBreakpointKey());
+		}
+		expect(results).toEqual(['M', 'T', 'T', 'D', 'D']);
+	});
 
+	test.each([
+		['AU', 'on', true],
+		['AU', 'off', true],
+		['NZ', 'on', true],
+		['NZ', 'off', true],
+		['GB', 'on', true],
+		['GB', 'off', false],
+		['US', 'on', false],
+		['CA', 'on', false],
+		['FK', 'on', true],
+		['GI', 'on', true],
+		['GG', 'on', true],
+		['IM', 'on', true],
+		['JE', 'on', true],
+		['SH', 'on', true],
+		['FK', 'off', false],
+		['GI', 'off', false],
+		['GG', 'off', false],
+		['IM', 'off', false],
+		['JE', 'off', false],
+		['SH', 'off', false],
+	])(
+		`In %s, if switch is %s, shouldIncludeAppNexus should return %s`,
+		(region, switchState, expected) => {
+			config.switches.prebidAppnexusUkRow = switchState === 'on';
+			getCountryCode.mockReturnValue(region);
+			expect(shouldIncludeAppNexus()).toBe(expected);
+		},
+	);
 
-    test.each([
-        ['AU','on', true],
-        ['AU','off', true],
-            ['NZ','on', true],
-            ['NZ','off', true],
-            ['GB','on', true],
-            ['GB','off', false],
-            ['US','on', false],
-            ['CA','on', false],
-            ['FK','on', true],
-            ['GI','on', true],
-            ['GG','on', true],
-            ['IM','on', true],
-            ['JE','on', true],
-            ['SH','on', true],
-            ['FK','off', false],
-            ['GI','off', false],
-            ['GG','off', false],
-            ['IM','off', false],
-            ['JE','off', false],
-            ['SH','off', false]
-    ])(`In %s, if switch is %s, shouldIncludeAppNexus should return %s`, (region, switchState, expected) => {
-        config.switches.prebidAppnexusUkRow = (switchState === 'on');
-        getCountryCode.mockReturnValue(region);
-        expect(shouldIncludeAppNexus()).toBe(expected);
-    });
+	test('shouldIncludeOpenx should return true if geolocation is GB', () => {
+		getCountryCode.mockReturnValueOnce('GB');
+		expect(shouldIncludeOpenx()).toBe(true);
+	});
 
-    test('shouldIncludeOpenx should return true if geolocation is GB', () => {
-        getCountryCode.mockReturnValueOnce('GB');
-        expect(shouldIncludeOpenx()).toBe(true);
-    });
+	test('shouldIncludeOpenx should return true if within ROW region', () => {
+		const testGeos = ['FK', 'GI', 'GG', 'IM', 'JE', 'SH', 'IE'];
+		for (let i = 0; i < testGeos.length; i += 1) {
+			getCountryCode.mockReturnValueOnce(testGeos[i]);
+			expect(shouldIncludeOpenx()).toBe(true);
+		}
+	});
 
-    test('shouldIncludeOpenx should return true if within ROW region', () => {
-        const testGeos = ['FK', 'GI', 'GG', 'IM', 'JE', 'SH', 'IE'];
-        for (let i = 0; i < testGeos.length; i += 1) {
-            getCountryCode.mockReturnValueOnce(testGeos[i]);
-            expect(shouldIncludeOpenx()).toBe(true);
-        }
-    });
+	test('shouldIncludeOpenx should return false if within US region', () => {
+		const testGeos = ['CA', 'US'];
+		for (let i = 0; i < testGeos.length; i += 1) {
+			getCountryCode.mockReturnValue(testGeos[i]);
+			expect(shouldIncludeOpenx()).toBe(false);
+		}
+	});
 
-    test('shouldIncludeOpenx should return false if within US region', () => {
-        const testGeos = ['CA', 'US'];
-        for (let i = 0; i < testGeos.length; i += 1) {
-            getCountryCode.mockReturnValue(testGeos[i]);
-            expect(shouldIncludeOpenx()).toBe(false);
-        }
-    });
+	test('shouldIncludeOpenx should return true if within AU region', () => {
+		const testGeos = ['NZ', 'AU'];
+		for (let i = 0; i < testGeos.length; i += 1) {
+			getCountryCode.mockReturnValue(testGeos[i]);
+			expect(shouldIncludeOpenx()).toBe(true);
+		}
+	});
 
-    test('shouldIncludeOpenx should return true if within AU region', () => {
-        const testGeos = ['NZ', 'AU'];
-        for (let i = 0; i < testGeos.length; i += 1) {
-            getCountryCode.mockReturnValue(testGeos[i]);
-            expect(shouldIncludeOpenx()).toBe(true);
-        }
-    });
+	test('shouldIncludeTrustX should return true if geolocation is US', () => {
+		getCountryCode.mockReturnValueOnce('US');
+		expect(shouldIncludeTrustX()).toBe(true);
+	});
 
-    test('shouldIncludeTrustX should return true if geolocation is US', () => {
-        getCountryCode.mockReturnValueOnce('US');
-        expect(shouldIncludeTrustX()).toBe(true);
-    });
+	test('shouldIncludeTrustX should otherwise return false', () => {
+		const testGeos = ['FK', 'GI', 'GG', 'IM', 'JE', 'SH', 'AU'];
+		for (let i = 0; i < testGeos.length; i += 1) {
+			getCountryCode.mockReturnValueOnce(testGeos[i]);
+			expect(shouldIncludeTrustX()).toBe(false);
+		}
+	});
 
-    test('shouldIncludeTrustX should otherwise return false', () => {
-        const testGeos = ['FK', 'GI', 'GG', 'IM', 'JE', 'SH', 'AU'];
-        for (let i = 0; i < testGeos.length; i += 1) {
-            getCountryCode.mockReturnValueOnce(testGeos[i]);
-            expect(shouldIncludeTrustX()).toBe(false);
-        }
-    });
+	test('shouldIncludeImproveDigital should return true if geolocation is GB', () => {
+		getCountryCode.mockReturnValue('GB');
+		expect(shouldIncludeImproveDigital()).toBe(true);
+	});
 
-    test('shouldIncludeImproveDigital should return true if geolocation is GB', () => {
-        getCountryCode.mockReturnValue('GB');
-        expect(shouldIncludeImproveDigital()).toBe(true);
-    });
+	test('shouldIncludeImproveDigital should return true if geolocation is ROW', () => {
+		getCountryCode.mockReturnValue('FR');
+		expect(shouldIncludeImproveDigital()).toBe(true);
+	});
 
-    test('shouldIncludeImproveDigital should return true if geolocation is ROW', () => {
-        getCountryCode.mockReturnValue('FR');
-        expect(shouldIncludeImproveDigital()).toBe(true);
-    });
+	test('shouldIncludeImproveDigital should return false if geolocation is AU', () => {
+		getCountryCode.mockReturnValue('AU');
+		expect(shouldIncludeImproveDigital()).toBe(false);
+	});
 
-    test('shouldIncludeImproveDigital should return false if geolocation is AU', () => {
-        getCountryCode.mockReturnValue('AU');
-        expect(shouldIncludeImproveDigital()).toBe(false);
-    });
+	test('shouldIncludeImproveDigital should return false if geolocation is US', () => {
+		getCountryCode.mockReturnValue('US');
+		expect(shouldIncludeImproveDigital()).toBe(false);
+	});
 
-    test('shouldIncludeImproveDigital should return false if geolocation is US', () => {
-        getCountryCode.mockReturnValue('US');
-        expect(shouldIncludeImproveDigital()).toBe(false);
-    });
+	test('shouldIncludeXaxis should be true if geolocation is GB and opted in AB test variant', () => {
+		isInVariantSynchronous.mockImplementationOnce(
+			(testId, variantId) => variantId === 'variant',
+		);
+		config.set('page.isDev', true);
+		getCountryCode.mockReturnValue('GB');
+		expect(shouldIncludeXaxis()).toBe(true);
+	});
 
-    test('shouldIncludeXaxis should be true if geolocation is GB and opted in AB test variant', () => {
-        isInVariantSynchronous.mockImplementationOnce(
-            (testId, variantId) => variantId === 'variant'
-        );
-        config.set('page.isDev', true);
-        getCountryCode.mockReturnValue('GB');
-        expect(shouldIncludeXaxis()).toBe(true);
-    });
+	test('shouldIncludeXaxis should be false if geolocation is not GB', () => {
+		config.set('page.isDev', true);
+		const testGeos = [
+			'FK',
+			'GI',
+			'GG',
+			'IM',
+			'JE',
+			'SH',
+			'AU',
+			'US',
+			'CA',
+			'NZ',
+		];
+		for (let i = 0; i < testGeos.length; i += 1) {
+			getCountryCode.mockReturnValue(testGeos[i]);
+			expect(shouldIncludeXaxis()).toBe(false);
+		}
+	});
 
-    test('shouldIncludeXaxis should be false if geolocation is not GB', () => {
-        config.set('page.isDev', true);
-        const testGeos = [
-            'FK',
-            'GI',
-            'GG',
-            'IM',
-            'JE',
-            'SH',
-            'AU',
-            'US',
-            'CA',
-            'NZ',
-        ];
-        for (let i = 0; i < testGeos.length; i += 1) {
-            getCountryCode.mockReturnValue(testGeos[i]);
-            expect(shouldIncludeXaxis()).toBe(false);
-        }
-    });
+	test('shouldIncludeSonobi should return true if geolocation is US', () => {
+		const testGeos = ['US', 'CA'];
+		for (let i = 0; i < testGeos.length; i += 1) {
+			getCountryCode.mockReturnValueOnce(testGeos[i]);
+			expect(shouldIncludeSonobi()).toBe(true);
+		}
+	});
 
-    test('shouldIncludeSonobi should return true if geolocation is US', () => {
-        const testGeos = ['US', 'CA'];
-        for (let i = 0; i < testGeos.length; i += 1) {
-            getCountryCode.mockReturnValueOnce(testGeos[i]);
-            expect(shouldIncludeSonobi()).toBe(true);
-        }
-    });
+	test('shouldIncludeSonobi should otherwise return false', () => {
+		const testGeos = ['FK', 'GI', 'GG', 'IM', 'JE', 'SH', 'AU'];
+		for (let i = 0; i < testGeos.length; i += 1) {
+			getCountryCode.mockReturnValueOnce(testGeos[i]);
+			expect(shouldIncludeSonobi()).toBe(false);
+		}
+	});
 
-    test('shouldIncludeSonobi should otherwise return false', () => {
-        const testGeos = ['FK', 'GI', 'GG', 'IM', 'JE', 'SH', 'AU'];
-        for (let i = 0; i < testGeos.length; i += 1) {
-            getCountryCode.mockReturnValueOnce(testGeos[i]);
-            expect(shouldIncludeSonobi()).toBe(false);
-        }
-    });
+	test('stripMobileSuffix', () => {
+		expect(stripMobileSuffix('top-above-nav--mobile')).toBe(
+			'top-above-nav',
+		);
+		expect(stripMobileSuffix('inline1--mobile')).toBe('inline1');
+	});
 
-    test('stripMobileSuffix', () => {
-        expect(stripMobileSuffix('top-above-nav--mobile')).toBe(
-            'top-above-nav'
-        );
-        expect(stripMobileSuffix('inline1--mobile')).toBe('inline1');
-    });
+	test('stripTrailingNumbersAbove1', () => {
+		expect(stripTrailingNumbersAbove1('inline1')).toBe('inline1');
+		expect(stripTrailingNumbersAbove1('inline2')).toBe('inline');
+		expect(stripTrailingNumbersAbove1('inline10')).toBe('inline');
+		expect(stripTrailingNumbersAbove1('inline23')).toBe('inline');
+		expect(stripTrailingNumbersAbove1('inline101')).toBe('inline');
+		expect(stripTrailingNumbersAbove1('inline456')).toBe('inline');
+	});
 
-    test('stripTrailingNumbersAbove1', () => {
-        expect(stripTrailingNumbersAbove1('inline1')).toBe('inline1');
-        expect(stripTrailingNumbersAbove1('inline2')).toBe('inline');
-        expect(stripTrailingNumbersAbove1('inline10')).toBe('inline');
-        expect(stripTrailingNumbersAbove1('inline23')).toBe('inline');
-        expect(stripTrailingNumbersAbove1('inline101')).toBe('inline');
-        expect(stripTrailingNumbersAbove1('inline456')).toBe('inline');
-    });
+	test('shouldIncludeAdYouLike when not in any tests', () => {
+		expect(shouldIncludeAdYouLike([[300, 250]])).toBe(true);
+		expect(
+			shouldIncludeAdYouLike([
+				[300, 600],
+				[300, 250],
+			]),
+		).toBe(true);
+		expect(shouldIncludeAdYouLike([[728, 90]])).toBe(false);
+	});
 
-    test('shouldIncludeAdYouLike when not in any tests', () => {
-        expect(shouldIncludeAdYouLike([[300, 250]])).toBe(true);
-        expect(shouldIncludeAdYouLike([[300, 600], [300, 250]])).toBe(true);
-        expect(shouldIncludeAdYouLike([[728, 90]])).toBe(false);
-    });
+	test('removeFalseyValues correctly remove non-truthy values', () => {
+		const result = removeFalseyValues({
+			testString: 'non empty string',
+			testEmptyString: '',
+		});
 
-    test('removeFalseyValues correctly remove non-truthy values', () => {
-        const result = removeFalseyValues({
-            testString: 'non empty string',
-            testEmptyString: '',
-        });
+		expect(result).toEqual({
+			testString: 'non empty string',
+		});
+	});
 
-        expect(result).toEqual({
-            testString: 'non empty string',
-        });
-    });
+	['US', 'CA', 'AU', 'NZ'].forEach((region) => {
+		test(`should include mobile sticky if geolocation is ${region}, switch is ON and content is Article on mobiles`, () => {
+			config.set('page.contentType', 'Article');
+			config.set('switches.mobileStickyLeaderboard', true);
+			getCountryCode.mockReturnValue(region);
+			isBreakpoint.mockReturnValue(true);
+			expect(shouldIncludeMobileSticky()).toBe(true);
+		});
+	});
 
-    ['US', 'CA', 'AU', 'NZ'].forEach(region => {
-        test(`should include mobile sticky if geolocation is ${region}, switch is ON and content is Article on mobiles`, () => {
-            config.set('page.contentType', 'Article');
-            config.set('switches.mobileStickyLeaderboard', true);
-            getCountryCode.mockReturnValue(region);
-            isBreakpoint.mockReturnValue(true);
-            expect(shouldIncludeMobileSticky()).toBe(true);
-        });
-    });
+	test('shouldIncludeMobileSticky should be false if all conditions true except content type ', () => {
+		config.set('page.contentType', 'Network Front');
+		config.set('switches.mobileStickyLeaderboard', true);
+		isBreakpoint.mockReturnValue(true);
+		getCountryCode.mockReturnValue('US');
+		expect(shouldIncludeMobileSticky()).toBe(false);
+	});
 
-    test('shouldIncludeMobileSticky should be false if all conditions true except content type ', () => {
-        config.set('page.contentType', 'Network Front');
-        config.set('switches.mobileStickyLeaderboard', true);
-        isBreakpoint.mockReturnValue(true);
-        getCountryCode.mockReturnValue('US');
-        expect(shouldIncludeMobileSticky()).toBe(false);
-    });
+	test('shouldIncludeMobileSticky should be false if all conditions true except switch', () => {
+		config.set('page.contentType', 'Article');
+		isBreakpoint.mockReturnValue(true);
+		config.set('switches.mobileStickyLeaderboard', false);
+		getCountryCode.mockReturnValue('US');
+		expect(shouldIncludeMobileSticky()).toBe(false);
+	});
 
-    test('shouldIncludeMobileSticky should be false if all conditions true except switch', () => {
-        config.set('page.contentType', 'Article');
-        isBreakpoint.mockReturnValue(true);
-        config.set('switches.mobileStickyLeaderboard', false);
-        getCountryCode.mockReturnValue('US');
-        expect(shouldIncludeMobileSticky()).toBe(false);
-    });
+	test('shouldIncludeMobileSticky should be false if all conditions true except isHosted condition', () => {
+		config.set('page.contentType', 'Article');
+		isBreakpoint.mockReturnValue(true);
+		config.set('switches.mobileStickyLeaderboard', true);
+		config.set('page.isHosted', true);
+		getCountryCode.mockReturnValue('US');
+		expect(shouldIncludeMobileSticky()).toBe(false);
+	});
 
-    test('shouldIncludeMobileSticky should be false if all conditions true except isHosted condition', () => {
-        config.set('page.contentType', 'Article');
-        isBreakpoint.mockReturnValue(true);
-        config.set('switches.mobileStickyLeaderboard', true);
-        config.set('page.isHosted', true);
-        getCountryCode.mockReturnValue('US');
-        expect(shouldIncludeMobileSticky()).toBe(false);
-    });
+	test('shouldIncludeMobileSticky should be false if all conditions true except continent', () => {
+		config.set('page.contentType', 'Article');
+		config.set('switches.mobileStickyLeaderboard', true);
+		isBreakpoint.mockReturnValue(true);
+		getCountryCode.mockReturnValue('GB');
+		expect(shouldIncludeMobileSticky()).toBe(false);
+	});
 
-    test('shouldIncludeMobileSticky should be false if all conditions true except continent', () => {
-        config.set('page.contentType', 'Article');
-        config.set('switches.mobileStickyLeaderboard', true);
-        isBreakpoint.mockReturnValue(true);
-        getCountryCode.mockReturnValue('GB');
-        expect(shouldIncludeMobileSticky()).toBe(false);
-    });
+	test('shouldIncludeMobileSticky should be false if all conditions true except mobile', () => {
+		config.set('page.contentType', 'Article');
+		config.set('switches.mobileStickyLeaderboard', true);
+		isBreakpoint.mockReturnValue(false);
+		getCountryCode.mockReturnValue('US');
+		expect(shouldIncludeMobileSticky()).toBe(false);
+	});
 
-    test('shouldIncludeMobileSticky should be false if all conditions true except mobile', () => {
-        config.set('page.contentType', 'Article');
-        config.set('switches.mobileStickyLeaderboard', true);
-        isBreakpoint.mockReturnValue(false);
-        getCountryCode.mockReturnValue('US');
-        expect(shouldIncludeMobileSticky()).toBe(false);
-    });
-
-    test('shouldIncludeMobileSticky should be true if test param exists irrespective of other conditions', () => {
-        config.set('page.contentType', 'Network Front');
-        config.set('switches.mobileStickyLeaderboard', false);
-        isBreakpoint.mockReturnValue(false);
-        getCountryCode.mockReturnValue('US');
-        window.location.hash = '#mobile-sticky';
-        expect(shouldIncludeMobileSticky()).toBe(true);
-    });
+	test('shouldIncludeMobileSticky should be true if test param exists irrespective of other conditions', () => {
+		config.set('page.contentType', 'Network Front');
+		config.set('switches.mobileStickyLeaderboard', false);
+		isBreakpoint.mockReturnValue(false);
+		getCountryCode.mockReturnValue('US');
+		window.location.hash = '#mobile-sticky';
+		expect(shouldIncludeMobileSticky()).toBe(true);
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/high-merch.js
+++ b/static/src/javascripts/projects/commercial/modules/high-merch.js
@@ -4,28 +4,28 @@ import { createSlots } from './dfp/create-slots';
 import { commercialFeatures } from '../../common/modules/commercial/commercial-features';
 
 export const init = () => {
-    if (commercialFeatures.highMerch) {
-        const anchorSelector = config.get('page.commentable')
-            ? '#comments + *'
-            : '.content-footer > :first-child';
-        const anchor = document.querySelector(anchorSelector);
-        const container = document.createElement('div');
+	if (commercialFeatures.highMerch) {
+		const anchorSelector = config.get('page.commentable')
+			? '#comments + *'
+			: '.content-footer > :first-child';
+		const anchor = document.querySelector(anchorSelector);
+		const container = document.createElement('div');
 
-        container.className = 'fc-container fc-container--commercial';
-        const slots = createSlots(
-            config.get('page.isPaidContent') ? 'high-merch-paid' : 'high-merch'
-        );
+		container.className = 'fc-container fc-container--commercial';
+		const slots = createSlots(
+			config.get('page.isPaidContent') ? 'high-merch-paid' : 'high-merch',
+		);
 
-        slots.forEach(slot => {
-            container.appendChild(slot);
-        });
+		slots.forEach((slot) => {
+			container.appendChild(slot);
+		});
 
-        return fastdom.mutate(() => {
-            if (anchor && anchor.parentNode) {
-                anchor.parentNode.insertBefore(container, anchor);
-            }
-        });
-    }
+		return fastdom.mutate(() => {
+			if (anchor && anchor.parentNode) {
+				anchor.parentNode.insertBefore(container, anchor);
+			}
+		});
+	}
 
-    return Promise.resolve();
+	return Promise.resolve();
 };

--- a/static/src/javascripts/projects/commercial/modules/hosted/about.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/about.spec.js
@@ -7,48 +7,48 @@ import { init } from './about';
  */
 
 describe('Hosted About Popup', () => {
-    beforeEach(() => {
-        if (document.body) {
-            document.body.innerHTML = '<div class="js-hosted-about"></div>';
-        }
-    });
+	beforeEach(() => {
+		if (document.body) {
+			document.body.innerHTML = '<div class="js-hosted-about"></div>';
+		}
+	});
 
-    afterEach(() => {
-        if (document.body) {
-            document.body.innerHTML = '';
-        }
-        const overlay = document.querySelector('.js-survey-overlay');
-        if (overlay) overlay.parentNode.removeChild(overlay);
-    });
+	afterEach(() => {
+		if (document.body) {
+			document.body.innerHTML = '';
+		}
+		const overlay = document.querySelector('.js-survey-overlay');
+		if (overlay) overlay.parentNode.removeChild(overlay);
+	});
 
-    it('should exist', () => {
-        expect(init).toBeDefined();
-    });
+	it('should exist', () => {
+		expect(init).toBeDefined();
+	});
 
-    it('should hide popup after initialization', done => {
-        init()
-            .then(() => {
-                expect(
-                    (document.querySelector(
-                        '.js-survey-overlay'
-                    )).classList.toString()
-                ).toEqual(expect.stringContaining('u-h'));
-            })
-            .then(done)
-            .catch(done.fail);
-    });
+	it('should hide popup after initialization', (done) => {
+		init()
+			.then(() => {
+				expect(
+					document
+						.querySelector('.js-survey-overlay')
+						.classList.toString(),
+				).toEqual(expect.stringContaining('u-h'));
+			})
+			.then(done)
+			.catch(done.fail);
+	});
 
-    it('should show popup after clicking on the button', done => {
-        init()
-            .then(() => {
-                (document.querySelector('.js-hosted-about')).click();
-                expect(
-                    (document.querySelector(
-                        '.js-survey-overlay'
-                    )).classList.toString()
-                ).not.toEqual(expect.stringContaining('u-h'));
-            })
-            .then(done)
-            .catch(done.fail);
-    });
+	it('should show popup after clicking on the button', (done) => {
+		init()
+			.then(() => {
+				document.querySelector('.js-hosted-about').click();
+				expect(
+					document
+						.querySelector('.js-survey-overlay')
+						.classList.toString(),
+				).not.toEqual(expect.stringContaining('u-h'));
+			})
+			.then(done)
+			.catch(done.fail);
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
@@ -9,544 +9,588 @@ import { pushUrl } from '../../../../lib/url';
 import interactionTracking from '../../../common/modules/analytics/interaction-tracking';
 
 class HostedGallery {
+	constructor() {
+		// CONFIG
+		const breakpoint = getBreakpoint();
+		this.useSwipe =
+			hasTouchScreen() &&
+			(breakpoint === 'mobile' || breakpoint === 'tablet');
+		this.swipeThreshold = 0.05;
+		this.index = this.index || 1;
+		this.imageRatios = [];
 
-    constructor() {
-        // CONFIG
-        const breakpoint = getBreakpoint();
-        this.useSwipe =
-            hasTouchScreen() &&
-            (breakpoint === 'mobile' || breakpoint === 'tablet');
-        this.swipeThreshold = 0.05;
-        this.index = this.index || 1;
-        this.imageRatios = [];
+		// ELEMENT BINDINGS
+		this.$galleryEl = document.querySelector(
+			'.js-hosted-gallery-container',
+		);
+		this.$galleryFrame = document.querySelector('.js-hosted-gallery-frame');
+		this.$header = document.querySelector('.js-hosted-headerwrap');
+		this.$imagesContainer = this.$galleryEl.querySelector(
+			'.js-hosted-gallery-images',
+		);
+		this.$captionContainer = document.querySelector(
+			'.js-gallery-caption-bar',
+		);
+		this.$captions = [
+			...this.$captionContainer.querySelectorAll(
+				'.js-hosted-gallery-caption',
+			),
+		];
+		this.$scrollEl = this.$galleryEl.querySelector(
+			'.js-hosted-gallery-scroll-container',
+		);
 
-        // ELEMENT BINDINGS
-        this.$galleryEl = document.querySelector('.js-hosted-gallery-container');
-        this.$galleryFrame = document.querySelector('.js-hosted-gallery-frame');
-        this.$header = document.querySelector('.js-hosted-headerwrap');
-        this.$imagesContainer = this.$galleryEl.querySelector('.js-hosted-gallery-images');
-        this.$captionContainer = document.querySelector('.js-gallery-caption-bar');
-        this.$captions = [...this.$captionContainer.querySelectorAll('.js-hosted-gallery-caption')];
-        this.$scrollEl = this.$galleryEl.querySelector('.js-hosted-gallery-scroll-container');
+		this.$images = [
+			...this.$imagesContainer.querySelectorAll(
+				'.js-hosted-gallery-image',
+			),
+		];
+		this.$progress = this.$galleryEl.querySelector(
+			'.js-hosted-gallery-progress',
+		);
+		this.$border = this.$progress.querySelector(
+			'.js-hosted-gallery-rotating-border',
+		);
+		this.prevBtn = this.$progress.querySelector('.inline-arrow-up');
+		this.nextBtn = this.$progress.querySelector('.inline-arrow-down');
+		this.infoBtn = this.$captionContainer.querySelector(
+			'.js-gallery-caption-button',
+		);
+		this.$counter = this.$progress.querySelector(
+			'.js-hosted-gallery-image-count',
+		);
+		this.$ctaFloat = this.$galleryEl.querySelector(
+			'.js-hosted-gallery-cta',
+		);
+		this.$ojFloat = this.$galleryEl.querySelector('.js-hosted-gallery-oj');
+		this.$meta = this.$galleryEl.querySelector('.js-hosted-gallery-meta');
+		this.ojClose = this.$ojFloat.querySelector(
+			'.js-hosted-gallery-oj-close',
+		);
 
-        this.$images = [...this.$imagesContainer.querySelectorAll('.js-hosted-gallery-image')];
-        this.$progress = this.$galleryEl.querySelector('.js-hosted-gallery-progress');
-        this.$border = this.$progress.querySelector('.js-hosted-gallery-rotating-border');
-        this.prevBtn = this.$progress.querySelector('.inline-arrow-up');
-        this.nextBtn = this.$progress.querySelector('.inline-arrow-down');
-        this.infoBtn = this.$captionContainer.querySelector('.js-gallery-caption-button');
-        this.$counter = this.$progress.querySelector('.js-hosted-gallery-image-count');
-        this.$ctaFloat = this.$galleryEl.querySelector('.js-hosted-gallery-cta');
-        this.$ojFloat = this.$galleryEl.querySelector('.js-hosted-gallery-oj');
-        this.$meta = this.$galleryEl.querySelector('.js-hosted-gallery-meta');
-        this.ojClose = this.$ojFloat.querySelector('.js-hosted-gallery-oj-close');
+		if (this.$galleryEl) {
+			this.resize = this.trigger.bind(this, 'resize');
+			mediator.on('window:throttledResize', this.resize);
 
-        if (this.$galleryEl) {
-            this.resize = this.trigger.bind(this, 'resize');
-            mediator.on('window:throttledResize', this.resize);
+			// FSM CONFIG
+			this.fsm = new FiniteStateMachine({
+				initial: 'image',
+				onChangeState() {},
+				context: this,
 
-            // FSM CONFIG
-            this.fsm = new FiniteStateMachine({
-                initial: 'image',
-                onChangeState() {},
-                context: this,
+				states: this.states,
+			});
 
-                states: this.states,
-            });
+			this.infoBtn.addEventListener(
+				'click',
+				this.trigger.bind(this, 'toggle-info'),
+			);
+			this.ojClose.addEventListener('click', this.toggleOj.bind(this));
 
-            this.infoBtn.addEventListener(
-                'click',
-                this.trigger.bind(this, 'toggle-info')
-            );
-            this.ojClose.addEventListener('click', this.toggleOj.bind(this));
+			if (document.body) {
+				document.body.addEventListener(
+					'keydown',
+					this.handleKeyEvents.bind(this),
+				);
+			}
+			this.loadSurroundingImages(1, this.$images.length);
+			this.setPageWidth();
 
-            if (document.body) {
-                document.body.addEventListener(
-                    'keydown',
-                    this.handleKeyEvents.bind(this)
-                );
-            }
-            this.loadSurroundingImages(1, this.$images.length);
-            this.setPageWidth();
+			if (this.useSwipe) {
+				this.$galleryEl.classList.add('use-swipe');
+				this.initSwipe();
+			} else {
+				this.$galleryEl.classList.add('use-scroll');
+				this.initScroll();
+			}
+		}
+	}
 
-            if (this.useSwipe) {
-                this.$galleryEl.classList.add('use-swipe');
-                this.initSwipe();
-            } else {
-                this.$galleryEl.classList.add('use-scroll');
-                this.initScroll();
-            }
-        }
-    }
+	toggleOj() {
+		this.$ojFloat.classList.toggle('minimise-oj');
+	}
 
-    toggleOj() {
-        this.$ojFloat.classList.toggle('minimise-oj');
-    }
+	toggleClass(el, className, opt_condition) {
+		if (el) {
+			typeof opt_condition !== 'undefined'
+				? opt_condition
+					? el.classList.add(className)
+					: el.classList.remove(className)
+				: el.toggleClass(className);
+		}
+	}
 
-    toggleClass(el, className, opt_condition) {
-        if (el) {
-              typeof opt_condition !== 'undefined' ?
-                opt_condition ? el.classList.add(className) : el.classList.remove(className) :
-                el.toggleClass(className);
-        }
-    }
+	initScroll() {
+		this.nextBtn.addEventListener('click', () => {
+			this.scrollTo(this.index + 1);
+			if (this.index < this.$images.length) {
+				this.trigger('next', {
+					nav: 'Click',
+				});
+			} else {
+				this.trigger('reload');
+			}
+		});
+		this.prevBtn.addEventListener('click', () => {
+			this.scrollTo(this.index - 1);
+			if (this.index > 1) {
+				this.trigger('prev', {
+					nav: 'Click',
+				});
+			} else {
+				this.trigger('reload');
+			}
+		});
 
-    initScroll() {
-        this.nextBtn.addEventListener('click', () => {
-            this.scrollTo(this.index + 1);
-            if (this.index < this.$images.length) {
-                this.trigger('next', {
-                    nav: 'Click',
-                });
-            } else {
-                this.trigger('reload');
-            }
-        });
-        this.prevBtn.addEventListener('click', () => {
-            this.scrollTo(this.index - 1);
-            if (this.index > 1) {
-                this.trigger('prev', {
-                    nav: 'Click',
-                });
-            } else {
-                this.trigger('reload');
-            }
-        });
+		this.$scrollEl.addEventListener(
+			'scroll',
+			throttle(this.fadeContent.bind(this), 20),
+		);
+	}
 
-        this.$scrollEl.addEventListener(
-            'scroll',
-            throttle(this.fadeContent.bind(this), 20)
-        );
-    }
+	initSwipe() {
+		let threshold; // time in ms
+		let ox;
+		let dx;
+		const updateTime = 20;
+		this.$imagesContainer.style.setProperty(
+			'width',
+			`${this.$images.length}00%`,
+		);
 
-    initSwipe() {
-        let threshold; // time in ms
-        let ox;
-        let dx;
-        const updateTime = 20;
-        this.$imagesContainer.style.setProperty('width', `${this.$images.length}00%`);
+		this.$galleryEl.addEventListener('touchstart', (e) => {
+			threshold = this.swipeContainerWidth * this.swipeThreshold;
+			ox = e.touches[0].pageX;
+			dx = 0;
+		});
 
-        this.$galleryEl.addEventListener('touchstart', e => {
-            threshold = this.swipeContainerWidth * this.swipeThreshold;
-            ox = e.touches[0].pageX;
-            dx = 0;
-        });
+		const touchMove = (e) => {
+			e.preventDefault();
+			if (e.touches.length > 1 || (e.scale && e.scale !== 1)) {
+				return;
+			}
+			dx = e.touches[0].pageX - ox;
+			this.translateContent(this.index, dx, updateTime);
+		};
 
-        const touchMove = e => {
-            e.preventDefault();
-            if (e.touches.length > 1 || (e.scale && e.scale !== 1)) {
-                return;
-            }
-            dx = e.touches[0].pageX - ox;
-            this.translateContent(this.index, dx, updateTime);
-        };
+		this.$galleryEl.addEventListener(
+			'touchmove',
+			throttle(touchMove, updateTime, {
+				trailing: false,
+			}),
+		);
 
-        this.$galleryEl.addEventListener(
-            'touchmove',
-            throttle(touchMove, updateTime, {
-                trailing: false,
-            })
-        );
+		this.$galleryEl.addEventListener('touchend', () => {
+			let direction;
+			if (Math.abs(dx) > threshold) {
+				direction = dx > threshold ? 1 : -1;
+			} else {
+				direction = 0;
+			}
+			dx = 0;
 
-        this.$galleryEl.addEventListener('touchend', () => {
-            let direction;
-            if (Math.abs(dx) > threshold) {
-                direction = dx > threshold ? 1 : -1;
-            } else {
-                direction = 0;
-            }
-            dx = 0;
+			if (direction === 1) {
+				if (this.index > 1) {
+					this.trigger('prev', {
+						nav: 'Swipe',
+					});
+				} else {
+					this.trigger('reload');
+				}
+			} else if (direction === -1) {
+				if (this.index < this.$images.length) {
+					this.trigger('next', {
+						nav: 'Swipe',
+					});
+				} else {
+					this.trigger('reload');
+				}
+			} else {
+				this.trigger('reload');
+			}
+		});
+	}
 
-            if (direction === 1) {
-                if (this.index > 1) {
-                    this.trigger('prev', {
-                        nav: 'Swipe',
-                    });
-                } else {
-                    this.trigger('reload');
-                }
-            } else if (direction === -1) {
-                if (this.index < this.$images.length) {
-                    this.trigger('next', {
-                        nav: 'Swipe',
-                    });
-                } else {
-                    this.trigger('reload');
-                }
-            } else {
-                this.trigger('reload');
-            }
-        });
-    }
+	static ctaIndex() {
+		const ctaIndex = config.get('page.ctaIndex');
+		const images = config.get('page.images');
+		return ctaIndex > 0 && ctaIndex < images.length - 1
+			? ctaIndex
+			: undefined;
+	}
 
-    static ctaIndex() {
-        const ctaIndex = config.get('page.ctaIndex');
-        const images = config.get('page.images');
-        return ctaIndex > 0 && ctaIndex < images.length - 1
-            ? ctaIndex
-            : undefined;
-    }
+	trigger(event, data) {
+		this.fsm.trigger(event, data);
+	}
 
-    trigger(event, data) {
-        this.fsm.trigger(event, data);
-    }
+	loadSurroundingImages(index, count) {
+		let $img;
+		const that = this;
 
-    loadSurroundingImages(index, count) {
-        let $img;
-        const that = this;
+		const setSize = ($image, imageIndex) => {
+			if (!that.imageRatios[imageIndex]) {
+				that.imageRatios[imageIndex] =
+					$image.naturalWidth / $image.naturalHeight;
+			}
+			that.resizeImage.call(that, imageIndex);
+		};
 
-        const setSize = ($image, imageIndex) => {
-            if (!that.imageRatios[imageIndex]) {
-                that.imageRatios[imageIndex] =
-                    $image.naturalWidth / $image.naturalHeight;
-            }
-            that.resizeImage.call(that, imageIndex);
-        };
+		[0, 1, 2]
+			.map((i) => (index + i === 0 ? count - 1 : (index - 1 + i) % count))
+			.forEach(function (i) {
+				$img = this.$images[i].querySelector('img');
+				if (!$img.complete) {
+					$img.addEventListener('load', setSize.bind(this, $img, i));
+				} else {
+					setSize($img, i);
+				}
+			}, this);
+	}
 
-        [0, 1, 2]
-            .map(i => (index + i === 0 ? count - 1 : (index - 1 + i) % count))
-            .forEach(function(i) {
-                $img = this.$images[i].querySelector('img');
-                if (!$img.complete) {
-                    $img.addEventListener(
-                        'load',
-                        setSize.bind(this, $img, i)
-                    );
-                } else {
-                    setSize($img, i);
-                }
-            }, this);
-    }
+	resizeImage(imgIndex) {
+		const $galleryFrame = this.$galleryFrame;
+		const width = $galleryFrame.clientWidth;
+		const height = $galleryFrame.clientHeight;
 
-    resizeImage(imgIndex) {
-        const $galleryFrame = this.$galleryFrame;
-        const width = $galleryFrame.clientWidth;
-        const height = $galleryFrame.clientHeight;
+		const getFrame = (desiredRatio, w = width, h = height) => {
+			const frame = {
+				height: h,
+				width: w,
+				topBottom: 0,
+				leftRight: 0,
+			};
+			if (!desiredRatio) return frame;
+			if (desiredRatio > w / h) {
+				// portrait screens
+				frame.height = w / desiredRatio;
+				frame.topBottom = (h - frame.height) / 2;
+			} else {
+				// landscape screens
+				frame.width = h * desiredRatio;
+				frame.leftRight = (w - frame.width) / 2;
+			}
+			return frame;
+		};
 
-        const getFrame = (desiredRatio, w = width, h = height) => {
-            const frame = {
-                height: h,
-                width: w,
-                topBottom: 0,
-                leftRight: 0,
-            };
-            if (!desiredRatio) return frame;
-            if (desiredRatio > w / h) {
-                // portrait screens
-                frame.height = w / desiredRatio;
-                frame.topBottom = (h - frame.height) / 2;
-            } else {
-                // landscape screens
-                frame.width = h * desiredRatio;
-                frame.leftRight = (w - frame.width) / 2;
-            }
-            return frame;
-        };
+		const $imageDiv = this.$images[imgIndex];
+		const $ctaFloat = this.$ctaFloat;
+		const $ojFloat = this.$ojFloat;
+		const $meta = this.$meta;
+		const $images = this.$images;
+		const $sizer = $imageDiv.querySelector(
+			'.js-hosted-gallery-image-sizer',
+		);
+		const imgRatio = this.imageRatios[imgIndex];
+		const ctaSize = getFrame(0);
+		const ctaIndex = HostedGallery.ctaIndex();
+		const tabletSize = 740;
+		const imageSize = getFrame(imgRatio);
 
-        const $imageDiv = this.$images[imgIndex];
-        const $ctaFloat = this.$ctaFloat;
-        const $ojFloat = this.$ojFloat;
-        const $meta = this.$meta;
-        const $images = this.$images;
-        const $sizer = $imageDiv.querySelector('.js-hosted-gallery-image-sizer');
-        const imgRatio = this.imageRatios[imgIndex];
-        const ctaSize = getFrame(0);
-        const ctaIndex = HostedGallery.ctaIndex();
-        const tabletSize = 740;
-        const imageSize = getFrame(imgRatio);
+		fastdom.mutate(() => {
+			$sizer.style.setProperty('width', imageSize.width);
+			$sizer.style.setProperty('height', imageSize.height);
+			$sizer.style.setProperty('top', imageSize.topBottom);
+			$sizer.style.setProperty('left', imageSize.leftRight);
+			if (imgIndex === ctaIndex) {
+				$ctaFloat.style.setProperty('bottom', ctaSize.topBottom);
+			}
+			if (imgIndex === $images.length - 1) {
+				$ojFloat.style.setProperty('bottom', ctaSize.topBottom);
+			}
+			if (imgIndex === $images.length - 1) {
+				$ojFloat.style.setProperty(
+					'padding-bottom',
+					ctaSize.topBottom > 40 || width > tabletSize ? 0 : 40,
+				);
+			}
+			if (imgIndex === 0) {
+				$meta.style.setProperty(
+					'padding-bottom',
+					imageSize.topBottom > 40 || width > tabletSize ? 20 : 40,
+				);
+			}
+		});
+	}
 
-        fastdom.mutate(() => {
-            $sizer.style.setProperty('width', imageSize.width);
-            $sizer.style.setProperty('height', imageSize.height);
-            $sizer.style.setProperty('top', imageSize.topBottom);
-            $sizer.style.setProperty('left', imageSize.leftRight);
-            if (imgIndex === ctaIndex) {
-                $ctaFloat.style.setProperty('bottom', ctaSize.topBottom);
-            }
-            if (imgIndex === $images.length - 1) {
-                $ojFloat.style.setProperty('bottom', ctaSize.topBottom);
-            }
-            if (imgIndex === $images.length - 1) {
-                $ojFloat.style.setProperty('padding-bottom', ctaSize.topBottom > 40 || width > tabletSize ? 0 : 40);
-            }
-            if (imgIndex === 0) {
-                $meta.style.setProperty('padding-bottom', imageSize.topBottom > 40 || width > tabletSize ? 20 : 40);
-            }
-        });
-    }
+	translateContent(imgIndex, offset, duration) {
+		const px = -1 * (imgIndex - 1) * this.swipeContainerWidth;
+		const galleryEl = this.$imagesContainer;
+		const $meta = this.$meta;
 
-    translateContent(imgIndex, offset, duration) {
-        const px = -1 * (imgIndex - 1) * this.swipeContainerWidth;
-        const galleryEl = this.$imagesContainer;
-        const $meta = this.$meta;
+		fastdom.mutate(() => {
+			galleryEl.style.setProperty('transition-duration', `${duration}ms`);
+			galleryEl.style.setProperty(
+				'transform',
+				`translate(${px + offset}px,0) translateZ(0)`,
+			);
+			$meta.style.setProperty('opacity', offset !== 0 ? 0 : 1);
+		});
+	}
 
-        fastdom.mutate(() => {
-            galleryEl.style.setProperty('transition-duration', `${duration}ms`);
-            galleryEl.style.setProperty('transform', `translate(${px +
-                offset}px,0) translateZ(0)`);
-            $meta.style.setProperty('opacity', offset !== 0 ? 0 : 1);
-        });
-    }
+	fadeContent(e) {
+		const length = this.$images.length;
+		const scrollTop =
+			e.target instanceof HTMLElement ? e.target.scrollTop : 0;
+		const scrollHeight =
+			e.target instanceof HTMLElement ? e.target.scrollHeight : 0;
+		const progress =
+			Math.round(length * (scrollTop / scrollHeight) * 100) / 100;
+		const fractionProgress = progress % 1;
+		const deg = Math.ceil(fractionProgress * 360);
+		const newIndex = Math.round(progress + 0.75);
+		const ctaIndex = HostedGallery.ctaIndex() || -1;
+		fastdom.mutate(() => {
+			this.$images.forEach((image, index) => {
+				const opacity = ((progress - index + 1) * 16) / 11 - 0.0625;
+				image.style.setProperty(
+					'opacity',
+					Math.min(Math.max(opacity, 0), 1),
+				);
+			});
 
-    fadeContent(e) {
-        const length = this.$images.length;
-        const scrollTop =
-            e.target instanceof HTMLElement ? e.target.scrollTop : 0;
-        const scrollHeight =
-            e.target instanceof HTMLElement ? e.target.scrollHeight : 0;
-        const progress =
-            Math.round(length * (scrollTop / scrollHeight) * 100) / 100;
-        const fractionProgress = progress % 1;
-        const deg = Math.ceil(fractionProgress * 360);
-        const newIndex = Math.round(progress + 0.75);
-        const ctaIndex = HostedGallery.ctaIndex() || -1;
-        fastdom.mutate(() => {
-            this.$images.forEach((image, index) => {
-                const opacity = ((progress - index + 1) * 16) / 11 - 0.0625;
-                image.style.setProperty('opacity', Math.min(Math.max(opacity, 0), 1));
-            });
+			this.$border.style.setProperty('transform', `rotate(${deg}deg)`);
 
-            this.$border.style.setProperty('transform', `rotate(${deg}deg)`);
+			this.toggleClass(
+				this.$galleryEl,
+				'show-cta',
+				progress <= ctaIndex && progress >= ctaIndex - 0.25,
+			);
 
-            this.toggleClass(
-                this.$galleryEl,
-                'show-cta',
-                progress <= ctaIndex && progress >= ctaIndex - 0.25
-            );
+			this.toggleClass(
+				this.$galleryEl,
+				'show-oj',
+				progress >= length - 1.25,
+			);
 
-            this.toggleClass(
-                this.$galleryEl,
-                'show-oj',
-                progress >= length - 1.25
-            );
+			this.toggleClass(
+				this.$progress,
+				'first-half',
+				fractionProgress && fractionProgress < 0.5,
+			);
 
-            this.toggleClass(
-                this.$progress,
-                'first-half',
-                fractionProgress && fractionProgress < 0.5
-            );
+			this.$meta.style.setProperty('opacity', progress !== 0 ? 0 : 1);
+		});
 
-            this.$meta.style.setProperty('opacity', progress !== 0 ? 0 : 1);
-        });
+		if (newIndex && newIndex !== this.index) {
+			this.index = newIndex;
+			this.trigger('reload', {
+				nav: 'Scroll',
+			});
+		}
+	}
 
-        if (newIndex && newIndex !== this.index) {
-            this.index = newIndex;
-            this.trigger('reload', {
-                nav: 'Scroll',
-            });
-        }
-    }
+	scrollTo(index) {
+		const scrollEl = this.$scrollEl;
+		const length = this.$images.length;
+		const scrollHeight = scrollEl.scrollHeight;
+		fastdom.mutate(() => {
+			scrollEl.scrollTop = ((index - 1) * scrollHeight) / length;
+		});
+	}
 
-    scrollTo(index) {
-        const scrollEl = this.$scrollEl;
-        const length = this.$images.length;
-        const scrollHeight = scrollEl.scrollHeight;
-        fastdom.mutate(() => {
-            scrollEl.scrollTop = ((index - 1) * scrollHeight) / length;
-        });
-    }
+	trackNavBetweenImages(data) {
+		if (data && data.nav) {
+			const trackingPrefix = config.get('page.trackingPrefix', '');
+			interactionTracking.trackNonClickInteraction(
+				`${trackingPrefix + data.nav} - image ${this.index}`,
+			);
+		}
+	}
 
-    trackNavBetweenImages(data) {
-        if (data && data.nav) {
-            const trackingPrefix = config.get('page.trackingPrefix', '');
-            interactionTracking.trackNonClickInteraction(
-                `${trackingPrefix + data.nav} - image ${this.index}`
-            );
-        }
-    }
+	onResize() {
+		this.resizer =
+			this.resizer ||
+			(() => {
+				this.loadSurroundingImages(this.index, this.$images.length);
+				if (this.useSwipe) {
+					this.swipeContainerWidth = this.$galleryFrame.offsetWidth;
+					this.translateContent(this.index, 0, 0);
+				}
+				this.setPageWidth();
+			});
+		throttle(this.resizer, 200)();
+	}
 
-    onResize() {
-        this.resizer =
-            this.resizer ||
-            (() => {
-                this.loadSurroundingImages(this.index, this.$images.length);
-                if (this.useSwipe) {
-                    this.swipeContainerWidth = this.$galleryFrame.offsetWidth;
-                    this.translateContent(this.index, 0, 0);
-                }
-                this.setPageWidth();
-            });
-        throttle(this.resizer, 200)();
-    }
+	setPageWidth() {
+		const $imagesContainer = this.$imagesContainer;
+		const $gallery = this.$galleryEl;
+		const width = $gallery.clientWidth;
+		const height = $imagesContainer.clientHeight;
+		const $header = this.$header;
+		const $footer = this.$captionContainer;
+		const $galleryFrame = this.$galleryFrame;
+		const imgRatio = 5 / 3;
+		let imageWidth = width;
+		let leftRight = 0;
+		const that = this;
+		if (imgRatio < width / height) {
+			imageWidth = height * imgRatio;
+			leftRight = `${(width - imageWidth) / 2}px`;
+		}
+		this.swipeContainerWidth = imageWidth;
+		fastdom.mutate(() => {
+			if ($header) {
+				$header.style.setProperty('width', imageWidth);
+			}
+			if ($footer) {
+				$footer.style.setProperty('margin', `0 ${leftRight}`);
+				$footer.style.setProperty('width', 'auto');
+			}
+			if ($gallery) {
+				$galleryFrame.style.setProperty('left', leftRight);
+				$galleryFrame.style.setProperty('right', leftRight);
+			}
+			that.loadSurroundingImages(that.index, that.$images.length);
+		});
+	}
 
-    setPageWidth() {
-        const $imagesContainer = this.$imagesContainer;
-        const $gallery = this.$galleryEl;
-        const width = $gallery.clientWidth;
-        const height = $imagesContainer.clientHeight;
-        const $header = this.$header;
-        const $footer = this.$captionContainer;
-        const $galleryFrame = this.$galleryFrame;
-        const imgRatio = 5 / 3;
-        let imageWidth = width;
-        let leftRight = 0;
-        const that = this;
-        if (imgRatio < width / height) {
-            imageWidth = height * imgRatio;
-            leftRight = `${(width - imageWidth) / 2}px`;
-        }
-        this.swipeContainerWidth = imageWidth;
-        fastdom.mutate(() => {
-            if ($header) {
-                $header.style.setProperty('width', imageWidth);
-            }
-            if ($footer) {
-                $footer.style.setProperty('margin', `0 ${leftRight}`);
-                $footer.style.setProperty('width', 'auto');
-            }
-            if ($gallery) {
-                $galleryFrame.style.setProperty('left', leftRight);
-                $galleryFrame.style.setProperty('right', leftRight);
-            }
-            that.loadSurroundingImages(that.index, that.$images.length);
-        });
-    }
+	handleKeyEvents(e) {
+		const keyNames = {
+			37: 'left',
+			38: 'up',
+			39: 'right',
+			40: 'down',
+		};
+		if (e.keyCode === 37 || e.keyCode === 38) {
+			// up/left
+			e.preventDefault();
+			this.scrollTo(this.index - 1);
+			this.trigger('prev', {
+				nav: `KeyPress:${keyNames[e.keyCode]}`,
+			});
+			return false;
+		} else if (e.keyCode === 39 || e.keyCode === 40) {
+			// down/right
+			e.preventDefault();
+			this.scrollTo(this.index + 1);
+			this.trigger('next', {
+				nav: `KeyPress:${keyNames[e.keyCode]}`,
+			});
+			return false;
+		} else if (e.keyCode === 73) {
+			// 'i'
+			this.trigger('toggle-info');
+		}
+	}
 
-    handleKeyEvents(e) {
-        const keyNames = {
-            '37': 'left',
-            '38': 'up',
-            '39': 'right',
-            '40': 'down',
-        };
-        if (e.keyCode === 37 || e.keyCode === 38) {
-            // up/left
-            e.preventDefault();
-            this.scrollTo(this.index - 1);
-            this.trigger('prev', {
-                nav: `KeyPress:${keyNames[e.keyCode]}`,
-            });
-            return false;
-        } else if (e.keyCode === 39 || e.keyCode === 40) {
-            // down/right
-            e.preventDefault();
-            this.scrollTo(this.index + 1);
-            this.trigger('next', {
-                nav: `KeyPress:${keyNames[e.keyCode]}`,
-            });
-            return false;
-        } else if (e.keyCode === 73) {
-            // 'i'
-            this.trigger('toggle-info');
-        }
-    }
-
-    loadAtIndex(i) {
-        this.index = i;
-        this.trigger('reload');
-        if (this.useSwipe) {
-            this.translateContent(this.index, 0, 0);
-        } else {
-            this.scrollTo(this.index);
-        }
-    }
+	loadAtIndex(i) {
+		this.index = i;
+		this.trigger('reload');
+		if (this.useSwipe) {
+			this.translateContent(this.index, 0, 0);
+		} else {
+			this.scrollTo(this.index);
+		}
+	}
 }
 // TODO: If we add `states` to the list of annotations within the class, it is `undefined` in the constructor. Wat?
 
 HostedGallery.prototype.states = {
-    image: {
-        enter() {
-            const that = this;
+	image: {
+		enter() {
+			const that = this;
 
-            // load prev/current/next
-            this.loadSurroundingImages(this.index, this.$images.length);
-            this.$captions.forEach((caption, index) => {
-                this.toggleClass(
-                    caption,
-                    'current-caption',
-                    that.index === index + 1
-                );
-            });
-            this.$counter.textContent = `${this.index}/${this.$images.length}`;
+			// load prev/current/next
+			this.loadSurroundingImages(this.index, this.$images.length);
+			this.$captions.forEach((caption, index) => {
+				this.toggleClass(
+					caption,
+					'current-caption',
+					that.index === index + 1,
+				);
+			});
+			this.$counter.textContent = `${this.index}/${this.$images.length}`;
 
-            if (this.useSwipe) {
-                this.translateContent(this.index, 0, 100);
-                this.toggleClass(
-                    this.$galleryEl,
-                    'show-oj',
-                    this.index === this.$images.length
-                );
-                this.toggleClass(
-                    this.$galleryEl,
-                    'show-cta',
-                    this.index === HostedGallery.ctaIndex() + 1
-                );
-            }
+			if (this.useSwipe) {
+				this.translateContent(this.index, 0, 100);
+				this.toggleClass(
+					this.$galleryEl,
+					'show-oj',
+					this.index === this.$images.length,
+				);
+				this.toggleClass(
+					this.$galleryEl,
+					'show-cta',
+					this.index === HostedGallery.ctaIndex() + 1,
+				);
+			}
 
-            const pageName =
-                config.get('page.pageName') ||
-                window.location.pathname.substr(
-                    window.location.pathname.lastIndexOf('/') + 1
-                );
-            pushUrl({}, document.title, `${pageName}#img-${this.index}`, true);
-            // event bindings
-            mediator.on('window:throttledResize', this.resize);
-        },
-        leave() {
-            this.trigger('hide-info');
-            mediator.off('window:throttledResize', this.resize);
-        },
-        events: {
-            next(e) {
-                if (this.index < this.$images.length) {
-                    // last img
-                    this.index += 1;
-                    this.trackNavBetweenImages(e);
-                }
-                this.reloadState = true;
-            },
-            prev(e) {
-                if (this.index > 1) {
-                    // first img
-                    this.index -= 1;
-                    this.trackNavBetweenImages(e);
-                }
-                this.reloadState = true;
-            },
-            reload(e) {
-                this.trackNavBetweenImages(e);
-                this.reloadState = true;
-            },
-            'toggle-info': function() {
-                this.$captionContainer.classList.toggle(
-                    'hosted-gallery--show-caption'
-                );
-            },
-            'hide-info': function() {
-                this.$captionContainer.classList.remove(
-                    'hosted-gallery--show-caption'
-                );
-            },
-            'show-info': function() {
-                this.$captionContainer.classList.add('hosted-gallery--show-caption');
-            },
-            resize() {
-                this.onResize();
-            },
-        },
-    },
+			const pageName =
+				config.get('page.pageName') ||
+				window.location.pathname.substr(
+					window.location.pathname.lastIndexOf('/') + 1,
+				);
+			pushUrl({}, document.title, `${pageName}#img-${this.index}`, true);
+			// event bindings
+			mediator.on('window:throttledResize', this.resize);
+		},
+		leave() {
+			this.trigger('hide-info');
+			mediator.off('window:throttledResize', this.resize);
+		},
+		events: {
+			next(e) {
+				if (this.index < this.$images.length) {
+					// last img
+					this.index += 1;
+					this.trackNavBetweenImages(e);
+				}
+				this.reloadState = true;
+			},
+			prev(e) {
+				if (this.index > 1) {
+					// first img
+					this.index -= 1;
+					this.trackNavBetweenImages(e);
+				}
+				this.reloadState = true;
+			},
+			reload(e) {
+				this.trackNavBetweenImages(e);
+				this.reloadState = true;
+			},
+			'toggle-info': function () {
+				this.$captionContainer.classList.toggle(
+					'hosted-gallery--show-caption',
+				);
+			},
+			'hide-info': function () {
+				this.$captionContainer.classList.remove(
+					'hosted-gallery--show-caption',
+				);
+			},
+			'show-info': function () {
+				this.$captionContainer.classList.add(
+					'hosted-gallery--show-caption',
+				);
+			},
+			resize() {
+				this.onResize();
+			},
+		},
+	},
 };
 
 export const init = () => {
-    if (document.querySelectorAll('.js-hosted-gallery-container').length) {
-        return loadCssPromise.then(() => {
-            let res;
-            const galleryHash = window.location.hash;
-            const gallery = new HostedGallery();
-            const match = /\?index=(\d+)/.exec(document.location.href);
-            if (match) {
-                // index specified so launch gallery at that index
-                gallery.loadAtIndex(parseInt(match[1], 10));
-            } else {
-                res = /^#(?:img-)?(\d+)$/.exec(galleryHash);
-                if (res) {
-                    gallery.loadAtIndex(parseInt(res[1], 10));
-                }
-            }
+	if (document.querySelectorAll('.js-hosted-gallery-container').length) {
+		return loadCssPromise.then(() => {
+			let res;
+			const galleryHash = window.location.hash;
+			const gallery = new HostedGallery();
+			const match = /\?index=(\d+)/.exec(document.location.href);
+			if (match) {
+				// index specified so launch gallery at that index
+				gallery.loadAtIndex(parseInt(match[1], 10));
+			} else {
+				res = /^#(?:img-)?(\d+)$/.exec(galleryHash);
+				if (res) {
+					gallery.loadAtIndex(parseInt(res[1], 10));
+				}
+			}
 
-            return gallery;
-        });
-    }
+			return gallery;
+		});
+	}
 
-    return Promise.resolve();
+	return Promise.resolve();
 };

--- a/static/src/javascripts/projects/commercial/modules/hosted/gallery.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/gallery.spec.js
@@ -9,138 +9,134 @@ import { galleryHtml } from './gallery-html';
  */
 
 jest.mock('../../../../lib/detect', () => ({
-    hasPushStateSupport: jest.fn(),
-    getBreakpoint: jest.fn(),
-    hasTouchScreen: jest.fn(),
+	hasPushStateSupport: jest.fn(),
+	getBreakpoint: jest.fn(),
+	hasTouchScreen: jest.fn(),
 }));
 jest.mock('../../../common/modules/analytics/interaction-tracking', () => ({
-    trackNonClickInteraction: jest.fn(() => Promise.resolve()),
+	trackNonClickInteraction: jest.fn(() => Promise.resolve()),
 }));
 jest.mock('../../../../lib/load-css-promise', () => ({
-    loadCssPromise: Promise.resolve(),
+	loadCssPromise: Promise.resolve(),
 }));
 
 let gallery;
 
 describe('Hosted Gallery', () => {
-    beforeEach(done => {
-        if (document.body) {
-            document.body.innerHTML = galleryHtml;
-        }
-        init().then(galleryInstance => {
-            gallery = galleryInstance;
-            done();
-        });
-    });
+	beforeEach((done) => {
+		if (document.body) {
+			document.body.innerHTML = galleryHtml;
+		}
+		init().then((galleryInstance) => {
+			gallery = galleryInstance;
+			done();
+		});
+	});
 
-    afterEach(() => {
-        jest.resetAllMocks();
+	afterEach(() => {
+		jest.resetAllMocks();
 
-        if (document.body) {
-            document.body.innerHTML = '';
-        }
-    });
+		if (document.body) {
+			document.body.innerHTML = '';
+		}
+	});
 
-    it('should exist', done => {
-        expect(gallery).toBeDefined();
-        done();
-    });
+	it('should exist', (done) => {
+		expect(gallery).toBeDefined();
+		done();
+	});
 
-    const classListFor = (className) =>
-        (document.querySelector(`.${className}`)).classList.toString();
+	const classListFor = (className) =>
+		document.querySelector(`.${className}`).classList.toString();
 
-    it('should open and close the caption on click', () => {
-        const button = document.querySelector(
-            '.js-gallery-caption-button'
-        );
+	it('should open and close the caption on click', () => {
+		const button = document.querySelector('.js-gallery-caption-button');
 
-        button.click();
+		button.click();
 
-        expect(classListFor('js-gallery-caption-bar')).toEqual(
-            expect.stringContaining('hosted-gallery--show-caption')
-        );
+		expect(classListFor('js-gallery-caption-bar')).toEqual(
+			expect.stringContaining('hosted-gallery--show-caption'),
+		);
 
-        button.click();
+		button.click();
 
-        expect(classListFor('js-gallery-caption-bar')).not.toEqual(
-            expect.stringContaining('hosted-gallery--show-caption')
-        );
-    });
+		expect(classListFor('js-gallery-caption-bar')).not.toEqual(
+			expect.stringContaining('hosted-gallery--show-caption'),
+		);
+	});
 
-    it('should open and close  the caption on pressing "i"', () => {
-        gallery.handleKeyEvents({ keyCode: 73 });
+	it('should open and close  the caption on pressing "i"', () => {
+		gallery.handleKeyEvents({ keyCode: 73 });
 
-        expect(classListFor('js-gallery-caption-bar')).toEqual(
-            expect.stringContaining('hosted-gallery--show-caption')
-        );
+		expect(classListFor('js-gallery-caption-bar')).toEqual(
+			expect.stringContaining('hosted-gallery--show-caption'),
+		);
 
-        gallery.handleKeyEvents({ keyCode: 73 });
+		gallery.handleKeyEvents({ keyCode: 73 });
 
-        expect(classListFor('js-gallery-caption-bar')).not.toEqual(
-            expect.stringContaining('hosted-gallery--show-caption')
-        );
-    });
+		expect(classListFor('js-gallery-caption-bar')).not.toEqual(
+			expect.stringContaining('hosted-gallery--show-caption'),
+		);
+	});
 
-    it('should open and close the onward journey on click', () => {
-        const button = document.querySelector(
-            '.js-hosted-gallery-oj-close'
-        );
-        button.click();
+	it('should open and close the onward journey on click', () => {
+		const button = document.querySelector('.js-hosted-gallery-oj-close');
+		button.click();
 
-        expect(classListFor('js-hosted-gallery-oj')).toEqual(
-            expect.stringContaining('minimise-oj')
-        );
+		expect(classListFor('js-hosted-gallery-oj')).toEqual(
+			expect.stringContaining('minimise-oj'),
+		);
 
-        button.click();
+		button.click();
 
-        expect(classListFor('js-hosted-gallery-oj')).not.toEqual(
-            expect.stringContaining('minimise-oj')
-        );
-    });
+		expect(classListFor('js-hosted-gallery-oj')).not.toEqual(
+			expect.stringContaining('minimise-oj'),
+		);
+	});
 
-    it('should log navigation in GA when using arrow key navigation', () => {
-        gallery.handleKeyEvents({ keyCode: 40, preventDefault: noop });
-        expect(
-            interactionTracking.trackNonClickInteraction
-        ).toHaveBeenCalledWith('KeyPress:down - image 2');
-        gallery.handleKeyEvents({ keyCode: 39, preventDefault: noop });
-        expect(
-            interactionTracking.trackNonClickInteraction
-        ).toHaveBeenCalledWith('KeyPress:right - image 3');
-        gallery.handleKeyEvents({ keyCode: 38, preventDefault: noop });
-        expect(
-            interactionTracking.trackNonClickInteraction
-        ).toHaveBeenCalledWith('KeyPress:up - image 2');
-        gallery.handleKeyEvents({ keyCode: 37, preventDefault: noop });
-        expect(
-            interactionTracking.trackNonClickInteraction
-        ).toHaveBeenCalledWith('KeyPress:left - image 1');
-    });
+	it('should log navigation in GA when using arrow key navigation', () => {
+		gallery.handleKeyEvents({ keyCode: 40, preventDefault: noop });
+		expect(
+			interactionTracking.trackNonClickInteraction,
+		).toHaveBeenCalledWith('KeyPress:down - image 2');
+		gallery.handleKeyEvents({ keyCode: 39, preventDefault: noop });
+		expect(
+			interactionTracking.trackNonClickInteraction,
+		).toHaveBeenCalledWith('KeyPress:right - image 3');
+		gallery.handleKeyEvents({ keyCode: 38, preventDefault: noop });
+		expect(
+			interactionTracking.trackNonClickInteraction,
+		).toHaveBeenCalledWith('KeyPress:up - image 2');
+		gallery.handleKeyEvents({ keyCode: 37, preventDefault: noop });
+		expect(
+			interactionTracking.trackNonClickInteraction,
+		).toHaveBeenCalledWith('KeyPress:left - image 1');
+	});
 
-    it('should log navigation in GA when clicking through images', () => {
-        gallery.initScroll.call(gallery);
-        (document.querySelector('.inline-arrow-down')).click();
-        expect(
-            interactionTracking.trackNonClickInteraction
-        ).toHaveBeenCalledWith('Click - image 2');
-        (document.querySelector('.inline-arrow-up')).click();
-        expect(
-            interactionTracking.trackNonClickInteraction
-        ).toHaveBeenCalledWith('Click - image 1');
-    });
+	it('should log navigation in GA when clicking through images', () => {
+		gallery.initScroll.call(gallery);
+		document.querySelector('.inline-arrow-down').click();
+		expect(
+			interactionTracking.trackNonClickInteraction,
+		).toHaveBeenCalledWith('Click - image 2');
+		document.querySelector('.inline-arrow-up').click();
+		expect(
+			interactionTracking.trackNonClickInteraction,
+		).toHaveBeenCalledWith('Click - image 1');
+	});
 
-    it('should log navigation in GA when scrolling through images', () => {
-        const nativeHTMLElement = window.HTMLElement;
-        window.HTMLElement = function() {
-            this.scrollTop = 20;
-            this.scrollHeight = 30;
-        };
-        gallery.fadeContent({
-            target: new window.HTMLElement(),
-        });
-        expect(
-            interactionTracking.trackNonClickInteraction
-        ).toHaveBeenCalledWith('Scroll - image 3');
-        window.HTMLElement = nativeHTMLElement;
-    });
+	it('should log navigation in GA when scrolling through images', () => {
+		const nativeHTMLElement = window.HTMLElement;
+		window.HTMLElement = function () {
+			this.scrollTop = 20;
+			this.scrollHeight = 30;
+		};
+		gallery.fadeContent({
+			target: new window.HTMLElement(),
+		});
+		expect(
+			interactionTracking.trackNonClickInteraction,
+		).toHaveBeenCalledWith('Scroll - image 3');
+		window.HTMLElement = nativeHTMLElement;
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/hosted/next-video.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/next-video.js
@@ -3,27 +3,27 @@ import { fetchJson } from '../../../../lib/fetch-json';
 import fastdom from '../../../../lib/fastdom-promise';
 
 const loadNextVideo = () => {
-    const placeholders = document.querySelectorAll('.js-autoplay-placeholder');
+	const placeholders = document.querySelectorAll('.js-autoplay-placeholder');
 
-    if (placeholders.length) {
-        return fetchJson(
-            `${config.get('page.ajaxUrl')}/${config.get(
-                'page.pageId'
-            )}/autoplay.json`,
-            {
-                mode: 'cors',
-            }
-        ).then(json =>
-            fastdom.mutate(() => {
-                let i;
-                for (i = 0; i < placeholders.length; i += 1) {
-                    placeholders[i].innerHTML = json.html;
-                }
-            })
-        );
-    }
+	if (placeholders.length) {
+		return fetchJson(
+			`${config.get('page.ajaxUrl')}/${config.get(
+				'page.pageId',
+			)}/autoplay.json`,
+			{
+				mode: 'cors',
+			},
+		).then((json) =>
+			fastdom.mutate(() => {
+				let i;
+				for (i = 0; i < placeholders.length; i += 1) {
+					placeholders[i].innerHTML = json.html;
+				}
+			}),
+		);
+	}
 
-    return Promise.resolve();
+	return Promise.resolve();
 };
 
 export { loadNextVideo as init, loadNextVideo as load };

--- a/static/src/javascripts/projects/commercial/modules/hosted/next-video.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/next-video.spec.js
@@ -9,43 +9,43 @@ jest.mock('../../../../lib/fetch-json', () => ({
 }));
 
 describe('Hosted Next Video', () => {
-    beforeAll(() => {
-        config.set('page', {
-            ajaxUrl: 'some.url',
-            pageId: 'pageId',
-        });
-    });
-    beforeEach(() => {
-        if (document.body) {
-            document.body.innerHTML =
-                '<div class="js-autoplay-placeholder"></div>';
-        }
-    });
+	beforeAll(() => {
+		config.set('page', {
+			ajaxUrl: 'some.url',
+			pageId: 'pageId',
+		});
+	});
+	beforeEach(() => {
+		if (document.body) {
+			document.body.innerHTML =
+				'<div class="js-autoplay-placeholder"></div>';
+		}
+	});
 
-    afterEach(() => {
-        if (document.body) {
-            document.body.innerHTML = '';
-        }
-    });
+	afterEach(() => {
+		if (document.body) {
+			document.body.innerHTML = '';
+		}
+	});
 
-    it('should exist', () => {
-        expect(load).toBeDefined();
-    });
+	it('should exist', () => {
+		expect(load).toBeDefined();
+	});
 
-    it('should make an ajax call and insert html', done => {
-        load()
-            .then(() => {
-                expect(fetchJson).toHaveBeenCalledWith(
-                    'some.url/pageId/autoplay.json',
-                    {
-                        mode: 'cors',
-                    }
-                );
-                expect(
-                    document.querySelector('.js-autoplay-placeholder .video')
-                ).not.toBeNull();
-            })
-            .then(done)
-            .catch(done.fail);
-    });
+	it('should make an ajax call and insert html', (done) => {
+		load()
+			.then(() => {
+				expect(fetchJson).toHaveBeenCalledWith(
+					'some.url/pageId/autoplay.json',
+					{
+						mode: 'cors',
+					},
+				);
+				expect(
+					document.querySelector('.js-autoplay-placeholder .video'),
+				).not.toBeNull();
+			})
+			.then(done)
+			.catch(done.fail);
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/hosted/onward-journey-carousel.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/onward-journey-carousel.spec.js
@@ -8,9 +8,9 @@ import { initHostedCarousel } from './onward-journey-carousel';
  */
 
 describe('Hosted onward journey carousel', () => {
-    beforeEach(() => {
-        if (document.body) {
-            document.body.innerHTML = `
+	beforeEach(() => {
+		if (document.body) {
+			document.body.innerHTML = `
                     <div>
                         <div>
                             <span class="prev-oj-item"></span>
@@ -33,69 +33,64 @@ describe('Hosted onward journey carousel', () => {
 
                     </div>
                 `;
-        }
-    });
+		}
+	});
 
-    afterEach(() => {
-        if (document.body) {
-            document.body.innerHTML = '';
-        }
-    });
+	afterEach(() => {
+		if (document.body) {
+			document.body.innerHTML = '';
+		}
+	});
 
-    it('should exist', () => {
-        expect(initHostedCarousel).toBeDefined();
-    });
+	it('should exist', () => {
+		expect(initHostedCarousel).toBeDefined();
+	});
 
-    const clickAndExpectNthPage = (
-        clickOn,
-        expectedPage
-    ) => {
-        (document.querySelector(`.${clickOn}`)).click();
-        return fastdom.measure(() => {
-            const transform = (1 - expectedPage) * 100;
+	const clickAndExpectNthPage = (clickOn, expectedPage) => {
+		document.querySelector(`.${clickOn}`).click();
+		return fastdom.measure(() => {
+			const transform = (1 - expectedPage) * 100;
 
-            expect(
-                (document.querySelector(
-                    '.js-carousel-pages'
-                )).getAttribute('style')
-            ).toEqual(
-                `transform: translate(${transform || '-000'}%, 0);`
-            );
+			expect(
+				document
+					.querySelector('.js-carousel-pages')
+					.getAttribute('style'),
+			).toEqual(`transform: translate(${transform || '-000'}%, 0);`);
 
-            [1, 2, 3, 4].forEach(i => {
-                const cssClasses = (document.querySelector(
-                    `.js-carousel-dot:nth-child(${i})`
-                )).classList.toString();
-                if (i === expectedPage) {
-                    expect(cssClasses).toEqual(
-                        expect.stringContaining('highlighted')
-                    );
-                } else {
-                    expect(cssClasses).not.toEqual(
-                        expect.stringContaining('highlighted')
-                    );
-                }
-            });
-        });
-    };
+			[1, 2, 3, 4].forEach((i) => {
+				const cssClasses = document
+					.querySelector(`.js-carousel-dot:nth-child(${i})`)
+					.classList.toString();
+				if (i === expectedPage) {
+					expect(cssClasses).toEqual(
+						expect.stringContaining('highlighted'),
+					);
+				} else {
+					expect(cssClasses).not.toEqual(
+						expect.stringContaining('highlighted'),
+					);
+				}
+			});
+		});
+	};
 
-    it('should show next page on clicking arrow buttons', done => {
-        initHostedCarousel()
-            .then(clickAndExpectNthPage('next-oj-item', 2))
-            .then(clickAndExpectNthPage('next-oj-item', 3))
-            .then(clickAndExpectNthPage('prev-oj-item', 2))
-            .then(clickAndExpectNthPage('prev-oj-item', 1))
-            .then(done)
-            .catch(done.fail);
-    });
+	it('should show next page on clicking arrow buttons', (done) => {
+		initHostedCarousel()
+			.then(clickAndExpectNthPage('next-oj-item', 2))
+			.then(clickAndExpectNthPage('next-oj-item', 3))
+			.then(clickAndExpectNthPage('prev-oj-item', 2))
+			.then(clickAndExpectNthPage('prev-oj-item', 1))
+			.then(done)
+			.catch(done.fail);
+	});
 
-    it('should change page on clicking the dots', done => {
-        initHostedCarousel()
-            .then(clickAndExpectNthPage('js-carousel-dot:nth-child(4)', 4))
-            .then(clickAndExpectNthPage('js-carousel-dot:nth-child(2)', 2))
-            .then(clickAndExpectNthPage('js-carousel-dot:nth-child(3)', 3))
-            .then(clickAndExpectNthPage('js-carousel-dot:nth-child(1)', 1))
-            .then(done)
-            .catch(done.fail);
-    });
+	it('should change page on clicking the dots', (done) => {
+		initHostedCarousel()
+			.then(clickAndExpectNthPage('js-carousel-dot:nth-child(4)', 4))
+			.then(clickAndExpectNthPage('js-carousel-dot:nth-child(2)', 2))
+			.then(clickAndExpectNthPage('js-carousel-dot:nth-child(3)', 3))
+			.then(clickAndExpectNthPage('js-carousel-dot:nth-child(1)', 1))
+			.then(done)
+			.catch(done.fail);
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/hosted/onward.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/onward.js
@@ -5,46 +5,39 @@ import { initHostedCarousel } from './onward-journey-carousel';
 
 // there should only ever be one onward component on the page
 // if the component does not exist, return an empty array rather than `undefined`
-const getPlaceholderFromDom = (
-    dom = document
-) =>
-    Array.from(dom.getElementsByClassName('js-onward-placeholder')).slice(0, 1);
+const getPlaceholderFromDom = (dom = document) =>
+	Array.from(dom.getElementsByClassName('js-onward-placeholder')).slice(0, 1);
 
-const generateUrlFromConfig = (
-    c = config
-) =>
-    c.page.pageId && c.page.contentType
-        ? `${c.page.ajaxUrl || ''}/${
-              c.page.pageId
-          }/${c.page.contentType.toLowerCase()}/onward.json`
-        : '';
+const generateUrlFromConfig = (c = config) =>
+	c.page.pageId && c.page.contentType
+		? `${c.page.ajaxUrl || ''}/${
+				c.page.pageId
+		  }/${c.page.contentType.toLowerCase()}/onward.json`
+		: '';
 
-const insertHTMLfromPlaceholders = (
-    json,
-    placeholders
-) => {
-    placeholders[0].insertAdjacentHTML('beforeend', json.html);
+const insertHTMLfromPlaceholders = (json, placeholders) => {
+	placeholders[0].insertAdjacentHTML('beforeend', json.html);
 };
 
 export const loadOnwardComponent = (
-    insertHtmlFn = insertHTMLfromPlaceholders
+	insertHtmlFn = insertHTMLfromPlaceholders,
 ) => {
-    const placeholders = getPlaceholderFromDom();
-    const jsonUrl = generateUrlFromConfig();
+	const placeholders = getPlaceholderFromDom();
+	const jsonUrl = generateUrlFromConfig();
 
-    if (placeholders && placeholders.length) {
-        fetchJson(jsonUrl, { mode: 'cors' })
-            .then(json =>
-                fastdom.mutate(() => {
-                    insertHtmlFn(json, placeholders);
-                })
-            )
-            .then(() => {
-                initHostedCarousel();
-            });
-    }
+	if (placeholders && placeholders.length) {
+		fetchJson(jsonUrl, { mode: 'cors' })
+			.then((json) =>
+				fastdom.mutate(() => {
+					insertHtmlFn(json, placeholders);
+				}),
+			)
+			.then(() => {
+				initHostedCarousel();
+			});
+	}
 
-    return Promise.resolve();
+	return Promise.resolve();
 };
 
 export const _ = { insertHTMLfromPlaceholders, generateUrlFromConfig };

--- a/static/src/javascripts/projects/commercial/modules/hosted/onward.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/onward.spec.js
@@ -1,4 +1,4 @@
-import {fetchJson as fetchJson_} from '../../../../lib/fetch-json';
+import { fetchJson as fetchJson_ } from '../../../../lib/fetch-json';
 import { loadOnwardComponent, _ } from './onward.js';
 
 const { insertHTMLfromPlaceholders, generateUrlFromConfig } = _;
@@ -8,41 +8,41 @@ const fetchJson = fetchJson_;
 jest.mock('../../../../lib/fetch-json', () => ({ fetchJson: jest.fn() }));
 
 describe('URL generator', () => {
-    it('generates correct URL from valid config', () => {
-        const fakeConfig = {
-            page: {
-                ajaxUrl: 'some.url',
-                contentType: 'gallery',
-                pageId: 'pageId',
-            },
-        };
-        const expectResult = 'some.url/pageId/gallery/onward.json';
-        const result = generateUrlFromConfig(fakeConfig);
+	it('generates correct URL from valid config', () => {
+		const fakeConfig = {
+			page: {
+				ajaxUrl: 'some.url',
+				contentType: 'gallery',
+				pageId: 'pageId',
+			},
+		};
+		const expectResult = 'some.url/pageId/gallery/onward.json';
+		const result = generateUrlFromConfig(fakeConfig);
 
-        expect(result).toEqual(expectResult);
-    });
+		expect(result).toEqual(expectResult);
+	});
 });
 
 describe('Insert onward HTML', () => {
-    it('calls own insertion method', () => {
-        const fakePlaceholder = document.createElement('div');
-        fakePlaceholder.innerHTML = '<div class="js-onward-placeholder"></div>';
-        const fakeJson = { html: '<div class="next-page"></div>' };
-        const result =
-            '<div class="js-onward-placeholder"></div><div class="next-page"></div>';
+	it('calls own insertion method', () => {
+		const fakePlaceholder = document.createElement('div');
+		fakePlaceholder.innerHTML = '<div class="js-onward-placeholder"></div>';
+		const fakeJson = { html: '<div class="next-page"></div>' };
+		const result =
+			'<div class="js-onward-placeholder"></div><div class="next-page"></div>';
 
-        insertHTMLfromPlaceholders(fakeJson, [fakePlaceholder]);
-        expect(fakePlaceholder.innerHTML).toBe(result);
-    });
+		insertHTMLfromPlaceholders(fakeJson, [fakePlaceholder]);
+		expect(fakePlaceholder.innerHTML).toBe(result);
+	});
 });
 
 describe('Loading onward component', () => {
-    afterEach(() => {
-        fetchJson.mockReset();
-    });
+	afterEach(() => {
+		fetchJson.mockReset();
+	});
 
-    it('Does not fetch onwards if placeholder length is 0', () => {
-        loadOnwardComponent();
-        expect(fetchJson).not.toHaveBeenCalled();
-    });
+	it('Does not fetch onwards if placeholder length is 0', () => {
+		loadOnwardComponent();
+		expect(fetchJson).not.toHaveBeenCalled();
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/ipsos-mori.js
+++ b/static/src/javascripts/projects/commercial/modules/ipsos-mori.js
@@ -1,38 +1,39 @@
 import {
-    getConsentFor,
-    onConsentChange,
+	getConsentFor,
+	onConsentChange,
 } from '@guardian/consent-management-platform';
 import { getLocale, loadScript } from '@guardian/libs';
 import config from '../../../lib/config';
 
 const loadIpsosScript = () => {
+	window.dm = window.dm || { AjaxData: [] };
+	window.dm.AjaxEvent = (et, d, ssid, ad) => {
+		dm.AjaxData.push({ et, d, ssid, ad }); // eslint-disable-line no-undef
+		if (window.DotMetricsObj) {
+			DotMetricsObj.onAjaxDataUpdate(); // eslint-disable-line no-undef
+		}
+	};
+	const ipsosSource = `https://uk-script.dotmetrics.net/door.js?d=${
+		document.location.host
+	}&t=${config.get('page.ipsosTag')}`;
 
-    window.dm = window.dm ||{ AjaxData:[]};
-    window.dm.AjaxEvent = (et, d, ssid, ad) => {
-        
-        dm.AjaxData.push({ et,d,ssid,ad}); // eslint-disable-line no-undef
-        if (window.DotMetricsObj) {
-                
-                DotMetricsObj.onAjaxDataUpdate(); // eslint-disable-line no-undef
-        }
-    };
-    const ipsosSource = `https://uk-script.dotmetrics.net/door.js?d=${  document.location.host  }&t=${ config.get('page.ipsosTag')}`;
-
-    return loadScript(ipsosSource, { id: 'ipsos', async: true, type: 'text/javascript' });
+	return loadScript(ipsosSource, {
+		id: 'ipsos',
+		async: true,
+		type: 'text/javascript',
+	});
 };
 
 export const init = () => {
+	getLocale().then((locale) => {
+		if (locale === 'GB') {
+			onConsentChange((state) => {
+				if (getConsentFor('ipsos', state)) {
+					return loadIpsosScript();
+				}
+			});
+		}
+	});
 
-    getLocale().then((locale) => {
-        if(locale === 'GB') {
-            onConsentChange(state => {
-                if (getConsentFor('ipsos', state)) {
-                    return loadIpsosScript();
-                }
-            });
-        }
-    });
-
-    return Promise.resolve();
+	return Promise.resolve();
 };
-

--- a/static/src/javascripts/projects/commercial/modules/liveblog-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/liveblog-adverts.js
@@ -14,125 +14,122 @@ let WINDOWHEIGHT;
 let firstSlot;
 
 const startListening = () => {
-    // eslint-disable-next-line no-use-before-define
-    mediator.on('modules:autoupdate:updates', onUpdate);
+	// eslint-disable-next-line no-use-before-define
+	mediator.on('modules:autoupdate:updates', onUpdate);
 };
 
 const stopListening = () => {
-    // eslint-disable-next-line no-use-before-define
-    mediator.off('modules:autoupdate:updates', onUpdate);
+	// eslint-disable-next-line no-use-before-define
+	mediator.off('modules:autoupdate:updates', onUpdate);
 };
 
 const getWindowHeight = (doc = document) => {
-    if (doc.documentElement && doc.documentElement.clientHeight) {
-        return doc.documentElement.clientHeight;
-    }
-    return 0; // #? zero, or throw an error?
+	if (doc.documentElement && doc.documentElement.clientHeight) {
+		return doc.documentElement.clientHeight;
+	}
+	return 0; // #? zero, or throw an error?
 };
 
-const getSpaceFillerRules = (
-    windowHeight,
-    update
-) => {
-    let prevSlot;
-    const shouldUpdate = !!update;
+const getSpaceFillerRules = (windowHeight, update) => {
+	let prevSlot;
+	const shouldUpdate = !!update;
 
-    // Only use a slot if it is double the window height from the previous slot.
-    const filterSlot = (slot) => {
-        if (!prevSlot) {
-            prevSlot = slot;
-            return !shouldUpdate;
-        } else if (Math.abs(slot.top - prevSlot.top) > windowHeight * 2) {
-            prevSlot = slot;
-            return true;
-        }
-        return false;
-    };
+	// Only use a slot if it is double the window height from the previous slot.
+	const filterSlot = (slot) => {
+		if (!prevSlot) {
+			prevSlot = slot;
+			return !shouldUpdate;
+		} else if (Math.abs(slot.top - prevSlot.top) > windowHeight * 2) {
+			prevSlot = slot;
+			return true;
+		}
+		return false;
+	};
 
-    return {
-        bodySelector: '.js-liveblog-body',
-        slotSelector: ' > .block',
-        fromBottom: shouldUpdate,
-        startAt: shouldUpdate ? firstSlot : null,
-        absoluteMinAbove: shouldUpdate ? 0 : WINDOWHEIGHT * OFFSET,
-        minAbove: 0,
-        minBelow: 0,
-        clearContentMeta: 0,
-        selectors: {},
-        filter: filterSlot,
-    };
+	return {
+		bodySelector: '.js-liveblog-body',
+		slotSelector: ' > .block',
+		fromBottom: shouldUpdate,
+		startAt: shouldUpdate ? firstSlot : null,
+		absoluteMinAbove: shouldUpdate ? 0 : WINDOWHEIGHT * OFFSET,
+		minAbove: 0,
+		minBelow: 0,
+		clearContentMeta: 0,
+		selectors: {},
+		filter: filterSlot,
+	};
 };
 
 const getSlotName = (isMobile, slotCounter) => {
-    if (isMobile && slotCounter === 0) {
-        return 'top-above-nav';
-    } else if (isMobile) {
-        return `inline${slotCounter}`;
-    }
-    return `inline${slotCounter + 1}`;
+	if (isMobile && slotCounter === 0) {
+		return 'top-above-nav';
+	} else if (isMobile) {
+		return `inline${slotCounter}`;
+	}
+	return `inline${slotCounter + 1}`;
 };
 
 const insertAds = (slots) => {
-    const isMobile = getBreakpoint() === 'mobile';
+	const isMobile = getBreakpoint() === 'mobile';
 
-    for (let i = 0; i < slots.length && SLOTCOUNTER < MAX_ADS; i += 1) {
-        const slotName = getSlotName(isMobile, SLOTCOUNTER);
+	for (let i = 0; i < slots.length && SLOTCOUNTER < MAX_ADS; i += 1) {
+		const slotName = getSlotName(isMobile, SLOTCOUNTER);
 
-        const adSlots = createSlots('inline', {
-            name: slotName,
-            classes: 'liveblog-inline',
-        });
+		const adSlots = createSlots('inline', {
+			name: slotName,
+			classes: 'liveblog-inline',
+		});
 
-        adSlots.forEach(adSlot => {
-            if (slots[i] && slots[i].parentNode) {
-                slots[i].parentNode.insertBefore(adSlot, slots[i].nextSibling);
-            }
-        });
+		adSlots.forEach((adSlot) => {
+			if (slots[i] && slots[i].parentNode) {
+				slots[i].parentNode.insertBefore(adSlot, slots[i].nextSibling);
+			}
+		});
 
-        // Only add the first adSlot (the DFP one) in DFP/GTP
-        if (slots[i] && slots[i].parentNode) {
-            addSlot(adSlots[0], false);
-            SLOTCOUNTER += 1;
-        }
-    }
+		// Only add the first adSlot (the DFP one) in DFP/GTP
+		if (slots[i] && slots[i].parentNode) {
+			addSlot(adSlots[0], false);
+			SLOTCOUNTER += 1;
+		}
+	}
 };
 
 const fill = (rules) =>
-    spaceFiller.fillSpace(rules, insertAds).then(result => {
-        if (result && SLOTCOUNTER < MAX_ADS) {
-            const el = document.querySelector(
-                `${rules.bodySelector} > .ad-slot`
-            );
-            if (el && el.previousSibling instanceof HTMLElement) {
-                firstSlot = el.previousSibling;
-            } else {
-                firstSlot = null;
-            }
-            startListening();
-        } else {
-            firstSlot = null;
-        }
-    });
+	spaceFiller.fillSpace(rules, insertAds).then((result) => {
+		if (result && SLOTCOUNTER < MAX_ADS) {
+			const el = document.querySelector(
+				`${rules.bodySelector} > .ad-slot`,
+			);
+			if (el && el.previousSibling instanceof HTMLElement) {
+				firstSlot = el.previousSibling;
+			} else {
+				firstSlot = null;
+			}
+			startListening();
+		} else {
+			firstSlot = null;
+		}
+	});
 
 const onUpdate = () => {
-    stopListening();
-    Promise.resolve(getSpaceFillerRules(WINDOWHEIGHT, true)).then(fill);
+	stopListening();
+	Promise.resolve(getSpaceFillerRules(WINDOWHEIGHT, true)).then(fill);
 };
 
 export const init = () => {
-    if (!commercialFeatures.liveblogAdverts) {
-        return Promise.resolve();
-    }
+	if (!commercialFeatures.liveblogAdverts) {
+		return Promise.resolve();
+	}
 
-    fastdom
-        .measure(() => {
-            WINDOWHEIGHT = getWindowHeight();
-            return WINDOWHEIGHT;
-        })
-        .then(getSpaceFillerRules)
-        .then(fill);
+	fastdom
+		.measure(() => {
+			WINDOWHEIGHT = getWindowHeight();
+			return WINDOWHEIGHT;
+		})
+		.then(getSpaceFillerRules)
+		.then(fill);
 
-    return Promise.resolve();
+	return Promise.resolve();
 };
 
 export const _ = { getSlotName };

--- a/static/src/javascripts/projects/commercial/modules/liveblog-adverts.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/liveblog-adverts.spec.js
@@ -3,28 +3,28 @@ import { init, _ } from './liveblog-adverts';
 const { getSlotName } = _;
 
 jest.mock('../../../lib/detect', () => ({
-    getBreakpoint: jest.fn(),
-    hasPushStateSupport: jest.fn(),
+	getBreakpoint: jest.fn(),
+	hasPushStateSupport: jest.fn(),
 }));
 
 jest.mock('../../common/modules/article/space-filler', () => ({
-    fillSpace: jest.fn(),
+	fillSpace: jest.fn(),
 }));
 
 jest.mock('../../common/modules/commercial/commercial-features', () => ({
-    commercialFeatures: {
-        liveblogAdverts: true,
-    },
+	commercialFeatures: {
+		liveblogAdverts: true,
+	},
 }));
 
 jest.mock('./dfp/add-slot', () => ({
-    addSlot: jest.fn(),
+	addSlot: jest.fn(),
 }));
 
 describe('Liveblog Dynamic Adverts', () => {
-    beforeEach(() => {
-        if (document.body) {
-            document.body.innerHTML = `
+	beforeEach(() => {
+		if (document.body) {
+			document.body.innerHTML = `
                 <div class="js-liveblog-body">
                     <div class="block x1"></div>
                     <div class="block x2"></div>
@@ -40,44 +40,44 @@ describe('Liveblog Dynamic Adverts', () => {
                     <div class="block x12"></div>
                 </div>';
                 `;
-        }
-    });
+		}
+	});
 
-    afterEach(() => {
-        if (document.body) {
-            document.body.innerHTML = '';
-        }
-    });
+	afterEach(() => {
+		if (document.body) {
+			document.body.innerHTML = '';
+		}
+	});
 
-    it('should exist', () => {
-        expect(init).toBeDefined();
-    });
+	it('should exist', () => {
+		expect(init).toBeDefined();
+	});
 
-    it('should return the correct slot name', () => {
-        const firstMobileSlot = getSlotName(true, 0);
-        const otherMobileSlot = getSlotName(true, 2);
-        const desktopSlot = getSlotName(false, 0);
+	it('should return the correct slot name', () => {
+		const firstMobileSlot = getSlotName(true, 0);
+		const otherMobileSlot = getSlotName(true, 2);
+		const desktopSlot = getSlotName(false, 0);
 
-        expect(firstMobileSlot).toBe('top-above-nav');
-        expect(otherMobileSlot).toBe('inline2');
-        expect(desktopSlot).toBe('inline1');
-    });
+		expect(firstMobileSlot).toBe('top-above-nav');
+		expect(otherMobileSlot).toBe('inline2');
+		expect(desktopSlot).toBe('inline1');
+	});
 
-    // todo: difficult to mock spacefiller, which is not yet ES6'ed, so come back to this
-    it.skip('should insert ads every 5th block', () =>
-        init().then(() => {
-            const adSlots = document.querySelectorAll(
-                '.js-liveblog-body .ad-slot'
-            );
-            const candidates = document.querySelectorAll(
-                '.js-liveblog-body > *:nth-child(5n+1)'
-            );
-            const candidatesAreAllAds = Array.prototype.every.call(
-                candidates,
-                c => c.classList.contains('ad-slot')
-            );
-            expect(adSlots.length).toBeGreaterThan(0);
-            expect(candidatesAreAllAds).toBe(true);
-            expect(candidates.length).toEqual(adSlots.length);
-        }));
+	// todo: difficult to mock spacefiller, which is not yet ES6'ed, so come back to this
+	it.skip('should insert ads every 5th block', () =>
+		init().then(() => {
+			const adSlots = document.querySelectorAll(
+				'.js-liveblog-body .ad-slot',
+			);
+			const candidates = document.querySelectorAll(
+				'.js-liveblog-body > *:nth-child(5n+1)',
+			);
+			const candidatesAreAllAds = Array.prototype.every.call(
+				candidates,
+				(c) => c.classList.contains('ad-slot'),
+			);
+			expect(adSlots.length).toBeGreaterThan(0);
+			expect(candidatesAreAllAds).toBe(true);
+			expect(candidates.length).toEqual(adSlots.length);
+		}));
 });

--- a/static/src/javascripts/projects/commercial/modules/measure-timing.js
+++ b/static/src/javascripts/projects/commercial/modules/measure-timing.js
@@ -1,33 +1,33 @@
 export const measureTiming = (name) => {
-    if (window.performance && window.performance.now) {
-        const perf = window.performance;
-        const startKey = `${name}-start`;
-        const endKey = `${name}-end`;
+	if (window.performance && window.performance.now) {
+		const perf = window.performance;
+		const startKey = `${name}-start`;
+		const endKey = `${name}-end`;
 
-        const start = () => {
-            perf.mark(startKey);
-        };
+		const start = () => {
+			perf.mark(startKey);
+		};
 
-        const end = () => {
-            perf.mark(endKey);
-            perf.measure(name, startKey, endKey);
+		const end = () => {
+			perf.mark(endKey);
+			perf.measure(name, startKey, endKey);
 
-            const measureEntries = perf.getEntriesByName(name, "measure");
-            const timeTakenFloat = measureEntries[0].duration;
-            const timeTakenInt = Math.round(timeTakenFloat);
+			const measureEntries = perf.getEntriesByName(name, 'measure');
+			const timeTakenFloat = measureEntries[0].duration;
+			const timeTakenInt = Math.round(timeTakenFloat);
 
-            return timeTakenInt;
-        };
+			return timeTakenInt;
+		};
 
-        const clear = () => {
-            perf.clearMarks(startKey)
-        }
+		const clear = () => {
+			perf.clearMarks(startKey);
+		};
 
-        return {
-            start,
-            end,
-            clear
-        };
-    }
-    return { start: () => null, end: () => null, clear: () => null }
+		return {
+			start,
+			end,
+			clear,
+		};
+	}
+	return { start: () => null, end: () => null, clear: () => null };
 };

--- a/static/src/javascripts/projects/commercial/modules/messenger.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger.js
@@ -5,50 +5,46 @@ const LISTENERS = {};
 let REGISTERED_LISTENERS = 0;
 
 const error405 = {
-    code: 405,
-    message: 'Service %% not implemented',
+	code: 405,
+	message: 'Service %% not implemented',
 };
 const error500 = {
-    code: 500,
-    message: 'Internal server error\n\n%%',
+	code: 500,
+	message: 'Internal server error\n\n%%',
 };
-
-
 
 // A legacy from programmatic ads running in friendly iframes. They can
 // on occasion be larger than the size returned by DFP. And so they
 // have been setup to send a message of the form:
 
-const isProgrammaticMessage = (
-    payload
-) =>
-    payload.type === 'set-ad-height' &&
-    ('id' in payload.value || 'slotId' in payload.value) &&
-    'height' in payload.value;
+const isProgrammaticMessage = (payload) =>
+	payload.type === 'set-ad-height' &&
+	('id' in payload.value || 'slotId' in payload.value) &&
+	'height' in payload.value;
 
 const toStandardMessage = (payload) => ({
-    id: 'aaaa0000-bb11-cc22-dd33-eeeeee444444',
-    type: 'resize',
-    iframeId: payload.value.id,
-    slotId: payload.value.slotId,
-    value: {
-        height: +payload.value.height,
-        width: +payload.value.width,
-    },
+	id: 'aaaa0000-bb11-cc22-dd33-eeeeee444444',
+	type: 'resize',
+	iframeId: payload.value.id,
+	slotId: payload.value.slotId,
+	value: {
+		height: +payload.value.height,
+		width: +payload.value.width,
+	},
 });
 
 // Incoming messages contain the ID of the iframe into which the
 // source window is embedded.
 const getIframe = (data) => {
-    if (data.slotId) {
-        const container = document.getElementById(`dfp-ad--${data.slotId}`);
-        const iframes = container
-            ? container.getElementsByTagName('iframe')
-            : null;
-        return iframes && iframes.length ? iframes[0] : null;
-    } else if (data.iframeId) {
-        return document.getElementById(data.iframeId);
-    }
+	if (data.slotId) {
+		const container = document.getElementById(`dfp-ad--${data.slotId}`);
+		const iframes = container
+			? container.getElementsByTagName('iframe')
+			: null;
+		return iframes && iframes.length ? iframes[0] : null;
+	} else if (data.iframeId) {
+		return document.getElementById(data.iframeId);
+	}
 };
 
 // Until DFP provides a way for us to identify with 100% certainty our
@@ -56,13 +52,13 @@ const getIframe = (data) => {
 // such as validating the anatomy of the payload and whitelisting
 // event type
 const isValidPayload = (payload) =>
-    typeof payload === 'object' &&
-    !!payload && // Needed because typeof null==='object'
-    'type' in payload &&
-    'value' in payload &&
-    'id' in payload &&
-    payload.type in LISTENERS &&
-    /^[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}$/.test(payload.id);
+	typeof payload === 'object' &&
+	!!payload && // Needed because typeof null==='object'
+	'type' in payload &&
+	'value' in payload &&
+	'id' in payload &&
+	payload.type in LISTENERS &&
+	/^[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}$/.test(payload.id);
 
 // Cheap string formatting function. It accepts as its first argument
 // an object `{ code, message }`. `message` is a string where successive
@@ -70,153 +66,148 @@ const isValidPayload = (payload) =>
 // `formatError({ message: "%%, you are so %%" }, "Regis", "lovely")`
 // returns `{ message: "Regis, you are so lovely" }`. Oh, thank you!
 const formatError = (error, ...args) =>
-    args.reduce((e, arg) => {
-        e.message = e.message.replace('%%', arg);
-        return e;
-    }, error);
+	args.reduce((e, arg) => {
+		e.message = e.message.replace('%%', arg);
+		return e;
+	}, error);
 
 const onMessage = (event) => {
-    let data;
+	let data;
 
-    // #? This try-catch is a good target for splitting out into a seperate function
-    try {
-        // Even though the postMessage API allows passing objects as-is, the
-        // serialisation/deserialisation is slower than using JSON
-        // Source: https://bugs.chromium.org/p/chromium/issues/detail?id=536620#c11
-        data = JSON.parse(event.data);
-    } catch (ex) {
-        return;
-    }
+	// #? This try-catch is a good target for splitting out into a seperate function
+	try {
+		// Even though the postMessage API allows passing objects as-is, the
+		// serialisation/deserialisation is slower than using JSON
+		// Source: https://bugs.chromium.org/p/chromium/issues/detail?id=536620#c11
+		data = JSON.parse(event.data);
+	} catch (ex) {
+		return;
+	}
 
-    // These legacy messages are converted into bona fide resize messages
-    if (isProgrammaticMessage(data)) {
-        data = toStandardMessage(data);
-    }
+	// These legacy messages are converted into bona fide resize messages
+	if (isProgrammaticMessage(data)) {
+		data = toStandardMessage(data);
+	}
 
-    if (!isValidPayload(data)) {
-        return;
-    }
+	if (!isValidPayload(data)) {
+		return;
+	}
 
-    const respond = (error, result) => {
-        postMessage(
-            {
-                id: data.id,
-                error,
-                result,
-            },
-            event.source,
-        );
-    };
+	const respond = (error, result) => {
+		postMessage(
+			{
+				id: data.id,
+				error,
+				result,
+			},
+			event.source,
+		);
+	};
 
-    if (Array.isArray(LISTENERS[data.type]) && LISTENERS[data.type].length) {
-        // Because any listener can have side-effects (by unregistering itself),
-        // we run the promise chain on a copy of the `LISTENERS` array.
-        // Hat tip @piuccio
-        const promise = LISTENERS[data.type]
-            .slice()
-            // We offer, but don't impose, the possibility that a listener returns
-            // a value that must be sent back to the calling frame. To do this,
-            // we pass the cumulated returned value as a second argument to each
-            // listener. Notice we don't try some clever way to compose the result
-            // value ourselves, this would only make the solution more complex.
-            // That means a listener can ignore the cumulated return value and
-            // return something else entirely—life is unfair.
-            // We don't know what each callack will be made of, we don't want to.
-            // And so we wrap each call in a promise chain, in case one drops the
-            // occasional fastdom bomb in the middle.
-            .reduce(
-                (func, listener) =>
-                    func.then(ret => {
-                        const thisRet = listener(
-                            data.value,
-                            ret,
-                            getIframe(data)
-                        );
-                        return thisRet === undefined ? ret : thisRet;
-                    }),
-                Promise.resolve(true)
-            );
+	if (Array.isArray(LISTENERS[data.type]) && LISTENERS[data.type].length) {
+		// Because any listener can have side-effects (by unregistering itself),
+		// we run the promise chain on a copy of the `LISTENERS` array.
+		// Hat tip @piuccio
+		const promise = LISTENERS[data.type]
+			.slice()
+			// We offer, but don't impose, the possibility that a listener returns
+			// a value that must be sent back to the calling frame. To do this,
+			// we pass the cumulated returned value as a second argument to each
+			// listener. Notice we don't try some clever way to compose the result
+			// value ourselves, this would only make the solution more complex.
+			// That means a listener can ignore the cumulated return value and
+			// return something else entirely—life is unfair.
+			// We don't know what each callack will be made of, we don't want to.
+			// And so we wrap each call in a promise chain, in case one drops the
+			// occasional fastdom bomb in the middle.
+			.reduce(
+				(func, listener) =>
+					func.then((ret) => {
+						const thisRet = listener(
+							data.value,
+							ret,
+							getIframe(data),
+						);
+						return thisRet === undefined ? ret : thisRet;
+					}),
+				Promise.resolve(true),
+			);
 
-        return promise
-            .then(response => {
-                respond(null, response);
-            })
-            .catch(ex => {
-                reportError(ex, {
-                    feature: 'native-ads',
-                });
-                respond(formatError(error500, ex), null);
-            });
-    } else if (typeof LISTENERS[data.type] === 'function') {
-        // We found a persistent listener, to which we just delegate
-        // responsibility to write something. Anything. Really.
-        LISTENERS[data.type](respond, data.value, getIframe(data));
-    } else {
-        // If there is no routine attached to this event type, we just answer
-        // with an error code
-        respond(formatError(error405, data.type), null);
-    }
+		return promise
+			.then((response) => {
+				respond(null, response);
+			})
+			.catch((ex) => {
+				reportError(ex, {
+					feature: 'native-ads',
+				});
+				respond(formatError(error500, ex), null);
+			});
+	} else if (typeof LISTENERS[data.type] === 'function') {
+		// We found a persistent listener, to which we just delegate
+		// responsibility to write something. Anything. Really.
+		LISTENERS[data.type](respond, data.value, getIframe(data));
+	} else {
+		// If there is no routine attached to this event type, we just answer
+		// with an error code
+		respond(formatError(error405, data.type), null);
+	}
 };
 
 const on = (window) => {
-    window.addEventListener('message', onMessage);
+	window.addEventListener('message', onMessage);
 };
 
 const off = (window) => {
-    window.removeEventListener('message', onMessage);
+	window.removeEventListener('message', onMessage);
 };
-
 
 export const register = (type, callback, options) => {
-    if (REGISTERED_LISTENERS === 0) {
-        on((options && options.window) || window);
-    }
+	if (REGISTERED_LISTENERS === 0) {
+		on((options && options.window) || window);
+	}
 
-    /* Persistent LISTENERS are exclusive */
-    if (options && options.persist) {
-        LISTENERS[type] = callback;
-        REGISTERED_LISTENERS += 1;
-    } else {
-        // set LISTENERS[type] to an empty array, if it is currently undefined or null
-        LISTENERS[type] = LISTENERS[type] || [];
+	/* Persistent LISTENERS are exclusive */
+	if (options && options.persist) {
+		LISTENERS[type] = callback;
+		REGISTERED_LISTENERS += 1;
+	} else {
+		// set LISTENERS[type] to an empty array, if it is currently undefined or null
+		LISTENERS[type] = LISTENERS[type] || [];
 
-        if (LISTENERS[type].indexOf(callback) === -1) {
-            LISTENERS[type].push(callback);
-            REGISTERED_LISTENERS += 1;
-        }
-    }
+		if (LISTENERS[type].indexOf(callback) === -1) {
+			LISTENERS[type].push(callback);
+			REGISTERED_LISTENERS += 1;
+		}
+	}
 };
 
-export const unregister = (
-    type,
-    callback,
-    options = {}
-) => {
-    if (LISTENERS[type] === undefined) {
-        throw new Error(formatError(error405, type));
-    }
+export const unregister = (type, callback, options = {}) => {
+	if (LISTENERS[type] === undefined) {
+		throw new Error(formatError(error405, type));
+	}
 
-    if (callback === undefined) {
-        REGISTERED_LISTENERS -= LISTENERS[type].length;
-        LISTENERS[type].length = 0;
-    } else if (LISTENERS[type] === callback) {
-        LISTENERS[type] = null;
-        REGISTERED_LISTENERS -= 1;
-    } else {
-        const idx = LISTENERS[type].indexOf(callback);
-        if (idx > -1) {
-            REGISTERED_LISTENERS -= 1;
-            LISTENERS[type].splice(idx, 1);
-        }
-    }
+	if (callback === undefined) {
+		REGISTERED_LISTENERS -= LISTENERS[type].length;
+		LISTENERS[type].length = 0;
+	} else if (LISTENERS[type] === callback) {
+		LISTENERS[type] = null;
+		REGISTERED_LISTENERS -= 1;
+	} else {
+		const idx = LISTENERS[type].indexOf(callback);
+		if (idx > -1) {
+			REGISTERED_LISTENERS -= 1;
+			LISTENERS[type].splice(idx, 1);
+		}
+	}
 
-    if (REGISTERED_LISTENERS === 0) {
-        off(options.window || window);
-    }
+	if (REGISTERED_LISTENERS === 0) {
+		off(options.window || window);
+	}
 };
 
 export const init = (...modules) => {
-    modules.forEach(moduleInit => moduleInit(register));
+	modules.forEach((moduleInit) => moduleInit(register));
 };
 
 export const _ = { onMessage };

--- a/static/src/javascripts/projects/commercial/modules/messenger.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger.spec.js
@@ -1,8 +1,8 @@
 import { noop } from '../../../lib/noop';
 import {
-    register as register_,
-    unregister as unregister_,
-    _ as testExports,
+	register as register_,
+	unregister as unregister_,
+	_ as testExports,
 } from './messenger';
 import { postMessage } from './messenger/post-message';
 
@@ -11,246 +11,248 @@ const register = register_;
 const unregister = unregister_;
 
 const addEventListenerSpy = jest
-    .spyOn(global, 'addEventListener')
-    .mockImplementation(() => {});
+	.spyOn(global, 'addEventListener')
+	.mockImplementation(() => {});
 const removeEventListenerSpy = jest
-    .spyOn(global, 'removeEventListener')
-    .mockImplementation(() => {});
+	.spyOn(global, 'removeEventListener')
+	.mockImplementation(() => {});
 const jsonParseSpy = jest.spyOn(JSON, 'parse');
-const mockOrigin = "someorigin.com";
+const mockOrigin = 'someorigin.com';
 
 jest.mock('./messenger/post-message', () => ({
-    postMessage: jest.fn(),
+	postMessage: jest.fn(),
 }));
 
 jest.mock('../../../lib/report-error', () => jest.fn());
 
 describe('Cross-frame messenger', () => {
-    const routines = {
-        thrower() {
-            throw new Error('catch this if you can!');
-        },
-        respond(value) {
-            return `${value} johnny!`;
-        },
-        add1(value) {
-            return value + 1;
-        },
-        add2(_, ret) {
-            return ret + 2;
-        },
-        rubicon() {
-            return 'rubicon';
-        },
-    };
+	const routines = {
+		thrower() {
+			throw new Error('catch this if you can!');
+		},
+		respond(value) {
+			return `${value} johnny!`;
+		},
+		add1(value) {
+			return value + 1;
+		},
+		add2(_, ret) {
+			return ret + 2;
+		},
+		rubicon() {
+			return 'rubicon';
+		},
+	};
 
-    beforeEach(() => {
-        jest.resetAllMocks();
-        expect.hasAssertions();
-    });
+	beforeEach(() => {
+		jest.resetAllMocks();
+		expect.hasAssertions();
+	});
 
-    it('should expose register and unregister as a public API', () => {
-        expect(register).toBeDefined();
-        expect(unregister).toBeDefined();
-    });
+	it('should expose register and unregister as a public API', () => {
+		expect(register).toBeDefined();
+		expect(unregister).toBeDefined();
+	});
 
-    it('should register an event listener when there is at least one message routine', () => {
-        register('test', noop);
-        expect(addEventListenerSpy).toHaveBeenCalled();
-        unregister('test', noop);
-        expect(removeEventListenerSpy).toHaveBeenCalled();
-    });
+	it('should register an event listener when there is at least one message routine', () => {
+		register('test', noop);
+		expect(addEventListenerSpy).toHaveBeenCalled();
+		unregister('test', noop);
+		expect(removeEventListenerSpy).toHaveBeenCalled();
+	});
 
-    it('should not respond when sending malformed JSON', done => {
-        jsonParseSpy.mockImplementation(() => {
-            throw new Error();
-        });
+	it('should not respond when sending malformed JSON', (done) => {
+		jsonParseSpy.mockImplementation(() => {
+			throw new Error();
+		});
 
-        Promise.resolve()
-            .then(() => onMessage({ origin: mockOrigin, data: '{', source: '' }))
-            .then(() => {
-                expect(postMessage).not.toHaveBeenCalled();
-            })
-            .then(done)
-            .catch(done.fail);
-    });
+		Promise.resolve()
+			.then(() =>
+				onMessage({ origin: mockOrigin, data: '{', source: '' }),
+			)
+			.then(() => {
+				expect(postMessage).not.toHaveBeenCalled();
+			})
+			.then(done)
+			.catch(done.fail);
+	});
 
-    it('should not respond when sending incomplete payload', done => {
-        const payloads = [
-            { type: 'missing data' },
-            { value: 'missing type' },
-            { type: 'unregistered', value: 'type' },
-        ];
+	it('should not respond when sending incomplete payload', (done) => {
+		const payloads = [
+			{ type: 'missing data' },
+			{ value: 'missing type' },
+			{ type: 'unregistered', value: 'type' },
+		];
 
-        Promise.all(
-            payloads.map(data => {
-                jsonParseSpy.mockReturnValueOnce(data);
-                return onMessage({ origin: mockOrigin, data: '', source: '' });
-            })
-        ).then(() => {
-            expect(postMessage).not.toHaveBeenCalled();
-            done();
-        });
-    });
+		Promise.all(
+			payloads.map((data) => {
+				jsonParseSpy.mockReturnValueOnce(data);
+				return onMessage({ origin: mockOrigin, data: '', source: '' });
+			}),
+		).then(() => {
+			expect(postMessage).not.toHaveBeenCalled();
+			done();
+		});
+	});
 
-    it('should respond with a 405 code when no listener is attached to a message type', done => {
-        const payload = {
-            id: '01234567-89ab-cdef-fedc-ba9876543210',
-            type: 'that',
-            value: 'hello',
-        };
-        jsonParseSpy.mockImplementationOnce(() => payload);
-        register('this', noop);
-        register('that', noop);
-        unregister('that', noop);
-        Promise.resolve()
-            .then(() =>
-                onMessage({
-                    origin: mockOrigin,
-                    data: JSON.stringify(payload),
-                    source: 'source',
-                })
-            )
-            .then(() => {
-                expect(postMessage).toHaveBeenCalledWith(
-                    {
-                        error: {
-                            code: 405,
-                            message: 'Service that not implemented',
-                        },
-                        id: payload.id,
-                        result: null,
-                    },
-                    'source',
-                );
-            })
-            .then(done)
-            .catch(done.fail)
-            .then(() => {
-                unregister('this', noop);
-            });
-    });
+	it('should respond with a 405 code when no listener is attached to a message type', (done) => {
+		const payload = {
+			id: '01234567-89ab-cdef-fedc-ba9876543210',
+			type: 'that',
+			value: 'hello',
+		};
+		jsonParseSpy.mockImplementationOnce(() => payload);
+		register('this', noop);
+		register('that', noop);
+		unregister('that', noop);
+		Promise.resolve()
+			.then(() =>
+				onMessage({
+					origin: mockOrigin,
+					data: JSON.stringify(payload),
+					source: 'source',
+				}),
+			)
+			.then(() => {
+				expect(postMessage).toHaveBeenCalledWith(
+					{
+						error: {
+							code: 405,
+							message: 'Service that not implemented',
+						},
+						id: payload.id,
+						result: null,
+					},
+					'source',
+				);
+			})
+			.then(done)
+			.catch(done.fail)
+			.then(() => {
+				unregister('this', noop);
+			});
+	});
 
-    it('should throw when the listener fails', done => {
-        const payload = {
-            id: '01234567-89ab-cdef-fedc-ba9876543210',
-            type: 'this',
-            value: 'hello',
-        };
-        jsonParseSpy.mockImplementationOnce(() => payload);
-        register('this', routines.thrower);
-        Promise.resolve()
-            .then(() =>
-                onMessage({ origin: mockOrigin, data: '', source: 'source' })
-            )
-            .then(() => {
-                expect(postMessage).toHaveBeenCalledWith(
-                    {
-                        error: {
-                            code: 500,
-                            message:
-                                'Internal server error\n\nError: catch this if you can!',
-                        },
-                        id: payload.id,
-                        result: null,
-                    },
-                    'source',
-                );
-            })
-            .then(done)
-            .catch(done.fail)
-            .then(() => {
-                unregister('this', routines.thrower);
-            });
-    });
+	it('should throw when the listener fails', (done) => {
+		const payload = {
+			id: '01234567-89ab-cdef-fedc-ba9876543210',
+			type: 'this',
+			value: 'hello',
+		};
+		jsonParseSpy.mockImplementationOnce(() => payload);
+		register('this', routines.thrower);
+		Promise.resolve()
+			.then(() =>
+				onMessage({ origin: mockOrigin, data: '', source: 'source' }),
+			)
+			.then(() => {
+				expect(postMessage).toHaveBeenCalledWith(
+					{
+						error: {
+							code: 500,
+							message:
+								'Internal server error\n\nError: catch this if you can!',
+						},
+						id: payload.id,
+						result: null,
+					},
+					'source',
+				);
+			})
+			.then(done)
+			.catch(done.fail)
+			.then(() => {
+				unregister('this', routines.thrower);
+			});
+	});
 
-    it("should respond with the routine's return value", done => {
-        const payload = {
-            id: '01234567-89ab-cdef-fedc-ba9876543210',
-            type: 'this',
-            value: 'hello',
-        };
-        jsonParseSpy.mockImplementationOnce(() => payload);
-        register('this', routines.respond);
-        Promise.resolve()
-            .then(() =>
-                onMessage({
-                    origin: mockOrigin,
-                    data: '',
-                    source: 'sauce',
-                })
-            )
-            .then(() => {
-                expect(postMessage).toHaveBeenCalledWith(
-                    {
-                        error: null,
-                        id: payload.id,
-                        result: 'hello johnny!',
-                    },
-                    'sauce',
-                );
-            })
-            .then(done)
-            .catch(done.fail)
-            .then(() => {
-                unregister('this', routines.respond);
-            });
-    });
+	it("should respond with the routine's return value", (done) => {
+		const payload = {
+			id: '01234567-89ab-cdef-fedc-ba9876543210',
+			type: 'this',
+			value: 'hello',
+		};
+		jsonParseSpy.mockImplementationOnce(() => payload);
+		register('this', routines.respond);
+		Promise.resolve()
+			.then(() =>
+				onMessage({
+					origin: mockOrigin,
+					data: '',
+					source: 'sauce',
+				}),
+			)
+			.then(() => {
+				expect(postMessage).toHaveBeenCalledWith(
+					{
+						error: null,
+						id: payload.id,
+						result: 'hello johnny!',
+					},
+					'sauce',
+				);
+			})
+			.then(done)
+			.catch(done.fail)
+			.then(() => {
+				unregister('this', routines.respond);
+			});
+	});
 
-    it('should respond with the listeners cumulative result', done => {
-        const payload = {
-            id: '01234567-89ab-cdef-fedc-ba9876543210',
-            type: 'this',
-            value: 1,
-        };
-        jsonParseSpy.mockImplementationOnce(() => payload);
-        register('this', routines.add1);
-        register('this', routines.add2);
+	it('should respond with the listeners cumulative result', (done) => {
+		const payload = {
+			id: '01234567-89ab-cdef-fedc-ba9876543210',
+			type: 'this',
+			value: 1,
+		};
+		jsonParseSpy.mockImplementationOnce(() => payload);
+		register('this', routines.add1);
+		register('this', routines.add2);
 
-        Promise.resolve()
-            .then(() =>
-                onMessage({ origin: mockOrigin, data: '', source: 'sorcery' })
-            )
-            .then(() => {
-                expect(postMessage).toHaveBeenCalledWith(
-                    {
-                        error: null,
-                        id: payload.id,
-                        result: 4,
-                    },
-                    'sorcery',
-                );
-            })
-            .then(done)
-            .catch(done.fail)
-            .then(() => {
-                unregister('this', routines.add1);
-                unregister('this', routines.add2);
-            });
-    });
+		Promise.resolve()
+			.then(() =>
+				onMessage({ origin: mockOrigin, data: '', source: 'sorcery' }),
+			)
+			.then(() => {
+				expect(postMessage).toHaveBeenCalledWith(
+					{
+						error: null,
+						id: payload.id,
+						result: 4,
+					},
+					'sorcery',
+				);
+			})
+			.then(done)
+			.catch(done.fail)
+			.then(() => {
+				unregister('this', routines.add1);
+				unregister('this', routines.add2);
+			});
+	});
 
-    it('should respond to Rubicon messages with no IDs', done => {
-        const payload = {
-            type: 'set-ad-height',
-            value: { id: 'test', height: '20px' },
-        };
-        jsonParseSpy.mockImplementationOnce(() => payload);
-        register('resize', routines.rubicon);
-        onMessage({ origin: mockOrigin, data: '', source: 'saucy' })
-            .then(() => {
-                expect(postMessage).toHaveBeenCalledWith(
-                    {
-                        error: null,
-                        id: 'aaaa0000-bb11-cc22-dd33-eeeeee444444',
-                        result: 'rubicon',
-                    },
-                    'saucy',
-                );
-            })
-            .then(done)
-            .catch(done.fail)
-            .then(() => {
-                unregister('resize', routines.rubicon);
-            });
-    });
+	it('should respond to Rubicon messages with no IDs', (done) => {
+		const payload = {
+			type: 'set-ad-height',
+			value: { id: 'test', height: '20px' },
+		};
+		jsonParseSpy.mockImplementationOnce(() => payload);
+		register('resize', routines.rubicon);
+		onMessage({ origin: mockOrigin, data: '', source: 'saucy' })
+			.then(() => {
+				expect(postMessage).toHaveBeenCalledWith(
+					{
+						error: null,
+						id: 'aaaa0000-bb11-cc22-dd33-eeeeee444444',
+						result: 'rubicon',
+					},
+					'saucy',
+				);
+			})
+			.then(done)
+			.catch(done.fail)
+			.then(() => {
+				unregister('resize', routines.rubicon);
+			});
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.js
@@ -2,292 +2,271 @@ import config from '../../../../lib/config';
 import { addEventListener } from '../../../../lib/events';
 import fastdom from '../../../../lib/fastdom-promise';
 import {
-    renderStickyAdLabel,
-    renderStickyScrollForMoreLabel,
+	renderStickyAdLabel,
+	renderStickyScrollForMoreLabel,
 } from '../dfp/render-advert-label';
 
-
-
-
 const getStylesFromSpec = (specs) =>
-    Object.keys(specs).reduce((result, key) => {
-        if (key !== 'scrollType') {
-            result[key] = specs[key];
-        }
-        // Flow is love, Flow is Life! DFP has been passing us `backgroundColour`
-        // all along, and the setting of this css prop has been silently failing
-        if (key === 'backgroundColour') {
-            result.backgroundColor = specs[key];
-        }
-        return result;
-    }, {});
+	Object.keys(specs).reduce((result, key) => {
+		if (key !== 'scrollType') {
+			result[key] = specs[key];
+		}
+		// Flow is love, Flow is Life! DFP has been passing us `backgroundColour`
+		// all along, and the setting of this css prop has been silently failing
+		if (key === 'backgroundColour') {
+			result.backgroundColor = specs[key];
+		}
+		return result;
+	}, {});
 
 const setBackground = (specs, adSlot) => {
-    if (
-        !specs ||
-        !('backgroundImage' in specs) ||
-        !('backgroundRepeat' in specs) ||
-        !('backgroundPosition' in specs) ||
-        !('scrollType' in specs) ||
-        !(adSlot instanceof Element)
-    ) {
-        return Promise.resolve();
-    }
+	if (
+		!specs ||
+		!('backgroundImage' in specs) ||
+		!('backgroundRepeat' in specs) ||
+		!('backgroundPosition' in specs) ||
+		!('scrollType' in specs) ||
+		!(adSlot instanceof Element)
+	) {
+		return Promise.resolve();
+	}
 
-    const specStyles = getStylesFromSpec(specs);
+	const specStyles = getStylesFromSpec(specs);
 
-    // check to see whether the parent div exists already, if so, jut alter the style
+	// check to see whether the parent div exists already, if so, jut alter the style
 
-    const backgroundParentClass =
-        specs.scrollType === 'interscroller'
-            ? 'creative__background-parent-interscroller'
-            : 'creative__background-parent';
-    const backgroundClass = 'creative__background';
+	const backgroundParentClass =
+		specs.scrollType === 'interscroller'
+			? 'creative__background-parent-interscroller'
+			: 'creative__background-parent';
+	const backgroundClass = 'creative__background';
 
-    const maybeBackgroundParent = ((adSlot.getElementsByClassName(
-        backgroundParentClass
-    )))[0];
-    const maybeBackground = maybeBackgroundParent
-        ? ((maybeBackgroundParent.getElementsByClassName(
-              backgroundClass
-          )))[0]
-        : null;
-    const backgroundAlreadyExists = !!(
-        maybeBackgroundParent && maybeBackground
-    );
+	const maybeBackgroundParent = adSlot.getElementsByClassName(
+		backgroundParentClass,
+	)[0];
+	const maybeBackground = maybeBackgroundParent
+		? maybeBackgroundParent.getElementsByClassName(backgroundClass)[0]
+		: null;
+	const backgroundAlreadyExists = !!(
+		maybeBackgroundParent && maybeBackground
+	);
 
-    const getBackground = () => {
-        if (
-            maybeBackground &&
-            maybeBackgroundParent &&
-            backgroundAlreadyExists
-        ) {
-            return Promise.resolve({
-                backgroundParent: maybeBackgroundParent,
-                background: maybeBackground,
-            });
-        }
-        // Wrap the background image in a DIV for positioning. Also, we give
-        // this DIV a background colour if it is provided. This is because
-        // if we set the background colour in the creative itself, the background
-        // image won't be visible (think z-indexed layers)
-        const backgroundParent = document.createElement('div');
+	const getBackground = () => {
+		if (
+			maybeBackground &&
+			maybeBackgroundParent &&
+			backgroundAlreadyExists
+		) {
+			return Promise.resolve({
+				backgroundParent: maybeBackgroundParent,
+				background: maybeBackground,
+			});
+		}
+		// Wrap the background image in a DIV for positioning. Also, we give
+		// this DIV a background colour if it is provided. This is because
+		// if we set the background colour in the creative itself, the background
+		// image won't be visible (think z-indexed layers)
+		const backgroundParent = document.createElement('div');
 
-        // Create an element to hold the background image
-        const background = document.createElement('div');
-        backgroundParent.appendChild(background);
+		// Create an element to hold the background image
+		const background = document.createElement('div');
+		backgroundParent.appendChild(background);
 
-        // Inject styles in DCR (from _creatives.scss)
-        // mark: 0bf74539-5466-4907-ae7b-c0d8fc41112d
-        if (config.get('isDotcomRendering', false)) {
-            backgroundParent.style.position = 'absolute';
-            backgroundParent.style.top = '0';
-            backgroundParent.style.left = '0';
-            backgroundParent.style.right = '0';
-            backgroundParent.style.bottom = '0';
-            backgroundParent.style.clip = 'rect(0, auto, auto, 0)';
+		// Inject styles in DCR (from _creatives.scss)
+		// mark: 0bf74539-5466-4907-ae7b-c0d8fc41112d
+		if (config.get('isDotcomRendering', false)) {
+			backgroundParent.style.position = 'absolute';
+			backgroundParent.style.top = '0';
+			backgroundParent.style.left = '0';
+			backgroundParent.style.right = '0';
+			backgroundParent.style.bottom = '0';
+			backgroundParent.style.clip = 'rect(0, auto, auto, 0)';
 
-            background.style.top = '0';
-            background.style.left = '0';
-            background.style.right = '0';
-            background.style.bottom = '0';
-            background.style.transition = 'background 100ms ease';
-        }
+			background.style.top = '0';
+			background.style.left = '0';
+			background.style.right = '0';
+			background.style.bottom = '0';
+			background.style.transition = 'background 100ms ease';
+		}
 
-        return fastdom
-            .mutate(() => {
-                if (backgroundParent) {
-                    // Create a stacking context in DCR
-                    if (
-                        config.get('isDotcomRendering', false) &&
-                        adSlot.firstChild &&
-                        adSlot.firstChild instanceof HTMLElement
-                    )
-                        adSlot.firstChild.style.contain = 'layout';
+		return fastdom
+			.mutate(() => {
+				if (backgroundParent) {
+					// Create a stacking context in DCR
+					if (
+						config.get('isDotcomRendering', false) &&
+						adSlot.firstChild &&
+						adSlot.firstChild instanceof HTMLElement
+					)
+						adSlot.firstChild.style.contain = 'layout';
 
-                    if (specs.scrollType === 'interscroller') {
-                        adSlot.style.height = '85vh';
-                        adSlot.style.marginBottom = '12px';
-                        adSlot.style.position = 'relative';
+					if (specs.scrollType === 'interscroller') {
+						adSlot.style.height = '85vh';
+						adSlot.style.marginBottom = '12px';
+						adSlot.style.position = 'relative';
 
-                        if (specs.ctaUrl != null) {
-                            const ctaURLAnchor = document.createElement('a');
-                            ctaURLAnchor.href = specs.ctaUrl;
-                            ctaURLAnchor.target = '_new';
-                            ctaURLAnchor.appendChild(backgroundParent);
-                            ctaURLAnchor.style.display = 'inline-block';
-                            ctaURLAnchor.style.width = '100%';
-                            ctaURLAnchor.style.height = '100%';
-                            adSlot.insertBefore(
-                                ctaURLAnchor,
-                                adSlot.firstChild
-                            );
-                        }
+						if (specs.ctaUrl != null) {
+							const ctaURLAnchor = document.createElement('a');
+							ctaURLAnchor.href = specs.ctaUrl;
+							ctaURLAnchor.target = '_new';
+							ctaURLAnchor.appendChild(backgroundParent);
+							ctaURLAnchor.style.display = 'inline-block';
+							ctaURLAnchor.style.width = '100%';
+							ctaURLAnchor.style.height = '100%';
+							adSlot.insertBefore(
+								ctaURLAnchor,
+								adSlot.firstChild,
+							);
+						}
 
-                        if (config.get('isDotcomRendering', false)) {
-                            background.style.position = 'fixed';
-                            const bottomLine = document.createElement('div');
-                            bottomLine.classList.add('ad-slot__line');
-                            bottomLine.style.position = 'absolute';
-                            bottomLine.style.width = '100%';
-                            bottomLine.style.bottom = '0';
-                            bottomLine.style.borderBottom = '1px solid #dcdcdc';
-                            backgroundParent.appendChild(bottomLine);
-                        }
-                    } else {
-                        adSlot.insertBefore(
-                            backgroundParent,
-                            adSlot.firstChild
-                        );
-                    }
-                }
-            })
-            .then(() => ({ backgroundParent, background }));
-    };
+						if (config.get('isDotcomRendering', false)) {
+							background.style.position = 'fixed';
+							const bottomLine = document.createElement('div');
+							bottomLine.classList.add('ad-slot__line');
+							bottomLine.style.position = 'absolute';
+							bottomLine.style.width = '100%';
+							bottomLine.style.bottom = '0';
+							bottomLine.style.borderBottom = '1px solid #dcdcdc';
+							backgroundParent.appendChild(bottomLine);
+						}
+					} else {
+						adSlot.insertBefore(
+							backgroundParent,
+							adSlot.firstChild,
+						);
+					}
+				}
+			})
+			.then(() => ({ backgroundParent, background }));
+	};
 
-    const updateStyles = (
-        backgroundParent,
-        background
-    ) => {
-        backgroundParent.className = backgroundParentClass;
-        background.className = `${backgroundClass} creative__background--${
-            specs.scrollType
-        }`;
+	const updateStyles = (backgroundParent, background) => {
+		backgroundParent.className = backgroundParentClass;
+		background.className = `${backgroundClass} creative__background--${specs.scrollType}`;
 
-        if (
-            config.get('isDotcomRendering', false) &&
-            specs.scrollType === 'parallax'
-        )
-            background.style.position = 'absolute';
+		if (
+			config.get('isDotcomRendering', false) &&
+			specs.scrollType === 'parallax'
+		)
+			background.style.position = 'absolute';
 
-        Object.assign(background.style, specStyles);
+		Object.assign(background.style, specStyles);
 
-        if (specs.scrollType === 'fixed') {
-            return fastdom
-                .measure(() => {
-                    if (adSlot instanceof Element) {
-                        return adSlot.getBoundingClientRect();
-                    }
-                })
-                .then(rect =>
-                    fastdom.mutate(() => {
-                        if (config.get('isDotcomRendering', false)) {
-                            background.style.position = 'fixed';
-                        }
-                        if (specStyles.backgroundColor) {
-                            backgroundParent.style.backgroundColor =
-                                specStyles.backgroundColor;
-                        }
-                        if (rect) {
-                            background.style.left = `${rect.left}px`;
-                            background.style.right = `${rect.right}px`;
-                            background.style.width = `${rect.width}px`;
-                        }
-                    })
-                )
-                .then(() => ({ backgroundParent, background }));
-        }
+		if (specs.scrollType === 'fixed') {
+			return fastdom
+				.measure(() => {
+					if (adSlot instanceof Element) {
+						return adSlot.getBoundingClientRect();
+					}
+				})
+				.then((rect) =>
+					fastdom.mutate(() => {
+						if (config.get('isDotcomRendering', false)) {
+							background.style.position = 'fixed';
+						}
+						if (specStyles.backgroundColor) {
+							backgroundParent.style.backgroundColor =
+								specStyles.backgroundColor;
+						}
+						if (rect) {
+							background.style.left = `${rect.left}px`;
+							background.style.right = `${rect.right}px`;
+							background.style.width = `${rect.width}px`;
+						}
+					}),
+				)
+				.then(() => ({ backgroundParent, background }));
+		}
 
-        return Promise.resolve({ backgroundParent, background });
-    };
+		return Promise.resolve({ backgroundParent, background });
+	};
 
-    const onInterscrollerScroll = (
-        backgroundParent,
-        background
-    ) => {
-        fastdom.measure(() => {
-            const rect = adSlot.getBoundingClientRect();
-            background.style.clip = `rect(${rect.top}px,100vw,${
-                rect.bottom
-            }px,0)`;
-        });
-    };
+	const onInterscrollerScroll = (backgroundParent, background) => {
+		fastdom.measure(() => {
+			const rect = adSlot.getBoundingClientRect();
+			background.style.clip = `rect(${rect.top}px,100vw,${rect.bottom}px,0)`;
+		});
+	};
 
-    const onScroll = (
-        backgroundParent,
-        background
-    ) => {
-        fastdom.measure(() => {
-            // We update the style in a read batch because the DIV
-            // has been promoted to its own layer and is also
-            // strictly self-contained. Also, without doing that
-            // the animation is extremely jittery.
-            const rect = background.getBoundingClientRect();
-            const backgroundHeight = rect.height;
-            const windowHeight = window.innerHeight;
+	const onScroll = (backgroundParent, background) => {
+		fastdom.measure(() => {
+			// We update the style in a read batch because the DIV
+			// has been promoted to its own layer and is also
+			// strictly self-contained. Also, without doing that
+			// the animation is extremely jittery.
+			const rect = background.getBoundingClientRect();
+			const backgroundHeight = rect.height;
+			const windowHeight = window.innerHeight;
 
-            // we should scroll at a rate such that we don't run out of background (when non-repeating)
-            const parallaxBackgroundMovement = Math.floor(
-                (rect.bottom / (windowHeight + backgroundHeight)) * 130
-            );
+			// we should scroll at a rate such that we don't run out of background (when non-repeating)
+			const parallaxBackgroundMovement = Math.floor(
+				(rect.bottom / (windowHeight + backgroundHeight)) * 130,
+			);
 
-            // #? Flow does not currently list backgroundPositionY in
-            // CSSStyleDeclaration: https://github.com/facebook/flow/issues/396
-            // ...So we have to use a more convoluted hack-around:
-            (background.style).backgroundPositionY = `${parallaxBackgroundMovement}%`;
-        });
-    };
+			// #? Flow does not currently list backgroundPositionY in
+			// CSSStyleDeclaration: https://github.com/facebook/flow/issues/396
+			// ...So we have to use a more convoluted hack-around:
+			background.style.backgroundPositionY = `${parallaxBackgroundMovement}%`;
+		});
+	};
 
-    const onIntersect = (entries) => {
-        entries
-            .filter(entry => entry.isIntersecting)
-            .forEach(entry => {
-                if (!backgroundAlreadyExists) {
-                    const backgroundParent = entry.target;
-                    const background = backgroundParent.firstChild;
+	const onIntersect = (entries) => {
+		entries
+			.filter((entry) => entry.isIntersecting)
+			.forEach((entry) => {
+				if (!backgroundAlreadyExists) {
+					const backgroundParent = entry.target;
+					const background = backgroundParent.firstChild;
 
-                    if (background && background instanceof HTMLElement) {
-                        addEventListener(
-                            window,
-                            'scroll',
-                            () => onScroll(backgroundParent, background),
-                            {
-                                passive: true,
-                            }
-                        );
-                        onScroll(backgroundParent, background);
-                    }
-                }
-            });
-    };
+					if (background && background instanceof HTMLElement) {
+						addEventListener(
+							window,
+							'scroll',
+							() => onScroll(backgroundParent, background),
+							{
+								passive: true,
+							},
+						);
+						onScroll(backgroundParent, background);
+					}
+				}
+			});
+	};
 
-    const observer = new IntersectionObserver(onIntersect, {
-        rootMargin: '10px',
-    });
+	const observer = new IntersectionObserver(onIntersect, {
+		rootMargin: '10px',
+	});
 
-    return getBackground()
-        .then(({ backgroundParent, background }) =>
-            updateStyles(backgroundParent, background)
-        )
-        .then(({ backgroundParent, background }) => {
-            if (specs.scrollType === 'interscroller') {
-                renderStickyAdLabel(backgroundParent);
-                renderStickyScrollForMoreLabel(backgroundParent);
+	return getBackground()
+		.then(({ backgroundParent, background }) =>
+			updateStyles(backgroundParent, background),
+		)
+		.then(({ backgroundParent, background }) => {
+			if (specs.scrollType === 'interscroller') {
+				renderStickyAdLabel(backgroundParent);
+				renderStickyScrollForMoreLabel(backgroundParent);
 
-                addEventListener(
-                    window,
-                    'scroll',
-                    () => onInterscrollerScroll(backgroundParent, background),
-                    {
-                        passive: true,
-                    }
-                );
-            } else {
-                observer.observe(backgroundParent);
-            }
-        });
+				addEventListener(
+					window,
+					'scroll',
+					() => onInterscrollerScroll(backgroundParent, background),
+					{
+						passive: true,
+					},
+				);
+			} else {
+				observer.observe(backgroundParent);
+			}
+		});
 };
 
 const init = (register) => {
-    register(
-        'background',
-        (specs, ret, iframe) => {
-            if (iframe && specs) {
-                return setBackground(specs, iframe.closest('.js-ad-slot'));
-            }
-            return Promise.resolve();
-        }
-    );
+	register('background', (specs, ret, iframe) => {
+		if (iframe && specs) {
+			return setBackground(specs, iframe.closest('.js-ad-slot'));
+		}
+		return Promise.resolve();
+	});
 };
 
 export const _ = { setBackground, getStylesFromSpec };

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.spec.js
@@ -3,68 +3,68 @@ import { _ } from './background';
 const { setBackground, getStylesFromSpec } = _;
 
 const adSpec = {
-    scrollType: 'fixed',
-    backgroundColour: 'ffffff',
-    backgroundImage: 'image',
-    backgroundRepeat: 'no-repeat',
-    backgroundPosition: 'absolute',
-    backgroundSize: 'contain',
-    ctaUrl: 'theguardian.com',
-    transform: 'translate3d(0,0,0)',
+	scrollType: 'fixed',
+	backgroundColour: 'ffffff',
+	backgroundImage: 'image',
+	backgroundRepeat: 'no-repeat',
+	backgroundPosition: 'absolute',
+	backgroundSize: 'contain',
+	ctaUrl: 'theguardian.com',
+	transform: 'translate3d(0,0,0)',
 };
 
 describe('Cross-frame messenger: setBackground', () => {
-    class IntersectionObserver {
-        constructor() {
-            return Object.freeze({
-                observe: () => {},
-                unobserve: () => {},
-                disconnect: () => {},
-            });
-        }
-    }
+	class IntersectionObserver {
+		constructor() {
+			return Object.freeze({
+				observe: () => {},
+				unobserve: () => {},
+				disconnect: () => {},
+			});
+		}
+	}
 
-    beforeEach(() => {
-        if (document.body) {
-            document.body.innerHTML = `
+	beforeEach(() => {
+		if (document.body) {
+			document.body.innerHTML = `
               <div>
                   <div id="slot01"><div id="iframe01" class="iframe"></div></div>
               </div>`;
-        }
+		}
 
-        Object.defineProperty(global, 'IntersectionObserver', {
-            value: IntersectionObserver,
-            writable: true,
-        });
+		Object.defineProperty(global, 'IntersectionObserver', {
+			value: IntersectionObserver,
+			writable: true,
+		});
 
-        expect.hasAssertions();
-    });
+		expect.hasAssertions();
+	});
 
-    it('should create new elements if there are specs', () => {
-        const fallback = document.createElement('div');
-        const fakeAdSlot = document.getElementById('slot01') || fallback;
+	it('should create new elements if there are specs', () => {
+		const fallback = document.createElement('div');
+		const fakeAdSlot = document.getElementById('slot01') || fallback;
 
-        return setBackground(adSpec, fakeAdSlot).then(() => {
-            const creative =
-                document.querySelector('.creative__background') || {};
-            const parent =
-                document.querySelector('.creative__background-parent') || {};
-            expect(creative.toString()).toEqual('[object HTMLDivElement]');
-            expect(parent.toString()).toEqual('[object HTMLDivElement]');
-            expect(creative.className).toMatch(/background--fixed/);
-        });
-    });
+		return setBackground(adSpec, fakeAdSlot).then(() => {
+			const creative =
+				document.querySelector('.creative__background') || {};
+			const parent =
+				document.querySelector('.creative__background-parent') || {};
+			expect(creative.toString()).toEqual('[object HTMLDivElement]');
+			expect(parent.toString()).toEqual('[object HTMLDivElement]');
+			expect(creative.className).toMatch(/background--fixed/);
+		});
+	});
 });
 
 describe('Cross-frame messenger: getStylesFromSpec', () => {
-    it('should return an object of valid styles', () => {
-        const specStyles = getStylesFromSpec(adSpec);
-        expect(specStyles.scrollType).toBeUndefined();
-        expect(specStyles.backgroundColor).toBe('ffffff');
-        expect(specStyles.backgroundImage).toBe('image');
-        expect(specStyles.backgroundRepeat).toBe('no-repeat');
-        expect(specStyles.backgroundPosition).toBe('absolute');
-        expect(specStyles.backgroundSize).toBe('contain');
-        expect(specStyles.transform).toBe('translate3d(0,0,0)');
-    });
+	it('should return an object of valid styles', () => {
+		const specStyles = getStylesFromSpec(adSpec);
+		expect(specStyles.scrollType).toBeUndefined();
+		expect(specStyles.backgroundColor).toBe('ffffff');
+		expect(specStyles.backgroundImage).toBe('image');
+		expect(specStyles.backgroundRepeat).toBe('no-repeat');
+		expect(specStyles.backgroundPosition).toBe('absolute');
+		expect(specStyles.backgroundSize).toBe('contain');
+		expect(specStyles.transform).toBe('translate3d(0,0,0)');
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/messenger/click.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/click.js
@@ -1,18 +1,18 @@
 import { trackNativeAdLinkClick } from '../../../common/modules/analytics/google';
 
 const sendClick = (adSlot, linkName) => {
-    trackNativeAdLinkClick(adSlot.id, linkName);
+	trackNativeAdLinkClick(adSlot.id, linkName);
 };
 
 const init = (register) => {
-    register('click', (linkName, ret, iframe = {}) =>
-        sendClick(
-            iframe.closest('.js-ad-slot') || {
-                id: 'unknown',
-            },
-            linkName || ''
-        )
-    );
+	register('click', (linkName, ret, iframe = {}) =>
+		sendClick(
+			iframe.closest('.js-ad-slot') || {
+				id: 'unknown',
+			},
+			linkName || '',
+		),
+	);
 };
 
 export { init };

--- a/static/src/javascripts/projects/commercial/modules/messenger/click.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/click.spec.js
@@ -6,18 +6,18 @@ const { sendClick } = _;
 // Jest understands `register.mock.calls`, however, Flow gets angry because:
 // 'property mock not found in statics of function'. This is a helper to allow
 // `expect(register.mock.calls[0][0]).toBe('click');` to pass linting
-const foolFlow = (mockFn) => ((mockFn));
+const foolFlow = (mockFn) => mockFn;
 
 jest.mock('../../../common/modules/analytics/google', () => ({
-    trackNativeAdLinkClick: jest.fn(),
+	trackNativeAdLinkClick: jest.fn(),
 }));
 
 describe('Cross-frame messenger: sendClick', () => {
-    it('should call trackNativeAdLinkClick', () => {
-        const fakeAdSlot = document.createElement('div');
-        sendClick(fakeAdSlot, 'name');
+	it('should call trackNativeAdLinkClick', () => {
+		const fakeAdSlot = document.createElement('div');
+		sendClick(fakeAdSlot, 'name');
 
-        expect(trackNativeAdLinkClick).toHaveBeenCalled();
-        expect(foolFlow(trackNativeAdLinkClick).mock.calls[0][1]).toBe('name');
-    });
+		expect(trackNativeAdLinkClick).toHaveBeenCalled();
+		expect(foolFlow(trackNativeAdLinkClick).mock.calls[0][1]).toBe('name');
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/messenger/disable-refresh.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/disable-refresh.js
@@ -26,21 +26,21 @@ self.addEventListener('message', function onMessage(evt) {
 */
 
 const findAdvert = (adSlot) =>
-    dfpEnv.adverts.find((advert) => advert.node.isSameNode(adSlot));
+	dfpEnv.adverts.find((advert) => advert.node.isSameNode(adSlot));
 
 const init = (register) => {
-    register('disable-refresh', (specs, ret, iframe) => {
-        if (iframe) {
-            const adSlot = iframe.closest('.js-ad-slot');
+	register('disable-refresh', (specs, ret, iframe) => {
+		if (iframe) {
+			const adSlot = iframe.closest('.js-ad-slot');
 
-            if (adSlot instanceof HTMLElement) {
-                const advert = findAdvert(adSlot);
-                if (advert) {
-                    advert.shouldRefresh = false;
-                }
-            }
-        }
-    });
+			if (adSlot instanceof HTMLElement) {
+				const advert = findAdvert(adSlot);
+				if (advert) {
+					advert.shouldRefresh = false;
+				}
+			}
+		}
+	});
 };
 
 export { init };

--- a/static/src/javascripts/projects/commercial/modules/messenger/get-page-targeting.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/get-page-targeting.js
@@ -1,7 +1,7 @@
 import config from '../../../../lib/config';
 
 const init = (register) => {
-    register('get-page-targeting', () => config.get('page.sharedAdTargeting'));
+	register('get-page-targeting', () => config.get('page.sharedAdTargeting'));
 };
 
 export { init };

--- a/static/src/javascripts/projects/commercial/modules/messenger/get-page-url.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/get-page-url.js
@@ -1,5 +1,8 @@
 const init = (register) => {
-    register('get-page-url', () => window.location.origin + window.location.pathname);
+	register(
+		'get-page-url',
+		() => window.location.origin + window.location.pathname,
+	);
 };
 
 export { init };

--- a/static/src/javascripts/projects/commercial/modules/messenger/get-stylesheet.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/get-stylesheet.js
@@ -1,43 +1,40 @@
 const getStyles = (specs, styleSheets) => {
-    if (!specs || typeof specs.selector !== 'string') {
-        return null;
-    }
+	if (!specs || typeof specs.selector !== 'string') {
+		return null;
+	}
 
-    const result = [];
-    for (let i = 0; i < styleSheets.length; i += 1) {
-        const sheet = (styleSheets[i]);
-        const ownerNode = (sheet.ownerNode);
+	const result = [];
+	for (let i = 0; i < styleSheets.length; i += 1) {
+		const sheet = styleSheets[i];
+		const ownerNode = sheet.ownerNode;
 
-        if (
-            ownerNode &&
-            ownerNode.matches &&
-            ownerNode.matches(specs.selector)
-        ) {
-            if (ownerNode.tagName === 'STYLE') {
-                result.push(ownerNode.textContent);
-            } else {
-                result.push(
-                    Array.prototype.reduce.call(
-                        sheet.cssRules || [],
-                        (res, input) => res + input.cssText,
-                        ''
-                    )
-                );
-            }
-        }
-    }
-    return result;
+		if (
+			ownerNode &&
+			ownerNode.matches &&
+			ownerNode.matches(specs.selector)
+		) {
+			if (ownerNode.tagName === 'STYLE') {
+				result.push(ownerNode.textContent);
+			} else {
+				result.push(
+					Array.prototype.reduce.call(
+						sheet.cssRules || [],
+						(res, input) => res + input.cssText,
+						'',
+					),
+				);
+			}
+		}
+	}
+	return result;
 };
 
 const init = (register) => {
-    register(
-        'get-styles',
-        (specs) => {
-            if (specs) {
-                return getStyles(specs, document.styleSheets);
-            }
-        }
-    );
+	register('get-styles', (specs) => {
+		if (specs) {
+			return getStyles(specs, document.styleSheets);
+		}
+	});
 };
 
 export const _ = { getStyles };

--- a/static/src/javascripts/projects/commercial/modules/messenger/get-stylesheet.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/get-stylesheet.spec.js
@@ -5,71 +5,71 @@ const getStyles = _.getStyles;
 let styleSheets;
 
 describe('Cross-frame messenger: get stylesheets', () => {
-    beforeEach(done => {
-        if (document.body) {
-            document.body.innerHTML = `
+	beforeEach((done) => {
+		if (document.body) {
+			document.body.innerHTML = `
             <style class="webfont"></style>
             <style class="webfont" data-cache-name="GuardianSansWeb"></style>
             <style class="webfont" data-cache-name="GuardianSansTextWeb"></style>
             <style class="notawebfont"></style>`;
-        }
+		}
 
-        // Why are we having to mess about with the DOM? JSDOM does not recognise
-        // `ownerNode`: https://github.com/tmpvar/jsdom/issues/992
-        styleSheets = Array.prototype.map.call(
-            document.querySelectorAll('style'),
-            style =>
-                Object.assign(
-                    {
-                        ownerNode: Object.assign(
-                            {
-                                matches: selector => {
-                                    const res = Array.prototype.slice.call(
-                                        document.querySelectorAll(selector)
-                                    );
-                                    return res.indexOf(style) > -1;
-                                },
-                            },
-                            style
-                        ),
-                    },
-                    style
-                )
-        );
+		// Why are we having to mess about with the DOM? JSDOM does not recognise
+		// `ownerNode`: https://github.com/tmpvar/jsdom/issues/992
+		styleSheets = Array.prototype.map.call(
+			document.querySelectorAll('style'),
+			(style) =>
+				Object.assign(
+					{
+						ownerNode: Object.assign(
+							{
+								matches: (selector) => {
+									const res = Array.prototype.slice.call(
+										document.querySelectorAll(selector),
+									);
+									return res.indexOf(style) > -1;
+								},
+							},
+							style,
+						),
+					},
+					style,
+				),
+		);
 
-        done();
-    });
+		done();
+	});
 
-    afterEach(() => {
-        if (document.body) {
-            document.body.innerHTML = '';
-        }
-    });
+	afterEach(() => {
+		if (document.body) {
+			document.body.innerHTML = '';
+		}
+	});
 
-    it('should return nothing if there is no CSS selector', () => {
-        expect(getStyles({})).toBeNull();
-        expect(getStyles({ dontcare: 'hello' }, [])).toBeNull();
-    });
+	it('should return nothing if there is no CSS selector', () => {
+		expect(getStyles({})).toBeNull();
+		expect(getStyles({ dontcare: 'hello' }, [])).toBeNull();
+	});
 
-    it('should return all webfonts available', () => {
-        expect(styleSheets.length).toBe(4);
-        const result = getStyles({ selector: '.webfont' }, styleSheets);
-        expect(result).not.toBeNull();
-        expect(result.length).toBe(3);
-    });
+	it('should return all webfonts available', () => {
+		expect(styleSheets.length).toBe(4);
+		const result = getStyles({ selector: '.webfont' }, styleSheets);
+		expect(result).not.toBeNull();
+		expect(result.length).toBe(3);
+	});
 
-    it('should return only the GuardianSansWeb webfont', () => {
-        const selector = '.webfont[data-cache-name="GuardianSansWeb"]';
-        const result = getStyles({ selector }, styleSheets);
-        expect(result).not.toBeNull();
-        expect(result.length).toBe(1);
-    });
+	it('should return only the GuardianSansWeb webfont', () => {
+		const selector = '.webfont[data-cache-name="GuardianSansWeb"]';
+		const result = getStyles({ selector }, styleSheets);
+		expect(result).not.toBeNull();
+		expect(result.length).toBe(1);
+	});
 
-    it('should return only the GuardianSansWeb and GuardianSansTextWeb webfonts', () => {
-        const selector =
-            '.webfont[data-cache-name="GuardianSansWeb"], .webfont[data-cache-name="GuardianSansTextWeb"]';
-        const result = getStyles({ selector }, styleSheets);
-        expect(result).not.toBeNull();
-        expect(result.length).toBe(2);
-    });
+	it('should return only the GuardianSansWeb and GuardianSansTextWeb webfonts', () => {
+		const selector =
+			'.webfont[data-cache-name="GuardianSansWeb"], .webfont[data-cache-name="GuardianSansTextWeb"]';
+		const result = getStyles({ selector }, styleSheets);
+		expect(result).not.toBeNull();
+		expect(result.length).toBe(2);
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/messenger/measure-ad-load.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/measure-ad-load.js
@@ -1,4 +1,4 @@
-import { EventTimer } from "@guardian/commercial-core";
+import { EventTimer } from '@guardian/commercial-core';
 
 // This message is intended to be used with a GAM creative wrapper.
 // For reference, the wrapper will post a message, like so:
@@ -23,9 +23,9 @@ top.window.postMessage(JSON.stringify(
 const eventTimer = EventTimer.get();
 
 const init = (register) => {
-    register('measure-ad-load', (specs) => {
-        eventTimer.trigger('adOnPage',specs.slotId);
-    });
-}
+	register('measure-ad-load', (specs) => {
+		eventTimer.trigger('adOnPage', specs.slotId);
+	});
+};
 
 export { init };

--- a/static/src/javascripts/projects/commercial/modules/messenger/post-message.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/post-message.js
@@ -1,10 +1,3 @@
-export const postMessage = (
-    message,
-    targetWindow,
-    targetOrigin
-) => {
-    targetWindow.postMessage(
-        JSON.stringify(message),
-        targetOrigin || '*'
-    );
+export const postMessage = (message, targetWindow, targetOrigin) => {
+	targetWindow.postMessage(JSON.stringify(message), targetOrigin || '*');
 };

--- a/static/src/javascripts/projects/commercial/modules/messenger/resize.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/resize.js
@@ -1,72 +1,66 @@
 import fastdom from '../../../../lib/fastdom-promise';
 
-
 const normalise = (length) => {
-    const lengthRegexp = /^(\d+)(%|px|em|ex|ch|rem|vh|vw|vmin|vmax)?/;
-    const defaultUnit = 'px';
-    const matches = String(length).match(lengthRegexp);
-    if (!matches) {
-        return '';
-    }
-    return matches[1] + (matches[2] === undefined ? defaultUnit : matches[2]);
+	const lengthRegexp = /^(\d+)(%|px|em|ex|ch|rem|vh|vw|vmin|vmax)?/;
+	const defaultUnit = 'px';
+	const matches = String(length).match(lengthRegexp);
+	if (!matches) {
+		return '';
+	}
+	return matches[1] + (matches[2] === undefined ? defaultUnit : matches[2]);
 };
 
 const isLiveBlogInlineAdSlot = (adSlot) =>
-    !!adSlot && adSlot.classList.contains('ad-slot--liveblog-inline');
+	!!adSlot && adSlot.classList.contains('ad-slot--liveblog-inline');
 
-const resize = (
-    specs,
-    iframe,
-    iframeContainer,
-    adSlot
-) => {
-    if (
-        !specs ||
-        !('height' in specs || 'width' in specs) ||
-        !iframe ||
-        !adSlot
-    ) {
-        return null;
-    }
+const resize = (specs, iframe, iframeContainer, adSlot) => {
+	if (
+		!specs ||
+		!('height' in specs || 'width' in specs) ||
+		!iframe ||
+		!adSlot
+	) {
+		return null;
+	}
 
-    const styles = {};
+	const styles = {};
 
-    if (specs.width && !isLiveBlogInlineAdSlot(adSlot)) {
-        styles.width = normalise(specs.width);
-    }
+	if (specs.width && !isLiveBlogInlineAdSlot(adSlot)) {
+		styles.width = normalise(specs.width);
+	}
 
-    if (specs.height) {
-        styles.height = normalise(specs.height);
-    }
+	if (specs.height) {
+		styles.height = normalise(specs.height);
+	}
 
-    return fastdom.mutate(() => {
-        Object.assign(iframe.style, styles);
+	return fastdom.mutate(() => {
+		Object.assign(iframe.style, styles);
 
-        if (iframeContainer) {
-            Object.assign(iframeContainer.style, styles);
-        }
-    });
+		if (iframeContainer) {
+			Object.assign(iframeContainer.style, styles);
+		}
+	});
 };
 
 // When an outstream resizes we want it to revert to its original styling
 const removeAnyOutstreamClass = (adSlot) => {
-    fastdom.mutate(() => {
-        if (adSlot) {
-            adSlot.classList.remove('ad-slot--outstream');
-        }
-    });
+	fastdom.mutate(() => {
+		if (adSlot) {
+			adSlot.classList.remove('ad-slot--outstream');
+		}
+	});
 };
 
 const init = (register) => {
-    register('resize', (specs, ret, iframe) => {
-        if (iframe && specs) {
-            const adSlot = iframe && iframe.closest('.js-ad-slot');
-            removeAnyOutstreamClass(adSlot);
-            const iframeContainer =
-                iframe && iframe.closest('.ad-slot__content');
-            return resize(specs, iframe, iframeContainer, adSlot);
-        }
-    });
+	register('resize', (specs, ret, iframe) => {
+		if (iframe && specs) {
+			const adSlot = iframe && iframe.closest('.js-ad-slot');
+			removeAnyOutstreamClass(adSlot);
+			const iframeContainer =
+				iframe && iframe.closest('.ad-slot__content');
+			return resize(specs, iframe, iframeContainer, adSlot);
+		}
+	});
 };
 
 export const _ = { resize, normalise };

--- a/static/src/javascripts/projects/commercial/modules/messenger/resize.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/resize.spec.js
@@ -2,85 +2,85 @@ import { _ } from './resize.js';
 
 const { normalise, resize } = _;
 
-const foolFlow = (mockFn) => ((mockFn));
+const foolFlow = (mockFn) => mockFn;
 
 describe('Cross-frame messenger: resize', () => {
-    beforeEach(() => {
-        if (document.body) {
-            document.body.innerHTML = `
+	beforeEach(() => {
+		if (document.body) {
+			document.body.innerHTML = `
               <div id="slot01" class="js-ad-slot" style="width: 7px; height: 14px;" >
                 <div id="container01">
                     <div id="iframe01" class="iframe" data-unit="ch"></div>
                 </div>
               </div>`;
-        }
-        expect.hasAssertions();
-    });
+		}
+		expect.hasAssertions();
+	});
 
-    afterEach(() => {
-        if (document.body) {
-            document.body.innerHTML = '';
-        }
-    });
+	afterEach(() => {
+		if (document.body) {
+			document.body.innerHTML = '';
+		}
+	});
 
-    describe('normalise function', () => {
-        it('should normalise the length passed in', () => {
-            expect(normalise('300')).toBe('300px');
-            expect(normalise('600px')).toBe('600px');
-            expect(normalise('900??')).toBe('900px');
-        });
+	describe('normalise function', () => {
+		it('should normalise the length passed in', () => {
+			expect(normalise('300')).toBe('300px');
+			expect(normalise('600px')).toBe('600px');
+			expect(normalise('900??')).toBe('900px');
+		});
 
-        it('should accept all relative units', () => {
-            const units = [
-                'ch',
-                'px',
-                'em',
-                'rem',
-                'vmin',
-                'vmax',
-                'vh',
-                'vw',
-                'ex',
-            ];
-            units.forEach(unit => {
-                expect(normalise(`10${unit}`)).toBe(`10${unit}`);
-            });
-        });
-    });
+		it('should accept all relative units', () => {
+			const units = [
+				'ch',
+				'px',
+				'em',
+				'rem',
+				'vmin',
+				'vmax',
+				'vh',
+				'vw',
+				'ex',
+			];
+			units.forEach((unit) => {
+				expect(normalise(`10${unit}`)).toBe(`10${unit}`);
+			});
+		});
+	});
 
-    describe('resize function', () => {
-        it('should resolve if the specs are empty', () => {
-            const fakeAdSlot = document.createElement('div');
-            const fakeIframeContainer = document.createElement('div');
-            const fakeIframe = document.createElement('iframe');
-            const result = resize(
-                {},
-                fakeIframe,
-                fakeIframeContainer,
-                fakeAdSlot
-            );
-            expect(result).toBeNull();
-        });
+	describe('resize function', () => {
+		it('should resolve if the specs are empty', () => {
+			const fakeAdSlot = document.createElement('div');
+			const fakeIframeContainer = document.createElement('div');
+			const fakeIframe = document.createElement('iframe');
+			const result = resize(
+				{},
+				fakeIframe,
+				fakeIframeContainer,
+				fakeAdSlot,
+			);
+			expect(result).toBeNull();
+		});
 
-        it('should set width and height of the iFrame and leave ad slot unchanged', () => {
-            const fallback = document.createElement('div');
-            const fakeIframeContainer =
-                document.getElementById('container01') || fallback;
-            const fakeIframe = document.getElementById('iframe01') || fallback;
-            const fakeAdSlot = document.getElementById('slot01') || fallback;
-            return foolFlow(
-                resize(
-                    { width: '20', height: '10' },
-                    fakeIframe,
-                    fakeIframeContainer,
-                    fakeAdSlot
-                )
-            ).then(() => {
-                expect(fakeIframe.style.height).toBe('10px');
-                expect(fakeIframe.style.width).toBe('20px');
-                expect(fakeAdSlot.style.height).toBe('14px');
-                expect(fakeAdSlot.style.width).toBe('7px');
-            });
-        });
-    });
+		it('should set width and height of the iFrame and leave ad slot unchanged', () => {
+			const fallback = document.createElement('div');
+			const fakeIframeContainer =
+				document.getElementById('container01') || fallback;
+			const fakeIframe = document.getElementById('iframe01') || fallback;
+			const fakeAdSlot = document.getElementById('slot01') || fallback;
+			return foolFlow(
+				resize(
+					{ width: '20', height: '10' },
+					fakeIframe,
+					fakeIframeContainer,
+					fakeAdSlot,
+				),
+			).then(() => {
+				expect(fakeIframe.style.height).toBe('10px');
+				expect(fakeIframe.style.width).toBe('20px');
+				expect(fakeAdSlot.style.height).toBe('14px');
+				expect(fakeAdSlot.style.width).toBe('7px');
+			});
+		});
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/messenger/scroll.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/scroll.js
@@ -13,132 +13,128 @@ let observer;
 let visibleIframeIds;
 
 const reset = (useIO_) => {
-    useIO = useIO_;
-    taskQueued = false;
-    iframes = {};
-    iframeCounter = 0;
+	useIO = useIO_;
+	taskQueued = false;
+	iframes = {};
+	iframeCounter = 0;
 };
-
 
 // Instances of classes bound to the current view are not serialised correctly
 // by JSON.stringify. That's ok, we don't care if it's a DOMRect or some other
 // object, as long as the calling view receives the frame coordinates.
 const domRectToRect = (rect) => ({
-    width: rect.width,
-    height: rect.height,
-    top: rect.top,
-    bottom: rect.bottom,
-    left: rect.left,
-    right: rect.right,
+	width: rect.width,
+	height: rect.height,
+	top: rect.top,
+	bottom: rect.bottom,
+	left: rect.left,
+	right: rect.right,
 });
 
 const sendCoordinates = (iframeId, domRect) => {
-    iframes[iframeId].respond(null, domRectToRect(domRect));
+	iframes[iframeId].respond(null, domRectToRect(domRect));
 };
 
-const getDimensions = (id) => [
-    id,
-    iframes[id].node.getBoundingClientRect(),
-];
+const getDimensions = (id) => [id, iframes[id].node.getBoundingClientRect()];
 
-const isIframeInViewport = function(item) {
-    return item[1].bottom > 0 && item[1].top < this.height;
+const isIframeInViewport = function (item) {
+	return item[1].bottom > 0 && item[1].top < this.height;
 };
 
-const onIntersect = changes => {
-    visibleIframeIds = changes
-        .filter(_ => _.intersectionRatio > 0)
-        .map(_ => _.target.id);
+const onIntersect = (changes) => {
+	visibleIframeIds = changes
+		.filter((_) => _.intersectionRatio > 0)
+		.map((_) => _.target.id);
 };
 
 const onScroll = () => {
-    if (!taskQueued) {
-        const viewport = getViewport();
-        taskQueued = true;
+	if (!taskQueued) {
+		const viewport = getViewport();
+		taskQueued = true;
 
-        return fastdom.measure(() => {
-            taskQueued = false;
+		return fastdom.measure(() => {
+			taskQueued = false;
 
-            const iframeIds = Object.keys(iframes);
+			const iframeIds = Object.keys(iframes);
 
-            if (useIO) {
-                visibleIframeIds.map(getDimensions).forEach(data => {
-                    sendCoordinates(data[0], data[1]);
-                });
-            } else {
-                iframeIds
-                    .map(getDimensions)
-                    .filter(isIframeInViewport, viewport)
-                    .forEach(data => {
-                        sendCoordinates(data[0], data[1]);
-                    });
-            }
-        });
-    }
+			if (useIO) {
+				visibleIframeIds.map(getDimensions).forEach((data) => {
+					sendCoordinates(data[0], data[1]);
+				});
+			} else {
+				iframeIds
+					.map(getDimensions)
+					.filter(isIframeInViewport, viewport)
+					.forEach((data) => {
+						sendCoordinates(data[0], data[1]);
+					});
+			}
+		});
+	}
 };
 
 const addScrollListener = (iframe, respond) => {
-    if (iframeCounter === 0) {
-        addEventListener(w, 'scroll', onScroll, {
-            passive: true,
-        });
-        if (useIO) {
-            observer = new w.IntersectionObserver(onIntersect);
-        }
-    }
+	if (iframeCounter === 0) {
+		addEventListener(w, 'scroll', onScroll, {
+			passive: true,
+		});
+		if (useIO) {
+			observer = new w.IntersectionObserver(onIntersect);
+		}
+	}
 
-    iframes[iframe.id] = {
-        node: iframe,
-        // When using IOs, a slot is hidden by default. When the IO starts
-        // observing it, the onIntersect callback will be triggered if it
-        // is already in the viewport
-        visible: !useIO,
-        respond,
-    };
-    iframeCounter += 1;
+	iframes[iframe.id] = {
+		node: iframe,
+		// When using IOs, a slot is hidden by default. When the IO starts
+		// observing it, the onIntersect callback will be triggered if it
+		// is already in the viewport
+		visible: !useIO,
+		respond,
+	};
+	iframeCounter += 1;
 
-    if (useIO && observer) {
-        observer.observe(iframe);
-    }
+	if (useIO && observer) {
+		observer.observe(iframe);
+	}
 
-    fastdom
-        .measure(() => iframe.getBoundingClientRect())
-        .then(domRect => {
-            sendCoordinates(iframe.id, domRect);
-        });
+	fastdom
+		.measure(() => iframe.getBoundingClientRect())
+		.then((domRect) => {
+			sendCoordinates(iframe.id, domRect);
+		});
 };
 
 const removeScrollListener = (iframe) => {
-    if (iframes[iframe.id]) {
-        if (useIO && observer) {
-            observer.unobserve(iframe);
-        }
-        iframes[iframe.id] = false;
-        iframeCounter -= 1;
-    }
+	if (iframes[iframe.id]) {
+		if (useIO && observer) {
+			observer.unobserve(iframe);
+		}
+		iframes[iframe.id] = false;
+		iframeCounter -= 1;
+	}
 
-    if (iframeCounter === 0) {
-        w.removeEventListener('scroll', onScroll);
-        if (useIO && observer) {
-            observer.disconnect();
-            observer = null;
-        }
-    }
+	if (iframeCounter === 0) {
+		w.removeEventListener('scroll', onScroll);
+		if (useIO && observer) {
+			observer.disconnect();
+			observer = null;
+		}
+	}
 };
 
 const onMessage = (respond, start, iframe) => {
-    if (!iframe) return;
-    if (start) {
-        addScrollListener(iframe, respond);
-    } else {
-        removeScrollListener(iframe);
-    }
+	if (!iframe) return;
+	if (start) {
+		addScrollListener(iframe, respond);
+	} else {
+		removeScrollListener(iframe);
+	}
 };
 
 const init = (register) => {
-    register('scroll', onMessage, {
-        persist: true,
-    });
+	register('scroll', onMessage, {
+		persist: true,
+	});
 };
 
 export const _ = { addScrollListener, removeScrollListener, reset, onMessage };

--- a/static/src/javascripts/projects/commercial/modules/messenger/scroll.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/scroll.spec.js
@@ -7,160 +7,160 @@ const removeScrollListener = testExports.removeScrollListener;
 const reset = testExports.reset;
 
 jest.mock('../messenger', () => ({
-    register: jest.fn(),
+	register: jest.fn(),
 }));
 
 jest.mock('../../../../lib/detect', () => ({
-    getViewport: jest.fn(),
+	getViewport: jest.fn(),
 }));
 
 // TODO either remove or resolve flakiness of these tests.
 describe.skip('Cross-frame messenger: scroll', () => {
-    let iframe1 = {};
-    let iframe2 = {};
-    let onScroll = () => Promise.resolve();
+	let iframe1 = {};
+	let iframe2 = {};
+	let onScroll = () => Promise.resolve();
 
-    const respond1 = jest.fn();
-    const respond2 = jest.fn();
+	const respond1 = jest.fn();
+	const respond2 = jest.fn();
 
-    const domSnippet = `
+	const domSnippet = `
          <div id="ad-slot-1" class="js-ad-slot"><div id="iframe1" style="height: 200px"></div></div>
          <div id="ad-slot-2" class="js-ad-slot"><div id="iframe2" style="height: 200px"></div></div>
      `;
 
-    const mockIframePosition = (iframe, top) => {
-        jest.spyOn(iframe, 'getBoundingClientRect').mockImplementationOnce(
-            () => ({
-                left: 8,
-                right: 392,
-                height: 200,
-                width: 384,
-                top,
-                bottom: top + 200,
-            })
-        );
-    };
+	const mockIframePosition = (iframe, top) => {
+		jest.spyOn(iframe, 'getBoundingClientRect').mockImplementationOnce(
+			() => ({
+				left: 8,
+				right: 392,
+				height: 200,
+				width: 384,
+				top,
+				bottom: top + 200,
+			}),
+		);
+	};
 
-    beforeEach(() => {
-        jest.spyOn(global, 'addEventListener').mockImplementation(
-            (_, callback) => {
-                onScroll = callback;
-            }
-        );
-        jest.spyOn(global, 'removeEventListener').mockImplementation(() => {
-            onScroll = () => Promise.resolve();
-        });
-        if (document.body) {
-            document.body.innerHTML = domSnippet;
-        }
-        iframe1 = document.getElementById('iframe1');
-        iframe2 = document.getElementById('iframe2');
+	beforeEach(() => {
+		jest.spyOn(global, 'addEventListener').mockImplementation(
+			(_, callback) => {
+				onScroll = callback;
+			},
+		);
+		jest.spyOn(global, 'removeEventListener').mockImplementation(() => {
+			onScroll = () => Promise.resolve();
+		});
+		if (document.body) {
+			document.body.innerHTML = domSnippet;
+		}
+		iframe1 = document.getElementById('iframe1');
+		iframe2 = document.getElementById('iframe2');
 
-        getViewport.mockReturnValue({ width: 400, height: 300 });
+		getViewport.mockReturnValue({ width: 400, height: 300 });
 
-        expect.hasAssertions();
-    });
+		expect.hasAssertions();
+	});
 
-    afterEach(() => {
-        removeScrollListener(iframe1);
-        removeScrollListener(iframe2);
-        iframe1 = {};
-        iframe2 = {};
-        jest.resetModules();
-        jest.resetAllMocks();
-        if (document.body) {
-            document.body.innerHTML = '';
-        }
-    });
+	afterEach(() => {
+		removeScrollListener(iframe1);
+		removeScrollListener(iframe2);
+		iframe1 = {};
+		iframe2 = {};
+		jest.resetModules();
+		jest.resetAllMocks();
+		if (document.body) {
+			document.body.innerHTML = '';
+		}
+	});
 
-    describe('With IntersectionObserver', () => {
-        let onIntersect = null;
-        class IntersectionObserver {
-            constructor(callback) {
-                onIntersect = callback;
-                return Object.freeze({
-                    observe: () => {},
-                    unobserve: () => {},
-                    disconnect: () => {
-                        onIntersect = null;
-                    },
-                });
-            }
-        }
+	describe('With IntersectionObserver', () => {
+		let onIntersect = null;
+		class IntersectionObserver {
+			constructor(callback) {
+				onIntersect = callback;
+				return Object.freeze({
+					observe: () => {},
+					unobserve: () => {},
+					disconnect: () => {
+						onIntersect = null;
+					},
+				});
+			}
+		}
 
-        beforeEach(() => {
-            Object.defineProperty(global, 'IntersectionObserver', {
-                value: IntersectionObserver,
-                writable: true,
-            });
-            reset(true);
-            addScrollListener(iframe1, respond1);
-            addScrollListener(iframe2, respond2);
-        });
+		beforeEach(() => {
+			Object.defineProperty(global, 'IntersectionObserver', {
+				value: IntersectionObserver,
+				writable: true,
+			});
+			reset(true);
+			addScrollListener(iframe1, respond1);
+			addScrollListener(iframe2, respond2);
+		});
 
-        afterEach(() => {
-            Object.defineProperty(global, 'IntersectionObserver', {
-                value: null,
-                writable: true,
-            });
-        });
+		afterEach(() => {
+			Object.defineProperty(global, 'IntersectionObserver', {
+				value: null,
+				writable: true,
+			});
+		});
 
-        it('should call respond1 but not respond2 at the top of the page', () => {
-            mockIframePosition(iframe1, 8);
-            mockIframePosition(iframe2, 6320);
-            if (onIntersect) {
-                onIntersect([
-                    { target: iframe1, intersectionRatio: 0.5 },
-                    { target: iframe2, intersectionRatio: 0 },
-                ]);
-            }
-            return onScroll().then(() => {
-                expect(respond1).toHaveBeenCalledTimes(2);
-                expect(respond2).toHaveBeenCalledTimes(1);
-            });
-        });
+		it('should call respond1 but not respond2 at the top of the page', () => {
+			mockIframePosition(iframe1, 8);
+			mockIframePosition(iframe2, 6320);
+			if (onIntersect) {
+				onIntersect([
+					{ target: iframe1, intersectionRatio: 0.5 },
+					{ target: iframe2, intersectionRatio: 0 },
+				]);
+			}
+			return onScroll().then(() => {
+				expect(respond1).toHaveBeenCalledTimes(2);
+				expect(respond2).toHaveBeenCalledTimes(1);
+			});
+		});
 
-        it('should call respond2 but not respond1 at the bottom of the page', () => {
-            mockIframePosition(iframe1, -6304);
-            mockIframePosition(iframe2, 8);
-            if (onIntersect) {
-                onIntersect([
-                    { target: iframe1, intersectionRatio: 0 },
-                    { target: iframe2, intersectionRatio: 0.5 },
-                ]);
-            }
-            return onScroll().then(() => {
-                expect(respond1).toHaveBeenCalledTimes(1);
-                expect(respond2).toHaveBeenCalledTimes(2);
-            });
-        });
-    });
+		it('should call respond2 but not respond1 at the bottom of the page', () => {
+			mockIframePosition(iframe1, -6304);
+			mockIframePosition(iframe2, 8);
+			if (onIntersect) {
+				onIntersect([
+					{ target: iframe1, intersectionRatio: 0 },
+					{ target: iframe2, intersectionRatio: 0.5 },
+				]);
+			}
+			return onScroll().then(() => {
+				expect(respond1).toHaveBeenCalledTimes(1);
+				expect(respond2).toHaveBeenCalledTimes(2);
+			});
+		});
+	});
 
-    describe('Without IntersectionObserver', () => {
-        beforeEach(() => {
-            reset(false);
-            return Promise.all([
-                addScrollListener(iframe1, respond1),
-                addScrollListener(iframe2, respond2),
-            ]);
-        });
+	describe('Without IntersectionObserver', () => {
+		beforeEach(() => {
+			reset(false);
+			return Promise.all([
+				addScrollListener(iframe1, respond1),
+				addScrollListener(iframe2, respond2),
+			]);
+		});
 
-        it('should call respond1 but not respond2 at the top of the page', () => {
-            mockIframePosition(iframe1, 8);
-            mockIframePosition(iframe2, 6320);
-            return onScroll().then(() => {
-                expect(respond1).toHaveBeenCalledTimes(2);
-                expect(respond2).toHaveBeenCalledTimes(1);
-            });
-        });
+		it('should call respond1 but not respond2 at the top of the page', () => {
+			mockIframePosition(iframe1, 8);
+			mockIframePosition(iframe2, 6320);
+			return onScroll().then(() => {
+				expect(respond1).toHaveBeenCalledTimes(2);
+				expect(respond2).toHaveBeenCalledTimes(1);
+			});
+		});
 
-        it('should call respond2 but not respond1 at the bottom of the page', () => {
-            mockIframePosition(iframe1, -6304);
-            mockIframePosition(iframe2, 8);
-            return onScroll().then(() => {
-                expect(respond1).toHaveBeenCalledTimes(1);
-                expect(respond2).toHaveBeenCalledTimes(2);
-            });
-        });
-    });
+		it('should call respond2 but not respond1 at the bottom of the page', () => {
+			mockIframePosition(iframe1, -6304);
+			mockIframePosition(iframe2, 8);
+			return onScroll().then(() => {
+				expect(respond1).toHaveBeenCalledTimes(1);
+				expect(respond2).toHaveBeenCalledTimes(2);
+			});
+		});
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/messenger/send.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/send.js
@@ -3,18 +3,18 @@ import { postMessage } from './post-message';
 /* eslint no-bitwise: "off" */
 
 const send = (type, payload) => {
-    const msg = {
-        id: 'xxxxxxxxxx'.replace(/x/g, () =>
-            ((Math.random() * 36) | 0).toString(36)
-        ),
-        iframeId: window.name,
-        type,
-        value: payload,
-    };
+	const msg = {
+		id: 'xxxxxxxxxx'.replace(/x/g, () =>
+			((Math.random() * 36) | 0).toString(36),
+		),
+		iframeId: window.name,
+		type,
+		value: payload,
+	};
 
-    postMessage(msg, window.top, '*');
+	postMessage(msg, window.top, '*');
 
-    return msg.id;
+	return msg.id;
 };
 
 export { send };

--- a/static/src/javascripts/projects/commercial/modules/messenger/send.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/send.spec.js
@@ -2,28 +2,28 @@ import { postMessage } from './post-message';
 import { send } from './send';
 
 jest.mock('./post-message', () => ({
-    postMessage: jest.fn(),
+	postMessage: jest.fn(),
 }));
 
 describe('Cross-frame messenger: send', () => {
-    it('should exist', () => {
-        expect(send).toBeDefined();
-    });
+	it('should exist', () => {
+		expect(send).toBeDefined();
+	});
 
-    it('should post a message with an id', () => {
-        const type = 'a_type';
-        const value = 'a_payload';
-        const id = send(type, value);
-        expect(id).toMatch(/[a-z0-9]{10}/);
-        expect(postMessage).toHaveBeenCalledWith(
-            expect.objectContaining({
-                id,
-                iframeId: expect.any(String),
-                type,
-                value,
-            }),
-            expect.any(Object),
-            '*'
-        );
-    });
+	it('should post a message with an id', () => {
+		const type = 'a_type';
+		const value = 'a_payload';
+		const id = send(type, value);
+		expect(id).toMatch(/[a-z0-9]{10}/);
+		expect(postMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				id,
+				iframeId: expect.any(String),
+				type,
+				value,
+			}),
+			expect.any(Object),
+			'*',
+		);
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/messenger/type.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/type.js
@@ -1,12 +1,12 @@
 import fastdom from '../../../../lib/fastdom-promise';
 
 const setType = (type, adSlot) =>
-    fastdom.mutate(() => {
-        adSlot.classList.add(`ad-slot--${type || ''}`);
-    });
+	fastdom.mutate(() => {
+		adSlot.classList.add(`ad-slot--${type || ''}`);
+	});
 const init = (register) => {
-    register('type', (specs, ret, iframe) =>
-        setType(specs, iframe && iframe.closest('.js-ad-slot'))
-    );
+	register('type', (specs, ret, iframe) =>
+		setType(specs, iframe && iframe.closest('.js-ad-slot')),
+	);
 };
 export { init };

--- a/static/src/javascripts/projects/commercial/modules/messenger/viewport.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/viewport.js
@@ -9,69 +9,69 @@ let taskQueued = false;
 const lastViewportRead = () => fastdom.measure(() => getViewport());
 
 const reset = (window_) => {
-    w = window_ || window;
-    taskQueued = false;
-    iframes = {};
-    iframeCounter = 0;
+	w = window_ || window;
+	taskQueued = false;
+	iframes = {};
+	iframeCounter = 0;
 };
 
 const sendViewportDimensions = (iframeId, viewport) => {
-    if (iframes[iframeId] && iframes[iframeId].respond) {
-        iframes[iframeId].respond(null, viewport);
-    }
+	if (iframes[iframeId] && iframes[iframeId].respond) {
+		iframes[iframeId].respond(null, viewport);
+	}
 };
 
 const onResize = () => {
-    if (!taskQueued) {
-        taskQueued = true;
+	if (!taskQueued) {
+		taskQueued = true;
 
-        return lastViewportRead().then(viewport => {
-            Object.keys(iframes).forEach(iframeId => {
-                sendViewportDimensions(iframeId, viewport);
-            });
-            taskQueued = false;
-        });
-    }
+		return lastViewportRead().then((viewport) => {
+			Object.keys(iframes).forEach((iframeId) => {
+				sendViewportDimensions(iframeId, viewport);
+			});
+			taskQueued = false;
+		});
+	}
 };
 
 const addResizeListener = (iframe, respond) => {
-    if (iframeCounter === 0) {
-        w.addEventListener('resize', onResize);
-    }
+	if (iframeCounter === 0) {
+		w.addEventListener('resize', onResize);
+	}
 
-    iframes[iframe.id] = {
-        node: iframe,
-        respond,
-    };
-    iframeCounter += 1;
-    return lastViewportRead().then(viewport => {
-        sendViewportDimensions(iframe.id, viewport);
-    });
+	iframes[iframe.id] = {
+		node: iframe,
+		respond,
+	};
+	iframeCounter += 1;
+	return lastViewportRead().then((viewport) => {
+		sendViewportDimensions(iframe.id, viewport);
+	});
 };
 
 const removeResizeListener = (iframe) => {
-    if (iframes[iframe.id]) {
-        iframes[iframe.id] = false;
-        iframeCounter -= 1;
-    }
+	if (iframes[iframe.id]) {
+		iframes[iframe.id] = false;
+		iframeCounter -= 1;
+	}
 
-    if (iframeCounter === 0) {
-        w.removeEventListener('resize', onResize);
-    }
+	if (iframeCounter === 0) {
+		w.removeEventListener('resize', onResize);
+	}
 };
 
 const onMessage = (respond, start, iframe) => {
-    if (!iframe) return;
-    if (start) {
-        addResizeListener(iframe, respond);
-    } else {
-        removeResizeListener(iframe);
-    }
+	if (!iframe) return;
+	if (start) {
+		addResizeListener(iframe, respond);
+	} else {
+		removeResizeListener(iframe);
+	}
 };
 const init = (register) => {
-    register('viewport', onMessage, {
-        persist: true,
-    });
+	register('viewport', onMessage, {
+		persist: true,
+	});
 };
 
 export const _ = { addResizeListener, removeResizeListener, reset, onMessage };

--- a/static/src/javascripts/projects/commercial/modules/messenger/viewport.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/viewport.spec.js
@@ -7,11 +7,11 @@ const addResizeListener = testExports.addResizeListener;
 const reset = testExports.reset;
 
 jest.mock('../../../../lib/detect', () => ({
-    getViewport: jest.fn(),
+	getViewport: jest.fn(),
 }));
 
 jest.mock('../messenger', () => ({
-    register: jest.fn(),
+	register: jest.fn(),
 }));
 
 const domSnippet = `
@@ -19,57 +19,57 @@ const domSnippet = `
 `;
 
 describe('Cross-frame messenger: viewport', () => {
-    const respond = jest.fn();
-    let iframe;
-    let onResize;
+	const respond = jest.fn();
+	let iframe;
+	let onResize;
 
-    const mockWindow = {
-        addEventListener(_, callback) {
-            onResize = callback;
-        },
-        removeEventListener() {
-            onResize = null;
-        },
-    };
+	const mockWindow = {
+		addEventListener(_, callback) {
+			onResize = callback;
+		},
+		removeEventListener() {
+			onResize = null;
+		},
+	};
 
-    beforeEach(() => {
-        if (document.body) {
-            document.body.innerHTML = domSnippet;
-        }
-        iframe = document.getElementById('iframe1');
-        reset(mockWindow);
-        expect.hasAssertions();
-    });
+	beforeEach(() => {
+		if (document.body) {
+			document.body.innerHTML = domSnippet;
+		}
+		iframe = document.getElementById('iframe1');
+		reset(mockWindow);
+		expect.hasAssertions();
+	});
 
-    afterEach(() => {
-        iframe = null;
-        reset();
-        if (document.body) {
-            document.body.innerHTML = '';
-        }
-    });
+	afterEach(() => {
+		iframe = null;
+		reset();
+		if (document.body) {
+			document.body.innerHTML = '';
+		}
+	});
 
-    it('should send viewport dimensions as soon as the iframe starts listening', () => {
-        const size = {
-            width: 800,
-            height: 600,
-        };
-        getViewport.mockReturnValue(size);
-        return addResizeListener(iframe, respond).then(() => {
-            expect(respond).toHaveBeenCalledWith(null, size);
-        });
-    });
+	it('should send viewport dimensions as soon as the iframe starts listening', () => {
+		const size = {
+			width: 800,
+			height: 600,
+		};
+		getViewport.mockReturnValue(size);
+		return addResizeListener(iframe, respond).then(() => {
+			expect(respond).toHaveBeenCalledWith(null, size);
+		});
+	});
 
-    it('should send viewport dimensions when the window gets resized', () => {
-        const size = {
-            width: 1024,
-            height: 768,
-        };
-        getViewport.mockReturnValue(size);
-        return addResizeListener(iframe, respond)
-            .then(() => onResize && onResize())
-            .then(() => {
-                expect(respond).toHaveBeenCalledWith(null, size);
-            });
-    });
+	it('should send viewport dimensions when the window gets resized', () => {
+		const size = {
+			width: 1024,
+			height: 768,
+		};
+		getViewport.mockReturnValue(size);
+		return addResizeListener(iframe, respond)
+			.then(() => onResize && onResize())
+			.then(() => {
+				expect(respond).toHaveBeenCalledWith(null, size);
+			});
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/mobile-sticky.js
+++ b/static/src/javascripts/projects/commercial/modules/mobile-sticky.js
@@ -5,46 +5,46 @@ import { shouldIncludeMobileSticky } from './header-bidding/utils';
 import config from '../../../lib/config';
 
 const createAdWrapperClassic = () => {
-    const wrapper = document.createElement('div');
-    wrapper.className = 'mobilesticky-container';
-    const adSlot = createSlots('mobile-sticky', {})[0];
-    wrapper.appendChild(adSlot);
-    return wrapper;
+	const wrapper = document.createElement('div');
+	wrapper.className = 'mobilesticky-container';
+	const adSlot = createSlots('mobile-sticky', {})[0];
+	wrapper.appendChild(adSlot);
+	return wrapper;
 };
 
 const createAdWrapperDCR = () => {
-    const wrapper = document.querySelector('.mobilesticky-container');
-    if (wrapper) {
-        const adSlot = createSlots('mobile-sticky', {})[0];
-        wrapper.appendChild(adSlot);
-    }
-    return wrapper;
+	const wrapper = document.querySelector('.mobilesticky-container');
+	if (wrapper) {
+		const adSlot = createSlots('mobile-sticky', {})[0];
+		wrapper.appendChild(adSlot);
+	}
+	return wrapper;
 };
 
 const createAdWrapper = () => {
-    if (!config.get('isDotcomRendering', false)) {
-        return createAdWrapperClassic();
-    }
-    return createAdWrapperDCR();
+	if (!config.get('isDotcomRendering', false)) {
+		return createAdWrapperClassic();
+	}
+	return createAdWrapperDCR();
 };
 
 export const init = () => {
-    if (shouldIncludeMobileSticky()) {
-        const mobileStickyWrapper = createAdWrapper();
-        return fastdom
-            .mutate(() => {
-                if (document.body && mobileStickyWrapper)
-                    document.body.appendChild(mobileStickyWrapper);
-            })
-            .then(() => {
-                if (mobileStickyWrapper) {
-                    const mobileStickyAdSlot = mobileStickyWrapper.querySelector(
-                        '#dfp-ad--mobile-sticky'
-                    );
-                    if (mobileStickyAdSlot) addSlot(mobileStickyAdSlot, true);
-                }
-            });
-    }
+	if (shouldIncludeMobileSticky()) {
+		const mobileStickyWrapper = createAdWrapper();
+		return fastdom
+			.mutate(() => {
+				if (document.body && mobileStickyWrapper)
+					document.body.appendChild(mobileStickyWrapper);
+			})
+			.then(() => {
+				if (mobileStickyWrapper) {
+					const mobileStickyAdSlot = mobileStickyWrapper.querySelector(
+						'#dfp-ad--mobile-sticky',
+					);
+					if (mobileStickyAdSlot) addSlot(mobileStickyAdSlot, true);
+				}
+			});
+	}
 
-    return Promise.resolve();
+	return Promise.resolve();
 };

--- a/static/src/javascripts/projects/commercial/modules/paidfor-band.js
+++ b/static/src/javascripts/projects/commercial/modules/paidfor-band.js
@@ -2,14 +2,14 @@ import { Sticky } from '../../common/modules/ui/sticky';
 import { commercialFeatures } from '../../common/modules/commercial/commercial-features';
 
 export const init = () => {
-    if (!commercialFeatures.paidforBand) {
-        return Promise.resolve(false);
-    }
+	if (!commercialFeatures.paidforBand) {
+		return Promise.resolve(false);
+	}
 
-    const elem = document.querySelector('.paidfor-band');
-    if (elem) {
-        new Sticky(elem).init();
-    }
+	const elem = document.querySelector('.paidfor-band');
+	if (elem) {
+		new Sticky(elem).init();
+	}
 
-    return Promise.resolve(true);
+	return Promise.resolve(true);
 };

--- a/static/src/javascripts/projects/commercial/modules/paidfor-band.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/paidfor-band.spec.js
@@ -2,28 +2,28 @@ import { Sticky } from '../../common/modules/ui/sticky';
 import { init } from './paidfor-band';
 
 jest.mock('../../common/modules/commercial/commercial-features', () => ({
-    commercialFeatures: {
-        paidforBand: true,
-    },
+	commercialFeatures: {
+		paidforBand: true,
+	},
 }));
 
 jest.mock('../../common/modules/ui/sticky', () => ({
-    Sticky: class {},
+	Sticky: class {},
 }));
 
 describe('Paid for band', () => {
-    it('should exist', () => {
-        expect(init).toBeDefined();
-    });
+	it('should exist', () => {
+		expect(init).toBeDefined();
+	});
 
-    it('should create a Sticky element', () => {
-        if (document.body) {
-            document.body.innerHTML = '<div class="paidfor-band"></div>';
-        }
-        (Sticky.prototype).init = jest.fn();
+	it('should create a Sticky element', () => {
+		if (document.body) {
+			document.body.innerHTML = '<div class="paidfor-band"></div>';
+		}
+		Sticky.prototype.init = jest.fn();
 
-        return init().then(() => {
-            expect(Sticky.prototype.init).toHaveBeenCalled();
-        });
-    });
+		return init().then(() => {
+			expect(Sticky.prototype.init).toHaveBeenCalled();
+		});
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/remove-slots.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/remove-slots.spec.js
@@ -4,14 +4,14 @@ const adSlotSelector = '.js-ad-slot';
 const toggledAdLabelSelector = '.ad-slot__label--toggle';
 
 describe('Remove ad slots and labels', () => {
-    afterEach(() => {
-        if (document.body) {
-            document.body.innerHTML = '';
-        }
-    });
-    test('Remove all ad slots and toggled labels', () => {
-        if (document.body) {
-            document.body.innerHTML = `
+	afterEach(() => {
+		if (document.body) {
+			document.body.innerHTML = '';
+		}
+	});
+	test('Remove all ad slots and toggled labels', () => {
+		if (document.body) {
+			document.body.innerHTML = `
                 <div>
                     <div class="ad-slot__label ad-slot__label--toggle hidden">Advertisement</div>
                     <div class="ad-slot__label ad-slot__label--toggle hidden">Advertisement</div>
@@ -20,19 +20,25 @@ describe('Remove ad slots and labels', () => {
                     <div class="js-ad-slot"></div>
                 </div>
             `;
-        }
-        expect(document.querySelectorAll(adSlotSelector).length).toEqual(2);
-        expect(document.querySelectorAll(toggledAdLabelSelector).length).toEqual(2);
-        return removeSlots().then(() => {
-            expect(document.querySelectorAll(adSlotSelector).length).toEqual(0);
-            expect(document.querySelectorAll(toggledAdLabelSelector).length).toEqual(0);
-            expect(document.querySelectorAll('.ad-slot__label').length).toEqual(1);
-        });
-    });
+		}
+		expect(document.querySelectorAll(adSlotSelector).length).toEqual(2);
+		expect(
+			document.querySelectorAll(toggledAdLabelSelector).length,
+		).toEqual(2);
+		return removeSlots().then(() => {
+			expect(document.querySelectorAll(adSlotSelector).length).toEqual(0);
+			expect(
+				document.querySelectorAll(toggledAdLabelSelector).length,
+			).toEqual(0);
+			expect(document.querySelectorAll('.ad-slot__label').length).toEqual(
+				1,
+			);
+		});
+	});
 
-    test('Remove all disabled (ie display: none) ad slots and toggled labels', () => {
-        if (document.body) {
-            document.body.innerHTML = `
+	test('Remove all disabled (ie display: none) ad slots and toggled labels', () => {
+		if (document.body) {
+			document.body.innerHTML = `
                 <div>
                     <div style="display: none" class="ad-slot__label ad-slot__label--toggle hidden">Advertisement</div>
                     <div class="ad-slot__label ad-slot__label--toggle hidden">Advertisement</div>
@@ -41,13 +47,19 @@ describe('Remove ad slots and labels', () => {
                     <div class="js-ad-slot"></div>
                 </div>
             `;
-        }
-        expect(document.querySelectorAll(adSlotSelector).length).toEqual(2);
-        expect(document.querySelectorAll(toggledAdLabelSelector).length).toEqual(2);
-        return removeDisabledSlots().then(() => {
-            expect(document.querySelectorAll(adSlotSelector).length).toEqual(1);
-            expect(document.querySelectorAll(toggledAdLabelSelector).length).toEqual(1);
-            expect(document.querySelectorAll('.ad-slot__label').length).toEqual(2);
-        });
-    });
+		}
+		expect(document.querySelectorAll(adSlotSelector).length).toEqual(2);
+		expect(
+			document.querySelectorAll(toggledAdLabelSelector).length,
+		).toEqual(2);
+		return removeDisabledSlots().then(() => {
+			expect(document.querySelectorAll(adSlotSelector).length).toEqual(1);
+			expect(
+				document.querySelectorAll(toggledAdLabelSelector).length,
+			).toEqual(1);
+			expect(document.querySelectorAll('.ad-slot__label').length).toEqual(
+				2,
+			);
+		});
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/set-adtest-cookie.js
+++ b/static/src/javascripts/projects/commercial/modules/set-adtest-cookie.js
@@ -2,14 +2,14 @@ import { getUrlVars } from '../../../lib/url';
 import { removeCookie, addCookie } from '../../../lib/cookies';
 
 const init = () => {
-    const queryParams = getUrlVars();
+	const queryParams = getUrlVars();
 
-    if (queryParams.adtest === 'clear') {
-        removeCookie('adtest');
-    } else if (queryParams.adtest) {
-        addCookie('adtest', encodeURIComponent(queryParams.adtest), 10);
-    }
-    return Promise.resolve();
+	if (queryParams.adtest === 'clear') {
+		removeCookie('adtest');
+	} else if (queryParams.adtest) {
+		addCookie('adtest', encodeURIComponent(queryParams.adtest), 10);
+	}
+	return Promise.resolve();
 };
 
 export { init };

--- a/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-mpu.js
@@ -5,104 +5,104 @@ import { Sticky } from '../../common/modules/ui/sticky';
 import { register, unregister } from './messenger';
 
 const noSticky = !!(
-    document.documentElement &&
-    document.documentElement.classList.contains('has-no-sticky')
+	document.documentElement &&
+	document.documentElement.classList.contains('has-no-sticky')
 );
 let stickyElement;
 let stickySlot;
 
 const onResize = (specs, _, iframe) => {
-    if (stickySlot.contains(iframe)) {
-        unregister('resize', onResize);
-        stickyElement.updatePosition();
-    }
+	if (stickySlot.contains(iframe)) {
+		unregister('resize', onResize);
+		stickyElement.updatePosition();
+	}
 };
 
 const isStickyMpuSlot = (adSlot) => {
-    const dataName = adSlot.dataset.name;
-    return dataName === 'comments' || dataName === 'right';
+	const dataName = adSlot.dataset.name;
+	return dataName === 'comments' || dataName === 'right';
 };
 
 const stickyCommentsMpu = (adSlot) => {
-    if (isStickyMpuSlot(adSlot)) {
-        stickySlot = adSlot;
-    }
+	if (isStickyMpuSlot(adSlot)) {
+		stickySlot = adSlot;
+	}
 
-    const referenceElement = document.querySelector(
-        '.js-comments'
-    );
+	const referenceElement = document.querySelector('.js-comments');
 
-    if (!referenceElement || !adSlot) {
-        return;
-    }
+	if (!referenceElement || !adSlot) {
+		return;
+	}
 
-    fastdom
-        .measure(() => referenceElement.offsetHeight - 600)
-        .then(newHeight =>
-            fastdom.mutate(() => {
-                (adSlot.parentNode).style.height = `${newHeight}px`;
-            })
-        )
-        .then(() => {
-            if (noSticky) {
-                stickyElement = new Sticky(adSlot);
-                stickyElement.init();
-                register('resize', onResize);
-            }
-            mediator.emit('page:commercial:sticky-comments-mpu');
-        });
+	fastdom
+		.measure(() => referenceElement.offsetHeight - 600)
+		.then((newHeight) =>
+			fastdom.mutate(() => {
+				adSlot.parentNode.style.height = `${newHeight}px`;
+			}),
+		)
+		.then(() => {
+			if (noSticky) {
+				stickyElement = new Sticky(adSlot);
+				stickyElement.init();
+				register('resize', onResize);
+			}
+			mediator.emit('page:commercial:sticky-comments-mpu');
+		});
 };
 
-stickyCommentsMpu.whenRendered = new Promise(resolve => {
-    mediator.on('page:commercial:sticky-comments-mpu', resolve);
+stickyCommentsMpu.whenRendered = new Promise((resolve) => {
+	mediator.on('page:commercial:sticky-comments-mpu', resolve);
 });
 
 const stickyMpu = (adSlot) => {
-    if (isStickyMpuSlot(adSlot)) {
-        stickySlot = adSlot;
-    }
+	if (isStickyMpuSlot(adSlot)) {
+		stickySlot = adSlot;
+	}
 
-    const referenceElement = document.querySelector(
-        ['.js-article__body:not([style*="display: none;"])',
-        '.js-liveblog-body-content:not([style*="display: none;"])'].join(', ')
-    );
+	const referenceElement = document.querySelector(
+		[
+			'.js-article__body:not([style*="display: none;"])',
+			'.js-liveblog-body-content:not([style*="display: none;"])',
+		].join(', '),
+	);
 
-    // Fixes overlapping ad issue on liveblogs by Setting to max ad height.
-    const stickyPixelBoundary = config.get('page.isLiveBlog') ? 600 : 300;
+	// Fixes overlapping ad issue on liveblogs by Setting to max ad height.
+	const stickyPixelBoundary = config.get('page.isLiveBlog') ? 600 : 300;
 
-    if (
-        !referenceElement ||
-        !adSlot ||
-        config.get('page.hasShowcaseMainElement')
-    ) {
-        return;
-    }
+	if (
+		!referenceElement ||
+		!adSlot ||
+		config.get('page.hasShowcaseMainElement')
+	) {
+		return;
+	}
 
-    fastdom
-        .measure(() => referenceElement.offsetTop + stickyPixelBoundary)
-        .then(newHeight =>
-            fastdom.mutate(() => {
-                (adSlot.parentNode).style.height = `${newHeight}px`;
-            })
-        )
-        .then(() => {
-            if (noSticky) {
-                // if there is a sticky 'paid by' band move the sticky mpu down so it will be always visible
-                const options = config.get('page.isPaidContent')
-                    ? {
-                          top: 43,
-                      }
-                    : {};
-                stickyElement = new Sticky(adSlot, options);
-                stickyElement.init();
-                register('resize', onResize);
-            }
-            mediator.emit('page:commercial:sticky-mpu');
-        });
+	fastdom
+		.measure(() => referenceElement.offsetTop + stickyPixelBoundary)
+		.then((newHeight) =>
+			fastdom.mutate(() => {
+				adSlot.parentNode.style.height = `${newHeight}px`;
+			}),
+		)
+		.then(() => {
+			if (noSticky) {
+				// if there is a sticky 'paid by' band move the sticky mpu down so it will be always visible
+				const options = config.get('page.isPaidContent')
+					? {
+							top: 43,
+					  }
+					: {};
+				stickyElement = new Sticky(adSlot, options);
+				stickyElement.init();
+				register('resize', onResize);
+			}
+			mediator.emit('page:commercial:sticky-mpu');
+		});
 };
 
-stickyMpu.whenRendered = new Promise(resolve => {
-    mediator.on('page:commercial:sticky-mpu', resolve);
+stickyMpu.whenRendered = new Promise((resolve) => {
+	mediator.on('page:commercial:sticky-mpu', resolve);
 });
 
 export { stickyMpu, stickyCommentsMpu };

--- a/static/src/javascripts/projects/commercial/modules/sticky-mpu.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-mpu.spec.js
@@ -7,102 +7,94 @@ jest.mock('../../../lib/raven');
 // Workaround to fix issue where dataset is missing from jsdom, and solve the
 // 'cannot set property [...] which has only a getter' TypeError
 Object.defineProperty(HTMLElement.prototype, 'dataset', {
-    writable: true,
-    value: {},
+	writable: true,
+	value: {},
 });
 
 const mockHeight = (height) => {
-    jest.spyOn(fastdom, 'measure').mockReturnValue(Promise.resolve(height));
+	jest.spyOn(fastdom, 'measure').mockReturnValue(Promise.resolve(height));
 };
 
 describe('Sticky MPU', () => {
-    const domSnippet = `
+	const domSnippet = `
         <div class="content__article-body js-article__body"><div>
     `;
 
-    const adSlotRight =
-        '<div id="dfp-ad--right" class="js-ad-slot ad-slot ad-slot--right" data-name="right" data-mobile="1,1|2,2|300,250|300,274|300,600|fluid"></div>';
+	const adSlotRight =
+		'<div id="dfp-ad--right" class="js-ad-slot ad-slot ad-slot--right" data-name="right" data-mobile="1,1|2,2|300,250|300,274|300,600|fluid"></div>';
 
-    beforeEach(() => {
-        jest.resetAllMocks();
+	beforeEach(() => {
+		jest.resetAllMocks();
 
-        if (document.body) {
-            document.body.innerHTML = `${domSnippet}<div class="aside-slot-container" aria-hidden="true">${adSlotRight}</div>`;
-        }
-    });
+		if (document.body) {
+			document.body.innerHTML = `${domSnippet}<div class="aside-slot-container" aria-hidden="true">${adSlotRight}</div>`;
+		}
+	});
 
-    afterEach(() => {
-        if (document.body) {
-            document.body.innerHTML = '';
-        }
-    });
+	afterEach(() => {
+		if (document.body) {
+			document.body.innerHTML = '';
+		}
+	});
 
-    it('should exist', () => {
-        expect(stickyMpu).toBeDefined();
-        expect(stickyMpu.whenRendered).toBeDefined();
-    });
+	it('should exist', () => {
+		expect(stickyMpu).toBeDefined();
+		expect(stickyMpu.whenRendered).toBeDefined();
+	});
 
-    it('should resize the parent container', done => {
-        mockHeight(8000);
-        const targetSlot = (document.querySelector(
-            '.js-ad-slot'
-        ));
-        targetSlot.dataset = {
-            name: targetSlot.getAttribute('data-name') || '',
-        };
-        mediator.once('page:commercial:sticky-mpu', () => {
-            const container = (document.querySelector(
-                '.aside-slot-container'
-            ));
-            expect(container.style.height).toBe('8000px');
-            done();
-        });
-        stickyMpu(targetSlot);
-    });
+	it('should resize the parent container', (done) => {
+		mockHeight(8000);
+		const targetSlot = document.querySelector('.js-ad-slot');
+		targetSlot.dataset = {
+			name: targetSlot.getAttribute('data-name') || '',
+		};
+		mediator.once('page:commercial:sticky-mpu', () => {
+			const container = document.querySelector('.aside-slot-container');
+			expect(container.style.height).toBe('8000px');
+			done();
+		});
+		stickyMpu(targetSlot);
+	});
 });
 
 describe('Sticky Comments MPU', () => {
-    const domSnippet = `
+	const domSnippet = `
         <div class="js-comments"><div>
     `;
 
-    const adSlotComments =
-        '<div id="dfp-ad--comments" class="js-ad-slot ad-slot ad-slot--comments" data-name="comments" data-mobile="1,1|2,2|300,250|300,274|300,600|fluid"></div>';
+	const adSlotComments =
+		'<div id="dfp-ad--comments" class="js-ad-slot ad-slot ad-slot--comments" data-name="comments" data-mobile="1,1|2,2|300,250|300,274|300,600|fluid"></div>';
 
-    beforeEach(() => {
-        jest.resetAllMocks();
+	beforeEach(() => {
+		jest.resetAllMocks();
 
-        if (document.body) {
-            document.body.innerHTML = `${domSnippet}<div class="aside-slot-container" aria-hidden="true">${adSlotComments}</div>`;
-        }
-    });
+		if (document.body) {
+			document.body.innerHTML = `${domSnippet}<div class="aside-slot-container" aria-hidden="true">${adSlotComments}</div>`;
+		}
+	});
 
-    afterEach(() => {
-        if (document.body) {
-            document.body.innerHTML = '';
-        }
-    });
+	afterEach(() => {
+		if (document.body) {
+			document.body.innerHTML = '';
+		}
+	});
 
-    it('should exist', () => {
-        expect(stickyCommentsMpu).toBeDefined();
-        expect(stickyCommentsMpu.whenRendered).toBeDefined();
-    });
+	it('should exist', () => {
+		expect(stickyCommentsMpu).toBeDefined();
+		expect(stickyCommentsMpu.whenRendered).toBeDefined();
+	});
 
-    it('should resize the parent container', done => {
-        mockHeight(10000);
-        const targetSlot = (document.querySelector(
-            '.js-ad-slot'
-        ));
-        targetSlot.dataset = {
-            name: targetSlot.getAttribute('data-name') || '',
-        };
-        mediator.once('page:commercial:sticky-comments-mpu', () => {
-            const container = (document.querySelector(
-                '.aside-slot-container'
-            ));
-            expect(container.style.height).toBe('10000px');
-            done();
-        });
-        stickyCommentsMpu(targetSlot);
-    });
+	it('should resize the parent container', (done) => {
+		mockHeight(10000);
+		const targetSlot = document.querySelector('.js-ad-slot');
+		targetSlot.dataset = {
+			name: targetSlot.getAttribute('data-name') || '',
+		};
+		mediator.once('page:commercial:sticky-comments-mpu', () => {
+			const container = document.querySelector('.aside-slot-container');
+			expect(container.style.height).toBe('10000px');
+			done();
+		});
+		stickyCommentsMpu(targetSlot);
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/sticky-top-banner.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-top-banner.js
@@ -22,83 +22,83 @@ let scrollY;
 // This is also the best place to adjust the scrolling position in case the
 // user has scrolled past the header.
 const resizeStickyBanner = (newHeight) => {
-    if (topSlotHeight === newHeight) {
-        return Promise.resolve(-1);
-    }
+	if (topSlotHeight === newHeight) {
+		return Promise.resolve(-1);
+	}
 
-    return fastdom.mutate(() => {
-        if (stickyBanner && header) {
-            const newCSSHeight = `${newHeight}px`;
-            stickyBanner.classList.add('sticky-top-banner-ad');
-            stickyBanner.style.height = newCSSHeight;
-            header.style.marginTop = newCSSHeight;
-        }
-        if (topSlotHeight !== undefined && headerHeight <= scrollY) {
-            window.scrollBy(0, newHeight - topSlotHeight);
-        }
-        topSlotHeight = newHeight;
+	return fastdom.mutate(() => {
+		if (stickyBanner && header) {
+			const newCSSHeight = `${newHeight}px`;
+			stickyBanner.classList.add('sticky-top-banner-ad');
+			stickyBanner.style.height = newCSSHeight;
+			header.style.marginTop = newCSSHeight;
+		}
+		if (topSlotHeight !== undefined && headerHeight <= scrollY) {
+			window.scrollBy(0, newHeight - topSlotHeight);
+		}
+		topSlotHeight = newHeight;
 
-        return newHeight;
-    });
+		return newHeight;
+	});
 };
 
 // Sudden changes in the layout can be jarring to the user, so we animate
 // them for a better experience. We only do this if the slot is in view
 // though.
 const setupAnimation = () =>
-    fastdom.mutate(() => {
-        if (stickyBanner && header) {
-            if (scrollY <= headerHeight) {
-                header.classList.add('l-header--animate');
-                stickyBanner.classList.add('sticky-top-banner-ad--animate');
-            } else {
-                header.classList.remove('l-header--animate');
-                stickyBanner.classList.remove('sticky-top-banner-ad--animate');
-            }
-        }
-    });
+	fastdom.mutate(() => {
+		if (stickyBanner && header) {
+			if (scrollY <= headerHeight) {
+				header.classList.add('l-header--animate');
+				stickyBanner.classList.add('sticky-top-banner-ad--animate');
+			} else {
+				header.classList.remove('l-header--animate');
+				stickyBanner.classList.remove('sticky-top-banner-ad--animate');
+			}
+		}
+	});
 
 const onScroll = () => {
-    scrollY = window.pageYOffset;
-    if (!updateQueued) {
-        updateQueued = true;
+	scrollY = window.pageYOffset;
+	if (!updateQueued) {
+		updateQueued = true;
 
-        return fastdom
-            .mutate(() => {
-                updateQueued = false;
-                if (stickyBanner) {
-                    if (headerHeight < scrollY) {
-                        stickyBanner.style.position = 'absolute';
-                        stickyBanner.style.top = `${headerHeight}px`;
-                    } else {
-                        stickyBanner.style.position = '';
-                        stickyBanner.style.top = '';
-                    }
-                }
-            })
-            .then(setupAnimation);
-    }
+		return fastdom
+			.mutate(() => {
+				updateQueued = false;
+				if (stickyBanner) {
+					if (headerHeight < scrollY) {
+						stickyBanner.style.position = 'absolute';
+						stickyBanner.style.top = `${headerHeight}px`;
+					} else {
+						stickyBanner.style.position = '';
+						stickyBanner.style.top = '';
+					}
+				}
+			})
+			.then(setupAnimation);
+	}
 
-    return Promise.resolve();
+	return Promise.resolve();
 };
 
 const update = (newHeight) =>
-    fastdom
-        .measure(() => {
-            topSlotStyles = topSlotStyles || window.getComputedStyle(topSlot);
-            return (
-                newHeight +
-                parseInt(topSlotStyles.paddingTop, 10) +
-                parseInt(topSlotStyles.paddingBottom, 10)
-            );
-        })
-        .then(resizeStickyBanner);
+	fastdom
+		.measure(() => {
+			topSlotStyles = topSlotStyles || window.getComputedStyle(topSlot);
+			return (
+				newHeight +
+				parseInt(topSlotStyles.paddingTop, 10) +
+				parseInt(topSlotStyles.paddingBottom, 10)
+			);
+		})
+		.then(resizeStickyBanner);
 
 const onResize = (specs, _, iframe) => {
-    if (topSlot && topSlot.contains(iframe)) {
-        update(specs.height);
-        unregister('resize', onResize);
-    }
+	if (topSlot && topSlot.contains(iframe)) {
+		update(specs.height);
+		unregister('resize', onResize);
+	}
 };
 
 // Register a message listener for when the creative wants to resize
@@ -106,102 +106,103 @@ const onResize = (specs, _, iframe) => {
 // We also listen for scroll events if we need to, to snap the slot in
 // place when it reaches the end of the header.
 const setupListeners = () => {
-    register('resize', onResize);
-    addEventListener(window, 'scroll', onScroll, {
-        passive: true,
-    });
+	register('resize', onResize);
+	addEventListener(window, 'scroll', onScroll, {
+		passive: true,
+	});
 };
 
 const getAdvertSizeByIndex = (advert, index) => {
-    if (advert && advert.size && typeof advert.size !== 'string') {
-        return advert.size[index];
-    }
+	if (advert && advert.size && typeof advert.size !== 'string') {
+		return advert.size[index];
+	}
 };
 
 const onFirstRender = () => {
-    /* eslint-disable no-use-before-define */
-    
-    _.whenFirstRendered = trackAdRender(topSlotId).then(isRendered => {
-        if (isRendered) {
-            const advert = getAdvertById(topSlotId);
-            const adSize0 = getAdvertSizeByIndex(advert, 0);
-            const adSize1 = getAdvertSizeByIndex(advert, 1);
+	/* eslint-disable no-use-before-define */
 
-            if (
-                // skip for Fabric creatives
-                adSize0 !== 88 &&
-                // skip for native ads
-                adSize1 &&
-                adSize1 > 0
-            ) {
-                return fastdom
-                    .measure(() => {
-                        const styles = window.getComputedStyle(topSlot);
+	_.whenFirstRendered = trackAdRender(topSlotId).then((isRendered) => {
+		if (isRendered) {
+			const advert = getAdvertById(topSlotId);
+			const adSize0 = getAdvertSizeByIndex(advert, 0);
+			const adSize1 = getAdvertSizeByIndex(advert, 1);
 
-                        return (
-                            parseInt(styles.paddingTop, 10) +
-                                parseInt(styles.paddingBottom, 10) +
-                                adSize1 || 0
-                        );
-                    })
-                    .then(resizeStickyBanner);
-            }
-            return fastdom
-                .measure(
-                    () =>
-                        (topSlot && topSlot.getBoundingClientRect().height) || 0
-                )
-                .then(resizeStickyBanner);
-        }
-    });
-    /* eslint-enable no-use-before-define */
+			if (
+				// skip for Fabric creatives
+				adSize0 !== 88 &&
+				// skip for native ads
+				adSize1 &&
+				adSize1 > 0
+			) {
+				return fastdom
+					.measure(() => {
+						const styles = window.getComputedStyle(topSlot);
+
+						return (
+							parseInt(styles.paddingTop, 10) +
+								parseInt(styles.paddingBottom, 10) +
+								adSize1 || 0
+						);
+					})
+					.then(resizeStickyBanner);
+			}
+			return fastdom
+				.measure(
+					() =>
+						(topSlot && topSlot.getBoundingClientRect().height) ||
+						0,
+				)
+				.then(resizeStickyBanner);
+		}
+	});
+	/* eslint-enable no-use-before-define */
 };
 
 const initState = () =>
-    fastdom
-        .measure(() => {
-            if (header) {
-                headerHeight = header.getBoundingClientRect().height;
-            }
+	fastdom
+		.measure(() => {
+			if (header) {
+				headerHeight = header.getBoundingClientRect().height;
+			}
 
-            return (topSlot && topSlot.getBoundingClientRect().height) || 0;
-        })
-        .then(currentHeight =>
-            Promise.all([resizeStickyBanner(currentHeight), onScroll()])
-        );
+			return (topSlot && topSlot.getBoundingClientRect().height) || 0;
+		})
+		.then((currentHeight) =>
+			Promise.all([resizeStickyBanner(currentHeight), onScroll()]),
+		);
 
 const init = () => {
-    if (!commercialFeatures.stickyTopBannerAd) {
-        return Promise.resolve();
-    }
+	if (!commercialFeatures.stickyTopBannerAd) {
+		return Promise.resolve();
+	}
 
-    topSlot = document.getElementById(topSlotId);
-    if (
-        topSlot &&
-        isBreakpoint({
-            min: 'desktop',
-        })
-    ) {
-        header = document.getElementById('header');
-        stickyBanner = (topSlot.parentNode);
+	topSlot = document.getElementById(topSlotId);
+	if (
+		topSlot &&
+		isBreakpoint({
+			min: 'desktop',
+		})
+	) {
+		header = document.getElementById('header');
+		stickyBanner = topSlot.parentNode;
 
-        // First, let's assign some default values so that everything
-        // is in good order before we start animating changes in height
-        return (
-            initState()
-                // Second, start listening for height and scroll changes
-                .then(setupListeners)
-                .then(onFirstRender)
-        );
-    }
-    topSlot = null;
-    return Promise.resolve();
+		// First, let's assign some default values so that everything
+		// is in good order before we start animating changes in height
+		return (
+			initState()
+				// Second, start listening for height and scroll changes
+				.then(setupListeners)
+				.then(onFirstRender)
+		);
+	}
+	topSlot = null;
+	return Promise.resolve();
 };
 
 export const _ = {
-    update,
-    resizeStickyBanner,
-    onScroll,
-    whenFirstRendered: null,
+	update,
+	resizeStickyBanner,
+	onScroll,
+	whenFirstRendered: null,
 };
 export { init };

--- a/static/src/javascripts/projects/commercial/modules/sticky-top-banner.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/sticky-top-banner.spec.js
@@ -5,178 +5,178 @@ import { init, _ } from './sticky-top-banner';
 const { resizeStickyBanner, update, onScroll } = _;
 
 jest.mock('../../../lib/detect', () => ({
-    isBreakpoint: jest.fn(() => true),
+	isBreakpoint: jest.fn(() => true),
 }));
 jest.mock('./messenger', () => ({
-    register: jest.fn(),
+	register: jest.fn(),
 }));
 jest.mock('./dfp/track-ad-render', () => ({
-    trackAdRender: () => Promise.resolve(true),
+	trackAdRender: () => Promise.resolve(true),
 }));
 jest.mock('../../../lib/events', () => ({
-    addEventListener: jest.fn(),
+	addEventListener: jest.fn(),
 }));
 jest.mock('../../common/modules/commercial/commercial-features', () => ({
-    commercialFeatures: {
-        stickyTopBannerAd: true,
-    },
+	commercialFeatures: {
+		stickyTopBannerAd: true,
+	},
 }));
 jest.mock('./dfp/get-advert-by-id', () => ({
-    getAdvertById: jest.fn(() => ({
-        size: [0, 1],
-    })),
+	getAdvertById: jest.fn(() => ({
+		size: [0, 1],
+	})),
 }));
 const registerSpy = require('./messenger').register;
 
 Element.prototype.getBoundingClientRect = jest.fn(() => ({ height: 500 }));
 
 describe('Sticky ad banner', () => {
-    const scrollBySpy = jest.spyOn(window, 'scrollBy');
-    const chance = new Chance();
-    let header;
-    let stickyBanner;
+	const scrollBySpy = jest.spyOn(window, 'scrollBy');
+	const chance = new Chance();
+	let header;
+	let stickyBanner;
 
-    beforeEach(() => {
-        if (document.body) {
-            document.body.innerHTML = `
+	beforeEach(() => {
+		if (document.body) {
+			document.body.innerHTML = `
                 <div id="top-banner-parent">
                     <div id="dfp-ad--top-above-nav"></div>
                 </div>
                 <div id="header"></div>
             `;
-        }
-        header = document.getElementById('header');
-        stickyBanner = document.getElementById('top-banner-parent');
-        expect.hasAssertions();
-    });
+		}
+		header = document.getElementById('header');
+		stickyBanner = document.getElementById('top-banner-parent');
+		expect.hasAssertions();
+	});
 
-    afterEach(() => {
-        scrollBySpy.mockReset();
-        window.pageYOffset = 0;
-    });
+	afterEach(() => {
+		scrollBySpy.mockReset();
+		window.pageYOffset = 0;
+	});
 
-    it('should add listeners and classes', () =>
-        init().then(() => {
-            if (!header || !stickyBanner) {
-                throw Error('missing header or sticky banner element');
-            } else {
-                expect(registerSpy.mock.calls.length).toBe(1);
-                expect(addEventListenerSpy).toHaveBeenCalled();
-                expect(header.classList.contains('l-header--animate')).toBe(
-                    true
-                );
-                expect(
-                    stickyBanner.classList.contains(
-                        'sticky-top-banner-ad--animate'
-                    )
-                ).toBe(true);
-            }
-        }));
+	it('should add listeners and classes', () =>
+		init().then(() => {
+			if (!header || !stickyBanner) {
+				throw Error('missing header or sticky banner element');
+			} else {
+				expect(registerSpy.mock.calls.length).toBe(1);
+				expect(addEventListenerSpy).toHaveBeenCalled();
+				expect(header.classList.contains('l-header--animate')).toBe(
+					true,
+				);
+				expect(
+					stickyBanner.classList.contains(
+						'sticky-top-banner-ad--animate',
+					),
+				).toBe(true);
+			}
+		}));
 
-    it('should not add classes when scrolled past the header', () => {
-        window.pageYOffset = 501;
+	it('should not add classes when scrolled past the header', () => {
+		window.pageYOffset = 501;
 
-        return init().then(() => {
-            if (!header || !stickyBanner) {
-                throw Error('missing header or sticky banner element');
-            } else {
-                window.pageYOffset = 0;
-                expect(header.classList.contains('l-header--animate')).toBe(
-                    false
-                );
-                expect(
-                    stickyBanner.classList.contains(
-                        'sticky-top-banner-ad--animate'
-                    )
-                ).toBe(false);
-            }
-        });
-    });
+		return init().then(() => {
+			if (!header || !stickyBanner) {
+				throw Error('missing header or sticky banner element');
+			} else {
+				window.pageYOffset = 0;
+				expect(header.classList.contains('l-header--animate')).toBe(
+					false,
+				);
+				expect(
+					stickyBanner.classList.contains(
+						'sticky-top-banner-ad--animate',
+					),
+				).toBe(false);
+			}
+		});
+	});
 
-    it('should set the slot height and the header top margin', () => {
-        const randomHeight = chance.integer({
-            max: 500,
-        });
+	it('should set the slot height and the header top margin', () => {
+		const randomHeight = chance.integer({
+			max: 500,
+		});
 
-        return init()
-            .then(() => _.whenFirstRendered)
-            .then(() => resizeStickyBanner(randomHeight))
-            .then(() => {
-                if (!header || !stickyBanner) {
-                    throw Error('missing header or sticky banner element');
-                } else {
-                    expect(header.style.marginTop).toBe(`${randomHeight}px`);
-                    expect(stickyBanner.style.height).toBe(`${randomHeight}px`);
-                }
-            });
-    });
+		return init()
+			.then(() => _.whenFirstRendered)
+			.then(() => resizeStickyBanner(randomHeight))
+			.then(() => {
+				if (!header || !stickyBanner) {
+					throw Error('missing header or sticky banner element');
+				} else {
+					expect(header.style.marginTop).toBe(`${randomHeight}px`);
+					expect(stickyBanner.style.height).toBe(`${randomHeight}px`);
+				}
+			});
+	});
 
-    it('should adjust the scroll position', () => {
-        const randomHeight = chance.integer({
-            max: 500,
-        });
-        window.pageYOffset = 501;
+	it('should adjust the scroll position', () => {
+		const randomHeight = chance.integer({
+			max: 500,
+		});
+		window.pageYOffset = 501;
 
-        return init()
-            .then(() => resizeStickyBanner(randomHeight))
-            .then(() => {
-                window.pageYOffset = 0;
-                expect(scrollBySpy).toHaveBeenCalled();
-            });
-    });
+		return init()
+			.then(() => resizeStickyBanner(randomHeight))
+			.then(() => {
+				window.pageYOffset = 0;
+				expect(scrollBySpy).toHaveBeenCalled();
+			});
+	});
 
-    it('should include height and paddings when setting the slot height', () => {
-        const padingTop = chance.integer({
-            max: 50,
-        });
-        const paddingBottom = chance.integer({
-            max: 50,
-        });
-        const height = chance.integer({
-            max: 500,
-        });
-        const topSlot = document.getElementById('dfp-ad--top-above-nav');
+	it('should include height and paddings when setting the slot height', () => {
+		const padingTop = chance.integer({
+			max: 50,
+		});
+		const paddingBottom = chance.integer({
+			max: 50,
+		});
+		const height = chance.integer({
+			max: 500,
+		});
+		const topSlot = document.getElementById('dfp-ad--top-above-nav');
 
-        if (topSlot) {
-            topSlot.style.paddingTop = `${padingTop}px`;
-            topSlot.style.paddingBottom = `${paddingBottom}px`;
-        }
+		if (topSlot) {
+			topSlot.style.paddingTop = `${padingTop}px`;
+			topSlot.style.paddingBottom = `${paddingBottom}px`;
+		}
 
-        return init()
-            .then(() => update(height))
-            .then(() => {
-                if (!stickyBanner) {
-                    throw Error('missing sticky banner element');
-                } else {
-                    expect(stickyBanner.style.height).toBe(
-                        `${height + padingTop + paddingBottom}px`
-                    );
-                }
-            });
-    });
+		return init()
+			.then(() => update(height))
+			.then(() => {
+				if (!stickyBanner) {
+					throw Error('missing sticky banner element');
+				} else {
+					expect(stickyBanner.style.height).toBe(
+						`${height + padingTop + paddingBottom}px`,
+					);
+				}
+			});
+	});
 
-    it('should reset the banner position and top styles at the top of the page', () =>
-        onScroll().then(() => {
-            if (!stickyBanner) {
-                throw Error('missing header or sticky banner element');
-            } else {
-                expect(stickyBanner.style.position).toBe('');
-                expect(stickyBanner.style.top).toBe('');
-            }
-        }));
+	it('should reset the banner position and top styles at the top of the page', () =>
+		onScroll().then(() => {
+			if (!stickyBanner) {
+				throw Error('missing header or sticky banner element');
+			} else {
+				expect(stickyBanner.style.position).toBe('');
+				expect(stickyBanner.style.top).toBe('');
+			}
+		}));
 
-    it('should position the banner absolutely past the header', () => {
-        window.pageYOffset = 501;
+	it('should position the banner absolutely past the header', () => {
+		window.pageYOffset = 501;
 
-        return init()
-            .then(onScroll)
-            .then(() => {
-                if (!stickyBanner) {
-                    throw Error('missing header or sticky banner element');
-                } else {
-                    expect(stickyBanner.style.position).toBe('absolute');
-                    expect(stickyBanner.style.top).toBe('500px');
-                }
-            });
-    });
+		return init()
+			.then(onScroll)
+			.then(() => {
+				if (!stickyBanner) {
+					throw Error('missing header or sticky banner element');
+				} else {
+					expect(stickyBanner.style.position).toBe('absolute');
+					expect(stickyBanner.style.top).toBe('500px');
+				}
+			});
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -1,16 +1,16 @@
 /* A regionalised container for all the commercial tags. */
 
 import {
-    fbPixel,
-    ias,
-    inizio,
-    permutive,
-    remarketing,
-    twitter,
+	fbPixel,
+	ias,
+	inizio,
+	permutive,
+	remarketing,
+	twitter,
 } from '@guardian/commercial-core';
 import {
-    getConsentFor,
-    onConsentChange,
+	getConsentFor,
+	onConsentChange,
 } from '@guardian/consent-management-platform';
 import config from '../../../lib/config';
 import fastdom from '../../../lib/fastdom-promise';
@@ -18,98 +18,98 @@ import { commercialFeatures } from '../../common/modules/commercial/commercial-f
 import { imrWorldwide } from './third-party-tags/imr-worldwide';
 import { imrWorldwideLegacy } from './third-party-tags/imr-worldwide-legacy';
 
-const addScripts = tags => {
-    const ref = document.scripts[0];
-    const frag = document.createDocumentFragment();
-    let hasScriptsToInsert = false;
+const addScripts = (tags) => {
+	const ref = document.scripts[0];
+	const frag = document.createDocumentFragment();
+	let hasScriptsToInsert = false;
 
-    tags.forEach(tag => {
-        if (tag.loaded === true) return;
+	tags.forEach((tag) => {
+		if (tag.loaded === true) return;
 
-        if (tag.beforeLoad) tag.beforeLoad();
+		if (tag.beforeLoad) tag.beforeLoad();
 
-        // Tag is either an image, a snippet or a script.
-        if (tag.useImage === true && typeof tag.url !== 'undefined') {
-            new Image().src = tag.url;
-        } else if (tag.insertSnippet) {
-            tag.insertSnippet();
-        } else {
-            hasScriptsToInsert = true;
-            const script = document.createElement('script');
-            if (typeof tag.url !== 'undefined') {
-                script.src = tag.url;
-            }
-            script.onload = tag.onLoad;
-            if (tag.async === true) {
-                script.setAttribute('async', '');
-            }
-            if (tag.attrs) {
-                tag.attrs.forEach(attr => {
-                    script.setAttribute(attr.name, attr.value);
-                });
-            }
-            frag.appendChild(script);
-        }
-        tag.loaded = true;
-    });
+		// Tag is either an image, a snippet or a script.
+		if (tag.useImage === true && typeof tag.url !== 'undefined') {
+			new Image().src = tag.url;
+		} else if (tag.insertSnippet) {
+			tag.insertSnippet();
+		} else {
+			hasScriptsToInsert = true;
+			const script = document.createElement('script');
+			if (typeof tag.url !== 'undefined') {
+				script.src = tag.url;
+			}
+			script.onload = tag.onLoad;
+			if (tag.async === true) {
+				script.setAttribute('async', '');
+			}
+			if (tag.attrs) {
+				tag.attrs.forEach((attr) => {
+					script.setAttribute(attr.name, attr.value);
+				});
+			}
+			frag.appendChild(script);
+		}
+		tag.loaded = true;
+	});
 
-    if (hasScriptsToInsert) {
-        fastdom.mutate(() => {
-            if (ref && ref.parentNode) {
-                ref.parentNode.insertBefore(frag, ref);
-            }
-        });
-    }
+	if (hasScriptsToInsert) {
+		fastdom.mutate(() => {
+			if (ref && ref.parentNode) {
+				ref.parentNode.insertBefore(frag, ref);
+			}
+		});
+	}
 };
 
 const insertScripts = (
-    advertisingServices,
-    performanceServices // performanceServices always run
+	advertisingServices,
+	performanceServices, // performanceServices always run
 ) => {
-    addScripts(performanceServices);
-    onConsentChange(state => {
-        const consentedAdvertisingServices = advertisingServices.filter(
-            script => getConsentFor(script.name, state)
-        );
+	addScripts(performanceServices);
+	onConsentChange((state) => {
+		const consentedAdvertisingServices = advertisingServices.filter(
+			(script) => getConsentFor(script.name, state),
+		);
 
-        if (consentedAdvertisingServices.length > 0) {
-            addScripts(consentedAdvertisingServices);
-        }
-    });
+		if (consentedAdvertisingServices.length > 0) {
+			addScripts(consentedAdvertisingServices);
+		}
+	});
 };
 
 const loadOther = () => {
-    const advertisingServices = [
-        remarketing({ shouldRun: config.get('switches.remarketing', false) }),
-        permutive({ shouldRun: config.get('switches.permutive', false) }),
-        ias({ shouldRun: config.get('switches.iasAdTargeting', false) }),
-        inizio({ shouldRun: config.get('switches.inizio', false) }),
-        fbPixel({
-            shouldRun: config.get('switches.facebookTrackingPixel', false),
-        }),
-        twitter({ shouldRun: config.get('switches.twitterUwt', false) }),
-    ].filter(_ => _.shouldRun);
+	const advertisingServices = [
+		remarketing({ shouldRun: config.get('switches.remarketing', false) }),
+		permutive({ shouldRun: config.get('switches.permutive', false) }),
+		ias({ shouldRun: config.get('switches.iasAdTargeting', false) }),
+		inizio({ shouldRun: config.get('switches.inizio', false) }),
+		fbPixel({
+			shouldRun: config.get('switches.facebookTrackingPixel', false),
+		}),
+		twitter({ shouldRun: config.get('switches.twitterUwt', false) }),
+	].filter((_) => _.shouldRun);
 
-    const performanceServices = [
-        imrWorldwide, // only in AU & NZ
-        imrWorldwideLegacy, // only in AU & NZ
-    ].filter(_ => _.shouldRun);
+	const performanceServices = [
+		imrWorldwide, // only in AU & NZ
+		imrWorldwideLegacy, // only in AU & NZ
+	].filter((_) => _.shouldRun);
 
-    insertScripts(advertisingServices, performanceServices);
+	insertScripts(advertisingServices, performanceServices);
 };
 
 const init = () => {
-    if (!commercialFeatures.thirdPartyTags) {
-        return Promise.resolve(false);
-    }
+	if (!commercialFeatures.thirdPartyTags) {
+		return Promise.resolve(false);
+	}
 
-    loadOther();
+	loadOther();
 
-    return Promise.resolve(true);
+	return Promise.resolve(true);
 };
 
 export { init };
 export const _ = {
-    insertScripts,
-    loadOther,
+	insertScripts,
+	loadOther,
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
@@ -1,6 +1,6 @@
 import {
-    getConsentFor as getConsentFor_,
-    onConsentChange as onConsentChange_,
+	getConsentFor as getConsentFor_,
+	onConsentChange as onConsentChange_,
 } from '@guardian/consent-management-platform';
 import { commercialFeatures } from '../../common/modules/commercial/commercial-features';
 import { init, _ } from './third-party-tags';
@@ -10,236 +10,236 @@ const { insertScripts, loadOther } = _;
 jest.mock('../../../lib/raven');
 
 jest.mock('@guardian/consent-management-platform', () => ({
-    onConsentChange: jest.fn(),
-    getConsentFor: jest.fn(),
+	onConsentChange: jest.fn(),
+	getConsentFor: jest.fn(),
 }));
 
 const onConsentChange = onConsentChange_;
 const getConsentFor = getConsentFor_;
 
-const tcfv2AllConsentMock = callback =>
-    callback({
-        tcfv2: {
-            consents: {
-                '1': true,
-                '2': true,
-                '3': true,
-                '4': true,
-                '5': true,
-                '6': true,
-                '7': true,
-                '8': true,
-                '9': true,
-                '10': true,
-            },
-            vendorConsents: { '100': true, '200': true, '300': true },
-        },
-    });
+const tcfv2AllConsentMock = (callback) =>
+	callback({
+		tcfv2: {
+			consents: {
+				1: true,
+				2: true,
+				3: true,
+				4: true,
+				5: true,
+				6: true,
+				7: true,
+				8: true,
+				9: true,
+				10: true,
+			},
+			vendorConsents: { 100: true, 200: true, 300: true },
+		},
+	});
 
-const tcfv2WithConsentMock = callback =>
-    callback({
-        tcfv2: {
-            consents: {
-                '1': true,
-                '2': false,
-                '3': false,
-                '4': false,
-                '5': false,
-                '6': false,
-                '7': true,
-                '8': true,
-                '9': false,
-                '10': false,
-            },
-            vendorConsents: { '100': true, '200': false, '300': false },
-        },
-    });
+const tcfv2WithConsentMock = (callback) =>
+	callback({
+		tcfv2: {
+			consents: {
+				1: true,
+				2: false,
+				3: false,
+				4: false,
+				5: false,
+				6: false,
+				7: true,
+				8: true,
+				9: false,
+				10: false,
+			},
+			vendorConsents: { 100: true, 200: false, 300: false },
+		},
+	});
 
-const tcfv2WithoutConsentMock = callback =>
-    callback({
-        tcfv2: {
-            consents: {
-                '1': false,
-                '2': false,
-                '3': false,
-                '4': false,
-                '5': false,
-                '6': false,
-                '7': false,
-                '8': false,
-                '9': false,
-                '10': false,
-            },
-            vendorConsents: { '100': false, '200': false, '300': false },
-        },
-    });
+const tcfv2WithoutConsentMock = (callback) =>
+	callback({
+		tcfv2: {
+			consents: {
+				1: false,
+				2: false,
+				3: false,
+				4: false,
+				5: false,
+				6: false,
+				7: false,
+				8: false,
+				9: false,
+				10: false,
+			},
+			vendorConsents: { 100: false, 200: false, 300: false },
+		},
+	});
 
 beforeEach(() => {
-    const firstScript = document.createElement('script');
-    if (document.body && firstScript) {
-        document.body.appendChild(firstScript);
-    }
-    expect.hasAssertions();
+	const firstScript = document.createElement('script');
+	if (document.body && firstScript) {
+		document.body.appendChild(firstScript);
+	}
+	expect.hasAssertions();
 });
 
 afterEach(() => {
-    if (document.body) {
-        document.body.innerHTML = '';
-    }
+	if (document.body) {
+		document.body.innerHTML = '';
+	}
 });
 
 jest.mock('ophan/ng', () => null);
 
 jest.mock('../../common/modules/commercial/commercial-features', () => ({
-    commercialFeatures: {
-        thirdPartyTags: true,
-    },
+	commercialFeatures: {
+		thirdPartyTags: true,
+	},
 }));
 
 jest.mock('./third-party-tags/imr-worldwide', () => ({
-    imrWorldwide: {
-        shouldRun: true,
-        url: '//fakeThirdPartyTag.js',
-        onLoad: jest.fn(),
-    },
+	imrWorldwide: {
+		shouldRun: true,
+		url: '//fakeThirdPartyTag.js',
+		onLoad: jest.fn(),
+	},
 }));
 
 describe('third party tags', () => {
-    it('should exist', () => {
-        expect(init).toBeDefined();
-        expect(loadOther).toBeDefined();
-        expect(insertScripts).toBeDefined();
-    });
+	it('should exist', () => {
+		expect(init).toBeDefined();
+		expect(loadOther).toBeDefined();
+		expect(insertScripts).toBeDefined();
+	});
 
-    it('should not run if disabled in commercial features', done => {
-        commercialFeatures.thirdPartyTags = false;
-        init()
-            .then(enabled => {
-                expect(enabled).toBe(false);
-                done();
-            })
-            .catch(() => {
-                done.fail('third-party tags failed');
-            });
-    });
+	it('should not run if disabled in commercial features', (done) => {
+		commercialFeatures.thirdPartyTags = false;
+		init()
+			.then((enabled) => {
+				expect(enabled).toBe(false);
+				done();
+			})
+			.catch(() => {
+				done.fail('third-party tags failed');
+			});
+	});
 
-    it('should run if commercial enabled', done => {
-        commercialFeatures.thirdPartyTags = true;
-        commercialFeatures.adFree = false;
-        init()
-            .then(enabled => {
-                expect(enabled).toBe(true);
-                done();
-            })
-            .catch(() => {
-                done.fail('init failed');
-            });
-    });
+	it('should run if commercial enabled', (done) => {
+		commercialFeatures.thirdPartyTags = true;
+		commercialFeatures.adFree = false;
+		init()
+			.then((enabled) => {
+				expect(enabled).toBe(true);
+				done();
+			})
+			.catch(() => {
+				done.fail('init failed');
+			});
+	});
 
-    describe('insertScripts', () => {
-        const fakeThirdPartyAdvertisingTag = {
-            shouldRun: true,
-            url: '//fakeThirdPartyAdvertisingTag.js',
-            onLoad: jest.fn(),
-            name: 'permutive',
-        };
-        const fakeThirdPartyAdvertisingTag2 = {
-            shouldRun: true,
-            url: '//fakeThirdPartyAdvertisingTag2.js',
-            onLoad: jest.fn(),
-            name: 'inizio',
-        };
-        const fakeThirdPartyPerformanceTag = {
-            shouldRun: true,
-            url: '//fakeThirdPartyPerformanceTag.js',
-            onLoad: jest.fn(),
-            name: 'twitter',
-        };
+	describe('insertScripts', () => {
+		const fakeThirdPartyAdvertisingTag = {
+			shouldRun: true,
+			url: '//fakeThirdPartyAdvertisingTag.js',
+			onLoad: jest.fn(),
+			name: 'permutive',
+		};
+		const fakeThirdPartyAdvertisingTag2 = {
+			shouldRun: true,
+			url: '//fakeThirdPartyAdvertisingTag2.js',
+			onLoad: jest.fn(),
+			name: 'inizio',
+		};
+		const fakeThirdPartyPerformanceTag = {
+			shouldRun: true,
+			url: '//fakeThirdPartyPerformanceTag.js',
+			onLoad: jest.fn(),
+			name: 'twitter',
+		};
 
-        beforeEach(() => {
-            fakeThirdPartyAdvertisingTag.loaded = undefined;
-            fakeThirdPartyAdvertisingTag2.loaded = undefined;
-            fakeThirdPartyPerformanceTag.loaded = undefined;
-        });
+		beforeEach(() => {
+			fakeThirdPartyAdvertisingTag.loaded = undefined;
+			fakeThirdPartyAdvertisingTag2.loaded = undefined;
+			fakeThirdPartyPerformanceTag.loaded = undefined;
+		});
 
-        it('should add scripts to the document when TCFv2 consent has been given', () => {
-            onConsentChange.mockImplementation(tcfv2AllConsentMock);
-            getConsentFor.mockReturnValue(true);
-            insertScripts(
-                [fakeThirdPartyAdvertisingTag],
-                [fakeThirdPartyPerformanceTag]
-            );
-            expect(document.scripts.length).toBe(3);
-        });
+		it('should add scripts to the document when TCFv2 consent has been given', () => {
+			onConsentChange.mockImplementation(tcfv2AllConsentMock);
+			getConsentFor.mockReturnValue(true);
+			insertScripts(
+				[fakeThirdPartyAdvertisingTag],
+				[fakeThirdPartyPerformanceTag],
+			);
+			expect(document.scripts.length).toBe(3);
+		});
 
-        it('should only add performance scripts to the document when TCFv2 consent has not been given', () => {
-            onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
-            getConsentFor.mockReturnValue(false);
-            insertScripts(
-                [fakeThirdPartyAdvertisingTag],
-                [fakeThirdPartyPerformanceTag]
-            );
-            expect(document.scripts.length).toBe(2);
-        });
-        it('should add scripts to the document when CCPA consent has been given', () => {
-            onConsentChange.mockImplementation(callback =>
-                callback({ ccpa: { doNotSell: false } })
-            );
-            getConsentFor.mockReturnValue(true);
-            insertScripts(
-                [fakeThirdPartyAdvertisingTag],
-                [fakeThirdPartyPerformanceTag]
-            );
-            expect(document.scripts.length).toBe(3);
-        });
-        it('should only add performance scripts to the document when CCPA consent has not been given', () => {
-            onConsentChange.mockImplementation(callback =>
-                callback({ ccpa: { doNotSell: true } })
-            );
-            getConsentFor.mockReturnValue(false);
-            insertScripts(
-                [fakeThirdPartyAdvertisingTag],
-                [fakeThirdPartyPerformanceTag]
-            );
-            expect(document.scripts.length).toBe(2);
-        });
+		it('should only add performance scripts to the document when TCFv2 consent has not been given', () => {
+			onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
+			getConsentFor.mockReturnValue(false);
+			insertScripts(
+				[fakeThirdPartyAdvertisingTag],
+				[fakeThirdPartyPerformanceTag],
+			);
+			expect(document.scripts.length).toBe(2);
+		});
+		it('should add scripts to the document when CCPA consent has been given', () => {
+			onConsentChange.mockImplementation((callback) =>
+				callback({ ccpa: { doNotSell: false } }),
+			);
+			getConsentFor.mockReturnValue(true);
+			insertScripts(
+				[fakeThirdPartyAdvertisingTag],
+				[fakeThirdPartyPerformanceTag],
+			);
+			expect(document.scripts.length).toBe(3);
+		});
+		it('should only add performance scripts to the document when CCPA consent has not been given', () => {
+			onConsentChange.mockImplementation((callback) =>
+				callback({ ccpa: { doNotSell: true } }),
+			);
+			getConsentFor.mockReturnValue(false);
+			insertScripts(
+				[fakeThirdPartyAdvertisingTag],
+				[fakeThirdPartyPerformanceTag],
+			);
+			expect(document.scripts.length).toBe(2);
+		});
 
-        it('should only add consented custom vendors to the document for TCFv2', () => {
-            onConsentChange.mockImplementation(tcfv2WithConsentMock);
-            getConsentFor.mockReturnValueOnce(true);
-            getConsentFor.mockReturnValueOnce(false);
-            insertScripts(
-                [fakeThirdPartyAdvertisingTag, fakeThirdPartyAdvertisingTag2],
-                []
-            );
-            expect(document.scripts.length).toBe(2);
-        });
+		it('should only add consented custom vendors to the document for TCFv2', () => {
+			onConsentChange.mockImplementation(tcfv2WithConsentMock);
+			getConsentFor.mockReturnValueOnce(true);
+			getConsentFor.mockReturnValueOnce(false);
+			insertScripts(
+				[fakeThirdPartyAdvertisingTag, fakeThirdPartyAdvertisingTag2],
+				[],
+			);
+			expect(document.scripts.length).toBe(2);
+		});
 
-        it('should not add already loaded tags ', () => {
-            onConsentChange.mockImplementation(tcfv2WithConsentMock);
-            getConsentFor.mockReturnValueOnce(true);
-            getConsentFor.mockReturnValueOnce(false);
-            getConsentFor.mockReturnValueOnce(true);
-            getConsentFor.mockReturnValueOnce(false);
-            insertScripts(
-                [fakeThirdPartyAdvertisingTag, fakeThirdPartyAdvertisingTag2],
-                []
-            );
-            insertScripts(
-                [fakeThirdPartyAdvertisingTag, fakeThirdPartyAdvertisingTag2],
-                []
-            );
-            expect(document.scripts.length).toBe(2);
-        });
+		it('should not add already loaded tags ', () => {
+			onConsentChange.mockImplementation(tcfv2WithConsentMock);
+			getConsentFor.mockReturnValueOnce(true);
+			getConsentFor.mockReturnValueOnce(false);
+			getConsentFor.mockReturnValueOnce(true);
+			getConsentFor.mockReturnValueOnce(false);
+			insertScripts(
+				[fakeThirdPartyAdvertisingTag, fakeThirdPartyAdvertisingTag2],
+				[],
+			);
+			insertScripts(
+				[fakeThirdPartyAdvertisingTag, fakeThirdPartyAdvertisingTag2],
+				[],
+			);
+			expect(document.scripts.length).toBe(2);
+		});
 
-        it('should not add scripts to the document when TCFv2 consent has not been given', () => {
-            onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
-            getConsentFor.mockReturnValue(false);
-            insertScripts(
-                [fakeThirdPartyAdvertisingTag, fakeThirdPartyAdvertisingTag2],
-                []
-            );
-            expect(document.scripts.length).toBe(1);
-        });
-    });
+		it('should not add scripts to the document when TCFv2 consent has not been given', () => {
+			onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
+			getConsentFor.mockReturnValue(false);
+			insertScripts(
+				[fakeThirdPartyAdvertisingTag, fakeThirdPartyAdvertisingTag2],
+				[],
+			);
+			expect(document.scripts.length).toBe(1);
+		});
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide-legacy.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide-legacy.js
@@ -4,18 +4,18 @@ import { isInAuOrNz } from '../../../common/modules/commercial/geo-utils';
 // nol_t is a global function defined by the IMR worldwide library
 
 const onLoad = () => {
-    const pvar = {
-        cid: 'au-guardian',
-        content: '0',
-        server: 'secure-gl',
-    };
+	const pvar = {
+		cid: 'au-guardian',
+		content: '0',
+		server: 'secure-gl',
+	};
 
-    const trac = window.nol_t(pvar);
-    trac.record().post();
+	const trac = window.nol_t(pvar);
+	trac.record().post();
 };
 
 export const imrWorldwideLegacy = {
-    shouldRun: config.get('switches.imrWorldwide') && isInAuOrNz(),
-    url: '//secure-au.imrworldwide.com/v60.js',
-    onLoad,
+	shouldRun: config.get('switches.imrWorldwide') && isInAuOrNz(),
+	url: '//secure-au.imrworldwide.com/v60.js',
+	onLoad,
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide-legacy.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide-legacy.spec.js
@@ -3,11 +3,11 @@ import { imrWorldwideLegacy } from './imr-worldwide-legacy';
 const { shouldRun, url, onLoad } = imrWorldwideLegacy;
 
 jest.mock('../../../common/modules/commercial/geo-utils', () => ({
-    isInAuOrNz: jest.fn().mockReturnValue(true)
+	isInAuOrNz: jest.fn().mockReturnValue(true),
 }));
 
 jest.mock('../../../common/modules/experiments/ab', () => ({
-    isInVariantSynchronous: jest.fn(),
+	isInVariantSynchronous: jest.fn(),
 }));
 
 /**
@@ -16,25 +16,25 @@ jest.mock('../../../common/modules/experiments/ab', () => ({
  * that are dependent on config.
  * */
 jest.mock('../../../../lib/config', () => {
-    const defaultConfig = {
-        switches: {
-            imrWorldwide: true,
-        },
-    };
+	const defaultConfig = {
+		switches: {
+			imrWorldwide: true,
+		},
+	};
 
-    return Object.assign({}, defaultConfig, {
-        get: (path = '', defaultValue) =>
-            path
-                .replace(/\[(.+?)]/g, '.$1')
-                .split('.')
-                .reduce((o, key) => o[key], defaultConfig) || defaultValue,
-    });
+	return Object.assign({}, defaultConfig, {
+		get: (path = '', defaultValue) =>
+			path
+				.replace(/\[(.+?)]/g, '.$1')
+				.split('.')
+				.reduce((o, key) => o[key], defaultConfig) || defaultValue,
+	});
 });
 
 describe('third party tag IMR worldwide legacy', () => {
-    it('should exist and have the correct exports', () => {
-        expect(shouldRun).toBe(true);
-        expect(onLoad).toBeDefined();
-        expect(url).toBe('//secure-au.imrworldwide.com/v60.js');
-    });
+	it('should exist and have the correct exports', () => {
+		expect(shouldRun).toBe(true);
+		expect(onLoad).toBeDefined();
+		expect(url).toBe('//secure-au.imrworldwide.com/v60.js');
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide.js
@@ -4,90 +4,90 @@ import { isInAuOrNz } from '../../../common/modules/commercial/geo-utils';
 // NOLCMB is a global function defined by the IMR worldwide library
 
 const guMetadata = {
-    books: 'P5033A084-E9BF-453A-91D3-C558751D9A85',
-    business: 'P5B109609-6223-45BA-B052-55F34A79D7AD',
-    commentisfree: 'PA878EFC7-93C8-4352-905E-9E03883FD6BD',
-    artanddesign: 'PE5076E6F-B85D-4B45-9536-F150EF3FC853',
-    culture: 'PE5076E6F-B85D-4B45-9536-F150EF3FC853',
-    stage: 'PE5076E6F-B85D-4B45-9536-F150EF3FC853',
-    education: 'P4A01DB74-5B97-435A-89F0-C07EA2C739EC',
-    environment: 'P2F34A388-A280-4C3F-AF43-FAF16EFCB7B1',
-    cities: 'P2F34A388-A280-4C3F-AF43-FAF16EFCB7B1',
-    'global-development': 'P2F34A388-A280-4C3F-AF43-FAF16EFCB7B1',
-    'sustainable-business': 'P2F34A388-A280-4C3F-AF43-FAF16EFCB7B1',
-    fashion: 'PCF345621-F34D-40B2-852C-6223C9C8F1E2',
-    film: 'P878ECFA5-14A7-4038-9924-3696C93706FC',
-    law: 'P1FA129DD-9B9E-49BB-98A4-AA7ED8523DFD',
-    lifeandstyle: 'PCFE04250-E5F6-48C7-91DB-5CED6854818C',
-    media: 'P1434DC6D-6585-4932-AE17-2864CD0AAE99',
-    money: 'PB71E7F1E-F231-4F73-9CC8-BE8822ADD0C2',
-    music: 'P78382DEE-CC9B-4B36-BD27-809007BFF300',
-    international: 'P505182AA-1D71-49D8-8287-AA222CD05424',
-    au: 'P505182AA-1D71-49D8-8287-AA222CD05424',
-    'australia-news': 'P505182AA-1D71-49D8-8287-AA222CD05424',
-    uk: 'P505182AA-1D71-49D8-8287-AA222CD05424',
-    'uk-news': 'P505182AA-1D71-49D8-8287-AA222CD05424',
-    us: 'P505182AA-1D71-49D8-8287-AA222CD05424',
-    'us-news': 'P505182AA-1D71-49D8-8287-AA222CD05424',
-    world: 'P505182AA-1D71-49D8-8287-AA222CD05424',
-    politics: 'P5B7468E3-CE04-40FD-9444-22FB872FE83E',
-    careers: 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
-    'culture-professionals-network': 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
-    'global-development-professionals-network':
-        'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
-    'government-computing-network': 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
-    'guardian-professional': 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
-    'healthcare-network': 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
-    'higher-education-network': 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
-    'housing-network': 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
-    'local-government-network': 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
-    'local-leaders-network': 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
-    'public-leaders-network': 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
-    'small-business-network': 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
-    'social-care-network': 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
-    'teacher-network': 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
-    'voluntary-sector-network': 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
-    'women-in-leadership': 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
-    science: 'PDAD6BC22-C97B-4151-956B-7F069B2C56E9',
-    society: 'P7AF4A592-96FB-4255-B33F-352406F4C7D2',
-    sport: 'PCC1AEBB6-7D1A-4F34-8256-EFC314E5D0C3',
-    football: 'PCC1AEBB6-7D1A-4F34-8256-EFC314E5D0C3',
-    technology: 'P29EF991A-3FEE-4215-9F03-58EACA8286B9',
-    travel: 'PD1CEDC3E-2653-4CB6-A4FD-8A315DE07548',
-    'tv-and-radio': 'P66E48909-8FC9-49E8-A7E6-0D31C61805AD',
-    'brand-only': 'P0EE0F4F4-8D7C-4082-A2A4-82C84728DC59',
+	books: 'P5033A084-E9BF-453A-91D3-C558751D9A85',
+	business: 'P5B109609-6223-45BA-B052-55F34A79D7AD',
+	commentisfree: 'PA878EFC7-93C8-4352-905E-9E03883FD6BD',
+	artanddesign: 'PE5076E6F-B85D-4B45-9536-F150EF3FC853',
+	culture: 'PE5076E6F-B85D-4B45-9536-F150EF3FC853',
+	stage: 'PE5076E6F-B85D-4B45-9536-F150EF3FC853',
+	education: 'P4A01DB74-5B97-435A-89F0-C07EA2C739EC',
+	environment: 'P2F34A388-A280-4C3F-AF43-FAF16EFCB7B1',
+	cities: 'P2F34A388-A280-4C3F-AF43-FAF16EFCB7B1',
+	'global-development': 'P2F34A388-A280-4C3F-AF43-FAF16EFCB7B1',
+	'sustainable-business': 'P2F34A388-A280-4C3F-AF43-FAF16EFCB7B1',
+	fashion: 'PCF345621-F34D-40B2-852C-6223C9C8F1E2',
+	film: 'P878ECFA5-14A7-4038-9924-3696C93706FC',
+	law: 'P1FA129DD-9B9E-49BB-98A4-AA7ED8523DFD',
+	lifeandstyle: 'PCFE04250-E5F6-48C7-91DB-5CED6854818C',
+	media: 'P1434DC6D-6585-4932-AE17-2864CD0AAE99',
+	money: 'PB71E7F1E-F231-4F73-9CC8-BE8822ADD0C2',
+	music: 'P78382DEE-CC9B-4B36-BD27-809007BFF300',
+	international: 'P505182AA-1D71-49D8-8287-AA222CD05424',
+	au: 'P505182AA-1D71-49D8-8287-AA222CD05424',
+	'australia-news': 'P505182AA-1D71-49D8-8287-AA222CD05424',
+	uk: 'P505182AA-1D71-49D8-8287-AA222CD05424',
+	'uk-news': 'P505182AA-1D71-49D8-8287-AA222CD05424',
+	us: 'P505182AA-1D71-49D8-8287-AA222CD05424',
+	'us-news': 'P505182AA-1D71-49D8-8287-AA222CD05424',
+	world: 'P505182AA-1D71-49D8-8287-AA222CD05424',
+	politics: 'P5B7468E3-CE04-40FD-9444-22FB872FE83E',
+	careers: 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
+	'culture-professionals-network': 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
+	'global-development-professionals-network':
+		'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
+	'government-computing-network': 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
+	'guardian-professional': 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
+	'healthcare-network': 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
+	'higher-education-network': 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
+	'housing-network': 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
+	'local-government-network': 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
+	'local-leaders-network': 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
+	'public-leaders-network': 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
+	'small-business-network': 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
+	'social-care-network': 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
+	'teacher-network': 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
+	'voluntary-sector-network': 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
+	'women-in-leadership': 'P3637DC6B-E43C-4E92-B22C-3F255CC573DA',
+	science: 'PDAD6BC22-C97B-4151-956B-7F069B2C56E9',
+	society: 'P7AF4A592-96FB-4255-B33F-352406F4C7D2',
+	sport: 'PCC1AEBB6-7D1A-4F34-8256-EFC314E5D0C3',
+	football: 'PCC1AEBB6-7D1A-4F34-8256-EFC314E5D0C3',
+	technology: 'P29EF991A-3FEE-4215-9F03-58EACA8286B9',
+	travel: 'PD1CEDC3E-2653-4CB6-A4FD-8A315DE07548',
+	'tv-and-radio': 'P66E48909-8FC9-49E8-A7E6-0D31C61805AD',
+	'brand-only': 'P0EE0F4F4-8D7C-4082-A2A4-82C84728DC59',
 };
 
 const onLoad = () => {
-    const sectionFromMeta = config.get('page.section', '').toLowerCase();
-    const subBrandApId =
-        guMetadata[sectionFromMeta] || guMetadata['brand-only'];
+	const sectionFromMeta = config.get('page.section', '').toLowerCase();
+	const subBrandApId =
+		guMetadata[sectionFromMeta] || guMetadata['brand-only'];
 
-    const sectionRef =
-        sectionFromMeta in guMetadata
-            ? sectionFromMeta
-            : 'The Guardian - brand only';
+	const sectionRef =
+		sectionFromMeta in guMetadata
+			? sectionFromMeta
+			: 'The Guardian - brand only';
 
-    const nolggGlobalParams = {
-        sfcode: 'dcr',
-        apid: subBrandApId,
-        apn: 'theguardian',
-    };
+	const nolggGlobalParams = {
+		sfcode: 'dcr',
+		apid: subBrandApId,
+		apn: 'theguardian',
+	};
 
-    const nSdkInstance = window.NOLCMB.getInstance(nolggGlobalParams.apid);
-    nSdkInstance.ggInitialize(nolggGlobalParams);
+	const nSdkInstance = window.NOLCMB.getInstance(nolggGlobalParams.apid);
+	nSdkInstance.ggInitialize(nolggGlobalParams);
 
-    const dcrStaticMetadata = {
-        type: 'static',
-        assetid: config.get('page.pageId'),
-        section: sectionRef,
-    };
+	const dcrStaticMetadata = {
+		type: 'static',
+		assetid: config.get('page.pageId'),
+		section: sectionRef,
+	};
 
-    nSdkInstance.ggPM('staticstart', dcrStaticMetadata);
+	nSdkInstance.ggPM('staticstart', dcrStaticMetadata);
 };
 
 export const imrWorldwide = {
-    shouldRun: config.get('switches.imrWorldwide') && isInAuOrNz(),
-    url: '//secure-dcr.imrworldwide.com/novms/js/2/ggcmb510.js',
-    onLoad,
+	shouldRun: config.get('switches.imrWorldwide') && isInAuOrNz(),
+	url: '//secure-dcr.imrworldwide.com/novms/js/2/ggcmb510.js',
+	onLoad,
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags/imr-worldwide.spec.js
@@ -10,86 +10,86 @@ const onLoad = imrWorldwide.onLoad;
  * */
 
 jest.mock('../../../../lib/config', () => {
-    const defaultConfig = {
-        switches: {
-            imrWorldwide: true,
-        },
-        page: {
-            headline: 'Starship Enterprise',
-            author: 'Captain Kirk',
-            section: 'spaceexploration',
-            sectionName: 'Space Exploration',
-            keywords: 'Space,Travel',
-            webPublicationDate: 1498113262000,
-            isFront: false,
-            isPaidContent: true,
-            pageId: 100,
-        },
-    };
+	const defaultConfig = {
+		switches: {
+			imrWorldwide: true,
+		},
+		page: {
+			headline: 'Starship Enterprise',
+			author: 'Captain Kirk',
+			section: 'spaceexploration',
+			sectionName: 'Space Exploration',
+			keywords: 'Space,Travel',
+			webPublicationDate: 1498113262000,
+			isFront: false,
+			isPaidContent: true,
+			pageId: 100,
+		},
+	};
 
-    return Object.assign({}, defaultConfig, {
-        get: (path = '', defaultValue) =>
-            path
-                .replace(/\[(.+?)]/g, '.$1')
-                .split('.')
-                .reduce((o, key) => o[key], defaultConfig) || defaultValue,
-    });
+	return Object.assign({}, defaultConfig, {
+		get: (path = '', defaultValue) =>
+			path
+				.replace(/\[(.+?)]/g, '.$1')
+				.split('.')
+				.reduce((o, key) => o[key], defaultConfig) || defaultValue,
+	});
 });
 
 jest.mock('../../../common/modules/commercial/geo-utils', () => ({
-        isInAuOrNz: jest.fn().mockReturnValue(true)
+	isInAuOrNz: jest.fn().mockReturnValue(true),
 }));
 
 jest.mock('../../../common/modules/experiments/ab', () => ({
-    isInVariantSynchronous: jest.fn(),
+	isInVariantSynchronous: jest.fn(),
 }));
 
 const nSdkInstance = {
-    ggInitialize: jest.fn(),
-    ggPM: jest.fn(),
+	ggInitialize: jest.fn(),
+	ggPM: jest.fn(),
 };
 
 window.NOLCMB = {
-    getInstance: jest.fn(() => nSdkInstance),
+	getInstance: jest.fn(() => nSdkInstance),
 };
 
 describe('third party tag IMR in AUS', () => {
-    beforeEach(() => {
-        jest.clearAllMocks();
-    });
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
 
-    afterAll(() => {
-        jest.clearAllMocks();
-    });
+	afterAll(() => {
+		jest.clearAllMocks();
+	});
 
-    it('should exist and have the correct exports', () => {
-        expect(shouldRun).toBe(true);
-        expect(url).toBe(
-            '//secure-dcr.imrworldwide.com/novms/js/2/ggcmb510.js'
-        );
-    });
+	it('should exist and have the correct exports', () => {
+		expect(shouldRun).toBe(true);
+		expect(url).toBe(
+			'//secure-dcr.imrworldwide.com/novms/js/2/ggcmb510.js',
+		);
+	});
 
-    it('should initalize, with a brand-only apid on an unmatched section', () => {
-        // If a section does not exist in guMetadata, it will use the default apid
-        const expectedNolggParams = {
-            sfcode: 'dcr',
-            apid: 'P0EE0F4F4-8D7C-4082-A2A4-82C84728DC59',
-            apn: 'theguardian',
-        };
-        onLoad();
-        expect(nSdkInstance.ggInitialize).toBeCalledWith(expectedNolggParams);
-    });
+	it('should initalize, with a brand-only apid on an unmatched section', () => {
+		// If a section does not exist in guMetadata, it will use the default apid
+		const expectedNolggParams = {
+			sfcode: 'dcr',
+			apid: 'P0EE0F4F4-8D7C-4082-A2A4-82C84728DC59',
+			apn: 'theguardian',
+		};
+		onLoad();
+		expect(nSdkInstance.ggInitialize).toBeCalledWith(expectedNolggParams);
+	});
 
-    it('should call nSdkInstance.ggPM with staticstart and dcrStaticMetadata', () => {
-        const expectedMetadata = {
-            assetid: 100,
-            section: 'The Guardian - brand only',
-            type: 'static',
-        };
-        onLoad();
-        expect(nSdkInstance.ggPM).toBeCalledWith(
-            'staticstart',
-            expectedMetadata
-        );
-    });
+	it('should call nSdkInstance.ggPM with staticstart and dcrStaticMetadata', () => {
+		const expectedMetadata = {
+			assetid: 100,
+			section: 'The Guardian - brand only',
+			type: 'static',
+		};
+		onLoad();
+		expect(nSdkInstance.ggPM).toBeCalledWith(
+			'staticstart',
+			expectedMetadata,
+		);
+	});
 });

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -5,112 +5,114 @@ import { addCountryGroupToSupportLink } from './support-utilities';
 // from the Mother Load campaign and the Wide Brown Land campaign.
 // Work needs to be done so we don't have to hard code what campaigns are running.
 const validIframeUrls = [
-    'https://interactive.guim.co.uk/embed/2017/12/the-mother-load/',
-    'https://interactive.guim.co.uk/embed/2018/this-wide-brown-land/',
+	'https://interactive.guim.co.uk/embed/2017/12/the-mother-load/',
+	'https://interactive.guim.co.uk/embed/2018/this-wide-brown-land/',
 ];
 
 const isCurrentCampaign = (iframeSrc) =>
-    validIframeUrls.some(validIframeUrl =>
-        iframeSrc.startsWith(validIframeUrl)
-    );
+	validIframeUrls.some((validIframeUrl) =>
+		iframeSrc.startsWith(validIframeUrl),
+	);
 
 const addReferrerDataToAcquisitionLink = (rawUrl) => {
-    const acquisitionDataField = 'acquisitionData';
+	const acquisitionDataField = 'acquisitionData';
 
-    let url;
-    try {
-        url = new URL(rawUrl);
-    } catch (e) {
-        return rawUrl;
-    }
+	let url;
+	try {
+		url = new URL(rawUrl);
+	} catch (e) {
+		return rawUrl;
+	}
 
-    let acquisitionData;
-    try {
-        const acquisitionDataJsonString = url.searchParams.get(
-            acquisitionDataField
-        );
+	let acquisitionData;
+	try {
+		const acquisitionDataJsonString = url.searchParams.get(
+			acquisitionDataField,
+		);
 
-        if (!acquisitionDataJsonString) return rawUrl;
+		if (!acquisitionDataJsonString) return rawUrl;
 
-        acquisitionData = JSON.parse(acquisitionDataJsonString);
-    } catch (e) {
-        return rawUrl;
-    }
+		acquisitionData = JSON.parse(acquisitionDataJsonString);
+	} catch (e) {
+		return rawUrl;
+	}
 
-    if (acquisitionData) {
-        acquisitionData = addReferrerData(acquisitionData);
-        url.searchParams.set(
-            acquisitionDataField,
-            JSON.stringify(acquisitionData)
-        );
-    }
+	if (acquisitionData) {
+		acquisitionData = addReferrerData(acquisitionData);
+		url.searchParams.set(
+			acquisitionDataField,
+			JSON.stringify(acquisitionData),
+		);
+	}
 
-    return url.toString();
+	return url.toString();
 };
 
 const ACQUISITION_LINK_CLASS = 'js-acquisition-link';
 
 const enrichAcquisitionLinksOnPage = () => {
-    const links = Array.from(
-        document.getElementsByClassName(ACQUISITION_LINK_CLASS)
-    );
+	const links = Array.from(
+		document.getElementsByClassName(ACQUISITION_LINK_CLASS),
+	);
 
-    links.forEach(el => {
-        const link = el.getAttribute('href');
-        if (link) {
-            let modifiedLink = addReferrerDataToAcquisitionLink(link);
-            modifiedLink = addCountryGroupToSupportLink(modifiedLink);
-            el.setAttribute('href', modifiedLink);
-        }
-    });
+	links.forEach((el) => {
+		const link = el.getAttribute('href');
+		if (link) {
+			let modifiedLink = addReferrerDataToAcquisitionLink(link);
+			modifiedLink = addCountryGroupToSupportLink(modifiedLink);
+			el.setAttribute('href', modifiedLink);
+		}
+	});
 };
 
 const addReferrerDataToAcquisitionLinksInInteractiveIframes = () => {
-    window.addEventListener('message', event => {
-        let data;
-        try {
-            data = JSON.parse(event.data);
-        } catch (e) {
-            return;
-        }
+	window.addEventListener('message', (event) => {
+		let data;
+		try {
+			data = JSON.parse(event.data);
+		} catch (e) {
+			return;
+		}
 
-        // TODO: remove this when only https://github.com/guardian/acquisition-iframe-tracking
-        // TODO: is being used for acquisition iframe tracking
-        // Expects enrich requests to be made via iframe-messenger:
-        // https://github.com/guardian/iframe-messenger
-        if (data.type === 'enrich-acquisition-links' && data.id) {
-            data.referrerData = addReferrerData({});
-            Array.from(document.getElementsByTagName('iframe')).forEach(
-                iframe => {
-                    iframe.contentWindow.postMessage(
-                        JSON.stringify(data),
-                        'https://interactive.guim.co.uk'
-                    );
-                }
-            );
-        }
+		// TODO: remove this when only https://github.com/guardian/acquisition-iframe-tracking
+		// TODO: is being used for acquisition iframe tracking
+		// Expects enrich requests to be made via iframe-messenger:
+		// https://github.com/guardian/iframe-messenger
+		if (data.type === 'enrich-acquisition-links' && data.id) {
+			data.referrerData = addReferrerData({});
+			Array.from(document.getElementsByTagName('iframe')).forEach(
+				(iframe) => {
+					iframe.contentWindow.postMessage(
+						JSON.stringify(data),
+						'https://interactive.guim.co.uk',
+					);
+				},
+			);
+		}
 
-        if (data.type === 'acquisition-data-request') {
-            Array.from(document.getElementsByTagName('iframe')).forEach(el => {
-                const iframeSrc = el.getAttribute('src');
-                if (iframeSrc && isCurrentCampaign(iframeSrc)) {
-                    el.contentWindow.postMessage(
-                        JSON.stringify({
-                            type: 'acquisition-data-response',
-                            acquisitionData: {
-                                ...addReferrerData({}),
-                                source: 'GUARDIAN_WEB',
-                            },
-                        }),
-                        '*'
-                    );
-                }
-            });
-        }
-    });
+		if (data.type === 'acquisition-data-request') {
+			Array.from(document.getElementsByTagName('iframe')).forEach(
+				(el) => {
+					const iframeSrc = el.getAttribute('src');
+					if (iframeSrc && isCurrentCampaign(iframeSrc)) {
+						el.contentWindow.postMessage(
+							JSON.stringify({
+								type: 'acquisition-data-response',
+								acquisitionData: {
+									...addReferrerData({}),
+									source: 'GUARDIAN_WEB',
+								},
+							}),
+							'*',
+						);
+					}
+				},
+			);
+		}
+	});
 };
 
 export const init = () => {
-    addReferrerDataToAcquisitionLinksInInteractiveIframes();
-    enrichAcquisitionLinksOnPage();
+	addReferrerDataToAcquisitionLinksInInteractiveIframes();
+	enrichAcquisitionLinksOnPage();
 };

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-ophan.js
@@ -3,66 +3,67 @@ import config from '../../../../lib/config';
 import { constructQuery as constructURLQuery } from '../../../../lib/url';
 
 export const submitComponentEvent = (componentEvent) => {
-    ophan.record({ componentEvent });
+	ophan.record({ componentEvent });
 };
 
-export const submitInsertEvent = (
-    componentEvent
-) =>
-    submitComponentEvent({
-        ...componentEvent,
-        action: 'INSERT',
-    });
+export const submitInsertEvent = (componentEvent) =>
+	submitComponentEvent({
+		...componentEvent,
+		action: 'INSERT',
+	});
 
 export const submitViewEvent = (componentEvent) =>
-    submitComponentEvent({
-        ...componentEvent,
-        action: 'VIEW',
-    });
+	submitComponentEvent({
+		...componentEvent,
+		action: 'VIEW',
+	});
 
 export const submitClickEvent = (componentEvent) =>
-    submitComponentEvent({
-        ...componentEvent,
-        action: 'CLICK',
-    });
+	submitComponentEvent({
+		...componentEvent,
+		action: 'CLICK',
+	});
 
 export const addReferrerData = (acquisitionData) =>
-    // Note: the current page is the referrer data in the context of the acquisition.
-    ({
-        ...acquisitionData,
-        referrerPageviewId: config.get('ophan.pageViewId'),
-        referrerUrl: window.location.href.split('?')[0],
-    });
+	// Note: the current page is the referrer data in the context of the acquisition.
+	({
+		...acquisitionData,
+		referrerPageviewId: config.get('ophan.pageViewId'),
+		referrerUrl: window.location.href.split('?')[0],
+	});
 
 // Adds acquisition tracking codes if it is a support url
 export const addTrackingCodesToUrl = ({
-    base,
-    componentType,
-    componentId,
-    campaignCode,
-    abTest,
+	base,
+	componentType,
+	componentId,
+	campaignCode,
+	abTest,
 }) => {
-    const isSupportUrl = base.search(/(support.theguardian.com)(\/[a-z]*)?\/(contribute|subscribe)/) >= 0;
+	const isSupportUrl =
+		base.search(
+			/(support.theguardian.com)(\/[a-z]*)?\/(contribute|subscribe)/,
+		) >= 0;
 
-    if (isSupportUrl) {
-        const acquisitionData = addReferrerData({
-            source: 'GUARDIAN_WEB',
-            componentId,
-            componentType,
-            campaignCode,
-            abTest,
-        });
+	if (isSupportUrl) {
+		const acquisitionData = addReferrerData({
+			source: 'GUARDIAN_WEB',
+			componentId,
+			componentType,
+			campaignCode,
+			abTest,
+		});
 
-        const params = {
-            REFPVID: config.get('ophan.pageViewId') || 'not_found',
-            INTCMP: campaignCode,
-            acquisitionData: JSON.stringify(acquisitionData),
-        };
+		const params = {
+			REFPVID: config.get('ophan.pageViewId') || 'not_found',
+			INTCMP: campaignCode,
+			acquisitionData: JSON.stringify(acquisitionData),
+		};
 
-        return `${base}${base.includes('?') ? '&' : '?'}${constructURLQuery(
-            params
-        )}`;
-    }
+		return `${base}${base.includes('?') ? '&' : '?'}${constructURLQuery(
+			params,
+		)}`;
+	}
 
-    return base;
+	return base;
 };

--- a/static/src/javascripts/projects/common/modules/commercial/ad-free-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ad-free-banner.js
@@ -6,31 +6,32 @@ import { isAdFreeUser } from './user-features';
 const messageCode = 'ad-free-banner';
 const image = config.get('images.acquisitions.ad-free', '');
 
-const isInExperiment = () =>
-    config.get('switches.scAdFreeBanner', false);
+const isInExperiment = () => config.get('switches.scAdFreeBanner', false);
 
 const hideBanner = (banner) => {
-    banner.acknowledge();
+	banner.acknowledge();
 };
 
 const canShow = () =>
-    Promise.resolve(
-        !hasUserAcknowledgedBanner(messageCode) &&
-            isAdFreeUser() &&
-            isInExperiment()
-    );
+	Promise.resolve(
+		!hasUserAcknowledgedBanner(messageCode) &&
+			isAdFreeUser() &&
+			isInExperiment(),
+	);
 
 const show = () => {
-    new Message(messageCode, {
-        siteMessageLinkName: messageCode,
-        siteMessageCloseBtn: 'hide',
-        trackDisplay: true,
-        cssModifierClass: messageCode,
-        customJs() {
-            const dismissButton = document.querySelector('.js-ad-free-banner-dismiss-button');
-            dismissButton?.addEventListener('click', () => hideBanner(this))
-        },
-    }).show(`
+	new Message(messageCode, {
+		siteMessageLinkName: messageCode,
+		siteMessageCloseBtn: 'hide',
+		trackDisplay: true,
+		cssModifierClass: messageCode,
+		customJs() {
+			const dismissButton = document.querySelector(
+				'.js-ad-free-banner-dismiss-button',
+			);
+			dismissButton?.addEventListener('click', () => hideBanner(this));
+		},
+	}).show(`
         <div class="site-message__copy-text">
             <h2 class="site-message__copy-heading">No ads, no interruptions</h2>
             <p>As a valued subscriber, you won’t see adverts while logged in to the Guardian. Thank you for your support.</p>
@@ -42,13 +43,13 @@ const show = () => {
             <img src="${image}" alt="" />
         </div>
     `);
-    return Promise.resolve(true);
+	return Promise.resolve(true);
 };
 
 const adFreeBanner = {
-    id: messageCode,
-    show,
-    canShow,
+	id: messageCode,
+	show,
+	canShow,
 };
 
 export { adFreeBanner };

--- a/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.js
@@ -1,42 +1,40 @@
 import { addCookie, getCookie } from '../../../../lib/cookies';
 import { onConsentSet } from '../analytics/send-privacy-prefs';
 
-
-
 const cookieExpiryDate = 30 * 18;
 
 const thirdPartyTrackingAdConsent = {
-    label: 'Third party tracking',
-    cookie: 'GU_TK',
+	label: 'Third party tracking',
+	cookie: 'GU_TK',
 };
 
 const allAdConsents = [thirdPartyTrackingAdConsent];
 
 const setAdConsentState = (provider, state) => {
-    const cookie = [state ? '1' : '0', Date.now()].join('.');
-    addCookie(provider.cookie, cookie, cookieExpiryDate, true);
-    onConsentSet(provider, state);
+	const cookie = [state ? '1' : '0', Date.now()].join('.');
+	addCookie(provider.cookie, cookie, cookieExpiryDate, true);
+	onConsentSet(provider, state);
 };
 
 const getAdConsentState = (provider) => {
-    const cookieRaw = getCookie(provider.cookie);
-    if (!cookieRaw) return null;
-    const cookieParsed = cookieRaw.split('.')[0];
-    if (cookieParsed === '1') return true;
-    if (cookieParsed === '0') return false;
-    return null;
+	const cookieRaw = getCookie(provider.cookie);
+	if (!cookieRaw) return null;
+	const cookieParsed = cookieRaw.split('.')[0];
+	if (cookieParsed === '1') return true;
+	if (cookieParsed === '0') return false;
+	return null;
 };
 
 const getAllAdConsentsWithState = () =>
-    allAdConsents.map((consent) => ({
-        consent,
-        state: getAdConsentState(consent),
-    }));
+	allAdConsents.map((consent) => ({
+		consent,
+		state: getAdConsentState(consent),
+	}));
 
 export {
-    setAdConsentState,
-    getAdConsentState,
-    getAllAdConsentsWithState,
-    allAdConsents,
-    thirdPartyTrackingAdConsent,
+	setAdConsentState,
+	getAdConsentState,
+	getAllAdConsentsWithState,
+	allAdConsents,
+	thirdPartyTrackingAdConsent,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ad-prefs.lib.spec.js
@@ -1,6 +1,6 @@
 import {
-    getCookie as getCookie_,
-    addCookie as addCookie_,
+	getCookie as getCookie_,
+	addCookie as addCookie_,
 } from '../../../../lib/cookies';
 import { setAdConsentState, getAdConsentState } from './ad-prefs.lib';
 
@@ -8,49 +8,49 @@ const getCookie = getCookie_;
 const addCookie = addCookie_;
 
 const testConsent = {
-    label: 'Test consent',
-    cookie: 'GU_AD_CONSENT_TEST',
+	label: 'Test consent',
+	cookie: 'GU_AD_CONSENT_TEST',
 };
 
 jest.mock('../../../../lib/cookies', () => ({
-    getCookie: jest.fn(() => null),
-    addCookie: jest.fn(() => null),
+	getCookie: jest.fn(() => null),
+	addCookie: jest.fn(() => null),
 }));
 
 jest.mock('../analytics/send-privacy-prefs', () => ({
-    onConsentSet: jest.fn(() => null),
+	onConsentSet: jest.fn(() => null),
 }));
 
 beforeEach(() => {
-    addCookie.mockReset();
-    getCookie.mockReset();
+	addCookie.mockReset();
+	getCookie.mockReset();
 });
 
 describe('getAdConsentState', () => {
-    it('should convert false & true cookies properly', () => {
-        getCookie.mockImplementation(() => '0');
-        expect(getAdConsentState(testConsent)).toBe(false);
-        getCookie.mockImplementation(() => '1');
-        expect(getAdConsentState(testConsent)).toBe(true);
-    });
-    it('should convert null & inconsistent cookies properly', () => {
-        getCookie.mockImplementation(() => null);
-        expect(getAdConsentState(testConsent)).toBe(null);
-        getCookie.mockImplementation(() => 'verdadero');
-        expect(getAdConsentState(testConsent)).toBe(null);
-    });
+	it('should convert false & true cookies properly', () => {
+		getCookie.mockImplementation(() => '0');
+		expect(getAdConsentState(testConsent)).toBe(false);
+		getCookie.mockImplementation(() => '1');
+		expect(getAdConsentState(testConsent)).toBe(true);
+	});
+	it('should convert null & inconsistent cookies properly', () => {
+		getCookie.mockImplementation(() => null);
+		expect(getAdConsentState(testConsent)).toBe(null);
+		getCookie.mockImplementation(() => 'verdadero');
+		expect(getAdConsentState(testConsent)).toBe(null);
+	});
 });
 
 describe('setAdConsentState', () => {
-    it('should set a full proper cookie', () => {
-        setAdConsentState(testConsent, true);
-        expect(addCookie.mock.calls[0][0]).toBe('GU_AD_CONSENT_TEST');
-        expect(addCookie.mock.calls[0][1]).toMatch('1.');
-        expect(addCookie.mock.calls[0][2]).toBe(30 * 18);
-        expect(addCookie.mock.calls[0][3]).toBe(true);
-    });
-    it('should set a false cookie', () => {
-        setAdConsentState(testConsent, false);
-        expect(addCookie.mock.calls[0][1]).toMatch('0.');
-    });
+	it('should set a full proper cookie', () => {
+		setAdConsentState(testConsent, true);
+		expect(addCookie.mock.calls[0][0]).toBe('GU_AD_CONSENT_TEST');
+		expect(addCookie.mock.calls[0][1]).toMatch('1.');
+		expect(addCookie.mock.calls[0][2]).toBe(30 * 18);
+		expect(addCookie.mock.calls[0][3]).toBe(true);
+	});
+	it('should set a false cookie', () => {
+		setAdConsentState(testConsent, false);
+		expect(addCookie.mock.calls[0][1]).toMatch('0.');
+	});
 });

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -4,9 +4,9 @@ import { once, pick } from 'lodash-es';
 import config from '../../../../lib/config';
 import { getCookie } from '../../../../lib/cookies';
 import {
-    getBreakpoint,
-    getReferrer as detectGetReferrer,
-    getViewport,
+	getBreakpoint,
+	getReferrer as detectGetReferrer,
+	getViewport,
 } from '../../../../lib/detect';
 import { getCountryCode } from '../../../../lib/geolocation';
 import { getPrivacyFramework } from '../../../../lib/getPrivacyFramework';
@@ -24,343 +24,337 @@ let latestCMPState;
 const AMTGRP_STORAGE_KEY = 'gu.adManagerGroup';
 
 const findBreakpoint = () => {
-    switch (getBreakpoint(true)) {
-        case 'mobile':
-        case 'mobileMedium':
-        case 'mobileLandscape':
-            return 'mobile';
-        case 'phablet':
-        case 'tablet':
-            return 'tablet';
-        case 'desktop':
-        case 'leftCol':
-        case 'wide':
-            return 'desktop';
-        default:
-            return 'mobile';
-    }
+	switch (getBreakpoint(true)) {
+		case 'mobile':
+		case 'mobileMedium':
+		case 'mobileLandscape':
+			return 'mobile';
+		case 'phablet':
+		case 'tablet':
+			return 'tablet';
+		case 'desktop':
+		case 'leftCol':
+		case 'wide':
+			return 'desktop';
+		default:
+			return 'mobile';
+	}
 };
 
 const skinsizeTargetting = () => {
-    const vp = getViewport();
-    return (vp && vp.width >= 1560) ? "l" : "s";
+	const vp = getViewport();
+	return vp && vp.width >= 1560 ? 'l' : 's';
 };
 
 const inskinTargetting = () => {
-// Don’t show inskin if we cannot tell if a privacy message will be shown
-    if (!cmp.hasInitialised()) return 'f';
-    return cmp.willShowPrivacyMessageSync() ? 'f' : 't';
+	// Don’t show inskin if we cannot tell if a privacy message will be shown
+	if (!cmp.hasInitialised()) return 'f';
+	return cmp.willShowPrivacyMessageSync() ? 'f' : 't';
 };
 
-const format = (keyword) =>
-    keyword.replace(/[+\s]+/g, '-').toLowerCase();
+const format = (keyword) => keyword.replace(/[+\s]+/g, '-').toLowerCase();
 
 // flowlint sketchy-null-string:warn
 const formatTarget = (target) =>
-    target
-        ? format(target)
-              .replace(/&/g, 'and')
-              .replace(/'/g, '')
-        : null;
+	target ? format(target).replace(/&/g, 'and').replace(/'/g, '') : null;
 
 const abParam = () => {
-    const abParticipations = getSynchronousParticipations();
-    const abParams = [];
+	const abParticipations = getSynchronousParticipations();
+	const abParams = [];
 
-    const pushAbParams = (testName, testValue) => {
-        if (typeof testValue === 'string' && testValue !== 'notintest') {
-            const testData = `${testName}-${testValue}`;
-            // DFP key-value pairs accept value strings up to 40 characters long
-            abParams.push(testData.substring(0, 40));
-        }
-    };
+	const pushAbParams = (testName, testValue) => {
+		if (typeof testValue === 'string' && testValue !== 'notintest') {
+			const testData = `${testName}-${testValue}`;
+			// DFP key-value pairs accept value strings up to 40 characters long
+			abParams.push(testData.substring(0, 40));
+		}
+	};
 
-    Object.keys(abParticipations).forEach(
-        (testKey) => {
-            const testValue = abParticipations[testKey];
-            pushAbParams(testKey, testValue.variant);
-        }
-    );
+	Object.keys(abParticipations).forEach((testKey) => {
+		const testValue = abParticipations[testKey];
+		pushAbParams(testKey, testValue.variant);
+	});
 
-    const tests = config.get('tests');
+	const tests = config.get('tests');
 
-    if (tests) {
-        Object.entries(tests).forEach(([testName, testValue]) => {
-            pushAbParams(testName, testValue);
-        });
-    }
+	if (tests) {
+		Object.entries(tests).forEach(([testName, testValue]) => {
+			pushAbParams(testName, testValue);
+		});
+	}
 
-    return abParams;
+	return abParams;
 };
 
 const getVisitedValue = () => {
-    const visitCount =
-        parseInt(storage.local.getRaw('gu.alreadyVisited'), 10) || 0;
+	const visitCount =
+		parseInt(storage.local.getRaw('gu.alreadyVisited'), 10) || 0;
 
-    if (visitCount <= 5) {
-        return visitCount.toString();
-    } else if (visitCount >= 6 && visitCount <= 9) {
-        return '6-9';
-    } else if (visitCount >= 10 && visitCount <= 15) {
-        return '10-15';
-    } else if (visitCount >= 16 && visitCount <= 19) {
-        return '16-19';
-    } else if (visitCount >= 20 && visitCount <= 29) {
-        return '20-29';
-    } else if (visitCount >= 30) {
-        return '30plus';
-    }
+	if (visitCount <= 5) {
+		return visitCount.toString();
+	} else if (visitCount >= 6 && visitCount <= 9) {
+		return '6-9';
+	} else if (visitCount >= 10 && visitCount <= 15) {
+		return '10-15';
+	} else if (visitCount >= 16 && visitCount <= 19) {
+		return '16-19';
+	} else if (visitCount >= 20 && visitCount <= 29) {
+		return '20-29';
+	} else if (visitCount >= 30) {
+		return '30plus';
+	}
 
-    return visitCount.toString();
+	return visitCount.toString();
 };
 
 const getReferrer = () => {
-    const referrerTypes = [
-        {
-            id: 'facebook',
-            match: 'facebook.com',
-        },
-        {
-            id: 'twitter',
-            match: 't.co/',
-        }, // added (/) because without slash it is picking up reddit.com too
-        {
-            id: 'reddit',
-            match: 'reddit.com',
-        },
-        {
-            id: 'google',
-            match: 'www.google',
-        },
-    ];
+	const referrerTypes = [
+		{
+			id: 'facebook',
+			match: 'facebook.com',
+		},
+		{
+			id: 'twitter',
+			match: 't.co/',
+		}, // added (/) because without slash it is picking up reddit.com too
+		{
+			id: 'reddit',
+			match: 'reddit.com',
+		},
+		{
+			id: 'google',
+			match: 'www.google',
+		},
+	];
 
-    const matchedRef =
-        referrerTypes.filter(
-            referrerType => detectGetReferrer().indexOf(referrerType.match) > -1
-        )[0] || {};
+	const matchedRef =
+		referrerTypes.filter(
+			(referrerType) =>
+				detectGetReferrer().indexOf(referrerType.match) > -1,
+		)[0] || {};
 
-    return matchedRef.id;
+	return matchedRef.id;
 };
 
 const getWhitelistedQueryParams = () => {
-    const whiteList = ['0p19G'];
-    return pick(getUrlVars(), whiteList);
+	const whiteList = ['0p19G'];
+	return pick(getUrlVars(), whiteList);
 };
 
 const getUrlKeywords = (pageId) => {
-    if (pageId) {
-        const segments = pageId.split('/');
-        const lastPathname = segments.pop() || segments.pop(); // This handles a trailing slash
-        return lastPathname.split('-');
-    }
-    return [];
+	if (pageId) {
+		const segments = pageId.split('/');
+		const lastPathname = segments.pop() || segments.pop(); // This handles a trailing slash
+		return lastPathname.split('-');
+	}
+	return [];
 };
 
 const formatAppNexusTargeting = (obj) => {
-    const asKeyValues = Object.keys(obj)
-        .map((key) => {
-            const value = obj[key];
-            return Array.isArray(value)
-                ? value.map(nestedValue => `${key}=${nestedValue}`)
-                : `${key}=${value}`;
-        });
+	const asKeyValues = Object.keys(obj).map((key) => {
+		const value = obj[key];
+		return Array.isArray(value)
+			? value.map((nestedValue) => `${key}=${nestedValue}`)
+			: `${key}=${value}`;
+	});
 
-    const flattenDeep = Array.prototype.concat.apply([], asKeyValues);
-    return flattenDeep.join(',');
-}
+	const flattenDeep = Array.prototype.concat.apply([], asKeyValues);
+	return flattenDeep.join(',');
+};
 
-const buildAppNexusTargetingObject = once(
-    (pageTargeting) =>
-        removeFalseyValues({
-            sens: pageTargeting.sens,
-            pt1: pageTargeting.url,
-            pt2: pageTargeting.edition,
-            pt3: pageTargeting.ct,
-            pt4: pageTargeting.p,
-            pt5: pageTargeting.k,
-            pt6: pageTargeting.su,
-            pt7: pageTargeting.bp,
-            pt8: pageTargeting.x, // OpenX cannot handle this being undefined
-            pt9: [
-                pageTargeting.gdncrm,
-                pageTargeting.pv,
-                pageTargeting.co,
-                pageTargeting.tn,
-                pageTargeting.slot,
-            ].join('|'),
-            permutive: pageTargeting.permutive,
-        })
+const buildAppNexusTargetingObject = once((pageTargeting) =>
+	removeFalseyValues({
+		sens: pageTargeting.sens,
+		pt1: pageTargeting.url,
+		pt2: pageTargeting.edition,
+		pt3: pageTargeting.ct,
+		pt4: pageTargeting.p,
+		pt5: pageTargeting.k,
+		pt6: pageTargeting.su,
+		pt7: pageTargeting.bp,
+		pt8: pageTargeting.x, // OpenX cannot handle this being undefined
+		pt9: [
+			pageTargeting.gdncrm,
+			pageTargeting.pv,
+			pageTargeting.co,
+			pageTargeting.tn,
+			pageTargeting.slot,
+		].join('|'),
+		permutive: pageTargeting.permutive,
+	}),
 );
 
-const buildAppNexusTargeting = once(
-    (pageTargeting) =>
-        formatAppNexusTargeting(buildAppNexusTargetingObject(pageTargeting))
+const buildAppNexusTargeting = once((pageTargeting) =>
+	formatAppNexusTargeting(buildAppNexusTargetingObject(pageTargeting)),
 );
 
 const getRdpValue = (ccpaState) => {
-    if (ccpaState === null) {
-        return 'na';
-    }
-    return ccpaState ? 't' : 'f';
+	if (ccpaState === null) {
+		return 'na';
+	}
+	return ccpaState ? 't' : 'f';
 };
 
 const getTcfv2ConsentValue = (tcfv2State) => {
-    if (getPrivacyFramework().tcfv2 && tcfv2State !== null) {
-        return tcfv2State ? 't' : 'f';
-    }
-    return 'na';
+	if (getPrivacyFramework().tcfv2 && tcfv2State !== null) {
+		return tcfv2State ? 't' : 'f';
+	}
+	return 'na';
 };
 
 const getAdConsentFromState = (state) => {
-    if (state.ccpa) {
-        // CCPA mode
-        return !state.ccpa.doNotSell;
-    } else if (state.tcfv2) {
-        // TCFv2 mode
-        return state.tcfv2.consents
-            ? Object.keys(state.tcfv2.consents).length > 0 &&
-              Object.values(state.tcfv2.consents).every(Boolean)
-            : false;
-    } else if (state.aus) {
-        // AUS mode
-        return state.aus.personalisedAdvertising;
-    }
-    // Unknown mode
-    return false;
-}
+	if (state.ccpa) {
+		// CCPA mode
+		return !state.ccpa.doNotSell;
+	} else if (state.tcfv2) {
+		// TCFv2 mode
+		return state.tcfv2.consents
+			? Object.keys(state.tcfv2.consents).length > 0 &&
+					Object.values(state.tcfv2.consents).every(Boolean)
+			: false;
+	} else if (state.aus) {
+		// AUS mode
+		return state.aus.personalisedAdvertising;
+	}
+	// Unknown mode
+	return false;
+};
 
 const getAdManagerGroup = (consented = true) => {
 	if (!consented) return null;
-	return storage.local.getRaw(AMTGRP_STORAGE_KEY) || createAdManagerGroup()
-}
+	return storage.local.getRaw(AMTGRP_STORAGE_KEY) || createAdManagerGroup();
+};
 
 const createAdManagerGroup = () => {
-    // users are assigned to groups 1-12
-    const group = String(Math.floor(Math.random() * 12) + 1);
-    storage.local.setRaw(AMTGRP_STORAGE_KEY, group);
-    return group;
-}
+	// users are assigned to groups 1-12
+	const group = String(Math.floor(Math.random() * 12) + 1);
+	storage.local.setRaw(AMTGRP_STORAGE_KEY, group);
+	return group;
+};
 
 const filterEmptyValues = (pageTargets) => {
-    const filtered = {};
-    for (const key in pageTargets) {
-        const value = pageTargets[key];
-        if (!value) {
-            continue;
-        }
-        if (Array.isArray(value) && value.length === 0) {
-            continue;
-        }
-        filtered[key] = value;
-    }
-    return filtered;
-}
+	const filtered = {};
+	for (const key in pageTargets) {
+		const value = pageTargets[key];
+		if (!value) {
+			continue;
+		}
+		if (Array.isArray(value) && value.length === 0) {
+			continue;
+		}
+		filtered[key] = value;
+	}
+	return filtered;
+};
 
 const rebuildPageTargeting = () => {
-    latestCmpHasInitialised = cmp.hasInitialised();
-    const adConsentState = getAdConsentFromState(latestCMPState);
-    const ccpaState = latestCMPState.ccpa ? latestCMPState.ccpa.doNotSell : null;
-    const tcfv2EventStatus = latestCMPState.tcfv2 ? latestCMPState.tcfv2.eventStatus : 'na';
-    const page = config.get('page');
-    const amtgrp = latestCMPState.tcfv2
+	latestCmpHasInitialised = cmp.hasInitialised();
+	const adConsentState = getAdConsentFromState(latestCMPState);
+	const ccpaState = latestCMPState.ccpa
+		? latestCMPState.ccpa.doNotSell
+		: null;
+	const tcfv2EventStatus = latestCMPState.tcfv2
+		? latestCMPState.tcfv2.eventStatus
+		: 'na';
+	const page = config.get('page');
+	const amtgrp = latestCMPState.tcfv2
 		? getAdManagerGroup(adConsentState)
 		: getAdManagerGroup();
-    // personalised ads targeting
-    if (adConsentState === false) clearPermutiveSegments();
-    // flowlint-next-line sketchy-null-bool:off
-    const paTargeting = { pa: adConsentState ? 't' : 'f' };
-    const adFreeTargeting = commercialFeatures.adFree ? { af: 't' } : {};
-    const pageTargets = Object.assign(
-        {
-            ab: abParam(),
-            amtgrp,
-            at: getCookie('adtest') || undefined,
-            bp: findBreakpoint(),
-            cc: getCountryCode(),
-            cmp_interaction: tcfv2EventStatus || 'na',
-            consent_tcfv2: getTcfv2ConsentValue(adConsentState),
-            // dcre: DCR eligible
-            // when the page is DCR eligible and was rendered by DCR or
-            // when the page is DCR eligible but rendered by frontend for a user not in the DotcomRendering experiment
-            dcre:
-                config.get('isDotcomRendering', false) ||
-                config.get('page.dcrCouldRender', false)
-                    ? 't'
-                    : 'f',
-            fr: getVisitedValue(),
-            gdncrm: getUserSegments(adConsentState),
-            inskin: inskinTargetting(),
-            ms: formatTarget(page.source),
-            permutive: getPermutiveSegments(),
-            pv: config.get('ophan.pageViewId'),
-            rdp: getRdpValue(ccpaState),
-            ref: getReferrer(),
-            // rp: rendering platform
-            rp: config.get('isDotcomRendering', false)
-                ? 'dotcom-rendering'
-                : 'dotcom-platform',
-            // s: section
-            // for reference in a macro, so cannot be extracted from ad unit
-            s: page.section,
-            sens: page.isSensitive ? 't' : 'f',
-            si: isUserLoggedIn() ? 't' : 'f',
-            skinsize: skinsizeTargetting(),
-            urlkw: getUrlKeywords(page.pageId),
-            // vl: video length
-            // round video duration up to nearest 30 multiple
-            vl: page.videoDuration
-                ? (Math.ceil(page.videoDuration / 30.0) * 30).toString()
-                : undefined,
-        },
-        page.sharedAdTargeting,
-        paTargeting,
-        adFreeTargeting,
-        getWhitelistedQueryParams()
-    );
+	// personalised ads targeting
+	if (adConsentState === false) clearPermutiveSegments();
+	// flowlint-next-line sketchy-null-bool:off
+	const paTargeting = { pa: adConsentState ? 't' : 'f' };
+	const adFreeTargeting = commercialFeatures.adFree ? { af: 't' } : {};
+	const pageTargets = Object.assign(
+		{
+			ab: abParam(),
+			amtgrp,
+			at: getCookie('adtest') || undefined,
+			bp: findBreakpoint(),
+			cc: getCountryCode(),
+			cmp_interaction: tcfv2EventStatus || 'na',
+			consent_tcfv2: getTcfv2ConsentValue(adConsentState),
+			// dcre: DCR eligible
+			// when the page is DCR eligible and was rendered by DCR or
+			// when the page is DCR eligible but rendered by frontend for a user not in the DotcomRendering experiment
+			dcre:
+				config.get('isDotcomRendering', false) ||
+				config.get('page.dcrCouldRender', false)
+					? 't'
+					: 'f',
+			fr: getVisitedValue(),
+			gdncrm: getUserSegments(adConsentState),
+			inskin: inskinTargetting(),
+			ms: formatTarget(page.source),
+			permutive: getPermutiveSegments(),
+			pv: config.get('ophan.pageViewId'),
+			rdp: getRdpValue(ccpaState),
+			ref: getReferrer(),
+			// rp: rendering platform
+			rp: config.get('isDotcomRendering', false)
+				? 'dotcom-rendering'
+				: 'dotcom-platform',
+			// s: section
+			// for reference in a macro, so cannot be extracted from ad unit
+			s: page.section,
+			sens: page.isSensitive ? 't' : 'f',
+			si: isUserLoggedIn() ? 't' : 'f',
+			skinsize: skinsizeTargetting(),
+			urlkw: getUrlKeywords(page.pageId),
+			// vl: video length
+			// round video duration up to nearest 30 multiple
+			vl: page.videoDuration
+				? (Math.ceil(page.videoDuration / 30.0) * 30).toString()
+				: undefined,
+		},
+		page.sharedAdTargeting,
+		paTargeting,
+		adFreeTargeting,
+		getWhitelistedQueryParams(),
+	);
 
-    // filter out empty values
-    const pageTargeting = filterEmptyValues(pageTargets);
+	// filter out empty values
+	const pageTargeting = filterEmptyValues(pageTargets);
 
-    // third-parties wish to access our page targeting, before the googletag script is loaded.
-    page.appNexusPageTargeting = buildAppNexusTargeting(pageTargeting);
+	// third-parties wish to access our page targeting, before the googletag script is loaded.
+	page.appNexusPageTargeting = buildAppNexusTargeting(pageTargeting);
 
-    // This can be removed once we get sign-off from third parties who prefer to use appNexusPageTargeting.
-    page.pageAdTargeting = pageTargeting;
+	// This can be removed once we get sign-off from third parties who prefer to use appNexusPageTargeting.
+	page.pageAdTargeting = pageTargeting;
 
 	log('commercial', 'pageTargeting object:', pageTargeting);
 
-    return pageTargeting;
-}
+	return pageTargeting;
+};
 
 const getPageTargeting = () => {
+	if (Object.keys(myPageTargetting).length !== 0) {
+		// If CMP was initialised since the last time myPageTargetting was built - rebuild
+		if (latestCmpHasInitialised !== cmp.hasInitialised()) {
+			myPageTargetting = rebuildPageTargeting();
+		}
+		return myPageTargetting;
+	}
 
-    if (Object.keys(myPageTargetting).length !== 0) {
-        // If CMP was initialised since the last time myPageTargetting was built - rebuild
-        if (latestCmpHasInitialised !== cmp.hasInitialised()) {
-            myPageTargetting = rebuildPageTargeting();
-        }
-        return myPageTargetting;
-    }
-
-    // First call binds to onConsentChange and returns {}
-    onConsentChange((state)=>{
-    // On every consent change we rebuildPageTargeting
-        latestCMPState = state;
-        myPageTargetting = rebuildPageTargeting();
-    });
-    return myPageTargetting;
+	// First call binds to onConsentChange and returns {}
+	onConsentChange((state) => {
+		// On every consent change we rebuildPageTargeting
+		latestCMPState = state;
+		myPageTargetting = rebuildPageTargeting();
+	});
+	return myPageTargetting;
 };
 
 const resetPageTargeting = () => {
-    myPageTargetting = {};
+	myPageTargetting = {};
 };
 
 export {
-    getPageTargeting,
-    buildAppNexusTargeting,
-    buildAppNexusTargetingObject,
+	getPageTargeting,
+	buildAppNexusTargeting,
+	buildAppNexusTargetingObject,
 };
 
 export const _ = {
-    resetPageTargeting,
+	resetPageTargeting,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.js
@@ -1,14 +1,14 @@
 import {
-    cmp as cmp_,
-    onConsentChange,
+	cmp as cmp_,
+	onConsentChange,
 } from '@guardian/consent-management-platform';
 import { storage } from '@guardian/libs';
 import config from '../../../../lib/config';
 import { getCookie as getCookie_ } from '../../../../lib/cookies';
 import {
-    getBreakpoint as getBreakpoint_,
-    getReferrer as getReferrer_,
-    getViewport as getViewport_,
+	getBreakpoint as getBreakpoint_,
+	getReferrer as getReferrer_,
+	getViewport as getViewport_,
 } from '../../../../lib/detect';
 import { getCountryCode as getCountryCode_ } from '../../../../lib/geolocation';
 import { getPrivacyFramework as getPrivacyFramework_ } from '../../../../lib/getPrivacyFramework';
@@ -31,548 +31,544 @@ const cmp = cmp_;
 
 jest.mock('../../../../lib/config');
 jest.mock('../../../../lib/cookies', () => ({
-    getCookie: jest.fn(),
+	getCookie: jest.fn(),
 }));
 jest.mock('../../../../lib/detect', () => ({
-    getViewport: jest.fn(),
-    getBreakpoint: jest.fn(),
-    getReferrer: jest.fn(),
-    hasPushStateSupport: jest.fn(),
+	getViewport: jest.fn(),
+	getBreakpoint: jest.fn(),
+	getReferrer: jest.fn(),
+	hasPushStateSupport: jest.fn(),
 }));
 jest.mock('../../../../lib/geolocation', () => ({
-    getCountryCode: jest.fn(),
+	getCountryCode: jest.fn(),
 }));
 jest.mock('../../../../lib/getPrivacyFramework', () => ({
-    getPrivacyFramework: jest.fn(),
+	getPrivacyFramework: jest.fn(),
 }));
 jest.mock('../identity/api', () => ({
-    isUserLoggedIn: jest.fn(),
+	isUserLoggedIn: jest.fn(),
 }));
 jest.mock('./user-ad-targeting', () => ({
-    getUserSegments: jest.fn(),
+	getUserSegments: jest.fn(),
 }));
 jest.mock('../experiments/ab', () => ({
-    getSynchronousParticipations: jest.fn(),
+	getSynchronousParticipations: jest.fn(),
 }));
-jest.mock('lodash-es/once', () => fn => fn);
-jest.mock('lodash-es/memoize', () => fn => fn);
+jest.mock('lodash-es/once', () => (fn) => fn);
+jest.mock('lodash-es/memoize', () => (fn) => fn);
 jest.mock('./commercial-features', () => ({
-    commercialFeatures() {},
+	commercialFeatures() {},
 }));
 jest.mock('@guardian/consent-management-platform', () => ({
-    onConsentChange: jest.fn(),
-    cmp: {
-        hasInitialised: jest.fn(),
-        willShowPrivacyMessageSync: jest.fn(),
-    },
+	onConsentChange: jest.fn(),
+	cmp: {
+		hasInitialised: jest.fn(),
+		willShowPrivacyMessageSync: jest.fn(),
+	},
 }));
 
 // TCFv1
 const tcfWithConsentMock = (callback) =>
-    callback({ '1': true, '2': true, '3': true, '4': true, '5': true });
+	callback({ 1: true, 2: true, 3: true, 4: true, 5: true });
 const tcfMixedConsentMock = (callback) =>
-    callback({
-        '1': false,
-        '2': true,
-        '3': true,
-        '4': false,
-        '5': true,
-    });
+	callback({
+		1: false,
+		2: true,
+		3: true,
+		4: false,
+		5: true,
+	});
 
 // CCPA
 const ccpaWithConsentMock = (callback) =>
-    callback({ ccpa: { doNotSell: false } });
+	callback({ ccpa: { doNotSell: false } });
 const ccpaWithoutConsentMock = (callback) =>
-    callback({ ccpa: { doNotSell: true } });
+	callback({ ccpa: { doNotSell: true } });
 
 // AUS
 const ausWithConsentMock = (callback) =>
-callback({ aus: { personalisedAdvertising: true } });
+	callback({ aus: { personalisedAdvertising: true } });
 const ausWithoutConsentMock = (callback) =>
-callback({ aus: { personalisedAdvertising: false } });
+	callback({ aus: { personalisedAdvertising: false } });
 
 // TCFv2
 const tcfv2WithConsentMock = (callback) =>
-    callback({
-        tcfv2: {
-            consents: { '1': true, '2': true },
-            eventStatus: 'useractioncomplete',
-        },
-    });
+	callback({
+		tcfv2: {
+			consents: { 1: true, 2: true },
+			eventStatus: 'useractioncomplete',
+		},
+	});
 const tcfv2WithoutConsentMock = (callback) =>
-    callback({ tcfv2: { consents: {}, eventStatus: 'cmpuishown' } });
+	callback({ tcfv2: { consents: {}, eventStatus: 'cmpuishown' } });
 const tcfv2NullConsentMock = (callback) => callback({ tcfv2: {} });
 const tcfv2MixedConsentMock = (callback) =>
-    callback({
-        tcfv2: {
-            consents: { '1': false, '2': true },
-            eventStatus: 'useractioncomplete',
-        },
-    });
+	callback({
+		tcfv2: {
+			consents: { 1: false, 2: true },
+			eventStatus: 'useractioncomplete',
+		},
+	});
 
 describe('Build Page Targeting', () => {
-    beforeEach(() => {
-        config.page = {
-            authorIds: 'profile/gabrielle-chan',
-            blogIds: 'a/blog',
-            contentType: 'Video',
-            edition: 'US',
-            keywordIds:
-                'uk-news/prince-charles-letters,uk/uk,uk/prince-charles',
-            pageId: 'football/series/footballweekly',
-            publication: 'The Observer',
-            seriesId: 'film/series/filmweekly',
-            source: 'ITN',
-            sponsorshipType: 'advertisement-features',
-            tones: 'News',
-            videoDuration: 63,
-            sharedAdTargeting: {
-                bl: ['blog'],
-                br: 'p',
-                co: ['gabrielle-chan'],
-                ct: 'video',
-                edition: 'us',
-                k: ['prince-charles-letters', 'uk/uk', 'prince-charles'],
-                ob: 't',
-                p: 'ng',
-                se: ['filmweekly'],
-                su: ['5'],
-                tn: ['news'],
-                url: '/football/series/footballweekly',
-            },
-            isSensitive: false,
-        };
-        config.ophan = { pageViewId: 'presetOphanPageViewId' };
-
-        commercialFeatures.adFree = false;
-
-        // Reset mocking to default values.
-        getCookie.mockReturnValue('ng101');
-        _.resetPageTargeting();
-        onConsentChange.mockImplementation(tcfv2NullConsentMock);
-
-        getBreakpoint.mockReturnValue('mobile');
-        getReferrer.mockReturnValue('');
-
-        isUserLoggedIn.mockReturnValue(true);
-
-        getUserSegments.mockReturnValue(['seg1', 'seg2']);
-
-        getSynchronousParticipations.mockReturnValue({
-            MtMaster: {
-                variant: 'variantName',
-            },
-        });
-
-        storage.local.setRaw('gu.alreadyVisited', 0);
-
-        getCountryCode.mockReturnValue('US');
-        getPrivacyFramework.mockReturnValue({ ccpa: true });
-
-        jest.spyOn(global.Math, 'random').mockReturnValue(0.5);
-
-        expect.hasAssertions();
-    });
-
-    afterEach(() => {
-        jest.spyOn(global.Math, 'random').mockRestore();
-        jest.resetAllMocks();
-    });
-
-    it('should exist', () => {
-        expect(getPageTargeting).toBeDefined();
-    });
-
-    it('should build correct page targeting', () => {
-        const pageTargeting = getPageTargeting();
-
-        expect(pageTargeting.sens).toBe('f');
-        expect(pageTargeting.edition).toBe('us');
-        expect(pageTargeting.ct).toBe('video');
-        expect(pageTargeting.p).toBe('ng');
-        expect(pageTargeting.su).toEqual(['5']);
-        expect(pageTargeting.bp).toBe('mobile');
-        expect(pageTargeting.at).toBe('ng101');
-        expect(pageTargeting.si).toEqual('t');
-        expect(pageTargeting.gdncrm).toEqual(['seg1', 'seg2']);
-        expect(pageTargeting.co).toEqual(['gabrielle-chan']);
-        expect(pageTargeting.bl).toEqual(['blog']);
-        expect(pageTargeting.ms).toBe('itn');
-        expect(pageTargeting.tn).toEqual(['news']);
-        expect(pageTargeting.vl).toEqual('90');
-        expect(pageTargeting.pv).toEqual('presetOphanPageViewId');
-        expect(pageTargeting.pa).toEqual('f');
-        expect(pageTargeting.cc).toEqual('US');
-        expect(pageTargeting.rp).toEqual('dotcom-platform');
-    });
-
-    it('should set correct personalized ad (pa) param', () => {
-        onConsentChange.mockImplementation(tcfv2WithConsentMock);
-        expect(getPageTargeting().pa).toBe('t');
-
-        _.resetPageTargeting();
-        onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
-        expect(getPageTargeting().pa).toBe('f');
+	beforeEach(() => {
+		config.page = {
+			authorIds: 'profile/gabrielle-chan',
+			blogIds: 'a/blog',
+			contentType: 'Video',
+			edition: 'US',
+			keywordIds:
+				'uk-news/prince-charles-letters,uk/uk,uk/prince-charles',
+			pageId: 'football/series/footballweekly',
+			publication: 'The Observer',
+			seriesId: 'film/series/filmweekly',
+			source: 'ITN',
+			sponsorshipType: 'advertisement-features',
+			tones: 'News',
+			videoDuration: 63,
+			sharedAdTargeting: {
+				bl: ['blog'],
+				br: 'p',
+				co: ['gabrielle-chan'],
+				ct: 'video',
+				edition: 'us',
+				k: ['prince-charles-letters', 'uk/uk', 'prince-charles'],
+				ob: 't',
+				p: 'ng',
+				se: ['filmweekly'],
+				su: ['5'],
+				tn: ['news'],
+				url: '/football/series/footballweekly',
+			},
+			isSensitive: false,
+		};
+		config.ophan = { pageViewId: 'presetOphanPageViewId' };
+
+		commercialFeatures.adFree = false;
+
+		// Reset mocking to default values.
+		getCookie.mockReturnValue('ng101');
+		_.resetPageTargeting();
+		onConsentChange.mockImplementation(tcfv2NullConsentMock);
+
+		getBreakpoint.mockReturnValue('mobile');
+		getReferrer.mockReturnValue('');
+
+		isUserLoggedIn.mockReturnValue(true);
+
+		getUserSegments.mockReturnValue(['seg1', 'seg2']);
+
+		getSynchronousParticipations.mockReturnValue({
+			MtMaster: {
+				variant: 'variantName',
+			},
+		});
+
+		storage.local.setRaw('gu.alreadyVisited', 0);
+
+		getCountryCode.mockReturnValue('US');
+		getPrivacyFramework.mockReturnValue({ ccpa: true });
+
+		jest.spyOn(global.Math, 'random').mockReturnValue(0.5);
+
+		expect.hasAssertions();
+	});
+
+	afterEach(() => {
+		jest.spyOn(global.Math, 'random').mockRestore();
+		jest.resetAllMocks();
+	});
+
+	it('should exist', () => {
+		expect(getPageTargeting).toBeDefined();
+	});
+
+	it('should build correct page targeting', () => {
+		const pageTargeting = getPageTargeting();
+
+		expect(pageTargeting.sens).toBe('f');
+		expect(pageTargeting.edition).toBe('us');
+		expect(pageTargeting.ct).toBe('video');
+		expect(pageTargeting.p).toBe('ng');
+		expect(pageTargeting.su).toEqual(['5']);
+		expect(pageTargeting.bp).toBe('mobile');
+		expect(pageTargeting.at).toBe('ng101');
+		expect(pageTargeting.si).toEqual('t');
+		expect(pageTargeting.gdncrm).toEqual(['seg1', 'seg2']);
+		expect(pageTargeting.co).toEqual(['gabrielle-chan']);
+		expect(pageTargeting.bl).toEqual(['blog']);
+		expect(pageTargeting.ms).toBe('itn');
+		expect(pageTargeting.tn).toEqual(['news']);
+		expect(pageTargeting.vl).toEqual('90');
+		expect(pageTargeting.pv).toEqual('presetOphanPageViewId');
+		expect(pageTargeting.pa).toEqual('f');
+		expect(pageTargeting.cc).toEqual('US');
+		expect(pageTargeting.rp).toEqual('dotcom-platform');
+	});
+
+	it('should set correct personalized ad (pa) param', () => {
+		onConsentChange.mockImplementation(tcfv2WithConsentMock);
+		expect(getPageTargeting().pa).toBe('t');
+
+		_.resetPageTargeting();
+		onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
+		expect(getPageTargeting().pa).toBe('f');
 
-        _.resetPageTargeting();
-        onConsentChange.mockImplementation(tcfv2NullConsentMock);
-        expect(getPageTargeting().pa).toBe('f');
+		_.resetPageTargeting();
+		onConsentChange.mockImplementation(tcfv2NullConsentMock);
+		expect(getPageTargeting().pa).toBe('f');
 
-        _.resetPageTargeting();
-        onConsentChange.mockImplementation(tcfv2MixedConsentMock);
-        expect(getPageTargeting().pa).toBe('f');
-
-        _.resetPageTargeting();
-        onConsentChange.mockImplementation(ccpaWithConsentMock);
-        expect(getPageTargeting().pa).toBe('t');
-
-        _.resetPageTargeting();
-        onConsentChange.mockImplementation(ccpaWithoutConsentMock);
-        expect(getPageTargeting().pa).toBe('f');
-    });
-
-    it('Should correctly set the RDP flag (rdp) param', () => {
-        onConsentChange.mockImplementation(tcfWithConsentMock);
-        expect(getPageTargeting().rdp).toBe('na');
-
-        _.resetPageTargeting();
-        onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
-        expect(getPageTargeting().rdp).toBe('na');
-
-        _.resetPageTargeting();
-        onConsentChange.mockImplementation(tcfv2NullConsentMock);
-        expect(getPageTargeting().rdp).toBe('na');
-
-        _.resetPageTargeting();
-        onConsentChange.mockImplementation(tcfMixedConsentMock);
-        expect(getPageTargeting().rdp).toBe('na');
-
-        _.resetPageTargeting();
-        onConsentChange.mockImplementation(ccpaWithConsentMock);
-        expect(getPageTargeting().rdp).toBe('f');
-
-        _.resetPageTargeting();
-        onConsentChange.mockImplementation(ccpaWithoutConsentMock);
-        expect(getPageTargeting().rdp).toBe('t');
-    });
-
-    it('Should correctly set the TCFv2 (consent_tcfv2, cmp_interaction) params', () => {
-        _.resetPageTargeting();
-        getPrivacyFramework.mockReturnValue({ tcfv2: true });
-
-        onConsentChange.mockImplementation(tcfv2WithConsentMock);
-
-        expect(getPageTargeting().consent_tcfv2).toBe('t');
-        expect(getPageTargeting().cmp_interaction).toBe('useractioncomplete');
-
-        _.resetPageTargeting();
-        onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
-
-        expect(getPageTargeting().consent_tcfv2).toBe('f');
-        expect(getPageTargeting().cmp_interaction).toBe('cmpuishown');
-
-        _.resetPageTargeting();
-        onConsentChange.mockImplementation(tcfv2MixedConsentMock);
-
-        expect(getPageTargeting().consent_tcfv2).toBe('f');
-        expect(getPageTargeting().cmp_interaction).toBe('useractioncomplete');
-
-        _.resetPageTargeting();
-        getPrivacyFramework.mockReturnValue({ tcfv1: true });
-        onConsentChange.mockImplementation(tcfWithConsentMock);
-
-        expect(getPageTargeting().consent_tcfv2).toBe('na');
-        expect(getPageTargeting().cmp_interaction).toBe('na');
-    });
-
-    it('should set correct edition param', () => {
-        expect(getPageTargeting().edition).toBe('us');
-    });
-
-    it('should set correct se param', () => {
-        expect(getPageTargeting().se).toEqual(['filmweekly']);
-    });
-
-    it('should set correct k param', () => {
-        expect(getPageTargeting().k).toEqual([
-            'prince-charles-letters',
-            'uk/uk',
-            'prince-charles',
-        ]);
-    });
-
-    it('should set correct ab param', () => {
-        expect(getPageTargeting().ab).toEqual(['MtMaster-variantName']);
-    });
-
-    it('should set Observer flag for Observer content', () => {
-        expect(getPageTargeting().ob).toEqual('t');
-    });
-
-    it('should set correct branding param for paid content', () => {
-        expect(getPageTargeting().br).toEqual('p');
-    });
-
-    it('should not contain an ad-free targeting value', () => {
-        expect(getPageTargeting().af).toBeUndefined();
-    });
-
-    it('should remove empty values', () => {
-        config.page = {};
-        config.ophan = { pageViewId: '123456' };
-        getUserSegments.mockReturnValue([]);
-
-        expect(getPageTargeting()).toEqual({
-            sens: 'f',
-            bp: 'mobile',
-            at: 'ng101',
-            si: 't',
-            skinsize: 's',
-            ab: ['MtMaster-variantName'],
-            pv: '123456',
-            fr: '0',
-            inskin: 'f',
-            pa: 'f',
-            cc: 'US',
-            rp: 'dotcom-platform',
-            dcre: 'f',
-            rdp: 'na',
-            consent_tcfv2: 'na',
-            cmp_interaction: 'na',
-        });
-    });
-
-    describe('Breakpoint targeting', () => {
-        it('should set correct breakpoint targeting for a mobile device', () => {
-            getBreakpoint.mockReturnValue('mobile');
-            expect(getPageTargeting().bp).toEqual('mobile');
-        });
-
-        it('should set correct breakpoint targeting for a medium mobile device', () => {
-            getBreakpoint.mockReturnValue('mobileMedium');
-            expect(getPageTargeting().bp).toEqual('mobile');
-        });
-
-        it('should set correct breakpoint targeting for a mobile device in landscape mode', () => {
-            getBreakpoint.mockReturnValue('mobileLandscape');
-            expect(getPageTargeting().bp).toEqual('mobile');
-        });
-
-        it('should set correct breakpoint targeting for a phablet device', () => {
-            getBreakpoint.mockReturnValue('phablet');
-            expect(getPageTargeting().bp).toEqual('tablet');
-        });
-
-        it('should set correct breakpoint targeting for a tablet device', () => {
-            getBreakpoint.mockReturnValue('tablet');
-            expect(getPageTargeting().bp).toEqual('tablet');
-        });
-
-        it('should set correct breakpoint targeting for a desktop device', () => {
-            getBreakpoint.mockReturnValue('desktop');
-            expect(getPageTargeting().bp).toEqual('desktop');
-        });
-
-        it('should set correct breakpoint targeting for a leftCol device', () => {
-            getBreakpoint.mockReturnValue('leftCol');
-            expect(getPageTargeting().bp).toEqual('desktop');
-        });
-
-        it('should set correct breakpoint targeting for a wide device', () => {
-            getBreakpoint.mockReturnValue('wide');
-            expect(getPageTargeting().bp).toEqual('desktop');
-        });
-
-
-        it('should set appNexusPageTargeting as flatten string', () => {
-            getBreakpoint.mockReturnValue('desktop');
-            getPageTargeting();
-            expect(config.get('page').appNexusPageTargeting).toEqual(
-                "sens=f,pt1=/football/series/footballweekly,pt2=us,pt3=video,pt4=ng,pt5=prince-charles-letters,pt5=uk/uk,pt5=prince-charles,pt6=5,pt7=desktop,pt9=seg1,seg2|presetOphanPageViewId|gabrielle-chan|news|"
-            );
-        });
-    });
-
-    describe('Build Page Targeting (ad-free)', () => {
-        it('should set the ad-free param to t when enabled', () => {
-            commercialFeatures.adFree = true;
-            expect(getPageTargeting().af).toBe('t');
-        });
-    });
-
-    describe('Already visited frequency', () => {
-        it('can pass a value of five or less', () => {
-            storage.local.setRaw('gu.alreadyVisited', 5);
-            expect(getPageTargeting().fr).toEqual('5');
-        });
-
-        it('between five and thirty, includes it in a bucket in the form "x-y"', () => {
-            storage.local.setRaw('gu.alreadyVisited', 18);
-            expect(getPageTargeting().fr).toEqual('16-19');
-        });
-
-        it('over thirty, includes it in the bucket "30plus"', () => {
-            storage.local.setRaw('gu.alreadyVisited', 300);
-            expect(getPageTargeting().fr).toEqual('30plus');
-        });
-
-        it('passes a value of 0 if the value is not stored', () => {
-            storage.local.remove('gu.alreadyVisited');
-            expect(getPageTargeting().fr).toEqual('0');
-        });
-    });
-
-    describe('Referrer', () => {
-        it('should set ref to Facebook', () => {
-            getReferrer.mockReturnValue(
-                'https://www.facebook.com/feel-the-force'
-            );
-            expect(getPageTargeting().ref).toEqual('facebook');
-        });
-
-        it('should set ref to Twitter', () => {
-            getReferrer.mockReturnValue(
-                'https://www.t.co/you-must-unlearn-what-you-have-learned'
-            );
-            expect(getPageTargeting().ref).toEqual('twitter');
-        });
-
-        it('should set ref to reddit', () => {
-            getReferrer.mockReturnValue(
-                'https://www.reddit.com/its-not-my-fault'
-            );
-            expect(getPageTargeting().ref).toEqual('reddit');
-        });
-
-        it('should set ref to google', () => {
-            getReferrer.mockReturnValue(
-                'https://www.google.com/i-find-your-lack-of-faith-distrubing'
-            );
-            expect(getPageTargeting().ref).toEqual('google');
-        });
-
-        it('should set ref empty string if referrer does not match', () => {
-            getReferrer.mockReturnValue('https://theguardian.com');
-            expect(getPageTargeting().ref).toEqual(undefined);
-        });
-    });
-
-    describe('URL Keywords', () => {
-        it('should return correct keywords from pageId', () => {
-            expect(getPageTargeting().urlkw).toEqual(['footballweekly']);
-        });
-
-        it('should extract multiple url keywords correctly', () => {
-            config.page.pageId =
-                'stage/2016/jul/26/harry-potter-cursed-child-review-palace-theatre-london';
-            expect(getPageTargeting().urlkw).toEqual([
-                'harry',
-                'potter',
-                'cursed',
-                'child',
-                'review',
-                'palace',
-                'theatre',
-                'london',
-            ]);
-        });
-
-        it('should get correct keywords when trailing slash is present', () => {
-            config.page.pageId =
-                'stage/2016/jul/26/harry-potter-cursed-child-review-palace-theatre-london/';
-            expect(getPageTargeting().urlkw).toEqual([
-                'harry',
-                'potter',
-                'cursed',
-                'child',
-                'review',
-                'palace',
-                'theatre',
-                'london',
-            ]);
-        });
-    });
-
-    describe('inskin targetting', () => {
-        it('should not allow inskin if cmp has not initialised', () => {
-            cmp.hasInitialised.mockReturnValue(false);
-            cmp.willShowPrivacyMessageSync.mockReturnValue(false);
-            getViewport.mockReturnValue({ width: 1920, height: 1080 });
-            expect(getPageTargeting().inskin).toBe('f');
-        });
-
-        it('should not allow inskin if cmp will show a banner', () => {
-            cmp.hasInitialised.mockReturnValue(true);
-            cmp.willShowPrivacyMessageSync.mockReturnValue(true);
-            getViewport.mockReturnValue({ width: 1920, height: 1080 });
-            expect(getPageTargeting().inskin).toBe('f');
-        });
-    });
-
-    describe('skinsize targetting', () => {
-        it.each([
-            ['s', 1280],
-            ['s', 1440],
-            ['s', 1559],
-            ['l', 1560],
-            ['l', 1561],
-            ['l', 1920],
-            ['l', 2560],
-        ])("should return '%s' if viewport width is %s", (expected, width) => {
-            cmp.hasInitialised.mockReturnValue(true);
-            cmp.willShowPrivacyMessageSync.mockReturnValue(false);
-            getViewport.mockReturnValue({ width, height: 800 });
-            expect(getPageTargeting().skinsize).toBe(expected);
-        });
-
-        it("should return 's' if vp does not have a width", () => {
-            getViewport.mockReturnValue(undefined);
-            expect(getPageTargeting().skinsize).toBe('s');
-        });
-    });
-
-    describe('ad manager group value', () => {
-        const STORAGE_KEY = 'gu.adManagerGroup';
-        it('if present in localstorage, use value from storage', () => {
-            onConsentChange.mockImplementation(tcfv2WithConsentMock);
-
-            storage.local.setRaw(STORAGE_KEY, '10');
-            expect(getPageTargeting().amtgrp).toEqual('10');
-            storage.local.remove(STORAGE_KEY);
-        });
-
-        it.each(
-            [
-                [ccpaWithConsentMock, '9'],
-                [ccpaWithoutConsentMock, '9'],
-
-                [ausWithConsentMock, '9'],
-                [ausWithoutConsentMock, '9'],
-
-                [tcfv2WithConsentMock, '9'],
-                [tcfv2WithoutConsentMock, undefined],
-                [tcfv2MixedConsentMock, undefined],
-                [tcfv2MixedConsentMock, undefined],
-            ]
-        )('Framework %p => amtgrp is %s', (framewok, value) => {
-                onConsentChange.mockImplementation(framewok);
-
-                storage.local.setRaw(STORAGE_KEY, '9');
-                expect(getPageTargeting().amtgrp).toEqual(value);
-                storage.local.remove(STORAGE_KEY);
-
-        })
-
-        it('if not present in localstorage, generate a random group 1-12, store in localstorage', () => {
-            onConsentChange.mockImplementation(tcfv2WithConsentMock);
-
-            // restore Math.random for this test so we can assert the group value range is 1-12
-            jest.spyOn(global.Math, 'random').mockRestore();
-            const valueGenerated = getPageTargeting().amtgrp;
-            expect(Number(valueGenerated)).toBeGreaterThanOrEqual(1);
-            expect(Number(valueGenerated)).toBeLessThanOrEqual(12);
-            const valueFromStorage = storage.local.getRaw(STORAGE_KEY);
-            expect(valueFromStorage).toEqual(valueGenerated);
-        });
-    });
+		_.resetPageTargeting();
+		onConsentChange.mockImplementation(tcfv2MixedConsentMock);
+		expect(getPageTargeting().pa).toBe('f');
+
+		_.resetPageTargeting();
+		onConsentChange.mockImplementation(ccpaWithConsentMock);
+		expect(getPageTargeting().pa).toBe('t');
+
+		_.resetPageTargeting();
+		onConsentChange.mockImplementation(ccpaWithoutConsentMock);
+		expect(getPageTargeting().pa).toBe('f');
+	});
+
+	it('Should correctly set the RDP flag (rdp) param', () => {
+		onConsentChange.mockImplementation(tcfWithConsentMock);
+		expect(getPageTargeting().rdp).toBe('na');
+
+		_.resetPageTargeting();
+		onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
+		expect(getPageTargeting().rdp).toBe('na');
+
+		_.resetPageTargeting();
+		onConsentChange.mockImplementation(tcfv2NullConsentMock);
+		expect(getPageTargeting().rdp).toBe('na');
+
+		_.resetPageTargeting();
+		onConsentChange.mockImplementation(tcfMixedConsentMock);
+		expect(getPageTargeting().rdp).toBe('na');
+
+		_.resetPageTargeting();
+		onConsentChange.mockImplementation(ccpaWithConsentMock);
+		expect(getPageTargeting().rdp).toBe('f');
+
+		_.resetPageTargeting();
+		onConsentChange.mockImplementation(ccpaWithoutConsentMock);
+		expect(getPageTargeting().rdp).toBe('t');
+	});
+
+	it('Should correctly set the TCFv2 (consent_tcfv2, cmp_interaction) params', () => {
+		_.resetPageTargeting();
+		getPrivacyFramework.mockReturnValue({ tcfv2: true });
+
+		onConsentChange.mockImplementation(tcfv2WithConsentMock);
+
+		expect(getPageTargeting().consent_tcfv2).toBe('t');
+		expect(getPageTargeting().cmp_interaction).toBe('useractioncomplete');
+
+		_.resetPageTargeting();
+		onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
+
+		expect(getPageTargeting().consent_tcfv2).toBe('f');
+		expect(getPageTargeting().cmp_interaction).toBe('cmpuishown');
+
+		_.resetPageTargeting();
+		onConsentChange.mockImplementation(tcfv2MixedConsentMock);
+
+		expect(getPageTargeting().consent_tcfv2).toBe('f');
+		expect(getPageTargeting().cmp_interaction).toBe('useractioncomplete');
+
+		_.resetPageTargeting();
+		getPrivacyFramework.mockReturnValue({ tcfv1: true });
+		onConsentChange.mockImplementation(tcfWithConsentMock);
+
+		expect(getPageTargeting().consent_tcfv2).toBe('na');
+		expect(getPageTargeting().cmp_interaction).toBe('na');
+	});
+
+	it('should set correct edition param', () => {
+		expect(getPageTargeting().edition).toBe('us');
+	});
+
+	it('should set correct se param', () => {
+		expect(getPageTargeting().se).toEqual(['filmweekly']);
+	});
+
+	it('should set correct k param', () => {
+		expect(getPageTargeting().k).toEqual([
+			'prince-charles-letters',
+			'uk/uk',
+			'prince-charles',
+		]);
+	});
+
+	it('should set correct ab param', () => {
+		expect(getPageTargeting().ab).toEqual(['MtMaster-variantName']);
+	});
+
+	it('should set Observer flag for Observer content', () => {
+		expect(getPageTargeting().ob).toEqual('t');
+	});
+
+	it('should set correct branding param for paid content', () => {
+		expect(getPageTargeting().br).toEqual('p');
+	});
+
+	it('should not contain an ad-free targeting value', () => {
+		expect(getPageTargeting().af).toBeUndefined();
+	});
+
+	it('should remove empty values', () => {
+		config.page = {};
+		config.ophan = { pageViewId: '123456' };
+		getUserSegments.mockReturnValue([]);
+
+		expect(getPageTargeting()).toEqual({
+			sens: 'f',
+			bp: 'mobile',
+			at: 'ng101',
+			si: 't',
+			skinsize: 's',
+			ab: ['MtMaster-variantName'],
+			pv: '123456',
+			fr: '0',
+			inskin: 'f',
+			pa: 'f',
+			cc: 'US',
+			rp: 'dotcom-platform',
+			dcre: 'f',
+			rdp: 'na',
+			consent_tcfv2: 'na',
+			cmp_interaction: 'na',
+		});
+	});
+
+	describe('Breakpoint targeting', () => {
+		it('should set correct breakpoint targeting for a mobile device', () => {
+			getBreakpoint.mockReturnValue('mobile');
+			expect(getPageTargeting().bp).toEqual('mobile');
+		});
+
+		it('should set correct breakpoint targeting for a medium mobile device', () => {
+			getBreakpoint.mockReturnValue('mobileMedium');
+			expect(getPageTargeting().bp).toEqual('mobile');
+		});
+
+		it('should set correct breakpoint targeting for a mobile device in landscape mode', () => {
+			getBreakpoint.mockReturnValue('mobileLandscape');
+			expect(getPageTargeting().bp).toEqual('mobile');
+		});
+
+		it('should set correct breakpoint targeting for a phablet device', () => {
+			getBreakpoint.mockReturnValue('phablet');
+			expect(getPageTargeting().bp).toEqual('tablet');
+		});
+
+		it('should set correct breakpoint targeting for a tablet device', () => {
+			getBreakpoint.mockReturnValue('tablet');
+			expect(getPageTargeting().bp).toEqual('tablet');
+		});
+
+		it('should set correct breakpoint targeting for a desktop device', () => {
+			getBreakpoint.mockReturnValue('desktop');
+			expect(getPageTargeting().bp).toEqual('desktop');
+		});
+
+		it('should set correct breakpoint targeting for a leftCol device', () => {
+			getBreakpoint.mockReturnValue('leftCol');
+			expect(getPageTargeting().bp).toEqual('desktop');
+		});
+
+		it('should set correct breakpoint targeting for a wide device', () => {
+			getBreakpoint.mockReturnValue('wide');
+			expect(getPageTargeting().bp).toEqual('desktop');
+		});
+
+		it('should set appNexusPageTargeting as flatten string', () => {
+			getBreakpoint.mockReturnValue('desktop');
+			getPageTargeting();
+			expect(config.get('page').appNexusPageTargeting).toEqual(
+				'sens=f,pt1=/football/series/footballweekly,pt2=us,pt3=video,pt4=ng,pt5=prince-charles-letters,pt5=uk/uk,pt5=prince-charles,pt6=5,pt7=desktop,pt9=seg1,seg2|presetOphanPageViewId|gabrielle-chan|news|',
+			);
+		});
+	});
+
+	describe('Build Page Targeting (ad-free)', () => {
+		it('should set the ad-free param to t when enabled', () => {
+			commercialFeatures.adFree = true;
+			expect(getPageTargeting().af).toBe('t');
+		});
+	});
+
+	describe('Already visited frequency', () => {
+		it('can pass a value of five or less', () => {
+			storage.local.setRaw('gu.alreadyVisited', 5);
+			expect(getPageTargeting().fr).toEqual('5');
+		});
+
+		it('between five and thirty, includes it in a bucket in the form "x-y"', () => {
+			storage.local.setRaw('gu.alreadyVisited', 18);
+			expect(getPageTargeting().fr).toEqual('16-19');
+		});
+
+		it('over thirty, includes it in the bucket "30plus"', () => {
+			storage.local.setRaw('gu.alreadyVisited', 300);
+			expect(getPageTargeting().fr).toEqual('30plus');
+		});
+
+		it('passes a value of 0 if the value is not stored', () => {
+			storage.local.remove('gu.alreadyVisited');
+			expect(getPageTargeting().fr).toEqual('0');
+		});
+	});
+
+	describe('Referrer', () => {
+		it('should set ref to Facebook', () => {
+			getReferrer.mockReturnValue(
+				'https://www.facebook.com/feel-the-force',
+			);
+			expect(getPageTargeting().ref).toEqual('facebook');
+		});
+
+		it('should set ref to Twitter', () => {
+			getReferrer.mockReturnValue(
+				'https://www.t.co/you-must-unlearn-what-you-have-learned',
+			);
+			expect(getPageTargeting().ref).toEqual('twitter');
+		});
+
+		it('should set ref to reddit', () => {
+			getReferrer.mockReturnValue(
+				'https://www.reddit.com/its-not-my-fault',
+			);
+			expect(getPageTargeting().ref).toEqual('reddit');
+		});
+
+		it('should set ref to google', () => {
+			getReferrer.mockReturnValue(
+				'https://www.google.com/i-find-your-lack-of-faith-distrubing',
+			);
+			expect(getPageTargeting().ref).toEqual('google');
+		});
+
+		it('should set ref empty string if referrer does not match', () => {
+			getReferrer.mockReturnValue('https://theguardian.com');
+			expect(getPageTargeting().ref).toEqual(undefined);
+		});
+	});
+
+	describe('URL Keywords', () => {
+		it('should return correct keywords from pageId', () => {
+			expect(getPageTargeting().urlkw).toEqual(['footballweekly']);
+		});
+
+		it('should extract multiple url keywords correctly', () => {
+			config.page.pageId =
+				'stage/2016/jul/26/harry-potter-cursed-child-review-palace-theatre-london';
+			expect(getPageTargeting().urlkw).toEqual([
+				'harry',
+				'potter',
+				'cursed',
+				'child',
+				'review',
+				'palace',
+				'theatre',
+				'london',
+			]);
+		});
+
+		it('should get correct keywords when trailing slash is present', () => {
+			config.page.pageId =
+				'stage/2016/jul/26/harry-potter-cursed-child-review-palace-theatre-london/';
+			expect(getPageTargeting().urlkw).toEqual([
+				'harry',
+				'potter',
+				'cursed',
+				'child',
+				'review',
+				'palace',
+				'theatre',
+				'london',
+			]);
+		});
+	});
+
+	describe('inskin targetting', () => {
+		it('should not allow inskin if cmp has not initialised', () => {
+			cmp.hasInitialised.mockReturnValue(false);
+			cmp.willShowPrivacyMessageSync.mockReturnValue(false);
+			getViewport.mockReturnValue({ width: 1920, height: 1080 });
+			expect(getPageTargeting().inskin).toBe('f');
+		});
+
+		it('should not allow inskin if cmp will show a banner', () => {
+			cmp.hasInitialised.mockReturnValue(true);
+			cmp.willShowPrivacyMessageSync.mockReturnValue(true);
+			getViewport.mockReturnValue({ width: 1920, height: 1080 });
+			expect(getPageTargeting().inskin).toBe('f');
+		});
+	});
+
+	describe('skinsize targetting', () => {
+		it.each([
+			['s', 1280],
+			['s', 1440],
+			['s', 1559],
+			['l', 1560],
+			['l', 1561],
+			['l', 1920],
+			['l', 2560],
+		])("should return '%s' if viewport width is %s", (expected, width) => {
+			cmp.hasInitialised.mockReturnValue(true);
+			cmp.willShowPrivacyMessageSync.mockReturnValue(false);
+			getViewport.mockReturnValue({ width, height: 800 });
+			expect(getPageTargeting().skinsize).toBe(expected);
+		});
+
+		it("should return 's' if vp does not have a width", () => {
+			getViewport.mockReturnValue(undefined);
+			expect(getPageTargeting().skinsize).toBe('s');
+		});
+	});
+
+	describe('ad manager group value', () => {
+		const STORAGE_KEY = 'gu.adManagerGroup';
+		it('if present in localstorage, use value from storage', () => {
+			onConsentChange.mockImplementation(tcfv2WithConsentMock);
+
+			storage.local.setRaw(STORAGE_KEY, '10');
+			expect(getPageTargeting().amtgrp).toEqual('10');
+			storage.local.remove(STORAGE_KEY);
+		});
+
+		it.each([
+			[ccpaWithConsentMock, '9'],
+			[ccpaWithoutConsentMock, '9'],
+
+			[ausWithConsentMock, '9'],
+			[ausWithoutConsentMock, '9'],
+
+			[tcfv2WithConsentMock, '9'],
+			[tcfv2WithoutConsentMock, undefined],
+			[tcfv2MixedConsentMock, undefined],
+			[tcfv2MixedConsentMock, undefined],
+		])('Framework %p => amtgrp is %s', (framewok, value) => {
+			onConsentChange.mockImplementation(framewok);
+
+			storage.local.setRaw(STORAGE_KEY, '9');
+			expect(getPageTargeting().amtgrp).toEqual(value);
+			storage.local.remove(STORAGE_KEY);
+		});
+
+		it('if not present in localstorage, generate a random group 1-12, store in localstorage', () => {
+			onConsentChange.mockImplementation(tcfv2WithConsentMock);
+
+			// restore Math.random for this test so we can assert the group value range is 1-12
+			jest.spyOn(global.Math, 'random').mockRestore();
+			const valueGenerated = getPageTargeting().amtgrp;
+			expect(Number(valueGenerated)).toBeGreaterThanOrEqual(1);
+			expect(Number(valueGenerated)).toBeLessThanOrEqual(12);
+			const valueFromStorage = storage.local.getRaw(STORAGE_KEY);
+			expect(valueFromStorage).toEqual(valueGenerated);
+		});
+	});
 });

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
@@ -6,125 +6,119 @@ import userPrefs from '../user-prefs';
 
 // Having a constructor means we can easily re-instantiate the object in a test
 class CommercialFeatures {
+	constructor(config = defaultConfig) {
+		// this is used for SpeedCurve tests
+		const noadsUrl = /[#&]noads(&.*)?$/.test(window.location.hash);
+		const forceAdFree = /[#&]noadsaf(&.*)?$/.test(window.location.hash);
+		const forceAds = /[?&]forceads(&.*)?$/.test(window.location.search);
+		const externalAdvertising = !noadsUrl && !userPrefs.isOff('adverts');
+		const sensitiveContent =
+			config.get('page.shouldHideAdverts') ||
+			config.get('page.section') === 'childrens-books-site';
+		const isMinuteArticle = config.get('page.isMinuteArticle');
+		const isArticle = config.get('page.contentType') === 'Article';
+		const isInteractive = config.get('page.contentType') === 'Interactive';
+		const isLiveBlog = config.get('page.isLiveBlog');
+		const isHosted = config.get('page.isHosted');
+		const isIdentityPage =
+			config.get('page.contentType') === 'Identity' ||
+			config.get('page.section') === 'identity'; // needed for pages under profile.* subdomain
+		const switches = config.get('switches');
+		const isWidePage = getBreakpoint() === 'wide';
+		const supportsSticky =
+			document.documentElement &&
+			document.documentElement.classList.contains('has-sticky');
+		const newRecipeDesign =
+			config.get('page.showNewRecipeDesign') &&
+			config.get('tests.abNewRecipeDesign');
 
+		this.isSecureContact = [
+			'help/ng-interactive/2017/mar/17/contact-the-guardian-securely',
+			'help/2016/sep/19/how-to-contact-the-guardian-securely',
+		].includes(config.get('page.pageId', ''));
 
-    constructor(config = defaultConfig) {
-        // this is used for SpeedCurve tests
-        const noadsUrl = /[#&]noads(&.*)?$/.test(window.location.hash);
-        const forceAdFree = /[#&]noadsaf(&.*)?$/.test(
-            window.location.hash
-        );
-        const forceAds = /[?&]forceads(&.*)?$/.test(
-            window.location.search
-        );
-        const externalAdvertising = !noadsUrl && !userPrefs.isOff('adverts');
-        const sensitiveContent =
-            config.get('page.shouldHideAdverts') ||
-            config.get('page.section') === 'childrens-books-site';
-        const isMinuteArticle = config.get('page.isMinuteArticle');
-        const isArticle = config.get('page.contentType') === 'Article';
-        const isInteractive = config.get('page.contentType') === 'Interactive';
-        const isLiveBlog = config.get('page.isLiveBlog');
-        const isHosted = config.get('page.isHosted');
-        const isIdentityPage =
-            config.get('page.contentType') === 'Identity' ||
-            config.get('page.section') === 'identity'; // needed for pages under profile.* subdomain
-        const switches = config.get('switches');
-        const isWidePage = getBreakpoint() === 'wide';
-        const supportsSticky =
-            document.documentElement &&
-            document.documentElement.classList.contains('has-sticky');
-        const newRecipeDesign =
-            config.get('page.showNewRecipeDesign') &&
-            config.get('tests.abNewRecipeDesign');
+		// Feature switches
+		this.adFree = !!forceAdFree || isAdFreeUser();
 
-        this.isSecureContact = [
-            'help/ng-interactive/2017/mar/17/contact-the-guardian-securely',
-            'help/2016/sep/19/how-to-contact-the-guardian-securely',
-        ].includes(config.get('page.pageId', ''));
+		this.dfpAdvertising =
+			forceAds ||
+			(switches.commercial &&
+				externalAdvertising &&
+				!sensitiveContent &&
+				!isIdentityPage &&
+				!this.adFree);
 
-        // Feature switches
-        this.adFree = !!forceAdFree || isAdFreeUser();
+		this.stickyTopBannerAd =
+			!this.adFree &&
+			!config.get('page.disableStickyTopBanner') &&
+			!supportsSticky;
 
-        this.dfpAdvertising =
-            forceAds ||
-            (switches.commercial &&
-                externalAdvertising &&
-                !sensitiveContent &&
-                !isIdentityPage &&
-                !this.adFree);
+		this.articleBodyAdverts =
+			this.dfpAdvertising &&
+			!this.adFree &&
+			!isMinuteArticle &&
+			isArticle &&
+			!isLiveBlog &&
+			!isHosted &&
+			!newRecipeDesign;
 
-        this.stickyTopBannerAd =
-            !this.adFree &&
-            !config.get('page.disableStickyTopBanner') &&
-            !supportsSticky;
+		this.carrotTrafficDriver =
+			!this.adFree &&
+			this.articleBodyAdverts &&
+			config.get('switches.carrotTrafficDriver', false) &&
+			!config.get('page.isPaidContent');
 
-        this.articleBodyAdverts =
-            this.dfpAdvertising &&
-            !this.adFree &&
-            !isMinuteArticle &&
-            isArticle &&
-            !isLiveBlog &&
-            !isHosted &&
-            !newRecipeDesign;
+		this.highMerch =
+			this.dfpAdvertising &&
+			!this.adFree &&
+			!isMinuteArticle &&
+			!isHosted &&
+			!isInteractive &&
+			!config.get('page.isFront') &&
+			!config.get('isDotcomRendering', false) &&
+			!newRecipeDesign;
 
-        this.carrotTrafficDriver =
-            !this.adFree &&
-            this.articleBodyAdverts &&
-            config.get('switches.carrotTrafficDriver', false) &&
-            !config.get('page.isPaidContent');
+		this.thirdPartyTags =
+			!this.adFree &&
+			externalAdvertising &&
+			!isIdentityPage &&
+			!this.isSecureContact;
 
-        this.highMerch =
-            this.dfpAdvertising &&
-            !this.adFree &&
-            !isMinuteArticle &&
-            !isHosted &&
-            !isInteractive &&
-            !config.get('page.isFront') &&
-            !config.get('isDotcomRendering', false) &&
-            !newRecipeDesign;
+		this.launchpad =
+			!this.adFree &&
+			externalAdvertising &&
+			!isIdentityPage &&
+			!this.isSecureContact &&
+			config.get('switches.redplanetForAus', false);
 
-        this.thirdPartyTags =
-            !this.adFree &&
-            externalAdvertising &&
-            !isIdentityPage &&
-            !this.isSecureContact;
+		this.relatedWidgetEnabled =
+			this.dfpAdvertising &&
+			!this.adFree &&
+			!noadsUrl &&
+			!sensitiveContent &&
+			isArticle &&
+			!config.get('page.isPreview') &&
+			config.get('page.showRelatedContent') &&
+			!(isUserLoggedIn() && config.get('page.commentable'));
 
-        this.launchpad =
-            !this.adFree &&
-            externalAdvertising &&
-            !isIdentityPage &&
-            !this.isSecureContact &&
-            config.get('switches.redplanetForAus', false);
+		this.commentAdverts =
+			this.dfpAdvertising &&
+			!this.adFree &&
+			!isMinuteArticle &&
+			config.get('switches.enableDiscussionSwitch') &&
+			config.get('page.commentable') &&
+			(!isLiveBlog || isWidePage);
 
-        this.relatedWidgetEnabled =
-            this.dfpAdvertising &&
-            !this.adFree &&
-            !noadsUrl &&
-            !sensitiveContent &&
-            isArticle &&
-            !config.get('page.isPreview') &&
-            config.get('page.showRelatedContent') &&
-            !(isUserLoggedIn() && config.get('page.commentable'));
+		this.liveblogAdverts =
+			isLiveBlog && this.dfpAdvertising && !this.adFree;
 
-        this.commentAdverts =
-            this.dfpAdvertising &&
-            !this.adFree &&
-            !isMinuteArticle &&
-            config.get('switches.enableDiscussionSwitch') &&
-            config.get('page.commentable') &&
-            (!isLiveBlog || isWidePage);
+		this.paidforBand = config.get('page.isPaidContent') && !supportsSticky;
 
-        this.liveblogAdverts =
-            isLiveBlog && this.dfpAdvertising && !this.adFree;
-
-        this.paidforBand = config.get('page.isPaidContent') && !supportsSticky;
-
-        this.comscore =
-            config.get('switches.comscore', false) &&
-            !isIdentityPage &&
-            !this.isSecureContact;
-    }
+		this.comscore =
+			config.get('switches.comscore', false) &&
+			!isIdentityPage &&
+			!this.isSecureContact;
+	}
 }
 
 export const commercialFeatures = new CommercialFeatures();

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.spec.js
@@ -4,402 +4,402 @@ import userPrefs from '../user-prefs';
 import { getBreakpoint as getBreakpoint_ } from '../../../../lib/detect';
 import { isUserLoggedIn as isUserLoggedIn_ } from '../identity/api';
 import {
-    isPayingMember as isPayingMember_,
-    isRecentOneOffContributor as isRecentOneOffContributor_,
-    shouldHideSupportMessaging as shouldHideSupportMessaging_,
-    isAdFreeUser as isAdFreeUser_,
+	isPayingMember as isPayingMember_,
+	isRecentOneOffContributor as isRecentOneOffContributor_,
+	shouldHideSupportMessaging as shouldHideSupportMessaging_,
+	isAdFreeUser as isAdFreeUser_,
 } from './user-features';
 
-const isPayingMember = (isPayingMember_);
-const isRecentOneOffContributor = (isRecentOneOffContributor_);
-const shouldHideSupportMessaging = (shouldHideSupportMessaging_);
-const isAdFreeUser = (isAdFreeUser_);
+const isPayingMember = isPayingMember_;
+const isRecentOneOffContributor = isRecentOneOffContributor_;
+const shouldHideSupportMessaging = shouldHideSupportMessaging_;
+const isAdFreeUser = isAdFreeUser_;
 const getBreakpoint = getBreakpoint_;
 const isUserLoggedIn = isUserLoggedIn_;
 
 const CommercialFeatures = commercialFeatures.constructor;
 
 jest.mock('./user-features', () => ({
-    isPayingMember: jest.fn(),
-    isRecentOneOffContributor: jest.fn(),
-    shouldHideSupportMessaging: jest.fn(),
-    isAdFreeUser: jest.fn(),
+	isPayingMember: jest.fn(),
+	isRecentOneOffContributor: jest.fn(),
+	shouldHideSupportMessaging: jest.fn(),
+	isAdFreeUser: jest.fn(),
 }));
 
 jest.mock('../../../../lib/detect', () => ({
-    getBreakpoint: jest.fn(),
+	getBreakpoint: jest.fn(),
 }));
 
 jest.mock('../identity/api', () => ({
-    isUserLoggedIn: jest.fn(),
+	isUserLoggedIn: jest.fn(),
 }));
 
 describe('Commercial features', () => {
-    beforeEach(() => {
-        jest.resetAllMocks();
+	beforeEach(() => {
+		jest.resetAllMocks();
 
-        // Set up a happy path by default
-        config.set('page', {
-            contentType: 'Article',
-            isMinuteArticle: false,
-            section: 'politics',
-            pageId: 'politics-article',
-            shouldHideAdverts: false,
-            shouldHideReaderRevenue: false,
-            isFront: false,
-            showRelatedContent: true,
-        });
+		// Set up a happy path by default
+		config.set('page', {
+			contentType: 'Article',
+			isMinuteArticle: false,
+			section: 'politics',
+			pageId: 'politics-article',
+			shouldHideAdverts: false,
+			shouldHideReaderRevenue: false,
+			isFront: false,
+			showRelatedContent: true,
+		});
 
-        config.set('switches', {
-            commercial: true,
-            enableDiscussionSwitch: true,
-        });
+		config.set('switches', {
+			commercial: true,
+			enableDiscussionSwitch: true,
+		});
 
-        window.location.hash = '';
+		window.location.hash = '';
 
-        userPrefs.removeSwitch('adverts');
+		userPrefs.removeSwitch('adverts');
 
-        getBreakpoint.mockReturnValue('desktop');
-        isPayingMember.mockReturnValue(false);
-        isRecentOneOffContributor.mockReturnValue(false);
-        shouldHideSupportMessaging.mockReturnValue(false);
-        isAdFreeUser.mockReturnValue(false);
-        isUserLoggedIn.mockReturnValue(true);
+		getBreakpoint.mockReturnValue('desktop');
+		isPayingMember.mockReturnValue(false);
+		isRecentOneOffContributor.mockReturnValue(false);
+		shouldHideSupportMessaging.mockReturnValue(false);
+		isAdFreeUser.mockReturnValue(false);
+		isUserLoggedIn.mockReturnValue(true);
 
-        expect.hasAssertions();
-    });
+		expect.hasAssertions();
+	});
 
-    describe('DFP advertising', () => {
-        it('Runs by default', () => {
-            const features = new CommercialFeatures();
-            expect(features.dfpAdvertising).toBe(true);
-        });
+	describe('DFP advertising', () => {
+		it('Runs by default', () => {
+			const features = new CommercialFeatures();
+			expect(features.dfpAdvertising).toBe(true);
+		});
 
-        it('Is disabled on sensitive pages', () => {
-            // Like all newspapers, the Guardian must sometimes cover disturbing and graphic content.
-            // Showing adverts on these pages would be crass - callous, even.
-            config.set('page.shouldHideAdverts', true);
-            const features = new CommercialFeatures();
-            expect(features.dfpAdvertising).toBe(false);
-        });
+		it('Is disabled on sensitive pages', () => {
+			// Like all newspapers, the Guardian must sometimes cover disturbing and graphic content.
+			// Showing adverts on these pages would be crass - callous, even.
+			config.set('page.shouldHideAdverts', true);
+			const features = new CommercialFeatures();
+			expect(features.dfpAdvertising).toBe(false);
+		});
 
-        it('Is disabled on the children`s book site', () => {
-            // ASA guidelines prohibit us from showing adverts on anything that might be deemed childrens' content
-            config.set('page.section', 'childrens-books-site');
-            const features = new CommercialFeatures();
-            expect(features.dfpAdvertising).toBe(false);
-        });
+		it('Is disabled on the children`s book site', () => {
+			// ASA guidelines prohibit us from showing adverts on anything that might be deemed childrens' content
+			config.set('page.section', 'childrens-books-site');
+			const features = new CommercialFeatures();
+			expect(features.dfpAdvertising).toBe(false);
+		});
 
-        it('Is skipped for speedcurve tests', () => {
-            // We don't want external dependencies getting in the way of perf tests
-            window.location.hash = '#noads';
-            const features = new CommercialFeatures();
-            expect(features.dfpAdvertising).toBe(false);
-        });
+		it('Is skipped for speedcurve tests', () => {
+			// We don't want external dependencies getting in the way of perf tests
+			window.location.hash = '#noads';
+			const features = new CommercialFeatures();
+			expect(features.dfpAdvertising).toBe(false);
+		});
 
-        it('Is disabled for speedcurve tests in ad-free mode', () => {
-            window.location.hash = '#noadsaf';
-            const features = new CommercialFeatures();
-            expect(features.adFree).toBe(true);
-            expect(features.dfpAdvertising).toBe(false);
-        });
-    });
+		it('Is disabled for speedcurve tests in ad-free mode', () => {
+			window.location.hash = '#noadsaf';
+			const features = new CommercialFeatures();
+			expect(features.adFree).toBe(true);
+			expect(features.dfpAdvertising).toBe(false);
+		});
+	});
 
-    describe('Article body adverts', () => {
-        it('Runs by default', () => {
-            const features = new CommercialFeatures();
-            expect(features.articleBodyAdverts).toBe(true);
-        });
+	describe('Article body adverts', () => {
+		it('Runs by default', () => {
+			const features = new CommercialFeatures();
+			expect(features.articleBodyAdverts).toBe(true);
+		});
 
-        it('Doesn`t run in minute articles', () => {
-            config.set('page.isMinuteArticle', true);
-            const features = new CommercialFeatures();
-            expect(features.articleBodyAdverts).toBe(false);
-        });
+		it('Doesn`t run in minute articles', () => {
+			config.set('page.isMinuteArticle', true);
+			const features = new CommercialFeatures();
+			expect(features.articleBodyAdverts).toBe(false);
+		});
 
-        it('Doesn`t run in non-article pages', () => {
-            config.set('page.contentType', 'Network Front');
-            const features = new CommercialFeatures();
-            expect(features.articleBodyAdverts).toBe(false);
-        });
+		it('Doesn`t run in non-article pages', () => {
+			config.set('page.contentType', 'Network Front');
+			const features = new CommercialFeatures();
+			expect(features.articleBodyAdverts).toBe(false);
+		});
 
-        it('Doesn`t run in live blogs', () => {
-            config.set('page.isLiveBlog', true);
-            const features = new CommercialFeatures();
-            expect(features.articleBodyAdverts).toBe(false);
-        });
-    });
+		it('Doesn`t run in live blogs', () => {
+			config.set('page.isLiveBlog', true);
+			const features = new CommercialFeatures();
+			expect(features.articleBodyAdverts).toBe(false);
+		});
+	});
 
-    describe('Article body adverts under ad-free', () => {
-        // LOL grammar
-        it('are disabled', () => {
-            isAdFreeUser.mockReturnValue(true);
-            const features = new CommercialFeatures();
-            expect(features.articleBodyAdverts).toBe(false);
-        });
-    });
+	describe('Article body adverts under ad-free', () => {
+		// LOL grammar
+		it('are disabled', () => {
+			isAdFreeUser.mockReturnValue(true);
+			const features = new CommercialFeatures();
+			expect(features.articleBodyAdverts).toBe(false);
+		});
+	});
 
-    describe('High-relevance commercial component', () => {
-        it('Does not run on fronts', () => {
-            config.set('page.isFront', true);
-            const features = new CommercialFeatures();
-            expect(features.highMerch).toBe(false);
-        });
+	describe('High-relevance commercial component', () => {
+		it('Does not run on fronts', () => {
+			config.set('page.isFront', true);
+			const features = new CommercialFeatures();
+			expect(features.highMerch).toBe(false);
+		});
 
-        it('Does run on outside of fronts', () => {
-            config.set('page.isFront', false);
-            const features = new CommercialFeatures();
-            expect(features.highMerch).toBe(true);
-        });
+		it('Does run on outside of fronts', () => {
+			config.set('page.isFront', false);
+			const features = new CommercialFeatures();
+			expect(features.highMerch).toBe(true);
+		});
 
-        it('Does not run on minute articles', () => {
-            config.set('page.isMinuteArticle', true);
-            const features = new CommercialFeatures();
-            expect(features.highMerch).toBe(false);
-        });
-    });
+		it('Does not run on minute articles', () => {
+			config.set('page.isMinuteArticle', true);
+			const features = new CommercialFeatures();
+			expect(features.highMerch).toBe(false);
+		});
+	});
 
-    describe('High-relevance commercial component under ad-free', () => {
-        beforeEach(() => {
-            isAdFreeUser.mockReturnValue(true);
-        });
+	describe('High-relevance commercial component under ad-free', () => {
+		beforeEach(() => {
+			isAdFreeUser.mockReturnValue(true);
+		});
 
-        it('Does not run on fronts', () => {
-            config.set('page.isFront', true);
-            const features = new CommercialFeatures();
-            expect(features.highMerch).toBe(false);
-        });
+		it('Does not run on fronts', () => {
+			config.set('page.isFront', true);
+			const features = new CommercialFeatures();
+			expect(features.highMerch).toBe(false);
+		});
 
-        it('Does not run outside of fronts', () => {
-            config.set('page.isFront', false);
-            const features = new CommercialFeatures();
-            expect(features.highMerch).toBe(false);
-        });
+		it('Does not run outside of fronts', () => {
+			config.set('page.isFront', false);
+			const features = new CommercialFeatures();
+			expect(features.highMerch).toBe(false);
+		});
 
-        it('Does not run on minute articles', () => {
-            config.set('page.isMinuteArticle', true);
-            const features = new CommercialFeatures();
-            expect(features.highMerch).toBe(false);
-        });
-    });
+		it('Does not run on minute articles', () => {
+			config.set('page.isMinuteArticle', true);
+			const features = new CommercialFeatures();
+			expect(features.highMerch).toBe(false);
+		});
+	});
 
-    describe('Third party tags', () => {
-        it('Runs by default', () => {
-            const features = new CommercialFeatures();
-            expect(features.thirdPartyTags).toBe(true);
-        });
+	describe('Third party tags', () => {
+		it('Runs by default', () => {
+			const features = new CommercialFeatures();
+			expect(features.thirdPartyTags).toBe(true);
+		});
 
-        it('Does not run on identity pages', () => {
-            config.set('page.contentType', 'Identity');
-            const features = new CommercialFeatures();
-            expect(features.thirdPartyTags).toBe(false);
-        });
+		it('Does not run on identity pages', () => {
+			config.set('page.contentType', 'Identity');
+			const features = new CommercialFeatures();
+			expect(features.thirdPartyTags).toBe(false);
+		});
 
-        it('Does not run on identity section', () => {
-            // This is needed for identity pages in the profile subdomain
-            config.set('page.section', 'identity');
-            const features = new CommercialFeatures();
-            expect(features.thirdPartyTags).toBe(false);
-        });
+		it('Does not run on identity section', () => {
+			// This is needed for identity pages in the profile subdomain
+			config.set('page.section', 'identity');
+			const features = new CommercialFeatures();
+			expect(features.thirdPartyTags).toBe(false);
+		});
 
-        it('Does not run on the secure contact interactive', () => {
-            config.set(
-                'page.pageId',
-                'help/ng-interactive/2017/mar/17/contact-the-guardian-securely'
-            );
+		it('Does not run on the secure contact interactive', () => {
+			config.set(
+				'page.pageId',
+				'help/ng-interactive/2017/mar/17/contact-the-guardian-securely',
+			);
 
-            const features = new CommercialFeatures();
-            expect(features.thirdPartyTags).toBe(false);
-        });
+			const features = new CommercialFeatures();
+			expect(features.thirdPartyTags).toBe(false);
+		});
 
-        it('Does not run on secure contact help page', () => {
-            config.set(
-                'page.pageId',
-                'help/2016/sep/19/how-to-contact-the-guardian-securely'
-            );
+		it('Does not run on secure contact help page', () => {
+			config.set(
+				'page.pageId',
+				'help/2016/sep/19/how-to-contact-the-guardian-securely',
+			);
 
-            const features = new CommercialFeatures();
-            expect(features.thirdPartyTags).toBe(false);
-        });
-    });
+			const features = new CommercialFeatures();
+			expect(features.thirdPartyTags).toBe(false);
+		});
+	});
 
-    describe('Third party tags under ad-free', () => {
-        beforeEach(() => {
-            isAdFreeUser.mockReturnValue(true);
-        });
+	describe('Third party tags under ad-free', () => {
+		beforeEach(() => {
+			isAdFreeUser.mockReturnValue(true);
+		});
 
-        it('Does not run by default', () => {
-            const features = new CommercialFeatures();
-            expect(features.thirdPartyTags).toBe(false);
-        });
+		it('Does not run by default', () => {
+			const features = new CommercialFeatures();
+			expect(features.thirdPartyTags).toBe(false);
+		});
 
-        it('Does not run on identity pages', () => {
-            config.set('page.contentType', 'Identity');
-            const features = new CommercialFeatures();
-            expect(features.thirdPartyTags).toBe(false);
-        });
+		it('Does not run on identity pages', () => {
+			config.set('page.contentType', 'Identity');
+			const features = new CommercialFeatures();
+			expect(features.thirdPartyTags).toBe(false);
+		});
 
-        it('Does not run on identity section', () => {
-            // This is needed for identity pages in the profile subdomain
-            config.set('page.section', 'identity');
-            const features = new CommercialFeatures();
-            expect(features.thirdPartyTags).toBe(false);
-        });
+		it('Does not run on identity section', () => {
+			// This is needed for identity pages in the profile subdomain
+			config.set('page.section', 'identity');
+			const features = new CommercialFeatures();
+			expect(features.thirdPartyTags).toBe(false);
+		});
 
-        it('Does not run on secure contact pages', () => {
-            config.set(
-                'page.pageId',
-                'help/ng-interactive/2017/mar/17/contact-the-guardian-securely'
-            );
+		it('Does not run on secure contact pages', () => {
+			config.set(
+				'page.pageId',
+				'help/ng-interactive/2017/mar/17/contact-the-guardian-securely',
+			);
 
-            const features = new CommercialFeatures();
-            expect(features.thirdPartyTags).toBe(false);
-        });
-    });
+			const features = new CommercialFeatures();
+			expect(features.thirdPartyTags).toBe(false);
+		});
+	});
 
-    describe('Comment adverts', () => {
-        beforeEach(() => {
-            config.set('page.commentable', true);
-            isUserLoggedIn.mockReturnValue(true);
-        });
+	describe('Comment adverts', () => {
+		beforeEach(() => {
+			config.set('page.commentable', true);
+			isUserLoggedIn.mockReturnValue(true);
+		});
 
-        it('Displays when page has comments', () => {
-            const features = new CommercialFeatures();
-            expect(features.commentAdverts).toBe(true);
-        });
+		it('Displays when page has comments', () => {
+			const features = new CommercialFeatures();
+			expect(features.commentAdverts).toBe(true);
+		});
 
-        it('Will also display when the user is not logged in', () => {
-            isUserLoggedIn.mockReturnValue(false);
-            const features = new CommercialFeatures();
-            expect(features.commentAdverts).toBe(true);
-        });
+		it('Will also display when the user is not logged in', () => {
+			isUserLoggedIn.mockReturnValue(false);
+			const features = new CommercialFeatures();
+			expect(features.commentAdverts).toBe(true);
+		});
 
-        it('Does not display on minute articles', () => {
-            config.set('page.isMinuteArticle', true);
-            const features = new CommercialFeatures();
-            expect(features.commentAdverts).toBe(false);
-        });
+		it('Does not display on minute articles', () => {
+			config.set('page.isMinuteArticle', true);
+			const features = new CommercialFeatures();
+			expect(features.commentAdverts).toBe(false);
+		});
 
-        it('Short circuits when no comments to add adverts to', () => {
-            config.set('page.commentable', false);
-            const features = new CommercialFeatures();
-            expect(features.commentAdverts).toBe(false);
-        });
+		it('Short circuits when no comments to add adverts to', () => {
+			config.set('page.commentable', false);
+			const features = new CommercialFeatures();
+			expect(features.commentAdverts).toBe(false);
+		});
 
-        describe('If live blog', () => {
-            beforeEach(() => {
-                config.set('page.isLiveBlog', true);
-            });
+		describe('If live blog', () => {
+			beforeEach(() => {
+				config.set('page.isLiveBlog', true);
+			});
 
-            it('Appears if page is wide', () => {
-                getBreakpoint.mockReturnValue('wide');
-                const features = new CommercialFeatures();
-                expect(features.commentAdverts).toBe(true);
-            });
+			it('Appears if page is wide', () => {
+				getBreakpoint.mockReturnValue('wide');
+				const features = new CommercialFeatures();
+				expect(features.commentAdverts).toBe(true);
+			});
 
-            it('Does not appear if page is not wide', () => {
-                getBreakpoint.mockReturnValue('desktop');
-                const features = new CommercialFeatures();
-                expect(features.commentAdverts).toBe(false);
-            });
-        });
-    });
+			it('Does not appear if page is not wide', () => {
+				getBreakpoint.mockReturnValue('desktop');
+				const features = new CommercialFeatures();
+				expect(features.commentAdverts).toBe(false);
+			});
+		});
+	});
 
-    describe('Comment adverts under ad-free', () => {
-        beforeEach(() => {
-            config.set('page.commentable', true);
-            isAdFreeUser.mockReturnValue(true);
-        });
+	describe('Comment adverts under ad-free', () => {
+		beforeEach(() => {
+			config.set('page.commentable', true);
+			isAdFreeUser.mockReturnValue(true);
+		});
 
-        it('Does not display when page has comments', () => {
-            const features = new CommercialFeatures();
-            expect(features.commentAdverts).toBe(false);
-        });
+		it('Does not display when page has comments', () => {
+			const features = new CommercialFeatures();
+			expect(features.commentAdverts).toBe(false);
+		});
 
-        it('Does not display on minute articles', () => {
-            config.set('page.isMinuteArticle', true);
-            const features = new CommercialFeatures();
-            expect(features.commentAdverts).toBe(false);
-        });
+		it('Does not display on minute articles', () => {
+			config.set('page.isMinuteArticle', true);
+			const features = new CommercialFeatures();
+			expect(features.commentAdverts).toBe(false);
+		});
 
-        it('Does not appear when user signed out', () => {
-            isUserLoggedIn.mockReturnValue(false);
-            const features = new CommercialFeatures();
-            expect(features.commentAdverts).toBe(false);
-        });
+		it('Does not appear when user signed out', () => {
+			isUserLoggedIn.mockReturnValue(false);
+			const features = new CommercialFeatures();
+			expect(features.commentAdverts).toBe(false);
+		});
 
-        it('Short circuits when no comments to add adverts to', () => {
-            config.set('page.commentable', false);
-            const features = new CommercialFeatures();
-            expect(features.commentAdverts).toBe(false);
-        });
+		it('Short circuits when no comments to add adverts to', () => {
+			config.set('page.commentable', false);
+			const features = new CommercialFeatures();
+			expect(features.commentAdverts).toBe(false);
+		});
 
-        describe('If live blog', () => {
-            beforeEach(() => {
-                config.set('page.isLiveBlog', true);
-            });
+		describe('If live blog', () => {
+			beforeEach(() => {
+				config.set('page.isLiveBlog', true);
+			});
 
-            it('Does not appear if page is wide', () => {
-                getBreakpoint.mockReturnValue('wide');
-                const features = new CommercialFeatures();
-                expect(features.commentAdverts).toBe(false);
-            });
+			it('Does not appear if page is wide', () => {
+				getBreakpoint.mockReturnValue('wide');
+				const features = new CommercialFeatures();
+				expect(features.commentAdverts).toBe(false);
+			});
 
-            it('Does not appear if page is not wide', () => {
-                getBreakpoint.mockReturnValue('desktop');
-                const features = new CommercialFeatures();
-                expect(features.commentAdverts).toBe(false);
-            });
-        });
-    });
+			it('Does not appear if page is not wide', () => {
+				getBreakpoint.mockReturnValue('desktop');
+				const features = new CommercialFeatures();
+				expect(features.commentAdverts).toBe(false);
+			});
+		});
+	});
 
-    describe('comscore ', () => {
-        beforeEach(() => {
-            config.set('switches.comscore', true);
-        });
+	describe('comscore ', () => {
+		beforeEach(() => {
+			config.set('switches.comscore', true);
+		});
 
-        it('Runs if switch is on', () => {
-            const features = new CommercialFeatures();
-            expect(features.comscore).toBe(true);
-        });
+		it('Runs if switch is on', () => {
+			const features = new CommercialFeatures();
+			expect(features.comscore).toBe(true);
+		});
 
-        it('Does not run if switch is off', () => {
-            config.set('switches.comscore', false);
-            const features = new CommercialFeatures();
-            expect(features.comscore).toBe(false);
-        });
+		it('Does not run if switch is off', () => {
+			config.set('switches.comscore', false);
+			const features = new CommercialFeatures();
+			expect(features.comscore).toBe(false);
+		});
 
-        it('Does not run on identity pages', () => {
-            config.set('page.contentType', 'Identity');
-            const features = new CommercialFeatures();
-            expect(features.comscore).toBe(false);
-        });
+		it('Does not run on identity pages', () => {
+			config.set('page.contentType', 'Identity');
+			const features = new CommercialFeatures();
+			expect(features.comscore).toBe(false);
+		});
 
-        it('Does not run on identity section', () => {
-            // This is needed for identity pages in the profile subdomain
-            config.set('page.section', 'identity');
-            const features = new CommercialFeatures();
-            expect(features.comscore).toBe(false);
-        });
+		it('Does not run on identity section', () => {
+			// This is needed for identity pages in the profile subdomain
+			config.set('page.section', 'identity');
+			const features = new CommercialFeatures();
+			expect(features.comscore).toBe(false);
+		});
 
-        it('Does not run on the secure contact interactive', () => {
-            config.set(
-                'page.pageId',
-                'help/ng-interactive/2017/mar/17/contact-the-guardian-securely'
-            );
+		it('Does not run on the secure contact interactive', () => {
+			config.set(
+				'page.pageId',
+				'help/ng-interactive/2017/mar/17/contact-the-guardian-securely',
+			);
 
-            const features = new CommercialFeatures();
-            expect(features.comscore).toBe(false);
-        });
+			const features = new CommercialFeatures();
+			expect(features.comscore).toBe(false);
+		});
 
-        it('Does not run on secure contact help page', () => {
-            config.set(
-                'page.pageId',
-                'help/2016/sep/19/how-to-contact-the-guardian-securely'
-            );
+		it('Does not run on secure contact help page', () => {
+			config.set(
+				'page.pageId',
+				'help/2016/sep/19/how-to-contact-the-guardian-securely',
+			);
 
-            const features = new CommercialFeatures();
-            expect(features.comscore).toBe(false);
-        });
-    });
+			const features = new CommercialFeatures();
+			expect(features.comscore).toBe(false);
+		});
+	});
 });

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-liveblog-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-liveblog-utilities.js
@@ -2,28 +2,25 @@ import { mountDynamic } from '@guardian/automat-modules';
 import $ from '../../../../lib/$';
 
 const getBlockToInsertEpicAfter = () => {
-    const blocks = document.getElementsByClassName('block');
-    const epicsAlreadyOnPage = document.getElementsByClassName('is-epic');
+	const blocks = document.getElementsByClassName('block');
+	const epicsAlreadyOnPage = document.getElementsByClassName('is-epic');
 
-    const isLiveblogLongEnoughYet = blocks.length > 4;
+	const isLiveblogLongEnoughYet = blocks.length > 4;
 
-    if (epicsAlreadyOnPage.length < 1 && isLiveblogLongEnoughYet) {
-        const autoBlockNum = Math.floor(Math.random() * 3);
-        return blocks[autoBlockNum];
-    }
+	if (epicsAlreadyOnPage.length < 1 && isLiveblogLongEnoughYet) {
+		const autoBlockNum = Math.floor(Math.random() * 3);
+		return blocks[autoBlockNum];
+	}
 };
 
-export const setupRemoteEpicInLiveblog = (
-    Component,
-    props,
-) => {
-    const block = getBlockToInsertEpicAfter();
-    // Only insert 1 epic. The existing code will be cleaned up in a follow-up PR
-    if (block) {
-        const epic = $.create('<div class="block"/>');
-        epic.insertAfter(block);
-        mountDynamic(epic[0], Component, props, true);
+export const setupRemoteEpicInLiveblog = (Component, props) => {
+	const block = getBlockToInsertEpicAfter();
+	// Only insert 1 epic. The existing code will be cleaned up in a follow-up PR
+	if (block) {
+		const epic = $.create('<div class="block"/>');
+		epic.insertAfter(block);
+		mountDynamic(epic[0], Component, props, true);
 
-        return epic[0];
-    }
+		return epic[0];
+	}
 };

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -1,7 +1,7 @@
 import {
-    getEpicMeta,
-    getViewLog,
-    getWeeklyArticleHistory,
+	getEpicMeta,
+	getViewLog,
+	getWeeklyArticleHistory,
 } from '@guardian/automat-contributions';
 import { mountDynamic } from '@guardian/automat-modules';
 import { onConsentChange } from '@guardian/consent-management-platform';
@@ -18,16 +18,16 @@ import { getMvtValue } from '../analytics/mvt-cookie';
 import { submitComponentEvent, submitViewEvent } from './acquisitions-ophan';
 import { setupRemoteEpicInLiveblog } from './contributions-liveblog-utilities';
 import {
-    getVisitCount,
-    setupOphanView,
-    submitOphanInsert,
+	getVisitCount,
+	setupOphanView,
+	submitOphanInsert,
 } from './contributions-utilities';
 import {
-    ARTICLES_VIEWED_OPT_OUT_COOKIE,
-    getLastOneOffContributionTimestamp,
-    getLastOneOffContributionDate,
-    isRecurringContributor,
-    shouldHideSupportMessaging,
+	ARTICLES_VIEWED_OPT_OUT_COOKIE,
+	getLastOneOffContributionTimestamp,
+	getLastOneOffContributionDate,
+	isRecurringContributor,
+	shouldHideSupportMessaging,
 } from './user-features';
 
 // See https://github.com/guardian/support-dotcom-components/blob/main/module-versions.md
@@ -35,500 +35,558 @@ export const ModulesVersion = 'v2';
 
 const isHosted = config.get('page.isHosted');
 
-const buildKeywordTags = page => {
-    const keywordIds = page.keywordIds.split(',');
-    const keywords = page.keywords.split(',');
-    return keywordIds.map((id, idx) => ({
-        id,
-        type: 'Keyword',
-        title: keywords[idx],
-    }));
+const buildKeywordTags = (page) => {
+	const keywordIds = page.keywordIds.split(',');
+	const keywords = page.keywords.split(',');
+	return keywordIds.map((id, idx) => ({
+		id,
+		type: 'Keyword',
+		title: keywords[idx],
+	}));
 };
-const buildSeriesTag = page => ({
-    id: page.seriesId,
-    type: 'Series',
-    title: page.series,
+const buildSeriesTag = (page) => ({
+	id: page.seriesId,
+	type: 'Series',
+	title: page.series,
 });
 
 const epicEl = () => {
-    const target = document.querySelector(
-        '.submeta'
-    );
-    if (!target) {
-        throw new Error(
-            'Could not find target element for Epic'
-        );
-    }
+	const target = document.querySelector('.submeta');
+	if (!target) {
+		throw new Error('Could not find target element for Epic');
+	}
 
-    const parent = target.parentNode;
-    if (!parent) {
-        throw new Error(
-            'Could not find parent element for Epic'
-        );
-    }
+	const parent = target.parentNode;
+	if (!parent) {
+		throw new Error('Could not find parent element for Epic');
+	}
 
-    const container = document.createElement('div');
-    parent.insertBefore(container, target);
+	const container = document.createElement('div');
+	parent.insertBefore(container, target);
 
-    return container;
-}
+	return container;
+};
 
 const hasOptedOutOfArticleCount = () =>
-    !!getCookie(ARTICLES_VIEWED_OPT_OUT_COOKIE.name)
+	!!getCookie(ARTICLES_VIEWED_OPT_OUT_COOKIE.name);
 
 const DAILY_ARTICLE_COUNT_KEY = 'gu.history.dailyArticleCount';
 const WEEKLY_ARTICLE_COUNT_KEY = 'gu.history.weeklyArticleCount';
 
 const removeArticleCountsFromLocalStorage = () => {
-    window.localStorage.removeItem(DAILY_ARTICLE_COUNT_KEY);
-    window.localStorage.removeItem(WEEKLY_ARTICLE_COUNT_KEY);
-}
+	window.localStorage.removeItem(DAILY_ARTICLE_COUNT_KEY);
+	window.localStorage.removeItem(WEEKLY_ARTICLE_COUNT_KEY);
+};
 
 const REQUIRED_CONSENTS_FOR_ARTICLE_COUNT = [1, 3, 7];
 
 /* eslint-disable guardian-frontend/exports-last */
 export const getArticleCountConsent = () => {
-    if (hasOptedOutOfArticleCount()) {
-        return Promise.resolve(false);
-    }
-    return new Promise((resolve) => {
-        onConsentChange(({ ccpa, tcfv2 , aus}) => {
-            if (ccpa || aus) {
-                resolve(true);
-            } else if (tcfv2) {
-                const hasRequiredConsents = REQUIRED_CONSENTS_FOR_ARTICLE_COUNT.every(
-                    (consent) => tcfv2.consents[consent],
-                );
+	if (hasOptedOutOfArticleCount()) {
+		return Promise.resolve(false);
+	}
+	return new Promise((resolve) => {
+		onConsentChange(({ ccpa, tcfv2, aus }) => {
+			if (ccpa || aus) {
+				resolve(true);
+			} else if (tcfv2) {
+				const hasRequiredConsents = REQUIRED_CONSENTS_FOR_ARTICLE_COUNT.every(
+					(consent) => tcfv2.consents[consent],
+				);
 
-                if (!hasRequiredConsents) {
-                    removeArticleCountsFromLocalStorage();
-                }
+				if (!hasRequiredConsents) {
+					removeArticleCountsFromLocalStorage();
+				}
 
-                resolve(hasRequiredConsents);
-            }
-        });
-    });
+				resolve(hasRequiredConsents);
+			}
+		});
+	});
 };
 
 const buildEpicPayload = async () => {
-    const ophan = config.get('ophan');
-    const page = config.get('page');
+	const ophan = config.get('ophan');
+	const page = config.get('page');
 
-    const countryCode = getCountryCode();
+	const countryCode = getCountryCode();
 
-    const tracking = {
-        ophanPageId: ophan.pageViewId,
-        platformId: 'GUARDIAN_WEB',
-        clientName: 'frontend',
-        referrerUrl:
-            window.location.origin + window.location.pathname,
-    };
+	const tracking = {
+		ophanPageId: ophan.pageViewId,
+		platformId: 'GUARDIAN_WEB',
+		clientName: 'frontend',
+		referrerUrl: window.location.origin + window.location.pathname,
+	};
 
-    const targeting = {
-        contentType: page.contentType,
-        sectionName: page.section,
-        shouldHideReaderRevenue: page.shouldHideReaderRevenue,
-        isMinuteArticle: config.hasTone('Minute'),
-        isPaidContent: page.isPaidContent,
-        isSensitive: page.isSensitive,
-        tags: buildKeywordTags(page).concat([buildSeriesTag(page)]),
-        showSupportMessaging: !shouldHideSupportMessaging(),
-        isRecurringContributor: isRecurringContributor(),
-        lastOneOffContributionDate:
-            getLastOneOffContributionTimestamp() || undefined,
-        mvtId: getMvtValue(),
-        countryCode,
-        epicViewLog: getViewLog(storage.local),
-        weeklyArticleHistory: getWeeklyArticleHistory(storage.local),
-        hasOptedOutOfArticleCount: !(await getArticleCountConsent()),
-        modulesVersion: ModulesVersion,
-        url: window.location.origin + window.location.pathname,
-    };
+	const targeting = {
+		contentType: page.contentType,
+		sectionName: page.section,
+		shouldHideReaderRevenue: page.shouldHideReaderRevenue,
+		isMinuteArticle: config.hasTone('Minute'),
+		isPaidContent: page.isPaidContent,
+		isSensitive: page.isSensitive,
+		tags: buildKeywordTags(page).concat([buildSeriesTag(page)]),
+		showSupportMessaging: !shouldHideSupportMessaging(),
+		isRecurringContributor: isRecurringContributor(),
+		lastOneOffContributionDate:
+			getLastOneOffContributionTimestamp() || undefined,
+		mvtId: getMvtValue(),
+		countryCode,
+		epicViewLog: getViewLog(storage.local),
+		weeklyArticleHistory: getWeeklyArticleHistory(storage.local),
+		hasOptedOutOfArticleCount: !(await getArticleCountConsent()),
+		modulesVersion: ModulesVersion,
+		url: window.location.origin + window.location.pathname,
+	};
 
-    return {
-        tracking,
-        targeting,
-    };
+	return {
+		tracking,
+		targeting,
+	};
 };
 
 const buildHeaderLinksPayload = () => {
-    const ophan = config.get('ophan');
-    const countryCode = getCountryCode();
-    const edition = config.get('page.edition', '');
-    return {
-        tracking: {
-            ophanPageId: ophan.pageViewId,
-            platformId: 'GUARDIAN_WEB',
-            referrerUrl: window.location.origin + window.location.pathname,
-            clientName: 'frontend',
-        },
-        targeting: {
-            showSupportMessaging: !shouldHideSupportMessaging(),
-            edition,
-            countryCode,
-            modulesVersion: ModulesVersion,
-            mvtId: getMvtValue(),
-            lastOneOffContributionDate: getLastOneOffContributionDate() || undefined,
-        },
-    };
-}
+	const ophan = config.get('ophan');
+	const countryCode = getCountryCode();
+	const edition = config.get('page.edition', '');
+	return {
+		tracking: {
+			ophanPageId: ophan.pageViewId,
+			platformId: 'GUARDIAN_WEB',
+			referrerUrl: window.location.origin + window.location.pathname,
+			clientName: 'frontend',
+		},
+		targeting: {
+			showSupportMessaging: !shouldHideSupportMessaging(),
+			edition,
+			countryCode,
+			modulesVersion: ModulesVersion,
+			mvtId: getMvtValue(),
+			lastOneOffContributionDate:
+				getLastOneOffContributionDate() || undefined,
+		},
+	};
+};
 
-export const NO_RR_BANNER_TIMESTAMP_KEY = 'gu.noRRBannerTimestamp';   // timestamp of when we were last told not to show a RR banner
-const twentyMins = 20*60000;
+export const NO_RR_BANNER_TIMESTAMP_KEY = 'gu.noRRBannerTimestamp'; // timestamp of when we were last told not to show a RR banner
+const twentyMins = 20 * 60000;
 
 export const withinLocalNoBannerCachePeriod = () => {
-    const item = window.localStorage.getItem(NO_RR_BANNER_TIMESTAMP_KEY);
-    if (item && !Number.isNaN(parseInt(item, 10))) {
-        const withinCachePeriod = (parseInt(item, 10) + twentyMins) > Date.now();
-        if (!withinCachePeriod) {
-            // Expired
-            window.localStorage.removeItem(NO_RR_BANNER_TIMESTAMP_KEY);
-        }
-        return withinCachePeriod;
-    }
-    return false;
+	const item = window.localStorage.getItem(NO_RR_BANNER_TIMESTAMP_KEY);
+	if (item && !Number.isNaN(parseInt(item, 10))) {
+		const withinCachePeriod = parseInt(item, 10) + twentyMins > Date.now();
+		if (!withinCachePeriod) {
+			// Expired
+			window.localStorage.removeItem(NO_RR_BANNER_TIMESTAMP_KEY);
+		}
+		return withinCachePeriod;
+	}
+	return false;
 };
 
 export const setLocalNoBannerCachePeriod = () =>
-    window.localStorage.setItem(NO_RR_BANNER_TIMESTAMP_KEY, `${Date.now()}`);
+	window.localStorage.setItem(NO_RR_BANNER_TIMESTAMP_KEY, `${Date.now()}`);
 
 const buildBannerPayload = async () => {
-    const page = config.get('page');
+	const page = config.get('page');
 
-    // TODO: Review whether we need to send all of this in the payload to the server
-    const tracking = {
-        ophanPageId: config.get('ophan.pageViewId'),
-        platformId: 'GUARDIAN_WEB',
-        clientName: 'frontend',
-        referrerUrl: window.location.origin + window.location.pathname,
-    };
+	// TODO: Review whether we need to send all of this in the payload to the server
+	const tracking = {
+		ophanPageId: config.get('ophan.pageViewId'),
+		platformId: 'GUARDIAN_WEB',
+		clientName: 'frontend',
+		referrerUrl: window.location.origin + window.location.pathname,
+	};
 
-    const targeting = {
-        alreadyVisitedCount: getVisitCount(),
-        shouldHideReaderRevenue: page.shouldHideReaderRevenue,
-        isPaidContent: page.isPaidContent,
-        showSupportMessaging: !shouldHideSupportMessaging(),
-        engagementBannerLastClosedAt: userPrefs.get('engagementBannerLastClosedAt') || undefined,
-        subscriptionBannerLastClosedAt: userPrefs.get('subscriptionBannerLastClosedAt') || undefined,
-        mvtId: getMvtValue(),
-        countryCode: getCountryCode(),
-        weeklyArticleHistory: getWeeklyArticleHistory(storage.local),
-        hasOptedOutOfArticleCount: !(await getArticleCountConsent()),
-        modulesVersion: ModulesVersion,
-    };
+	const targeting = {
+		alreadyVisitedCount: getVisitCount(),
+		shouldHideReaderRevenue: page.shouldHideReaderRevenue,
+		isPaidContent: page.isPaidContent,
+		showSupportMessaging: !shouldHideSupportMessaging(),
+		engagementBannerLastClosedAt:
+			userPrefs.get('engagementBannerLastClosedAt') || undefined,
+		subscriptionBannerLastClosedAt:
+			userPrefs.get('subscriptionBannerLastClosedAt') || undefined,
+		mvtId: getMvtValue(),
+		countryCode: getCountryCode(),
+		weeklyArticleHistory: getWeeklyArticleHistory(storage.local),
+		hasOptedOutOfArticleCount: !(await getArticleCountConsent()),
+		modulesVersion: ModulesVersion,
+	};
 
-    return {
-        tracking,
-        targeting,
-    };
+	return {
+		tracking,
+		targeting,
+	};
 };
 
-const checkResponseOk = response => {
-    if (response.ok) {
-        return response;
-    }
+const checkResponseOk = (response) => {
+	if (response.ok) {
+		return response;
+	}
 
-    throw new Error(
-        `Contributions fetch failed with response code: ${response.status}`
-    );
+	throw new Error(
+		`Contributions fetch failed with response code: ${response.status}`,
+	);
 };
 
 const getForcedVariant = (type) => {
-    if (URLSearchParams) {
-        const params = new URLSearchParams(window.location.search);
-        const value = params.get(`force-${type}`);
-        if (value) {
-            return value;
-        }
-    }
+	if (URLSearchParams) {
+		const params = new URLSearchParams(window.location.search);
+		const value = params.get(`force-${type}`);
+		if (value) {
+			return value;
+		}
+	}
 
-    return null;
+	return null;
 };
 
 // TODO: add this to the client library
 const getStickyBottomBanner = (payload) => {
-    const isProd = config.get('page.isProd');
-    const URL = isProd ? 'https://contributions.guardianapis.com/banner' : 'https://contributions.code.dev-guardianapis.com/banner';
-    const json = JSON.stringify(payload);
+	const isProd = config.get('page.isProd');
+	const URL = isProd
+		? 'https://contributions.guardianapis.com/banner'
+		: 'https://contributions.code.dev-guardianapis.com/banner';
+	const json = JSON.stringify(payload);
 
-    return fetchJson(URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: json,
-    });
+	return fetchJson(URL, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: json,
+	});
 };
 
 const getPuzzlesBanner = (payload) => {
-    const isProd = config.get('page.isProd');
-    const URL = isProd ? 'https://contributions.guardianapis.com/puzzles' : 'https://contributions.code.dev-guardianapis.com/puzzles?';
-    const json = JSON.stringify(payload);
+	const isProd = config.get('page.isProd');
+	const URL = isProd
+		? 'https://contributions.guardianapis.com/puzzles'
+		: 'https://contributions.code.dev-guardianapis.com/puzzles?';
+	const json = JSON.stringify(payload);
 
-    const forcedVariant = getForcedVariant('banner');
-    const queryString = forcedVariant ? `?force=${forcedVariant}` : '';
+	const forcedVariant = getForcedVariant('banner');
+	const queryString = forcedVariant ? `?force=${forcedVariant}` : '';
 
-    return fetchJson(`${URL}${queryString}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: json,
-    });
-}
+	return fetchJson(`${URL}${queryString}`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: json,
+	});
+};
 
 const getHeaderLinks = (payload) => {
-    const isProd = config.get('page.isProd');
-    const url = isProd ? 'https://contributions.guardianapis.com/header' : 'https://contributions.code.dev-guardianapis.com/header';
-    const json = JSON.stringify(payload);
+	const isProd = config.get('page.isProd');
+	const url = isProd
+		? 'https://contributions.guardianapis.com/header'
+		: 'https://contributions.code.dev-guardianapis.com/header';
+	const json = JSON.stringify(payload);
 
-    const forcedVariant = getForcedVariant('header');
-    const queryString = forcedVariant ? `?force=${forcedVariant}` : '';
+	const forcedVariant = getForcedVariant('header');
+	const queryString = forcedVariant ? `?force=${forcedVariant}` : '';
 
-    return fetchJson(`${url}${queryString}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: json,
-    });
-}
+	return fetchJson(`${url}${queryString}`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: json,
+	});
+};
 
 const getEpicUrl = (contentType) => {
-    const path = contentType === 'LiveBlog' ? 'liveblog-epic' : 'epic';
-    return config.get('page.isDev') ?
-        `https://contributions.code.dev-guardianapis.com/${path}` :
-        `https://contributions.guardianapis.com/${path}`
+	const path = contentType === 'LiveBlog' ? 'liveblog-epic' : 'epic';
+	return config.get('page.isDev')
+		? `https://contributions.code.dev-guardianapis.com/${path}`
+		: `https://contributions.guardianapis.com/${path}`;
 };
 
 const renderLiveblogEpic = async (module, meta) => {
-    const component = await window.guardianPolyfilledImport(module.url);
+	const component = await window.guardianPolyfilledImport(module.url);
 
-    const {
-        abTestName,
-        abTestVariant,
-        componentType,
-        products = [],
-        campaignCode,
-        campaignId
-    } = meta;
+	const {
+		abTestName,
+		abTestVariant,
+		componentType,
+		products = [],
+		campaignCode,
+		campaignId,
+	} = meta;
 
-    const element = setupRemoteEpicInLiveblog(component.ContributionsLiveblogEpic, module.props);
+	const element = setupRemoteEpicInLiveblog(
+		component.ContributionsLiveblogEpic,
+		module.props,
+	);
 
-    if (element) {
-        submitOphanInsert(abTestName, abTestVariant, componentType, products, campaignCode);
-        setupOphanView(
-            element,
-            abTestName,
-            abTestVariant,
-            campaignCode,
-            campaignId,
-            componentType,
-            products,
-        );
-    }
+	if (element) {
+		submitOphanInsert(
+			abTestName,
+			abTestVariant,
+			componentType,
+			products,
+			campaignCode,
+		);
+		setupOphanView(
+			element,
+			abTestName,
+			abTestVariant,
+			campaignCode,
+			campaignId,
+			componentType,
+			products,
+		);
+	}
 };
 
 const renderEpic = async (module, meta) => {
-    const component = await window.guardianPolyfilledImport(module.url);
+	const component = await window.guardianPolyfilledImport(module.url);
 
-    const {
-        abTestName,
-        abTestVariant,
-        componentType,
-        products = [],
-        campaignCode,
-        campaignId,
-        labels,
-    } = meta;
+	const {
+		abTestName,
+		abTestVariant,
+		componentType,
+		products = [],
+		campaignCode,
+		campaignId,
+		labels,
+	} = meta;
 
-    const el = epicEl();
-    mountDynamic(el, component.ContributionsEpic, module.props, true);
+	const el = epicEl();
+	mountDynamic(el, component.ContributionsEpic, module.props, true);
 
-    submitOphanInsert(abTestName, abTestVariant, componentType, products, campaignCode, labels);
-    setupOphanView(
-        el,
-        abTestName,
-        abTestVariant,
-        campaignCode,
-        campaignId,
-        componentType,
-        products,
-        labels,
-    );
+	submitOphanInsert(
+		abTestName,
+		abTestVariant,
+		componentType,
+		products,
+		campaignCode,
+		labels,
+	);
+	setupOphanView(
+		el,
+		abTestName,
+		abTestVariant,
+		campaignCode,
+		campaignId,
+		componentType,
+		products,
+		labels,
+	);
 };
 
 export const fetchPuzzlesData = async () => {
-    const page = config.get('page');
-    const payload = await buildBannerPayload();
-    const isPuzzlesBannerSwitchOn = config.get('switches.puzzlesBanner', false);
-    const isPuzzlesPage = page.section === 'crosswords' || page.series === 'Sudoku';
+	const page = config.get('page');
+	const payload = await buildBannerPayload();
+	const isPuzzlesBannerSwitchOn = config.get('switches.puzzlesBanner', false);
+	const isPuzzlesPage =
+		page.section === 'crosswords' || page.series === 'Sudoku';
 
-    if (payload.targeting.shouldHideReaderRevenue || payload.targeting.isPaidContent) {
-        return null;
-    }
+	if (
+		payload.targeting.shouldHideReaderRevenue ||
+		payload.targeting.isPaidContent
+	) {
+		return null;
+	}
 
-    if (isPuzzlesBannerSwitchOn && isPuzzlesPage) {
-        return getPuzzlesBanner(payload).then(json => {
-            if (!json.data) {
-                return null;
-            }
-            return (json);
-        })
-    }
-    return null;
-}
+	if (isPuzzlesBannerSwitchOn && isPuzzlesPage) {
+		return getPuzzlesBanner(payload).then((json) => {
+			if (!json.data) {
+				return null;
+			}
+			return json;
+		});
+	}
+	return null;
+};
 
 export const fetchBannerData = async () => {
-    const payload = await buildBannerPayload();
+	const payload = await buildBannerPayload();
 
-    if (payload.targeting.shouldHideReaderRevenue || payload.targeting.isPaidContent || isHosted) {
-        return Promise.resolve(null);
-    }
+	if (
+		payload.targeting.shouldHideReaderRevenue ||
+		payload.targeting.isPaidContent ||
+		isHosted
+	) {
+		return Promise.resolve(null);
+	}
 
-    if (payload.targeting.engagementBannerLastClosedAt &&
-        payload.targeting.subscriptionBannerLastClosedAt &&
-        withinLocalNoBannerCachePeriod()
-    ) {
-        return Promise.resolve(null);
-    }
+	if (
+		payload.targeting.engagementBannerLastClosedAt &&
+		payload.targeting.subscriptionBannerLastClosedAt &&
+		withinLocalNoBannerCachePeriod()
+	) {
+		return Promise.resolve(null);
+	}
 
-    return getStickyBottomBanner(payload).then(json => {
-        if (!json.data) {
-            if (payload.targeting.engagementBannerLastClosedAt && payload.targeting.subscriptionBannerLastClosedAt) {
-                setLocalNoBannerCachePeriod();
-            }
-            return null;
-        }
+	return getStickyBottomBanner(payload).then((json) => {
+		if (!json.data) {
+			if (
+				payload.targeting.engagementBannerLastClosedAt &&
+				payload.targeting.subscriptionBannerLastClosedAt
+			) {
+				setLocalNoBannerCachePeriod();
+			}
+			return null;
+		}
 
-        return (json);
-    });
+		return json;
+	});
 };
 
 export const renderBanner = (response) => {
-    const { module, meta } = response.data;
-    if (!module) {
-        return Promise.resolve(false);
-    }
+	const { module, meta } = response.data;
+	if (!module) {
+		return Promise.resolve(false);
+	}
 
-    return window.guardianPolyfilledImport(module.url)
-        .then(bannerModule => {
-            const Banner = bannerModule[module.name];
-            const isPuzzlesBanner = module.name === 'PuzzlesBanner';
+	return window
+		.guardianPolyfilledImport(module.url)
+		.then((bannerModule) => {
+			const Banner = bannerModule[module.name];
+			const isPuzzlesBanner = module.name === 'PuzzlesBanner';
 
-            return fastdom.mutate(() => {
-                const container = document.createElement('div');
-                container.classList.add('site-message--banner');
-                container.classList.add('remote-banner');
-                if (isPuzzlesBanner) {
-                    container.classList.add('remote-banner--puzzles');
-                }
+			return fastdom
+				.mutate(() => {
+					const container = document.createElement('div');
+					container.classList.add('site-message--banner');
+					container.classList.add('remote-banner');
+					if (isPuzzlesBanner) {
+						container.classList.add('remote-banner--puzzles');
+					}
 
-                if (document.body) {
-                    document.body.insertAdjacentElement('beforeend', container);
-                }
+					if (document.body) {
+						document.body.insertAdjacentElement(
+							'beforeend',
+							container,
+						);
+					}
 
-                return mountDynamic(
-                    container,
-                    Banner,
-                    { submitComponentEvent, ...module.props},
-                    !isPuzzlesBanner // The puzzles banner has its own CacheProvider component, and needs this to be false
-                );
-            }).then(() => {
-                const {
-                    abTestName,
-                    abTestVariant,
-                    componentType,
-                    products = [],
-                    campaignCode
-                } = meta;
+					return mountDynamic(
+						container,
+						Banner,
+						{ submitComponentEvent, ...module.props },
+						!isPuzzlesBanner, // The puzzles banner has its own CacheProvider component, and needs this to be false
+					);
+				})
+				.then(() => {
+					const {
+						abTestName,
+						abTestVariant,
+						componentType,
+						products = [],
+						campaignCode,
+					} = meta;
 
-                submitOphanInsert(abTestName, abTestVariant, componentType, products, campaignCode);
+					submitOphanInsert(
+						abTestName,
+						abTestVariant,
+						componentType,
+						products,
+						campaignCode,
+					);
 
-                // Submit view event now, as the standard view tracking is unreliable if the component is instantly in view
-                submitViewEvent({
-                    component: {
-                        componentType,
-                        products,
-                        campaignCode,
-                        id: campaignCode,
-                    },
-                    abTest: {
-                        name: abTestName,
-                        variant: abTestVariant,
-                    }
-                });
+					// Submit view event now, as the standard view tracking is unreliable if the component is instantly in view
+					submitViewEvent({
+						component: {
+							componentType,
+							products,
+							campaignCode,
+							id: campaignCode,
+						},
+						abTest: {
+							name: abTestName,
+							variant: abTestVariant,
+						},
+					});
 
-                // track banner view event in Google Analytics for subscriptions banner
-                if (componentType === 'ACQUISITIONS_SUBSCRIPTIONS_BANNER') {
-                    trackNonClickInteraction('subscription-banner : display')
-                }
+					// track banner view event in Google Analytics for subscriptions banner
+					if (componentType === 'ACQUISITIONS_SUBSCRIPTIONS_BANNER') {
+						trackNonClickInteraction(
+							'subscription-banner : display',
+						);
+					}
 
-                return true
-            });
-        })
-        .catch(error => {
-            console.log(`Error importing remote banner: ${error}`);
-            reportError(new Error(`Error importing remote banner: ${error}`), {}, false);
-            return false;
-        });
+					return true;
+				});
+		})
+		.catch((error) => {
+			console.log(`Error importing remote banner: ${error}`);
+			reportError(
+				new Error(`Error importing remote banner: ${error}`),
+				{},
+				false,
+			);
+			return false;
+		});
 };
 
 export const fetchAndRenderEpic = async () => {
-    const page = config.get('page');
+	const page = config.get('page');
 
-    if ((page.contentType === 'Article' || page.contentType === 'LiveBlog') && !isHosted) {
-        try {
-            const payload = await buildEpicPayload();
+	if (
+		(page.contentType === 'Article' || page.contentType === 'LiveBlog') &&
+		!isHosted
+	) {
+		try {
+			const payload = await buildEpicPayload();
 
-            const url = getEpicUrl(page.contentType);
-            const response = await getEpicMeta(payload, url);
-            checkResponseOk(response);
-            const json = await response.json();
+			const url = getEpicUrl(page.contentType);
+			const response = await getEpicMeta(payload, url);
+			checkResponseOk(response);
+			const json = await response.json();
 
-            if (json && json.data) {
-                const {module, meta} = json.data;
+			if (json && json.data) {
+				const { module, meta } = json.data;
 
-                if (page.contentType === 'Article') {
-                    await renderEpic(module, meta);
-                } else if (page.contentType === 'LiveBlog') {
-                    await renderLiveblogEpic(module, meta);
-                }
-            }
-
-        } catch (error) {
-            console.log(`Error importing remote epic: ${error}`);
-            reportError(new Error(`Error importing remote epic: ${error}`), {}, false);
-        }
-    }
+				if (page.contentType === 'Article') {
+					await renderEpic(module, meta);
+				} else if (page.contentType === 'LiveBlog') {
+					await renderLiveblogEpic(module, meta);
+				}
+			}
+		} catch (error) {
+			console.log(`Error importing remote epic: ${error}`);
+			reportError(
+				new Error(`Error importing remote epic: ${error}`),
+				{},
+				false,
+			);
+		}
+	}
 };
 
 export const fetchAndRenderHeaderLinks = async () => {
-    const requestData = buildHeaderLinksPayload();
+	const requestData = buildHeaderLinksPayload();
 
-    if (!config.get('switches.remoteHeader', false)) {
-        return;
-    }
+	if (!config.get('switches.remoteHeader', false)) {
+		return;
+	}
 
-    if (config.get('page.contentType') === 'Gallery') {
-        return;
-    }
+	if (config.get('page.contentType') === 'Gallery') {
+		return;
+	}
 
-    try {
-        const response = await getHeaderLinks(requestData);
-        if (!response.data) {
-            return null;
-        }
-        const {module} = response.data;
-        const component = await window.guardianPolyfilledImport(module.url);
-        const Header = component.Header;
+	try {
+		const response = await getHeaderLinks(requestData);
+		if (!response.data) {
+			return null;
+		}
+		const { module } = response.data;
+		const component = await window.guardianPolyfilledImport(module.url);
+		const Header = component.Header;
 
-        const el = document.createElement('div');
-        const container = document.querySelector('.new-header__cta-bar');
-        container.appendChild(el);
+		const el = document.createElement('div');
+		const container = document.querySelector('.new-header__cta-bar');
+		container.appendChild(el);
 
-        mountDynamic(
-            el,
-            Header,
-            {submitComponentEvent, ...module.props},
-            true,
-        );
-    } catch (error) {
-        console.log(`Error importing remote header: ${error}`);
-        reportError(new Error(`Error importing remote header: ${error}`), {}, false);
-    }
+		mountDynamic(
+			el,
+			Header,
+			{ submitComponentEvent, ...module.props },
+			true,
+		);
+	} catch (error) {
+		console.log(`Error importing remote header: ${error}`);
+		reportError(
+			new Error(`Error importing remote header: ${error}`),
+			{},
+			false,
+		);
+	}
 };

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -4,72 +4,72 @@ import config from '../../../../lib/config';
 import { elementInView } from '../../../../lib/element-inview';
 import { submitInsertEvent, submitViewEvent } from './acquisitions-ophan';
 
-const getVisitCount = () => parseInt(storage.local.getRaw('gu.alreadyVisited'), 10) || 0;
+const getVisitCount = () =>
+	parseInt(storage.local.getRaw('gu.alreadyVisited'), 10) || 0;
 
 const pageShouldHideReaderRevenue = () =>
-    config.get('page.shouldHideReaderRevenue') ||
-    config.get('page.sponsorshipType') === 'paid-content';
+	config.get('page.shouldHideReaderRevenue') ||
+	config.get('page.sponsorshipType') === 'paid-content';
 
 const submitOphanInsert = (
-    testId,
-    variantId,
-    componentType,
-    products,
-    campaignCode,
-    labels,
+	testId,
+	variantId,
+	componentType,
+	products,
+	campaignCode,
+	labels,
 ) => {
-    submitInsertEvent({
-        component: {
-            componentType,
-            products,
-            campaignCode,
-            id: campaignCode,
-            labels,
-        },
-        abTest: {
-            name: testId,
-            variant: variantId,
-        },
-    });
+	submitInsertEvent({
+		component: {
+			componentType,
+			products,
+			campaignCode,
+			id: campaignCode,
+			labels,
+		},
+		abTest: {
+			name: testId,
+			variant: variantId,
+		},
+	});
 };
 
 const setupOphanView = (
-    element,
-    testId,
-    variantId,
-    campaignCode,
-    trackingCampaignId,
-    componentType,
-    products,
-    labels,
+	element,
+	testId,
+	variantId,
+	campaignCode,
+	trackingCampaignId,
+	componentType,
+	products,
+	labels,
 ) => {
-    const inView = elementInView(element, window, {
-        top: 18,
-    });
+	const inView = elementInView(element, window, {
+		top: 18,
+	});
 
-    inView.on('firstview', () => {
-        logView(storage.local, testId);
+	inView.on('firstview', () => {
+		logView(storage.local, testId);
 
-        submitViewEvent({
-                component: {
-                    componentType,
-                    products,
-                    campaignCode,
-                    id: campaignCode,
-                    labels,
-                },
-                abTest: {
-                    name: testId,
-                    variant: variantId,
-                }
-            }
-        );
-    });
+		submitViewEvent({
+			component: {
+				componentType,
+				products,
+				campaignCode,
+				id: campaignCode,
+				labels,
+			},
+			abTest: {
+				name: testId,
+				variant: variantId,
+			},
+		});
+	});
 };
 
 export {
-    pageShouldHideReaderRevenue,
-    getVisitCount,
-    submitOphanInsert,
-    setupOphanView,
+	pageShouldHideReaderRevenue,
+	getVisitCount,
+	submitOphanInsert,
+	setupOphanView,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/geo-utils.js
+++ b/static/src/javascripts/projects/common/modules/commercial/geo-utils.js
@@ -2,10 +2,10 @@ import { getCountryCode } from '../../../../lib/geolocation';
 
 // cache the users location so we only have to look it up once
 let geo;
-const currentGeoLocation = (() => {
-    geo = geo || getCountryCode();
-    return geo;
-});
+const currentGeoLocation = () => {
+	geo = geo || getCountryCode();
+	return geo;
+};
 
 export const isInUk = () => currentGeoLocation() === 'GB';
 
@@ -23,4 +23,8 @@ export const isInAuOrNz = () => isInAustralia() || isInNewZealand();
 
 export const isInRow = () => !isInUk() && !isInUsOrCa() && !isInAuOrNz();
 
-export const _ = { resetModule: () => { geo = undefined } };
+export const _ = {
+	resetModule: () => {
+		geo = undefined;
+	},
+};

--- a/static/src/javascripts/projects/common/modules/commercial/geo-utils.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/geo-utils.spec.js
@@ -1,111 +1,111 @@
 import {
-    isInUk,
-    isInUsa,
-    isInCanada,
-    isInAustralia,
-    isInNewZealand,
-    isInUsOrCa,
-    isInAuOrNz,
-    isInRow,
-    _,
+	isInUk,
+	isInUsa,
+	isInCanada,
+	isInAustralia,
+	isInNewZealand,
+	isInUsOrCa,
+	isInAuOrNz,
+	isInRow,
+	_,
 } from 'common/modules/commercial/geo-utils';
 
 let mockCountryCode;
 jest.mock('../../../../lib/geolocation', () => ({
-    getCountryCode: jest.fn(() => mockCountryCode),
+	getCountryCode: jest.fn(() => mockCountryCode),
 }));
 
 describe('Geolocation Utils', () => {
-    beforeEach(() => {
-        _.resetModule();
-    })
+	beforeEach(() => {
+		_.resetModule();
+	});
 
-    const testCases = [
-        {
-            fnName: 'isInUk()',
-            mockCountryCode: 'GB',
-            expectedUKValue: true,
-            expectedUsaValue: false,
-            expectedCaValue: false,
-            expectedAuValue: false,
-            expectedNzValue: false,
-            expectedUsOrCaValue: false,
-            expectedAuOrNzValue: false,
-            expectedRowValue: false,
-        },
-        {
-            fnName: 'isInUsa() and isInUsOrCa()',
-            mockCountryCode: 'US',
-            expectedUKValue: false,
-            expectedUsaValue: true,
-            expectedCaValue: false,
-            expectedAuValue: false,
-            expectedNzValue: false,
-            expectedUsOrCaValue: true,
-            expectedAuOrNzValue: false,
-            expectedRowValue: false,
-        },
-        {
-            fnName: 'isInCanada() and isInUsOrCa()',
-            mockCountryCode: 'CA',
-            expectedUKValue: false,
-            expectedUsaValue: false,
-            expectedCaValue: true,
-            expectedAuValue: false,
-            expectedNzValue: false,
-            expectedUsOrCaValue: true,
-            expectedAuOrNzValue: false,
-            expectedRowValue: false,
-        },
-        {
-            fnName: 'isInAustralia() and isInAuOrNz()',
-            mockCountryCode: 'AU',
-            expectedUKValue: false,
-            expectedUsaValue: false,
-            expectedCaValue: false,
-            expectedAuValue: true,
-            expectedNzValue: false,
-            expectedUsOrCaValue: false,
-            expectedAuOrNzValue: true,
-            expectedRowValue: false,
-        },
-        {
-            fnName: 'isInNewZealand() and isInAuOrNz()',
-            mockCountryCode: 'NZ',
-            expectedUKValue: false,
-            expectedUsaValue: false,
-            expectedCaValue: false,
-            expectedAuValue: false,
-            expectedNzValue: true,
-            expectedUsOrCaValue: false,
-            expectedAuOrNzValue: true,
-            expectedRowValue: false,
-        },
-        {
-            fnName: 'isInRow()',
-            mockCountryCode: 'NONE_OF_THE_ABOVE',
-            expectedUKValue: false,
-            expectedUsaValue: false,
-            expectedCaValue: false,
-            expectedAuValue: false,
-            expectedNzValue: false,
-            expectedUsOrCaValue: false,
-            expectedAuOrNzValue: false,
-            expectedRowValue: true,
-        }
-    ]
+	const testCases = [
+		{
+			fnName: 'isInUk()',
+			mockCountryCode: 'GB',
+			expectedUKValue: true,
+			expectedUsaValue: false,
+			expectedCaValue: false,
+			expectedAuValue: false,
+			expectedNzValue: false,
+			expectedUsOrCaValue: false,
+			expectedAuOrNzValue: false,
+			expectedRowValue: false,
+		},
+		{
+			fnName: 'isInUsa() and isInUsOrCa()',
+			mockCountryCode: 'US',
+			expectedUKValue: false,
+			expectedUsaValue: true,
+			expectedCaValue: false,
+			expectedAuValue: false,
+			expectedNzValue: false,
+			expectedUsOrCaValue: true,
+			expectedAuOrNzValue: false,
+			expectedRowValue: false,
+		},
+		{
+			fnName: 'isInCanada() and isInUsOrCa()',
+			mockCountryCode: 'CA',
+			expectedUKValue: false,
+			expectedUsaValue: false,
+			expectedCaValue: true,
+			expectedAuValue: false,
+			expectedNzValue: false,
+			expectedUsOrCaValue: true,
+			expectedAuOrNzValue: false,
+			expectedRowValue: false,
+		},
+		{
+			fnName: 'isInAustralia() and isInAuOrNz()',
+			mockCountryCode: 'AU',
+			expectedUKValue: false,
+			expectedUsaValue: false,
+			expectedCaValue: false,
+			expectedAuValue: true,
+			expectedNzValue: false,
+			expectedUsOrCaValue: false,
+			expectedAuOrNzValue: true,
+			expectedRowValue: false,
+		},
+		{
+			fnName: 'isInNewZealand() and isInAuOrNz()',
+			mockCountryCode: 'NZ',
+			expectedUKValue: false,
+			expectedUsaValue: false,
+			expectedCaValue: false,
+			expectedAuValue: false,
+			expectedNzValue: true,
+			expectedUsOrCaValue: false,
+			expectedAuOrNzValue: true,
+			expectedRowValue: false,
+		},
+		{
+			fnName: 'isInRow()',
+			mockCountryCode: 'NONE_OF_THE_ABOVE',
+			expectedUKValue: false,
+			expectedUsaValue: false,
+			expectedCaValue: false,
+			expectedAuValue: false,
+			expectedNzValue: false,
+			expectedUsOrCaValue: false,
+			expectedAuOrNzValue: false,
+			expectedRowValue: true,
+		},
+	];
 
-    testCases.forEach( testCase => {
-        it(`Only ${testCase.fnName} return true for geolocation '${testCase.mockCountryCode}'`, () => {
-            mockCountryCode = testCase.mockCountryCode;
-            expect(isInUk()).toBe(testCase.expectedUKValue);
-            expect(isInUsa()).toBe(testCase.expectedUsaValue);
-            expect(isInCanada()).toBe(testCase.expectedCaValue);
-            expect(isInAustralia()).toBe(testCase.expectedAuValue);
-            expect(isInNewZealand()).toBe(testCase.expectedNzValue);
-            expect(isInUsOrCa()).toBe(testCase.expectedUsOrCaValue);
-            expect(isInAuOrNz()).toBe(testCase.expectedAuOrNzValue);
-            expect(isInRow()).toBe(testCase.expectedRowValue);
-        })
-    })
-})
+	testCases.forEach((testCase) => {
+		it(`Only ${testCase.fnName} return true for geolocation '${testCase.mockCountryCode}'`, () => {
+			mockCountryCode = testCase.mockCountryCode;
+			expect(isInUk()).toBe(testCase.expectedUKValue);
+			expect(isInUsa()).toBe(testCase.expectedUsaValue);
+			expect(isInCanada()).toBe(testCase.expectedCaValue);
+			expect(isInAustralia()).toBe(testCase.expectedAuValue);
+			expect(isInNewZealand()).toBe(testCase.expectedNzValue);
+			expect(isInUsOrCa()).toBe(testCase.expectedUsOrCaValue);
+			expect(isInAuOrNz()).toBe(testCase.expectedAuOrNzValue);
+			expect(isInRow()).toBe(testCase.expectedRowValue);
+		});
+	});
+});

--- a/static/src/javascripts/projects/common/modules/commercial/permutive.js
+++ b/static/src/javascripts/projects/common/modules/commercial/permutive.js
@@ -4,27 +4,27 @@ const PERMUTIVE_KEY = `_papns`;
 const PERMUTIVE_PFP_KEY = `_pdfps`;
 
 const getSegments = (key) => {
-    try {
-        return JSON.parse(storage.local.getRaw(key) || '[]')
-            .slice(0, 250)
-            .map(s => Number.parseInt(s, 10))
-            .filter(n => typeof n === 'number' && !Number.isNaN(n))
-            .map(String);
-    } catch (e) {
-        return [];
-    }
+	try {
+		return JSON.parse(storage.local.getRaw(key) || '[]')
+			.slice(0, 250)
+			.map((s) => Number.parseInt(s, 10))
+			.filter((n) => typeof n === 'number' && !Number.isNaN(n))
+			.map(String);
+	} catch (e) {
+		return [];
+	}
 };
 
 export const getPermutiveSegments = () => getSegments(PERMUTIVE_KEY);
 export const getPermutivePFPSegments = () => getSegments(PERMUTIVE_PFP_KEY);
 
 export const clearPermutiveSegments = () => {
-    storage.local.remove(PERMUTIVE_KEY);
-    storage.local.remove(PERMUTIVE_PFP_KEY);
+	storage.local.remove(PERMUTIVE_KEY);
+	storage.local.remove(PERMUTIVE_PFP_KEY);
 };
 
 export const _ = {
-    PERMUTIVE_KEY,
-    PERMUTIVE_PFP_KEY,
-    getSegments,
+	PERMUTIVE_KEY,
+	PERMUTIVE_PFP_KEY,
+	getSegments,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/permutive.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/permutive.spec.js
@@ -2,47 +2,47 @@ import { storage } from '@guardian/libs';
 import { getPermutiveSegments, getPermutivePFPSegments, _ } from './permutive';
 
 jest.mock('@guardian/libs', () => ({
-    storage: {
-        local: {
-            getRaw: jest.fn(),
-        },
-    }
+	storage: {
+		local: {
+			getRaw: jest.fn(),
+		},
+	},
 }));
 
 afterEach(() => {
-    jest.clearAllMocks();
+	jest.clearAllMocks();
 });
 
 describe('getSegments', () => {
-    const DUMMY_KEY = `_dummyKey`;
-    test('parses Permutive segments correctly', () => {
-        storage.local.getRaw.mockReturnValue(['[42,84,63]']);
-        expect(_.getSegments(DUMMY_KEY)).toEqual(['42', '84', '63']);
-        storage.local.getRaw.mockReturnValue([]);
-        expect(_.getSegments(DUMMY_KEY)).toEqual([]);
-    });
-    test('returns an empty array for bad inputs', () => {
-        storage.local.getRaw.mockReturnValue('-1');
-        expect(_.getSegments(DUMMY_KEY)).toEqual([]);
-        storage.local.getRaw.mockReturnValue('bad-string');
-        expect(_.getSegments(DUMMY_KEY)).toEqual([]);
-        storage.local.getRaw.mockReturnValue('{}');
-        expect(_.getSegments(DUMMY_KEY)).toEqual([]);
-        storage.local.getRaw.mockReturnValue('["not-a-number-segment"]');
-        expect(_.getSegments(DUMMY_KEY)).toEqual([]);
-    });
+	const DUMMY_KEY = `_dummyKey`;
+	test('parses Permutive segments correctly', () => {
+		storage.local.getRaw.mockReturnValue(['[42,84,63]']);
+		expect(_.getSegments(DUMMY_KEY)).toEqual(['42', '84', '63']);
+		storage.local.getRaw.mockReturnValue([]);
+		expect(_.getSegments(DUMMY_KEY)).toEqual([]);
+	});
+	test('returns an empty array for bad inputs', () => {
+		storage.local.getRaw.mockReturnValue('-1');
+		expect(_.getSegments(DUMMY_KEY)).toEqual([]);
+		storage.local.getRaw.mockReturnValue('bad-string');
+		expect(_.getSegments(DUMMY_KEY)).toEqual([]);
+		storage.local.getRaw.mockReturnValue('{}');
+		expect(_.getSegments(DUMMY_KEY)).toEqual([]);
+		storage.local.getRaw.mockReturnValue('["not-a-number-segment"]');
+		expect(_.getSegments(DUMMY_KEY)).toEqual([]);
+	});
 });
 
 describe('getPermutiveSegments', () => {
-    test('calls the right key from localStorage', () => {
-        getPermutiveSegments();
-        expect(storage.local.getRaw).toHaveBeenCalledWith(_.PERMUTIVE_KEY);
-    });
+	test('calls the right key from localStorage', () => {
+		getPermutiveSegments();
+		expect(storage.local.getRaw).toHaveBeenCalledWith(_.PERMUTIVE_KEY);
+	});
 });
 
 describe('getPermutivePFPSegments', () => {
-    test('calls the right key from localStorage', () => {
-        getPermutivePFPSegments();
-        expect(storage.local.getRaw).toHaveBeenCalledWith(_.PERMUTIVE_PFP_KEY);
-    });
+	test('calls the right key from localStorage', () => {
+		getPermutivePFPSegments();
+		expect(storage.local.getRaw).toHaveBeenCalledWith(_.PERMUTIVE_PFP_KEY);
+	});
 });

--- a/static/src/javascripts/projects/common/modules/commercial/puzzles-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/puzzles-banner.js
@@ -5,27 +5,32 @@ const messageCode = 'puzzles-banner';
 
 let data = null;
 
-const show = () => data ? renderBanner(data) : Promise.resolve(false);
+const show = () => (data ? renderBanner(data) : Promise.resolve(false));
 
 const canShow = () => {
-
-    return fetchPuzzlesData()
-        .then((response)  => {
-            if (response) {
-                data = response;
-                return true;
-            }
-            return false;
-        }).catch(error => {
-            console.log(`Error fetching remote puzzles banner data: ${error}`);
-            reportError(new Error(`Error fetching remote puzzles banner data: ${error}`), {}, false);
-            return false;
-        });
+	return fetchPuzzlesData()
+		.then((response) => {
+			if (response) {
+				data = response;
+				return true;
+			}
+			return false;
+		})
+		.catch((error) => {
+			console.log(`Error fetching remote puzzles banner data: ${error}`);
+			reportError(
+				new Error(
+					`Error fetching remote puzzles banner data: ${error}`,
+				),
+				{},
+				false,
+			);
+			return false;
+		});
 };
 
-
 export const puzzlesBanner = {
-    id: messageCode,
-    show,
-    canShow,
+	id: messageCode,
+	show,
+	canShow,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/reader-revenue-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/reader-revenue-banner.js
@@ -6,33 +6,39 @@ const messageCode = 'reader-revenue-banner';
 
 let data = null;
 
-const show = () => data ? renderBanner(data) : Promise.resolve(false);
+const show = () => (data ? renderBanner(data) : Promise.resolve(false));
 
 const canShow = () => {
-    const forceBanner = window.location.search.includes('force-remote-banner=true');
-    const enabled = config.get('switches.remoteBanner') || forceBanner;
+	const forceBanner = window.location.search.includes(
+		'force-remote-banner=true',
+	);
+	const enabled = config.get('switches.remoteBanner') || forceBanner;
 
-    if (!enabled) {
-        return Promise.resolve(false);
-    }
+	if (!enabled) {
+		return Promise.resolve(false);
+	}
 
-    return fetchBannerData()
-        .then((response)  => {
-            if (response) {
-                data = response;
-                return true;
-            }
-            return false;
-        }).catch(error => {
-            console.log(`Error fetching remote banner data: ${error}`);
-            reportError(new Error(`Error fetching remote banner data: ${error}`), {}, false);
-            return false;
-        });
+	return fetchBannerData()
+		.then((response) => {
+			if (response) {
+				data = response;
+				return true;
+			}
+			return false;
+		})
+		.catch((error) => {
+			console.log(`Error fetching remote banner data: ${error}`);
+			reportError(
+				new Error(`Error fetching remote banner data: ${error}`),
+				{},
+				false,
+			);
+			return false;
+		});
 };
 
-
 export const readerRevenueBanner = {
-    id: messageCode,
-    show,
-    canShow,
+	id: messageCode,
+	show,
+	canShow,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js
+++ b/static/src/javascripts/projects/common/modules/commercial/reader-revenue-dev-utils.js
@@ -1,21 +1,21 @@
 import { storage } from '@guardian/libs';
 import { addCookie, removeCookie } from '../../../../lib/cookies';
 import {
-    getCountryCode,
-    overrideGeolocation,
+	getCountryCode,
+	overrideGeolocation,
 } from '../../../../lib/geolocation';
 import {
-    decrementMvtCookie,
-    incrementMvtCookie,
-    initMvtCookie,
+	decrementMvtCookie,
+	incrementMvtCookie,
+	initMvtCookie,
 } from '../analytics/mvt-cookie';
 import { clearParticipations } from '../experiments/ab-local-storage';
 import { isUserLoggedIn } from '../identity/api';
 import userPrefs from '../user-prefs';
 import { pageShouldHideReaderRevenue } from './contributions-utilities';
 import {
-    fakeOneOffContributor,
-    readerRevenueRelevantCookies,
+	fakeOneOffContributor,
+	readerRevenueRelevantCookies,
 } from './user-features';
 
 const lastClosedAtKey = 'engagementBannerLastClosedAt';
@@ -23,76 +23,76 @@ const minArticlesBeforeShowingBanner = 2;
 
 const viewKey = 'gu.contributions.views';
 const clearEpicViewLog = () => {
-    storage.local.remove(viewKey);
+	storage.local.remove(viewKey);
 };
 
-const clearCommonReaderRevenueStateAndReload = (
-    asExistingSupporter
-) => {
-    if (pageShouldHideReaderRevenue()) {
-        alert(
-            'This page has "Prevent membership/contribution appeals" ticked in Composer. Please try a different page'
-        );
-        return;
-    }
+const clearCommonReaderRevenueStateAndReload = (asExistingSupporter) => {
+	if (pageShouldHideReaderRevenue()) {
+		alert(
+			'This page has "Prevent membership/contribution appeals" ticked in Composer. Please try a different page',
+		);
+		return;
+	}
 
-    readerRevenueRelevantCookies.forEach(cookie => removeCookie(cookie));
+	readerRevenueRelevantCookies.forEach((cookie) => removeCookie(cookie));
 
-    initMvtCookie();
-    clearParticipations();
+	initMvtCookie();
+	clearParticipations();
 
-    // Most versions of the epic only display for a certain number of pageviews in
-    // a given time window (typically, 4 per 30 days).
-    // We always want to clear out this view log, since otherwise this
-    // reload might mean the epic no longer appears on the next page view.
-    clearEpicViewLog();
+	// Most versions of the epic only display for a certain number of pageviews in
+	// a given time window (typically, 4 per 30 days).
+	// We always want to clear out this view log, since otherwise this
+	// reload might mean the epic no longer appears on the next page view.
+	clearEpicViewLog();
 
-    if (asExistingSupporter) {
-        // We use the one-off contributions cookie since the others
-        // get updated based on AJAX calls.
-        // This mechanism will break when start sending data on one-off contributions
-        // from the members-data-api and updating cookies based on that.
-        fakeOneOffContributor();
-    }
+	if (asExistingSupporter) {
+		// We use the one-off contributions cookie since the others
+		// get updated based on AJAX calls.
+		// This mechanism will break when start sending data on one-off contributions
+		// from the members-data-api and updating cookies based on that.
+		fakeOneOffContributor();
+	}
 
-    if (isUserLoggedIn() && !asExistingSupporter) {
-        if (window.location.origin.includes('localhost')) {
-            // Assume they don't have identity running locally
-            // So try and remove the identity cookie manually
-            removeCookie('GU_U');
-        } else {
-            const profileUrl = window.location.origin.replace(
-                /(www\.|m\.)/,
-                'profile.'
-            );
-            window.location.assign(`${profileUrl}/signout`);
-        }
-    } else {
-        window.location.reload();
-    }
+	if (isUserLoggedIn() && !asExistingSupporter) {
+		if (window.location.origin.includes('localhost')) {
+			// Assume they don't have identity running locally
+			// So try and remove the identity cookie manually
+			removeCookie('GU_U');
+		} else {
+			const profileUrl = window.location.origin.replace(
+				/(www\.|m\.)/,
+				'profile.',
+			);
+			window.location.assign(`${profileUrl}/signout`);
+		}
+	} else {
+		window.location.reload();
+	}
 };
 
 const showMeTheEpic = (asExistingSupporter = false) => {
-    // Clearing out the epic view log happens before all reloads
-    clearCommonReaderRevenueStateAndReload(asExistingSupporter);
+	// Clearing out the epic view log happens before all reloads
+	clearCommonReaderRevenueStateAndReload(asExistingSupporter);
 };
 
 const clearBannerHistory = () => {
-    userPrefs.remove(lastClosedAtKey);
+	userPrefs.remove(lastClosedAtKey);
 };
 
 const showMeTheBanner = (asExistingSupporter = false) => {
-    clearBannerHistory();
+	clearBannerHistory();
 
-    // The banner only displays after a certain number of pageviews. So let's get there quick!
-    storage.local.setRaw('gu.alreadyVisited', minArticlesBeforeShowingBanner + 1);
+	// The banner only displays after a certain number of pageviews. So let's get there quick!
+	storage.local.setRaw(
+		'gu.alreadyVisited',
+		minArticlesBeforeShowingBanner + 1,
+	);
 
-
-    clearCommonReaderRevenueStateAndReload(asExistingSupporter);
+	clearCommonReaderRevenueStateAndReload(asExistingSupporter);
 };
 
 const showMeTheDoubleBanner = (asExistingSupporter = false) => {
-    showMeTheBanner(asExistingSupporter);
+	showMeTheBanner(asExistingSupporter);
 };
 
 // For the below functions, assume the user can currently see the thing
@@ -100,35 +100,35 @@ const showMeTheDoubleBanner = (asExistingSupporter = false) => {
 // we don't necessarily want the banner popping up if someone's working
 // with the epic.
 const showNextVariant = (asExistingSupporter = false) => {
-    incrementMvtCookie();
-    clearCommonReaderRevenueStateAndReload(asExistingSupporter);
+	incrementMvtCookie();
+	clearCommonReaderRevenueStateAndReload(asExistingSupporter);
 };
 
 const showPreviousVariant = (asExistingSupporter = false) => {
-    decrementMvtCookie();
-    clearCommonReaderRevenueStateAndReload(asExistingSupporter);
+	decrementMvtCookie();
+	clearCommonReaderRevenueStateAndReload(asExistingSupporter);
 };
 
 const changeGeolocation = (asExistingSupporter = false) => {
-    const geo = window.prompt(
-        `Enter two-letter geolocation code (e.g. GB, US, AU). Current is ${getCountryCode()}.`
-    );
-    if (geo === 'UK') {
-        alert(`'UK' is not a valid geolocation - please use 'GB' instead!`);
-    } else if (geo) {
-        overrideGeolocation(geo);
-        clearCommonReaderRevenueStateAndReload(asExistingSupporter);
-    }
+	const geo = window.prompt(
+		`Enter two-letter geolocation code (e.g. GB, US, AU). Current is ${getCountryCode()}.`,
+	);
+	if (geo === 'UK') {
+		alert(`'UK' is not a valid geolocation - please use 'GB' instead!`);
+	} else if (geo) {
+		overrideGeolocation(geo);
+		clearCommonReaderRevenueStateAndReload(asExistingSupporter);
+	}
 };
 
 export const init = () => {
-    // Expose functions so they can be called on the console and within bookmarklets
-    window.guardian.readerRevenue = {
-        showMeTheEpic,
-        showMeTheBanner,
-        showMeTheDoubleBanner,
-        showNextVariant,
-        showPreviousVariant,
-        changeGeolocation,
-    };
+	// Expose functions so they can be called on the console and within bookmarklets
+	window.guardian.readerRevenue = {
+		showMeTheEpic,
+		showMeTheBanner,
+		showMeTheDoubleBanner,
+		showNextVariant,
+		showPreviousVariant,
+		changeGeolocation,
+	};
 };

--- a/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
@@ -1,40 +1,39 @@
 import {
-    countryCodeToSupportInternationalisationId,
-    getCountryCode,
+	countryCodeToSupportInternationalisationId,
+	getCountryCode,
 } from '../../../../lib/geolocation';
 
 const addCountryGroupToSupportLink = (rawUrl) => {
-    const countryCode = getCountryCode();
-    if (countryCode) {
-        const countryGroup = countryCodeToSupportInternationalisationId(
-            countryCode
-        );
-        return rawUrl.replace(
-            /(support.theguardian.com)\/(contribute|subscribe)/,
-            (_, domain, path) =>
-                `${domain}/${countryGroup.toLowerCase()}/${path}`
-        );
-    }
+	const countryCode = getCountryCode();
+	if (countryCode) {
+		const countryGroup = countryCodeToSupportInternationalisationId(
+			countryCode,
+		);
+		return rawUrl.replace(
+			/(support.theguardian.com)\/(contribute|subscribe)/,
+			(_, domain, path) =>
+				`${domain}/${countryGroup.toLowerCase()}/${path}`,
+		);
+	}
 
-    return rawUrl;
+	return rawUrl;
 };
 
 const supportContributeGeoRedirectURL =
-    'https://support.theguardian.com/contribute';
+	'https://support.theguardian.com/contribute';
 const supportSubscribeGeoRedirectURL =
-    'https://support.theguardian.com/subscribe';
+	'https://support.theguardian.com/subscribe';
 const supportContributeURL = () =>
-    addCountryGroupToSupportLink(supportContributeGeoRedirectURL);
+	addCountryGroupToSupportLink(supportContributeGeoRedirectURL);
 const supportSubscribeURL = () =>
-    addCountryGroupToSupportLink(supportSubscribeGeoRedirectURL);
-const supportSubscribeDigitalURL = () =>
-    `${supportSubscribeURL()}/digital`;
+	addCountryGroupToSupportLink(supportSubscribeGeoRedirectURL);
+const supportSubscribeDigitalURL = () => `${supportSubscribeURL()}/digital`;
 
 export {
-    supportContributeGeoRedirectURL,
-    supportSubscribeGeoRedirectURL,
-    supportContributeURL,
-    supportSubscribeURL,
-    supportSubscribeDigitalURL,
-    addCountryGroupToSupportLink,
+	supportContributeGeoRedirectURL,
+	supportSubscribeGeoRedirectURL,
+	supportContributeURL,
+	supportSubscribeURL,
+	supportSubscribeDigitalURL,
+	addCountryGroupToSupportLink,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/support-utilities.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/support-utilities.spec.js
@@ -2,40 +2,40 @@ import { addCountryGroupToSupportLink } from './support-utilities';
 import { getCookie } from '../../../../lib/cookies';
 
 jest.mock('../../../../lib/cookies', () => ({
-    getCookie: jest.fn(() => null),
+	getCookie: jest.fn(() => null),
 }));
 
 jest.mock('lib/raven');
 
 describe('addCountryGroupToSupportLink', () => {
-    beforeEach(() => {
-        getCookie.mockImplementation(() => null);
-    });
+	beforeEach(() => {
+		getCookie.mockImplementation(() => null);
+	});
 
-    test('adds country group to subscribe link', async () => {
-        getCookie.mockImplementation(() => 'GB');
-        expect(
-            await addCountryGroupToSupportLink(
-                'https://support.theguardian.com/subscribe'
-            )
-        ).toEqual('https://support.theguardian.com/uk/subscribe');
-    });
+	test('adds country group to subscribe link', async () => {
+		getCookie.mockImplementation(() => 'GB');
+		expect(
+			await addCountryGroupToSupportLink(
+				'https://support.theguardian.com/subscribe',
+			),
+		).toEqual('https://support.theguardian.com/uk/subscribe');
+	});
 
-    test('adds country group to contribute link', async () => {
-        getCookie.mockImplementation(() => 'FR');
-        expect(
-            await addCountryGroupToSupportLink(
-                'https://support.theguardian.com/contribute'
-            )
-        ).toEqual('https://support.theguardian.com/eu/contribute');
-    });
+	test('adds country group to contribute link', async () => {
+		getCookie.mockImplementation(() => 'FR');
+		expect(
+			await addCountryGroupToSupportLink(
+				'https://support.theguardian.com/contribute',
+			),
+		).toEqual('https://support.theguardian.com/eu/contribute');
+	});
 
-    test('does not add country group to contribute link with country group already in it', async () => {
-        getCookie.mockImplementation(() => 'GB');
-        expect(
-            await addCountryGroupToSupportLink(
-                'https://support.theguardian.com/int/contribute'
-            )
-        ).toEqual('https://support.theguardian.com/int/contribute');
-    });
+	test('does not add country group to contribute link with country group already in it', async () => {
+		getCookie.mockImplementation(() => 'GB');
+		expect(
+			await addCountryGroupToSupportLink(
+				'https://support.theguardian.com/int/contribute',
+			),
+		).toEqual('https://support.theguardian.com/int/contribute');
+	});
 });

--- a/static/src/javascripts/projects/common/modules/commercial/user-ad-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-ad-targeting.js
@@ -4,48 +4,48 @@ import { getUserFromCookie, getUserFromApi } from '../identity/api';
 const userSegmentsKey = 'gu.ads.userSegmentsData';
 
 const getUserSegments = (adConsentState) => {
-    if (storage.local.isAvailable() && adConsentState !== false) {
-        const userSegmentsData = storage.local.get(userSegmentsKey);
+	if (storage.local.isAvailable() && adConsentState !== false) {
+		const userSegmentsData = storage.local.get(userSegmentsKey);
 
-        if (userSegmentsData) {
-            const userCookieData = getUserFromCookie();
+		if (userSegmentsData) {
+			const userCookieData = getUserFromCookie();
 
-            if (
-                userCookieData &&
-                userSegmentsData.userHash === userCookieData.id % 9999
-            ) {
-                return userSegmentsData.segments;
-            }
-            storage.local.remove(userSegmentsKey);
-        }
-    }
+			if (
+				userCookieData &&
+				userSegmentsData.userHash === userCookieData.id % 9999
+			) {
+				return userSegmentsData.segments;
+			}
+			storage.local.remove(userSegmentsKey);
+		}
+	}
 
-    return [];
+	return [];
 };
 
 const requestUserSegmentsFromId = () => {
-    if (
-        storage.local.isAvailable() &&
-        storage.local.get(userSegmentsKey) === null &&
-        getUserFromCookie()
-    ) {
-        getUserFromApi(user => {
-            if (user && user.adData) {
-                const userSegments = [];
-                Object.keys(user.adData).forEach(key => {
-                    userSegments.push(key + user.adData[key]);
-                });
-                storage.local.set(
-                    userSegmentsKey,
-                    {
-                        segments: userSegments,
-                        userHash: user.id % 9999,
-                    },
-                    new Date().getTime() + 24 * 60 * 60 * 1000
-                );
-            }
-        });
-    }
+	if (
+		storage.local.isAvailable() &&
+		storage.local.get(userSegmentsKey) === null &&
+		getUserFromCookie()
+	) {
+		getUserFromApi((user) => {
+			if (user && user.adData) {
+				const userSegments = [];
+				Object.keys(user.adData).forEach((key) => {
+					userSegments.push(key + user.adData[key]);
+				});
+				storage.local.set(
+					userSegmentsKey,
+					{
+						segments: userSegments,
+						userHash: user.id % 9999,
+					},
+					new Date().getTime() + 24 * 60 * 60 * 1000,
+				);
+			}
+		});
+	}
 };
 
 export { getUserSegments, requestUserSegmentsFromId };

--- a/static/src/javascripts/projects/common/modules/commercial/user-ad-targeting.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-ad-targeting.spec.js
@@ -1,74 +1,74 @@
 import { storage } from '@guardian/libs';
 import {
-    getUserFromApi as getUserFromApi_,
-    getUserFromCookie as getUserFromCookie_,
+	getUserFromApi as getUserFromApi_,
+	getUserFromCookie as getUserFromCookie_,
 } from '../identity/api';
 import {
-    getUserSegments,
-    requestUserSegmentsFromId,
+	getUserSegments,
+	requestUserSegmentsFromId,
 } from './user-ad-targeting';
 
 const getUserFromApi = getUserFromApi_;
 const getUserFromCookie = getUserFromCookie_;
 
 jest.mock('../identity/api', () => ({
-    getUserFromCookie: jest.fn(),
-    getUserFromApi: jest.fn(),
+	getUserFromCookie: jest.fn(),
+	getUserFromApi: jest.fn(),
 }));
 const userSegmentsKey = 'gu.ads.userSegmentsData';
 
 describe('User Ad Targeting', () => {
-    beforeEach(() => {
-        jest.resetAllMocks();
-        getUserFromCookie.mockReturnValue({ id: 999900123 });
-    });
+	beforeEach(() => {
+		jest.resetAllMocks();
+		getUserFromCookie.mockReturnValue({ id: 999900123 });
+	});
 
-    it('should exist', () => {
-        expect(getUserSegments).toBeDefined();
-        expect(requestUserSegmentsFromId).toBeDefined();
-    });
+	it('should exist', () => {
+		expect(getUserSegments).toBeDefined();
+		expect(requestUserSegmentsFromId).toBeDefined();
+	});
 
-    it('should only return segments when consent is true or null', () => {
-        storage.local.set(userSegmentsKey, {
-            userHash: 123,
-            segments: 'something',
-        });
-        expect(getUserSegments(null)).toBe('something');
-        expect(getUserSegments(true)).toBe('something');
-        expect(getUserSegments(false).length).toBe(0);
-    });
+	it('should only return segments when consent is true or null', () => {
+		storage.local.set(userSegmentsKey, {
+			userHash: 123,
+			segments: 'something',
+		});
+		expect(getUserSegments(null)).toBe('something');
+		expect(getUserSegments(true)).toBe('something');
+		expect(getUserSegments(false).length).toBe(0);
+	});
 
-    it('should return user segments data from local storage', () => {
-        storage.local.set(userSegmentsKey, {
-            userHash: 123,
-            segments: 'something',
-        });
-        expect(getUserSegments(true)).toBe('something');
-    });
+	it('should return user segments data from local storage', () => {
+		storage.local.set(userSegmentsKey, {
+			userHash: 123,
+			segments: 'something',
+		});
+		expect(getUserSegments(true)).toBe('something');
+	});
 
-    it('should remove user segments belonging to another user from local storage', () => {
-        storage.local.set(userSegmentsKey, {
-            userHash: 456,
-            segments: 'anything',
-        });
-        expect(getUserSegments(true).length).toBe(0);
-        expect(storage.local.get(userSegmentsKey)).toBeFalsy();
-    });
+	it('should remove user segments belonging to another user from local storage', () => {
+		storage.local.set(userSegmentsKey, {
+			userHash: 456,
+			segments: 'anything',
+		});
+		expect(getUserSegments(true).length).toBe(0);
+		expect(storage.local.get(userSegmentsKey)).toBeFalsy();
+	});
 
-    it('should request user data from API and populate local storage', () => {
-        getUserFromApi.mockImplementation(fn =>
-            fn({
-                id: 999900789,
-                adData: {
-                    a: 'b',
-                    c: 'd',
-                },
-            })
-        );
-        requestUserSegmentsFromId();
-        expect(storage.local.get(userSegmentsKey)).toMatchObject({
-            segments: ['ab', 'cd'],
-            userHash: 789,
-        });
-    });
+	it('should request user data from API and populate local storage', () => {
+		getUserFromApi.mockImplementation((fn) =>
+			fn({
+				id: 999900789,
+				adData: {
+					a: 'b',
+					c: 'd',
+				},
+			}),
+		);
+		requestUserSegmentsFromId();
+		expect(storage.local.get(userSegmentsKey)).toMatchObject({
+			segments: ['ab', 'cd'],
+			userHash: 789,
+		});
+	});
 });

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -19,197 +19,191 @@ const ONE_OFF_CONTRIBUTION_DATE_COOKIE = 'gu_one_off_contribution_date';
 // These cookies are dropped by support frontend at the point of making
 // a recurring contribution
 const SUPPORT_RECURRING_CONTRIBUTOR_MONTHLY_COOKIE =
-    'gu.contributions.recurring.contrib-timestamp.Monthly';
+	'gu.contributions.recurring.contrib-timestamp.Monthly';
 const SUPPORT_RECURRING_CONTRIBUTOR_ANNUAL_COOKIE =
-    'gu.contributions.recurring.contrib-timestamp.Annual';
+	'gu.contributions.recurring.contrib-timestamp.Annual';
 const SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE =
-    'gu.contributions.contrib-timestamp';
+	'gu.contributions.contrib-timestamp';
 
 const ARTICLES_VIEWED_OPT_OUT_COOKIE = {
-    name: 'gu_article_count_opt_out',
-    daysToLive: 90,
+	name: 'gu_article_count_opt_out',
+	daysToLive: 90,
 };
 
 const CONTRIBUTIONS_REMINDER_SIGNED_UP = {
-    name: 'gu_contributions_reminder_signed_up',
-    daysToLive: 90,
+	name: 'gu_contributions_reminder_signed_up',
+	daysToLive: 90,
 };
 
-const forcedAdFreeMode = !!window.location.hash.match(
-    /[#&]noadsaf(&.*)?$/
-);
+const forcedAdFreeMode = !!window.location.hash.match(/[#&]noadsaf(&.*)?$/);
 
 const userHasData = () => {
-    const cookie =
-        getCookie(ACTION_REQUIRED_FOR_COOKIE) ||
-        getCookie(USER_FEATURES_EXPIRY_COOKIE) ||
-        getCookie(PAYING_MEMBER_COOKIE) ||
-        getCookie(RECURRING_CONTRIBUTOR_COOKIE) ||
-        getCookie(ONE_OFF_CONTRIBUTION_DATE_COOKIE) ||
-        getCookie(AD_FREE_USER_COOKIE) ||
-        getCookie(DIGITAL_SUBSCRIBER_COOKIE) ||
-        getCookie(HIDE_SUPPORT_MESSAGING_COOKIE);
-    return !!cookie;
+	const cookie =
+		getCookie(ACTION_REQUIRED_FOR_COOKIE) ||
+		getCookie(USER_FEATURES_EXPIRY_COOKIE) ||
+		getCookie(PAYING_MEMBER_COOKIE) ||
+		getCookie(RECURRING_CONTRIBUTOR_COOKIE) ||
+		getCookie(ONE_OFF_CONTRIBUTION_DATE_COOKIE) ||
+		getCookie(AD_FREE_USER_COOKIE) ||
+		getCookie(DIGITAL_SUBSCRIBER_COOKIE) ||
+		getCookie(HIDE_SUPPORT_MESSAGING_COOKIE);
+	return !!cookie;
 };
 
-const accountDataUpdateWarning = () =>
-    getCookie(ACTION_REQUIRED_FOR_COOKIE);
+const accountDataUpdateWarning = () => getCookie(ACTION_REQUIRED_FOR_COOKIE);
 
 const adFreeDataIsPresent = () => {
-    const cookieVal = getCookie(AD_FREE_USER_COOKIE);
-    return !Number.isNaN(parseInt(cookieVal, 10));
+	const cookieVal = getCookie(AD_FREE_USER_COOKIE);
+	return !Number.isNaN(parseInt(cookieVal, 10));
 };
 
 const timeInDaysFromNow = (daysFromNow) => {
-    const tmpDate = new Date();
-    tmpDate.setDate(tmpDate.getDate() + daysFromNow);
-    return tmpDate.getTime().toString();
+	const tmpDate = new Date();
+	tmpDate.setDate(tmpDate.getDate() + daysFromNow);
+	return tmpDate.getTime().toString();
 };
 
 const persistResponse = (JsonResponse) => {
-    addCookie(USER_FEATURES_EXPIRY_COOKIE, timeInDaysFromNow(1));
-    addCookie(PAYING_MEMBER_COOKIE, JsonResponse.contentAccess.paidMember);
-    addCookie(
-        RECURRING_CONTRIBUTOR_COOKIE,
-        JsonResponse.contentAccess.recurringContributor
-    );
-    addCookie(
-        DIGITAL_SUBSCRIBER_COOKIE,
-        JsonResponse.contentAccess.digitalPack
-    );
-    addCookie(
-        HIDE_SUPPORT_MESSAGING_COOKIE,
-        !JsonResponse.showSupportMessaging
-    );
-    if (JsonResponse.oneOffContributionDate) {
-        addCookie(
-            ONE_OFF_CONTRIBUTION_DATE_COOKIE,
-            JsonResponse.oneOffContributionDate
-        );
-    }
+	addCookie(USER_FEATURES_EXPIRY_COOKIE, timeInDaysFromNow(1));
+	addCookie(PAYING_MEMBER_COOKIE, JsonResponse.contentAccess.paidMember);
+	addCookie(
+		RECURRING_CONTRIBUTOR_COOKIE,
+		JsonResponse.contentAccess.recurringContributor,
+	);
+	addCookie(
+		DIGITAL_SUBSCRIBER_COOKIE,
+		JsonResponse.contentAccess.digitalPack,
+	);
+	addCookie(
+		HIDE_SUPPORT_MESSAGING_COOKIE,
+		!JsonResponse.showSupportMessaging,
+	);
+	if (JsonResponse.oneOffContributionDate) {
+		addCookie(
+			ONE_OFF_CONTRIBUTION_DATE_COOKIE,
+			JsonResponse.oneOffContributionDate,
+		);
+	}
 
-    removeCookie(ACTION_REQUIRED_FOR_COOKIE);
-    if ('alertAvailableFor' in JsonResponse) {
-        addCookie(ACTION_REQUIRED_FOR_COOKIE, JsonResponse.alertAvailableFor);
-    }
+	removeCookie(ACTION_REQUIRED_FOR_COOKIE);
+	if ('alertAvailableFor' in JsonResponse) {
+		addCookie(ACTION_REQUIRED_FOR_COOKIE, JsonResponse.alertAvailableFor);
+	}
 
-    if (
-        adFreeDataIsPresent() &&
-        !forcedAdFreeMode &&
-        !JsonResponse.contentAccess.digitalPack
-    ) {
-        removeCookie(AD_FREE_USER_COOKIE);
-    }
+	if (
+		adFreeDataIsPresent() &&
+		!forcedAdFreeMode &&
+		!JsonResponse.contentAccess.digitalPack
+	) {
+		removeCookie(AD_FREE_USER_COOKIE);
+	}
 
-    if (JsonResponse.contentAccess.digitalPack) {
-        addCookie(AD_FREE_USER_COOKIE, timeInDaysFromNow(2));
-    }
+	if (JsonResponse.contentAccess.digitalPack) {
+		addCookie(AD_FREE_USER_COOKIE, timeInDaysFromNow(2));
+	}
 };
 
 const deleteOldData = () => {
-    // We expect adfree cookies to be cleaned up by the logout process, but what if the user's login simply times out?
-    removeCookie(USER_FEATURES_EXPIRY_COOKIE);
-    removeCookie(PAYING_MEMBER_COOKIE);
-    removeCookie(RECURRING_CONTRIBUTOR_COOKIE);
-    removeCookie(AD_FREE_USER_COOKIE);
-    removeCookie(ACTION_REQUIRED_FOR_COOKIE);
-    removeCookie(DIGITAL_SUBSCRIBER_COOKIE);
-    removeCookie(HIDE_SUPPORT_MESSAGING_COOKIE);
-    removeCookie(ONE_OFF_CONTRIBUTION_DATE_COOKIE);
+	// We expect adfree cookies to be cleaned up by the logout process, but what if the user's login simply times out?
+	removeCookie(USER_FEATURES_EXPIRY_COOKIE);
+	removeCookie(PAYING_MEMBER_COOKIE);
+	removeCookie(RECURRING_CONTRIBUTOR_COOKIE);
+	removeCookie(AD_FREE_USER_COOKIE);
+	removeCookie(ACTION_REQUIRED_FOR_COOKIE);
+	removeCookie(DIGITAL_SUBSCRIBER_COOKIE);
+	removeCookie(HIDE_SUPPORT_MESSAGING_COOKIE);
+	removeCookie(ONE_OFF_CONTRIBUTION_DATE_COOKIE);
 };
 
 const requestNewData = () =>
-    fetchJson(`${config.get('page.userAttributesApiUrl')}/me`, {
-        mode: 'cors',
-        credentials: 'include',
-    })
-        .then(persistResponse)
-        .catch(() => {});
+	fetchJson(`${config.get('page.userAttributesApiUrl')}/me`, {
+		mode: 'cors',
+		credentials: 'include',
+	})
+		.then(persistResponse)
+		.catch(() => {});
 
 const datedCookieIsOld = (datedCookieName) => {
-    const expiryDateFromCookie = getCookie(datedCookieName);
-    const expiryTime = parseInt(expiryDateFromCookie, 10);
-    const timeNow = new Date().getTime();
-    return timeNow >= expiryTime;
+	const expiryDateFromCookie = getCookie(datedCookieName);
+	const expiryTime = parseInt(expiryDateFromCookie, 10);
+	const timeNow = new Date().getTime();
+	return timeNow >= expiryTime;
 };
 
-const featuresDataIsMissing = () =>
-    !getCookie(USER_FEATURES_EXPIRY_COOKIE);
+const featuresDataIsMissing = () => !getCookie(USER_FEATURES_EXPIRY_COOKIE);
 
-const featuresDataIsOld = () =>
-    datedCookieIsOld(USER_FEATURES_EXPIRY_COOKIE);
+const featuresDataIsOld = () => datedCookieIsOld(USER_FEATURES_EXPIRY_COOKIE);
 
 const adFreeDataIsOld = () => {
-    const switches = config.get('switches');
-    return (
-        switches.adFreeStrictExpiryEnforcement &&
-        datedCookieIsOld(AD_FREE_USER_COOKIE)
-    );
+	const switches = config.get('switches');
+	return (
+		switches.adFreeStrictExpiryEnforcement &&
+		datedCookieIsOld(AD_FREE_USER_COOKIE)
+	);
 };
 
 const userNeedsNewFeatureData = () =>
-    featuresDataIsMissing() ||
-    featuresDataIsOld() ||
-    (adFreeDataIsPresent() && adFreeDataIsOld());
+	featuresDataIsMissing() ||
+	featuresDataIsOld() ||
+	(adFreeDataIsPresent() && adFreeDataIsOld());
 
-const userHasDataAfterSignout = () =>
-    !isUserLoggedIn() && userHasData();
+const userHasDataAfterSignout = () => !isUserLoggedIn() && userHasData();
 
 /**
  * Updates the user's data in a lazy fashion
  */
 const refresh = () => {
-    if (isUserLoggedIn() && userNeedsNewFeatureData()) {
-        return requestNewData();
-    } else if (userHasDataAfterSignout() && !forcedAdFreeMode) {
-        deleteOldData();
-    }
-    return Promise.resolve();
+	if (isUserLoggedIn() && userNeedsNewFeatureData()) {
+		return requestNewData();
+	} else if (userHasDataAfterSignout() && !forcedAdFreeMode) {
+		deleteOldData();
+	}
+	return Promise.resolve();
 };
 
 const supportSiteRecurringCookiePresent = () =>
-    getCookie(SUPPORT_RECURRING_CONTRIBUTOR_MONTHLY_COOKIE) != null ||
-    getCookie(SUPPORT_RECURRING_CONTRIBUTOR_ANNUAL_COOKIE) != null;
+	getCookie(SUPPORT_RECURRING_CONTRIBUTOR_MONTHLY_COOKIE) != null ||
+	getCookie(SUPPORT_RECURRING_CONTRIBUTOR_ANNUAL_COOKIE) != null;
 
 /**
  * Does our _existing_ data say the user is a paying member?
  * This data may be stale; we do not wait for userFeatures.refresh()
  */
 const isPayingMember = () =>
-    // If the user is logged in, but has no cookie yet, play it safe and assume they're a paying user
-    isUserLoggedIn() && getCookie(PAYING_MEMBER_COOKIE) !== 'false';
+	// If the user is logged in, but has no cookie yet, play it safe and assume they're a paying user
+	isUserLoggedIn() && getCookie(PAYING_MEMBER_COOKIE) !== 'false';
 
 // Expects milliseconds since epoch
 const getSupportFrontendOneOffContributionTimestamp = () => {
-    const supportFrontendCookie = getCookie(
-        SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE
-    );
+	const supportFrontendCookie = getCookie(
+		SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
+	);
 
-    if (supportFrontendCookie) {
-        const ms = parseInt(supportFrontendCookie, 10);
-        if (Number.isInteger(ms)) return ms;
-    }
+	if (supportFrontendCookie) {
+		const ms = parseInt(supportFrontendCookie, 10);
+		if (Number.isInteger(ms)) return ms;
+	}
 
-    return null;
+	return null;
 };
 
 // Expects YYYY-MM-DD format
 const getAttributesOneOffContributionTimestamp = () => {
-    const attributesCookie = getCookie(ONE_OFF_CONTRIBUTION_DATE_COOKIE);
+	const attributesCookie = getCookie(ONE_OFF_CONTRIBUTION_DATE_COOKIE);
 
-    if (attributesCookie) {
-        const ms = Date.parse(attributesCookie);
-        if (Number.isInteger(ms)) return ms;
-    }
+	if (attributesCookie) {
+		const ms = Date.parse(attributesCookie);
+		if (Number.isInteger(ms)) return ms;
+	}
 
-    return null;
+	return null;
 };
 
 // number returned is Epoch time in milliseconds.
 // null value signifies no last contribution date.
 const getLastOneOffContributionTimestamp = () =>
-    getSupportFrontendOneOffContributionTimestamp() ||
-    getAttributesOneOffContributionTimestamp();
+	getSupportFrontendOneOffContributionTimestamp() ||
+	getAttributesOneOffContributionTimestamp();
 
 const getLastOneOffContributionDate = () => {
 	const timestamp = getLastOneOffContributionTimestamp();
@@ -224,70 +218,68 @@ const getLastOneOffContributionDate = () => {
 	const day = date.getDate().toString().padStart(2, '0');
 
 	return `${year}-${month}-${day}`;
-}
+};
 
 const getLastRecurringContributionDate = () => {
-    // Check for cookies, ensure that cookies parse, and ensure parsed results are integers
-    const monthlyCookie = getCookie(
-        SUPPORT_RECURRING_CONTRIBUTOR_MONTHLY_COOKIE
-    );
-    const annualCookie = getCookie(SUPPORT_RECURRING_CONTRIBUTOR_ANNUAL_COOKIE);
-    const monthlyTime = monthlyCookie ? parseInt(monthlyCookie, 10) : null;
-    const annualTime = annualCookie ? parseInt(annualCookie, 10) : null;
-    const monthlyMS =
-        monthlyTime && Number.isInteger(monthlyTime) ? monthlyTime : null;
-    const annualMS =
-        annualTime && Number.isInteger(annualTime) ? annualTime : null;
+	// Check for cookies, ensure that cookies parse, and ensure parsed results are integers
+	const monthlyCookie = getCookie(
+		SUPPORT_RECURRING_CONTRIBUTOR_MONTHLY_COOKIE,
+	);
+	const annualCookie = getCookie(SUPPORT_RECURRING_CONTRIBUTOR_ANNUAL_COOKIE);
+	const monthlyTime = monthlyCookie ? parseInt(monthlyCookie, 10) : null;
+	const annualTime = annualCookie ? parseInt(annualCookie, 10) : null;
+	const monthlyMS =
+		monthlyTime && Number.isInteger(monthlyTime) ? monthlyTime : null;
+	const annualMS =
+		annualTime && Number.isInteger(annualTime) ? annualTime : null;
 
-    if (!monthlyMS && !annualMS) {
-        return null;
-    }
+	if (!monthlyMS && !annualMS) {
+		return null;
+	}
 
-    if (monthlyMS && annualMS) {
-        return Math.max(monthlyMS, annualMS);
-    }
+	if (monthlyMS && annualMS) {
+		return Math.max(monthlyMS, annualMS);
+	}
 
-    return monthlyMS || annualMS || null;
+	return monthlyMS || annualMS || null;
 };
 
 const getDaysSinceLastOneOffContribution = () => {
-    const lastContributionDate = getLastOneOffContributionTimestamp();
-    if (lastContributionDate === null) {
-        return null;
-    }
-    return dateDiffDays(lastContributionDate, Date.now());
+	const lastContributionDate = getLastOneOffContributionTimestamp();
+	if (lastContributionDate === null) {
+		return null;
+	}
+	return dateDiffDays(lastContributionDate, Date.now());
 };
 
 // defaults to last three months
 const isRecentOneOffContributor = (askPauseDays = 90) => {
-    const daysSinceLastContribution = getDaysSinceLastOneOffContribution();
-    if (daysSinceLastContribution === null) {
-        return false;
-    }
-    return daysSinceLastContribution <= askPauseDays;
+	const daysSinceLastContribution = getDaysSinceLastOneOffContribution();
+	if (daysSinceLastContribution === null) {
+		return false;
+	}
+	return daysSinceLastContribution <= askPauseDays;
 };
 
 // true if the user has completed their ask-free period
-const isPostAskPauseOneOffContributor = (
-    askPauseDays = 90
-) => {
-    const daysSinceLastContribution = getDaysSinceLastOneOffContribution();
-    if (daysSinceLastContribution === null) {
-        return false;
-    }
-    return daysSinceLastContribution > askPauseDays;
+const isPostAskPauseOneOffContributor = (askPauseDays = 90) => {
+	const daysSinceLastContribution = getDaysSinceLastOneOffContribution();
+	if (daysSinceLastContribution === null) {
+		return false;
+	}
+	return daysSinceLastContribution > askPauseDays;
 };
 
 const isRecurringContributor = () =>
-    // If the user is logged in, but has no cookie yet, play it safe and assume they're a contributor
-    (isUserLoggedIn() && getCookie(RECURRING_CONTRIBUTOR_COOKIE) !== 'false') ||
-    supportSiteRecurringCookiePresent();
+	// If the user is logged in, but has no cookie yet, play it safe and assume they're a contributor
+	(isUserLoggedIn() && getCookie(RECURRING_CONTRIBUTOR_COOKIE) !== 'false') ||
+	supportSiteRecurringCookiePresent();
 
 const isDigitalSubscriber = () =>
-    getCookie(DIGITAL_SUBSCRIBER_COOKIE) === 'true';
+	getCookie(DIGITAL_SUBSCRIBER_COOKIE) === 'true';
 
 const shouldNotBeShownSupportMessaging = () =>
-    getCookie(HIDE_SUPPORT_MESSAGING_COOKIE) === 'true';
+	getCookie(HIDE_SUPPORT_MESSAGING_COOKIE) === 'true';
 
 /*
     Whenever the checks are updated, please make sure to update
@@ -298,69 +290,73 @@ const shouldNotBeShownSupportMessaging = () =>
 */
 
 const shouldHideSupportMessaging = () =>
-    shouldNotBeShownSupportMessaging() ||
-    isRecentOneOffContributor() || // because members-data-api is unaware of one-off contributions so relies on cookie
-    isRecurringContributor(); // guest checkout means that members-data-api isn't aware of all recurring contributions so relies on cookie
+	shouldNotBeShownSupportMessaging() ||
+	isRecentOneOffContributor() || // because members-data-api is unaware of one-off contributions so relies on cookie
+	isRecurringContributor(); // guest checkout means that members-data-api isn't aware of all recurring contributions so relies on cookie
 
 const readerRevenueRelevantCookies = [
-    PAYING_MEMBER_COOKIE,
-    DIGITAL_SUBSCRIBER_COOKIE,
-    RECURRING_CONTRIBUTOR_COOKIE,
-    SUPPORT_RECURRING_CONTRIBUTOR_MONTHLY_COOKIE,
-    SUPPORT_RECURRING_CONTRIBUTOR_ANNUAL_COOKIE,
-    SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
-    HIDE_SUPPORT_MESSAGING_COOKIE,
+	PAYING_MEMBER_COOKIE,
+	DIGITAL_SUBSCRIBER_COOKIE,
+	RECURRING_CONTRIBUTOR_COOKIE,
+	SUPPORT_RECURRING_CONTRIBUTOR_MONTHLY_COOKIE,
+	SUPPORT_RECURRING_CONTRIBUTOR_ANNUAL_COOKIE,
+	SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
+	HIDE_SUPPORT_MESSAGING_COOKIE,
 ];
 
 // For debug/test purposes
 const fakeOneOffContributor = () => {
-    addCookie(SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE, Date.now().toString());
+	addCookie(SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE, Date.now().toString());
 };
 
 const isAdFreeUser = () =>
-    isDigitalSubscriber() || (adFreeDataIsPresent() && !adFreeDataIsOld());
+	isDigitalSubscriber() || (adFreeDataIsPresent() && !adFreeDataIsOld());
 
 // Extend the expiry of the contributions cookie by 1 year beyond the date of the contribution
 const extendContribsCookieExpiry = () => {
-    const cookie = getCookie(SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE);
-    if (cookie) {
-        const contributionDate = parseInt(cookie, 10);
-        if (Number.isInteger(contributionDate)) {
-            const daysToLive = 365 - dateDiffDays(contributionDate, Date.now());
-            addCookie(
-                SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
-                contributionDate.toString(),
-                daysToLive
-            );
-        }
-    }
+	const cookie = getCookie(SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE);
+	if (cookie) {
+		const contributionDate = parseInt(cookie, 10);
+		if (Number.isInteger(contributionDate)) {
+			const daysToLive = 365 - dateDiffDays(contributionDate, Date.now());
+			addCookie(
+				SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
+				contributionDate.toString(),
+				daysToLive,
+			);
+		}
+	}
 };
 
 const canShowContributionsReminderFeature = () => {
-    const signedUpForReminder = !!getCookie(CONTRIBUTIONS_REMINDER_SIGNED_UP.name);
-    return config.get('switches.showContributionReminder') && !signedUpForReminder;
+	const signedUpForReminder = !!getCookie(
+		CONTRIBUTIONS_REMINDER_SIGNED_UP.name,
+	);
+	return (
+		config.get('switches.showContributionReminder') && !signedUpForReminder
+	);
 };
 
 export {
-    accountDataUpdateWarning,
-    isAdFreeUser,
-    isPayingMember,
-    isRecentOneOffContributor,
-    isRecurringContributor,
-    isDigitalSubscriber,
-    shouldHideSupportMessaging,
-    refresh,
-    deleteOldData,
-    getLastOneOffContributionTimestamp,
-    getLastOneOffContributionDate,
-    getLastRecurringContributionDate,
-    getDaysSinceLastOneOffContribution,
-    isPostAskPauseOneOffContributor,
-    readerRevenueRelevantCookies,
-    fakeOneOffContributor,
-    shouldNotBeShownSupportMessaging,
-    extendContribsCookieExpiry,
-    ARTICLES_VIEWED_OPT_OUT_COOKIE,
-    CONTRIBUTIONS_REMINDER_SIGNED_UP,
-    canShowContributionsReminderFeature
+	accountDataUpdateWarning,
+	isAdFreeUser,
+	isPayingMember,
+	isRecentOneOffContributor,
+	isRecurringContributor,
+	isDigitalSubscriber,
+	shouldHideSupportMessaging,
+	refresh,
+	deleteOldData,
+	getLastOneOffContributionTimestamp,
+	getLastOneOffContributionDate,
+	getLastRecurringContributionDate,
+	getDaysSinceLastOneOffContribution,
+	isPostAskPauseOneOffContributor,
+	readerRevenueRelevantCookies,
+	fakeOneOffContributor,
+	shouldNotBeShownSupportMessaging,
+	extendContribsCookieExpiry,
+	ARTICLES_VIEWED_OPT_OUT_COOKIE,
+	CONTRIBUTIONS_REMINDER_SIGNED_UP,
+	canShowContributionsReminderFeature,
 };

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.js
@@ -3,23 +3,23 @@ import { fetchJson } from '../../../../lib/fetch-json';
 import { isUserLoggedIn as isUserLoggedIn_ } from '../identity/api';
 import config from '../../../../lib/config';
 import {
-    refresh,
-    isAdFreeUser,
-    isPayingMember,
-    isRecurringContributor,
-    accountDataUpdateWarning,
-    isDigitalSubscriber,
-    getLastOneOffContributionTimestamp,
-    getDaysSinceLastOneOffContribution,
-    isRecentOneOffContributor,
-    shouldNotBeShownSupportMessaging,
-    getLastRecurringContributionDate,
-    isPostAskPauseOneOffContributor,
+	refresh,
+	isAdFreeUser,
+	isPayingMember,
+	isRecurringContributor,
+	accountDataUpdateWarning,
+	isDigitalSubscriber,
+	getLastOneOffContributionTimestamp,
+	getDaysSinceLastOneOffContribution,
+	isRecentOneOffContributor,
+	shouldNotBeShownSupportMessaging,
+	getLastRecurringContributionDate,
+	isPostAskPauseOneOffContributor,
 } from './user-features.js';
 
 jest.mock('../../../../lib/raven');
 jest.mock('projects/common/modules/identity/api', () => ({
-    isUserLoggedIn: jest.fn(),
+	isUserLoggedIn: jest.fn(),
 }));
 jest.mock('../../../../lib/fetch-json', () => ({
 	fetchJson: jest.fn(() => Promise.resolve()),
@@ -29,578 +29,582 @@ const fetchJsonSpy = fetchJson;
 const isUserLoggedIn = isUserLoggedIn_;
 
 const PERSISTENCE_KEYS = {
-    USER_FEATURES_EXPIRY_COOKIE: 'gu_user_features_expiry',
-    PAYING_MEMBER_COOKIE: 'gu_paying_member',
-    RECURRING_CONTRIBUTOR_COOKIE: 'gu_recurring_contributor',
-    AD_FREE_USER_COOKIE: 'GU_AF1',
-    ACTION_REQUIRED_FOR_COOKIE: 'gu_action_required_for',
-    DIGITAL_SUBSCRIBER_COOKIE: 'gu_digital_subscriber',
-    SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE: 'gu.contributions.contrib-timestamp',
-    ONE_OFF_CONTRIBUTION_DATE_COOKIE: 'gu_one_off_contribution_date',
-    HIDE_SUPPORT_MESSAGING_COOKIE: 'gu_hide_support_messaging',
-    SUPPORT_MONTHLY_CONTRIBUTION_COOKIE:
-        'gu.contributions.recurring.contrib-timestamp.Monthly',
-    SUPPORT_ANNUAL_CONTRIBUTION_COOKIE:
-        'gu.contributions.recurring.contrib-timestamp.Annual',
+	USER_FEATURES_EXPIRY_COOKIE: 'gu_user_features_expiry',
+	PAYING_MEMBER_COOKIE: 'gu_paying_member',
+	RECURRING_CONTRIBUTOR_COOKIE: 'gu_recurring_contributor',
+	AD_FREE_USER_COOKIE: 'GU_AF1',
+	ACTION_REQUIRED_FOR_COOKIE: 'gu_action_required_for',
+	DIGITAL_SUBSCRIBER_COOKIE: 'gu_digital_subscriber',
+	SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE: 'gu.contributions.contrib-timestamp',
+	ONE_OFF_CONTRIBUTION_DATE_COOKIE: 'gu_one_off_contribution_date',
+	HIDE_SUPPORT_MESSAGING_COOKIE: 'gu_hide_support_messaging',
+	SUPPORT_MONTHLY_CONTRIBUTION_COOKIE:
+		'gu.contributions.recurring.contrib-timestamp.Monthly',
+	SUPPORT_ANNUAL_CONTRIBUTION_COOKIE:
+		'gu.contributions.recurring.contrib-timestamp.Annual',
 };
 
-const setAllFeaturesData = opts => {
-    const currentTime = new Date().getTime();
-    const msInOneDay = 24 * 60 * 60 * 1000;
-    const expiryDate = opts.isExpired
-        ? new Date(currentTime - msInOneDay)
-        : new Date(currentTime + msInOneDay);
-    const adFreeExpiryDate = opts.isExpired
-        ? new Date(currentTime - msInOneDay * 2)
-        : new Date(currentTime + msInOneDay * 2);
-    addCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE, 'true');
-    addCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE, 'true');
-    addCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE, 'true');
-    addCookie(PERSISTENCE_KEYS.HIDE_SUPPORT_MESSAGING_COOKIE, 'true');
-    addCookie(
-        PERSISTENCE_KEYS.AD_FREE_USER_COOKIE,
-        adFreeExpiryDate.getTime().toString()
-    );
-    addCookie(
-        PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE,
-        expiryDate.getTime().toString()
-    );
-    addCookie(PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE, 'test');
+const setAllFeaturesData = (opts) => {
+	const currentTime = new Date().getTime();
+	const msInOneDay = 24 * 60 * 60 * 1000;
+	const expiryDate = opts.isExpired
+		? new Date(currentTime - msInOneDay)
+		: new Date(currentTime + msInOneDay);
+	const adFreeExpiryDate = opts.isExpired
+		? new Date(currentTime - msInOneDay * 2)
+		: new Date(currentTime + msInOneDay * 2);
+	addCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE, 'true');
+	addCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE, 'true');
+	addCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE, 'true');
+	addCookie(PERSISTENCE_KEYS.HIDE_SUPPORT_MESSAGING_COOKIE, 'true');
+	addCookie(
+		PERSISTENCE_KEYS.AD_FREE_USER_COOKIE,
+		adFreeExpiryDate.getTime().toString(),
+	);
+	addCookie(
+		PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE,
+		expiryDate.getTime().toString(),
+	);
+	addCookie(PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE, 'test');
 };
 
 const setExpiredAdFreeData = () => {
-    const currentTime = new Date().getTime();
-    const msInOneDay = 24 * 60 * 60 * 1000;
-    const expiryDate = new Date(currentTime - msInOneDay * 2);
-    addCookie(
-        PERSISTENCE_KEYS.AD_FREE_USER_COOKIE,
-        expiryDate.getTime().toString()
-    );
+	const currentTime = new Date().getTime();
+	const msInOneDay = 24 * 60 * 60 * 1000;
+	const expiryDate = new Date(currentTime - msInOneDay * 2);
+	addCookie(
+		PERSISTENCE_KEYS.AD_FREE_USER_COOKIE,
+		expiryDate.getTime().toString(),
+	);
 };
 
 const deleteAllFeaturesData = () => {
-    removeCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE);
-    removeCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE);
-    removeCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE);
-    removeCookie(PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE);
-    removeCookie(PERSISTENCE_KEYS.AD_FREE_USER_COOKIE);
-    removeCookie(PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE);
-    removeCookie(PERSISTENCE_KEYS.HIDE_SUPPORT_MESSAGING_COOKIE);
+	removeCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE);
+	removeCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE);
+	removeCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE);
+	removeCookie(PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE);
+	removeCookie(PERSISTENCE_KEYS.AD_FREE_USER_COOKIE);
+	removeCookie(PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE);
+	removeCookie(PERSISTENCE_KEYS.HIDE_SUPPORT_MESSAGING_COOKIE);
 };
 
 beforeAll(() => {
-    config.set('switches.adFreeStrictExpiryEnforcement', true);
-    config.set('page.userAttributesApiUrl', '');
+	config.set('switches.adFreeStrictExpiryEnforcement', true);
+	config.set('page.userAttributesApiUrl', '');
 });
 
 describe('Refreshing the features data', () => {
-    describe('If user signed in', () => {
-        beforeEach(() => {
-            jest.resetAllMocks();
-            isUserLoggedIn.mockReturnValue(true);
-            fetchJsonSpy.mockReturnValue(Promise.resolve());
-        });
+	describe('If user signed in', () => {
+		beforeEach(() => {
+			jest.resetAllMocks();
+			isUserLoggedIn.mockReturnValue(true);
+			fetchJsonSpy.mockReturnValue(Promise.resolve());
+		});
 
-        it('Performs an update if the user has missing data', () => {
-            deleteAllFeaturesData();
-            refresh();
-            expect(fetchJsonSpy).toHaveBeenCalledTimes(1);
-        });
+		it('Performs an update if the user has missing data', () => {
+			deleteAllFeaturesData();
+			refresh();
+			expect(fetchJsonSpy).toHaveBeenCalledTimes(1);
+		});
 
-        it('Performs an update if the user has expired data', () => {
-            setAllFeaturesData({ isExpired: true });
-            refresh();
-            expect(fetchJsonSpy).toHaveBeenCalledTimes(1);
-        });
+		it('Performs an update if the user has expired data', () => {
+			setAllFeaturesData({ isExpired: true });
+			refresh();
+			expect(fetchJsonSpy).toHaveBeenCalledTimes(1);
+		});
 
-        it('Does not delete the data just because it has expired', () => {
-            setAllFeaturesData({ isExpired: true });
-            refresh();
-            expect(getCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE)).toBe(
-                'true'
-            );
-            expect(
-                getCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE)
-            ).toBe('true');
-            expect(
-                getCookie(PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE)
-            ).toEqual(expect.stringMatching(/\d{13}/));
-            expect(getCookie(PERSISTENCE_KEYS.AD_FREE_USER_COOKIE)).toEqual(
-                expect.stringMatching(/\d{13}/)
-            );
-        });
+		it('Does not delete the data just because it has expired', () => {
+			setAllFeaturesData({ isExpired: true });
+			refresh();
+			expect(getCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE)).toBe(
+				'true',
+			);
+			expect(
+				getCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE),
+			).toBe('true');
+			expect(
+				getCookie(PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE),
+			).toEqual(expect.stringMatching(/\d{13}/));
+			expect(getCookie(PERSISTENCE_KEYS.AD_FREE_USER_COOKIE)).toEqual(
+				expect.stringMatching(/\d{13}/),
+			);
+		});
 
-        it('Does not perform update if user has fresh feature data', () => {
-            setAllFeaturesData({ isExpired: false });
-            refresh();
-            expect(fetchJsonSpy).not.toHaveBeenCalled();
-        });
+		it('Does not perform update if user has fresh feature data', () => {
+			setAllFeaturesData({ isExpired: false });
+			refresh();
+			expect(fetchJsonSpy).not.toHaveBeenCalled();
+		});
 
-        it('Performs an update if membership-frontend wipes just the paying-member cookie', () => {
-            // Set everything except paying-member cookie
-            setAllFeaturesData({ isExpired: true });
-            removeCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE);
+		it('Performs an update if membership-frontend wipes just the paying-member cookie', () => {
+			// Set everything except paying-member cookie
+			setAllFeaturesData({ isExpired: true });
+			removeCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE);
 
-            refresh();
-            expect(fetchJsonSpy).toHaveBeenCalledTimes(1);
-        });
+			refresh();
+			expect(fetchJsonSpy).toHaveBeenCalledTimes(1);
+		});
 
-        it('Performs an update if the ad-free state is stale and strict expiry enforcement is enabled', () => {
-            // This is a slightly synthetic setup - the ad-free cookie is rewritten with every
-            // refresh that happens as a result of expired features data, but we want to check
-            // that a refresh could be triggered based on ad-free state alone if the strict
-            // expiry enforcement switch is ON.
-            // Set everything except the ad-free cookie
-            setAllFeaturesData({ isExpired: false });
-            setExpiredAdFreeData();
+		it('Performs an update if the ad-free state is stale and strict expiry enforcement is enabled', () => {
+			// This is a slightly synthetic setup - the ad-free cookie is rewritten with every
+			// refresh that happens as a result of expired features data, but we want to check
+			// that a refresh could be triggered based on ad-free state alone if the strict
+			// expiry enforcement switch is ON.
+			// Set everything except the ad-free cookie
+			setAllFeaturesData({ isExpired: false });
+			setExpiredAdFreeData();
 
-            refresh();
-            expect(fetchJsonSpy).toHaveBeenCalledTimes(1);
-        });
-    });
+			refresh();
+			expect(fetchJsonSpy).toHaveBeenCalledTimes(1);
+		});
+	});
 
-    describe('If user signed out', () => {
-        beforeEach(() => {
-            jest.resetAllMocks();
-            isUserLoggedIn.mockReturnValue(false);
-            fetchJsonSpy.mockReturnValue(Promise.resolve());
-        });
+	describe('If user signed out', () => {
+		beforeEach(() => {
+			jest.resetAllMocks();
+			isUserLoggedIn.mockReturnValue(false);
+			fetchJsonSpy.mockReturnValue(Promise.resolve());
+		});
 
-        it('Does not perform update, even if feature data missing', () => {
-            deleteAllFeaturesData();
-            refresh();
-            expect(fetchJsonSpy).not.toHaveBeenCalled();
-        });
+		it('Does not perform update, even if feature data missing', () => {
+			deleteAllFeaturesData();
+			refresh();
+			expect(fetchJsonSpy).not.toHaveBeenCalled();
+		});
 
-        it('Deletes leftover feature data', () => {
-            setAllFeaturesData({ isExpired: false });
-            refresh();
-            expect(getCookie(PERSISTENCE_KEYS.AD_FREE_USER_COOKIE)).toBeNull();
-            expect(getCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE)).toBeNull();
-            expect(
-                getCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE)
-            ).toBeNull();
-            expect(
-                getCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE)
-            ).toBeNull();
-            expect(
-                getCookie(PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE)
-            ).toBeNull();
-        });
-    });
+		it('Deletes leftover feature data', () => {
+			setAllFeaturesData({ isExpired: false });
+			refresh();
+			expect(getCookie(PERSISTENCE_KEYS.AD_FREE_USER_COOKIE)).toBeNull();
+			expect(getCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE)).toBeNull();
+			expect(
+				getCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE),
+			).toBeNull();
+			expect(
+				getCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE),
+			).toBeNull();
+			expect(
+				getCookie(PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE),
+			).toBeNull();
+		});
+	});
 });
 
 describe('The account data update warning getter', () => {
-    it('Is not set when the user is logged out', () => {
-        jest.resetAllMocks();
-        isUserLoggedIn.mockReturnValue(false);
-        expect(accountDataUpdateWarning()).toBe(null);
-    });
+	it('Is not set when the user is logged out', () => {
+		jest.resetAllMocks();
+		isUserLoggedIn.mockReturnValue(false);
+		expect(accountDataUpdateWarning()).toBe(null);
+	});
 
-    describe('When the user is logged in', () => {
-        beforeEach(() => {
-            jest.resetAllMocks();
-            isUserLoggedIn.mockReturnValue(true);
-        });
+	describe('When the user is logged in', () => {
+		beforeEach(() => {
+			jest.resetAllMocks();
+			isUserLoggedIn.mockReturnValue(true);
+		});
 
-        it('Is the same when the user has an account data update link cookie', () => {
-            addCookie(PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE, 'the-same');
-            expect(accountDataUpdateWarning()).toBe('the-same');
-        });
+		it('Is the same when the user has an account data update link cookie', () => {
+			addCookie(PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE, 'the-same');
+			expect(accountDataUpdateWarning()).toBe('the-same');
+		});
 
-        it('Is null when the user does not have an account data update link cookie', () => {
-            removeCookie(PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE);
-            expect(accountDataUpdateWarning()).toBe(null);
-        });
-    });
+		it('Is null when the user does not have an account data update link cookie', () => {
+			removeCookie(PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE);
+			expect(accountDataUpdateWarning()).toBe(null);
+		});
+	});
 });
 
 describe('The isAdFreeUser getter', () => {
-    it('Is false when the user is logged out', () => {
-        jest.resetAllMocks();
-        isUserLoggedIn.mockReturnValue(false);
-        expect(isAdFreeUser()).toBe(false);
-    });
+	it('Is false when the user is logged out', () => {
+		jest.resetAllMocks();
+		isUserLoggedIn.mockReturnValue(false);
+		expect(isAdFreeUser()).toBe(false);
+	});
 });
 
 describe('The isPayingMember getter', () => {
-    it('Is false when the user is logged out', () => {
-        jest.resetAllMocks();
-        isUserLoggedIn.mockReturnValue(false);
-        expect(isPayingMember()).toBe(false);
-    });
+	it('Is false when the user is logged out', () => {
+		jest.resetAllMocks();
+		isUserLoggedIn.mockReturnValue(false);
+		expect(isPayingMember()).toBe(false);
+	});
 
-    describe('When the user is logged in', () => {
-        beforeEach(() => {
-            jest.resetAllMocks();
-            isUserLoggedIn.mockReturnValue(true);
-        });
+	describe('When the user is logged in', () => {
+		beforeEach(() => {
+			jest.resetAllMocks();
+			isUserLoggedIn.mockReturnValue(true);
+		});
 
-        it('Is true when the user has a `true` paying member cookie', () => {
-            addCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE, 'true');
-            expect(isPayingMember()).toBe(true);
-        });
+		it('Is true when the user has a `true` paying member cookie', () => {
+			addCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE, 'true');
+			expect(isPayingMember()).toBe(true);
+		});
 
-        it('Is false when the user has a `false` paying member cookie', () => {
-            addCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE, 'false');
-            expect(isPayingMember()).toBe(false);
-        });
+		it('Is false when the user has a `false` paying member cookie', () => {
+			addCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE, 'false');
+			expect(isPayingMember()).toBe(false);
+		});
 
-        it('Is true when the user has no paying member cookie', () => {
-            // If we don't know, we err on the side of caution, rather than annoy paying users
-            removeCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE);
-            expect(isPayingMember()).toBe(true);
-        });
-    });
+		it('Is true when the user has no paying member cookie', () => {
+			// If we don't know, we err on the side of caution, rather than annoy paying users
+			removeCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE);
+			expect(isPayingMember()).toBe(true);
+		});
+	});
 });
 
 describe('The isRecurringContributor getter', () => {
-    it('Is false when the user is logged out', () => {
-        jest.resetAllMocks();
-        isUserLoggedIn.mockReturnValue(false);
-        expect(isRecurringContributor()).toBe(false);
-    });
+	it('Is false when the user is logged out', () => {
+		jest.resetAllMocks();
+		isUserLoggedIn.mockReturnValue(false);
+		expect(isRecurringContributor()).toBe(false);
+	});
 
-    describe('When the user is logged in', () => {
-        beforeEach(() => {
-            jest.resetAllMocks();
-            isUserLoggedIn.mockReturnValue(true);
-        });
+	describe('When the user is logged in', () => {
+		beforeEach(() => {
+			jest.resetAllMocks();
+			isUserLoggedIn.mockReturnValue(true);
+		});
 
-        it('Is true when the user has a `true` recurring contributor cookie', () => {
-            addCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE, 'true');
-            expect(isRecurringContributor()).toBe(true);
-        });
+		it('Is true when the user has a `true` recurring contributor cookie', () => {
+			addCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE, 'true');
+			expect(isRecurringContributor()).toBe(true);
+		});
 
-        it('Is false when the user has a `false` recurring contributor cookie', () => {
-            addCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE, 'false');
-            expect(isRecurringContributor()).toBe(false);
-        });
+		it('Is false when the user has a `false` recurring contributor cookie', () => {
+			addCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE, 'false');
+			expect(isRecurringContributor()).toBe(false);
+		});
 
-        it('Is true when the user has no recurring contributor cookie', () => {
-            // If we don't know, we err on the side of caution, rather than annoy paying users
-            removeCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE);
-            expect(isRecurringContributor()).toBe(true);
-        });
-    });
+		it('Is true when the user has no recurring contributor cookie', () => {
+			// If we don't know, we err on the side of caution, rather than annoy paying users
+			removeCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE);
+			expect(isRecurringContributor()).toBe(true);
+		});
+	});
 });
 
 describe('The isDigitalSubscriber getter', () => {
-    it('Is false when the user is logged out', () => {
-        jest.resetAllMocks();
-        isUserLoggedIn.mockReturnValue(false);
-        expect(isDigitalSubscriber()).toBe(false);
-    });
+	it('Is false when the user is logged out', () => {
+		jest.resetAllMocks();
+		isUserLoggedIn.mockReturnValue(false);
+		expect(isDigitalSubscriber()).toBe(false);
+	});
 
-    describe('When the user is logged in', () => {
-        beforeEach(() => {
-            jest.resetAllMocks();
-            isUserLoggedIn.mockReturnValue(true);
-        });
+	describe('When the user is logged in', () => {
+		beforeEach(() => {
+			jest.resetAllMocks();
+			isUserLoggedIn.mockReturnValue(true);
+		});
 
-        it('Is true when the user has a `true` digital subscriber cookie', () => {
-            addCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE, 'true');
-            expect(isDigitalSubscriber()).toBe(true);
-        });
+		it('Is true when the user has a `true` digital subscriber cookie', () => {
+			addCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE, 'true');
+			expect(isDigitalSubscriber()).toBe(true);
+		});
 
-        it('Is false when the user has a `false` digital subscriber cookie', () => {
-            addCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE, 'false');
-            expect(isDigitalSubscriber()).toBe(false);
-        });
+		it('Is false when the user has a `false` digital subscriber cookie', () => {
+			addCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE, 'false');
+			expect(isDigitalSubscriber()).toBe(false);
+		});
 
-        it('Is false when the user has no digital subscriber cookie', () => {
-            removeCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE);
-            expect(isDigitalSubscriber()).toBe(false);
-        });
-    });
+		it('Is false when the user has no digital subscriber cookie', () => {
+			removeCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE);
+			expect(isDigitalSubscriber()).toBe(false);
+		});
+	});
 });
 
 describe('The shouldNotBeShownSupportMessaging getter', () => {
-    it('Returns false when the user is logged out', () => {
-        jest.resetAllMocks();
-        isUserLoggedIn.mockReturnValue(false);
-        expect(shouldNotBeShownSupportMessaging()).toBe(false);
-    });
+	it('Returns false when the user is logged out', () => {
+		jest.resetAllMocks();
+		isUserLoggedIn.mockReturnValue(false);
+		expect(shouldNotBeShownSupportMessaging()).toBe(false);
+	});
 
-    describe('When the user is logged in', () => {
-        beforeEach(() => {
-            jest.resetAllMocks();
-            isUserLoggedIn.mockReturnValue(true);
-        });
+	describe('When the user is logged in', () => {
+		beforeEach(() => {
+			jest.resetAllMocks();
+			isUserLoggedIn.mockReturnValue(true);
+		});
 
-        it('Returns true when the user has a `true` hide support messaging cookie', () => {
-            addCookie(PERSISTENCE_KEYS.HIDE_SUPPORT_MESSAGING_COOKIE, 'true');
-            expect(shouldNotBeShownSupportMessaging()).toBe(true);
-        });
+		it('Returns true when the user has a `true` hide support messaging cookie', () => {
+			addCookie(PERSISTENCE_KEYS.HIDE_SUPPORT_MESSAGING_COOKIE, 'true');
+			expect(shouldNotBeShownSupportMessaging()).toBe(true);
+		});
 
-        it('Returns false when the user has a `false` hide support messaging cookie', () => {
-            addCookie(PERSISTENCE_KEYS.HIDE_SUPPORT_MESSAGING_COOKIE, 'false');
-            expect(shouldNotBeShownSupportMessaging()).toBe(false);
-        });
+		it('Returns false when the user has a `false` hide support messaging cookie', () => {
+			addCookie(PERSISTENCE_KEYS.HIDE_SUPPORT_MESSAGING_COOKIE, 'false');
+			expect(shouldNotBeShownSupportMessaging()).toBe(false);
+		});
 
-        it('Returns false when the user has no hide support messaging cookie', () => {
-            removeCookie(PERSISTENCE_KEYS.HIDE_SUPPORT_MESSAGING_COOKIE);
-            expect(shouldNotBeShownSupportMessaging()).toBe(false);
-        });
-    });
+		it('Returns false when the user has no hide support messaging cookie', () => {
+			removeCookie(PERSISTENCE_KEYS.HIDE_SUPPORT_MESSAGING_COOKIE);
+			expect(shouldNotBeShownSupportMessaging()).toBe(false);
+		});
+	});
 });
 
 describe('Storing new feature data', () => {
-    beforeEach(() => {
-        jest.resetAllMocks();
-        fetchJsonSpy.mockReturnValue(Promise.resolve());
-        deleteAllFeaturesData();
-        isUserLoggedIn.mockReturnValue(true);
-    });
+	beforeEach(() => {
+		jest.resetAllMocks();
+		fetchJsonSpy.mockReturnValue(Promise.resolve());
+		deleteAllFeaturesData();
+		isUserLoggedIn.mockReturnValue(true);
+	});
 
-    it('Puts the paying-member state and ad-free state in appropriate cookie', () => {
-        fetchJsonSpy.mockReturnValueOnce(
-            Promise.resolve({
-                contentAccess: {
-                    paidMember: false,
-                    recurringContributor: false,
-                    digitalPack: false,
-                },
-                adFree: false,
-            })
-        );
-        return refresh().then(() => {
-            expect(getCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE)).toBe(
-                'false'
-            );
-            expect(
-                getCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE)
-            ).toBe('false');
-            expect(getCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE)).toBe(
-                'false'
-            );
-            expect(getCookie(PERSISTENCE_KEYS.AD_FREE_USER_COOKIE)).toBeNull();
-        });
-    });
+	it('Puts the paying-member state and ad-free state in appropriate cookie', () => {
+		fetchJsonSpy.mockReturnValueOnce(
+			Promise.resolve({
+				contentAccess: {
+					paidMember: false,
+					recurringContributor: false,
+					digitalPack: false,
+				},
+				adFree: false,
+			}),
+		);
+		return refresh().then(() => {
+			expect(getCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE)).toBe(
+				'false',
+			);
+			expect(
+				getCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE),
+			).toBe('false');
+			expect(getCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE)).toBe(
+				'false',
+			);
+			expect(getCookie(PERSISTENCE_KEYS.AD_FREE_USER_COOKIE)).toBeNull();
+		});
+	});
 
-    it('Puts the paying-member state and ad-free state in appropriate cookie', () => {
-        fetchJsonSpy.mockReturnValueOnce(
-            Promise.resolve({
-                contentAccess: {
-                    paidMember: true,
-                    recurringContributor: true,
-                    digitalPack: true,
-                },
-                adFree: true,
-            })
-        );
-        return refresh().then(() => {
-            expect(getCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE)).toBe(
-                'true'
-            );
-            expect(
-                getCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE)
-            ).toBe('true');
-            expect(getCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE)).toBe(
-                'true'
-            );
-            expect(
-                getCookie(PERSISTENCE_KEYS.AD_FREE_USER_COOKIE)
-            ).toBeTruthy();
-            expect(
-                Number.isNaN(
-                    parseInt(
-                        getCookie(PERSISTENCE_KEYS.AD_FREE_USER_COOKIE),
-                        10
-                    )
-                )
-            ).toBe(false);
-        });
-    });
+	it('Puts the paying-member state and ad-free state in appropriate cookie', () => {
+		fetchJsonSpy.mockReturnValueOnce(
+			Promise.resolve({
+				contentAccess: {
+					paidMember: true,
+					recurringContributor: true,
+					digitalPack: true,
+				},
+				adFree: true,
+			}),
+		);
+		return refresh().then(() => {
+			expect(getCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE)).toBe(
+				'true',
+			);
+			expect(
+				getCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE),
+			).toBe('true');
+			expect(getCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE)).toBe(
+				'true',
+			);
+			expect(
+				getCookie(PERSISTENCE_KEYS.AD_FREE_USER_COOKIE),
+			).toBeTruthy();
+			expect(
+				Number.isNaN(
+					parseInt(
+						getCookie(PERSISTENCE_KEYS.AD_FREE_USER_COOKIE),
+						10,
+					),
+				),
+			).toBe(false);
+		});
+	});
 
-    it('Puts an expiry date in an accompanying cookie', () =>
-        refresh().then(() => {
-            const expiryDate = getCookie(
-                PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE
-            );
-            expect(expiryDate).toBeTruthy();
-            expect(Number.isNaN(parseInt(expiryDate, 10))).toBe(false);
-        }));
+	it('Puts an expiry date in an accompanying cookie', () =>
+		refresh().then(() => {
+			const expiryDate = getCookie(
+				PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE,
+			);
+			expect(expiryDate).toBeTruthy();
+			expect(Number.isNaN(parseInt(expiryDate, 10))).toBe(false);
+		}));
 
-    it('The expiry date is in the future', () =>
-        refresh().then(() => {
-            const expiryDateString = getCookie(
-                PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE
-            );
-            const expiryDateEpoch = parseInt(expiryDateString, 10);
-            const currentTimeEpoch = new Date().getTime();
-            expect(currentTimeEpoch < expiryDateEpoch).toBe(true);
-        }));
+	it('The expiry date is in the future', () =>
+		refresh().then(() => {
+			const expiryDateString = getCookie(
+				PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE,
+			);
+			const expiryDateEpoch = parseInt(expiryDateString, 10);
+			const currentTimeEpoch = new Date().getTime();
+			expect(currentTimeEpoch < expiryDateEpoch).toBe(true);
+		}));
 });
 
 const setSupportFrontendOneOffContributionCookie = (value) =>
-    addCookie(PERSISTENCE_KEYS.SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE, value);
+	addCookie(PERSISTENCE_KEYS.SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE, value);
 
 const removeSupportFrontendOneOffContributionCookie = () =>
-    removeCookie(PERSISTENCE_KEYS.SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE);
+	removeCookie(PERSISTENCE_KEYS.SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE);
 
 const setAttributesOneOffContributionCookie = (value) =>
-    addCookie(PERSISTENCE_KEYS.ONE_OFF_CONTRIBUTION_DATE_COOKIE, value);
+	addCookie(PERSISTENCE_KEYS.ONE_OFF_CONTRIBUTION_DATE_COOKIE, value);
 
 const removeAttributesOneOffContributionCookie = () =>
-    removeCookie(PERSISTENCE_KEYS.ONE_OFF_CONTRIBUTION_DATE_COOKIE);
+	removeCookie(PERSISTENCE_KEYS.ONE_OFF_CONTRIBUTION_DATE_COOKIE);
 
 describe('getting the last one-off contribution date of a user', () => {
-    beforeEach(() => {
-        removeSupportFrontendOneOffContributionCookie();
-        removeAttributesOneOffContributionCookie();
-    });
+	beforeEach(() => {
+		removeSupportFrontendOneOffContributionCookie();
+		removeAttributesOneOffContributionCookie();
+	});
 
-    const contributionDate = '2018-01-06';
-    const contributionDateTimeEpoch = Date.parse(contributionDate);
+	const contributionDate = '2018-01-06';
+	const contributionDateTimeEpoch = Date.parse(contributionDate);
 
-    it("returns null if the user hasn't previously contributed", () => {
-        expect(getLastOneOffContributionTimestamp()).toBe(null);
-    });
+	it("returns null if the user hasn't previously contributed", () => {
+		expect(getLastOneOffContributionTimestamp()).toBe(null);
+	});
 
-    it('return the correct date if the user support-frontend contribution cookie is set', () => {
-        setSupportFrontendOneOffContributionCookie(
-            contributionDateTimeEpoch.toString()
-        );
-        expect(getLastOneOffContributionTimestamp()).toBe(contributionDateTimeEpoch);
-    });
+	it('return the correct date if the user support-frontend contribution cookie is set', () => {
+		setSupportFrontendOneOffContributionCookie(
+			contributionDateTimeEpoch.toString(),
+		);
+		expect(getLastOneOffContributionTimestamp()).toBe(
+			contributionDateTimeEpoch,
+		);
+	});
 
-    it('returns null if the cookie has been set with an invalid value', () => {
-        setSupportFrontendOneOffContributionCookie('invalid value');
-        expect(getLastOneOffContributionTimestamp()).toBe(null);
-    });
+	it('returns null if the cookie has been set with an invalid value', () => {
+		setSupportFrontendOneOffContributionCookie('invalid value');
+		expect(getLastOneOffContributionTimestamp()).toBe(null);
+	});
 
-    it('returns the correct date if cookie from attributes is set', () => {
-        setAttributesOneOffContributionCookie(contributionDate.toString());
-        expect(getLastOneOffContributionTimestamp()).toBe(contributionDateTimeEpoch);
-    });
+	it('returns the correct date if cookie from attributes is set', () => {
+		setAttributesOneOffContributionCookie(contributionDate.toString());
+		expect(getLastOneOffContributionTimestamp()).toBe(
+			contributionDateTimeEpoch,
+		);
+	});
 });
 
 const setMonthlyContributionCookie = (value) =>
-    addCookie(PERSISTENCE_KEYS.SUPPORT_MONTHLY_CONTRIBUTION_COOKIE, value);
+	addCookie(PERSISTENCE_KEYS.SUPPORT_MONTHLY_CONTRIBUTION_COOKIE, value);
 
 const setAnnualContributionCookie = (value) =>
-    addCookie(PERSISTENCE_KEYS.SUPPORT_ANNUAL_CONTRIBUTION_COOKIE, value);
+	addCookie(PERSISTENCE_KEYS.SUPPORT_ANNUAL_CONTRIBUTION_COOKIE, value);
 
 const removeMonthlyContributionCookie = () =>
-    removeCookie(PERSISTENCE_KEYS.SUPPORT_MONTHLY_CONTRIBUTION_COOKIE);
+	removeCookie(PERSISTENCE_KEYS.SUPPORT_MONTHLY_CONTRIBUTION_COOKIE);
 
 const removeAnnualContributionCookie = () =>
-    removeCookie(PERSISTENCE_KEYS.SUPPORT_ANNUAL_CONTRIBUTION_COOKIE);
+	removeCookie(PERSISTENCE_KEYS.SUPPORT_ANNUAL_CONTRIBUTION_COOKIE);
 
 describe('getting the last recurring contribution date of a user', () => {
-    beforeEach(() => {
-        removeMonthlyContributionCookie();
-        removeAnnualContributionCookie();
-    });
+	beforeEach(() => {
+		removeMonthlyContributionCookie();
+		removeAnnualContributionCookie();
+	});
 
-    const monthlyContributionTimestamp = 1556124724;
-    const annualContributionTimestamp = 1556125286;
+	const monthlyContributionTimestamp = 1556124724;
+	const annualContributionTimestamp = 1556125286;
 
-    it("returns null if the user isn't a recurring contributor", () => {
-        expect(getLastRecurringContributionDate()).toBe(null);
-    });
+	it("returns null if the user isn't a recurring contributor", () => {
+		expect(getLastRecurringContributionDate()).toBe(null);
+	});
 
-    it('return the correct date if the user is a monthly recurring contributor', () => {
-        setMonthlyContributionCookie(monthlyContributionTimestamp.toString());
-        expect(getLastRecurringContributionDate()).toBe(
-            monthlyContributionTimestamp
-        );
-    });
+	it('return the correct date if the user is a monthly recurring contributor', () => {
+		setMonthlyContributionCookie(monthlyContributionTimestamp.toString());
+		expect(getLastRecurringContributionDate()).toBe(
+			monthlyContributionTimestamp,
+		);
+	});
 
-    it('return the correct date if the user is a annual recurring contributor', () => {
-        setAnnualContributionCookie(annualContributionTimestamp.toString());
-        expect(getLastRecurringContributionDate()).toBe(
-            annualContributionTimestamp
-        );
-    });
+	it('return the correct date if the user is a annual recurring contributor', () => {
+		setAnnualContributionCookie(annualContributionTimestamp.toString());
+		expect(getLastRecurringContributionDate()).toBe(
+			annualContributionTimestamp,
+		);
+	});
 
-    it('return the correct date if the user is both annual and monthly recurring contributor', () => {
-        setAnnualContributionCookie(annualContributionTimestamp.toString());
-        setMonthlyContributionCookie(monthlyContributionTimestamp.toString());
-        expect(getLastRecurringContributionDate()).toBe(
-            annualContributionTimestamp
-        );
-    });
+	it('return the correct date if the user is both annual and monthly recurring contributor', () => {
+		setAnnualContributionCookie(annualContributionTimestamp.toString());
+		setMonthlyContributionCookie(monthlyContributionTimestamp.toString());
+		expect(getLastRecurringContributionDate()).toBe(
+			annualContributionTimestamp,
+		);
+	});
 
-    it('returns null if the cookie has been set with an invalid value', () => {
-        setAnnualContributionCookie('not a date string one');
-        setMonthlyContributionCookie('not a date string two');
-        expect(getLastRecurringContributionDate()).toBe(null);
-    });
+	it('returns null if the cookie has been set with an invalid value', () => {
+		setAnnualContributionCookie('not a date string one');
+		setMonthlyContributionCookie('not a date string two');
+		expect(getLastRecurringContributionDate()).toBe(null);
+	});
 });
 
 describe('getting the days since last contribution', () => {
-    beforeEach(() => {
-        removeSupportFrontendOneOffContributionCookie();
-        removeAttributesOneOffContributionCookie();
-    });
+	beforeEach(() => {
+		removeSupportFrontendOneOffContributionCookie();
+		removeAttributesOneOffContributionCookie();
+	});
 
-    const contributionDateTimeEpoch = Date.parse('2018-08-01T12:00:30Z');
+	const contributionDateTimeEpoch = Date.parse('2018-08-01T12:00:30Z');
 
-    it('returns null if the last one-off contribution date is null', () => {
-        expect(getDaysSinceLastOneOffContribution()).toBe(null);
-    });
+	it('returns null if the last one-off contribution date is null', () => {
+		expect(getDaysSinceLastOneOffContribution()).toBe(null);
+	});
 
-    it('returns the difference in days between the last contribution date and now if the last contribution date is set', () => {
-        global.Date.now = jest.fn(() => Date.parse('2018-08-07T10:50:34'));
-        setSupportFrontendOneOffContributionCookie(contributionDateTimeEpoch);
-        expect(getDaysSinceLastOneOffContribution()).toBe(5);
-    });
+	it('returns the difference in days between the last contribution date and now if the last contribution date is set', () => {
+		global.Date.now = jest.fn(() => Date.parse('2018-08-07T10:50:34'));
+		setSupportFrontendOneOffContributionCookie(contributionDateTimeEpoch);
+		expect(getDaysSinceLastOneOffContribution()).toBe(5);
+	});
 });
 
 describe('isRecentOneOffContributor', () => {
-    beforeEach(() => {
-        removeSupportFrontendOneOffContributionCookie();
-        removeAttributesOneOffContributionCookie();
-    });
+	beforeEach(() => {
+		removeSupportFrontendOneOffContributionCookie();
+		removeAttributesOneOffContributionCookie();
+	});
 
-    const contributionDateTimeEpoch = Date.parse('2018-08-01T12:00:30Z');
+	const contributionDateTimeEpoch = Date.parse('2018-08-01T12:00:30Z');
 
-    it('returns false if there is no one-off contribution cookie', () => {
-        expect(isRecentOneOffContributor()).toBe(false);
-    });
+	it('returns false if there is no one-off contribution cookie', () => {
+		expect(isRecentOneOffContributor()).toBe(false);
+	});
 
-    it('returns true if there are 5 days between the last contribution date and now', () => {
-        global.Date.now = jest.fn(() => Date.parse('2018-08-07T10:50:34'));
-        setSupportFrontendOneOffContributionCookie(contributionDateTimeEpoch);
-        expect(isRecentOneOffContributor()).toBe(true);
-    });
+	it('returns true if there are 5 days between the last contribution date and now', () => {
+		global.Date.now = jest.fn(() => Date.parse('2018-08-07T10:50:34'));
+		setSupportFrontendOneOffContributionCookie(contributionDateTimeEpoch);
+		expect(isRecentOneOffContributor()).toBe(true);
+	});
 
-    it('returns true if there are 0 days between the last contribution date and now', () => {
-        global.Date.now = jest.fn(() => Date.parse('2018-08-01T13:00:30'));
-        setSupportFrontendOneOffContributionCookie(contributionDateTimeEpoch);
-        expect(isRecentOneOffContributor()).toBe(true);
-    });
+	it('returns true if there are 0 days between the last contribution date and now', () => {
+		global.Date.now = jest.fn(() => Date.parse('2018-08-01T13:00:30'));
+		setSupportFrontendOneOffContributionCookie(contributionDateTimeEpoch);
+		expect(isRecentOneOffContributor()).toBe(true);
+	});
 
-    it('returns false if the one-off contribution was more than 3 months ago', () => {
-        global.Date.now = jest.fn(() => Date.parse('2019-08-01T13:00:30'));
-        setSupportFrontendOneOffContributionCookie(contributionDateTimeEpoch);
-        expect(isRecentOneOffContributor()).toBe(false);
-    });
+	it('returns false if the one-off contribution was more than 3 months ago', () => {
+		global.Date.now = jest.fn(() => Date.parse('2019-08-01T13:00:30'));
+		setSupportFrontendOneOffContributionCookie(contributionDateTimeEpoch);
+		expect(isRecentOneOffContributor()).toBe(false);
+	});
 });
 
 describe('isPostAskPauseOneOffContributor', () => {
-    beforeEach(() => {
-        removeSupportFrontendOneOffContributionCookie();
-        removeAttributesOneOffContributionCookie();
-    });
+	beforeEach(() => {
+		removeSupportFrontendOneOffContributionCookie();
+		removeAttributesOneOffContributionCookie();
+	});
 
-    const contributionDateTimeEpoch = Date.parse('2018-08-01T12:00:30Z');
+	const contributionDateTimeEpoch = Date.parse('2018-08-01T12:00:30Z');
 
-    it('returns false if there is no one-off contribution cookie', () => {
-        expect(isPostAskPauseOneOffContributor()).toBe(false);
-    });
+	it('returns false if there is no one-off contribution cookie', () => {
+		expect(isPostAskPauseOneOffContributor()).toBe(false);
+	});
 
-    it('returns false if there are 5 days between the last contribution date and now', () => {
-        global.Date.now = jest.fn(() => Date.parse('2018-08-07T10:50:34'));
-        setSupportFrontendOneOffContributionCookie(contributionDateTimeEpoch);
-        expect(isPostAskPauseOneOffContributor()).toBe(false);
-    });
+	it('returns false if there are 5 days between the last contribution date and now', () => {
+		global.Date.now = jest.fn(() => Date.parse('2018-08-07T10:50:34'));
+		setSupportFrontendOneOffContributionCookie(contributionDateTimeEpoch);
+		expect(isPostAskPauseOneOffContributor()).toBe(false);
+	});
 
-    it('returns true if the one-off contribution was more than 3 months ago', () => {
-        global.Date.now = jest.fn(() => Date.parse('2019-02-01T13:00:30'));
-        setSupportFrontendOneOffContributionCookie(contributionDateTimeEpoch);
-        expect(isPostAskPauseOneOffContributor()).toBe(true);
-    });
+	it('returns true if the one-off contribution was more than 3 months ago', () => {
+		global.Date.now = jest.fn(() => Date.parse('2019-02-01T13:00:30'));
+		setSupportFrontendOneOffContributionCookie(contributionDateTimeEpoch);
+		expect(isPostAskPauseOneOffContributor()).toBe(true);
+	});
 });

--- a/tools/__tasks__/commercial/validate/index.js
+++ b/tools/__tasks__/commercial/validate/index.js
@@ -1,0 +1,8 @@
+module.exports = {
+    description: 'Lint and format commercial assets',
+    task: [
+        require('./prettier'),
+        require('../../validate'),
+    ],
+    concurrent: true,
+};

--- a/tools/__tasks__/commercial/validate/prettier.js
+++ b/tools/__tasks__/commercial/validate/prettier.js
@@ -1,0 +1,6 @@
+const execa = require('execa');
+
+module.exports = {
+    description: 'Run prettier on Commercial JS',
+    task: 'yarn prettier -w static/src/javascripts/**/commercial/**/*.js',
+}


### PR DESCRIPTION
## What does this change?

Enforces Prettier on commercial JavaScript.

```zsh
yarn prettier -c static/src/javascripts/**/commercial/**/*.js
```

## What is the value of this and can you measure success?

Hopefully, this will help following files through their TypeScript conversion.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
