### PR TITLE
Ab/pinned post scrolling

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/liveblog.js
+++ b/static/src/javascripts/bootstraps/enhanced/liveblog.js
@@ -81,6 +81,11 @@ const keepTimestampsCurrent = () => {
     window.setInterval(() => initRelativeDates(), 60000);
 };
 
+const isVisible = (element) => {
+    const position = element.getBoundingClientRect();
+    return position.top >= 0 && position.bottom <= window.innerHeight
+}
+
 const setupListeners = () => {
     bean.on(document.body, 'change', '.live-blog__filter-switch-label', () => {
         const hasParam = window.location.search.includes(`filterKeyEvents=true`);
@@ -89,9 +94,11 @@ const setupListeners = () => {
     })
 
     bean.on(document.body, 'click', '.pinned-block__btn', () => {
-        const pinnedBlockTop = document.querySelector('.pinned-block__header')
+        const pinnedBlockHeader = document.querySelector('.pinned-block__header')
         const pinnedBlockToggle = document.querySelector('.pinned-block__toggle')
-        pinnedBlockToggle.checked && scrollToElement(pinnedBlockTop)
+        if (!isVisible(pinnedBlockHeader) && pinnedBlockToggle.checked) {
+            scrollToElement(pinnedBlockHeader)
+        }
     })
 }
 

--- a/static/src/stylesheets/module/content-garnett/_live-blog.scss
+++ b/static/src/stylesheets/module/content-garnett/_live-blog.scss
@@ -469,7 +469,7 @@ $block-padding-left: gs-span(1) + 4;
     margin-right: $gs-gutter/2;
     @include mq(tablet) {
         margin-right: $gs-gutter;
-        margin-left: $block-padding-left;
+        margin-left: 3rem;
     }
 
 }


### PR DESCRIPTION
## What does this change?
This pr was reverting in error by another PR. This reintroduces the required changes to add padding to the timestamp and only scroll on click if the pinned block is not visible

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
