### PR TITLE
remove HTML from tag and StripHtmlTagsAndUnescapeEntities in metadata

### DIFF
--- a/common/app/model/Tag.scala
+++ b/common/app/model/Tag.scala
@@ -6,7 +6,7 @@ import common.{Pagination, RelativePathEscaper}
 import conf.Configuration
 import contentapi.SectionTagLookUp
 import play.api.libs.json._
-import views.support.{Contributor, ImgSrc, Item140}
+import views.support.{Contributor, ImgSrc, Item140, StripHtmlTagsAndUnescapeEntities}
 import navigation.GuardianFoundationHelper
 
 object Tag {
@@ -22,7 +22,7 @@ object Tag {
     def optionalMapEntry(key: String, o: Option[String]): Map[String, String] =
       o.map(value => Map(key -> value)).getOrElse(Map())
 
-    val openGraphDescription: Option[String] = tag.bio.orElse(tag.description)
+    val openGraphDescription: Option[String] = tag.bio.orElse(tag.description).map(StripHtmlTagsAndUnescapeEntities(_))
     val openGraphImage = tag.bylineImageUrl
       .map(ImgSrc(_, Item140))
       .map { s: String => if (s.startsWith("//")) s"http:$s" else s }

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -1,3 +1,4 @@
+@import views.support.StripHtmlTagsAndUnescapeEntities
 @()(implicit page: model.Page, request: RequestHeader, context: model.ApplicationContext)
 
 @import common.{AnalyticsHost, _}
@@ -101,19 +102,20 @@
             <meta name="keywords" content="@c.item.tags.keywords.map(_.name).mkString(",")" />
             <meta name="news_keywords" content="@c.item.tags.keywords.take(10).map(_.name).mkString(",")" />
         }
+
         @c.getOpenGraphProperties.map { case (key, value) =>
-            <meta property="@key" content="@StripHtmlTags(value)" />
+            <meta property="@key" content="@StripHtmlTagsAndUnescapeEntities(value)" />
         }
         @c.getTwitterProperties.map{ case (key, value) =>
-            <meta name="@key" content="@StripHtmlTags(value)" />
+            <meta name="@key" content="@StripHtmlTagsAndUnescapeEntities(value)" />
         }
     }
     case s: model.StandalonePage => {
         @s.getOpenGraphProperties.map{ case (key, value) =>
-            <meta property="@key" content="@StripHtmlTags(value)" />
+            <meta property="@key" content="@StripHtmlTagsAndUnescapeEntities(value)" />
         }
         @s.getTwitterProperties.map{ case (key, value) =>
-            <meta name="@key" content="@StripHtmlTags(value)" />
+            <meta name="@key" content="@StripHtmlTagsAndUnescapeEntities(value)" />
         }
     }
     case _ => {}


### PR DESCRIPTION
Fixes #24657

## What does this change?
Turns out `StripHtmlTags` also escapes `HtmlTags`. So `https://theguardian.com/?page=1&amp;size=1` => `https://theguardian.com/?page=1&amp;amp;size=1`. This is not desirable, especially on the `og:image`. 

I've also added the strip to the bio from [the previous PR on this](https://github.com/guardian/frontend/pull/24646) as we [do it elsewhere](https://github.com/guardian/frontend/blob/main/common/app/model/content.scala#L354-L355)

I can't find any tests for this, so might have a go at adding some retrospectively as this is causing issues in prod.

This seems to be another indicator that we transform in too many places, making it hard to know what the data might look like at the different stages at the edges of our applications. 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

### before 
![Screenshot 2022-02-17 at 10 13 22](https://user-images.githubusercontent.com/31692/154455426-1a667cd2-eb7f-4da9-ad98-877f8544ade2.png)

### after
![Screenshot 2022-02-17 at 10 11 34](https://user-images.githubusercontent.com/31692/154455419-c8068a17-fe9c-45c9-9ca8-a0023478c075.png)
