### PR TITLE
Replace 50% non-refreshable experiment with a switch

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -561,4 +561,14 @@ trait PrebidSwitches {
     exposeClientSide = true,
   )
 
+  val fetchNonRefreshableLineItems: Switch = Switch(
+    group = Commercial,
+    name = "fetch-non-refreshable-line-items",
+    description = "Lazily fetch non-refreshable line item ids from an endpoint",
+    owners = group(Commercial),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
+
 }

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -7,7 +7,6 @@ import java.time.LocalDate
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
     LiveblogRendering,
-    FetchNonRefreshableLineItems,
   )
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -20,13 +19,4 @@ object LiveblogRendering
       owners = Seq(Owner.withGithub("shtukas")),
       sellByDate = LocalDate.of(2022, 6, 2),
       participationGroup = Perc10A,
-    )
-
-object FetchNonRefreshableLineItems
-    extends Experiment(
-      name = "fetch-non-refreshable-line-items",
-      description = "Fetch non-refreshable line items via a new endpoint",
-      owners = Seq(Owner.withGithub("chrislomaxjones")),
-      sellByDate = LocalDate.of(2022, 1, 24),
-      participationGroup = Perc50,
     )

--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -5,13 +5,13 @@ import common.Edition
 import common.Maps.RichMap
 import common.commercial.EditionAdTargeting._
 import conf.Configuration.environment
+import conf.switches.Switches.fetchNonRefreshableLineItems
 import conf.{Configuration, DiscussionAsset}
 import model._
 import play.api.libs.json._
 import model.IpsosTags.getScriptTag
 import model.dotcomrendering.DotcomRenderingUtils.assetURL
 import play.api.mvc.RequestHeader
-import experiments.{ActiveExperiments, FetchNonRefreshableLineItems}
 
 object JavaScriptPage {
 
@@ -43,8 +43,8 @@ object JavaScriptPage {
     }
 
     // Only attach the non-refreshable line items to the commercial config
-    // if not participating in the `FetchNonRefreshableLineItems` experiment
-    val nonRefreshableConfig = if (!ActiveExperiments.isParticipating(FetchNonRefreshableLineItems)(request)) {
+    // if the `fetchNonRefreshableLineItems` switch is off
+    val nonRefreshableConfig = if (fetchNonRefreshableLineItems.isSwitchedOff) {
       Map("nonRefreshableLineItemIds" -> nonRefreshableLineItemIds)
     } else {
       Map()

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.ts
@@ -74,10 +74,13 @@ export const onSlotRender = (
 			dfpEnv.creativeIDs.push(String(event.creativeId));
 		}
 
-		// Check if the non-refreshable line items are attached to the page config
+		// Check if the non-refreshable line items are attached to the page config and fetching is switched off
 		// If they are then use these values to determine slot refresh at this point
 		// Otherwise wait until slot is viewable to fetch line item ids from endpoint
-		if (window.guardian.config.page.nonRefreshableLineItemIds) {
+		if (
+			!window.guardian.config.switches.fetchNonRefreshableLineItems &&
+			window.guardian.config.page.nonRefreshableLineItemIds
+		) {
 			// Set refresh field based on the outcome of the slot render.
 			advert.shouldRefresh = shouldRefresh(
 				advert,

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.ts
@@ -17,9 +17,9 @@ const setSlotAdRefresh = (
 
 	// Asynchronously retrieve the non-refreshable line item ids
 	// Only do this if they haven't been attached to the page config
-	const { tests, page } = window.guardian.config;
+	const { switches, page } = window.guardian.config;
 	if (
-		tests?.fetchNonRefreshableLineItemsVariant === 'variant' &&
+		switches.fetchNonRefreshableLineItems &&
 		!page.nonRefreshableLineItemIds
 	) {
 		// Call the memoized function so we only retrieve the value from the API once


### PR DESCRIPTION
## What does this change?

Remove the `fetch-non-refreshable-line items` server-side experiment and replace with a switch. The experiment was previously at 50% participation and this change will in effect increase participation to 100%.

The original work to introduce the feature and experiment can be found in #24387.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

As we have rolled this change out to 50% (see #24533) of the audience and recorded few actionable errors in Sentry, the next step is to roll out to 100% participation. Rather than remove the experiment entirely it has been replaced with a switch so we can turn the feature off if necessary.

### Tested

- [X] Locally
- [ ] On CODE (optional)