### PR TITLE
Check for more deadblog support to be logged in kibana

### DIFF
--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -106,16 +106,17 @@ class LiveBlogController(
             Future.successful(common.renderHtml(MinuteHtmlPage.html(minute), minute))
           case (blog: LiveBlogPage, HtmlFormat) =>
             val dcrCouldRender = LiveBlogController.checkIfSupported(blog)
+            val dcrCouldRenderNotOld = LiveBlogController.checkIfSupportedNotOld(blog)
             val participatingInTest = ActiveExperiments.isParticipating(LiveblogRendering)
             val properties =
               Map(
                 "participatingInTest" -> participatingInTest.toString,
                 "dcrCouldRender" -> dcrCouldRender.toString,
+                "dcrCouldRenderNotOld" -> dcrCouldRenderNotOld.toString,
                 "isLiveBlog" -> "true",
               )
             val remoteRendering =
               shouldRemoteRender(request.forceDCROff, request.forceDCR, participatingInTest, dcrCouldRender)
-
             if (remoteRendering) {
               DotcomponentsLogger.logger.logRequest(s"liveblog executing in dotcomponents", properties, page)
               val pageType: PageType = PageType(blog, request, context)
@@ -302,5 +303,8 @@ object LiveBlogController {
 
   def checkIfSupported(blog: PageWithStoryPackage): Boolean = {
     isDeadBlog(blog) && isSupportedTheme(blog) && isNotRecent(blog)
+  }
+  def checkIfSupportedNotOld(blog: PageWithStoryPackage): Boolean = {
+    isDeadBlog(blog) && isSupportedTheme(blog)
   }
 }

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -106,13 +106,21 @@ class LiveBlogController(
             Future.successful(common.renderHtml(MinuteHtmlPage.html(minute), minute))
           case (blog: LiveBlogPage, HtmlFormat) =>
             val dcrCouldRender = LiveBlogController.checkIfSupported(blog)
-            val dcrCouldRenderNotOld = LiveBlogController.checkIfSupportedNotOld(blog)
             val participatingInTest = ActiveExperiments.isParticipating(LiveblogRendering)
+            val isRecent = !LiveBlogController.isNotRecent(blog)
+            val theme = blog.article.content.metadata.format.getOrElse(ContentFormat.defaultContentFormat).theme
+            val design = blog.article.content.metadata.format.getOrElse(ContentFormat.defaultContentFormat).design
+            val display = blog.article.content.metadata.format.getOrElse(ContentFormat.defaultContentFormat).display
+            val isDeadBlog = LiveBlogController.isDeadBlog
             val properties =
               Map(
                 "participatingInTest" -> participatingInTest.toString,
                 "dcrCouldRender" -> dcrCouldRender.toString,
-                "dcrCouldRenderNotOld" -> dcrCouldRenderNotOld.toString,
+                "theme" -> theme.toString,
+                "design" -> design.toString,
+                "display" -> display.toString,
+                "isRecent" -> isRecent.toString,
+                "isDead" -> isDeadBlog.toString,
                 "isLiveBlog" -> "true",
               )
             val remoteRendering =
@@ -294,17 +302,14 @@ object LiveBlogController {
     }
   }
 
-  private def isDeadBlog(blog: PageWithStoryPackage): Boolean = !blog.article.fields.isLive
+  def isDeadBlog(blog: PageWithStoryPackage): Boolean = !blog.article.fields.isLive
 
-  private def isNotRecent(blog: PageWithStoryPackage) = {
+  def isNotRecent(blog: PageWithStoryPackage) = {
     val twoDaysAgo = new DateTime(DateTimeZone.UTC).minusDays(2)
     blog.article.fields.lastModified.isBefore(twoDaysAgo)
   }
 
   def checkIfSupported(blog: PageWithStoryPackage): Boolean = {
     isDeadBlog(blog) && isSupportedTheme(blog) && isNotRecent(blog)
-  }
-  def checkIfSupportedNotOld(blog: PageWithStoryPackage): Boolean = {
-    isDeadBlog(blog) && isSupportedTheme(blog)
   }
 }

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -111,7 +111,7 @@ class LiveBlogController(
             val theme = blog.article.content.metadata.format.getOrElse(ContentFormat.defaultContentFormat).theme
             val design = blog.article.content.metadata.format.getOrElse(ContentFormat.defaultContentFormat).design
             val display = blog.article.content.metadata.format.getOrElse(ContentFormat.defaultContentFormat).display
-            val isDeadBlog = LiveBlogController.isDeadBlog
+            val isDeadBlog = LiveBlogController.isDeadBlog(blog)
             val properties =
               Map(
                 "participatingInTest" -> participatingInTest.toString,


### PR DESCRIPTION
## What does this change?
Added more values for us to pass through to Kibana that will allow us to give a better picture of what it means to support different types of blog. This will also mean that we can log out the true amount of deadblog pages we could serve via DCR if we switched it on for 100% of the audience

