### PR TITLE
Non-refreshable line item experiment participation to 20%

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -38,5 +38,5 @@ object FetchNonRefreshableLineItems
       description = "Fetch non-refreshable line items via a new endpoint",
       owners = Seq(Owner.withGithub("chrislomaxjones")),
       sellByDate = LocalDate.of(2022, 1, 24),
-      participationGroup = Perc1A,
+      participationGroup = Perc20A,
     )


### PR DESCRIPTION
## What does this change?

Increase participation in the fetch-non-refreshable-line-items experiment to 20% of the audience. This experiment was introduced in #24387 and increased to 1% participation in #24478.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Expose more of the audience to the change so we can monitor for adversity.

### Tested

- [ ] Locally
- [ ] On CODE (optional)