### PR TITLE
Fix email signup embed privacy wording behaviour

### DIFF
--- a/common/app/views/emailEmbed.scala.html
+++ b/common/app/views/emailEmbed.scala.html
@@ -7,6 +7,7 @@
 @import play.api.Mode.Dev
 @import conf.Static
 @import views.support.RenderClasses
+@import conf.switches.Switches.NewslettersRemoveConfirmationStep
 
 <!doctype html>
 <html>
@@ -33,6 +34,15 @@
         @body
     </body>
     <script src="https://interactive.guim.co.uk/libs/iframe-messenger/iframeMessenger.js"></script>
+    @if(NewslettersRemoveConfirmationStep.isSwitchedOn) {
+        <script>
+            document.querySelector('.email-sub__text-input')
+                .addEventListener('focusin', () => {
+                    document.querySelector('.newsletters-terms').setAttribute('data-privacy-visible', "true")
+                    iframeMessenger?.resize()
+                });
+        </script>
+    }
     @if(EmailSignupRecaptcha.isSwitchedOn) {
         <script>
             window.addEventListener('message', (event) => {

--- a/common/app/views/fragments/email/signup/privacyNoticeContent.scala.html
+++ b/common/app/views/fragments/email/signup/privacyNoticeContent.scala.html
@@ -1,7 +1,7 @@
 
-@(plural: Boolean = true, termsClass: String  = "")(implicit request: RequestHeader)
+@(plural: Boolean = true)(implicit request: RequestHeader)
 
-<span id="privacy-notice" class="newsletters-privacy-notice @termsClass">
+<span class="newsletters-privacy-notice">
     We thought you should know @if(plural){ these newsletters } else { this newsletter } may also contain information about Guardian products,
     services and chosen charities or online advertisements.
     Newsletters may also contain content funded by outside parties.

--- a/common/app/views/fragments/email/signup/recaptchaTerms.scala.html
+++ b/common/app/views/fragments/email/signup/recaptchaTerms.scala.html
@@ -1,5 +1,5 @@
-@(privacyNotice: Html = null, dark: String = "")(implicit request: RequestHeader)
+@(privacyNotice: Html = null)(implicit request: RequestHeader)
 
-<div class="newsletters-terms @dark">
+<div class="newsletters-terms">
     @privacyNotice We operate Google reCAPTCHA to protect our website and the Google <a href="https://policies.google.com/privacy" target="_blank">Privacy Policy</a> and <a href="https://policies.google.com/terms" target="_blank">Terms of Service</a> apply.
 </div>

--- a/common/app/views/fragments/email/signup/recaptchaTerms.scala.html
+++ b/common/app/views/fragments/email/signup/recaptchaTerms.scala.html
@@ -1,5 +1,5 @@
 @(privacyNotice: Html = null, dark: String = "")(implicit request: RequestHeader)
 
-<div id="newsletters-terms" class="terms @dark">
+<div class="newsletters-terms @dark">
     @privacyNotice We operate Google reCAPTCHA to protect our website and the Google <a href="https://policies.google.com/privacy" target="_blank">Privacy Policy</a> and <a href="https://policies.google.com/terms" target="_blank">Terms of Service</a> apply.
 </div>

--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -79,10 +79,4 @@
     trackClickEvent(document.getElementById("email-embed-signup-button--old"))
     document.getElementById("email-sub__ref-input").value = window.parent.location.href
     document.getElementById("email-sub__refviewid-input").value = window.parent.guardian.config.ophan.pageViewId
-    @if(NewslettersRemoveConfirmationStep.isSwitchedOn) {
-        document.getElementById("@inputId")
-        .addEventListener("focusin", ()=> iframeMessenger?.resize());
-    document.getElementById("@inputId")
-        .addEventListener("focusout", ()=> iframeMessenger?.resize());
-    }
 </script>

--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -53,14 +53,14 @@
 
             </div>
             <button type="submit" class="email-sub__submit-button button button--tertiary button--large" id="email-embed-signup-button--old" data-component="email-signup-button @componentClass-@listName" data-link-name="@componentClass | @listName">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
-            @if(EmailSignupRecaptcha.isSwitchedOn && NewslettersRemoveConfirmationStep.isSwitchedOn ) {
+            @if(EmailSignupRecaptcha.isSwitchedOn && NewslettersRemoveConfirmationStep.isSwitchedOn) {
                 @fragments.email.signup.recaptchaContainer()
-                @fragments.email.signup.recaptchaTerms(fragments.email.signup.privacyNoticeContent(plural = false), "dark")
+                @fragments.email.signup.recaptchaTerms(fragments.email.signup.privacyNoticeContent(plural = false))
             } else if(EmailSignupRecaptcha.isSwitchedOn) {
                 @fragments.email.signup.recaptchaContainer()
                 @fragments.email.signup.recaptchaTerms()
             }else if(NewslettersRemoveConfirmationStep.isSwitchedOn) {
-                @fragments.email.signup.privacyNoticeContent(plural = false, termsClass = "terms dark")
+                @fragments.email.signup.privacyNoticeContent(plural = false)
             }
         </div>
     </form>

--- a/static/src/stylesheets/module/email-signup/_iframe.scss
+++ b/static/src/stylesheets/module/email-signup/_iframe.scss
@@ -15,15 +15,27 @@ body {
     visibility: hidden;
 }
 
-.email-sub .terms {
+.email-sub .newsletters-terms {
     color: $brightness-46;
     clear: both;
     font-family: $f-sans-serif-text;
     font-size: .7rem;
+    line-height: 16px;
     margin-left: 5px;
 
     a {
         color: $brightness-46;
+    }
+
+    &[data-privacy-visible="true"] {
+        .newsletters-privacy-notice {
+            display: inline;
+        }
+
+        color: $brightness-7;
+        a {
+            color: $brightness-7;
+        }
     }
 }
 
@@ -35,22 +47,8 @@ body {
     }
 }
 
-.email-sub__form-wrapper {
-    .newsletters-privacy-notice {
-        display: none;
-    }
-}
-
-.email-sub__form-wrapper:focus-within {
-    .newsletters-privacy-notice {
-        display: inline;
-    }
-    .dark {
-        color: $brightness-7;
-        a {
-            color: $brightness-7;
-        }
-    }
+.email-sub__form-wrapper .newsletters-privacy-notice {
+    display: none;
 }
 
 /**

--- a/static/src/stylesheets/module/email-signup/_iframe.scss
+++ b/static/src/stylesheets/module/email-signup/_iframe.scss
@@ -27,7 +27,7 @@ body {
         color: $brightness-46;
     }
 
-    &[data-privacy-visible="true"] {
+    &[data-privacy-visible='true'] {
         .newsletters-privacy-notice {
             display: inline;
         }


### PR DESCRIPTION
## What does this change?

* Simplifies the display of the extended privacy wording on email signup embeds
* Only shows the extended wording when the user focuses on the email input
* Once shown, the wording is not then hidden by any event

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Tested

* [x] locally
* [x] on CODE
