### PR TITLE
correct data-link-name for filter toggle

### DIFF
--- a/article/app/views/liveblog/filterButton.scala.html
+++ b/article/app/views/liveblog/filterButton.scala.html
@@ -6,8 +6,8 @@
 
 <div class="live-blog__filter-switch" data-component="filter-key-events">
     <label class="live-blog__filter-switch-label" for="filter-switch">
-        @defining(if(filterKeyEvents) "off" else "on") { case switchState =>
-            <input type="checkbox" id="filter-switch" value="@(filterKeyEvents)" data-link-name="filter-key-events-@(switchState)">
+        @defining(if(filterKeyEvents) "off" else "on") { case nextSwitchState =>
+            <input type="checkbox" id="filter-switch" value="@(filterKeyEvents)" data-link-name="filter-key-events-@(nextSwitchState)">
         }
         <span class="live-blog__filter-switch-slider round"></span>
         <span class="live-blog__filter-switch-text">Show key events only</span>

--- a/article/app/views/liveblog/filterButton.scala.html
+++ b/article/app/views/liveblog/filterButton.scala.html
@@ -4,10 +4,10 @@
 * This template is used for the liveblog filter switch
 *@
 
-<div class="live-blog__filter-switch" data-component="filter-key-events">
+<div class="live-blog__filter-switch">
     <label class="live-blog__filter-switch-label" for="filter-switch">
         @defining(if(filterKeyEvents) "off" else "on") { case nextSwitchState =>
-            <input type="checkbox" id="filter-switch" value="@(filterKeyEvents)" data-link-name="filter-key-events-@(nextSwitchState)">
+            <input type="checkbox" id="filter-switch" value="@(filterKeyEvents)" data-component="filter-key-events" data-link-name="filter-key-events-@(nextSwitchState)">
         }
         <span class="live-blog__filter-switch-slider round"></span>
         <span class="live-blog__filter-switch-text">Show key events only</span>

--- a/article/app/views/liveblog/filterButton.scala.html
+++ b/article/app/views/liveblog/filterButton.scala.html
@@ -6,7 +6,7 @@
 
 <div class="live-blog__filter-switch" data-component="filter-key-events">
     <label class="live-blog__filter-switch-label" for="filter-switch">
-        @defining(if(filterKeyEvents) "on" else "off") { case switchState =>
+        @defining(if(filterKeyEvents) "off" else "on") { case switchState =>
             <input type="checkbox" id="filter-switch" value="@(filterKeyEvents)" data-link-name="filter-key-events-@(switchState)">
         }
         <span class="live-blog__filter-switch-slider round"></span>


### PR DESCRIPTION
## What does this change?
When tracking clicks on the "show key events only" toggle, events were being sent with the opposite values to what the user was doing. This PR corrects this such that:
-> when a user clicks to toggle the filter button on: we send an event with clickLinkNames= filter-key-events-on
-> when a user clicks to toggle the filter button off: we send an event with clickLinkNames= filter-key-events-off

