### PR TITLE
Add Object.fromEntries to polyfill.io request

### DIFF
--- a/static/src/javascripts/polyfill.io
+++ b/static/src/javascripts/polyfill.io
@@ -1,1 +1,1 @@
-https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,fetch,navigator.sendBeacon,performance.now&flags=gated&callback=guardianPolyfilled&unknown=polyfill&clearCache=5
+https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6,es7,es2017,default-3.6,HTMLPictureElement,IntersectionObserver,IntersectionObserverEntry,fetch,navigator.sendBeacon,performance.now,Object.fromEntries&flags=gated&callback=guardianPolyfilled&unknown=polyfill&clearCache=5


### PR DESCRIPTION
## What does this change?

Add Object.fromEntries to polyfill.io request

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)
- [x] Maybe?


## What is the value of this and can you measure success?

Source v4 removes an inline polyfill for `Object.fromEntries`. It now expects consumers to define the environment in which Source is executed. This is in line with our [NPM package recommendations](https://github.com/guardian/recommendations/blob/main/npm-packages.md#using-guardian-npm-packages)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
