### PR TITLE
Decide when to use DCR for liveblogs

### DIFF
--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -61,7 +61,7 @@ class LiveBlogController(
           case (minute: MinutePage, HtmlFormat) =>
             Future.successful(common.renderHtml(MinuteHtmlPage.html(minute), minute))
           case (blog: LiveBlogPage, HtmlFormat) => {
-            // dcrCanRender is always false because right now blogs are supported by DCR
+            // dcrCanRender is always false because right now blogs are not supported by DCR
             // but we included this variable as an indication of what is going to be possible in the future
             val dcrCanRender = false
             val participatingInTest = ActiveExperiments.isParticipating(LiveblogRendering)

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -65,11 +65,8 @@ class LiveBlogController(
             // but we included this variable as an indication of what is going to be possible in the future
             val dcrCanRender = false
             val participatingInTest = ActiveExperiments.isParticipating(LiveblogRendering)
-            val remoteRendering = shouldRemoteRender(
-                                      request.forceDCROff,
-                                      request.forceDCR,
-                                      participatingInTest,
-                                      dcrCanRender)
+            val remoteRendering =
+              shouldRemoteRender(request.forceDCROff, request.forceDCR, participatingInTest, dcrCanRender)
 
             remoteRendering match {
               case false => Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
@@ -90,17 +87,19 @@ class LiveBlogController(
     }
   }
 
-  def shouldRemoteRender(forceDCROff: Boolean,
-                         forceDCR: Boolean,
-                         participatingInTest: Boolean,
-                         dcrCanRender: Boolean): Boolean = {
-      // ?dcr=false, so never render DCR
-      if (forceDCROff) false
-      // ?dcr=true, so always render DCR
-      else if (forceDCR) true
-      // User is in the test and dcr supports this blog . No param passed
-      else if (participatingInTest && dcrCanRender) true
-      else false
+  def shouldRemoteRender(
+      forceDCROff: Boolean,
+      forceDCR: Boolean,
+      participatingInTest: Boolean,
+      dcrCanRender: Boolean,
+  ): Boolean = {
+    // ?dcr=false, so never render DCR
+    if (forceDCROff) false
+    // ?dcr=true, so always render DCR
+    else if (forceDCR) true
+    // User is in the test and dcr supports this blog . No param passed
+    else if (participatingInTest && dcrCanRender) true
+    else false
   }
 
   def renderArticle(path: String, page: Option[String] = None, format: Option[String] = None): Action[AnyContent] = {

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -15,11 +15,12 @@ import play.api.mvc._
 import services.CAPILookup
 import views.support.RenderOtherStatus
 import implicits.{AmpFormat, HtmlFormat}
-import model.dotcomrendering.{DotcomRenderingDataModel, DotcomRenderingUtils}
+import model.dotcomrendering.{DotcomRenderingDataModel}
 import renderers.DotcomRenderingService
 
 import scala.concurrent.Future
 import model.dotcomrendering.PageType
+import services.dotcomponents.{LocalRenderArticle, RemoteRender}
 
 case class MinutePage(article: Article, related: RelatedContent) extends PageWithStoryPackage
 
@@ -60,7 +61,16 @@ class LiveBlogController(
           case (minute: MinutePage, HtmlFormat) =>
             Future.successful(common.renderHtml(MinuteHtmlPage.html(minute), minute))
           case (blog: LiveBlogPage, HtmlFormat) => {
-            val remoteRendering = request.forceDCR || ActiveExperiments.isParticipating(LiveblogRendering)
+            // dcrCanRender is always false because right now blogs are supported by DCR
+            // but we included this variable as an indication of what is going to be possible in the future
+            val dcrCanRender = false
+            val participatingInTest = ActiveExperiments.isParticipating(LiveblogRendering)
+            val remoteRendering = shouldRemoteRender(
+                                      request.forceDCROff,
+                                      request.forceDCR,
+                                      participatingInTest,
+                                      dcrCanRender)
+
             remoteRendering match {
               case false => Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
               case true => {
@@ -76,7 +86,21 @@ class LiveBlogController(
           case _ => Future.successful(NotFound)
         }
       }
+
     }
+  }
+
+  def shouldRemoteRender(forceDCROff: Boolean,
+                         forceDCR: Boolean,
+                         participatingInTest: Boolean,
+                         dcrCanRender: Boolean): Boolean = {
+      // ?dcr=false, so never render DCR
+      if (forceDCROff) false
+      // ?dcr=true, so always render DCR
+      else if (forceDCR) true
+      // User is in the test and dcr supports this blog . No param passed
+      else if (participatingInTest && dcrCanRender) true
+      else false
   }
 
   def renderArticle(path: String, page: Option[String] = None, format: Option[String] = None): Action[AnyContent] = {

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -60,7 +60,7 @@ class LiveBlogController(
           case (minute: MinutePage, HtmlFormat) =>
             Future.successful(common.renderHtml(MinuteHtmlPage.html(minute), minute))
           case (blog: LiveBlogPage, HtmlFormat) => {
-            val remoteRendering = request.forceDCR && ActiveExperiments.isParticipating(LiveblogRendering)
+            val remoteRendering = request.forceDCR || ActiveExperiments.isParticipating(LiveblogRendering)
             remoteRendering match {
               case false => Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
               case true => {

--- a/article/test/LiveBlogControllerTest.scala
+++ b/article/test/LiveBlogControllerTest.scala
@@ -6,7 +6,7 @@ import play.api.test.Helpers._
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 
 @DoNotDiscover class LiveBlogControllerTest
-  extends FlatSpec
+    extends FlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll
@@ -53,14 +53,14 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 
   }
 
-
   it should "use DCR if the parameter dcr=true is passed" in {
     val forceDCROff = false
     val forceDCR = true
     val participatingInTest = false
     val dcrCanRender = true
 
-    val shouldRemoteRender = liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, participatingInTest, dcrCanRender)
+    val shouldRemoteRender =
+      liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, participatingInTest, dcrCanRender)
     shouldRemoteRender should be(true)
   }
 
@@ -70,7 +70,8 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
     val participatingInTest = false
     val dcrCanRender = true
 
-    val shouldRemoteRender = liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, participatingInTest, dcrCanRender)
+    val shouldRemoteRender =
+      liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, participatingInTest, dcrCanRender)
     shouldRemoteRender should be(false)
 
   }
@@ -81,7 +82,8 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
     val participatingInTest = true
     val dcrCanRender = true
 
-    val shouldRemoteRender = liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, participatingInTest, dcrCanRender)
+    val shouldRemoteRender =
+      liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, participatingInTest, dcrCanRender)
     shouldRemoteRender should be(true)
   }
 
@@ -91,7 +93,8 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
     val participatingInTest = false
     val dcrCanRender = true
 
-    val shouldRemoteRender = liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, participatingInTest, dcrCanRender)
+    val shouldRemoteRender =
+      liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, participatingInTest, dcrCanRender)
     shouldRemoteRender should be(false)
   }
 
@@ -101,7 +104,8 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
     val participatingInTest = true
     val dcrCanRender = false
 
-    val shouldRemoteRender = liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, participatingInTest, dcrCanRender)
+    val shouldRemoteRender =
+      liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, participatingInTest, dcrCanRender)
     shouldRemoteRender should be(true)
   }
 
@@ -111,7 +115,8 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
     val participatingInTest = true
     val dcrCanRender = false
 
-    val shouldRemoteRender = liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, participatingInTest, dcrCanRender)
+    val shouldRemoteRender =
+      liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, participatingInTest, dcrCanRender)
     shouldRemoteRender should be(false)
   }
 }

--- a/article/test/LiveBlogControllerTest.scala
+++ b/article/test/LiveBlogControllerTest.scala
@@ -6,7 +6,7 @@ import play.api.test.Helpers._
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 
 @DoNotDiscover class LiveBlogControllerTest
-    extends FlatSpec
+  extends FlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll
@@ -53,4 +53,65 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 
   }
 
+
+  it should "use DCR if the parameter dcr=true is passed" in {
+    val forceDCROff = false
+    val forceDCR = true
+    val participatingInTest = false
+    val dcrCanRender = true
+
+    val shouldRemoteRender = liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, participatingInTest, dcrCanRender)
+    shouldRemoteRender should be(true)
+  }
+
+  it should "use frontend if the parameter dcr=false is passed" in {
+    val forceDCROff = true
+    val forceDCR = false
+    val participatingInTest = false
+    val dcrCanRender = true
+
+    val shouldRemoteRender = liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, participatingInTest, dcrCanRender)
+    shouldRemoteRender should be(false)
+
+  }
+
+  it should "use dcr if the user is in the test and no dcr param is included" in {
+    val forceDCROff = false
+    val forceDCR = false
+    val participatingInTest = true
+    val dcrCanRender = true
+
+    val shouldRemoteRender = liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, participatingInTest, dcrCanRender)
+    shouldRemoteRender should be(true)
+  }
+
+  it should " use frontend if it can render but not in test" in {
+    val forceDCROff = false
+    val forceDCR = false
+    val participatingInTest = false
+    val dcrCanRender = true
+
+    val shouldRemoteRender = liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, participatingInTest, dcrCanRender)
+    shouldRemoteRender should be(false)
+  }
+
+  it should "use DCR if dcrCanRender is false and dcr=true" in {
+    val forceDCROff = false
+    val forceDCR = true
+    val participatingInTest = true
+    val dcrCanRender = false
+
+    val shouldRemoteRender = liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, participatingInTest, dcrCanRender)
+    shouldRemoteRender should be(true)
+  }
+
+  it should "use frontend if dcrCanRender is false no param is passed" in {
+    val forceDCROff = false
+    val forceDCR = false
+    val participatingInTest = true
+    val dcrCanRender = false
+
+    val shouldRemoteRender = liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, participatingInTest, dcrCanRender)
+    shouldRemoteRender should be(false)
+  }
 }


### PR DESCRIPTION
## What
We're adding logic to decide when to use DCR to render liveblogs and when to use frontend. The decision matrix is described by this table:

|             | dcr=true | dcr=false | No param |
|-------------|----------|-----------|----------|
| In test     | DCR      | Frontend  | DCR      |
| not in test | DCR      | Frontend  | Frontend |

## Why?
To make it easier to develop liveblogs on DCR