### PR TITLE
Restrict Criteo to non-Aus/NZ regions

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/header-bidding/utils.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/utils.ts
@@ -185,7 +185,8 @@ const inSSPTest = (): boolean => isInABTestSynchronous(integrateCriteo);
  * or that they are in the variant of the Criteo test
  */
 export const shouldIncludeCriteo = (): boolean =>
-	!inSSPTest() || isInVariantSynchronous(integrateCriteo, 'variant');
+	!isInAuOrNz() &&
+	(!inSSPTest() || isInVariantSynchronous(integrateCriteo, 'variant'));
 
 export const shouldIncludeMobileSticky = once(
 	(): boolean =>


### PR DESCRIPTION
## What does this change?

This PR restricts Criteo to participate in auctions only outside of Australia and New Zealand. We include this in `shouldIncludeCriteo`, blocking any use of Criteo outside of Aus/NZ (regardless of AB test participation). ~Further, we restrict the AB test so it only runs outside Aus/NZ.~

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Criteo is not supposed to participate in bids in Australia / New Zealand

### Tested

- [x] Locally
- [ ] On CODE (optional)