### PR TITLE
Add spacefinder visualiser

### DIFF
--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -75,6 +75,7 @@ class DevParametersHttpRequestHandler(
     "utm_medium", // Google Analytics medium
     "utm_campaign", // Google Analytics campaign
     "utm_term", // Google Analytics term
+    "sfdebug", // enable spacefinder visualiser. '1' = first pass, '2' = second pass
   )
 
   val playBugs = Seq("") // (Play 2.5 bug?) request.queryString is returning an empty string when empty

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.js
@@ -10,11 +10,15 @@ import { createAdSlot } from './dfp/create-slot';
 import { commercialFeatures } from '../../common/modules/commercial/commercial-features';
 import { initCarrot } from './carrot-traffic-driver';
 import { getBreakpoint, getTweakpoint, getViewport } from 'lib/detect-viewport';
+import { getUrlVars } from 'lib/url';
 
 import { filterNearbyCandidatesBroken } from './filter-nearby-candidates-broken.ts';
 import { filterNearbyCandidatesFixed } from './filter-nearby-candidates-fixed.ts';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { spacefinderOkr1FilterNearby } from 'common/modules/experiments/tests/spacefinder-okr-1-filter-nearby';
+
+const sfdebug = getUrlVars().sfdebug;
+
 const isPaidContent = config.get('page.isPaidContent', false);
 
 const adSlotClassSelectorSizes = {
@@ -110,6 +114,10 @@ const addDesktopInlineAds = (isInline1) => {
 			.map((para, i) => {
 				const inlineId = i + (isInline1 ? 1 : 2);
 
+				if (sfdebug) {
+					para.style.cssText += 'border: thick solid green;';
+				}
+
 				return insertAdAtPara(
 					para,
 					`inline${inlineId}`,
@@ -124,10 +132,14 @@ const addDesktopInlineAds = (isInline1) => {
 		return Promise.all(slots).then(() => slots.length);
 	};
 
+	const enableDebug =
+		(sfdebug === '1' && isInline1) || (sfdebug === '2' && !isInline1);
+
 	return spaceFiller.fillSpace(rules, insertAds, {
 		waitForImages: true,
 		waitForLinks: true,
 		waitForInteractives: true,
+		debug: enableDebug,
 	});
 };
 
@@ -165,11 +177,14 @@ const addMobileInlineAds = () => {
 		return Promise.all(slots).then(() => slots.length);
 	};
 
+	const enableDebug = sfdebug === '1';
+
 	// This just returns whatever is passed in the second argument
 	return spaceFiller.fillSpace(rules, insertAds, {
 		waitForImages: true,
 		waitForLinks: true,
 		waitForInteractives: true,
+		debug: enableDebug,
 	});
 };
 

--- a/static/src/javascripts/projects/common/modules/mark-candidates.js
+++ b/static/src/javascripts/projects/common/modules/mark-candidates.js
@@ -1,0 +1,83 @@
+export const markCandidates = (exclusions, winners, options) => {
+	if (!options.debug) return winners;
+
+	const colours = {
+		red: 'rgb(255 178 178)',
+		orange: 'rgb(255 213 178)',
+		yellow: 'rgb(254 255 178)',
+		blue: 'rgb(178 248 255)',
+		pink: 'rgb(255 178 242)',
+		green: 'rgb(178 255 184)',
+	};
+
+	const exclusionTypes = {
+		absoluteMinAbove: {
+			colour: colours.red,
+			reason: 'Too close to the top of page',
+		},
+		aboveAndBelow: {
+			colour: colours.orange,
+			reason: 'Too close to top or bottom of article',
+		},
+		custom: {
+			colour: colours.yellow,
+			reason: 'Too close to other winner',
+		},
+	};
+
+	const addHoverListener = (candidate, tooClose) => {
+		tooClose.forEach((opponent) => {
+			candidate.addEventListener(
+				'mouseenter',
+				() =>
+					(opponent.style.cssText = `box-shadow: 0px 0px 0px 20px ${colours.blue}`),
+			);
+
+			candidate.addEventListener(
+				'mouseleave',
+				() => (opponent.style.cssText = ''),
+			);
+		});
+	};
+
+	const addExplainer = (element, text) => {
+		const explainer = document.createElement('div');
+		explainer.appendChild(document.createTextNode(text));
+		explainer.style.cssText = `
+            position:absolute;
+            right:0;
+            background-color:#fffffff7;
+            padding:10px;
+            border-radius:0 0 0 10px;
+            font-family: sans-serif;
+        `;
+		element.before(explainer);
+	};
+
+	// Mark losing candidates
+	for (const [key, arr] of Object.entries(exclusions)) {
+		arr.forEach((exclusion) => {
+			const type = exclusionTypes[key];
+
+			if (type) {
+				addExplainer(exclusion.element, type.reason);
+				exclusion.element.style.cssText += `background:${type.colour}`;
+			} else if (exclusion.meta.tooClose.length > 0) {
+				addExplainer(exclusion.element, 'Too close to other element');
+				exclusion.element.style.cssText += `background:${colours.blue}`;
+				addHoverListener(exclusion.element, exclusion.meta.tooClose);
+			} else {
+				addExplainer(exclusion.element, `Unknown key: ${key}`);
+				exclusion.element.style.cssText += `background:${colours.pink}`;
+			}
+		});
+	}
+
+	// Mark winning candidates
+	winners.forEach((winner) => {
+		addExplainer(winner.element, 'Winner');
+		winner.element.style.cssText += `background:${colours.green};`;
+	});
+
+	return winners;
+};

--- a/static/src/javascripts/projects/common/modules/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/spacefinder.js
@@ -4,6 +4,7 @@ import bean from 'bean';
 import fastdom from '../../../lib/fastdom-promise';
 import { mediator } from '../../../lib/mediator';
 import { memoize } from 'lodash-es';
+import { markCandidates } from './mark-candidates';
 
 const query = (selector, context) => [
 	...(context ?? document).querySelectorAll(selector),
@@ -201,90 +202,6 @@ const enforceRules = (measurements, rules, exclusions) => {
 	}
 
 	return candidates;
-};
-
-const markCandidates = (exclusions, winners, options) => {
-	if (!options.debug) return winners;
-
-	const colours = {
-		red: 'rgb(255 178 178)',
-		orange: 'rgb(255 213 178)',
-		yellow: 'rgb(254 255 178)',
-		blue: 'rgb(178 248 255)',
-		pink: 'rgb(255 178 242)',
-		green: 'rgb(178 255 184)',
-	};
-
-	const exclusionTypes = {
-		absoluteMinAbove: {
-			colour: colours.red,
-			reason: 'Too close to the top of page',
-		},
-		aboveAndBelow: {
-			colour: colours.orange,
-			reason: 'Too close to top or bottom of article',
-		},
-		custom: {
-			colour: colours.yellow,
-			reason: 'Too close to other winner',
-		},
-	};
-
-	const addHoverListener = (candidate, tooClose) => {
-		tooClose.forEach((opponent) => {
-			candidate.addEventListener(
-				'mouseenter',
-				() =>
-					(opponent.style.cssText = `box-shadow: 0px 0px 0px 20px ${colours.blue}`),
-			);
-
-			candidate.addEventListener(
-				'mouseleave',
-				() => (opponent.style.cssText = ''),
-			);
-		});
-	};
-
-	const addExplainer = (element, text) => {
-		const explainer = document.createElement('div');
-		explainer.appendChild(document.createTextNode(text));
-		explainer.style.cssText = `
-            position:absolute;
-            right:0;
-            background-color:#fffffff7;
-            padding:10px;
-            border-radius:0 0 0 10px;
-            font-family: sans-serif;
-        `;
-		element.before(explainer);
-	};
-
-	// Mark losing candidates
-	for (const [key, arr] of Object.entries(exclusions)) {
-		arr.forEach((exclusion) => {
-			const type = exclusionTypes[key];
-
-			if (type) {
-				addExplainer(exclusion.element, type.reason);
-				exclusion.element.style.cssText += `background:${type.colour}`;
-			} else if (exclusion.meta.tooClose.length > 0) {
-				addExplainer(exclusion.element, 'Too close to other element');
-				exclusion.element.style.cssText += `background:${colours.blue}`;
-				addHoverListener(exclusion.element, exclusion.meta.tooClose);
-			} else {
-				addExplainer(exclusion.element, `Unknown key: ${key}`);
-				exclusion.element.style.cssText += `background:${colours.pink}`;
-			}
-		});
-	}
-
-	// Mark winning candidates
-	winners.forEach((winner) => {
-		addExplainer(winner.element, 'Winner');
-		winner.element.style.cssText += `background:${colours.green};`;
-	});
-
-	return winners;
 };
 
 class SpaceError extends Error {

--- a/static/src/javascripts/projects/common/modules/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/spacefinder.js
@@ -123,22 +123,22 @@ const filter = (list, filterElement) => {
 };
 
 // test one element vs another for the given rules
-const testCandidate = (rule, challenger, opponent) => {
-	const isMinAbove = challenger.top - opponent.bottom >= rule.minAbove;
-	const isMinBelow = opponent.top - challenger.top >= rule.minBelow;
+const testCandidate = (rule, candidate, opponent) => {
+	const isMinAbove = candidate.top - opponent.bottom >= rule.minAbove;
+	const isMinBelow = opponent.top - candidate.top >= rule.minBelow;
 
 	const pass = isMinAbove || isMinBelow;
 
 	if (!pass) {
-		challenger.meta.tooClose.push(opponent.element);
+		candidate.meta.tooClose.push(opponent.element);
 	}
 
 	return pass;
 };
 
 // test one element vs an array of other elements for the given rules
-const testCandidates = (rules, challenger, opponents) =>
-	opponents.every(testCandidate.bind(undefined, rules, challenger));
+const testCandidates = (rules, candidate, opponents) =>
+	opponents.every(testCandidate.bind(undefined, rules, candidate));
 
 const enforceRules = (measurements, rules, exclusions) => {
 	let candidates = measurements.candidates;

--- a/static/src/javascripts/projects/common/modules/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/spacefinder.js
@@ -235,7 +235,7 @@ const markCandidates = (exclusions, winners, options) => {
 			candidate.addEventListener(
 				'mouseenter',
 				() =>
-					(opponent.style.cssText = `border: thick solid ${colours.blue}; color: ${colours.blue}`),
+					(opponent.style.cssText = `box-shadow: 0px 0px 0px 20px ${colours.blue}`),
 			);
 
 			candidate.addEventListener(
@@ -245,20 +245,34 @@ const markCandidates = (exclusions, winners, options) => {
 		});
 	};
 
+	const addExplainer = (element, text) => {
+		const explainer = document.createElement('div');
+		explainer.appendChild(document.createTextNode(text));
+		explainer.style.cssText = `
+            position:absolute;
+            right:0;
+            background-color:#fffffff7;
+            padding:10px;
+            border-radius:0 0 0 10px;
+            font-family: sans-serif;
+        `;
+		element.before(explainer);
+	};
+
 	// Mark losing candidates
 	for (const [key, arr] of Object.entries(exclusions)) {
 		arr.forEach((exclusion) => {
 			const type = exclusionTypes[key];
 
 			if (type) {
-				exclusion.element.title = type.reason;
+				addExplainer(exclusion.element, type.reason);
 				exclusion.element.style.cssText += `background:${type.colour}`;
 			} else if (exclusion.meta.tooClose.length > 0) {
-				exclusion.element.title = 'Too close to other element';
+				addExplainer(exclusion.element, 'Too close to other element');
 				exclusion.element.style.cssText += `background:${colours.blue}`;
 				addHoverListener(exclusion.element, exclusion.meta.tooClose);
 			} else {
-				exclusion.element.title = `Unknown key: ${key}`;
+				addExplainer(exclusion.element, `Unknown key: ${key}`);
 				exclusion.element.style.cssText += `background:${colours.pink}`;
 			}
 		});
@@ -266,7 +280,7 @@ const markCandidates = (exclusions, winners, options) => {
 
 	// Mark winning candidates
 	winners.forEach((winner) => {
-		winner.element.title = 'Winner';
+		addExplainer(winner.element, 'Winner');
 		winner.element.style.cssText += `background:${colours.green};`;
 	});
 

--- a/static/src/javascripts/projects/common/modules/spacefinder.spec.js
+++ b/static/src/javascripts/projects/common/modules/spacefinder.spec.js
@@ -8,7 +8,7 @@ describe('spacefinder', () => {
     test('should test elements correctly', () => {
         const rules = { minAbove: 50, minBelow: 300 };
         const element = document.createElement('div');
-        const para = { top: 200, bottom: 300, element };
+        const para = { top: 200, bottom: 300, element, meta: { tooClose: [] } };
         const others = [
             {
                 opponent: { top: 0, bottom: 100, element },

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -93,6 +93,7 @@
   "../lib/detect-viewport.ts",
   "../lib/fastdom-promise.js",
   "../lib/mediator.ts",
+  "../lib/url.ts",
   "../projects/commercial/modules/carrot-traffic-driver.ts",
   "../projects/commercial/modules/dfp/add-slot.ts",
   "../projects/commercial/modules/dfp/create-slot.ts",


### PR DESCRIPTION
## What does this change?

Spacefinder is notoriously complex and opaque. This PR introduces a debug mode which, when enabled, annotates articles with information about decisions spacefinder made. It reveals why candidate paragraphs were chosen (or not) for the insertion of inline ads. This will hopefully be useful for tracking down bugs and optimisations.

On desktop articles, spacefinder runs twice when calculating where to insert inline ads. The first pass is responsible for inserting an `inline1` ad, and the second pass for inserting `inline2`, `inline3`, etc. ads. The rules are different, which is why we need two passes.

The debug mode can be enabled using the URL query parameter `sfdebug`, where:

`sfdebug=1` shows information about the first pass
`sfdebug=2` shows information about the second pass

On mobile articles, spacefinder runs just once so only `sfdebug=1` is supported.

### Features

Each paragraph is coloured according to why is was chosen or rejected.

Green = winning paragraph
Red = too close to top of page
Orange = too close to top or bottom of article
Yellow = too close to previous winning paragraph from this pass
Blue = too close to specific HTML element (e.g. image, heading, ad-slot)
Pink = rejected for unknown reason

If you hover over a blue paragraph, it will highlight _which_ element or elements are too close.

Finally, a dark green border is applied to winning paragraphs _across both passes_.

### Known limitations

- It currently only displays one of potentially many reasons a given paragraph was rejected. This is because of the way spacefinder is implemented. It applies the rules one after the other, reducing the list each time. This is more efficient than applying all rules to all paragraphs, but it could be a source of confusion here.
- It currently only works on articles. If it proves useful, we could add support for other uses of spacefinder, such as liveblogs.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

It should help anyone in the team answer the question: "why is/isn't there an ad there?"

It was already used to identify and fix these bugs: 

https://github.com/guardian/frontend/pull/24592
https://github.com/guardian/frontend/pull/24610

### Tested

- [x] Locally
- [ ] On CODE (optional)

### Bookmarklets

These bookmarklets are handy for setting the `sfdebug` query parameter

#### First pass

```
javascript:const value="1",re=new RegExp("([?&])sfdebug=.*?(&|$)","i"),separator=-1!==window.location.href.indexOf("?")?"&":"?";window.location.href=window.location.href.match(re)?window.location.href.replace(re,"$1sfdebug=1$2"):window.location.href+separator+"sfdebug=1";
```

#### Second pass

```
javascript:const value="2",re=new RegExp("([?&])sfdebug=.*?(&|$)","i"),separator=-1!==window.location.href.indexOf("?")?"&":"?";window.location.href=window.location.href.match(re)?window.location.href.replace(re,"$1sfdebug=1$2"):window.location.href+separator+"sfdebug=1";
```

## Screenshot
![screencapture-localhost-9000-us-news-2022-feb-11-saved-the-wordle-clue-that-helped-rescue-80-year-old-woman-from-hostage-ordeal-2022-02-11-11_45_20](https://user-images.githubusercontent.com/7423751/153626699-328d29a6-9227-495a-beef-05dc644a8912.png)

