### PR TITLE
Add filterKeyEvents field to DCR rendering

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -112,7 +112,7 @@ class ArticleController(
       case AmpFormat if isAmpSupported =>
         remoteRenderer.getAMPArticle(ws, article, blocks, pageType)
       case HtmlFormat | AmpFormat if tier == RemoteRender =>
-        remoteRenderer.getArticle(ws, article, blocks, pageType)
+        remoteRenderer.getArticle(ws, article, blocks, pageType, false)
       case HtmlFormat | AmpFormat =>
         Future.successful(common.renderHtml(ArticleHtmlPage.html(article), article))
     }

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -112,7 +112,7 @@ class ArticleController(
       case AmpFormat if isAmpSupported =>
         remoteRenderer.getAMPArticle(ws, article, blocks, pageType)
       case HtmlFormat | AmpFormat if tier == RemoteRender =>
-        remoteRenderer.getArticle(ws, article, blocks, pageType, false)
+        remoteRenderer.getArticle(ws, article, blocks, pageType, filterKeyEvents = false)
       case HtmlFormat | AmpFormat =>
         Future.successful(common.renderHtml(ArticleHtmlPage.html(article), article))
     }

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -128,13 +128,13 @@ class LiveBlogController(
             if (remoteRendering) {
               DotcomponentsLogger.logger.logRequest(s"liveblog executing in dotcomponents", properties, page)
               val pageType: PageType = PageType(blog, request, context)
-              remoteRenderer.getArticle(ws, blog, blocks, pageType)
+              remoteRenderer.getArticle(ws, blog, blocks, pageType, filterKeyEvents)
             } else {
               DotcomponentsLogger.logger.logRequest(s"liveblog executing in web", properties, page)
               Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
             }
           case (blog: LiveBlogPage, AmpFormat) if isAmpSupported =>
-            remoteRenderer.getAMPArticle(ws, blog, blocks, pageType)
+            remoteRenderer.getAMPArticle(ws, blog, blocks, pageType, filterKeyEvents)
           case (blog: LiveBlogPage, AmpFormat) =>
             Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
           case _ => Future.successful(NotFound)
@@ -237,7 +237,7 @@ class LiveBlogController(
       blocks: Blocks,
   )(implicit request: RequestHeader): Result = {
     val pageType: PageType = PageType(blog, request, context)
-    val model = DotcomRenderingDataModel.forLiveblog(blog, blocks, request, pageType)
+    val model = DotcomRenderingDataModel.forLiveblog(blog, blocks, request, pageType, false)
     val json = DotcomRenderingDataModel.toJson(model)
     common.renderJson(json, blog).as("application/json")
   }

--- a/article/test/DCRFake.scala
+++ b/article/test/DCRFake.scala
@@ -17,6 +17,7 @@ class DCRFake(implicit context: ApplicationContext) extends renderers.DotcomRend
       article: PageWithStoryPackage,
       blocks: Blocks,
       pageType: PageType,
+      filterKeyEvents: Boolean,
   )(implicit request: RequestHeader): Future[Result] = {
     implicit val ec = ExecutionContext.global
     Future(

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -37,6 +37,7 @@ case class DotcomRenderingDataModel(
     webTitle: String,
     mainMediaElements: List[PageElement],
     main: String,
+    filterKeyEvents: Boolean,
     keyEvents: List[Block],
     blocks: List[Block],
     pagination: Option[Pagination],
@@ -101,6 +102,7 @@ object DotcomRenderingDataModel {
         "webTitle" -> model.webTitle,
         "mainMediaElements" -> model.mainMediaElements,
         "main" -> model.main,
+        "filterKeyEvents" -> model.filterKeyEvents,
         "keyEvents" -> model.keyEvents,
         "blocks" -> model.blocks,
         "pagination" -> model.pagination,
@@ -215,6 +217,7 @@ object DotcomRenderingDataModel {
       blocks: APIBlocks,
       request: RequestHeader,
       pageType: PageType,
+      filterKeyEvents: Boolean,
   ): DotcomRenderingDataModel = {
     val pagination = page.currentPage.pagination.map(paginationInfo => {
       Pagination(
@@ -258,6 +261,7 @@ object DotcomRenderingDataModel {
       pageType,
       page.related.hasStoryPackage,
       keyEvents,
+      filterKeyEvents,
     )
   }
 
@@ -271,6 +275,7 @@ object DotcomRenderingDataModel {
       pageType: PageType, // TODO remove as format is better
       hasStoryPackage: Boolean,
       keyEvents: Seq[APIBlock],
+      filterKeyEvents: Boolean = false,
   ): DotcomRenderingDataModel = {
 
     val edition = Edition.edition(request)
@@ -398,6 +403,7 @@ object DotcomRenderingDataModel {
       isImmersive = isImmersive,
       isLegacyInteractive = isLegacyInteractive,
       isSpecialReport = DotcomRenderingUtils.isSpecialReport(page),
+      filterKeyEvents = filterKeyEvents,
       keyEvents = keyEventsDCR.toList,
       linkedData = linkedData,
       main = content.fields.main,

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -106,11 +106,13 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       page: PageWithStoryPackage,
       blocks: Blocks,
       pageType: PageType,
+      filterKeyEvents: Boolean = false,
   )(implicit request: RequestHeader): Future[Result] = {
 
     val dataModel = page match {
-      case liveblog: LiveBlogPage => DotcomRenderingDataModel.forLiveblog(liveblog, blocks, request, pageType)
-      case _                      => DotcomRenderingDataModel.forArticle(page, blocks, request, pageType)
+      case liveblog: LiveBlogPage =>
+        DotcomRenderingDataModel.forLiveblog(liveblog, blocks, request, pageType, filterKeyEvents)
+      case _ => DotcomRenderingDataModel.forArticle(page, blocks, request, pageType)
     }
     val json = DotcomRenderingDataModel.toJson(dataModel)
 
@@ -122,11 +124,13 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       page: PageWithStoryPackage,
       blocks: Blocks,
       pageType: PageType,
+      filterKeyEvents: Boolean,
   )(implicit request: RequestHeader): Future[Result] = {
 
     val dataModel = page match {
-      case liveblog: LiveBlogPage => DotcomRenderingDataModel.forLiveblog(liveblog, blocks, request, pageType)
-      case _                      => DotcomRenderingDataModel.forArticle(page, blocks, request, pageType)
+      case liveblog: LiveBlogPage =>
+        DotcomRenderingDataModel.forLiveblog(liveblog, blocks, request, pageType, filterKeyEvents)
+      case _ => DotcomRenderingDataModel.forArticle(page, blocks, request, pageType)
     }
 
     val json = DotcomRenderingDataModel.toJson(dataModel)


### PR DESCRIPTION
## What does this change?

Adds a `filterKeyEvents` field to the `DotcomRenderingModel` and `DotcomRenderingService`. This value is set by the `filterKeyEvents` query parameter and passed through from `LiveBlogController.scala`.

Once we have this value in DCR we're able to use it to drive the timeline links.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

No UI changes.

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
