### PR TITLE
Braze ad slots in article emails

### DIFF
--- a/article/app/views/fragments/email/emailArticleBody.scala.html
+++ b/article/app/views/fragments/email/emailArticleBody.scala.html
@@ -139,16 +139,31 @@
         }
     }
 
+    @row(Seq("no-pad braze-advert-placeholder")) {
+        @brazePlaceholder(s"Above Headline")
+    }
+
     @row(Seq("padded")) {
         <h1>@article.trail.headline</h1>
+    }
+
+    @row(Seq("no-pad braze-advert-placeholder")) {
+        @brazePlaceholder(s"Above Standfirst")
     }
 
     @article.fields.standfirst.map { standfirst =>
         @row(Seq("padded"))(Html(standfirst))
     }
 
+    @row(Seq("no-pad braze-advert-placeholder")) {
+        @brazePlaceholder(s"Above MainMedia")
+    }
+
     @fragments.emailMainMedia(article)
 
+    @row(Seq("no-pad braze-advert-placeholder")) {
+        @brazePlaceholder(s"Above Byline")
+    }
     @defining(
         article.tags.contributors,
         article.tags.tones.exists { _.id == "tone/features" } ||
@@ -177,6 +192,10 @@
         @blocks.body.map { block =>
 
             @block.elements.zipWithIndex.map { case (element, elementIndex )=>
+
+                @row(Seq("no-pad braze-advert-placeholder")) {
+                    @brazePlaceholder(s"Above Element ${elementIndex + 1}")
+                }
                 @element match {
                     case TextBlockElement(Some(html)) => {
                         @row(Seq("padded"))(Html(html))
@@ -262,7 +281,9 @@
                     case _ => {}
                 }
 
-                @brazePlaceholder(s"Below Element ${elementIndex + 1}")
+                @row(Seq("no-pad braze-advert-placeholder")) {
+                    @brazePlaceholder(s"Below Element ${elementIndex + 1}")
+                }
             }
         }
     }

--- a/article/app/views/fragments/email/emailArticleBody.scala.html
+++ b/article/app/views/fragments/email/emailArticleBody.scala.html
@@ -176,7 +176,7 @@
     @page.article.fields.blocks.toSeq.map { blocks =>
         @blocks.body.map { block =>
 
-            @block.elements.map { element =>
+            @block.elements.zipWithIndex.map { case (element, elementIndex )=>
                 @element match {
                     case TextBlockElement(Some(html)) => {
                         @row(Seq("padded"))(Html(html))
@@ -261,6 +261,8 @@
 
                     case _ => {}
                 }
+
+                @brazePlaceholder(s"Below Element ${elementIndex + 1}")
             }
         }
     }


### PR DESCRIPTION
## What does this change? 
Adds Rows containing brazePlaceholder comments between each section  in the emailArticleBody template. 

This is to allow the advertising team to insert adverts in the body of the article when rendering them to be send via Braze, in the same way as they use the existing "Above Footer" comment.

The adverts that will be inserted are self contained table elements. The new brazePlaceholder comments need to be wrapped in table rows to fit within the structure of the .article-body table The row cells use the 'no-pad' class and contain no visible children - so there is no visible impact on the page, (until a comment is replaced by an advert in braze).

The new brazePlaceholder comments are named as followed (and positioned accordingly):
 - "Above Headline"
 - "Above StandFirst"
 - "Above MainMedia"
 - "Above Byline"
 - (for each element in article content, starting from n=1) 
   - "Above Element ``n``" 
   - "Below Element ``n``"

## Does this change need to be reproduced in dotcom-rendering ?

- [X ] No
- [ ] Yes (please indicate your plans for DCR Implementation)


-->

## What is the value of this and can you measure success?
Advertising team are able to insert adverts in article newsletters using Braze logic blocks in the email templates.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Tested

- [X] Locally
- [ ] On CODE (optional)

