### PR TITLE
Make pinned block accessible

### DIFF
--- a/article/app/views/liveblog/pinnedPost.scala.html
+++ b/article/app/views/liveblog/pinnedPost.scala.html
@@ -7,8 +7,8 @@
 * This template is to wrap pinned posts
 *@
 <div class="pinned-block__collapsible-container">
-    <input id="collapsible" class="pinned-block__toggle" type="checkbox">
-    <label for="collapsible" class="pinned-block__btn pinned-block--toggle">
+    <input id="collapsible" class="pinned-block__toggle" type="checkbox" tabindex="-1" aria-controls="pinned-block" />
+    <label for="collapsible" class="pinned-block__btn pinned-block--toggle" tabindex="0">
         @fragments.inlineSvg("plus", "icon", List("pinned-block__btn-icon--expand"))
         @fragments.inlineSvg("minus", "icon", List("pinned-block__btn-icon--collapse"))
     </label>
@@ -19,7 +19,7 @@
             <p class="pinned-block__timestamp">
                 From@views.html.liveblog.dateBlock(block.referenceDateForDisplay().map(LiveBlogDate(_, timezone)), true, false)</p>
         </div>
-        <div class="pinned-block__body">
+        <div class="pinned-block__body" id="pinned-block">
             @views.html.liveblog.liveBlogBlock(block, article, timezone, true)
             <div class="pinned-block__overlay" />
         </div>

--- a/static/src/javascripts/bootstraps/enhanced/liveblog.js
+++ b/static/src/javascripts/bootstraps/enhanced/liveblog.js
@@ -44,6 +44,16 @@ const initFilterCheckbox = () => {
     }
 }
 
+const initAccessibleClickListener = (label) => {
+    const spacebar = 32
+    const enter = 13
+    label.addEventListener('keydown', e => {
+        if (e.which === spacebar || e.which === enter) {
+            e.preventDefault();
+            label.click();
+        };
+    });
+}
 
 const initPinnedPost = () => {
     const pinnedBlock = document.querySelector('.pinned-block__body')
@@ -57,6 +67,8 @@ const initPinnedPost = () => {
         overlay.style.display = "none"
         pinnedBlockBtn.style.display = "none"
     }
+    initAccessibleClickListener(pinnedBlockBtn)
+
 }
 
 const createAutoUpdate = () => {

--- a/static/src/stylesheets/module/content-garnett/_live-blog.scss
+++ b/static/src/stylesheets/module/content-garnett/_live-blog.scss
@@ -475,7 +475,7 @@ $block-padding-left: gs-span(1) + 4;
 }
 
 .pinned-block__overlay {
-    background-image: linear-gradient(0deg, #ffffff, #ffffff 40%, transparent);
+    background-image: linear-gradient(0deg, #ffffff, #ffffff 40%, rgba(255, 255, 255, 0));
     height: 5rem;
     z-index: 1;
     position: absolute;


### PR DESCRIPTION
## What does this change?

The pinned post collapsible toggle can be navigated to by tab key and toggled by enter or spacebar. Screenreaders will also announce the label of show more / show less on click.

This PR also fixes a small UI bug that made the transparent portion of the fade grey in safari browsers by using rgba value instead.


## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
