### PR TITLE
move listener out of autoupdate so we don't load js we don't need

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/liveblog.js
+++ b/static/src/javascripts/bootstraps/enhanced/liveblog.js
@@ -8,6 +8,7 @@ import { init as initRelativeDates } from 'common/modules/ui/relativedates';
 import { init as initLiveblogCommon } from 'bootstraps/enhanced/article-liveblog-common';
 import { initTrails } from 'bootstraps/enhanced/trail';
 import { catchErrorsWithContext } from 'lib/robust';
+import bean from "bean";
 
 const affixTimeline = () => {
     const keywordIds = config.get('page.keywordIds', '');
@@ -39,8 +40,15 @@ const initFilterCheckbox = () => {
 }
 
 const createAutoUpdate = () => {
-    const isLiveblog = config.get('page.isLive')
-    updateBlocks({}, isLiveblog);
+    if (config.get('page.isLive')) {
+        updateBlocks();
+    }
+
+    bean.on(document.body, 'change', '.live-blog__filter-switch-label', () => {
+        const hasParam = window.location.search.includes(`filterKeyEvents=true`);
+        const param = `?filterKeyEvents=${hasParam ? 'false' : 'true'}`;
+        window.location.assign(`${window.location.pathname}${param}`);
+    })
 };
 
 const keepTimestampsCurrent = () => {

--- a/static/src/javascripts/bootstraps/enhanced/liveblog.js
+++ b/static/src/javascripts/bootstraps/enhanced/liveblog.js
@@ -43,17 +43,19 @@ const createAutoUpdate = () => {
     if (config.get('page.isLive')) {
         updateBlocks();
     }
-
-    bean.on(document.body, 'change', '.live-blog__filter-switch-label', () => {
-        const hasParam = window.location.search.includes(`filterKeyEvents=true`);
-        const param = `?filterKeyEvents=${hasParam ? 'false' : 'true'}`;
-        window.location.assign(`${window.location.pathname}${param}`);
-    })
 };
 
 const keepTimestampsCurrent = () => {
     window.setInterval(() => initRelativeDates(), 60000);
 };
+
+const setupListeners = () => {
+    bean.on(document.body, 'change', '.live-blog__filter-switch-label', () => {
+        const hasParam = window.location.search.includes(`filterKeyEvents=true`);
+        const param = `?filterKeyEvents=${hasParam ? 'false' : 'true'}`;
+        window.location.assign(`${window.location.pathname}${param}`);
+    })
+}
 
 const init = () => {
     catchErrorsWithContext([
@@ -66,6 +68,7 @@ const init = () => {
     initFilterCheckbox();
     initTrails();
     initLiveblogCommon();
+    setupListeners();
 
     catchErrorsWithContext([
         [

--- a/static/src/javascripts/projects/common/modules/ui/autoupdate.js
+++ b/static/src/javascripts/projects/common/modules/ui/autoupdate.js
@@ -15,7 +15,7 @@ import {initNotificationCounter} from 'common/modules/ui/notification-counter';
 import {checkElemsForVideos} from 'common/modules/atoms/youtube';
 
 
-const updateBlocks = (opts, isLiveblog) => {
+const updateBlocks = (opts) => {
     const options = Object.assign(
         {
             toastOffsetTop: 12,
@@ -53,7 +53,7 @@ const updateBlocks = (opts, isLiveblog) => {
         $liveblogBody.offset().top < window.pageYOffset;
 
     const isLivePage = !window.location.search.includes('page=');
-    const filterKeyEvents = window.location.search.includes('?filterKeyEvents=true');
+    const filterKeyEvents = window.location.search.includes('filterKeyEvents=true');
 
     const revealInjectedElements = () => {
         fastdom.mutate(() => {
@@ -115,12 +115,12 @@ const updateBlocks = (opts, isLiveblog) => {
         }
 
         let count = 0;
-        const filterEventState = filterKeyEvents ? true : false
         const filterKeyEventsParam = `&filterKeyEvents=${filterKeyEvents ? 'true' : 'false'}`;
         const shouldFetchBlocks = `&isLivePage=${isLivePage ? 'true' : 'false'}`;
         const latestKeyBlockId = $timeline.data('latest-key-block');
         const latestId = latestBlockId || 'block-0';
-        const latestBlockIdToUse = filterEventState ? latestKeyBlockId : latestId;
+        const latestBlockIdToUse = filterKeyEvents ? latestKeyBlockId : latestId;
+
         const params = `?lastUpdate=${latestBlockIdToUse}${shouldFetchBlocks}${filterKeyEventsParam}`;
         const endpoint = `${window.location.pathname}.json${params}`;
 
@@ -166,21 +166,16 @@ const updateBlocks = (opts, isLiveblog) => {
                     }
                 }
 
-                isLiveblog && setUpdateDelay();
+                setUpdateDelay();
             })
             .catch(() => {
-                isLiveblog && setUpdateDelay();
+                setUpdateDelay();
             });
     };
 
     const getBooleanParam = (key) => {
         const hasParam = window.location.search.includes(`${key}=true`);
         return `?${key}=${hasParam ? 'true' : 'false'}`;
-    }
-
-    const getReverseBooleanParam = (key) => {
-        const hasParam = window.location.search.includes(`${key}=true`);
-        return `?${key}=${hasParam ? 'false' : 'true'}`;
     }
 
     const refreshWindow = () => {
@@ -206,11 +201,6 @@ const updateBlocks = (opts, isLiveblog) => {
                 refreshWindow()
             }
         });
-
-        bean.on(document.body, 'change', '.live-blog__filter-switch-label', () => {
-            const param = getReverseBooleanParam("filterKeyEvents")
-            window.location.assign(`${window.location.pathname}${param}`);
-        })
 
         mediator.on('modules:toast__tofix:unfixed', () => {
             if (isLivePage && unreadBlocksNo > 0) {
@@ -243,7 +233,7 @@ const updateBlocks = (opts, isLiveblog) => {
         containInParent: false,
     }).init();
 
-    checkForUpdates(true);
+    checkForUpdates();
     initPageVisibility();
     setUpListeners();
 


### PR DESCRIPTION
## What does this change?
move listener out of autoupdate so we don't load js we don't need

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
