### PR TITLE
Set a min-height for email embed iframes

### DIFF
--- a/static/src/stylesheets/module/email-signup/_form.scss
+++ b/static/src/stylesheets/module/email-signup/_form.scss
@@ -3,6 +3,7 @@
 }
 
 .email-sub__iframe {
+    min-height: 60px;
     // Fallback for browsers that don't support calc
     width: 100%;
 }


### PR DESCRIPTION
## What does this change?

* Sets a `min-height` of `60px` for email embed iframes, to help prevent clipping when showing the reCAPTCHA message

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (https://github.com/guardian/dotcom-rendering/pull/4019)