### PR TITLE
Fix emailConfirmation input name

### DIFF
--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -55,7 +55,7 @@
                         <input class="newsletter-card__text-input js-newsletter-card__text-input" type="email" name="email" placeholder="Email address" required aria-label="Enter email address" title="Email address"/>
                     </label>
                     <input class="js-email-sub__listname-input" type="hidden" name="listName" value="@emailListing.identityName" aria-hidden="true"/>
-                    <input class="js-email-sub__emailconfirmation-input" type="hidden" name="listName" value="@emailListing.emailConfirmation" aria-hidden="true"/>
+                    <input class="js-email-sub__emailconfirmation-input" type="hidden" name="emailConfirmation" value="@emailListing.emailConfirmation" aria-hidden="true"/>
 
                     <button class="newsletter-card__lozenge js-newsletter-signup-button newsletter-card__lozenge--submit" data-link-name="Subscribe to @emailListing.identityName" type="submit" value="@emailListing.listIdV1">
                         <span>Sign up</span>


### PR DESCRIPTION
For the newsletter confirmation email removal, we use an emailConfirmation input, this PR fix the name being incorrect.