### PR TITLE
Capture metrics for `spacefinderOkr1FilterNearby`

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
@@ -1,8 +1,10 @@
 import type { ABTest } from '@guardian/ab-core';
 import { isInABTestSynchronous } from '../experiments/ab';
+import { spacefinderOkr1FilterNearby } from '../experiments/tests/spacefinder-okr-1-filter-nearby';
 
 const defaultClientSideTests: ABTest[] = [
 	/* linter, please keep this array multi-line */
+	spacefinderOkr1FilterNearby,
 ];
 
 const serverSideTests: ServerSideABTest[] = [];


### PR DESCRIPTION
I forgot to add this in the previous PR: https://github.com/guardian/frontend/pull/24592