### PR TITLE
More tracking ref and refViewId when readers signup to newsletters

### DIFF
--- a/common/app/views/emailEmbed.scala.html
+++ b/common/app/views/emailEmbed.scala.html
@@ -9,6 +9,7 @@
 @import views.support.RenderClasses
 
 <!doctype html>
+<html>
 <head>
     @if(FontSwitch.isSwitchedOn) {
         @fragments.fontFaces()
@@ -27,7 +28,6 @@
     </script>
 
 </head>
-<html>
     <body>
         @body
     </body>

--- a/common/app/views/fragments/email/signup/footer/emailSignUpFooter.scala.html
+++ b/common/app/views/fragments/email/signup/footer/emailSignUpFooter.scala.html
@@ -22,6 +22,8 @@
                 <label class="email-sub__label" for="@inputId">@fragments.inlineSvg("envelope", "icon", Seq("label__icon"))Email address</label>
                 <input class="email-sub__text-input u-h" autocomplete="off" type="text" name="name" id="@dummyInputId" />
                 <input class="email-sub__listname-input" type="hidden" name="listName" value="@listName" />
+                <input class="email-sub__ref-input" type="hidden" name="ref" id="email-sub__ref-input" value="" />
+                <input class="email-sub__refviewid-input" type="hidden" name="refViewId" id="email-sub__refviewid-input" value="" />
 
             </div>
             <button type="submit" class="email-sub__submit-button button button--tertiary button--large" id="email-embed-signup-button" data-component="email-signup-button footer-@listName" data-link-name="footer | @listName">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
@@ -40,5 +42,7 @@
 
 <script>
     trackClickEvent(document.getElementById("email-embed-signup-button"))
+    document.getElementById("email-sub__ref-input").value = window.parent.location.href
+    document.getElementById("email-sub__refviewid-input").value = window.parent.guardian.ophan.pageViewId
 </script>
 

--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -45,6 +45,8 @@
                 <input class="email-sub__text-input u-h" autocomplete="off" type="text" name="name" id="@dummyInputId" placeholder="Name" />
 
                 <input class="email-sub__listname-input" type="hidden" name="listName" value="@listName" />
+                <input class="email-sub__ref-input" type="hidden" name="ref" id="email-sub__ref-input" value="" />
+                <input class="email-sub__refviewid-input" type="hidden" name="refViewId" id="email-sub__refviewid-input" value="" />
 
             </div>
             <button type="submit" class="email-sub__submit-button button button--tertiary button--large" id="email-embed-signup-button--old" data-component="email-signup-button @componentClass-@listName" data-link-name="@componentClass | @listName">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
@@ -63,5 +65,7 @@
 
 <script>
     trackClickEvent(document.getElementById("email-embed-signup-button--old"))
+    document.getElementById("email-sub__ref-input").value = window.parent.location.href
+    document.getElementById("email-sub__refviewid-input").value = window.parent.guardian.ophan.pageViewId
 </script>
 

--- a/common/app/views/fragments/email/signup/subscription/emailSignUpNewDesign.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUpNewDesign.scala.html
@@ -39,6 +39,8 @@
             id="@dummyInputId"
             placeholder="Name" />
             <input class="email-sub__listname-input" type="hidden" name="listName" value="@listName" />
+            <input class="email-sub__ref-input" type="hidden" name="ref" id="email-sub__ref-input" value="" />
+            <input class="email-sub__refviewid-input" type="hidden" name="refViewId" id="email-sub__refviewid-input" value="" />
 
 
             <button
@@ -85,5 +87,7 @@
 
 <script>
     trackClickEvent(document.getElementById("email-embed-signup-button"))
+    document.getElementById("email-sub__ref-input").value = window.parent.location.href
+    document.getElementById("email-sub__refviewid-input").value = window.parent.guardian.ophan.pageViewId
 </script>
 


### PR DESCRIPTION
## What does this change?

Adds the `ref` and `refViewId` params to ​the POST request made by email signup iframe when a reader subscribes to a newsletter. See related change - https://github.com/guardian/frontend/pull/24249.  Example article using this iframe is https://www.theguardian.com/info/ng-interactive/2021/jun/25/techscape-sign-up

These parameters are populated from the `window.parent` object since the JS runs in the context of an iframe.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
