### PR TITLE
Stop toast and count showing on deadblogs

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/autoupdate.js
+++ b/static/src/javascripts/projects/common/modules/ui/autoupdate.js
@@ -16,7 +16,6 @@ import { checkElemsForVideos } from 'common/modules/atoms/youtube';
 
 
 const updateBlocks = (opts, pollUpdates) => {
-    console.log(pollUpdates)
     const options = Object.assign(
         {
             toastOffsetTop: 12,
@@ -143,7 +142,7 @@ const updateBlocks = (opts, pollUpdates) => {
             .then(resp => {
                 count = resp.numNewBlocks;
 
-                if (count > 0) {
+                if (pollUpdates && count > 0) {
                     unreadBlocksNo += count;
 
                     // updates notification bar with number of unread blocks


### PR DESCRIPTION
## What does this change?
Check if blog polls (and is therefore not a dead blog) before implementing new block logic which includes updating the new blog count and showing the toast button. 

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

### Tested

- [X] Locally
- [ ] On CODE (optional)

To test, open a [dead blog](http://localhost:9000/world/live/2021/oct/21/coronavirus-news-live-india-administers-1bn-vaccine-doses-singapore-at-risk-of-being-overwhelmed-amid-record-deaths) and a [live blog](https://www.theguardian.com/world/series/coronavirus-live) and filter key events. The toast and count should not appear on either.