### PR TITLE
Add summary blocks to the liveblog timeline

### DIFF
--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -212,7 +212,7 @@ class LiveBlogController(
     val blocksHtml = views.html.liveblog.liveBlogBlocks(newBlocks, page.article, Edition(request).timezone)
     val timelineHtml = views.html.liveblog.keyEvents(
       "",
-      model.KeyEventData(newBlocks, Edition(request).timezone, filterKeyEvents),
+      model.KeyEventData(newBlocks, Edition(request).timezone),
       filterKeyEvents,
     )
 

--- a/article/app/model/KeyEventData.scala
+++ b/article/app/model/KeyEventData.scala
@@ -8,21 +8,22 @@ object KeyEventData {
 
   // just for convenience for use from the templates
   def apply(maybeBlocks: Option[Blocks], timezone: DateTimeZone, filterKeyEvents: Boolean): Seq[KeyEventData] = {
-
-    val blocks =
-      maybeBlocks.toSeq.flatMap(blocks => blocks.requestedBodyBlocks.getOrElse(CanonicalLiveBlog.timeline, blocks.body))
-
+    val blocks = maybeBlocks.toSeq.flatMap(blocks => {
+      if (blocks.body.length > 0) {
+        blocks.body.filter(block => block.eventType == SummaryEvent || block.eventType == KeyEvent)
+      } else {
+        val keyEvent = blocks.requestedBodyBlocks.getOrElse(CanonicalLiveBlog.timeline, Seq())
+        val summaryEvent = blocks.requestedBodyBlocks.getOrElse(CanonicalLiveBlog.summary, Seq())
+        keyEvent ++ summaryEvent
+      }
+    })
     apply(blocks, timezone, filterKeyEvents)
   }
 
   def apply(blocks: Seq[BodyBlock], timezone: DateTimeZone, filterKeyEvents: Boolean): Seq[KeyEventData] = {
     val TimelineMaxEntries = 7
-    val latestSummary = blocks.find(_.eventType == SummaryEvent)
-    val keyEvents = blocks.filter(_.eventType == KeyEvent)
-    val filteredBlocks = if (filterKeyEvents) keyEvents else latestSummary.toSeq ++ keyEvents
-    val bodyBlocks = filteredBlocks.sortBy(_.publishedCreatedTimestamp).reverse.take(TimelineMaxEntries)
-
-    bodyBlocks.map { bodyBlock =>
+    val timelineBlocks = blocks.sortBy(_.publishedCreatedTimestamp).reverse.take(TimelineMaxEntries)
+    timelineBlocks.map { bodyBlock =>
       KeyEventData(bodyBlock.id, bodyBlock.referenceDateForDisplay().map(LiveBlogDate(_, timezone)), bodyBlock.title)
     }
   }

--- a/article/app/model/KeyEventData.scala
+++ b/article/app/model/KeyEventData.scala
@@ -7,7 +7,7 @@ import com.github.nscala_time.time.Imports._
 object KeyEventData {
 
   // just for convenience for use from the templates
-  def apply(maybeBlocks: Option[Blocks], timezone: DateTimeZone, filterKeyEvents: Boolean): Seq[KeyEventData] = {
+  def apply(maybeBlocks: Option[Blocks], timezone: DateTimeZone): Seq[KeyEventData] = {
     val blocks = maybeBlocks.toSeq.flatMap(blocks => {
       if (blocks.body.length > 0) {
         blocks.body.filter(block => block.eventType == SummaryEvent || block.eventType == KeyEvent)
@@ -17,10 +17,10 @@ object KeyEventData {
         keyEvent ++ summaryEvent
       }
     })
-    apply(blocks, timezone, filterKeyEvents)
+    apply(blocks, timezone)
   }
 
-  def apply(blocks: Seq[BodyBlock], timezone: DateTimeZone, filterKeyEvents: Boolean): Seq[KeyEventData] = {
+  def apply(blocks: Seq[BodyBlock], timezone: DateTimeZone): Seq[KeyEventData] = {
     val TimelineMaxEntries = 7
     val timelineBlocks = blocks.sortBy(_.publishedCreatedTimestamp).reverse.take(TimelineMaxEntries)
     timelineBlocks.map { bodyBlock =>

--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -74,7 +74,7 @@
                         <div class="js-live-blog__sticky-components">
                             <div class="js-live-blog__sticky-components-container live-blog__sticky-components-container">
                                 @if(article.hasKeyEvents) {
-                                    @defining(KeyEventData(article.content.fields.blocks, timezone, model.filterKeyEvents)) { case keyEventData =>
+                                    @defining(KeyEventData(article.content.fields.blocks, timezone)) { case keyEventData =>
                                         <div class="modern-visible js-updates-desktop">
                                             <div data-component="timeline">
                                             @fragments.dropdown("Key events", Some("key-events"), true) {

--- a/article/test/model/KeyEventDataTest.scala
+++ b/article/test/model/KeyEventDataTest.scala
@@ -1,0 +1,136 @@
+package model
+
+import common.Edition
+import model.liveblog.{BlockAttributes, Blocks, BodyBlock}
+import org.joda.time.DateTime
+import org.scalatest.{FlatSpec, Matchers}
+
+class KeyEventDataTest extends FlatSpec with Matchers {
+  def fakeBlock(
+      publicationOrder: Int,
+      isKeyEvent: Boolean = false,
+      isPinnedBlock: Boolean = false,
+      isSummaryBlock: Boolean = false,
+  ): BodyBlock =
+    BodyBlock(
+      s"$publicationOrder",
+      "",
+      "",
+      None,
+      BlockAttributes(isPinnedBlock, isKeyEvent, isSummaryBlock, None),
+      false,
+      None,
+      firstPublishedDate = Some(new DateTime(publicationOrder)),
+      None,
+      None,
+      Nil,
+      Nil,
+    )
+
+  private def fakeBlocks(
+      number: Int,
+      ofWhichKeyEvents: Int = 0,
+      ofWhichPinnedBlocks: Int = 0,
+      ofWhichSummaries: Int = 0,
+  ): List[BodyBlock] = {
+    number should be >= ofWhichKeyEvents + ofWhichPinnedBlocks + ofWhichSummaries
+
+    val regular =
+      Range(number, ofWhichKeyEvents + ofWhichPinnedBlocks + ofWhichSummaries, -1).map(p => fakeBlock(p)).toList
+
+    val keyEvents = Range(
+      ofWhichKeyEvents + ofWhichPinnedBlocks + ofWhichSummaries,
+      ofWhichPinnedBlocks + ofWhichSummaries,
+      -1,
+    ).map(p => fakeBlock(p, true, false)).toList
+
+    val pinnedBlocks =
+      Range(ofWhichPinnedBlocks + ofWhichSummaries, ofWhichSummaries, -1).map(p => fakeBlock(p, false, true)).toList
+
+    val summaries = Range(ofWhichSummaries, 0, -1).map(p => fakeBlock(p, false, false, true)).toList
+
+    regular ++ keyEvents ++ pinnedBlocks ++ summaries
+  }
+
+  it should "return an empty list if there are no blocks" in {
+    val gotKeyEventData = KeyEventData(None, Edition.defaultEdition.timezone)
+
+    gotKeyEventData should be(List())
+  }
+
+  it should "return an empty list if there are no blocks in body or requstedBodyBlocks" in {
+    val blocks = Some(
+      Blocks(
+        10,
+        Nil,
+        None,
+        Map(),
+      ),
+    )
+
+    val gotKeyEventData = KeyEventData(blocks, Edition.defaultEdition.timezone)
+
+    gotKeyEventData should be(List())
+  }
+
+  it should "return a filtered list of key event and summary ids when requestedBodyBlocks has key events and summary blocks " in {
+    val blockCount = 8
+    val allBlocks = fakeBlocks(blockCount, 3, 0, 3)
+    val regularBlocks = allBlocks.slice(0, 2)
+    val keyEventBlocks = allBlocks.slice(2, 5)
+    val summaryBlocks = allBlocks.slice(5, 8)
+    val requestedBodyBlocks = Map(
+      CanonicalLiveBlog.timeline -> keyEventBlocks,
+      CanonicalLiveBlog.summary -> summaryBlocks,
+    )
+    val blocks = Some(
+      Blocks(
+        blockCount,
+        Nil,
+        None,
+        requestedBodyBlocks,
+      ),
+    )
+
+    val keyEventData = KeyEventData(blocks, Edition.defaultEdition.timezone)
+
+    val gotBlockIds = keyEventData.map(_.id)
+    val expectedBlockIds = (keyEventBlocks ++ summaryBlocks).map(_.id)
+    gotBlockIds should be(expectedBlockIds)
+  }
+
+  it should "return a filtered list of key event and summary ids when body has key events and summary blocks " in {
+    val blockCount = 8
+    val allBlocks = fakeBlocks(blockCount, 3, 0, 3)
+    val regularBlocks = allBlocks.slice(0, 2)
+    val keyEventBlocks = allBlocks.slice(2, 5)
+    val summaryBlocks = allBlocks.slice(5, 8)
+    val blocks = Some(
+      Blocks(
+        blockCount,
+        allBlocks,
+        None,
+        Map(),
+      ),
+    )
+
+    val keyEventData = KeyEventData(blocks, Edition.defaultEdition.timezone)
+
+    val gotBlockIds = keyEventData.map(_.id)
+    val expectedBlockIds = (keyEventBlocks ++ summaryBlocks).map(_.id)
+    gotBlockIds should be(expectedBlockIds)
+  }
+
+  it should "return the keyEventData block ids in chronological order, newest to oldest" in {
+    val oldestBlock = fakeBlock(1, true)
+    val newestBlock = fakeBlock(2, true)
+    val unorderedBlockList = Seq(oldestBlock, newestBlock)
+    val blocks = Some(Blocks(2, unorderedBlockList, None, Map()))
+
+    val gotKeyEventData = KeyEventData(blocks, Edition.defaultEdition.timezone)
+
+    val gotBlockIds = gotKeyEventData.map(_.id)
+    val expectedOrderedBlockIds = Seq(newestBlock.id, oldestBlock.id)
+    gotBlockIds should be(expectedOrderedBlockIds)
+  }
+}


### PR DESCRIPTION
## What does this change?

Adds all summary blocks along with key events into the timeline on liveblogs. 

Previously, there was different timeline behaviour dependent on the state of the filter key events toggle. This is no longer the case; we want to the most recent 7 summary and key event blocks in the timeline at all times. As a consequence, this logic has been removed as well as the filterkeyevents prop. 

There was also no testing for key event data so I have added a new test file with tests for:
 - what happens when we have no block data 
 - filtering out regular blocks from the timeline 
 - checking blocks appear in the correct chronological order within the timeline. 


## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

## Screenshots

**Before**
<img width="1705" alt="Screenshot 2022-01-20 at 17 31 34" src="https://user-images.githubusercontent.com/20416599/150394925-5f13e7d2-f5c6-4f3b-ac6c-e9cf5bcc77c8.png"> 

**After**
<img width="1705" alt="Screenshot 2022-01-20 at 17 29 23" src="https://user-images.githubusercontent.com/20416599/150394949-01931e5a-67c5-4d67-82d1-b660fc12bfcc.png"> 

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
