### PR TITLE
Extend Confiant Refresh ad to 20 Oct

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -24,6 +24,7 @@ trait ABTestSwitches {
     exposeClientSide = true,
   )
 
+  // experiments/tests/refresh-confiant-blocked-ads.ts
   Switch(
     ABTests,
     "ab-refresh-confiant-blocked-ads",

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -31,7 +31,7 @@ trait ABTestSwitches {
     "Check whether refreshing blocked ads lead to revenue uplift",
     owners = Seq(Owner.withGithub("mxdvl")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2021, 10, 15)),
+    sellByDate = Some(LocalDate.of(2021, 10, 20)),
     exposeClientSide = true,
   )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/refresh-confiant-blocked-ads.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/refresh-confiant-blocked-ads.ts
@@ -5,7 +5,7 @@ export const refreshConfiantBlockedAds: ABTest = {
 	id: 'RefreshConfiantBlockedAds',
 	author: 'Max Duval (@mxdvl)',
 	start: '2021-09-07',
-	expiry: '2021-10-15',
+	expiry: '2021-10-20',
 	audience: 1,
 	audienceOffset: 0,
 	audienceCriteria: 'All users',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/refresh-confiant-blocked-ads.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/refresh-confiant-blocked-ads.ts
@@ -5,7 +5,7 @@ export const refreshConfiantBlockedAds: ABTest = {
 	id: 'RefreshConfiantBlockedAds',
 	author: 'Max Duval (@mxdvl)',
 	start: '2021-09-07',
-	expiry: '2021-10-08',
+	expiry: '2021-10-15',
 	audience: 1,
 	audienceOffset: 0,
 	audienceCriteria: 'All users',


### PR DESCRIPTION

## What does this change?

Extend TS experiment to match the Scala switch