### PR TITLE
Extend Prebid timeout AB test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -41,7 +41,7 @@ trait ABTestSwitches {
     "Vary length of prebid timeout",
     owners = Seq(Owner.withGithub("chrislomaxjones")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2021, 10, 22)),
+    sellByDate = Some(LocalDate.of(2021, 10, 29)),
     exposeClientSide = true,
   )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/prebid-timeout.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/prebid-timeout.ts
@@ -5,7 +5,7 @@ export const prebidTimeout: ABTest = {
 	id: 'PrebidTimeout',
 	author: 'Chris Jones (@chrislomaxjones)',
 	start: '2021-10-6',
-	expiry: '2021-10-22',
+	expiry: '2021-10-29',
 	audience: 3 / 100,
 	audienceOffset: 0,
 	audienceCriteria: 'All users',


### PR DESCRIPTION
## What does this change?

Extend the Prebid timeout test until 29th October 2021.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

The test has only recently been switched on, so it should be extended to ensure we obtain a sufficient volume of data.

### Tested

- [X] Locally
- [ ] On CODE (optional)
