### PR TITLE
Revert "Upgrade Consent Management Platform to version 9.0.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@guardian/automat-modules": "^0.3.8",
     "@guardian/braze-components": "^4.1.0",
     "@guardian/commercial-core": "0.24.x",
-    "@guardian/consent-management-platform": "^9.0.1",
+    "@guardian/consent-management-platform": "6.11.5",
     "@guardian/libs": "^3.4.1",
     "@guardian/shimport": "^1.0.2",
     "@guardian/src-button": "3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1908,12 +1908,12 @@
   resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.24.0.tgz#6ba387bd80bbed14561d073de5e7573b2fb5f663"
   integrity sha512-dBtJX+6mzjYJcy6hXMJ5w5oKDZu+Ob18z+vXZtkN+j3Bp2ex+jQik6IuQTwfn+KkN6VEMoIzYK1ZN3fqPHMwYw==
 
-"@guardian/consent-management-platform@^9.0.1":
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-9.0.1.tgz#bfcfca3eb32a65faa0f60ff723a294ba840d9953"
-  integrity sha512-ZN4tf7VpGxQu1CcqRsHNzWK61Q3KlaLGf8HKEX2oGotKzWZdoCx22tEA/v5Stdlv1ZkcMSqnfmtF1fJ5STgWGg==
+"@guardian/consent-management-platform@6.11.5":
+  version "6.11.5"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.11.5.tgz#93681cbf61de0fadb4b65d835d7fc445cb847b31"
+  integrity sha512-ap7b09qk8I/EfoWB3NR8kT63hBpm4ATFGpRicCQ61DLMw2PgCWunMvizdbSmo5wNCQKPFgmX9cfRT5IGfPneKw==
   dependencies:
-    "@guardian/libs" "1.6.1 - 3.3.0"
+    "@guardian/libs" "^1"
 
 "@guardian/eslint-config-typescript@^0.7.0":
   version "0.7.0"
@@ -1934,10 +1934,10 @@
     eslint-plugin-import "2.24.0"
     eslint-plugin-prettier "3.4.0"
 
-"@guardian/libs@1.6.1 - 3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-3.3.0.tgz#fa98c7b8216ab35b8cf3087cd9ba336958fac99a"
-  integrity sha512-XB9o8qtDOg+KlPh1sjEr4u+Ai3RFTRr2riZ/HJpdlh8Cu4ZpYjCSGUZXSGkxp1CwFWT9sduANnsWSqZ97iBloQ==
+"@guardian/libs@^1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-1.8.1.tgz#22bccd66be7c5bf70cd5bbb1bf7700d94610ccb7"
+  integrity sha512-Q/JPLhNeYa5XhDPJhw/1+fbZmszopvovWW8I7dGEuFPGWeNUmXAbW8J3kzuonDu7l9/tuFZg8jljbKHZlrFx0A==
 
 "@guardian/libs@^3.1.0":
   version "3.4.0"


### PR DESCRIPTION
Reverts guardian/frontend#24304
This change broke advertising in Canada