### PR TITLE
Read Ophan `pageViewId from `config`

### DIFF
--- a/common/app/views/fragments/email/signup/footer/emailSignUpFooter.scala.html
+++ b/common/app/views/fragments/email/signup/footer/emailSignUpFooter.scala.html
@@ -43,6 +43,6 @@
 <script>
     trackClickEvent(document.getElementById("email-embed-signup-button"))
     document.getElementById("email-sub__ref-input").value = window.parent.location.href
-    document.getElementById("email-sub__refviewid-input").value = window.parent.guardian.ophan.pageViewId
+    document.getElementById("email-sub__refviewid-input").value = window.parent.guardian.config.ophan.pageViewId
 </script>
 

--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -66,6 +66,6 @@
 <script>
     trackClickEvent(document.getElementById("email-embed-signup-button--old"))
     document.getElementById("email-sub__ref-input").value = window.parent.location.href
-    document.getElementById("email-sub__refviewid-input").value = window.parent.guardian.ophan.pageViewId
+    document.getElementById("email-sub__refviewid-input").value = window.parent.guardian.config.ophan.pageViewId
 </script>
 

--- a/common/app/views/fragments/email/signup/subscription/emailSignUpNewDesign.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUpNewDesign.scala.html
@@ -88,6 +88,6 @@
 <script>
     trackClickEvent(document.getElementById("email-embed-signup-button"))
     document.getElementById("email-sub__ref-input").value = window.parent.location.href
-    document.getElementById("email-sub__refviewid-input").value = window.parent.guardian.ophan.pageViewId
+    document.getElementById("email-sub__refviewid-input").value = window.parent.guardian.config.ophan.pageViewId
 </script>
 


### PR DESCRIPTION
## What does this change?
Replaces `window.guardian.ophan.pageViewId` with `window.guardian.config.ophan.pageViewId`

## Why?
Because this is where the `pageViewId` is first set. See [this line in tracker.js](https://github.com/guardian/ophan/blob/main/tracker-js/assets/coffee/ophan/transmit.coffee#L10). It does end up being copied over into `guardian.pageViewId` later but on DCR that process happens after the script has run causing the value to be empty on those pages.