### PR TITLE
Update CODEOWNERS to make dotcom-platofrm global codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,11 @@
 # See https://help.github.com/articles/about-codeowners/
+# Global owners
+*   @guardian/dotcom-platform
 
 # Commercial Dev code
-/static/src/javascripts/projects/common/modules/commercial/ @guardian/commercial-dev @guardian/dotcom-platform
-/static/src/javascripts/projects/commercial/ @guardian/commercial-dev @guardian/dotcom-platform
-/commercial/ @guardian/commercial-dev @guardian/dotcom-platform
+/static/src/javascripts/projects/common/modules/commercial/ @guardian/commercial-dev
+/static/src/javascripts/projects/commercial/ @guardian/commercial-dev
+/commercial/ @guardian/commercial-dev
 
 # Targeted Experiences (TX)
 /static/src/javascripts/projects/common/modules/commercial/braze @guardian/tx-engineers


### PR DESCRIPTION
## What does this change?

Update the CODEOWNERS file to make @guardian/dotcom-platform global owners.

This will mean all members of the dotcom-platform will be requested as a reviewers on PR's opened in the repo. We will be using this instead of requiring a member of the dotcom team to merge PR's from other teams, while still ensuring visibility of code changing on the platform.
