### PR TITLE
Send sectionId in epic targeting payload

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -115,7 +115,7 @@ const buildEpicPayload = async () => {
 
 	const targeting = {
 		contentType: page.contentType,
-		sectionName: page.section,
+		sectionId: page.section,
 		shouldHideReaderRevenue: page.shouldHideReaderRevenue,
 		isMinuteArticle: config.hasTone('Minute'),
 		isPaidContent: page.isPaidContent,


### PR DESCRIPTION
Currently frontend sends the `sectionName` in the epic targeting payload to SDC.
It's actually sending the section ID in this field! And this is ok, because we want to use section ID.
This PR just updates the field name to match what SDC now expects.

For a time SDC will support both fields:
https://github.com/guardian/support-dotcom-components/pull/559