### PR TITLE
Remove Adomik

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -106,16 +106,6 @@ trait CommercialSwitches {
     exposeClientSide = true,
   )
 
-  val AdomikSwitch = Switch(
-    Commercial,
-    "adomik",
-    "Enable Adomik traffic splitting.",
-    owners = group(Commercial),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true,
-  )
-
   val PermutiveSwitch = Switch(
     Commercial,
     "permutive",

--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
@@ -61,19 +61,6 @@ const getSizeOpts = (sizesByBreakpoint) => {
 	};
 };
 
-const adomikClassify = () => {
-	const rand = Math.random();
-
-	switch (true) {
-		case rand < 0.09:
-			return `ad_ex${Math.floor(100 * rand)}`;
-		case rand < 0.1:
-			return 'ad_bc';
-		default:
-			return 'ad_opt';
-	}
-};
-
 const isEligibleForOutstream = (slotTarget) =>
 	typeof slotTarget === 'string' &&
 	(slotTarget === 'inline1' || slotTarget === 'top-above-nav');
@@ -211,11 +198,6 @@ const defineSlot = (adSlotNode, sizes) => {
 
 	if (fabricKeyValues.has(slotTarget)) {
 		slot.setTargeting('slot-fabric', fabricKeyValues.get(slotTarget));
-	}
-
-	if (config.get('switches.adomik')) {
-		slot.setTargeting('ad_group', adomikClassify());
-		slot.setTargeting('ad_h', new Date().getUTCHours().toString());
 	}
 
 	slot.addService(window.googletag.pubads()).setTargeting('slot', slotTarget);


### PR DESCRIPTION
## What does this change?

Removes Adomik, which is no longer used

Reverts: https://github.com/guardian/frontend/pull/17653

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)
