### PR TITLE
Retrieve newsletters from newsletters API instead of identity

### DIFF
--- a/applications/app/controllers/SignupPageController.scala
+++ b/applications/app/controllers/SignupPageController.scala
@@ -7,7 +7,8 @@ import pages.NewsletterHtmlPage
 import play.api.libs.ws.WSClient
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 import play.filters.csrf.CSRFAddToken
-import services.newsletters.{GroupedNewslettersResponse, NewsletterSignupAgent}
+import services.newsletters.GroupedNewslettersResponse.GroupedNewslettersResponse
+import services.newsletters.NewsletterSignupAgent
 import staticpages.StaticPages
 
 import scala.concurrent.duration._
@@ -34,7 +35,7 @@ class SignupPageController(
           case Right(groupedNewsletters) =>
             Cached(defaultCacheDuration)(
               RevalidatableResult.Ok(
-                NewsletterHtmlPage.html(StaticPages.simpleNewslettersPage(request.path, groupedNewsletters.toList())),
+                NewsletterHtmlPage.html(StaticPages.simpleNewslettersPage(request.path, groupedNewsletters)),
               ),
             )
           case Left(e) =>

--- a/applications/app/pages/NewsletterHtmlPage.scala
+++ b/applications/app/pages/NewsletterHtmlPage.scala
@@ -1,6 +1,5 @@
 package pages
 
-import common.Edition
 import conf.switches.Switches.WeAreHiring
 import html.HtmlPageHelpers._
 import html.{HtmlPage, Styles}
@@ -16,7 +15,6 @@ import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.signup.newsletterContent
 import html.HtmlPageHelpers.ContentCSSFile
 import staticpages.NewsletterRoundupPage
-import views.html.stacked
 
 object NewsletterHtmlPage extends HtmlPage[NewsletterRoundupPage] {
 

--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -17,7 +17,7 @@
     </div>
     <div class="newsletter-card__wrapper">
     @emailListings.zipWithRowInfo.map { case (emailListing, row) =>
-        <div class="newsletter-card" data-component="newsletter-card @emailListing.id">
+        <div class="newsletter-card" data-component="newsletter-card @emailListing.identityName">
             <div class="newsletter-card__content js-newsletter-content">
                 <div class="newsletter-card__name">
                     @emailListing.name
@@ -42,7 +42,7 @@
                     </div>
                 </div>
 
-                <form action="@LinkTo("/email")" method="post" target="newsletterSignup" class="newsletter-card__signup" name="newsletter-signup-@emailListing.id">
+                <form action="@LinkTo("/email")" method="post" target="newsletterSignup" class="newsletter-card__signup" name="newsletter-signup-@emailListing.identityName">
                     @if(EmailSignupRecaptcha.isSwitchedOn) {
                         @fragments.email.signup.recaptchaContainer()
                     }
@@ -54,9 +54,9 @@
                         <span class="u-h">email address</span>
                         <input class="newsletter-card__text-input js-newsletter-card__text-input" type="email" name="email" placeholder="Email address" required aria-label="Enter email address" title="Email address"/>
                     </label>
-                    <input class="js-email-sub__listname-input" type="hidden" name="listName" value="@emailListing.id" aria-hidden="true"/>
+                    <input class="js-email-sub__listname-input" type="hidden" name="listName" value="@emailListing.identityName" aria-hidden="true"/>
 
-                    <button class="newsletter-card__lozenge js-newsletter-signup-button newsletter-card__lozenge--submit" data-link-name="Subscribe to @emailListing.id" type="submit" value="@emailListing.listIdv1">
+                    <button class="newsletter-card__lozenge js-newsletter-signup-button newsletter-card__lozenge--submit" data-link-name="Subscribe to @emailListing.identityName" type="submit" value="@emailListing.listIdV1">
                         <span>Sign up</span>
                     </button>
                 </form>
@@ -64,7 +64,7 @@
                 <div class="newsletter-card__example js-newsletter-preview is-hidden">
                 @if(emailListing.exampleUrl.isDefined) {
                     <a href="@emailListing.exampleUrl" target="preview-email-@emailListing.listId">
-                        <div class="newsletter-card__lozenge newsletter-card__lozenge--preview" data-link-name="Preview @emailListing.id">
+                        <div class="newsletter-card__lozenge newsletter-card__lozenge--preview" data-link-name="Preview @emailListing.identityName">
                             <span class="newsletter-card__preview">Preview  @fragments.inlineSvg("arrow-right", "icon")</span>
                         </div>
                     </a>

--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -55,6 +55,7 @@
                         <input class="newsletter-card__text-input js-newsletter-card__text-input" type="email" name="email" placeholder="Email address" required aria-label="Enter email address" title="Email address"/>
                     </label>
                     <input class="js-email-sub__listname-input" type="hidden" name="listName" value="@emailListing.identityName" aria-hidden="true"/>
+                    <input class="js-email-sub__emailconfirmation-input" type="hidden" name="listName" value="@emailListing.emailConfirmation" aria-hidden="true"/>
 
                     <button class="newsletter-card__lozenge js-newsletter-signup-button newsletter-card__lozenge--submit" data-link-name="Subscribe to @emailListing.identityName" type="submit" value="@emailListing.listIdV1">
                         <span>Sign up</span>

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -26,8 +26,8 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 object emailLandingPage extends StandalonePage {
-  override val metadata = MetaData.make(id = id, section = None, webTitle = "Email Landing Page")
   private val id = "email-landing-page"
+  override val metadata = MetaData.make(id = id, section = None, webTitle = "Email Landing Page")
 }
 
 case class EmailForm(

--- a/common/app/services/newsletters/NewsletterApi.scala
+++ b/common/app/services/newsletters/NewsletterApi.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}
 
 case class NewsletterResponse(
-    id: String,
+    identityName: String,
     name: String,
     brazeNewsletterName: String,
     brazeSubscribeAttributeName: String,
@@ -18,13 +18,16 @@ case class NewsletterResponse(
     theme: String,
     description: String,
     frequency: String,
-    exactTargetListId: Int,
-    listIdv1: Int,
+    listIdV1: Int,
     listId: Int,
     exampleUrl: Option[String],
     emailEmbed: EmailEmbed,
     illustration: Option[NewsletterIllustration] = None,
     signupPage: Option[String],
+    restricted: Boolean,
+    paused: Boolean,
+    emailConfirmation: Boolean,
+    group: String,
 )
 
 object NewsletterResponse {
@@ -33,73 +36,16 @@ object NewsletterResponse {
   implicit val newsletterResponseReads = Json.reads[NewsletterResponse]
 }
 
-case class GroupedNewsletterResponse(
-    displayName: String,
-    newsletters: List[NewsletterResponse],
-)
-
-object GroupedNewsletterResponse {
-  implicit val groupedNewsletterResponseReads = Json.reads[GroupedNewsletterResponse]
-}
-
-// TODO: Find a better way to define this that means Frontend doesn't have knowledge of the fields returned.
-case class GroupedNewslettersResponse(
-    newsRoundups: Option[GroupedNewsletterResponse],
-    newsByTopic: Option[GroupedNewsletterResponse],
-    features: Option[GroupedNewsletterResponse],
-    sport: Option[GroupedNewsletterResponse],
-    culture: Option[GroupedNewsletterResponse],
-    lifestyle: Option[GroupedNewsletterResponse],
-    comment: Option[GroupedNewsletterResponse],
-    work: Option[GroupedNewsletterResponse],
-    fromThePapers: Option[GroupedNewsletterResponse],
-) {
-  val toList: () => List[(String, List[NewsletterResponse])] = () =>
-    List(
-      newsRoundups,
-      newsByTopic,
-      features,
-      sport,
-      culture,
-      lifestyle,
-      comment,
-      work,
-      fromThePapers,
-    ).flatten.map(g => (g.displayName, g.newsletters))
-}
-
 object GroupedNewslettersResponse {
-  implicit val groupedNewslettersResponseReads = Json.reads[GroupedNewslettersResponse]
-
-  // Create an empty response to initialise the box
-  val empty = GroupedNewslettersResponse(
-    Option(GroupedNewsletterResponse("News roundups", Nil)),
-    Option(GroupedNewsletterResponse("News by topic", Nil)),
-    Option(GroupedNewsletterResponse("Features", Nil)),
-    Option(GroupedNewsletterResponse("Sport", Nil)),
-    Option(GroupedNewsletterResponse("Culture", Nil)),
-    Option(GroupedNewsletterResponse("Lifestyle", Nil)),
-    Option(GroupedNewsletterResponse("Comment", Nil)),
-    Option(GroupedNewsletterResponse("Work", Nil)),
-    Option(GroupedNewsletterResponse("From the papers", Nil)),
-  )
+  type GroupedNewslettersResponse = List[(String, List[NewsletterResponse])]
+}
+object GroupedNewsletterResponse {
+  type GroupedNewsletterResponse = (String, List[NewsletterResponse])
 }
 
 case class NewsletterApi(wsClient: WSClient)(implicit executionContext: ExecutionContext)
     extends GuLogging
     with implicits.WSRequests {
-
-  def getGroupedNewsletters(): Future[Either[String, GroupedNewslettersResponse]] = {
-    getBody("newsletters/grouped").map { json =>
-      {
-        json.validate[GroupedNewslettersResponse] match {
-          case succ: JsSuccess[GroupedNewslettersResponse] =>
-            Right(succ.get)
-          case err: JsError => Left(err.toString)
-        }
-      }
-    }
-  }
 
   def getNewsletters(): Future[Either[String, List[NewsletterResponse]]] = {
     getBody("newsletters").map { json =>

--- a/common/app/services/newsletters/NewsletterSignupAgent.scala
+++ b/common/app/services/newsletters/NewsletterSignupAgent.scala
@@ -2,26 +2,54 @@ package services.newsletters
 
 import com.gu.Box
 import common.GuLogging
+import services.newsletters.GroupedNewslettersResponse.GroupedNewslettersResponse
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 class NewsletterSignupAgent(newsletterApi: NewsletterApi) extends GuLogging {
 
-  // Newsletters (not grouped by theme)
+  // Newsletters
   private val newslettersAgent = Box[Either[String, List[NewsletterResponse]]](Right(Nil))
+  // Grouped Newsletters (grouped by group)
+  private val groupedNewslettersAgent = Box[Either[String, GroupedNewslettersResponse]](Right(List.empty))
+
+  def getNewsletterByName(listName: String): Either[String, Option[NewsletterResponse]] = {
+    newslettersAgent.get() match {
+      case Left(err)          => Left(err)
+      case Right(newsletters) => Right(newsletters.find(newsletter => newsletter.identityName == listName))
+    }
+  }
+
+  def getNewsletterById(listId: Int): Either[String, Option[NewsletterResponse]] = {
+    newslettersAgent.get() match {
+      case Left(err) => Left(err)
+      case Right(newsletters) =>
+        Right(
+          newsletters.find(newsletter => newsletter.listId == listId || newsletter.listIdV1 == listId),
+        )
+    }
+  }
+
+  def getGroupedNewsletters(): Either[String, GroupedNewslettersResponse] = groupedNewslettersAgent.get()
+
+  def getNewsletters(): Either[String, List[NewsletterResponse]] = newslettersAgent.get()
+
+  def refresh()(implicit ec: ExecutionContext): Unit = {
+    refreshNewsletters()
+  }
 
   def refreshNewsletters()(implicit ec: ExecutionContext): Unit = {
-    log.info("Refreshing newsletters for newsletter signup embeds.")
+    log.info("Refreshing newsletters and Grouped Newsletters for newsletter signup embeds.")
 
     val newslettersQuery = newsletterApi.getNewsletters()
-
     newslettersQuery.flatMap { newsletters =>
       newslettersAgent.alter(newsletters match {
         case Right(response) =>
-          log.info("Successfully refreshed Newsletters embed cache.")
+          log.info("Successfully refreshed Newsletters and Grouped Newsletters embed cache.")
+          groupedNewslettersAgent.alter(Right(buildGroupedNewsletters(response)))
           Right(response)
         case Left(err) =>
-          log.error(s"Failed to refresh Newsletters embed cache: $err")
+          log.error(s"Failed to refresh Newsletters and Grouped Newsletters embed cache: $err")
           Left(err)
       })
     } recover {
@@ -33,58 +61,14 @@ class NewsletterSignupAgent(newsletterApi: NewsletterApi) extends GuLogging {
 
   }
 
-  def getNewsletterByName(listName: String): Either[String, Option[NewsletterResponse]] = {
-    newslettersAgent.get() match {
-      case Left(err)          => Left(err)
-      case Right(newsletters) => Right(newsletters.find(newsletter => newsletter.id == listName))
-    }
-  }
+  private def buildGroupedNewsletters(newsletters: List[NewsletterResponse]): GroupedNewslettersResponse = {
+    val displayedNewsletters = newsletters.filter(n => !n.paused && !n.restricted)
+    val groupedNewsletters = displayedNewsletters.groupBy(n => n.group)
 
-  def getNewsletterById(listId: Int): Either[String, Option[NewsletterResponse]] = {
-    newslettersAgent.get() match {
-      case Left(err) => Left(err)
-      case Right(newsletters) =>
-        Right(
-          newsletters.find(newsletter => newsletter.exactTargetListId == listId || newsletter.listIdv1 == listId),
-        )
-    }
-  }
-
-  // Grouped Newsletters (grouped by theme)
-
-  private val groupedNewslettersAgent =
-    Box[Either[String, GroupedNewslettersResponse]](Right(GroupedNewslettersResponse.empty))
-
-  def refreshGroupedNewsletters()(implicit ec: ExecutionContext): Unit = {
-    log.info("Refreshing Grouped Newsletters for round up page.")
-
-    val groupedNewslettersQuery = newsletterApi.getGroupedNewsletters()
-
-    groupedNewslettersQuery.flatMap { newsletters =>
-      groupedNewslettersAgent.alter(newsletters match {
-        case Right(response) =>
-          log.info("Successfully refreshed Grouped Newsletters cache.")
-          Right(response)
-        case Left(err) =>
-          log.error(s"Failed to refresh Grouped Newsletters cache: $err")
-          Left(err)
-      })
-    } recover {
-      case e =>
-        val errMessage = s"Call to Grouped Newsletter API failed: ${e.getMessage}"
-        log.error(errMessage)
-        Left(errMessage)
-    }
-
-  }
-
-  def getGroupedNewsletters(): Either[String, GroupedNewslettersResponse] = groupedNewslettersAgent.get()
-
-  def getNewsletters(): Either[String, List[NewsletterResponse]] = newslettersAgent.get()
-
-  def refresh()(implicit ec: ExecutionContext): Unit = {
-    refreshNewsletters()
-    refreshGroupedNewsletters()
+    displayedNewsletters
+      .map(_.group)
+      .distinct
+      .map { group => (group, groupedNewsletters.getOrElse(group, Nil)) }
   }
 
 }

--- a/common/app/views/emailFragment.scala.html
+++ b/common/app/views/emailFragment.scala.html
@@ -4,7 +4,7 @@
 @emailEmbed(page) {
     @fragments.email.signup.subscription.emailSignUp(
         emailType,
-        emailNewsletter.id,
+        emailNewsletter.identityName,
         emailNewsletter.emailEmbed
     )
 }

--- a/common/app/views/emailFragment.scala.html
+++ b/common/app/views/emailFragment.scala.html
@@ -5,7 +5,8 @@
     @fragments.email.signup.subscription.emailSignUp(
         emailType,
         emailNewsletter.identityName,
-        emailNewsletter.emailEmbed
+        emailNewsletter.emailEmbed,
+        emailNewsletter.emailConfirmation,
     )
 }
 

--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -2,7 +2,8 @@
 @import com.gu.identity.model.EmailEmbed
 @(  componentClass: String,
     listName:String,
-    emailEmbedData: EmailEmbed)(implicit request: RequestHeader)
+    emailEmbedData: EmailEmbed,
+    emailConfirmation: Boolean)(implicit request: RequestHeader)
 
 @import common.LinkTo
 @import conf.switches.Switches.EmailSignupRecaptcha
@@ -50,6 +51,7 @@
                 <input class="email-sub__listname-input" type="hidden" name="listName" value="@listName" />
                 <input class="email-sub__ref-input" type="hidden" name="ref" id="email-sub__ref-input" value="" />
                 <input class="email-sub__refviewid-input" type="hidden" name="refViewId" id="email-sub__refviewid-input" value="" />
+                <input class="email-sub__emailconfirmation-input" type="hidden" name="emailConfirmation" id="email-sub__emailconfirmation-input" value="@emailConfirmation" />
 
             </div>
             <button type="submit" class="email-sub__submit-button button button--tertiary button--large" id="email-embed-signup-button--old" data-component="email-signup-button @componentClass-@listName" data-link-name="@componentClass | @listName">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>

--- a/common/app/views/fragments/emailLandingBody.scala.html
+++ b/common/app/views/fragments/emailLandingBody.scala.html
@@ -14,7 +14,8 @@
                 @fragments.email.signup.subscription.emailSignUp(
                     "landing",
                     EmailNewsletters.guardianTodayUk.identityName,
-                    EmailNewsletters.guardianTodayUk.emailEmbed
+                    EmailNewsletters.guardianTodayUk.emailEmbed,
+                    true
                 )
             </div>
         </div>

--- a/identity/app/views/fragments/emailListCategories.scala.html
+++ b/identity/app/views/fragments/emailListCategories.scala.html
@@ -29,16 +29,7 @@
 }
 
 <div class="email-subscriptions">
-    @List(
-        "news",
-        "features",
-        "sport",
-        "culture",
-        "lifestyle",
-        "comment",
-        "work",
-        "From the papers"
-    ).zipWithIndex.map { case (theme, index) =>
+    @availableLists.map(_.theme).distinct.zipWithIndex.map { case (theme, index) =>
         @emailListCategoryList(
             theme,
             availableLists.filter(_.theme == theme),

--- a/identity/app/views/fragments/newsletterSwitch.scala.html
+++ b/identity/app/views/fragments/newsletterSwitch.scala.html
@@ -56,5 +56,5 @@
     extraFields = Nil,
     footer = Some(buildFooter(newsletter)),
     skin = skin,
-    newsletterIdentityName = Some(newsletter.id)
+    newsletterIdentityName = Some(newsletter.identityName)
 )(nonInputFields, messages)

--- a/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/store/fetch.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/store/fetch.js
@@ -55,7 +55,7 @@ const fetchNewsletters = Promise.all([
         nl =>
             new EmailConsentWithState(
                 nl,
-                subscribedNewsletters.includes(nl.exactTargetListId.toString())
+                subscribedNewsletters.includes(nl.listId.toString())
             )
     )
 );


### PR DESCRIPTION
## What does this change?
Retrieve newsletters from newsletters API
Add 4 fields: 
- paused: true if newsletter is paused, it will not appear on all newsletter page but still in user preferences
- restricted: true if newsletter is restricted, can only be signed up by subscribers
- emailConfirmation: true, if the newsletter require an email confirmation (incoming feature)
- group: newsletters are grouped with group on email newsletter page and theme in user preference
Rename field on newsletter object: id => identityName
Replace redundant field exactTargetListId by ListId

## Screenshots
No visual changes
### Tested

- [X] Locally