### PR TITLE
Use separate switch to control display of privacy wording

### DIFF
--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -2,7 +2,7 @@
 @import views.support.`package`.Seq2zipWithRowInfo
 @import staticpages.NewsletterRoundupPage
 @import conf.switches.Switches.EmailSignupRecaptcha
-@import conf.switches.Switches.NewslettersRemoveConfirmationStep
+@import conf.switches.Switches.ShowNewPrivacyWordingOnEmailSignupEmbeds
 @import common.LinkTo
 
 @(signupPage: NewsletterRoundupPage)(implicit request: RequestHeader, context: model.ApplicationContext)
@@ -98,7 +98,7 @@
                     </div>
                 </a>
             </div>
-            @if(NewslettersRemoveConfirmationStep.isSwitchedOn) {
+            @if(ShowNewPrivacyWordingOnEmailSignupEmbeds.isSwitchedOn) {
                 <div class="newsletters-heading__divider"></div>
                 <div class="newsletters-privacy-notice__container">
                     <div class="newsletters-privacy-notice__heading">

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -484,6 +484,16 @@ trait FeatureSwitches {
     exposeClientSide = false,
   )
 
+  val ShowNewPrivacyWordingOnEmailSignupEmbeds = Switch(
+    SwitchGroup.Feature,
+    "show-new-privacy-wording-on-email-signup-embeds",
+    "Show new privacy wording on email signup embeds",
+    owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
+    safeState = Off,
+    sellByDate = LocalDate.of(2022, 5, 4),
+    exposeClientSide = true,
+  )
+
   val ValidateEmailSignupRecaptchaTokens = Switch(
     SwitchGroup.Feature,
     "validate-email-signup-recaptcha-tokens",

--- a/common/app/views/emailEmbed.scala.html
+++ b/common/app/views/emailEmbed.scala.html
@@ -7,7 +7,7 @@
 @import play.api.Mode.Dev
 @import conf.Static
 @import views.support.RenderClasses
-@import conf.switches.Switches.NewslettersRemoveConfirmationStep
+@import conf.switches.Switches.ShowNewPrivacyWordingOnEmailSignupEmbeds
 
 <!doctype html>
 <html>
@@ -34,7 +34,7 @@
         @body
     </body>
     <script src="https://interactive.guim.co.uk/libs/iframe-messenger/iframeMessenger.js"></script>
-    @if(NewslettersRemoveConfirmationStep.isSwitchedOn) {
+    @if(ShowNewPrivacyWordingOnEmailSignupEmbeds.isSwitchedOn) {
         <script>
             document.querySelector('.email-sub__text-input')
                 .addEventListener('focusin', () => {

--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -61,7 +61,7 @@
             } else if(EmailSignupRecaptcha.isSwitchedOn) {
                 @fragments.email.signup.recaptchaContainer()
                 @fragments.email.signup.recaptchaTerms()
-            }else if(ShowNewPrivacyWordingOnEmailSignupEmbeds.isSwitchedOn) {
+            } else if(ShowNewPrivacyWordingOnEmailSignupEmbeds.isSwitchedOn) {
                 @fragments.email.signup.privacyNoticeContent(plural = false)
             }
         </div>

--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -7,7 +7,7 @@
 
 @import common.LinkTo
 @import conf.switches.Switches.EmailSignupRecaptcha
-@import conf.switches.Switches.NewslettersRemoveConfirmationStep
+@import conf.switches.Switches.ShowNewPrivacyWordingOnEmailSignupEmbeds
 
 @listNamesTones = @{  List(
     bestOfOpinionUK.identityName -> "comment",
@@ -55,13 +55,13 @@
 
             </div>
             <button type="submit" class="email-sub__submit-button button button--tertiary button--large" id="email-embed-signup-button--old" data-component="email-signup-button @componentClass-@listName" data-link-name="@componentClass | @listName">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
-            @if(EmailSignupRecaptcha.isSwitchedOn && NewslettersRemoveConfirmationStep.isSwitchedOn) {
+            @if(EmailSignupRecaptcha.isSwitchedOn && ShowNewPrivacyWordingOnEmailSignupEmbeds.isSwitchedOn) {
                 @fragments.email.signup.recaptchaContainer()
                 @fragments.email.signup.recaptchaTerms(fragments.email.signup.privacyNoticeContent(plural = false))
             } else if(EmailSignupRecaptcha.isSwitchedOn) {
                 @fragments.email.signup.recaptchaContainer()
                 @fragments.email.signup.recaptchaTerms()
-            }else if(NewslettersRemoveConfirmationStep.isSwitchedOn) {
+            }else if(ShowNewPrivacyWordingOnEmailSignupEmbeds.isSwitchedOn) {
                 @fragments.email.signup.privacyNoticeContent(plural = false)
             }
         </div>


### PR DESCRIPTION
## What does this change?

* Uses a separate switch for controlling the display of the new privacy wording

This is so we can turn on the display of the new privacy wording without affecting the `EmailSignupController` submit method

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)
