### PR TITLE
Sublink Kicker is no longer darker than the card title

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -246,7 +246,7 @@ $pillars: (
         }
     }
 
-    /* Deployed */
+
     &.fc-item--type-media .fc-sublink__kicker {
         color: map-get($palette, invertedKicker);
     }

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -246,8 +246,7 @@ $pillars: (
         }
     }
 
-    &.fc-item--type-media,
-    .fc-sublink__kicker {
+    &.fc-item--type-media .fc-sublink__kicker {
         color: map-get($palette, invertedKicker);
     }
 

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -246,6 +246,7 @@ $pillars: (
         }
     }
 
+    /* Deployed */
     &.fc-item--type-media .fc-sublink__kicker {
         color: map-get($palette, invertedKicker);
     }

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -247,9 +247,9 @@ $pillars: (
     }
 
     &.fc-item--type-media,
-        .fc-sublink__kicker {
-            color: map-get($palette, invertedKicker);
-        }
+    .fc-sublink__kicker {
+        color: map-get($palette, invertedKicker);
+    }
 
     .fc-item__media-meta {
         color: map-get($palette, invertedKicker);

--- a/static/src/stylesheets/module/facia-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/facia-garnett/_pillars.scss
@@ -246,6 +246,11 @@ $pillars: (
         }
     }
 
+    &.fc-item--type-media,
+        .fc-sublink__kicker {
+            color: map-get($palette, invertedKicker);
+        }
+
     .fc-item__media-meta {
         color: map-get($palette, invertedKicker);
 


### PR DESCRIPTION
## What does this change?

The sublink kickers on inverted cards appeared darker than the title of the card. This fixes that, big up @HarryFischer.

## Screenshots
Before:
![Screenshot 2021-10-19 at 15 02 50](https://user-images.githubusercontent.com/35331926/137940028-c26b355f-0c98-4ed2-874a-3f59f5a5c58f.png)

After:
<img width="220" alt="Screenshot 2021-10-19 at 16 11 51" src="https://user-images.githubusercontent.com/35331926/137940101-71e2293a-75ed-498e-9937-eba85e9bb23a.png">

### Tested

- [ ] Locally
- [x] On CODE (optional)
