### PR TITLE
Revert "Update link text and destinations for single front door test"

### DIFF
--- a/common/app/navigation/ReaderRevenueSite.scala
+++ b/common/app/navigation/ReaderRevenueSite.scala
@@ -29,10 +29,6 @@ object ReaderRevenueSite extends enumeratum.Enum[ReaderRevenueSite] {
     val url: String = s"${Configuration.id.supportUrl}/subscribe"
   }
 
-  case object SupportGuardianWeekly extends ReaderRevenueSite {
-    val url: String = s"${Configuration.id.supportUrl}/subscribe/weekly"
-  }
-
   case object SupportContribute extends ReaderRevenueSite {
     val url: String = s"${Configuration.id.supportUrl}/contribute"
   }

--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -64,11 +64,7 @@ object UrlHelpers {
   def readerRevenueLinks(implicit request: RequestHeader): List[NavLink] =
     List(
       NavLink("Make a contribution", getReaderRevenueUrl(SupportContribute, SideMenu)),
-      NavLink(
-        "Print subscriptions",
-        getReaderRevenueUrl(SupportGuardianWeekly, SideMenu),
-        classList = Seq("js-subscribe"),
-      ),
+      NavLink("Subscribe", getReaderRevenueUrl(SupportSubscribe, SideMenu), classList = Seq("js-subscribe")),
     )
 
   private val uriEncoder = UriConfig.default.copy(

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -87,6 +87,7 @@
                             </ul>
                         }
 
+                        @readerRevenueLinks(Edition(request).id.toLowerCase())
 
                     } else {
                         <div class="colophon__list">

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -1,4 +1,3 @@
-@import navigation.ReaderRevenueSite.SupportGuardianWeekly
 @()(implicit page: model.Page, request: RequestHeader)
 
 @import common.{LinkTo, Edition}
@@ -49,12 +48,15 @@
             <div class="new-header__top-bar hide-until-mobile">
                 @defining(Edition(request).id.toLowerCase()) { editionId =>
                 @if(!page.metadata.hasSlimHeader) {
-                    <div class="top-bar__commercial-items">
-                        <span class="top-bar__item__seperator hide-until-desktop"></span>
-                        <a class="top-bar__item hide-until-desktop" data-link-name="nav2 : supporter-cta" data-edition="@{editionId}" href="@getReaderRevenueUrl(SupportGuardianWeekly, Header)">
-                            Print subscriptions
-                        </a>
-                    </div>
+                <div class="top-bar__commercial-items js-supporter-cta is-hidden">
+                    <span class="top-bar__item__seperator hide-until-desktop"></span>
+                    <a class="top-bar__item hide-until-desktop"
+                       data-link-name="nav2 : supporter-cta"
+                       data-edition="@{editionId}"
+                       href="@getReaderRevenueUrl(SupporterCTA, Header)">
+                        Subscriptions
+                    </a>
+                </div>
 
                 @if(editionId != "au" || editionId == "uk") {
                 <div class="top-bar__commercial-items">


### PR DESCRIPTION
We're now ready to end the Single Front Door test so we can revert these changes.

Reverts guardian/frontend#24554