### PR TITLE
Remove check for liveblogs when resizing adverts

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/messenger/resize.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger/resize.js
@@ -10,9 +10,6 @@ const normalise = (length) => {
 	return matches[1] + (matches[2] === undefined ? defaultUnit : matches[2]);
 };
 
-const isLiveBlogInlineAdSlot = (adSlot) =>
-	!!adSlot && adSlot.classList.contains('ad-slot--liveblog-inline');
-
 const resize = (specs, iframe, iframeContainer, adSlot) => {
 	if (
 		!specs ||
@@ -25,7 +22,7 @@ const resize = (specs, iframe, iframeContainer, adSlot) => {
 
 	const styles = {};
 
-	if (specs.width && !isLiveBlogInlineAdSlot(adSlot)) {
+	if (specs.width) {
 		styles.width = normalise(specs.width);
 	}
 


### PR DESCRIPTION
## What does this change?

This PR removes a condition where a liveblog advert that wishes to resize has the requested width ignored.

For context, we currently listen for messages of type `resize` posted from advert iframes, instructing the page to resize the advert's iframe and its parent element. These messages are used when an advert that employs _passback_ (inline1 on desktop liveblogs, inline2 on mobile liveblogs), and the creative that is displayed during passback is a different size to the slot we've setup.

There is an additional check that ignores the resized width on liveblog adverts that call for a resize. This check was introduced in #21776 to fix an alignment issue caused by this resize. However, this check no longer seems to be required, as it causes an issue at mobile breakpoints where the resize ignores the width. This causes too much space to be reserved for smaller creatives when we pass back (see the before images below).

Removing the check fixes the issue, causing the iframe to resize to the correct dimensions posted by the creative.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No 
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

**On Frontend rendered pages:** 

| Before      | After      |
|-------------|------------|
| ![Screenshot 2022-01-11 at 15 45 18](https://user-images.githubusercontent.com/8000415/148975225-87f766e9-c71e-4e0c-843f-150b4aa7d1c7.png) | <img width="642" alt="Screenshot 2022-01-11 at 15 39 21" src="https://user-images.githubusercontent.com/8000415/148975334-4d67585a-1766-41fa-b048-d065127bb406.png">  |

**On DCR rendered pages:** 
(with Spacefinder introduced via [this PR](https://github.com/guardian/dotcom-rendering/pull/3773)).

| Before      | After      |
|-------------|------------|
| ![Screenshot 2022-01-11 at 15 15 56](https://user-images.githubusercontent.com/8000415/148969497-17b82ac5-9722-4e15-b099-7cc488fb72d5.png)  | ![Screenshot 2022-01-11 at 15 16 06](https://user-images.githubusercontent.com/8000415/148969511-3d82aeb7-79c3-4fda-a83d-ee900f144ebb.png) |

## What is the value of this and can you measure success?

This fixes a layout issue when passback creatives are rendered on liveblogs.

### Tested

- [X] Locally
- [ ] On CODE (optional)