### PR TITLE
Convert 415s from DCR to 404s

### DIFF
--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -6,11 +6,13 @@ import common.{GuLogging, LinkTo}
 import concurrent.CircuitBreakerRegistry
 import conf.Configuration
 import conf.switches.Switches.CircuitBreakerSwitch
-import model.Cached.RevalidatableResult
+import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
+import model.CacheTime
 import model.dotcomrendering.{DotcomRenderingDataModel, DotcomRenderingUtils}
 import model.{ArticlePage, Cached, InteractivePage, LiveBlogPage, NoCache, Page, PageWithStoryPackage}
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc.{RequestHeader, Result}
+import play.api.mvc.Results.{InternalServerError, NotFound}
 import play.twirl.api.Html
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -77,19 +79,16 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
             .withPreconnect(HttpPreconnections.defaultUrls)
         case 400 =>
           // if DCR returns a 400 it's because *we* failed, so frontend should return a 500
-          NoCache(play.api.mvc.Results.InternalServerError("Remote renderer validation error (400)"))
+          NoCache(InternalServerError("Remote renderer validation error (400)"))
             .withHeaders("X-GU-Dotcomponents" -> "true")
         case 415 =>
           // if DCR returns a 415 it's because we can't render a specific component, so page is not available
-          NoCache(
-            play.api.mvc.Results.NotFound
-              .withHeaders("X-GU-Dotcomponents" -> "true"),
-          )
+          Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound))
+            .withHeaders("X-GU-Dotcomponents" -> "true")
         case _ =>
           log.error(s"Request to DCR failed: status ${response.status}, body: ${response.body}")
           NoCache(
-            play.api.mvc.Results
-              .InternalServerError("Remote renderer error (500)")
+            InternalServerError("Remote renderer error (500)")
               .withHeaders("X-GU-Dotcomponents" -> "true"),
           )
       }

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -79,6 +79,12 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
           // if DCR returns a 400 it's because *we* failed, so frontend should return a 500
           NoCache(play.api.mvc.Results.InternalServerError("Remote renderer validation error (400)"))
             .withHeaders("X-GU-Dotcomponents" -> "true")
+        case 415 =>
+          // if DCR returns a 415 it's because we can't render a specific component, so page is not available
+          NoCache(
+            play.api.mvc.Results.NotFound
+              .withHeaders("X-GU-Dotcomponents" -> "true"),
+          )
         case _ =>
           log.error(s"Request to DCR failed: status ${response.status}, body: ${response.body}")
           NoCache(

--- a/common/test/CommonTestSuite.scala
+++ b/common/test/CommonTestSuite.scala
@@ -4,12 +4,14 @@ import conf.CachedHealthCheckTest
 import conf.audio.FlagshipFrontContainerSpec
 import navigation.NavigationTest
 import org.scalatest.Suites
+import renderers.DotcomRenderingServiceTest
 
 class CommonTestSuite
     extends Suites(
       new CachedHealthCheckTest,
       new NavigationTest,
       new FlagshipFrontContainerSpec,
+      new DotcomRenderingServiceTest,
     )
     with SingleServerSuite {
   override lazy val port: Int = 19016

--- a/common/test/renderers/DotcomRenderingServiceTest.scala
+++ b/common/test/renderers/DotcomRenderingServiceTest.scala
@@ -1,5 +1,6 @@
 package renderers
 
+import model.{MetaData, Page}
 import model.dotcomrendering.PageType
 import org.apache.commons.codec.digest.DigestUtils
 import org.scalatest.mockito.MockitoSugar
@@ -7,9 +8,14 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers, Priv
 import play.api.test.Helpers._
 import play.api.test._
 import test.{ConfiguredTestSuite, TestRequest, WithMaterializer, WithTestApplicationContext, WithTestWsClient}
-import play.api.libs.ws.WSClient
+import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 import play.api.mvc.{RequestHeader, Result, Results}
+import conf.Configuration
+import org.mockito.Matchers.any
+import org.mockito.Mockito.when
+
 import scala.concurrent.{ExecutionContext, Future}
+import org.scalatest.concurrent.ScalaFutures
 
 @DoNotDiscover class DotcomRenderingServiceTest
     extends FlatSpec
@@ -20,23 +26,45 @@ import scala.concurrent.{ExecutionContext, Future}
     with WithMaterializer
     with WithTestWsClient
     with WithTestApplicationContext
-    with PrivateMethodTester {
+    with PrivateMethodTester
+    with ScalaFutures {
 
   val dotcomRenderingService = DotcomRenderingService()
   val articleUrl = "politics/2021/oct/07/coronavirus-report-warned-of-impact-on-uk-four-years-before-pandemic"
   val post = PrivateMethod[Future[Result]]('post)
+  private case class fakePage() extends Page {
+    override val metadata = MetaData.make(
+      id = "",
+      section = None,
+      webTitle = "",
+    )
+  }
+  private val wsMock = mock[WSClient]
+  private val wsResponseMock = mock[WSResponse]
+  private val wsRequestMock = mock[WSRequest]
+
+  when(wsMock.url(any[String])).thenReturn(wsRequestMock)
+  when(wsRequestMock.withRequestTimeout(any())).thenReturn(wsRequestMock)
+  when(wsRequestMock.addHttpHeaders(any())).thenReturn(wsRequestMock)
+  when(wsRequestMock.post("payload")).thenReturn(Future.successful(wsResponseMock))
 
   "post" should "return a 404 for DCR 415 errors" in {
-    val result = dotcomRenderingService invokePrivate post()
+    when(wsResponseMock.status).thenReturn(415)
 
-//    val result = dotcomRenderingService invokePrivate post(
-//      wsClient,
-//      "payloadString",
-//      "https://an-endpoint.com",
-//      "page",
-//    )
+    implicit val request = TestRequest()
+    whenReady(
+      dotcomRenderingService invokePrivate post(
+        wsMock,
+        "payload",
+        "https://endpoint.com",
+        fakePage(),
+        Configuration.rendering.timeout,
+        request,
+      ),
+    ) { result =>
+      result.header.status should be(404)
+    }
 
-//    result should be(404)
   }
 
 }

--- a/common/test/renderers/DotcomRenderingServiceTest.scala
+++ b/common/test/renderers/DotcomRenderingServiceTest.scala
@@ -7,13 +7,12 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers, PrivateMethodTester}
 import play.api.test.Helpers._
 import play.api.test._
-import test.{ConfiguredTestSuite, TestRequest, WithMaterializer, WithTestApplicationContext, WithTestWsClient}
+import test.{ConfiguredTestSuite, TestRequest, WithMaterializer, WithTestWsClient}
 import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 import play.api.mvc.{RequestHeader, Result, Results}
 import conf.Configuration
 import org.mockito.Matchers.any
 import org.mockito.Mockito.when
-
 import scala.concurrent.{ExecutionContext, Future}
 import org.scalatest.concurrent.ScalaFutures
 
@@ -25,13 +24,13 @@ import org.scalatest.concurrent.ScalaFutures
     with BeforeAndAfterAll
     with WithMaterializer
     with WithTestWsClient
-    with WithTestApplicationContext
     with PrivateMethodTester
     with ScalaFutures {
 
   val dotcomRenderingService = DotcomRenderingService()
   val articleUrl = "politics/2021/oct/07/coronavirus-report-warned-of-impact-on-uk-four-years-before-pandemic"
   val post = PrivateMethod[Future[Result]]('post)
+  val request = TestRequest()
   private case class fakePage() extends Page {
     override val metadata = MetaData.make(
       id = "",
@@ -43,19 +42,18 @@ import org.scalatest.concurrent.ScalaFutures
   private val wsResponseMock = mock[WSResponse]
   private val wsRequestMock = mock[WSRequest]
 
-  when(wsMock.url(any[String])).thenReturn(wsRequestMock)
-  when(wsRequestMock.withRequestTimeout(any())).thenReturn(wsRequestMock)
-  when(wsRequestMock.addHttpHeaders(any())).thenReturn(wsRequestMock)
-  when(wsRequestMock.post("payload")).thenReturn(Future.successful(wsResponseMock))
-
   "post" should "return a 404 for DCR 415 errors" in {
+    val payload = "payload"
+    when(wsMock.url(any[String])).thenReturn(wsRequestMock)
+    when(wsRequestMock.withRequestTimeout(any())).thenReturn(wsRequestMock)
+    when(wsRequestMock.addHttpHeaders(any())).thenReturn(wsRequestMock)
+    when(wsRequestMock.post(payload)).thenReturn(Future.successful(wsResponseMock))
     when(wsResponseMock.status).thenReturn(415)
 
-    implicit val request = TestRequest()
     whenReady(
       dotcomRenderingService invokePrivate post(
         wsMock,
-        "payload",
+        payload,
         "https://endpoint.com",
         fakePage(),
         Configuration.rendering.timeout,

--- a/common/test/renderers/DotcomRenderingServiceTest.scala
+++ b/common/test/renderers/DotcomRenderingServiceTest.scala
@@ -1,0 +1,42 @@
+package renderers
+
+import model.dotcomrendering.PageType
+import org.apache.commons.codec.digest.DigestUtils
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers, PrivateMethodTester}
+import play.api.test.Helpers._
+import play.api.test._
+import test.{ConfiguredTestSuite, TestRequest, WithMaterializer, WithTestApplicationContext, WithTestWsClient}
+import play.api.libs.ws.WSClient
+import play.api.mvc.{RequestHeader, Result, Results}
+import scala.concurrent.{ExecutionContext, Future}
+
+@DoNotDiscover class DotcomRenderingServiceTest
+    extends FlatSpec
+    with Matchers
+    with ConfiguredTestSuite
+    with MockitoSugar
+    with BeforeAndAfterAll
+    with WithMaterializer
+    with WithTestWsClient
+    with WithTestApplicationContext
+    with PrivateMethodTester {
+
+  val dotcomRenderingService = DotcomRenderingService()
+  val articleUrl = "politics/2021/oct/07/coronavirus-report-warned-of-impact-on-uk-four-years-before-pandemic"
+  val post = PrivateMethod[Future[Result]]('post)
+
+  "post" should "return a 404 for DCR 415 errors" in {
+    val result = dotcomRenderingService invokePrivate post()
+
+//    val result = dotcomRenderingService invokePrivate post(
+//      wsClient,
+//      "payloadString",
+//      "https://an-endpoint.com",
+//      "page",
+//    )
+
+//    result should be(404)
+  }
+
+}


### PR DESCRIPTION
## What does this change?
DCR was updated to explicitly handle components not being renderable in AMP (https://github.com/guardian/dotcom-rendering/pull/3563). This resulted in DCR returning 415 error codes to frontend.

The motivation for that change was to reduce 5xx alerts being returned from the rendering load balancer. However we're still seeing 5xx alerts from the router load balancer and suspect this is because frontend is returning 500 errors to the client when DCR returns a 415.

This change updates frontend to match on 415 error codes from dcr and translate them to a 404 error code for the client. We felt a 'not found' error code was appropriate for the client (given the article can't be returned in AMP format).

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/45561419/140961788-f4abfaa4-bf9f-476a-9461-b4bb79685b26.png
[after]: https://user-images.githubusercontent.com/45561419/140961843-130ac3b8-2803-4112-934a-fe6b8bc28898.png

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

