### PR TITLE
Remove Ad Targeting `ms` (Media Source) 

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.ts
@@ -147,7 +147,6 @@ describe('Build Page Targeting', () => {
 			pageId: 'football/series/footballweekly',
 			publication: 'The Observer',
 			seriesId: 'film/series/filmweekly',
-			source: 'ITN',
 			sponsorshipType: 'advertisement-features',
 			tones: 'News',
 			videoDuration: 63,
@@ -233,7 +232,6 @@ describe('Build Page Targeting', () => {
 		expect(pageTargeting.gdncrm).toEqual(['seg1', 'seg2']);
 		expect(pageTargeting.co).toEqual(['gabrielle-chan']);
 		expect(pageTargeting.bl).toEqual(['blog']);
-		expect(pageTargeting.ms).toBe('itn');
 		expect(pageTargeting.tn).toEqual(['news']);
 		expect(pageTargeting.vl).toEqual('90');
 		expect(pageTargeting.pv).toEqual('presetOphanPageViewId');

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.ts
@@ -83,7 +83,6 @@ type PageTargeting = PartialWithNulls<{
 	edition: 'uk' | 'us' | 'au' | 'int';
 	gdncrm: string | string[]; // GuarDiaN CRM
 	k: string[]; // Keywords
-	ms: string; // Media Source
 	p: 'r2' | 'ng' | 'app' | 'amp'; // Platform (web)
 	pa: TrueOrFalse; // Personalised Ads consent
 	permutive: string[]; // predefined segment values
@@ -149,15 +148,6 @@ const inskinTargeting = (): TrueOrFalse => {
 	if (!cmp.hasInitialised()) return 'f';
 	return cmp.willShowPrivacyMessageSync() ? 'f' : 't';
 };
-
-const WHITESPACE_CHARACTERS = /[+\s]+/g;
-const format = (keyword: string): string =>
-	keyword.replace(WHITESPACE_CHARACTERS, '-').toLowerCase();
-
-const AND = /&/g;
-const APOSTROPHE = /'/g;
-const formatTarget = (target?: string | null): string | null =>
-	target ? format(target).replace(AND, 'and').replace(APOSTROPHE, '') : null;
 
 const abParam = (): string[] => {
 	const abParticipations: Participations = getSynchronousParticipations();
@@ -411,7 +401,6 @@ const rebuildPageTargeting = () => {
 			fr: getFrequencyValue(),
 			gdncrm: getUserSegments(adConsentState),
 			inskin: inskinTargeting(),
-			ms: formatTarget(page.source),
 			permutive: getPermutiveSegments(),
 			pv: window.guardian.config.ophan.pageViewId,
 			rdp: getRdpValue(ccpaState),


### PR DESCRIPTION
## What does this change?

It’s deprecated, for example, results of `window.guardian.config.page.source`:
- `""` for https://www.theguardian.com/music/video/2021/nov/18/the-beatles-get-back-and-london-on-the-trail-of-a-timeless-story-video yields  
- `undefined` for pages without media.

### Related PRs
- #24424 
- #24361 

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
