### PR TITLE
add summary title for summary blocks with missing title

### DIFF
--- a/article/app/views/liveblog/liveBlogBlock.scala.html
+++ b/article/app/views/liveblog/liveBlogBlock.scala.html
@@ -3,6 +3,7 @@
 @import model.liveblog.{LiveBlogDate, BodyBlock}
 @import views.BodyProcessor
 @import model.DotcomContentType
+@import model.liveblog.BodyBlock.SummaryEvent
 @(block: BodyBlock, article: Article, timezone: DateTimeZone, isPinnedBlock: Boolean = false, isOriginalPinnedBlock: Boolean = false)(implicit request: RequestHeader, context: model.ApplicationContext)
 @*
 * This template is for individual blocks
@@ -39,9 +40,15 @@ itemtype="http://schema.org/BlogPosting"
             @fragments.inlineSvg("pin", "icon", List("inline-icon", "pinned-block-original__icon"))
         }
     </p>
-
-    @block.title.map { title =>
-        <h2 class="block-title">@title</h2>
+    
+    @if(block.title.isDefined) {
+        @block.title.map { title =>
+            <h2 class="block-title">@title</h2>
+        }
+    } else {
+      @if(block.eventType == SummaryEvent) {
+          <h2 class="block-title">Summary</h2>
+      }
     }
 
     @block.contributors.map { contributorId =>


### PR DESCRIPTION
## What does this change?
This PR forces frontend to have `Summary` title for summary blocks with missing title. 
## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

## Screenshots
| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/15894063/150784237-11444805-2815-4e45-b547-fe62092df821.png) | ![image](https://user-images.githubusercontent.com/15894063/150784124-3673700d-428c-43cb-ac45-c8e472798d6d.png) |
<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][![image](https://user-images.githubusercontent.com/15894063/150784124-3673700d-428c-43cb-ac45-c8e472798d6d.png)] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
