### PR TITLE
Bump @guardian/braze-components to 5.2.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@guardian/atom-renderer": "1.2.2",
     "@guardian/automat-contributions": "^0.4.2",
     "@guardian/automat-modules": "^0.3.8",
-    "@guardian/braze-components": "^5.0.0",
+    "@guardian/braze-components": "^5.2.0",
     "@guardian/commercial-core": "^0.39.0",
     "@guardian/consent-management-platform": "^10.1.0",
     "@guardian/libs": "^3.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1247,10 +1247,10 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
-"@guardian/braze-components@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/@guardian/braze-components/-/braze-components-5.0.0.tgz#e4f8656929ebbae705ae29c7a41b4b41342b1bb6"
-  integrity sha512-bBZdtQ1b54lWj+Z3fmgxETJKgVyCZ2sX2vUiAx1dMPjCF0ZHHnjKfDn+kts8xZRrm+B1nD1kE6MMn/eYEWQpjg==
+"@guardian/braze-components@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-5.2.0.tgz#2df527364471bdc8905824f34e67312214b7684e"
+  integrity sha512-8x5iyWIOIvlF/XMVbNxzBxaAlekbicc5XqqvPRJRPVOQBTnZalwOin2XzfaUuE73q/00cICQXCtgAnqr1clCKw==
 
 "@guardian/commercial-core@^0.39.0":
   version "0.39.0"


### PR DESCRIPTION
## What does this change?

Bump @guardian/braze-components to 5.2.0.

This release contains the new BannerWithLink component.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation) guardian/dotcom-rendering#3809

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [x] On CODE (optional)

Tested the new banner with a test canvas in CODE (copy and image aren't the real thing):

![Screenshot 2022-01-12 at 10 04 28](https://user-images.githubusercontent.com/379839/149120146-34bbc44b-ac1a-4f22-84e4-9bd89eae5b1a.png)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
