### PR TITLE
Use Fastly Cricket API

### DIFF
--- a/admin/app/conf/AdminConfiguration.scala
+++ b/admin/app/conf/AdminConfiguration.scala
@@ -19,7 +19,7 @@ object AdminConfiguration {
       .getOrElse(throw new RuntimeException("unable to load pa cricket api key"))
 
     lazy val footballHost = PaClientConfig.baseUrl
-    lazy val cricketHost = "http://cricket.api.press.net/v1"
+    lazy val cricketHost = "http://cricket-api.guardianapis.com/v1"
     lazy val apiExplorer = "http://developer.press.net/io-docs"
   }
 

--- a/sport/app/cricket/feed/cricketPaFeed.scala
+++ b/sport/app/cricket/feed/cricketPaFeed.scala
@@ -21,7 +21,7 @@ object PaFeed {
 
 class PaFeed(wsClient: WSClient, actorSystem: ActorSystem, materializer: Materializer) extends GuLogging {
 
-  private val paEndpoint = "https://cricket.api.press.net/v1"
+  private val paEndpoint = "https://cricket-api.guardianapis.com/v1"
   private val credentials = conf.SportConfiguration.pa.cricketKey.map { ("Apikey", _) }
   private val xmlContentType = ("Accept", "application/xml")
   private implicit val throttler = new CricketThrottler(actorSystem, materializer)
@@ -62,6 +62,7 @@ class PaFeed(wsClient: WSClient, actorSystem: ActorSystem, materializer: Materia
   def getMatchIds(team: CricketTeam, fromDate: LocalDate)(implicit
       executionContext: ExecutionContext,
   ): Future[Seq[String]] = {
+    println(paEndpoint)
     Future
       .sequence(
         Seq(

--- a/sport/app/cricket/feed/cricketPaFeed.scala
+++ b/sport/app/cricket/feed/cricketPaFeed.scala
@@ -62,7 +62,6 @@ class PaFeed(wsClient: WSClient, actorSystem: ActorSystem, materializer: Materia
   def getMatchIds(team: CricketTeam, fromDate: LocalDate)(implicit
       executionContext: ExecutionContext,
   ): Future[Seq[String]] = {
-    println(paEndpoint)
     Future
       .sequence(
         Seq(


### PR DESCRIPTION
## What does this change?

A new service has been created in Fastly to act as a cache between our queries to `cricket.api.press.net`. This PR points Frontend to this new URL

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

## Checklist

### Tested

- [x] Locally
- [x] On CODE (optional) - TODO

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
