### PR TITLE
Handle prebid rejected promise from user consent rejection

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.ts
@@ -3,6 +3,7 @@ import {
 	onConsentChange,
 } from '@guardian/consent-management-platform';
 import type { Framework } from '@guardian/consent-management-platform/dist/types';
+import { log } from '@guardian/libs';
 import { once } from 'lodash-es';
 import config from '../../../../lib/config';
 import { isGoogleProxy } from '../../../../lib/detect';
@@ -37,16 +38,18 @@ const loadPrebid = async (framework: Framework): Promise<void> => {
 const setupPrebid = async (): Promise<void> => {
 	let resolvePrebidLoaded: (value: void | PromiseLike<void>) => void;
 	let rejectPrebidLoaded: (
-		reason: 'no consent for prebid' | 'unknown framework',
+		reason: 'No consent for prebid' | 'Unknown framework',
 	) => void;
 	const promise = new Promise<void>((resolve, reject) => {
 		resolvePrebidLoaded = resolve;
 		rejectPrebidLoaded = reject;
+	}).catch((e) => {
+		log('commercial', '⚠️ Failed to execute prebid', e);
 	});
 
 	onConsentChange((state) => {
 		if (!getConsentFor('prebid', state)) {
-			rejectPrebidLoaded('no consent for prebid');
+			rejectPrebidLoaded('No consent for prebid');
 			return;
 		}
 
@@ -56,7 +59,7 @@ const setupPrebid = async (): Promise<void> => {
 		if (state.aus) framework = 'aus';
 
 		if (!framework) {
-			rejectPrebidLoaded('unknown framework');
+			rejectPrebidLoaded('Unknown framework');
 			return;
 		}
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
@@ -2,6 +2,7 @@ import {
 	getConsentFor,
 	onConsentChange,
 } from '@guardian/consent-management-platform';
+import { log } from '@guardian/libs';
 import config from '../../../../lib/config';
 import { commercialFeatures } from '../../../common/modules/commercial/commercial-features';
 import { isInAuOrNz } from '../../../common/modules/commercial/geo-utils';
@@ -34,6 +35,8 @@ const setupRedplanet = async () => {
 	const promise = new Promise((resolve, reject) => {
 		resolveRedPlanetLoaded = resolve;
 		rejectRedPlanetLoaded = reject;
+	}).catch((e) => {
+		log('commercial', '⚠️ Failed to execute redplanet', e);
 	});
 
 	onConsentChange((state) => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.spec.js
@@ -2,6 +2,7 @@ import {
 	getConsentFor as getConsentFor_,
 	onConsentChange as onConsentChange_,
 } from '@guardian/consent-management-platform';
+import { log } from '@guardian/libs';
 import config from '../../../../lib/config';
 import { commercialFeatures } from '../../../common/modules/commercial/commercial-features';
 import { isInAuOrNz as isInAuOrNz_ } from '../../../common/modules/commercial/geo-utils';
@@ -46,10 +47,6 @@ jest.mock('../../../common/modules/commercial/build-page-targeting', () => ({
 	buildPageTargeting: jest.fn(),
 }));
 
-jest.mock('@guardian/libs', () => ({
-	loadScript: () => Promise.resolve(),
-}));
-
 jest.mock('@guardian/consent-management-platform', () => ({
 	onConsentChange: jest.fn(),
 	getConsentFor: jest.fn(),
@@ -57,6 +54,10 @@ jest.mock('@guardian/consent-management-platform', () => ({
 
 jest.mock('../../../common/modules/experiments/ab', () => ({
 	isInVariantSynchronous: jest.fn(),
+}));
+
+jest.mock('@guardian/libs', () => ({
+	log: jest.fn(),
 }));
 
 const CcpaWithConsentMock = (callback) =>
@@ -130,7 +131,12 @@ describe('init', () => {
 		isInAuOrNz.mockReturnValue(true);
 		onConsentChange.mockImplementation(AusWithoutConsentMock);
 		getConsentFor.mockReturnValue(false);
-		await expect(init()).rejects.toEqual('No consent for redplanet');
+		await init();
+        expect(log).toHaveBeenCalledWith(
+            'commercial',
+            expect.stringContaining("Failed to execute redplanet"),
+            expect.stringContaining("No consent for redplanet"),
+        );
 		expect(window.launchpad).not.toBeCalled();
 	});
 
@@ -140,7 +146,13 @@ describe('init', () => {
 		isInAuOrNz.mockReturnValue(true);
 		onConsentChange.mockImplementation(CcpaWithConsentMock);
 		getConsentFor.mockReturnValue(true);
-		await expect(init()).rejects.toEqual('Redplanet should only run in Australia on AUS mode');
+        await init();
+        expect(log).toHaveBeenCalledWith(
+            'commercial',
+            expect.stringContaining("Failed to execute redplanet"),
+            expect.stringContaining("Redplanet should only run in Australia on AUS mode"),
+        );
+        expect(window.launchpad).not.toBeCalled();
 	});
 
 	it('should not initialise redplanet when launchpad conditions are false', async () => {


### PR DESCRIPTION
## What does this change?

Handle rejected promises coming from header bidding providers `prepare-prebid` and `redplanet`.

When a user rejects consent the promise rejection is unhandled and is reported on Sentry.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

**Before**

<img width="975" alt="Screenshot 2021-11-09 at 13 56 50" src="https://user-images.githubusercontent.com/7014230/140937166-7e2ead73-593b-41fc-89e0-f38dca05f917.png">

<img width="1179" alt="Screenshot 2021-11-09 at 14 12 04" src="https://user-images.githubusercontent.com/7014230/140939671-ae348dcf-3ac0-43c2-988d-90905d8c9905.png">


**After**

<img width="970" alt="Screenshot 2021-11-09 at 13 57 04" src="https://user-images.githubusercontent.com/7014230/140937239-05fcfdd1-83c3-48f4-853b-3e6d977a1908.png">

### Tested

- [x] Locally
- [ ] On CODE (optional)
