### PR TITLE
Imported fix for upgrade of Prebid 5.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "object-fit-videos": "^1.0.3",
     "ophan-tracker-js": "1.3.28",
     "preact": "^10.5.13",
-    "prebid.js": "https://github.com/guardian/Prebid.js#411bc658",
+    "prebid.js": "https://github.com/guardian/Prebid.js#6862a86",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11587,9 +11587,9 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.13.tgz#85f6c9197ecd736ce8e3bec044d08fd1330fa019"
   integrity sha512-q/vlKIGNwzTLu+jCcvywgGrt+H/1P/oIRSD6mV4ln3hmlC+Aa34C7yfPI4+5bzW8pONyVXYS7SvXosy2dKKtWQ==
 
-"prebid.js@https://github.com/guardian/Prebid.js#411bc658":
+"prebid.js@https://github.com/guardian/Prebid.js#6862a86":
   version "5.20.0"
-  resolved "https://github.com/guardian/Prebid.js#411bc6581943504e3c9e8db82c7cf2c9f55dec92"
+  resolved "https://github.com/guardian/Prebid.js#6862a86f5b7e0a5c8fb8a101bb70a64ff9c66978"
   dependencies:
     "@guardian/libs" "^3.1.0"
     babel-plugin-transform-object-assign "^6.22.0"


### PR DESCRIPTION
## What does this change?

Import the [Prebid.js build](https://github.com/guardian/Prebid.js/pull/122) that includes a fix to resolve errors with Appnexus bid adapters.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [X] Locally
- [ ] On CODE (optional)
