### PR TITLE
extend prebid timeout switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -30,7 +30,7 @@ trait ABTestSwitches {
     "Vary length of prebid timeout",
     owners = Seq(Owner.withGithub("chrislomaxjones")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2021, 10, 29)),
+    sellByDate = Some(LocalDate.of(2021, 11, 5)),
     exposeClientSide = true,
   )
 }


### PR DESCRIPTION
## What does this change?

Extend Prebid timeout A/B test until Friday 5 November. #24290 

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)