### PR TITLE
Filter toggle accessibility

### DIFF
--- a/article/app/views/liveblog/filterButton.scala.html
+++ b/article/app/views/liveblog/filterButton.scala.html
@@ -10,6 +10,6 @@
             <input type="checkbox" id="filter-switch" value="@(filterKeyEvents)" data-link-name="filter-key-events-@(switchState)">
         }
         <span class="live-blog__filter-switch-slider round"></span>
+        <span class="live-blog__filter-switch-text">Show key events only</span>
     </label>
-   <span class="live-blog__filter-switch-text">Show key events only</span>
 </div>

--- a/static/src/stylesheets/module/_dropdown.scss
+++ b/static/src/stylesheets/module/_dropdown.scss
@@ -56,7 +56,6 @@
         }
         .dropdown__content {
             margin-bottom: $gs-baseline;
-            margin-top: $gs-baseline;
         }
     }
 }

--- a/static/src/stylesheets/module/content-garnett/_live-blog.scss
+++ b/static/src/stylesheets/module/content-garnett/_live-blog.scss
@@ -260,7 +260,7 @@
     display: flex;
     align-items: center;
     height: $gs-baseline;
-    margin: $gs-baseline 0;
+    margin: $gs-gutter 0;
 }
 
 .live-blog__filter-switch-label {

--- a/static/src/stylesheets/module/content-garnett/_live-blog.scss
+++ b/static/src/stylesheets/module/content-garnett/_live-blog.scss
@@ -350,13 +350,6 @@ input:focus-visible + .live-blog__filter-switch-slider {
     outline: 1px auto -webkit-focus-ring-color;
 }
 
-
-//.live-blog__filter-switch-slider:focus {
-//    outline: 1px dotted #212121; /* 1 */
-//    outline: 1px auto -webkit-focus-ring-color; /* 1 */
-//}
-
-
 input:checked + .live-blog__filter-switch-slider:before {
     -webkit-transform: translateX(1.15rem);
     -ms-transform: translateX(1.15rem);

--- a/static/src/stylesheets/module/content-garnett/_live-blog.scss
+++ b/static/src/stylesheets/module/content-garnett/_live-blog.scss
@@ -347,8 +347,7 @@ input:checked + .live-blog__filter-switch-slider {
 }
 
 input:focus-visible + .live-blog__filter-switch-slider {
-    outline: 1px dotted #212121; /* 1 */
-    outline: 1px auto -webkit-focus-ring-color; /* 1 */
+    outline: 1px auto -webkit-focus-ring-color;
 }
 
 

--- a/static/src/stylesheets/module/content-garnett/_live-blog.scss
+++ b/static/src/stylesheets/module/content-garnett/_live-blog.scss
@@ -260,7 +260,7 @@
     display: flex;
     align-items: center;
     height: $gs-baseline;
-    margin: $gs-gutter 0;
+    margin: 18px 0;
 }
 
 .live-blog__filter-switch-label {
@@ -276,7 +276,7 @@
     position: absolute;
     margin-left: 3.25rem;
     font-size: 15px;
-    line-height: 1.4rem;
+    line-height: 1.5rem;
     font-weight: 400;
     color: inherit;
     -webkit-user-select: none; /* Safari */

--- a/static/src/stylesheets/module/content-garnett/_live-blog.scss
+++ b/static/src/stylesheets/module/content-garnett/_live-blog.scss
@@ -259,11 +259,12 @@
 .live-blog__filter-switch {
     display: flex;
     align-items: center;
-    margin-bottom: 12px;
+    height: $gs-baseline;
+    margin: $gs-baseline 0;
 }
 
 .live-blog__filter-switch-label {
-    position: relative;
+    position: absolute;
     display: inline-block;
     width: 2.75rem;
     height: 1.5rem;
@@ -271,11 +272,17 @@
 
 .live-blog__filter-switch-text {
     @include f-textSans;
-    margin-left: .5rem;
+    width: 9.75rem;
+    position: absolute;
+    margin-left: 3.25rem;
     font-size: 15px;
-    line-height: 20px;
+    line-height: 1.4rem;
     font-weight: 400;
     color: inherit;
+    -webkit-user-select: none; /* Safari */
+    -moz-user-select: none; /* Firefox */
+    -ms-user-select: none; /* IE10+/Edge */
+    user-select: none; /* Standard */
 }
 
 /* Hide default HTML checkbox */
@@ -339,9 +346,16 @@ input:checked + .live-blog__filter-switch-slider {
     background-color: #58d08b;
 }
 
-input:focus + .live-blog__filter-switch-slider {
-    box-shadow: 0 0 1px #58d08b;
+input:focus-visible + .live-blog__filter-switch-slider {
+    outline: 1px dotted #212121; /* 1 */
+    outline: 1px auto -webkit-focus-ring-color; /* 1 */
 }
+
+
+//.live-blog__filter-switch-slider:focus {
+//    outline: 1px dotted #212121; /* 1 */
+//    outline: 1px auto -webkit-focus-ring-color; /* 1 */
+//}
 
 
 input:checked + .live-blog__filter-switch-slider:before {

--- a/static/src/stylesheets/module/content-garnett/live-blog/_live-blog.head.scss
+++ b/static/src/stylesheets/module/content-garnett/live-blog/_live-blog.head.scss
@@ -548,7 +548,7 @@ $block-padding-left: gs-span(1) + $gs-gutter;
 
         @include mq($until: desktop) {
             background-color: $brightness-97;
-            padding: $gs-baseline $content-gutter;
+            padding: 0 $content-gutter;
         }
 
         @include mq(desktop) {

--- a/static/src/stylesheets/module/content/live-blog/_live-blog.head.scss
+++ b/static/src/stylesheets/module/content/live-blog/_live-blog.head.scss
@@ -488,7 +488,7 @@ $block-padding-left: gs-span(1) + $gs-gutter;
 
         @include mq($until: desktop) {
             background-color: $brightness-97;
-            padding: $gs-baseline $content-gutter;
+            padding: 0 $content-gutter;
         }
 
         @include mq(desktop) {


### PR DESCRIPTION
## What does this change?
Make filter key keyboard accessible and make sure label is clickable and its text not selectable. 

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
