### PR TITLE
`getInitialConsentState` helper function in commercial modules

### DIFF
--- a/static/src/javascripts/projects/commercial/initialConsentState.ts
+++ b/static/src/javascripts/projects/commercial/initialConsentState.ts
@@ -1,0 +1,31 @@
+import { onConsentChange } from '@guardian/consent-management-platform';
+import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
+
+export const getInitialConsentState = (): Promise<ConsentState> => {
+	let resolveInitialState: (state: ConsentState) => void;
+	let rejectInitialState: (reason: 'Unknown framework') => void;
+	const promise = new Promise<ConsentState>((resolve, reject) => {
+		resolveInitialState = resolve;
+		rejectInitialState = reject;
+	});
+
+	onConsentChange((state) => {
+		if (state.tcfv2) {
+			// For tcfv2 only, the first onConsentChange is fired before the user has
+			// interacted this the consent banner. We want to ignore this.
+			if (state.tcfv2.eventStatus !== 'cmpuishown')
+				resolveInitialState({ tcfv2: state.tcfv2 });
+			else return;
+		}
+		if (state.ccpa) {
+			resolveInitialState({ ccpa: state.ccpa });
+		}
+		if (state.aus) {
+			resolveInitialState({ aus: state.aus });
+		}
+
+		rejectInitialState('Unknown framework');
+	});
+
+	return promise;
+};

--- a/static/src/javascripts/projects/commercial/initialConsentState.ts
+++ b/static/src/javascripts/projects/commercial/initialConsentState.ts
@@ -5,7 +5,8 @@ import type { ConsentState } from '@guardian/consent-management-platform/dist/ty
  * Return a promise containing the first consent state provided by the user
  * as soon as it becomes available. This will only resolve once whereas
  * callbacks passed to onConsentChange are executed each time consent state changes.
- * Avoid using this method in contexts where
+ * Avoid using this function in contexts where subsequent consent states must be listened for.
+ *
  * NOTE: depending on where this function is eventually used, it might be more appropriate
  * for it to be defined in the consent-management-platform
  */

--- a/static/src/javascripts/projects/commercial/initialConsentState.ts
+++ b/static/src/javascripts/projects/commercial/initialConsentState.ts
@@ -22,14 +22,10 @@ export const getInitialConsentState = (): Promise<ConsentState> => {
 			// For tcfv2 only, the first onConsentChange is fired before the user has
 			// interacted with the consent banner. We want to ignore this first consent state.
 			if (state.tcfv2.eventStatus !== 'cmpuishown')
-				resolveInitialState({ tcfv2: state.tcfv2 });
+				resolveInitialState(state);
 			else return;
-		}
-		if (state.ccpa) {
-			resolveInitialState({ ccpa: state.ccpa });
-		}
-		if (state.aus) {
-			resolveInitialState({ aus: state.aus });
+		} else if (state.ccpa || state.aus) {
+			resolveInitialState(state);
 		}
 
 		rejectInitialState('Unknown framework');

--- a/static/src/javascripts/projects/commercial/initialConsentState.ts
+++ b/static/src/javascripts/projects/commercial/initialConsentState.ts
@@ -2,8 +2,9 @@ import { onConsentChange } from '@guardian/consent-management-platform';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 
 /**
- * return a promise containing the first consent state provided by the user
- * as soon as it becomes available.
+ * Return a promise containing the first consent state provided by the user
+ * as soon as it becomes available. This will only only resolve once whereas
+ * callbacks passed to onConsentChange are executed each time consent state changes.
  * NOTE: depending on where this function is eventually used, it might be more appropriate
  * for it to be defined in the consent-management-platform
  * @returns Promise

--- a/static/src/javascripts/projects/commercial/initialConsentState.ts
+++ b/static/src/javascripts/projects/commercial/initialConsentState.ts
@@ -3,7 +3,7 @@ import type { ConsentState } from '@guardian/consent-management-platform/dist/ty
 
 /**
  * Return a promise containing the first consent state provided by the user
- * as soon as it becomes available. This will only only resolve once whereas
+ * as soon as it becomes available. This will only resolve once whereas
  * callbacks passed to onConsentChange are executed each time consent state changes.
  * NOTE: depending on where this function is eventually used, it might be more appropriate
  * for it to be defined in the consent-management-platform

--- a/static/src/javascripts/projects/commercial/initialConsentState.ts
+++ b/static/src/javascripts/projects/commercial/initialConsentState.ts
@@ -1,6 +1,13 @@
 import { onConsentChange } from '@guardian/consent-management-platform';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 
+/**
+ * return a promise containing the first consent state provided by the user
+ * as soon as it becomes available.
+ * NOTE: depending on where this function is eventually used, it might be more appropriate
+ * for it to be defined in the consent-management-platform
+ * @returns Promise
+ */
 export const getInitialConsentState = (): Promise<ConsentState> => {
 	let resolveInitialState: (state: ConsentState) => void;
 	let rejectInitialState: (reason: 'Unknown framework') => void;
@@ -12,7 +19,7 @@ export const getInitialConsentState = (): Promise<ConsentState> => {
 	onConsentChange((state) => {
 		if (state.tcfv2) {
 			// For tcfv2 only, the first onConsentChange is fired before the user has
-			// interacted this the consent banner. We want to ignore this.
+			// interacted with the consent banner. We want to ignore this first consent state.
 			if (state.tcfv2.eventStatus !== 'cmpuishown')
 				resolveInitialState({ tcfv2: state.tcfv2 });
 			else return;

--- a/static/src/javascripts/projects/commercial/initialConsentState.ts
+++ b/static/src/javascripts/projects/commercial/initialConsentState.ts
@@ -5,9 +5,9 @@ import type { ConsentState } from '@guardian/consent-management-platform/dist/ty
  * Return a promise containing the first consent state provided by the user
  * as soon as it becomes available. This will only resolve once whereas
  * callbacks passed to onConsentChange are executed each time consent state changes.
+ * Avoid using this method in contexts where
  * NOTE: depending on where this function is eventually used, it might be more appropriate
  * for it to be defined in the consent-management-platform
- * @returns Promise
  */
 export const getInitialConsentState = (): Promise<ConsentState> => {
 	let resolveInitialState: (state: ConsentState) => void;

--- a/static/src/javascripts/projects/commercial/modules/comscore.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.js
@@ -42,7 +42,7 @@ const initOnConsent = (state) => {
 
 export const init = () => {
 	if (commercialFeatures.comscore) {
-		getInitialConsentState().then((state) => {
+		void getInitialConsentState().then((state) => {
 			/* Rule is that comscore can run:
                 - in Tcfv2: Based on consent for comscore
                 - in Australia: Always

--- a/static/src/javascripts/projects/commercial/modules/comscore.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.js
@@ -42,7 +42,7 @@ const initOnConsent = (state) => {
 
 export const init = () => {
 	if (commercialFeatures.comscore) {
-		getInitialConsentState.then((state) => {
+		getInitialConsentState().then((state) => {
 			/* Rule is that comscore can run:
                 - in Tcfv2: Based on consent for comscore
                 - in Australia: Always

--- a/static/src/javascripts/projects/commercial/modules/comscore.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.js
@@ -42,7 +42,7 @@ const initOnConsent = (state) => {
 
 export const init = () => {
 	if (commercialFeatures.comscore) {
-		return getInitialConsentState.then((state) => {
+		getInitialConsentState.then((state) => {
 			/* Rule is that comscore can run:
                 - in Tcfv2: Based on consent for comscore
                 - in Australia: Always

--- a/static/src/javascripts/projects/commercial/modules/comscore.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.js
@@ -1,8 +1,6 @@
-import {
-	getConsentFor,
-	onConsentChange,
-} from '@guardian/consent-management-platform';
+import { getConsentFor } from '@guardian/consent-management-platform';
 import { loadScript } from '@guardian/libs';
+import { getInitialConsentState } from 'commercial/initialConsentState';
 import config from '../../../lib/config';
 import { commercialFeatures } from '../../common/modules/commercial/commercial-features';
 
@@ -44,9 +42,9 @@ const initOnConsent = (state) => {
 
 export const init = () => {
 	if (commercialFeatures.comscore) {
-		onConsentChange((state) => {
+		return getInitialConsentState.then((state) => {
 			/* Rule is that comscore can run:
-                - in Tcfv2: Based on consent for comsocre
+                - in Tcfv2: Based on consent for comscore
                 - in Australia: Always
                 - in CCPA: If the user hasn't chosen Do Not Sell
             */

--- a/static/src/javascripts/projects/commercial/modules/comscore.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/comscore.spec.js
@@ -89,40 +89,40 @@ describe('comscore init', () => {
 			_.resetInit();
 		});
 
-		it('TCFv2 with consent: runs', () => {
+		it('TCFv2 with consent: runs', async () => {
 			onConsentChange.mockImplementation(tcfv2WithConsentMock);
 			getConsentFor.mockReturnValue(true);
-			init();
+			await init();
 			expect(loadScript).toBeCalled();
 		});
 
-		it('TCFv2 without consent: does not run', () => {
+		it('TCFv2 without consent: does not run', async () => {
 			onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
 			getConsentFor.mockReturnValue(false);
-			init();
+			await init();
 			expect(loadScript).not.toBeCalled();
 		});
-		it('CCPA with consent: runs', () => {
+		it('CCPA with consent: runs', async () => {
 			onConsentChange.mockImplementation(ccpaWithConsentMock);
-			init();
+			await init();
 			expect(loadScript).toBeCalled();
 		});
 
-		it('CCPA without consent: does not run', () => {
+		it('CCPA without consent: does not run', async () => {
 			onConsentChange.mockImplementation(ccpaWithoutConsentMock);
-			init();
+			await init();
 			expect(loadScript).not.toBeCalled();
 		});
 
-		it('Aus without consent: runs', () => {
+		it('Aus without consent: runs', async () => {
 			onConsentChange.mockImplementation(AusWithoutConsentMock);
-			init();
+			await init();
 			expect(loadScript).toBeCalled();
 		});
 
-		it('Aus with consent: runs', () => {
+		it('Aus with consent: runs', async () => {
 			onConsentChange.mockImplementation(AusWithConsentMock);
-			init();
+			await init();
 			expect(loadScript).toBeCalled();
 		});
 	});

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-a9.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-a9.js
@@ -1,7 +1,4 @@
-import {
-	getConsentFor,
-	onConsentChange,
-} from '@guardian/consent-management-platform';
+import { getConsentFor } from '@guardian/consent-management-platform';
 import { getInitialConsentState } from 'commercial/initialConsentState';
 import { once } from 'lodash-es';
 import config from '../../../../lib/config';
@@ -44,7 +41,7 @@ const setupA9 = () => {
 const setupA9Once = once(setupA9);
 
 export const init = () => {
-	return getInitialConsentState((state) => {
+	getInitialConsentState((state) => {
 		if (getConsentFor('a9', state)) {
 			return setupA9Once();
 		} else {
@@ -53,6 +50,8 @@ export const init = () => {
 	}).catch((e) => {
 		log('commercial', '⚠️ Failed to execute a9', e);
 	});
+
+	return Promise.resolve();
 };
 
 export const _ = {

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-a9.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-a9.js
@@ -41,7 +41,7 @@ const setupA9 = () => {
 const setupA9Once = once(setupA9);
 
 export const init = () => {
-	getInitialConsentState()
+	void getInitialConsentState()
 		.then((state) => {
 			if (getConsentFor('a9', state)) {
 				return setupA9Once();

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-a9.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-a9.js
@@ -41,7 +41,7 @@ const setupA9 = () => {
 const setupA9Once = once(setupA9);
 
 export const init = () => {
-	getInitialConsentState
+	getInitialConsentState()
 		.then((state) => {
 			if (getConsentFor('a9', state)) {
 				return setupA9Once();

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-a9.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-a9.js
@@ -41,15 +41,17 @@ const setupA9 = () => {
 const setupA9Once = once(setupA9);
 
 export const init = () => {
-	getInitialConsentState((state) => {
-		if (getConsentFor('a9', state)) {
-			return setupA9Once();
-		} else {
-			throw Error('No consent for a9');
-		}
-	}).catch((e) => {
-		log('commercial', '⚠️ Failed to execute a9', e);
-	});
+	getInitialConsentState
+		.then((state) => {
+			if (getConsentFor('a9', state)) {
+				return setupA9Once();
+			} else {
+				throw Error('No consent for a9');
+			}
+		})
+		.catch((e) => {
+			log('commercial', '⚠️ Failed to execute a9', e);
+		});
 
 	return Promise.resolve();
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-a9.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-a9.js
@@ -2,6 +2,7 @@ import {
 	getConsentFor,
 	onConsentChange,
 } from '@guardian/consent-management-platform';
+import { getInitialConsentState } from 'commercial/initialConsentState';
 import { once } from 'lodash-es';
 import config from '../../../../lib/config';
 import { isGoogleProxy } from '../../../../lib/detect-google-proxy';
@@ -42,13 +43,15 @@ const setupA9 = () => {
 const setupA9Once = once(setupA9);
 
 export const init = () => {
-	onConsentChange((state) => {
+	return getInitialConsentState((state) => {
 		if (getConsentFor('a9', state)) {
-			setupA9Once();
+			return setupA9Once();
+		} else {
+			throw Error('No consent for a9');
 		}
+	}).catch((e) => {
+		log('commercial', '⚠️ Failed to execute a9', e);
 	});
-
-	return Promise.resolve();
 };
 
 export const _ = {

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-a9.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-a9.js
@@ -10,6 +10,7 @@ import { commercialFeatures } from '../../../common/modules/commercial/commercia
 import a9 from '../header-bidding/a9/a9';
 import { shouldIncludeOnlyA9 } from '../header-bidding/utils';
 import { dfpEnv } from './dfp-env';
+import { log } from '@guardian/libs';
 
 const setupA9 = () => {
 	// TODO: Understand why we want to skip A9 for Google Proxy

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.ts
@@ -91,7 +91,7 @@ export const init = (): Promise<void> => {
 			},
 		);
 
-		return getInitialConsentState().then((state) => {
+		void getInitialConsentState().then((state) => {
 			let canRun = true;
 			if (state.ccpa) {
 				const doNotSell = state.ccpa.doNotSell;
@@ -141,6 +141,7 @@ export const init = (): Promise<void> => {
 				);
 			}
 		});
+		return Promise.resolve();
 	};
 
 	if (commercialFeatures.dfpAdvertising) {

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.ts
@@ -1,8 +1,6 @@
-import {
-	getConsentFor,
-	onConsentChange,
-} from '@guardian/consent-management-platform';
+import { getConsentFor } from '@guardian/consent-management-platform';
 import { loadScript } from '@guardian/libs';
+import { getInitialConsentState } from 'commercial/initialConsentState';
 import { init as initMeasureAdLoad } from 'commercial/modules/messenger/measure-ad-load';
 import config from '../../../../lib/config';
 import raven from '../../../../lib/raven';
@@ -93,7 +91,7 @@ export const init = (): Promise<void> => {
 			},
 		);
 
-		onConsentChange((state) => {
+		return getInitialConsentState().then((state) => {
 			let canRun = true;
 			if (state.ccpa) {
 				const doNotSell = state.ccpa.doNotSell;
@@ -143,7 +141,6 @@ export const init = (): Promise<void> => {
 				);
 			}
 		});
-		return Promise.resolve();
 	};
 
 	if (commercialFeatures.dfpAdvertising) {

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.ts
@@ -35,7 +35,7 @@ const loadPrebid = async (framework: Framework): Promise<void> => {
 	return;
 };
 
-const setupPrebid = async (): Promise<void> =>
+const setupPrebid = (): Promise<void> =>
 	getInitialConsentState()
 		.then((state) => {
 			let framework: Framework | null = null;

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.ts
@@ -35,8 +35,8 @@ const loadPrebid = async (framework: Framework): Promise<void> => {
 	return;
 };
 
-const setupPrebid = async (): Promise<void> => {
-	return getInitialConsentState()
+const setupPrebid = async (): Promise<void> =>
+	getInitialConsentState()
 		.then((state) => {
 			let framework: Framework | null = null;
 			if (state.tcfv2) framework = 'tcfv2';
@@ -54,7 +54,6 @@ const setupPrebid = async (): Promise<void> => {
 		.catch((e) => {
 			log('commercial', '⚠️ Failed to execute prebid', e);
 		});
-};
 
 export const setupPrebidOnce: () => Promise<void> = once(setupPrebid);
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.ts
@@ -44,10 +44,10 @@ const setupPrebid = async (): Promise<void> => {
 			if (state.aus) framework = 'aus';
 
 			if (!framework) {
-				throw new Error('Unknown framework');
+				return Promise.reject('Unknown framework');
 			}
 			if (!getConsentFor('prebid', state)) {
-				throw new Error('No consent for prebid');
+				return Promise.reject('No consent for prebid');
 			}
 			return loadPrebid(framework);
 		})

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.ts
@@ -1,7 +1,4 @@
-import {
-	getConsentFor,
-	onConsentChange,
-} from '@guardian/consent-management-platform';
+import { getConsentFor } from '@guardian/consent-management-platform';
 import type { Framework } from '@guardian/consent-management-platform/dist/types';
 import { log } from '@guardian/libs';
 import { once } from 'lodash-es';
@@ -9,6 +6,7 @@ import { isGoogleProxy } from 'lib/detect-google-proxy';
 import config from '../../../../lib/config';
 import { getPageTargeting } from '../../../common/modules/commercial/build-page-targeting';
 import { commercialFeatures } from '../../../common/modules/commercial/commercial-features';
+import { getInitialConsentState } from '../../initialConsentState';
 import { prebid } from '../header-bidding/prebid/prebid';
 import { shouldIncludeOnlyA9 } from '../header-bidding/utils';
 import { dfpEnv } from './dfp-env';
@@ -38,39 +36,24 @@ const loadPrebid = async (framework: Framework): Promise<void> => {
 };
 
 const setupPrebid = async (): Promise<void> => {
-	let resolvePrebidLoaded: (value: void | PromiseLike<void>) => void;
-	let rejectPrebidLoaded: (
-		reason: 'No consent for prebid' | 'Unknown framework',
-	) => void;
-	const promise = new Promise<void>((resolve, reject) => {
-		resolvePrebidLoaded = resolve;
-		rejectPrebidLoaded = reject;
-	}).catch((e) => {
-		log('commercial', '⚠️ Failed to execute prebid', e);
-	});
+	return getInitialConsentState()
+		.then((state) => {
+			let framework: Framework | null = null;
+			if (state.tcfv2) framework = 'tcfv2';
+			if (state.ccpa) framework = 'ccpa';
+			if (state.aus) framework = 'aus';
 
-	onConsentChange((state) => {
-		if (!getConsentFor('prebid', state)) {
-			rejectPrebidLoaded('No consent for prebid');
-			return;
-		}
-
-		let framework: Framework | null = null;
-		if (state.tcfv2) framework = 'tcfv2';
-		if (state.ccpa) framework = 'ccpa';
-		if (state.aus) framework = 'aus';
-
-		if (!framework) {
-			rejectPrebidLoaded('Unknown framework');
-			return;
-		}
-
-		void loadPrebid(framework).then(() => {
-			resolvePrebidLoaded();
+			if (!framework) {
+				throw new Error('Unknown framework');
+			}
+			if (!getConsentFor('prebid', state)) {
+				throw new Error('No consent for prebid');
+			}
+			return loadPrebid(framework);
+		})
+		.catch((e) => {
+			log('commercial', '⚠️ Failed to execute prebid', e);
 		});
-	});
-
-	return promise;
 };
 
 export const setupPrebidOnce: () => Promise<void> = once(setupPrebid);

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
@@ -1,7 +1,4 @@
-import {
-	getConsentFor,
-	onConsentChange,
-} from '@guardian/consent-management-platform';
+import { getConsentFor } from '@guardian/consent-management-platform';
 import { log } from '@guardian/libs';
 import { getInitialConsentState } from 'commercial/initialConsentState';
 import config from '../../../../lib/config';

--- a/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/redplanet.js
@@ -3,6 +3,7 @@ import {
 	onConsentChange,
 } from '@guardian/consent-management-platform';
 import { log } from '@guardian/libs';
+import { getInitialConsentState } from 'commercial/initialConsentState';
 import config from '../../../../lib/config';
 import { commercialFeatures } from '../../../common/modules/commercial/commercial-features';
 import { isInAuOrNz } from '../../../common/modules/commercial/geo-utils';
@@ -29,42 +30,32 @@ const initialise = () => {
 	});
 };
 
-const setupRedplanet = async () => {
-	let resolveRedPlanetLoaded;
-	let rejectRedPlanetLoaded;
-	const promise = new Promise((resolve, reject) => {
-		resolveRedPlanetLoaded = resolve;
-		rejectRedPlanetLoaded = reject;
-	}).catch((e) => {
-		log('commercial', '⚠️ Failed to execute redplanet', e);
-	});
+const setupRedplanet = () =>
+	getInitialConsentState()
+		.then((state) => {
+			if (!getConsentFor('redplanet', state)) {
+				return Promise.reject('No consent for redplanet');
+			}
 
-	onConsentChange((state) => {
-		if (!getConsentFor('redplanet', state)) {
-			rejectRedPlanetLoaded('No consent for redplanet');
-			return;
-		}
+			if (!state.aus) {
+				return Promise.reject(
+					'Redplanet should only run in Australia on AUS mode',
+				);
+			}
 
-		if (!state.aus) {
-			rejectRedPlanetLoaded(
-				'Redplanet should only run in Australia on AUS mode',
-			);
-			return;
-		}
-
-		if (!initialised) {
-			initialised = true;
-			import(
-				/* webpackChunkName: "redplanet" */ '../../../../lib/launchpad.js'
-			).then(() => {
-				initialise();
-				resolveRedPlanetLoaded();
-			});
-		}
-	});
-
-	return promise;
-};
+			if (!initialised) {
+				initialised = true;
+				return import(
+					/* webpackChunkName: "redplanet" */ '../../../../lib/launchpad.js'
+				);
+			}
+		})
+		.then(() => {
+			initialise();
+		})
+		.catch((e) => {
+			log('commercial', '⚠️ Failed to execute redplanet', e);
+		});
 
 export const init = () => {
 	if (commercialFeatures.launchpad && isInAuOrNz()) {

--- a/static/src/javascripts/projects/commercial/modules/ipsos-mori.js
+++ b/static/src/javascripts/projects/commercial/modules/ipsos-mori.js
@@ -1,7 +1,4 @@
-import {
-	getConsentFor,
-	onConsentChange,
-} from '@guardian/consent-management-platform';
+import { getConsentFor } from '@guardian/consent-management-platform';
 import { getLocale, loadScript } from '@guardian/libs';
 import { getInitialConsentState } from 'commercial/initialConsentState';
 import config from '../../../lib/config';

--- a/static/src/javascripts/projects/commercial/modules/ipsos-mori.js
+++ b/static/src/javascripts/projects/commercial/modules/ipsos-mori.js
@@ -27,7 +27,7 @@ const loadIpsosScript = () => {
 };
 
 export const init = () => {
-	return getLocale()
+	getLocale()
 		.then((locale) => {
 			if (locale === 'GB') {
 				return getInitialConsentState();
@@ -45,4 +45,5 @@ export const init = () => {
 		.catch((e) => {
 			log('commercial', '⚠️ Failed to execute ipsos', e);
 		});
+	return Promise.resolve();
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -68,7 +68,7 @@ const insertScripts = (
 	performanceServices, // performanceServices always run
 ) => {
 	addScripts(performanceServices);
-	return getInitialConsentState().then((state) => {
+	getInitialConsentState().then((state) => {
 		const consentedAdvertisingServices = advertisingServices.filter(
 			(script) => getConsentFor(script.name, state),
 		);
@@ -96,7 +96,7 @@ const loadOther = () => {
 		imrWorldwideLegacy, // only in AU & NZ
 	].filter((_) => _.shouldRun);
 
-	return insertScripts(advertisingServices, performanceServices);
+	insertScripts(advertisingServices, performanceServices);
 };
 
 const init = () => {

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -68,7 +68,7 @@ const insertScripts = (
 	performanceServices, // performanceServices always run
 ) => {
 	addScripts(performanceServices);
-	getInitialConsentState().then((state) => {
+	void getInitialConsentState().then((state) => {
 		const consentedAdvertisingServices = advertisingServices.filter(
 			(script) => getConsentFor(script.name, state),
 		);

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -12,6 +12,7 @@ import {
 	getConsentFor,
 	onConsentChange,
 } from '@guardian/consent-management-platform';
+import { getInitialConsentState } from 'commercial/initialConsentState';
 import config from '../../../lib/config';
 import fastdom from '../../../lib/fastdom-promise';
 import { commercialFeatures } from '../../common/modules/commercial/commercial-features';
@@ -67,7 +68,7 @@ const insertScripts = (
 	performanceServices, // performanceServices always run
 ) => {
 	addScripts(performanceServices);
-	onConsentChange((state) => {
+	return getInitialConsentState().then((state) => {
 		const consentedAdvertisingServices = advertisingServices.filter(
 			(script) => getConsentFor(script.name, state),
 		);
@@ -95,7 +96,7 @@ const loadOther = () => {
 		imrWorldwideLegacy, // only in AU & NZ
 	].filter((_) => _.shouldRun);
 
-	insertScripts(advertisingServices, performanceServices);
+	return insertScripts(advertisingServices, performanceServices);
 };
 
 const init = () => {
@@ -103,9 +104,7 @@ const init = () => {
 		return Promise.resolve(false);
 	}
 
-	loadOther();
-
-	return Promise.resolve(true);
+	return loadOther();
 };
 
 export { init };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -103,8 +103,9 @@ const init = () => {
 	if (!commercialFeatures.thirdPartyTags) {
 		return Promise.resolve(false);
 	}
+    loadOther();
 
-	return loadOther();
+	return Promise.resolve(true);
 };
 
 export { init };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -8,10 +8,7 @@ import {
 	remarketing,
 	twitter,
 } from '@guardian/commercial-core';
-import {
-	getConsentFor,
-	onConsentChange,
-} from '@guardian/consent-management-platform';
+import { getConsentFor } from '@guardian/consent-management-platform';
 import { getInitialConsentState } from 'commercial/initialConsentState';
 import config from '../../../lib/config';
 import fastdom from '../../../lib/fastdom-promise';

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.js
@@ -103,7 +103,7 @@ const init = () => {
 	if (!commercialFeatures.thirdPartyTags) {
 		return Promise.resolve(false);
 	}
-    loadOther();
+	loadOther();
 
 	return Promise.resolve(true);
 };

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
@@ -136,7 +136,7 @@ describe('third party tags', () => {
 			});
 	});
 
-	describe('await insertScripts', () => {
+	describe('insertScripts', () => {
 		const fakeThirdPartyAdvertisingTag = {
 			shouldRun: true,
 			url: '//fakeThirdPartyAdvertisingTag.js',

--- a/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/third-party-tags.spec.js
@@ -136,7 +136,7 @@ describe('third party tags', () => {
 			});
 	});
 
-	describe('insertScripts', () => {
+	describe('await insertScripts', () => {
 		const fakeThirdPartyAdvertisingTag = {
 			shouldRun: true,
 			url: '//fakeThirdPartyAdvertisingTag.js',
@@ -162,80 +162,80 @@ describe('third party tags', () => {
 			fakeThirdPartyPerformanceTag.loaded = undefined;
 		});
 
-		it('should add scripts to the document when TCFv2 consent has been given', () => {
+		it('should add scripts to the document when TCFv2 consent has been given', async () => {
 			onConsentChange.mockImplementation(tcfv2AllConsentMock);
 			getConsentFor.mockReturnValue(true);
-			insertScripts(
+			await insertScripts(
 				[fakeThirdPartyAdvertisingTag],
 				[fakeThirdPartyPerformanceTag],
 			);
 			expect(document.scripts.length).toBe(3);
 		});
 
-		it('should only add performance scripts to the document when TCFv2 consent has not been given', () => {
+		it('should only add performance scripts to the document when TCFv2 consent has not been given', async () => {
 			onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
 			getConsentFor.mockReturnValue(false);
-			insertScripts(
+			await insertScripts(
 				[fakeThirdPartyAdvertisingTag],
 				[fakeThirdPartyPerformanceTag],
 			);
 			expect(document.scripts.length).toBe(2);
 		});
-		it('should add scripts to the document when CCPA consent has been given', () => {
+		it('should add scripts to the document when CCPA consent has been given', async () => {
 			onConsentChange.mockImplementation((callback) =>
 				callback({ ccpa: { doNotSell: false } }),
 			);
 			getConsentFor.mockReturnValue(true);
-			insertScripts(
+			await insertScripts(
 				[fakeThirdPartyAdvertisingTag],
 				[fakeThirdPartyPerformanceTag],
 			);
 			expect(document.scripts.length).toBe(3);
 		});
-		it('should only add performance scripts to the document when CCPA consent has not been given', () => {
+		it('should only add performance scripts to the document when CCPA consent has not been given', async () => {
 			onConsentChange.mockImplementation((callback) =>
 				callback({ ccpa: { doNotSell: true } }),
 			);
 			getConsentFor.mockReturnValue(false);
-			insertScripts(
+			await insertScripts(
 				[fakeThirdPartyAdvertisingTag],
 				[fakeThirdPartyPerformanceTag],
 			);
 			expect(document.scripts.length).toBe(2);
 		});
 
-		it('should only add consented custom vendors to the document for TCFv2', () => {
+		it('should only add consented custom vendors to the document for TCFv2', async () => {
 			onConsentChange.mockImplementation(tcfv2WithConsentMock);
 			getConsentFor.mockReturnValueOnce(true);
 			getConsentFor.mockReturnValueOnce(false);
-			insertScripts(
+			await insertScripts(
 				[fakeThirdPartyAdvertisingTag, fakeThirdPartyAdvertisingTag2],
 				[],
 			);
 			expect(document.scripts.length).toBe(2);
 		});
 
-		it('should not add already loaded tags ', () => {
+		it('should not add already loaded tags ', async () => {
 			onConsentChange.mockImplementation(tcfv2WithConsentMock);
 			getConsentFor.mockReturnValueOnce(true);
 			getConsentFor.mockReturnValueOnce(false);
 			getConsentFor.mockReturnValueOnce(true);
 			getConsentFor.mockReturnValueOnce(false);
-			insertScripts(
+			await insertScripts(
 				[fakeThirdPartyAdvertisingTag, fakeThirdPartyAdvertisingTag2],
 				[],
 			);
-			insertScripts(
+			await insertScripts(
 				[fakeThirdPartyAdvertisingTag, fakeThirdPartyAdvertisingTag2],
 				[],
 			);
 			expect(document.scripts.length).toBe(2);
 		});
 
-		it('should not add scripts to the document when TCFv2 consent has not been given', () => {
+		it('should not add scripts to the document when TCFv2 consent has not been given', async () => {
 			onConsentChange.mockImplementation(tcfv2WithoutConsentMock);
 			getConsentFor.mockReturnValue(false);
-			insertScripts(
+			await insertScripts(
 				[fakeThirdPartyAdvertisingTag, fakeThirdPartyAdvertisingTag2],
 				[],
 			);

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -60,6 +60,10 @@
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../projects/common/modules/analytics/shouldCaptureMetrics.ts"
  ],
+ "../projects/commercial/initialConsentState.ts": [
+  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
+  "../../../../node_modules/@guardian/consent-management-platform/dist/types/index.d.ts"
+ ],
  "../projects/commercial/modules/ad-free-slot-remove.ts": [
   "../../../../node_modules/@types/lodash-es/index.d.ts",
   "../lib/$$.ts",
@@ -123,6 +127,7 @@
   "../../../../node_modules/@guardian/consent-management-platform/dist/index.js",
   "../../../../node_modules/@guardian/libs/dist/cjs/index.js",
   "../lib/config.js",
+  "../projects/commercial/initialConsentState.ts",
   "../projects/common/modules/commercial/commercial-features.ts"
  ],
  "../projects/commercial/modules/creatives/page-skin.ts": [
@@ -238,10 +243,12 @@
  ],
  "../projects/commercial/modules/dfp/prepare-a9.js": [
   "../../../../node_modules/@guardian/consent-management-platform/dist/index.js",
+  "../../../../node_modules/@guardian/libs/dist/cjs/index.js",
   "../../../../node_modules/lodash-es/lodash.js",
   "../lib/a9-apstag.js",
   "../lib/config.js",
   "../lib/detect-google-proxy.ts",
+  "../projects/commercial/initialConsentState.ts",
   "../projects/commercial/modules/dfp/dfp-env.ts",
   "../projects/commercial/modules/header-bidding/a9/a9.js",
   "../projects/commercial/modules/header-bidding/utils.ts",
@@ -252,6 +259,7 @@
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/config.d.ts",
   "../lib/raven.js",
+  "../projects/commercial/initialConsentState.ts",
   "../projects/commercial/modules/ad-free-slot-remove.ts",
   "../projects/commercial/modules/dfp/fill-advert-slots.ts",
   "../projects/commercial/modules/dfp/on-slot-load.ts",
@@ -288,6 +296,7 @@
   "../../../../node_modules/prebid.js/build/dist/prebid.js",
   "../lib/config.d.ts",
   "../lib/detect-google-proxy.ts",
+  "../projects/commercial/initialConsentState.ts",
   "../projects/commercial/modules/dfp/dfp-env.ts",
   "../projects/commercial/modules/header-bidding/prebid/prebid.ts",
   "../projects/commercial/modules/header-bidding/utils.ts",
@@ -402,7 +411,9 @@
  "../projects/commercial/modules/ipsos-mori.js": [
   "../../../../node_modules/@guardian/consent-management-platform/dist/index.js",
   "../../../../node_modules/@guardian/libs/dist/cjs/index.js",
-  "../lib/config.js"
+  "../../../../node_modules/@guardian/libs/dist/cjs/index.js",
+  "../lib/config.js",
+  "../projects/commercial/initialConsentState.ts"
  ],
  "../projects/commercial/modules/liveblog-adverts.js": [
   "../lib/detect.js",
@@ -497,6 +508,7 @@
   "../../../../node_modules/@guardian/consent-management-platform/dist/index.js",
   "../lib/config.js",
   "../lib/fastdom-promise.js",
+  "../projects/commercial/initialConsentState.ts",
   "../projects/commercial/modules/third-party-tags/imr-worldwide-legacy.js",
   "../projects/commercial/modules/third-party-tags/imr-worldwide.js",
   "../projects/common/modules/commercial/commercial-features.ts"

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -312,6 +312,7 @@
   "../../../../node_modules/@guardian/libs/dist/cjs/index.js",
   "../lib/config.js",
   "../lib/launchpad.js",
+  "../projects/commercial/initialConsentState.ts",
   "../projects/common/modules/commercial/commercial-features.ts",
   "../projects/common/modules/commercial/geo-utils.js"
  ],


### PR DESCRIPTION
## What does this change?
- Defines a helper function `getInitialConsentState` which wraps `onConsentChange` and returns a promise containing the first consent state.
- Replace usage of `onConsentChange` with `getInitialConsentState` in commercial modules
   - comscore.js
   - prepare-a9.js
   - prepare-googletag.ts 
   - prepare-prebid.ts 
   - redplanet.js 
   - ipsos-mori.js 
   - third-party-tags.js 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
- Use of `getInitialConsentState` removes duplicate code needed to promisify `onConsentChange`
- Simplifies a future change to have all commercial module init functions return a promise

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
