### PR TITLE
use 'show more' label for pinned posts expand button

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_live-blog.scss
+++ b/static/src/stylesheets/module/content-garnett/_live-blog.scss
@@ -402,7 +402,7 @@ input:focus-visible + .pinned-block__label {
 }
 
 .pinned-block__button + label::after {
-    content: 'Show all';
+    content: 'Show more';
 }
 
 .pinned-block__button:checked + label::after {


### PR DESCRIPTION
## What does this change?
Changing the label on the pinned post expand button to 'show more' from 'show all' based on some user feedback (P&E/Journalism Team) 
