### PR TITLE
Pass consent state when setting GPT targeting

### DIFF
--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -258,6 +258,7 @@
  ],
  "../projects/commercial/modules/dfp/prepare-googletag.ts": [
   "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
+  "../../../../node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/config.d.ts",
   "../lib/raven.js",
@@ -548,7 +549,8 @@
  ],
  "../projects/common/modules/analytics/shouldCaptureMetrics.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
-  "../projects/common/modules/experiments/ab.ts"
+  "../projects/common/modules/experiments/ab.ts",
+  "../projects/common/modules/experiments/tests/spacefinder-okr-1-filter-nearby.ts"
  ],
  "../projects/common/modules/article/space-filler.js": [
   "../lib/fastdom-promise.js",


### PR DESCRIPTION
Coauthored by @lucymonie @zekehuntergreen @arelra.

## What does this change?

Call `getPageTargeting` with consent state as a parameter at the point we set key-values in GPT. This ensures that the resulting page targeting contains key-values associated with consent (notably `consent_tcfv2`).

Previously, this call to `getPageTargeting` gave `consent_tcfv2='na'`, but should give `consent_tcfv2='t'` when consented.

In order to call `getPageTargeting(consentState)`, we have to wait until we've obtained consent. Therefore, the point at which we push commands onto the googletag command array has been moved until just before we load the GPT script, where consent state is available.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

This fixes an issue where Teads adverts weren't eligible for display on any pages, since they require the `consent_tcfv2` targeting key to have value `'t'`. By passing consent state into `getPageTargeting` at the point we set GPT, we are able to correctly pass this key-value to GAM and display Teads adverts.

### Tested

- [X] Locally
- [X] On CODE (optional)
