### PR TITLE
Remove Sticky Nav experiment

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -10,7 +10,6 @@ object ActiveExperiments extends ExperimentsDefinition {
     ShowPressedInteractives,
     StandaloneCommercialBundle,
     StandaloneCommercialBundleTracking,
-    RemoveStickyNav,
   )
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -50,13 +49,4 @@ object StandaloneCommercialBundleTracking
       owners = Seq(Owner.withGithub("mxdvl")),
       sellByDate = LocalDate.of(2021, 10, 15),
       participationGroup = Perc1A,
-    )
-
-object RemoveStickyNav
-    extends Experiment(
-      name = "remove-sticky-nav",
-      description = "Remove sticky behaviour from the nav bar",
-      owners = Seq(Owner.withGithub("MarSavar")),
-      sellByDate = LocalDate.of(2021, 10, 12),
-      participationGroup = Perc1B,
     )


### PR DESCRIPTION
## What does this change?

Removes the experiment we ran in #24165.

The conclusion is that we will **no longer** keep the sticky navigation, as it impacts revenue negatively, and does not improve onward journeys.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes **TBC** https://trello.com/c/d7J3nYKl/1586-unsticky-the-nav