### PR TITLE
Extend privacy wording switch expiry to match reCAPTCHA

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -480,7 +480,7 @@ trait FeatureSwitches {
     "Remove confirmation step when user sign up to a newsletter",
     owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
     safeState = Off,
-    sellByDate = LocalDate.of(2022, 3, 4),
+    sellByDate = LocalDate.of(2022, 5, 4),
     exposeClientSide = false,
   )
 


### PR DESCRIPTION
## What does this change?

* Extends the expiry of the privacy wording switch to match the accompanying reCAPTCHA switches