### PR TITLE
removed fixed border width so value defaults

### DIFF
--- a/static/src/stylesheets/module/content-garnett/_pillars.scss
+++ b/static/src/stylesheets/module/content-garnett/_pillars.scss
@@ -26,7 +26,7 @@
         background: $pillarColor;
     }
     .pinned-block__collapsible-content {
-        border: 2px solid $pillarColor;
+        border: solid $pillarColor;
     }
 
     .pinned-block__label {


### PR DESCRIPTION
## What does this change?

This PR removes the `2px` `border-width` CSS property from the Pinned Post border. 

In Frontend the `px` values our SCSS files compile to `rem` values. These then scale with the zoom, often resulting in a bug [where fractional pixel values don't render correctly in Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=727669). This bug leaves a gap between the border and the content it is surrounding.

By removing the `px` value, the `border-width` [value defaults to `medium`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width) - a dynamic value of `~3px` which does not result in the whitespace bug. 

Oddly specifying `border-width: medium` also results in the bug, it is only when the `border-width` value is left blank that the bug is resolved. 

This fix has been tested in Chrome, Safari and Firefox and across all realistic zoom levels. The fix was discussed with @alinaboghiu and @benwuersching and considered the most appropriate course of action.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

## Screenshots


| Before      | After      |
|-------------|------------|
| <img width="300" alt="Screenshot 2022-01-18 at 11 03 28" src="https://user-images.githubusercontent.com/77005274/149928162-a826aa39-6c2f-45c3-a55b-c33285e68e3c.png">| <img width="300" alt="Screenshot 2022-01-18 at 11 02 54" src="https://user-images.githubusercontent.com/77005274/149928105-3c6e83b4-3f10-4c5e-a431-41b0671f7d5b.png"> |






## What is the value of this and can you measure success?

The white space so no longer show at any level.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
