### PR TITLE
Basic sticky video

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/liveblog.js
+++ b/static/src/javascripts/bootstraps/enhanced/liveblog.js
@@ -12,6 +12,8 @@ import bean from 'bean';
 import { scrollToElement } from 'lib/scroller';
 import { elementInView } from 'lib/element-inview';
 import ophan from 'ophan/ng';
+import $ from 'lib/$';
+
 
 const affixTimeline = () => {
 	const keywordIds = config.get('page.keywordIds', '');
@@ -101,7 +103,22 @@ const trackOphanClick = (pinnedBlockId, clickValue) => {
 };
 
 const setupListeners = () => {
+    const $window = $(window)
 	const pinnedBlockButton = document.querySelector('.pinned-block__button');
+    const $mediaAtom = $(`.element-atom--media`)
+    const nextSibling = $mediaAtom.next('p')
+
+    bean.on(window, 'scroll', () => {
+        const windowScrollTop = $window.scrollTop()
+        const videoBottom = nextSibling.offset().top - $mediaAtom.height();
+
+        if (windowScrollTop > videoBottom ) {
+            $mediaAtom.addClass("stuck")
+        } else {
+            $mediaAtom.removeClass("stuck")
+        }
+    })
+
 
 	bean.on(document.body, 'change', '.live-blog__filter-switch-label', () => {
 		const hasParam =

--- a/static/src/stylesheets/module/content-garnett/_types.scss
+++ b/static/src/stylesheets/module/content-garnett/_types.scss
@@ -345,9 +345,29 @@ $quote-mark: 35px;
         line-height: 75px;
     }
 
+    @keyframes fade-in-up {
+        0% { opacity: 0; }
+        100% { transform: translateY(0); opacity: 1; }
+    }
+
     .element-atom--media {
         .fc-item.fc-item--media::before {
             content: none;
+        }
+
+        &.stuck {
+            position: fixed;
+            bottom: 20px;
+            right: 20px;
+            width: 260px;
+            height: 145px;
+            z-index: 9999999;
+            transform: translateY(100%);
+            animation: fade-in-up .25s ease forwards;
+
+            figcaption {
+                display: none;
+            }
         }
     }
 


### PR DESCRIPTION
## What does this change?

Beginnings of a spike into how sticky videos might work in live blogs.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

## Screenshots


https://user-images.githubusercontent.com/77005274/153040800-904f3f5d-5e3b-4b16-93ee-c307a8c87869.mov



## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
