### PR TITLE
Press music review interactive

### DIFF
--- a/common/app/services/dotcomrendering/PressedContent.scala
+++ b/common/app/services/dotcomrendering/PressedContent.scala
@@ -59,6 +59,7 @@ object PressedContent {
     "/us-news/2015/nov/05/police-tasers-deaths-the-counted",
     "/environment/ng-interactive/2015/nov/26/the-mekong-river-stories-from-the-heart-of-the-climate-crisis-interactive",
     "/us-news/2015/dec/01/the-county-kern-county-deadliest-police-killings",
+    "/music/ng-interactive/2015/dec/02/best-albums-of-2015",
     "/us-news/2015/dec/04/the-county-kern-county-california-deputies-tactics",
     "/us-news/2015/dec/08/the-county-kern-county-california-sexual-assault-secret-payoffs",
     "/us-news/2015/dec/10/kern-county-california-police-killings-misconduct-district-attorney",


### PR DESCRIPTION
## What does this change?
Presses an interactive that's been identified as broken in dcr: https://www.theguardian.com/music/ng-interactive/2015/dec/02/best-albums-of-2015?dcr=false

The interactive was flagged to the visuals team and they suggested it was a good candidate for pressing. This PR will ensure that readers see the pressed (working) version.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)
