### PR TITLE
Add listName to the query string params sent to consent mailer

### DIFF
--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -58,7 +58,9 @@ class EmailFormService(wsClient: WSClient) extends LazyLogging with RemoteAddres
         .map(ip => List("X-Forwarded-For" -> ip))
         .getOrElse(List.empty) :+ "X-GU-ID-Client-Access-Token" -> s"Bearer $idAccessClientToken"
 
-      val queryStringParameters = form.ref.map("ref" -> _).toList ++ form.refViewId.map("refViewId" -> _).toList
+      val queryStringParameters = form.ref.map("ref" -> _).toList ++
+        form.refViewId.map("refViewId" -> _).toList ++
+        form.listName.map("listName" -> _).toList
 
       //FIXME: this should go via the identity api client / app
       wsClient


### PR DESCRIPTION
## What does this change?

This adds the `listName` to the query parameters sent to the consent mailer endpoint of IDAPI. This is so we can measure how many people confirm their subscription to each list

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No

## Checklist

### Tested

- [x] Locally

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
