### PR TITLE
Integrate Criteo as new Prebid SSP

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -501,6 +501,16 @@ trait PrebidSwitches {
     exposeClientSide = true,
   )
 
+  val prebidCriteo: Switch = Switch(
+    group = CommercialPrebid,
+    name = "prebid-criteo",
+    description = "Include Criteo adapter in Prebid auctions",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
+
   val mobileStickyLeaderboard: Switch = Switch(
     group = Commercial,
     name = "mobile-sticky-leaderboard",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "object-fit-videos": "^1.0.3",
     "ophan-tracker-js": "1.3.28",
     "preact": "^10.5.13",
-    "prebid.js": "https://github.com/guardian/Prebid.js#6862a86",
+    "prebid.js": "https://github.com/guardian/Prebid.js#25374fa9",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.ts
@@ -422,6 +422,14 @@ const adYouLikeBidder: PrebidBidder = {
 	},
 };
 
+const criteoBidder: PrebidBidder = {
+	name: 'criteo',
+	switchName: 'prebidCriteo',
+	bidParams: () => ({
+		networkId: 337,
+	}),
+};
+
 // There's an IX bidder for every size that the slot can take
 const indexExchangeBidders = (
 	slotSizes: HeaderBiddingSize[],
@@ -449,6 +457,8 @@ const biddersSwitchedOn = (allBidders: PrebidBidder[]): PrebidBidder[] => {
 
 const currentBidders = (slotSizes: HeaderBiddingSize[]): PrebidBidder[] => {
 	const otherBidders: PrebidBidder[] = [
+		// Currently only include Criteo if explicitly using pbtest query parameter
+		...(inPbTestOr(false) ? [criteoBidder] : []),
 		...(inPbTestOr(shouldIncludeSonobi()) ? [sonobiBidder] : []),
 		...(inPbTestOr(shouldIncludeTrustX()) ? [trustXBidder] : []),
 		...(inPbTestOr(shouldIncludeTripleLift()) ? [tripleLiftBidder] : []),

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/types.d.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/types.d.ts
@@ -86,6 +86,7 @@ type BidderCode =
 	| 'adyoulike'
 	| 'and'
 	| 'appnexus'
+	| 'criteo'
 	| 'improvedigital'
 	| 'ix'
 	| 'oxd'
@@ -94,22 +95,21 @@ type BidderCode =
 	| 'sonobi'
 	| 'triplelift'
 	| 'trustx'
-	| 'xhb'
-	| 'criteo';
+	| 'xhb';
 
 type PrebidParams =
-	| PrebidSonobiParams
-	| PrebidIndexExchangeParams
-	| PrebidTrustXParams
-	| PrebidTripleLiftParams
-	| PrebidImproveParams
-	| PrebidXaxisParams
+	| PrebidAdYouLikeParams
 	| PrebidAppNexusParams
+	| PrebidCriteoParams
+	| PrebidImproveParams
+	| PrebidIndexExchangeParams
 	| PrebidOpenXParams
 	| PrebidOzoneParams
-	| PrebidAdYouLikeParams
 	| PrebidPubmaticParams
-	| PrebidCriteoParams;
+	| PrebidSonobiParams
+	| PrebidTripleLiftParams
+	| PrebidTrustXParams
+	| PrebidXaxisParams;
 
 type PrebidBidder = {
 	name: BidderCode;

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/types.d.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/types.d.ts
@@ -78,6 +78,10 @@ type PrebidAdYouLikeParams = {
 	placement: string;
 };
 
+type PrebidCriteoParams = {
+	networkId: number;
+};
+
 type BidderCode =
 	| 'adyoulike'
 	| 'and'
@@ -90,7 +94,8 @@ type BidderCode =
 	| 'sonobi'
 	| 'triplelift'
 	| 'trustx'
-	| 'xhb';
+	| 'xhb'
+	| 'criteo';
 
 type PrebidParams =
 	| PrebidSonobiParams
@@ -103,7 +108,8 @@ type PrebidParams =
 	| PrebidOpenXParams
 	| PrebidOzoneParams
 	| PrebidAdYouLikeParams
-	| PrebidPubmaticParams;
+	| PrebidPubmaticParams
+	| PrebidCriteoParams;
 
 type PrebidBidder = {
 	name: BidderCode;

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -506,7 +506,6 @@
  ],
  "../projects/common/modules/analytics/forceSendMetrics.ts": [],
  "../projects/common/modules/analytics/google.ts": [
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../../../../node_modules/web-vitals/dist/modules/index.d.ts",
   "../lib/config.d.ts",
   "../lib/mediator.js"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10325,9 +10325,9 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.15.tgz#6df94d8afecf3f9e10a742fd8c362ddab464225f"
   integrity sha512-5chK29n6QcJc3m1lVrKQSQ+V7K1Gb8HeQY6FViQ5AxCAEGu3DaHffWNDkC9+miZgsLvbvU9rxbV1qinGHMHzqA==
 
-"prebid.js@https://github.com/guardian/Prebid.js#6862a86":
+"prebid.js@https://github.com/guardian/Prebid.js#25374fa9":
   version "5.20.0"
-  resolved "https://github.com/guardian/Prebid.js#6862a86f5b7e0a5c8fb8a101bb70a64ff9c66978"
+  resolved "https://github.com/guardian/Prebid.js#25374fa9fb264f6a81bb490335e16ab6bdc943e6"
   dependencies:
     "@guardian/libs" "^3.1.0"
     babel-plugin-transform-object-assign "^6.22.0"


### PR DESCRIPTION
## What does this change?

This PR adds Criteo as a new Prebid bidder, gated by a switch so that we can enable/disable their participation in auctions.

As this is a new Prebid adapter we also bump the build of Prebid.js we're using to the one that includes the Criteo in the list of modules (see the corresponding PR in [@guardian/Prebid.js](https://github.com/guardian/Prebid.js/pull/123)).

Initially we only allow Criteo to participate if the `?pbtest=criteo` query parameter is provided with URLs. This is so we can provide test pages in production of auctions involving the new bidder without rolling out to the full audience.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

<!-- ## Screenshots

Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

This will allow us to provide URLs of the form `https://theguardian.com/uk?pbtest=criteo` in order to test a new Prebid bidder without rolling out to all users of the website.

### Tested

- [X] Locally
- [x] On CODE (optional)
