### PR TITLE
Render amp pages as HTML using DCR/Frontend as appropriate

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -105,12 +105,16 @@ class ArticleController(
     request.getRequestFormat match {
       case JsonFormat if request.forceDCR =>
         Future.successful(common.renderJson(getGuuiJson(article, blocks), article).as("application/json"))
-      case JsonFormat                         => Future.successful(common.renderJson(getJson(article), article))
-      case EmailFormat                        => Future.successful(common.renderEmail(ArticleEmailHtmlPage.html(article), article))
-      case HtmlFormat if tier == RemoteRender => remoteRenderer.getArticle(ws, article, blocks, pageType)
-      case HtmlFormat                         => Future.successful(common.renderHtml(ArticleHtmlPage.html(article), article))
-      case AmpFormat if isAmpSupported        => remoteRenderer.getAMPArticle(ws, article, blocks, pageType)
-      case AmpFormat                          => Future.successful(common.renderHtml(ArticleHtmlPage.html(article), article))
+      case JsonFormat =>
+        Future.successful(common.renderJson(getJson(article), article))
+      case EmailFormat =>
+        Future.successful(common.renderEmail(ArticleEmailHtmlPage.html(article), article))
+      case AmpFormat if isAmpSupported =>
+        remoteRenderer.getAMPArticle(ws, article, blocks, pageType)
+      case HtmlFormat | AmpFormat if tier == RemoteRender =>
+        remoteRenderer.getArticle(ws, article, blocks, pageType)
+      case HtmlFormat | AmpFormat =>
+        Future.successful(common.renderHtml(ArticleHtmlPage.html(article), article))
     }
   }
 


### PR DESCRIPTION
## What does this change?

When we cannot render an article  in AMP format we instead serve HTML.  Previously if the `shouldAmplify` check was false, we rendered the HTML using the Frontend templates.  This PR changes the behaviour to use DCR or Frontend as the fallback render, based on the existing rules for rendering HTML.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

Articles that cannot be rendered as AMP will often be rendered using DCR which is better.

For example, after merging https://amp.theguardian.com/society/2021/apr/25/the-uks-femicide-epidemic-whos-killing-our-daughters should be rendered by DCR.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
