### PR TITLE
server side switch

### DIFF
--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -26,12 +26,12 @@ import model.liveblog.BodyBlock.KeyEvent
 case class MinutePage(article: Article, related: RelatedContent) extends PageWithStoryPackage
 
 class LiveBlogController(
-                          contentApiClient: ContentApiClient,
-                          val controllerComponents: ControllerComponents,
-                          ws: WSClient,
-                          remoteRenderer: renderers.DotcomRenderingService = DotcomRenderingService(),
-                        )(implicit context: ApplicationContext)
-  extends BaseController
+    contentApiClient: ContentApiClient,
+    val controllerComponents: ControllerComponents,
+    ws: WSClient,
+    remoteRenderer: renderers.DotcomRenderingService = DotcomRenderingService(),
+)(implicit context: ApplicationContext)
+    extends BaseController
     with GuLogging
     with ImplicitControllerExecutionContext {
 
@@ -48,64 +48,74 @@ class LiveBlogController(
         case (minute: MinutePage, blocks) =>
           Future.successful(common.renderEmail(ArticleEmailHtmlPage.html(minute), minute))
         case (blog: LiveBlogPage, blocks) => Future.successful(common.renderEmail(LiveBlogHtmlPage.html(blog), blog))
-        case _ => Future.successful(NotFound)
+        case _                            => Future.successful(NotFound)
       }
     }
   }
 
-  private def renderWithRange(path: String, range: BlockRange, filterKeyEvents: Option[Boolean])(implicit request: RequestHeader): Future[Result] = {
-    mapModel(path, range, filterKeyEvents) { (page, blocks) => {
-      val isAmpSupported = page.article.content.shouldAmplify
-      val pageType: PageType = PageType(page, request, context)
-      (page, request.getRequestFormat) match {
-        case (minute: MinutePage, HtmlFormat) =>
-          Future.successful(common.renderHtml(MinuteHtmlPage.html(minute), minute))
-        case (blog: LiveBlogPage, HtmlFormat) => {
-          val remoteRendering = request.forceDCR && ActiveExperiments.isParticipating(LiveblogRendering)
-          remoteRendering match {
-            case false => Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
-            case true => {
-              val pageType: PageType = PageType(blog, request, context)
-              remoteRenderer.getArticle(ws, blog, blocks, pageType)
+  private def renderWithRange(path: String, range: BlockRange, filterKeyEvents: Option[Boolean])(implicit
+      request: RequestHeader,
+  ): Future[Result] = {
+    mapModel(path, range, filterKeyEvents) { (page, blocks) =>
+      {
+        val isAmpSupported = page.article.content.shouldAmplify
+        val pageType: PageType = PageType(page, request, context)
+        (page, request.getRequestFormat) match {
+          case (minute: MinutePage, HtmlFormat) =>
+            Future.successful(common.renderHtml(MinuteHtmlPage.html(minute), minute))
+          case (blog: LiveBlogPage, HtmlFormat) => {
+            val remoteRendering = request.forceDCR && ActiveExperiments.isParticipating(LiveblogRendering)
+            remoteRendering match {
+              case false => Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
+              case true => {
+                val pageType: PageType = PageType(blog, request, context)
+                remoteRenderer.getArticle(ws, blog, blocks, pageType)
+              }
             }
           }
+          case (blog: LiveBlogPage, AmpFormat) if isAmpSupported =>
+            remoteRenderer.getAMPArticle(ws, blog, blocks, pageType)
+          case (blog: LiveBlogPage, AmpFormat) =>
+            Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
+          case _ => Future.successful(NotFound)
         }
-        case (blog: LiveBlogPage, AmpFormat) if isAmpSupported =>
-          remoteRenderer.getAMPArticle(ws, blog, blocks, pageType)
-        case (blog: LiveBlogPage, AmpFormat) =>
-          Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
-        case _ => Future.successful(NotFound)
       }
-    }
     }
   }
 
   def renderArticle(path: String, page: Option[String] = None, filterKeyEvents: Option[Boolean]): Action[AnyContent] = {
     Action.async { implicit request =>
       page.map(ParseBlockId.fromPageParam) match {
-        case Some(ParsedBlockId(id)) => renderWithRange(path, PageWithBlock(id), filterKeyEvents) // we know the id of a block
-        case Some(InvalidFormat) => Future.successful(Cached(10)(WithoutRevalidationResult(NotFound))) // page param there but couldn't extract a block id
+        case Some(ParsedBlockId(id)) =>
+          renderWithRange(path, PageWithBlock(id), filterKeyEvents) // we know the id of a block
+        case Some(InvalidFormat) =>
+          Future.successful(
+            Cached(10)(WithoutRevalidationResult(NotFound)),
+          ) // page param there but couldn't extract a block id
         case None => renderWithRange(path, CanonicalLiveBlog, filterKeyEvents) // no page param
       }
     }
   }
 
-  def renderJson(path: String,
-                 lastUpdate: Option[String],
-                 rendered: Option[Boolean],
-                 isLivePage: Option[Boolean],
-                 filterKeyEvents: Option[Boolean]): Action[AnyContent] = {
+  def renderJson(
+      path: String,
+      lastUpdate: Option[String],
+      rendered: Option[Boolean],
+      isLivePage: Option[Boolean],
+      filterKeyEvents: Option[Boolean],
+  ): Action[AnyContent] = {
     Action.async { implicit request: Request[AnyContent] =>
       val range = getRange(lastUpdate)
       mapModel(path, range, filterKeyEvents) {
         case (blog: LiveBlogPage, blocks) if rendered.contains(false) => getJsonForFronts(blog)
-        case (blog: LiveBlogPage, blocks) if request.forceDCR => Future.successful(renderGuuiJson(path, blog, blocks))
-        case (blog: LiveBlogPage, blocks) => getJson(blog, range, isLivePage, filterKeyEvents)
+        case (blog: LiveBlogPage, blocks) if request.forceDCR         => Future.successful(renderGuuiJson(path, blog, blocks))
+        case (blog: LiveBlogPage, blocks)                             => getJson(blog, range, isLivePage, filterKeyEvents)
         case (minute: MinutePage, blocks) =>
           Future.successful(common.renderJson(views.html.fragments.minuteBody(minute), minute))
-        case _ => Future {
-          Cached(600)(WithoutRevalidationResult(NotFound))
-        }
+        case _ =>
+          Future {
+            Cached(600)(WithoutRevalidationResult(NotFound))
+          }
       }
     }
   }
@@ -114,7 +124,7 @@ class LiveBlogController(
   private[this] def getRange(lastUpdate: Option[String]): BlockRange = {
     lastUpdate.map(ParseBlockId.fromBlockId) match {
       case Some(ParsedBlockId(id)) => SinceBlockId(id)
-      case _ => CanonicalLiveBlog
+      case _                       => CanonicalLiveBlog
     }
   }
 
@@ -125,22 +135,23 @@ class LiveBlogController(
   }
 
   private[this] def getJson(
-                             liveblog: LiveBlogPage,
-                             range: BlockRange,
-                             isLivePage: Option[Boolean],
-                             filterKeyEvents: Option[Boolean]
-                           )(implicit request: RequestHeader): Future[Result] = {
+      liveblog: LiveBlogPage,
+      range: BlockRange,
+      isLivePage: Option[Boolean],
+      filterKeyEvents: Option[Boolean],
+  )(implicit request: RequestHeader): Future[Result] = {
     range match {
-      case SinceBlockId(lastBlockId) => renderNewerUpdatesJson(liveblog, SinceBlockId(lastBlockId), isLivePage, filterKeyEvents)
+      case SinceBlockId(lastBlockId) =>
+        renderNewerUpdatesJson(liveblog, SinceBlockId(lastBlockId), isLivePage, filterKeyEvents)
       case _ => Future.successful(common.renderJson(views.html.liveblog.liveBlogBody(liveblog), liveblog))
     }
   }
 
   private[this] def flatMapBlocks(
-                                   page: PageWithStoryPackage,
-                                   lastUpdateBlockId: SinceBlockId,
-                                   filterKeyEvents: Option[Boolean],
-                                 ): Seq[BodyBlock] = {
+      page: PageWithStoryPackage,
+      lastUpdateBlockId: SinceBlockId,
+      filterKeyEvents: Option[Boolean],
+  ): Seq[BodyBlock] = {
     filterKeyEvents match {
       case Some(true) =>
         page.article.fields.blocks.toSeq
@@ -164,11 +175,11 @@ class LiveBlogController(
   }
 
   private[this] def renderNewerUpdatesJson(
-                                            page: PageWithStoryPackage,
-                                            lastUpdateBlockId: SinceBlockId,
-                                            isLivePage: Option[Boolean],
-                                            filterKeyEvents: Option[Boolean]
-                                          )(implicit request: RequestHeader): Future[Result] = {
+      page: PageWithStoryPackage,
+      lastUpdateBlockId: SinceBlockId,
+      isLivePage: Option[Boolean],
+      filterKeyEvents: Option[Boolean],
+  )(implicit request: RequestHeader): Future[Result] = {
     val newBlocks = flatMapBlocks(page, lastUpdateBlockId, filterKeyEvents);
 
     val blocksHtml = views.html.liveblog.liveBlogBlocks(newBlocks, page.article, Edition(request).timezone)
@@ -195,10 +206,10 @@ class LiveBlogController(
   }
 
   private[this] def renderGuuiJson(
-                                    path: String,
-                                    blog: LiveBlogPage,
-                                    blocks: Blocks,
-                                  )(implicit request: RequestHeader): Result = {
+      path: String,
+      blog: LiveBlogPage,
+      blocks: Blocks,
+  )(implicit request: RequestHeader): Result = {
     val pageType: PageType = PageType(blog, request, context)
     val model = DotcomRenderingDataModel.forLiveblog(blog, blocks, request, pageType)
     val json = DotcomRenderingDataModel.toJson(model)
@@ -206,7 +217,7 @@ class LiveBlogController(
   }
 
   private[this] def mapModel(path: String, range: BlockRange, filterKeyEvents: Option[Boolean])(
-    render: (PageWithStoryPackage, Blocks) => Future[Result],
+      render: (PageWithStoryPackage, Blocks) => Future[Result],
   )(implicit request: RequestHeader): Future[Result] = {
     capiLookup
       .lookup(path, Some(range))
@@ -214,14 +225,14 @@ class LiveBlogController(
       .recover(convertApiExceptions)
       .flatMap {
         case Left((model, blocks)) => render(model, blocks)
-        case Right(other) => Future.successful(RenderOtherStatus(other))
+        case Right(other)          => Future.successful(RenderOtherStatus(other))
       }
   }
 
   private[this] def responseToModelOrResult(
-                                             range: BlockRange,
-                                             filterKeyEvents: Option[Boolean]
-                                           )(response: ItemResponse)(implicit request: RequestHeader): Either[(PageWithStoryPackage, Blocks), Result] = {
+      range: BlockRange,
+      filterKeyEvents: Option[Boolean],
+  )(response: ItemResponse)(implicit request: RequestHeader): Either[(PageWithStoryPackage, Blocks), Result] = {
     val supportedContent: Option[ContentType] = response.content.filter(isSupported).map(Content(_))
     val supportedContentResult: Either[ContentType, Result] = ModelOrResult(supportedContent, response)
     val blocks = response.content.flatMap(_.blocks).getOrElse(Blocks())

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -4,7 +4,7 @@ import com.gu.contentapi.client.model.v1.{Block, Blocks, ItemResponse, Content =
 import common.`package`.{convertApiExceptions => _, renderFormat => _}
 import common.{JsonComponent, RichRequestHeader, _}
 import contentapi.ContentApiClient
-import experiments.{ActiveExperiments, LiveblogRendering}
+import experiments.{ActiveExperiments, LiveblogRendering, LiveblogFiltering}
 import model.Cached.WithoutRevalidationResult
 import model.LiveBlogHelpers._
 import model.ParseBlockId.{InvalidFormat, ParsedBlockId}
@@ -26,12 +26,12 @@ import model.liveblog.BodyBlock.KeyEvent
 case class MinutePage(article: Article, related: RelatedContent) extends PageWithStoryPackage
 
 class LiveBlogController(
-    contentApiClient: ContentApiClient,
-    val controllerComponents: ControllerComponents,
-    ws: WSClient,
-    remoteRenderer: renderers.DotcomRenderingService = DotcomRenderingService(),
-)(implicit context: ApplicationContext)
-    extends BaseController
+                          contentApiClient: ContentApiClient,
+                          val controllerComponents: ControllerComponents,
+                          ws: WSClient,
+                          remoteRenderer: renderers.DotcomRenderingService = DotcomRenderingService(),
+                        )(implicit context: ApplicationContext)
+  extends BaseController
     with GuLogging
     with ImplicitControllerExecutionContext {
 
@@ -48,71 +48,64 @@ class LiveBlogController(
         case (minute: MinutePage, blocks) =>
           Future.successful(common.renderEmail(ArticleEmailHtmlPage.html(minute), minute))
         case (blog: LiveBlogPage, blocks) => Future.successful(common.renderEmail(LiveBlogHtmlPage.html(blog), blog))
-        case _                            => Future.successful(NotFound)
+        case _ => Future.successful(NotFound)
       }
     }
   }
 
-  def renderWithRange(path: String, range: BlockRange, filterKeyEvents: Option[Boolean])(implicit
-      request: RequestHeader,
-  ): Future[Result] = {
-    mapModel(path, range, filterKeyEvents) { (page, blocks) =>
-      {
-        val isAmpSupported = page.article.content.shouldAmplify
-        val pageType: PageType = PageType(page, request, context)
-        (page, request.getRequestFormat) match {
-          case (minute: MinutePage, HtmlFormat) =>
-            Future.successful(common.renderHtml(MinuteHtmlPage.html(minute), minute))
-          case (blog: LiveBlogPage, HtmlFormat) => {
-            val remoteRendering = request.forceDCR && ActiveExperiments.isParticipating(LiveblogRendering)
-            remoteRendering match {
-              case false => Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
-              case true => {
-                val pageType: PageType = PageType(blog, request, context)
-                remoteRenderer.getArticle(ws, blog, blocks, pageType)
-              }
+  private def renderWithRange(path: String, range: BlockRange, filterKeyEvents: Option[Boolean])(implicit request: RequestHeader): Future[Result] = {
+    mapModel(path, range, filterKeyEvents) { (page, blocks) => {
+      val isAmpSupported = page.article.content.shouldAmplify
+      val pageType: PageType = PageType(page, request, context)
+      (page, request.getRequestFormat) match {
+        case (minute: MinutePage, HtmlFormat) =>
+          Future.successful(common.renderHtml(MinuteHtmlPage.html(minute), minute))
+        case (blog: LiveBlogPage, HtmlFormat) => {
+          val remoteRendering = request.forceDCR && ActiveExperiments.isParticipating(LiveblogRendering)
+          remoteRendering match {
+            case false => Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
+            case true => {
+              val pageType: PageType = PageType(blog, request, context)
+              remoteRenderer.getArticle(ws, blog, blocks, pageType)
             }
           }
-          case (blog: LiveBlogPage, AmpFormat) if isAmpSupported =>
-            remoteRenderer.getAMPArticle(ws, blog, blocks, pageType)
-          case (blog: LiveBlogPage, AmpFormat) =>
-            Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
-          case _ => Future.successful(NotFound)
         }
+        case (blog: LiveBlogPage, AmpFormat) if isAmpSupported =>
+          remoteRenderer.getAMPArticle(ws, blog, blocks, pageType)
+        case (blog: LiveBlogPage, AmpFormat) =>
+          Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
+        case _ => Future.successful(NotFound)
       }
+    }
     }
   }
 
   def renderArticle(path: String, page: Option[String] = None, filterKeyEvents: Option[Boolean]): Action[AnyContent] = {
     Action.async { implicit request =>
       page.map(ParseBlockId.fromPageParam) match {
-        case Some(ParsedBlockId(id)) =>
-          renderWithRange(path, PageWithBlock(id), filterKeyEvents) // we know the id of a block
-        case Some(InvalidFormat) =>
-          Future.successful(
-            Cached(10)(WithoutRevalidationResult(NotFound)),
-          ) // page param there but couldn't extract a block id
+        case Some(ParsedBlockId(id)) => renderWithRange(path, PageWithBlock(id), filterKeyEvents) // we know the id of a block
+        case Some(InvalidFormat) => Future.successful(Cached(10)(WithoutRevalidationResult(NotFound))) // page param there but couldn't extract a block id
         case None => renderWithRange(path, CanonicalLiveBlog, filterKeyEvents) // no page param
       }
     }
   }
 
-  def renderJson(
-      path: String,
-      lastUpdate: Option[String],
-      rendered: Option[Boolean],
-      isLivePage: Option[Boolean],
-      filterKeyEvents: Option[Boolean],
-  ): Action[AnyContent] = {
+  def renderJson(path: String,
+                 lastUpdate: Option[String],
+                 rendered: Option[Boolean],
+                 isLivePage: Option[Boolean],
+                 filterKeyEvents: Option[Boolean]): Action[AnyContent] = {
     Action.async { implicit request: Request[AnyContent] =>
       val range = getRange(lastUpdate)
       mapModel(path, range, filterKeyEvents) {
         case (blog: LiveBlogPage, blocks) if rendered.contains(false) => getJsonForFronts(blog)
-        case (blog: LiveBlogPage, blocks) if request.forceDCR         => Future.successful(renderGuuiJson(path, blog, blocks))
-        case (blog: LiveBlogPage, blocks)                             => getJson(blog, range, isLivePage, filterKeyEvents)
+        case (blog: LiveBlogPage, blocks) if request.forceDCR => Future.successful(renderGuuiJson(path, blog, blocks))
+        case (blog: LiveBlogPage, blocks) => getJson(blog, range, isLivePage, filterKeyEvents)
         case (minute: MinutePage, blocks) =>
           Future.successful(common.renderJson(views.html.fragments.minuteBody(minute), minute))
-        case _ => Future { Cached(600)(WithoutRevalidationResult(NotFound)) }
+        case _ => Future {
+          Cached(600)(WithoutRevalidationResult(NotFound))
+        }
       }
     }
   }
@@ -121,7 +114,7 @@ class LiveBlogController(
   private[this] def getRange(lastUpdate: Option[String]): BlockRange = {
     lastUpdate.map(ParseBlockId.fromBlockId) match {
       case Some(ParsedBlockId(id)) => SinceBlockId(id)
-      case _                       => CanonicalLiveBlog
+      case _ => CanonicalLiveBlog
     }
   }
 
@@ -132,23 +125,22 @@ class LiveBlogController(
   }
 
   private[this] def getJson(
-      liveblog: LiveBlogPage,
-      range: BlockRange,
-      isLivePage: Option[Boolean],
-      filterKeyEvents: Option[Boolean],
-  )(implicit request: RequestHeader): Future[Result] = {
+                             liveblog: LiveBlogPage,
+                             range: BlockRange,
+                             isLivePage: Option[Boolean],
+                             filterKeyEvents: Option[Boolean]
+                           )(implicit request: RequestHeader): Future[Result] = {
     range match {
-      case SinceBlockId(lastBlockId) =>
-        renderNewerUpdatesJson(liveblog, SinceBlockId(lastBlockId), isLivePage, filterKeyEvents)
+      case SinceBlockId(lastBlockId) => renderNewerUpdatesJson(liveblog, SinceBlockId(lastBlockId), isLivePage, filterKeyEvents)
       case _ => Future.successful(common.renderJson(views.html.liveblog.liveBlogBody(liveblog), liveblog))
     }
   }
 
   private[this] def flatMapBlocks(
-      page: PageWithStoryPackage,
-      lastUpdateBlockId: SinceBlockId,
-      filterKeyEvents: Option[Boolean],
-  ): Seq[BodyBlock] = {
+                                   page: PageWithStoryPackage,
+                                   lastUpdateBlockId: SinceBlockId,
+                                   filterKeyEvents: Option[Boolean],
+                                 ): Seq[BodyBlock] = {
     filterKeyEvents match {
       case Some(true) =>
         page.article.fields.blocks.toSeq
@@ -172,11 +164,11 @@ class LiveBlogController(
   }
 
   private[this] def renderNewerUpdatesJson(
-      page: PageWithStoryPackage,
-      lastUpdateBlockId: SinceBlockId,
-      isLivePage: Option[Boolean],
-      filterKeyEvents: Option[Boolean],
-  )(implicit request: RequestHeader): Future[Result] = {
+                                            page: PageWithStoryPackage,
+                                            lastUpdateBlockId: SinceBlockId,
+                                            isLivePage: Option[Boolean],
+                                            filterKeyEvents: Option[Boolean]
+                                          )(implicit request: RequestHeader): Future[Result] = {
     val newBlocks = flatMapBlocks(page, lastUpdateBlockId, filterKeyEvents);
 
     val blocksHtml = views.html.liveblog.liveBlogBlocks(newBlocks, page.article, Edition(request).timezone)
@@ -203,10 +195,10 @@ class LiveBlogController(
   }
 
   private[this] def renderGuuiJson(
-      path: String,
-      blog: LiveBlogPage,
-      blocks: Blocks,
-  )(implicit request: RequestHeader): Result = {
+                                    path: String,
+                                    blog: LiveBlogPage,
+                                    blocks: Blocks,
+                                  )(implicit request: RequestHeader): Result = {
     val pageType: PageType = PageType(blog, request, context)
     val model = DotcomRenderingDataModel.forLiveblog(blog, blocks, request, pageType)
     val json = DotcomRenderingDataModel.toJson(model)
@@ -214,7 +206,7 @@ class LiveBlogController(
   }
 
   private[this] def mapModel(path: String, range: BlockRange, filterKeyEvents: Option[Boolean])(
-      render: (PageWithStoryPackage, Blocks) => Future[Result],
+    render: (PageWithStoryPackage, Blocks) => Future[Result],
   )(implicit request: RequestHeader): Future[Result] = {
     capiLookup
       .lookup(path, Some(range))
@@ -222,14 +214,14 @@ class LiveBlogController(
       .recover(convertApiExceptions)
       .flatMap {
         case Left((model, blocks)) => render(model, blocks)
-        case Right(other)          => Future.successful(RenderOtherStatus(other))
+        case Right(other) => Future.successful(RenderOtherStatus(other))
       }
   }
 
   private[this] def responseToModelOrResult(
-      range: BlockRange,
-      filterKeyEvents: Option[Boolean],
-  )(response: ItemResponse)(implicit request: RequestHeader): Either[(PageWithStoryPackage, Blocks), Result] = {
+                                             range: BlockRange,
+                                             filterKeyEvents: Option[Boolean]
+                                           )(response: ItemResponse)(implicit request: RequestHeader): Either[(PageWithStoryPackage, Blocks), Result] = {
     val supportedContent: Option[ContentType] = response.content.filter(isSupported).map(Content(_))
     val supportedContentResult: Either[ContentType, Result] = ModelOrResult(supportedContent, response)
     val blocks = response.content.flatMap(_.blocks).getOrElse(Blocks())
@@ -240,7 +232,8 @@ class LiveBlogController(
       case liveBlog: Article if liveBlog.isLiveBlog && request.isEmail =>
         Left(MinutePage(liveBlog, StoryPackages(liveBlog.metadata.id, response)), blocks)
       case liveBlog: Article if liveBlog.isLiveBlog =>
-        createLiveBlogModel(liveBlog, response, range, filterKeyEvents).left.map(_ -> blocks)
+        val shouldFilter = ActiveExperiments.isParticipating(LiveblogFiltering)
+        createLiveBlogModel(liveBlog, response, range, shouldFilter, filterKeyEvents).left.map(_ -> blocks)
       case unknown => {
         log.error(s"Requested non-liveblog: ${unknown.metadata.id}")
         Right(InternalServerError)

--- a/article/app/model/LiveBlogHelpers.scala
+++ b/article/app/model/LiveBlogHelpers.scala
@@ -14,22 +14,22 @@ object LiveBlogHelpers {
   // Get a Seq[BodyBlock] given an article and the "page" request parameter on live-blog pages.
 
   def blocksForLiveBlogRequest(
-                                article: Article,
-                                param: Option[String],
-                                filterKeyEvents: Option[Boolean],
-                              ): Seq[BodyBlock] = {
+      article: Article,
+      param: Option[String],
+      filterKeyEvents: Option[Boolean],
+  ): Seq[BodyBlock] = {
 
     def modelWithRange(range: BlockRange) =
       LiveBlogHelpers.createLiveBlogModel(article, range, filterKeyEvents)
 
     val lbcp = param.map(ParseBlockId.fromPageParam) match {
       case Some(ParsedBlockId(id)) => modelWithRange(PageWithBlock(id))
-      case _ => modelWithRange(CanonicalLiveBlog)
+      case _                       => modelWithRange(CanonicalLiveBlog)
     }
 
     lbcp match {
       case Some(blog) => blog.currentPage.blocks
-      case None => Seq()
+      case None       => Seq()
     }
 
   }
@@ -37,10 +37,10 @@ object LiveBlogHelpers {
   // Given a BlockRange and an article, return a combined LiveBlogCurrentPage instance
 
   def createLiveBlogModel(
-                           liveBlog: Article,
-                           range: BlockRange,
-                           filterKeyEvents: Option[Boolean],
-                         ): Option[LiveBlogCurrentPage] = {
+      liveBlog: Article,
+      range: BlockRange,
+      filterKeyEvents: Option[Boolean],
+  ): Option[LiveBlogCurrentPage] = {
 
     val pageSize = if (liveBlog.content.tags.tags.map(_.id).contains("sport/sport")) 30 else 10
 
@@ -58,12 +58,12 @@ object LiveBlogHelpers {
   }
 
   def createLiveBlogModel(
-                           liveBlog: Article,
-                           response: ItemResponse,
-                           range: BlockRange,
-                           shouldFilter: Boolean,
-                           filterKeyEvents: Option[Boolean]
-                         ): Either[LiveBlogPage, Status] = {
+      liveBlog: Article,
+      response: ItemResponse,
+      range: BlockRange,
+      shouldFilter: Boolean,
+      filterKeyEvents: Option[Boolean],
+  ): Either[LiveBlogPage, Status] = {
 
     val pageSize = if (liveBlog.content.tags.tags.map(_.id).contains("sport/sport")) 30 else 10
 
@@ -73,7 +73,7 @@ object LiveBlogHelpers {
           pageSize = pageSize,
           blocks,
           range,
-          filterKeyEvents
+          filterKeyEvents,
         )
       } getOrElse None
 
@@ -96,13 +96,15 @@ object LiveBlogHelpers {
           content = liveBlog.content.copy(metadata = liveBlog.content.metadata.copy(cacheTime = cacheTime)),
         )
 
-        Left(LiveBlogPage(
-          article = liveBlogCache,
-          currentPage = pageModel,
-          related = StoryPackages(liveBlog.metadata.id, response),
-          shouldFilter = shouldFilter,
-          filterKeyEvents = filterKeyEvents.getOrElse(false),
-        ))
+        Left(
+          LiveBlogPage(
+            article = liveBlogCache,
+            currentPage = pageModel,
+            related = StoryPackages(liveBlog.metadata.id, response),
+            shouldFilter = shouldFilter,
+            filterKeyEvents = filterKeyEvents.getOrElse(false),
+          ),
+        )
       }
       .getOrElse(Right(NotFound))
 
@@ -111,12 +113,12 @@ object LiveBlogHelpers {
   def blockTextJson(page: LiveBlogPage, number: Int): JsValue = {
 
     case class TextBlock(
-                          id: String,
-                          title: Option[String],
-                          publishedDateTime: Option[DateTime],
-                          lastUpdatedDateTime: Option[DateTime],
-                          body: String,
-                        )
+        id: String,
+        title: Option[String],
+        publishedDateTime: Option[DateTime],
+        lastUpdatedDateTime: Option[DateTime],
+        body: String,
+    )
 
     implicit val dateToTimestampWrites = play.api.libs.json.JodaWrites.JodaDateTimeNumberWrites
 
@@ -126,7 +128,7 @@ object LiveBlogHelpers {
         (__ \ "publishedDateTime").write[Option[DateTime]] ~
         (__ \ "lastUpdatedDateTime").write[Option[DateTime]] ~
         (__ \ "body").write[String]
-      ) (unlift(TextBlock.unapply))
+    )(unlift(TextBlock.unapply))
 
     val firstPageBlocks = for {
       blocks <- page.article.blocks.toSeq

--- a/article/app/model/LiveBlogHelpers.scala
+++ b/article/app/model/LiveBlogHelpers.scala
@@ -2,6 +2,7 @@ package model
 
 import com.gu.contentapi.client.model.v1.ItemResponse
 import common.`package`._
+import experiments.{ActiveExperiments, LiveblogRendering}
 import model.liveblog.BodyBlock
 import model.ParseBlockId.ParsedBlockId
 import org.joda.time.DateTime
@@ -13,22 +14,22 @@ object LiveBlogHelpers {
   // Get a Seq[BodyBlock] given an article and the "page" request parameter on live-blog pages.
 
   def blocksForLiveBlogRequest(
-      article: Article,
-      param: Option[String],
-      filterKeyEvents: Option[Boolean],
-  ): Seq[BodyBlock] = {
+                                article: Article,
+                                param: Option[String],
+                                filterKeyEvents: Option[Boolean],
+                              ): Seq[BodyBlock] = {
 
     def modelWithRange(range: BlockRange) =
       LiveBlogHelpers.createLiveBlogModel(article, range, filterKeyEvents)
 
     val lbcp = param.map(ParseBlockId.fromPageParam) match {
       case Some(ParsedBlockId(id)) => modelWithRange(PageWithBlock(id))
-      case _                       => modelWithRange(CanonicalLiveBlog)
+      case _ => modelWithRange(CanonicalLiveBlog)
     }
 
     lbcp match {
       case Some(blog) => blog.currentPage.blocks
-      case None       => Seq()
+      case None => Seq()
     }
 
   }
@@ -36,10 +37,10 @@ object LiveBlogHelpers {
   // Given a BlockRange and an article, return a combined LiveBlogCurrentPage instance
 
   def createLiveBlogModel(
-      liveBlog: Article,
-      range: BlockRange,
-      filterKeyEvents: Option[Boolean],
-  ): Option[LiveBlogCurrentPage] = {
+                           liveBlog: Article,
+                           range: BlockRange,
+                           filterKeyEvents: Option[Boolean],
+                         ): Option[LiveBlogCurrentPage] = {
 
     val pageSize = if (liveBlog.content.tags.tags.map(_.id).contains("sport/sport")) 30 else 10
 
@@ -57,11 +58,12 @@ object LiveBlogHelpers {
   }
 
   def createLiveBlogModel(
-      liveBlog: Article,
-      response: ItemResponse,
-      range: BlockRange,
-      filterKeyEvents: Option[Boolean],
-  ): Either[LiveBlogPage, Status] = {
+                           liveBlog: Article,
+                           response: ItemResponse,
+                           range: BlockRange,
+                           shouldFilter: Boolean,
+                           filterKeyEvents: Option[Boolean]
+                         ): Either[LiveBlogPage, Status] = {
 
     val pageSize = if (liveBlog.content.tags.tags.map(_.id).contains("sport/sport")) 30 else 10
 
@@ -71,7 +73,7 @@ object LiveBlogHelpers {
           pageSize = pageSize,
           blocks,
           range,
-          filterKeyEvents,
+          filterKeyEvents
         )
       } getOrElse None
 
@@ -94,14 +96,13 @@ object LiveBlogHelpers {
           content = liveBlog.content.copy(metadata = liveBlog.content.metadata.copy(cacheTime = cacheTime)),
         )
 
-        Left(
-          LiveBlogPage(
-            liveBlogCache,
-            pageModel,
-            StoryPackages(liveBlog.metadata.id, response),
-            filterKeyEvents.getOrElse(false),
-          ),
-        )
+        Left(LiveBlogPage(
+          article = liveBlogCache,
+          currentPage = pageModel,
+          related = StoryPackages(liveBlog.metadata.id, response),
+          shouldFilter = shouldFilter,
+          filterKeyEvents = filterKeyEvents.getOrElse(false),
+        ))
       }
       .getOrElse(Right(NotFound))
 
@@ -110,12 +111,12 @@ object LiveBlogHelpers {
   def blockTextJson(page: LiveBlogPage, number: Int): JsValue = {
 
     case class TextBlock(
-        id: String,
-        title: Option[String],
-        publishedDateTime: Option[DateTime],
-        lastUpdatedDateTime: Option[DateTime],
-        body: String,
-    )
+                          id: String,
+                          title: Option[String],
+                          publishedDateTime: Option[DateTime],
+                          lastUpdatedDateTime: Option[DateTime],
+                          body: String,
+                        )
 
     implicit val dateToTimestampWrites = play.api.libs.json.JodaWrites.JodaDateTimeNumberWrites
 
@@ -125,7 +126,7 @@ object LiveBlogHelpers {
         (__ \ "publishedDateTime").write[Option[DateTime]] ~
         (__ \ "lastUpdatedDateTime").write[Option[DateTime]] ~
         (__ \ "body").write[String]
-    )(unlift(TextBlock.unapply))
+      ) (unlift(TextBlock.unapply))
 
     val firstPageBlocks = for {
       blocks <- page.article.blocks.toSeq

--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -76,10 +76,12 @@
                             <div class="js-live-blog__sticky-components-container live-blog__sticky-components-container">
                                 @if(article.hasKeyEvents) {
                                     @defining(KeyEventData(article.content.fields.blocks, timezone, model.filterKeyEvents)) { case keyEventData =>
-                                        @if(model.filterKeyEvents) {
-                                            <a href="?filterKeyEvents=@(!model.filterKeyEvents)">Show All</a>
-                                        } else {
-                                            <a href="?filterKeyEvents=@(!model.filterKeyEvents)">Filter</a>
+                                        @if(model.shouldFilter) {
+                                            @if(model.filterKeyEvents) {
+                                                <a href="?filterKeyEvents=@(!model.filterKeyEvents)">Show All</a>
+                                            } else {
+                                                <a href="?filterKeyEvents=@(!model.filterKeyEvents)">Filter</a>
+                                            }
                                         }
 
                                         <div class="modern-visible js-updates-desktop">

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -15,28 +15,37 @@ object ActiveExperiments extends ExperimentsDefinition {
 }
 
 object LiveblogRendering
-    extends Experiment(
-      name = "liveblog-rendering",
-      description = "Use DCR for liveblogs",
-      owners = Seq(Owner.withGithub("shtukas")),
-      sellByDate = LocalDate.of(2021, 11, 30),
-      participationGroup = Perc0A,
-    )
+  extends Experiment(
+    name = "liveblog-rendering",
+    description = "Use DCR for liveblogs",
+    owners = Seq(Owner.withGithub("shtukas")),
+    sellByDate = LocalDate.of(2021, 11, 30),
+    participationGroup = Perc0A,
+  )
 
 object StandaloneCommercialBundle
-    extends Experiment(
-      name = "standalone-commercial-bundle",
-      description = "Serve a standalone commercial bundle to a subset of users",
-      owners = Seq(Owner.withGithub("mxdvl")),
-      sellByDate = LocalDate.of(2021, 11, 1),
-      participationGroup = Perc50,
-    )
+  extends Experiment(
+    name = "standalone-commercial-bundle",
+    description = "Serve a standalone commercial bundle to a subset of users",
+    owners = Seq(Owner.withGithub("mxdvl")),
+    sellByDate = LocalDate.of(2021, 11, 1),
+    participationGroup = Perc50,
+  )
 
 object StandaloneCommercialBundleTracking
-    extends Experiment(
-      name = "standalone-commercial-bundle-tracking",
-      description = "Track performance metrics for the standalone commercial bundle",
-      owners = Seq(Owner.withGithub("mxdvl")),
-      sellByDate = LocalDate.of(2021, 11, 1),
-      participationGroup = Perc1A,
-    )
+  extends Experiment(
+    name = "standalone-commercial-bundle-tracking",
+    description = "Track performance metrics for the standalone commercial bundle",
+    owners = Seq(Owner.withGithub("mxdvl")),
+    sellByDate = LocalDate.of(2021, 11, 1),
+    participationGroup = Perc1A,
+  )
+
+object LiveblogFiltering
+  extends Experiment(
+    name = "liveblog-filtering",
+    description = "Filter liveblogs by key events",
+    owners = Seq(Owner.withGithub("alinaboghiu")),
+    sellByDate = LocalDate.of(2021, 12, 1),
+    participationGroup = Perc2A,
+  )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -15,37 +15,37 @@ object ActiveExperiments extends ExperimentsDefinition {
 }
 
 object LiveblogRendering
-  extends Experiment(
-    name = "liveblog-rendering",
-    description = "Use DCR for liveblogs",
-    owners = Seq(Owner.withGithub("shtukas")),
-    sellByDate = LocalDate.of(2021, 11, 30),
-    participationGroup = Perc0A,
-  )
+    extends Experiment(
+      name = "liveblog-rendering",
+      description = "Use DCR for liveblogs",
+      owners = Seq(Owner.withGithub("shtukas")),
+      sellByDate = LocalDate.of(2021, 11, 30),
+      participationGroup = Perc0A,
+    )
 
 object StandaloneCommercialBundle
-  extends Experiment(
-    name = "standalone-commercial-bundle",
-    description = "Serve a standalone commercial bundle to a subset of users",
-    owners = Seq(Owner.withGithub("mxdvl")),
-    sellByDate = LocalDate.of(2021, 11, 1),
-    participationGroup = Perc50,
-  )
+    extends Experiment(
+      name = "standalone-commercial-bundle",
+      description = "Serve a standalone commercial bundle to a subset of users",
+      owners = Seq(Owner.withGithub("mxdvl")),
+      sellByDate = LocalDate.of(2021, 11, 1),
+      participationGroup = Perc50,
+    )
 
 object StandaloneCommercialBundleTracking
-  extends Experiment(
-    name = "standalone-commercial-bundle-tracking",
-    description = "Track performance metrics for the standalone commercial bundle",
-    owners = Seq(Owner.withGithub("mxdvl")),
-    sellByDate = LocalDate.of(2021, 11, 1),
-    participationGroup = Perc1A,
-  )
+    extends Experiment(
+      name = "standalone-commercial-bundle-tracking",
+      description = "Track performance metrics for the standalone commercial bundle",
+      owners = Seq(Owner.withGithub("mxdvl")),
+      sellByDate = LocalDate.of(2021, 11, 1),
+      participationGroup = Perc1A,
+    )
 
 object LiveblogFiltering
-  extends Experiment(
-    name = "liveblog-filtering",
-    description = "Filter liveblogs by key events",
-    owners = Seq(Owner.withGithub("alinaboghiu")),
-    sellByDate = LocalDate.of(2021, 12, 1),
-    participationGroup = Perc2A,
-  )
+    extends Experiment(
+      name = "liveblog-filtering",
+      description = "Filter liveblogs by key events",
+      owners = Seq(Owner.withGithub("alinaboghiu")),
+      sellByDate = LocalDate.of(2021, 12, 1),
+      participationGroup = Perc2A,
+    )

--- a/common/app/model/LiveBlogPage.scala
+++ b/common/app/model/LiveBlogPage.scala
@@ -1,8 +1,9 @@
 package model
 
-case class LiveBlogPage(article: Article,
-                        currentPage: LiveBlogCurrentPage,
-                        related: RelatedContent,
-                        shouldFilter: Boolean,
-                        filterKeyEvents: Boolean)
-  extends PageWithStoryPackage
+case class LiveBlogPage(
+    article: Article,
+    currentPage: LiveBlogCurrentPage,
+    related: RelatedContent,
+    shouldFilter: Boolean,
+    filterKeyEvents: Boolean,
+) extends PageWithStoryPackage

--- a/common/app/model/LiveBlogPage.scala
+++ b/common/app/model/LiveBlogPage.scala
@@ -1,8 +1,8 @@
 package model
 
-case class LiveBlogPage(
-    article: Article,
-    currentPage: LiveBlogCurrentPage,
-    related: RelatedContent,
-    filterKeyEvents: Boolean,
-) extends PageWithStoryPackage
+case class LiveBlogPage(article: Article,
+                        currentPage: LiveBlogCurrentPage,
+                        related: RelatedContent,
+                        shouldFilter: Boolean,
+                        filterKeyEvents: Boolean)
+  extends PageWithStoryPackage

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -435,12 +435,12 @@ GET            /$path<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>                         
 GET            /$leftSide<[^+]+>+*rightSide                                                                                      controllers.IndexController.renderCombiner(leftSide, rightSide)
 
 # Live Blogs
-GET     /$path<[^/]+/([^/]+/)?live/.*>.json                                                                                      controllers.LiveBlogController.renderJson(path, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean])
+GET     /$path<[^/]+/([^/]+/)?live/.*>.json                                                                                      controllers.LiveBlogController.renderJson(path, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean], filterKeyEvents: Option[Boolean])
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email                                                                                     controllers.LiveBlogController.renderEmail(path)
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email/headline.txt                                                                        controllers.ArticleController.renderHeadline(path)
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email.emailjson                                                                           controllers.LiveBlogController.renderEmail(path)
 GET     /$path<[^/]+/([^/]+/)?live/.*>/email.emailtxt                                                                            controllers.LiveBlogController.renderEmail(path)
-GET     /$path<[^/]+/([^/]+/)?live/.*>                                                                                           controllers.LiveBlogController.renderArticle(path, page: Option[String], format: Option[String])
+GET     /$path<[^/]+/([^/]+/)?live/.*>                                                                                           controllers.LiveBlogController.renderArticle(path, page: Option[String], filterKeyEvents: Option[Boolean])
 
 # articles, finished liveblogs
 


### PR DESCRIPTION
## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
