### PR TITLE
Ab/fix false update

### DIFF
--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -1,14 +1,13 @@
 
 @import model.Badges.badgeFor
-@import model.{KeyEventData, LiveBlogPage}
+@import model.{KeyEventData, LatestKeyBlock, LiveBlogPage}
 
 @(model: LiveBlogPage)(implicit request: RequestHeader, context: _root_.model.ApplicationContext)
 
 @import common.{Edition, LinkTo}
-@import conf.switches.Switches._
 @import layout.{FaciaCardAndIndex, ItemClasses}
 @import views.html.fragments.items.facia_cards.item
-@import views.support.Commercial.{isPaidContent, articleAsideOptionalSizes, shouldShowAds}
+@import views.support.Commercial.{articleAsideOptionalSizes, isPaidContent, shouldShowAds}
 @import views.support.TrailCssClasses._
 
 @defining((model.article, Edition(request).timezone)) { case (article, timezone) =>
@@ -87,7 +86,8 @@
                                         <div class="modern-visible js-updates-desktop">
                                             <div data-component="timeline">
                                             @fragments.dropdown("Key events", Some("key-events"), true) {
-                                                <ul class="timeline js-live-blog__timeline u-unstyled">
+                                                <ul class="timeline js-live-blog__timeline u-unstyled"
+                                                data-latest-key-block="block-@{LatestKeyBlock(article.blocks)}">
                                                 @views.html.liveblog.keyEvents("/" + article.metadata.id, keyEventData, model.filterKeyEvents)
                                                 </ul>
                                             }

--- a/common/app/model/LiveBlogCurrentPage.scala
+++ b/common/app/model/LiveBlogCurrentPage.scala
@@ -190,3 +190,15 @@ object LatestBlock {
     }
   }
 }
+
+object LatestKeyBlock {
+  def apply(maybeBlocks: Option[Blocks]): Option[String] = {
+    maybeBlocks.flatMap { blocks =>
+      blocks.requestedBodyBlocks
+        .getOrElse(CanonicalLiveBlog.firstPage, blocks.body)
+        .filter(_.eventType == KeyEvent)
+        .headOption
+        .map(_.id)
+    }
+  }
+}

--- a/static/src/javascripts/projects/common/modules/ui/autoupdate.js
+++ b/static/src/javascripts/projects/common/modules/ui/autoupdate.js
@@ -28,6 +28,7 @@ const updateBlocks = (opts, pollUpdates) => {
 
     // Cache selectors
     const $liveblogBody = $('.js-liveblog-body');
+    const $timeline = $('.js-live-blog__timeline')
     const $toastButton = $('.toast__button');
     const $toastText = $('.toast__text', $toastButton);
     const toastContainer = qwery('.toast__container')[0];
@@ -115,9 +116,12 @@ const updateBlocks = (opts, pollUpdates) => {
         }
 
         let count = 0;
+        const filterEventState = filterKeyEvents ? true : false
         const filterKeyEventsParam = `&filterKeyEvents=${filterKeyEvents ? 'true' : 'false'}`;
         const shouldFetchBlocks = `&isLivePage=${isLivePage ? 'true' : 'false'}`;
-        const latestBlockIdToUse = latestBlockId || 'block-0';
+        const latestKeyBlockId = $timeline.data('latest-key-block');
+        const latestId = latestBlockId || 'block-0';
+        const latestBlockIdToUse = filterEventState ? latestKeyBlockId : latestId;
         const params = `?lastUpdate=${latestBlockIdToUse}${shouldFetchBlocks}${filterKeyEventsParam}`;
         const endpoint = `${window.location.pathname}.json${params}`;
 


### PR DESCRIPTION
## What does this change?
We use the latest block id to check for updates. If we are filtering key events, the latest block id will be the latest `key event` block id. This is not necessarily the latest overall block id. This PR adds a new data point to access the latest key event id, checks what state we are in and then uses the relevant id (filtered or unfiltered) to check for updates.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)


