### PR TITLE
Give Guardian Labs paid content sponsor image fixed height

### DIFF
--- a/common/app/views/fragments/commercial/containers/paidContainer.scala.html
+++ b/common/app/views/fragments/commercial/containers/paidContainer.scala.html
@@ -52,7 +52,7 @@
                 </summary>
                 <div class="dumathoin__row dumathoin__row--wrap dumathoin__3cols">
                     @containerModel.content.showMoreCards.map(card => views.html.fragments.commercial.cards.itemSmallCard(
-                                            card,
+                                            item = card,
                                             optAdvertClassNames = Some(Seq("paidfor")),
                                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
                                             useCardBranding = !containerModel.isSingleSponsorContainer))

--- a/common/app/views/fragments/commercial/logo.scala.html
+++ b/common/app/views/fragments/commercial/logo.scala.html
@@ -3,7 +3,11 @@
 @(branding: Branding, onDarkBackground: Boolean = false)(implicit request: RequestHeader)
 
 @standardLogo(logo: Logo) = {
-    <img src="@logo.src" alt="@branding.sponsorName" class="badge__logo">
+    <img src="@logo.src" alt="@branding.sponsorName" class="badge__logo"
+        @logo.dimensions.map { dim =>
+            height="@dim.height"
+        }
+    >
 }
 
 @ampLogo(logo: Logo) = {


### PR DESCRIPTION
## What does this change?

This addresses [a card about potential reflow on Guardian Labs paid content slots](https://trello.com/c/0qcQlxUu/1277-placeholder-paid-for-logo). Before there was no fixed height on sponsor logo images, so when they loaded they resized the overall card. The PR sets a fixed height for the `<img>` container using the image's height value, so the space is accounted for before it loads.

Worth mentioning here that we noticed the full card is itself responsible for a pretty hefty layout shift which ought to be addressed if possible, but we thought that was beyond the scope of this PR. 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

![image](https://user-images.githubusercontent.com/11380557/138100059-d44ef5c0-0c5c-457e-9e95-ede1597617c3.png)

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
