### PR TITLE
Use commercial constants

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -38,7 +38,7 @@ object StandaloneCommercialBundle
       name = "standalone-commercial-bundle",
       description = "Serve a standalone commercial bundle to a subset of users",
       owners = Seq(Owner.withGithub("mxdvl")),
-      sellByDate = LocalDate.of(2021, 10, 15),
+      sellByDate = LocalDate.of(2021, 11, 1),
       participationGroup = Perc50,
     )
 
@@ -47,6 +47,6 @@ object StandaloneCommercialBundleTracking
       name = "standalone-commercial-bundle-tracking",
       description = "Track performance metrics for the standalone commercial bundle",
       owners = Seq(Owner.withGithub("mxdvl")),
-      sellByDate = LocalDate.of(2021, 10, 15),
+      sellByDate = LocalDate.of(2021, 11, 1),
       participationGroup = Perc1A,
     )

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@guardian/automat-contributions": "^0.4.2",
     "@guardian/automat-modules": "^0.3.8",
     "@guardian/braze-components": "^4.1.0",
-    "@guardian/commercial-core": "^0.23.0",
+    "@guardian/commercial-core": "0.24.x",
     "@guardian/consent-management-platform": "6.11.5",
     "@guardian/libs": "^3.1.0",
     "@guardian/shimport": "^1.0.2",

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
@@ -1,4 +1,5 @@
 import { EventTimer } from '@guardian/commercial-core';
+import { PREBID_TIMEOUT } from '@guardian/commercial-core/dist/esm/constants';
 import { isString, log } from '@guardian/libs';
 import type { Advert } from 'commercial/modules/dfp/Advert';
 import { prebidTimeout } from 'common/modules/experiments/tests/prebid-timeout';
@@ -162,16 +163,13 @@ declare global {
  * Retrieve the bidder timeout from AB test variant
  */
 const getBidderTimeoutFromABTest = (): number => {
-	// The default bidder timeout to use if not part of an AB test
-	const defaultBidderTimeout = 1500;
-
 	// Find the possible bidder timeout from variants of AB test
 	// Note these timeout values HAVE to match those in defined in the test variants
 	const bidderTimeout = [500, 1500, 4000].find((timeout) =>
 		isInVariantSynchronous(prebidTimeout, `variant${timeout}`),
 	);
 
-	return bidderTimeout ?? defaultBidderTimeout;
+	return bidderTimeout ?? PREBID_TIMEOUT;
 };
 
 /**

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -93,7 +93,7 @@
     background-color: $brightness-97;
     border-bottom: 1px solid $brightness-86;
 
-    min-height: 90px + 24px;
+    min-height: 90px + 24px; // https://git.io/JK9vs -- topAboveNavHeight.ts
     padding-bottom: $gs-row-height / 2;
     display: flex;
     flex-direction: column;

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -95,7 +95,7 @@
   "../projects/commercial/modules/carrot-traffic-driver.ts",
   "../projects/commercial/modules/dfp/add-slot.ts",
   "../projects/commercial/modules/dfp/create-slots.ts",
-  "../projects/commercial/modules/dfp/track-ad-render.js",
+  "../projects/commercial/modules/dfp/track-ad-render.ts",
   "../projects/common/modules/article/space-filler.js",
   "../projects/common/modules/commercial/commercial-features.js"
  ],
@@ -322,7 +322,7 @@
   "../projects/commercial/modules/dfp/render-advert-label.ts",
   "../projects/commercial/modules/sticky-mpu.js"
  ],
- "../projects/commercial/modules/dfp/track-ad-render.js": [
+ "../projects/commercial/modules/dfp/track-ad-render.ts": [
   "../projects/commercial/modules/dfp/wait-for-advert.ts"
  ],
  "../projects/commercial/modules/dfp/wait-for-advert.ts": [
@@ -352,6 +352,7 @@
  ],
  "../projects/commercial/modules/header-bidding/prebid/prebid.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/esm/constants/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/config.d.ts",
   "../projects/commercial/modules/dfp/Advert.ts",
@@ -508,7 +509,7 @@
   "../lib/events.js",
   "../lib/fastdom-promise.js",
   "../projects/commercial/modules/dfp/get-advert-by-id.ts",
-  "../projects/commercial/modules/dfp/track-ad-render.js",
+  "../projects/commercial/modules/dfp/track-ad-render.ts",
   "../projects/commercial/modules/messenger.js",
   "../projects/common/modules/commercial/commercial-features.js"
  ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1903,10 +1903,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-4.1.0.tgz#09cc2546d521790382256c2ed431194a4c8a3761"
   integrity sha512-Q1MPpV6GKJjpuRqzBqn8s7B5sSh3wt9eF72K1DeOY0NoEtV60GnX7gCFnR6SeRMKV8TsEpKT+f1am8SU98S33Q==
 
-"@guardian/commercial-core@^0.23.0":
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.23.0.tgz#d82348fc9baa8f4dfddc227bef12ac01daf0eda5"
-  integrity sha512-IWqOlO49ke2hlSs80VakyweIPZ3Lv0nsTxw30rV4mSIQBhkpMVTpeBGAHcWZJiB613FXvEb6Am80v8h7I1qYjg==
+"@guardian/commercial-core@0.24.x":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.24.0.tgz#6ba387bd80bbed14561d073de5e7573b2fb5f663"
+  integrity sha512-dBtJX+6mzjYJcy6hXMJ5w5oKDZu+Ob18z+vXZtkN+j3Bp2ex+jQik6IuQTwfn+KkN6VEMoIzYK1ZN3fqPHMwYw==
 
 "@guardian/consent-management-platform@6.11.5":
   version "6.11.5"


### PR DESCRIPTION
- bump commercial-core to v0.24
- use PREBID_TIMEOUT from commercial-core
- add reference to commercial-core constants

## What does this change?

Use commercial-defined constants. Introduced in https://github.com/guardian/commercial-core/pull/396

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes https://github.com/guardian/dotcom-rendering/pull/3537

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |


[before]: https://user-images.githubusercontent.com/76776/137714322-bdd0eaa9-9675-4f23-99fa-4a4eb3094e32.png "magic value 90: 'min-height: ${90 + padding + labelHeight}px;'"

[after]: https://user-images.githubusercontent.com/76776/137714121-4390e568-2b14-40b7-829a-ea141b4a063b.png "90px description in IDE: 'Unit: pixels. The majority of ads in the top banner are 250px high. We ran an experiment in October 2021 to set the minimum height to 250, and let smaller ads be centred in the space. We did not process with this option, as it had a negative impact on viewability and revenue.'"

## What is the value of this and can you measure success?

These “magic values” come from experimentation, and their embedded knowledge is describe through JSDoc. This means that:

- one can easily grasp why it was changed
- ownership of this value changing resides with @guardian/commercial-dev


## Checklist

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
