### PR TITLE
Fix bug in spacefinder nearby candidate filtering

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -23,4 +23,14 @@ trait ABTestSwitches {
     sellByDate = Some(LocalDate.of(2022, 12, 1)),
     exposeClientSide = true,
   )
+
+  Switch(
+    ABTests,
+    "ab-spacefinder-okr-1-filter-nearby",
+    "Check whether fixing a bug in spacefinder's nearby candidate filtering mechanism leads to revenue uplift",
+    owners = Seq(Owner.withGithub("simonbyford")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2022, 2, 21)),
+    exposeClientSide = true,
+  )
 }

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -37,17 +37,13 @@ const insertAdAtPara = (para, name, type, classes, sizes) => {
 		});
 };
 
-let previousAllowedCandidate;
-
 // this facilitates a second filtering, now taking into account the candidates' position/size relative to the other candidates
-const filterNearbyCandidates = (maximumAdHeight) => (candidate) => {
+const filterNearbyCandidates = (maximumAdHeight) => (candidate, lastWinner) => {
 	if (
-		!previousAllowedCandidate ||
-		Math.abs(candidate.top - previousAllowedCandidate.top) -
-			maximumAdHeight >=
+		!lastWinner ||
+		Math.abs(candidate.top - lastWinner.top) - maximumAdHeight >=
 			adSlotClassSelectorSizes.minBelow
 	) {
-		previousAllowedCandidate = candidate;
 		return true;
 	}
 	return false;

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -11,6 +11,10 @@ import { commercialFeatures } from '../../common/modules/commercial/commercial-f
 import { initCarrot } from './carrot-traffic-driver';
 import { getBreakpoint, getTweakpoint, getViewport } from 'lib/detect-viewport';
 
+import { filterNearbyCandidatesBroken } from './filter-nearby-candidates-broken.ts';
+import { filterNearbyCandidatesFixed } from './filter-nearby-candidates-fixed.ts';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { spacefinderOkr1FilterNearby } from 'common/modules/experiments/tests/spacefinder-okr-1-filter-nearby';
 const isPaidContent = config.get('page.isPaidContent', false);
 
 const adSlotClassSelectorSizes = {
@@ -37,17 +41,12 @@ const insertAdAtPara = (para, name, type, classes, sizes) => {
 		});
 };
 
-// this facilitates a second filtering, now taking into account the candidates' position/size relative to the other candidates
-const filterNearbyCandidates = (maximumAdHeight) => (candidate, lastWinner) => {
-	if (
-		!lastWinner ||
-		Math.abs(candidate.top - lastWinner.top) - maximumAdHeight >=
-			adSlotClassSelectorSizes.minBelow
-	) {
-		return true;
-	}
-	return false;
-};
+const filterNearbyCandidates = isInVariantSynchronous(
+	spacefinderOkr1FilterNearby,
+	'variant',
+)
+	? filterNearbyCandidatesFixed
+	: filterNearbyCandidatesBroken;
 
 const isDotcomRendering = config.get('isDotcomRendering', false);
 const articleBodySelector = isDotcomRendering

--- a/static/src/javascripts/projects/commercial/modules/filter-nearby-candidates-broken.ts
+++ b/static/src/javascripts/projects/commercial/modules/filter-nearby-candidates-broken.ts
@@ -1,0 +1,28 @@
+const adSlotClassSelectorSizes = {
+	minAbove: 500,
+	minBelow: 500,
+};
+
+type SpacefinderItem = {
+	top: number;
+	bottom: number;
+	element: HTMLElement;
+};
+
+let previousAllowedCandidate: SpacefinderItem | undefined;
+
+// this facilitates a second filtering, now taking into account the candidates' position/size relative to the other candidates
+export const filterNearbyCandidatesBroken =
+	(maximumAdHeight: number) =>
+	(candidate: SpacefinderItem): boolean => {
+		if (
+			!previousAllowedCandidate ||
+			Math.abs(candidate.top - previousAllowedCandidate.top) -
+				maximumAdHeight >=
+				adSlotClassSelectorSizes.minBelow
+		) {
+			previousAllowedCandidate = candidate;
+			return true;
+		}
+		return false;
+	};

--- a/static/src/javascripts/projects/commercial/modules/filter-nearby-candidates-fixed.ts
+++ b/static/src/javascripts/projects/commercial/modules/filter-nearby-candidates-fixed.ts
@@ -1,0 +1,27 @@
+const adSlotClassSelectorSizes = {
+	minAbove: 500,
+	minBelow: 500,
+};
+
+type SpacefinderItem = {
+	top: number;
+	bottom: number;
+	element: HTMLElement;
+};
+
+// this facilitates a second filtering, now taking into account the candidates' position/size relative to the other candidates
+export const filterNearbyCandidatesFixed =
+	(maximumAdHeight: number) =>
+	(
+		candidate: SpacefinderItem,
+		lastWinner: SpacefinderItem | undefined,
+	): boolean => {
+		if (
+			!lastWinner ||
+			Math.abs(candidate.top - lastWinner.top) - maximumAdHeight >=
+				adSlotClassSelectorSizes.minBelow
+		) {
+			return true;
+		}
+		return false;
+	};

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -2,6 +2,7 @@ import type { ABTest } from '@guardian/ab-core';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
+import { spacefinderOkr1FilterNearby } from './tests/spacefinder-okr-1-filter-nearby';
 
 // keep in sync with ab-tests in dotcom-rendering
 // https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/experiments/ab-tests.ts
@@ -9,4 +10,5 @@ export const concurrentTests: readonly ABTest[] = [
 	signInGateMainVariant,
 	signInGateMainControl,
 	remoteRRHeaderLinksTest,
+	spacefinderOkr1FilterNearby,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/spacefinder-okr-1-filter-nearby.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/spacefinder-okr-1-filter-nearby.ts
@@ -1,0 +1,21 @@
+import type { ABTest } from '@guardian/ab-core';
+import { noop } from '../../../../../lib/noop';
+
+export const spacefinderOkr1FilterNearby: ABTest = {
+	id: 'SpacefinderOkr1FilterNearby',
+	author: 'Simon Byford (@simonbyford)',
+	start: '2022-02-07',
+	expiry: '2022-02-21',
+	audience: 20 / 100,
+	audienceOffset: 0,
+	audienceCriteria: 'All pageviews on non-mobile, non-paid for articles',
+	successMeasure:
+		'Fixing the bug leads to an increase in inline programmatic revenue per 1000 pageviews',
+	description:
+		"Check whether fixing a bug in spacefinder's nearby candidate filtering mechanism leads to an increase in inline programmatic revenue per 1000 pageviews",
+	variants: [
+		{ id: 'control', test: noop },
+		{ id: 'variant', test: noop },
+	],
+	canRun: () => true,
+};

--- a/static/src/javascripts/projects/common/modules/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/spacefinder.js
@@ -111,7 +111,7 @@ const onInteractivesLoaded = memoize((rules) => {
 const filter = (list, filterElement, exclusions) => {
 	const filtered = [];
 	list.forEach((element) => {
-		if (filterElement(element)) {
+		if (filterElement(element, filtered[filtered.length - 1])) {
 			filtered.push(element);
 		} else {
 			exclusions.push(element);

--- a/static/src/javascripts/projects/common/modules/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/spacefinder.js
@@ -108,8 +108,9 @@ const onInteractivesLoaded = memoize((rules) => {
 		  ).then(() => undefined);
 }, getFuncId);
 
-const filter = (list, filterElement, exclusions) => {
+const filter = (list, filterElement) => {
 	const filtered = [];
+	const exclusions = [];
 	list.forEach((element) => {
 		if (filterElement(element, filtered[filtered.length - 1])) {
 			filtered.push(element);
@@ -117,7 +118,7 @@ const filter = (list, filterElement, exclusions) => {
 			exclusions.push(element);
 		}
 	});
-	return filtered;
+	return { filtered, exclusions };
 };
 
 // test one element vs another for the given rules
@@ -134,65 +135,62 @@ const testCandidates = (rules, challenger, opponents) =>
 
 const enforceRules = (measurements, rules, exclusions) => {
 	let candidates = measurements.candidates;
+	let result;
 
 	// enforce absoluteMinAbove rule
-	exclusions.absoluteMinAbove = [];
-	candidates = filter(
+	result = filter(
 		candidates,
 		(candidate) =>
 			!rules.absoluteMinAbove ||
 			candidate.top + measurements.bodyTop >= rules.absoluteMinAbove,
-		exclusions.absoluteMinAbove,
 	);
+	exclusions.absoluteMinAbove = result.exclusions;
+	candidates = result.filtered;
 
 	// enforce minAbove and minBelow rules
-	exclusions.aboveAndBelow = [];
-	candidates = filter(
-		candidates,
-		(candidate) => {
-			const farEnoughFromTopOfBody = candidate.top >= rules.minAbove;
-			const farEnoughFromBottomOfBody =
-				candidate.top + rules.minBelow <= measurements.bodyHeight;
-			return farEnoughFromTopOfBody && farEnoughFromBottomOfBody;
-		},
-		exclusions.aboveAndBelow,
-	);
+	result = filter(candidates, (candidate) => {
+		const farEnoughFromTopOfBody = candidate.top >= rules.minAbove;
+		const farEnoughFromBottomOfBody =
+			candidate.top + rules.minBelow <= measurements.bodyHeight;
+		return farEnoughFromTopOfBody && farEnoughFromBottomOfBody;
+	});
+	exclusions.aboveAndBelow = result.exclusions;
+	candidates = result.filtered;
 
 	// enforce content meta rule
 	if (rules.clearContentMeta) {
-		exclusions.contentMeta = [];
-		candidates = filter(
+		result = filter(
 			candidates,
 			(c) =>
 				!!measurements.contentMeta &&
 				c.top >
 					measurements.contentMeta.bottom + rules.clearContentMeta,
-			exclusions.contentMeta,
 		);
+		exclusions.contentMeta = result.exclusions;
+		candidates = result.filtered;
 	}
 
 	// enforce selector rules
 	if (rules.selectors) {
 		Object.keys(rules.selectors).forEach((selector) => {
-			exclusions[selector] = [];
-			candidates = filter(
-				candidates,
-				(candidate) =>
-					testCandidates(
-						rules.selectors[selector],
-						candidate,
-						measurements.opponents
-							? measurements.opponents[selector]
-							: [],
-					),
-				exclusions[selector],
+			result = filter(candidates, (candidate) =>
+				testCandidates(
+					rules.selectors[selector],
+					candidate,
+					measurements.opponents
+						? measurements.opponents[selector]
+						: [],
+				),
 			);
+			exclusions[selector] = result.exclusions;
+			candidates = result.filtered;
 		});
 	}
 
 	if (rules.filter) {
-		exclusions.custom = [];
-		candidates = filter(candidates, rules.filter, exclusions.custom);
+		result = filter(candidates, rules.filter);
+		exclusions.custom = result.exclusions;
+		candidates = result.filtered;
 	}
 
 	return candidates;
@@ -218,36 +216,31 @@ const getReady = (rules, options) =>
 
 const getCandidates = (rules, exclusions) => {
 	let candidates = query(rules.bodySelector + rules.slotSelector);
+	let result;
 	if (rules.fromBottom) {
 		candidates.reverse();
 	}
 	if (rules.startAt) {
 		let drop = true;
-		exclusions.startAt = [];
-		candidates = filter(
-			candidates,
-			(candidate) => {
-				if (candidate === rules.startAt) {
-					drop = false;
-				}
-				return !drop;
-			},
-			exclusions.startAt,
-		);
+		result = filter(candidates, (candidate) => {
+			if (candidate === rules.startAt) {
+				drop = false;
+			}
+			return !drop;
+		});
+		exclusions.startAt = result.exclusions;
+		candidates = result.filtered;
 	}
 	if (rules.stopAt) {
 		let keep = true;
-		exclusions.stopAt = [];
-		candidates = filter(
-			candidates,
-			(candidate) => {
-				if (candidate === rules.stopAt) {
-					keep = false;
-				}
-				return keep;
-			},
-			exclusions.stopAt,
-		);
+		result = filter(candidates, (candidate) => {
+			if (candidate === rules.stopAt) {
+				keep = false;
+			}
+			return keep;
+		});
+		exclusions.stopAt = result.exclusions;
+		candidates = result.filtered;
 	}
 	return candidates;
 };

--- a/static/src/javascripts/projects/common/modules/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/spacefinder.js
@@ -1,4 +1,4 @@
-// total_hours_spent_maintaining_this = 72
+// total_hours_spent_maintaining_this = 80
 
 import bean from 'bean';
 import fastdom from '../../../lib/fastdom-promise';

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -663,8 +663,6 @@
  "../projects/common/modules/experiments/tests/sign-in-gate-main-variant.js": [],
  "../projects/common/modules/experiments/tests/spacefinder-okr-1-filter-nearby.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
-  "../lib/config.d.ts",
-  "../lib/detect-viewport.ts",
   "../lib/noop.ts"
  ],
  "../projects/common/modules/identity/api.ts": [

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -97,8 +97,12 @@
   "../projects/commercial/modules/dfp/add-slot.ts",
   "../projects/commercial/modules/dfp/create-slot.ts",
   "../projects/commercial/modules/dfp/track-ad-render.ts",
+  "../projects/commercial/modules/filter-nearby-candidates-broken.ts",
+  "../projects/commercial/modules/filter-nearby-candidates-fixed.ts",
   "../projects/common/modules/article/space-filler.js",
-  "../projects/common/modules/commercial/commercial-features.ts"
+  "../projects/common/modules/commercial/commercial-features.ts",
+  "../projects/common/modules/experiments/ab.ts",
+  "../projects/common/modules/experiments/tests/spacefinder-okr-1-filter-nearby.ts"
  ],
  "../projects/commercial/modules/carrot-traffic-driver.ts": [
   "../lib/config.d.ts",
@@ -346,6 +350,8 @@
   "../projects/commercial/modules/dfp/Advert.ts",
   "../projects/commercial/modules/dfp/get-advert-by-id.ts"
  ],
+ "../projects/commercial/modules/filter-nearby-candidates-broken.ts": [],
+ "../projects/commercial/modules/filter-nearby-candidates-fixed.ts": [],
  "../projects/commercial/modules/header-bidding/a9/a9.ts": [
   "../lib/config.d.ts",
   "../lib/noop.ts",
@@ -628,7 +634,8 @@
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
   "../projects/common/modules/experiments/tests/remote-header-test.js",
   "../projects/common/modules/experiments/tests/sign-in-gate-main-control.js",
-  "../projects/common/modules/experiments/tests/sign-in-gate-main-variant.js"
+  "../projects/common/modules/experiments/tests/sign-in-gate-main-variant.js",
+  "../projects/common/modules/experiments/tests/spacefinder-okr-1-filter-nearby.ts"
  ],
  "../projects/common/modules/experiments/ab-url.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
@@ -654,6 +661,12 @@
  "../projects/common/modules/experiments/tests/remote-header-test.js": [],
  "../projects/common/modules/experiments/tests/sign-in-gate-main-control.js": [],
  "../projects/common/modules/experiments/tests/sign-in-gate-main-variant.js": [],
+ "../projects/common/modules/experiments/tests/spacefinder-okr-1-filter-nearby.ts": [
+  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
+  "../lib/config.d.ts",
+  "../lib/detect-viewport.ts",
+  "../lib/noop.ts"
+ ],
  "../projects/common/modules/identity/api.ts": [
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/config.d.ts",


### PR DESCRIPTION
## What does this change?

Fixes a bug in the "nearby candidate filtering" mechanism in spacefinder. Nearby candidate filtering is the last rule to be applied and is designed to filter out winning paragraphs which are too close to each other.

The bug was caused by a variable (`previousAllowedCandidate`) being defined in the global scope and not being managed correctly. As a result, state would be shared between consecutive calls to `filterNearbyCandidates`. This sometimes led to strange behaviour.

In particular, it sometimes meant candidate paragraphs which should have been marked as winning paragraphs were instead excluded on the basis they were too close to a previous winning paragraph.

The fix was to prevent `filterNearbyCandidates` relying on global state to keep track of the last winning paragraph. Instead, this responsibility was moved into the `filter` function in spacefinder, which now passes the last winning paragraph into `filterElement` as an optional second argument.

This bug only affected articles being viewed on desktop. Paid content articles and articles being viewed on mobile were not affected.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

More ads on affected pages! 

I believe this bug explains many of the entries in the [list of known articles with weirdly few ads](https://docs.google.com/spreadsheets/d/1NvBMULLeJHk3g9r8jmdr7F7qk-9UkS9Ypha_rpOuhI8/edit#gid=0). For example:

| Article | Inline ads (before) | Inline ads (after) |
|---------|---------------------|--------------------|
| [link](https://www.theguardian.com/football/2021/jul/18/uefas-conference-league-bohemians-new-saints-gets-thumbs-up-from-smaller-clubs?adrefresh=false)        |  1                   |  2                  |
| [link](https://www.theguardian.com/politics/2021/nov/18/support-for-populist-sentiment-falls-across-europe-survey-finds)        |  1                   | 2                   |
| [link](https://www.theguardian.com/commentisfree/2021/aug/10/techies-think-were-on-the-cusp-of-a-virtual-world-called-the-metaverse-im-skeptical?adrefresh=false)        |  1                   | 3                   |
| [link](https://www.theguardian.com/world/2022/jan/20/belgian-briton-zara-rutherford-is-youngest-woman-to-fly-solo-around-world?adrefresh=false)        | 1                    | 2                   |
| [link](https://www.theguardian.com/environment/2021/mar/04/people-wasting-almost-billion-tonnes-food-year-un-report?adrefresh=false)        | 1                    | 2                   |
| [link](https://www.theguardian.com/commentisfree/2022/jan/20/uk-government-yemen-war-saudi-arabia-westminster?adrefresh=false)        |  1                   | 2                   |
| [link](https://www.theguardian.com/environment/2022/jan/17/revealed-many-common-omega-3-fish-oil-supplements-are-rancid?adrefresh=false)       | 1                    |  3                  |
| [link](https://www.theguardian.com/environment/2022/jan/15/finland-sweden-norway-cull-wolf-population-eu?adrefresh=false)       | 1                    | 3                   | 

### <a name="ab"></a>A/B test

To measure the impact of this change, I've put the fix behind an A/B test `SpacefinderOkr1FilterNearby`. 

### Participation

20% of all users will participate in the test. Furthermore, the test will only run for pageviews where the following are true:

- the page is an article
- the page isn't paid content
- the page isn't being viewed on a mobile breakpoint

Update: we decided against filtering in the test config. Instead, this will happen in the analysis phase of the experiment.

### Variants

Half of test participants will see the page without the fix (`control`) while half will see it with the fix (`variant`)

## Tested

- [x] Locally
- [x] On CODE

## Screenshots

These screenshots were taken using the spacefinder visualisation tool which is still a work in progress. Winning paragraphs are shown with a green border. Paragraphs highlighted in yellow were excluded on the basis of being too close to previous winners.

| Before      | After      |
|-------------|------------|
| ![[before]](https://user-images.githubusercontent.com/7423751/151519032-d27926c8-e22a-4392-8a28-0ef35279f69a.png) | ![[after]](https://user-images.githubusercontent.com/7423751/151519016-06a89f7e-9664-4cc2-80ee-92ea08adbb02.png) |