### PR TITLE
Warped sponsor logo fix

### DIFF
--- a/static/src/stylesheets/module/commercial/_brandbadge.scss
+++ b/static/src/stylesheets/module/commercial/_brandbadge.scss
@@ -48,6 +48,7 @@
         max-height: 6 * $gs-baseline;
         @include mq(tablet) {
             max-height: none;
+            height: auto;
         }
         max-width: 100%;
         margin: 0 0 5px;


### PR DESCRIPTION
## What does this change?

This addresses a knock-on effect of https://github.com/guardian/frontend/pull/24293 which is causing sponsor logos on podcasts to stretch beyond their natural ratio. This PR tweaks the CSS in `_brandbadge.scss` to ensure this no longer happens. Setting the `height` to `auto` will keep the image dimensions as they should be while still guarding against reflow.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before](https://user-images.githubusercontent.com/11380557/138873631-ec0c3795-99a9-4ed4-86c2-5bb368584fc8.png) | ![after](https://user-images.githubusercontent.com/11380557/138873472-baa20b3c-cf31-4b7f-87ae-f0620bd79d0f.png) |

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
