### PR TITLE
Revert "add extra logging to help debug failed press of us news and technology fronts"

### DIFF
--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -4,14 +4,11 @@ import metrics.SamplerMetric
 import com.gu.contentapi.client.{ContentApiClient => CapiContentApiClient}
 import com.gu.contentapi.client.model.v1.ItemResponse
 import com.gu.contentapi.client.model.{ItemQuery, SearchQuery}
-import com.gu.facia.api.contentapi.ContentApi
 import com.gu.facia.api.contentapi.ContentApi.{AdjustItemQuery, AdjustSearchQuery}
 import com.gu.facia.api.models.{Collection, Front}
-import com.gu.facia.api.utils.BackfillResolver.backfill
-import com.gu.facia.api.utils.{BackfillResolver, CapiBackfill, CollectionBackfill, EmptyBackfill}
 import com.gu.facia.api.{FAPI, Response}
 import com.gu.facia.client.ApiClient
-import com.gu.facia.client.models.{Backfill, Breaking, Canonical, ConfigJson, Metadata, Special}
+import com.gu.facia.client.models.{Breaking, Canonical, ConfigJson, Metadata, Special}
 import common.LoggingField.LogFieldString
 import common.{LoggingField, _}
 import common.commercial.CommercialProperties
@@ -124,7 +121,7 @@ trait EmailFrontPress extends GuLogging {
       frontProperties: FrontProperties,
   ): PressedPageVersions
   def collectionsIdsFromConfigForPath(path: String, config: ConfigJson): List[String]
-  def generateCollectionJsonFromFapiClient(collectionId: String, path: String, messageId: String)(implicit
+  def generateCollectionJsonFromFapiClient(collectionId: String)(implicit
       executionContext: ExecutionContext,
   ): Response[PressedCollectionVisibility]
   def getFrontSeoAndProperties(path: String)(implicit
@@ -133,17 +130,12 @@ trait EmailFrontPress extends GuLogging {
 
   def pressEmailFront(
       emailFrontPath: EmailFrontPath,
-      messageId: String,
   )(implicit executionContext: ExecutionContext): Response[PressedPageVersions] = {
     for {
       config <- Response.Async.Right(fapiClient.config)
       collectionIds = collectionsIdsFromConfigForPath(emailFrontPath.path, config)
-      pressedCollections <- Response.traverse(
-        collectionIds.map(collectionId =>
-          generateCollectionJsonFromFapiClient(collectionId, emailFrontPath.path, messageId),
-        ),
-      )
-      extraEmailCollections <- buildExtraEmailCollections(emailFrontPath, config, pressedCollections, messageId)
+      pressedCollections <- Response.traverse(collectionIds.map(generateCollectionJsonFromFapiClient))
+      extraEmailCollections <- buildExtraEmailCollections(emailFrontPath, config, pressedCollections)
       seoWithProperties <- Response.Async.Right(getFrontSeoAndProperties(emailFrontPath.path))
     } yield seoWithProperties match {
       case (seoData, frontProperties) =>
@@ -164,7 +156,6 @@ trait EmailFrontPress extends GuLogging {
       frontPath: EmailFrontPath,
       config: ConfigJson,
       pressedCollections: List[PressedCollectionVisibility],
-      messageId: String,
   )(implicit ec: ExecutionContext): Response[EmailExtraCollections] = {
     def findCollectionIds(metadata: Metadata): List[String] = {
       for {
@@ -175,23 +166,15 @@ trait EmailFrontPress extends GuLogging {
       } yield collectionId
     }
 
-    def findMetaContainersWithLimit(
-        metadata: Metadata,
-        limit: Int,
-        path: String,
-        messageId: String,
-    ): Response[List[PressedCollectionVisibility]] = {
+    def findMetaContainersWithLimit(metadata: Metadata, limit: Int): Response[List[PressedCollectionVisibility]] = {
       Response
-        .traverse(
-          findCollectionIds(metadata)
-            .map(collectionId => generateCollectionJsonFromFapiClient(collectionId, path, messageId)),
-        )
+        .traverse(findCollectionIds(metadata).map(generateCollectionJsonFromFapiClient))
         .map(_.map(_.withVisible(limit)))
     }
 
-    val canonicalPressedF = findMetaContainersWithLimit(Canonical, 6, frontPath.path, messageId)
-    val breakingPressedF = findMetaContainersWithLimit(Breaking, 5, frontPath.path, messageId)
-    val specialPressedF = findMetaContainersWithLimit(Special, 1, frontPath.path, messageId)
+    val canonicalPressedF = findMetaContainersWithLimit(Canonical, 6)
+    val breakingPressedF = findMetaContainersWithLimit(Breaking, 5)
+    val specialPressedF = findMetaContainersWithLimit(Special, 1)
 
     for {
       canonicalPressed <- canonicalPressedF
@@ -248,7 +231,7 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
       .showBlocks(showBlocks)
 
   def pressByPathId(path: String, messageId: String)(implicit executionContext: ExecutionContext): Future[Unit] = {
-    log.info(s"FapiFrontPress: pressByPathId for path $path messageId $messageId")
+    log.info(s"FapiFrontPress: pressByPathId for path $path")
     def pressDependentPaths(paths: Seq[String]): Future[Unit] = {
       Future
         .traverse(paths)(p => pressPath(p, messageId))
@@ -268,7 +251,7 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
     log.info(s"FapiFrontPress: pressPath $path")
     val stopWatch: StopWatch = new StopWatch
 
-    val pressFuture = getPressedFrontForPath(path, messageId)
+    val pressFuture = getPressedFrontForPath(path)
       .map { pressedFronts: PressedPageVersions =>
         // temporary logging to investigate fronts weirdness on code - log entire front out
         // temporarily log for suspicious fronts on PROD
@@ -334,13 +317,11 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
 
   def generateCollectionJsonFromFapiClient(
       collectionId: String,
-      path: String,
-      messageId: String,
   )(implicit executionContext: ExecutionContext): Response[PressedCollectionVisibility] = {
     for {
       collection <- FAPI.getCollection(collectionId)
       curated <- getCurated(collection)
-      backfill <- getBackfill(collection, path, messageId)
+      backfill <- getBackfill(collection)
       treats <- getTreats(collection)
     } yield {
       val doNotTrimContainerOfTypes = Seq("nav/list")
@@ -422,25 +403,7 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
 
   private def getBackfill(
       collection: Collection,
-      path: String,
-      messageId: String,
   )(implicit executionContext: ExecutionContext): Response[List[PressedContent]] = {
-    log.info(s"Collection config for path '$path', messageId $messageId: ${collection.collectionConfig}")
-
-    if (path == "us-news" || path == "us/technology") {
-      log.info(s"Get backfill for path '$path''")
-      val backfillQuery = BackfillResolver.resolveFromConfig(collection.collectionConfig)
-      backfillQuery match {
-        case CapiBackfill(query, collectionConfig) =>
-          val q = ContentApi.buildBackfillQuery(query) match {
-            case Right(value) => value.getUrl("")
-            case Left(value)  => value.getUrl("")
-          }
-          log.info(s"CAPI backfill query for path '$path', messageId $messageId: $q")
-        case _ => log.info(s"Backfill query not capi for path '$path', messageId $messageId")
-      }
-    }
-
     FAPI
       .backfillFromConfig(collection.collectionConfig, searchApiQuery, itemApiQuery)
       .map(_.map(PressedContent.make))
@@ -473,22 +436,17 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
 
   def getPressedFrontForPath(
       path: String,
-      messageId: String = "unknown",
   )(implicit executionContext: ExecutionContext): Response[PressedPageVersions] = {
-    log.info(s"Get pressed front for path $path, messageId $messageId")
-    EmailFrontPath.fromPath(path).fold(pressFront(path, messageId))(pressEmailFront(_, messageId))
+    log.info(s"Get pressed front for path $path")
+    EmailFrontPath.fromPath(path).fold(pressFront(path))(pressEmailFront)
   }
 
-  def pressFront(path: String, messageId: String)(implicit
-      executionContext: ExecutionContext,
-  ): Response[PressedPageVersions] = {
-    log.info(s"Press front $path, messageId $messageId")
+  def pressFront(path: String)(implicit executionContext: ExecutionContext): Response[PressedPageVersions] = {
+    log.info(s"Press front $path")
     for {
       config <- Response.Async.Right(fapiClient.config)
       collectionIds = collectionsIdsFromConfigForPath(path, config)
-      pressedCollections <- Response.traverse(
-        collectionIds.map(collectionId => generateCollectionJsonFromFapiClient(collectionId, path, messageId)),
-      )
+      pressedCollections <- Response.traverse(collectionIds.map(generateCollectionJsonFromFapiClient))
       seoWithProperties <- Response.Async.Right(getFrontSeoAndProperties(path))
     } yield seoWithProperties match {
       case (seoData, frontProperties) =>


### PR DESCRIPTION
Reverts guardian/frontend#24353

We now understand facia-press a bit better and were able to identify the invalid backfill queries in PROD.

If we don't revert this change the facia-press logs are cluttered with unnecessary logging.