### PR TITLE
Convert dfpEnv to a class

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-env.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-env.ts
@@ -1,8 +1,6 @@
 import config from '../../../../lib/config';
-import { getUrlVars as _getUrlVars } from '../../../../lib/url';
+import { getUrlVars } from '../../../../lib/url';
 import type { Advert } from './Advert';
-
-const getUrlVars = _getUrlVars as (arg?: string) => Record<string, string>;
 
 interface DfpEnv {
 	renderStartTime: number;
@@ -58,12 +56,6 @@ export const dfpEnv: DfpEnv = {
 	shouldLazyLoad(): boolean {
 		// We do not want lazy loading on pageskins because it messes up the roadblock
 		// Also, if the special dll parameter is passed with a value of 1, we don't lazy load
-		return (
-			!(
-				config as {
-					get: (arg: string) => boolean;
-				}
-			).get('page.hasPageSkin') && getUrlVars().dll !== '1'
-		);
+		return !config.get('page.hasPageSkin') && getUrlVars().dll !== '1';
 	},
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-env.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-env.ts
@@ -6,21 +6,10 @@ interface HbImpl {
 	prebid: boolean;
 	a9: boolean;
 }
-interface IDfpEnv {
-	readonly adSlotSelector: string;
-	hbImpl: HbImpl;
-	lazyLoadObserve: boolean;
-	creativeIDs: string[];
-	advertIds: Record<string, number>;
-	advertsToLoad: Advert[];
-	advertsToRefresh: Advert[];
-	adverts: Advert[];
-	shouldLazyLoad: () => boolean;
-}
 
 const { switches } = window.guardian.config;
 
-class DfpEnv implements IDfpEnv {
+class DfpEnv {
 	/**
 	 * A CSS selector to query ad slots in the DOM
 	 */

--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-env.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-env.ts
@@ -23,34 +23,54 @@ interface IDfpEnv {
 const { switches } = window.guardian.config;
 
 class DfpEnv implements IDfpEnv {
-	/* renderStartTime: integer. Point in time when DFP kicks in */
+	/**
+	 * Point in time when DFP kicks in
+	 */
 	renderStartTime: number;
 
-	/* adSlotSelector: string. A CSS selector to query ad slots in the DOM */
+	/**
+	 * A CSS selector to query ad slots in the DOM
+	 */
 	readonly adSlotSelector: string;
 
-	/* hbImpl: Returns an object {'prebid': boolean, 'a9': boolean} to indicate which header bidding implementations are switched on */
+	/**
+	 * Indicates which header bidding implementations are switched on
+	 */
 	hbImpl: HbImpl;
 
-	/* lazyLoadEnabled: boolean. Set to true when adverts are lazy-loaded */
+	/**
+	 * lazyLoadEnabled: boolean. Set to true when adverts are lazy-loaded
+	 */
 	lazyLoadEnabled: boolean;
 
-	/* lazyLoadObserve: boolean. Use IntersectionObserver in supporting browsers */
+	/**
+	 * Use IntersectionObserver in supporting browsers
+	 */
 	lazyLoadObserve: boolean;
 
-	/* creativeIDs: array<string>. List of loaded creative IDs */
+	/**
+	 * List of loaded creative IDs
+	 */
 	creativeIDs: string[];
 
-	/* advertIds: map<string -> int>. Keeps track of slot IDs and their position in the array of adverts */
+	/**
+	 * Keeps track of slot IDs and their position in the array of adverts
+	 */
 	advertIds: Record<string, number>;
 
-	/* advertsToLoad: array<Advert>. Lists adverts waiting to be loaded */
+	/**
+	 * Lists adverts waiting to be loaded
+	 */
 	advertsToLoad: Advert[];
 
-	/* advertsToRefresh: array<Advert>. Lists adverts refreshed when a breakpoint has been crossed */
+	/**
+	 * Lists adverts refreshed when a breakpoint has been crossed
+	 */
 	advertsToRefresh: Advert[];
 
-	/* adverts: array<Advert>. Keeps track of adverts and their state */
+	/**
+	 * Keeps track of adverts and their state
+	 */
 	adverts: Advert[];
 
 	constructor(
@@ -71,7 +91,9 @@ class DfpEnv implements IDfpEnv {
 		this.adverts = [];
 	}
 
-	/* shouldLazyLoad: () -> boolean. Determines whether ads should be lazy loaded */
+	/**
+	 * Determines whether ads should be lazy loaded
+	 */
 	shouldLazyLoad(): boolean {
 		// We do not want lazy loading on pageskins because it messes up the roadblock
 		// Also, if the special dll parameter is passed with a value of 1, we don't lazy load

--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-env.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-env.ts
@@ -2,9 +2,9 @@ import config from '../../../../lib/config';
 import { getUrlVars } from '../../../../lib/url';
 import type { Advert } from './Advert';
 
-interface DfpEnv {
+interface IDfpEnv {
 	renderStartTime: number;
-	adSlotSelector: string;
+	readonly adSlotSelector: string;
 	hbImpl: Record<string, boolean>;
 	lazyLoadEnabled: boolean;
 	lazyLoadObserve: boolean;
@@ -18,44 +18,63 @@ interface DfpEnv {
 
 const { switches } = window.guardian.config;
 
-export const dfpEnv: DfpEnv = {
+class DfpEnv implements IDfpEnv {
 	/* renderStartTime: integer. Point in time when DFP kicks in */
-	renderStartTime: -1,
+	renderStartTime: number;
 
 	/* adSlotSelector: string. A CSS selector to query ad slots in the DOM */
-	adSlotSelector: '.js-ad-slot',
+	readonly adSlotSelector: string;
 
 	/* hbImpl: Returns an object {'prebid': boolean, 'a9': boolean} to indicate which header bidding implementations are switched on */
 	hbImpl: {
-		// TODO: fix the Switch type upstream
-		prebid: switches.prebidHeaderBidding ?? false,
-		a9: switches.a9HeaderBidding ?? false,
-	},
+		prebid: boolean;
+		a9: boolean;
+	};
+
 	/* lazyLoadEnabled: boolean. Set to true when adverts are lazy-loaded */
-	lazyLoadEnabled: false,
+	lazyLoadEnabled: boolean;
 
 	/* lazyLoadObserve: boolean. Use IntersectionObserver in supporting browsers */
-	lazyLoadObserve: 'IntersectionObserver' in window,
+	lazyLoadObserve: boolean;
 
 	/* creativeIDs: array<string>. List of loaded creative IDs */
-	creativeIDs: [],
+	creativeIDs: string[];
 
 	/* advertIds: map<string -> int>. Keeps track of slot IDs and their position in the array of adverts */
-	advertIds: {},
+	advertIds: Record<string, number>;
 
 	/* advertsToLoad: array<Advert>. Lists adverts waiting to be loaded */
-	advertsToLoad: [],
+	advertsToLoad: Advert[];
 
 	/* advertsToRefresh: array<Advert>. Lists adverts refreshed when a breakpoint has been crossed */
-	advertsToRefresh: [],
+	advertsToRefresh: Advert[];
 
 	/* adverts: array<Advert>. Keeps track of adverts and their state */
-	adverts: [],
+	adverts: Advert[];
+
+	constructor() {
+		this.renderStartTime = -1;
+		this.adSlotSelector = '.js-ad-slot';
+		this.hbImpl = {
+			// TODO: fix the Switch type upstream
+			prebid: switches.prebidHeaderBidding ?? false,
+			a9: switches.a9HeaderBidding ?? false,
+		};
+		this.lazyLoadEnabled = false;
+		this.lazyLoadObserve = 'IntersectionObserver' in window;
+		this.creativeIDs = [];
+		this.advertIds = {};
+		this.advertsToLoad = [];
+		this.advertsToRefresh = [];
+		this.adverts = [];
+	}
 
 	/* shouldLazyLoad: () -> boolean. Determines whether ads should be lazy loaded */
 	shouldLazyLoad(): boolean {
 		// We do not want lazy loading on pageskins because it messes up the roadblock
 		// Also, if the special dll parameter is passed with a value of 1, we don't lazy load
 		return !config.get('page.hasPageSkin') && getUrlVars().dll !== '1';
-	},
-};
+	}
+}
+
+export const dfpEnv = new DfpEnv();

--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-env.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-env.ts
@@ -2,10 +2,14 @@ import config from '../../../../lib/config';
 import { getUrlVars } from '../../../../lib/url';
 import type { Advert } from './Advert';
 
+interface HbImpl {
+	prebid: boolean;
+	a9: boolean;
+}
 interface IDfpEnv {
 	renderStartTime: number;
 	readonly adSlotSelector: string;
-	hbImpl: Record<string, boolean>;
+	hbImpl: HbImpl;
 	lazyLoadEnabled: boolean;
 	lazyLoadObserve: boolean;
 	creativeIDs: string[];
@@ -26,10 +30,7 @@ class DfpEnv implements IDfpEnv {
 	readonly adSlotSelector: string;
 
 	/* hbImpl: Returns an object {'prebid': boolean, 'a9': boolean} to indicate which header bidding implementations are switched on */
-	hbImpl: {
-		prebid: boolean;
-		a9: boolean;
-	};
+	hbImpl: HbImpl;
 
 	/* lazyLoadEnabled: boolean. Set to true when adverts are lazy-loaded */
 	lazyLoadEnabled: boolean;
@@ -52,16 +53,17 @@ class DfpEnv implements IDfpEnv {
 	/* adverts: array<Advert>. Keeps track of adverts and their state */
 	adverts: Advert[];
 
-	constructor() {
+	constructor(
+		adSlotSelector: string,
+		hbImpl: HbImpl,
+		lazyLoadEnabled: boolean,
+		lazyLoadObserve: boolean,
+	) {
 		this.renderStartTime = -1;
-		this.adSlotSelector = '.js-ad-slot';
-		this.hbImpl = {
-			// TODO: fix the Switch type upstream
-			prebid: switches.prebidHeaderBidding ?? false,
-			a9: switches.a9HeaderBidding ?? false,
-		};
-		this.lazyLoadEnabled = false;
-		this.lazyLoadObserve = 'IntersectionObserver' in window;
+		this.adSlotSelector = adSlotSelector;
+		this.hbImpl = hbImpl;
+		this.lazyLoadEnabled = lazyLoadEnabled;
+		this.lazyLoadObserve = lazyLoadObserve;
 		this.creativeIDs = [];
 		this.advertIds = {};
 		this.advertsToLoad = [];
@@ -77,4 +79,13 @@ class DfpEnv implements IDfpEnv {
 	}
 }
 
-export const dfpEnv = new DfpEnv();
+export const dfpEnv = new DfpEnv(
+	'.js-ad-slot',
+	{
+		// TODO: fix the Switch type upstream
+		prebid: switches.prebidHeaderBidding ?? false,
+		a9: switches.a9HeaderBidding ?? false,
+	},
+	false,
+	'IntersectionObserver' in window,
+);

--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-env.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-env.ts
@@ -7,10 +7,8 @@ interface HbImpl {
 	a9: boolean;
 }
 interface IDfpEnv {
-	renderStartTime: number;
 	readonly adSlotSelector: string;
 	hbImpl: HbImpl;
-	lazyLoadEnabled: boolean;
 	lazyLoadObserve: boolean;
 	creativeIDs: string[];
 	advertIds: Record<string, number>;
@@ -24,11 +22,6 @@ const { switches } = window.guardian.config;
 
 class DfpEnv implements IDfpEnv {
 	/**
-	 * Point in time when DFP kicks in
-	 */
-	renderStartTime: number;
-
-	/**
 	 * A CSS selector to query ad slots in the DOM
 	 */
 	readonly adSlotSelector: string;
@@ -37,11 +30,6 @@ class DfpEnv implements IDfpEnv {
 	 * Indicates which header bidding implementations are switched on
 	 */
 	hbImpl: HbImpl;
-
-	/**
-	 * lazyLoadEnabled: boolean. Set to true when adverts are lazy-loaded
-	 */
-	lazyLoadEnabled: boolean;
 
 	/**
 	 * Use IntersectionObserver in supporting browsers
@@ -76,13 +64,10 @@ class DfpEnv implements IDfpEnv {
 	constructor(
 		adSlotSelector: string,
 		hbImpl: HbImpl,
-		lazyLoadEnabled: boolean,
 		lazyLoadObserve: boolean,
 	) {
-		this.renderStartTime = -1;
 		this.adSlotSelector = adSlotSelector;
 		this.hbImpl = hbImpl;
-		this.lazyLoadEnabled = lazyLoadEnabled;
 		this.lazyLoadObserve = lazyLoadObserve;
 		this.creativeIDs = [];
 		this.advertIds = {};
@@ -108,6 +93,5 @@ export const dfpEnv = new DfpEnv(
 		prebid: switches.prebidHeaderBidding ?? false,
 		a9: switches.a9HeaderBidding ?? false,
 	},
-	false,
 	'IntersectionObserver' in window,
 );


### PR DESCRIPTION
## What does this change?

Convert the `dfpEnv` object to a singleton object of class `DfpEnv`, preserving the properties* in the object.

This PR also:
- Removes some unnecessary type casts, since `getUrlVars` and `config.get` are now typed.
- (*) Removes two properties `renderStartTime` and `lazyLoadEnabled` as they're never referenced again.

## Why?

The `dfpEnv` object is used to track collections of adverts on the page (where adverts summarise slot and other metadata for a given ad on the page). This object currently has a simple interface that allows each of its properties to be accessed/mutated and it is directly referenced in 22 other files. This PR is a proposal to convert the `dfpEnv` to a singleton object of class `DfpEnv`.

Some possible future advantages of doing this are:
- Lots of functions are scattered throughout the codebase that operate directly on `dfpEnv` and return adverts. These could be better suited as methods and moved to the `DfpEnv` class.
- Properties can be marked as `private` as we start only exposing the methods, providing a safer interface.
- If we were to move this functionality to commercial-core in the future it would mean moving the _recipe_ for creating these environment, and allow us to keep the logic of instantiating a DFP env in frontend.
- It will make it easier to create different instances `dfpEnv` when unit testing.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [ ] Locally
- [ ] On CODE (optional)
