### PR TITLE
add preview for pressed interactives

### DIFF
--- a/admin/app/controllers/admin/InteractiveLibrarianController.scala
+++ b/admin/app/controllers/admin/InteractiveLibrarianController.scala
@@ -20,7 +20,7 @@ class InteractiveLibrarianController(
 
   def pressForm(): Action[AnyContent] =
     Action { implicit request =>
-      Ok(views.html.pressInteractive())
+      Ok(views.html.pressInteractive(services.S3Archive.bucket))
     }
 
   /**

--- a/admin/app/views/pressInteractive.scala.html
+++ b/admin/app/views/pressInteractive.scala.html
@@ -1,4 +1,4 @@
-@()(implicit request: RequestHeader, context: model.ApplicationContext)
+@(bucket: String = "aws-frontend-archive")(implicit request: RequestHeader, context: model.ApplicationContext)
 @import conf.switches.Switches.InteractiveLibrarianAdminRoutes
 
 @admin_main("Interactive Presser (archiver)", isAuthed = true) {
@@ -81,8 +81,10 @@
             })
             .then(res => {
                 if (res.ok) {
-                    const markStyle = 'background-color:#00cc00;color:#fff'
-                    document.getElementById('server-message').innerHTML = `<mark style=${markStyle}>Pressing successful</mark>`;
+                    const mark = `<mark style="background-color:#00cc00;color:#fff">Pressing successful</mark>`;
+                    const linkHref = `https://${"@bucket"}.s3.eu-west-1.amazonaws.com/${url.host}${url.pathname}`;
+                    const link = `<a id="preview-link" type="button" target="_blank" href="${linkHref}">Preview</a>`;
+                    document.getElementById('server-message').innerHTML = `${mark}<span> - </span>${link}`;
                 } else {
                     throw res;
                 }


### PR DESCRIPTION
## What does this change?
This adds a preview link for pressed interactives. After an interactive has been successfully pressed and cleaned via the admin tool, the user can view how the page would appear to readers.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/45561419/136962282-80da4101-faa3-42cb-a4a3-886efd617b6d.png
[after]: https://user-images.githubusercontent.com/45561419/136962321-825043b7-194d-4181-a5b1-da7c11be68fe.png

## What is the value of this and can you measure success?
This change was suggested by the Visuals team to gain confidence in the pressing process. By enabling users to preview pressed content before it goes live we will reduce the friction of the overall interactive migration.

### Tested

- [x] Locally
- [ ] On CODE (optional)

