### PR TITLE
Add Winter Olympics in the sport navbar

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -382,6 +382,7 @@ private object NavLinks {
   val auSportPillar = ukSportPillar.copy(
     children = List(
       football,
+      winterOlympics,
       AFL,
       NRL,
       aLeague,
@@ -395,6 +396,7 @@ private object NavLinks {
   val usSportPillar = ukSportPillar.copy(
     children = List(
       soccer,
+      winterOlympics,
       NFL,
       tennis,
       MLB,
@@ -406,6 +408,7 @@ private object NavLinks {
   val intSportPillar = ukSportPillar.copy(
     children = List(
       football,
+      winterOlympics,
       cricket,
       rugbyUnion,
       tennis,

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -112,6 +112,7 @@ private object NavLinks {
       NavLink("Clubs", "/football/teams", Some("football/teams")),
     ),
   )
+  val winterOlympics = NavLink("Winter Olympics", "/sport/winter-olympics-2022")
   val soccer = football.copy(title = "Soccer")
   val cricket = NavLink("Cricket", "/sport/cricket")
   val cycling = NavLink("Cycling", "/sport/cycling")
@@ -365,6 +366,7 @@ private object NavLinks {
     iconName = Some("home"),
     List(
       football,
+      winterOlympics,
       cricket,
       rugbyUnion,
       tennis,


### PR DESCRIPTION
## What does this change?
Updates nav links on sport nav in all regions to include 'Winter Olympics' in the 2nd place. 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse: -->

| Before | After |
|--------|-------|
| ![image](https://user-images.githubusercontent.com/19683595/152031982-34797396-7c79-438b-ae76-26132f922b62.png) | ![image](https://user-images.githubusercontent.com/19683595/152127837-726609d2-17b9-44f3-876b-6e0eb8ea1e4d.png) |
| ![image](https://user-images.githubusercontent.com/19683595/152032457-3f509dc8-d884-4545-8260-ad55237199e0.png) | ![image](https://user-images.githubusercontent.com/19683595/152127924-4e7fe251-2c9a-4336-a7a8-e6e4f7fd3748.png) |
| ![image](https://user-images.githubusercontent.com/19683595/152032548-edadadb5-ec7d-4783-83ae-6407710354eb.png) | ![image](https://user-images.githubusercontent.com/19683595/152129058-ba6fa442-8dfb-4fb6-aea7-f292e8861746.png) |
| ![image](https://user-images.githubusercontent.com/19683595/152032631-10105837-dac3-4fad-ab99-aa64ffb2215f.png) | ![image](https://user-images.githubusercontent.com/19683595/152129130-ef65c1c6-1e94-4ccf-90d3-6b158f2d2a2c.png) |

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
