### PR TITLE
Add captcha to email signup iframes

### DIFF
--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -43,7 +43,9 @@
                 </div>
 
                 <form action="@LinkTo("/email")" method="post" target="newsletterSignup" class="newsletter-card__signup">
-                    <div class="grecaptcha_container"></div>
+                    @if(EmailSignupRecaptcha.isSwitchedOn) {
+                        @fragments.email.signup.recaptchaContainer()
+                    }
                     @helper.CSRF.formField
                     <input class="newsletter-card__text-input u-h" type="text" name="name" autocomplete="off"/>
                     <input class="newsletter-card__text-input js-newsletter-card__text-input" type="email" name="email" placeholder="Email address" required/>
@@ -92,11 +94,7 @@
             @* This iframe is used for submitting the form without reloading the page *@
             <iframe class="u-h" width="0" height="0" border="0" name="newsletterSignup" id="newsletterSignup" tabindex="-1"></iframe>
             @if(EmailSignupRecaptcha.isSwitchedOn) {
-                <div class="captcha-terms">
-                    <p>
-                        This page is protected by reCAPTCHA and the Google <a href="https://policies.google.com/privacy" target="_blank">Privacy Policy</a> and <a href="https://policies.google.com/terms" target="_blank">Terms of Service</a> apply.
-                    </p>
-                </div>
+                @fragments.email.signup.recaptchaTerms()
             }
             @displayNewslettersByTheme
         </div>

--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -91,11 +91,13 @@
             </div>
             @* This iframe is used for submitting the form without reloading the page *@
             <iframe class="u-h" width="0" height="0" border="0" name="newsletterSignup" id="newsletterSignup" tabindex="-1"></iframe>
-            <div class="captcha-terms">
-                <p>
-                    This page is protected by reCAPTCHA and the Google <a href="https://policies.google.com/privacy" target="_blank">Privacy Policy</a> and <a href="https://policies.google.com/terms" target="_blank">Terms of Service</a> apply.
-                </p>
-            </div>
+            @if(EmailSignupRecaptcha.isSwitchedOn) {
+                <div class="captcha-terms">
+                    <p>
+                        This page is protected by reCAPTCHA and the Google <a href="https://policies.google.com/privacy" target="_blank">Privacy Policy</a> and <a href="https://policies.google.com/terms" target="_blank">Terms of Service</a> apply.
+                    </p>
+                </div>
+            }
             @displayNewslettersByTheme
         </div>
     </div>

--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -43,7 +43,7 @@
                 </div>
 
                 <form action="@LinkTo("/email")" method="post" target="newsletterSignup" class="newsletter-card__signup">
-                    <div id="grecaptcha_container-@emailListing.listIdv1"></div>
+                    <div class="grecaptcha_container"></div>
                     @helper.CSRF.formField
                     <input class="newsletter-card__text-input u-h" type="text" name="name" autocomplete="off"/>
                     <input class="newsletter-card__text-input js-newsletter-card__text-input" type="email" name="email" placeholder="Email address" required/>

--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -91,6 +91,11 @@
             </div>
             @* This iframe is used for submitting the form without reloading the page *@
             <iframe class="u-h" width="0" height="0" border="0" name="newsletterSignup" id="newsletterSignup" tabindex="-1"></iframe>
+            <div class="captcha-terms">
+                <p>
+                    This page is protected by reCAPTCHA and the Google <a href="https://policies.google.com/privacy" target="_blank">Privacy Policy</a> and <a href="https://policies.google.com/terms" target="_blank">Terms of Service</a> apply.
+                </p>
+            </div>
             @displayNewslettersByTheme
         </div>
     </div>

--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -1,6 +1,7 @@
 @import services.newsletters.NewsletterResponse
 @import views.support.`package`.Seq2zipWithRowInfo
 @import staticpages.NewsletterRoundupPage
+@import conf.switches.Switches.EmailSignupRecaptcha
 
 @import common.LinkTo
 
@@ -42,6 +43,7 @@
                 </div>
 
                 <form action="@LinkTo("/email")" method="post" target="newsletterSignup" class="newsletter-card__signup">
+                    <div id="grecaptcha_container-@emailListing.listIdv1"></div>
                     @helper.CSRF.formField
                     <input class="newsletter-card__text-input u-h" type="text" name="name" autocomplete="off"/>
                     <input class="newsletter-card__text-input js-newsletter-card__text-input" type="email" name="email" placeholder="Email address" required/>
@@ -93,3 +95,7 @@
         </div>
     </div>
 </div>
+
+@if(EmailSignupRecaptcha.isSwitchedOn) {
+    <script src="https://www.google.com/recaptcha/api.js?render=explicit" async defer></script>
+}

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -269,6 +269,7 @@ class GuardianConfiguration extends GuLogging {
   object google {
     lazy val subscribeWithGoogleApiUrl =
       configuration.getStringProperty("google.subscribeWithGoogleApiUrl").getOrElse("https://swg.theguardian.com")
+    lazy val googleRecaptchaSiteKey = configuration.getMandatoryStringProperty("guardian.page.googleRecaptchaSiteKey")
   }
 
   object affiliateLinks {

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -464,4 +464,14 @@ trait FeatureSwitches {
     exposeClientSide = false,
   )
 
+  val emailSignupRecaptcha = Switch(
+    SwitchGroup.Feature,
+    "email-signup-recaptcha",
+    "Enables showing reCAPTCHA when signing up to email newsletters",
+    owners = Seq(Owner.withGithub("georgeblahblah")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
+
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -464,7 +464,7 @@ trait FeatureSwitches {
     exposeClientSide = false,
   )
 
-  val emailSignupRecaptcha = Switch(
+  val EmailSignupRecaptcha = Switch(
     SwitchGroup.Feature,
     "email-signup-recaptcha",
     "Enables showing reCAPTCHA when signing up to email newsletters",

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -32,6 +32,7 @@ case class EmailForm(
     ref: Option[String],
     refViewId: Option[String],
     campaignCode: Option[String],
+    googleRecaptchaResponse: Option[String],
     name: String,
 ) {
 
@@ -91,6 +92,7 @@ class EmailSignupController(
       "ref" -> optional[String](of[String]),
       "refViewId" -> optional[String](of[String]),
       "campaignCode" -> optional[String](of[String]),
+      "g-recaptcha-response" -> optional[String](of[String]),
       "name" -> text,
     )(EmailForm.apply)(EmailForm.unapply),
   )
@@ -260,6 +262,7 @@ class EmailSignupController(
               s"email: ${form.email}, " +
               s"ref: ${form.ref}, " +
               s"refViewId: ${form.refViewId}, " +
+              s"g-recaptcha-response: ${form.googleRecaptchaResponse}, " +
               s"referer: ${request.headers.get("referer").getOrElse("unknown")}, " +
               s"user-agent: ${request.headers.get("user-agent").getOrElse("unknown")}, " +
               s"x-requested-with: ${request.headers.get("x-requested-with").getOrElse("unknown")}",
@@ -325,6 +328,7 @@ class EmailSignupController(
               s"email: ${form.email}, " +
               s"ref: ${form.ref}, " +
               s"refViewId: ${form.refViewId}, " +
+              s"g-recaptcha-response: ${form.googleRecaptchaResponse}," +
               s"referer: ${request.headers.get("referer").getOrElse("unknown")}, " +
               s"user-agent: ${request.headers.get("user-agent").getOrElse("unknown")}, " +
               s"x-requested-with: ${request.headers.get("x-requested-with").getOrElse("unknown")}",

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -117,7 +117,6 @@ class EmailSignupController(
         val identityNewsletter = emailEmbedAgent.getNewsletterByName(listName)
         identityNewsletter match {
           case Right(Some(newsletter)) =>
-            println(newsletter, EmailSignupRecaptcha.isSwitchedOn)
             if (EmailSignupRecaptcha.isSwitchedOn && newsletter.signupPage.isDefined) {
               Cached(1.day)(RevalidatableResult.Ok(views.html.linkToEmailSignupPage(emailLandingPage, newsletter.signupPage.get, newsletter.name)))
             } else {

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -118,7 +118,10 @@ class EmailSignupController(
         identityNewsletter match {
           case Right(Some(newsletter)) =>
             if (EmailSignupRecaptcha.isSwitchedOn && newsletter.signupPage.isDefined) {
-              Cached(1.day)(RevalidatableResult.Ok(views.html.linkToEmailSignupPage(emailLandingPage, newsletter.signupPage.get, newsletter.name)))
+              Cached(1.day)(
+                RevalidatableResult
+                  .Ok(views.html.linkToEmailSignupPage(emailLandingPage, newsletter.signupPage.get, newsletter.name)),
+              )
             } else {
               Cached(1.day)(RevalidatableResult.Ok(views.html.emailFragmentFooter(emailLandingPage, listName)))
             }

--- a/common/app/services/newsletters/NewsletterApi.scala
+++ b/common/app/services/newsletters/NewsletterApi.scala
@@ -24,6 +24,7 @@ case class NewsletterResponse(
     exampleUrl: Option[String],
     emailEmbed: EmailEmbed,
     illustration: Option[NewsletterIllustration] = None,
+    signupPage: Option[String],
 )
 
 object NewsletterResponse {

--- a/common/app/views/emailEmbed.scala.html
+++ b/common/app/views/emailEmbed.scala.html
@@ -71,8 +71,8 @@
         }
 
         function onCaptchaCompleted(token) {
-            console.log(token)
             resizeToOriginalHeight()
+            document.querySelector('.email-sub__form').submit()
         }
 
         function onCaptchaError() {

--- a/common/app/views/emailEmbed.scala.html
+++ b/common/app/views/emailEmbed.scala.html
@@ -38,14 +38,17 @@
     </script>
     @if(EmailSignupRecaptcha.isSwitchedOn) {
         <script>
-            (() => {
+            const resizeToCurrentHeight = () => {
                 var height = parseInt(document.body.offsetHeight, 10);
                 var styles = document.defaultView.getComputedStyle(document.body);
                 height += parseInt(styles.getPropertyValue('margin-bottom'), 10);
                 height += parseInt(styles.getPropertyValue('margin-top'), 10);
-                sendResizeMessage(height)
-            })()
-            const submitButton = document.querySelector('.email-sub__submit-button')
+                sendResizeMessage(height);
+            }
+            window.addEventListener('message', (event) => {
+                if (event.data === 'resize') resizeToCurrentHeight();
+            })
+
             setupSubmitListener()
 
             const resizeToOriginalHeight = (() => {
@@ -56,8 +59,7 @@
             function sendResizeMessage(height) {
                 window.parent.postMessage(JSON.stringify({
                     type: 'set-height',
-                    value: height,
-                    src: window.location.href
+                    value: height
                 }), '*')
             }
 
@@ -66,6 +68,7 @@
             }
 
             function setupSubmitListener() {
+                const submitButton = document.querySelector('.email-sub__submit-button')
                 submitButton.addEventListener('click', (e) => onSubmit(e))
             }
 

--- a/common/app/views/emailEmbed.scala.html
+++ b/common/app/views/emailEmbed.scala.html
@@ -38,16 +38,31 @@
     </script>
     @if(EmailSignupRecaptcha.isSwitchedOn) {
         <script>
+            (() => {
+                var height = parseInt(document.body.offsetHeight, 10);
+                var styles = document.defaultView.getComputedStyle(document.body);
+                height += parseInt(styles.getPropertyValue('margin-bottom'), 10);
+                height += parseInt(styles.getPropertyValue('margin-top'), 10);
+                sendResizeMessage(height)
+            })()
             const submitButton = document.querySelector('.email-sub__submit-button')
             setupSubmitListener()
 
             const resizeToOriginalHeight = (() => {
                 const originalHeight = document.body.clientHeight
-                return () => iframeMessenger.resize(`${originalHeight}px`)
+                return () => sendResizeMessage(`${originalHeight}px`)
             })()
 
+            function sendResizeMessage(height) {
+                window.parent.postMessage(JSON.stringify({
+                    type: 'set-height',
+                    value: height,
+                    src: window.location.href
+                }), '*')
+            }
+
             function resizeToFitCaptcha() {
-                iframeMessenger.resize('500px')
+                sendResizeMessage('500px')
             }
 
             function setupSubmitListener() {

--- a/common/app/views/emailEmbed.scala.html
+++ b/common/app/views/emailEmbed.scala.html
@@ -1,4 +1,4 @@
-@(metaData: model.Page)(body: Html)(implicit request: RequestHeader, context: model.ApplicationContext)
+@(page: model.Page)(body: Html)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @import conf.switches.Switches._
 @import common.InlineJs
@@ -24,6 +24,7 @@
     }
 
     <script>
+        @Html(config(page).body)
         @InlineJs(emailIframeTracking().body, "emailIframeTracking.js")
     </script>
 
@@ -34,5 +35,54 @@
     <script src="https://interactive.guim.co.uk/libs/iframe-messenger/iframeMessenger.js"></script>
     <script>
         iframeMessenger.enableAutoResize();
+        const submitButton = document.querySelector('.email-sub__submit-button')
+
+        const resizeToOriginalHeight = (() => {
+            const originalHeight = document.body.clientHeight
+            return () => iframeMessenger.resize(`${originalHeight}px`)
+        })()
+
+        function resizeToFitCaptcha() {
+            iframeMessenger.resize('500px')
+        }
+
+        function setupSubmitListener() {
+            submitButton.addEventListener('click', (e) => onSubmit(e))
+        }
+
+        function onSubmit(e) {
+            console.log(`Click`)
+            e.preventDefault()
+            resizeToFitCaptcha()
+            grecaptcha.execute()
+        }
+
+        function onRecaptchaScriptLoaded() {
+            console.log(`Loaded`)
+            submitButton.removeAttribute('disabled')
+            setupSubmitListener()
+            grecaptcha.render('grecaptcha_container', {
+                sitekey: window.guardian.config.page.googleRecaptchaSiteKey,
+                callback: onCaptchaCompleted,
+                'error-callback': onCaptchaError,
+                'expired-callback': onCaptchaExpired,
+                size: 'invisible'
+            })
+        }
+
+        function onCaptchaCompleted(token) {
+            console.log(token)
+            resizeToOriginalHeight()
+        }
+
+        function onCaptchaError() {
+            resizeToOriginalHeight()
+        }
+
+        function onCaptchaExpired() {
+            resizeToOriginalHeight()
+        }
     </script>
+    <script src="https://www.google.com/recaptcha/api.js?onload=onRecaptchaScriptLoaded&render=explicit"
+    async defer></script>
 </html>

--- a/common/app/views/emailEmbed.scala.html
+++ b/common/app/views/emailEmbed.scala.html
@@ -78,8 +78,9 @@
             }
 
             function onRecaptchaScriptLoaded() {
-                resizeToFitCaptcha()
-                grecaptcha.render('grecaptcha_container', {
+                resizeToFitCaptcha();
+                const captchaContainer = document.getElementsByClassName('grecaptcha_container')[0]
+                grecaptcha.render(captchaContainer, {
                     sitekey: window.guardian.config.page.googleRecaptchaSiteKey,
                     callback: onCaptchaCompleted,
                     'error-callback': onCaptchaError,

--- a/common/app/views/emailEmbed.scala.html
+++ b/common/app/views/emailEmbed.scala.html
@@ -35,52 +35,56 @@
     <script src="https://interactive.guim.co.uk/libs/iframe-messenger/iframeMessenger.js"></script>
     <script>
         iframeMessenger.enableAutoResize();
-        const submitButton = document.querySelector('.email-sub__submit-button')
-
-        const resizeToOriginalHeight = (() => {
-            const originalHeight = document.body.clientHeight
-            return () => iframeMessenger.resize(`${originalHeight}px`)
-        })()
-
-        function resizeToFitCaptcha() {
-            iframeMessenger.resize('500px')
-        }
-
-        function setupSubmitListener() {
-            submitButton.addEventListener('click', (e) => onSubmit(e))
-        }
-
-        function onSubmit(e) {
-            e.preventDefault()
-            resizeToFitCaptcha()
-            grecaptcha.execute()
-        }
-
-        function onRecaptchaScriptLoaded() {
-            submitButton.removeAttribute('disabled')
-            setupSubmitListener()
-            grecaptcha.render('grecaptcha_container', {
-                sitekey: window.guardian.config.page.googleRecaptchaSiteKey,
-                callback: onCaptchaCompleted,
-                'error-callback': onCaptchaError,
-                'expired-callback': onCaptchaExpired,
-                size: 'invisible'
-            })
-        }
-
-        function onCaptchaCompleted(token) {
-            resizeToOriginalHeight()
-            document.querySelector('.email-sub__form').submit()
-        }
-
-        function onCaptchaError() {
-            resizeToOriginalHeight()
-        }
-
-        function onCaptchaExpired() {
-            resizeToOriginalHeight()
-        }
     </script>
-    <script src="https://www.google.com/recaptcha/api.js?onload=onRecaptchaScriptLoaded&render=explicit"
-    async defer></script>
+    @if(EmailSignupRecaptcha.isSwitchedOn) {
+        <script>
+            const submitButton = document.querySelector('.email-sub__submit-button')
+
+            const resizeToOriginalHeight = (() => {
+                const originalHeight = document.body.clientHeight
+                return () => iframeMessenger.resize(`${originalHeight}px`)
+            })()
+
+            function resizeToFitCaptcha() {
+                iframeMessenger.resize('500px')
+            }
+
+            function setupSubmitListener() {
+                submitButton.addEventListener('click', (e) => onSubmit(e))
+            }
+
+            function onSubmit(e) {
+                e.preventDefault()
+                resizeToFitCaptcha()
+                grecaptcha.execute()
+            }
+
+            function onRecaptchaScriptLoaded() {
+                submitButton.removeAttribute('disabled')
+                setupSubmitListener()
+                grecaptcha.render('grecaptcha_container', {
+                    sitekey: window.guardian.config.page.googleRecaptchaSiteKey,
+                    callback: onCaptchaCompleted,
+                    'error-callback': onCaptchaError,
+                    'expired-callback': onCaptchaExpired,
+                    size: 'invisible'
+                })
+            }
+
+            function onCaptchaCompleted(token) {
+                resizeToOriginalHeight()
+                document.querySelector('.email-sub__form').submit()
+            }
+
+            function onCaptchaError() {
+                resizeToOriginalHeight()
+            }
+
+            function onCaptchaExpired() {
+                resizeToOriginalHeight()
+            }
+        </script>
+        <script src="https://www.google.com/recaptcha/api.js?onload=onRecaptchaScriptLoaded&render=explicit"
+        async defer></script>
+    }
 </html>

--- a/common/app/views/emailEmbed.scala.html
+++ b/common/app/views/emailEmbed.scala.html
@@ -53,7 +53,7 @@
 
             const resizeToOriginalHeight = (() => {
                 const originalHeight = document.body.clientHeight
-                return () => sendResizeMessage(`${originalHeight}px`)
+                return () => sendResizeMessage(originalHeight)
             })()
 
             function sendResizeMessage(height) {

--- a/common/app/views/emailEmbed.scala.html
+++ b/common/app/views/emailEmbed.scala.html
@@ -51,14 +51,12 @@
         }
 
         function onSubmit(e) {
-            console.log(`Click`)
             e.preventDefault()
             resizeToFitCaptcha()
             grecaptcha.execute()
         }
 
         function onRecaptchaScriptLoaded() {
-            console.log(`Loaded`)
             submitButton.removeAttribute('disabled')
             setupSubmitListener()
             grecaptcha.render('grecaptcha_container', {

--- a/common/app/views/emailEmbed.scala.html
+++ b/common/app/views/emailEmbed.scala.html
@@ -39,7 +39,7 @@
     @if(EmailSignupRecaptcha.isSwitchedOn) {
         <script>
             const submitButton = document.querySelector('.email-sub__submit-button')
-            submitButton.setAttribute("disabled", true)
+            setupSubmitListener()
 
             const resizeToOriginalHeight = (() => {
                 const originalHeight = document.body.clientHeight
@@ -56,14 +56,18 @@
 
             function onSubmit(e) {
                 e.preventDefault()
-                resizeToFitCaptcha()
-                grecaptcha.execute()
+                (function(d, script) {
+                    script = d.createElement('script');
+                    script.type = 'text/javascript';
+                    script.async = true;
+                    script.defer = true
+                    script.src = 'https://www.google.com/recaptcha/api.js?onload=onRecaptchaScriptLoaded&render=explicit';
+                    d.getElementsByTagName('head')[0].appendChild(script);
+                }(document));
             }
 
             function onRecaptchaScriptLoaded() {
-                submitButton.setAttribute("type", "button")
-                submitButton.setAttribute("disabled", false)
-                setupSubmitListener()
+                resizeToFitCaptcha()
                 grecaptcha.render('grecaptcha_container', {
                     sitekey: window.guardian.config.page.googleRecaptchaSiteKey,
                     callback: onCaptchaCompleted,
@@ -71,6 +75,7 @@
                     'expired-callback': onCaptchaExpired,
                     size: 'invisible'
                 })
+                grecaptcha.execute()
             }
 
             function onCaptchaCompleted(token) {
@@ -86,7 +91,5 @@
                 resizeToOriginalHeight()
             }
         </script>
-        <script src="https://www.google.com/recaptcha/api.js?onload=onRecaptchaScriptLoaded&render=explicit"
-        async defer></script>
     }
 </html>

--- a/common/app/views/emailEmbed.scala.html
+++ b/common/app/views/emailEmbed.scala.html
@@ -39,6 +39,7 @@
     @if(EmailSignupRecaptcha.isSwitchedOn) {
         <script>
             const submitButton = document.querySelector('.email-sub__submit-button')
+            submitButton.setAttribute("disabled", true)
 
             const resizeToOriginalHeight = (() => {
                 const originalHeight = document.body.clientHeight
@@ -60,7 +61,8 @@
             }
 
             function onRecaptchaScriptLoaded() {
-                submitButton.removeAttribute('disabled')
+                submitButton.setAttribute("type", "button")
+                submitButton.setAttribute("disabled", false)
                 setupSubmitListener()
                 grecaptcha.render('grecaptcha_container', {
                     sitekey: window.guardian.config.page.googleRecaptchaSiteKey,

--- a/common/app/views/emailEmbed.scala.html
+++ b/common/app/views/emailEmbed.scala.html
@@ -64,7 +64,7 @@
             }
 
             function resizeToFitCaptcha() {
-                sendResizeMessage('500px')
+                sendResizeMessage(500)
             }
 
             function setupSubmitListener() {

--- a/common/app/views/emailEmbed.scala.html
+++ b/common/app/views/emailEmbed.scala.html
@@ -33,43 +33,36 @@
         @body
     </body>
     <script src="https://interactive.guim.co.uk/libs/iframe-messenger/iframeMessenger.js"></script>
-    <script>
-        iframeMessenger.enableAutoResize();
-    </script>
     @if(EmailSignupRecaptcha.isSwitchedOn) {
         <script>
-            const resizeToCurrentHeight = () => {
-                var height = parseInt(document.body.offsetHeight, 10);
-                var styles = document.defaultView.getComputedStyle(document.body);
-                height += parseInt(styles.getPropertyValue('margin-bottom'), 10);
-                height += parseInt(styles.getPropertyValue('margin-top'), 10);
-                sendResizeMessage(height);
-            }
             window.addEventListener('message', (event) => {
+                const allowedOrigins = ['https://www.theguardian.com'];
+                if (!allowedOrigins.includes(event.origin)) return;
                 if (event.data === 'resize') resizeToCurrentHeight();
             })
+            setupSubmitListener();
+            resizeToCurrentHeight();
 
-            setupSubmitListener()
+            function resizeToCurrentHeight() {
+                iframeMessenger.resize()
+            }
 
             const resizeToOriginalHeight = (() => {
-                const originalHeight = document.body.clientHeight
-                return () => sendResizeMessage(originalHeight)
-            })()
+                const originalHeight = document.body.clientHeight;
+                return () => sendResizeMessage(originalHeight);
+            })();
 
             function sendResizeMessage(height) {
-                window.parent.postMessage(JSON.stringify({
-                    type: 'set-height',
-                    value: height
-                }), '*')
+                iframeMessenger.resize(height);
             }
 
             function resizeToFitCaptcha() {
-                sendResizeMessage(500)
+                sendResizeMessage(500);
             }
 
             function setupSubmitListener() {
-                const submitButton = document.querySelector('.email-sub__submit-button')
-                submitButton.addEventListener('click', (e) => onSubmit(e))
+                const submitButton = document.querySelector('.email-sub__submit-button');
+                submitButton.addEventListener('click', (e) => onSubmit(e));
             }
 
             function onSubmit(e) {
@@ -78,7 +71,7 @@
                     script = d.createElement('script');
                     script.type = 'text/javascript';
                     script.async = true;
-                    script.defer = true
+                    script.defer = true;
                     script.src = 'https://www.google.com/recaptcha/api.js?onload=onRecaptchaScriptLoaded&render=explicit';
                     d.getElementsByTagName('head')[0].appendChild(script);
                 }(document));
@@ -92,21 +85,21 @@
                     'error-callback': onCaptchaError,
                     'expired-callback': onCaptchaExpired,
                     size: 'invisible'
-                })
-                grecaptcha.execute()
+                });
+                grecaptcha.execute();
             }
 
             function onCaptchaCompleted(token) {
-                resizeToOriginalHeight()
-                document.querySelector('.email-sub__form').submit()
+                resizeToOriginalHeight();
+                document.querySelector('.email-sub__form').submit();
             }
 
             function onCaptchaError() {
-                resizeToOriginalHeight()
+                resizeToOriginalHeight();
             }
 
             function onCaptchaExpired() {
-                resizeToOriginalHeight()
+                resizeToOriginalHeight();
             }
         </script>
     }

--- a/common/app/views/fragments/email/signup/footer/emailSignUpFooter.scala.html
+++ b/common/app/views/fragments/email/signup/footer/emailSignUpFooter.scala.html
@@ -1,5 +1,7 @@
 @(listName: String)(implicit request: RequestHeader)
 
+@import conf.switches.Switches.EmailSignupRecaptcha
+
 @import common.LinkTo
 @formId = @{"footer-email-sub-form"}
 @inputId = @{"footer-email-sub-input" }
@@ -27,7 +29,9 @@
 
             </div>
             <button type="submit" class="email-sub__submit-button button button--tertiary button--large" id="email-embed-signup-button" data-component="email-signup-button footer-@listName" data-link-name="footer | @listName">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
-            <div id="grecaptcha_container"></div>
+            @if(EmailSignupRecaptcha.isSwitchedOn) {
+                @fragments.email.signup.recaptcha()
+            }
         </div>
     </form>
 }

--- a/common/app/views/fragments/email/signup/footer/emailSignUpFooter.scala.html
+++ b/common/app/views/fragments/email/signup/footer/emailSignUpFooter.scala.html
@@ -26,7 +26,7 @@
                 <input class="email-sub__refviewid-input" type="hidden" name="refViewId" id="email-sub__refviewid-input" value="" />
 
             </div>
-            <button type="button" disabled class="email-sub__submit-button button button--tertiary button--large" id="email-embed-signup-button" data-component="email-signup-button footer-@listName" data-link-name="footer | @listName">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
+            <button type="submit" class="email-sub__submit-button button button--tertiary button--large" id="email-embed-signup-button" data-component="email-signup-button footer-@listName" data-link-name="footer | @listName">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
             <div id="grecaptcha_container"></div>
         </div>
     </form>

--- a/common/app/views/fragments/email/signup/footer/emailSignUpFooter.scala.html
+++ b/common/app/views/fragments/email/signup/footer/emailSignUpFooter.scala.html
@@ -30,7 +30,8 @@
             </div>
             <button type="submit" class="email-sub__submit-button button button--tertiary button--large" id="email-embed-signup-button" data-component="email-signup-button footer-@listName" data-link-name="footer | @listName">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
             @if(EmailSignupRecaptcha.isSwitchedOn) {
-                @fragments.email.signup.recaptcha()
+                @fragments.email.signup.recaptchaContainer()
+                @fragments.email.signup.recaptchaTerms()
             }
         </div>
     </form>

--- a/common/app/views/fragments/email/signup/footer/emailSignUpFooter.scala.html
+++ b/common/app/views/fragments/email/signup/footer/emailSignUpFooter.scala.html
@@ -26,7 +26,8 @@
                 <input class="email-sub__refviewid-input" type="hidden" name="refViewId" id="email-sub__refviewid-input" value="" />
 
             </div>
-            <button type="submit" class="email-sub__submit-button button button--tertiary button--large" id="email-embed-signup-button" data-component="email-signup-button footer-@listName" data-link-name="footer | @listName">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
+            <button type="button" disabled class="email-sub__submit-button button button--tertiary button--large" id="email-embed-signup-button" data-component="email-signup-button footer-@listName" data-link-name="footer | @listName">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
+            <div id="grecaptcha_container"></div>
         </div>
     </form>
 }

--- a/common/app/views/fragments/email/signup/recaptcha.scala.html
+++ b/common/app/views/fragments/email/signup/recaptcha.scala.html
@@ -1,4 +1,4 @@
 <div id="grecaptcha_container"></div>
 <div class="captcha-terms">
-    This site is protected by reCAPTCHA and the Google <a href="https://policies.google.com/privacy">Privacy Policy</a> and <a href="https://policies.google.com/terms">Terms of Service</a> apply.
+    This site is protected by reCAPTCHA and the Google <a href="https://policies.google.com/privacy" target="_blank">Privacy Policy</a> and <a href="https://policies.google.com/terms" target="_blank">Terms of Service</a> apply.
 </div>

--- a/common/app/views/fragments/email/signup/recaptcha.scala.html
+++ b/common/app/views/fragments/email/signup/recaptcha.scala.html
@@ -1,4 +1,0 @@
-<div class="grecaptcha_container"></div>
-<div class="captcha-terms">
-    This site is protected by reCAPTCHA and the Google <a href="https://policies.google.com/privacy" target="_blank">Privacy Policy</a> and <a href="https://policies.google.com/terms" target="_blank">Terms of Service</a> apply.
-</div>

--- a/common/app/views/fragments/email/signup/recaptcha.scala.html
+++ b/common/app/views/fragments/email/signup/recaptcha.scala.html
@@ -1,4 +1,4 @@
-<div id="grecaptcha_container"></div>
+<div class="grecaptcha_container"></div>
 <div class="captcha-terms">
     This site is protected by reCAPTCHA and the Google <a href="https://policies.google.com/privacy" target="_blank">Privacy Policy</a> and <a href="https://policies.google.com/terms" target="_blank">Terms of Service</a> apply.
 </div>

--- a/common/app/views/fragments/email/signup/recaptcha.scala.html
+++ b/common/app/views/fragments/email/signup/recaptcha.scala.html
@@ -1,0 +1,4 @@
+<div id="grecaptcha_container"></div>
+<div class="captcha-terms">
+    This site is protected by reCAPTCHA and the Google <a href="https://policies.google.com/privacy">Privacy Policy</a> and <a href="https://policies.google.com/terms">Terms of Service</a> apply.
+</div>

--- a/common/app/views/fragments/email/signup/recaptchaContainer.scala.html
+++ b/common/app/views/fragments/email/signup/recaptchaContainer.scala.html
@@ -1,0 +1,1 @@
+<div class="grecaptcha_container"></div>

--- a/common/app/views/fragments/email/signup/recaptchaTerms.scala.html
+++ b/common/app/views/fragments/email/signup/recaptchaTerms.scala.html
@@ -1,0 +1,3 @@
+<div class="captcha-terms">
+    This page is protected by reCAPTCHA and the Google <a href="https://policies.google.com/privacy" target="_blank">Privacy Policy</a> and <a href="https://policies.google.com/terms" target="_blank">Terms of Service</a> apply.
+</div>

--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -5,6 +5,7 @@
     emailEmbedData: EmailEmbed)(implicit request: RequestHeader)
 
 @import common.LinkTo
+@import conf.switches.Switches.EmailSignupRecaptcha
 
 @listNamesTones = @{  List(
     bestOfOpinionUK.identityName -> "comment",
@@ -50,7 +51,9 @@
 
             </div>
             <button type="submit" class="email-sub__submit-button button button--tertiary button--large" id="email-embed-signup-button--old" data-component="email-signup-button @componentClass-@listName" data-link-name="@componentClass | @listName">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
-            <div id="grecaptcha_container"></div>
+            @if(EmailSignupRecaptcha.isSwitchedOn) {
+                @fragments.email.signup.recaptcha()
+            }
         </div>
     </form>
 }

--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -52,7 +52,8 @@
             </div>
             <button type="submit" class="email-sub__submit-button button button--tertiary button--large" id="email-embed-signup-button--old" data-component="email-signup-button @componentClass-@listName" data-link-name="@componentClass | @listName">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
             @if(EmailSignupRecaptcha.isSwitchedOn) {
-                @fragments.email.signup.recaptcha()
+                @fragments.email.signup.recaptchaContainer()
+                @fragments.email.signup.recaptchaTerms()
             }
         </div>
     </form>

--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -49,7 +49,8 @@
                 <input class="email-sub__refviewid-input" type="hidden" name="refViewId" id="email-sub__refviewid-input" value="" />
 
             </div>
-            <button type="submit" class="email-sub__submit-button button button--tertiary button--large" id="email-embed-signup-button--old" data-component="email-signup-button @componentClass-@listName" data-link-name="@componentClass | @listName">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
+            <button type="button" disabled class="email-sub__submit-button button button--tertiary button--large" id="email-embed-signup-button--old" data-component="email-signup-button @componentClass-@listName" data-link-name="@componentClass | @listName">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
+            <div id="grecaptcha_container"></div>
         </div>
     </form>
 }

--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -49,7 +49,7 @@
                 <input class="email-sub__refviewid-input" type="hidden" name="refViewId" id="email-sub__refviewid-input" value="" />
 
             </div>
-            <button type="button" disabled class="email-sub__submit-button button button--tertiary button--large" id="email-embed-signup-button--old" data-component="email-signup-button @componentClass-@listName" data-link-name="@componentClass | @listName">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
+            <button type="submit" class="email-sub__submit-button button button--tertiary button--large" id="email-embed-signup-button--old" data-component="email-signup-button @componentClass-@listName" data-link-name="@componentClass | @listName">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
             <div id="grecaptcha_container"></div>
         </div>
     </form>

--- a/common/app/views/linkToEmailSignupPage.scala.html
+++ b/common/app/views/linkToEmailSignupPage.scala.html
@@ -23,8 +23,8 @@
 </head>
 <body>
     <div class="@wrapperClass">
-        <a class="email-sub__link-button" href="@signupPage" target="_parent">@buttonText</a>
         <div class="email-sub__description">@Html(formDescription)</div>
+        <a class="email-sub__link-button" href="@signupPage" target="_parent">@buttonText</a>
     </div>
 </body>
 </html>

--- a/common/app/views/linkToEmailSignupPage.scala.html
+++ b/common/app/views/linkToEmailSignupPage.scala.html
@@ -1,0 +1,30 @@
+@(page: model.Page, signupPage: String, listName: String)(implicit request: RequestHeader, context: model.ApplicationContext)
+
+@import conf.Static
+@import conf.switches.Switches._
+@import play.api.Mode.Dev
+
+@wrapperClass = @{ "email-sub email-sub__link--footer" }
+@buttonText = @{"Sign up for the Guardian Today email"}
+@formDescription = @{"All the day's headlines and highlights from the Guardian, direct to you every morning"}
+<!doctype html>
+<head>
+    @if(FontSwitch.isSwitchedOn) {
+        @fragments.fontFaces()
+    }
+
+    @if(context.environment.mode == Dev || !InlineCriticalCss.isSwitchedOn) {
+        <link rel="stylesheet" type="text/css" href="@Static("stylesheets/head.email-signup.css")" />
+    } else {
+        <style class="js-loggable">
+        @Html(common.Assets.css.head(Some("email-signup")))
+        </style>
+    }
+</head>
+<body>
+    <div class="@wrapperClass">
+        <a class="email-sub__link-button" href="@signupPage" target="_parent">@buttonText</a>
+        <div class="email-sub__description">@Html(formDescription)</div>
+    </div>
+</body>
+</html>

--- a/static/src/javascripts/bootstraps/enhanced/newsletters.js
+++ b/static/src/javascripts/bootstraps/enhanced/newsletters.js
@@ -107,7 +107,7 @@ const createSubscriptionFormEventHandlers = (buttonEl) => {
         const form = buttonEl.form;
         if (validate(form)) {
             if (window.guardian.config.switches.emailSignupRecaptcha) {
-                showCaptcha(buttonEl.value, () => submitForm(form, buttonEl))
+                showCaptcha(form, () => submitForm(form, buttonEl))
             } else {
                 submitForm(form, buttonEl);
             }
@@ -115,8 +115,9 @@ const createSubscriptionFormEventHandlers = (buttonEl) => {
     });
 };
 
-const showCaptcha = (listId, callback) => {
-    const captchaId = grecaptcha.render(`grecaptcha_container-${listId}`, {
+const showCaptcha = (form, callback) => {
+    const captchaContainer = $('.grecaptcha_container', form).get(0)
+    const captchaId = grecaptcha.render(captchaContainer, {
         sitekey: window.guardian.config.page.googleRecaptchaSiteKey,
         callback: callback,
         size: 'invisible'

--- a/static/src/javascripts/bootstraps/standard/emailEmbeds.js
+++ b/static/src/javascripts/bootstraps/standard/emailEmbeds.js
@@ -1,3 +1,5 @@
+import { isObject } from '@guardian/libs'
+
 const initEmbedResize = () => {
 	const allIframes = [].slice.call(
 		document.querySelectorAll(
@@ -21,7 +23,7 @@ const initEmbedResize = () => {
 
 		const iframes = allIframes.filter((i) => {
 			try {
-                if (i.contentWindow !== null && event.source !== null) return false
+                if (i.contentWindow === null && event.source === null) return false
 				return (
 					i.contentWindow === event.source
 				);
@@ -29,12 +31,17 @@ const initEmbedResize = () => {
 				return false;
 			}
 		});
+
 		if (iframes.length !== 0) {
 			try {
 				const message = JSON.parse(event.data);
+                if (!isObject(message) || typeof message.type !== 'string') {
+                    return
+                }
+
 				switch (message.type) {
 					case 'set-height':
-						const value = parseInt(message.value);
+                        const value = (typeof message.value === 'number') ? message.value : parseInt(message.value, 10)
 						if (!Number.isInteger(value)) return;
 
 						iframes.forEach((iframe) => {

--- a/static/src/javascripts/bootstraps/standard/emailEmbeds.js
+++ b/static/src/javascripts/bootstraps/standard/emailEmbeds.js
@@ -9,7 +9,7 @@ const initEmbedResize = () => {
 	// Otherwise, earlier resize events might be missed
 	allIframes.forEach((iframe) => {
 		if (iframe && iframe.contentWindow)
-			iframe.contentWindow.postMessage("resize", "*");
+			iframe.contentWindow.postMessage("resize", "https://www.theguardian.com");
 	});
 
 	const allowedOrigins = ['https://www.theguardian.com']

--- a/static/src/javascripts/bootstraps/standard/emailEmbeds.js
+++ b/static/src/javascripts/bootstraps/standard/emailEmbeds.js
@@ -5,10 +5,16 @@ const initEmbedResize = () => {
 		),
 	);
 
+    const allowedOrigins = ['https://www.theguardian.com', 'https://m.code.dev-theguardian.com', 'http://localhost:9000']
+
 	window.addEventListener('message', (event) => {
+        if (!allowedOrigins.includes(event.origin)) return
+
 		const iframes = allIframes.filter((i) => {
 			try {
-				return i.src === event.source.location.href;
+				return (
+					i.contentWindow === event.source
+				);
 			} catch (e) {
 				return false;
 			}
@@ -18,8 +24,11 @@ const initEmbedResize = () => {
 				const message = JSON.parse(event.data);
 				switch (message.type) {
 					case 'set-height':
+                        const value = parseInt(message.value);
+						if (!Number.isInteger(value)) return;
+
 						iframes.forEach((iframe) => {
-							iframe.height = message.value;
+							iframe.height = value;
 						});
 						break;
 					default:

--- a/static/src/javascripts/bootstraps/standard/emailEmbeds.js
+++ b/static/src/javascripts/bootstraps/standard/emailEmbeds.js
@@ -33,7 +33,7 @@ const initEmbedResize = () => {
 				const message = JSON.parse(event.data);
 				switch (message.type) {
 					case 'set-height':
-                        const value = parseInt(message.value);
+						const value = parseInt(message.value);
 						if (!Number.isInteger(value)) return;
 
 						iframes.forEach((iframe) => {

--- a/static/src/javascripts/bootstraps/standard/emailEmbeds.js
+++ b/static/src/javascripts/bootstraps/standard/emailEmbeds.js
@@ -5,8 +5,17 @@ const initEmbedResize = () => {
 		),
 	);
 
-    const allowedOrigins = ['https://www.theguardian.com', 'https://m.code.dev-theguardian.com', 'http://localhost:9000']
+	// Tell the iframes to resize once this script is loaded
+	// Otherwise, earlier resize events might be missed
+	allIframes.forEach((iframe) => {
+		if (iframe && iframe.contentWindow)
+			iframe.contentWindow.postMessage("resize", "*");
+	});
 
+	const allowedOrigins = ['https://www.theguardian.com']
+	if (window.guardian.config.page.isDev) {
+		allowedOrigins.push('https://m.code.dev-theguardian.com')
+	}
 	window.addEventListener('message', (event) => {
         if (!allowedOrigins.includes(event.origin)) return
 
@@ -28,7 +37,7 @@ const initEmbedResize = () => {
 						if (!Number.isInteger(value)) return;
 
 						iframes.forEach((iframe) => {
-							iframe.height = value;
+							iframe.height = `${value}`;
 						});
 						break;
 					default:

--- a/static/src/javascripts/bootstraps/standard/emailEmbeds.js
+++ b/static/src/javascripts/bootstraps/standard/emailEmbeds.js
@@ -1,8 +1,7 @@
 const initEmbedResize = () => {
     const allIframes = [].slice.call(
-        document.querySelectorAll('.element-embed > .email-sub__iframe')
+        document.querySelectorAll('.element-embed > .email-sub__iframe, #footer__email-form'),
     );
-
     window.addEventListener('message', event => {
         const iframes = allIframes.filter(i => {
             try {

--- a/static/src/javascripts/bootstraps/standard/emailEmbeds.js
+++ b/static/src/javascripts/bootstraps/standard/emailEmbeds.js
@@ -1,41 +1,32 @@
-const allowedOrigins = [
-    'https://www.theguardian.com',
-    'https://theguardian.com',
-    'https://m.code.dev-theguardian.com',
-    'http://localhost:3000'
-]
 const initEmbedResize = () => {
-    const allIframes = [].slice.call(
-        document.querySelectorAll('.element-embed > .email-sub__iframe, #footer__email-form'),
-    );
-    window.addEventListener('message', event => {
-        if (!allowedOrigins.includes(event.origin)) return
-        const message = JSON.parse(event.data)
-        const iframes = allIframes.filter(i => {
-            try {
-                if (message.src)
-                    return i.src === message.src
-                else
-                    return i.src === event.source.location.href
-            } catch (e) {
-                return false
-            }
-        })
+	const allIframes = [].slice.call(
+		document.querySelectorAll(
+			'.element-embed > .email-sub__iframe, #footer__email-form',
+		),
+	);
 
-        if (iframes.length !== 0) {
-            try {
-                switch (message.type) {
-                    case 'set-height':
-                        iframes.forEach( iframe => {
-                            iframe.height = message.value;
-                        })
-                        break;
-                    default:
-                }
-                // eslint-disable-next-line no-empty
-            } catch (e) {
-            }
-        }
-    });
+	window.addEventListener('message', (event) => {
+		const iframes = allIframes.filter((i) => {
+			try {
+				return i.src === event.source.location.href;
+			} catch (e) {
+				return false;
+			}
+		});
+		if (iframes.length !== 0) {
+			try {
+				const message = JSON.parse(event.data);
+				switch (message.type) {
+					case 'set-height':
+						iframes.forEach((iframe) => {
+							iframe.height = message.value;
+						});
+						break;
+					default:
+				}
+				// eslint-disable-next-line no-empty
+			} catch (e) {}
+		}
+	});
 };
 export { initEmbedResize };

--- a/static/src/javascripts/bootstraps/standard/emailEmbeds.js
+++ b/static/src/javascripts/bootstraps/standard/emailEmbeds.js
@@ -21,6 +21,7 @@ const initEmbedResize = () => {
 
 		const iframes = allIframes.filter((i) => {
 			try {
+                if (i.contentWindow !== null && event.source !== null) return false
 				return (
 					i.contentWindow === event.source
 				);

--- a/static/src/javascripts/bootstraps/standard/emailEmbeds.js
+++ b/static/src/javascripts/bootstraps/standard/emailEmbeds.js
@@ -1,18 +1,29 @@
+const allowedOrigins = [
+    'https://www.theguardian.com',
+    'https://theguardian.com',
+    'https://m.code.dev-theguardian.com',
+    'http://localhost:3000'
+]
 const initEmbedResize = () => {
     const allIframes = [].slice.call(
         document.querySelectorAll('.element-embed > .email-sub__iframe, #footer__email-form'),
     );
     window.addEventListener('message', event => {
+        if (!allowedOrigins.includes(event.origin)) return
+        const message = JSON.parse(event.data)
         const iframes = allIframes.filter(i => {
             try {
-                return i.src === event.source.location.href;
+                if (message.src)
+                    return i.src === message.src
+                else
+                    return i.src === event.source.location.href
             } catch (e) {
-                return false;
+                return false
             }
-        });
+        })
+
         if (iframes.length !== 0) {
             try {
-                const message = JSON.parse(event.data);
                 switch (message.type) {
                     case 'set-height':
                         iframes.forEach( iframe => {

--- a/static/src/stylesheets/module/email-signup/_iframe.scss
+++ b/static/src/stylesheets/module/email-signup/_iframe.scss
@@ -16,13 +16,13 @@ body {
 }
 
 .email-sub .captcha-terms {
-    color: #121212;
+    color: $brightness-7;
     clear: both;
     font-family: $f-sans-serif-text;
     font-size: 12px;
 
     a {
-        color: #121212;
+        color: $brightness-7;
     }
 }
 

--- a/static/src/stylesheets/module/email-signup/_iframe.scss
+++ b/static/src/stylesheets/module/email-signup/_iframe.scss
@@ -237,11 +237,12 @@ body {
 * Styles for temporary footer link to sign up page
 */
 .email-sub__link--footer {
-    margin: 5px 0;
 
     .email-sub__description {
         @include fs-textSans(3);
         border: 0;
+        margin-top: 12px;
+        margin-bottom: 8px;
     }
 
     .email-sub__link-button {

--- a/static/src/stylesheets/module/email-signup/_iframe.scss
+++ b/static/src/stylesheets/module/email-signup/_iframe.scss
@@ -16,13 +16,13 @@ body {
 }
 
 .email-sub .captcha-terms {
-    color: #767676;
+    color: #121212;
     clear: both;
     font-family: $f-sans-serif-text;
     font-size: 12px;
 
     a {
-        color: #007abc;
+        color: #121212;
     }
 }
 

--- a/static/src/stylesheets/module/email-signup/_iframe.scss
+++ b/static/src/stylesheets/module/email-signup/_iframe.scss
@@ -11,8 +11,22 @@ body {
 /**
 * Google reCAPTCHA styles
 */
-.grecaptcha-badge {
+.email-sub .grecaptcha-badge {
     visibility: hidden;
+}
+
+.email-sub .captcha-terms {
+    clear: both;
+    font-family: $f-sans-serif-text;
+    font-size: 12px;
+}
+
+.email-sub--footer .captcha-terms {
+    color: #ffffff;
+
+    a {
+        color: #ffffff;
+    }
 }
 
 /**

--- a/static/src/stylesheets/module/email-signup/_iframe.scss
+++ b/static/src/stylesheets/module/email-signup/_iframe.scss
@@ -22,7 +22,7 @@ body {
     font-size: 12px;
 
     a {
-        color: #007ABC;
+        color: #007abc;
     }
 }
 
@@ -240,8 +240,8 @@ body {
     margin: 5px 0;
 
     .email-sub__description {
-        border: none;
         @include fs-textSans(3);
+        border: 0;
     }
 
     .email-sub__link-button {
@@ -251,11 +251,11 @@ body {
         -moz-box-align: center;
         align-items: center;
         box-sizing: border-box;
-        background: white;
+        background: #ffffff;
         cursor: pointer;
         text-decoration: none;
         font-family: $f-sans-serif-text;
-        font-size: 0.9rem;
+        font-size: .9rem;
         line-height: 1.5;
         font-weight: 700;
         height: 44px;

--- a/static/src/stylesheets/module/email-signup/_iframe.scss
+++ b/static/src/stylesheets/module/email-signup/_iframe.scss
@@ -233,6 +233,39 @@ body {
     }
 }
 
+/**
+* Styles for temporary footer link to sign up page
+*/
+.email-sub__link--footer {
+    margin: 5px 0;
+
+    .email-sub__description {
+        border: none;
+        @include fs-textSans(3);
+    }
+
+    .email-sub__link-button {
+        display: inline-flex;
+        -moz-box-pack: justify;
+        justify-content: space-between;
+        -moz-box-align: center;
+        align-items: center;
+        box-sizing: border-box;
+        background: white;
+        cursor: pointer;
+        text-decoration: none;
+        font-family: $f-sans-serif-text;
+        font-size: 0.9rem;
+        line-height: 1.5;
+        font-weight: 700;
+        height: 44px;
+        min-height: 44px;
+        padding: 0px 20px 2px;
+        border-radius: 44px;
+        color: rgb(5, 41, 98);
+    }
+}
+
 .email-sub__form--article {
     @include right-padding-to-match-article-content;
 

--- a/static/src/stylesheets/module/email-signup/_iframe.scss
+++ b/static/src/stylesheets/module/email-signup/_iframe.scss
@@ -9,6 +9,13 @@ body {
 }
 
 /**
+* Google reCAPTCHA styles
+*/
+.grecaptcha-badge {
+    visibility: hidden;
+}
+
+/**
 * IFRAME MODS
 */
 .email-sub__text-input,

--- a/static/src/stylesheets/module/email-signup/_iframe.scss
+++ b/static/src/stylesheets/module/email-signup/_iframe.scss
@@ -16,9 +16,14 @@ body {
 }
 
 .email-sub .captcha-terms {
+    color: #767676;
     clear: both;
     font-family: $f-sans-serif-text;
     font-size: 12px;
+
+    a {
+        color: #007ABC;
+    }
 }
 
 .email-sub--footer .captcha-terms {

--- a/static/src/stylesheets/module/signup/_newsletters.scss
+++ b/static/src/stylesheets/module/signup/_newsletters.scss
@@ -278,3 +278,7 @@
         width: gs-span(3);
     }
 }
+
+.grecaptcha-badge {
+    visibility: hidden;
+}


### PR DESCRIPTION
## What does this change?

* Adds a feature switch to challenge users with a captcha when signing up for an email newsletter
* Handles email singup embed resize messages, to accommodate the captcha
* Logs the captcha token. Validating the token will be implemented in another PR, behind a separate feature switch
* Transforms the footer signup to a button link to the canonical signup page

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (https://github.com/guardian/dotcom-rendering/pull/3732)

## Screenshots

<details>
<summary>captcha displayed in article</summary>

</details>

<details>
<summary>email signup embed with links to Google terms & conditions</summary>
<img width="672" alt="Screenshot 2022-01-05 at 14 25 36" src="https://user-images.githubusercontent.com/705427/148233694-4da671e0-3774-4aa0-8c96-fb48d01ece1a.png">
</details>

<details>
<summary>captcha displayed on /email-newsletters</summary>
<img width="807" alt="Screenshot 2022-01-05 at 14 20 47" src="https://user-images.githubusercontent.com/705427/148233711-9c59e08b-2510-4876-be75-d8b830d14b88.png">
</details>

## What is the value of this and can you measure success?

To help prevent bot signups

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [x] Apps (https://github.com/guardian/dotcom-rendering/pull/3732 & https://github.com/guardian/mobile-apps-article-templates/pull/1499)
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)
- [ ] 
### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
