### PR TITLE
Read latest block id from body blocks when first page is not requested

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -27,6 +27,8 @@ import play.api.libs.json._
 import play.api.mvc.RequestHeader
 import views.support.{AffiliateLinksCleaner, CamelCase, ContentLayout, JavaScriptPage}
 
+import java.io
+
 // -----------------------------------------------------------------
 // DCR DataModel
 // -----------------------------------------------------------------
@@ -259,8 +261,8 @@ object DotcomRenderingDataModel {
         .getOrElse(blocks.body.fold(Seq.empty[APIBlock])(_.filter(_.attributes.pinned.contains(true))))
         .headOption
 
-    val mostRecentBlockId =
-      blocks.requestedBodyBlocks.flatMap(_.get(CanonicalLiveBlog.firstPage).flatMap(_.headOption)).map(_.id)
+    val mostRecentBlockId = blocks.requestedBodyBlocks
+      .flatMap(_.get(CanonicalLiveBlog.firstPage)).getOrElse(blocks.body.getOrElse(Seq.empty)).headOption.map(_.id)
 
     apply(
       page,

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -262,7 +262,10 @@ object DotcomRenderingDataModel {
         .headOption
 
     val mostRecentBlockId = blocks.requestedBodyBlocks
-      .flatMap(_.get(CanonicalLiveBlog.firstPage)).getOrElse(blocks.body.getOrElse(Seq.empty)).headOption.map(_.id)
+      .flatMap(_.get(CanonicalLiveBlog.firstPage))
+      .getOrElse(blocks.body.getOrElse(Seq.empty))
+      .headOption
+      .map(_.id)
 
     apply(
       page,

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -27,8 +27,6 @@ import play.api.libs.json._
 import play.api.mvc.RequestHeader
 import views.support.{AffiliateLinksCleaner, CamelCase, ContentLayout, JavaScriptPage}
 
-import java.io
-
 // -----------------------------------------------------------------
 // DCR DataModel
 // -----------------------------------------------------------------


### PR DESCRIPTION
## What does this change?

When requesting older pages, the CAPI query asks for all the blocks:
https://github.com/guardian/frontend/blob/main/common/app/model/ArticleBlocks.scala#L35-L37
As such the "requestedBodyBlocks" section in the response will not be present, so we should fall back to the "body" section instead. 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
