### PR TITLE
Hotfix liveblog adverts

### DIFF
--- a/static/src/javascripts/projects/common/modules/article/space-filler.js
+++ b/static/src/javascripts/projects/common/modules/article/space-filler.js
@@ -24,6 +24,7 @@ class SpaceFiller {
 			fastdom.mutate(() => writer(paragraphs));
 
 		const onNoSpacesFound = (ex) => {
+			console.log(ex);
 			if (ex instanceof SpaceError) {
 				return false;
 			}

--- a/static/src/javascripts/projects/common/modules/article/space-filler.js
+++ b/static/src/javascripts/projects/common/modules/article/space-filler.js
@@ -24,7 +24,6 @@ class SpaceFiller {
 			fastdom.mutate(() => writer(paragraphs));
 
 		const onNoSpacesFound = (ex) => {
-			console.log(ex);
 			if (ex instanceof SpaceError) {
 				return false;
 			}

--- a/static/src/javascripts/projects/common/modules/mark-candidates.js
+++ b/static/src/javascripts/projects/common/modules/mark-candidates.js
@@ -1,5 +1,5 @@
 export const markCandidates = (exclusions, winners, options) => {
-	if (!options.debug) return winners;
+	if (!options?.debug) return winners;
 
 	const colours = {
 		red: 'rgb(255 178 178)',


### PR DESCRIPTION
## What does this change?
Fixes a regression in spacefinder for liveblog advertisements introduced in #24618 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?
- Liveblogs will show ads again!

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
