### PR TITLE
Add winter olympics 2022 badge

### DIFF
--- a/common/app/model/Badges.scala
+++ b/common/app/model/Badges.scala
@@ -102,6 +102,8 @@ object Badges {
     Badge("sport/tokyo-paralympic-games-2020", Static("images/badges/tokyo-2020.svg"))
   val cop26 =
     Badge("environment/cop26-glasgow-climate-change-conference-2021", Static("images/badges/cop26-badge.svg"))
+  val winterOlympics2022 =
+    Badge("sport/winter-olympics-2022", Static("images/badges/winter-olympics-2022-badge.svg"))
 
   val allBadges = Seq(
     newArrivals,
@@ -153,6 +155,7 @@ object Badges {
     paralympics2020,
     tokyoparalympics2020,
     cop26,
+    winterOlympics2022,
   )
 
   def badgeFor(c: ContentType): Option[Badge] = {

--- a/static/public/images/badges/winter-olympics-2022-badge.svg
+++ b/static/public/images/badges/winter-olympics-2022-badge.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.4.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 452.54 248.2" style="enable-background:new 0 0 452.54 248.2;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#BCCDEA;}
+	.st1{fill:#FCC200;}
+	.st2{fill:#F2904A;}
+	.st3{fill:#D10A11;}
+</style>
+<g>
+	<path class="st0" d="M113.64,193.44c0,31.21-26.5,54.76-57.12,54.76C24.73,248.2,0,224.64,0,193.44s24.73-55.35,56.53-55.35
+		C87.15,138.09,113.64,162.23,113.64,193.44z"/>
+	<path class="st1" d="M283.09,193.44c0,31.21-26.5,54.76-57.12,54.76c-31.79,0-56.53-23.55-56.53-54.76s24.73-55.35,56.53-55.35
+		C256.59,138.09,283.09,162.23,283.09,193.44z"/>
+	<path class="st2" d="M452.54,193.44c0,31.21-26.5,54.76-57.12,54.76c-31.79,0-56.53-23.55-56.53-54.76s24.73-55.35,56.53-55.35
+		C426.04,138.09,452.54,162.23,452.54,193.44z"/>
+</g>
+<g>
+	<polygon class="st3" points="286.05,0 233.5,92.62 246.16,114.93 251.79,114.93 316.99,0 	"/>
+	<polygon class="st3" points="200.75,114.93 231.69,114.93 166.49,0 135.55,0 	"/>
+</g>
+</svg>


### PR DESCRIPTION
## What does this change?

Adds winter olympics 2022 badge to tag `sport/winter-olympics-2022`

## screenhots
Before:
<img width="393" alt="image" src="https://user-images.githubusercontent.com/9575458/153026231-34824075-7c43-4f86-af80-77d42f4d296e.png">
After:
<img width="443" alt="image" src="https://user-images.githubusercontent.com/9575458/153026198-e6119b79-46a5-4416-a9d2-ec080609f72b.png">

