### PR TITLE
Handle no posts

### DIFF
--- a/article/app/views/liveblog/liveBlogBodyContent.scala.html
+++ b/article/app/views/liveblog/liveBlogBodyContent.scala.html
@@ -31,13 +31,19 @@
         >
 
         @if(model.currentPage.currentPage.blocks.isEmpty) {
-            <div> There is nothing to see here </div>
+            <div class="live-blog__no-blocks-container">
+                <span class="live-blog__no-blocks-text">
+                    There have not been any key events yet. Please wait for updates
+                </span>
+            </div>
         } else {
             @views.html.liveblog.liveBlogBlocks(model.currentPage.currentPage.blocks, article, timezone)
         }
         </div>
 
-        @fragments.liveBlogNavigation(article.content.metadata.id, model.currentPage)
+        @if(model.currentPage.currentPage.blocks.nonEmpty) {
+            @fragments.liveBlogNavigation(article.content.metadata.id, model.currentPage)
+        }
 
     </div>
 }

--- a/article/app/views/liveblog/liveBlogBodyContent.scala.html
+++ b/article/app/views/liveblog/liveBlogBodyContent.scala.html
@@ -33,7 +33,7 @@
         @if(model.currentPage.currentPage.blocks.isEmpty) {
             <div class="live-blog__no-blocks-container">
                 <span class="live-blog__no-blocks-text">
-                    There have not been any key events yet. Please wait for updates
+                    There have not been any key events yet. Please wait for updates.
                 </span>
             </div>
         } else {

--- a/article/app/views/liveblog/liveBlogBodyContent.scala.html
+++ b/article/app/views/liveblog/liveBlogBodyContent.scala.html
@@ -30,8 +30,11 @@
             data-test-id="live-blog-blocks"
         >
 
+        @if(model.currentPage.currentPage.blocks.isEmpty) {
+            <div> There is nothing to see here </div>
+        } else {
             @views.html.liveblog.liveBlogBlocks(model.currentPage.currentPage.blocks, article, timezone)
-
+        }
         </div>
 
         @fragments.liveBlogNavigation(article.content.metadata.id, model.currentPage)

--- a/article/app/views/liveblog/liveBlogBodyContent.scala.html
+++ b/article/app/views/liveblog/liveBlogBodyContent.scala.html
@@ -38,12 +38,10 @@
             </div>
         } else {
             @views.html.liveblog.liveBlogBlocks(model.currentPage.currentPage.blocks, article, timezone)
+            @fragments.liveBlogNavigation(article.content.metadata.id, model.currentPage)
+
         }
         </div>
-
-        @if(model.currentPage.currentPage.blocks.nonEmpty) {
-            @fragments.liveBlogNavigation(article.content.metadata.id, model.currentPage)
-        }
 
     </div>
 }

--- a/common/app/model/LiveBlogCurrentPage.scala
+++ b/common/app/model/LiveBlogCurrentPage.scala
@@ -49,8 +49,7 @@ object LiveBlogCurrentPage {
 
       (keyEvents, keyEventsCount, oldestPageBlockId)
     } else {
-      // val noBlocks: Seq[BodyBlock] = Seq.empty
-      val firstPageBlocks = blocks.requestedBodyBlocks.get(CanonicalLiveBlog.firstPage) // Some(noBlocks)
+      val firstPageBlocks = blocks.requestedBodyBlocks.get(CanonicalLiveBlog.firstPage)
       val oldestPageBlockId =
         blocks.requestedBodyBlocks.get(CanonicalLiveBlog.oldestPage) flatMap (_.headOption.map(_.id))
 

--- a/common/app/model/LiveBlogCurrentPage.scala
+++ b/common/app/model/LiveBlogCurrentPage.scala
@@ -45,10 +45,12 @@ object LiveBlogCurrentPage {
     val (maybeRequestedBodyBlocks, blockCount, oldestPageBlockId) = if (filterKeyEvents) {
       val keyEvents = blocks.requestedBodyBlocks.get(CanonicalLiveBlog.timeline)
       val keyEventsCount = keyEvents.getOrElse(Seq.empty).size
+      val oldestPageBlockId = keyEvents.flatMap(_.lastOption map (_.id))
 
-      (keyEvents, keyEventsCount, keyEvents.map(_.last.id))
+      (keyEvents, keyEventsCount, oldestPageBlockId)
     } else {
-      val firstPageBlocks = blocks.requestedBodyBlocks.get(CanonicalLiveBlog.firstPage)
+      // val noBlocks: Seq[BodyBlock] = Seq.empty
+      val firstPageBlocks = blocks.requestedBodyBlocks.get(CanonicalLiveBlog.firstPage) // Some(noBlocks)
       val oldestPageBlockId =
         blocks.requestedBodyBlocks.get(CanonicalLiveBlog.oldestPage) flatMap (_.headOption.map(_.id))
 

--- a/static/src/stylesheets/module/content-garnett/_live-blog.scss
+++ b/static/src/stylesheets/module/content-garnett/_live-blog.scss
@@ -252,6 +252,9 @@
     }
 }
 
+/* Filter switch
+   ========================================================================== */
+
 /* The switch - the box around the slider */
 .live-blog__filter-switch {
     display: flex;
@@ -323,3 +326,16 @@ input:checked + .live-blog__filter-switch-slider:before {
     transform: translateX(1.15rem);
 }
 
+/* No blocks
+   ========================================================================== */
+
+.live-blog__no-blocks-container {
+    padding: .625rem .5rem;
+    border: 1px solid $brightness-86;
+}
+
+.live-blog__no-blocks-text {
+    font-family: 'Guardian Text Sans', sans-serif;
+    color: $brightness-46;
+    font-size: 15px;
+}


### PR DESCRIPTION
## What does this change?

- Fixes a bug where the page would crash if no key event blocks were present and the filter was activated.
- Adds copy to alert users that there is no key events present.
- Hides pagination 

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

## Screenshots



| Before      | After      |
|-------------|------------|
|  <img width="300" alt="Screenshot 2021-11-04 at 12 02 02" src="https://user-images.githubusercontent.com/77005274/140311785-115cfbf2-58a7-4325-b1b6-8a9d5f9b770f.png">| <img width="300" alt="Screenshot 2021-11-04 at 12 07 51" src="https://user-images.githubusercontent.com/77005274/140311722-5e86b8d9-9f09-478a-8e29-f31cdd26b071.png"> |


