### PR TITLE
remove Africa Cup of Nations football table

### DIFF
--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -28,7 +28,6 @@ class LeagueTableController(
   // Competitions must be added to this list to show up at /football/tables
   val tableOrder: Seq[String] = Seq(
     "Premier League",
-    "Africa Cup of Nations",
     "Bundesliga",
     "Serie A",
     "La Liga",


### PR DESCRIPTION
## What does this change?
Fixes #24686 
Removes Africa Cup of Nations from football tables.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

## Before
<img width="1003" alt="Screenshot 2022-02-23 at 10 26 33" src="https://user-images.githubusercontent.com/31692/155301750-03919474-e4ab-4a89-8eeb-f922524a2018.png">

## After
<img width="958" alt="Screenshot 2022-02-23 at 10 26 21" src="https://user-images.githubusercontent.com/31692/155301742-f1148e41-eb84-4ebc-86fe-1a008347e4cb.png">

