### PR TITLE
chore(deps): bump @guardian/consent-management-platform from 10.1.1 to 10.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@guardian/automat-modules": "^0.3.8",
     "@guardian/braze-components": "^5.3.0",
     "@guardian/commercial-core": "^0.41.0",
-    "@guardian/consent-management-platform": "^10.1.1",
+    "@guardian/consent-management-platform": "^10.1.2",
     "@guardian/libs": "^3.6.1",
     "@guardian/shimport": "^1.0.2",
     "@guardian/source-foundations": "^4.0.0-rc.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1252,10 +1252,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-0.41.0.tgz#5ac9848d151b8291a0f0bdd2d4f278048bda39b7"
   integrity sha512-A5G5qd+ZqFfV8SlAJ+SS+EwkUkscbLo0M4+3xIlIcpxGUb6cVkYJItt6hUR/FmFS/6Ie5177bBzFqRpxQziIFg==
 
-"@guardian/consent-management-platform@^10.1.1":
-  version "10.1.1"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-10.1.1.tgz#c49ccdde26582b571accd925f576fb178c619004"
-  integrity sha512-hzhmrlhNVkwshKXKYVQUrl4NBA6iCkyFg79LQHUD3nDpo5IjxzwOGlUU4ML1gzFFID4lZ1AM2klxkM7ZUfYySg==
+"@guardian/consent-management-platform@^10.1.2":
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-10.1.2.tgz#f7ea2ce14c1ee9c5822c8f0fe34aec006adfda89"
+  integrity sha512-2rJxMIqAekwWxerxscWai4pbEnOnmf1rrPO5kawLlkppv9AKMS+KpK+9/C8vqqHBC2Niat5JpT845IJJUYv4CA==
   dependencies:
     "@guardian/libs" "1.6.1 - 3.3.0"
 


### PR DESCRIPTION
## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes ([please indicate your plans for DCR Implementation](https://github.com/guardian/dotcom-rendering/pull/3997))

## What is the value of this and can you measure success?

Bumps the CMP to 10.1.2 to incorporate changes from https://github.com/guardian/consent-management-platform/pull/552.

This change keep frontend up to date with the latest version of the CMP.

## Checklist

### Tested

- [X] Locally
- [ ] On CODE (optional)