### PR TITLE
Prettier + ESLint on JavaScript

### DIFF
--- a/static/src/javascripts/lib/__mocks__/config.js
+++ b/static/src/javascripts/lib/__mocks__/config.js
@@ -1,19 +1,17 @@
 export default {
-    get(path, defaultValue) {
-        const value = path
-            .split('.')
-            .reduce((acc, prop) => {
-                if (acc[prop]) {
-                    return acc[prop];
-                }
+	get(path, defaultValue) {
+		const value = path.split('.').reduce((acc, prop) => {
+			if (acc[prop]) {
+				return acc[prop];
+			}
 
-                return defaultValue;
-            }, this);
+			return defaultValue;
+		}, this);
 
-        if (typeof value !== 'undefined') {
-            return value;
-        }
+		if (typeof value !== 'undefined') {
+			return value;
+		}
 
-        return defaultValue;
-    },
+		return defaultValue;
+	},
 };

--- a/static/src/javascripts/lib/__mocks__/fastdom-promise.js
+++ b/static/src/javascripts/lib/__mocks__/fastdom-promise.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
 export default {
-    measure: (fn, ctx) => Promise.resolve(fn()),
-    mutate: (fn, ctx) => Promise.resolve(fn()),
-    clear: (id) => {},
+	measure: (fn, ctx) => Promise.resolve(fn()),
+	mutate: (fn, ctx) => Promise.resolve(fn()),
+	clear: (id) => {},
 };

--- a/static/src/javascripts/lib/__mocks__/fastdom.js
+++ b/static/src/javascripts/lib/__mocks__/fastdom.js
@@ -1,9 +1,9 @@
-import promised from './fastdom-promise'
+import promised from './fastdom-promise';
 
 /* eslint-disable no-unused-vars */
 export default {
-    measure: (fn, ctx) => fn(),
-    mutate: (fn, ctx) => fn(),
-    clear: (id) => {},
-    extend: () => promised
+	measure: (fn, ctx) => fn(),
+	mutate: (fn, ctx) => fn(),
+	clear: (id) => {},
+	extend: () => promised,
 };

--- a/static/src/javascripts/lib/__mocks__/mediator.js
+++ b/static/src/javascripts/lib/__mocks__/mediator.js
@@ -2,21 +2,21 @@ let events = {};
 
 // eslint-disable-next-line guardian-frontend/no-default-export
 export default {
-    on(eventName, callback) {
-        events[eventName] = callback;
-    },
-    once(eventName, callback) {
-        events[eventName] = callback;
-    },
-    emit(eventName, params) {
-        if (events[eventName]) {
-            events[eventName](params);
-        }
-    },
-    removeEvent(eventName) {
-        delete events[eventName];
-    },
-    removeAllListeners() {
-        events = {};
-    },
+	on(eventName, callback) {
+		events[eventName] = callback;
+	},
+	once(eventName, callback) {
+		events[eventName] = callback;
+	},
+	emit(eventName, params) {
+		if (events[eventName]) {
+			events[eventName](params);
+		}
+	},
+	removeEvent(eventName) {
+		delete events[eventName];
+	},
+	removeAllListeners() {
+		events = {};
+	},
 };

--- a/static/src/javascripts/lib/__mocks__/raven.js
+++ b/static/src/javascripts/lib/__mocks__/raven.js
@@ -1,6 +1,6 @@
 export default {
-    wrap(fn) {
-        return fn;
-    },
-    captureException() {},
+	wrap(fn) {
+		return fn;
+	},
+	captureException() {},
 };

--- a/static/src/javascripts/lib/array-utils.js
+++ b/static/src/javascripts/lib/array-utils.js
@@ -1,20 +1,17 @@
 const isLastElement = (elementIndex, arrayLength) =>
-    elementIndex + 1 === arrayLength;
+	elementIndex + 1 === arrayLength;
 
-export const appendToLastElement = (
-    array,
-    stringToAppend
-) =>
-    array.map((element, index) =>
-        isLastElement(index, array.length)
-            ? `${element}${stringToAppend}`
-            : element
-    );
+export const appendToLastElement = (array, stringToAppend) =>
+	array.map((element, index) =>
+		isLastElement(index, array.length)
+			? `${element}${stringToAppend}`
+			: element,
+	);
 
 export const throwIfEmptyArray = (name, array) => {
-    if (Array.isArray(array) && array.length > 0) {
-        return array;
-    }
+	if (Array.isArray(array) && array.length > 0) {
+		return array;
+	}
 
-    throw new Error(`${name} is empty`);
+	throw new Error(`${name} is empty`);
 };

--- a/static/src/javascripts/lib/comready.js
+++ b/static/src/javascripts/lib/comready.js
@@ -2,24 +2,24 @@ import { send } from 'commercial/modules/messenger/send';
 
 /** Allows cross-frame communication with in-app articles */
 const comready = (resolve, reject) => {
-    const MAX_COUNT = 5;
-    let count = 0;
-    send('syn', true);
-    const intId = setInterval(() => {
-        count += 1;
-        if (count === MAX_COUNT) {
-            clearInterval(intId);
-            reject(new Error('Failed to reach page messenger'));
-        }
-        send('syn', true);
-    }, 500);
-    window.addEventListener('message', evt => {
-        if (JSON.parse(evt.data).result !== 'ack') {
-            return;
-        }
-        clearInterval(intId);
-        resolve();
-    });
+	const MAX_COUNT = 5;
+	let count = 0;
+	send('syn', true);
+	const intId = setInterval(() => {
+		count += 1;
+		if (count === MAX_COUNT) {
+			clearInterval(intId);
+			reject(new Error('Failed to reach page messenger'));
+		}
+		send('syn', true);
+	}, 500);
+	window.addEventListener('message', (evt) => {
+		if (JSON.parse(evt.data).result !== 'ack') {
+			return;
+		}
+		clearInterval(intId);
+		resolve();
+	});
 };
 
 export { comready };

--- a/static/src/javascripts/lib/config.js
+++ b/static/src/javascripts/lib/config.js
@@ -6,16 +6,16 @@ const config = window.guardian.config;
 // allows you to safely get items from config using a query of
 // dot or bracket notation, with optional default fallback
 const get = (path = '', defaultValue) => {
-    const value = path
-        .replace(/\[(.+?)\]/g, '.$1')
-        .split('.')
-        .reduce((o, key) => o && o[key], config);
+	const value = path
+		.replace(/\[(.+?)\]/g, '.$1')
+		.split('.')
+		.reduce((o, key) => o && o[key], config);
 
-    if (typeof value !== 'undefined') {
-        return value;
-    }
+	if (typeof value !== 'undefined') {
+		return value;
+	}
 
-    return defaultValue;
+	return defaultValue;
 };
 
 // let S = { l1, l2, ..., ln } be a non-empty ordered set of labels
@@ -24,65 +24,63 @@ const get = (path = '', defaultValue) => {
 // object following the path described by S, making sure that path
 // actually leads somewhere.
 const set = (path, value) => {
-    const pathSegments = path.split('.');
-    const last = pathSegments.pop();
-    pathSegments.reduce((obj, subpath) => {
-        if (typeof obj[subpath] === 'object') {
-            return obj[subpath];
-        }
-        obj[subpath] = {};
-        return obj[subpath];
-    }, config)[last] = value;
+	const pathSegments = path.split('.');
+	const last = pathSegments.pop();
+	pathSegments.reduce((obj, subpath) => {
+		if (typeof obj[subpath] === 'object') {
+			return obj[subpath];
+		}
+		obj[subpath] = {};
+		return obj[subpath];
+	}, config)[last] = value;
 };
 
-const hasTone = (name) =>
-    (config.page.tones || '').includes(name);
+const hasTone = (name) => (config.page.tones || '').includes(name);
 
-const hasSeries = (name) =>
-    (config.page.series || '').includes(name);
+const hasSeries = (name) => (config.page.series || '').includes(name);
 
 const referencesOfType = (name) =>
-    (config.page.references || [])
-        .filter(reference => typeof reference[name] !== 'undefined')
-        .map(reference => reference[name]);
+	(config.page.references || [])
+		.filter((reference) => typeof reference[name] !== 'undefined')
+		.map((reference) => reference[name]);
 
 const referenceOfType = (name) => referencesOfType(name)[0];
 
 // the date nicely formatted and padded for use as part of a url
 // looks like    2012/04/31
 const webPublicationDateAsUrlPart = () => {
-    const webPublicationDate = config.page.webPublicationDate;
+	const webPublicationDate = config.page.webPublicationDate;
 
-    if (webPublicationDate) {
-        const pubDate = new Date(webPublicationDate);
-        return `${pubDate.getFullYear()}/${(pubDate.getMonth() + 1)
-            .toString()
-            .padStart(2, '0')}/${pubDate
-            .getDate()
-            .toString()
-            .padStart(2, '0')}`;
-    }
+	if (webPublicationDate) {
+		const pubDate = new Date(webPublicationDate);
+		return `${pubDate.getFullYear()}/${(pubDate.getMonth() + 1)
+			.toString()
+			.padStart(2, '0')}/${pubDate
+			.getDate()
+			.toString()
+			.padStart(2, '0')}`;
+	}
 
-    return null;
+	return null;
 };
 
 // returns 2014/apr/22
 const dateFromSlug = () => {
-    const s = config.page.pageId.match(/\d{4}\/\w{3}\/\d{2}/);
-    return s ? s[0] : null;
+	const s = config.page.pageId.match(/\d{4}\/\w{3}\/\d{2}/);
+	return s ? s[0] : null;
 };
 
 export default Object.assign(
-    {},
-    {
-        get,
-        set,
-        hasTone,
-        hasSeries,
-        referencesOfType,
-        referenceOfType,
-        webPublicationDateAsUrlPart,
-        dateFromSlug,
-    },
-    config
+	{},
+	{
+		get,
+		set,
+		hasTone,
+		hasSeries,
+		referencesOfType,
+		referenceOfType,
+		webPublicationDateAsUrlPart,
+		dateFromSlug,
+	},
+	config,
 );

--- a/static/src/javascripts/lib/config.spec.js
+++ b/static/src/javascripts/lib/config.spec.js
@@ -1,20 +1,19 @@
 /* eslint-disable guardian-frontend/global-config */
 
 Object.assign(window.guardian.config, {
-    page: {
-        tones: 'foo',
-        series: 'bar',
-        references: [{ baz: 'one' }, { baz: 'two' }],
-        webPublicationDate: '2013-03-20T17:07:00.000Z',
-        pageId:
-            'politics/2017/mar/14/ukip-donor-arron-banks-says-he-has-quit-party-to-set-up-ukip-20',
-        x: {
-            y: {
-                z: 'z',
-            },
-        },
-        falsyValue: false,
-    },
+	page: {
+		tones: 'foo',
+		series: 'bar',
+		references: [{ baz: 'one' }, { baz: 'two' }],
+		webPublicationDate: '2013-03-20T17:07:00.000Z',
+		pageId: 'politics/2017/mar/14/ukip-donor-arron-banks-says-he-has-quit-party-to-set-up-ukip-20',
+		x: {
+			y: {
+				z: 'z',
+			},
+		},
+		falsyValue: false,
+	},
 });
 
 // We need to hoist setting the window.guardian.config to code under test above import
@@ -23,65 +22,65 @@ Object.assign(window.guardian.config, {
 import config from './config';
 
 describe('Config', () => {
-    it('should have "hasTone" property', () => {
-        expect(config.hasTone('foo')).toBeTruthy();
-        expect(config.hasTone('foo-bad')).toBeFalsy();
-    });
+	it('should have "hasTone" property', () => {
+		expect(config.hasTone('foo')).toBeTruthy();
+		expect(config.hasTone('foo-bad')).toBeFalsy();
+	});
 
-    it('should have "hasSeries" property', () => {
-        expect(config.hasSeries('bar')).toBeTruthy();
-        expect(config.hasSeries('bar-bad')).toBeFalsy();
-    });
+	it('should have "hasSeries" property', () => {
+		expect(config.hasSeries('bar')).toBeTruthy();
+		expect(config.hasSeries('bar-bad')).toBeFalsy();
+	});
 
-    it('should have "referencesOfType" property', () => {
-        expect(config.referencesOfType('baz')).toEqual(['one', 'two']);
-        expect(config.referencesOfType('bar-bad')).toEqual([]);
-    });
+	it('should have "referencesOfType" property', () => {
+		expect(config.referencesOfType('baz')).toEqual(['one', 'two']);
+		expect(config.referencesOfType('bar-bad')).toEqual([]);
+	});
 
-    it('should have "referenceOfType" property', () => {
-        expect(config.referenceOfType('baz')).toEqual('one');
-        expect(config.referenceOfType('bar-bad')).toBeUndefined();
-    });
+	it('should have "referenceOfType" property', () => {
+		expect(config.referenceOfType('baz')).toEqual('one');
+		expect(config.referenceOfType('bar-bad')).toBeUndefined();
+	});
 
-    it('should have "webPublicationDateAsUrlPart" property', () => {
-        expect(config.webPublicationDateAsUrlPart()).toBe('2013/03/20');
-    });
+	it('should have "webPublicationDateAsUrlPart" property', () => {
+		expect(config.webPublicationDateAsUrlPart()).toBe('2013/03/20');
+	});
 
-    it('should return the expected dateFromSlug', () => {
-        expect(config.dateFromSlug()).toEqual('2017/mar/14');
-    });
+	it('should return the expected dateFromSlug', () => {
+		expect(config.dateFromSlug()).toEqual('2017/mar/14');
+	});
 
-    it('`get` should return a value using dot notation', () => {
-        expect(config.get('page.x.y.z')).toEqual('z');
-    });
+	it('`get` should return a value using dot notation', () => {
+		expect(config.get('page.x.y.z')).toEqual('z');
+	});
 
-    it('`get` should return undefined for non existing indexes', () => {
-        expect(config.get('page.x.z.y')).toEqual(undefined);
-        expect(config.get('page.x.z.y', false)).toEqual(false);
-    });
+	it('`get` should return undefined for non existing indexes', () => {
+		expect(config.get('page.x.z.y')).toEqual(undefined);
+		expect(config.get('page.x.z.y', false)).toEqual(false);
+	});
 
-    it('`get` should return a value using bracket notation', () => {
-        expect(config.get('page[x].y[z]')).toEqual('z');
-    });
+	it('`get` should return a value using bracket notation', () => {
+		expect(config.get('page[x].y[z]')).toEqual('z');
+	});
 
-    it('`get` should return undefined for non-existing key', () => {
-        expect(config.get('page.qwert')).toBeUndefined();
-    });
+	it('`get` should return undefined for non-existing key', () => {
+		expect(config.get('page.qwert')).toBeUndefined();
+	});
 
-    it('`get` should return default value for non-existing key with a default', () => {
-        expect(config.get('page.qwert', ['I am the default'])).toEqual([
-            'I am the default',
-        ]);
-    });
+	it('`get` should return default value for non-existing key with a default', () => {
+		expect(config.get('page.qwert', ['I am the default'])).toEqual([
+			'I am the default',
+		]);
+	});
 
-    it('`get` should return falsy value for defined key with a default', () => {
-        expect(config.get('page.falsyValue', 'I am the default')).toEqual(
-            false
-        );
-    });
+	it('`get` should return falsy value for defined key with a default', () => {
+		expect(config.get('page.falsyValue', 'I am the default')).toEqual(
+			false,
+		);
+	});
 
-    it('`set` should safely set (or orverride) a value deep inside the config object', () => {
-        config.set('some.random.path', 'hello');
-        expect(config.get('some.random.path')).toEqual('hello');
-    });
+	it('`set` should safely set (or orverride) a value deep inside the config object', () => {
+		config.set('some.random.path', 'hello');
+		expect(config.get('some.random.path')).toEqual('hello');
+	});
 });

--- a/static/src/javascripts/lib/cookies.js
+++ b/static/src/javascripts/lib/cookies.js
@@ -4,149 +4,132 @@ import config from './config';
 const ERR_INVALID_COOKIE_NAME = `Cookie must not contain invalid characters (space, tab and the following characters: '()<>@,;"/[]?={}')`;
 
 // subset of https://github.com/guzzle/guzzle/pull/1131
-const isValidCookieValue = (name) =>
-    !/[()<>@,;"\\/[\]?={} \t]/g.test(name);
+const isValidCookieValue = (name) => !/[()<>@,;"\\/[\]?={} \t]/g.test(name);
 
-const getShortDomain = ({
-    isCrossSubdomain = false,
-} = {}) => {
-    const domain = document.domain || '';
+const getShortDomain = ({ isCrossSubdomain = false } = {}) => {
+	const domain = document.domain || '';
 
-    if (domain === 'localhost' || config.get('page.isPreview')) {
-        return domain;
-    }
+	if (domain === 'localhost' || config.get('page.isPreview')) {
+		return domain;
+	}
 
-    // Trim any possible subdomain (will be shared with supporter, identity, etc)
-    if (isCrossSubdomain) {
-        return ['', ...domain.split('.').slice(-2)].join('.');
-    }
-    // Trim subdomains for prod (www.theguardian), code (m.code.dev-theguardian) and dev (dev.theguardian, m.thegulocal)
-    return domain.replace(/^(www|m\.code|dev|m)\./, '.');
+	// Trim any possible subdomain (will be shared with supporter, identity, etc)
+	if (isCrossSubdomain) {
+		return ['', ...domain.split('.').slice(-2)].join('.');
+	}
+	// Trim subdomains for prod (www.theguardian), code (m.code.dev-theguardian) and dev (dev.theguardian, m.thegulocal)
+	return domain.replace(/^(www|m\.code|dev|m)\./, '.');
 };
 
-const getDomainAttribute = ({
-    isCrossSubdomain = false,
-} = {}) => {
-    const shortDomain = getShortDomain({ isCrossSubdomain });
-    return shortDomain === 'localhost' ? '' : ` domain=${shortDomain};`;
+const getDomainAttribute = ({ isCrossSubdomain = false } = {}) => {
+	const shortDomain = getShortDomain({ isCrossSubdomain });
+	return shortDomain === 'localhost' ? '' : ` domain=${shortDomain};`;
 };
 
-const removeCookie = (
-    name,
-    currentDomainOnly = false
-) => {
-    const expires = 'expires=Thu, 01 Jan 1970 00:00:01 GMT;';
-    const path = 'path=/;';
+const removeCookie = (name, currentDomainOnly = false) => {
+	const expires = 'expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+	const path = 'path=/;';
 
-    // Remove cookie, implicitly using the document's domain.
-    document.cookie = `${name}=;${path}${expires}`;
-    if (!currentDomainOnly) {
-        // also remove from the short domain
-        document.cookie = `${name}=;${path}${expires} domain=${getShortDomain()};`;
-    }
+	// Remove cookie, implicitly using the document's domain.
+	document.cookie = `${name}=;${path}${expires}`;
+	if (!currentDomainOnly) {
+		// also remove from the short domain
+		document.cookie = `${name}=;${path}${expires} domain=${getShortDomain()};`;
+	}
 };
 
-const addCookie = (
-    name,
-    value,
-    daysToLive,
-    isCrossSubdomain = false
-) => {
-    const expires = new Date();
+const addCookie = (name, value, daysToLive, isCrossSubdomain = false) => {
+	const expires = new Date();
 
-    if (!isValidCookieValue(name) || !isValidCookieValue(value)) {
-        reportError(
-            new Error(`${ERR_INVALID_COOKIE_NAME} .${name}=${value}`),
-            {},
-            false
-        );
-    }
+	if (!isValidCookieValue(name) || !isValidCookieValue(value)) {
+		reportError(
+			new Error(`${ERR_INVALID_COOKIE_NAME} .${name}=${value}`),
+			{},
+			false,
+		);
+	}
 
-    if (daysToLive) {
-        expires.setDate(expires.getDate() + daysToLive);
-    } else {
-        expires.setMonth(expires.getMonth() + 5);
-        expires.setDate(1);
-    }
+	if (daysToLive) {
+		expires.setDate(expires.getDate() + daysToLive);
+	} else {
+		expires.setMonth(expires.getMonth() + 5);
+		expires.setDate(1);
+	}
 
-    document.cookie = `${name}=${value}; path=/; expires=${expires.toUTCString()};${getDomainAttribute(
-        {
-            isCrossSubdomain,
-        }
-    )}`;
+	document.cookie = `${name}=${value}; path=/; expires=${expires.toUTCString()};${getDomainAttribute(
+		{
+			isCrossSubdomain,
+		},
+	)}`;
 };
 
 const cleanUp = (names) => {
-    names.forEach(name => {
-        removeCookie(name);
-    });
+	names.forEach((name) => {
+		removeCookie(name);
+	});
 };
 
-const addForMinutes = (
-    name,
-    value,
-    minutesToLive
-) => {
-    const expires = new Date();
+const addForMinutes = (name, value, minutesToLive) => {
+	const expires = new Date();
 
-    if (!isValidCookieValue(name) || !isValidCookieValue(value)) {
-        reportError(
-            new Error(`${ERR_INVALID_COOKIE_NAME} .${name}=${value}`),
-            {},
-            false
-        );
-    }
+	if (!isValidCookieValue(name) || !isValidCookieValue(value)) {
+		reportError(
+			new Error(`${ERR_INVALID_COOKIE_NAME} .${name}=${value}`),
+			{},
+			false,
+		);
+	}
 
-    expires.setMinutes(expires.getMinutes() + minutesToLive);
-    document.cookie = `${name}=${value}; path=/; expires=${expires.toUTCString()};${getDomainAttribute()}`;
+	expires.setMinutes(expires.getMinutes() + minutesToLive);
+	document.cookie = `${name}=${value}; path=/; expires=${expires.toUTCString()};${getDomainAttribute()}`;
 };
 
 const addSessionCookie = (name, value) => {
-    if (!isValidCookieValue(name) || !isValidCookieValue(value)) {
-        reportError(
-            new Error(`${ERR_INVALID_COOKIE_NAME} .${name}=${value}`),
-            {},
-            false
-        );
-    }
-    document.cookie = `${name}=${value}; path=/;${getDomainAttribute()}`;
+	if (!isValidCookieValue(name) || !isValidCookieValue(value)) {
+		reportError(
+			new Error(`${ERR_INVALID_COOKIE_NAME} .${name}=${value}`),
+			{},
+			false,
+		);
+	}
+	document.cookie = `${name}=${value}; path=/;${getDomainAttribute()}`;
 };
 
 const getCookieValues = (name) => {
-    const nameEq = `${name}=`;
-    const cookies = document.cookie.split(';');
+	const nameEq = `${name}=`;
+	const cookies = document.cookie.split(';');
 
-    return cookies.reduce((acc, cookie) => {
-        const cookieTrimmed = cookie.trim();
+	return cookies.reduce((acc, cookie) => {
+		const cookieTrimmed = cookie.trim();
 
-        if (cookieTrimmed.indexOf(nameEq) === 0) {
-            acc.push(
-                cookieTrimmed.substring(nameEq.length, cookieTrimmed.length)
-            );
-        }
+		if (cookieTrimmed.indexOf(nameEq) === 0) {
+			acc.push(
+				cookieTrimmed.substring(nameEq.length, cookieTrimmed.length),
+			);
+		}
 
-        return acc;
-    }, []);
+		return acc;
+	}, []);
 };
 
 const getCookie = (name) => {
-    const cookieVal = getCookieValues(name);
+	const cookieVal = getCookieValues(name);
 
-    if (cookieVal.length > 0) {
-        return cookieVal[0];
-    }
-    return null;
+	if (cookieVal.length > 0) {
+		return cookieVal[0];
+	}
+	return null;
 };
 
 export const _ = {
-    isValidCookieValue,
+	isValidCookieValue,
 };
 
 export {
-    cleanUp,
-    addCookie,
-    addSessionCookie,
-    addForMinutes,
-    removeCookie,
-    getCookie,
+	cleanUp,
+	addCookie,
+	addSessionCookie,
+	addForMinutes,
+	removeCookie,
+	getCookie,
 };

--- a/static/src/javascripts/lib/cookies.spec.js
+++ b/static/src/javascripts/lib/cookies.spec.js
@@ -1,11 +1,11 @@
 import {
-    cleanUp,
-    addCookie,
-    addSessionCookie,
-    addForMinutes,
-    removeCookie,
-    getCookie,
-    _,
+	cleanUp,
+	addCookie,
+	addSessionCookie,
+	addForMinutes,
+	removeCookie,
+	getCookie,
+	_,
 } from 'lib/cookies';
 
 const { isValidCookieValue } = _;
@@ -17,118 +17,112 @@ const OriginalDate = global.Date;
 global.Date = jest.fn(() => new OriginalDate(0));
 
 describe('Cookies', () => {
-    let cookieValue = '';
+	let cookieValue = '';
 
-    Object.defineProperty(document, 'domain', { value: 'www.theguardian.com' });
-    Object.defineProperty(
-        document,
-        'cookie',
-        ({
-            get() {
-                return cookieValue
-                    .replace('|', ';')
-                    .replace(/^[;|]|[;|]$/g, '');
-            },
+	Object.defineProperty(document, 'domain', { value: 'www.theguardian.com' });
+	Object.defineProperty(document, 'cookie', {
+		get() {
+			return cookieValue.replace('|', ';').replace(/^[;|]|[;|]$/g, '');
+		},
 
-            set(value) {
-                const name = value.split('=')[0];
-                const newVal = cookieValue
-                    .split('|')
-                    .filter(cookie => cookie.split('=')[0] !== name);
+		set(value) {
+			const name = value.split('=')[0];
+			const newVal = cookieValue
+				.split('|')
+				.filter((cookie) => cookie.split('=')[0] !== name);
 
-                newVal.push(value);
-                cookieValue = newVal.join('|');
-            },
-        })
-    );
+			newVal.push(value);
+			cookieValue = newVal.join('|');
+		},
+	});
 
-    beforeEach(() => {
-        cookieValue = '';
-    });
+	beforeEach(() => {
+		cookieValue = '';
+	});
 
-    it('should be able the clean a list of cookies', () => {
-        document.cookie = 'cookie-1-name=cookie-1-value';
-        document.cookie = 'cookie-2-name=cookie-2-value';
-        document.cookie = 'cookie-3-name=cookie-3-value';
+	it('should be able the clean a list of cookies', () => {
+		document.cookie = 'cookie-1-name=cookie-1-value';
+		document.cookie = 'cookie-2-name=cookie-2-value';
+		document.cookie = 'cookie-3-name=cookie-3-value';
 
-        cleanUp(['cookie-1-name', 'cookie-2-name']);
+		cleanUp(['cookie-1-name', 'cookie-2-name']);
 
-        const { cookie } = document;
+		const { cookie } = document;
 
-        expect(cookie).toMatch(
-            new RegExp(
-                'cookie-1-name=;path=/;expires=Thu, 01 Jan 1970 00:00:01 GMT; domain=.theguardian.com'
-            )
-        );
-        expect(cookie).toMatch(
-            new RegExp(
-                'cookie-2-name=;path=/;expires=Thu, 01 Jan 1970 00:00:01 GMT; domain=.theguardian.com'
-            )
-        );
-    });
+		expect(cookie).toMatch(
+			new RegExp(
+				'cookie-1-name=;path=/;expires=Thu, 01 Jan 1970 00:00:01 GMT; domain=.theguardian.com',
+			),
+		);
+		expect(cookie).toMatch(
+			new RegExp(
+				'cookie-2-name=;path=/;expires=Thu, 01 Jan 1970 00:00:01 GMT; domain=.theguardian.com',
+			),
+		);
+	});
 
-    describe('isValidCookieValue', () => {
-        it('should be able to detect malformed cookies', () => {
-            expect(isValidCookieValue('bad,cookie')).toBeFalsy();
-            expect(isValidCookieValue('bad;cookie')).toBeFalsy();
-            expect(isValidCookieValue('bad cookie')).toBeFalsy();
-            expect(isValidCookieValue('bad  cookie')).toBeFalsy();
-            expect(isValidCookieValue('bad=cookie')).toBeFalsy();
-        });
+	describe('isValidCookieValue', () => {
+		it('should be able to detect malformed cookies', () => {
+			expect(isValidCookieValue('bad,cookie')).toBeFalsy();
+			expect(isValidCookieValue('bad;cookie')).toBeFalsy();
+			expect(isValidCookieValue('bad cookie')).toBeFalsy();
+			expect(isValidCookieValue('bad  cookie')).toBeFalsy();
+			expect(isValidCookieValue('bad=cookie')).toBeFalsy();
+		});
 
-        it('should be able to detect good cookies', () => {
-            expect(isValidCookieValue('good-cookie')).toBeTruthy();
-            expect(isValidCookieValue('cool.cookie')).toBeTruthy();
-        });
-    });
+		it('should be able to detect good cookies', () => {
+			expect(isValidCookieValue('good-cookie')).toBeTruthy();
+			expect(isValidCookieValue('cool.cookie')).toBeTruthy();
+		});
+	});
 
-    it('should be able to set a cookie', () => {
-        addCookie('cookie-1-name', 'cookie-1-value');
-        expect(document.cookie).toMatch(
-            new RegExp(
-                'cookie-1-name=cookie-1-value; path=/; expires=Mon, 01 Jun 1970 00:00:00 GMT; domain=.theguardian.com'
-            )
-        );
-    });
+	it('should be able to set a cookie', () => {
+		addCookie('cookie-1-name', 'cookie-1-value');
+		expect(document.cookie).toMatch(
+			new RegExp(
+				'cookie-1-name=cookie-1-value; path=/; expires=Mon, 01 Jun 1970 00:00:00 GMT; domain=.theguardian.com',
+			),
+		);
+	});
 
-    it('should be able to set a cookie for a specific number of days', () => {
-        addCookie('cookie-1-name', 'cookie-1-value', 7);
-        expect(document.cookie).toEqual(
-            'cookie-1-name=cookie-1-value; path=/; expires=Thu, 08 Jan 1970 00:00:00 GMT; domain=.theguardian.com'
-        );
-    });
+	it('should be able to set a cookie for a specific number of days', () => {
+		addCookie('cookie-1-name', 'cookie-1-value', 7);
+		expect(document.cookie).toEqual(
+			'cookie-1-name=cookie-1-value; path=/; expires=Thu, 08 Jan 1970 00:00:00 GMT; domain=.theguardian.com',
+		);
+	});
 
-    it('should be able to set a cookie for a specific number of minutes', () => {
-        addForMinutes('cookie-1-name', 'cookie-1-value', 91);
-        expect(document.cookie).toEqual(
-            'cookie-1-name=cookie-1-value; path=/; expires=Thu, 01 Jan 1970 01:31:00 GMT; domain=.theguardian.com'
-        );
-    });
+	it('should be able to set a cookie for a specific number of minutes', () => {
+		addForMinutes('cookie-1-name', 'cookie-1-value', 91);
+		expect(document.cookie).toEqual(
+			'cookie-1-name=cookie-1-value; path=/; expires=Thu, 01 Jan 1970 01:31:00 GMT; domain=.theguardian.com',
+		);
+	});
 
-    it('should be able to set a session cookie', () => {
-        addSessionCookie('cookie-1-name', 'cookie-1-value');
-        expect(document.cookie).toEqual(
-            'cookie-1-name=cookie-1-value; path=/; domain=.theguardian.com'
-        );
-    });
+	it('should be able to set a session cookie', () => {
+		addSessionCookie('cookie-1-name', 'cookie-1-value');
+		expect(document.cookie).toEqual(
+			'cookie-1-name=cookie-1-value; path=/; domain=.theguardian.com',
+		);
+	});
 
-    it('should be able remove cookies', () => {
-        removeCookie('cookie-1-name');
-        expect(document.cookie).toEqual(
-            'cookie-1-name=;path=/;expires=Thu, 01 Jan 1970 00:00:01 GMT; domain=.theguardian.com'
-        );
-    });
+	it('should be able remove cookies', () => {
+		removeCookie('cookie-1-name');
+		expect(document.cookie).toEqual(
+			'cookie-1-name=;path=/;expires=Thu, 01 Jan 1970 00:00:01 GMT; domain=.theguardian.com',
+		);
+	});
 
-    it('should be able to get a cookie', () => {
-        document.cookie =
-            'optimizelyEndUserId=oeu1398171767331r0.5280374749563634; __qca=P0-938012256-1398171768649; __gads=ID=85aa476fff43818a:T=1398171769:S=ALNI_MbfMkJmvVDwlqDMvJk1oCBV3jNUoA; noticebar_cookie=2; GU_mvt_id=717659; fsr.r=%7B%22d%22%3A90%2C%22i%22%3A%22de37431-93457748-eb61-2581-cce6c%22%2C%22e%22%3A1416223264445%7D; _ga=GA1.2.555908995.1398171761; QSI_HistorySession=http%3A%2F%2Fwww.theguardian.com%2Fworld%2F2014%2Fnov%2F11%2Findian-women-die-mass-steri…ov%2F11%2Fputin-gallant-gesture-chinese-leader-wife-censored~1415796988465; mlUserID=amIIKWa5S6ha; _em_vt=eed0af5afb2b123c5293cbae36c953ec8ab6445d73-180037745475ec3b; GU_EDITION=UK; GU_MI=mi_i%3D13552794%3Bmi_p%3DCRE%2CRCO%3Bgu_pk%3DCRE%2CRCO%3Bmi_e%3D%21201412141140%3Bmi_dn%3DJohn+Duffell%3Bmi_s%3Da7dd96e91fffd189215abaa69107bf13; GU_U=WyIxMzU1Mjc5NCIsImpvaG4uZHVmZmVsbEBndWFyZGlhbi5jby51ayIsIkpvaG4gRHVmZmVsbCIsIjIiLDE0MjQ5NTA4NDgwMDEsMSwxNDA1OTUxMDgyMDAwLHRydWVd.MCwCFErJFuSa3ptSv2V6JYkIjTtTFUKiAhQDLOlsFAulk4mg7yj8DWswB3p_1Q; _cb_ls=1; s_campaign=twt_gu; _chartbeat2=CbF00iBuBN28SPnnY.1417174852129.1417516877697.10001; fsr.s=%7B%22v2%22%3A-2%2C%22v1%22%3A1%2C%22rid%22%3A%22de37431-93457748-eb61-2581-cce6c%22%2C%22ru%22%3A%22http%3A%2F%2Fwww.theguardian.com%2Fuk%22%2C%22r%22%3A%22www.theguardian.com%22%2C%22st%2…22Y%22%7D%2C%22l%22%3A%22en%22%2C%22i%22%3A-1%2C%22f%22%3A1417516902586%7D; fsr.a=1417516904960; s_pers=%20s_fid%3D7BD36E2BEA3FA475-209CB26F08488520%7C1473689665518%3B%20s_daily_habit%3D16315%252C16316%252C16317%252C16318%252C16321%252C16323%252C16325%7C1568297665542%3B%20s_lv%3D1413290266527%7C1507898266527%3B%20s_nr%3D1413290266538-Repeat%7C1444826266538%3B%20s_prev_prop9%3Dno%2520value%7C1417605835703%3B; s_sess=%20s_sv_sid%3D1337774611744%3B%20s_campaign%3DEMCNEWEML6619I2%3B%20s_ppv%3D-%252C17%252C17%252C695%3B%20s_cc%3Dtrue%3B%20s_visit%3D1%3B%20s_sq%3Dguardiangu-network%253D%252526pid%25253DGFE%2525253Anews%2525253AArticle%2525253A10-years-bullying-data%252526pidt%25253D1%252526oid%25253Dhttp%2525253A%2525252F%2525252Fwww.theguardian.com%2525252Fpreference%2525252Fplatform%2525252Fclassic%252…%252525252F2013%252525252Fmay%252525252F23%252525252F1%252526ot%25253DA%3B; OAX=X5GDnlPairgACdD1; optimizelySegments=%7B%22172123993%22%3A%22none%22%2C%22172180831%22%3A%22none%22%2C%22172233718%22%3A%22false%22%2C%22172284779%22%3A%22gc%22%2C%22172321425%22%3A%22false%22%2C%22172361369%22%3A%22referral%22%2C%22172368238%22%3A%22search%22%2C%22172387121%22%3A%22gc%22%2C%22280150302%22%3A%22gc%22%2C%22280266488%22%3A%22false%22%2C%22280820196%22%3A%22none%22%2C%22280923576%22%3A%22referral%22%2C%22290314994%22%3A%22false%22%2C%22290553915%22%3A%22direct%22%2C%22293452255%22%3A%22gc%22%2C%22293462044%22%3A%22none%22%2C%22812091703%22%3A%22true%22%2C%22813360577%22%3A%22true%22%2C%221214390054%22%3A%22true%22%2C%221992100896%22%3A%22false%22%2C%222001830212%22%3A%22none%22%2C%222004900216%22%3A%22referral%22%2C%222005870214%22%3A%22gc%22%7D; optimizelyBuckets=%7B%7D; s_pers=%20s_fid%3D7BD36E2BEA3FA475-209CB26F08488520%7C1473689665518%3B%20s_daily_habit%3D16315%252C16316%252C16317%252C16318%252C16321%252C16323%252C16325%7C1568297665542%3B%20s_lv%3D1413290266527%7C1507898266527%3B%20s_prev_prop9%3Dno%2520value%7C1417605835703%3B%20s_nr%3D1417605906076-Repeat%7C1449141906076%3B; s_sess=%20s_sv_sid%3D1337774611744%3B%20s_campaign%3DEMCNEWEML6619I2%3B%20s_ppv%3D-%252C17%252C17%252C695%3B%20s_cc%3Dtrue%3B%20s_visit%3D1%3B%20s_sq%3Dguardiangu-network%253D%252526pid%25253DGFE%2525253Anews%2525253AArticle%2525253A10-years-bullying-data%252526pidt%25253D1%252526oid%25253Dhttp%2525253A%2525252F%2525252Fwww.theguardian.com%2525252Fpreference%2525252Fplatform%2525252Fclassic%252…%252525252F2013%252525252Fmay%252525252F23%252525252F1%252526ot%25253DA%3B; s_sq=%5B%5BB%5D%5D; GU_VIEW=responsive; s_cc=true; bwid=kvdn_943h8SSC6h3R5hyJ31g; s_fid=470C3252CA9A4650-35C6B54A21985FBA; s_daily_habit=16406%2C16407%2C16408; s_lv=1417705099834; s_nr=1417705099835-Repeat; s_vi=[CS]v1|29AB343C05013259-4000014980021C3D[CE]; cto2_guardian=';
-        expect(getCookie('s_vi')).toEqual(
-            '[CS]v1|29AB343C05013259-4000014980021C3D[CE]'
-        );
-    });
+	it('should be able to get a cookie', () => {
+		document.cookie =
+			'optimizelyEndUserId=oeu1398171767331r0.5280374749563634; __qca=P0-938012256-1398171768649; __gads=ID=85aa476fff43818a:T=1398171769:S=ALNI_MbfMkJmvVDwlqDMvJk1oCBV3jNUoA; noticebar_cookie=2; GU_mvt_id=717659; fsr.r=%7B%22d%22%3A90%2C%22i%22%3A%22de37431-93457748-eb61-2581-cce6c%22%2C%22e%22%3A1416223264445%7D; _ga=GA1.2.555908995.1398171761; QSI_HistorySession=http%3A%2F%2Fwww.theguardian.com%2Fworld%2F2014%2Fnov%2F11%2Findian-women-die-mass-steri…ov%2F11%2Fputin-gallant-gesture-chinese-leader-wife-censored~1415796988465; mlUserID=amIIKWa5S6ha; _em_vt=eed0af5afb2b123c5293cbae36c953ec8ab6445d73-180037745475ec3b; GU_EDITION=UK; GU_MI=mi_i%3D13552794%3Bmi_p%3DCRE%2CRCO%3Bgu_pk%3DCRE%2CRCO%3Bmi_e%3D%21201412141140%3Bmi_dn%3DJohn+Duffell%3Bmi_s%3Da7dd96e91fffd189215abaa69107bf13; GU_U=WyIxMzU1Mjc5NCIsImpvaG4uZHVmZmVsbEBndWFyZGlhbi5jby51ayIsIkpvaG4gRHVmZmVsbCIsIjIiLDE0MjQ5NTA4NDgwMDEsMSwxNDA1OTUxMDgyMDAwLHRydWVd.MCwCFErJFuSa3ptSv2V6JYkIjTtTFUKiAhQDLOlsFAulk4mg7yj8DWswB3p_1Q; _cb_ls=1; s_campaign=twt_gu; _chartbeat2=CbF00iBuBN28SPnnY.1417174852129.1417516877697.10001; fsr.s=%7B%22v2%22%3A-2%2C%22v1%22%3A1%2C%22rid%22%3A%22de37431-93457748-eb61-2581-cce6c%22%2C%22ru%22%3A%22http%3A%2F%2Fwww.theguardian.com%2Fuk%22%2C%22r%22%3A%22www.theguardian.com%22%2C%22st%2…22Y%22%7D%2C%22l%22%3A%22en%22%2C%22i%22%3A-1%2C%22f%22%3A1417516902586%7D; fsr.a=1417516904960; s_pers=%20s_fid%3D7BD36E2BEA3FA475-209CB26F08488520%7C1473689665518%3B%20s_daily_habit%3D16315%252C16316%252C16317%252C16318%252C16321%252C16323%252C16325%7C1568297665542%3B%20s_lv%3D1413290266527%7C1507898266527%3B%20s_nr%3D1413290266538-Repeat%7C1444826266538%3B%20s_prev_prop9%3Dno%2520value%7C1417605835703%3B; s_sess=%20s_sv_sid%3D1337774611744%3B%20s_campaign%3DEMCNEWEML6619I2%3B%20s_ppv%3D-%252C17%252C17%252C695%3B%20s_cc%3Dtrue%3B%20s_visit%3D1%3B%20s_sq%3Dguardiangu-network%253D%252526pid%25253DGFE%2525253Anews%2525253AArticle%2525253A10-years-bullying-data%252526pidt%25253D1%252526oid%25253Dhttp%2525253A%2525252F%2525252Fwww.theguardian.com%2525252Fpreference%2525252Fplatform%2525252Fclassic%252…%252525252F2013%252525252Fmay%252525252F23%252525252F1%252526ot%25253DA%3B; OAX=X5GDnlPairgACdD1; optimizelySegments=%7B%22172123993%22%3A%22none%22%2C%22172180831%22%3A%22none%22%2C%22172233718%22%3A%22false%22%2C%22172284779%22%3A%22gc%22%2C%22172321425%22%3A%22false%22%2C%22172361369%22%3A%22referral%22%2C%22172368238%22%3A%22search%22%2C%22172387121%22%3A%22gc%22%2C%22280150302%22%3A%22gc%22%2C%22280266488%22%3A%22false%22%2C%22280820196%22%3A%22none%22%2C%22280923576%22%3A%22referral%22%2C%22290314994%22%3A%22false%22%2C%22290553915%22%3A%22direct%22%2C%22293452255%22%3A%22gc%22%2C%22293462044%22%3A%22none%22%2C%22812091703%22%3A%22true%22%2C%22813360577%22%3A%22true%22%2C%221214390054%22%3A%22true%22%2C%221992100896%22%3A%22false%22%2C%222001830212%22%3A%22none%22%2C%222004900216%22%3A%22referral%22%2C%222005870214%22%3A%22gc%22%7D; optimizelyBuckets=%7B%7D; s_pers=%20s_fid%3D7BD36E2BEA3FA475-209CB26F08488520%7C1473689665518%3B%20s_daily_habit%3D16315%252C16316%252C16317%252C16318%252C16321%252C16323%252C16325%7C1568297665542%3B%20s_lv%3D1413290266527%7C1507898266527%3B%20s_prev_prop9%3Dno%2520value%7C1417605835703%3B%20s_nr%3D1417605906076-Repeat%7C1449141906076%3B; s_sess=%20s_sv_sid%3D1337774611744%3B%20s_campaign%3DEMCNEWEML6619I2%3B%20s_ppv%3D-%252C17%252C17%252C695%3B%20s_cc%3Dtrue%3B%20s_visit%3D1%3B%20s_sq%3Dguardiangu-network%253D%252526pid%25253DGFE%2525253Anews%2525253AArticle%2525253A10-years-bullying-data%252526pidt%25253D1%252526oid%25253Dhttp%2525253A%2525252F%2525252Fwww.theguardian.com%2525252Fpreference%2525252Fplatform%2525252Fclassic%252…%252525252F2013%252525252Fmay%252525252F23%252525252F1%252526ot%25253DA%3B; s_sq=%5B%5BB%5D%5D; GU_VIEW=responsive; s_cc=true; bwid=kvdn_943h8SSC6h3R5hyJ31g; s_fid=470C3252CA9A4650-35C6B54A21985FBA; s_daily_habit=16406%2C16407%2C16408; s_lv=1417705099834; s_nr=1417705099835-Repeat; s_vi=[CS]v1|29AB343C05013259-4000014980021C3D[CE]; cto2_guardian=';
+		expect(getCookie('s_vi')).toEqual(
+			'[CS]v1|29AB343C05013259-4000014980021C3D[CE]',
+		);
+	});
 });
 
 afterAll(() => {
-    global.Date = OriginalDate;
-    expect(new Date().toString()).not.toMatch(new RegExp('Thu Jan 01 1970'));
+	global.Date = OriginalDate;
+	expect(new Date().toString()).not.toMatch(new RegExp('Thu Jan 01 1970'));
 });

--- a/static/src/javascripts/lib/defer-to-analytics.js
+++ b/static/src/javascripts/lib/defer-to-analytics.js
@@ -1,5 +1,5 @@
 const deferToAnalytics = (afterAnalytics) => {
-    afterAnalytics();
+	afterAnalytics();
 };
 
 export default deferToAnalytics;

--- a/static/src/javascripts/lib/detect.js
+++ b/static/src/javascripts/lib/detect.js
@@ -1,54 +1,50 @@
 import config from './config';
 import mediator from './mediator';
 
-
-
-
-
 // These should match those defined in:
 //   stylesheets/_vars.scss
 //   common/app/layout/Breakpoint.scala
 const breakpoints = [
-    {
-        name: 'mobile',
-        isTweakpoint: false,
-        width: 0,
-    },
-    {
-        name: 'mobileMedium',
-        isTweakpoint: true,
-        width: 375,
-    },
-    {
-        name: 'mobileLandscape',
-        isTweakpoint: true,
-        width: 480,
-    },
-    {
-        name: 'phablet',
-        isTweakpoint: true,
-        width: 660,
-    },
-    {
-        name: 'tablet',
-        isTweakpoint: false,
-        width: 740,
-    },
-    {
-        name: 'desktop',
-        isTweakpoint: false,
-        width: 980,
-    },
-    {
-        name: 'leftCol',
-        isTweakpoint: true,
-        width: 1140,
-    },
-    {
-        name: 'wide',
-        isTweakpoint: false,
-        width: 1300,
-    },
+	{
+		name: 'mobile',
+		isTweakpoint: false,
+		width: 0,
+	},
+	{
+		name: 'mobileMedium',
+		isTweakpoint: true,
+		width: 375,
+	},
+	{
+		name: 'mobileLandscape',
+		isTweakpoint: true,
+		width: 480,
+	},
+	{
+		name: 'phablet',
+		isTweakpoint: true,
+		width: 660,
+	},
+	{
+		name: 'tablet',
+		isTweakpoint: false,
+		width: 740,
+	},
+	{
+		name: 'desktop',
+		isTweakpoint: false,
+		width: 980,
+	},
+	{
+		name: 'leftCol',
+		isTweakpoint: true,
+		width: 1140,
+	},
+	{
+		name: 'wide',
+		isTweakpoint: false,
+		width: 1300,
+	},
 ];
 
 let currentBreakpoint;
@@ -56,207 +52,199 @@ let currentTweakpoint;
 let supportsPushState;
 // #?: Consider dropping support for vendor-specific implementations
 let pageVisibility =
-    document.visibilityState ||
+	document.visibilityState ||
+	document.webkitVisibilityState ||
+	document.mozVisibilityState ||
+	document.msVisibilityState ||
+	'visible';
 
-    document.webkitVisibilityState ||
-
-    document.mozVisibilityState ||
-
-    document.msVisibilityState ||
-    'visible';
-
-const breakpointNames = breakpoints.map(
-    breakpoint => breakpoint.name
-);
+const breakpointNames = breakpoints.map((breakpoint) => breakpoint.name);
 
 const findBreakpoint = (tweakpoint) => {
-    let breakpointIndex = breakpointNames.indexOf(tweakpoint);
-    let breakpoint = breakpoints[breakpointIndex];
-    while (breakpointIndex >= 0 && breakpoint.isTweakpoint) {
-        breakpointIndex -= 1;
-        breakpoint = breakpoints[breakpointIndex];
-    }
-    return breakpoint.name;
+	let breakpointIndex = breakpointNames.indexOf(tweakpoint);
+	let breakpoint = breakpoints[breakpointIndex];
+	while (breakpointIndex >= 0 && breakpoint.isTweakpoint) {
+		breakpointIndex -= 1;
+		breakpoint = breakpoints[breakpointIndex];
+	}
+	return breakpoint.name;
 };
 
 const updateBreakpoint = (breakpoint) => {
-    currentTweakpoint = breakpoint.name;
+	currentTweakpoint = breakpoint.name;
 
-    if (breakpoint.isTweakpoint) {
-        currentBreakpoint = findBreakpoint(currentTweakpoint);
-    } else {
-        currentBreakpoint = currentTweakpoint;
-    }
+	if (breakpoint.isTweakpoint) {
+		currentBreakpoint = findBreakpoint(currentTweakpoint);
+	} else {
+		currentBreakpoint = currentTweakpoint;
+	}
 };
 
 // this function has a Breakpoint as context, so we can't use fat arrows
-const onMatchingBreakpoint = function(
-    mql
-) {
-    if (mql && mql.matches) {
-        updateBreakpoint(this);
-    }
+const onMatchingBreakpoint = function (mql) {
+	if (mql && mql.matches) {
+		updateBreakpoint(this);
+	}
 };
 
 const updateBreakpoints = () => {
-    // The implementation for browsers that don't support window.matchMedia is simpler,
-    // but relies on (1) the resize event, (2) layout and (3) hidden generated content
-    // on a pseudo-element
-    const bodyStyle = window.getComputedStyle(document.body, '::after');
-    const breakpointName = bodyStyle.content.substring(
-        1,
-        bodyStyle.content.length - 1
-    );
-    const breakpointIndex = breakpointNames.indexOf(breakpointName);
-    updateBreakpoint(breakpoints[breakpointIndex]);
+	// The implementation for browsers that don't support window.matchMedia is simpler,
+	// but relies on (1) the resize event, (2) layout and (3) hidden generated content
+	// on a pseudo-element
+	const bodyStyle = window.getComputedStyle(document.body, '::after');
+	const breakpointName = bodyStyle.content.substring(
+		1,
+		bodyStyle.content.length - 1,
+	);
+	const breakpointIndex = breakpointNames.indexOf(breakpointName);
+	updateBreakpoint(breakpoints[breakpointIndex]);
 };
 
 const initMediaQueryListeners = () => {
-    breakpoints.forEach((bp, index, bps) => {
-        // We create mutually exclusive (min-width) and (max-width) media queries
-        // to facilitate the breakpoint/tweakpoint logic.
-        const minWidth = `(min-width: ${bp.width}px)`;
+	breakpoints.forEach((bp, index, bps) => {
+		// We create mutually exclusive (min-width) and (max-width) media queries
+		// to facilitate the breakpoint/tweakpoint logic.
+		const minWidth = `(min-width: ${bp.width}px)`;
 
-        bp.mql =
-            index < bps.length - 1
-                ? window.matchMedia(
-                      `${minWidth} and (max-width: ${bps[index + 1].width -
-                          1}px)`
-                  )
-                : window.matchMedia(minWidth);
+		bp.mql =
+			index < bps.length - 1
+				? window.matchMedia(
+						`${minWidth} and (max-width: ${
+							bps[index + 1].width - 1
+						}px)`,
+				  )
+				: window.matchMedia(minWidth);
 
-        bp.listener = onMatchingBreakpoint.bind(bp);
+		bp.listener = onMatchingBreakpoint.bind(bp);
 
-        if (bp.mql) {
-            bp.mql.addListener(bp.listener);
-        }
+		if (bp.mql) {
+			bp.mql.addListener(bp.listener);
+		}
 
-        if (bp.mql && bp.listener) {
-            bp.listener(bp.mql);
-        }
-    });
+		if (bp.mql && bp.listener) {
+			bp.listener(bp.mql);
+		}
+	});
 };
 
 const initBreakpoints = () => {
-    if ('matchMedia' in window) {
-        initMediaQueryListeners();
-    } else {
-        updateBreakpoints();
-        mediator.on('window:throttledResize', updateBreakpoints);
-    }
+	if ('matchMedia' in window) {
+		initMediaQueryListeners();
+	} else {
+		updateBreakpoints();
+		mediator.on('window:throttledResize', updateBreakpoints);
+	}
 };
 
 const getViewport = () => {
-    if (
-        !window.innerWidth ||
-        !(document && document.body && document.body.clientWidth)
-    ) {
-        return {
-            height: 0,
-            width: 0,
-        };
-    }
+	if (
+		!window.innerWidth ||
+		!(document && document.body && document.body.clientWidth)
+	) {
+		return {
+			height: 0,
+			width: 0,
+		};
+	}
 
-    return {
-        width: window.innerWidth || document.body.clientWidth,
-        height: window.innerHeight || document.body.clientHeight,
-    };
+	return {
+		width: window.innerWidth || document.body.clientWidth,
+		height: window.innerHeight || document.body.clientHeight,
+	};
 };
 
 const getBreakpoint = (includeTweakpoint) =>
-    includeTweakpoint ? currentTweakpoint : currentBreakpoint;
+	includeTweakpoint ? currentTweakpoint : currentBreakpoint;
 
 const isBreakpoint = (criteria) => {
-    const indexMin = criteria.min ? breakpointNames.indexOf(criteria.min) : 0;
-    const indexMax = criteria.max
-        ? breakpointNames.indexOf(criteria.max)
-        : breakpointNames.length - 1;
-    const indexCur = breakpointNames.indexOf(
-        currentTweakpoint || currentBreakpoint
-    );
+	const indexMin = criteria.min ? breakpointNames.indexOf(criteria.min) : 0;
+	const indexMax = criteria.max
+		? breakpointNames.indexOf(criteria.max)
+		: breakpointNames.length - 1;
+	const indexCur = breakpointNames.indexOf(
+		currentTweakpoint || currentBreakpoint,
+	);
 
-    return indexMin <= indexCur && indexCur <= indexMax;
+	return indexMin <= indexCur && indexCur <= indexMax;
 };
 
 const hasCrossedBreakpoint = (includeTweakpoint) => {
-    let was = getBreakpoint(includeTweakpoint);
+	let was = getBreakpoint(includeTweakpoint);
 
-    return (callback) => {
-        const is = getBreakpoint(includeTweakpoint);
+	return (callback) => {
+		const is = getBreakpoint(includeTweakpoint);
 
-        if (is !== was) {
-            callback(is, was);
-            was = is;
-        }
-    };
+		if (is !== was) {
+			callback(is, was);
+			was = is;
+		}
+	};
 };
 
 // https://developer.apple.com/documentation/apple_pay_on_the_web/apple_pay_js_api/checking_for_apple_pay_availability
 const applePayApiAvailable = !!window.ApplePaySession;
 
-const isIOS = () =>
-    /(iPad|iPhone|iPod touch)/i.test(navigator.userAgent);
+const isIOS = () => /(iPad|iPhone|iPod touch)/i.test(navigator.userAgent);
 
 const isAndroid = () => /Android/i.test(navigator.userAgent);
 
 const hasTouchScreen = () =>
-    'ontouchstart' in window ||
-    (window.DocumentTouch && document instanceof window.DocumentTouch);
+	'ontouchstart' in window ||
+	(window.DocumentTouch && document instanceof window.DocumentTouch);
 
 const hasPushStateSupport = () => {
-    if (supportsPushState !== undefined) {
-        return supportsPushState;
-    }
+	if (supportsPushState !== undefined) {
+		return supportsPushState;
+	}
 
-    if (window.history && window.history.pushState) {
-        supportsPushState = true;
-        // Android stock browser lies about its HistoryAPI support.
-        if (window.navigator.userAgent.match(/Android/i)) {
-            supportsPushState = !!window.navigator.userAgent.match(
-                /(Chrome|Firefox)/i
-            );
-        }
-    }
+	if (window.history && window.history.pushState) {
+		supportsPushState = true;
+		// Android stock browser lies about its HistoryAPI support.
+		if (window.navigator.userAgent.match(/Android/i)) {
+			supportsPushState =
+				!!window.navigator.userAgent.match(/(Chrome|Firefox)/i);
+		}
+	}
 
-    return supportsPushState;
+	return supportsPushState;
 };
 
 const initPageVisibility = () => {
-    const onchange = (evt = window.event) => {
-        const v = 'visible';
-        const evtMap = {
-            focus: v,
-            focusin: v,
-            pageshow: v,
-            blur: 'hidden',
-            focusout: 'hidden',
-            pagehide: 'hidden',
-        };
+	const onchange = (evt = window.event) => {
+		const v = 'visible';
+		const evtMap = {
+			focus: v,
+			focusin: v,
+			pageshow: v,
+			blur: 'hidden',
+			focusout: 'hidden',
+			pagehide: 'hidden',
+		};
 
-        if (evt.type in evtMap) {
-            pageVisibility = evtMap[evt.type];
-        } else {
-            pageVisibility = document && document.hidden ? 'hidden' : 'visible';
-        }
-        mediator.emit(`modules:detect:pagevisibility:${pageVisibility}`);
-    };
+		if (evt.type in evtMap) {
+			pageVisibility = evtMap[evt.type];
+		} else {
+			pageVisibility = document && document.hidden ? 'hidden' : 'visible';
+		}
+		mediator.emit(`modules:detect:pagevisibility:${pageVisibility}`);
+	};
 
-    // Standards:
-    if ('hidden' in document) {
-        document.addEventListener('visibilitychange', onchange);
-    } else if ('msHidden' in document) {
-        document.addEventListener('msvisibilitychange', onchange);
-    } else if ('onfocusin' in document) {
-        // IE 9 and lower:
-        window.onfocusout = onchange;
-        window.onfocusin = onchange;
-    } else {
-        // All others:
-        window.onpageshow = onchange;
-        window.onpagehide = onchange;
-        window.onfocus = onchange;
-        window.onblur = onchange;
-    }
+	// Standards:
+	if ('hidden' in document) {
+		document.addEventListener('visibilitychange', onchange);
+	} else if ('msHidden' in document) {
+		document.addEventListener('msvisibilitychange', onchange);
+	} else if ('onfocusin' in document) {
+		// IE 9 and lower:
+		window.onfocusout = onchange;
+		window.onfocusin = onchange;
+	} else {
+		// All others:
+		window.onpageshow = onchange;
+		window.onpagehide = onchange;
+		window.onfocus = onchange;
+		window.onblur = onchange;
+	}
 };
 
 const pageVisible = () => pageVisibility === 'visible';
@@ -264,18 +252,18 @@ const pageVisible = () => pageVisibility === 'visible';
 const isEnhanced = () => window.guardian.isEnhanced;
 
 const getAdblockInUse = () => {
-    if (config.get('isDotcomRendering', false)) {
-        return Promise.resolve(false);
-    }
-    return new Promise(resolve => {
-        if (window.guardian.adBlockers.hasOwnProperty('active')) {
-            // adblock detection has completed
-            resolve(window.guardian.adBlockers.active);
-        } else {
-            // Push a listener for when the JS loads
-            window.guardian.adBlockers.onDetect.push(resolve);
-        }
-    });
+	if (config.get('isDotcomRendering', false)) {
+		return Promise.resolve(false);
+	}
+	return new Promise((resolve) => {
+		if (window.guardian.adBlockers.hasOwnProperty('active')) {
+			// adblock detection has completed
+			resolve(window.guardian.adBlockers.active);
+		} else {
+			// Push a listener for when the JS loads
+			window.guardian.adBlockers.onDetect.push(resolve);
+		}
+	});
 };
 
 const adblockInUse = getAdblockInUse();
@@ -283,75 +271,75 @@ const adblockInUse = getAdblockInUse();
 const getReferrer = () => document.referrer || '';
 
 const getUserAgent = (() => {
-    if (!navigator && !navigator.userAgent) {
-        return '';
-    }
+	if (!navigator && !navigator.userAgent) {
+		return '';
+	}
 
-    const ua = navigator.userAgent;
-    let tem;
-    let M =
-        ua.match(
-            /(opera|chrome|safari|firefox|msie|trident(?=\/))\/?\s*(\d+)/i
-        ) || [];
+	const ua = navigator.userAgent;
+	let tem;
+	let M =
+		ua.match(
+			/(opera|chrome|safari|firefox|msie|trident(?=\/))\/?\s*(\d+)/i,
+		) || [];
 
-    if (M && M[1] && /trident/i.test(M[1])) {
-        tem = /\brv[ :]+(\d+)/g.exec(ua);
+	if (M && M[1] && /trident/i.test(M[1])) {
+		tem = /\brv[ :]+(\d+)/g.exec(ua);
 
-        if (tem && tem[1]) {
-            return `IE ${tem[1]}`;
-        }
-    }
+		if (tem && tem[1]) {
+			return `IE ${tem[1]}`;
+		}
+	}
 
-    if (M && M[1] === 'Chrome') {
-        tem = ua.match(/\bOPR\/(\d+)/);
+	if (M && M[1] === 'Chrome') {
+		tem = ua.match(/\bOPR\/(\d+)/);
 
-        if (tem && tem[1]) {
-            return `Opera ${tem[1]}`;
-        }
-    }
+		if (tem && tem[1]) {
+			return `Opera ${tem[1]}`;
+		}
+	}
 
-    M =
-        M && M[2]
-            ? [M[1], M[2]]
-            : [navigator.appName, navigator.appVersion, '-?'];
-    tem = ua.match(/version\/(\d+)/i);
+	M =
+		M && M[2]
+			? [M[1], M[2]]
+			: [navigator.appName, navigator.appVersion, '-?'];
+	tem = ua.match(/version\/(\d+)/i);
 
-    if (tem && tem[1]) {
-        M.splice(1, 1, tem[1]);
-    }
+	if (tem && tem[1]) {
+		M.splice(1, 1, tem[1]);
+	}
 
-    return {
-        browser: M[0],
-        version: M[1],
-    };
+	return {
+		browser: M[0],
+		version: M[1],
+	};
 })();
 
 const isGoogleProxy = () =>
-    !!(
-        navigator &&
-        navigator.userAgent &&
-        (navigator.userAgent.indexOf('Google Web Preview') > -1 ||
-            navigator.userAgent.indexOf('googleweblight') > -1)
-    );
+	!!(
+		navigator &&
+		navigator.userAgent &&
+		(navigator.userAgent.indexOf('Google Web Preview') > -1 ||
+			navigator.userAgent.indexOf('googleweblight') > -1)
+	);
 
 initBreakpoints();
 
 export {
-    hasCrossedBreakpoint,
-    hasTouchScreen,
-    hasPushStateSupport,
-    getBreakpoint,
-    getUserAgent,
-    getViewport,
-    isIOS,
-    applePayApiAvailable,
-    isAndroid,
-    isBreakpoint,
-    initPageVisibility,
-    pageVisible,
-    breakpoints,
-    isEnhanced,
-    adblockInUse,
-    getReferrer,
-    isGoogleProxy,
+	hasCrossedBreakpoint,
+	hasTouchScreen,
+	hasPushStateSupport,
+	getBreakpoint,
+	getUserAgent,
+	getViewport,
+	isIOS,
+	applePayApiAvailable,
+	isAndroid,
+	isBreakpoint,
+	initPageVisibility,
+	pageVisible,
+	breakpoints,
+	isEnhanced,
+	adblockInUse,
+	getReferrer,
+	isGoogleProxy,
 };

--- a/static/src/javascripts/lib/getPrivacyFramework.js
+++ b/static/src/javascripts/lib/getPrivacyFramework.js
@@ -1,16 +1,15 @@
-
 import { isInUsa } from 'projects/common/modules/commercial/geo-utils.js';
 
 let frameworks;
 
 export const getPrivacyFramework = () => {
-    if (typeof frameworks === 'undefined') {
-        const isInUS = isInUsa();
+	if (typeof frameworks === 'undefined') {
+		const isInUS = isInUsa();
 
-        frameworks = {
-            ccpa: isInUS,
-            tcfv2: !isInUS,
-        };
-    }
-    return frameworks;
+		frameworks = {
+			ccpa: isInUS,
+			tcfv2: !isInUS,
+		};
+	}
+	return frameworks;
 };

--- a/static/src/javascripts/lib/raven.js
+++ b/static/src/javascripts/lib/raven.js
@@ -8,82 +8,83 @@ const sentryUrl = `https://${sentryPublicApiKey}@${sentryHost}`;
 let adblockBeingUsed = false;
 
 const sentryOptions = {
-    whitelistUrls: [
-        // localhost will not log errors, but call `shouldSendCallback`
-        /localhost/,
-        /assets\.guim\.co\.uk/,
-        /ophan\.co\.uk/,
-    ],
+	whitelistUrls: [
+		// localhost will not log errors, but call `shouldSendCallback`
+		/localhost/,
+		/assets\.guim\.co\.uk/,
+		/ophan\.co\.uk/,
+	],
 
-    tags: {
-        edition: config.get('page.edition'),
-        contentType: config.get('page.contentType'),
-        revisionNumber: config.get('page.revisionNumber'),
-    },
+	tags: {
+		edition: config.get('page.edition'),
+		contentType: config.get('page.contentType'),
+		revisionNumber: config.get('page.revisionNumber'),
+	},
 
-    ignoreErrors: [
-        "Can't execute code from a freed script",
-        /There is no space left matching rules from/gi,
-        'Top comments failed to load:',
-        'Comments failed to load:',
-        /InvalidStateError/gi,
-        /Fetch error:/gi,
-        'Network request failed',
-        'This video is no longer available.',
-        'UnknownError',
-        'TypeError: Failed to fetch',
-        'TypeError: NetworkError when attempting to fetch resource',
+	ignoreErrors: [
+		"Can't execute code from a freed script",
+		/There is no space left matching rules from/gi,
+		'Top comments failed to load:',
+		'Comments failed to load:',
+		/InvalidStateError/gi,
+		/Fetch error:/gi,
+		'Network request failed',
+		'This video is no longer available.',
+		'UnknownError',
+		'TypeError: Failed to fetch',
+		'TypeError: NetworkError when attempting to fetch resource',
 
-        // weatherapi/city.json frequently 404s and lib/fetch-json throws an error
-        'Fetch error while requesting https://api.nextgen.guardianapps.co.uk/weatherapi/city.json:',
-    ],
+		// weatherapi/city.json frequently 404s and lib/fetch-json throws an error
+		'Fetch error while requesting https://api.nextgen.guardianapps.co.uk/weatherapi/city.json:',
+	],
 
-    dataCallback(data) {
-        const { culprit = false } = data;
-        const resp = data;
-        const culpritMatches = /j.ophan.co.uk/.test(data.culprit);
+	dataCallback(data) {
+		const { culprit = false } = data;
+		const resp = data;
+		const culpritMatches = /j.ophan.co.uk/.test(data.culprit);
 
-        if (culprit) {
-            resp.culprit = culprit.replace(/\/[a-z\d]{32}(\/[^/]+)$/, '$1');
-        }
+		if (culprit) {
+			resp.culprit = culprit.replace(/\/[a-z\d]{32}(\/[^/]+)$/, '$1');
+		}
 
-        resp.tags.origin = culpritMatches ? 'ophan' : 'app';
+		resp.tags.origin = culpritMatches ? 'ophan' : 'app';
 
-        return resp;
-    },
+		return resp;
+	},
 
-    shouldSendCallback(data) {
-        const { isDev } = config.get('page');
-        const isIgnored =
-            typeof data.tags.ignored !== 'undefined' && data.tags.ignored;
-        const { enableSentryReporting } = config.get('switches');
-        const isSentinelLoggingEvent = data?.tags?.tag === 'commercial-sentinel'
+	shouldSendCallback(data) {
+		const { isDev } = config.get('page');
+		const isIgnored =
+			typeof data.tags.ignored !== 'undefined' && data.tags.ignored;
+		const { enableSentryReporting } = config.get('switches');
+		const isSentinelLoggingEvent =
+			data?.tags?.tag === 'commercial-sentinel';
 
-        // isInSample is always true if the tag is commercial-sentinel.
-        // Otherwise, sample at .08%
-        const isInSample = isSentinelLoggingEvent
-                ? true
-                : Math.random() < 0.008;
+		// isInSample is always true if the tag is commercial-sentinel.
+		// Otherwise, sample at .08%
+		const isInSample = isSentinelLoggingEvent
+			? true
+			: Math.random() < 0.008;
 
-        if (isDev && !isIgnored) {
-            // Some environments don't support or don't always expose the console Object
-            if (window.console && window.console.warn) {
-                window.console.warn('Raven captured event.', data);
-            }
-        }
+		if (isDev && !isIgnored) {
+			// Some environments don't support or don't always expose the console Object
+			if (window.console && window.console.warn) {
+				window.console.warn('Raven captured event.', data);
+			}
+		}
 
-        return (
-            enableSentryReporting &&
-            isInSample &&
-            !isIgnored &&
-            !adblockBeingUsed &&
-            (!isDev || isSentinelLoggingEvent)
-        );
-    },
+		return (
+			enableSentryReporting &&
+			isInSample &&
+			!isIgnored &&
+			!adblockBeingUsed &&
+			(!isDev || isSentinelLoggingEvent)
+		);
+	},
 };
 
-adblockInUse.then(isUse => {
-    adblockBeingUsed = isUse;
+adblockInUse.then((isUse) => {
+	adblockBeingUsed = isUse;
 });
 
 export default raven.config(sentryUrl, sentryOptions).install();

--- a/static/src/javascripts/lib/report-error.js
+++ b/static/src/javascripts/lib/report-error.js
@@ -8,20 +8,14 @@
 
 import raven from './raven';
 
-
-
-const reportError = (
-    err,
-    tags,
-    shouldThrow = true
-) => {
-    raven.captureException(err, { tags });
-    if (shouldThrow) {
-        // Flag to ensure it is not reported to Sentry again via global handlers
-        const error = err;
-        error.reported = true;
-        throw error;
-    }
+const reportError = (err, tags, shouldThrow = true) => {
+	raven.captureException(err, { tags });
+	if (shouldThrow) {
+		// Flag to ensure it is not reported to Sentry again via global handlers
+		const error = err;
+		error.reported = true;
+		throw error;
+	}
 };
 
 export default reportError;

--- a/static/src/javascripts/lib/robust.js
+++ b/static/src/javascripts/lib/robust.js
@@ -6,50 +6,39 @@
 import reportError from './report-error';
 
 const catchErrors = (fn) => {
-    let error;
+	let error;
 
-    try {
-        fn();
-    } catch (e) {
-        error = e;
-    }
+	try {
+		fn();
+	} catch (e) {
+		error = e;
+	}
 
-    return error;
+	return error;
 };
 
-const logError = (
-    module,
-    error,
-    tags
-) => {
-    if (window.console && window.console.warn) {
-        window.console.warn('Caught error.', error.stack);
-    }
+const logError = (module, error, tags) => {
+	if (window.console && window.console.warn) {
+		window.console.warn('Caught error.', error.stack);
+	}
 
-    if (tags) {
-        reportError(error, Object.assign({ module }, tags), false);
-    } else {
-        reportError(error, { module }, false);
-    }
+	if (tags) {
+		reportError(error, Object.assign({ module }, tags), false);
+	} else {
+		reportError(error, { module }, false);
+	}
 };
 
-const catchAndLogError = (
-    name,
-    fn,
-    tags
-) => {
-    const error = catchErrors(fn);
+const catchAndLogError = (name, fn, tags) => {
+	const error = catchErrors(fn);
 
-    if (error) {
-        logError(name, error, tags);
-    }
+	if (error) {
+		logError(name, error, tags);
+	}
 };
 
-const catchErrorsWithContext = (
-    modules,
-    tags
-) => {
-    modules.forEach(([name, fn]) => catchAndLogError(name, fn, tags));
+const catchErrorsWithContext = (modules, tags) => {
+	modules.forEach(([name, fn]) => catchAndLogError(name, fn, tags));
 };
 
 export { catchErrorsWithContext, logError };

--- a/static/src/javascripts/lib/user-timing.spec.js
+++ b/static/src/javascripts/lib/user-timing.spec.js
@@ -6,42 +6,42 @@ const mockIO = { entries: [] };
 const mockedNowValue = chance.integer();
 
 jest.mock('lib/window-performance', () => ({
-    now: jest.fn(() => mockedNowValue),
+	now: jest.fn(() => mockedNowValue),
 
-    mark: jest.fn(name => {
-        mockIO.entries.push({
-            entryType: 'mark',
-            name,
-            startTime: mockedNowValue,
-            duration: 0,
-        });
-    }),
+	mark: jest.fn((name) => {
+		mockIO.entries.push({
+			entryType: 'mark',
+			name,
+			startTime: mockedNowValue,
+			duration: 0,
+		});
+	}),
 
-    getEntriesByName: jest.fn((name, type) => {
-        const item = mockIO.entries.find(
-            timingMark =>
-                timingMark.entryType === type && timingMark.name === name
-        );
-        return [item];
-    }),
+	getEntriesByName: jest.fn((name, type) => {
+		const item = mockIO.entries.find(
+			(timingMark) =>
+				timingMark.entryType === type && timingMark.name === name,
+		);
+		return [item];
+	}),
 }));
 
 describe('user-timing', () => {
-    test('getCurrentTime()', () => {
-        expect(getCurrentTime()).toBe(mockedNowValue);
-    });
+	test('getCurrentTime()', () => {
+		expect(getCurrentTime()).toBe(mockedNowValue);
+	});
 
-    test('markTime()', () => {
-        const name = chance.word();
-        mockIO.entries = [];
-        markTime(name);
-        expect(mockIO.entries.length).toBe(1);
-    });
+	test('markTime()', () => {
+		const name = chance.word();
+		mockIO.entries = [];
+		markTime(name);
+		expect(mockIO.entries.length).toBe(1);
+	});
 
-    test('getMarkTime()', () => {
-        const name = chance.word();
-        markTime(name);
-        const timer = getMarkTime(name);
-        expect(timer).toBe(mockedNowValue);
-    });
+	test('getMarkTime()', () => {
+		const name = chance.word();
+		markTime(name);
+		const timer = getMarkTime(name);
+		expect(timer).toBe(mockedNowValue);
+	});
 });

--- a/static/src/javascripts/lib/window-performance.js
+++ b/static/src/javascripts/lib/window-performance.js
@@ -1,7 +1,7 @@
 const api =
-    window.performance ||
-    window.msPerformance ||
-    window.webkitPerformance ||
-    window.mozPerformance;
+	window.performance ||
+	window.msPerformance ||
+	window.webkitPerformance ||
+	window.mozPerformance;
 
 export default api;

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-a9.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-a9.js
@@ -11,8 +11,8 @@ import { shouldIncludeOnlyA9 } from '../header-bidding/utils';
 import { dfpEnv } from './dfp-env';
 
 const setupA9 = () => {
-    // TODO: Understand why we want to skip A9 for Google Proxy
-    if (isGoogleProxy()) return Promise.resolve(false);
+	// TODO: Understand why we want to skip A9 for Google Proxy
+	if (isGoogleProxy()) return Promise.resolve(false);
 
 	// There are two articles that InfoSec would like to avoid loading scripts on
 	if (commercialFeatures.isSecureContact) {

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-a9.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-a9.spec.js
@@ -46,9 +46,9 @@ jest.mock('@guardian/libs', () => ({
 const originalUA = navigator.userAgent;
 const fakeUserAgent = (userAgent) => {
 	Object.defineProperty(navigator, 'userAgent', {
-        get: () => userAgent ?? originalUA,
-        configurable: true
-    });
+		get: () => userAgent ?? originalUA,
+		configurable: true,
+	});
 };
 
 describe('init', () => {
@@ -77,7 +77,7 @@ describe('init', () => {
 		expect(a9.initialise).toBeCalled();
 	});
 
-    it('should not initialise A9 when useragent is Google Web Preview', async () => {
+	it('should not initialise A9 when useragent is Google Web Preview', async () => {
 		fakeUserAgent('Google Web Preview');
 		await setupA9();
 		expect(a9.initialise).not.toBeCalled();

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-permutive.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-permutive.js
@@ -36,21 +36,18 @@ const generatePayload = (permutiveConfig = { page: {}, user: {} }) => {
 		toneIds,
 	} = page;
 
-	const safeAuthors = (author && typeof author === 'string'
-		? author.split(',')
-		: []
+	const safeAuthors = (
+		author && typeof author === 'string' ? author.split(',') : []
 	).map((str) => str.trim());
-	const safeKeywords = (keywords && typeof keywords === 'string'
-		? keywords.split(',')
-		: []
+	const safeKeywords = (
+		keywords && typeof keywords === 'string' ? keywords.split(',') : []
 	).map((str) => str.trim());
 	const safePublishedAt =
 		webPublicationDate && typeof webPublicationDate === 'number'
 			? new Date(webPublicationDate).toISOString()
 			: '';
-	const safeToneIds = (toneIds && typeof toneIds === 'string'
-		? toneIds.split(',')
-		: []
+	const safeToneIds = (
+		toneIds && typeof toneIds === 'string' ? toneIds.split(',') : []
 	).map((str) => str.trim());
 	const cleanPayload = removeEmpty({
 		content: {

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-permutive.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-permutive.spec.js
@@ -176,8 +176,7 @@ describe('Generating Permutive payload utils', () => {
 			};
 			const config3 = {
 				page: {
-					pageId:
-						'the-abcs-of-recruiting-teachers-remotely/2020/may/01/',
+					pageId: 'the-abcs-of-recruiting-teachers-remotely/2020/may/01/',
 					headline: 'Teacher training',
 					contentType: 'Article',
 					section: 'the-abcs-of-recruiting-teachers-remotely',
@@ -316,12 +315,10 @@ describe('Generating Permutive payload utils', () => {
 			};
 
 			_.runPermutive(config, mockPermutive, logger);
-			const [
-				identifyCallOrder,
-			] = mockPermutive.identify.mock.invocationCallOrder;
-			const [
-				addonCallOrder,
-			] = mockPermutive.addon.mock.invocationCallOrder;
+			const [identifyCallOrder] =
+				mockPermutive.identify.mock.invocationCallOrder;
+			const [addonCallOrder] =
+				mockPermutive.addon.mock.invocationCallOrder;
 			expect(identifyCallOrder).toBeLessThan(addonCallOrder);
 		});
 		it('does not call the identify method if no browser ID is present', () => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
@@ -46,17 +46,21 @@ const setupRedplanet = async () => {
 		}
 
 		if (!state.aus) {
-			rejectRedPlanetLoaded('Redplanet should only run in Australia on AUS mode');
+			rejectRedPlanetLoaded(
+				'Redplanet should only run in Australia on AUS mode',
+			);
 			return;
 		}
 
-        if (!initialised) {
-            initialised = true;
-            import(/* webpackChunkName: "redplanet" */ '../../../../lib/launchpad.js').then(() => {
-                initialise();
-                resolveRedPlanetLoaded();
-            });
-        }
+		if (!initialised) {
+			initialised = true;
+			import(
+				/* webpackChunkName: "redplanet" */ '../../../../lib/launchpad.js'
+			).then(() => {
+				initialise();
+				resolveRedPlanetLoaded();
+			});
+		}
 	});
 
 	return promise;

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.spec.js
@@ -132,27 +132,28 @@ describe('init', () => {
 		onConsentChange.mockImplementation(AusWithoutConsentMock);
 		getConsentFor.mockReturnValue(false);
 		await init();
-        expect(log).toHaveBeenCalledWith(
-            'commercial',
-            expect.stringContaining("Failed to execute redplanet"),
-            expect.stringContaining("No consent for redplanet"),
-        );
+		expect(log).toHaveBeenCalledWith(
+			'commercial',
+			expect.stringContaining('Failed to execute redplanet'),
+			expect.stringContaining('No consent for redplanet'),
+		);
 		expect(window.launchpad).not.toBeCalled();
 	});
-
 
 	it('should throw an error when on CCPA mode', async () => {
 		commercialFeatures.launchpad = true;
 		isInAuOrNz.mockReturnValue(true);
 		onConsentChange.mockImplementation(CcpaWithConsentMock);
 		getConsentFor.mockReturnValue(true);
-        await init();
-        expect(log).toHaveBeenCalledWith(
-            'commercial',
-            expect.stringContaining("Failed to execute redplanet"),
-            expect.stringContaining("Redplanet should only run in Australia on AUS mode"),
-        );
-        expect(window.launchpad).not.toBeCalled();
+		await init();
+		expect(log).toHaveBeenCalledWith(
+			'commercial',
+			expect.stringContaining('Failed to execute redplanet'),
+			expect.stringContaining(
+				'Redplanet should only run in Australia on AUS mode',
+			),
+		);
+		expect(window.launchpad).not.toBeCalled();
 	});
 
 	it('should not initialise redplanet when launchpad conditions are false', async () => {

--- a/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
+++ b/static/src/javascripts/projects/commercial/modules/hosted/gallery.js
@@ -287,12 +287,12 @@ class HostedGallery {
 		const imageSize = getFrame(imgRatio);
 
 		fastdom.mutate(() => {
-            if ($sizer) {
-                $sizer.style.setProperty('width', imageSize.width);
-                $sizer.style.setProperty('height', imageSize.height);
-                $sizer.style.setProperty('top', imageSize.topBottom);
-                $sizer.style.setProperty('left', imageSize.leftRight);
-            }
+			if ($sizer) {
+				$sizer.style.setProperty('width', imageSize.width);
+				$sizer.style.setProperty('height', imageSize.height);
+				$sizer.style.setProperty('top', imageSize.topBottom);
+				$sizer.style.setProperty('left', imageSize.leftRight);
+			}
 			if (imgIndex === ctaIndex) {
 				$ctaFloat.style.setProperty('bottom', ctaSize.topBottom);
 			}

--- a/static/src/javascripts/projects/common/modules/analytics/mvt-cookie.js
+++ b/static/src/javascripts/projects/common/modules/analytics/mvt-cookie.js
@@ -6,42 +6,41 @@ const MAX_CLIENT_MVT_ID = 1000000;
 
 // For test purposes only.
 export const overwriteMvtCookie = (testId) =>
-    addCookie(MULTIVARIATE_ID_COOKIE, String(testId), 365);
+	addCookie(MULTIVARIATE_ID_COOKIE, String(testId), 365);
 
-export const getMvtValue = () =>
-    Number(getCookie(MULTIVARIATE_ID_COOKIE));
+export const getMvtValue = () => Number(getCookie(MULTIVARIATE_ID_COOKIE));
 
 // For test purposes only.
 // Since it's set by Fastly, sometimes it's not set in dev,
 // but it's needed for certain A/B tests to work properly.
 export const initMvtCookie = () => {
-    if (!getCookie(MULTIVARIATE_ID_COOKIE)) {
-        addCookie(MULTIVARIATE_ID_COOKIE, '1');
-    }
+	if (!getCookie(MULTIVARIATE_ID_COOKIE)) {
+		addCookie(MULTIVARIATE_ID_COOKIE, '1');
+	}
 };
 
 export const incrementMvtCookie = () => {
-    const mvtId = parseInt(getCookie('GU_mvt_id'), 10);
-    if (mvtId) {
-        if (mvtId === MAX_CLIENT_MVT_ID) {
-            // Wrap back to 1 if it would exceed the max
-            overwriteMvtCookie(1);
-        } else {
-            overwriteMvtCookie(mvtId + 1);
-        }
-    }
+	const mvtId = parseInt(getCookie('GU_mvt_id'), 10);
+	if (mvtId) {
+		if (mvtId === MAX_CLIENT_MVT_ID) {
+			// Wrap back to 1 if it would exceed the max
+			overwriteMvtCookie(1);
+		} else {
+			overwriteMvtCookie(mvtId + 1);
+		}
+	}
 };
 
 export const decrementMvtCookie = () => {
-    const mvtId = parseInt(getCookie('GU_mvt_id'), 10);
-    if (mvtId) {
-        if (mvtId === 0) {
-            // Wrap back to max if it would be less than 0
-            overwriteMvtCookie(MAX_CLIENT_MVT_ID);
-        } else {
-            overwriteMvtCookie(mvtId - 1);
-        }
-    }
+	const mvtId = parseInt(getCookie('GU_mvt_id'), 10);
+	if (mvtId) {
+		if (mvtId === 0) {
+			// Wrap back to max if it would be less than 0
+			overwriteMvtCookie(MAX_CLIENT_MVT_ID);
+		} else {
+			overwriteMvtCookie(mvtId - 1);
+		}
+	}
 };
 
 export const getMvtNumValues = () => Number(MAX_CLIENT_MVT_ID);

--- a/static/src/javascripts/projects/common/modules/article/space-filler.js
+++ b/static/src/javascripts/projects/common/modules/article/space-filler.js
@@ -3,46 +3,40 @@ import fastdom from 'lib/fastdom-promise';
 import { findSpace, SpaceError } from 'common/modules/spacefinder';
 
 const onError = (e) => {
-    // e.g. if writer fails
-    raven.captureException(e);
-    return false;
+	// e.g. if writer fails
+	raven.captureException(e);
+	return false;
 };
 
 class SpaceFiller {
+	constructor() {
+		this.queue = Promise.resolve();
+	}
 
+	/**
+	 * A safer way of using spacefinder.
+	 * Given a set of spacefinder rules, applies a writer to the first matching paragraph.
+	 * Uses fastdom to avoid layout-thrashing, but queues up asynchronous writes to avoid race conditions. We don't
+	 * seek a slot for a new component until all the other component writes have finished.
+	 */
+	fillSpace(rules, writer, options) {
+		const onSpacesFound = (paragraphs) =>
+			fastdom.mutate(() => writer(paragraphs));
 
-    constructor() {
-        this.queue = Promise.resolve();
-    }
+		const onNoSpacesFound = (ex) => {
+			if (ex instanceof SpaceError) {
+				return false;
+			}
+			throw ex;
+		};
 
-    /**
-     * A safer way of using spacefinder.
-     * Given a set of spacefinder rules, applies a writer to the first matching paragraph.
-     * Uses fastdom to avoid layout-thrashing, but queues up asynchronous writes to avoid race conditions. We don't
-     * seek a slot for a new component until all the other component writes have finished.
-     */
-    fillSpace(
-        rules,
-        writer,
-        options
-    ) {
-        const onSpacesFound = (paragraphs) =>
-            fastdom.mutate(() => writer(paragraphs));
+		const insertNextContent = () =>
+			findSpace(rules, options).then(onSpacesFound, onNoSpacesFound);
 
-        const onNoSpacesFound = (ex) => {
-            if (ex instanceof SpaceError) {
-                return false;
-            }
-            throw ex;
-        };
+		this.queue = this.queue.then(insertNextContent).catch(onError);
 
-        const insertNextContent = () =>
-            findSpace(rules, options).then(onSpacesFound, onNoSpacesFound);
-
-        this.queue = this.queue.then(insertNextContent).catch(onError);
-
-        return this.queue;
-    }
+		return this.queue;
+	}
 }
 
 const spaceFiller = new SpaceFiller();

--- a/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
+++ b/static/src/javascripts/projects/common/modules/commercial/acquisitions-link-enrichment.js
@@ -26,9 +26,8 @@ const addReferrerDataToAcquisitionLink = (rawUrl) => {
 
 	let acquisitionData;
 	try {
-		const acquisitionDataJsonString = url.searchParams.get(
-			acquisitionDataField,
-		);
+		const acquisitionDataJsonString =
+			url.searchParams.get(acquisitionDataField);
 
 		if (!acquisitionDataJsonString) return rawUrl;
 

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -86,9 +86,10 @@ export const getArticleCountConsent = () => {
 			if (ccpa || aus) {
 				resolve(true);
 			} else if (tcfv2) {
-				const hasRequiredConsents = REQUIRED_CONSENTS_FOR_ARTICLE_COUNT.every(
-					(consent) => tcfv2.consents[consent],
-				);
+				const hasRequiredConsents =
+					REQUIRED_CONSENTS_FOR_ARTICLE_COUNT.every(
+						(consent) => tcfv2.consents[consent],
+					);
 
 				if (!hasRequiredConsents) {
 					removeArticleCountsFromLocalStorage();
@@ -188,7 +189,7 @@ const buildTagIds = (page) => {
 	const tones = toneIds ? toneIds.split(',') : [];
 	const series = seriesId ? [seriesId] : [];
 	return keywords.concat(tones).concat(series);
-}
+};
 
 const buildBannerPayload = async () => {
 	const page = config.get('page');
@@ -317,7 +318,7 @@ const renderLiveblogEpic = async (module, meta) => {
 
 	const element = setupRemoteEpicInLiveblog(
 		component.ContributionsLiveblogEpic,
-		{ submitComponentEvent, ...module.props }
+		{ submitComponentEvent, ...module.props },
 	);
 };
 
@@ -325,7 +326,12 @@ const renderEpic = async (module, meta) => {
 	const component = await window.guardianPolyfilledImport(module.url);
 
 	const el = epicEl();
-	mountDynamic(el, component.ContributionsEpic, { submitComponentEvent, ...module.props }, true);
+	mountDynamic(
+		el,
+		component.ContributionsEpic,
+		{ submitComponentEvent, ...module.props },
+		true,
+	);
 };
 
 export const fetchPuzzlesData = async () => {

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-service.js
@@ -23,7 +23,7 @@ import {
 	getLastOneOffContributionTimestamp,
 	getLastOneOffContributionDate,
 	isRecurringContributor,
-	shouldHideSupportMessaging,
+	shouldHideSupƒportMessaging,
 } from './user-features';
 
 // See https://github.com/guardian/support-dotcom-components/blob/main/module-versions.md

--- a/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/contributions-utilities.js
@@ -8,7 +8,4 @@ const pageShouldHideReaderRevenue = () =>
 	config.get('page.shouldHideReaderRevenue') ||
 	config.get('page.sponsorshipType') === 'paid-content';
 
-export {
-	pageShouldHideReaderRevenue,
-	getVisitCount,
-};
+export { pageShouldHideReaderRevenue, getVisitCount };

--- a/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
+++ b/static/src/javascripts/projects/common/modules/commercial/support-utilities.js
@@ -6,9 +6,8 @@ import {
 const addCountryGroupToSupportLink = (rawUrl) => {
 	const countryCode = getCountryCode();
 	if (countryCode) {
-		const countryGroup = countryCodeToSupportInternationalisationId(
-			countryCode,
-		);
+		const countryGroup =
+			countryCodeToSupportInternationalisationId(countryCode);
 		return rawUrl.replace(
 			/(support.theguardian.com)\/(contribute|subscribe)/,
 			(_, domain, path) =>

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-control.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-control.js
@@ -2,27 +2,27 @@
 // control audience does not see the gate
 
 export const signInGateMainControl = {
-    id: 'SignInGateMainControl',
-    start: '2020-05-20',
-    expiry: '2022-12-01',
-    author: 'Mahesh Makani',
-    description:
-        'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Control Audience.',
-    audience: 0.1,
-    audienceOffset: 0.9,
-    successMeasure: 'N/A - User does not see gate, only to compare to variant.',
-    audienceCriteria:
-        '3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
-    ophanComponentId: 'main_control_4',
-    dataLinkNames: 'SignInGateMain',
-    idealOutcome:
-        'Increase the number of users signed in whilst running at a reasonable scale',
-    showForSensitive: false,
-    canRun: () => true,
-    variants: [
-        {
-            id: 'main-control-4',
-            test: () => {},
-        },
-    ],
+	id: 'SignInGateMainControl',
+	start: '2020-05-20',
+	expiry: '2022-12-01',
+	author: 'Mahesh Makani',
+	description:
+		'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Control Audience.',
+	audience: 0.1,
+	audienceOffset: 0.9,
+	successMeasure: 'N/A - User does not see gate, only to compare to variant.',
+	audienceCriteria:
+		'3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
+	ophanComponentId: 'main_control_4',
+	dataLinkNames: 'SignInGateMain',
+	idealOutcome:
+		'Increase the number of users signed in whilst running at a reasonable scale',
+	showForSensitive: false,
+	canRun: () => true,
+	variants: [
+		{
+			id: 'main-control-4',
+			test: () => {},
+		},
+	],
 };

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
@@ -2,27 +2,27 @@
 // variant audience sees the gate
 
 export const signInGateMainVariant = {
-    id: 'SignInGateMainVariant',
-    start: '2020-05-20',
-    expiry: '2022-12-01',
-    author: 'Mahesh Makani',
-    description:
-        'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Main/Variant Audience.',
-    audience: 0.9,
-    audienceOffset: 0.0,
-    successMeasure: 'Users sign in or create a Guardian account',
-    audienceCriteria:
-        '3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
-    ophanComponentId: 'main_variant_4',
-    dataLinkNames: 'SignInGateMain',
-    idealOutcome:
-        'Increase the number of users signed in whilst running at a reasonable scale',
-    showForSensitive: false,
-    canRun: () => true,
-    variants: [
-        {
-            id: 'main-variant-4',
-            test: () => {},
-        },
-    ],
+	id: 'SignInGateMainVariant',
+	start: '2020-05-20',
+	expiry: '2022-12-01',
+	author: 'Mahesh Makani',
+	description:
+		'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Main/Variant Audience.',
+	audience: 0.9,
+	audienceOffset: 0.0,
+	successMeasure: 'Users sign in or create a Guardian account',
+	audienceCriteria:
+		'3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
+	ophanComponentId: 'main_variant_4',
+	dataLinkNames: 'SignInGateMain',
+	idealOutcome:
+		'Increase the number of users signed in whilst running at a reasonable scale',
+	showForSensitive: false,
+	canRun: () => true,
+	variants: [
+		{
+			id: 'main-variant-4',
+			test: () => {},
+		},
+	],
 };

--- a/static/src/javascripts/projects/common/modules/identity/auth-component-event-params.js
+++ b/static/src/javascripts/projects/common/modules/identity/auth-component-event-params.js
@@ -1,17 +1,22 @@
-import {constructQuery} from "../../../../lib/url";
-
+import { constructQuery } from '../../../../lib/url';
 
 export const createAuthenticationComponentEvent = (componentId, pageViewId) => {
-    const params = {
-        componentType: 'identityauthentication',
-        componentId,
-    };
+	const params = {
+		componentType: 'identityauthentication',
+		componentId,
+	};
 
-    if (pageViewId) {
-        params.viewId = pageViewId;
-    }
+	if (pageViewId) {
+		params.viewId = pageViewId;
+	}
 
-    return constructQuery(params);
+	return constructQuery(params);
 };
 
-export const createAuthenticationComponentEventParams = (componentId, pageViewId) => `componentEventParams=${encodeURIComponent(createAuthenticationComponentEvent(componentId, pageViewId))}`;
+export const createAuthenticationComponentEventParams = (
+	componentId,
+	pageViewId,
+) =>
+	`componentEventParams=${encodeURIComponent(
+		createAuthenticationComponentEvent(componentId, pageViewId),
+	)}`;

--- a/static/src/javascripts/projects/common/modules/onward/geo-most-popular.js
+++ b/static/src/javascripts/projects/common/modules/onward/geo-most-popular.js
@@ -8,63 +8,59 @@ import mediator from '../../../../lib/mediator';
 import { once } from 'lodash-es';
 
 const promise = new Promise((resolve, reject) => {
-    mediator.on('modules:onward:geo-most-popular:ready', resolve);
-    mediator.on('modules:onward:geo-most-popular:cancel', resolve);
-    mediator.on('modules:onward:geo-most-popular:error', reject);
+	mediator.on('modules:onward:geo-most-popular:ready', resolve);
+	mediator.on('modules:onward:geo-most-popular:cancel', resolve);
+	mediator.on('modules:onward:geo-most-popular:error', reject);
 });
 
 class GeoMostPopular extends Component {
-    static error(error) {
-        mediator.emit('modules:onward:geo-most-popular:error', error);
-    }
+	static error(error) {
+		mediator.emit('modules:onward:geo-most-popular:error', error);
+	}
 
-    constructor() {
-        super();
+	constructor() {
+		super();
 
-        this.endpoint = '/most-read-geo.json';
+		this.endpoint = '/most-read-geo.json';
 
-        mediator.emit('register:begin', 'geo-most-popular');
-    }
+		mediator.emit('register:begin', 'geo-most-popular');
+	}
 
-    ready() {
-        mediator.emit('register:end', 'geo-most-popular');
-        mediator.emit('modules:onward:geo-most-popular:ready', this);
-    }
+	ready() {
+		mediator.emit('register:end', 'geo-most-popular');
+		mediator.emit('modules:onward:geo-most-popular:ready', this);
+	}
 }
 
 // we don't want to show most popular on short articles as the sticky right mpu slot will push most popular behind other containers at the bottom.
 const showMostPopularThreshold = 1500;
 
 const fetchMostPopular = (articleBodyHeight) => {
-    if (articleBodyHeight > showMostPopularThreshold) {
-        new GeoMostPopular().fetch(
-            document.querySelectorAll('.js-components-container'),
-            'rightHtml'
-        );
-    }
+	if (articleBodyHeight > showMostPopularThreshold) {
+		new GeoMostPopular().fetch(
+			document.querySelectorAll('.js-components-container'),
+			'rightHtml',
+		);
+	}
 };
 
 const geoMostPopular = {
-    render: once(
-        () => {
-            fastdom
-                .measure(() => {
-                    const jsArticleBodyElement = document.querySelector(
-                        '.js-article__body'
-                    );
-                    return jsArticleBodyElement
-                        ? jsArticleBodyElement.getBoundingClientRect() &&
-                              jsArticleBodyElement.getBoundingClientRect()
-                                  .height
-                        : 0;
-                })
-                .then(fetchMostPopular);
+	render: once(() => {
+		fastdom
+			.measure(() => {
+				const jsArticleBodyElement =
+					document.querySelector('.js-article__body');
+				return jsArticleBodyElement
+					? jsArticleBodyElement.getBoundingClientRect() &&
+							jsArticleBodyElement.getBoundingClientRect().height
+					: 0;
+			})
+			.then(fetchMostPopular);
 
-            return promise;
-        }
-    ),
+		return promise;
+	}),
 
-    whenRendered: promise,
+	whenRendered: promise,
 };
 
 export { geoMostPopular };

--- a/static/src/javascripts/projects/common/modules/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/spacefinder.js
@@ -5,382 +5,323 @@ import fastdom from '../../../lib/fastdom-promise';
 import mediator from '../../../lib/mediator';
 import { memoize } from 'lodash-es';
 
-const query = (selector, context) =>
-    [...(context ?? document).querySelectorAll(selector)];
+const query = (selector, context) => [
+	...(context ?? document).querySelectorAll(selector),
+];
 
 // maximum time (in ms) to wait for images to be loaded and rich links
 // to be upgraded
 const LOADING_TIMEOUT = 5000;
 
 const defaultOptions = {
-    waitForImages: true,
-    waitForLinks: true,
-    waitForInteractives: false,
+	waitForImages: true,
+	waitForLinks: true,
+	waitForInteractives: false,
 };
 
 const isIframe = (node) => node instanceof HTMLIFrameElement;
 
 const isIframeLoaded = (iframe) => {
-    try {
-        return (
-            iframe.contentWindow &&
-            iframe.contentWindow.document &&
-            iframe.contentWindow.document.readyState === 'complete'
-        );
-    } catch (err) {
-        return true;
-    }
+	try {
+		return (
+			iframe.contentWindow &&
+			iframe.contentWindow.document &&
+			iframe.contentWindow.document.readyState === 'complete'
+		);
+	} catch (err) {
+		return true;
+	}
 };
 
 const expire = (resolve) => {
-    window.setTimeout(resolve, LOADING_TIMEOUT);
+	window.setTimeout(resolve, LOADING_TIMEOUT);
 };
 
-const getFuncId = (rules) =>
-    rules.bodySelector || 'document';
+const getFuncId = (rules) => rules.bodySelector || 'document';
 
 const onImagesLoaded = memoize((rules) => {
-    const notLoaded = query('img', rules.body).filter(
-        img => !img.complete
-    );
+	const notLoaded = query('img', rules.body).filter((img) => !img.complete);
 
-    return notLoaded.length === 0
-        ? Promise.resolve()
-        : new Promise(resolve => {
-              let loadedCount = 0;
-              bean.on(rules.body, 'load', notLoaded, function onImgLoaded() {
-                  loadedCount += 1;
-                  if (loadedCount === notLoaded.length) {
-                      bean.off(rules.body, 'load', onImgLoaded);
-                      notLoaded.length = 0;
-                      resolve();
-                  }
-              });
-          });
+	return notLoaded.length === 0
+		? Promise.resolve()
+		: new Promise((resolve) => {
+				let loadedCount = 0;
+				bean.on(rules.body, 'load', notLoaded, function onImgLoaded() {
+					loadedCount += 1;
+					if (loadedCount === notLoaded.length) {
+						bean.off(rules.body, 'load', onImgLoaded);
+						notLoaded.length = 0;
+						resolve();
+					}
+				});
+		  });
 }, getFuncId);
 
 const onRichLinksUpgraded = memoize(
-    (rules) =>
-        query('.element-rich-link--not-upgraded', rules.body).length === 0
-            ? Promise.resolve()
-            : new Promise(resolve => {
-                  mediator.once('rich-link:loaded', resolve);
-              }),
-    getFuncId
+	(rules) =>
+		query('.element-rich-link--not-upgraded', rules.body).length === 0
+			? Promise.resolve()
+			: new Promise((resolve) => {
+					mediator.once('rich-link:loaded', resolve);
+			  }),
+	getFuncId,
 );
 
-const onInteractivesLoaded = memoize(
-    (rules) => {
-        const notLoaded = query(
-            '.element-interactive',
-            rules.body
-        ).filter(
-            (interactive) => {
-                const iframe = (Array.from(
-                    interactive.children
-                ).filter(isIframe));
-                return !(iframe.length && isIframeLoaded(iframe[0]));
-            }
-        );
+const onInteractivesLoaded = memoize((rules) => {
+	const notLoaded = query('.element-interactive', rules.body).filter(
+		(interactive) => {
+			const iframe = Array.from(interactive.children).filter(isIframe);
+			return !(iframe.length && isIframeLoaded(iframe[0]));
+		},
+	);
 
-        return notLoaded.length === 0 || !('MutationObserver' in window)
-            ? Promise.resolve()
-            : Promise.all(
-                  notLoaded.map(
-                      (interactive) =>
-                          new Promise(resolve => {
-                              new MutationObserver(
-                                  (
-                                      records,
-                                      instance
-                                  ) => {
-                                      if (
-                                          !records.length ||
-                                          !records[0].addedNodes.length ||
-                                          !isIframe(
-                                              (records[0].addedNodes[0])
-                                          )
-                                      ) {
-                                          return;
-                                      }
+	return notLoaded.length === 0 || !('MutationObserver' in window)
+		? Promise.resolve()
+		: Promise.all(
+				notLoaded.map(
+					(interactive) =>
+						new Promise((resolve) => {
+							new MutationObserver((records, instance) => {
+								if (
+									!records.length ||
+									!records[0].addedNodes.length ||
+									!isIframe(records[0].addedNodes[0])
+								) {
+									return;
+								}
 
-                                      const iframe = records[0].addedNodes[0];
-                                      if (isIframeLoaded((iframe))) {
-                                          instance.disconnect();
-                                          resolve();
-                                      } else {
-                                          iframe.addEventListener(
-                                              'load',
-                                              () => {
-                                                  instance.disconnect();
-                                                  resolve();
-                                              }
-                                          );
-                                      }
-                                  }
-                              ).observe(interactive, {
-                                  childList: true,
-                              });
-                          })
-                  )
-              ).then(() => undefined);
-    },
-    getFuncId
-);
+								const iframe = records[0].addedNodes[0];
+								if (isIframeLoaded(iframe)) {
+									instance.disconnect();
+									resolve();
+								} else {
+									iframe.addEventListener('load', () => {
+										instance.disconnect();
+										resolve();
+									});
+								}
+							}).observe(interactive, {
+								childList: true,
+							});
+						}),
+				),
+		  ).then(() => undefined);
+}, getFuncId);
 
-const filter =(
-    list,
-    filterElement,
-    exclusions
-) => {
-    const filtered = [];
-    list.forEach(element => {
-        if (filterElement(element)) {
-            filtered.push(element);
-        } else {
-            exclusions.push(element);
-        }
-    });
-    return filtered;
+const filter = (list, filterElement, exclusions) => {
+	const filtered = [];
+	list.forEach((element) => {
+		if (filterElement(element)) {
+			filtered.push(element);
+		} else {
+			exclusions.push(element);
+		}
+	});
+	return filtered;
 };
 
 // test one element vs another for the given rules
-const testCandidate = (
-    rule,
-    challenger,
-    opponent
-) => {
-    const isMinAbove = challenger.top - opponent.bottom >= rule.minAbove;
-    const isMinBelow = opponent.top - challenger.top >= rule.minBelow;
+const testCandidate = (rule, challenger, opponent) => {
+	const isMinAbove = challenger.top - opponent.bottom >= rule.minAbove;
+	const isMinBelow = opponent.top - challenger.top >= rule.minBelow;
 
-    return isMinAbove || isMinBelow;
+	return isMinAbove || isMinBelow;
 };
 
 // test one element vs an array of other elements for the given rules
-const testCandidates = (
-    rules,
-    challenger,
-    opponents
-) => opponents.every(testCandidate.bind(undefined, rules, challenger));
+const testCandidates = (rules, challenger, opponents) =>
+	opponents.every(testCandidate.bind(undefined, rules, challenger));
 
-const enforceRules = (
-    measurements,
-    rules,
-    exclusions
-) => {
-    let candidates = measurements.candidates;
+const enforceRules = (measurements, rules, exclusions) => {
+	let candidates = measurements.candidates;
 
-    // enforce absoluteMinAbove rule
-    exclusions.absoluteMinAbove = [];
-    candidates = filter(
-        candidates,
-        candidate =>
-            !rules.absoluteMinAbove ||
-            candidate.top + measurements.bodyTop >= rules.absoluteMinAbove,
-        exclusions.absoluteMinAbove
-    );
+	// enforce absoluteMinAbove rule
+	exclusions.absoluteMinAbove = [];
+	candidates = filter(
+		candidates,
+		(candidate) =>
+			!rules.absoluteMinAbove ||
+			candidate.top + measurements.bodyTop >= rules.absoluteMinAbove,
+		exclusions.absoluteMinAbove,
+	);
 
-    // enforce minAbove and minBelow rules
-    exclusions.aboveAndBelow = [];
-    candidates = filter(
-        candidates,
-        candidate => {
-            const farEnoughFromTopOfBody = candidate.top >= rules.minAbove;
-            const farEnoughFromBottomOfBody =
-                candidate.top + rules.minBelow <= measurements.bodyHeight;
-            return farEnoughFromTopOfBody && farEnoughFromBottomOfBody;
-        },
-        exclusions.aboveAndBelow
-    );
+	// enforce minAbove and minBelow rules
+	exclusions.aboveAndBelow = [];
+	candidates = filter(
+		candidates,
+		(candidate) => {
+			const farEnoughFromTopOfBody = candidate.top >= rules.minAbove;
+			const farEnoughFromBottomOfBody =
+				candidate.top + rules.minBelow <= measurements.bodyHeight;
+			return farEnoughFromTopOfBody && farEnoughFromBottomOfBody;
+		},
+		exclusions.aboveAndBelow,
+	);
 
-    // enforce content meta rule
-    if (rules.clearContentMeta) {
-        exclusions.contentMeta = [];
-        candidates = filter(
-            candidates,
-            c =>
-                !!measurements.contentMeta &&
-                c.top >
-                    measurements.contentMeta.bottom + rules.clearContentMeta,
-            exclusions.contentMeta
-        );
-    }
+	// enforce content meta rule
+	if (rules.clearContentMeta) {
+		exclusions.contentMeta = [];
+		candidates = filter(
+			candidates,
+			(c) =>
+				!!measurements.contentMeta &&
+				c.top >
+					measurements.contentMeta.bottom + rules.clearContentMeta,
+			exclusions.contentMeta,
+		);
+	}
 
-    // enforce selector rules
-    if (rules.selectors) {
-        Object.keys(rules.selectors).forEach(selector => {
-            exclusions[selector] = [];
-            candidates = filter(
-                candidates,
-                candidate =>
-                    testCandidates(
-                        rules.selectors[selector],
-                        candidate,
-                        measurements.opponents
-                            ? measurements.opponents[selector]
-                            : []
-                    ),
-                exclusions[selector]
-            );
-        });
-    }
+	// enforce selector rules
+	if (rules.selectors) {
+		Object.keys(rules.selectors).forEach((selector) => {
+			exclusions[selector] = [];
+			candidates = filter(
+				candidates,
+				(candidate) =>
+					testCandidates(
+						rules.selectors[selector],
+						candidate,
+						measurements.opponents
+							? measurements.opponents[selector]
+							: [],
+					),
+				exclusions[selector],
+			);
+		});
+	}
 
-    if (rules.filter) {
-        exclusions.custom = [];
-        candidates = filter(candidates, rules.filter, exclusions.custom);
-    }
+	if (rules.filter) {
+		exclusions.custom = [];
+		candidates = filter(candidates, rules.filter, exclusions.custom);
+	}
 
-    return candidates;
+	return candidates;
 };
 
 class SpaceError extends Error {
-
-    constructor(rules) {
-        super();
-        this.name = 'SpaceError';
-        this.message = `There is no space left matching rules from ${
-            rules.bodySelector
-        }`;
-    }
+	constructor(rules) {
+		super();
+		this.name = 'SpaceError';
+		this.message = `There is no space left matching rules from ${rules.bodySelector}`;
+	}
 }
 
-const getReady = (
-    rules,
-    options
-) =>
-    Promise.race([
-        new Promise(expire),
-        Promise.all([
-            options.waitForImages ? onImagesLoaded(rules) : true,
-            options.waitForLinks ? onRichLinksUpgraded(rules) : true,
-            options.waitForInteractives ? onInteractivesLoaded(rules) : true,
-        ]),
-    ]).then(() => rules);
+const getReady = (rules, options) =>
+	Promise.race([
+		new Promise(expire),
+		Promise.all([
+			options.waitForImages ? onImagesLoaded(rules) : true,
+			options.waitForLinks ? onRichLinksUpgraded(rules) : true,
+			options.waitForInteractives ? onInteractivesLoaded(rules) : true,
+		]),
+	]).then(() => rules);
 
-const getCandidates = (
-    rules,
-    exclusions
-) => {
-    let candidates = query(
-        rules.bodySelector + rules.slotSelector
-    );
-    if (rules.fromBottom) {
-        candidates.reverse();
-    }
-    if (rules.startAt) {
-        let drop = true;
-        exclusions.startAt = [];
-        candidates = filter(
-            candidates,
-            candidate => {
-                if (candidate === rules.startAt) {
-                    drop = false;
-                }
-                return !drop;
-            },
-            exclusions.startAt
-        );
-    }
-    if (rules.stopAt) {
-        let keep = true;
-        exclusions.stopAt = [];
-        candidates = filter(
-            candidates,
-            candidate => {
-                if (candidate === rules.stopAt) {
-                    keep = false;
-                }
-                return keep;
-            },
-            exclusions.stopAt
-        );
-    }
-    return candidates;
+const getCandidates = (rules, exclusions) => {
+	let candidates = query(rules.bodySelector + rules.slotSelector);
+	if (rules.fromBottom) {
+		candidates.reverse();
+	}
+	if (rules.startAt) {
+		let drop = true;
+		exclusions.startAt = [];
+		candidates = filter(
+			candidates,
+			(candidate) => {
+				if (candidate === rules.startAt) {
+					drop = false;
+				}
+				return !drop;
+			},
+			exclusions.startAt,
+		);
+	}
+	if (rules.stopAt) {
+		let keep = true;
+		exclusions.stopAt = [];
+		candidates = filter(
+			candidates,
+			(candidate) => {
+				if (candidate === rules.stopAt) {
+					keep = false;
+				}
+				return keep;
+			},
+			exclusions.stopAt,
+		);
+	}
+	return candidates;
 };
 
 const getDimensions = (el) =>
-    Object.freeze({
-        top: el.offsetTop,
-        bottom: el.offsetTop + el.offsetHeight,
-        element: el,
-    });
+	Object.freeze({
+		top: el.offsetTop,
+		bottom: el.offsetTop + el.offsetHeight,
+		element: el,
+	});
 
-const getMeasurements = (
-    rules,
-    candidates
-) => {
-    const contentMeta = rules.clearContentMeta
-        ? document.querySelector('.js-content-meta')
-        : null;
-    const opponents = rules.selectors
-        ? Object.keys(rules.selectors).map(selector => [
-              selector,
-              query(rules.bodySelector + selector),
-          ])
-        : null;
+const getMeasurements = (rules, candidates) => {
+	const contentMeta = rules.clearContentMeta
+		? document.querySelector('.js-content-meta')
+		: null;
+	const opponents = rules.selectors
+		? Object.keys(rules.selectors).map((selector) => [
+				selector,
+				query(rules.bodySelector + selector),
+		  ])
+		: null;
 
-    return fastdom.measure(() => {
-        const bodyDims =
-            rules.body instanceof Element && rules.body.getBoundingClientRect();
-        const candidatesWithDims = candidates.map(
-            getDimensions
-        );
-        const contentMetaWithDims =
-            rules.clearContentMeta && contentMeta
-                ? getDimensions(contentMeta)
-                : null;
-        const opponentsWithDims = opponents
-            ? opponents.reduce((result, selectorAndElements) => {
-                  result[selectorAndElements[0]] = selectorAndElements[1].map(
-                      getDimensions
-                  );
-                  return result;
-              }, {})
-            : null;
+	return fastdom.measure(() => {
+		const bodyDims =
+			rules.body instanceof Element && rules.body.getBoundingClientRect();
+		const candidatesWithDims = candidates.map(getDimensions);
+		const contentMetaWithDims =
+			rules.clearContentMeta && contentMeta
+				? getDimensions(contentMeta)
+				: null;
+		const opponentsWithDims = opponents
+			? opponents.reduce((result, selectorAndElements) => {
+					result[selectorAndElements[0]] =
+						selectorAndElements[1].map(getDimensions);
+					return result;
+			  }, {})
+			: null;
 
-        return {
-            bodyTop: bodyDims.top || 0,
-            bodyHeight: bodyDims.height || 0,
-            candidates: candidatesWithDims,
-            contentMeta: contentMetaWithDims,
-            opponents: opponentsWithDims,
-        };
-    });
+		return {
+			bodyTop: bodyDims.top || 0,
+			bodyHeight: bodyDims.height || 0,
+			candidates: candidatesWithDims,
+			contentMeta: contentMetaWithDims,
+			opponents: opponentsWithDims,
+		};
+	});
 };
 
-const returnCandidates = (
-    rules,
-    candidates
-) => {
-    if (!candidates.length) {
-        throw new SpaceError(rules);
-    }
-    return candidates.map(candidate => candidate.element);
+const returnCandidates = (rules, candidates) => {
+	if (!candidates.length) {
+		throw new SpaceError(rules);
+	}
+	return candidates.map((candidate) => candidate.element);
 };
 
 // Rather than calling this directly, use spaceFiller to inject content into the page.
 // SpaceFiller will safely queue up all the various asynchronous DOM actions to avoid any race conditions.
-const findSpace = (
-    rules,
-    options,
-    excluded
-) => {
-    rules.body =
-        (rules.bodySelector && document.querySelector(rules.bodySelector)) ||
-        document;
+const findSpace = (rules, options, excluded) => {
+	rules.body =
+		(rules.bodySelector && document.querySelector(rules.bodySelector)) ||
+		document;
 
-    const exclusions = excluded || {};
+	const exclusions = excluded || {};
 
-    return getReady(rules, options || defaultOptions)
-        .then(() => getCandidates(rules, exclusions))
-        .then(candidates => getMeasurements(rules, candidates))
-        .then(measurements => enforceRules(measurements, rules, exclusions))
-        .then(winners => returnCandidates(rules, winners));
+	return getReady(rules, options || defaultOptions)
+		.then(() => getCandidates(rules, exclusions))
+		.then((candidates) => getMeasurements(rules, candidates))
+		.then((measurements) => enforceRules(measurements, rules, exclusions))
+		.then((winners) => returnCandidates(rules, winners));
 };
 
 export const _ = {
-    testCandidate, // exposed for unit testing
-    testCandidates, // exposed for unit testing
+	testCandidate, // exposed for unit testing
+	testCandidates, // exposed for unit testing
 };
 
 export { findSpace, SpaceError };

--- a/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
+++ b/static/src/javascripts/projects/common/modules/ui/cmp-ui.js
@@ -3,50 +3,46 @@ import { cmp } from '@guardian/consent-management-platform';
 import { getPrivacyFramework } from 'lib/getPrivacyFramework';
 
 export const addPrivacySettingsLink = () => {
-    if (!config.get('switches.consentManagement', true)) {
-        return;
-    }
+	if (!config.get('switches.consentManagement', true)) {
+		return;
+	}
 
-    const privacyLink = document.querySelector(
-        'a[data-link-name=privacy]'
-    );
+	const privacyLink = document.querySelector('a[data-link-name=privacy]');
 
-    if (privacyLink) {
-        const privacyLinkListItem = privacyLink.parentElement;
+	if (privacyLink) {
+		const privacyLinkListItem = privacyLink.parentElement;
 
-        if (privacyLinkListItem) {
-            const newPrivacyLink = privacyLink.cloneNode(false);
+		if (privacyLinkListItem) {
+			const newPrivacyLink = privacyLink.cloneNode(false);
 
-            newPrivacyLink.dataset.linkName = 'privacy-settings';
-            newPrivacyLink.removeAttribute('href');
-            newPrivacyLink.innerText = getPrivacyFramework().ccpa
-                ? 'California resident – Do Not Sell'
-                : 'Privacy settings';
+			newPrivacyLink.dataset.linkName = 'privacy-settings';
+			newPrivacyLink.removeAttribute('href');
+			newPrivacyLink.innerText = getPrivacyFramework().ccpa
+				? 'California resident – Do Not Sell'
+				: 'Privacy settings';
 
-            const newPrivacyLinkListItem = privacyLinkListItem.cloneNode(
-                false
-            );
+			const newPrivacyLinkListItem = privacyLinkListItem.cloneNode(false);
 
-            newPrivacyLinkListItem.appendChild(newPrivacyLink);
+			newPrivacyLinkListItem.appendChild(newPrivacyLink);
 
-            privacyLinkListItem.insertAdjacentElement(
-                'beforebegin',
-                newPrivacyLinkListItem
-            );
+			privacyLinkListItem.insertAdjacentElement(
+				'beforebegin',
+				newPrivacyLinkListItem,
+			);
 
-            newPrivacyLink.addEventListener('click', () => {
-                cmp.showPrivacyManager();
-            });
-        }
-    }
+			newPrivacyLink.addEventListener('click', () => {
+				cmp.showPrivacyManager();
+			});
+		}
+	}
 };
 
 export const cmpBannerCandidate = {
-    id: 'cmpUi',
-    canShow: () => {
-        if (!config.get('switches.cmp', true)) return Promise.resolve(false);
-        return cmp.willShowPrivacyMessage();
-    },
-    // Remote banner is injected first: show() always resolves to `true`
-    show: () => Promise.resolve(true),
+	id: 'cmpUi',
+	canShow: () => {
+		if (!config.get('switches.cmp', true)) return Promise.resolve(false);
+		return cmp.willShowPrivacyMessage();
+	},
+	// Remote banner is injected first: show() always resolves to `true`
+	show: () => Promise.resolve(true),
 };

--- a/static/src/javascripts/projects/common/modules/ui/sticky.js
+++ b/static/src/javascripts/projects/common/modules/ui/sticky.js
@@ -5,95 +5,93 @@ import fastdom from 'fastdom';
  * @todo: check if browser natively supports "position: sticky"
  */
 class Sticky {
+	constructor(element, options = {}) {
+		this.element = element;
 
+		this.opts = Object.assign(
+			{},
+			{
+				top: 0,
+				containInParent: true,
+				emitMessage: false,
+			},
+			options,
+		);
+	}
 
-    constructor(element, options = {}) {
-        this.element = element;
+	init() {
+		const parentElement = this.element.parentElement;
 
-        this.opts = Object.assign(
-            {},
-            {
-                top: 0,
-                containInParent: true,
-                emitMessage: false,
-            },
-            options
-        );
-    }
+		if (!parentElement) {
+			return;
+		}
 
-    init() {
-        const parentElement = this.element.parentElement;
+		fastdom.measure(() => {
+			this.offsetFromParent =
+				this.element.getBoundingClientRect().top -
+				parentElement.getBoundingClientRect().top;
+		}, this);
+		mediator.on('window:throttledScroll', this.updatePosition.bind(this));
+		// kick off an initial position update
+		fastdom.measure(this.updatePosition, this);
+	}
 
-        if (!parentElement) {
-            return;
-        }
+	updatePosition() {
+		const parentElement = this.element.parentElement;
 
-        fastdom.measure(() => {
-            this.offsetFromParent =
-                this.element.getBoundingClientRect().top -
-                parentElement.getBoundingClientRect().top;
-        }, this);
-        mediator.on('window:throttledScroll', this.updatePosition.bind(this));
-        // kick off an initial position update
-        fastdom.measure(this.updatePosition, this);
-    }
+		if (!parentElement) {
+			return;
+		}
 
-    updatePosition() {
-        const parentElement = this.element.parentElement;
+		const elementRect = this.element.getBoundingClientRect();
+		const parentRect = parentElement.getBoundingClientRect();
+		const elementHeight = elementRect.height;
+		let css;
+		let message;
+		let stick;
 
-        if (!parentElement) {
-            return;
-        }
+		// have we scrolled past the element
+		if (parentRect.top + this.offsetFromParent > 0) {
+			stick = false;
+			css = {
+				top: '',
+			};
+			message = 'unfixed';
+		} else {
+			stick = true;
+			const top =
+				this.opts.containInParent &&
+				parentRect.bottom <= elementRect.height
+					? Math.floor(
+							parentRect.bottom - elementHeight - this.opts.top,
+					  )
+					: this.opts.top;
+			css = {
+				top: `${top}px`,
+			};
+			message = 'fixed';
+		}
 
-        const elementRect = this.element.getBoundingClientRect();
-        const parentRect = parentElement.getBoundingClientRect();
-        const elementHeight = elementRect.height;
-        let css;
-        let message;
-        let stick;
+		if (this.opts.emitMessage && message && message !== this.lastMessage) {
+			this.emitMessage(message);
+			this.lastMessage = message;
+		}
 
-        // have we scrolled past the element
-        if (parentRect.top + this.offsetFromParent > 0) {
-            stick = false;
-            css = {
-                top: '',
-            };
-            message = 'unfixed';
-        } else {
-            stick = true;
-            const top =
-                this.opts.containInParent &&
-                parentRect.bottom <= elementRect.height
-                    ? Math.floor(
-                          parentRect.bottom - elementHeight - this.opts.top
-                      )
-                    : this.opts.top;
-            css = {
-                top: `${top}px`,
-            };
-            message = 'fixed';
-        }
+		if (css) {
+			fastdom.mutate(() => {
+				if (stick) {
+					this.element.classList.add('is-sticky');
+				} else {
+					this.element.classList.remove('is-sticky');
+				}
+				Object.assign(this.element.style, css);
+			}, this);
+		}
+	}
 
-        if (this.opts.emitMessage && message && message !== this.lastMessage) {
-            this.emitMessage(message);
-            this.lastMessage = message;
-        }
-
-        if (css) {
-            fastdom.mutate(() => {
-                if (stick) {
-                    this.element.classList.add('is-sticky');
-                } else {
-                    this.element.classList.remove('is-sticky');
-                }
-                Object.assign(this.element.style, css);
-            }, this);
-        }
-    }
-
-    emitMessage(message) {
-        mediator.emit(`modules:${this.element.id}:${message}`);
-    }
+	emitMessage(message) {
+		mediator.emit(`modules:${this.element.id}:${message}`);
+	}
 }
 
 export { Sticky };


### PR DESCRIPTION
# What does this change?

No code change, [see the diff without whitespace](https://github.com/guardian/frontend/pull/24468/files?w=1).

- format files in the commercial bundle
- also run prettier in `lib` and `common/modules/commercial`

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Better handling of files when they get converted to TypeScript.