### PR TITLE
Update discussion frontend to version 1.6.0

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -442,7 +442,7 @@ class GuardianConfiguration extends GuLogging {
     lazy val d2Uid = configuration.getMandatoryStringProperty("discussion.d2Uid")
     lazy val frontendAssetsMap = configuration.getStringProperty("discussion.frontend.assetsMap")
     lazy val frontendAssetsMapRefreshInterval = 5.seconds
-    lazy val frontendAssetsVersion = "v1.5.0"
+    lazy val frontendAssetsVersion = "v1.6.0"
   }
 
   object readerRevenue {

--- a/static/src/javascripts/projects/common/modules/discussion/api.ts
+++ b/static/src/javascripts/projects/common/modules/discussion/api.ts
@@ -117,4 +117,4 @@ export const reportComment = (
 	send(`/comment/${id}/reportAbuse`, 'POST', report);
 
 export const getUser = (id: Id = 'me'): Promise<CommentResponse> =>
-	send(`/profile/${id}`, 'GET');
+	send(`/profile/${id}?strict_sanctions_check=false`, 'GET');


### PR DESCRIPTION
## What does this change?

This removes the check when looking up a users profile which would query all accounts with the same email address to see if they are banned from commenting. 

If the user was registered with the same email as another account banned from commenting, they would be shown the 'commenting is disabled for this account' dialogue, and would not get the comment box.

After this change, these checks will be performed when the comment is submitted instead, saving resource usage which is required as part of the Identity migration.

1. Add `?strict_sanctions_check=false` to query in discussion for profile
2. Update discussion frontend to version 1.6.0 (which adds the sanction check param to the build, see https://github.com/guardian/discussion-frontend/pull/34)

> Note: Outside of this PR, the dotcom team should consider looking at the functionality when a non-200 (e.g 4xx, which don't throw errors in the fetch API like you'd expect from a 5xx) response code is given when submitting a comment, as right now it is not handled correctly, however since this PR only addresses edge-case functionality, we've decided to leave it for now.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes - This change has already been implemented in dcr: https://github.com/guardian/dotcom-rendering/pull/3684

### Tested

- [ ] Locally
- [x] On CODE (optional) We've tested all edge cases for this in CODE

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
