### PR TITLE
Integrate Smart as new Prebid bidder

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -521,6 +521,16 @@ trait PrebidSwitches {
     exposeClientSide = true,
   )
 
+  val prebidSmart: Switch = Switch(
+    group = CommercialPrebid,
+    name = "prebid-smart",
+    description = "Include the Smart AdServer adapter in Prebid auctions",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
+
   val mobileStickyLeaderboard: Switch = Switch(
     group = Commercial,
     name = "mobile-sticky-leaderboard",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "object-fit-videos": "^1.0.3",
     "ophan-tracker-js": "1.3.28",
     "preact": "^10.5.13",
-    "prebid.js": "https://github.com/guardian/Prebid.js#25374fa9",
+    "prebid.js": "https://github.com/guardian/Prebid.js#c9ab051",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "object-fit-videos": "^1.0.3",
     "ophan-tracker-js": "1.3.28",
     "preact": "^10.5.13",
-    "prebid.js": "https://github.com/guardian/Prebid.js#c9ab051",
+    "prebid.js": "https://github.com/guardian/Prebid.js#d196736",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.ts
@@ -432,7 +432,7 @@ const criteoBidder: PrebidBidder = {
 };
 
 const smartBidder: PrebidBidder = {
-	name: 'smart',
+	name: 'smartadserver',
 	switchName: 'prebidSmart',
 	bidParams: () => ({
 		siteID: 465656,

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.ts
@@ -431,6 +431,16 @@ const criteoBidder: PrebidBidder = {
 	}),
 };
 
+const smartBidder: PrebidBidder = {
+	name: 'smart',
+	switchName: 'prebidSmart',
+	bidParams: () => ({
+		siteID: 465656,
+		pageID: 1472549,
+		formatID: 105870,
+	}),
+};
+
 // There's an IX bidder for every size that the slot can take
 const indexExchangeBidders = (
 	slotSizes: HeaderBiddingSize[],
@@ -459,6 +469,7 @@ const biddersSwitchedOn = (allBidders: PrebidBidder[]): PrebidBidder[] => {
 const currentBidders = (slotSizes: HeaderBiddingSize[]): PrebidBidder[] => {
 	const otherBidders: PrebidBidder[] = [
 		...(inPbTestOr(shouldIncludeCriteo()) ? [criteoBidder] : []),
+		...(inPbTestOr(false) ? [smartBidder] : []),
 		...(inPbTestOr(shouldIncludeSonobi()) ? [sonobiBidder] : []),
 		...(inPbTestOr(shouldIncludeTrustX()) ? [trustXBidder] : []),
 		...(inPbTestOr(shouldIncludeTripleLift()) ? [tripleLiftBidder] : []),

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/types.d.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/types.d.ts
@@ -82,6 +82,12 @@ type PrebidCriteoParams = {
 	networkId: number;
 };
 
+type PrebidSmartParams = {
+	siteID: number;
+	pageID: number;
+	formatID: number;
+};
+
 type BidderCode =
 	| 'adyoulike'
 	| 'and'
@@ -92,6 +98,7 @@ type BidderCode =
 	| 'oxd'
 	| 'ozone'
 	| 'pubmatic'
+	| 'smart'
 	| 'sonobi'
 	| 'triplelift'
 	| 'trustx'
@@ -106,6 +113,7 @@ type PrebidParams =
 	| PrebidOpenXParams
 	| PrebidOzoneParams
 	| PrebidPubmaticParams
+	| PrebidSmartParams
 	| PrebidSonobiParams
 	| PrebidTripleLiftParams
 	| PrebidTrustXParams

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/types.d.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/types.d.ts
@@ -98,7 +98,7 @@ type BidderCode =
 	| 'oxd'
 	| 'ozone'
 	| 'pubmatic'
-	| 'smart'
+	| 'smartadserver'
 	| 'sonobi'
 	| 'triplelift'
 	| 'trustx'

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -13,7 +13,7 @@
   "../lib/config.js",
   "../lib/mediator.js"
  ],
- "../lib/events.js": [],
+ "../lib/events.ts": [],
  "../lib/fastdom-promise.js": [
   "../../../../node_modules/fastdom/extensions/fastdom-promised.js",
   "../../../../node_modules/fastdom/fastdom.js"
@@ -416,7 +416,7 @@
  ],
  "../projects/commercial/modules/messenger/background.js": [
   "../lib/config.js",
-  "../lib/events.js",
+  "../lib/events.ts",
   "../lib/fastdom-promise.js",
   "../projects/commercial/modules/dfp/render-advert-label.ts"
  ],
@@ -440,7 +440,7 @@
  ],
  "../projects/commercial/modules/messenger/scroll.js": [
   "../lib/detect.js",
-  "../lib/events.js",
+  "../lib/events.ts",
   "../lib/fastdom-promise.js"
  ],
  "../projects/commercial/modules/messenger/type.js": [
@@ -482,7 +482,7 @@
  ],
  "../projects/commercial/modules/sticky-top-banner.js": [
   "../lib/detect.js",
-  "../lib/events.js",
+  "../lib/events.ts",
   "../lib/fastdom-promise.js",
   "../projects/commercial/modules/dfp/get-advert-by-id.ts",
   "../projects/commercial/modules/dfp/track-ad-render.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9753,9 +9753,9 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.15.tgz#6df94d8afecf3f9e10a742fd8c362ddab464225f"
   integrity sha512-5chK29n6QcJc3m1lVrKQSQ+V7K1Gb8HeQY6FViQ5AxCAEGu3DaHffWNDkC9+miZgsLvbvU9rxbV1qinGHMHzqA==
 
-"prebid.js@https://github.com/guardian/Prebid.js#c9ab051":
+"prebid.js@https://github.com/guardian/Prebid.js#d196736":
   version "5.20.0"
-  resolved "https://github.com/guardian/Prebid.js#c9ab051f971872aa5ebf97939f96d895429a57b5"
+  resolved "https://github.com/guardian/Prebid.js#d196736041aaaa49ce846d4023375e2e1da6dcda"
   dependencies:
     "@guardian/libs" "^3.1.0"
     babel-plugin-transform-object-assign "^6.22.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9753,9 +9753,9 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.15.tgz#6df94d8afecf3f9e10a742fd8c362ddab464225f"
   integrity sha512-5chK29n6QcJc3m1lVrKQSQ+V7K1Gb8HeQY6FViQ5AxCAEGu3DaHffWNDkC9+miZgsLvbvU9rxbV1qinGHMHzqA==
 
-"prebid.js@https://github.com/guardian/Prebid.js#25374fa9":
+"prebid.js@https://github.com/guardian/Prebid.js#c9ab051":
   version "5.20.0"
-  resolved "https://github.com/guardian/Prebid.js#25374fa9fb264f6a81bb490335e16ab6bdc943e6"
+  resolved "https://github.com/guardian/Prebid.js#c9ab051f971872aa5ebf97939f96d895429a57b5"
   dependencies:
     "@guardian/libs" "^3.1.0"
     babel-plugin-transform-object-assign "^6.22.0"


### PR DESCRIPTION
## What does this change?

This PR adds [Smart AdServer](https://docs.prebid.org/dev-docs/pbs-bidders.html#smartadserver) as a Prebid bidder, gated by a switch so that we can enable/disable their participation in auctions. It points to [an updated build of Prebid.js that includes Smart in its list of modules](https://github.com/guardian/Prebid.js/pull/124).

This will be followed up with a PR allowing us to test Smart.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

Running locally:

![image](https://user-images.githubusercontent.com/11380557/143032354-0916fade-4619-42c8-a1ca-13efe2db6076.png)

## What is the value of this and can you measure success?

This will allow us to provide URLs of the form https://theguardian.com/uk?pbtest=smartadserver in order to test a new Prebid bidder without rolling out to all users of the website.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
