### PR TITLE
SPIKE - experiment with monix observable

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,6 +91,7 @@ val sport = application("sport")
   .settings(
     libraryDependencies ++= Seq(
       paClient,
+      monix,
     ),
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -78,6 +78,7 @@ object Dependencies {
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.9"
   val capiAws = "com.gu" %% "content-api-client-aws" % "0.5"
   val okhttp = "com.squareup.okhttp3" % "okhttp" % "3.10.0"
+  val monix = "io.monix" %% "monix" % "3.3.0"
 
   /*
     Note: Although frontend compiles and passes all the current tests when jackson is removed, be careful that this

--- a/sport/app/football/conf/context.scala
+++ b/sport/app/football/conf/context.scala
@@ -79,12 +79,6 @@ class FootballLifecycle(
     // We need a schedular in scope
     lazy implicit val scheduler = Scheduler(scala.concurrent.ExecutionContext.Implicits.global, AlwaysAsyncExecution)
 
-    // Maybe handle error like this?
-    def retryWithDelay[A](source: Observable[A], delay: FiniteDuration): Observable[A] =
-      source.onErrorHandleWith { _ =>
-        retryWithDelay(source, delay).delayExecution(delay)
-      }
-
     import scala.collection.immutable
 
     val observableInterval = 10.second


### PR DESCRIPTION
## What does this change?

This PR is experimenting with monix by replacing the cron based job schedulars with monix observable. 

The idea came from working on this https://github.com/guardian/frontend/pull/24605 where we needed to fine grain one of the scheduled jobs by running it quickly only when the match is live and running it slowly when there's no live matches. But the quartz scheduled jobs didn't give us much flexibility to dynamically change the frequency of the jobs. 

Using Monix, would give us the ability to have an unstream that emit data streams in time intervals to several consumers (down stream).  

As an example, this way, the upstream can push data in smaller intervals (every 1 minute) which would trigger task1, but then using filter, we can omit some of the intervals and then run the next task (task2). We can even use the state of the task1, and decide if the we still want to run task2 or not.