### PR TITLE
title case More on this story container

### DIFF
--- a/common/app/views/fragments/storyPackagePlaceholder.scala.html
+++ b/common/app/views/fragments/storyPackagePlaceholder.scala.html
@@ -15,7 +15,7 @@
 @defining(Seq("related") ++ (if(isPaidContent) Seq("paid-content") else Nil)) { classes =>
     @if(related.hasStoryPackage) {
         <aside class="@classes.mkString(" ") more-on-this-story js-outbrain-anchor" aria-labelledby="related-content-head">
-            @container("more on this story", "more-on-this-story", href = None)
+            @container("More on this story", "more-on-this-story", href = None)
         </aside>
     } else {
         <aside class="@classes.mkString(" ") js-related hide-on-childrens-books-site" data-test-id="related-content">


### PR DESCRIPTION
Fixes #24652 

## What does this change?
Capitalises the "More on this story container" as that's the correct style.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

It's already right in DCR.

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/31692/154278214-f4d829b5-44c3-47b6-aa73-0c61f42dc30c.png

[after]: https://user-images.githubusercontent.com/31692/154278238-39f1f6cb-fedc-434d-8b2c-8e6ff7366b7e.png


