### PR TITLE
Jc/filter dead blogs

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/liveblog.js
+++ b/static/src/javascripts/bootstraps/enhanced/liveblog.js
@@ -3,7 +3,7 @@ import { isBreakpoint } from 'lib/detect';
 import mediator from 'lib/mediator';
 import { upgradeRichLinks } from 'common/modules/article/rich-links';
 import { Affix } from 'common/modules/experiments/affix';
-import { autoUpdate } from 'common/modules/ui/autoupdate';
+import { updateBlocks } from 'common/modules/ui/autoupdate';
 import { init as initRelativeDates } from 'common/modules/ui/relativedates';
 import { init as initLiveblogCommon } from 'bootstraps/enhanced/article-liveblog-common';
 import { initTrails } from 'bootstraps/enhanced/trail';
@@ -34,9 +34,8 @@ const affixTimeline = () => {
 };
 
 const createAutoUpdate = () => {
-    if (config.get('page.isLive')) {
-        autoUpdate();
-    }
+    const pollUpdates = config.get('page.isLive')
+    updateBlocks(_, pollUpdates);
 };
 
 const keepTimestampsCurrent = () => {

--- a/static/src/javascripts/projects/common/modules/ui/autoupdate.js
+++ b/static/src/javascripts/projects/common/modules/ui/autoupdate.js
@@ -15,7 +15,7 @@ import { initNotificationCounter } from 'common/modules/ui/notification-counter'
 import { checkElemsForVideos } from 'common/modules/atoms/youtube';
 
 
-const autoUpdate = (opts) => {
+const updateBlocks = (opts, pollUpdates) => {
     const options = Object.assign(
         {
             toastOffsetTop: 12,
@@ -124,7 +124,7 @@ const autoUpdate = (opts) => {
         const latestBlockIdToUse = latestBlockId || 'block-0';
         const params = `?lastUpdate=${latestBlockIdToUse}${shouldFetchBlocks}${filterByKeyEvents}${userInteraction}`;
         const endpoint = `${window.location.pathname}.json${params}`;
-        console.log(endpoint)
+
         // #? One day this should be in Promise.finally()
         const setUpdateDelay = () => {
             if (count === 0 || currentUpdateDelay > 0) {
@@ -144,7 +144,6 @@ const autoUpdate = (opts) => {
             mode: 'cors',
         })
             .then(resp => {
-                console.log("fetchJson response => ",resp)
                 count = resp.numNewBlocks;
                 if (count > 0) {
                     unreadBlocksNo += count;
@@ -167,10 +166,10 @@ const autoUpdate = (opts) => {
                     }
                 }
 
-                setUpdateDelay();
+                pollUpdates && setUpdateDelay();
             })
             .catch(() => {
-                setUpdateDelay();
+                pollUpdates && setUpdateDelay();
             });
     };
 
@@ -239,4 +238,4 @@ const autoUpdate = (opts) => {
     });
 };
 
-export { autoUpdate };
+export { updateBlocks };


### PR DESCRIPTION
## What does this change?

Blocks polling in `updateBlocks` if we're on a deadblog.

## Does this change need to be reproduced in dotcom-rendering ?

- [] No
- [X] Yes (please indicate your plans for DCR Implementation)

This is part of a body of work that allows filtering in liveblogs. The liveblog to dotcom-rendering migration is currently WIP so we cannot make these changes in dotcom-rendering at present but, if a/b testing shows a desire for this feature, we will need to implement this in DCR liveblogs once available.


### Tested

- [X] Locally
- [ ] On CODE (optional)


