### PR TITLE
Add test for today's match logic

### DIFF
--- a/sport/app/football/implicits/Football.scala
+++ b/sport/app/football/implicits/Football.scala
@@ -45,7 +45,7 @@ trait Football extends Collections {
     )
 
     def isOn(date: LocalDate): Boolean =
-      m.date.toLocalDate.isAfter(date) && m.date.toLocalDate.isBefore(date.plusDays(1))
+      m.date.toLocalDate.isEqual(date)
 
     //results and fixtures do not actually have a status field in the API
     lazy val matchStatus = m match {

--- a/sport/test/football/feed/CompetitionsTest.scala
+++ b/sport/test/football/feed/CompetitionsTest.scala
@@ -37,6 +37,25 @@ class CompetitionsTest extends FreeSpec with Matchers with OptionValues {
         isAMatchInProgress should equal(testcase._2)
       }
     }
+    "withTodaysMatches should only return the matches that are on today" in {
+
+      //for now, i am manually creating the matches within the test so it is clearly visible how many are on today.
+      val matches = Seq(
+        FootballTestData
+          .result("Bolton", "Derby", 1, 1, FootballTestData.today.minusDays(1), Some("Bolton win 4-2 on penalties.")),
+        FootballTestData.liveMatch(false, "Cardiff", "Brighton", 2, 0, FootballTestData.today),
+        FootballTestData.liveMatch(true, "Derby", "Manchester", 3, 1, FootballTestData.today),
+        FootballTestData.fixture("Wolves", "Burnley", FootballTestData.today.plusDays(2)),
+      )
+      val testCompetition = FootballTestData.competitions(1).copy(matches = matches)
+      val competitions = Competitions(Seq(testCompetition))
+
+      val todaysCompetition = competitions.withTodaysMatches
+      val todaysMatchesTotal = todaysCompetition.matches.length
+
+      todaysMatchesTotal should equal(2)
+
+    }
   }
 
   // I had trouble using the original FootballTestData because it needed testFootballClient
@@ -132,7 +151,7 @@ class CompetitionsTest extends FreeSpec with Matchers with OptionValues {
       ),
     )
 
-    private def liveMatch(
+    def liveMatch(
         isLive: Boolean,
         homeName: String,
         awayName: String,
@@ -147,7 +166,7 @@ class CompetitionsTest extends FreeSpec with Matchers with OptionValues {
         awayTeam = team.copy(id = awayName, name = awayName, score = Some(awayScore)),
       )
 
-    private def fixture(homeName: String, awayName: String, date: ZonedDateTime) =
+    def fixture(homeName: String, awayName: String, date: ZonedDateTime) =
       _fixture.copy(
         id = s"fixture $homeName $awayName ${date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ"))}",
         date = date,
@@ -155,7 +174,7 @@ class CompetitionsTest extends FreeSpec with Matchers with OptionValues {
         awayTeam = team.copy(id = awayName, name = awayName, score = None),
       )
 
-    private def result(
+    def result(
         homeName: String,
         awayName: String,
         homeScore: Int,


### PR DESCRIPTION
## What does this change?

This PR adds a test for the `withTodaysMatches` logic with should give us a competition with only todays matches in. In doing so, it uncovered that the logic within this method (`isOn`) didnt work. It's suprising that this hasn't caused any issues as it is being used in production code so perhaps I am misunderstanding here and this should be vigorously tested. 

The new implementation only returns true if todays date is equal to the match date and it therefore todays match. 

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
