### PR TITLE
Add Criteo AB test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -33,4 +33,14 @@ trait ABTestSwitches {
     sellByDate = Some(LocalDate.of(2021, 11, 29)),
     exposeClientSide = true,
   )
+
+  Switch(
+    ABTests,
+    "ab-integrate-criteo",
+    "Integrate Criteo as a Prebid SSP",
+    owners = Seq(Owner.withGithub("chrislomaxjones")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2022, 1, 10)),
+    exposeClientSide = true,
+  )
 }

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.ts
@@ -21,6 +21,7 @@ import {
 	getBreakpointKey,
 	shouldIncludeAdYouLike,
 	shouldIncludeAppNexus,
+	shouldIncludeCriteo,
 	shouldIncludeImproveDigital,
 	shouldIncludeImproveDigitalSkin,
 	shouldIncludeOpenx,
@@ -457,8 +458,7 @@ const biddersSwitchedOn = (allBidders: PrebidBidder[]): PrebidBidder[] => {
 
 const currentBidders = (slotSizes: HeaderBiddingSize[]): PrebidBidder[] => {
 	const otherBidders: PrebidBidder[] = [
-		// Currently only include Criteo if explicitly using pbtest query parameter
-		...(inPbTestOr(false) ? [criteoBidder] : []),
+		...(inPbTestOr(shouldIncludeCriteo()) ? [criteoBidder] : []),
 		...(inPbTestOr(shouldIncludeSonobi()) ? [sonobiBidder] : []),
 		...(inPbTestOr(shouldIncludeTrustX()) ? [trustXBidder] : []),
 		...(inPbTestOr(shouldIncludeTripleLift()) ? [tripleLiftBidder] : []),

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
@@ -59,6 +59,9 @@ type PbjsConfig = {
 	userSync: UserSync;
 	consentManagement?: ConsentManagement;
 	realTimeData?: unknown;
+	criteo?: {
+		fastBidVersion: 'latest' | 'none' | `${number}`;
+	};
 };
 
 type PbjsEvent = 'bidWon';
@@ -278,6 +281,12 @@ const initialise = (window: Window, framework: Framework = 'tcfv2'): void => {
 					},
 				},
 			],
+		};
+	}
+
+	if (window.guardian.config.switches.prebidCriteo) {
+		pbjsConfig.criteo = {
+			fastBidVersion: 'latest',
 		};
 	}
 

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/utils.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/utils.ts
@@ -1,6 +1,9 @@
 import { isString } from '@guardian/libs';
 import { once } from 'lodash-es';
-import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import {
+	isInABTestSynchronous,
+	isInVariantSynchronous,
+} from 'common/modules/experiments/ab';
 import { integrateCriteo } from 'common/modules/experiments/tests/integrate-criteo';
 import config from '../../../../lib/config';
 import { getBreakpoint, isBreakpoint } from '../../../../lib/detect';
@@ -169,14 +172,20 @@ export const shouldIncludeImproveDigitalSkin = (): boolean =>
 	getBreakpointKey() === 'D'; // Desktop only
 
 /**
- * 	Include Criteo if not in the control group of the AB test
+ * Determine if a visitor is participating in a test for integrating an SSP
  *
- *  Equivalent to those in the variant group and those not participating
+ * Add additional tests here when integrating a new SSP
+ */
+const inSSPTest = (): boolean => isInABTestSynchronous(integrateCriteo);
+
+/**
+ * Determine whether to include Criteo as a bidder
  *
- * TODO check they're not participating in the Smart AB test either!
+ * Include Criteo if visitor is not a participant in an AB test for integrating an SSP
+ * or that they are in the variant of the Criteo test
  */
 export const shouldIncludeCriteo = (): boolean =>
-	!isInVariantSynchronous(integrateCriteo, 'control');
+	!inSSPTest() || isInVariantSynchronous(integrateCriteo, 'variant');
 
 export const shouldIncludeMobileSticky = once(
 	(): boolean =>

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/utils.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/utils.ts
@@ -1,5 +1,7 @@
 import { isString } from '@guardian/libs';
 import { once } from 'lodash-es';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { integrateCriteo } from 'common/modules/experiments/tests/integrate-criteo';
 import config from '../../../../lib/config';
 import { getBreakpoint, isBreakpoint } from '../../../../lib/detect';
 import { pbTestNameMap } from '../../../../lib/url';
@@ -165,6 +167,16 @@ export const shouldIncludeImproveDigitalSkin = (): boolean =>
 	window.guardian.config.page.isFront &&
 	(isInUk() || isInRow()) &&
 	getBreakpointKey() === 'D'; // Desktop only
+
+/**
+ * 	Include Criteo if not in the control group of the AB test
+ *
+ *  Equivalent to those in the variant group and those not participating
+ *
+ * TODO check they're not participating in the Smart AB test either!
+ */
+export const shouldIncludeCriteo = (): boolean =>
+	!isInVariantSynchronous(integrateCriteo, 'control');
 
 export const shouldIncludeMobileSticky = once(
 	(): boolean =>

--- a/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
@@ -1,8 +1,9 @@
 import type { ABTest } from '@guardian/ab-core';
 import { isInABTestSynchronous } from '../experiments/ab';
+import { integrateCriteo } from '../experiments/tests/integrate-criteo';
 import { prebidTimeout } from '../experiments/tests/prebid-timeout';
 
-const defaultClientSideTests: ABTest[] = [prebidTimeout];
+const defaultClientSideTests: ABTest[] = [prebidTimeout, integrateCriteo];
 
 const serverSideTests: ServerSideABTest[] = [];
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -1,4 +1,5 @@
 import type { ABTest } from '@guardian/ab-core';
+import { integrateCriteo } from './tests/integrate-criteo';
 import { prebidTimeout } from './tests/prebid-timeout';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
@@ -11,4 +12,5 @@ export const concurrentTests: readonly ABTest[] = [
 	signInGateMainControl,
 	remoteRRHeaderLinksTest,
 	prebidTimeout,
+	integrateCriteo,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/integrate-criteo.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/integrate-criteo.ts
@@ -1,0 +1,21 @@
+import type { ABTest } from '@guardian/ab-core';
+import { noop } from '../../../../../lib/noop';
+
+export const integrateCriteo: ABTest = {
+	id: 'IntegrateCriteo',
+	author: 'Chris Jones (@chrislomaxjones)',
+	start: '2021-11-22',
+	expiry: '2022-01-10',
+	audience: 2 / 100,
+	audienceOffset: 0,
+	audienceCriteria: 'All users',
+	description:
+		'Integrate new Prebid bidder and measure revenue uplift / impact of commercial performance metrics',
+	successMeasure:
+		'Revenue uplift with no significant impact on performance metrics',
+	variants: [
+		{ id: 'control', test: noop },
+		{ id: 'variant', test: noop },
+	],
+	canRun: () => true,
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/integrate-criteo.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/integrate-criteo.ts
@@ -7,7 +7,7 @@ export const integrateCriteo: ABTest = {
 	start: '2021-11-22',
 	expiry: '2022-01-10',
 	audience: 2 / 100,
-	audienceOffset: 0,
+	audienceOffset: 96 / 100,
 	audienceCriteria: 'All users',
 	description:
 		'Integrate new Prebid bidder and measure revenue uplift / impact of commercial performance metrics',

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -386,7 +386,9 @@
   "../lib/config.d.ts",
   "../lib/detect.js",
   "../lib/url.ts",
-  "../projects/common/modules/commercial/geo-utils.js"
+  "../projects/common/modules/commercial/geo-utils.js",
+  "../projects/common/modules/experiments/ab.ts",
+  "../projects/common/modules/experiments/tests/integrate-criteo.ts"
  ],
  "../projects/commercial/modules/high-merch.ts": [
   "../lib/config.d.ts",
@@ -516,6 +518,7 @@
  "../projects/common/modules/analytics/shouldCaptureMetrics.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
   "../projects/common/modules/experiments/ab.ts",
+  "../projects/common/modules/experiments/tests/integrate-criteo.ts",
   "../projects/common/modules/experiments/tests/prebid-timeout.ts"
  ],
  "../projects/common/modules/article/space-filler.js": [
@@ -596,6 +599,7 @@
  ],
  "../projects/common/modules/experiments/ab-tests.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
+  "../projects/common/modules/experiments/tests/integrate-criteo.ts",
   "../projects/common/modules/experiments/tests/prebid-timeout.ts",
   "../projects/common/modules/experiments/tests/remote-header-test.js",
   "../projects/common/modules/experiments/tests/sign-in-gate-main-control.js",
@@ -622,6 +626,10 @@
   "../projects/common/modules/experiments/ab-utils.ts"
  ],
  "../projects/common/modules/experiments/automatLog.ts": [],
+ "../projects/common/modules/experiments/tests/integrate-criteo.ts": [
+  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
+  "../lib/noop.ts"
+ ],
  "../projects/common/modules/experiments/tests/prebid-timeout.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
   "../lib/noop.ts"


### PR DESCRIPTION
## What does this change?

Add a new AB test `IntegrateCriteo` that will allow us to test integrating Criteo as a new Prebid partner and measure impact on revenue and performance metrics. This builds on the work in #24405 and also includes adding the Criteo publishertag library along with the test.

The test consists of two groups (`variant` and `control`), each comprising 1% of the total audience:
- Those in the variant group will include Criteo as an additional bidder
- Those in the control group wont include Criteo as an additional bidder

Additionally, the rest of the audience that is not participating in the test will include Criteo. This is to attempt to maximise any uplift we may gain from integrating a new SSP whilst still being able to perform the 1% test.

Note that in the future it will be necessary to ensure that the conditions for including Criteo do not overlap with any other tests for integrating new SSPs.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes (please indicate your plans for DCR Implementation) - [DCR #3658](https://github.com/guardian/dotcom-rendering/pull/3658)

## What is the value of this and can you measure success?

Adding this test will allow us to assess the commercial and performance impact of integrating a new Prebid SSP.

Exposing the rest of the audience that is not in the test to the change will hopefully capture an expected uplift from integrating the new partner.

### Tested

- [X] Locally
- [x] On CODE (optional)