### PR TITLE
Fix typo in email signup privacy wording

### DIFF
--- a/common/app/views/fragments/email/signup/privacyNoticeContent.scala.html
+++ b/common/app/views/fragments/email/signup/privacyNoticeContent.scala.html
@@ -4,6 +4,6 @@
 <span id="@privacyNoticeId" class="@privacyNoticeClass">
     We thought you should know @if(plural){ these newsletters } else { this newsletter } may also contain information about Guardian products,
     services and chosen charities or online advertisements.
-    Newsletters mays also contain content funded by outside parties.
+    Newsletters may also contain content funded by outside parties.
     You can read more about <a href="/help/privacy-policy" data-link-name="privacy-policy" target="_blank">our privacy policy here</a>.
 </span>


### PR DESCRIPTION
## What does this change?

* Fixes a typo, correcting `mays` to `may` 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)
