### PR TITLE
Send tag and section ids to banner service

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -183,10 +183,11 @@ export const setLocalNoBannerCachePeriod = () =>
 	window.localStorage.setItem(NO_RR_BANNER_TIMESTAMP_KEY, `${Date.now()}`);
 
 const buildTagIds = (page) => {
-    const { keywordIds, toneIds } = page;
+    const { keywordIds, toneIds, seriesId } = page;
     const keywords = keywordIds ? keywordIds.split(',') : [];
     const tones = toneIds ? toneIds.split(',') : [];
-    return keywords.concat(tones);
+    const series = seriesId ? [seriesId] : [];
+    return keywords.concat(tones).concat(series);
 }
 
 const buildBannerPayload = async () => {

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -182,6 +182,13 @@ export const withinLocalNoBannerCachePeriod = () => {
 export const setLocalNoBannerCachePeriod = () =>
 	window.localStorage.setItem(NO_RR_BANNER_TIMESTAMP_KEY, `${Date.now()}`);
 
+const buildTagIds = (page) => {
+    const { keywordIds, toneIds } = page;
+    const keywords = keywordIds ? keywordIds.split(',') : [];
+    const tones = toneIds ? toneIds.split(',') : [];
+    return keywords.concat(tones);
+}
+
 const buildBannerPayload = async () => {
 	const page = config.get('page');
 
@@ -207,6 +214,8 @@ const buildBannerPayload = async () => {
 		weeklyArticleHistory: getWeeklyArticleHistory(storage.local),
 		hasOptedOutOfArticleCount: !(await getArticleCountConsent()),
 		modulesVersion: ModulesVersion,
+        sectionId: page.section,
+        tagIds: buildTagIds(page),
 	};
 
 	return {

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -183,11 +183,11 @@ export const setLocalNoBannerCachePeriod = () =>
 	window.localStorage.setItem(NO_RR_BANNER_TIMESTAMP_KEY, `${Date.now()}`);
 
 const buildTagIds = (page) => {
-    const { keywordIds, toneIds, seriesId } = page;
-    const keywords = keywordIds ? keywordIds.split(',') : [];
-    const tones = toneIds ? toneIds.split(',') : [];
-    const series = seriesId ? [seriesId] : [];
-    return keywords.concat(tones).concat(series);
+	const { keywordIds, toneIds, seriesId } = page;
+	const keywords = keywordIds ? keywordIds.split(',') : [];
+	const tones = toneIds ? toneIds.split(',') : [];
+	const series = seriesId ? [seriesId] : [];
+	return keywords.concat(tones).concat(series);
 }
 
 const buildBannerPayload = async () => {
@@ -215,8 +215,8 @@ const buildBannerPayload = async () => {
 		weeklyArticleHistory: getWeeklyArticleHistory(storage.local),
 		hasOptedOutOfArticleCount: !(await getArticleCountConsent()),
 		modulesVersion: ModulesVersion,
-        sectionId: page.section,
-        tagIds: buildTagIds(page),
+		sectionId: page.section,
+		tagIds: buildTagIds(page),
 	};
 
 	return {
@@ -317,7 +317,7 @@ const renderLiveblogEpic = async (module, meta) => {
 
 	const element = setupRemoteEpicInLiveblog(
 		component.ContributionsLiveblogEpic,
-        { submitComponentEvent, ...module.props }
+		{ submitComponentEvent, ...module.props }
 	);
 };
 


### PR DESCRIPTION
We're testing targeting banners by content/tag, see https://github.com/guardian/support-dotcom-components/pull/548

Request now includes `sectionId` and `tagIds`:
![Screen Shot 2021-10-28 at 16 09 25](https://user-images.githubusercontent.com/1513454/139284804-6ac4da1a-d440-465a-afc0-a72e4cc3b67e.png)
