### PR TITLE
Exclude Amazon line items from sponsorship IDs

### DIFF
--- a/admin/app/dfp/DfpApi.scala
+++ b/admin/app/dfp/DfpApi.scala
@@ -75,11 +75,17 @@ class DfpApi(dataMapper: DataMapper, dataValidation: DataValidation) extends GuL
 
   def readSponsorshipLineItemIds(): Seq[Long] = {
 
+    // The advertiser ID for "Amazon Transparent Ad Marketplace"
+    val amazonAdvertiserId = 4751525411L
+
     val stmtBuilder = new StatementBuilder()
-      .where("(status = :readyStatus OR status = :deliveringStatus) AND lineItemType = :sponsorshipType")
+      .where(
+        "(status = :readyStatus OR status = :deliveringStatus) AND lineItemType = :sponsorshipType AND advertiserId != :amazonAdvertiserId",
+      )
       .withBindVariableValue("readyStatus", ComputedStatus.READY.toString)
       .withBindVariableValue("deliveringStatus", ComputedStatus.DELIVERING.toString)
       .withBindVariableValue("sponsorshipType", LineItemType.SPONSORSHIP.toString)
+      .withBindVariableValue("amazonAdvertiserId", amazonAdvertiserId.toString)
       .orderBy("id ASC")
 
     // Lets avoid Prebid lineitems


### PR DESCRIPTION
## What does this change?

Exclude line items associated with the advertiser "Amazon Transparent Ad Marketplace" from the list of IDs for sponsorship line items. This is because they're not actually "sponsored", they've just been classified as such in google ad manager for operational reasons. They need to be excluded so they don't appear in the list of non-refreshable line items (i.e. unlike sponsored ads, they should refresh)

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

It should reduce the size of `dfpNonRefreshableLineItemIds` by approximately 850 (~43% decrease)

### Tested

- [ ] Locally
- [x] On CODE (optional)