### PR TITLE
Provide the most recent block ID in the DCR response, for use on older pages

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -40,6 +40,7 @@ case class DotcomRenderingDataModel(
     filterKeyEvents: Boolean,
     pinnedPost: Option[Block],
     keyEvents: List[Block],
+    mostRecentBlockId: Option[String],
     blocks: List[Block],
     pagination: Option[Pagination],
     author: Author,
@@ -106,6 +107,7 @@ object DotcomRenderingDataModel {
         "filterKeyEvents" -> model.filterKeyEvents,
         "pinnedPost" -> model.pinnedPost,
         "keyEvents" -> model.keyEvents,
+        "mostRecentBlockId" -> model.mostRecentBlockId,
         "blocks" -> model.blocks,
         "pagination" -> model.pagination,
         "author" -> model.author,
@@ -256,6 +258,10 @@ object DotcomRenderingDataModel {
         .getOrElse(blocks.body.fold(Seq.empty[APIBlock])(_.filter(_.attributes.pinned.contains(true))))
         .headOption
 
+    val mostRecentBlockId = page.currentPage.pagination.flatMap(paginationInfo =>
+      paginationInfo.newest.flatMap(_.blocks.headOption.map(_.id)),
+    )
+
     apply(
       page,
       request,
@@ -268,6 +274,7 @@ object DotcomRenderingDataModel {
       pinnedPost,
       keyEvents,
       filterKeyEvents,
+      mostRecentBlockId,
     )
   }
 
@@ -283,6 +290,7 @@ object DotcomRenderingDataModel {
       pinnedPost: Option[APIBlock],
       keyEvents: Seq[APIBlock],
       filterKeyEvents: Boolean = false,
+      mostRecentBlockId: Option[String] = None,
   ): DotcomRenderingDataModel = {
 
     val edition = Edition.edition(request)
@@ -418,6 +426,7 @@ object DotcomRenderingDataModel {
       filterKeyEvents = filterKeyEvents,
       pinnedPost = pinnedPostDCR,
       keyEvents = keyEventsDCR.toList,
+      mostRecentBlockId = mostRecentBlockId,
       linkedData = linkedData,
       main = content.fields.main,
       mainMediaElements = mainMediaElements,

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -13,6 +13,7 @@ import model.dotcomrendering.pageElements.{PageElement, TextCleaner}
 import model.{
   ArticleDateTimes,
   Badges,
+  CanonicalLiveBlog,
   ContentFormat,
   ContentPage,
   DotcomContentType,
@@ -258,9 +259,8 @@ object DotcomRenderingDataModel {
         .getOrElse(blocks.body.fold(Seq.empty[APIBlock])(_.filter(_.attributes.pinned.contains(true))))
         .headOption
 
-    val mostRecentBlockId = page.currentPage.pagination.flatMap(paginationInfo =>
-      paginationInfo.newest.flatMap(_.blocks.headOption.map(_.id)),
-    )
+    val mostRecentBlockId =
+      blocks.requestedBodyBlocks.flatMap(_.get(CanonicalLiveBlog.firstPage).flatMap(_.headOption)).map(_.id)
 
     apply(
       page,


### PR DESCRIPTION
## What does this change?

This PR adds a mostRecentBlockId property in the DCR model, to be used when loading older pages of the liveblog for polling new blocks. 

It does this by using the firstPage section of the requested blocks

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Screenshots

<img width="1335" alt="Screenshot 2022-02-24 at 16 45 17" src="https://user-images.githubusercontent.com/1229808/155569057-375e8556-7ca7-48ed-b447-fa09eb37580d.png">
<img width="1339" alt="Screenshot 2022-02-24 at 16 45 38" src="https://user-images.githubusercontent.com/1229808/155569067-2b6ddc73-5cbe-42f1-b042-00f2c8a3df61.png">


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
