### PR TITLE
Verify reCAPTCHA tokens

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -270,7 +270,7 @@ class GuardianConfiguration extends GuLogging {
     lazy val subscribeWithGoogleApiUrl =
       configuration.getStringProperty("google.subscribeWithGoogleApiUrl").getOrElse("https://swg.theguardian.com")
     lazy val googleRecaptchaSiteKey = configuration.getMandatoryStringProperty("guardian.page.googleRecaptchaSiteKey")
-    lazy val googleRecaptchaSecret = configuration.getMandatoryStringProperty("google.googlRecaptchaSecret")
+    lazy val googleRecaptchaSecret = configuration.getMandatoryStringProperty("google.googleRecaptchaSecret")
   }
 
   object affiliateLinks {

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -270,6 +270,7 @@ class GuardianConfiguration extends GuLogging {
     lazy val subscribeWithGoogleApiUrl =
       configuration.getStringProperty("google.subscribeWithGoogleApiUrl").getOrElse("https://swg.theguardian.com")
     lazy val googleRecaptchaSiteKey = configuration.getMandatoryStringProperty("guardian.page.googleRecaptchaSiteKey")
+    lazy val googleRecaptchaSecret = configuration.getMandatoryStringProperty("google.googlRecaptchaSecret")
   }
 
   object affiliateLinks {

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -162,6 +162,8 @@ object EmailSubsciptionMetrics {
   val APIHTTPError = CountMetric("email-api-http-error", "Non-200/201 response from email subscription API")
   val APINetworkError = CountMetric("email-api-network-error", "Email subscription API network failure")
   val ListIDError = CountMetric("email-list-id-error", "Invalid list ID in email subscription")
+  val RecaptchaValidationError = CountMetric("email-captcha-validation-failure", "Recaptcha validation error")
+  val RecaptchaValidationSuccess = CountMetric("email-captcha-validation-success", "Recaptcha validation success")
 }
 
 case class ApplicationMetrics(metrics: List[FrontendMetric])

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -164,7 +164,8 @@ object EmailSubsciptionMetrics {
   val ListIDError = CountMetric("email-list-id-error", "Invalid list ID in email subscription")
   val RecaptchaMissingTokenError = CountMetric("email-recaptcha-missing-token-failure", "Recaptcha missing token error")
   val RecaptchaValidationError = CountMetric("email-recaptcha-validation-failure", "Recaptcha validation error")
-  val RecaptchaAPIUnavailableError = CountMetric("email-recaptcha-api-unavailable-failure", "Recaptcha API unavailable error")
+  val RecaptchaAPIUnavailableError =
+    CountMetric("email-recaptcha-api-unavailable-failure", "Recaptcha API unavailable error")
   val RecaptchaValidationSuccess = CountMetric("email-recaptcha-validation-success", "Recaptcha validation success")
 }
 

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -162,8 +162,10 @@ object EmailSubsciptionMetrics {
   val APIHTTPError = CountMetric("email-api-http-error", "Non-200/201 response from email subscription API")
   val APINetworkError = CountMetric("email-api-network-error", "Email subscription API network failure")
   val ListIDError = CountMetric("email-list-id-error", "Invalid list ID in email subscription")
-  val RecaptchaValidationError = CountMetric("email-captcha-validation-failure", "Recaptcha validation error")
-  val RecaptchaValidationSuccess = CountMetric("email-captcha-validation-success", "Recaptcha validation success")
+  val RecaptchaMissingTokenError = CountMetric("email-recaptcha-missing-token-failure", "Recaptcha missing token error")
+  val RecaptchaValidationError = CountMetric("email-recaptcha-validation-failure", "Recaptcha validation error")
+  val RecaptchaAPIUnavailableError = CountMetric("email-recaptcha-api-unavailable-failure", "Recaptcha API unavailable error")
+  val RecaptchaValidationSuccess = CountMetric("email-recaptcha-validation-success", "Recaptcha validation success")
 }
 
 case class ApplicationMetrics(metrics: List[FrontendMetric])

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -470,7 +470,7 @@ trait FeatureSwitches {
     "Enables showing reCAPTCHA when signing up to email newsletters",
     owners = Seq(Owner.withGithub("georgeblahblah")),
     safeState = Off,
-    sellByDate = never,
+    sellByDate = LocalDate.of(2022, 5, 4),
     exposeClientSide = true,
   )
 
@@ -480,7 +480,7 @@ trait FeatureSwitches {
     "Enables validation of reCAPTCHA tokens on email signup submissions",
     owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
     safeState = Off,
-    sellByDate = never,
+    sellByDate = LocalDate.of(2022, 5, 4),
     exposeClientSide = false,
   )
 

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -474,4 +474,14 @@ trait FeatureSwitches {
     exposeClientSide = true,
   )
 
+  val ValidateEmailSignupRecaptchaTokens = Switch(
+    SwitchGroup.Feature,
+    "validate-email-signup-recaptcha-tokens",
+    "Enables validation of reCAPTCHA tokens on email signup submissions",
+    owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = false,
+  )
+
 }

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -313,9 +313,9 @@ class EmailSignupController(
                 },
               ) recover {
               case _: IllegalAccessException =>
-                respond(Subscribed)
+                respond(OtherError)
               case e: Exception =>
-                log.error(s"Error posting to Identity API: ${e.getMessage}")
+                log.error(s"Error validating captcha token: ${e.getMessage}")
                 APINetworkError.increment()
                 respond(OtherError)
             }
@@ -404,7 +404,14 @@ class EmailSignupController(
                   log.error(s"Google token validation failed with error: ${response.`error-codes`}")
                   Future.successful(respond(OtherError))
                 },
-              )
+              ) recover {
+              case _: IllegalAccessException =>
+                respond(OtherError)
+              case e: Exception =>
+                log.error(s"Error validating captcha token: ${e.getMessage}")
+                APINetworkError.increment()
+                respond(OtherError)
+            }
           } else {
             submitForm
           }

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -394,8 +394,10 @@ class EmailSignupController(
           if (ValidateEmailSignupRecaptchaTokens.isSwitchedOn) {
             def verifyGoogleResponse(googleResponse: GoogleResponse) = {
               if (googleResponse.success) {
+                RecaptchaValidationSuccess.increment()
                 Future.successful(())
               } else {
+                RecaptchaValidationError.increment()
                 Future.failed(
                   new Exception(s"Google token validation failed with error: ${googleResponse.`error-codes`}"),
                 )

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -377,7 +377,7 @@ class EmailSignupController(
                   respond(Subscribed, form.listName)
 
                 case status =>
-                  log.error(s"Error posting to ExactTarget: HTTP $status")
+                  log.error(s"Error posting to Identity API: HTTP $status")
                   APIHTTPError.increment()
                   respond(OtherError)
 
@@ -385,7 +385,7 @@ class EmailSignupController(
               case _: IllegalAccessException =>
                 respond(Subscribed, form.listName)
               case e: Exception =>
-                log.error(s"Error posting to ExactTarget: ${e.getMessage}")
+                log.error(s"Error posting to Identity API: ${e.getMessage}")
                 APINetworkError.increment()
                 respond(OtherError)
             }

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -310,7 +310,7 @@ class EmailSignupController(
                 respond(Subscribed)
 
               case status =>
-                log.error(s"Error posting to ExactTarget: HTTP $status")
+                log.error(s"Error posting to Identity API: HTTP $status")
                 APIHTTPError.increment()
                 respond(OtherError)
 
@@ -318,7 +318,7 @@ class EmailSignupController(
             case _: IllegalAccessException =>
               respond(Subscribed)
             case e: Exception =>
-              log.error(s"Error posting to ExactTarget: ${e.getMessage}")
+              log.error(s"Error posting to Identity API: ${e.getMessage}")
               APINetworkError.increment()
               respond(OtherError)
           }

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -384,9 +384,10 @@ class EmailSignupController(
             RecaptchaMissingTokenError.increment()
             Future.failed(new IllegalAccessException("reCAPTCHA client token not provided"))
         }
-        wsResponse <- googleRecaptchaTokenValidationService.submit(token) recoverWith { case e =>
-          RecaptchaAPIUnavailableError.increment()
-          Future.failed(e)
+        wsResponse <- googleRecaptchaTokenValidationService.submit(token) recoverWith {
+          case e =>
+            RecaptchaAPIUnavailableError.increment()
+            Future.failed(e)
         }
         googleResponse = wsResponse.json.as[GoogleResponse]
         _ <- {

--- a/common/app/services/newsletters/GoogleRecaptchaValidationApi.scala
+++ b/common/app/services/newsletters/GoogleRecaptchaValidationApi.scala
@@ -10,18 +10,12 @@ import utils.RemoteAddress
 import scala.concurrent.Future
 
 class GoogleRecaptchaValidationService(wsClient: WSClient) extends LazyLogging with RemoteAddress {
-  def submit(token: Option[String])(implicit request: Request[AnyContent]): Future[WSResponse] = {
-    if (token.isEmpty) {
-      Future.failed(new IllegalAccessException("reCAPTCHA client token not provided"))
-    } else {
-      val url = "https://www.google.com/recaptcha/api/siteverify"
-      val payload =
-        Map("response" -> Seq(token.get), "secret" -> Seq(Configuration.google.googleRecaptchaSecret))
-
-      wsClient
-        .url(url)
-        .post(payload)
-    }
+  def submit(token: String): Future[WSResponse] = {
+    val url = "https://www.google.com/recaptcha/api/siteverify"
+    val payload = Map("response" -> Seq(token), "secret" -> Seq(Configuration.google.googleRecaptchaSecret))
+    wsClient
+      .url(url)
+      .post(payload)
   }
 }
 

--- a/common/app/services/newsletters/GoogleRecaptchaValidationApi.scala
+++ b/common/app/services/newsletters/GoogleRecaptchaValidationApi.scala
@@ -1,0 +1,32 @@
+package services.newsletters
+
+import com.typesafe.scalalogging.LazyLogging
+import conf.Configuration
+import play.api.libs.json.Json
+import play.api.libs.ws.{WSClient, WSResponse}
+import play.api.mvc.{AnyContent, Request}
+import utils.RemoteAddress
+
+import scala.concurrent.Future
+
+class GoogleRecaptchaValidationService(wsClient: WSClient) extends LazyLogging with RemoteAddress {
+  def submit(token: Option[String])(implicit request: Request[AnyContent]): Future[WSResponse] = {
+    if (token.isEmpty) {
+      Future.failed(new IllegalAccessException("reCAPTCHA client token not provided"))
+    } else {
+      val url = "https://www.google.com/recaptcha/api/siteverify"
+      val payload =
+        Map("response" -> Seq(token.get), "secret" -> Seq(Configuration.google.googleRecaptchaSecret))
+
+      wsClient
+        .url(url)
+        .post(payload)
+    }
+  }
+}
+
+case class GoogleResponse(success: Boolean, `error-codes`: Option[Seq[String]])
+
+object GoogleResponse {
+  implicit val googleResponseReads = Json.reads[GoogleResponse]
+}

--- a/common/app/views/emailEmbed.scala.html
+++ b/common/app/views/emailEmbed.scala.html
@@ -66,7 +66,7 @@
             }
 
             function onSubmit(e) {
-                e.preventDefault()
+                e.preventDefault();
                 (function(d, script) {
                     script = d.createElement('script');
                     script.type = 'text/javascript';


### PR DESCRIPTION
## What does this change?

* adds a feature switch
  * if `on`, token validation will be performed
  * if `off`, sign up request sent straight to Identity API
* verifies the reCAPTCHA token supplied by the client with [Google's token verification service](https://developers.google.com/recaptcha/docs/verify)
* if token validation fails, the error will be logged and a generic error shown to the user
* if token validation is successful, the sign up request is forwarded to Identity API

More background on this feature can be found at [reCAPTCHA Implementation Overview
](https://docs.google.com/document/d/1O2-aS6o3Lj1lKeFfTB-Y0aBEEE6Xq5gE-q-BWa89EBQ/edit?usp=sharing)

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Tested

- [x] Locally
- [ ] On CODE (optional)
