### PR TITLE
Identity | Sign In Gate | Extend the sign in gate test expiry date

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -12,7 +12,7 @@ trait ABTestSwitches {
     "Control audience for the sign in gate to 9% audience. Will never see the sign in gate.",
     owners = Seq(Owner.withGithub("coldlink")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2021, 12, 1)),
+    sellByDate = Some(LocalDate.of(2022, 12, 1)),
     exposeClientSide = true,
   )
 
@@ -22,7 +22,7 @@ trait ABTestSwitches {
     "Show sign in gate to 90% of users on 3rd article view, variant/full audience",
     owners = Seq(Owner.withGithub("coldlink")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2021, 12, 1)),
+    sellByDate = Some(LocalDate.of(2022, 12, 1)),
     exposeClientSide = true,
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-control.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-control.js
@@ -4,7 +4,7 @@
 export const signInGateMainControl = {
     id: 'SignInGateMainControl',
     start: '2020-05-20',
-    expiry: '2021-12-01',
+    expiry: '2022-12-01',
     author: 'Mahesh Makani',
     description:
         'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Control Audience.',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
@@ -4,7 +4,7 @@
 export const signInGateMainVariant = {
     id: 'SignInGateMainVariant',
     start: '2020-05-20',
-    expiry: '2021-12-01',
+    expiry: '2022-12-01',
     author: 'Mahesh Makani',
     description:
         'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Main/Variant Audience.',


### PR DESCRIPTION
## What does this change?
- Extend the test by another year so the test/builds do not stop or fail.
  - We'll be resuming sign in tests properly shortly, this is a stop gap before that happens.


## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

[DCR PR](https://github.com/guardian/dotcom-rendering/pull/3701)
