### PR TITLE
Remove code adding inaccessible color to kicker

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -246,13 +246,6 @@ $pillars: (
         }
     }
 
-    &.fc-item--type-media,
-    &.fc-item--type-immersive {
-        .fc-sublink__kicker {
-            color: map-get($palette, invertedKicker);
-        }
-    }
-
     .fc-item__media-meta {
         color: map-get($palette, invertedKicker);
 


### PR DESCRIPTION
## What does this change?

There is a possibility where the kicker would be an inaccessible colour. In this case we can remove the offending code.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

Before:
![image](https://user-images.githubusercontent.com/9575458/136967503-bbc8cd13-9c92-45d0-bb10-16f68e203f0e.png)

After:
![image](https://user-images.githubusercontent.com/9575458/136967282-486dd6f8-48d0-4bea-85b5-d108cb11a47e.png)

## What is the value of this and can you measure success?

Colours will remain their darker (more accessible) versions

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
