### PR TITLE
Bump CMP for Prebid ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@guardian/automat-modules": "^0.3.8",
     "@guardian/braze-components": "^5.3.0",
     "@guardian/commercial-core": "^0.39.0",
-    "@guardian/consent-management-platform": "^10.1.0",
+    "@guardian/consent-management-platform": "^10.1.1",
     "@guardian/libs": "^3.4.1",
     "@guardian/shimport": "^1.0.2",
     "@guardian/source-foundations": "^4.0.0-rc.4",

--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-prebid.spec.ts
@@ -66,7 +66,7 @@ const tcfv2WithConsentMock = (callback: Callback) =>
 	callback({
 		tcfv2: {
 			...defaultTCFv2State,
-			vendorConsents: { '5f22bfd82a6b6c1afd1181a9': true },
+			vendorConsents: { '5f92a62aa22863685f4daa4c': true },
 		},
 	});
 
@@ -74,7 +74,7 @@ const tcfv2WithoutConsentMock = (callback: Callback) =>
 	callback({
 		tcfv2: {
 			...defaultTCFv2State,
-			vendorConsents: { '5f22bfd82a6b6c1afd1181a9': false },
+			vendorConsents: { '5f92a62aa22863685f4daa4c': false },
 		},
 	});
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1257,10 +1257,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.39.0.tgz#314af346a02599d75219492dac89a89be169cc93"
   integrity sha512-3OGfM9K3KQR1PMOJoPM6EL1tuy6s4YRoIfnFTvM4NY+Z5Yc11uDZXqthzXBmRjlnf8EHVMZo2a2ffDlZnrguTA==
 
-"@guardian/consent-management-platform@^10.1.0":
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-10.1.0.tgz#defabd279ca3e8344bfbfbb0d604e42ba549ae1c"
-  integrity sha512-7q4mb8b5jVcecOMYp0cTN02OIz7ZHw0HgKKVID7mOjV7NwSNBY+Lwtj85VyYAR/cnC2SJFbpezPivFdvyE5rTg==
+"@guardian/consent-management-platform@^10.1.1":
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-10.1.1.tgz#c49ccdde26582b571accd925f576fb178c619004"
+  integrity sha512-hzhmrlhNVkwshKXKYVQUrl4NBA6iCkyFg79LQHUD3nDpo5IjxzwOGlUU4ML1gzFFID4lZ1AM2klxkM7ZUfYySg==
   dependencies:
     "@guardian/libs" "1.6.1 - 3.3.0"
 


### PR DESCRIPTION
## What does this change?

- update prebid IAB ID
- bump cmp version to 10.1.1: https://github.com/guardian/consent-management-platform/pull/544

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes https://github.com/guardian/dotcom-rendering/pull/3859

## What is the value of this and can you measure success?

We currently are unable to establish consent for Prebid.

## Checklist

### Tested

- [X] Locally
- [ ] On CODE (optional)