### PR TITLE
strip HTML from meta[content] HTML tag

### DIFF
--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -25,6 +25,7 @@ import navigation.GuardianFoundationHelper
 
 import scala.util.matching.Regex
 import utils.ShortUrls
+import views.support.StripHtmlTagsAndUnescapeEntities
 
 import java.time.{OffsetDateTime, ZoneId, ZoneOffset}
 
@@ -498,7 +499,11 @@ trait ContentPage extends Page {
   def getOpenGraphProperties: Map[String, String] =
     metadata.opengraphProperties ++
       item.content.opengraphProperties ++
-      metadata.opengraphPropertiesOverrides
+      metadata.opengraphPropertiesOverrides map {
+      // We should never have HTML tags in `content` attribute of the <meta> tag
+      case (key, value) =>
+        (key, StripHtmlTagsAndUnescapeEntities(value))
+    }
 
   def getTwitterProperties: Map[String, String] =
     metadata.twitterProperties ++
@@ -521,7 +526,11 @@ trait StandalonePage extends Page {
     metadata.javascriptConfig ++ metadata.javascriptConfigOverrides
 
   def getOpenGraphProperties: Map[String, String] =
-    metadata.opengraphProperties ++ metadata.opengraphPropertiesOverrides
+    metadata.opengraphProperties ++ metadata.opengraphPropertiesOverrides map {
+      // We should never have HTML tags in `content` attribute of the <meta> tag
+      case (key, value) =>
+        (key, StripHtmlTagsAndUnescapeEntities(value))
+    }
 
   def getTwitterProperties: Map[String, String] =
     metadata.twitterProperties ++ metadata.twitterPropertiesOverrides

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -499,11 +499,7 @@ trait ContentPage extends Page {
   def getOpenGraphProperties: Map[String, String] =
     metadata.opengraphProperties ++
       item.content.opengraphProperties ++
-      metadata.opengraphPropertiesOverrides map {
-      // We should never have HTML tags in `content` attribute of the <meta> tag
-      case (key, value) =>
-        (key, StripHtmlTagsAndUnescapeEntities(value))
-    }
+      metadata.opengraphPropertiesOverrides
 
   def getTwitterProperties: Map[String, String] =
     metadata.twitterProperties ++
@@ -526,11 +522,7 @@ trait StandalonePage extends Page {
     metadata.javascriptConfig ++ metadata.javascriptConfigOverrides
 
   def getOpenGraphProperties: Map[String, String] =
-    metadata.opengraphProperties ++ metadata.opengraphPropertiesOverrides map {
-      // We should never have HTML tags in `content` attribute of the <meta> tag
-      case (key, value) =>
-        (key, StripHtmlTagsAndUnescapeEntities(value))
-    }
+    metadata.opengraphProperties ++ metadata.opengraphPropertiesOverrides
 
   def getTwitterProperties: Map[String, String] =
     metadata.twitterProperties ++ metadata.twitterPropertiesOverrides

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -25,7 +25,6 @@ import navigation.GuardianFoundationHelper
 
 import scala.util.matching.Regex
 import utils.ShortUrls
-import views.support.StripHtmlTagsAndUnescapeEntities
 
 import java.time.{OffsetDateTime, ZoneId, ZoneOffset}
 

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -110,7 +110,7 @@
     }
     case s: model.StandalonePage => {
         @s.getOpenGraphProperties.map{ case (key, value) =>
-            <meta property="@key" content="@value" />
+            <meta property="@key" content="@Html(value)" />
         }
         @s.getTwitterProperties.map{ case (key, value) =>
             <meta name="@key" content="@value" />

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -105,7 +105,7 @@
             <meta property="@key" content="@Html(value)" />
         }
         @c.getTwitterProperties.map{ case (key, value) =>
-            <meta name="@key" content="@value" />
+            <meta name="@key" content="@Html(value)" />
         }
     }
     case s: model.StandalonePage => {
@@ -113,7 +113,7 @@
             <meta property="@key" content="@Html(value)" />
         }
         @s.getTwitterProperties.map{ case (key, value) =>
-            <meta name="@key" content="@value" />
+            <meta name="@key" content="@Html(value)" />
         }
     }
     case _ => {}

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -102,18 +102,18 @@
             <meta name="news_keywords" content="@c.item.tags.keywords.take(10).map(_.name).mkString(",")" />
         }
         @c.getOpenGraphProperties.map { case (key, value) =>
-            <meta property="@key" content="@Html(value)" />
+            <meta property="@key" content="@StripHtmlTags(value)" />
         }
         @c.getTwitterProperties.map{ case (key, value) =>
-            <meta name="@key" content="@Html(value)" />
+            <meta name="@key" content="@StripHtmlTags(value)" />
         }
     }
     case s: model.StandalonePage => {
         @s.getOpenGraphProperties.map{ case (key, value) =>
-            <meta property="@key" content="@Html(value)" />
+            <meta property="@key" content="@StripHtmlTags(value)" />
         }
         @s.getTwitterProperties.map{ case (key, value) =>
-            <meta name="@key" content="@Html(value)" />
+            <meta name="@key" content="@StripHtmlTags(value)" />
         }
     }
     case _ => {}


### PR DESCRIPTION
## What does this change?
Makes sure we remove HTML tags when rendering into the `<meta content>` tag.

This is because we can't and shouldn't expect OpenGraph clients to render this as HTML, so they just render it as a string. Screenshot below

I've added this to the HTML template as I feel the edge of the application is the best place to deal with this, and we should expect any string from upstream and sanitise accordingly.

As Tag pages currently define OpenGraph data as [`tag.bio OR tag.description`](https://github.com/guardian/frontend/blob/main/common/app/model/Tag.scala#L25) and tag.bio can contain HTML we should expect that.

[I added this to the `getOpenGraphProperties`](https://github.com/guardian/frontend/commit/99978e02df55a739d015363f8e0689a76515b785#diff-b25f0791f2bad2610842efd170ce3206b51746f5c5442566d5cf407205feb41bR502-R533) methods [as DCR use them](https://github.com/guardian/frontend/blob/main/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala#L431).  

[I then removed them](https://github.com/guardian/frontend/commit/4b171f2cad3fe876a3f52c4ec3dd1a814d7a1e8c) for fear that this will cause issues of having future devs wondering where this data comes and where the devil it is getting transformed in our complex `data => transform => render` pipeline.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

We should ensure we never put HTML in our `<meta>` tags.

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse: -->

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/31692/154139962-08a27fdf-abf3-4a02-9d89-bb9f33a3cf11.png

[after]: https://user-images.githubusercontent.com/31692/154140005-8b1376f8-9502-47a7-ab6b-2803279c679d.png

**Screenshot from reported social card**

![screenshot of social card rendering HTML tags as strings](https://user-images.githubusercontent.com/31692/154129141-006044bc-4ec7-4abd-add5-ddea73c9c430.jpg).

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [x] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->

(This is possibly the longest PR description I have written for such a small change. So much code to follow through so thought I'd explain the 💎fun💎 I had on the way).