### PR TITLE
revert callouts fix

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/CalloutExtraction.scala
+++ b/common/app/model/dotcomrendering/pageElements/CalloutExtraction.scala
@@ -172,6 +172,116 @@ object CalloutExtraction {
       campaigns: Option[JsValue],
       calloutsUrl: Option[String],
   ): Option[CalloutBlockElement] = {
+
+    val campaignsX1: JsValue = Json.parse(
+      """
+  [
+    {
+      "id": "b06a08e0-ca5f-410c-a28b-95e7d7ca37b7",
+      "name": "CALLOUT: Coronavirus",
+      "rules": [
+
+      ],
+      "priority": 0,
+      "activeFrom": 1579651200000,
+      "displayOnSensitive": false,
+      "fields": {
+        "formId": 3730905,
+        "callout": "Share your stories",
+        "_type": "callout",
+        "description": "<p>If you have been affected or have any information, we'd like to hear from you. You can get in touch by filling in the form below, anonymously if you \nwish or contact us&nbsp;<a href=\"https://www.theguardian.com/info/2015/aug/12/whatsapp-sharing-stories-with-the-guardian\">via WhatsApp</a>&nbsp;by&nbsp;<a href=\"https://api.whatsapp.com/send?phone=447867825056\">clicking here&nbsp;</a>or adding the contact +44(0)7867825056. Only the Guardian can see your contributions and one of our \njournalists may contact you to discuss further.&nbsp;<br></p>",
+        "formFields": [
+          {
+            "name": "share_your_experiences_here",
+            "description": "Please include as much detail as possible ",
+            "hide_label": "0",
+            "label": "Share your experiences here",
+            "id": "87320974",
+            "type": "textarea",
+            "required": "1"
+          },
+          {
+            "text_size": 50,
+            "name": "name",
+            "description": "You do not need to use your full name",
+            "hide_label": "0",
+            "label": "Name",
+            "id": "87320975",
+            "type": "text",
+            "required": "1"
+          },
+          {
+            "text_size": 50,
+            "name": "where_do_you_live",
+            "description": "Town or area is fine",
+            "hide_label": "0",
+            "label": "Where do you live?",
+            "id": "87320976",
+            "type": "text",
+            "required": "1"
+          },
+          {
+            "name": "can_we_publish_your_response",
+            "options": [
+              {
+                "label": "Yes, entirely",
+                "value": "Yes, entirely"
+              },
+              {
+                "label": "Yes, but please keep me anonymous",
+                "value": "Yes, but please keep me anonymous"
+              },
+              {
+                "label": "Yes, but please contact me first",
+                "value": "Yes, but please contact me first"
+              },
+              {
+                "label": "No, this is information only",
+                "value": "No, this is information only"
+              }
+            ],
+            "hide_label": "0",
+            "label": "Can we publish your response?",
+            "id": "87320977",
+            "type": "radio",
+            "required": "1"
+          },
+          {
+            "text_size": 50,
+            "name": "email_address_",
+            "description": "Your contact details are helpful so we can contact you for more information. They will only be seen by the Guardian.",
+            "hide_label": "0",
+            "label": "Email address ",
+            "id": "87320978",
+            "type": "text",
+            "required": "1"
+          },
+          {
+            "text_size": 50,
+            "name": "phone_number",
+            "description": "Your contact details are helpful so we can contact you for more information. They will only be seen by the Guardian.",
+            "hide_label": "0",
+            "label": "Phone number",
+            "id": "87320979",
+            "type": "text",
+            "required": "0"
+          },
+          {
+            "name": "you_can_add_any_extra_information_here",
+            "hide_label": "0",
+            "label": "You can add any extra information here",
+            "id": "87320980",
+            "type": "textarea",
+            "required": "0"
+          }
+        ],
+        "tagName": "callout-coronavirus"
+      }
+    }
+  ]
+       """,
+    )
+
     val doc = Jsoup.parseBodyFragment(html)
     val tagName = doc.getElementsByTag("div").asScala.headOption.map(_.attr("data-callout-tagname"))
     for {

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -1605,32 +1605,27 @@ object PageElement {
       campaigns: Option[JsValue],
       calloutsUrl: Option[String],
   ): Option[PageElement] = {
-    calloutsUrl match {
-      case Some(_) =>
-        element.embedTypeData flatMap (_.html flatMap (html =>
-          CalloutExtraction.extractCallout(html, campaigns, calloutsUrl),
-        ))
-      case None =>
-        for {
-          d <- element.embedTypeData
-          html <- d.html
-          mandatory = d.isMandatory.getOrElse(false)
-          thirdPartyTracking = containsThirdPartyTracking(element.tracking)
-        } yield {
-          extractSoundcloudBlockElement(html, mandatory, thirdPartyTracking, d.source, d.sourceDomain).getOrElse {
-            EmbedBlockElement(
-              html,
-              d.safeEmbedCode,
-              d.alt,
-              mandatory,
-              d.role,
-              thirdPartyTracking,
-              d.source,
-              d.sourceDomain,
-              d.caption,
-            )
-          }
+    for {
+      d <- element.embedTypeData
+      html <- d.html
+      mandatory = d.isMandatory.getOrElse(false)
+      thirdPartyTracking = containsThirdPartyTracking(element.tracking)
+    } yield {
+      extractSoundcloudBlockElement(html, mandatory, thirdPartyTracking, d.source, d.sourceDomain).getOrElse {
+        CalloutExtraction.extractCallout(html: String, campaigns, calloutsUrl).getOrElse {
+          EmbedBlockElement(
+            html,
+            d.safeEmbedCode,
+            d.alt,
+            mandatory,
+            d.role,
+            thirdPartyTracking,
+            d.source,
+            d.sourceDomain,
+            d.caption,
+          )
         }
+      }
     }
   }
 


### PR DESCRIPTION
## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
