### PR TITLE
Revert "Check if legacy programmatic messages are still sent to the messenger"

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/messenger.js
+++ b/static/src/javascripts/projects/commercial/modules/messenger.js
@@ -1,6 +1,5 @@
 import reportError from '../../../lib/report-error';
 import { postMessage } from './messenger/post-message';
-import { amIUsed } from 'commercial/sentinel';
 
 const LISTENERS = {};
 let REGISTERED_LISTENERS = 0;
@@ -87,9 +86,6 @@ const onMessage = (event) => {
 
 	// These legacy messages are converted into bona fide resize messages
 	if (isProgrammaticMessage(data)) {
-		// Check if we ever reach the point that isProgrammaticMessage(data) is true
-		// This would imply these legacy messages are still in use
-		amIUsed('messenger.js', 'isProgrammaticMessage');
 		data = toStandardMessage(data);
 	}
 

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -423,8 +423,7 @@
  ],
  "../projects/commercial/modules/messenger.js": [
   "../lib/report-error.js",
-  "../projects/commercial/modules/messenger/post-message.ts",
-  "../projects/commercial/sentinel.ts"
+  "../projects/commercial/modules/messenger/post-message.ts"
  ],
  "../projects/commercial/modules/messenger/background.js": [
   "../lib/config.js",
@@ -519,9 +518,6 @@
  "../projects/commercial/modules/third-party-tags/imr-worldwide.js": [
   "../lib/config.js",
   "../projects/common/modules/commercial/geo-utils.js"
- ],
- "../projects/commercial/sentinel.ts": [
-  "../lib/config.d.ts"
  ],
  "../projects/common/modules/analytics/forceSendMetrics.ts": [],
  "../projects/common/modules/analytics/google.ts": [


### PR DESCRIPTION
## What does this change

This PR reverts guardian/frontend#24573.

## Why

We've now collected enough evidence that these programmatic messages are still in use.

Preview:
![Screenshot 2022-01-25 at 18 15 01](https://user-images.githubusercontent.com/8000415/151035178-e3b066c3-b140-4a16-994d-a08416249637.png)

