### PR TITLE
Remove Appnexus `slot` targeting

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.ts
@@ -397,7 +397,7 @@ describe('Build Page Targeting', () => {
 			getBreakpoint.mockReturnValue('desktop');
 			getPageTargeting();
 			expect(window.guardian.config.page.appNexusPageTargeting).toEqual(
-				'sens=f,pt1=/football/series/footballweekly,pt2=us,pt3=video,pt4=ng,pt5=prince-charles-letters,pt5=uk/uk,pt5=prince-charles,pt6=5,pt7=desktop,pt9=presetOphanPageViewId|gabrielle-chan|news|',
+				'sens=f,pt1=/football/series/footballweekly,pt2=us,pt3=video,pt4=ng,pt5=prince-charles-letters,pt5=uk/uk,pt5=prince-charles,pt6=5,pt7=desktop,pt9=presetOphanPageViewId|gabrielle-chan|news',
 			);
 		});
 	});

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.ts
@@ -268,11 +268,9 @@ const buildAppNexusTargetingObject = once(
 			pt6: pageTargeting.su,
 			pt7: pageTargeting.bp,
 			pt8: pageTargeting.x, // OpenX cannot handle this being undefined
-			pt9: [
-				pageTargeting.pv,
-				pageTargeting.co,
-				pageTargeting.tn,
-			].join('|'),
+			pt9: [pageTargeting.pv, pageTargeting.co, pageTargeting.tn].join(
+				'|',
+			),
 			permutive: pageTargeting.permutive,
 		}),
 );

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.ts
@@ -89,7 +89,6 @@ type PageTargeting = PartialWithNulls<{
 	sens: TrueOrFalse; // SenSitive
 	si: TrueOrFalse; // Signed In
 	skinsize: 'l' | 's';
-	slot: string; // (predefined list)
 	su: string; // SUrging article
 	tn: string; // ToNe
 	url: string;
@@ -273,7 +272,6 @@ const buildAppNexusTargetingObject = once(
 				pageTargeting.pv,
 				pageTargeting.co,
 				pageTargeting.tn,
-				pageTargeting.slot,
 			].join('|'),
 			permutive: pageTargeting.permutive,
 		}),


### PR DESCRIPTION
## What does this change?

Having `slot` be part of page targeting makes no sense: it should be associated with a single slot.

This changes fixes that, and removes it from the AppNexus targeting.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
