### PR TITLE
Make the weather widget more accessible

### DIFF
--- a/onward/app/views/weatherFragments/cityForecast.scala.html
+++ b/onward/app/views/weatherFragments/cityForecast.scala.html
@@ -4,17 +4,15 @@
 
 
 @for((forecast, index) <- forecasts.drop(1).zipWithIndex) {
-    <li class="forecast__item forecast__item--@index">
-        <div class="weather__time">
-            <span class="u-h">The temperature at</span>
-            <time class="weather__time-value">@forecast.hourString</time>
-        </div>
-        @fragments.inlineSvg(s"weather-${forecast.weatherIcon}", "weather", Seq("weather__icon","js-weather-icon"))<span class="u-h">@forecast.weatherText</span>
-        <div class="weather__temp">
-            <span class="u-h">will be</span>
-            @defining(forecast.temperatureForEdition(Edition(request))) { temp =>
+    @defining(forecast.temperatureForEdition(Edition(request))) { temp =>
+        <li class="forecast__item forecast__item--@index" aria-label="@(s"${forecast.hourString}: ${temp}, ${forecast.weatherText.toLowerCase()}.")" role="text">
+            <div class="weather__time" aria-hidden="true">
+                <time class="weather__time-value">@forecast.hourString</time>
+            </div>
+            @fragments.inlineSvg(s"weather-${forecast.weatherIcon}", "weather", Seq("weather__icon", "js-weather-icon"), Some(forecast.weatherText), true)
+            <div class="weather__temp" aria-hidden="true">
                 <span class="weather__temp-value">@temp</span>
-            }
-        </div>
-    </li>
+            </div>
+        </li>
+    }
 }

--- a/onward/app/views/weatherFragments/cityWeather.scala.html
+++ b/onward/app/views/weatherFragments/cityWeather.scala.html
@@ -2,43 +2,43 @@
 
 @import common.Edition
 
-
-<div class="weather js-weather">
-    <div class="u-unstyled forecast__item forecast__item--current js-weather-current">
-        <div class="weather__time">
-            <span class="u-h">The temperature</span>
-            <span class="weather__time-value">Now</span>
-        </div>
-        @fragments.inlineSvg(s"weather-${weatherResponse.WeatherIcon}", "weather", Seq("weather__icon","js-weather-icon"), Some(weatherResponse.WeatherText))<span class="u-h">@weatherResponse.WeatherText</span>
-        <div class="weather__temp">
-            <span class="u-h">is</span>
-            @defining(weatherResponse.temperatureForEdition(Edition(request))) { temp =>
-                <span class="weather__temp js-weather-temp">@math.round(temp.Value)°@temp.Unit</span>
-            }
-        </div>
-    </div>
-    <button class="weather__toggle-forecast meta-button js-toggle-forecast mobile-only" data-link-name="weather-toggle-forecast"
-    href="#toggle-forecast"><span class="u-h">Toggle forecast</span><i class="weather__toggle-icon"></i>
-    </button>
-    <ul class="js-weather-forecast forecast"></ul>
-    <div class="weather__link-to-full" >
-        <div class="weather__icon--external-link">
-            @fragments.inlineSvg("external-link", "icon", List("weather__icon--external-link"))
-        </div>
-            <a href=@weatherResponse.Link&partner=web_guardian_adc target=”_blank” data-link-name="weather-view-full-forecast">View full forecast</a>
-    </div>
-    <div class="weather__location">
-        <div class="search-tool js-search-tool">
-            <div class="search-tool__form u-cf">
-                <label class="u-h" for="editlocation">Edit your location</label>
-                <input id="editlocation" class="search-tool__input js-search-tool-input" type="text" data-link-name="weather-edit-location" value="<%=city%>" aria-label="enter location" />
-                @fragments.inlineSvg("search-36", "icon", List("weather__search-icon", "weather__edit-location"))
-                <button class="search-tool__btn">@fragments.inlineSvg("search-36", "icon")<span class="u-h">Search for city</span></button>
+@defining(weatherResponse.temperatureForEdition(Edition(request))) { temp =>
+    <aside class="weather js-weather" aria-label="Today's weather forecast for <%=city%>">
+        <div class="u-unstyled forecast__item forecast__item--current js-weather-current" aria-label="@(s"The weather now: ${math.round(temp.Value)}°${temp.Unit}, ${weatherResponse.WeatherText.toLowerCase()}")">
+            <div class="weather__time" aria-hidden="true">
+                <span class="weather__time-value">Now</span>
             </div>
-            <ul class="u-unstyled search-tool__list js-search-tool-list"></ul>
+            @fragments.inlineSvg(s"weather-${weatherResponse.WeatherIcon}", "weather", Seq("weather__icon", "js-weather-icon"), Some(weatherResponse.WeatherText), true)
+            <div class="weather__temp" aria-hidden="true">
+                <span class="weather__temp js-weather-temp">@math.round(temp.Value)°@temp.Unit</span>
+            </div>
         </div>
-        <button class="weather__close-location js-close-location meta-button u-h" data-link-name="weather-close-location"
-        href="#close-change-location" aria-label="stop editing location"><span class="u-h">Close change location</span> @fragments.inlineSvg("close", "icon", List("weather__close-icon"))
+        <button class="weather__toggle-forecast meta-button js-toggle-forecast mobile-only" data-link-name="weather-toggle-forecast"
+        href="#toggle-forecast"><span class="u-h">Toggle forecast</span><i class="weather__toggle-icon"></i>
         </button>
-    </div>
-</div>
+        <ul class="js-weather-forecast forecast" aria-label="24 hour forecast"></ul>
+        <div class="weather__link-to-full" >
+            <div class="weather__icon--external-link">
+            @fragments.inlineSvg("external-link", "icon", List("weather__icon--external-link"), None, true)
+            </div>
+            <a href=@weatherResponse.Link&partner=web_guardian_adc
+            target=”_blank” data-link-name="weather-view-full-forecast">View full forecast</a>
+        </div>
+        <div class="weather__location">
+            <div class="search-tool js-search-tool">
+                <div class="search-tool__form u-cf">
+                    <label class="u-h" for="editlocation">Edit your location</label>
+                    <input id="editlocation" class="search-tool__input js-search-tool-input" type="text" data-link-name="weather-edit-location" value="<%=city%>" aria-label="enter location" />
+                    @fragments.inlineSvg("search-36", "icon", List("weather__search-icon", "weather__edit-location"), None, true)
+                    <button class="search-tool__btn">@fragments.inlineSvg("search-36", "icon") <span class="u-h">
+                        Search for city</span></button>
+                </div>
+                <ul class="u-unstyled search-tool__list js-search-tool-list"></ul>
+            </div>
+            <button class="weather__close-location js-close-location meta-button u-h" data-link-name="weather-close-location"
+            href="#close-change-location" aria-label="stop editing location"><span class="u-h">
+                Close change location</span> @fragments.inlineSvg("close", "icon", List("weather__close-icon"))
+            </button>
+        </div>
+    </aside>
+}


### PR DESCRIPTION
## What does this change?
This PR makes the front page weather widget more accessible to screenreader users.

There were a number of problems with the existing widget when viewed via a screenreader. This was especially frustrating as the user must navigate through the widget in order to reach the rest of the content on the front page.

The problems:
- The icons all appear as unlabelled images.
- The information appears in an incoherent order
- The user has to navigate through ~25 nodes to get through the widget

As well as fixing these points, I've also contained the widget in a more semantically relevant `aside` element, and added titles to the lower icons that will show to browser users as tooltips upon hover (as is the case for the upper icon currently).

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes, eventually - but DCR does not have an equivalent of the front yet. The widget will probably be recreated in e.g. React

## Videos

Here is a comparison of the element as it was before the changes, and after the changes - please turn audio on!

**Old widget:**

https://user-images.githubusercontent.com/34686302/152778681-62d676df-f198-4baf-bfb7-fdd3f6115664.mp4

**New widget:**

https://user-images.githubusercontent.com/34686302/152780032-2c37b834-55e0-4365-ac72-9b76fe834dac.mp4

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [X] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [X] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)
