### PR TITLE
Session, Content and Viewport targeting from commercial core

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.ts
@@ -409,7 +409,7 @@ describe('Build Page Targeting', () => {
 
 		it('should set ref to Twitter', () => {
 			getReferrer.mockReturnValue(
-				'https://www.t.co/you-must-unlearn-what-you-have-learned',
+				'https://t.co/you-must-unlearn-what-you-have-learned',
 			);
 			expect(getPageTargeting().ref).toEqual('twitter');
 		});

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.ts
@@ -291,7 +291,10 @@ describe('Build Page Targeting', () => {
 	});
 
 	it('should remove empty values', () => {
-		window.guardian.config.page = {} as PageConfig;
+		window.guardian.config.page = {
+			// pageId should always be defined
+			pageId: 'football/series/footballweekly',
+		} as PageConfig;
 		window.guardian.config.ophan = { pageViewId: '123456' };
 
 		expect(getPageTargeting()).toEqual({
@@ -312,6 +315,7 @@ describe('Build Page Targeting', () => {
 			sens: 'f',
 			si: 't',
 			skinsize: 's',
+			urlkw: ['footballweekly'],
 		});
 	});
 

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.ts
@@ -1,13 +1,15 @@
+import type {
+	ContentTargeting,
+	SessionTargeting,
+	ViewportTargeting,
+} from '@guardian/commercial-core';
 import {
 	clearPermutiveSegments,
+	getContentTargeting,
 	getPermutiveSegments,
+	getSessionTargeting,
+	getViewportTargeting,
 } from '@guardian/commercial-core';
-import { getContentTargeting } from '@guardian/commercial-core/dist/esm/targeting/content';
-import type { ContentTargeting } from '@guardian/commercial-core/dist/esm/targeting/content';
-import type { SessionTargeting } from '@guardian/commercial-core/dist/esm/targeting/session';
-import { getSessionTargeting } from '@guardian/commercial-core/dist/esm/targeting/session';
-import type { ViewportTargeting } from '@guardian/commercial-core/dist/esm/targeting/viewport';
-import { getViewportTargeting } from '@guardian/commercial-core/dist/esm/targeting/viewport';
 import { cmp } from '@guardian/consent-management-platform';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import type { TCFv2ConsentList } from '@guardian/consent-management-platform/dist/types/tcfv2';
@@ -305,10 +307,11 @@ const getPageTargeting = (consentState?: ConsentState): PageTargeting => {
 		referrer: detectGetReferrer(),
 	});
 
-	const viewportTargeting: ViewportTargeting = getViewportTargeting(
-		getViewport().width,
-		!cmp.hasInitialised() || cmp.willShowPrivacyMessageSync(),
-	);
+	const viewportTargeting: ViewportTargeting = getViewportTargeting({
+		viewPortWidth: getViewport().width,
+		cmpBannerWillShow:
+			!cmp.hasInitialised() || cmp.willShowPrivacyMessageSync(),
+	});
 
 	const pageTargets: PageTargeting = {
 		fr: getFrequencyValue(),

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -69,7 +69,10 @@ interface Config {
 	};
 	page: PageConfig;
 	switches: Record<string, boolean | undefined>;
-	tests?: Record<ServerSideABTest, 'control' | 'variant'>;
+	tests?: {
+		[key: `${string}Control`]: 'control';
+		[key: `${string}Variant`]: 'variant';
+	};
 	isDotcomRendering: boolean;
 }
 

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -559,7 +559,7 @@
  ],
  "../projects/common/modules/async-call-merger.ts": [],
  "../projects/common/modules/commercial/build-page-targeting.ts": [
-  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
   "../../../../node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",


### PR DESCRIPTION
## What does this change?

This PR uses the page targeting functions defined in commercial-core to build parts of the targeting object: specifically the content targeting, session targeting and viewport targeting.

It also involves fixing up two tests that fail now we introduce these new methods of generating targeting, explained in comments below.

For more information on the specific targeting, these PRs give detail of the implementation:

- https://github.com/guardian/commercial-core/pull/421
- https://github.com/guardian/commercial-core/pull/423
- https://github.com/guardian/commercial-core/pull/424
- https://github.com/guardian/commercial-core/pull/455

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes - In the future DCR can use these functions on AMP as well

## What is the value of this and can you measure success?

The functions used to generate page targeting in commercial-core have typed targeting, that is we know precisely the types of all of the produced targeting values. This will be very helpful in managing the page targeting object moving forwards.

## Follow ups

Personalised and shared targeting will be imported from commercial-core in subsequent PRs. We should then be able to deprecate the targeting types in Frontend and solely use the ones in commercial-core.

### Tested

- [ ] Locally
- [ ] On CODE (optional)

