### PR TITLE
Render interactives via DCR by default

### DIFF
--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -118,8 +118,6 @@ class InteractiveController(
     def render(model: Either[(InteractivePage, Blocks), Result]): Future[Result] = {
       model match {
         case Left((page, blocks)) => {
-          val tags = page.interactive.tags.tags
-          val date = Chronos.jodaDateTimeToJavaTimeDateTime(page.interactive.trail.webPublicationDate)
           val tier = InteractivePicker.getRenderingTier(path)
 
           (requestFormat, tier) match {

--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -120,14 +120,14 @@ class InteractiveController(
         case Left((page, blocks)) => {
           val tags = page.interactive.tags.tags
           val date = Chronos.jodaDateTimeToJavaTimeDateTime(page.interactive.trail.webPublicationDate)
-          val tier = InteractivePicker.getRenderingTier(requestFormat, path, date, tags)
+          val tier = InteractivePicker.getRenderingTier(path)
 
           (requestFormat, tier) match {
-            case (AmpFormat, DotcomRendering)    => renderAmp(page, blocks)
-            case (JsonFormat, DotcomRendering)   => renderJson(page, blocks)
-            case (HtmlFormat, InteractiveLegacy) => servePressedPage(path)
-            case (HtmlFormat, DotcomRendering)   => renderHtml(page, blocks)
-            case _                               => renderNonDCR(page)
+            case (AmpFormat, DotcomRendering)     => renderAmp(page, blocks)
+            case (JsonFormat, DotcomRendering)    => renderJson(page, blocks)
+            case (HtmlFormat, PressedInteractive) => servePressedPage(path)
+            case (HtmlFormat, DotcomRendering)    => renderHtml(page, blocks)
+            case _                                => renderNonDCR(page)
           }
         }
         case Right(result) => Future.successful(result)

--- a/applications/app/services/InteractivePicker.scala
+++ b/applications/app/services/InteractivePicker.scala
@@ -1,11 +1,8 @@
 package services
 
-import model.Tag
 import conf.switches.Switches.InteractivePickerFeature
-import implicits.{AmpFormat, HtmlFormat, RequestFormat}
 import play.api.mvc.RequestHeader
 import implicits.Requests._
-import java.time.LocalDateTime
 import services.dotcomrendering.PressedInteractives
 
 sealed trait RenderingTier
@@ -29,7 +26,7 @@ object InteractivePicker {
     val forceDCROff = request.forceDCROff
     val fullPath = ensureStartingForwardSlash(path)
 
-    // Allow us to quickly revert to rendering via frontend, if necessary
+    // Allow us to quickly revert to rendering content (instead of serving pressed content)
     val switchOn = InteractivePickerFeature.isSwitchedOn
 
     if (isPressed(fullPath) && switchOn) PressedInteractive

--- a/applications/app/services/InteractivePicker.scala
+++ b/applications/app/services/InteractivePicker.scala
@@ -5,81 +5,35 @@ import conf.switches.Switches.InteractivePickerFeature
 import implicits.{AmpFormat, HtmlFormat, RequestFormat}
 import play.api.mvc.RequestHeader
 import implicits.Requests._
-import model.dotcomrendering.InteractiveSwitchOver
 import java.time.LocalDateTime
-import common.Chronos
-import experiments.{ActiveExperiments, ShowPressedInteractives}
 import services.dotcomrendering.PressedInteractives
 
 sealed trait RenderingTier
 object DotcomRendering extends RenderingTier
 object FrontendLegacy extends RenderingTier
 object USElectionTracker2020AmpPage extends RenderingTier
-object InteractiveLegacy extends RenderingTier
+object PressedInteractive extends RenderingTier
 
 object InteractivePicker {
-
-  val migratedPaths = List(
-    "/sport/ng-interactive/2018/dec/26/lebron-james-comments-nba-nfl-divide",
-  )
 
   def ensureStartingForwardSlash(str: String): String = {
     if (!str.startsWith("/")) ("/" + str) else str
   }
 
-  def dateIsPostTransition(date: LocalDateTime): Boolean = {
-    date.isAfter(InteractiveSwitchOver.date)
-  }
-
-  def isSupported(tags: List[Tag]): Boolean = {
-    val supported = Set(
-      "tone/cartoons",
-      "profile/david-squires",
-      "tone/documentaries",
-      "education/universityguide",
-      "tone/resource",
-    )
-
-    tags.exists(tag => supported.contains(tag.id))
-  }
-
-  def isOptedOut(tags: List[Tag]): Boolean = {
-    tags.exists(t => t.id == "tracking/platformfunctional/dcroptout")
-  }
-
-  def isAmpOptedIn(tags: List[Tag]): Boolean = {
-    tags.exists(t => t.id == "tracking/platformfunctional/ampinteractive")
-  }
-
   def getRenderingTier(
-      requestFormat: RequestFormat,
       path: String,
-      datetime: LocalDateTime,
-      tags: List[Tag],
       isPressed: (String => Boolean) = PressedInteractives.isPressed,
   )(implicit
       request: RequestHeader,
   ): RenderingTier = {
-    val forceDCR = request.forceDCR
-    val isMigrated = migratedPaths.contains(if (path.startsWith("/")) path else "/" + path)
+    val forceDCROff = request.forceDCROff
+    val fullPath = ensureStartingForwardSlash(path)
+
+    // Allow us to quickly revert to rendering via frontend, if necessary
     val switchOn = InteractivePickerFeature.isSwitchedOn
-    val publishedPostSwitch = dateIsPostTransition(datetime)
-    val isOptedInAmp = (requestFormat == AmpFormat) && isAmpOptedIn(tags)
-    val isWeb = requestFormat == HtmlFormat
-    val isOptOut = isOptedOut(tags)
 
-    // Temporarily retain this experiment
-    // The experiment will allow us to opt-in Visuals team after go-live
-    // After Visuals team are happy, suggest changing this experiment to a switch
-    val isParticipating = ActiveExperiments.isParticipating(ShowPressedInteractives)
-
-    // Temporarily force documentaries into DCR while Composer doesn't allow easy removal of opt-out tag.
-    val isDocumentary = tags.exists(tag => tag.id == "tone/documentaries")
-
-    if (isPressed(ensureStartingForwardSlash(path)) && isParticipating && !isOptedInAmp) InteractiveLegacy
-    else if (forceDCR || isMigrated || isOptedInAmp) DotcomRendering
-    else if (switchOn && publishedPostSwitch && isWeb && !isOptOut) DotcomRendering
-    else if (switchOn && isSupported(tags) && isWeb && (!isOptOut || isDocumentary)) DotcomRendering
-    else FrontendLegacy
+    if (isPressed(fullPath) && switchOn) PressedInteractive
+    else if (forceDCROff) FrontendLegacy
+    else DotcomRendering
   }
 }

--- a/applications/test/InteractiveControllerTest.scala
+++ b/applications/test/InteractiveControllerTest.scala
@@ -5,6 +5,17 @@ import play.api.test.Helpers._
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers, PrivateMethodTester}
 import conf.Configuration.interactive.cdnPath
 
+class DCRFake() extends renderers.DotcomRenderingService {
+  override def getInteractive(
+      ws: WSClient,
+      page: InteractivePage,
+      blocks: Blocks,
+      pageType: PageType,
+  )(implicit request: RequestHeader): Future[Result] = {
+    Future.successful(Html("DCR Fake Interactive"))
+  }
+}
+
 @DoNotDiscover class InteractiveControllerTest
     extends FlatSpec
     with Matchers
@@ -21,6 +32,7 @@ import conf.Configuration.interactive.cdnPath
     testContentApiClient,
     wsClient,
     play.api.test.Helpers.stubControllerComponents(),
+    new DCRFake(),
   )
   val getWebWorkerPath = PrivateMethod[String]('getWebWorkerPath)
 

--- a/applications/test/InteractiveControllerTest.scala
+++ b/applications/test/InteractiveControllerTest.scala
@@ -7,8 +7,9 @@ import conf.Configuration.interactive.cdnPath
 import play.api.libs.ws.WSClient
 import com.gu.contentapi.client.model.v1.Blocks
 import model.dotcomrendering.PageType
+import model.{InteractivePage}
 import play.twirl.api.Html
-import play.api.mvc.{RequestHeader, Result}
+import play.api.mvc.{RequestHeader, Result, Results}
 import scala.concurrent.{ExecutionContext, Future}
 
 class DCRFake() extends renderers.DotcomRenderingService {
@@ -18,7 +19,7 @@ class DCRFake() extends renderers.DotcomRenderingService {
       blocks: Blocks,
       pageType: PageType,
   )(implicit request: RequestHeader): Future[Result] = {
-    Future.successful(Html("DCR Fake Interactive"))
+    Future.successful(Results.Ok("test"))
   }
 }
 

--- a/applications/test/InteractiveControllerTest.scala
+++ b/applications/test/InteractiveControllerTest.scala
@@ -4,6 +4,12 @@ import controllers.InteractiveController
 import play.api.test.Helpers._
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers, PrivateMethodTester}
 import conf.Configuration.interactive.cdnPath
+import play.api.libs.ws.WSClient
+import com.gu.contentapi.client.model.v1.Blocks
+import model.dotcomrendering.PageType
+import play.twirl.api.Html
+import play.api.mvc.{RequestHeader, Result}
+import scala.concurrent.{ExecutionContext, Future}
 
 class DCRFake() extends renderers.DotcomRenderingService {
   override def getInteractive(

--- a/applications/test/InteractiveTemplateTest.scala
+++ b/applications/test/InteractiveTemplateTest.scala
@@ -6,7 +6,7 @@ import scala.collection.JavaConverters._
 @DoNotDiscover class InteractiveTemplateTest extends FlatSpec with Matchers with ConfiguredTestSuite {
 
   "Interactive html template" should "show the twitter card meta-data" in goTo(
-    "/us-news/ng-interactive/2015/apr/13/marco-rubio-campaign-resume-guardian",
+    "/us-news/ng-interactive/2015/apr/13/marco-rubio-campaign-resume-guardian?dcr=false",
   ) { browser =>
     import browser._
     $("meta[name='twitter:card']").attributes("content").asScala.head should be("summary_large_image")

--- a/applications/test/services/InteractivePickerTest.scala
+++ b/applications/test/services/InteractivePickerTest.scala
@@ -4,9 +4,6 @@ import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
 import test.{ConfiguredTestSuite, TestRequest}
 import implicits.HtmlFormat
 import play.api.test.Helpers._
-import experiments.ShowPressedInteractives
-
-import java.time.LocalDateTime
 
 @DoNotDiscover class InteractivePickerTest extends FlatSpec with Matchers {
   val path = "/lifeandstyle/ng-interactive/2016/mar/12/stephen-collins-cats-cartoon"
@@ -14,22 +11,37 @@ import java.time.LocalDateTime
     private[this] val interactives = Set[String](path)
     def isPressed(path: String): Boolean = interactives.contains(path)
   }
-  val date = LocalDateTime.now
 
-  "Interactive Picker get rendering tier" should "return InteractiveLegacy if pressed and not amp and part of experiment" in {
-    conf.switches.Switches.ServerSideExperiments.switchOn
-    ShowPressedInteractives.switch.switchOn()
+  "Interactive Picker get rendering tier" should "return PressedInteractive if pressed and switched on" in {
+    conf.switches.Switches.InteractivePickerFeature.switchOn
 
     val testRequest = TestRequest(path)
-      .withHeaders(
-        ShowPressedInteractives.participationGroup.headerName -> "variant",
-      )
-    val tags = List()
-    val requestFormat = HtmlFormat
-    val tier = InteractivePicker.getRenderingTier(requestFormat, path, date, tags, MockPressedInteractives.isPressed)(
+    val tier = InteractivePicker.getRenderingTier(path, MockPressedInteractives.isPressed)(
       testRequest,
     )
 
-    tier should be(InteractiveLegacy)
+    tier should be(PressedInteractive)
+  }
+
+  it should "return FrontendLegacy only if the request forces DCR off" in {
+    val legacyPath = "/world/live/2021/oct/13/covid-news-live?dcr=false"
+    val testRequest = TestRequest(legacyPath)
+    val tier =
+      InteractivePicker.getRenderingTier(legacyPath, MockPressedInteractives.isPressed)(
+        testRequest,
+      )
+
+    tier should be(FrontendLegacy)
+  }
+
+  it should "return DotcomRendering by default" in {
+    val unPressedPath = "/world/live/2021/oct/13/covid-news-live"
+    val testRequest = TestRequest(unPressedPath)
+    val tier =
+      InteractivePicker.getRenderingTier(unPressedPath, MockPressedInteractives.isPressed)(
+        testRequest,
+      )
+
+    tier should be(DotcomRendering)
   }
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -458,9 +458,9 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "interactive-picker",
     "Activate the Interactive Picker (routing interactives between frontend and DCR)",
-    owners = Seq(Owner.withName("Pascal")),
+    owners = Seq(Owner.withGithub("DavidLawes")),
     safeState = Off,
-    sellByDate = LocalDate.of(2021, 11, 30),
+    sellByDate = LocalDate.of(2022, 6, 30),
     exposeClientSide = false,
   )
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -458,7 +458,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "interactive-picker",
     "Activate the Interactive Picker (routing interactives between frontend and DCR)",
-    owners = Seq(Owner.withGithub("DavidLawes")),
+    owners = Seq(Owner.withEmail("dotcom.platform@guardian.co.uk")),
     safeState = Off,
     sellByDate = LocalDate.of(2022, 6, 30),
     exposeClientSide = false,

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -7,7 +7,6 @@ import java.time.LocalDate
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
     LiveblogRendering,
-    ShowPressedInteractives,
     StandaloneCommercialBundle,
     StandaloneCommercialBundleTracking,
   )
@@ -22,15 +21,6 @@ object LiveblogRendering
       owners = Seq(Owner.withGithub("shtukas")),
       sellByDate = LocalDate.of(2021, 11, 30),
       participationGroup = Perc0A,
-    )
-
-object ShowPressedInteractives
-    extends Experiment(
-      name = "interactive-librarian",
-      description = "The pressed interactives experiment",
-      owners = Seq(Owner.withGithub("shtukas")),
-      sellByDate = LocalDate.of(2022, 1, 31),
-      participationGroup = Perc0B,
     )
 
 object StandaloneCommercialBundle


### PR DESCRIPTION
## What does this change?
This change supports the migration of interactives into dcr. The agreement with the Visuals team is:
- Render everything via DCR by default
- Serve pressed content only by exception

The change is primarily to the interactive picker, where the selection of the rendering tier has been simplified:
- `PressedInteractive` is selected based on the path and the interactive-picker switch. I thought keeping the switch was a good idea for now, so we can more easily stop showing pressed content if there's an unforeseen error.
- `FrontendLegacy` will only be selected if the path includes the query param `?dcr=false`. I thought it might be useful to help with any debugging post-migration.
- `DotcomRendering` becomes the default rendering tier, as this is the intention of this migration.

Some notes:
- What about amp? Previously we indicated that interactives were suitable to render via amp by including a tracking tag (`tracking/platformfunctional/ampinteractive`) which forces the interactive to render via DCR. Note that (according to a query to the content api specifying `tag=(tracking/platformfunctional/ampinteractive)`) there have been no interactives created using this tag. I don't think we need to explicitly check for this tag because we now default to a rendering tier of DotcomRendering.
- What about dcr opt out? Approx 5months ago we allowed interactives to be created with tag `tracking/platformfunctional/dcroptout` (20 interactives have been created with this tag). Going forward I don't think we want to support the use of this tag, we should be enabling all interactives to be rendered via DCR. I'm double-checking with the Visuals team, but I think removing this option is the intended end-state post-migration.
- How do we resolve issues? In collaboration with the Visuals team we've reviewed how the top viewed interactives render via DCR. Any interactives we weren't happy with have been pressed. If there are issues with other interactives in production we should fix forward: either fix the interactive/dcr to render the interactive to an acceptable standard or press the interactive.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
Enables interactives to be rendered via DCR by default. When interactives are rendered we'll see `(modern)` in the footer, unless the article is to be served from archived content (in which case we'll see the archived copy appended below the footer).

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
