### PR TITLE
Revert call to google analytics

### DIFF
--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -132,6 +132,9 @@ window.guardian.googleAnalytics.initialiseGa = function() {
     }
 
     @defining(GoogleAnalyticsAccount.editorialTracker(context).trackerName) { trackerName =>
+
+        ga('@{trackerName}.send', 'pageview');
+
         @*
         If there is internal link click data in session storage, send a click event.?:
 


### PR DESCRIPTION

## What does this change?

Revert call to google analytics

This was removed in error in this PR: https://github.com/guardian/frontend/pull/24326

