### PR TITLE
Add type and functions for ad size mappings

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slots.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slots.ts
@@ -1,6 +1,6 @@
 import { adSizes } from '@guardian/commercial-core';
 import type { SizeMappings } from './size-mapping';
-import { mergeSizeMappings, sizeMappingsToString } from './size-mapping';
+import { concatSizeMappings, sizeMappingsToString } from './size-mapping';
 
 type AdSlotDefinition = {
 	sizeMappings: SizeMappings;
@@ -210,7 +210,7 @@ export const createSlots = (
 
 	const sizes =
 		options.sizes !== undefined
-			? mergeSizeMappings(definition.sizeMappings, options.sizes)
+			? concatSizeMappings(definition.sizeMappings, options.sizes)
 			: definition.sizeMappings;
 
 	const sizeStrings = sizeMappingsToString(sizes);

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slots.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slots.ts
@@ -1,7 +1,6 @@
 import { adSizes } from '@guardian/commercial-core';
-import type { AdSize } from '@guardian/commercial-core';
-
-type SizeMappings = Record<string, AdSize[]>;
+import type { SizeMappings } from './size-mapping';
+import { mergeSizeMappings, sizeMappingsToString } from './size-mapping';
 
 type AdSlotDefinition = {
 	sizeMappings: SizeMappings;
@@ -15,7 +14,7 @@ type AdSlotDefinitions = Record<string, AdSlotDefinition>;
 type CreateSlotOptions = {
 	classes?: string;
 	name?: string;
-	sizes?: Record<string, AdSize[] | undefined>; // allow an empty object
+	sizes?: SizeMappings;
 };
 
 const inlineDefinition: AdSlotDefinition = {
@@ -209,26 +208,9 @@ export const createSlots = (
 	const classes: string[] =
 		options.classes?.split(' ').map((cn) => `ad-slot--${cn}`) ?? [];
 
-	const sizes: SizeMappings = { ...definition.sizeMappings };
-	const sizeStrings: Record<string, string> = {};
+	const sizes = mergeSizeMappings(definition.sizeMappings, options.sizes);
 
-	const optionSizes = options.sizes;
-
-	if (optionSizes) {
-		Object.keys(optionSizes).forEach((optionSize: string) => {
-			const optionSizesArray = optionSizes[optionSize];
-			if (optionSizesArray) {
-				// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- update tsconfig: "noUncheckedIndexedAccess": true
-				sizes[optionSize] = sizes[optionSize]
-					? sizes[optionSize].concat(optionSizesArray)
-					: optionSizesArray;
-			}
-		});
-	}
-
-	Object.keys(sizes).forEach((size) => {
-		sizeStrings[size] = sizes[size].join('|');
-	});
+	const sizeStrings = sizeMappingsToString(sizes);
 
 	Object.assign(attributes, sizeStrings);
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slots.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slots.ts
@@ -208,7 +208,10 @@ export const createSlots = (
 	const classes: string[] =
 		options.classes?.split(' ').map((cn) => `ad-slot--${cn}`) ?? [];
 
-	const sizes = mergeSizeMappings(definition.sizeMappings, options.sizes);
+	const sizes =
+		options.sizes !== undefined
+			? mergeSizeMappings(definition.sizeMappings, options.sizes)
+			: definition.sizeMappings;
 
 	const sizeStrings = sizeMappingsToString(sizes);
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/size-mapping.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/size-mapping.spec.ts
@@ -1,0 +1,72 @@
+import { adSizes } from '@guardian/commercial-core';
+import { concatSizeMappings, sizeMappingsToString } from './size-mapping';
+
+describe('concatSizeMappings', () => {
+	it('different breakpoints', () => {
+		expect(
+			concatSizeMappings(
+				{ mobile: [adSizes.fluid], tablet: [adSizes.portrait] },
+				{ phablet: [adSizes.outOfPage], desktop: [adSizes.halfPage] },
+			),
+		).toEqual({
+			mobile: [adSizes.fluid],
+			tablet: [adSizes.portrait],
+			phablet: [adSizes.outOfPage],
+			desktop: [adSizes.halfPage],
+		});
+	});
+
+	it('merge same breakpoint', () => {
+		expect(
+			concatSizeMappings(
+				{ mobile: [adSizes.fluid] },
+				{ mobile: [adSizes.halfPage] },
+			),
+		).toEqual({
+			mobile: [adSizes.fluid, adSizes.halfPage],
+		});
+	});
+
+	it('merge across multiple breakpoints', () => {
+		expect(
+			concatSizeMappings(
+				{
+					mobile: [adSizes.fluid],
+					desktop: [adSizes.halfPage, adSizes.mpu],
+					tablet: [adSizes.merchandising],
+				},
+				{
+					tablet: [adSizes.merchandisingHigh],
+					mobile: [adSizes.halfPage, adSizes.fluid, adSizes.mpu],
+					phablet: [adSizes.outOfPage, adSizes.mobilesticky],
+				},
+			),
+		).toEqual({
+			mobile: [
+				adSizes.fluid,
+				adSizes.halfPage,
+				adSizes.fluid,
+				adSizes.mpu,
+			],
+			desktop: [adSizes.halfPage, adSizes.mpu],
+			phablet: [adSizes.outOfPage, adSizes.mobilesticky],
+			tablet: [adSizes.merchandising, adSizes.merchandisingHigh],
+		});
+	});
+});
+
+describe('sizeMappingToString', () => {
+	it('generates correct strings', () => {
+		expect(
+			sizeMappingsToString({
+				mobile: [adSizes.halfPage, adSizes.fluid, adSizes.fabric],
+				tablet: [adSizes.merchandising, adSizes.fluid, adSizes.mpu],
+				desktop: [adSizes.portrait, adSizes.mpu],
+			}),
+		).toEqual({
+			mobile: `${adSizes.halfPage.toString()}|${adSizes.fluid.toString()}|${adSizes.fabric.toString()}`,
+			tablet: `${adSizes.merchandising.toString()}|${adSizes.fluid.toString()}|${adSizes.mpu.toString()}`,
+			desktop: `${adSizes.portrait.toString()}|${adSizes.mpu.toString()}`,
+		});
+	});
+});

--- a/static/src/javascripts/projects/commercial/modules/dfp/size-mapping.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/size-mapping.ts
@@ -9,7 +9,7 @@ type SizeMappingsString = {
 	[B in Breakpoint]?: string;
 };
 
-export const mergeSizeMappings = (
+export const concatSizeMappings = (
 	sizeMappings1: SizeMappings,
 	sizeMappings2: SizeMappings,
 ): SizeMappings => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/size-mapping.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/size-mapping.ts
@@ -12,35 +12,32 @@ type SizeMappingsString = {
 export const concatSizeMappings = (
 	sizeMappings1: SizeMappings,
 	sizeMappings2: SizeMappings,
-): SizeMappings => {
-	const mergedMappings: SizeMappings = { ...sizeMappings1 };
-
-	(Object.keys(sizeMappings2) as Breakpoint[]).forEach((optionSize) => {
-		const optionSizesArray = sizeMappings2[optionSize];
-		const mergedSize = mergedMappings[optionSize];
-		if (optionSizesArray !== undefined) {
-			mergedMappings[optionSize] =
-				mergedSize !== undefined
-					? mergedSize.concat(optionSizesArray)
-					: optionSizesArray;
-		}
-	});
-
-	return mergedMappings;
-};
+): SizeMappings =>
+	(Object.keys(sizeMappings2) as Breakpoint[]).reduce<SizeMappings>(
+		(concatMappings, size) => {
+			concatMappings[size] = (concatMappings[size] ?? []).concat(
+				sizeMappings2[size] ?? [],
+			);
+			return concatMappings;
+		},
+		{ ...sizeMappings1 },
+	);
 
 const sizeMappingToString = (sizeMapping: AdSize[]): string =>
 	sizeMapping.map((adSize) => adSize.toString()).join('|');
 
 export const sizeMappingsToString = (
 	sizeMappings: SizeMappings,
-): SizeMappingsString => {
-	const sizeMappingsString: SizeMappingsString = {};
-	(Object.keys(sizeMappings) as Breakpoint[]).forEach((breakpoint) => {
-		const sizeMapping = sizeMappings[breakpoint];
-		if (sizeMapping !== undefined) {
-			sizeMappingsString[breakpoint] = sizeMappingToString(sizeMapping);
-		}
-	});
-	return sizeMappingsString;
-};
+): SizeMappingsString =>
+	(Object.keys(sizeMappings) as Breakpoint[]).reduce<SizeMappingsString>(
+		(sizeMappingsString, breakpoint) => {
+			const sizeMapping = sizeMappings[breakpoint];
+			if (sizeMapping !== undefined) {
+				sizeMappingsString[breakpoint] = sizeMappingToString(
+					sizeMapping,
+				);
+			}
+			return sizeMappingsString;
+		},
+		{},
+	);

--- a/static/src/javascripts/projects/commercial/modules/dfp/size-mapping.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/size-mapping.ts
@@ -11,21 +11,21 @@ type SizeMappingsString = {
 
 export const mergeSizeMappings = (
 	sizeMappings1: SizeMappings,
-	sizeMappings2?: SizeMappings,
+	sizeMappings2: SizeMappings,
 ): SizeMappings => {
 	const mergedMappings: SizeMappings = { ...sizeMappings1 };
-	if (sizeMappings2) {
-		(Object.keys(sizeMappings2) as Breakpoint[]).forEach((optionSize) => {
-			const optionSizesArray = sizeMappings2[optionSize];
-			const mergedSize = mergedMappings[optionSize];
-			if (optionSizesArray !== undefined) {
-				mergedMappings[optionSize] =
-					mergedSize !== undefined
-						? mergedSize.concat(optionSizesArray)
-						: optionSizesArray;
-			}
-		});
-	}
+
+	(Object.keys(sizeMappings2) as Breakpoint[]).forEach((optionSize) => {
+		const optionSizesArray = sizeMappings2[optionSize];
+		const mergedSize = mergedMappings[optionSize];
+		if (optionSizesArray !== undefined) {
+			mergedMappings[optionSize] =
+				mergedSize !== undefined
+					? mergedSize.concat(optionSizesArray)
+					: optionSizesArray;
+		}
+	});
+
 	return mergedMappings;
 };
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/size-mapping.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/size-mapping.ts
@@ -1,0 +1,46 @@
+import type { AdSize } from '@guardian/commercial-core';
+import type { Breakpoint } from '@guardian/src-foundations';
+
+export type SizeMappings = {
+	[B in Breakpoint]?: AdSize[];
+};
+
+type SizeMappingsString = {
+	[B in Breakpoint]?: string;
+};
+
+export const mergeSizeMappings = (
+	sizeMappings1: SizeMappings,
+	sizeMappings2?: SizeMappings,
+): SizeMappings => {
+	const mergedMappings: SizeMappings = { ...sizeMappings1 };
+	if (sizeMappings2) {
+		(Object.keys(sizeMappings2) as Breakpoint[]).forEach((optionSize) => {
+			const optionSizesArray = sizeMappings2[optionSize];
+			const mergedSize = mergedMappings[optionSize];
+			if (optionSizesArray !== undefined) {
+				mergedMappings[optionSize] =
+					mergedSize !== undefined
+						? mergedSize.concat(optionSizesArray)
+						: optionSizesArray;
+			}
+		});
+	}
+	return mergedMappings;
+};
+
+const sizeMappingToString = (sizeMapping: AdSize[]): string =>
+	sizeMapping.map((adSize) => adSize.toString()).join('|');
+
+export const sizeMappingsToString = (
+	sizeMappings: SizeMappings,
+): SizeMappingsString => {
+	const sizeMappingsString: SizeMappingsString = {};
+	(Object.keys(sizeMappings) as Breakpoint[]).forEach((breakpoint) => {
+		const sizeMapping = sizeMappings[breakpoint];
+		if (sizeMapping !== undefined) {
+			sizeMappingsString[breakpoint] = sizeMappingToString(sizeMapping);
+		}
+	});
+	return sizeMappingsString;
+};

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -147,7 +147,7 @@
  "../projects/commercial/modules/dfp/breakpoint-name-to-attribute.ts": [],
  "../projects/commercial/modules/dfp/create-slots.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts"
+  "../projects/commercial/modules/dfp/size-mapping.ts"
  ],
  "../projects/commercial/modules/dfp/define-slot.js": [
   "../../../../node_modules/lodash-es/lodash.js",
@@ -318,6 +318,10 @@
   "../projects/commercial/modules/dfp/get-ad-iframe.ts",
   "../projects/commercial/modules/dfp/render-advert-label.ts",
   "../projects/commercial/modules/sticky-mpu.js"
+ ],
+ "../projects/commercial/modules/dfp/size-mapping.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/src-foundations/dist/types/index.d.ts"
  ],
  "../projects/commercial/modules/dfp/track-ad-render.ts": [
   "../projects/commercial/modules/dfp/wait-for-advert.ts"


### PR DESCRIPTION
## What does this change?

Create a narrower `SizeMappings` type and move it to its own file. Split out the logic from `create-slots.ts` into functions that operate directly on size mappings. Additionally add tests for these functions.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

- Make the purpose of `createSlots` clearer by having it call named functions explicitly on size mappings.
- We can reuse the definitions of size mappings in other places in the commercial bundle and collect any functions that operate directly on size mappings here.
- Using breakpoint definitions from [Source](https://github.com/guardian/source) reduces reliance on `lib/detect` in the future.

### Todo

- Add TSDoc documentation

### Tested

- [ ] **TODO** Locally
- [ ] **TODO** On CODE (optional)