### PR TITLE
Reapply change: Retrieve newsletters from newsletters API instead of identity

### DIFF
--- a/applications/app/controllers/SignupPageController.scala
+++ b/applications/app/controllers/SignupPageController.scala
@@ -7,7 +7,8 @@ import pages.NewsletterHtmlPage
 import play.api.libs.ws.WSClient
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 import play.filters.csrf.CSRFAddToken
-import services.newsletters.{GroupedNewslettersResponse, NewsletterSignupAgent}
+import services.newsletters.GroupedNewslettersResponse.GroupedNewslettersResponse
+import services.newsletters.NewsletterSignupAgent
 import staticpages.StaticPages
 
 import scala.concurrent.duration._
@@ -34,7 +35,7 @@ class SignupPageController(
           case Right(groupedNewsletters) =>
             Cached(defaultCacheDuration)(
               RevalidatableResult.Ok(
-                NewsletterHtmlPage.html(StaticPages.simpleNewslettersPage(request.path, groupedNewsletters.toList())),
+                NewsletterHtmlPage.html(StaticPages.simpleNewslettersPage(request.path, groupedNewsletters)),
               ),
             )
           case Left(e) =>

--- a/applications/app/pages/NewsletterHtmlPage.scala
+++ b/applications/app/pages/NewsletterHtmlPage.scala
@@ -1,6 +1,5 @@
 package pages
 
-import common.Edition
 import conf.switches.Switches.WeAreHiring
 import html.HtmlPageHelpers._
 import html.{HtmlPage, Styles}
@@ -16,7 +15,6 @@ import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.signup.newsletterContent
 import html.HtmlPageHelpers.ContentCSSFile
 import staticpages.NewsletterRoundupPage
-import views.html.stacked
 
 object NewsletterHtmlPage extends HtmlPage[NewsletterRoundupPage] {
 

--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -17,7 +17,7 @@
     </div>
     <div class="newsletter-card__wrapper">
     @emailListings.zipWithRowInfo.map { case (emailListing, row) =>
-        <div class="newsletter-card" data-component="newsletter-card @emailListing.id">
+        <div class="newsletter-card" data-component="newsletter-card @emailListing.identityName">
             <div class="newsletter-card__content js-newsletter-content">
                 <div class="newsletter-card__name">
                     @emailListing.name
@@ -42,7 +42,7 @@
                     </div>
                 </div>
 
-                <form action="@LinkTo("/email")" method="post" target="newsletterSignup" class="newsletter-card__signup" name="newsletter-signup-@emailListing.id">
+                <form action="@LinkTo("/email")" method="post" target="newsletterSignup" class="newsletter-card__signup" name="newsletter-signup-@emailListing.identityName">
                     @if(EmailSignupRecaptcha.isSwitchedOn) {
                         @fragments.email.signup.recaptchaContainer()
                     }
@@ -54,9 +54,10 @@
                         <span class="u-h">email address</span>
                         <input class="newsletter-card__text-input js-newsletter-card__text-input" type="email" name="email" placeholder="Email address" required aria-label="Enter email address" title="Email address"/>
                     </label>
-                    <input class="js-email-sub__listname-input" type="hidden" name="listName" value="@emailListing.id" aria-hidden="true"/>
+                    <input class="js-email-sub__listname-input" type="hidden" name="listName" value="@emailListing.identityName" aria-hidden="true"/>
+                    <input class="js-email-sub__emailconfirmation-input" type="hidden" name="listName" value="@emailListing.emailConfirmation" aria-hidden="true"/>
 
-                    <button class="newsletter-card__lozenge js-newsletter-signup-button newsletter-card__lozenge--submit" data-link-name="Subscribe to @emailListing.id" type="submit" value="@emailListing.listIdv1">
+                    <button class="newsletter-card__lozenge js-newsletter-signup-button newsletter-card__lozenge--submit" data-link-name="Subscribe to @emailListing.identityName" type="submit" value="@emailListing.listIdV1">
                         <span>Sign up</span>
                     </button>
                 </form>
@@ -64,7 +65,7 @@
                 <div class="newsletter-card__example js-newsletter-preview is-hidden">
                 @if(emailListing.exampleUrl.isDefined) {
                     <a href="@emailListing.exampleUrl" target="preview-email-@emailListing.listId">
-                        <div class="newsletter-card__lozenge newsletter-card__lozenge--preview" data-link-name="Preview @emailListing.id">
+                        <div class="newsletter-card__lozenge newsletter-card__lozenge--preview" data-link-name="Preview @emailListing.identityName">
                             <span class="newsletter-card__preview">Preview  @fragments.inlineSvg("arrow-right", "icon")</span>
                         </div>
                     </a>

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -80,9 +80,10 @@ class EmailFormService(wsClient: WSClient) extends LazyLogging with RemoteAddres
 
   private def serviceUrl(form: EmailForm): String = {
     if (NewslettersRemoveConfirmationStep.isSwitchedOn && !form.emailConfirmation) {
-      return s"${Configuration.id.apiRoot}/consent-signup"
+      s"${Configuration.id.apiRoot}/consent-signup"
+    } else {
+      s"${Configuration.id.apiRoot}/consent-email"
     }
-    s"${Configuration.id.apiRoot}/consent-email"
   }
 }
 

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -4,7 +4,11 @@ import com.typesafe.scalalogging.LazyLogging
 import common.EmailSubsciptionMetrics._
 import common.{GuLogging, ImplicitControllerExecutionContext, LinkTo}
 import conf.Configuration
-import conf.switches.Switches.{EmailSignupRecaptcha, ValidateEmailSignupRecaptchaTokens}
+import conf.switches.Switches.{
+  EmailSignupRecaptcha,
+  NewslettersRemoveConfirmationStep,
+  ValidateEmailSignupRecaptchaTokens,
+}
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model._
 import play.api.data.Forms._
@@ -35,6 +39,7 @@ case class EmailForm(
     campaignCode: Option[String],
     googleRecaptchaResponse: Option[String],
     name: String,
+    emailConfirmation: Boolean,
 ) {
 
   // `name` is a hidden (via css) form input
@@ -49,12 +54,12 @@ case class EmailForm(
 
 class EmailFormService(wsClient: WSClient) extends LazyLogging with RemoteAddress {
 
-  def submit(form: EmailForm)(implicit request: Request[AnyContent]): Future[WSResponse] =
+  def submit(form: EmailForm)(implicit request: Request[AnyContent]): Future[WSResponse] = {
     if (form.isLikelyBotSubmission) {
       Future.failed(new IllegalAccessException("Form was likely submitted by a bot."))
     } else {
       val idAccessClientToken = Configuration.id.apiClientToken
-      val consentMailerUrl = s"${Configuration.id.apiRoot}/consent-email"
+      val consentMailerUrl = serviceUrl(form)
       val consentMailerPayload = JsObject(Json.obj("email" -> form.email, "set-lists" -> List(form.listName)).fields)
       val headers = clientIp(request)
         .map(ip => List("X-Forwarded-For" -> ip))
@@ -71,6 +76,14 @@ class EmailFormService(wsClient: WSClient) extends LazyLogging with RemoteAddres
         .addHttpHeaders(headers: _*)
         .post(consentMailerPayload)
     }
+  }
+
+  private def serviceUrl(form: EmailForm): String = {
+    if (NewslettersRemoveConfirmationStep.isSwitchedOn && !form.emailConfirmation) {
+      return s"${Configuration.id.apiRoot}/consent-signup"
+    }
+    s"${Configuration.id.apiRoot}/consent-email"
+  }
 }
 
 class EmailSignupController(
@@ -95,16 +108,9 @@ class EmailSignupController(
       "campaignCode" -> optional[String](of[String]),
       "g-recaptcha-response" -> optional[String](of[String]),
       "name" -> text,
+      "emailConfirmation" -> boolean,
     )(EmailForm.apply)(EmailForm.unapply),
   )
-
-  def logApiError(error: String): Unit = {
-    log.error(s"API call to get newsletters failed: $error")
-  }
-
-  def logNewsletterNotFoundError(newsletterName: String): Unit = {
-    log.error(s"Newsletter not found: Couldn't find $newsletterName")
-  }
 
   def renderPage(): Action[AnyContent] =
     Action { implicit request =>
@@ -218,6 +224,14 @@ class EmailSignupController(
       }
     }
 
+  def logApiError(error: String): Unit = {
+    log.error(s"API call to get newsletters failed: $error")
+  }
+
+  def logNewsletterNotFoundError(newsletterName: String): Unit = {
+    log.error(s"Newsletter not found: Couldn't find $newsletterName")
+  }
+
   def subscriptionNonsuccessResult(result: String): Action[AnyContent] =
     Action { implicit request =>
       Cached(1.hour)(result match {
@@ -268,69 +282,6 @@ class EmailSignupController(
       )
     }
 
-  def submit(): Action[AnyContent] =
-    Action.async { implicit request =>
-      AllEmailSubmission.increment()
-
-      emailForm.bindFromRequest.fold(
-        formWithErrors => {
-          log.info(s"Form has been submitted with errors: ${formWithErrors.errors}")
-          EmailFormError.increment()
-          Future.successful(respond(InvalidEmail))
-        },
-        form => {
-          log.info(
-            s"Post request received to /email/ - " +
-              s"email: ${form.email}, " +
-              s"ref: ${form.ref}, " +
-              s"refViewId: ${form.refViewId}, " +
-              s"g-recaptcha-response: ${form.googleRecaptchaResponse}, " +
-              s"referer: ${request.headers.get("referer").getOrElse("unknown")}, " +
-              s"user-agent: ${request.headers.get("user-agent").getOrElse("unknown")}, " +
-              s"x-requested-with: ${request.headers.get("x-requested-with").getOrElse("unknown")}",
-          )
-
-          (for {
-            _ <- validateCaptcha(form, ValidateEmailSignupRecaptchaTokens.isSwitchedOn)
-            result <- submitForm(form)
-          } yield {
-            result
-          }) recover {
-            case _ =>
-              respond(OtherError)
-          }
-        },
-      )
-    }
-
-  def options(): Action[AnyContent] =
-    Action { implicit request =>
-      TinyResponse.noContent(Some("GET, POST, OPTIONS"))
-    }
-
-  private def respond(result: SubscriptionResult, listName: Option[String] = None)(implicit
-      request: Request[AnyContent],
-  ): Result = {
-    render {
-      case Accepts.Html() =>
-        result match {
-          case Subscribed   => SeeOther(LinkTo(s"/email/success/${listName.get}"))
-          case InvalidEmail => SeeOther(LinkTo(s"/email/invalid"))
-          case OtherError   => SeeOther(LinkTo(s"/email/error"))
-        }
-
-      case Accepts.Json() =>
-        Cors(NoCache(result match {
-          case Subscribed   => Created("Subscribed")
-          case InvalidEmail => BadRequest("Invalid email")
-          case OtherError   => InternalServerError("Internal error")
-        }))
-      case _ =>
-        NotAccepted.increment()
-        NotAcceptable
-    }
-  }
-
   private def respondFooter(result: SubscriptionResult)(implicit
       request: Request[AnyContent],
   ): Result = {
@@ -351,29 +302,6 @@ class EmailSignupController(
       case _ =>
         NotAccepted.increment()
         NotAcceptable
-    }
-  }
-
-  private def submitForm(form: EmailForm)(implicit request: Request[AnyContent]) = {
-    emailFormService
-      .submit(form)
-      .map(_.status match {
-        case 200 | 201 =>
-          EmailSubmission.increment()
-          respond(Subscribed, form.listName)
-
-        case status =>
-          log.error(s"Error posting to Identity API: HTTP $status")
-          APIHTTPError.increment()
-          respond(OtherError)
-
-      }) recover {
-      case _: IllegalAccessException =>
-        respond(Subscribed, form.listName)
-      case e: Exception =>
-        log.error(s"Error posting to Identity API: ${e.getMessage}")
-        APINetworkError.increment()
-        respond(OtherError)
     }
   }
 
@@ -432,4 +360,90 @@ class EmailSignupController(
       Future.successful(())
     }
   }
+
+  def submit(): Action[AnyContent] =
+    Action.async { implicit request =>
+      AllEmailSubmission.increment()
+
+      emailForm.bindFromRequest.fold(
+        formWithErrors => {
+          log.info(s"Form has been submitted with errors: ${formWithErrors.errors}")
+          EmailFormError.increment()
+          Future.successful(respond(InvalidEmail))
+        },
+        form => {
+          log.info(
+            s"Post request received to /email/ - " +
+              s"email: ${form.email}, " +
+              s"ref: ${form.ref}, " +
+              s"refViewId: ${form.refViewId}, " +
+              s"g-recaptcha-response: ${form.googleRecaptchaResponse}, " +
+              s"referer: ${request.headers.get("referer").getOrElse("unknown")}, " +
+              s"user-agent: ${request.headers.get("user-agent").getOrElse("unknown")}, " +
+              s"x-requested-with: ${request.headers.get("x-requested-with").getOrElse("unknown")}",
+          )
+
+          (for {
+            _ <- validateCaptcha(form, ValidateEmailSignupRecaptchaTokens.isSwitchedOn)
+            result <- submitForm(form)
+          } yield {
+            result
+          }) recover {
+            case _ =>
+              respond(OtherError)
+          }
+        },
+      )
+    }
+
+  private def submitForm(form: EmailForm)(implicit request: Request[AnyContent]) = {
+    emailFormService
+      .submit(form)
+      .map(_.status match {
+        case 200 | 201 =>
+          EmailSubmission.increment()
+          respond(Subscribed, form.listName)
+
+        case status =>
+          log.error(s"Error posting to Identity API: HTTP $status")
+          APIHTTPError.increment()
+          respond(OtherError)
+
+      }) recover {
+      case _: IllegalAccessException =>
+        respond(Subscribed, form.listName)
+      case e: Exception =>
+        log.error(s"Error posting to Identity API: ${e.getMessage}")
+        APINetworkError.increment()
+        respond(OtherError)
+    }
+  }
+
+  private def respond(result: SubscriptionResult, listName: Option[String] = None)(implicit
+      request: Request[AnyContent],
+  ): Result = {
+    render {
+      case Accepts.Html() =>
+        result match {
+          case Subscribed   => SeeOther(LinkTo(s"/email/success/${listName.get}"))
+          case InvalidEmail => SeeOther(LinkTo(s"/email/invalid"))
+          case OtherError   => SeeOther(LinkTo(s"/email/error"))
+        }
+
+      case Accepts.Json() =>
+        Cors(NoCache(result match {
+          case Subscribed   => Created("Subscribed")
+          case InvalidEmail => BadRequest("Invalid email")
+          case OtherError   => InternalServerError("Internal error")
+        }))
+      case _ =>
+        NotAccepted.increment()
+        NotAcceptable
+    }
+  }
+
+  def options(): Action[AnyContent] =
+    Action { implicit request =>
+      TinyResponse.noContent(Some("GET, POST, OPTIONS"))
+    }
 }

--- a/common/app/services/newsletters/NewsletterApi.scala
+++ b/common/app/services/newsletters/NewsletterApi.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}
 
 case class NewsletterResponse(
-    id: String,
+    identityName: String,
     name: String,
     brazeNewsletterName: String,
     brazeSubscribeAttributeName: String,
@@ -18,13 +18,16 @@ case class NewsletterResponse(
     theme: String,
     description: String,
     frequency: String,
-    exactTargetListId: Int,
-    listIdv1: Int,
+    listIdV1: Int,
     listId: Int,
     exampleUrl: Option[String],
     emailEmbed: EmailEmbed,
     illustration: Option[NewsletterIllustration] = None,
     signupPage: Option[String],
+    restricted: Boolean,
+    paused: Boolean,
+    emailConfirmation: Boolean,
+    group: String,
 )
 
 object NewsletterResponse {
@@ -33,73 +36,16 @@ object NewsletterResponse {
   implicit val newsletterResponseReads = Json.reads[NewsletterResponse]
 }
 
-case class GroupedNewsletterResponse(
-    displayName: String,
-    newsletters: List[NewsletterResponse],
-)
-
-object GroupedNewsletterResponse {
-  implicit val groupedNewsletterResponseReads = Json.reads[GroupedNewsletterResponse]
-}
-
-// TODO: Find a better way to define this that means Frontend doesn't have knowledge of the fields returned.
-case class GroupedNewslettersResponse(
-    newsRoundups: Option[GroupedNewsletterResponse],
-    newsByTopic: Option[GroupedNewsletterResponse],
-    features: Option[GroupedNewsletterResponse],
-    sport: Option[GroupedNewsletterResponse],
-    culture: Option[GroupedNewsletterResponse],
-    lifestyle: Option[GroupedNewsletterResponse],
-    comment: Option[GroupedNewsletterResponse],
-    work: Option[GroupedNewsletterResponse],
-    fromThePapers: Option[GroupedNewsletterResponse],
-) {
-  val toList: () => List[(String, List[NewsletterResponse])] = () =>
-    List(
-      newsRoundups,
-      newsByTopic,
-      features,
-      sport,
-      culture,
-      lifestyle,
-      comment,
-      work,
-      fromThePapers,
-    ).flatten.map(g => (g.displayName, g.newsletters))
-}
-
 object GroupedNewslettersResponse {
-  implicit val groupedNewslettersResponseReads = Json.reads[GroupedNewslettersResponse]
-
-  // Create an empty response to initialise the box
-  val empty = GroupedNewslettersResponse(
-    Option(GroupedNewsletterResponse("News roundups", Nil)),
-    Option(GroupedNewsletterResponse("News by topic", Nil)),
-    Option(GroupedNewsletterResponse("Features", Nil)),
-    Option(GroupedNewsletterResponse("Sport", Nil)),
-    Option(GroupedNewsletterResponse("Culture", Nil)),
-    Option(GroupedNewsletterResponse("Lifestyle", Nil)),
-    Option(GroupedNewsletterResponse("Comment", Nil)),
-    Option(GroupedNewsletterResponse("Work", Nil)),
-    Option(GroupedNewsletterResponse("From the papers", Nil)),
-  )
+  type GroupedNewslettersResponse = List[(String, List[NewsletterResponse])]
+}
+object GroupedNewsletterResponse {
+  type GroupedNewsletterResponse = (String, List[NewsletterResponse])
 }
 
 case class NewsletterApi(wsClient: WSClient)(implicit executionContext: ExecutionContext)
     extends GuLogging
     with implicits.WSRequests {
-
-  def getGroupedNewsletters(): Future[Either[String, GroupedNewslettersResponse]] = {
-    getBody("newsletters/grouped").map { json =>
-      {
-        json.validate[GroupedNewslettersResponse] match {
-          case succ: JsSuccess[GroupedNewslettersResponse] =>
-            Right(succ.get)
-          case err: JsError => Left(err.toString)
-        }
-      }
-    }
-  }
 
   def getNewsletters(): Future[Either[String, List[NewsletterResponse]]] = {
     getBody("newsletters").map { json =>

--- a/common/app/services/newsletters/NewsletterSignupAgent.scala
+++ b/common/app/services/newsletters/NewsletterSignupAgent.scala
@@ -2,26 +2,54 @@ package services.newsletters
 
 import com.gu.Box
 import common.GuLogging
+import services.newsletters.GroupedNewslettersResponse.GroupedNewslettersResponse
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 class NewsletterSignupAgent(newsletterApi: NewsletterApi) extends GuLogging {
 
-  // Newsletters (not grouped by theme)
+  // Newsletters
   private val newslettersAgent = Box[Either[String, List[NewsletterResponse]]](Right(Nil))
+  // Grouped Newsletters (grouped by group)
+  private val groupedNewslettersAgent = Box[Either[String, GroupedNewslettersResponse]](Right(List.empty))
+
+  def getNewsletterByName(listName: String): Either[String, Option[NewsletterResponse]] = {
+    newslettersAgent.get() match {
+      case Left(err)          => Left(err)
+      case Right(newsletters) => Right(newsletters.find(newsletter => newsletter.identityName == listName))
+    }
+  }
+
+  def getNewsletterById(listId: Int): Either[String, Option[NewsletterResponse]] = {
+    newslettersAgent.get() match {
+      case Left(err) => Left(err)
+      case Right(newsletters) =>
+        Right(
+          newsletters.find(newsletter => newsletter.listId == listId || newsletter.listIdV1 == listId),
+        )
+    }
+  }
+
+  def getGroupedNewsletters(): Either[String, GroupedNewslettersResponse] = groupedNewslettersAgent.get()
+
+  def getNewsletters(): Either[String, List[NewsletterResponse]] = newslettersAgent.get()
+
+  def refresh()(implicit ec: ExecutionContext): Unit = {
+    refreshNewsletters()
+  }
 
   def refreshNewsletters()(implicit ec: ExecutionContext): Unit = {
-    log.info("Refreshing newsletters for newsletter signup embeds.")
+    log.info("Refreshing newsletters and Grouped Newsletters for newsletter signup embeds.")
 
     val newslettersQuery = newsletterApi.getNewsletters()
-
     newslettersQuery.flatMap { newsletters =>
       newslettersAgent.alter(newsletters match {
         case Right(response) =>
-          log.info("Successfully refreshed Newsletters embed cache.")
+          log.info("Successfully refreshed Newsletters and Grouped Newsletters embed cache.")
+          groupedNewslettersAgent.alter(Right(buildGroupedNewsletters(response)))
           Right(response)
         case Left(err) =>
-          log.error(s"Failed to refresh Newsletters embed cache: $err")
+          log.error(s"Failed to refresh Newsletters and Grouped Newsletters embed cache: $err")
           Left(err)
       })
     } recover {
@@ -33,58 +61,14 @@ class NewsletterSignupAgent(newsletterApi: NewsletterApi) extends GuLogging {
 
   }
 
-  def getNewsletterByName(listName: String): Either[String, Option[NewsletterResponse]] = {
-    newslettersAgent.get() match {
-      case Left(err)          => Left(err)
-      case Right(newsletters) => Right(newsletters.find(newsletter => newsletter.id == listName))
-    }
-  }
+  private def buildGroupedNewsletters(newsletters: List[NewsletterResponse]): GroupedNewslettersResponse = {
+    val displayedNewsletters = newsletters.filter(n => !n.paused && !n.restricted)
+    val groupedNewsletters = displayedNewsletters.groupBy(n => n.group)
 
-  def getNewsletterById(listId: Int): Either[String, Option[NewsletterResponse]] = {
-    newslettersAgent.get() match {
-      case Left(err) => Left(err)
-      case Right(newsletters) =>
-        Right(
-          newsletters.find(newsletter => newsletter.exactTargetListId == listId || newsletter.listIdv1 == listId),
-        )
-    }
-  }
-
-  // Grouped Newsletters (grouped by theme)
-
-  private val groupedNewslettersAgent =
-    Box[Either[String, GroupedNewslettersResponse]](Right(GroupedNewslettersResponse.empty))
-
-  def refreshGroupedNewsletters()(implicit ec: ExecutionContext): Unit = {
-    log.info("Refreshing Grouped Newsletters for round up page.")
-
-    val groupedNewslettersQuery = newsletterApi.getGroupedNewsletters()
-
-    groupedNewslettersQuery.flatMap { newsletters =>
-      groupedNewslettersAgent.alter(newsletters match {
-        case Right(response) =>
-          log.info("Successfully refreshed Grouped Newsletters cache.")
-          Right(response)
-        case Left(err) =>
-          log.error(s"Failed to refresh Grouped Newsletters cache: $err")
-          Left(err)
-      })
-    } recover {
-      case e =>
-        val errMessage = s"Call to Grouped Newsletter API failed: ${e.getMessage}"
-        log.error(errMessage)
-        Left(errMessage)
-    }
-
-  }
-
-  def getGroupedNewsletters(): Either[String, GroupedNewslettersResponse] = groupedNewslettersAgent.get()
-
-  def getNewsletters(): Either[String, List[NewsletterResponse]] = newslettersAgent.get()
-
-  def refresh()(implicit ec: ExecutionContext): Unit = {
-    refreshNewsletters()
-    refreshGroupedNewsletters()
+    displayedNewsletters
+      .map(_.group)
+      .distinct
+      .map { group => (group, groupedNewsletters.getOrElse(group, Nil)) }
   }
 
 }

--- a/common/app/views/emailFragment.scala.html
+++ b/common/app/views/emailFragment.scala.html
@@ -4,8 +4,9 @@
 @emailEmbed(page) {
     @fragments.email.signup.subscription.emailSignUp(
         emailType,
-        emailNewsletter.id,
-        emailNewsletter.emailEmbed
+        emailNewsletter.identityName,
+        emailNewsletter.emailEmbed,
+        emailNewsletter.emailConfirmation,
     )
 }
 

--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -2,7 +2,8 @@
 @import com.gu.identity.model.EmailEmbed
 @(  componentClass: String,
     listName:String,
-    emailEmbedData: EmailEmbed)(implicit request: RequestHeader)
+    emailEmbedData: EmailEmbed,
+    emailConfirmation: Boolean)(implicit request: RequestHeader)
 
 @import common.LinkTo
 @import conf.switches.Switches.EmailSignupRecaptcha
@@ -50,6 +51,7 @@
                 <input class="email-sub__listname-input" type="hidden" name="listName" value="@listName" />
                 <input class="email-sub__ref-input" type="hidden" name="ref" id="email-sub__ref-input" value="" />
                 <input class="email-sub__refviewid-input" type="hidden" name="refViewId" id="email-sub__refviewid-input" value="" />
+                <input class="email-sub__emailconfirmation-input" type="hidden" name="emailConfirmation" id="email-sub__emailconfirmation-input" value="@emailConfirmation" />
 
             </div>
             <button type="submit" class="email-sub__submit-button button button--tertiary button--large" id="email-embed-signup-button--old" data-component="email-signup-button @componentClass-@listName" data-link-name="@componentClass | @listName">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>

--- a/common/app/views/fragments/emailLandingBody.scala.html
+++ b/common/app/views/fragments/emailLandingBody.scala.html
@@ -14,7 +14,8 @@
                 @fragments.email.signup.subscription.emailSignUp(
                     "landing",
                     EmailNewsletters.guardianTodayUk.identityName,
-                    EmailNewsletters.guardianTodayUk.emailEmbed
+                    EmailNewsletters.guardianTodayUk.emailEmbed,
+                    true
                 )
             </div>
         </div>

--- a/identity/app/views/fragments/emailListCategories.scala.html
+++ b/identity/app/views/fragments/emailListCategories.scala.html
@@ -29,16 +29,7 @@
 }
 
 <div class="email-subscriptions">
-    @List(
-        "news",
-        "features",
-        "sport",
-        "culture",
-        "lifestyle",
-        "comment",
-        "work",
-        "From the papers"
-    ).zipWithIndex.map { case (theme, index) =>
+    @availableLists.map(_.theme).distinct.zipWithIndex.map { case (theme, index) =>
         @emailListCategoryList(
             theme,
             availableLists.filter(_.theme == theme),

--- a/identity/app/views/fragments/newsletterSwitch.scala.html
+++ b/identity/app/views/fragments/newsletterSwitch.scala.html
@@ -56,5 +56,5 @@
     extraFields = Nil,
     footer = Some(buildFooter(newsletter)),
     skin = skin,
-    newsletterIdentityName = Some(newsletter.id)
+    newsletterIdentityName = Some(newsletter.identityName)
 )(nonInputFields, messages)

--- a/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/store/fetch.js
+++ b/static/src/javascripts.flow.archive/projects/common/modules/identity/upsell/store/fetch.js
@@ -55,7 +55,7 @@ const fetchNewsletters = Promise.all([
         nl =>
             new EmailConsentWithState(
                 nl,
-                subscribedNewsletters.includes(nl.exactTargetListId.toString())
+                subscribedNewsletters.includes(nl.listId.toString())
             )
     )
 );


### PR DESCRIPTION
This PR is reapplying a change we had to roll back because of misconfiguration. 

In order to work, we need to update the Parameter Store value for `newsletterAPI.host` to point to the Newsletters API `https://newsletters.guardianapis.com` instead of the Identity API `https://idapi.theguardian.com`

Roll out order
- [x] Update Parameter Store value for `newsletterAPI.host` in PROD
- [ ] Merge this PR

For the change description please see: 
see https://github.com/guardian/frontend/pull/24647