### PR TITLE
Check that selector exists before listening for change

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/football.js
+++ b/static/src/javascripts/bootstraps/enhanced/football.js
@@ -347,7 +347,7 @@ const init = () => {
     );
 
 
-    if ( $('form.football-leagues')[0]) {
+    if ( $('form.football-leagues')?.[0]) {
         bean.on(
             document.body,
             'change',

--- a/static/src/javascripts/bootstraps/enhanced/football.js
+++ b/static/src/javascripts/bootstraps/enhanced/football.js
@@ -346,14 +346,17 @@ const init = () => {
         }
     );
 
-    bean.on(
-        document.body,
-        'change',
-        $('form.football-leagues')[0],
-        function onChange() {
-            window.location = this.value;
-        }
-    );
+
+    if ( $('form.football-leagues')[0]) {
+        bean.on(
+            document.body,
+            'change',
+            $('form.football-leagues')[0],
+            function onChange() {
+                window.location = this.value;
+            }
+        );
+    }
 
     tagPageStats();
 };


### PR DESCRIPTION
## What does this change?

There was a bug in Frontend whereby some liveblogs and deadblogs failed to filter by key events on toggle. They would filter if the filter param was passed in as a query param. 

This bug was only replicable on football live/dead blogs. 

Example of pages where the filter doesn't work:
- https://www.theguardian.com/football/live/2021/nov/21/manchester-united-v-arsenal-womens-super-league-live
- https://www.theguardian.com/football/live/2021/nov/21/tottenham-v-leeds-united-premier-league-live-score-updates?filterKeyEvents=true#liveblog-content


The reason for this is that the enhanced football javascript is listening for an event change on `$('form.football-leagues')[0]` which assumes we always have this selector. We do not and so when we try to listen for a change on it, [Bean](https://github.com/fat/bean) - the event emitting library we use -  throws an error. This also explains why we only saw this bug on Football liveblogs as this JS is football specific.

This PR adds a check to see if we have this selector available before listening for changes to it. 


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
### before
https://user-images.githubusercontent.com/20416599/155199980-8bb5d9f1-166c-4ea0-aaec-87a0131b8a39.mov

### after
https://user-images.githubusercontent.com/20416599/155199896-7dd964b3-70ec-4291-bd01-1e7974efd6a2.mov


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
