### PR TITLE
Enables more contents blocks

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -24,6 +24,8 @@ object ArticlePageChecks {
       "https://interactive.guim.co.uk/page-enhancers/super-lists/boot.js", // broken on frontend anyway
       "https://gdn-cdn.s3.amazonaws.com/quiz-builder/", // old quiz builder quizzes work fine
       "https://uploads.guim.co.uk/2019/03/20/boot.js", //creates a contents section component
+      "https://uploads.guim.co.uk/2019/12/11/boot.js", //another variant of the contents block
+      "https://interactive.guim.co.uk/page-enhancers/nav/boot.js", //another variant of the contents block
     )
 
     def unsupportedElement(blockElement: BlockElement) =


### PR DESCRIPTION
## What does this change?
Once https://github.com/guardian/dotcom-rendering/pull/3631 is merged, we can then serve more of these contents blocks via DCR
