### PR TITLE
Got as far as running dev-build with this config

### DIFF
--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -81,7 +81,7 @@ object SystemMetrics extends implicits.Numbers {
     description = "Total physical memory",
     get = () =>
       ManagementFactory.getOperatingSystemMXBean match {
-        case b: com.sun.management.OperatingSystemMXBean => bytesAsMb(b.getTotalPhysicalMemorySize)
+        case b: com.sun.management.OperatingSystemMXBean => bytesAsMb(b.getTotalMemorySize)
         case _                                           => -1
       },
   )
@@ -91,7 +91,7 @@ object SystemMetrics extends implicits.Numbers {
     description = "Free physical memory",
     get = () =>
       ManagementFactory.getOperatingSystemMXBean match {
-        case b: com.sun.management.OperatingSystemMXBean => bytesAsMb(b.getFreePhysicalMemorySize)
+        case b: com.sun.management.OperatingSystemMXBean => bytesAsMb(b.getTotalMemorySize)
         case _                                           => -1
       },
   )

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -32,12 +32,12 @@ object ProjectSettings {
     Compile / packageDoc / publishArtifact := false,
     Compile / doc / sources := Seq.empty,
     Compile / doc := target.map(_ / "none").value,
-    scalaVersion := "2.12.13",
+    scalaVersion := "2.12.15",
     initialize := {
       val _ = initialize.value
       assert(
-        sys.props("java.specification.version") == "11",
-        "Java 11 is required for this project.",
+        sys.props("java.specification.version") == "17",
+        "Java 17 is required for this project.",
       )
     },
     cleanAll := Def.taskDyn {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.7
+sbt.version=1.6.0

--- a/setup.sh
+++ b/setup.sh
@@ -66,7 +66,7 @@ region = eu-west-1" > "$path/$filename"
 
 install_homebrew() {
   if mac && ! installed brew; then
-    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
   fi
 }
 


### PR DESCRIPTION
## What does this change?
Was setting up a new Mac M1 and had to bash a few things to make this run.

Got as far as seeing `dev-build` running in my browser, so I'm calling it at that point. Will open up a draft PR for further detailed investigation is anyone feels so inclined.

👋 

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
