### PR TITLE
Place pinned icon span within the `dateBlock` template

### DIFF
--- a/article/app/views/liveblog/dateBlock.scala.html
+++ b/article/app/views/liveblog/dateBlock.scala.html
@@ -5,8 +5,15 @@
         @if(showDate) {
             <time datetime="@date.fullDate" data-relativeformat="med" class=" js-timestamp" itemprop="datePublished">@date.ampm <span class="timezone">@date.gmt</span></time>
         }
-        @if(showTimestamp) {
-            <span class="block-time__absolute @if(isPinned) { block-time__pinned }">@date.hhmm</span>
-        }
+
+        <span class="block-time__absolute @if(isPinned) { block-time__pinned }">
+            @if(showTimestamp) {
+                <span class="block-time__absolute">@date.hhmm</span>
+            }
+
+            @if(isPinned){
+                @fragments.inlineSvg("pin", "icon", List("inline-icon", "pinned-block-original__icon"))
+            }
+        </span>
     }
 

--- a/article/app/views/liveblog/liveBlogBlock.scala.html
+++ b/article/app/views/liveblog/liveBlogBlock.scala.html
@@ -35,9 +35,6 @@ itemtype="http://schema.org/BlogPosting"
         <a href="/@article.metadata.id?page=with:block-@block.id#block-@block.id" itemprop="url" class="block-time__link">
         @views.html.liveblog.dateBlock(block.referenceDateForDisplay().map(LiveBlogDate(_, timezone)), !isPinnedBlock, true, isOriginalPinnedBlock)
         </a>
-        @if(isOriginalPinnedBlock){
-            @fragments.inlineSvg("pin", "icon", List("inline-icon", "pinned-block-original__icon"))
-        }
     </p>
 
     @block.title.map { title =>

--- a/static/src/stylesheets/module/content-garnett/live-blog/_live-blog.head.scss
+++ b/static/src/stylesheets/module/content-garnett/live-blog/_live-blog.head.scss
@@ -214,7 +214,7 @@ $block-padding-left: gs-span(1) + $gs-gutter;
             margin-left: 0;
 
             &.block-time__pinned {
-                display: inline-flex;
+                display: flex;
             }
         }
     }

--- a/static/src/stylesheets/module/content/live-blog/_live-blog.head.scss
+++ b/static/src/stylesheets/module/content/live-blog/_live-blog.head.scss
@@ -166,7 +166,7 @@ $block-padding-left: gs-span(1) + $gs-gutter;
             margin-left: 0;
 
             &.block-time__pinned {
-                display: inline-flex;
+                display: flex;
             }
         }
     }


### PR DESCRIPTION
## What does this change?

This PR addresses a bug ([documented in more detail in this Trello card](https://trello.com/c/ZDKloYgq/222-pinned-icon-in-original-block-doesnt-look-as-expected-in-some-posts)) where the pin icon on pinned posts moved down to the next line when the the timestamps next to them comprised of numbers that made it a little bit wider. 

@marjisound and I have moved the pinned icon snippet from `liveBlogBlock.scala.html` and into `dateBlock.scala.html`, where it shares a `<span>` with the timestamp (provided `isPinned` is true). Combined with a CSS tweak to `display: flex` this ensures the pinned icon stays aligned with the timestamp. This does mean the icon now also acts as a link because the entire date block sits inside an `<a>` tag in `liveBlogBlock.scala.html`, but design have confirmed this is an acceptable trade off. 

A related issue of the gap between the timestamp and the icon being larger than [the desired 5px](https://www.figma.com/file/Hsh9wUoX4BEIltOiPo3rPe/liveblog-improvements?node-id=440%3A15234) is also addressed by this change. Because the timestamp and the icon now share the same container, there is no extra padding to contend with.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/11380557/150805208-52c6c00e-2251-4ffa-9438-ee7203d2906c.png
[after]: https://user-images.githubusercontent.com/11380557/150805440-728486d5-9a51-49ea-a621-5bfc213f1a69.png

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
