### PR TITLE
Send today's article count and contentType in banner requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@guardian/shimport": "^1.0.2",
     "@guardian/source-foundations": "^4.0.0-rc.4",
     "@guardian/source-react-components": "^4.0.0-rc.2",
-    "@guardian/support-dotcom-components": "^1.0.0",
+    "@guardian/support-dotcom-components": "^1.0.1",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",
     "bootstrap-sass": "^3.4.1",

--- a/static/src/javascripts/projects/common/modules/support/banner.ts
+++ b/static/src/javascripts/projects/common/modules/support/banner.ts
@@ -30,6 +30,7 @@ import config from 'lib/config';
 import fastdom from 'lib/fastdom-promise';
 import { getCountryCode } from 'lib/geolocation';
 import reportError from 'lib/report-error';
+import { getArticleViewCountForDays } from 'common/modules/onward/history';
 
 export const NO_RR_BANNER_TIMESTAMP_KEY = 'gu.noRRBannerTimestamp'; // timestamp of when we were last told not to show a RR banner
 const twentyMins = 20 * 60_000;
@@ -109,7 +110,7 @@ export const renderBanner = (
 };
 
 const buildBannerPayload = async (): Promise<BannerPayload> => {
-	const { section, shouldHideReaderRevenue, isPaidContent } =
+	const { contentType, section, shouldHideReaderRevenue, isPaidContent } =
 		window.guardian.config.page;
 
 	const targeting: BannerTargeting = {
@@ -126,10 +127,12 @@ const buildBannerPayload = async (): Promise<BannerPayload> => {
 		mvtId: getMvtValue() ?? 0,
 		countryCode: getCountryCode(),
 		weeklyArticleHistory: getWeeklyArticleHistory(storage.local),
+		articleCountToday: getArticleViewCountForDays(1),
 		hasOptedOutOfArticleCount: !(await getArticleCountConsent()),
 		modulesVersion: ModulesVersion,
 		sectionId: section,
 		tagIds: buildTagIds(),
+		contentType,
 	};
 
 	return {

--- a/static/src/javascripts/projects/common/modules/support/banner.ts
+++ b/static/src/javascripts/projects/common/modules/support/banner.ts
@@ -16,6 +16,7 @@ import { getMvtValue } from 'common/modules/analytics/mvt-cookie';
 import { submitComponentEvent } from 'common/modules/commercial/acquisitions-ophan';
 import { getVisitCount } from 'common/modules/commercial/contributions-utilities';
 import { shouldHideSupportMessaging } from 'common/modules/commercial/user-features';
+import { getArticleViewCountForDays } from 'common/modules/onward/history';
 import {
 	buildTagIds,
 	dynamicImport,
@@ -30,7 +31,6 @@ import config from 'lib/config';
 import fastdom from 'lib/fastdom-promise';
 import { getCountryCode } from 'lib/geolocation';
 import reportError from 'lib/report-error';
-import { getArticleViewCountForDays } from 'common/modules/onward/history';
 
 export const NO_RR_BANNER_TIMESTAMP_KEY = 'gu.noRRBannerTimestamp'; // timestamp of when we were last told not to show a RR banner
 const twentyMins = 20 * 60_000;
@@ -127,7 +127,7 @@ const buildBannerPayload = async (): Promise<BannerPayload> => {
 		mvtId: getMvtValue() ?? 0,
 		countryCode: getCountryCode(),
 		weeklyArticleHistory: getWeeklyArticleHistory(storage.local),
-		articleCountToday: getArticleViewCountForDays(1),
+		articleCountToday: getArticleViewCountForDays(1) as number,
 		hasOptedOutOfArticleCount: !(await getArticleCountConsent()),
 		modulesVersion: ModulesVersion,
 		sectionId: section,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1322,10 +1322,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-3.12.0.tgz#52d11d2fff649e04934033473b3ed7c7bf4a1639"
   integrity sha512-JIFBybaCd69tf+zJZZ7KNLdqaVePOAc36wGFor0I60vc9Ib0jMuzYVffMjMhF6LHSXMdoOcqGwiPdFucObVYAA==
 
-"@guardian/support-dotcom-components@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/support-dotcom-components/-/support-dotcom-components-1.0.0.tgz#802b507de87c4ef120ae9f02d6f44be1fea47353"
-  integrity sha512-zxtDDUYy3RDlizQ3UrYUYIQ2ooojj5gJmtEZjiAPN+SvL8cHlIPDQnX6aaTx6RMoIQUpQ4vVZyAVrLDOuUY37Q==
+"@guardian/support-dotcom-components@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/support-dotcom-components/-/support-dotcom-components-1.0.1.tgz#a6f51ce1c93efbaac705989a9d63a601bbf80328"
+  integrity sha512-zoxBAQIRUiz3iMi+wgutSi36igLjpGUI66JT+ByxHgFkTELiqsflG6Htn1ynYy4j5q80LyEIwahLqtuFFWq+YQ==
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"


### PR DESCRIPTION
SDC PR: https://github.com/guardian/support-dotcom-components/pull/624

This PR makes the client send 2 new fields in the targeting payload to SDC for banners:
- contentType
- articleCountToday (if available)

![Screen Shot 2022-02-10 at 11 45 55](https://user-images.githubusercontent.com/1513454/153405310-45464572-0597-4739-9937-7b99fb18cd62.png)
