### PR TITLE
Fix extra quote on fronts img attrs

### DIFF
--- a/common/app/views/fragments/items/elements/facia_cards/image.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/image.scala.html
@@ -28,6 +28,6 @@
     }
     <!--[if IE 9]></video><![endif]-->
     @maybeImageMedia.map(ImgSrc.getFallbackUrl(_)).orElse(maybeSrc).orElse(maybePath.map(ImgSrc(_, ImageProfile(width = widths.desktop.map(_.get))))).map { src =>
-        <img loading="@{ if (Switches.LazyLoadImages.isSwitchedOn && shouldLazyLoadIndex) "lazy" else "auto"}" class="@RenderClasses(classes: _*)" alt="" src="@src""/>
+        <img loading="@{ if (Switches.LazyLoadImages.isSwitchedOn && shouldLazyLoadIndex) "lazy" else "auto"}" class="@RenderClasses(classes: _*)" alt="" src="@src"/>
     }
 </picture>

--- a/common/app/views/fragments/items/elements/facia_cards/image.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/image.scala.html
@@ -1,11 +1,9 @@
+@import conf.switches.Switches
 @import layout.WidthsByBreakpoint
 @import model.ImageMedia
-@import views.support.{ImgSrc, RenderClasses, SrcSet}
+@import views.support.{ImageProfile, ImgSrc, RenderClasses, SrcSet}
 @import implicits.Requests._
-@import conf.switches.Switches
-@import experiments.{ActiveExperiments}
 
-@import views.support.ImageProfile
 @(
     classes: Seq[String],
     widths: WidthsByBreakpoint,


### PR DESCRIPTION
## What does this change?

* Fix the stray `"` on fronts `img` tags, as reported by https://validator.w3.org/nu/?doc=https%3A%2F%2Fwww.theguardian.com%2Fus

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before](https://user-images.githubusercontent.com/705427/152564461-9c0b8810-f637-4ff7-849a-c928259132ba.png) | ![after](https://user-images.githubusercontent.com/705427/152564517-9c83fad3-64b1-4098-ae26-9cf6b562d3c9.png)|



### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
