### PR TITLE
Ignore rich links when placing `inline1` ads on desktop

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -43,4 +43,14 @@ trait ABTestSwitches {
     sellByDate = Some(LocalDate.of(2022, 2, 28)),
     exposeClientSide = true,
   )
+
+  Switch(
+    ABTests,
+    "ab-spacefinder-okr-3-rich-links",
+    "Check whether ignoring rich links in spacefinder on desktop leads to revenue uplift",
+    owners = Seq(Owner.withGithub("simonbyford")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2022, 3, 21)),
+    exposeClientSide = true,
+  )
 }

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -1,6 +1,7 @@
 import { adSizes } from '@guardian/commercial-core';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { spacefinderOkr1FilterNearby } from 'common/modules/experiments/tests/spacefinder-okr-1-filter-nearby';
+import { spacefinderOkr3RichLinks } from 'common/modules/experiments/tests/spacefinder-okr-3-rich-links';
 import { getBreakpoint, getViewport } from 'lib/detect-viewport';
 import { getUrlVars } from 'lib/url';
 import config from '../../../lib/config';
@@ -67,6 +68,13 @@ const articleBodySelector = isDotcomRendering
 	: '.js-article__body';
 
 const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
+	const ignoreList = isInVariantSynchronous(
+		spacefinderOkr3RichLinks,
+		'variant',
+	)
+		? ' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate):not([data-spacefinder-component="rich-link"])'
+		: ' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate)';
+
 	const isImmersive = config.get('page.isImmersive');
 	const defaultRules: SpacefinderRules = {
 		bodySelector: articleBodySelector,
@@ -79,11 +87,10 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 				minBelow: 190,
 			},
 			' .ad-slot': adSlotClassSelectorSizes,
-			' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate):not([data-spacefinder-component="rich-link"])':
-				{
-					minAbove: 35,
-					minBelow: 400,
-				},
+			[ignoreList]: {
+				minAbove: 35,
+				minBelow: 400,
+			},
 			' figure.element-immersive': {
 				minAbove: 0,
 				minBelow: 600,

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -108,7 +108,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 				minAbove: 0,
 				minBelow: 600,
 			},
-			' [data-spacefinder-ignore="numbered-list-title"]': {
+			' [data-spacefinder-component="numbered-list-title"]': {
 				minAbove: 25,
 				minBelow: 0,
 			},

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -79,10 +79,11 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 				minBelow: 190,
 			},
 			' .ad-slot': adSlotClassSelectorSizes,
-			' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate)': {
-				minAbove: 35,
-				minBelow: 400,
-			},
+			' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate):not([data-spacefinder-component="rich-link"])':
+				{
+					minAbove: 35,
+					minBelow: 400,
+				},
 			' figure.element-immersive': {
 				minAbove: 0,
 				minBelow: 600,

--- a/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
@@ -2,11 +2,13 @@ import type { ABTest } from '@guardian/ab-core';
 import { isInABTestSynchronous } from '../experiments/ab';
 import { spacefinderOkr1FilterNearby } from '../experiments/tests/spacefinder-okr-1-filter-nearby';
 import { spacefinderOkr2ImagesLoaded } from '../experiments/tests/spacefinder-okr-2-images-loaded';
+import { spacefinderOkr3RichLinks } from '../experiments/tests/spacefinder-okr-3-rich-links';
 
 const defaultClientSideTests: ABTest[] = [
 	/* linter, please keep this array multi-line */
 	spacefinderOkr1FilterNearby,
 	spacefinderOkr2ImagesLoaded,
+	spacefinderOkr3RichLinks,
 ];
 
 const serverSideTests: ServerSideABTest[] = [];

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -4,6 +4,7 @@ import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
 import { spacefinderOkr1FilterNearby } from './tests/spacefinder-okr-1-filter-nearby';
 import { spacefinderOkr2ImagesLoaded } from './tests/spacefinder-okr-2-images-loaded';
+import { spacefinderOkr3RichLinks } from './tests/spacefinder-okr-3-rich-links';
 
 // keep in sync with ab-tests in dotcom-rendering
 // https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/experiments/ab-tests.ts
@@ -13,4 +14,5 @@ export const concurrentTests: readonly ABTest[] = [
 	remoteRRHeaderLinksTest,
 	spacefinderOkr1FilterNearby,
 	spacefinderOkr2ImagesLoaded,
+	spacefinderOkr3RichLinks,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/spacefinder-okr-3-rich-links.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/spacefinder-okr-3-rich-links.ts
@@ -1,0 +1,21 @@
+import type { ABTest } from '@guardian/ab-core';
+import { noop } from '../../../../../lib/noop';
+
+export const spacefinderOkr3RichLinks: ABTest = {
+	id: 'SpacefinderOkr3RichLinks',
+	author: 'Simon Byford (@simonbyford)',
+	start: '2022-02-28',
+	expiry: '2022-03-21',
+	audience: 10 / 100,
+	audienceOffset: 30 / 100,
+	audienceCriteria: 'All pageviews',
+	successMeasure:
+		'Fixing the bug leads to an increase in inline programmatic revenue per 1000 pageviews',
+	description:
+		'Check whether ignoring rich links in spacefinder on desktop leads to an increase in inline programmatic revenue per 1000 pageviews',
+	variants: [
+		{ id: 'control', test: noop },
+		{ id: 'variant', test: noop },
+	],
+	canRun: () => true,
+};

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -102,7 +102,8 @@
   "../projects/common/modules/article/space-filler.ts",
   "../projects/common/modules/commercial/commercial-features.ts",
   "../projects/common/modules/experiments/ab.ts",
-  "../projects/common/modules/experiments/tests/spacefinder-okr-1-filter-nearby.ts"
+  "../projects/common/modules/experiments/tests/spacefinder-okr-1-filter-nearby.ts",
+  "../projects/common/modules/experiments/tests/spacefinder-okr-3-rich-links.ts"
  ],
  "../projects/commercial/modules/carrot-traffic-driver.ts": [
   "../lib/config.d.ts",
@@ -551,7 +552,8 @@
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
   "../projects/common/modules/experiments/ab.ts",
   "../projects/common/modules/experiments/tests/spacefinder-okr-1-filter-nearby.ts",
-  "../projects/common/modules/experiments/tests/spacefinder-okr-2-images-loaded.ts"
+  "../projects/common/modules/experiments/tests/spacefinder-okr-2-images-loaded.ts",
+  "../projects/common/modules/experiments/tests/spacefinder-okr-3-rich-links.ts"
  ],
  "../projects/common/modules/article/space-filler.ts": [
   "../lib/raven.js",
@@ -638,7 +640,8 @@
   "../projects/common/modules/experiments/tests/sign-in-gate-main-control.js",
   "../projects/common/modules/experiments/tests/sign-in-gate-main-variant.js",
   "../projects/common/modules/experiments/tests/spacefinder-okr-1-filter-nearby.ts",
-  "../projects/common/modules/experiments/tests/spacefinder-okr-2-images-loaded.ts"
+  "../projects/common/modules/experiments/tests/spacefinder-okr-2-images-loaded.ts",
+  "../projects/common/modules/experiments/tests/spacefinder-okr-3-rich-links.ts"
  ],
  "../projects/common/modules/experiments/ab-url.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
@@ -669,6 +672,10 @@
   "../lib/noop.ts"
  ],
  "../projects/common/modules/experiments/tests/spacefinder-okr-2-images-loaded.ts": [
+  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
+  "../lib/noop.ts"
+ ],
+ "../projects/common/modules/experiments/tests/spacefinder-okr-3-rich-links.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
   "../lib/noop.ts"
  ],


### PR DESCRIPTION
Co-authored-by: Chris Jones [christopher.jones@theguardian.com](mailto:christopher.jones@theguardian.com)

## What does this change?

Ignore rich links when placing `inline1` ads on desktop.

Currently `inline1` ad placement is subject to strict rules which prevent them from being inserted near any HTML element not in the following list:

- `p`
- `h2`
- `.ad-slot`

Rich links are one such example, as they are rendered inside `figure` elements. On desktop, this doesn't make sense as rich links appear to the left of the article, meaning there is no risk of interference with ads.

The fix is to add rich links to the above list. We don't currently have a good way to identify rich links so this PR relies on `data-spacefinder-component` being set correctly in a [separate PR](https://github.com/guardian/dotcom-rendering/pull/4068).

## What is the value of this and can you measure success?

More chance of `inline1` ads appearing on desktop articles containing rich links.

In particular, several articles from the [list of known articles with weirdly few ads](https://docs.google.com/spreadsheets/d/1NvBMULLeJHk3g9r8jmdr7F7qk-9UkS9Ypha_rpOuhI8/edit#gid=0) now display `inline1` ads after this change:

[Article 1](https://www.theguardian.com/football/2022/feb/14/bundesliga-bochum-down-bayern-munich-in-game-of-century-contender?sfdebug=1)
[Article 2](https://www.theguardian.com/politics/2022/feb/14/oliver-dowden-says-painful-woke-psychodrama-weakening-the-west?sfdebug=1)
[Article 3](https://www.theguardian.com/sport/2022/jan/13/novak-djokovic-australia-considering-cancel-visa-tennis-2022-australian-open?adrefresh=false&sfdebug=1)
[Article 4](https://www.theguardian.com/film/2021/sep/23/johnny-depp-says-no-one-safe-from-cancel-culture-as-he-accepts-lifetime-achievement-award?adrefresh=false&sfdebug=1)
[Article 5](https://www.theguardian.com/film/2021/jan/04/why-cant-stormtroopers-shoot-straight?adrefresh=false&sfdebug=1)

### A/B test

To measure the impact of this change, I've put the fix behind an A/B test `SpacefinderOkr3RichLinks`. 

### Participation

TBD but something like this maybe

![Screenshot 2022-02-23 at 17 10 22](https://user-images.githubusercontent.com/7423751/155370640-f675750f-fc37-4672-ac02-3719d74e4ba1.png)

### Variants

Half of test participants will see the page without the fix (`control`) while half will see it with the fix (`variant`)

### Tested

- [x] Locally
- [ ] On CODE (optional)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![[before]](https://user-images.githubusercontent.com/7423751/155318512-a9aa013b-c0cc-4b22-a460-a676a80939fe.png) | ![[after]](https://user-images.githubusercontent.com/7423751/155318524-8bcf6916-377d-4a25-8b6c-fb57e2b8295d.png) |

