### PR TITLE
Use `getCookie` from @guardian/libs in Identity API

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/api.spec.js
+++ b/static/src/javascripts/projects/common/modules/identity/api.spec.js
@@ -9,9 +9,8 @@ import {
     getUserOrSignIn,
     shouldAutoSigninInUser,
 } from 'common/modules/identity/api';
-import { getCookie as getCookie_ } from 'lib/cookies';
 import { fetchJson as fetchJson_ } from 'lib/fetch-json';
-import { storage } from '@guardian/libs';
+import { removeCookie, setCookie, storage } from '@guardian/libs';
 
 const defaultConfig = {
 	page: {
@@ -29,9 +28,6 @@ jest.mock('lib/config', () => {
 	});
 });
 jest.mock('lib/fetch-json', () => ({ fetchJson: jest.fn() }));
-jest.mock('lib/cookies', () => ({
-    getCookie: jest.fn(),
-}));
 jest.mock('common/modules/async-call-merger', () => ({
     mergeCalls(callback) {
         callback.reset = jest.fn();
@@ -40,7 +36,6 @@ jest.mock('common/modules/async-call-merger', () => ({
     },
 }));
 
-const getCookieStub = getCookie_;
 const fetchJson = fetchJson_;
 
 const originalLocation = window.location;
@@ -48,11 +43,15 @@ const originalLocation = window.location;
 describe('Identity API', () => {
 
     beforeEach(() => {
-        getCookieStub.mockImplementation(
-            () =>
-                'WyIyMzEwOTU5IiwiamdvcnJpZUBnbWFpbC5jb20iLCJBbSVDMyVBOWxpZSBKJUMzJUI0c2UiLCI1MzQiLDEzODI5NTMwMzE1OTEsMV0' +
-                '.MC0CFBsFwIEITO91EGONK4puyO2ZgGQcAhUAqRa7PVDCoAjrbnJNYYvMFec4fAY'
-        );
+        setCookie({
+			name: 'GU_U',
+			value:
+				'WyIyMzEwOTU5IiwiamdvcnJpZUBnbWFpbC5jb20iLCJBbSVDMyVBOWxpZSBKJUMzJUI0c2UiLCI1MzQiLDEzODI5NTMwMzE1OTEsMV0' +
+				'.MC0CFBsFwIEITO91EGONK4puyO2ZgGQcAhUAqRa7PVDCoAjrbnJNYYvMFec4fAY',
+		});
+		removeCookie({
+			name: 'GU_SO',
+		});
         delete window.location;
         window.location = Object.defineProperties(
             {},
@@ -111,7 +110,7 @@ describe('Identity API', () => {
     });
 
     it('should not call api if the cookie does not exist', done => {
-        getCookieStub.mockImplementationOnce(() => null);
+        removeCookie({ name: 'GU_U' });
 
         const apiCallback = user => {
             expect(user).toBe(null);
@@ -128,7 +127,7 @@ describe('Identity API', () => {
         const returnUrl = 'https://theguardian.com/uk';
         window.location.assign(returnUrl);
 
-        getCookieStub.mockImplementationOnce(() => null);
+        removeCookie({ name: 'GU_U' });
         getUserOrSignIn('email_sign_in_banner');
 
         expect(window.location.href).toBe(
@@ -151,7 +150,7 @@ describe('Identity API', () => {
         const origHref = window.location.href;
         const returnUrl = 'http://www.theguardian.com/foo';
 
-        getCookieStub.mockImplementationOnce(() => null);
+        removeCookie({ name: 'GU_U' });
         getUserOrSignIn('email_sign_in_banner', returnUrl);
 
         expect(window.location.href).toBe(
@@ -164,9 +163,8 @@ describe('Identity API', () => {
     });
 
     it('should attempt to autosigin an user who is not currently signed in and has not previously signed out', () => {
-        getCookieStub
-            .mockImplementationOnce(() => null) // GU_U
-            .mockImplementationOnce(() => null); // GU_SO
+        removeCookie({ name: 'GU_U' });
+		removeCookie({ name: 'GU_SO' });
             storage.local.set('gu.id.nextFbCheck', 'blah|blah');
 
         expect(shouldAutoSigninInUser()).toBe(false);
@@ -175,9 +173,8 @@ describe('Identity API', () => {
     });
 
     it('should not attempt to autosigin a user who is not currently signed in, has not previously signed out, before the facebook check overlaps', () => {
-        getCookieStub
-            .mockImplementationOnce(() => null) // GU_U
-            .mockImplementationOnce(() => null); // GU_SO
+        removeCookie({ name: 'GU_U' });
+		removeCookie({ name: 'GU_SO' });
 
         expect(shouldAutoSigninInUser()).toBe(true);
     });
@@ -194,9 +191,8 @@ describe('Identity API', () => {
 
         const timeStampInSeconds = theDayBeforeYesterday.getTime() / 1000;
 
-        getCookieStub
-            .mockImplementationOnce(() => null) // GU_U
-            .mockImplementationOnce(() => timeStampInSeconds.toString()); // GU_SO
+        removeCookie({ name: 'GU_U' });
+		setCookie({ name: 'GU_SO', value: timeStampInSeconds.toString() });
 
         expect(shouldAutoSigninInUser()).toBe(true);
     });
@@ -208,9 +204,8 @@ describe('Identity API', () => {
 
         const timeStampInSeconds = theDayBeforeYesterday.getTime() / 1000;
 
-        getCookieStub
-            .mockImplementationOnce(() => null) // GU_U
-            .mockImplementationOnce(() => timeStampInSeconds.toString()); // GU_SO
+        removeCookie({ name: 'GU_U' });
+		setCookie({ name: 'GU_SO', value: timeStampInSeconds.toString() });
             storage.local.set('gu.id.nextFbCheck', 'blah|blah');
 
         expect(shouldAutoSigninInUser()).toBe(false);
@@ -225,9 +220,8 @@ describe('Identity API', () => {
 
         const timeStampInSeconds = fourHoursAgo.getTime() / 1000;
 
-        getCookieStub
-            .mockImplementationOnce(() => null) // GU_U
-            .mockImplementationOnce(() => timeStampInSeconds.toString()); // GU_SO
+        removeCookie({ name: 'GU_U' });
+		setCookie({ name: 'GU_SO', value: timeStampInSeconds.toString() });
 
         expect(shouldAutoSigninInUser()).toBe(false);
     });

--- a/static/src/javascripts/projects/common/modules/identity/api.ts
+++ b/static/src/javascripts/projects/common/modules/identity/api.ts
@@ -115,7 +115,7 @@ export const decodeBase64 = (str: string): string =>
 
 export const getUserFromCookie = (): IdentityUserFromCache => {
 	if (userFromCookieCache === null) {
-		const cookieData = getCookie({ name: cookieName, shouldMemoize: true });
+		const cookieData = getUserCookie();
 		let userData: string[] | null = null;
 
 		if (cookieData) {
@@ -237,7 +237,7 @@ export const reset = (): void => {
 	userFromCookieCache = null;
 };
 
-const getApiCookie = (): string | null =>
+const getUserCookie = (): string | null =>
 	getCookie({ name: cookieName, shouldMemoize: true });
 
 export const getUrl = (): string => profileRoot;
@@ -299,9 +299,7 @@ export const hasUserSignedOutInTheLast24Hours = (): boolean => {
 };
 
 export const shouldAutoSigninInUser = (): boolean => {
-	const signedInUser = Boolean(
-		getCookie({ name: cookieName, shouldMemoize: true }),
-	);
+	const signedInUser = Boolean(getUserCookie());
 	const checkFacebook = !!storage.local.get(fbCheckKey);
 	return (
 		!signedInUser && !checkFacebook && !hasUserSignedOutInTheLast24Hours()
@@ -359,4 +357,4 @@ export const setConsent = (consents: SettableConsent): Promise<void> =>
 		return Promise.reject();
 	});
 
-export { getApiCookie as getCookie };
+export { getUserCookie as getCookie };

--- a/static/src/javascripts/projects/common/modules/identity/api.ts
+++ b/static/src/javascripts/projects/common/modules/identity/api.ts
@@ -237,8 +237,7 @@ export const reset = (): void => {
 	userFromCookieCache = null;
 };
 
-const getUserCookie = (): string | null =>
-	getCookie({ name: cookieName, shouldMemoize: true });
+const getUserCookie = (): string | null => getCookie({ name: cookieName });
 
 export const getUrl = (): string => profileRoot;
 
@@ -286,7 +285,6 @@ export const getUserOrSignIn = (
 export const hasUserSignedOutInTheLast24Hours = (): boolean => {
 	const cookieData = getCookie({
 		name: signOutCookieName,
-		shouldMemoize: true,
 	});
 
 	if (cookieData) {
@@ -299,7 +297,7 @@ export const hasUserSignedOutInTheLast24Hours = (): boolean => {
 };
 
 export const shouldAutoSigninInUser = (): boolean => {
-	const signedInUser = Boolean(getUserCookie());
+	const signedInUser = !!getUserCookie();
 	const checkFacebook = !!storage.local.get(fbCheckKey);
 	return (
 		!signedInUser && !checkFacebook && !hasUserSignedOutInTheLast24Hours()

--- a/static/src/javascripts/projects/common/modules/identity/api.ts
+++ b/static/src/javascripts/projects/common/modules/identity/api.ts
@@ -1,7 +1,6 @@
-import { storage } from '@guardian/libs';
+import { getCookie, storage } from '@guardian/libs';
 import { mergeCalls } from 'common/modules/async-call-merger';
 import config from '../../../../lib/config';
-import { getCookie as getCookieByName } from '../../../../lib/cookies';
 import { fetchJson } from '../../../../lib/fetch-json';
 import mediator from '../../../../lib/mediator';
 import { getUrlVars } from '../../../../lib/url';
@@ -116,15 +115,15 @@ export const decodeBase64 = (str: string): string =>
 
 export const getUserFromCookie = (): IdentityUserFromCache => {
 	if (userFromCookieCache === null) {
-		const cookieData = getCookieByName(cookieName) as string;
-		let userData = null;
+		const cookieData = getCookie({ name: cookieName, shouldMemoize: true });
+		let userData: string[] | null = null;
 
 		if (cookieData) {
 			userData = JSON.parse(
 				decodeBase64(cookieData.split('.')[0]),
 			) as string[];
 		}
-		if (userData) {
+		if (userData && cookieData) {
 			const displayName = decodeURIComponent(userData[2]);
 			userFromCookieCache = {
 				id: parseInt(userData[0], 10),
@@ -238,8 +237,8 @@ export const reset = (): void => {
 	userFromCookieCache = null;
 };
 
-export const getCookie = (): string | null =>
-	getCookieByName(cookieName) as string | null;
+const getApiCookie = (): string | null =>
+	getCookie({ name: cookieName, shouldMemoize: true });
 
 export const getUrl = (): string => profileRoot;
 
@@ -285,7 +284,10 @@ export const getUserOrSignIn = (
 };
 
 export const hasUserSignedOutInTheLast24Hours = (): boolean => {
-	const cookieData = getCookieByName(signOutCookieName) as string;
+	const cookieData = getCookie({
+		name: signOutCookieName,
+		shouldMemoize: true,
+	});
 
 	if (cookieData) {
 		return (
@@ -297,7 +299,9 @@ export const hasUserSignedOutInTheLast24Hours = (): boolean => {
 };
 
 export const shouldAutoSigninInUser = (): boolean => {
-	const signedInUser = !!getCookieByName(cookieName);
+	const signedInUser = Boolean(
+		getCookie({ name: cookieName, shouldMemoize: true }),
+	);
 	const checkFacebook = !!storage.local.get(fbCheckKey);
 	return (
 		!signedInUser && !checkFacebook && !hasUserSignedOutInTheLast24Hours()
@@ -354,3 +358,5 @@ export const setConsent = (consents: SettableConsent): Promise<void> =>
 		if (resp.ok) return Promise.resolve();
 		return Promise.reject();
 	});
+
+export { getApiCookie as getCookie };

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -635,7 +635,6 @@
  "../projects/common/modules/identity/api.ts": [
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/config.d.ts",
-  "../lib/cookies.js",
   "../lib/fetch-json.ts",
   "../lib/mediator.js",
   "../lib/url.ts",


### PR DESCRIPTION
## What does this change?

Use `getCookie` from `@guardian/libs` instead of `lib/cookies`.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Used of shared libs, memoization of cookies, stronger types.

## Checklist

### Tested

- [X] Locally
- [x] On CODE (optional)
