### PR TITLE
Add default title to summary blocks in the timeline

### DIFF
--- a/article/app/model/KeyEventData.scala
+++ b/article/app/model/KeyEventData.scala
@@ -24,10 +24,18 @@ object KeyEventData {
     val TimelineMaxEntries = 7
     val timelineBlocks = blocks.sortBy(_.publishedCreatedTimestamp).reverse.take(TimelineMaxEntries)
     timelineBlocks.map { bodyBlock =>
-      KeyEventData(bodyBlock.id, bodyBlock.referenceDateForDisplay().map(LiveBlogDate(_, timezone)), bodyBlock.title)
+      /*
+    Composer should set a default title of `Summary` on summary blocks but instead it allows title to be empty (None).
+    Until this work is complete, the following pattern match ensures we set a default title of `Summary`
+       */
+      val title = bodyBlock.eventType match {
+        case SummaryEvent => bodyBlock.title.getOrElse("Summary")
+        case _            => bodyBlock.title.getOrElse("")
+      }
+      KeyEventData(bodyBlock.id, bodyBlock.referenceDateForDisplay().map(LiveBlogDate(_, timezone)), title)
     }
   }
 
 }
 
-case class KeyEventData(id: String, time: Option[LiveBlogDate], title: Option[String])
+case class KeyEventData(id: String, time: Option[LiveBlogDate], title: String)


### PR DESCRIPTION
## What does this change?

Adds a default title of `Summary` to summary blocks in the timeline.

Ideally this should be set in Composer and there is a ticket to do this work. As and when this work is completed in Composer and historic summary blocks have a default title added where required, this work can be removed.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

[before]: <img width="938" alt="Screenshot 2022-01-24 at 12 56 28" src="https://user-images.githubusercontent.com/20416599/150786707-b547f43a-4529-47a2-9265-3120c56611b7.png">

[after]: <img width="938" alt="Screenshot 2022-01-24 at 12 55 53" src="https://user-images.githubusercontent.com/20416599/150786747-21887c80-cb23-4a4a-b7cb-9b1f6bb902e1.png">


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
