### PR TITLE
Lazy load non-refreshable line items from an endpoint

### DIFF
--- a/commercial/app/AppLoader.scala
+++ b/commercial/app/AppLoader.scala
@@ -11,6 +11,7 @@ import commercial.model.merchandise.jobs.{Industries, JobsAgent}
 import commercial.model.merchandise.travel.TravelOffersAgent
 import common.CloudWatchMetricsLifecycle
 import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
+import common.dfp.DfpAgentLifecycle
 import conf.switches.SwitchboardLifecycle
 import conf.CachedHealthCheckLifeCycle
 import contentapi.{CapiHttpClient, ContentApiClient, HttpClient}
@@ -63,6 +64,7 @@ trait AppComponents extends FrontendComponents with CommercialControllers with C
   override lazy val lifecycleComponents = List(
     wire[LogstashLifecycle],
     wire[CommercialLifecycle],
+    wire[DfpAgentLifecycle],
     wire[SwitchboardLifecycle],
     wire[CloudWatchMetricsLifecycle],
     wire[CachedHealthCheckLifeCycle],

--- a/commercial/app/controllers/CommercialControllers.scala
+++ b/commercial/app/controllers/CommercialControllers.scala
@@ -36,5 +36,5 @@ trait CommercialControllers {
   lazy val prebidAnalyticsController = wire[PrebidAnalyticsController]
   lazy val passbackController = wire[PassbackController]
   lazy val ampIframeHtmlController = wire[AmpIframeHtmlController]
-  lazy val dfpNonRefreshableLineItemsController = wire[DfpNonRefreshableLineItemsController]
+  lazy val nonRefreshableLineItemsController = wire[nonRefreshableLineItemsController]
 }

--- a/commercial/app/controllers/CommercialControllers.scala
+++ b/commercial/app/controllers/CommercialControllers.scala
@@ -36,4 +36,5 @@ trait CommercialControllers {
   lazy val prebidAnalyticsController = wire[PrebidAnalyticsController]
   lazy val passbackController = wire[PassbackController]
   lazy val ampIframeHtmlController = wire[AmpIframeHtmlController]
+  lazy val dfpNonRefreshableLineItemsController = wire[DfpNonRefreshableLineItemsController]
 }

--- a/commercial/app/controllers/DfpNonRefreshableLineItemsController.scala
+++ b/commercial/app/controllers/DfpNonRefreshableLineItemsController.scala
@@ -1,0 +1,23 @@
+package commercial.controllers
+
+import common.JsonComponent
+import common.dfp.DfpAgent
+import model.Cached
+import play.api.libs.json.Json
+import play.api.mvc._
+
+import scala.concurrent.duration._
+
+class DfpNonRefreshableLineItemsController(val controllerComponents: ControllerComponents)
+    extends BaseController
+    with implicits.Requests {
+
+  def getIds: Action[AnyContent] =
+    Action { implicit request =>
+      val dfpNonRefreshableLineItems: Seq[Long] = DfpAgent.nonRefreshableLineItemIds()
+      val json = Json.toJson(dfpNonRefreshableLineItems)
+      Cached(15.minutes) {
+        JsonComponent(json)
+      }
+    }
+}

--- a/commercial/app/controllers/nonRefreshableLineItemsController.scala
+++ b/commercial/app/controllers/nonRefreshableLineItemsController.scala
@@ -8,14 +8,14 @@ import play.api.mvc._
 
 import scala.concurrent.duration._
 
-class DfpNonRefreshableLineItemsController(val controllerComponents: ControllerComponents)
+class nonRefreshableLineItemsController(val controllerComponents: ControllerComponents)
     extends BaseController
     with implicits.Requests {
 
   def getIds: Action[AnyContent] =
     Action { implicit request =>
-      val dfpNonRefreshableLineItems: Seq[Long] = DfpAgent.nonRefreshableLineItemIds()
-      val json = Json.toJson(dfpNonRefreshableLineItems)
+      val nonRefreshableLineItems: Seq[Long] = DfpAgent.nonRefreshableLineItemIds()
+      val json = Json.toJson(nonRefreshableLineItems)
       Cached(15.minutes) {
         JsonComponent(json)
       }

--- a/commercial/conf/routes
+++ b/commercial/conf/routes
@@ -56,3 +56,6 @@ GET         /commercial/ias-passback/:size                                  comm
 
 # AMP iframe HTML, needed for AMP (DCR repo)
 GET         /commercial/amp-iframe.html                                     commercial.controllers.AmpIframeHtmlController.renderAmpIframeHtml()
+
+# DFP Non refreshable line items
+GET         /commercial/dfp-non-refreshable-line-items.json                 commercial.controllers.DfpNonRefreshableLineItemsController.getIds

--- a/commercial/conf/routes
+++ b/commercial/conf/routes
@@ -58,4 +58,4 @@ GET         /commercial/ias-passback/:size                                  comm
 GET         /commercial/amp-iframe.html                                     commercial.controllers.AmpIframeHtmlController.renderAmpIframeHtml()
 
 # DFP Non refreshable line items
-GET         /commercial/dfp-non-refreshable-line-items.json                 commercial.controllers.DfpNonRefreshableLineItemsController.getIds
+GET         /commercial/non-refreshable-line-items.json                     commercial.controllers.nonRefreshableLineItemsController.getIds

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -8,6 +8,7 @@ object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
     LiveblogRendering,
     LiveblogPinnedBlock,
+    FetchNonRefreshableLineItems,
   )
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -29,4 +30,13 @@ object LiveblogPinnedBlock
       owners = Seq(Owner.withGithub("alinaboghiu")),
       sellByDate = LocalDate.of(2022, 1, 3),
       participationGroup = Perc0C,
+    )
+
+object FetchNonRefreshableLineItems
+    extends Experiment(
+      name = "fetch-non-refreshable-line-items",
+      description = "Fetch non-refreshable line items via a new endpoint",
+      owners = Seq(Owner.withGithub("chrislomaxjones")),
+      sellByDate = LocalDate.of(2022, 1, 24),
+      participationGroup = Perc0A,
     )

--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -45,7 +45,7 @@ object JavaScriptPage {
     // Only attach the non-refreshable line items to the commercial config
     // if not participating in the `FetchNonRefreshableLineItems` experiment
     val nonRefreshableConfig = if (!ActiveExperiments.isParticipating(FetchNonRefreshableLineItems)(request)) {
-      Map("dfpNonRefreshableLineItemIds" -> nonRefreshableLineItemIds)
+      Map("nonRefreshableLineItemIds" -> nonRefreshableLineItemIds)
     } else {
       Map()
     }

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -267,7 +267,7 @@ GET            /commercial/anx/anxresize.js                                     
 GET            /commercial/cmp/vendorlist.json                                            commercial.controllers.CmpDataController.renderVendorlist()
 GET            /commercial/cmp/shortvendorlist.json                                      commercial.controllers.CmpDataController.renderShortVendorlist()
 GET            /commercial/amp-iframe.html                                                                                       commercial.controllers.AmpIframeHtmlController.renderAmpIframeHtml()
-GET            /commercial/dfp-non-refreshable-line-items.json                                                                   commercial.controllers.DfpNonRefreshableLineItemsController.getIds
+GET            /commercial/non-refreshable-line-items.json                                                                       commercial.controllers.nonRefreshableLineItemsController.getIds
 
 
 GET            /ads.txt                                                                                                          commercial.controllers.AdsDotTextViewController.renderTextFile()

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -267,6 +267,8 @@ GET            /commercial/anx/anxresize.js                                     
 GET            /commercial/cmp/vendorlist.json                                            commercial.controllers.CmpDataController.renderVendorlist()
 GET            /commercial/cmp/shortvendorlist.json                                      commercial.controllers.CmpDataController.renderShortVendorlist()
 GET            /commercial/amp-iframe.html                                                                                       commercial.controllers.AmpIframeHtmlController.renderAmpIframeHtml()
+GET            /commercial/dfp-non-refreshable-line-items.json                                                                   commercial.controllers.DfpNonRefreshableLineItemsController.getIds
+
 
 GET            /ads.txt                                                                                                          commercial.controllers.AdsDotTextViewController.renderTextFile()
 GET            /app-ads.txt                                                                                                          commercial.controllers.AdsDotTextViewController.renderAppTextFile()

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -80,6 +80,7 @@ class Advert {
 		lazyWaitComplete: null,
 	};
 	hasPrebidSize = false;
+	lineItemId: number | null = null;
 
 	constructor(adSlotNode: HTMLElement) {
 		const sizes = getAdBreakpointSizes(adSlotNode);

--- a/static/src/javascripts/projects/commercial/modules/dfp/non-refreshable-line-items.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/non-refreshable-line-items.spec.ts
@@ -43,6 +43,24 @@ describe('nonRefreshableLineItems', () => {
 		expect(ids).toBeUndefined();
 	});
 
+	it('returns undefined when the API returns string array', async () => {
+		const response = {
+			ok: true,
+			json: () => Promise.resolve(['1', '2', '3']),
+		};
+
+		Object.defineProperty(window, 'fetch', {
+			value: jest.fn().mockReturnValue(Promise.resolve(response)),
+			writable: true,
+		});
+
+		const ids = await fetchNonRefreshableLineItemIds();
+
+		expect(reportErrorMock).not.toHaveBeenCalled();
+
+		expect(ids).toBeUndefined();
+	});
+
 	it('returns undefined and reports error when the API call fails', async () => {
 		const response = {
 			ok: false,

--- a/static/src/javascripts/projects/commercial/modules/dfp/non-refreshable-line-items.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/non-refreshable-line-items.spec.ts
@@ -1,0 +1,93 @@
+import reportErrorMock from 'lib/report-error';
+import {
+	fetchNonRefreshableLineItemIds,
+	memoizedFetchNonRefreshableLineItemIds,
+} from './non-refreshable-line-items';
+
+jest.mock('lib/report-error', () => jest.fn());
+
+describe('nonRefreshableLineItems', () => {
+	it('returns the same IDs as the API', async () => {
+		const response = {
+			ok: true,
+			json: () => Promise.resolve([1, 2, 3]),
+		};
+
+		Object.defineProperty(window, 'fetch', {
+			value: jest.fn().mockReturnValue(Promise.resolve(response)),
+			writable: true,
+		});
+
+		const ids = await fetchNonRefreshableLineItemIds();
+
+		expect(reportErrorMock).not.toHaveBeenCalled();
+
+		expect(ids).toEqual([1, 2, 3]);
+	});
+
+	it('returns undefined when the API returns a non-array', async () => {
+		const response = {
+			ok: true,
+			json: () => Promise.resolve({ foo: 'bar' }),
+		};
+
+		Object.defineProperty(window, 'fetch', {
+			value: jest.fn().mockReturnValue(Promise.resolve(response)),
+			writable: true,
+		});
+
+		const ids = await fetchNonRefreshableLineItemIds();
+
+		expect(reportErrorMock).not.toHaveBeenCalled();
+
+		expect(ids).toBeUndefined();
+	});
+
+	it('returns undefined and reports error when the API call fails', async () => {
+		const response = {
+			ok: false,
+			status: 404,
+		};
+
+		Object.defineProperty(window, 'fetch', {
+			value: jest.fn().mockReturnValue(Promise.resolve(response)),
+			writable: true,
+		});
+
+		const ids = await fetchNonRefreshableLineItemIds();
+
+		expect(reportErrorMock).toHaveBeenCalledWith(
+			new Error('Failed to fetch non-refreshable line items'),
+			{
+				feature: 'commercial',
+				status: 404,
+			},
+			false,
+		);
+
+		expect(ids).toBeUndefined();
+	});
+});
+
+describe('memoizedFetchNonRefreshableLineItemIds', () => {
+	it('should only call fetch once', async () => {
+		const response = {
+			ok: true,
+			json: () => Promise.resolve([1, 2, 3]),
+		};
+
+		Object.defineProperty(window, 'fetch', {
+			value: jest.fn().mockReturnValue(Promise.resolve(response)),
+			writable: true,
+		});
+
+		const ids = await memoizedFetchNonRefreshableLineItemIds();
+		const ids2 = await memoizedFetchNonRefreshableLineItemIds();
+		const ids3 = await memoizedFetchNonRefreshableLineItemIds();
+
+		expect(ids).toEqual([1, 2, 3]);
+		expect(ids2).toEqual([1, 2, 3]);
+		expect(ids3).toEqual([1, 2, 3]);
+		expect(window.fetch).toHaveBeenCalledTimes(1);
+	});
+});

--- a/static/src/javascripts/projects/commercial/modules/dfp/non-refreshable-line-items.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/non-refreshable-line-items.spec.ts
@@ -25,7 +25,7 @@ describe('nonRefreshableLineItems', () => {
 		expect(ids).toEqual([1, 2, 3]);
 	});
 
-	it('returns undefined when the API returns a non-array', async () => {
+	it('throws error when the API returns a non-array', async () => {
 		const response = {
 			ok: true,
 			json: () => Promise.resolve({ foo: 'bar' }),
@@ -36,11 +36,11 @@ describe('nonRefreshableLineItems', () => {
 			writable: true,
 		});
 
-		const ids = await fetchNonRefreshableLineItemIds();
+		await expect(fetchNonRefreshableLineItemIds()).rejects.toThrow(
+			'Failed to parse non-refreshable line items as an array',
+		);
 
 		expect(reportErrorMock).not.toHaveBeenCalled();
-
-		expect(ids).toBeUndefined();
 	});
 
 	it('returns undefined when the API returns string array', async () => {
@@ -54,11 +54,11 @@ describe('nonRefreshableLineItems', () => {
 			writable: true,
 		});
 
-		const ids = await fetchNonRefreshableLineItemIds();
+		await expect(fetchNonRefreshableLineItemIds()).rejects.toThrow(
+			'Failed to parse element in non-refreshable line item array as number',
+		);
 
 		expect(reportErrorMock).not.toHaveBeenCalled();
-
-		expect(ids).toBeUndefined();
 	});
 
 	it('returns undefined and reports error when the API call fails', async () => {
@@ -72,7 +72,9 @@ describe('nonRefreshableLineItems', () => {
 			writable: true,
 		});
 
-		const ids = await fetchNonRefreshableLineItemIds();
+		await expect(fetchNonRefreshableLineItemIds()).rejects.toThrow(
+			'Failed to fetch non-refreshable line items',
+		);
 
 		expect(reportErrorMock).toHaveBeenCalledWith(
 			new Error('Failed to fetch non-refreshable line items'),
@@ -82,8 +84,6 @@ describe('nonRefreshableLineItems', () => {
 			},
 			false,
 		);
-
-		expect(ids).toBeUndefined();
 	});
 });
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/non-refreshable-line-items.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/non-refreshable-line-items.ts
@@ -1,0 +1,31 @@
+import { memoize } from 'lodash-es';
+import reportError from 'lib/report-error';
+
+export const fetchNonRefreshableLineItemIds = async (): Promise<
+	number[] | undefined
+> => {
+	const response = await window.fetch(
+		'/commercial/dfp-non-refreshable-line-items.json',
+	);
+	if (response.ok) {
+		const json: unknown = await response.json();
+		if (Array.isArray(json)) {
+			return json.map((x) => Number(x));
+		}
+	} else {
+		// Report an error to Sentry if we don't get an ok response
+		reportError(
+			new Error('Failed to fetch non-refreshable line items'),
+			{
+				feature: 'commercial',
+				status: response.status,
+			},
+			false,
+		);
+	}
+	return undefined;
+};
+
+export const memoizedFetchNonRefreshableLineItemIds = memoize(
+	fetchNonRefreshableLineItemIds,
+);

--- a/static/src/javascripts/projects/commercial/modules/dfp/non-refreshable-line-items.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/non-refreshable-line-items.ts
@@ -6,7 +6,7 @@ export const fetchNonRefreshableLineItemIds = async (): Promise<
 	number[] | undefined
 > => {
 	const response = await window.fetch(
-		'/commercial/dfp-non-refreshable-line-items.json',
+		'/commercial/non-refreshable-line-items.json',
 	);
 	if (response.ok) {
 		const json: unknown = await response.json();

--- a/static/src/javascripts/projects/commercial/modules/dfp/non-refreshable-line-items.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/non-refreshable-line-items.ts
@@ -1,3 +1,4 @@
+//import { isUndefined } from '@guardian/libs';
 import { memoize } from 'lodash-es';
 import reportError from 'lib/report-error';
 
@@ -10,7 +11,14 @@ export const fetchNonRefreshableLineItemIds = async (): Promise<
 	if (response.ok) {
 		const json: unknown = await response.json();
 		if (Array.isArray(json)) {
-			return json.map((x) => Number(x));
+			// Return undefined if any of the elements in the array are not numbers
+			return json.reduce<number[] | undefined>(
+				(accum, lineItemId) =>
+					accum !== undefined && typeof lineItemId === 'number'
+						? [...accum, lineItemId]
+						: undefined,
+				[],
+			);
 		}
 	} else {
 		// Report an error to Sentry if we don't get an ok response

--- a/static/src/javascripts/projects/commercial/modules/dfp/non-refreshable-line-items.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/non-refreshable-line-items.ts
@@ -1,37 +1,49 @@
-//import { isUndefined } from '@guardian/libs';
 import { memoize } from 'lodash-es';
 import reportError from 'lib/report-error';
 
-export const fetchNonRefreshableLineItemIds = async (): Promise<
-	number[] | undefined
-> => {
+export const fetchNonRefreshableLineItemIds = async (): Promise<number[]> => {
 	const response = await window.fetch(
 		'/commercial/non-refreshable-line-items.json',
 	);
+
 	if (response.ok) {
 		const json: unknown = await response.json();
-		if (Array.isArray(json)) {
-			// Return undefined if any of the elements in the array are not numbers
-			return json.reduce<number[] | undefined>(
-				(accum, lineItemId) =>
-					accum !== undefined && typeof lineItemId === 'number'
-						? [...accum, lineItemId]
-						: undefined,
-				[],
+		if (!Array.isArray(json)) {
+			throw Error(
+				'Failed to parse non-refreshable line items as an array',
 			);
 		}
-	} else {
-		// Report an error to Sentry if we don't get an ok response
-		reportError(
-			new Error('Failed to fetch non-refreshable line items'),
-			{
-				feature: 'commercial',
-				status: response.status,
-			},
-			false,
+
+		// Throw an error if any of the elements in the array are not numbers
+		const lineItemsOrError = json.reduce<{ lineItems: number[] } | Error>(
+			(accum, lineItemId) =>
+				!(accum instanceof Error) && typeof lineItemId === 'number'
+					? { lineItems: [...accum.lineItems, lineItemId] }
+					: Error(
+							'Failed to parse element in non-refreshable line item array as number',
+					  ),
+			{ lineItems: [] },
 		);
+
+		if (lineItemsOrError instanceof Error) {
+			throw lineItemsOrError;
+		}
+
+		return lineItemsOrError.lineItems;
 	}
-	return undefined;
+
+	// Report an error to Sentry if we don't get an ok response
+	// Note that in other cases (JSON parsing failure) we throw but don't report the error
+	const error = Error('Failed to fetch non-refreshable line items');
+	reportError(
+		error,
+		{
+			feature: 'commercial',
+			status: response.status,
+		},
+		false,
+	);
+	throw error;
 };
 
 export const memoizedFetchNonRefreshableLineItemIds = memoize(

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.ts
@@ -82,6 +82,7 @@ export const onSlotRender = (
 			advert.shouldRefresh = shouldRefresh(
 				advert,
 				window.guardian.config.page.dfpNonRefreshableLineItemIds,
+				event.lineItemId ?? undefined,
 			);
 		} else {
 			// Otherwise associate the line item id with the advert

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.ts
@@ -74,14 +74,14 @@ export const onSlotRender = (
 			dfpEnv.creativeIDs.push(String(event.creativeId));
 		}
 
-		// Check if the dfp non-refreshable line items are attached to the page config
+		// Check if the non-refreshable line items are attached to the page config
 		// If they are then use these values to determine slot refresh at this point
 		// Otherwise wait until slot is viewable to fetch line item ids from endpoint
-		if (window.guardian.config.page.dfpNonRefreshableLineItemIds) {
+		if (window.guardian.config.page.nonRefreshableLineItemIds) {
 			// Set refresh field based on the outcome of the slot render.
 			advert.shouldRefresh = shouldRefresh(
 				advert,
-				window.guardian.config.page.dfpNonRefreshableLineItemIds,
+				window.guardian.config.page.nonRefreshableLineItemIds,
 				event.lineItemId ?? undefined,
 			);
 		} else {

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.ts
@@ -16,7 +16,7 @@ const setSlotAdRefresh = (
 
 	// Asynchronously retrieve the non-refreshable line item ids
 	// Only do this if they haven't been attached to the page config
-	if (!window.guardian.config.page.dfpNonRefreshableLineItemIds) {
+	if (!window.guardian.config.page.nonRefreshableLineItemIds) {
 		// Call the memoized function so we only retrieve the value from the API once
 		void memoizedFetchNonRefreshableLineItemIds().then(
 			(nonRefreshableLineItemIds) => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.ts
@@ -1,53 +1,8 @@
-import type { AdSizeString } from '@guardian/commercial-core';
-import { adSizes } from '@guardian/commercial-core';
-import config from 'lib/config';
 import { getUrlVars } from '../../../../lib/url';
-import type { Advert } from './Advert';
 import { getAdvertById } from './get-advert-by-id';
 import { enableLazyLoad } from './lazy-load';
 import { memoizedFetchNonRefreshableLineItemIds } from './non-refreshable-line-items';
-
-const outstreamSizes = [
-	adSizes.outstreamDesktop.toString(),
-	adSizes.outstreamMobile.toString(),
-	adSizes.outstreamGoogleDesktop.toString(),
-];
-
-/**
- * Determine whether an advert should refresh, taking into account
- * its size, whether there's a pageskin or whether the advert's
- * line item is marked as non-refreshable
- *
- *  - Fluid ads should not refresh
- *  - Outstream ads should not refresh
- *  - Pageskins should not refresh
- *  - Ads that have line items marked as non-refreshable should not be
- * 	  refreshed. This information is retrieved via the DFP non refreshable
- * 	  line item API endpoint
- *
- * @param advert The candidate advert to check
- * @param nonRefreshableLineItemIds The array of line item ids for which
- * adverts should not refresh
- */
-const shouldRefresh = (
-	advert: Advert,
-	nonRefreshableLineItemIds: number[] = [],
-): boolean => {
-	const sizeString = advert.size?.toString();
-	const isNotFluid = sizeString !== '0,0';
-	const isOutstream =
-		sizeString && outstreamSizes.includes(sizeString as AdSizeString);
-	const isNonRefreshableLineItem =
-		advert.lineItemId &&
-		nonRefreshableLineItemIds.includes(advert.lineItemId);
-
-	return (
-		isNotFluid &&
-		!isOutstream &&
-		!config.get('page.hasPageSkin') &&
-		!isNonRefreshableLineItem
-	);
-};
+import { shouldRefresh } from './should-refresh';
 
 const setSlotAdRefresh = (
 	event: googletag.events.ImpressionViewableEvent,

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.ts
@@ -16,7 +16,11 @@ const setSlotAdRefresh = (
 
 	// Asynchronously retrieve the non-refreshable line item ids
 	// Only do this if they haven't been attached to the page config
-	if (!window.guardian.config.page.nonRefreshableLineItemIds) {
+	const { tests, page } = window.guardian.config;
+	if (
+		tests?.fetchNonRefreshableLineItemsVariant === 'variant' &&
+		!page.nonRefreshableLineItemIds
+	) {
 		// Call the memoized function so we only retrieve the value from the API once
 		void memoizedFetchNonRefreshableLineItemIds().then(
 			(nonRefreshableLineItemIds) => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.ts
@@ -1,38 +1,103 @@
+import type { AdSizeString } from '@guardian/commercial-core';
+import { adSizes } from '@guardian/commercial-core';
+import config from 'lib/config';
 import { getUrlVars } from '../../../../lib/url';
+import type { Advert } from './Advert';
 import { getAdvertById } from './get-advert-by-id';
 import { enableLazyLoad } from './lazy-load';
+import { memoizedFetchNonRefreshableLineItemIds } from './non-refreshable-line-items';
 
-const setSlotAdRefresh = (event: googletag.events.Event): void => {
+const outstreamSizes = [
+	adSizes.outstreamDesktop.toString(),
+	adSizes.outstreamMobile.toString(),
+	adSizes.outstreamGoogleDesktop.toString(),
+];
+
+/**
+ * Determine whether an advert should refresh, taking into account
+ * its size, whether there's a pageskin or whether the advert's
+ * line item is marked as non-refreshable
+ *
+ *  - Fluid ads should not refresh
+ *  - Outstream ads should not refresh
+ *  - Pageskins should not refresh
+ *  - Ads that have line items marked as non-refreshable should not be
+ * 	  refreshed. This information is retrieved via the DFP non refreshable
+ * 	  line item API endpoint
+ *
+ * @param advert The candidate advert to check
+ * @param nonRefreshableLineItemIds The array of line item ids for which
+ * adverts should not refresh
+ */
+const shouldRefresh = (
+	advert: Advert,
+	nonRefreshableLineItemIds: number[] = [],
+): boolean => {
+	const sizeString = advert.size?.toString();
+	const isNotFluid = sizeString !== '0,0';
+	const isOutstream =
+		sizeString && outstreamSizes.includes(sizeString as AdSizeString);
+	const isNonRefreshableLineItem =
+		advert.lineItemId &&
+		nonRefreshableLineItemIds.includes(advert.lineItemId);
+
+	return (
+		isNotFluid &&
+		!isOutstream &&
+		!config.get('page.hasPageSkin') &&
+		!isNonRefreshableLineItem
+	);
+};
+
+const setSlotAdRefresh = (
+	event: googletag.events.ImpressionViewableEvent,
+): void => {
 	const advert = getAdvertById(event.slot.getSlotElementId());
 	const viewabilityThresholdMs = 30000; // 30 seconds refresh
 
-	if (advert?.shouldRefresh) {
-		const onDocumentVisible = () => {
-			if (!document.hidden) {
-				document.removeEventListener(
-					'visibilitychange',
-					onDocumentVisible,
-				);
-				enableLazyLoad(advert);
-			}
-		};
-
-		setTimeout(() => {
-			// During the elapsed time, a 'disable-refresh' message may have been posted.
-			// Check the flag again.
-			if (!advert.shouldRefresh) {
-				return;
-			}
-			if (document.hidden) {
-				document.addEventListener(
-					'visibilitychange',
-					onDocumentVisible,
-				);
-			} else {
-				enableLazyLoad(advert);
-			}
-		}, viewabilityThresholdMs);
+	if (!advert) {
+		return;
 	}
+
+	// Asynchronously retrieve the non-refreshable line item ids
+	// Only do this if they haven't been attached to the page config
+	if (!window.guardian.config.page.dfpNonRefreshableLineItemIds) {
+		// Call the memoized function so we only retrieve the value from the API once
+		void memoizedFetchNonRefreshableLineItemIds().then(
+			(nonRefreshableLineItemIds) => {
+				// Determine whether ad should refresh
+				// This value will then be checked when the timer has elapsed and
+				// we want to know whether to refresh
+				advert.shouldRefresh = shouldRefresh(
+					advert,
+					nonRefreshableLineItemIds,
+				);
+			},
+		);
+	}
+
+	// Event listener that will load an advert once a document becomes visible
+	const onDocumentVisible = () => {
+		if (!document.hidden) {
+			document.removeEventListener('visibilitychange', onDocumentVisible);
+			enableLazyLoad(advert);
+		}
+	};
+
+	setTimeout(() => {
+		// During the elapsed time, a 'disable-refresh' message may have been posted.
+		// Check the flag again.
+		if (!advert.shouldRefresh) {
+			return;
+		}
+		// If the document is hidden don't refresh immediately
+		// Instead add an event listener to refresh when document becomes visible again
+		if (document.hidden) {
+			document.addEventListener('visibilitychange', onDocumentVisible);
+		} else {
+			enableLazyLoad(advert);
+		}
+	}, viewabilityThresholdMs);
 };
 
 /*

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.ts
@@ -1,3 +1,4 @@
+import { log } from '@guardian/libs';
 import { getUrlVars } from '../../../../lib/url';
 import { getAdvertById } from './get-advert-by-id';
 import { enableLazyLoad } from './lazy-load';
@@ -22,8 +23,8 @@ const setSlotAdRefresh = (
 		!page.nonRefreshableLineItemIds
 	) {
 		// Call the memoized function so we only retrieve the value from the API once
-		void memoizedFetchNonRefreshableLineItemIds().then(
-			(nonRefreshableLineItemIds) => {
+		void memoizedFetchNonRefreshableLineItemIds()
+			.then((nonRefreshableLineItemIds) => {
 				// Determine whether ad should refresh
 				// This value will then be checked when the timer has elapsed and
 				// we want to know whether to refresh
@@ -31,8 +32,14 @@ const setSlotAdRefresh = (
 					advert,
 					nonRefreshableLineItemIds,
 				);
-			},
-		);
+			})
+			.catch((error) => {
+				log(
+					'commercial',
+					'⚠️ Error fetching non-refreshable line items',
+					error,
+				);
+			});
 	}
 
 	// Event listener that will load an advert once a document becomes visible

--- a/static/src/javascripts/projects/commercial/modules/dfp/should-refresh.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/should-refresh.ts
@@ -18,7 +18,7 @@ const outstreamSizes = [
  *  - Outstream ads should not refresh
  *  - Pageskins should not refresh
  *  - Ads that have line items marked as non-refreshable should not be
- * 	  refreshed. This information is retrieved via the DFP non refreshable
+ * 	  refreshed. This information is retrieved via the non refreshable
  * 	  line item API endpoint
  *
  * @param advert The candidate advert to check

--- a/static/src/javascripts/projects/commercial/modules/dfp/should-refresh.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/should-refresh.ts
@@ -1,0 +1,46 @@
+import type { AdSizeString } from '@guardian/commercial-core';
+import { adSizes } from '@guardian/commercial-core';
+import config from '../../../../lib/config';
+import type { Advert } from './Advert';
+
+const outstreamSizes = [
+	adSizes.outstreamDesktop.toString(),
+	adSizes.outstreamMobile.toString(),
+	adSizes.outstreamGoogleDesktop.toString(),
+];
+
+/**
+ * Determine whether an advert should refresh, taking into account
+ * its size, whether there's a pageskin or whether the advert's
+ * line item is marked as non-refreshable
+ *
+ *  - Fluid ads should not refresh
+ *  - Outstream ads should not refresh
+ *  - Pageskins should not refresh
+ *  - Ads that have line items marked as non-refreshable should not be
+ * 	  refreshed. This information is retrieved via the DFP non refreshable
+ * 	  line item API endpoint
+ *
+ * @param advert The candidate advert to check
+ * @param nonRefreshableLineItemIds The array of line item ids for which
+ * adverts should not refresh
+ */
+export const shouldRefresh = (
+	advert: Advert,
+	nonRefreshableLineItemIds: number[] = [],
+): boolean => {
+	const sizeString = advert.size?.toString();
+	const isNotFluid = sizeString !== '0,0';
+	const isOutstream =
+		sizeString && outstreamSizes.includes(sizeString as AdSizeString);
+	const isNonRefreshableLineItem =
+		advert.lineItemId &&
+		nonRefreshableLineItemIds.includes(advert.lineItemId);
+
+	return (
+		isNotFluid &&
+		!isOutstream &&
+		!config.get('page.hasPageSkin') &&
+		!isNonRefreshableLineItem
+	);
+};

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -85,7 +85,7 @@ interface PageConfig extends CommercialPageConfig {
 	hasPageSkin: boolean; //https://github.com/guardian/frontend/blob/b952f6b9/common/app/views/support/JavaScriptPage.scala#L48
 	assetsPath: string;
 	frontendAssetsFullURL?: string; // only in DCR
-	dfpNonRefreshableLineItemIds?: number[];
+	nonRefreshableLineItemIds?: number[];
 	section: string;
 	isPaidContent: boolean;
 	isSensitive: boolean;

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -219,8 +219,6 @@
   "../projects/commercial/modules/messenger/post-message.ts"
  ],
  "../projects/commercial/modules/dfp/on-slot-render.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/config.d.ts",
   "../lib/mediator.ts",
@@ -228,17 +226,15 @@
   "../projects/commercial/modules/dfp/dfp-env.ts",
   "../projects/commercial/modules/dfp/empty-advert.ts",
   "../projects/commercial/modules/dfp/get-advert-by-id.ts",
-  "../projects/commercial/modules/dfp/render-advert.ts"
+  "../projects/commercial/modules/dfp/render-advert.ts",
+  "../projects/commercial/modules/dfp/should-refresh.ts"
  ],
  "../projects/commercial/modules/dfp/on-slot-viewable.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../lib/config.d.ts",
   "../lib/url.ts",
-  "../projects/commercial/modules/dfp/Advert.ts",
   "../projects/commercial/modules/dfp/get-advert-by-id.ts",
   "../projects/commercial/modules/dfp/lazy-load.ts",
-  "../projects/commercial/modules/dfp/non-refreshable-line-items.ts"
+  "../projects/commercial/modules/dfp/non-refreshable-line-items.ts",
+  "../projects/commercial/modules/dfp/should-refresh.ts"
  ],
  "../projects/commercial/modules/dfp/on-slot-visibility-changed.js": [
   "../../../../node_modules/@guardian/libs/dist/cjs/index.js",
@@ -333,6 +329,12 @@
   "../projects/commercial/modules/dfp/get-ad-iframe.ts",
   "../projects/commercial/modules/dfp/render-advert-label.ts",
   "../projects/commercial/modules/sticky-mpu.js"
+ ],
+ "../projects/commercial/modules/dfp/should-refresh.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../lib/config.d.ts",
+  "../projects/commercial/modules/dfp/Advert.ts"
  ],
  "../projects/commercial/modules/dfp/track-ad-render.ts": [
   "../projects/commercial/modules/dfp/wait-for-advert.ts"

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -10,7 +10,9 @@
   "../lib/report-error.js"
  ],
  "../lib/detect-google-proxy.ts": [],
- "../lib/detect-viewport.ts": [],
+ "../lib/detect-viewport.ts": [
+  "../../../../node_modules/@guardian/source-foundations/dist/index.d.ts"
+ ],
  "../lib/detect.js": [
   "../lib/config.js",
   "../lib/mediator.ts"
@@ -227,6 +229,7 @@
   "../projects/commercial/modules/dfp/should-refresh.ts"
  ],
  "../projects/commercial/modules/dfp/on-slot-viewable.ts": [
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/url.ts",
   "../projects/commercial/modules/dfp/get-advert-by-id.ts",
   "../projects/commercial/modules/dfp/lazy-load.ts",

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -10,9 +10,7 @@
   "../lib/report-error.js"
  ],
  "../lib/detect-google-proxy.ts": [],
- "../lib/detect-viewport.ts": [
-  "../../../../node_modules/@guardian/source-foundations/dist/index.d.ts"
- ],
+ "../lib/detect-viewport.ts": [],
  "../lib/detect.js": [
   "../lib/config.js",
   "../lib/mediator.ts"
@@ -220,7 +218,6 @@
  ],
  "../projects/commercial/modules/dfp/on-slot-render.ts": [
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../lib/config.d.ts",
   "../lib/mediator.ts",
   "../lib/report-error.js",
   "../projects/commercial/modules/dfp/dfp-env.ts",

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -210,6 +210,10 @@
   "../projects/commercial/modules/header-bidding/prebid/prebid.ts",
   "../projects/commercial/modules/header-bidding/utils.ts"
  ],
+ "../projects/commercial/modules/dfp/non-refreshable-line-items.ts": [
+  "../../../../node_modules/@types/lodash-es/index.d.ts",
+  "../lib/report-error.js"
+ ],
  "../projects/commercial/modules/dfp/on-slot-load.ts": [
   "../projects/commercial/modules/dfp/get-advert-by-id.ts",
   "../projects/commercial/modules/messenger/post-message.ts"
@@ -227,9 +231,14 @@
   "../projects/commercial/modules/dfp/render-advert.ts"
  ],
  "../projects/commercial/modules/dfp/on-slot-viewable.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../lib/config.d.ts",
   "../lib/url.ts",
+  "../projects/commercial/modules/dfp/Advert.ts",
   "../projects/commercial/modules/dfp/get-advert-by-id.ts",
-  "../projects/commercial/modules/dfp/lazy-load.ts"
+  "../projects/commercial/modules/dfp/lazy-load.ts",
+  "../projects/commercial/modules/dfp/non-refreshable-line-items.ts"
  ],
  "../projects/commercial/modules/dfp/on-slot-visibility-changed.js": [
   "../../../../node_modules/@guardian/libs/dist/cjs/index.js",


### PR DESCRIPTION
## What does this change?

This PR adds an additional method by which a slot determines if it should refresh (i.e. after 30 seconds should we replace it with another ad?). This method is introduced by way of a **0% server-side test** so that it can be rolled out to increasing percentages of the audience, with the existing method still in place.

Instead of including the array of non-refreshable line items in the commercial config included with each page it's served from the commercial Play app via a cacheable API endpoint that returns the array as JSON.

Instead of checking whether an ad is refreshable at the point a slot renders the client now checks when at the point each slot is viewable. This check is done asynchronously using a memoized fetch from the new endpoint (so we only make a network request once regardless of the number of ads that become viewable on the page) and the result is used 30 seconds later when the check is used to decide whether or not to refresh.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Line items are denoted as non-refreshable if they are set to the sponsorship type in Google Ad Manager*. Since this information isn't available when slots are filled on the page it is necessary to maintain an array of the non-refreshable line item IDs and deliver it to the page so each slot can check whether its ID is part of the array, and not refresh if so.

Prior to this change the array of non-refreshable line items was placed in the commercial page config on each page. The list currently weighs in at around 20KB and this is delivered to each viewer on the page.

This change removes the array from the page config (shaving ~20KB off the payload of each page) and instead makes the non-refreshable line items available via an endpoint in the commercial app. Since we don't require knowing which line items refresh until they are at the point of refreshing (currently set as 30 seconds), we can delay fetching this endpoint until later in the commercial code. This should have the benefit of speeding up the initial page delivery by allowing us to delay fetching the line items until they are required later.

(* Note we filter some sponsorship-type line items because they are auto-generated for use with Prebid)

### Tested

- [X] Locally
- [x] On CODE (optional)

### Todo

- [x] Put behind a switch / 0% server side experiment
- [x] Capture errors fetching from the API in Sentry
- [ ] Check `disable-refresh` messages are properly handled (and that these messages are still used in the first place)
- [ ] Review the available caching strategies
