### PR TITLE
Update privacy policy wording

### DIFF
--- a/common/app/views/fragments/email/signup/privacyNoticeContent.scala.html
+++ b/common/app/views/fragments/email/signup/privacyNoticeContent.scala.html
@@ -1,9 +1,6 @@
 
-@(plural: Boolean = true)(implicit request: RequestHeader)
+@()(implicit request: RequestHeader)
 
 <span class="newsletters-privacy-notice">
-    We thought you should know @if(plural){ these newsletters } else { this newsletter } may also contain information about Guardian products,
-    services and chosen charities or online advertisements.
-    Newsletters may also contain content funded by outside parties.
-    You can read more about <a href="/help/privacy-policy" data-link-name="privacy-policy" target="_blank">our privacy policy here</a>.
+    Our newsletters may contain info about charities, online ads, and content funded by outside parties. For more information click <a href="/help/privacy-policy" data-link-name="privacy-policy" target="_blank">here</a> for our privacy policy.
 </span>

--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -55,12 +55,12 @@
             <button type="submit" class="email-sub__submit-button button button--tertiary button--large" id="email-embed-signup-button--old" data-component="email-signup-button @componentClass-@listName" data-link-name="@componentClass | @listName">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
             @if(EmailSignupRecaptcha.isSwitchedOn && ShowNewPrivacyWordingOnEmailSignupEmbeds.isSwitchedOn) {
                 @fragments.email.signup.recaptchaContainer()
-                @fragments.email.signup.recaptchaTerms(fragments.email.signup.privacyNoticeContent(plural = false))
+                @fragments.email.signup.recaptchaTerms(fragments.email.signup.privacyNoticeContent())
             } else if(EmailSignupRecaptcha.isSwitchedOn) {
                 @fragments.email.signup.recaptchaContainer()
                 @fragments.email.signup.recaptchaTerms()
             } else if(ShowNewPrivacyWordingOnEmailSignupEmbeds.isSwitchedOn) {
-                @fragments.email.signup.privacyNoticeContent(plural = false)
+                @fragments.email.signup.privacyNoticeContent()
             }
         </div>
     </form>


### PR DESCRIPTION
## What does this change?

* Updates the privacy policy wording in email signup embeds and the all newsletters sign up page

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="685" alt="Screenshot 2022-02-24 at 16 00 45" src="https://user-images.githubusercontent.com/705427/155560790-f726e3ac-1a12-4af1-9a20-abc30f608608.png"> | <img width="674" alt="Screenshot 2022-02-24 at 16 00 31" src="https://user-images.githubusercontent.com/705427/155560782-0c9bc3a5-13fb-4c38-9f5c-c581d19448ae.png"> |

### Tested

- [x] Locally
