### PR TITLE
Update to Ophan v1.3.29 to fix Attention Time clock-update susceptiblity

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "fence": "guardian/fence#0.2.11",
     "lodash-es": "^4.17.21",
     "object-fit-videos": "^1.0.3",
-    "ophan-tracker-js": "1.3.28",
+    "ophan-tracker-js": "1.3.29",
     "preact": "^10.5.13",
     "prebid.js": "https://github.com/guardian/Prebid.js#d196736",
     "qwery": "3.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9080,10 +9080,10 @@ openurl@1.1.1:
   resolved "https://registry.yarnpkg.com/openurl/-/openurl-1.1.1.tgz#3875b4b0ef7a52c156f0db41d4609dbb0f94b387"
   integrity sha1-OHW0sO96UsFW8NtB1GCduw+Us4c=
 
-ophan-tracker-js@1.3.28:
-  version "1.3.28"
-  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.28.tgz#52d24a03a507dc491b0c27f2ded51b1ad44bae8b"
-  integrity sha512-1azFLoS1MS1mUX3+LN/MR0tkYqJd+PHByf5AkHsfoNxKz0O+G5L92x7AGdTfPvNiQZ0BCO1qhMoLyRo1OgNMSA==
+ophan-tracker-js@1.3.29:
+  version "1.3.29"
+  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.29.tgz#db211a121065173ebf45c1250d57768898f49cbb"
+  integrity sha512-PQ9iKiZ5hegavEzviZbrjCBHPYFMNKpyqyi49elD0Ehlt9Aeh75Yr8IM2GoP7iMS3nmtVjhMCmYNL8xSMCh7sQ==
 
 opn@5.3.0:
   version "5.3.0"


### PR DESCRIPTION
## What does this change?

Ophan Tracker JS [v1.3.29](https://www.npmjs.com/package/ophan-tracker-js/v/1.3.29) introduces just one change: https://github.com/guardian/ophan/pull/4358. This switches Tracker JS to using `performance.now()` in preference to `new Date().getTime()` for calculating Attention Time durations.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (see https://github.com/guardian/dotcom-rendering/pull/3762)

## Screenshots

*  browser on the left ⬅️  ...shows current production Ophan Tracker JS running on the live site, when the system time is updated, we see an incorrect **negative** Attention Time at time position 13s.
* browser on the right ➡️  ...shows a local copy of [DCR](https://github.com/guardian/dotcom-rendering/) running with this PR's the updated Tracker JS. When the system time is updated, the attention time is recorded **correctly**

https://user-images.githubusercontent.com/52038/145476925-87c9812a-0293-4d6f-8b2c-c0d48d1d77d7.mov


## What is the value of this and can you measure success?

This should stop a major source of _negative_ Attention Times (as well as fix many Attention Times that are incorrect but not _obviously_ so) - the wrong Attention Time being reported when the user's system time is updated _while_ they're viewing the page.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
