### PR TITLE
Ioanna/username undefined

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -478,8 +478,17 @@ class CommentBox extends Component {
 
 			console.log('Onboarding author: ', onboardingAuthor);
 			console.log('Onboarding username: ', onboardingUsername);
+            console.log(
+                'This.getUserData().displayName',
+                this.getUserData().displayName,
+            );
 
-			if (onboardingAuthor) {
+            console.log(
+                'This.getUserData().displayName type',
+                typeof this.getUserData().displayName,
+            );
+
+			if (onboardingAuthor & this.getUserData().displayName) {
 				onboardingAuthor.innerHTML = this.getUserData().displayName;
 
 				console.log(
@@ -496,7 +505,7 @@ class CommentBox extends Component {
 			this.setState('onboarding-visible');
 			this.previewComment('onboardingPreviewSuccess');
 
-			if (onboardingUsername && this.options.hasUsername && this.getUserData().displayName) {
+			if (onboardingUsername && this.options.hasUsername) {
 				console.log(this.options);
 
 				onboardingUsername.classList.add('is-hidden');

--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -481,19 +481,22 @@ class CommentBox extends Component {
 
 			if (onboardingAuthor) {
 				onboardingAuthor.innerHTML = this.getUserData().displayName;
+
 				console.log(
 					'This.getUserData().displayName',
 					this.getUserData().displayName,
 				);
+
+                console.log(
+					'This.getUserData().displayName type',
+					typeof this.getUserData().displayName,
+				);
 			}
-			//   } else {
-			//     this.error('USERNAME_MISSING')
-			// }
 
 			this.setState('onboarding-visible');
 			this.previewComment('onboardingPreviewSuccess');
 
-			if (onboardingUsername && this.options.hasUsername) {
+			if (onboardingUsername && this.options.hasUsername && this.getUserData().displayName) {
 				console.log(this.options);
 
 				onboardingUsername.classList.add('is-hidden');

--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -505,7 +505,7 @@ class CommentBox extends Component {
 			this.setState('onboarding-visible');
 			this.previewComment('onboardingPreviewSuccess');
 
-			if (onboardingUsername && this.options.hasUsername) {
+			if (onboardingUsername && this.options.hasUsername && this.getUserData().displayName) {
 				console.log(this.options);
 
 				onboardingUsername.classList.add('is-hidden');

--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -473,19 +473,31 @@ class CommentBox extends Component {
 
             this.postComment();
         } else {
-            const onboardingAuthor = this.getElem('onboarding-author');
-            const onboardingUsername = this.getElem('onboarding-username');
+			const onboardingAuthor = this.getElem('onboarding-author');
+			const onboardingUsername = this.getElem('onboarding-username');
 
-            if (onboardingAuthor) {
-                onboardingAuthor.innerHTML = this.getUserData().displayName;
-            }
+			console.log('Onboarding author: ', onboardingAuthor);
+			console.log('Onboarding username: ', onboardingUsername);
 
-            this.setState('onboarding-visible');
-            this.previewComment('onboardingPreviewSuccess');
+			if (onboardingAuthor) {
+				onboardingAuthor.innerHTML = this.getUserData().displayName;
+				console.log(
+					'This.getUserData().displayName',
+					this.getUserData().displayName,
+				);
+			}
+			//   } else {
+			//     this.error('USERNAME_MISSING')
+			// }
 
-            if (onboardingUsername && this.options.hasUsername) {
-                onboardingUsername.classList.add('is-hidden');
-            }
+			this.setState('onboarding-visible');
+			this.previewComment('onboardingPreviewSuccess');
+
+			if (onboardingUsername && this.options.hasUsername) {
+				console.log(this.options);
+
+				onboardingUsername.classList.add('is-hidden');
+			}
         }
     }
 


### PR DESCRIPTION
## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
