### PR TITLE
Fix type of DFP non-refreshable line items

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.ts
@@ -90,7 +90,7 @@ export const onSlotRender = (
 			event.lineItemId &&
 			(
 				window.guardian.config.page.dfpNonRefreshableLineItemIds ?? []
-			).includes(String(event.lineItemId));
+			).includes(event.lineItemId);
 
 		advert.shouldRefresh =
 			isNotFluid &&

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -85,7 +85,7 @@ interface PageConfig extends CommercialPageConfig {
 	hasPageSkin: boolean; //https://github.com/guardian/frontend/blob/b952f6b9/common/app/views/support/JavaScriptPage.scala#L48
 	assetsPath: string;
 	frontendAssetsFullURL?: string; // only in DCR
-	dfpNonRefreshableLineItemIds?: string[];
+	dfpNonRefreshableLineItemIds?: number[];
 	section: string;
 	isPaidContent: boolean;
 	isSensitive: boolean;


### PR DESCRIPTION
Co-authored-by: Simon Byford <simon.byford@guardian.co.uk>

## What does this change?

Change the type of `dfpNonRefreshableLineItems` to `number[]` to match the type on the page config and remove the cast to a string when looking up items in this array.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Previously when looking up a line item id in the the non-refreshable array we cast the line item in question to a string. Since the array of line item ids is actually numbers this lookup fails. This means that line items marked as non-refreshable were erroneously being refreshed. This change fixes the cast and associated type so that line item ids can be looked up.

### Tested

- [X] Locally
- [ ] On CODE (optional)