### PR TITLE
use @types/googletag

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@babel/runtime": "^7.11.2",
     "@guardian/eslint-config-typescript": "^0.7.0",
     "@guardian/prettier": "^0.5.0",
-    "@types/googletag": "^1.1.2",
+    "@types/googletag": "^1.1.3",
     "@types/google.analytics": "^0.0.42",
     "@types/jest": "^26.0.20",
     "@types/lodash-es": "^4.17.4",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@babel/runtime": "^7.11.2",
     "@guardian/eslint-config-typescript": "^0.7.0",
     "@guardian/prettier": "^0.5.0",
-    "@types/doubleclick-gpt": "^2019111201.0.0",
+    "@types/googletag": "^1.1.2",
     "@types/google.analytics": "^0.0.42",
     "@types/jest": "^26.0.20",
     "@types/lodash-es": "^4.17.4",

--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.spec.ts
@@ -13,7 +13,9 @@ import { refreshAdvert as refreshAdvert_ } from './dfp/load-advert';
 // Mock advert type by overwriting slot property with only one function for defining size mapping
 // This avoids having to set the rest of the slot properties that are unnecessary for the tests
 type MockAdvert = Omit<Advert, 'slot'> & {
-	slot: { defineSizeMapping: (asm: SizeMapping[]) => googletag.Slot };
+	slot: {
+		defineSizeMapping: (asm: googletag.SizeMappingArray) => googletag.Slot;
+	};
 };
 
 // Workaround to fix issue where dataset is missing from jsdom, and solve the

--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.ts
@@ -1,3 +1,4 @@
+import type { SizeKeys } from '@guardian/commercial-core';
 import { adSizes } from '@guardian/commercial-core';
 import config from '../../../lib/config';
 import { getBreakpoint } from '../../../lib/detect';
@@ -65,7 +66,15 @@ const containsDMPU = (ad: Advert): boolean =>
 
 const maybeUpgradeSlot = (ad: Advert, adSlot: Element): Advert => {
 	if (!containsDMPU(ad)) {
-		ad.sizes.desktop.push([300, 600], [160, 600]);
+		const extraSizes: SizeKeys[] = ['halfPage', 'skyscraper'];
+		ad.sizes.desktop.push(
+			// TODO: add getTuple method to commercial-core
+			...extraSizes.map((size) => {
+				const { width, height } = adSizes[size];
+				const tuple: AdSizeTuple = [width, height];
+				return tuple;
+			}),
+		);
 		ad.slot.defineSizeMapping([[[0, 0], ad.sizes.desktop]]);
 		void fastdom.mutate(() => {
 			adSlot.setAttribute(

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.spec.ts
@@ -34,33 +34,35 @@ describe('Filter classes', () => {
 });
 
 describe('Advert', () => {
-	let googleSlot: Partial<googletag.Slot>;
+	let googleSlot: googletag.Slot;
 
 	beforeEach(() => {
-		const sizeMapping = {
-			sizes: [],
+		const sizeMapping: Partial<googletag.SizeMappingBuilder> = {
 			build: jest.fn(() => []),
-		} as Partial<googletag.SizeMappingBuilder>;
+		};
 
+		//@ts-expect-error - it is a partial mock
 		googleSlot = {
 			defineSizeMapping: jest.fn(() => googleSlot),
 			setSafeFrameConfig: jest.fn(() => googleSlot),
 			setTargeting: jest.fn(() => googleSlot),
 			addService: jest.fn(() => googleSlot),
-		} as Partial<googletag.Slot>;
+		};
 
-		// @ts-expect-error - this is a mock so type not totally compatible with Googletag
-		window.googletag = {
+		const partialGoogletag: Partial<typeof googletag> = {
 			pubads() {
-				return ({} as unknown) as googletag.PubAdsService;
+				return {} as googletag.PubAdsService;
 			},
 			sizeMapping() {
-				return sizeMapping;
+				return sizeMapping as googletag.SizeMappingBuilder;
 			},
 			defineSlot() {
 				return googleSlot;
 			},
-		} as Partial<googletag.Googletag>;
+		};
+
+		// @ts-expect-error -- we’re making it a partial
+		window.googletag = partialGoogletag;
 	});
 
 	it('should enable safeframe to expand in the top-above-nav slot', () => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -15,8 +15,12 @@ type Timings = {
 	lazyWaitComplete: number | null;
 };
 
-const stringToTuple = (size: string): [width: number, height: number] => {
+const stringToTuple = (size: string): AdSizeTuple => {
 	const dimensions = size.split(',', 2).map(Number);
+
+	// Return an outOfPage tuple if the string is not `{number},{number}`
+	if (dimensions.length !== 2 || dimensions.some((n) => isNaN(n)))
+		return [0, 0]; // adSizes.outOfPage
 
 	return [dimensions[0], dimensions[1]];
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -1,3 +1,4 @@
+import { isString } from '@guardian/libs';
 import { breakpoints } from '../../../../lib/detect';
 import { getCurrentTime } from '../../../../lib/user-timing';
 import { breakpointNameToAttribute } from './breakpoint-name-to-attribute';
@@ -15,6 +16,12 @@ type Timings = {
 	lazyWaitComplete: number | null;
 };
 
+const stringToTuple = (size: string): [width: number, height: number] => {
+	const dimensions = size.split(',', 2).map(Number);
+
+	return [dimensions[0], dimensions[1]];
+};
+
 /** A breakpoint can have various sizes assigned to it. You can assign either on
  * set of sizes or multiple.
  *
@@ -24,9 +31,7 @@ type Timings = {
 const createSizeMapping = (attr: string): AdSize[] =>
 	attr
 		.split('|')
-		.map((size) =>
-			size === 'fluid' ? 'fluid' : size.split(',').map(Number),
-		);
+		.map((size) => (size === 'fluid' ? 'fluid' : stringToTuple(size)));
 
 /** Extract the ad sizes from the breakpoint data attributes of an ad slot
  *

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -1,4 +1,3 @@
-import { isString } from '@guardian/libs';
 import { breakpoints } from '../../../../lib/detect';
 import { getCurrentTime } from '../../../../lib/user-timing';
 import { breakpointNameToAttribute } from './breakpoint-name-to-attribute';

--- a/static/src/javascripts/projects/commercial/modules/dfp/add-slot.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/add-slot.ts
@@ -17,7 +17,7 @@ const displayAd = (adSlot: HTMLElement, forceDisplay: boolean) => {
 };
 
 const addSlot = (adSlot: HTMLElement, forceDisplay: boolean): void => {
-	window.googletag?.cmd.push(() => {
+	window.googletag.cmd.push(() => {
 		if (!(adSlot.id in dfpEnv.advertIds)) {
 			// dynamically add ad slot
 			displayAd(adSlot, forceDisplay);

--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-api.spec.ts
@@ -153,14 +153,17 @@ jest.mock('@guardian/consent-management-platform', () => ({
 }));
 
 let $style: HTMLElement;
-const makeFakeEvent = (creativeId: string, id: string) => ({
+const makeFakeEvent = (
+	creativeId: number,
+	id: string,
+): DeepPartial<googletag.events.SlotRenderEndedEvent> => ({
 	creativeId,
 	slot: {
 		getSlotElementId() {
 			return id;
 		},
 	},
-	size: ['300', '250'],
+	size: [300, 250],
 });
 
 const reset = () => {
@@ -540,14 +543,14 @@ describe('DFP', () => {
 	});
 
 	it('should expose ads IDs', async () => {
-		const fakeEventOne = (makeFakeEvent(
-			'1',
+		const fakeEventOne = makeFakeEvent(
+			1,
 			'dfp-ad-html-slot',
-		) as unknown) as googletag.events.SlotRenderEndedEvent;
-		const fakeEventTwo = (makeFakeEvent(
-			'2',
+		) as googletag.events.SlotRenderEndedEvent;
+		const fakeEventTwo = makeFakeEvent(
+			2,
 			'dfp-ad-script-slot',
-		) as unknown) as googletag.events.SlotRenderEndedEvent;
+		) as googletag.events.SlotRenderEndedEvent;
 
 		await fillAdvertSlots();
 		await prepareGoogletag();

--- a/static/src/javascripts/projects/commercial/modules/dfp/display-ads.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/display-ads.ts
@@ -3,9 +3,9 @@ import { dfpEnv } from './dfp-env';
 import { loadAdvert } from './load-advert';
 
 const displayAds = (): void => {
-	window.googletag?.pubads().enableSingleRequest();
-	window.googletag?.pubads().collapseEmptyDivs();
-	window.googletag?.enableServices();
+	window.googletag.pubads().enableSingleRequest();
+	window.googletag.pubads().collapseEmptyDivs();
+	window.googletag.enableServices();
 
 	/*
 	 *as this is an single request call, only need to make a single display call (to the first ad

--- a/static/src/javascripts/projects/commercial/modules/dfp/display-lazy-ads.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/display-lazy-ads.ts
@@ -6,8 +6,8 @@ import { loadAdvert } from './load-advert';
 const instantLoadAdvertIds = ['dfp-ad--im'];
 
 const displayLazyAds = (): void => {
-	window.googletag?.pubads().collapseEmptyDivs();
-	window.googletag?.enableServices();
+	window.googletag.pubads().collapseEmptyDivs();
+	window.googletag.enableServices();
 
 	const [
 		instantLoadAdverts,

--- a/static/src/javascripts/projects/commercial/modules/dfp/empty-advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/empty-advert.ts
@@ -17,7 +17,7 @@ const removeFromDfpEnv = (advert: Advert) => {
 
 const emptyAdvert = (advert: Advert): void => {
 	fastdom.mutate(() => {
-		window.googletag?.destroySlots([advert.slot]);
+		window.googletag.destroySlots([advert.slot]);
 		advert.node.remove();
 		removeFromDfpEnv(advert);
 	});

--- a/static/src/javascripts/projects/commercial/modules/dfp/load-advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/load-advert.ts
@@ -48,7 +48,7 @@ export const loadAdvert = (advert: Advert): void => {
 		})
 		.then(() => {
 			eventTimer.trigger('slotInitialised', adName);
-			window.googletag?.display(advert.id);
+			window.googletag.display(advert.id);
 		});
 };
 
@@ -77,6 +77,6 @@ export const refreshAdvert = (advert: Advert): void => {
 					advert.slot.defineSizeMapping([[[0, 0], [advert.size]]]);
 				}
 			}
-			window.googletag?.pubads().refresh([advert.slot]);
+			window.googletag.pubads().refresh([advert.slot]);
 		});
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-load.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-load.ts
@@ -11,7 +11,7 @@ const host = `${window.location.protocol}//${window.location.host}`;
      But, this information is necessary in the window.postMessage call, and so
      we resort to sending it as a token of welcome :)
 */
-export const onSlotLoad = (event: SlotOnloadEvent): void => {
+export const onSlotLoad = (event: googletag.events.SlotOnloadEvent): void => {
 	const advert = getAdvertById(event.slot.getSlotElementId());
 	if (!advert) {
 		return;

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.ts
@@ -85,7 +85,7 @@ export const onSlotRender = (
 			advert.size = sizeEventToAdSize(event.size);
 		}
 
-		if (event.creativeId !== undefined) {
+		if (typeof event.creativeId === 'number') {
 			dfpEnv.creativeIDs.push(String(event.creativeId));
 		}
 		// Set refresh field based on the outcome of the slot render.

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.ts
@@ -85,7 +85,7 @@ export const onSlotRender = (
 			advert.size = sizeEventToAdSize(event.size);
 		}
 
-		if (typeof event.creativeId === 'number') {
+		if (event.creativeId) {
 			dfpEnv.creativeIDs.push(String(event.creativeId));
 		}
 		// Set refresh field based on the outcome of the slot render.

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.ts
@@ -43,7 +43,7 @@ const setSlotAdRefresh = (event: googletag.events.Event): void => {
 
  */
 export const onSlotViewableFunction = (): ((
-	event: googletag.events.Event,
+	event: googletag.events.ImpressionViewableEvent,
 ) => void) => {
 	const queryParams = getUrlVars();
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.ts
@@ -96,7 +96,6 @@ export const init = (): Promise<void> => {
 		// fulfilled), but don't assume fillAdvertSlots is complete when queueing subsequent work using cmd.push
 		window.googletag?.cmd.push(
 			setDfpListeners,
-			// @ts-expect-error - googletag.CommandArray.push() !== Array.push, it accepts multiple fn arguments
 			setPageTargeting,
 			refreshOnResize,
 			() => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.ts
@@ -45,8 +45,8 @@ initMessenger(
 );
 
 const setDfpListeners = (): void => {
-	const pubads = window.googletag?.pubads();
-	if (!pubads) return;
+	const pubads = window.googletag.pubads();
+
 	pubads.addEventListener(
 		'slotRenderEnded',
 		raven.wrap<typeof onSlotRender>(onSlotRender),
@@ -67,8 +67,7 @@ const setDfpListeners = (): void => {
 };
 
 const setPageTargeting = (): void => {
-	const pubads = window.googletag?.pubads();
-	if (!pubads) return;
+	const pubads = window.googletag.pubads();
 	// because commercialFeatures may export itself as {} in the event of an exception during construction
 	const targeting = getPageTargeting() as Record<string, string | string[]>;
 	Object.keys(targeting).forEach((key) => {
@@ -82,7 +81,7 @@ const setPublisherProvidedId = (): void => {
 		(userIdentifiers: IdentityUserIdentifiers | null) => {
 			if (userIdentifiers?.googleTagId) {
 				window.googletag
-					?.pubads()
+					.pubads()
 					.setPublisherProvidedId(userIdentifiers.googleTagId);
 			}
 		},
@@ -94,8 +93,9 @@ export const init = (): Promise<void> => {
 		// note: fillAdvertSlots isn't synchronous like most buffered cmds, it's a promise. It's put in here to ensure
 		// it strictly follows preceding prepare-googletag work (and the module itself ensures dependencies are
 		// fulfilled), but don't assume fillAdvertSlots is complete when queueing subsequent work using cmd.push
-		window.googletag?.cmd.push(
+		window.googletag.cmd.push(
 			setDfpListeners,
+			//@ts-expect-error -- oversight in type definition https://git.io/JPM1I
 			setPageTargeting,
 			refreshOnResize,
 			() => {
@@ -108,13 +108,13 @@ export const init = (): Promise<void> => {
 			if (state.ccpa) {
 				const doNotSell = state.ccpa.doNotSell;
 				// CCPA mode
-				window.googletag?.cmd.push(() => {
-					window.googletag?.pubads().setPrivacySettings({
+				window.googletag.cmd.push(() => {
+					window.googletag.pubads().setPrivacySettings({
 						restrictDataProcessing: doNotSell,
 					});
 				});
 				if (!state.ccpa.doNotSell) {
-					window.googletag?.cmd.push(setPublisherProvidedId);
+					window.googletag.cmd.push(setPublisherProvidedId);
 				}
 			} else {
 				if (state.tcfv2) {
@@ -123,7 +123,7 @@ export const init = (): Promise<void> => {
 						Boolean,
 					);
 					if (canTarget) {
-						window.googletag?.cmd.push(setPublisherProvidedId);
+						window.googletag.cmd.push(setPublisherProvidedId);
 					}
 
 					canRun = getConsentFor('googletag', state);
@@ -131,13 +131,13 @@ export const init = (): Promise<void> => {
 					// AUS mode
 					// canRun stays true, set NPA flag if consent is retracted
 					const npaFlag = !getConsentFor('googletag', state);
-					window.googletag?.cmd.push(() => {
+					window.googletag.cmd.push(() => {
 						window.googletag
-							?.pubads()
+							.pubads()
 							.setRequestNonPersonalizedAds(npaFlag ? 1 : 0);
 					});
 					if (!npaFlag) {
-						window.googletag?.cmd.push(setPublisherProvidedId);
+						window.googletag.cmd.push(setPublisherProvidedId);
 					}
 				}
 			}

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.ts
@@ -94,7 +94,6 @@ export const init = (): Promise<void> => {
 		// fulfilled), but don't assume fillAdvertSlots is complete when queueing subsequent work using cmd.push
 		window.googletag.cmd.push(
 			setDfpListeners,
-			//@ts-expect-error -- oversight in type definition https://git.io/JPM1I
 			setPageTargeting,
 			refreshOnResize,
 			() => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.ts
@@ -55,10 +55,9 @@ const setDfpListeners = (): void => {
 		'slotOnload',
 		raven.wrap<typeof onSlotLoad>(onSlotLoad),
 	);
-
 	pubads.addEventListener('impressionViewable', onSlotViewableFunction());
-
 	pubads.addEventListener('slotVisibilityChanged', onSlotVisibilityChanged);
+
 	if (storage.session.isAvailable()) {
 		const pageViews =
 			(storage.session.get('gu.commercial.pageViews') as number) || 0;

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.ts
@@ -53,9 +53,7 @@ const setDfpListeners = (): void => {
 	);
 	pubads.addEventListener(
 		'slotOnload',
-		raven.wrap(onSlotLoad) as (
-			event: googletag.events.SlotOnloadEvent,
-		) => void,
+		raven.wrap<typeof onSlotLoad>(onSlotLoad),
 	);
 
 	pubads.addEventListener('impressionViewable', onSlotViewableFunction());

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.ts
@@ -49,9 +49,7 @@ const setDfpListeners = (): void => {
 	if (!pubads) return;
 	pubads.addEventListener(
 		'slotRenderEnded',
-		raven.wrap(onSlotRender) as (
-			event: googletag.events.SlotRenderEndedEvent,
-		) => void,
+		raven.wrap<typeof onSlotRender>(onSlotRender),
 	);
 	pubads.addEventListener(
 		'slotOnload',

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
@@ -346,7 +346,7 @@ const initialise = (window: Window, framework: Framework = 'tcfv2'): void => {
 			return;
 		}
 
-		const size = [width, height]; // eg. [300, 250]
+		const size: AdSizeTuple = [width, height]; // eg. [300, 250]
 		const advert = getAdvertById(adUnitCode);
 
 		if (!advert) {

--- a/static/src/javascripts/projects/commercial/types.d.ts
+++ b/static/src/javascripts/projects/commercial/types.d.ts
@@ -58,11 +58,6 @@ type Slot = {
 	setTargeting: SetTargeting;
 };
 
-type SlotOnloadEvent = {
-	serviceName: string;
-	slot: Slot;
-};
-
 type ImpressionViewableEvent = {
 	serviceName: string;
 	slot: Slot;

--- a/static/src/javascripts/projects/commercial/types.d.ts
+++ b/static/src/javascripts/projects/commercial/types.d.ts
@@ -1,4 +1,7 @@
 type AdSizes = Record<string, AdSize[]>;
+/**
+ * Subtype of googletag.SizeMappingArray
+ */
 type AdSize = AdSizeTuple | 'fluid';
 type AdSizeTuple = [width: number, height: number];
 

--- a/static/src/javascripts/projects/commercial/types.d.ts
+++ b/static/src/javascripts/projects/commercial/types.d.ts
@@ -1,5 +1,6 @@
 type AdSizes = Record<string, AdSize[]>;
-type AdSize = [width: number, height: number] | 'fluid';
+type AdSize = AdSizeTuple | 'fluid';
+type AdSizeTuple = [width: number, height: number];
 
 type ResponseInformation = {
 	advertiserId: string;

--- a/static/src/javascripts/projects/commercial/types.d.ts
+++ b/static/src/javascripts/projects/commercial/types.d.ts
@@ -1,10 +1,6 @@
 type AdSizes = Record<string, AdSize[]>;
 type AdSize = [width: number, height: number] | 'fluid';
 
-type MultiSize = AdSize[];
-type GeneralSize = AdSize | MultiSize;
-type SizeMapping = GeneralSize[];
-
 type ResponseInformation = {
 	advertiserId: string;
 	campaignId: string;
@@ -17,58 +13,6 @@ type SafeFrameConfig = {
 	allowOverlayExpansion: boolean;
 	allowPushExpansion: boolean;
 	sandbox: boolean;
-};
-
-type AddService = (s: string) => Slot;
-type ClearCategoryExclusions = () => Slot;
-type ClearTargeting = (s?: string) => Slot;
-type DefineSizeMapping = (asm: SizeMapping[]) => Slot;
-type Get = (s: string) => string | null | undefined;
-type GetString = () => string;
-type GetStrings = () => string[];
-type GetResponseInformation = () => ResponseInformation | null | undefined;
-type GetTargeting = (s: string) => string[];
-type Set = (s1: string, s2: string) => Slot;
-type SetString = (s: string) => Slot;
-type SetCollapseEmptyDiv = (b1: boolean, b2: boolean) => Slot;
-type SetForceSafeFrame = (b1: boolean) => Slot;
-type SetSafeFrameConfig = (sfc: SafeFrameConfig) => Slot;
-type SetTargeting = (s: string, a: string | string[]) => Slot;
-
-type Slot = {
-	addService: AddService;
-	clearCategoryExclusions: ClearCategoryExclusions;
-	clearTargeting: ClearTargeting;
-	defineSizeMapping: DefineSizeMapping;
-	get: Get;
-	getAdUnitPath: GetString;
-	getAttributeKeys: GetStrings;
-	getCategoryExclusions: GetStrings;
-	getOutOfPage: () => boolean;
-	getResponseInformation: GetResponseInformation;
-	getSlotElementId: GetString;
-	getTargeting: GetTargeting;
-	getTargetingKeys: GetStrings;
-	set: Set;
-	setCategoryExclusion: SetString;
-	setClickUrl: SetString;
-	setCollapseEmptyDiv: SetCollapseEmptyDiv;
-	setForceSafeFrame: SetForceSafeFrame;
-	setSafeFrameConfig: SetSafeFrameConfig;
-	setTargeting: SetTargeting;
-};
-
-type ImpressionViewableEvent = {
-	serviceName: string;
-	slot: Slot;
-};
-
-type ImpressionViewableEventCallback = (arg0: ImpressionViewableEvent) => void;
-
-type SlotVisibilityChangedEvent = {
-	inViewPercentage: number;
-	serviceName: string;
-	slot: Slot;
 };
 
 type GuAdSize = {

--- a/static/src/javascripts/projects/commercial/types.d.ts
+++ b/static/src/javascripts/projects/commercial/types.d.ts
@@ -1,8 +1,6 @@
 type AdSizes = Record<string, AdSize[]>;
-type AdSize = SingleSizeArray | NamedSize;
+type AdSize = [width: number, height: number] | 'fluid';
 
-type SingleSizeArray = number[];
-type NamedSize = 'fluid';
 type MultiSize = AdSize[];
 type GeneralSize = AdSize | MultiSize;
 type SizeMapping = GeneralSize[];
@@ -63,19 +61,6 @@ type Slot = {
 type SlotOnloadEvent = {
 	serviceName: string;
 	slot: Slot;
-};
-
-type SlotRenderEndedEvent = {
-	advertiserId?: number;
-	campaignId?: number;
-	creativeId?: number;
-	isEmpty: boolean;
-	lineItemId?: number;
-	serviceName: string;
-	size: AdSize;
-	slot: Slot;
-	sourceAgnosticCreativeId?: number;
-	sourceAgnosticLineItemId?: number;
 };
 
 type ImpressionViewableEvent = {

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -171,6 +171,4 @@ interface Window {
 	};
 
 	confiant?: Confiant;
-
-	googletag?: googletag.Googletag;
 }

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -110,6 +110,7 @@
  ],
  "../projects/commercial/modules/comment-adverts.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../lib/config.d.ts",
   "../lib/detect.js",
   "../lib/fastdom-promise.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2409,10 +2409,10 @@
   resolved "https://registry.yarnpkg.com/@types/google.analytics/-/google.analytics-0.0.42.tgz#efe6ef9251a22ec8208dbb09f221a48a1863d720"
   integrity sha512-w0ZFj3SHznQXSq99kFCuO8tkN6w4T14znjrF2alLCSDnHOXEnpzneyNwxLvekcsDBInr8b5mXmzYh03GArqEyw==
 
-"@types/googletag@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@types/googletag/-/googletag-1.1.2.tgz#b6b41836abe11ad26cbe9749bd860528e3db6f13"
-  integrity sha512-rIDIih4vLP9zkQF4xkFJD3Kjmj4oMea6XuYIpVk98KqXeIBGhdFmwxcVhdYXRSs7n10/IQXymT8+pXqCWKIiLw==
+"@types/googletag@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@types/googletag/-/googletag-1.1.3.tgz#6d1c2f2d8cbb438e48f6a30f6e0d59c669156d40"
+  integrity sha512-9N3+77VovWnTi3uFZuAAjv9+8hPT5E5ORl5yX+5FA7baO24dEsUs0FLXRq3K+SNEFhuO1K2TIEE3K6/DSicVzg==
 
 "@types/graceful-fs@^4.1.2":
   version "4.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2390,11 +2390,6 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
-"@types/doubleclick-gpt@^2019111201.0.0":
-  version "2019111201.0.0"
-  resolved "https://registry.yarnpkg.com/@types/doubleclick-gpt/-/doubleclick-gpt-2019111201.0.0.tgz#0028485d2efbb3b8c79a5c1cb107486bd6e56d33"
-  integrity sha512-SNhaQ5wUAWcDsO2QYzhCeAQnnBEqouhAPnNyfjrOZDulR8fWyLq/FHWboqXh9cIVi/V2JULnv9SXJOiHS2gEtw==
-
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -2413,6 +2408,11 @@
   version "0.0.42"
   resolved "https://registry.yarnpkg.com/@types/google.analytics/-/google.analytics-0.0.42.tgz#efe6ef9251a22ec8208dbb09f221a48a1863d720"
   integrity sha512-w0ZFj3SHznQXSq99kFCuO8tkN6w4T14znjrF2alLCSDnHOXEnpzneyNwxLvekcsDBInr8b5mXmzYh03GArqEyw==
+
+"@types/googletag@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@types/googletag/-/googletag-1.1.2.tgz#b6b41836abe11ad26cbe9749bd860528e3db6f13"
+  integrity sha512-rIDIih4vLP9zkQF4xkFJD3Kjmj4oMea6XuYIpVk98KqXeIBGhdFmwxcVhdYXRSs7n10/IQXymT8+pXqCWKIiLw==
 
 "@types/graceful-fs@^4.1.2":
   version "4.1.3"


### PR DESCRIPTION
## What does this change?

- Brings better, stricter types for `googletag`, using @types/googletag, whilst also [adding minor improvements to it][1].
- Removed a lot of locally-defined commercial types in favour of native `googletag` ones.
- Rebuild the commercial graph

[1]: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56923

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Types are narrower, making it easier to understand what functions do.

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
