### PR TITLE
Refactor Prebid bidder selection

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.ts
@@ -468,27 +468,26 @@ const biddersSwitchedOn = (allBidders: PrebidBidder[]): PrebidBidder[] => {
 };
 
 const currentBidders = (slotSizes: HeaderBiddingSize[]): PrebidBidder[] => {
-	const otherBidders: PrebidBidder[] = [
-		...(inPbTestOr(shouldIncludeCriteo()) ? [criteoBidder] : []),
-		...(inPbTestOr(shouldIncludeSmart()) ? [smartBidder] : []),
-		...(inPbTestOr(shouldIncludeSonobi()) ? [sonobiBidder] : []),
-		...(inPbTestOr(shouldIncludeTrustX()) ? [trustXBidder] : []),
-		...(inPbTestOr(shouldIncludeTripleLift()) ? [tripleLiftBidder] : []),
-		...(inPbTestOr(shouldIncludeAppNexus()) ? [appNexusBidder] : []),
-		...(inPbTestOr(shouldIncludeImproveDigital())
-			? [improveDigitalBidder]
-			: []),
-		...(inPbTestOr(shouldIncludeImproveDigitalSkin())
-			? [improveDigitalSkinBidder]
-			: []),
-		...(inPbTestOr(shouldIncludeXaxis()) ? [xaxisBidder] : []),
-		pubmaticBidder,
-		...(inPbTestOr(shouldIncludeAdYouLike(slotSizes))
-			? [adYouLikeBidder]
-			: []),
-		...(inPbTestOr(shouldUseOzoneAdaptor()) ? [ozoneClientSideBidder] : []),
-		...(shouldIncludeOpenx() ? [openxClientSideBidder] : []),
+	const biddersToCheck: Array<[boolean, PrebidBidder]> = [
+		[shouldIncludeCriteo(), criteoBidder],
+		[shouldIncludeSmart(), smartBidder],
+		[shouldIncludeSonobi(), sonobiBidder],
+		[shouldIncludeTrustX(), trustXBidder],
+		[shouldIncludeTripleLift(), tripleLiftBidder],
+		[shouldIncludeAppNexus(), appNexusBidder],
+		[shouldIncludeImproveDigital(), improveDigitalBidder],
+		[shouldIncludeImproveDigitalSkin(), improveDigitalSkinBidder],
+		[shouldIncludeXaxis(), xaxisBidder],
+		[true, pubmaticBidder],
+		[shouldIncludeAdYouLike(slotSizes), adYouLikeBidder],
+		[shouldUseOzoneAdaptor(), ozoneClientSideBidder],
+		[shouldIncludeOpenx(), openxClientSideBidder],
 	];
+
+	const otherBidders = biddersToCheck
+		.filter(([shouldInclude]) => inPbTestOr(shouldInclude))
+		.map(([, bidder]) => bidder);
+
 	const allBidders = indexExchangeBidders(slotSizes).concat(otherBidders);
 	return isPbTestOn()
 		? biddersBeingTested(allBidders)


### PR DESCRIPTION
## What does this change?

This is a very small change to refactor the way we assemble the array of Prebid bidders.

Previously we used the array spread syntax to conditionally include bidders in the array based on a predicate (e.g. only include `criteoBidder` if `shouldIncludeCriteo()` is true.

This changes the method to use `reduce`, conditionally including the bidder based on the predicate.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Reduces the verbosity of using lots of array spread syntax and also reduces the amount of duplication (for example we only have to write `inPbTestOr(...)` once.

### Tested

- [ ] Locally
- [ ] On CODE (optional)