### PR TITLE
Dblatcher/newsletters accessibility fixes

### DIFF
--- a/applications/app/pages/NewsletterHtmlPage.scala
+++ b/applications/app/pages/NewsletterHtmlPage.scala
@@ -9,7 +9,7 @@ import play.api.mvc.RequestHeader
 import play.twirl.api.Html
 import views.html.fragments._
 import views.html.fragments.commercial.pageSkin
-import views.html.fragments.page.body.{bodyTag, skipToMainContent}
+import views.html.fragments.page.body.{bodyTag, mainContent, skipToMainContent}
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
 import views.html.fragments.page.head._
 import views.html.fragments.page.{devTakeShot, htmlTag}
@@ -51,6 +51,7 @@ object NewsletterHtmlPage extends HtmlPage[NewsletterRoundupPage] {
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkin(request),
         guardianHeaderHtml(),
+        mainContent(),
         newsletterContent(page),
         footer(),
         message(),

--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -42,14 +42,18 @@
                     </div>
                 </div>
 
-                <form action="@LinkTo("/email")" method="post" target="newsletterSignup" class="newsletter-card__signup">
+                <form action="@LinkTo("/email")" method="post" target="newsletterSignup" class="newsletter-card__signup" name="newsletter-signup-@emailListing.id">
                     @if(EmailSignupRecaptcha.isSwitchedOn) {
                         @fragments.email.signup.recaptchaContainer()
                     }
                     @helper.CSRF.formField
                     <input class="newsletter-card__text-input u-h" type="text" name="name" autocomplete="off"/>
-                    <input class="newsletter-card__text-input js-newsletter-card__text-input" type="email" name="email" placeholder="Email address" required/>
-                    <input class="js-email-sub__listname-input" type="hidden" name="listName" value="@emailListing.id" />
+                    <label>
+                        <span class="u-h">email address</span>
+                        <input class="newsletter-card__text-input js-newsletter-card__text-input" type="email" name="email" placeholder="Email address" required aria-label="Enter email address" title="Email address"/>
+                    </label>
+                    <input class="js-email-sub__listname-input" type="hidden" name="listName" value="@emailListing.id" aria-hidden="true"/>
+
                     <button class="newsletter-card__lozenge js-newsletter-signup-button newsletter-card__lozenge--submit" data-link-name="Subscribe to @emailListing.id" type="submit" value="@emailListing.listIdv1">
                         <span>Sign up</span>
                     </button>

--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -47,7 +47,9 @@
                         @fragments.email.signup.recaptchaContainer()
                     }
                     @helper.CSRF.formField
-                    <input class="newsletter-card__text-input u-h" type="text" name="name" autocomplete="off"/>
+                    <label aria-hidden="true">
+                        <input tabindex="-1" class="newsletter-card__text-input u-h" type="text" name="name" autocomplete="off"/>
+                    </label>
                     <label>
                         <span class="u-h">email address</span>
                         <input class="newsletter-card__text-input js-newsletter-card__text-input" type="email" name="email" placeholder="Email address" required aria-label="Enter email address" title="Email address"/>

--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -58,9 +58,9 @@
                 <div class="newsletter-card__example js-newsletter-preview is-hidden">
                 @if(emailListing.exampleUrl.isDefined) {
                     <a href="@emailListing.exampleUrl" target="preview-email-@emailListing.listId">
-                        <button class="newsletter-card__lozenge newsletter-card__lozenge--preview" data-link-name="Preview @emailListing.id" type="button">
+                        <div class="newsletter-card__lozenge newsletter-card__lozenge--preview" data-link-name="Preview @emailListing.id">
                             <span class="newsletter-card__preview">Preview  @fragments.inlineSvg("arrow-right", "icon")</span>
-                        </button>
+                        </div>
                     </a>
                 }
                 </div>

--- a/article/app/views/fragments/email/emailArticleBody.scala.html
+++ b/article/app/views/fragments/email/emailArticleBody.scala.html
@@ -18,13 +18,13 @@
                 sponsor.sponsorshipType.name.toLowerCase()
             }"
         }}">
-            <a class="rich-link__link" href="@href">
+            <a class="rich-link__link" href="@href" aria-label="read more: @title">
                 <h3 class="rich-link__header">@title</h3>
             </a>
 
             @if(!sponsorship.isDefined) {
                 <div class="rich-link__read-more">
-                    <a class="rich-link__link" href="@href">
+                    <a class="rich-link__link" href="@href" aria-label="read more: @title">
                         <p class="rich-link__read-more">
                             Read more
                         </p>
@@ -39,7 +39,7 @@
                             <tr>
                                 <td>
                                     <div class="rich-link__read-more">
-                                        <a class="rich-link__link" href="@href">
+                                        <a class="rich-link__link" href="@href" aria-label="read more: @title">
                                             <p class="rich-link__read-more">
                                                 Read more
                                             </p>

--- a/common/app/views/fragments/email/signup/footer/emailSignUpFooter.scala.html
+++ b/common/app/views/fragments/email/signup/footer/emailSignUpFooter.scala.html
@@ -22,7 +22,9 @@
             <div class="email-sub__inline-label">
                 <input class="email-sub__text-input" type="email" name="email" id="@inputId" />
                 <label class="email-sub__label" for="@inputId">@fragments.inlineSvg("envelope", "icon", Seq("label__icon"))Email address</label>
-                <input class="email-sub__text-input u-h" autocomplete="off" type="text" name="name" id="@dummyInputId" />
+                <label aria-hidden="true">
+                    <input tabindex="-1" class="email-sub__text-input u-h" autocomplete="off" type="text" name="name" id="@dummyInputId" />
+                </label>     
                 <input class="email-sub__listname-input" type="hidden" name="listName" value="@listName" />
                 <input class="email-sub__ref-input" type="hidden" name="ref" id="email-sub__ref-input" value="" />
                 <input class="email-sub__refviewid-input" type="hidden" name="refViewId" id="email-sub__refviewid-input" value="" />

--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -43,7 +43,9 @@
 
                 <input class="email-sub__text-input" type="email" name="email" id="@inputId" />
                 <label class="email-sub__label" for="@inputId">@fragments.inlineSvg("envelope", "icon", Seq("label__icon"))Enter your email address</label>
-                <input class="email-sub__text-input u-h" autocomplete="off" type="text" name="name" id="@dummyInputId" placeholder="Name" />
+                <label aria-hidden="true">
+                    <input tabindex="-1" class="email-sub__text-input u-h" autocomplete="off" type="text" name="name" id="@dummyInputId" placeholder="Name" />
+                </label>
 
                 <input class="email-sub__listname-input" type="hidden" name="listName" value="@listName" />
                 <input class="email-sub__ref-input" type="hidden" name="ref" id="email-sub__ref-input" value="" />

--- a/static/src/stylesheets/email/_footer.scss
+++ b/static/src/stylesheets/email/_footer.scss
@@ -24,6 +24,10 @@
     text-decoration: none;
     text-align: center;
     a {
+        text-decoration: underline !important;
+        text-underline-offset: 1px;
+        text-decoration-thickness: 2px;
+
         &,
         &:visited,
         &:hover,
@@ -35,7 +39,9 @@
             font-size: 12px !important;
             font-weight: lighter !important;
             line-height: 14px !important;
-            text-decoration: none !important;
+            text-decoration: underline !important;
+            text-underline-offset: 1px !important;
+            text-decoration-thickness: 2px !important;
         }
     }
 }

--- a/static/src/stylesheets/email/_footer.scss
+++ b/static/src/stylesheets/email/_footer.scss
@@ -24,9 +24,9 @@
     text-decoration: none;
     text-align: center;
     a {
-        text-decoration: underline !important;
-        text-underline-offset: 1px;
-        text-decoration-thickness: 2px;
+        display: inline-block;
+        text-decoration: none !important;
+        border-bottom: 2px solid #ffffff;
 
         &,
         &:visited,
@@ -39,9 +39,7 @@
             font-size: 12px !important;
             font-weight: lighter !important;
             line-height: 14px !important;
-            text-decoration: underline !important;
-            text-underline-offset: 1px !important;
-            text-decoration-thickness: 2px !important;
+            text-decoration: none !important;
         }
     }
 }

--- a/static/src/stylesheets/module/signup/_newsletters.scss
+++ b/static/src/stylesheets/module/signup/_newsletters.scss
@@ -161,6 +161,8 @@
     }
 
     .newsletter-card__lozenge--preview {
+        display: inline;
+        text-align: center;
         border-color: $brightness-7;
         color: $brightness-7;
         background-color: transparent;


### PR DESCRIPTION
## What does this change?
Addresses the newsletter related  [Dotcom accessibility issues identified by SortSite](https://docs.google.com/spreadsheets/d/12GSXv8eOU9dY_Ti3WKfW3eueaLFpzy-tffiv6iiBSac/edit#gid=873937718 ): 
 - accessibility fixes for email articles:
   - add prominent underline to links in the footer
   - add aria label to the "read more" links (using the title of the article being linked to)
  
 - accessibility fixes for email sign-up forms(footers, newsletters sign up page, embeds):
   - hide the 'fake' name input field (used to detect form submissions by bots) from screen readers
   - add accessible labels to email input fields

 - accessibility fixes for newsletters sign-up page
   - fix the 'skip to main content' link
   - add name attributes to the multiple sign up forms
   - don't use a button tag inside the 'preview' links



## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

Footer change:

| Before      | After      |
|-------------|------------|
| <img width="646" alt="Screenshot 2022-01-20 at 10 39 52" src="https://user-images.githubusercontent.com/30567854/150323146-a088ec54-541c-4224-bb84-8619e7a7b8a3.png">| <img width="646" alt="Screenshot 2022-01-20 at 10 39 13" src="https://user-images.githubusercontent.com/30567854/150323165-a1071c78-31b4-45fa-af58-f114e6c04065.png">


## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
