### PR TITLE
Check if legacy programmatic messages are still sent to the messenger

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/messenger.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger.js
@@ -1,5 +1,6 @@
 import reportError from '../../../lib/report-error';
 import { postMessage } from './messenger/post-message';
+import { amIUsed } from 'commercial/sentinel';
 
 const LISTENERS = {};
 let REGISTERED_LISTENERS = 0;
@@ -86,6 +87,9 @@ const onMessage = (event) => {
 
 	// These legacy messages are converted into bona fide resize messages
 	if (isProgrammaticMessage(data)) {
+		// Check if we ever reach the point that isProgrammaticMessage(data) is true
+		// This would imply these legacy messages are still in use
+		amIUsed('messenger.js', 'isProgrammaticMessage');
 		data = toStandardMessage(data);
 	}
 

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -421,7 +421,8 @@
  ],
  "../projects/commercial/modules/messenger.js": [
   "../lib/report-error.js",
-  "../projects/commercial/modules/messenger/post-message.ts"
+  "../projects/commercial/modules/messenger/post-message.ts",
+  "../projects/commercial/sentinel.ts"
  ],
  "../projects/commercial/modules/messenger/background.js": [
   "../lib/config.js",
@@ -516,6 +517,9 @@
  "../projects/commercial/modules/third-party-tags/imr-worldwide.js": [
   "../lib/config.js",
   "../projects/common/modules/commercial/geo-utils.js"
+ ],
+ "../projects/commercial/sentinel.ts": [
+  "../lib/config.d.ts"
  ],
  "../projects/common/modules/analytics/forceSendMetrics.ts": [],
  "../projects/common/modules/analytics/google.ts": [


### PR DESCRIPTION
## What does this change?

Add a call to `amIUsed` to check if legacy programmatic messages are still being sent from creatives.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

If we detect that no programmatic messages are still being sent we can remove the code that handles them (and simplify #24553).

### Tested

- [ ] Locally
- [ ] On CODE (optional)
