### PR TITLE
prioritise force dcr off in interactive picker

### DIFF
--- a/applications/app/services/InteractivePicker.scala
+++ b/applications/app/services/InteractivePicker.scala
@@ -30,8 +30,8 @@ object InteractivePicker {
     // Allow us to quickly revert to rendering content (instead of serving pressed content)
     val switchOn = InteractivePickerFeature.isSwitchedOn
 
-    if (isPressed(fullPath) && switchOn) PressedInteractive
-    else if (forceDCROff) FrontendLegacy
+    if (forceDCROff) FrontendLegacy
+    else if (isPressed(fullPath) && switchOn) PressedInteractive
     else DotcomRendering
   }
 }

--- a/applications/test/services/InteractivePickerTest.scala
+++ b/applications/test/services/InteractivePickerTest.scala
@@ -11,10 +11,9 @@ import play.api.test.Helpers._
     private[this] val interactives = Set[String](path)
     def isPressed(path: String): Boolean = interactives.contains(path)
   }
+  conf.switches.Switches.InteractivePickerFeature.switchOn
 
   "Interactive Picker get rendering tier" should "return PressedInteractive if pressed and switched on" in {
-    conf.switches.Switches.InteractivePickerFeature.switchOn
-
     val testRequest = TestRequest(path)
     val tier = InteractivePicker.getRenderingTier(path, MockPressedInteractives.isPressed)(
       testRequest,
@@ -23,11 +22,10 @@ import play.api.test.Helpers._
     tier should be(PressedInteractive)
   }
 
-  it should "return FrontendLegacy only if the request forces DCR off" in {
-    val legacyPath = "/world/live/2021/oct/13/covid-news-live?dcr=false"
-    val testRequest = TestRequest(legacyPath)
+  it should "return FrontendLegacy if the request forces DCR off" in {
+    val testRequest = TestRequest(s"$path?dcr=false")
     val tier =
-      InteractivePicker.getRenderingTier(legacyPath, MockPressedInteractives.isPressed)(
+      InteractivePicker.getRenderingTier(path, MockPressedInteractives.isPressed)(
         testRequest,
       )
 


### PR DESCRIPTION
## What does this change?
This change prioritises forcing dcr off, regardless of whether the page is pressed. This helps debugging in production.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)


## What is the value of this and can you measure success?
This change will help us debug in production (comparing pressed pages to those rendered via frontend).

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

