### PR TITLE
Increase fetch non refreshable line item experiment to 1%

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -38,5 +38,5 @@ object FetchNonRefreshableLineItems
       description = "Fetch non-refreshable line items via a new endpoint",
       owners = Seq(Owner.withGithub("chrislomaxjones")),
       sellByDate = LocalDate.of(2022, 1, 24),
-      participationGroup = Perc0A,
+      participationGroup = Perc1A,
     )


### PR DESCRIPTION
## What does this change?

Increase the participation group of the `fetch-non-refreshable-line-items` experiment to 1%. This experiment was introduced in #24387, where participants will fetch non-refreshable line items from an endpoint instead of having them attached to the page config.

You can opt into the test via the link https://theguardian.com/opt/in/fetch-non-refreshable-line-items.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Rolling this feature out to the audience incrementally will allow us to monitor for any adverse effects.

### Tested

- [ ] Locally
- [ ] On CODE (optional)