### PR TITLE
Revert "Merge pull request #24647 from guardian/nasser_dahmani/newsle…

### DIFF
--- a/applications/app/controllers/SignupPageController.scala
+++ b/applications/app/controllers/SignupPageController.scala
@@ -7,8 +7,7 @@ import pages.NewsletterHtmlPage
 import play.api.libs.ws.WSClient
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 import play.filters.csrf.CSRFAddToken
-import services.newsletters.GroupedNewslettersResponse.GroupedNewslettersResponse
-import services.newsletters.NewsletterSignupAgent
+import services.newsletters.{GroupedNewslettersResponse, NewsletterSignupAgent}
 import staticpages.StaticPages
 
 import scala.concurrent.duration._
@@ -35,7 +34,7 @@ class SignupPageController(
           case Right(groupedNewsletters) =>
             Cached(defaultCacheDuration)(
               RevalidatableResult.Ok(
-                NewsletterHtmlPage.html(StaticPages.simpleNewslettersPage(request.path, groupedNewsletters)),
+                NewsletterHtmlPage.html(StaticPages.simpleNewslettersPage(request.path, groupedNewsletters.toList())),
               ),
             )
           case Left(e) =>

--- a/applications/app/pages/NewsletterHtmlPage.scala
+++ b/applications/app/pages/NewsletterHtmlPage.scala
@@ -1,5 +1,6 @@
 package pages
 
+import common.Edition
 import conf.switches.Switches.WeAreHiring
 import html.HtmlPageHelpers._
 import html.{HtmlPage, Styles}
@@ -15,6 +16,7 @@ import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.signup.newsletterContent
 import html.HtmlPageHelpers.ContentCSSFile
 import staticpages.NewsletterRoundupPage
+import views.html.stacked
 
 object NewsletterHtmlPage extends HtmlPage[NewsletterRoundupPage] {
 

--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -17,7 +17,7 @@
     </div>
     <div class="newsletter-card__wrapper">
     @emailListings.zipWithRowInfo.map { case (emailListing, row) =>
-        <div class="newsletter-card" data-component="newsletter-card @emailListing.identityName">
+        <div class="newsletter-card" data-component="newsletter-card @emailListing.id">
             <div class="newsletter-card__content js-newsletter-content">
                 <div class="newsletter-card__name">
                     @emailListing.name
@@ -42,7 +42,7 @@
                     </div>
                 </div>
 
-                <form action="@LinkTo("/email")" method="post" target="newsletterSignup" class="newsletter-card__signup" name="newsletter-signup-@emailListing.identityName">
+                <form action="@LinkTo("/email")" method="post" target="newsletterSignup" class="newsletter-card__signup" name="newsletter-signup-@emailListing.id">
                     @if(EmailSignupRecaptcha.isSwitchedOn) {
                         @fragments.email.signup.recaptchaContainer()
                     }
@@ -54,10 +54,9 @@
                         <span class="u-h">email address</span>
                         <input class="newsletter-card__text-input js-newsletter-card__text-input" type="email" name="email" placeholder="Email address" required aria-label="Enter email address" title="Email address"/>
                     </label>
-                    <input class="js-email-sub__listname-input" type="hidden" name="listName" value="@emailListing.identityName" aria-hidden="true"/>
-                    <input class="js-email-sub__emailconfirmation-input" type="hidden" name="listName" value="@emailListing.emailConfirmation" aria-hidden="true"/>
+                    <input class="js-email-sub__listname-input" type="hidden" name="listName" value="@emailListing.id" aria-hidden="true"/>
 
-                    <button class="newsletter-card__lozenge js-newsletter-signup-button newsletter-card__lozenge--submit" data-link-name="Subscribe to @emailListing.identityName" type="submit" value="@emailListing.listIdV1">
+                    <button class="newsletter-card__lozenge js-newsletter-signup-button newsletter-card__lozenge--submit" data-link-name="Subscribe to @emailListing.id" type="submit" value="@emailListing.listIdv1">
                         <span>Sign up</span>
                     </button>
                 </form>
@@ -65,7 +64,7 @@
                 <div class="newsletter-card__example js-newsletter-preview is-hidden">
                 @if(emailListing.exampleUrl.isDefined) {
                     <a href="@emailListing.exampleUrl" target="preview-email-@emailListing.listId">
-                        <div class="newsletter-card__lozenge newsletter-card__lozenge--preview" data-link-name="Preview @emailListing.identityName">
+                        <div class="newsletter-card__lozenge newsletter-card__lozenge--preview" data-link-name="Preview @emailListing.id">
                             <span class="newsletter-card__preview">Preview  @fragments.inlineSvg("arrow-right", "icon")</span>
                         </div>
                     </a>

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -4,11 +4,7 @@ import com.typesafe.scalalogging.LazyLogging
 import common.EmailSubsciptionMetrics._
 import common.{GuLogging, ImplicitControllerExecutionContext, LinkTo}
 import conf.Configuration
-import conf.switches.Switches.{
-  EmailSignupRecaptcha,
-  NewslettersRemoveConfirmationStep,
-  ValidateEmailSignupRecaptchaTokens,
-}
+import conf.switches.Switches.{EmailSignupRecaptcha, ValidateEmailSignupRecaptchaTokens}
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model._
 import play.api.data.Forms._
@@ -39,7 +35,6 @@ case class EmailForm(
     campaignCode: Option[String],
     googleRecaptchaResponse: Option[String],
     name: String,
-    emailConfirmation: Boolean,
 ) {
 
   // `name` is a hidden (via css) form input
@@ -54,12 +49,12 @@ case class EmailForm(
 
 class EmailFormService(wsClient: WSClient) extends LazyLogging with RemoteAddress {
 
-  def submit(form: EmailForm)(implicit request: Request[AnyContent]): Future[WSResponse] = {
+  def submit(form: EmailForm)(implicit request: Request[AnyContent]): Future[WSResponse] =
     if (form.isLikelyBotSubmission) {
       Future.failed(new IllegalAccessException("Form was likely submitted by a bot."))
     } else {
       val idAccessClientToken = Configuration.id.apiClientToken
-      val consentMailerUrl = serviceUrl(form)
+      val consentMailerUrl = s"${Configuration.id.apiRoot}/consent-email"
       val consentMailerPayload = JsObject(Json.obj("email" -> form.email, "set-lists" -> List(form.listName)).fields)
       val headers = clientIp(request)
         .map(ip => List("X-Forwarded-For" -> ip))
@@ -76,14 +71,6 @@ class EmailFormService(wsClient: WSClient) extends LazyLogging with RemoteAddres
         .addHttpHeaders(headers: _*)
         .post(consentMailerPayload)
     }
-  }
-
-  private def serviceUrl(form: EmailForm): String = {
-    if (NewslettersRemoveConfirmationStep.isSwitchedOn && !form.emailConfirmation) {
-      return s"${Configuration.id.apiRoot}/consent-signup"
-    }
-    s"${Configuration.id.apiRoot}/consent-email"
-  }
 }
 
 class EmailSignupController(
@@ -108,9 +95,16 @@ class EmailSignupController(
       "campaignCode" -> optional[String](of[String]),
       "g-recaptcha-response" -> optional[String](of[String]),
       "name" -> text,
-      "emailConfirmation" -> boolean,
     )(EmailForm.apply)(EmailForm.unapply),
   )
+
+  def logApiError(error: String): Unit = {
+    log.error(s"API call to get newsletters failed: $error")
+  }
+
+  def logNewsletterNotFoundError(newsletterName: String): Unit = {
+    log.error(s"Newsletter not found: Couldn't find $newsletterName")
+  }
 
   def renderPage(): Action[AnyContent] =
     Action { implicit request =>
@@ -224,14 +218,6 @@ class EmailSignupController(
       }
     }
 
-  def logApiError(error: String): Unit = {
-    log.error(s"API call to get newsletters failed: $error")
-  }
-
-  def logNewsletterNotFoundError(newsletterName: String): Unit = {
-    log.error(s"Newsletter not found: Couldn't find $newsletterName")
-  }
-
   def subscriptionNonsuccessResult(result: String): Action[AnyContent] =
     Action { implicit request =>
       Cached(1.hour)(result match {
@@ -282,6 +268,69 @@ class EmailSignupController(
       )
     }
 
+  def submit(): Action[AnyContent] =
+    Action.async { implicit request =>
+      AllEmailSubmission.increment()
+
+      emailForm.bindFromRequest.fold(
+        formWithErrors => {
+          log.info(s"Form has been submitted with errors: ${formWithErrors.errors}")
+          EmailFormError.increment()
+          Future.successful(respond(InvalidEmail))
+        },
+        form => {
+          log.info(
+            s"Post request received to /email/ - " +
+              s"email: ${form.email}, " +
+              s"ref: ${form.ref}, " +
+              s"refViewId: ${form.refViewId}, " +
+              s"g-recaptcha-response: ${form.googleRecaptchaResponse}, " +
+              s"referer: ${request.headers.get("referer").getOrElse("unknown")}, " +
+              s"user-agent: ${request.headers.get("user-agent").getOrElse("unknown")}, " +
+              s"x-requested-with: ${request.headers.get("x-requested-with").getOrElse("unknown")}",
+          )
+
+          (for {
+            _ <- validateCaptcha(form, ValidateEmailSignupRecaptchaTokens.isSwitchedOn)
+            result <- submitForm(form)
+          } yield {
+            result
+          }) recover {
+            case _ =>
+              respond(OtherError)
+          }
+        },
+      )
+    }
+
+  def options(): Action[AnyContent] =
+    Action { implicit request =>
+      TinyResponse.noContent(Some("GET, POST, OPTIONS"))
+    }
+
+  private def respond(result: SubscriptionResult, listName: Option[String] = None)(implicit
+      request: Request[AnyContent],
+  ): Result = {
+    render {
+      case Accepts.Html() =>
+        result match {
+          case Subscribed   => SeeOther(LinkTo(s"/email/success/${listName.get}"))
+          case InvalidEmail => SeeOther(LinkTo(s"/email/invalid"))
+          case OtherError   => SeeOther(LinkTo(s"/email/error"))
+        }
+
+      case Accepts.Json() =>
+        Cors(NoCache(result match {
+          case Subscribed   => Created("Subscribed")
+          case InvalidEmail => BadRequest("Invalid email")
+          case OtherError   => InternalServerError("Internal error")
+        }))
+      case _ =>
+        NotAccepted.increment()
+        NotAcceptable
+    }
+  }
+
   private def respondFooter(result: SubscriptionResult)(implicit
       request: Request[AnyContent],
   ): Result = {
@@ -302,6 +351,29 @@ class EmailSignupController(
       case _ =>
         NotAccepted.increment()
         NotAcceptable
+    }
+  }
+
+  private def submitForm(form: EmailForm)(implicit request: Request[AnyContent]) = {
+    emailFormService
+      .submit(form)
+      .map(_.status match {
+        case 200 | 201 =>
+          EmailSubmission.increment()
+          respond(Subscribed, form.listName)
+
+        case status =>
+          log.error(s"Error posting to Identity API: HTTP $status")
+          APIHTTPError.increment()
+          respond(OtherError)
+
+      }) recover {
+      case _: IllegalAccessException =>
+        respond(Subscribed, form.listName)
+      case e: Exception =>
+        log.error(s"Error posting to Identity API: ${e.getMessage}")
+        APINetworkError.increment()
+        respond(OtherError)
     }
   }
 
@@ -360,90 +432,4 @@ class EmailSignupController(
       Future.successful(())
     }
   }
-
-  def submit(): Action[AnyContent] =
-    Action.async { implicit request =>
-      AllEmailSubmission.increment()
-
-      emailForm.bindFromRequest.fold(
-        formWithErrors => {
-          log.info(s"Form has been submitted with errors: ${formWithErrors.errors}")
-          EmailFormError.increment()
-          Future.successful(respond(InvalidEmail))
-        },
-        form => {
-          log.info(
-            s"Post request received to /email/ - " +
-              s"email: ${form.email}, " +
-              s"ref: ${form.ref}, " +
-              s"refViewId: ${form.refViewId}, " +
-              s"g-recaptcha-response: ${form.googleRecaptchaResponse}, " +
-              s"referer: ${request.headers.get("referer").getOrElse("unknown")}, " +
-              s"user-agent: ${request.headers.get("user-agent").getOrElse("unknown")}, " +
-              s"x-requested-with: ${request.headers.get("x-requested-with").getOrElse("unknown")}",
-          )
-
-          (for {
-            _ <- validateCaptcha(form, ValidateEmailSignupRecaptchaTokens.isSwitchedOn)
-            result <- submitForm(form)
-          } yield {
-            result
-          }) recover {
-            case _ =>
-              respond(OtherError)
-          }
-        },
-      )
-    }
-
-  private def submitForm(form: EmailForm)(implicit request: Request[AnyContent]) = {
-    emailFormService
-      .submit(form)
-      .map(_.status match {
-        case 200 | 201 =>
-          EmailSubmission.increment()
-          respond(Subscribed, form.listName)
-
-        case status =>
-          log.error(s"Error posting to Identity API: HTTP $status")
-          APIHTTPError.increment()
-          respond(OtherError)
-
-      }) recover {
-      case _: IllegalAccessException =>
-        respond(Subscribed, form.listName)
-      case e: Exception =>
-        log.error(s"Error posting to Identity API: ${e.getMessage}")
-        APINetworkError.increment()
-        respond(OtherError)
-    }
-  }
-
-  private def respond(result: SubscriptionResult, listName: Option[String] = None)(implicit
-      request: Request[AnyContent],
-  ): Result = {
-    render {
-      case Accepts.Html() =>
-        result match {
-          case Subscribed   => SeeOther(LinkTo(s"/email/success/${listName.get}"))
-          case InvalidEmail => SeeOther(LinkTo(s"/email/invalid"))
-          case OtherError   => SeeOther(LinkTo(s"/email/error"))
-        }
-
-      case Accepts.Json() =>
-        Cors(NoCache(result match {
-          case Subscribed   => Created("Subscribed")
-          case InvalidEmail => BadRequest("Invalid email")
-          case OtherError   => InternalServerError("Internal error")
-        }))
-      case _ =>
-        NotAccepted.increment()
-        NotAcceptable
-    }
-  }
-
-  def options(): Action[AnyContent] =
-    Action { implicit request =>
-      TinyResponse.noContent(Some("GET, POST, OPTIONS"))
-    }
 }

--- a/common/app/views/emailFragment.scala.html
+++ b/common/app/views/emailFragment.scala.html
@@ -4,9 +4,8 @@
 @emailEmbed(page) {
     @fragments.email.signup.subscription.emailSignUp(
         emailType,
-        emailNewsletter.identityName,
-        emailNewsletter.emailEmbed,
-        emailNewsletter.emailConfirmation,
+        emailNewsletter.id,
+        emailNewsletter.emailEmbed
     )
 }
 

--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -2,8 +2,7 @@
 @import com.gu.identity.model.EmailEmbed
 @(  componentClass: String,
     listName:String,
-    emailEmbedData: EmailEmbed,
-    emailConfirmation: Boolean)(implicit request: RequestHeader)
+    emailEmbedData: EmailEmbed)(implicit request: RequestHeader)
 
 @import common.LinkTo
 @import conf.switches.Switches.EmailSignupRecaptcha
@@ -51,7 +50,6 @@
                 <input class="email-sub__listname-input" type="hidden" name="listName" value="@listName" />
                 <input class="email-sub__ref-input" type="hidden" name="ref" id="email-sub__ref-input" value="" />
                 <input class="email-sub__refviewid-input" type="hidden" name="refViewId" id="email-sub__refviewid-input" value="" />
-                <input class="email-sub__emailconfirmation-input" type="hidden" name="emailConfirmation" id="email-sub__emailconfirmation-input" value="@emailConfirmation" />
 
             </div>
             <button type="submit" class="email-sub__submit-button button button--tertiary button--large" id="email-embed-signup-button--old" data-component="email-signup-button @componentClass-@listName" data-link-name="@componentClass | @listName">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>

--- a/common/app/views/fragments/emailLandingBody.scala.html
+++ b/common/app/views/fragments/emailLandingBody.scala.html
@@ -14,8 +14,7 @@
                 @fragments.email.signup.subscription.emailSignUp(
                     "landing",
                     EmailNewsletters.guardianTodayUk.identityName,
-                    EmailNewsletters.guardianTodayUk.emailEmbed,
-                    true
+                    EmailNewsletters.guardianTodayUk.emailEmbed
                 )
             </div>
         </div>

--- a/identity/app/views/fragments/emailListCategories.scala.html
+++ b/identity/app/views/fragments/emailListCategories.scala.html
@@ -29,7 +29,16 @@
 }
 
 <div class="email-subscriptions">
-    @availableLists.map(_.theme).distinct.zipWithIndex.map { case (theme, index) =>
+    @List(
+        "news",
+        "features",
+        "sport",
+        "culture",
+        "lifestyle",
+        "comment",
+        "work",
+        "From the papers"
+    ).zipWithIndex.map { case (theme, index) =>
         @emailListCategoryList(
             theme,
             availableLists.filter(_.theme == theme),

--- a/identity/app/views/fragments/newsletterSwitch.scala.html
+++ b/identity/app/views/fragments/newsletterSwitch.scala.html
@@ -56,5 +56,5 @@
     extraFields = Nil,
     footer = Some(buildFooter(newsletter)),
     skin = skin,
-    newsletterIdentityName = Some(newsletter.identityName)
+    newsletterIdentityName = Some(newsletter.id)
 )(nonInputFields, messages)

--- a/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/store/fetch.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/store/fetch.js
@@ -55,7 +55,7 @@ const fetchNewsletters = Promise.all([
         nl =>
             new EmailConsentWithState(
                 nl,
-                subscribedNewsletters.includes(nl.listId.toString())
+                subscribedNewsletters.includes(nl.exactTargetListId.toString())
             )
     )
 );


### PR DESCRIPTION
…tters-use-source-api"

This reverts commit d75c9028a55f8d5e2b9fba5687d2dcce7d744404, reversing
changes made to 0a94d56a55efb063fccc2db210fccf2bd9f95867.

## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
