### PR TITLE
Unpress interactive

### DIFF
--- a/common/app/services/dotcomrendering/PressedContent.scala
+++ b/common/app/services/dotcomrendering/PressedContent.scala
@@ -241,7 +241,6 @@ object PressedContent {
     "/us-news/ng-interactive/2017/jul/25/us-healthcare-system-vs-other-countries",
     "/uk-news/ng-interactive/2017/feb/20/what-the-eu27-want-brexit-red-lines-from-the-other-side-of-the-table",
     "/sport/ng-interactive/2017/aug/02/usain-bolt-fastest-man-ever-lived",
-    "/global-development/ng-interactive/2021/aug/23/devastating-how-cuts-in-uks-foreign-aid-could-hurt-the-worlds-poorest",
   )
 
   def isPressed(path: String): Boolean = content.contains(path)


### PR DESCRIPTION
## What does this change?
Un-presses one of the interactives pressed here https://github.com/guardian/frontend/pull/24660 for testing purposes.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

