### PR TITLE
Extend prebid switch until 2021-11-29

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -30,7 +30,7 @@ trait ABTestSwitches {
     "Vary length of prebid timeout",
     owners = Seq(Owner.withGithub("chrislomaxjones")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2021, 11, 15)),
+    sellByDate = Some(LocalDate.of(2021, 11, 29)),
     exposeClientSide = true,
   )
 }


### PR DESCRIPTION
## What does this change?

Extend the switch for the Prebid test for another 14 days. 

Although the test is complete and we have the required volume of data we'll leave in place and switch off until any followups are determined.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Allow tests to pass in CI.

### Tested

- [ ] Locally
- [ ] On CODE (optional)