### PR TITLE
Revert "Improve error messages for email newsletter signups during the Identity downtime"

### DIFF
--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -1,7 +1,6 @@
 @import services.newsletters.NewsletterResponse
 @import views.support.`package`.Seq2zipWithRowInfo
 @import staticpages.NewsletterRoundupPage
-@import conf.switches.Switches.IdentityDowntimeEmailSubscriptionError
 
 @import common.LinkTo
 
@@ -42,17 +41,15 @@
                     </div>
                 </div>
 
-                @if(!IdentityDowntimeEmailSubscriptionError.isSwitchedOn) {
-                    <form action="@LinkTo("/email")" method="post" target="newsletterSignup" class="newsletter-card__signup">
-                        @helper.CSRF.formField
-                        <input class="newsletter-card__text-input u-h" type="text" name="name" autocomplete="off"/>
-                        <input class="newsletter-card__text-input js-newsletter-card__text-input" type="email" name="email" placeholder="Email address" required/>
-                        <input class="js-email-sub__listname-input" type="hidden" name="listName" value="@emailListing.id" />
-                        <button class="newsletter-card__lozenge js-newsletter-signup-button newsletter-card__lozenge--submit" data-link-name="Subscribe to @emailListing.id" type="submit" value="@emailListing.listIdv1">
-                            <span>Sign up</span>
-                        </button>
-                    </form>
-                }
+                <form action="@LinkTo("/email")" method="post" target="newsletterSignup" class="newsletter-card__signup">
+                    @helper.CSRF.formField
+                    <input class="newsletter-card__text-input u-h" type="text" name="name" autocomplete="off"/>
+                    <input class="newsletter-card__text-input js-newsletter-card__text-input" type="email" name="email" placeholder="Email address" required/>
+                    <input class="js-email-sub__listname-input" type="hidden" name="listName" value="@emailListing.id" />
+                    <button class="newsletter-card__lozenge js-newsletter-signup-button newsletter-card__lozenge--submit" data-link-name="Subscribe to @emailListing.id" type="submit" value="@emailListing.listIdv1">
+                        <span>Sign up</span>
+                    </button>
+                </form>
 
                 <div class="newsletter-card__example js-newsletter-preview is-hidden">
                 @if(emailListing.exampleUrl.isDefined) {
@@ -92,11 +89,6 @@
             </div>
             @* This iframe is used for submitting the form without reloading the page *@
             <iframe class="u-h" width="0" height="0" border="0" name="newsletterSignup" id="newsletterSignup" tabindex="-1"></iframe>
-            @if(IdentityDowntimeEmailSubscriptionError.isSwitchedOn) {
-                <div>
-                    <p><strong>Please note:</strong> newsletter signups are currently unavailable due to scheduled maintenance. Please try again later.</p>
-                </div>
-            }
             @displayNewslettersByTheme
         </div>
     </div>

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -464,14 +464,4 @@ trait FeatureSwitches {
     exposeClientSide = false,
   )
 
-  val IdentityDowntimeEmailSubscriptionError = Switch(
-    SwitchGroup.Feature,
-    "identity-downtime-email-subscription-error",
-    "Use a different error message when Identity is offline for Postgres upgrade",
-    owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
-    safeState = Off,
-    sellByDate = LocalDate.of(2022, 1, 14),
-    exposeClientSide = false,
-  )
-
 }

--- a/common/app/views/fragments/email/signup/footer/subscriptionResultFooter.scala.html
+++ b/common/app/views/fragments/email/signup/footer/subscriptionResultFooter.scala.html
@@ -1,5 +1,4 @@
 @import model.{InvalidEmail, OtherError, Subscribed, SubscriptionResult}
-@import conf.switches.Switches.IdentityDowntimeEmailSubscriptionError
 
 @(result: SubscriptionResult)
 
@@ -26,13 +25,7 @@
             case OtherError => {
                 @fragments.inlineSvg("cross", "icon")
                 <h2 class="email-sub-footer__message__headline">Subscription error</h2>
-                <p class="email-sub-footer__message__description">
-                    @if(IdentityDowntimeEmailSubscriptionError.isSwitchedOn) {
-                        Sorry, there was a problem with your subscription request due to scheduled maintenance. Please try again later.
-                    } else {
-                        Sorry, there was a problem with your subscription request. Please try again or contact userhelp@@theguardian.com.
-                    }
-                </p>
+                <p class="email-sub-footer__message__description">Sorry, there was a problem with your subscription request. Please try again or contact userhelp@@theguardian.com.</p>
             }
         }
     </div>

--- a/common/app/views/fragments/email/signup/result/emailNonsuccess.scala.html
+++ b/common/app/views/fragments/email/signup/result/emailNonsuccess.scala.html
@@ -1,5 +1,4 @@
 @import model.{InvalidEmail, OtherError, NonsuccessResult}
-@import conf.switches.Switches.IdentityDowntimeEmailSubscriptionError
 
 @(result: NonsuccessResult)
 
@@ -15,13 +14,7 @@
         case OtherError => {
             @fragments.inlineSvg("cross", "icon")
             <h2 class="email-sub__message__headline">Subscription error</h2>
-            <p class="email-sub__message__description">
-                @if(IdentityDowntimeEmailSubscriptionError.isSwitchedOn) {
-                    Sorry, there was a problem with your subscription request due to scheduled maintenance. Please try again later.
-                } else {
-                    Sorry, there was a problem with your subscription request. Please try again or <a target=\"_blank\" href=\"https://manage.theguardian.com/help-centre/contact-us\">contact user help</a>.
-                }
-            </p>
+            <p class="email-sub__message__description">Sorry, there was a problem with your subscription request. Please try again or <a target="_blank" href="https://manage.theguardian.com/help-centre/contact-us">contact user help</a>.</p>
         }
     }
     </div>


### PR DESCRIPTION
Reverts guardian/frontend#24535 - the Identity downtime is now complete and these changes are no longer required