### PR TITLE
Adding culture and Lifestyle deadblogs to DCR

### DIFF
--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import com.gu.contentapi.client.model.v1.{Blocks, ItemResponse, Content => ApiContent}
-import com.gu.contentapi.client.utils.format.{NewsPillar, SportPillar}
+import com.gu.contentapi.client.utils.format.{NewsPillar, SportPillar, CulturePillar, LifestylePillar}
 import common.`package`.{convertApiExceptions => _, renderFormat => _}
 import common.{JsonComponent, RichRequestHeader, _}
 import contentapi.ContentApiClient

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -98,9 +98,11 @@ class LiveBlogController(
 
   private def isSupportedTheme(blog: LiveBlogPage): Boolean = {
     blog.article.content.metadata.format.getOrElse(ContentFormat.defaultContentFormat).theme match {
-      case NewsPillar  => true
-      case SportPillar => false
-      case _           => false
+      case NewsPillar      => true
+      case CulturePillar   => true
+      case LifestylePillar => true
+      case SportPillar     => false
+      case _               => false
     }
   }
 


### PR DESCRIPTION
## What does this change?
Now that we have made the changes to ensure culture deadblogs are accessible, let's add them to the allowlist for being served by DCR, as well as lifestyle.