### PR TITLE
Hyphenate container titles automatically on Labs fronts

### DIFF
--- a/static/src/stylesheets/module/commercial/_capi.scss
+++ b/static/src/stylesheets/module/commercial/_capi.scss
@@ -88,6 +88,7 @@
     .fc-container__header__title {
         @include f-textSans;
         font-weight: 400;
+        hyphens: auto;
     }
 
     .tone-news--item.fc-item,


### PR DESCRIPTION
## What does this change?

Adds hyphenation to container titles

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/146962897-ee4ceea3-7297-4611-8128-0942f6109a0e.png

[after]: https://user-images.githubusercontent.com/76776/146962898-f92cb58b-2755-47aa-a6a9-ea19b6713210.png

## What is the value of this and can you measure success?

No words left hidden!

## Checklist

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [X] Yes (please give details)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
