### PR TITLE
Extend `fetch-non-refreshable-line-items` participation to 50%

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -28,5 +28,5 @@ object FetchNonRefreshableLineItems
       description = "Fetch non-refreshable line items via a new endpoint",
       owners = Seq(Owner.withGithub("chrislomaxjones")),
       sellByDate = LocalDate.of(2022, 1, 24),
-      participationGroup = Perc20A,
+      participationGroup = Perc50,
     )


### PR DESCRIPTION
## What does this change?

Extend participation of the `fetch-non-refreshable-line-items` server side experiment to 50%.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

This is the next step in the incremental roll-out of lazily loading non-refreshable line items from an endpoint. See #24387 for the original implementation work.

### Tested

- [X] Locally
- [ ] On CODE (optional)