### PR TITLE
Extend Prebid timeout AB test until 2021-11-08

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -30,7 +30,7 @@ trait ABTestSwitches {
     "Vary length of prebid timeout",
     owners = Seq(Owner.withGithub("chrislomaxjones")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2021, 10, 29)),
+    sellByDate = Some(LocalDate.of(2021, 11, 8)),
     exposeClientSide = true,
   )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/prebid-timeout.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/prebid-timeout.ts
@@ -5,7 +5,7 @@ export const prebidTimeout: ABTest = {
 	id: 'PrebidTimeout',
 	author: 'Chris Jones (@chrislomaxjones)',
 	start: '2021-10-6',
-	expiry: '2021-10-29',
+	expiry: '2021-11-8',
 	audience: 3 / 100,
 	audienceOffset: 0,
 	audienceCriteria: 'All users',


### PR DESCRIPTION
## What does this change?

Extend the Prebid Timeout AB Test until 8th November 2021.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes - [#3578](https://github.com/guardian/dotcom-rendering/pull/3578)

## What is the value of this and can you measure success?

Continue collecting data and also to ensure switch expiry tests aren't failing on other branches.

### Tested

- [X] Locally
- [ ] On CODE (optional)