### PR TITLE
Don't consider `#sign-in-gate` in spacefinder

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -79,7 +79,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 				minBelow: 190,
 			},
 			' .ad-slot': adSlotClassSelectorSizes,
-			' > :not(p):not(h2):not(.ad-slot)': {
+			' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate)': {
 				minAbove: 35,
 				minBelow: 400,
 			},
@@ -163,7 +163,7 @@ const addMobileInlineAds = (): Promise<boolean> => {
 				minBelow: 250,
 			},
 			' .ad-slot': adSlotClassSelectorSizes,
-			' > :not(p):not(h2):not(.ad-slot)': {
+			' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate)': {
 				minAbove: 35,
 				minBelow: 200,
 			},
@@ -232,7 +232,7 @@ const attemptToAddInlineMerchAd = (): Promise<boolean> => {
 				minBelow: 250,
 			},
 			' .ad-slot': adSlotClassSelectorSizes,
-			' > :not(p):not(h2):not(.ad-slot)': {
+			' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate)': {
 				minAbove: 200,
 				minBelow: 400,
 			},

--- a/static/src/javascripts/projects/commercial/modules/carrot-traffic-driver.ts
+++ b/static/src/javascripts/projects/commercial/modules/carrot-traffic-driver.ts
@@ -43,7 +43,7 @@ const wideRules: SpacefinderRules = {
 			minAbove: 50,
 			minBelow: 50,
 		},
-		' > *:not(p):not(h2):not(blockquote)': {
+		' > *:not(p):not(h2):not(blockquote):not(#sign-in-gate)': {
 			minAbove: 50,
 			minBelow: 50,
 		},

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -550,7 +550,8 @@
  "../projects/common/modules/analytics/shouldCaptureMetrics.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
   "../projects/common/modules/experiments/ab.ts",
-  "../projects/common/modules/experiments/tests/spacefinder-okr-1-filter-nearby.ts"
+  "../projects/common/modules/experiments/tests/spacefinder-okr-1-filter-nearby.ts",
+  "../projects/common/modules/experiments/tests/spacefinder-okr-2-images-loaded.ts"
  ],
  "../projects/common/modules/article/space-filler.ts": [
   "../lib/raven.js",
@@ -636,7 +637,8 @@
   "../projects/common/modules/experiments/tests/remote-header-test.js",
   "../projects/common/modules/experiments/tests/sign-in-gate-main-control.js",
   "../projects/common/modules/experiments/tests/sign-in-gate-main-variant.js",
-  "../projects/common/modules/experiments/tests/spacefinder-okr-1-filter-nearby.ts"
+  "../projects/common/modules/experiments/tests/spacefinder-okr-1-filter-nearby.ts",
+  "../projects/common/modules/experiments/tests/spacefinder-okr-2-images-loaded.ts"
  ],
  "../projects/common/modules/experiments/ab-url.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
@@ -666,6 +668,10 @@
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
   "../lib/noop.ts"
  ],
+ "../projects/common/modules/experiments/tests/spacefinder-okr-2-images-loaded.ts": [
+  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
+  "../lib/noop.ts"
+ ],
  "../projects/common/modules/identity/api.ts": [
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/config.d.ts",
@@ -679,12 +685,22 @@
   "../lib/url.ts"
  ],
  "../projects/common/modules/mark-candidates.js": [],
- "../projects/common/modules/spacefinder.js": [
+ "../projects/common/modules/on-images-loaded-broken.js": [
   "../../../../node_modules/bean/bean.js",
+  "../../../../node_modules/lodash-es/lodash.js"
+ ],
+ "../projects/common/modules/on-images-loaded-fixed.js": [
+  "../../../../node_modules/lodash-es/lodash.js"
+ ],
+ "../projects/common/modules/spacefinder.js": [
   "../../../../node_modules/lodash-es/lodash.js",
   "../lib/fastdom-promise.js",
   "../lib/mediator.ts",
-  "../projects/common/modules/mark-candidates.js"
+  "../projects/common/modules/experiments/ab.ts",
+  "../projects/common/modules/experiments/tests/spacefinder-okr-2-images-loaded.ts",
+  "../projects/common/modules/mark-candidates.js",
+  "../projects/common/modules/on-images-loaded-broken.js",
+  "../projects/common/modules/on-images-loaded-fixed.js"
  ],
  "../projects/common/modules/ui/sticky.js": [
   "../../../../node_modules/fastdom/fastdom.js",


### PR DESCRIPTION
## What does this change?

Previously `#sign-in-gate` was a `p` and therefore not considered by default. Now it's a `div` we have to explicitly ignore it

Related PR: https://github.com/guardian/dotcom-rendering/pull/4083

## What is the value of this and can you measure success?

This shouldn't have any impact on anything. It was just incorrect.

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
