### PR TITLE
Update link text and destinations for single front door test

### DIFF
--- a/common/app/navigation/ReaderRevenueSite.scala
+++ b/common/app/navigation/ReaderRevenueSite.scala
@@ -29,6 +29,10 @@ object ReaderRevenueSite extends enumeratum.Enum[ReaderRevenueSite] {
     val url: String = s"${Configuration.id.supportUrl}/subscribe"
   }
 
+  case object SupportGuardianWeekly extends ReaderRevenueSite {
+    val url: String = s"${Configuration.id.supportUrl}/subscribe/weekly"
+  }
+
   case object SupportContribute extends ReaderRevenueSite {
     val url: String = s"${Configuration.id.supportUrl}/contribute"
   }

--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -64,7 +64,7 @@ object UrlHelpers {
   def readerRevenueLinks(implicit request: RequestHeader): List[NavLink] =
     List(
       NavLink("Make a contribution", getReaderRevenueUrl(SupportContribute, SideMenu)),
-      NavLink("Subscribe", getReaderRevenueUrl(SupportSubscribe, SideMenu), classList = Seq("js-subscribe")),
+      NavLink("Print subscriptions", getReaderRevenueUrl(SupportGuardianWeekly, SideMenu), classList = Seq("js-subscribe")),
     )
 
   private val uriEncoder = UriConfig.default.copy(

--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -10,45 +10,18 @@ import scala.PartialFunction.condOpt
 
 object UrlHelpers {
 
-  private val uriEncoder = UriConfig.default.copy(
-    // The default encoder does not encode double quotes in the querystring
-    queryEncoder = PercentEncoder(PercentEncoder.QUERY_CHARS_TO_ENCODE + '"'),
-  )
-
-  def readerRevenueLinks(implicit request: RequestHeader): List[NavLink] =
-    List(
-      NavLink("Make a contribution", getReaderRevenueUrl(SupportContribute, SideMenu)),
-      NavLink(
-        "Print subscriptions",
-        getReaderRevenueUrl(SupportGuardianWeekly, SideMenu),
-        classList = Seq("js-subscribe"),
-      ),
-    )
-
-  def getReaderRevenueUrl(destination: ReaderRevenueSite, position: Position): String = {
-    val componentId = getComponentId(destination, position)
-    val componentType = getComponentType(position)
-
-    val acquisitionData = Json.obj(
-      // GUARDIAN_WEB corresponds to a value in the Thrift enum
-      // https://dashboard.ophan.co.uk/docs/thrift/acquisition.html#Enum_AcquisitionSource
-      // ACQUISITIONS_HEADER and ACQUISITIONS_FOOTER correspond to values in the Thrift enum
-      // https://dashboard.ophan.co.uk/docs/thrift/componentevent.html#Enum_ComponentType
-      "source" -> "GUARDIAN_WEB",
-      "componentType" -> componentType,
-    ) ++ componentId.fold(Json.obj())(c =>
-      Json.obj(
-        "componentId" -> c,
-      ),
-    )
-
-    import com.netaporter.uri.dsl._
-
-    // INTCMP is passed as a separate param because people look at it in Google Analytics
-    // It's set to the most specific thing (componentId) to maximise its usefulness
-    val url = destination.url ? ("INTCMP" -> componentId) & ("acquisitionData" -> acquisitionData.toString)
-    url.toString(uriEncoder)
-  }
+  sealed trait Position
+  case object Header extends Position
+  // SlimHeaderDropdown can only be seen on slim header content, e.g. interactives
+  // It's the icon with the three dots in the top left
+  case object SlimHeaderDropdown extends Position
+  // SideMenu is the full menu you get from clicking the hamburger icon on mobile
+  case object SideMenu extends Position
+  case object AmpHeader extends Position
+  case object Footer extends Position
+  case object AmpFooter extends Position
+  case object ManageMyAccountUpsell extends Position
+  case object ManageMyAccountCancel extends Position
 
   def getComponentId(destination: ReaderRevenueSite, position: Position): Option[String] = {
     condOpt((destination, position)) {
@@ -88,31 +61,50 @@ object UrlHelpers {
       case Footer | AmpFooter                                 => "ACQUISITIONS_FOOTER"
     }
 
+  def readerRevenueLinks(implicit request: RequestHeader): List[NavLink] =
+    List(
+      NavLink("Make a contribution", getReaderRevenueUrl(SupportContribute, SideMenu)),
+      NavLink(
+        "Print subscriptions",
+        getReaderRevenueUrl(SupportGuardianWeekly, SideMenu),
+        classList = Seq("js-subscribe"),
+      ),
+    )
+
+  private val uriEncoder = UriConfig.default.copy(
+    // The default encoder does not encode double quotes in the querystring
+    queryEncoder = PercentEncoder(PercentEncoder.QUERY_CHARS_TO_ENCODE + '"'),
+  )
+
+  def getReaderRevenueUrl(destination: ReaderRevenueSite, position: Position): String = {
+    val componentId = getComponentId(destination, position)
+    val componentType = getComponentType(position)
+
+    val acquisitionData = Json.obj(
+      // GUARDIAN_WEB corresponds to a value in the Thrift enum
+      // https://dashboard.ophan.co.uk/docs/thrift/acquisition.html#Enum_AcquisitionSource
+      // ACQUISITIONS_HEADER and ACQUISITIONS_FOOTER correspond to values in the Thrift enum
+      // https://dashboard.ophan.co.uk/docs/thrift/componentevent.html#Enum_ComponentType
+      "source" -> "GUARDIAN_WEB",
+      "componentType" -> componentType,
+    ) ++ componentId.fold(Json.obj())(c =>
+      Json.obj(
+        "componentId" -> c,
+      ),
+    )
+
+    import com.netaporter.uri.dsl._
+
+    // INTCMP is passed as a separate param because people look at it in Google Analytics
+    // It's set to the most specific thing (componentId) to maximise its usefulness
+    val url = destination.url ? ("INTCMP" -> componentId) & ("acquisitionData" -> acquisitionData.toString)
+    url.toString(uriEncoder)
+  }
+
   def getJobUrl(editionId: String): String =
     if (editionId == "au") {
       "https://jobs.theguardian.com/landingpage/2868291/jobs-australia-html/?INTCMP=jobs_au_web_newheader"
     } else {
       s"https://jobs.theguardian.com/?INTCMP=jobs_${editionId}_web_newheader"
     }
-
-  sealed trait Position
-
-  case object Header extends Position
-
-  // SlimHeaderDropdown can only be seen on slim header content, e.g. interactives
-  // It's the icon with the three dots in the top left
-  case object SlimHeaderDropdown extends Position
-
-  // SideMenu is the full menu you get from clicking the hamburger icon on mobile
-  case object SideMenu extends Position
-
-  case object AmpHeader extends Position
-
-  case object Footer extends Position
-
-  case object AmpFooter extends Position
-
-  case object ManageMyAccountUpsell extends Position
-
-  case object ManageMyAccountCancel extends Position
 }

--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -10,18 +10,45 @@ import scala.PartialFunction.condOpt
 
 object UrlHelpers {
 
-  sealed trait Position
-  case object Header extends Position
-  // SlimHeaderDropdown can only be seen on slim header content, e.g. interactives
-  // It's the icon with the three dots in the top left
-  case object SlimHeaderDropdown extends Position
-  // SideMenu is the full menu you get from clicking the hamburger icon on mobile
-  case object SideMenu extends Position
-  case object AmpHeader extends Position
-  case object Footer extends Position
-  case object AmpFooter extends Position
-  case object ManageMyAccountUpsell extends Position
-  case object ManageMyAccountCancel extends Position
+  private val uriEncoder = UriConfig.default.copy(
+    // The default encoder does not encode double quotes in the querystring
+    queryEncoder = PercentEncoder(PercentEncoder.QUERY_CHARS_TO_ENCODE + '"'),
+  )
+
+  def readerRevenueLinks(implicit request: RequestHeader): List[NavLink] =
+    List(
+      NavLink("Make a contribution", getReaderRevenueUrl(SupportContribute, SideMenu)),
+      NavLink(
+        "Print subscriptions",
+        getReaderRevenueUrl(SupportGuardianWeekly, SideMenu),
+        classList = Seq("js-subscribe"),
+      ),
+    )
+
+  def getReaderRevenueUrl(destination: ReaderRevenueSite, position: Position): String = {
+    val componentId = getComponentId(destination, position)
+    val componentType = getComponentType(position)
+
+    val acquisitionData = Json.obj(
+      // GUARDIAN_WEB corresponds to a value in the Thrift enum
+      // https://dashboard.ophan.co.uk/docs/thrift/acquisition.html#Enum_AcquisitionSource
+      // ACQUISITIONS_HEADER and ACQUISITIONS_FOOTER correspond to values in the Thrift enum
+      // https://dashboard.ophan.co.uk/docs/thrift/componentevent.html#Enum_ComponentType
+      "source" -> "GUARDIAN_WEB",
+      "componentType" -> componentType,
+    ) ++ componentId.fold(Json.obj())(c =>
+      Json.obj(
+        "componentId" -> c,
+      ),
+    )
+
+    import com.netaporter.uri.dsl._
+
+    // INTCMP is passed as a separate param because people look at it in Google Analytics
+    // It's set to the most specific thing (componentId) to maximise its usefulness
+    val url = destination.url ? ("INTCMP" -> componentId) & ("acquisitionData" -> acquisitionData.toString)
+    url.toString(uriEncoder)
+  }
 
   def getComponentId(destination: ReaderRevenueSite, position: Position): Option[String] = {
     condOpt((destination, position)) {
@@ -61,46 +88,31 @@ object UrlHelpers {
       case Footer | AmpFooter                                 => "ACQUISITIONS_FOOTER"
     }
 
-  def readerRevenueLinks(implicit request: RequestHeader): List[NavLink] =
-    List(
-      NavLink("Make a contribution", getReaderRevenueUrl(SupportContribute, SideMenu)),
-      NavLink("Print subscriptions", getReaderRevenueUrl(SupportGuardianWeekly, SideMenu), classList = Seq("js-subscribe")),
-    )
-
-  private val uriEncoder = UriConfig.default.copy(
-    // The default encoder does not encode double quotes in the querystring
-    queryEncoder = PercentEncoder(PercentEncoder.QUERY_CHARS_TO_ENCODE + '"'),
-  )
-
-  def getReaderRevenueUrl(destination: ReaderRevenueSite, position: Position): String = {
-    val componentId = getComponentId(destination, position)
-    val componentType = getComponentType(position)
-
-    val acquisitionData = Json.obj(
-      // GUARDIAN_WEB corresponds to a value in the Thrift enum
-      // https://dashboard.ophan.co.uk/docs/thrift/acquisition.html#Enum_AcquisitionSource
-      // ACQUISITIONS_HEADER and ACQUISITIONS_FOOTER correspond to values in the Thrift enum
-      // https://dashboard.ophan.co.uk/docs/thrift/componentevent.html#Enum_ComponentType
-      "source" -> "GUARDIAN_WEB",
-      "componentType" -> componentType,
-    ) ++ componentId.fold(Json.obj())(c =>
-      Json.obj(
-        "componentId" -> c,
-      ),
-    )
-
-    import com.netaporter.uri.dsl._
-
-    // INTCMP is passed as a separate param because people look at it in Google Analytics
-    // It's set to the most specific thing (componentId) to maximise its usefulness
-    val url = destination.url ? ("INTCMP" -> componentId) & ("acquisitionData" -> acquisitionData.toString)
-    url.toString(uriEncoder)
-  }
-
   def getJobUrl(editionId: String): String =
     if (editionId == "au") {
       "https://jobs.theguardian.com/landingpage/2868291/jobs-australia-html/?INTCMP=jobs_au_web_newheader"
     } else {
       s"https://jobs.theguardian.com/?INTCMP=jobs_${editionId}_web_newheader"
     }
+
+  sealed trait Position
+
+  case object Header extends Position
+
+  // SlimHeaderDropdown can only be seen on slim header content, e.g. interactives
+  // It's the icon with the three dots in the top left
+  case object SlimHeaderDropdown extends Position
+
+  // SideMenu is the full menu you get from clicking the hamburger icon on mobile
+  case object SideMenu extends Position
+
+  case object AmpHeader extends Position
+
+  case object Footer extends Position
+
+  case object AmpFooter extends Position
+
+  case object ManageMyAccountUpsell extends Position
+
+  case object ManageMyAccountCancel extends Position
 }

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -87,7 +87,6 @@
                             </ul>
                         }
 
-                        @readerRevenueLinks(Edition(request).id.toLowerCase())
 
                     } else {
                         <div class="colophon__list">

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -1,3 +1,4 @@
+@import navigation.ReaderRevenueSite.SupportGuardianWeekly
 @()(implicit page: model.Page, request: RequestHeader)
 
 @import common.{LinkTo, Edition}
@@ -48,15 +49,12 @@
             <div class="new-header__top-bar hide-until-mobile">
                 @defining(Edition(request).id.toLowerCase()) { editionId =>
                 @if(!page.metadata.hasSlimHeader) {
-                <div class="top-bar__commercial-items js-supporter-cta is-hidden">
-                    <span class="top-bar__item__seperator hide-until-desktop"></span>
-                    <a class="top-bar__item hide-until-desktop"
-                       data-link-name="nav2 : supporter-cta"
-                       data-edition="@{editionId}"
-                       href="@getReaderRevenueUrl(SupporterCTA, Header)">
-                        Subscriptions
-                    </a>
-                </div>
+                    <div class="top-bar__commercial-items">
+                        <span class="top-bar__item__seperator hide-until-desktop"></span>
+                        <a class="top-bar__item hide-until-desktop" data-link-name="nav2 : supporter-cta" data-edition="@{editionId}" href="@getReaderRevenueUrl(SupportGuardianWeekly, Header)">
+                            Print subscriptions
+                        </a>
+                    </div>
 
                 @if(editionId != "au" || editionId == "uk") {
                 <div class="top-bar__commercial-items">


### PR DESCRIPTION
## What does this change?
To support the new product proposition work we are going to run an AB test to measure the effect of replacing the current contribute/subscribe split messaging with a single 'support the guardian' call to action.

This PR facilitates that by 
-  Hide Supporter Revenue links in the footer
- Update "Subscriptions" link in desktop navigation
- Update "Subscriptions" link in mobile navigation

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)
PR here: https://github.com/guardian/dotcom-rendering/pull/3832

## Screenshots
| Before      | After      |
|-------------|------------|
| ![before](https://user-images.githubusercontent.com/181371/149518422-8701f408-5742-4dfc-83d8-ff6493079107.png) | ![after](https://user-images.githubusercontent.com/181371/149518417-a3e61dff-022a-434e-b1f7-524549214335.png)|

## What is the value of this and can you measure success?
The value will be that we will gain insight into whether a single consistent support ask is better than two different asks.

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
