### PR TITLE
Add filterKeyEvents flag to timeline and hide summaries when filtered

### DIFF
--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -180,8 +180,11 @@ class LiveBlogController(
     val newBlocks = flatMapBlocks(page, lastUpdateBlockId, filterKeyEvents);
 
     val blocksHtml = views.html.liveblog.liveBlogBlocks(newBlocks, page.article, Edition(request).timezone)
-    val timelineHtml = views.html.liveblog
-      .keyEvents("", model.KeyEventData(newBlocks, Edition(request).timezone), filterKeyEvents.getOrElse(false))
+    val timelineHtml = views.html.liveblog.keyEvents(
+      "",
+      model.KeyEventData(newBlocks, Edition(request).timezone, filterKeyEvents),
+      filterKeyEvents.getOrElse(false),
+    )
 
     val allPagesJson = Seq(
       "timeline" -> timelineHtml,

--- a/article/app/model/KeyEventData.scala
+++ b/article/app/model/KeyEventData.scala
@@ -7,21 +7,24 @@ import com.github.nscala_time.time.Imports._
 object KeyEventData {
 
   // just for convenience for use from the templates
-  def apply(maybeBlocks: Option[Blocks], timezone: DateTimeZone): Seq[KeyEventData] = {
+  def apply(maybeBlocks: Option[Blocks], timezone: DateTimeZone, filterKeyEvents: Boolean): Seq[KeyEventData] = {
 
     val blocks =
       maybeBlocks.toSeq.flatMap(blocks => blocks.requestedBodyBlocks.getOrElse(CanonicalLiveBlog.timeline, blocks.body))
 
-    apply(blocks, timezone)
+    apply(blocks, timezone, Some(filterKeyEvents))
   }
 
-  def apply(blocks: Seq[BodyBlock], timezone: DateTimeZone): Seq[KeyEventData] = {
-
+  def apply(blocks: Seq[BodyBlock], timezone: DateTimeZone, filterKeyEvents: Option[Boolean]): Seq[KeyEventData] = {
     val TimelineMaxEntries = 7
     val latestSummary = blocks.find(_.eventType == SummaryEvent)
     val keyEvents = blocks.filter(_.eventType == KeyEvent)
-    val bodyBlocks =
-      (latestSummary.toSeq ++ keyEvents).sortBy(_.publishedCreatedTimestamp).reverse.take(TimelineMaxEntries)
+    val bodyBlocks = filterKeyEvents match {
+      case Some(true) =>
+        (keyEvents).sortBy(_.publishedCreatedTimestamp).reverse.take(TimelineMaxEntries)
+      case _ =>
+        (latestSummary.toSeq ++ keyEvents).sortBy(_.publishedCreatedTimestamp).reverse.take(TimelineMaxEntries)
+    }
 
     bodyBlocks.map { bodyBlock =>
       KeyEventData(bodyBlock.id, bodyBlock.referenceDateForDisplay().map(LiveBlogDate(_, timezone)), bodyBlock.title)

--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -75,7 +75,7 @@
                         <div class="js-live-blog__sticky-components">
                             <div class="js-live-blog__sticky-components-container live-blog__sticky-components-container">
                                 @if(article.hasKeyEvents) {
-                                    @defining(KeyEventData(article.content.fields.blocks, timezone)) { case keyEventData =>
+                                    @defining(KeyEventData(article.content.fields.blocks, timezone, model.filterKeyEvents)) { case keyEventData =>
                                         @if(model.filterKeyEvents) {
                                             <a href="?filterKeyEvents=@(!model.filterKeyEvents)">Show All</a>
                                         } else {


### PR DESCRIPTION
## What does this change?

Filters timeline events so we don't show summary events when we're filtering blocks to only show key events.

## To test

 - find a liveblog containing a summary ie: `/world/live/2021/oct/26/coronavirus-news-live-african-union-to-buy-110m-moderna-vaccines-nz-to-set-vaccine-mandates-for-40-of-workforce`
 - go to page 2
 - observe the summary in the timeline
 - click filter and observe the summary is no longer shown
 
