### PR TITLE
Draft - Improve logging for dcr deadblogs

### DIFF
--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -28,12 +28,12 @@ import scala.concurrent.Future
 case class MinutePage(article: Article, related: RelatedContent) extends PageWithStoryPackage
 
 class LiveBlogController(
-    contentApiClient: ContentApiClient,
-    val controllerComponents: ControllerComponents,
-    ws: WSClient,
-    remoteRenderer: renderers.DotcomRenderingService = DotcomRenderingService(),
-)(implicit context: ApplicationContext)
-    extends BaseController
+                          contentApiClient: ContentApiClient,
+                          val controllerComponents: ControllerComponents,
+                          ws: WSClient,
+                          remoteRenderer: renderers.DotcomRenderingService = DotcomRenderingService(),
+                        )(implicit context: ApplicationContext)
+  extends BaseController
     with GuLogging
     with ImplicitControllerExecutionContext {
 
@@ -71,12 +71,12 @@ class LiveBlogController(
   }
 
   def renderJson(
-      path: String,
-      lastUpdate: Option[String],
-      rendered: Option[Boolean],
-      isLivePage: Option[Boolean],
-      filterKeyEvents: Option[Boolean],
-  ): Action[AnyContent] = {
+                  path: String,
+                  lastUpdate: Option[String],
+                  rendered: Option[Boolean],
+                  isLivePage: Option[Boolean],
+                  filterKeyEvents: Option[Boolean],
+                ): Action[AnyContent] = {
     Action.async { implicit request: Request[AnyContent] =>
       val filter = shouldFilter(filterKeyEvents)
       val range = getRange(lastUpdate)
@@ -117,53 +117,70 @@ class LiveBlogController(
     isDeadBlog(blog) && isSupportedTheme(blog) && isNotRecent(blog)
   }
 
+  private def checkIfSupportedAll(blog: LiveBlogPage): Boolean = {
+    isDeadBlog(blog) && isSupportedTheme(blog)
+  }
+
   private[this] def renderWithRange(path: String, range: BlockRange, filterKeyEvents: Boolean)(implicit
-      request: RequestHeader,
+                                                                                               request: RequestHeader,
   ): Future[Result] = {
     mapModel(path, range, filterKeyEvents) { (page, blocks) =>
-      {
-        val isAmpSupported = page.article.content.shouldAmplify
-        val pageType: PageType = PageType(page, request, context)
-        (page, request.getRequestFormat) match {
-          case (minute: MinutePage, HtmlFormat) =>
-            Future.successful(common.renderHtml(MinuteHtmlPage.html(minute), minute))
-          case (blog: LiveBlogPage, HtmlFormat) =>
-            val dcrCouldRender = checkIfSupported(blog)
-            val participatingInTest = ActiveExperiments.isParticipating(LiveblogRendering)
-            val properties =
-              Map(
-                "participatingInTest" -> participatingInTest.toString,
-                "dcrCouldRender" -> dcrCouldRender.toString,
-                "isLiveBlog" -> "true",
-              )
-            val remoteRendering =
-              shouldRemoteRender(request.forceDCROff, request.forceDCR, participatingInTest, dcrCouldRender)
+    {
+      val isAmpSupported = page.article.content.shouldAmplify
+      val pageType: PageType = PageType(page, request, context)
+      (page, request.getRequestFormat) match {
+        case (minute: MinutePage, HtmlFormat) =>
+          Future.successful(common.renderHtml(MinuteHtmlPage.html(minute), minute))
+        case (blog: LiveBlogPage, HtmlFormat) =>
+          val dcrCouldRender = checkIfSupported(blog)
+          val dcrCouldRenderAll = checkIfSupportedAll(blog)
+          val participatingInTest = ActiveExperiments.isParticipating(LiveblogRendering)
+          val properties =
+            Map(
+              "participatingInTest" -> participatingInTest.toString,
+              "dcrCouldRender" -> dcrCouldRender.toString,
+              "isLiveBlog" -> "true",
+            )
+          val remoteRendering =
+            shouldRemoteRender(request.forceDCROff, request.forceDCR, participatingInTest, dcrCouldRender)
 
-            if (remoteRendering) {
-              DotcomponentsLogger.logger.logRequest(s"liveblog executing in dotcomponents", properties, page)
-              val pageType: PageType = PageType(blog, request, context)
-              remoteRenderer.getArticle(ws, blog, blocks, pageType)
-            } else {
-              DotcomponentsLogger.logger.logRequest(s"liveblog executing in web", properties, page)
-              Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
-            }
-          case (blog: LiveBlogPage, AmpFormat) if isAmpSupported =>
-            remoteRenderer.getAMPArticle(ws, blog, blocks, pageType)
-          case (blog: LiveBlogPage, AmpFormat) =>
+          val couldRemoteRender =
+            couldRemoteRender(request.forceDCROff, request.forceDCR, participatingInTest, dcrCouldRenderAll)
+
+          if (remoteRendering) {
+            DotcomponentsLogger.logger.logRequest(s"liveblog executing in dotcomponents", properties, page)
+            val pageType: PageType = PageType(blog, request, context)
+            remoteRenderer.getArticle(ws, blog, blocks, pageType)
+          } else {
+            DotcomponentsLogger.logger.logRequest(s"liveblog executing in web", properties, page)
             Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
-          case _ => Future.successful(NotFound)
-        }
+          }
+
+          if (couldRemoteRender) {
+            DotcomponentsLogger.logger.logRequest(s"liveblog could be executed in dotcomponents", properties, page)
+            val pageType: PageType = PageType(blog, request, context)
+            remoteRenderer.getArticle(ws, blog, blocks, pageType)
+          } else {
+            DotcomponentsLogger.logger.logRequest(s"liveblog not supported in dotcomponents", properties, page)
+            Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
+          }
+        case (blog: LiveBlogPage, AmpFormat) if isAmpSupported =>
+          remoteRenderer.getAMPArticle(ws, blog, blocks, pageType)
+        case (blog: LiveBlogPage, AmpFormat) =>
+          Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
+        case _ => Future.successful(NotFound)
       }
+    }
 
     }
   }
 
   def shouldRemoteRender(
-      forceDCROff: Boolean,
-      forceDCR: Boolean,
-      participatingInTest: Boolean,
-      dcrCouldRender: Boolean,
-  ): Boolean = {
+                          forceDCROff: Boolean,
+                          forceDCR: Boolean,
+                          participatingInTest: Boolean,
+                          dcrCouldRender: Boolean,
+                        ): Boolean = {
     // ?dcr=false, so never render DCR
     if (forceDCROff) false
     // ?dcr=true, so always render DCR
@@ -187,11 +204,11 @@ class LiveBlogController(
   }
 
   private[this] def getJson(
-      liveblog: LiveBlogPage,
-      range: BlockRange,
-      isLivePage: Option[Boolean],
-      filterKeyEvents: Boolean,
-  )(implicit request: RequestHeader): Future[Result] = {
+                             liveblog: LiveBlogPage,
+                             range: BlockRange,
+                             isLivePage: Option[Boolean],
+                             filterKeyEvents: Boolean,
+                           )(implicit request: RequestHeader): Future[Result] = {
     range match {
       case SinceBlockId(lastBlockId) =>
         renderNewerUpdatesJson(liveblog, SinceBlockId(lastBlockId), isLivePage, filterKeyEvents)
@@ -200,10 +217,10 @@ class LiveBlogController(
   }
 
   private[this] def getNewBlocks(
-      page: PageWithStoryPackage,
-      lastUpdateBlockId: SinceBlockId,
-      filterKeyEvents: Boolean,
-  ): Seq[BodyBlock] = {
+                                  page: PageWithStoryPackage,
+                                  lastUpdateBlockId: SinceBlockId,
+                                  filterKeyEvents: Boolean,
+                                ): Seq[BodyBlock] = {
     val requestedBlocks = page.article.fields.blocks.toSeq.flatMap {
       _.requestedBodyBlocks.getOrElse(lastUpdateBlockId.around, Seq())
     }
@@ -217,11 +234,11 @@ class LiveBlogController(
   }
 
   private[this] def renderNewerUpdatesJson(
-      page: PageWithStoryPackage,
-      lastUpdateBlockId: SinceBlockId,
-      isLivePage: Option[Boolean],
-      filterKeyEvents: Boolean,
-  )(implicit request: RequestHeader): Future[Result] = {
+                                            page: PageWithStoryPackage,
+                                            lastUpdateBlockId: SinceBlockId,
+                                            isLivePage: Option[Boolean],
+                                            filterKeyEvents: Boolean,
+                                          )(implicit request: RequestHeader): Future[Result] = {
     val newBlocks = getNewBlocks(page, lastUpdateBlockId, filterKeyEvents)
     val blocksHtml = views.html.liveblog.liveBlogBlocks(newBlocks, page.article, Edition(request).timezone)
     val timelineHtml = views.html.liveblog.keyEvents(
@@ -247,9 +264,9 @@ class LiveBlogController(
   }
 
   private[this] def renderGuuiJson(
-      blog: LiveBlogPage,
-      blocks: Blocks,
-  )(implicit request: RequestHeader): Result = {
+                                    blog: LiveBlogPage,
+                                    blocks: Blocks,
+                                  )(implicit request: RequestHeader): Result = {
     val pageType: PageType = PageType(blog, request, context)
     val model = DotcomRenderingDataModel.forLiveblog(blog, blocks, request, pageType)
     val json = DotcomRenderingDataModel.toJson(model)
@@ -257,7 +274,7 @@ class LiveBlogController(
   }
 
   private[this] def mapModel(path: String, range: BlockRange, filterKeyEvents: Boolean = false)(
-      render: (PageWithStoryPackage, Blocks) => Future[Result],
+    render: (PageWithStoryPackage, Blocks) => Future[Result],
   )(implicit request: RequestHeader): Future[Result] = {
     capiLookup
       .lookup(path, Some(range))
@@ -270,9 +287,9 @@ class LiveBlogController(
   }
 
   private[this] def responseToModelOrResult(
-      range: BlockRange,
-      filterKeyEvents: Boolean,
-  )(response: ItemResponse)(implicit request: RequestHeader): Either[(PageWithStoryPackage, Blocks), Result] = {
+                                             range: BlockRange,
+                                             filterKeyEvents: Boolean,
+                                           )(response: ItemResponse)(implicit request: RequestHeader): Either[(PageWithStoryPackage, Blocks), Result] = {
     val supportedContent: Option[ContentType] = response.content.filter(isSupported).map(Content(_))
     val supportedContentResult: Either[ContentType, Result] = ModelOrResult(supportedContent, response)
     val blocks = response.content.flatMap(_.blocks).getOrElse(Blocks())


### PR DESCRIPTION
## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
