### PR TITLE
Add filterKeyEvents value to renderJson DCR

### DIFF
--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -82,7 +82,7 @@ class LiveBlogController(
       val range = getRange(lastUpdate)
       mapModel(path, range, filter) {
         case (blog: LiveBlogPage, _) if rendered.contains(false) => getJsonForFronts(blog)
-        case (blog: LiveBlogPage, blocks) if request.forceDCR    => Future.successful(renderGuuiJson(blog, blocks))
+        case (blog: LiveBlogPage, blocks) if request.forceDCR    => Future.successful(renderGuuiJson(blog, blocks, filter))
         case (blog: LiveBlogPage, _)                             => getJson(blog, range, isLivePage, filter)
         case (minute: MinutePage, _) =>
           Future.successful(common.renderJson(views.html.fragments.minuteBody(minute), minute))
@@ -235,9 +235,10 @@ class LiveBlogController(
   private[this] def renderGuuiJson(
       blog: LiveBlogPage,
       blocks: Blocks,
+      filterKeyEvents: Boolean,
   )(implicit request: RequestHeader): Result = {
     val pageType: PageType = PageType(blog, request, context)
-    val model = DotcomRenderingDataModel.forLiveblog(blog, blocks, request, pageType, false)
+    val model = DotcomRenderingDataModel.forLiveblog(blog, blocks, request, pageType, filterKeyEvents)
     val json = DotcomRenderingDataModel.toJson(model)
     common.renderJson(json, blog).as("application/json")
   }


### PR DESCRIPTION
## What does this change?

[In DCR ](https://github.com/guardian/dotcom-rendering/pull/3786) we're using the `filterKeyEvents` value on `CAPI` to set the toggle state and timeline links correctly when the page first loads. Our initial understanding had been that the `.json` route below was used for live blog block updates only, however we now have realised that DCR uses this endpoint when running locally.

This PR fixes it so both _renderJson_ and _renderArticle_ contain the correct the `filterKeyEvents` parameter as it is in the url.

For context the earlier PR is [here](https://github.com/guardian/frontend/pull/24607)

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots



### Before
<img width="1176" alt="Screenshot 2022-02-08 at 09 29 53" src="https://user-images.githubusercontent.com/77005274/152961436-98632da3-3e2c-4d8a-aefe-c44a794fc21a.png">

### After
<img width="1251" alt="Screenshot 2022-02-08 at 09 30 11" src="https://user-images.githubusercontent.com/77005274/152961677-d5bd14e3-bae4-4d43-9c1d-437127f9fb13.png">


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
