### PR TITLE
Exclude paid content from being served as pressed

### DIFF
--- a/article/app/services/dotcomponents/ArticlePicker.scala
+++ b/article/app/services/dotcomponents/ArticlePicker.scala
@@ -87,7 +87,7 @@ object ArticlePicker {
     val checks = dcrChecks(page, request)
     val dcrCanRender = checks.values.forall(identity)
     val isNotPaidContent = ArticlePageChecks.isNotPaidContent(page)
-    val shouldServePressed = isNotPaidContent && PressedContent.isPressed(ensureStartingForwardSlash(path))
+    val shouldServePressed = PressedContent.isPressed(ensureStartingForwardSlash(path)) && isNotPaidContent
 
     val tier: RenderType = decideTier(shouldServePressed, dcrCanRender)
 

--- a/article/test/services/dotcomponents/ArticlePickerTest.scala
+++ b/article/test/services/dotcomponents/ArticlePickerTest.scala
@@ -24,7 +24,7 @@ import test.TestRequest
     tier should be(RemoteRender)
   }
 
-  it should "return RemoteRender if force DCR and content is pressed" in {
+  it should "return RemoteRender if force DCR and content should be served pressed" in {
     val testRequest = TestRequest("article-path?dcr=true")
     val tier = ArticlePicker.decideTier(true, true)(testRequest)
     tier should be(RemoteRender)
@@ -36,7 +36,7 @@ import test.TestRequest
     tier should be(PressedArticle)
   }
 
-  it should "return RemoteRender if dcr can render and article is not pressed" in {
+  it should "return RemoteRender if dcr can render and article should not be served pressed" in {
     val testRequest = TestRequest("article-path")
     val tier = ArticlePicker.decideTier(false, true)(testRequest)
     tier should be(RemoteRender)

--- a/common/app/services/dotcomrendering/PressedContent.scala
+++ b/common/app/services/dotcomrendering/PressedContent.scala
@@ -137,6 +137,11 @@ object PressedContent {
     "/lifeandstyle/ng-interactive/2018/feb/25/the-ofm-50-everything-we-love-in-the-world-of-food-right-now",
     "/cities/ng-interactive/2016/nov/10/subterranean-london",
     // articles
+    "/travel/2015/dec/03/machu-picchu-google-street-view-peru",
+    "/membership/2017/jan/23/saving-retirement-pension-generation-old-age",
+    "/us-news/2015/jun/05/black-women-police-killing-tanisha-anderson",
+    "/australia-news/2019/dec/18/too-hot-for-humans-first-nations-people-fear-becoming-australias-first-climate-refugees",
+    "/whats-in-your-blood-/2018/oct/11/ancestry-search-unexpected-discovery",
   )
 
   def isPressed(path: String): Boolean = content.contains(path)

--- a/common/app/services/dotcomrendering/PressedContent.scala
+++ b/common/app/services/dotcomrendering/PressedContent.scala
@@ -137,11 +137,6 @@ object PressedContent {
     "/lifeandstyle/ng-interactive/2018/feb/25/the-ofm-50-everything-we-love-in-the-world-of-food-right-now",
     "/cities/ng-interactive/2016/nov/10/subterranean-london",
     // articles
-    "/travel/2015/dec/03/machu-picchu-google-street-view-peru",
-    "/membership/2017/jan/23/saving-retirement-pension-generation-old-age",
-    "/us-news/2015/jun/05/black-women-police-killing-tanisha-anderson",
-    "/australia-news/2019/dec/18/too-hot-for-humans-first-nations-people-fear-becoming-australias-first-climate-refugees",
-    "/whats-in-your-blood-/2018/oct/11/ancestry-search-unexpected-discovery",
   )
 
   def isPressed(path: String): Boolean = content.contains(path)


### PR DESCRIPTION
Co-authored-by: David Lawes <david.lawes@guardian.co.uk>

## What does this change?
If an article with paid content gets accidentally pressed (i.e. archived to the S3 bucket) and added to the list in `PressedContent`, we want to make sure it will not be served as pressed but will continue to be rendered from DCR .

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
