### PR TITLE
Fix Smart Ad Server Prebid integration

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.ts
@@ -435,9 +435,9 @@ const smartBidder: PrebidBidder = {
 	name: 'smartadserver',
 	switchName: 'prebidSmart',
 	bidParams: () => ({
-		siteID: 465656,
-		pageID: 1472549,
-		formatID: 105870,
+		siteId: 465656,
+		pageId: 1472549,
+		formatId: 105870,
 	}),
 };
 

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/types.d.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/types.d.ts
@@ -83,9 +83,9 @@ type PrebidCriteoParams = {
 };
 
 type PrebidSmartParams = {
-	siteID: number;
-	pageID: number;
-	formatID: number;
+	siteId: number;
+	pageId: number;
+	formatId: number;
 };
 
 type BidderCode =


### PR DESCRIPTION
## What does this change?
Corrects the parameter names for Smart's `PrebidBidder`. This is currently keeping the bidder from functioning correctly:

![Screenshot 2021-11-25 at 17 29 08](https://user-images.githubusercontent.com/17057932/143486563-678e98c4-db43-4692-9bb6-109711cb403a.png)

Parameters documented [here](https://docs.prebid.org/dev-docs/bidders/smartadserver.html).

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?
- Fixes the bidder so that we can test that it works correctly.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
