### PR TITLE
Fix GA tracking in `google.ts`

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/google.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/google.ts
@@ -43,11 +43,8 @@ const trackExternalLinkClick = (target: HTMLElement, tag: string): void => {
 	window.ga(send, 'event', 'click', 'external', tag, data);
 };
 
-const trackSponsorLogoLinkClick = (target: Record<string, unknown>): void => {
-	const sponsorName =
-		isObject(target.dataset) && isString(target.dataset.sponsor)
-			? target.dataset.sponsor
-			: null;
+const trackSponsorLogoLinkClick = (target: HTMLElement): void => {
+	const sponsorName = target.dataset.sponsor;
 
 	window.ga(send, 'event', 'click', 'sponsor logo', sponsorName, {
 		nonInteraction: true,

--- a/static/src/javascripts/projects/common/modules/analytics/google.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/google.ts
@@ -1,4 +1,3 @@
-import { isObject, isString } from '@guardian/libs';
 import { getCLS, getFID, getLCP } from 'web-vitals';
 import config from 'lib/config';
 import mediator from 'lib/mediator';


### PR DESCRIPTION
## What does this change?

Use the proper type: target is an `HTMLElement`.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Better tracking of sponsor logo clicks.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [X] Yes – since #24220, tracking of sponsor has been broken.

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
