### PR TITLE
Change event timer metric name from `commercialEnd` to `commercialModulesLoaded`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@guardian/atom-renderer": "1.2.2",
     "@guardian/automat-modules": "^0.3.8",
     "@guardian/braze-components": "^5.3.0",
-    "@guardian/commercial-core": "^0.39.0",
+    "@guardian/commercial-core": "^0.41.0",
     "@guardian/consent-management-platform": "^10.1.1",
     "@guardian/libs": "^3.6.1",
     "@guardian/shimport": "^1.0.2",

--- a/static/src/javascripts/bootstraps/standalone.commercial.ts
+++ b/static/src/javascripts/bootstraps/standalone.commercial.ts
@@ -170,7 +170,7 @@ const bootCommercial = async (): Promise<void> => {
 		const promises = allModules.map((args) => loadModules(...args));
 
 		await Promise.all(promises).then(() => {
-			EventTimer.get().trigger('commercialEnd');
+			EventTimer.get().trigger('commercialModulesLoaded');
 		});
 	} catch (error) {
 		// report async errors in bootCommercial to Sentry with the commercial feature tag

--- a/yarn.lock
+++ b/yarn.lock
@@ -1247,10 +1247,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-5.3.0.tgz#abe79666e5636ad2a0064cb2f227a64239231d2f"
   integrity sha512-3tljnI79cIR2e3RrnXMc0liSPAuFjezDZ50MCpXw9Y3KX8jD92AqWDAfjsC0XrpGj946ZB149Z/EarhrSRQ/hg==
 
-"@guardian/commercial-core@^0.39.0":
-  version "0.39.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.39.0.tgz#314af346a02599d75219492dac89a89be169cc93"
-  integrity sha512-3OGfM9K3KQR1PMOJoPM6EL1tuy6s4YRoIfnFTvM4NY+Z5Yc11uDZXqthzXBmRjlnf8EHVMZo2a2ffDlZnrguTA==
+"@guardian/commercial-core@^0.41.0":
+  version "0.41.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.41.0.tgz#5ac9848d151b8291a0f0bdd2d4f278048bda39b7"
+  integrity sha512-A5G5qd+ZqFfV8SlAJ+SS+EwkUkscbLo0M4+3xIlIcpxGUb6cVkYJItt6hUR/FmFS/6Ie5177bBzFqRpxQziIFg==
 
 "@guardian/consent-management-platform@^10.1.1":
   version "10.1.1"


### PR DESCRIPTION
## What does this change?
Renames the commercial metric triggered after all commercial modules are loaded from `commercialEnd` to `commercialModulesLoaded`

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
The change from `commercialEnd` to `commercialModulesLoaded` reflects what has actually occurred when the metric is triggered; All commercial modules have been loaded (but haven't necessarily finished executing), but since more commercial events (e.g. initialising the first slot and showing the first ad) have yet to happen, `commercialEnd` could be misleading.

### Tested

- [x] Locally
- [ ] On CODE (optional)

### TODO
- upgrade version of commercial core to 0.41.0 once https://github.com/guardian/commercial-core/pull/498 is released

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
