### PR TITLE
add filterKeyEvents params to pagination links

### DIFF
--- a/article/app/views/fragments/liveBlogNavigation.scala.html
+++ b/article/app/views/fragments/liveBlogNavigation.scala.html
@@ -12,7 +12,7 @@
 
         <div class="liveblog-navigation__newer">
             <a @pagination.newest.map { newest =>
-                href="/@id@newest.suffix&@if(filterByKeyEvents) {filterKeyEvents=true} else {filterKeyEvents=false}"
+                href="/@id@newest.suffix"
                 title="Go to page @newest.pageNumber"
             }
             class="liveblog-navigation__link liveblog-navigation__link--secondary liveblog-navigation__link--secondary--newer @if(pagination.newest.isEmpty) { liveblog-navigation__link--disabled }"
@@ -29,7 +29,7 @@
             </a>
 
             <a @pagination.newer.map { newer =>
-                href="/@id@newer.suffix&@if(filterByKeyEvents) {filterKeyEvents=true} else {filterKeyEvents=false}@if(newer.isArchivePage) {#liveblog-navigation} else {}"
+                href="/@id@newer.suffix@if(newer.isArchivePage) {#liveblog-navigation} else {}"
                 title="Go to page @newer.pageNumber"
             }
             class="liveblog-navigation__link liveblog-navigation__link--primary @if(pagination.newer.isEmpty) { liveblog-navigation__link--disabled liveblog-navigation__link--primary--disabled }"
@@ -47,7 +47,7 @@
 
         <div class="liveblog-navigation__older">
             <a @pagination.older.map { older =>
-                href="/@id@older.suffix&@if(filterByKeyEvents) {filterKeyEvents=true} else {filterKeyEvents=false}#liveblog-navigation"
+                href="/@id@older.suffix#liveblog-navigation"
                 title="Go to page @older.pageNumber"
             }
             class="liveblog-navigation__link liveblog-navigation__link--primary @if(pagination.older.isEmpty) { liveblog-navigation__link--disabled liveblog-navigation__link--primary--disabled }"
@@ -63,7 +63,7 @@
             </a>
 
             <a @pagination.oldest.map { oldest =>
-                href="/@id@oldest.suffix&@if(filterByKeyEvents) {filterKeyEvents=true} else {filterKeyEvents=false}#liveblog-navigation"
+                href="/@id@oldest.suffix#liveblog-navigation"
                 title="Go to page @oldest.pageNumber"
             }
             class="liveblog-navigation__link liveblog-navigation__link--secondary liveblog-navigation__link--secondary--older @if(pagination.oldest.isEmpty) { liveblog-navigation__link--disabled }"

--- a/article/app/views/fragments/liveBlogNavigation.scala.html
+++ b/article/app/views/fragments/liveBlogNavigation.scala.html
@@ -1,7 +1,7 @@
 @import conf.Configuration
 @import model.LiveBlogCurrentPage
 
-@(id: String, currentPage: LiveBlogCurrentPage)
+@(id: String, currentPage: LiveBlogCurrentPage, filterByKeyEvents: Boolean)
 
 @currentPage.pagination.map { pagination =>
     <div id="liveblog-navigation" class="liveblog-navigation">
@@ -12,7 +12,7 @@
 
         <div class="liveblog-navigation__newer">
             <a @pagination.newest.map { newest =>
-                href="/@id@newest.suffix"
+                href="/@id@newest.suffix&@if(filterByKeyEvents) {filterKeyEvents=true} else {filterKeyEvents=false}"
                 title="Go to page @newest.pageNumber"
             }
             class="liveblog-navigation__link liveblog-navigation__link--secondary liveblog-navigation__link--secondary--newer @if(pagination.newest.isEmpty) { liveblog-navigation__link--disabled }"
@@ -29,7 +29,7 @@
             </a>
 
             <a @pagination.newer.map { newer =>
-                href="/@id@newer.suffix@if(newer.isArchivePage) {#liveblog-navigation} else {}"
+                href="/@id@newer.suffix&@if(filterByKeyEvents) {filterKeyEvents=true} else {filterKeyEvents=false}@if(newer.isArchivePage) {#liveblog-navigation} else {}"
                 title="Go to page @newer.pageNumber"
             }
             class="liveblog-navigation__link liveblog-navigation__link--primary @if(pagination.newer.isEmpty) { liveblog-navigation__link--disabled liveblog-navigation__link--primary--disabled }"
@@ -47,7 +47,7 @@
 
         <div class="liveblog-navigation__older">
             <a @pagination.older.map { older =>
-                href="/@id@older.suffix#liveblog-navigation"
+                href="/@id@older.suffix&@if(filterByKeyEvents) {filterKeyEvents=true} else {filterKeyEvents=false}#liveblog-navigation"
                 title="Go to page @older.pageNumber"
             }
             class="liveblog-navigation__link liveblog-navigation__link--primary @if(pagination.older.isEmpty) { liveblog-navigation__link--disabled liveblog-navigation__link--primary--disabled }"
@@ -63,7 +63,7 @@
             </a>
 
             <a @pagination.oldest.map { oldest =>
-                href="/@id@oldest.suffix#liveblog-navigation"
+                href="/@id@oldest.suffix&@if(filterByKeyEvents) {filterKeyEvents=true} else {filterKeyEvents=false}#liveblog-navigation"
                 title="Go to page @oldest.pageNumber"
             }
             class="liveblog-navigation__link liveblog-navigation__link--secondary liveblog-navigation__link--secondary--older @if(pagination.oldest.isEmpty) { liveblog-navigation__link--disabled }"

--- a/article/app/views/liveblog/liveBlogBodyContent.scala.html
+++ b/article/app/views/liveblog/liveBlogBodyContent.scala.html
@@ -17,7 +17,7 @@
         </div>
 
         @if(model.currentPage.currentPage.isArchivePage) {
-            @fragments.liveBlogNavigation(article.content.metadata.id, model.currentPage)
+            @fragments.liveBlogNavigation(article.content.metadata.id, model.currentPage, model.filterKeyEvents)
         }
 
         <div
@@ -30,7 +30,7 @@
 
         </div>
 
-        @fragments.liveBlogNavigation(article.content.metadata.id, model.currentPage)
+        @fragments.liveBlogNavigation(article.content.metadata.id, model.currentPage, model.filterKeyEvents)
 
     </div>
 }

--- a/preview/conf/routes
+++ b/preview/conf/routes
@@ -197,7 +197,7 @@ GET        /weatherapi/city.json                                                
 GET        /weatherapi/locations                                                               weather.controllers.LocationsController.findCity(query: String)
 
 # Articles
-GET     /$path<[^/]+/([^/]+/)?live/.*>.json controllers.LiveBlogController.renderJson(path, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean], filterKeyEvents: Option[Boolean], userInteraction: Option[Boolean])
+GET     /$path<[^/]+/([^/]+/)?live/.*>.json controllers.LiveBlogController.renderJson(path, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean], filterKeyEvents: Option[Boolean])
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email controllers.LiveBlogController.renderEmail(path)
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email.emailjson controllers.LiveBlogController.renderEmail(path)
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email.emailtxt  controllers.LiveBlogController.renderEmail(path)


### PR DESCRIPTION
## What does this change?

Adds `filterKeyEvents` parameter to links in liveblogs pagination.

To test: 

- Edit the pageSize val in both `createLiveBlogModel` methods to read as follows:

`val pageSize = if (liveBlog.content.tags.tags.map(_.id).contains("sport/sport")) 30 else 3`

- Check filter state persists when moving between pages and across links from the keyEvents side bar.


## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

## Screenshots

No UI changes

## What is the value of this and can you measure success?

## Checklist

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [x] Locally
- [ ] On CODE (optional)


