### PR TITLE
Improve error messages for email newsletter signups during the Identity downtime

### DIFF
--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -93,7 +93,7 @@
             @* This iframe is used for submitting the form without reloading the page *@
             <iframe class="u-h" width="0" height="0" border="0" name="newsletterSignup" id="newsletterSignup" tabindex="-1"></iframe>
             @if(IdentityDowntimeEmailSubscriptionError.isSwitchedOn) {
-                <div class="alert alert-info">
+                <div>
                     <p><strong>Please note:</strong> newsletter signups are currently unavailable due to scheduled maintenance. Please try again later.</p>
                 </div>
             }

--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -1,6 +1,7 @@
 @import services.newsletters.NewsletterResponse
 @import views.support.`package`.Seq2zipWithRowInfo
 @import staticpages.NewsletterRoundupPage
+@import conf.switches.Switches.IdentityDowntimeEmailSubscriptionError
 
 @import common.LinkTo
 
@@ -41,15 +42,17 @@
                     </div>
                 </div>
 
-                <form action="@LinkTo("/email")" method="post" target="newsletterSignup" class="newsletter-card__signup">
-                    @helper.CSRF.formField
-                    <input class="newsletter-card__text-input u-h" type="text" name="name" autocomplete="off"/>
-                    <input class="newsletter-card__text-input js-newsletter-card__text-input" type="email" name="email" placeholder="Email address" required/>
-                    <input class="js-email-sub__listname-input" type="hidden" name="listName" value="@emailListing.id" />
-                    <button class="newsletter-card__lozenge js-newsletter-signup-button newsletter-card__lozenge--submit" data-link-name="Subscribe to @emailListing.id" type="submit" value="@emailListing.listIdv1">
-                        <span>Sign up</span>
-                    </button>
-                </form>
+                @if(!IdentityDowntimeEmailSubscriptionError.isSwitchedOn) {
+                    <form action="@LinkTo("/email")" method="post" target="newsletterSignup" class="newsletter-card__signup">
+                        @helper.CSRF.formField
+                        <input class="newsletter-card__text-input u-h" type="text" name="name" autocomplete="off"/>
+                        <input class="newsletter-card__text-input js-newsletter-card__text-input" type="email" name="email" placeholder="Email address" required/>
+                        <input class="js-email-sub__listname-input" type="hidden" name="listName" value="@emailListing.id" />
+                        <button class="newsletter-card__lozenge js-newsletter-signup-button newsletter-card__lozenge--submit" data-link-name="Subscribe to @emailListing.id" type="submit" value="@emailListing.listIdv1">
+                            <span>Sign up</span>
+                        </button>
+                    </form>
+                }
 
                 <div class="newsletter-card__example js-newsletter-preview is-hidden">
                 @if(emailListing.exampleUrl.isDefined) {
@@ -89,6 +92,11 @@
             </div>
             @* This iframe is used for submitting the form without reloading the page *@
             <iframe class="u-h" width="0" height="0" border="0" name="newsletterSignup" id="newsletterSignup" tabindex="-1"></iframe>
+            @if(IdentityDowntimeEmailSubscriptionError.isSwitchedOn) {
+                <div class="alert alert-info">
+                    <p><strong>Please note:</strong> newsletter signups are currently unavailable due to scheduled maintenance. Please try again later.</p>
+                </div>
+            }
             @displayNewslettersByTheme
         </div>
     </div>

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -468,7 +468,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "identity-downtime-email-subscription-error",
     "Use a different error message when Identity is offline for Postgres upgrade",
-    owners = Seq(Owner.withGithub("georgeblahblah")),
+    owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
     safeState = Off,
     sellByDate = LocalDate.of(2022, 1, 14),
     exposeClientSide = false,

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -464,4 +464,14 @@ trait FeatureSwitches {
     exposeClientSide = false,
   )
 
+  val IdentityDowntimeEmailSubscriptionError = Switch(
+    SwitchGroup.Feature,
+    "identity-downtime-email-subscription-error",
+    "Use a different error message when Identity is offline for Postgres upgrade",
+    owners = Seq(Owner.withGithub("georgeblahblah")),
+    safeState = Off,
+    sellByDate = LocalDate.of(2022, 1, 30),
+    exposeClientSide = false
+  )
+
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -470,7 +470,7 @@ trait FeatureSwitches {
     "Use a different error message when Identity is offline for Postgres upgrade",
     owners = Seq(Owner.withGithub("georgeblahblah")),
     safeState = Off,
-    sellByDate = LocalDate.of(2022, 1, 30),
+    sellByDate = LocalDate.of(2022, 1, 14),
     exposeClientSide = false,
   )
 

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -471,7 +471,7 @@ trait FeatureSwitches {
     owners = Seq(Owner.withGithub("georgeblahblah")),
     safeState = Off,
     sellByDate = LocalDate.of(2022, 1, 30),
-    exposeClientSide = false
+    exposeClientSide = false,
   )
 
 }

--- a/common/app/views/fragments/email/signup/footer/subscriptionResultFooter.scala.html
+++ b/common/app/views/fragments/email/signup/footer/subscriptionResultFooter.scala.html
@@ -1,4 +1,5 @@
 @import model.{InvalidEmail, OtherError, Subscribed, SubscriptionResult}
+@import conf.switches.Switches.IdentityDowntimeEmailSubscriptionError
 
 @(result: SubscriptionResult)
 
@@ -25,7 +26,13 @@
             case OtherError => {
                 @fragments.inlineSvg("cross", "icon")
                 <h2 class="email-sub-footer__message__headline">Subscription error</h2>
-                <p class="email-sub-footer__message__description">Sorry, there was a problem with your subscription request. Please try again or contact userhelp@@theguardian.com.</p>
+                <p class="email-sub-footer__message__description">
+                    @if(IdentityDowntimeEmailSubscriptionError.isSwitchedOn) {
+                        Sorry, there was a problem with your subscription request due to scheduled maintenance. Please try again later.
+                    } else {
+                        Sorry, there was a problem with your subscription request. Please try again or contact userhelp@@theguardian.com.
+                    }
+                </p>
             }
         }
     </div>

--- a/common/app/views/fragments/email/signup/result/emailNonsuccess.scala.html
+++ b/common/app/views/fragments/email/signup/result/emailNonsuccess.scala.html
@@ -1,4 +1,5 @@
 @import model.{InvalidEmail, OtherError, NonsuccessResult}
+@import conf.switches.Switches.IdentityDowntimeEmailSubscriptionError
 
 @(result: NonsuccessResult)
 
@@ -14,7 +15,13 @@
         case OtherError => {
             @fragments.inlineSvg("cross", "icon")
             <h2 class="email-sub__message__headline">Subscription error</h2>
-            <p class="email-sub__message__description">Sorry, there was a problem with your subscription request. Please try again or <a target="_blank" href="https://manage.theguardian.com/help-centre/contact-us">contact user help</a>.</p>
+            <p class="email-sub__message__description">
+                @if(IdentityDowntimeEmailSubscriptionError.isSwitchedOn) {
+                    Sorry, there was a problem with your subscription request due to scheduled maintenance. Please try again later.
+                } else {
+                    Sorry, there was a problem with your subscription request. Please try again or <a target=\"_blank\" href=\"https://manage.theguardian.com/help-centre/contact-us\">contact user help</a>.
+                }
+            </p>
         }
     }
     </div>


### PR DESCRIPTION
## What does this change?

* adds a feature switch, to be turned on during the Identity downtime
* changes the error message when signing up to a newsletter fails during the downtime
* hides the signup forms on the all-newsletters signup page (`/email-newsletters`)

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

### Article
<img width="697" alt="Screenshot 2022-01-10 at 11 45 59" src="https://user-images.githubusercontent.com/705427/148764344-0e6dc008-dec8-4f37-9699-2baf91b5832d.png">

### Footer
<img width="465" alt="Screenshot 2022-01-10 at 11 47 43" src="https://user-images.githubusercontent.com/705427/148764349-9f0dfee3-5aca-4987-9422-756bd01e3a1a.png">

### All-newsletters signup page
<img width="759" alt="Screenshot 2022-01-10 at 12 14 56" src="https://user-images.githubusercontent.com/705427/148764538-4c14d6cc-86ff-4d80-a4dd-fc3313bcc7b3.png">

### Tested

- [x] Locally
- [x] On CODE (optional)
