### PR TITLE
Newsletters - embed - terms: Text color becomes black

### DIFF
--- a/common/app/views/fragments/email/signup/privacyNoticeContent.scala.html
+++ b/common/app/views/fragments/email/signup/privacyNoticeContent.scala.html
@@ -1,7 +1,7 @@
 
-@(privacyNoticeId: String = "privacy-notice", privacyNoticeClass: String  = "terms", plural: Boolean = true)(implicit request: RequestHeader)
+@(plural: Boolean = true, termsClass: String  = "")(implicit request: RequestHeader)
 
-<span id="@privacyNoticeId" class="@privacyNoticeClass">
+<span id="privacy-notice" class="newsletters-privacy-notice @termsClass">
     We thought you should know @if(plural){ these newsletters } else { this newsletter } may also contain information about Guardian products,
     services and chosen charities or online advertisements.
     Newsletters mays also contain content funded by outside parties.

--- a/common/app/views/fragments/email/signup/recaptchaTerms.scala.html
+++ b/common/app/views/fragments/email/signup/recaptchaTerms.scala.html
@@ -1,5 +1,5 @@
-@(privacyNotice: Html = null)(implicit request: RequestHeader)
+@(privacyNotice: Html = null, dark: String = "")(implicit request: RequestHeader)
 
-<div id="newsletters-terms" class="terms">
+<div id="newsletters-terms" class="terms @dark">
     @privacyNotice We operate Google reCAPTCHA to protect our website and the Google <a href="https://policies.google.com/privacy" target="_blank">Privacy Policy</a> and <a href="https://policies.google.com/terms" target="_blank">Terms of Service</a> apply.
 </div>

--- a/common/app/views/fragments/email/signup/recaptchaTerms.scala.html
+++ b/common/app/views/fragments/email/signup/recaptchaTerms.scala.html
@@ -1,5 +1,5 @@
 @(privacyNotice: Html = null)(implicit request: RequestHeader)
 
-<div class="terms">
+<div id="newsletters-terms" class="terms">
     @privacyNotice We operate Google reCAPTCHA to protect our website and the Google <a href="https://policies.google.com/privacy" target="_blank">Privacy Policy</a> and <a href="https://policies.google.com/terms" target="_blank">Terms of Service</a> apply.
 </div>

--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -53,10 +53,10 @@
 
             </div>
             <button type="submit" class="email-sub__submit-button button button--tertiary button--large" id="email-embed-signup-button--old" data-component="email-signup-button @componentClass-@listName" data-link-name="@componentClass | @listName">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
-            @if(!EmailSignupRecaptcha.isSwitchedOn && NewslettersRemoveConfirmationStep.isSwitchedOn ) {
+            @if(EmailSignupRecaptcha.isSwitchedOn && NewslettersRemoveConfirmationStep.isSwitchedOn ) {
                 @fragments.email.signup.recaptchaContainer()
                 @fragments.email.signup.recaptchaTerms(fragments.email.signup.privacyNoticeContent(false), "dark")
-            } else if(!EmailSignupRecaptcha.isSwitchedOn) {
+            } else if(EmailSignupRecaptcha.isSwitchedOn) {
                 @fragments.email.signup.recaptchaContainer()
                 @fragments.email.signup.recaptchaTerms()
             }else if(NewslettersRemoveConfirmationStep.isSwitchedOn) {

--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -55,7 +55,7 @@
             <button type="submit" class="email-sub__submit-button button button--tertiary button--large" id="email-embed-signup-button--old" data-component="email-signup-button @componentClass-@listName" data-link-name="@componentClass | @listName">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
             @if(EmailSignupRecaptcha.isSwitchedOn && NewslettersRemoveConfirmationStep.isSwitchedOn ) {
                 @fragments.email.signup.recaptchaContainer()
-                @fragments.email.signup.recaptchaTerms(fragments.email.signup.privacyNoticeContent(false), "dark")
+                @fragments.email.signup.recaptchaTerms(fragments.email.signup.privacyNoticeContent(plural = false), "dark")
             } else if(EmailSignupRecaptcha.isSwitchedOn) {
                 @fragments.email.signup.recaptchaContainer()
                 @fragments.email.signup.recaptchaTerms()

--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -60,7 +60,7 @@
                 @fragments.email.signup.recaptchaContainer()
                 @fragments.email.signup.recaptchaTerms()
             }else if(NewslettersRemoveConfirmationStep.isSwitchedOn) {
-                @fragments.email.signup.privacyNoticeContent(false, "terms dark")
+                @fragments.email.signup.privacyNoticeContent(plural = false, termsClass = "terms dark")
             }
         </div>
     </form>

--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -38,6 +38,8 @@
 @privacyNoticeId = @{"embed-privacy-notice"}
 @privacyNoticeHiddenClass = @{"newsletters-privacy-notice-hidden"}
 @privacyNoticeVisibleClass = @{"newsletters-privacy-notice-visible"}
+@termsId = @{"newsletters-terms"}
+@termsDark = @{"dark"}
 
 @form = {
     <form action="@LinkTo(s"/email")" method="post" id="@formId" class="@formClass" data-email-form-type="@componentClass" data-email-list-name="@listName">
@@ -84,11 +86,13 @@
         document.getElementById("@inputId")
         .addEventListener("focusin", ()=> {
             document.getElementById("@privacyNoticeId")?.setAttribute('class', '@privacyNoticeVisibleClass')
+            document.getElementById("@termsId")?.setAttribute('class', 'terms @termsDark')
             iframeMessenger?.resize();
         });
     document.getElementById("@inputId")
         .addEventListener("focusout", ()=> {
             document.getElementById("@privacyNoticeId")?.setAttribute('class', '@privacyNoticeHiddenClass')
+            document.getElementById("@termsId")?.setAttribute('class', 'terms')
             iframeMessenger?.resize();
         });
     }

--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -35,15 +35,10 @@
 @formClass = @{ "email-sub__form" + " email-sub__form--" + componentClass }
 @headerClass = @{"email-sub__header" + " email-sub__header--" + componentClass  }
 
-@privacyNoticeId = @{"embed-privacy-notice"}
-@privacyNoticeHiddenClass = @{"newsletters-privacy-notice-hidden"}
-@termsId = @{"newsletters-terms"}
-@termsDark = @{"dark"}
-
 @form = {
     <form action="@LinkTo(s"/email")" method="post" id="@formId" class="@formClass" data-email-form-type="@componentClass" data-email-list-name="@listName">
         @helper.CSRF.formField
-        <div class="email-sub__form-wrapper">
+        <div class="email-sub__form-wrapper" tabindex="-1">
             <div class="email-sub__inline-label">
 
                 <input class="email-sub__text-input" type="email" name="email" id="@inputId" />
@@ -58,11 +53,14 @@
 
             </div>
             <button type="submit" class="email-sub__submit-button button button--tertiary button--large" id="email-embed-signup-button--old" data-component="email-signup-button @componentClass-@listName" data-link-name="@componentClass | @listName">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
-            @if(EmailSignupRecaptcha.isSwitchedOn) {
+            @if(!EmailSignupRecaptcha.isSwitchedOn && NewslettersRemoveConfirmationStep.isSwitchedOn ) {
                 @fragments.email.signup.recaptchaContainer()
-                @fragments.email.signup.recaptchaTerms(fragments.email.signup.privacyNoticeContent(privacyNoticeId, privacyNoticeHiddenClass, false))
-            } else {
-                @fragments.email.signup.privacyNoticeContent(privacyNoticeId, privacyNoticeHiddenClass, false)
+                @fragments.email.signup.recaptchaTerms(fragments.email.signup.privacyNoticeContent(false), "dark")
+            } else if(!EmailSignupRecaptcha.isSwitchedOn) {
+                @fragments.email.signup.recaptchaContainer()
+                @fragments.email.signup.recaptchaTerms()
+            }else if(NewslettersRemoveConfirmationStep.isSwitchedOn) {
+                @fragments.email.signup.privacyNoticeContent(false, "terms dark")
             }
         </div>
     </form>
@@ -83,16 +81,8 @@
     document.getElementById("email-sub__refviewid-input").value = window.parent.guardian.config.ophan.pageViewId
     @if(NewslettersRemoveConfirmationStep.isSwitchedOn) {
         document.getElementById("@inputId")
-        .addEventListener("focusin", ()=> {
-            document.getElementById("@privacyNoticeId")?.classList?.remove("@privacyNoticeHiddenClass")
-            document.getElementById("@termsId")?.classList?.add("@termsDark")
-            iframeMessenger?.resize();
-        });
+        .addEventListener("focusin", ()=> iframeMessenger?.resize());
     document.getElementById("@inputId")
-        .addEventListener("focusout", ()=> {
-            document.getElementById("@privacyNoticeId")?.classList?.add("@privacyNoticeHiddenClass")
-            document.getElementById("@termsId")?.classList?.remove("@termsDark")
-            iframeMessenger?.resize();
-        });
+        .addEventListener("focusout", ()=> iframeMessenger?.resize());
     }
 </script>

--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -37,7 +37,6 @@
 
 @privacyNoticeId = @{"embed-privacy-notice"}
 @privacyNoticeHiddenClass = @{"newsletters-privacy-notice-hidden"}
-@privacyNoticeVisibleClass = @{"newsletters-privacy-notice-visible"}
 @termsId = @{"newsletters-terms"}
 @termsDark = @{"dark"}
 
@@ -85,14 +84,14 @@
     @if(NewslettersRemoveConfirmationStep.isSwitchedOn) {
         document.getElementById("@inputId")
         .addEventListener("focusin", ()=> {
-            document.getElementById("@privacyNoticeId")?.setAttribute('class', '@privacyNoticeVisibleClass')
-            document.getElementById("@termsId")?.setAttribute('class', 'terms @termsDark')
+            document.getElementById("@privacyNoticeId")?.classList?.remove("@privacyNoticeHiddenClass")
+            document.getElementById("@termsId")?.classList?.add("@termsDark")
             iframeMessenger?.resize();
         });
     document.getElementById("@inputId")
         .addEventListener("focusout", ()=> {
-            document.getElementById("@privacyNoticeId")?.setAttribute('class', '@privacyNoticeHiddenClass')
-            document.getElementById("@termsId")?.setAttribute('class', 'terms')
+            document.getElementById("@privacyNoticeId")?.classList?.add("@privacyNoticeHiddenClass")
+            document.getElementById("@termsId")?.classList?.remove("@termsDark")
             iframeMessenger?.resize();
         });
     }

--- a/static/src/stylesheets/module/email-signup/_iframe.scss
+++ b/static/src/stylesheets/module/email-signup/_iframe.scss
@@ -8,10 +8,6 @@ body {
     left: -2000px;
 }
 
-.email-sub .newsletters-privacy-notice-visible {
-    display: inline;
-}
-
 .email-sub .newsletters-privacy-notice-hidden {
     display: none;
 }

--- a/static/src/stylesheets/module/email-signup/_iframe.scss
+++ b/static/src/stylesheets/module/email-signup/_iframe.scss
@@ -35,6 +35,13 @@ body {
     }
 }
 
+.email-sub .dark {
+    color: $brightness-7;
+    a {
+        color: $brightness-7;
+    }
+}
+
 .email-sub--footer .terms {
     color: #ffffff;
 

--- a/static/src/stylesheets/module/email-signup/_iframe.scss
+++ b/static/src/stylesheets/module/email-signup/_iframe.scss
@@ -8,10 +8,6 @@ body {
     left: -2000px;
 }
 
-.email-sub .newsletters-privacy-notice-hidden {
-    display: none;
-}
-
 /**
 * Google reCAPTCHA styles
 */
@@ -31,18 +27,29 @@ body {
     }
 }
 
-.email-sub .dark {
-    color: $brightness-7;
-    a {
-        color: $brightness-7;
-    }
-}
-
 .email-sub--footer .terms {
     color: #ffffff;
 
     a {
         color: #ffffff;
+    }
+}
+
+.email-sub__form-wrapper {
+    .newsletters-privacy-notice {
+        display: none;
+    }
+}
+
+.email-sub__form-wrapper:focus-within {
+    .newsletters-privacy-notice {
+        display: inline;
+    }
+    .dark {
+        color: $brightness-7;
+        a {
+            color: $brightness-7;
+        }
     }
 }
 


### PR DESCRIPTION
## What does this change?
Privacy wording and captcha text become black when input is focused
## Screenshots

<img width="924" alt="nl-embed-dark" src="https://user-images.githubusercontent.com/12345673/154159016-22525e38-e30d-4f70-b459-ffe1d7b5d405.png">

<img width="924" alt="privacy-unfocused" src="https://user-images.githubusercontent.com/12345673/154671953-b7f9561c-27a1-4f67-8a01-fbd4dbb21ff2.png">



### Tested

- [X] Locally

