### PR TITLE
thrasher containers have transparent background by default

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_containers.scss
+++ b/static/src/stylesheets/module/facia-garnett/_containers.scss
@@ -1,6 +1,6 @@
 @import 'container--video';
 
-.fc-container--first#palette-styles-new-do-not-delete + .fc-container, 
+.fc-container--first#palette-styles-new-do-not-delete + .fc-container,
 .fc-container--first {
     margin-top: 0;
     padding-top: 0;
@@ -93,7 +93,7 @@
     margin-top: 0;
     margin-bottom: $gs-baseline * 2;
     padding-bottom: 0;
-    background: $brightness-97;
+    background: transparent;
 
     .fc-container__inner {
         border-top: 0;


### PR DESCRIPTION
## What does this change?
The containers for Thrasher atoms (example - the 'pushing buttons' banner currently on https://www.theguardian.com/games) will have transparent backgrounds by default instead of light grey. 

This is for a new design decision that these elements should not colour the page margins. Existing Thrashers that set a custom colour for their containers will eventually be changed individually.


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

DCR doesn't use these containers.

## Screenshots

### Before 
<img width="1479" alt="Screenshot 2022-02-14 at 14 12 42" src="https://user-images.githubusercontent.com/30567854/153880625-e76d4c61-8fd4-43b1-bfb9-6122e9f2389b.png">

### after
<img width="1479" alt="Screenshot 2022-02-14 at 14 12 29" src="https://user-images.githubusercontent.com/30567854/153880783-5b7407a1-20a1-4a5f-8a87-275609179322.png">


## Checklist

### Does this affect other platforms?

- [x] AMP <!-- AMP question? https://git.io/v9zIE -->
- [x] Apps
- [x] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
