### PR TITLE
Add Africa Cup of Nations to football league table

### DIFF
--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -28,6 +28,7 @@ class LeagueTableController(
   // Competitions must be added to this list to show up at /football/tables
   val tableOrder: Seq[String] = Seq(
     "Premier League",
+    "Africa Cup of Nations",
     "Bundesliga",
     "Serie A",
     "La Liga",


### PR DESCRIPTION
## What does this change?

This adds the definition for Africa Cup of Nations to the football league tables. CP requested this league be placed after the Premier League for now.

Note that some of the crests are missing, this will be rectified under https://github.com/guardian/football-assets/pull/61

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/45561419/148958764-f0ed643f-8e51-484d-990f-722290fe4dd7.png
[after]: https://user-images.githubusercontent.com/45561419/148958821-8a390b4a-58ef-4c5c-8aee-d508ef84a83b.png

Note that, after selecting Africa Cup of Nations from the 'Choose league' dropdown, you can see the full league table:
<img width="1307" alt="Screenshot 2022-01-11 at 14 15 37" src="https://user-images.githubusercontent.com/45561419/148959033-3ac316fc-2d1f-488b-8140-53d77d2c7e8e.png">


## What is the value of this and can you measure success?

Supports the request made by CP/Editorial to surface the results from this league.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
