### PR TITLE
Extend `ab-spacefinder-okr-1-filter-nearby` switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -30,7 +30,7 @@ trait ABTestSwitches {
     "Check whether fixing a bug in spacefinder's nearby candidate filtering mechanism leads to revenue uplift",
     owners = Seq(Owner.withGithub("simonbyford")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2022, 2, 21)),
+    sellByDate = Some(LocalDate.of(2022, 3, 7)),
     exposeClientSide = true,
   )
 


### PR DESCRIPTION
## What does this change?

Extends the `ab-spacefinder-okr-1-filter-nearby` switch by 2 weeks. It had expired and was breaking the build.
