### PR TITLE
Force interactive pressing via frontend

### DIFF
--- a/applications/app/services/InteractivePicker.scala
+++ b/applications/app/services/InteractivePicker.scala
@@ -23,6 +23,7 @@ object InteractivePicker {
   )(implicit
       request: RequestHeader,
   ): RenderingTier = {
+    // Allows us to press via InterativeLibrarian and also debug interactives rendering via dcr
     val forceDCROff = request.forceDCROff
     val fullPath = ensureStartingForwardSlash(path)
 

--- a/common/app/services/dotcomrendering/InteractiveLibrarian.scala
+++ b/common/app/services/dotcomrendering/InteractiveLibrarian.scala
@@ -114,7 +114,7 @@ object InteractiveLibrarian extends GuLogging {
     // 2. Queries the live contents ( https://www.theguardian.com/books/ng-interactive/2021/mar/05/this-months-best-paperbacks-michelle-obama-jan-morris-and-more )
     // 3. Stores the document at S3 path ( www.theguardian.com/books/ng-interactive/2021/mar/05/this-months-best-paperbacks-michelle-obama-jan-morris-and-more )
     log.info(s"Interactive Librarian. Pressing path: ${path}")
-    val liveUrl = s"https://www.theguardian.com/${path}"
+    val liveUrl = s"https://www.theguardian.com/${path}?dcr=false"
     val s3path = s"www.theguardian.com/${path}"
     val wsRequest = wsClient.url(liveUrl)
     wsRequest.get().flatMap { response =>


### PR DESCRIPTION
## What does this change?
Interactives now render via dcr by default. When we press we want to capture how the interactive renders via frontend. This PR forces all interactives to be pressed using content rendered via frontend.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
How page renders via frontend:
<img width="1767" alt="Screenshot 2021-10-26 at 17 19 01" src="https://user-images.githubusercontent.com/45561419/138919923-478483f5-d237-433e-ab35-78c2f5644aa5.png">


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/45561419/138920080-c585cc6b-214b-4e07-9400-b8e1eba1b102.png

[after]: https://user-images.githubusercontent.com/45561419/138920105-eade440b-ee47-41d0-a8d5-fe16f4fcae91.png


## What is the value of this and can you measure success?
When pages are pressed we capture the content as it is rendered via frontend, not dcr.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
