### PR TITLE
DCR Liveblogs with actual blocks

### DIFF
--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -119,7 +119,11 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       pageType: PageType,
   )(implicit request: RequestHeader): Future[Result] = {
 
-    val dataModel = DotcomRenderingDataModel.forArticle(page, blocks, request, pageType)
+    val dataModel = page match {
+      case liveblog: LiveBlogPage => DotcomRenderingDataModel.forLiveblog(liveblog, blocks, request, pageType)
+      case _                      => DotcomRenderingDataModel.forArticle(page, blocks, request, pageType)
+    }
+
     val json = DotcomRenderingDataModel.toJson(dataModel)
     post(ws, json, Configuration.rendering.baseURL + "/Article", page)
   }


### PR DESCRIPTION
## What does this change?
This fixes an issue where liveblogs when rendered by DCR were not showing any blocks

As with AMP, we now branch on `page` and when `liveblog` we use `DotcomRenderingDataModel.forLiveblog`. By using this correct model we get lovely blocks.

## Before
<img width="677" alt="Screenshot 2021-11-03 at 16 45 00" src="https://user-images.githubusercontent.com/1336821/140105394-e76bfc69-30b4-4709-8ef0-d42dc33a65e5.png">


## After
<img width="677" alt="Screenshot 2021-11-03 at 16 52 45" src="https://user-images.githubusercontent.com/1336821/140109378-20a0d5f8-abb5-4c32-8b6c-f0f144a32f5e.png">

