### PR TITLE
Ab/filtering key events

### DIFF
--- a/preview/conf/routes
+++ b/preview/conf/routes
@@ -197,11 +197,11 @@ GET        /weatherapi/city.json                                                
 GET        /weatherapi/locations                                                               weather.controllers.LocationsController.findCity(query: String)
 
 # Articles
-GET     /$path<[^/]+/([^/]+/)?live/.*>.json controllers.LiveBlogController.renderJson(path, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean], filterByKeyEvents: Option[Boolean])
+GET     /$path<[^/]+/([^/]+/)?live/.*>.json controllers.LiveBlogController.renderJson(path, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean], filterByKeyEvents: Option[Boolean], userInteraction: Option[Boolean])
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email controllers.LiveBlogController.renderEmail(path)
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email.emailjson controllers.LiveBlogController.renderEmail(path)
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email.emailtxt  controllers.LiveBlogController.renderEmail(path)
-GET     /$path<[^/]+/([^/]+/)?live/.*> controllers.LiveBlogController.renderArticle(path, page: Option[String], format: Option[String])
+GET     /$path<[^/]+/([^/]+/)?live/.*> controllers.LiveBlogController.renderArticle(path, page: Option[String], filterByKeyEvents: Option[Boolean])
 GET     /*path.json                 controllers.ArticleController.renderJson(path)
 GET     /*path/email                controllers.ArticleController.renderEmail(path)
 GET     /*path/email.emailjson      controllers.ArticleController.renderEmail(path)

--- a/static/src/javascripts/projects/common/modules/ui/autoupdate.js
+++ b/static/src/javascripts/projects/common/modules/ui/autoupdate.js
@@ -123,7 +123,6 @@ const autoUpdate = (opts) => {
         const latestBlockIdToUse = latestBlockId || 'block-0';
         const params = `?lastUpdate=${latestBlockIdToUse}${shouldFetchBlocks}${filterByKeyEvents}${userInteraction}`;
         const endpoint = `${window.location.pathname}.json${params}`;
-        console.log(endpoint)
         // #? One day this should be in Promise.finally()
         const setUpdateDelay = () => {
             if (count === 0 || currentUpdateDelay > 0) {
@@ -143,7 +142,6 @@ const autoUpdate = (opts) => {
             mode: 'cors',
         })
             .then(resp => {
-                console.log("fetchJson response => ",resp)
                 count = resp.numNewBlocks;
                 if (count > 0) {
                     unreadBlocksNo += count;

--- a/static/src/javascripts/projects/common/modules/ui/autoupdate.js
+++ b/static/src/javascripts/projects/common/modules/ui/autoupdate.js
@@ -81,7 +81,7 @@ const autoUpdate = (opts) => {
         });
     };
 
-    const injectNewBlocks = (newBlocks) => {
+    const injectNewBlocks = (newBlocks, userInteraction) => {
         // Clean up blocks before insertion
         const resultHtml = $.create(`<div>${newBlocks}</div>`)[0];
         let elementsToAdd;
@@ -90,11 +90,11 @@ const autoUpdate = (opts) => {
             bonzo(resultHtml.children).addClass('autoupdate--hidden');
             elementsToAdd = Array.from(resultHtml.children);
 
+            userInteraction && $liveblogBody.empty()
+
             // Insert new blocks
-            $liveblogBody.prepend(elementsToAdd);
-
+            $liveblogBody.prepend(elementsToAdd)
             mediator.emit('modules:autoupdate:updates', elementsToAdd.length);
-
             initRelativeDates();
             enhanceTweets();
             checkElemsForVideos(elementsToAdd);
@@ -155,7 +155,7 @@ const autoUpdate = (opts) => {
                     latestBlockId = resp.mostRecentBlockId;
 
                     if (isLivePage) {
-                        injectNewBlocks(resp.html);
+                        injectNewBlocks(resp.html, userInteraction);
 
                         if (scrolledPastTopBlock()) {
                             toastButtonRefresh();

--- a/static/src/javascripts/projects/common/modules/ui/autoupdate.js
+++ b/static/src/javascripts/projects/common/modules/ui/autoupdate.js
@@ -89,8 +89,7 @@ const autoUpdate = (opts) => {
         fastdom.mutate(() => {
             bonzo(resultHtml.children).addClass('autoupdate--hidden');
             elementsToAdd = Array.from(resultHtml.children);
-
-            userInteraction && $liveblogBody.empty()
+            if (userInteraction) $liveblogBody.empty()
 
             // Insert new blocks
             $liveblogBody.prepend(elementsToAdd)


### PR DESCRIPTION
## What does this change?

Checks to see if the update was triggered by user interaction and, if so, empties the liveblog body and replaces with the filtered/unfiltered blocks.

## Does this change need to be reproduced in dotcom-rendering ?

- [] No
- [X] Yes (please indicate your plans for DCR Implementation)

This is part of a body of work that allows filtering in liveblogs. The liveblog to dotcom-rendering migration is currently WIP so we cannot make these changes in dotcom-rendering at present but, if a/b testing shows a desire for this feature, we will need to implement this in DCR liveblogs once available.


### Tested

- [X] Locally
- [ ] On CODE (optional)


