### PR TITLE
Remove unused idapi client functions

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/api.ts
+++ b/static/src/javascripts/projects/common/modules/identity/api.ts
@@ -302,22 +302,6 @@ export const shouldAutoSigninInUser = (): boolean => {
 	);
 };
 
-export const getUserEmailSignUps = (): Promise<unknown> => {
-	const user = getUserFromCookie();
-
-	if (user) {
-		const endpoint = `${idApiRoot}/useremails/${user.id}`;
-		const request = fetch(endpoint, {
-			mode: 'cors',
-			credentials: 'include',
-		}).then((resp) => resp.json());
-
-		return request;
-	}
-
-	return Promise.resolve(null);
-};
-
 export const sendValidationEmail = (): unknown => {
 	const defaultReturnEndpoint = '/email-prefs';
 	const endpoint = `${idApiRoot}/user/send-validation-email`;
@@ -358,60 +342,6 @@ export const updateUsername = (username: string): unknown => {
 	return request;
 };
 
-export const getAllConsents = (): Promise<unknown> => {
-	const endpoint = '/consents';
-	const url = idApiRoot + endpoint;
-	return fetchJson(url, {
-		mode: 'cors',
-		method: 'GET',
-		headers: { Accept: 'application/json' },
-	});
-};
-
-export const getAllNewsletters = (): Promise<unknown> => {
-	const endpoint = '/newsletters';
-	const url = idApiRoot + endpoint;
-	return fetchJson(url, {
-		mode: 'cors',
-		method: 'GET',
-		headers: { Accept: 'application/json' },
-	});
-};
-
-export const getSubscribedNewsletters = (): Promise<string[]> => {
-	const endpoint = '/users/me/newsletters';
-	const url = idApiRoot + endpoint;
-
-	type Subscriptions = {
-		listId: string;
-	};
-
-	type NewslettersResponse =
-		| {
-				result?: {
-					globalSubscriptionStatus?: string;
-					htmlPreference?: string;
-					subscriptions?: Subscriptions[];
-					status?: 'ok' | string;
-				};
-		  }
-		| undefined;
-
-	return (fetchJson(url, {
-		mode: 'cors',
-		method: 'GET',
-		headers: { Accept: 'application/json' },
-		credentials: 'include',
-	}) as Promise<NewslettersResponse>) // assert unknown -> NewslettersResponse
-		.then((json: NewslettersResponse) => {
-			if (json?.result?.subscriptions) {
-				return json.result.subscriptions.map((sub) => sub.listId);
-			}
-			return [];
-		})
-		.catch(() => []);
-};
-
 export const setConsent = (consents: SettableConsent): Promise<void> =>
 	fetch(`${idApiRoot}/users/me/consents`, {
 		method: 'PATCH',
@@ -421,11 +351,4 @@ export const setConsent = (consents: SettableConsent): Promise<void> =>
 	}).then((resp) => {
 		if (resp.ok) return Promise.resolve();
 		return Promise.reject();
-	});
-
-export const getUserData = (): Promise<unknown> =>
-	fetchJson(`${idApiRoot}/user/me`, {
-		method: 'GET',
-		mode: 'cors',
-		credentials: 'include',
 	});


### PR DESCRIPTION
## What does this change?

Remove unused IDAPI client functions.
These functions are unused in the dotcom fontend project. We should be safe to remove them. They were probably left behind by previous refactoring.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
