### PR TITLE
Retrieve emailConfirmation status in the controller

### DIFF
--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -55,7 +55,6 @@
                         <input class="newsletter-card__text-input js-newsletter-card__text-input" type="email" name="email" placeholder="Email address" required aria-label="Enter email address" title="Email address"/>
                     </label>
                     <input class="js-email-sub__listname-input" type="hidden" name="listName" value="@emailListing.identityName" aria-hidden="true"/>
-                    <input class="js-email-sub__emailconfirmation-input" type="hidden" name="emailConfirmation" value="@emailListing.emailConfirmation" aria-hidden="true"/>
 
                     <button class="newsletter-card__lozenge js-newsletter-signup-button newsletter-card__lozenge--submit" data-link-name="Subscribe to @emailListing.identityName" type="submit" value="@emailListing.listIdV1">
                         <span>Sign up</span>

--- a/common/app/views/emailFragment.scala.html
+++ b/common/app/views/emailFragment.scala.html
@@ -6,7 +6,6 @@
         emailType,
         emailNewsletter.identityName,
         emailNewsletter.emailEmbed,
-        emailNewsletter.emailConfirmation,
     )
 }
 

--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -2,8 +2,7 @@
 @import com.gu.identity.model.EmailEmbed
 @(  componentClass: String,
     listName:String,
-    emailEmbedData: EmailEmbed,
-    emailConfirmation: Boolean)(implicit request: RequestHeader)
+    emailEmbedData: EmailEmbed)(implicit request: RequestHeader)
 
 @import common.LinkTo
 @import conf.switches.Switches.EmailSignupRecaptcha
@@ -51,7 +50,6 @@
                 <input class="email-sub__listname-input" type="hidden" name="listName" value="@listName" />
                 <input class="email-sub__ref-input" type="hidden" name="ref" id="email-sub__ref-input" value="" />
                 <input class="email-sub__refviewid-input" type="hidden" name="refViewId" id="email-sub__refviewid-input" value="" />
-                <input class="email-sub__emailconfirmation-input" type="hidden" name="emailConfirmation" id="email-sub__emailconfirmation-input" value="@emailConfirmation" />
 
             </div>
             <button type="submit" class="email-sub__submit-button button button--tertiary button--large" id="email-embed-signup-button--old" data-component="email-signup-button @componentClass-@listName" data-link-name="@componentClass | @listName">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>

--- a/common/app/views/fragments/emailLandingBody.scala.html
+++ b/common/app/views/fragments/emailLandingBody.scala.html
@@ -14,8 +14,7 @@
                 @fragments.email.signup.subscription.emailSignUp(
                     "landing",
                     EmailNewsletters.guardianTodayUk.identityName,
-                    EmailNewsletters.guardianTodayUk.emailEmbed,
-                    true
+                    EmailNewsletters.guardianTodayUk.emailEmbed
                 )
             </div>
         </div>


### PR DESCRIPTION
## What does this change?
The email confirmation status was added to the signup form and processed by the email signup controller as a parameter,`
this change this mechanism, the status is now retrieved in the controller and does not appear on the form, this is more reliable as the form had inconsistent behaviour.

### Tested

- [x] Locally
- [X] On CODE 