### PR TITLE
Respect dcr=true when interactive is pressed

### DIFF
--- a/applications/app/services/InteractivePicker.scala
+++ b/applications/app/services/InteractivePicker.scala
@@ -24,13 +24,13 @@ object InteractivePicker {
       request: RequestHeader,
   ): RenderingTier = {
     // Allows us to press via InterativeLibrarian and also debug interactives rendering via dcr
-    val forceDCROff = request.forceDCROff
     val fullPath = ensureStartingForwardSlash(path)
 
     // Allow us to quickly revert to rendering content (instead of serving pressed content)
     val switchOn = InteractivePickerFeature.isSwitchedOn
 
-    if (forceDCROff) FrontendLegacy
+    if (request.forceDCROff) FrontendLegacy
+    else if (request.forceDCR) DotcomRendering
     else if (isPressed(fullPath) && switchOn) PressedInteractive
     else DotcomRendering
   }

--- a/applications/test/services/InteractivePickerTest.scala
+++ b/applications/test/services/InteractivePickerTest.scala
@@ -42,4 +42,15 @@ import play.api.test.Helpers._
 
     tier should be(DotcomRendering)
   }
+
+  it should "return DotcomRendering if interactive is pressed and dcr=true" in {
+    val path = "/world/live/2021/oct/13/covid-news-live?dcr=true"
+    val testRequest = TestRequest(path)
+    val tier =
+      InteractivePicker.getRenderingTier(path, MockPressedInteractives.isPressed)(
+        testRequest,
+      )
+
+    tier should be(DotcomRendering)
+  }
 }

--- a/applications/test/services/InteractivePickerTest.scala
+++ b/applications/test/services/InteractivePickerTest.scala
@@ -44,8 +44,7 @@ import play.api.test.Helpers._
   }
 
   it should "return DotcomRendering if interactive is pressed and dcr=true" in {
-    val path = "/world/live/2021/oct/13/covid-news-live?dcr=true"
-    val testRequest = TestRequest(path)
+    val testRequest = TestRequest(s"$path?dcr=true")
     val tier =
       InteractivePicker.getRenderingTier(path, MockPressedInteractives.isPressed)(
         testRequest,


### PR DESCRIPTION
## What does this change?
It changes `InteractivePicker` to respect `dcr=true` flag even when an interactive has been pressed.

## Why?
In order to match how article controller renders pressed articles.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
