### PR TITLE
Remove `0p19G` query param

### DIFF
--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -68,7 +68,6 @@ class DevParametersHttpRequestHandler(
     "s", // section in commercial component requests
     "seg", // user segments in commercial component requests
     "t", // specific item targetting
-    "0p19G", // Google AMP AB test parameter
     "dll", // Disable lazy loading of ads
     "iasdebug", // IAS troubleshooting
     "cmpdebug", // CMP troubleshooting

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.ts
@@ -8,7 +8,7 @@ import type { ConsentState } from '@guardian/consent-management-platform/dist/ty
 import type { TCFv2ConsentList } from '@guardian/consent-management-platform/dist/types/tcfv2';
 import type { CountryCode } from '@guardian/libs';
 import { getCookie, isObject, isString, log, storage } from '@guardian/libs';
-import { once, pick } from 'lodash-es';
+import { once } from 'lodash-es';
 import config from '../../../../lib/config';
 import {
 	getReferrer as detectGetReferrer,
@@ -16,7 +16,6 @@ import {
 	getViewport,
 } from '../../../../lib/detect';
 import { getCountryCode } from '../../../../lib/geolocation';
-import { getUrlVars } from '../../../../lib/url';
 import { removeFalseyValues } from '../../../commercial/modules/header-bidding/utils';
 import { getSynchronousParticipations } from '../experiments/ab';
 import { isUserLoggedIn } from '../identity/api';
@@ -246,11 +245,6 @@ const getReferrer = (): string | null => {
 	return matchedRef.id;
 };
 
-const getWhitelistedQueryParams = (): Record<string, unknown> => {
-	const whiteList: string[] = ['0p19G'];
-	return pick(getUrlVars(), whiteList);
-};
-
 const getUrlKeywords = (pageId?: string): string[] => {
 	if (!pageId) return [];
 
@@ -442,7 +436,6 @@ const rebuildPageTargeting = () => {
 		...page.sharedAdTargeting,
 		...paTargeting,
 		...adFreeTargeting,
-		...getWhitelistedQueryParams(),
 	};
 
 	// filter out empty values


### PR DESCRIPTION
## What does this change?

Remove `0p19G` query param, as it’s a very old targeting used for an AMP experiment. It’s been gone since #19417 and introduced in #14228.

It’s seldom used in [The Guardian codebase](https://github.com/search?q=org%3Aguardian+%600p19G%60&type=code).

Here’s the run of `git log --oneline -S"0p19G" `:

- b4f5dd2c33 (origin/mxdvl/ad-targeting-prune/query-params) remove 0p19G query param
- 0f86fa1027 convert build-page-targeting to TS
- 9c156477b3 Revert "Merge pull request #23451 from guardian/ph-20210108-1246-test"
- 22cec1f5cf Decommission un-used DevParametersHttpRequestHandler
- 5eacaa782b Decommission un-used DevParametersHttpRequestHandler
- 6165f83791 create archive of flow-typed static/src/javascripts
- **67cd668d66 Remove amp remote html** &larr; this is relevant
- 697a3910e0 Remove commercial modules from control that should be in common
- 1c1090bfdd Duplicate commercial stack into commercial-legacy
- 022d7bac75 Remove stuff from facia
- f5cf54290f Add facia routes back
- b71e585194 Add attachQueryParams to amp_remote to send query params to DFP
- 51f48a223a Add the AMP AB test query param to DevParametersHttpRequestHandler
- **06aade0f00 Add the AMP query param to the page targeting** &larr; this is relevant

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Old stuff is gone.