### PR TITLE
Fix Font-Size being too large

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_container.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container.scss
@@ -132,8 +132,8 @@ $header-image-size-desktop: 100px;
     padding-bottom: $gs-baseline/3;
     color: $brightness-7;
 
-    h2{
-        font-size: 1.37rem; //Quick fix for a Glabs title issue
+    h2 {
+         font-size: 1.37rem; //Quick fix for a Glabs title issue
     }
 
     .has-page-skin & {

--- a/static/src/stylesheets/module/facia-garnett/_container.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container.scss
@@ -133,7 +133,7 @@ $header-image-size-desktop: 100px;
     color: $brightness-7;
 
     h2 {
-         font-size: 1.37rem; //Quick fix for a Glabs title issue
+        font-size: 1.37rem; //Quick fix for a Glabs title issue
     }
 
     .has-page-skin & {

--- a/static/src/stylesheets/module/facia-garnett/_container.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container.scss
@@ -133,7 +133,7 @@ $header-image-size-desktop: 100px;
     color: $brightness-7;
 
     h2 {
-        font-size: 1.37rem; //Quick fix for a Glabs title issue
+        font-size: 1.37rem; //Quick fix for a Glabs title issue, check out PR #24458 for the details
     }
 
     .has-page-skin & {

--- a/static/src/stylesheets/module/facia-garnett/_container.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container.scss
@@ -132,9 +132,12 @@ $header-image-size-desktop: 100px;
     padding-bottom: $gs-baseline/3;
     color: $brightness-7;
 
+    section.[data-component="radian-changemakers"] {
     h2 {
         font-size: 1.37rem; //Quick fix for a Glabs title issue, check out PR #24458 for the details
     }
+    }
+
 
     .has-page-skin & {
         @include mq(wide) {

--- a/static/src/stylesheets/module/facia-garnett/_container.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container.scss
@@ -132,6 +132,10 @@ $header-image-size-desktop: 100px;
     padding-bottom: $gs-baseline/3;
     color: $brightness-7;
 
+    h2{
+        font-size: 1.37rem; //Quick fix for a Glabs title issue
+    }
+
     .has-page-skin & {
         @include mq(wide) {
             float: left;

--- a/static/src/stylesheets/module/facia-garnett/_container.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container.scss
@@ -132,11 +132,10 @@ $header-image-size-desktop: 100px;
     padding-bottom: $gs-baseline/3;
     color: $brightness-7;
 
-    section.[data-component="radian-changemakers"] {
     h2 {
         font-size: 1.37rem; //Quick fix for a Glabs title issue, check out PR #24458 for the details
     }
-    }
+
 
 
     .has-page-skin & {


### PR DESCRIPTION
## What does this change?

This fixes an issue on a GLabs page where the text was too large. This will most likely need a better longterm fix or to be superseded by DCR.

[https://www.theguardian.com/radian-changemakers](https://www.theguardian.com/radian-changemakers)

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

**Before**

<img width="403" alt="Screenshot 2021-12-01 at 13 06 44" src="https://user-images.githubusercontent.com/35331926/144240667-0ab0f3ca-dbd0-4e98-bb7a-bdc062fa9913.png">

**After**

<img width="403" alt="Screenshot 2021-12-01 at 13 07 11" src="https://user-images.githubusercontent.com/35331926/144240695-8112eb7c-f796-4762-84f1-5a1271e2c2f8.png">



### Tested

- [X] Locally
- [ ] On CODE (optional)

