### PR TITLE
Render deadblogs in DCR after 2 days, rather than 3

### DIFF
--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -107,8 +107,8 @@ class LiveBlogController(
   private def isDeadBlog(blog: LiveBlogPage): Boolean = !blog.article.fields.isLive
 
   private def isNotRecent(blog: LiveBlogPage) = {
-    val threeDaysAgo = new DateTime(DateTimeZone.UTC).minusDays(3)
-    blog.article.fields.lastModified.isBefore(threeDaysAgo)
+    val twoDaysAgo = new DateTime(DateTimeZone.UTC).minusDays(2)
+    blog.article.fields.lastModified.isBefore(twoDaysAgo)
   }
 
   private def isNotAustraliaNewsBlog(blog: LiveBlogPage) = {


### PR DESCRIPTION
## What does this change?

Re-does the change from #24447 which appeared to get reverted due to merging issues!

Means that DCR will render deadblogs to opted in users that are only 2 days old, rather than 3, which will send more traffic overall to DCR.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
