### PR TITLE
Fix Pinned Post Tracking

### DIFF
--- a/article/app/views/liveblog/pinnedBlock.scala.html
+++ b/article/app/views/liveblog/pinnedBlock.scala.html
@@ -6,7 +6,7 @@
 @*
 * This template is to wrap pinned posts
 *@
-<div id="pinned-block" class="pinned-block" data-component="live-blog-pinned-post" data-block-id="@block.id">
+<div id="pinned-block" class="pinned-block" data-block-id="@block.id">
     <input id="pinned-block-button" class="pinned-block__button" type="checkbox" aria-controls="pinned-block" />
     <label for="pinned-block-button" class="pinned-block__label pinned-block__label--collapsed pinned-block__label--expanded">
         @fragments.inlineSvg("plus", "icon", List("pinned-block__label-icon--expand"))

--- a/static/src/javascripts/bootstraps/enhanced/liveblog.js
+++ b/static/src/javascripts/bootstraps/enhanced/liveblog.js
@@ -70,11 +70,13 @@ const cleanId = (blockIdString) => {
 };
 
 const componentEvent = (pinnedBlockId, action) => ({
-	component: {
-		componentType: 'LIVE_BLOG_PINNED_POST',
-		id: pinnedBlockId,
-	},
-	action: action,
+    componentEvent: {
+        component: {
+            componentType: 'LIVE_BLOG_PINNED_POST',
+            id: pinnedBlockId,
+        },
+        action: action,
+    }
 });
 
 const initTracking = () => {
@@ -95,8 +97,14 @@ const initTracking = () => {
 
 const trackOphanClick = (pinnedBlockId, clickValue) => {
 	ophan.record({
-		...componentEvent(pinnedBlockId, 'CLICK'),
-		value: clickValue,
+        componentEvent: {
+            component: {
+                componentType: 'LIVE_BLOG_PINNED_POST',
+                id: pinnedBlockId,
+            },
+            action: 'CLICK',
+            value: clickValue,
+        }
 	});
 };
 

--- a/static/src/javascripts/bootstraps/enhanced/liveblog.js
+++ b/static/src/javascripts/bootstraps/enhanced/liveblog.js
@@ -69,13 +69,14 @@ const cleanId = (blockIdString) => {
 	return blockIdString.substring(0, blockIdString.indexOf('-pinned'));
 };
 
-const componentEvent = (pinnedBlockId, action) => ({
+const componentEvent = (pinnedBlockId, action, value) => ({
     componentEvent: {
         component: {
             componentType: 'LIVE_BLOG_PINNED_POST',
             id: pinnedBlockId,
         },
         action: action,
+        ...value
     }
 });
 
@@ -96,16 +97,7 @@ const initTracking = () => {
 };
 
 const trackOphanClick = (pinnedBlockId, clickValue) => {
-	ophan.record({
-        componentEvent: {
-            component: {
-                componentType: 'LIVE_BLOG_PINNED_POST',
-                id: pinnedBlockId,
-            },
-            action: 'CLICK',
-            value: clickValue,
-        }
-	});
+    ophan.record(componentEvent(pinnedBlockId, 'VIEW', {value: clickValue}));
 };
 
 const setupListeners = () => {


### PR DESCRIPTION
## What does this change?
The pinned post tracking was initially implemented without a componentEvent key. This lead to the tracking data being stored as interactive data instead of componentEvent data. To pass data as a component event, its essential to use a componentEvent key. 

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
