### PR TITLE
Update `riff-raff` `publicReadAcl`

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -46,6 +46,7 @@ deployments:
       bucket: aws-frontend-static
       cacheControl: public, max-age=315360000
       prefixStack: false
+      publicReadAcl: true
   update-ami:
     type: ami-cloudformation-parameter
     parameters:


### PR DESCRIPTION
## What does this change?

Following this [riffraff PR](https://github.com/guardian/riff-raff/pull/665), explicitly set `publicReadAcl: true` in `riff-raff.yaml` for the `aws-s3` type.
