### PR TITLE
Remove Ad Targeting `x` Krux

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.ts
@@ -95,7 +95,6 @@ type PageTargeting = PartialWithNulls<{
 	url: string;
 	urlkw: string[]; // URL KeyWords
 	vl: string; // Video Length
-	x: string; // kruX user segments (deprecated?)
 	rdp: string;
 	consent_tcfv2: string;
 	cmp_interaction: string;
@@ -268,7 +267,6 @@ const buildAppNexusTargetingObject = once(
 			pt5: pageTargeting.k,
 			pt6: pageTargeting.su,
 			pt7: pageTargeting.bp,
-			pt8: pageTargeting.x, // OpenX cannot handle this being undefined
 			pt9: [
 				pageTargeting.pv,
 				pageTargeting.co,


### PR DESCRIPTION
## What does this change?

Removes the long-deprecated Krux Ad Targeting value `x`.

### Related PR
- #24424 
- #24424 
- #22341 (where it slipped through the net)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
