### PR TITLE
Bump CAPI version to 17.23

### DIFF
--- a/common/app/model/Formats.scala
+++ b/common/app/model/Formats.scala
@@ -174,6 +174,7 @@ object PressedContentFormat {
         case JsString("Quiz")                 => JsSuccess(com.gu.contentapi.client.utils.Quiz)
         case JsString("GuardianLabs")         => JsSuccess(com.gu.contentapi.client.utils.GuardianLabs)
         case JsString("AdvertisementFeature") => JsSuccess(com.gu.contentapi.client.utils.AdvertisementFeature)
+        case JsString("NewsletterSignup")     => JsSuccess(com.gu.contentapi.client.utils.NewsletterSignup)
         case _                                => JsError(s"Unknown design type: '$json'")
       }
     override def writes(dt: DesignType): JsValue =
@@ -194,6 +195,7 @@ object PressedContentFormat {
         case com.gu.contentapi.client.utils.Quiz                 => JsString("Quiz")
         case com.gu.contentapi.client.utils.GuardianLabs         => JsString("GuardianLabs")
         case com.gu.contentapi.client.utils.AdvertisementFeature => JsString("AdvertisementFeature")
+        case com.gu.contentapi.client.utils.NewsletterSignup     => JsString("NewsletterSignup")
       }
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ import sbt._
 object Dependencies {
   val identityLibVersion = "3.240-C4"
   val awsVersion = "1.11.240"
-  val capiVersion = "17.22"
+  val capiVersion = "17.23"
   val faciaVersion = "3.3.8"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"


### PR DESCRIPTION
## What does this change?
CAPI has been updated to support the `format` requirements of both the new and the old immersive interactive templates

https://github.com/guardian/content-api-scala-client/pull/342

## Does this change need to be reproduced in dotcom-rendering ? 

- No, the change here will be carried forward into DCR.

## Checklist

### Does this affect other platforms?

- [X] Apps
- [X] DCR
- 
### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [ ] Locally
- [ ] On CODE (optional)
