### PR TITLE
Change privacy wording to be plural on signup page, set feature switc…

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -479,7 +479,7 @@ trait FeatureSwitches {
     "newsletters-remove-confirmation-step",
     "Remove confirmation step when user sign up to a newsletter",
     owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
-    safeState = On,
+    safeState = Off,
     sellByDate = LocalDate.of(2022, 3, 4),
     exposeClientSide = false,
   )

--- a/common/app/views/fragments/email/signup/privacyNoticeContent.scala.html
+++ b/common/app/views/fragments/email/signup/privacyNoticeContent.scala.html
@@ -1,8 +1,8 @@
 
-@(privacyNoticeId: String = "privacy-notice", privacyNoticeClass: String  = "terms")(implicit request: RequestHeader)
+@(privacyNoticeId: String = "privacy-notice", privacyNoticeClass: String  = "terms", plural: Boolean = true)(implicit request: RequestHeader)
 
 <span id="@privacyNoticeId" class="@privacyNoticeClass">
-    We thought you should know this newsletter may also contain information about Guardian products,
+    We thought you should know @if(plural){ these newsletters } else { this newsletter } may also contain information about Guardian products,
     services and chosen charities or online advertisements.
     Newsletters mays also contain content funded by outside parties.
     You can read more about <a href="/help/privacy-policy" data-link-name="privacy-policy" target="_blank">our privacy policy here</a>.

--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -59,9 +59,9 @@
             <button type="submit" class="email-sub__submit-button button button--tertiary button--large" id="email-embed-signup-button--old" data-component="email-signup-button @componentClass-@listName" data-link-name="@componentClass | @listName">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
             @if(EmailSignupRecaptcha.isSwitchedOn) {
                 @fragments.email.signup.recaptchaContainer()
-                @fragments.email.signup.recaptchaTerms(fragments.email.signup.privacyNoticeContent(privacyNoticeId, privacyNoticeHiddenClass))
+                @fragments.email.signup.recaptchaTerms(fragments.email.signup.privacyNoticeContent(privacyNoticeId, privacyNoticeHiddenClass, false))
             } else {
-                @fragments.email.signup.privacyNoticeContent(privacyNoticeId, privacyNoticeHiddenClass)
+                @fragments.email.signup.privacyNoticeContent(privacyNoticeId, privacyNoticeHiddenClass, false)
             }
         </div>
     </form>


### PR DESCRIPTION
Privacy wording on the signup page was singular, this change it to be plural
The feature switch is set off by default

### Tested

- [X] Locally

