### PR TITLE
New live parameter to allow forcing a liveblog to be live

### DIFF
--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -133,7 +133,7 @@ class LiveBlogController(
             if (remoteRendering) {
               DotcomponentsLogger.logger.logRequest(s"liveblog executing in dotcomponents", properties, page)
               val pageType: PageType = PageType(blog, request, context)
-              remoteRenderer.getArticle(ws, blog, blocks, pageType, filterKeyEvents)
+              remoteRenderer.getArticle(ws, blog, blocks, pageType, filterKeyEvents, request.forceLive)
             } else {
               DotcomponentsLogger.logger.logRequest(s"liveblog executing in web", properties, page)
               Future.successful(common.renderHtml(LiveBlogHtmlPage.html(blog), blog))
@@ -294,7 +294,8 @@ class LiveBlogController(
       filterKeyEvents: Boolean,
   )(implicit request: RequestHeader): Result = {
     val pageType: PageType = PageType(blog, request, context)
-    val model = DotcomRenderingDataModel.forLiveblog(blog, blocks, request, pageType, filterKeyEvents)
+    val model =
+      DotcomRenderingDataModel.forLiveblog(blog, blocks, request, pageType, filterKeyEvents, request.forceLive)
     val json = DotcomRenderingDataModel.toJson(model)
     common.renderJson(json, blog).as("application/json")
   }

--- a/article/test/DCRFake.scala
+++ b/article/test/DCRFake.scala
@@ -18,6 +18,7 @@ class DCRFake(implicit context: ApplicationContext) extends renderers.DotcomRend
       blocks: Blocks,
       pageType: PageType,
       filterKeyEvents: Boolean,
+      forceLive: Boolean,
   )(implicit request: RequestHeader): Future[Result] = {
     implicit val ec = ExecutionContext.global
     Future(

--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -108,9 +108,8 @@ trait Requests {
 
     // dotcom-rendering (DCR) parameters
     lazy val forceDCROff: Boolean = r.getQueryString("dcr").contains("false")
-    lazy val forceDCR: Boolean = {
-      r.getQueryString("dcr").isDefined && !forceDCROff // don't check for .contains(true) so people can be lazy
-    }
+    // don't check for .contains(true) so people can be lazy
+    lazy val forceDCR: Boolean = r.getQueryString("dcr").isDefined && !forceDCROff
     lazy val forceLiveOff: Boolean = r.getQueryString("live").contains("false")
     lazy val forceLive: Boolean = r.getQueryString("live").isDefined && !forceLiveOff
 

--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -108,8 +108,11 @@ trait Requests {
 
     // dotcom-rendering (DCR) parameters
     lazy val forceDCROff: Boolean = r.getQueryString("dcr").contains("false")
-    lazy val forceDCR: Boolean =
+    lazy val forceDCR: Boolean = {
       r.getQueryString("dcr").isDefined && !forceDCROff // don't check for .contains(true) so people can be lazy
+    }
+    lazy val forceLiveOff: Boolean = r.getQueryString("live").contains("false")
+    lazy val forceLive: Boolean = r.getQueryString("live").isDefined && !forceLiveOff
 
     // slot machine
     lazy val slotMachineFlags = r.getQueryString("slot-machine-flags").getOrElse("")

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -306,16 +306,7 @@ object DotcomRenderingDataModel {
       twitterHandle = content.tags.contributors.headOption.flatMap(_.properties.twitterHandle),
     )
 
-    val shouldAddAffiliateLinks = AffiliateLinksCleaner.shouldAddAffiliateLinks(
-      switchedOn = Switches.AffiliateLinks.isSwitchedOn,
-      section = content.metadata.sectionId,
-      showAffiliateLinks = content.content.fields.showAffiliateLinks,
-      supportedSections = Configuration.affiliateLinks.affiliateLinkSections,
-      defaultOffTags = Configuration.affiliateLinks.defaultOffTags,
-      alwaysOffTags = Configuration.affiliateLinks.alwaysOffTags,
-      tagPaths = content.content.tags.tags.map(_.id),
-      firstPublishedDate = content.content.fields.firstPublicationDate,
-    )
+    val shouldAddAffiliateLinks = DotcomRenderingUtils.shouldAddAffiliateLinks(content)
 
     val contentDateTimes: ArticleDateTimes = ArticleDateTimes(
       webPublicationDate = content.trail.webPublicationDate,
@@ -387,21 +378,7 @@ object DotcomRenderingDataModel {
       )
     }
 
-    val modifiedFormat = {
-      val originalFormat = content.metadata.format.getOrElse(ContentFormat.defaultContentFormat)
-
-      // TODO move to content-api-scala-client once confirmed as correct
-      // behaviour. At the moment we are seeing interactive articles with other
-      // design types due to CAPI format logic. But interactive design should
-      // always take precendent (or so we think).
-      if (content.metadata.contentType.contains(DotcomContentType.Interactive)) {
-        originalFormat.copy(design = InteractiveDesign)
-      } else if (forceLive) {
-        originalFormat.copy(design = LiveBlogDesign)
-      } else {
-        originalFormat
-      }
-    }
+    val modifiedFormat = DotcomRenderingUtils.getModifiedContent(content, forceLive)
 
     val isLegacyInteractive =
       modifiedFormat.design == InteractiveDesign && content.trail.webPublicationDate

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -10,7 +10,18 @@ import conf.Configuration
 import conf.switches.Switches
 import experiments.ActiveExperiments
 import model.dotcomrendering.pageElements.{PageElement, TextCleaner}
-import model.{ArticleDateTimes, Badges, CanonicalLiveBlog, ContentFormat, ContentPage, DotcomContentType, GUDateTimeFormatNew, InteractivePage, LiveBlogPage, PageWithStoryPackage}
+import model.{
+  ArticleDateTimes,
+  Badges,
+  CanonicalLiveBlog,
+  ContentFormat,
+  ContentPage,
+  DotcomContentType,
+  GUDateTimeFormatNew,
+  InteractivePage,
+  LiveBlogPage,
+  PageWithStoryPackage,
+}
 import navigation._
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
@@ -209,7 +220,7 @@ object DotcomRenderingDataModel {
       request: RequestHeader,
       pageType: PageType,
       filterKeyEvents: Boolean,
-      forceLive: Boolean
+      forceLive: Boolean,
   ): DotcomRenderingDataModel = {
     val pagination = page.currentPage.pagination.map(paginationInfo => {
       Pagination(
@@ -265,7 +276,7 @@ object DotcomRenderingDataModel {
       keyEvents,
       filterKeyEvents,
       mostRecentBlockId,
-      forceLive
+      forceLive,
     )
   }
 
@@ -282,7 +293,7 @@ object DotcomRenderingDataModel {
       keyEvents: Seq[APIBlock],
       filterKeyEvents: Boolean = false,
       mostRecentBlockId: Option[String] = None,
-      forceLive: Boolean = false
+      forceLive: Boolean = false,
   ): DotcomRenderingDataModel = {
 
     val edition = Edition.edition(request)

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -2,6 +2,7 @@ package model.dotcomrendering
 
 import com.gu.contentapi.client.model.v1.ElementType.Text
 import com.gu.contentapi.client.model.v1.{Block => APIBlock, BlockElement => ClientBlockElement, Blocks => APIBlocks}
+import com.gu.contentapi.client.utils.format.{InteractiveDesign, LiveBlogDesign}
 import com.gu.contentapi.client.utils.{AdvertisementFeature, DesignType}
 import common.Edition
 import conf.switches.Switches
@@ -11,10 +12,11 @@ import model.dotcomrendering.pageElements.{DisclaimerBlockElement, PageElement, 
 import model.pressed.SpecialReport
 import model.{
   ArticleDateTimes,
-  BlockRange,
   CanonicalLiveBlog,
+  ContentFormat,
   ContentPage,
   ContentType,
+  DotcomContentType,
   GUDateTimeFormatNew,
   LiveBlogPage,
   Pillar,
@@ -62,26 +64,25 @@ object DotcomRenderingUtils {
       entries1 <- extraction1(references)
       entries2 =
         entries1
-          .map(entryToDataPair(_))
+          .map(entryToDataPair)
           .filter(_.isDefined)
           .map(_.get) // .get is fundamentally dangerous but fine in this case because we filtered the Nones out.
           .filter(_._1 == "pa-football-team")
     } yield {
       val pageId = URLEncoder.encode(articlePage.metadata.id, "UTF-8")
       entries2.toList match {
-        case e1 :: e2 :: _ => {
+        case e1 :: e2 :: _ =>
           val year = articlePage.item.trail.webPublicationDate.toString(DateTimeFormat.forPattern("yyy"))
           val month = articlePage.item.trail.webPublicationDate.toString(DateTimeFormat.forPattern("MM"))
           val day = articlePage.item.trail.webPublicationDate.toString(DateTimeFormat.forPattern("dd"))
-          s"${Configuration.ajax.url}/football/api/match-nav/${year}/${month}/${day}/${e1._2}/${e2._2}.json?dcr=true&page=${pageId}"
-        }
+          s"${Configuration.ajax.url}/football/api/match-nav/$year/$month/$day/${e1._2}/${e2._2}.json?dcr=true&page=$pageId"
         case _ => ""
       }
     }
 
     // We need one more transformation because we could have a Some(""), which we don't want
 
-    if (optionalUrl.getOrElse("").size > 0) {
+    if (optionalUrl.getOrElse("").nonEmpty) {
       optionalUrl
     } else {
       None
@@ -101,7 +102,7 @@ object DotcomRenderingUtils {
   def findPillar(pillar: Option[Pillar], designType: Option[DesignType]): String = {
     pillar
       .map { pillar =>
-        if (designType == AdvertisementFeature) "labs"
+        if (designType.contains(AdvertisementFeature)) "labs"
         else if (pillar.toString.toLowerCase == "arts") "culture"
         else pillar.toString.toLowerCase()
       }
@@ -134,10 +135,9 @@ object DotcomRenderingUtils {
     if (affiliateLinks) {
       val hasLinks = capiElems.exists(elem =>
         elem.`type` match {
-          case Text => {
+          case Text =>
             val textString = elem.textTypeData.toList.mkString("\n") // just concat all the elems here for this test
             AffiliateLinksCleaner.stringContainsAffiliateableLinks(textString)
-          }
           case _ => false
         },
       )
@@ -210,7 +210,7 @@ object DotcomRenderingUtils {
     }
   }
 
-  def shouldAddAffiliateLinks(content: ContentType) = {
+  def shouldAddAffiliateLinks(content: ContentType): Boolean = {
     AffiliateLinksCleaner.shouldAddAffiliateLinks(
       switchedOn = Switches.AffiliateLinks.isSwitchedOn,
       section = content.metadata.sectionId,
@@ -223,13 +223,29 @@ object DotcomRenderingUtils {
     )
   }
 
-  def contentDateTimes(content: ContentType) = {
+  def contentDateTimes(content: ContentType): ArticleDateTimes = {
     ArticleDateTimes(
       webPublicationDate = content.trail.webPublicationDate,
       firstPublicationDate = content.fields.firstPublicationDate,
       hasBeenModified = content.content.hasBeenModified,
       lastModificationDate = content.fields.lastModified,
     )
+  }
+
+  def getModifiedContent(content: ContentType, forceLive: Boolean): ContentFormat = {
+    val originalFormat = content.metadata.format.getOrElse(ContentFormat.defaultContentFormat)
+
+    // TODO move to content-api-scala-client once confirmed as correct
+    // behaviour. At the moment we are seeing interactive articles with other
+    // design types due to CAPI format logic. But interactive design should
+    // always take precendent (or so we think).
+    if (content.metadata.contentType.contains(DotcomContentType.Interactive)) {
+      originalFormat.copy(design = InteractiveDesign)
+    } else if (forceLive) {
+      originalFormat.copy(design = LiveBlogDesign)
+    } else {
+      originalFormat
+    }
   }
 
 }

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -305,7 +305,7 @@ object ContentFormat {
   implicit val contentFormatReads = contentFormatBuilder.apply(ContentFormat.apply _)
 }
 
-final case class MetaData(
+case class MetaData(
     id: String,
     url: String,
     webUrl: String,

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -127,7 +127,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       blocks: Blocks,
       pageType: PageType,
       filterKeyEvents: Boolean,
-      forceLive: Boolean = false
+      forceLive: Boolean = false,
   )(implicit request: RequestHeader): Future[Result] = {
 
     val dataModel = page match {

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -113,7 +113,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
 
     val dataModel = page match {
       case liveblog: LiveBlogPage =>
-        DotcomRenderingDataModel.forLiveblog(liveblog, blocks, request, pageType, filterKeyEvents)
+        DotcomRenderingDataModel.forLiveblog(liveblog, blocks, request, pageType, filterKeyEvents, forceLive = false)
       case _ => DotcomRenderingDataModel.forArticle(page, blocks, request, pageType)
     }
     val json = DotcomRenderingDataModel.toJson(dataModel)
@@ -127,11 +127,12 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       blocks: Blocks,
       pageType: PageType,
       filterKeyEvents: Boolean,
+      forceLive: Boolean = false
   )(implicit request: RequestHeader): Future[Result] = {
 
     val dataModel = page match {
       case liveblog: LiveBlogPage =>
-        DotcomRenderingDataModel.forLiveblog(liveblog, blocks, request, pageType, filterKeyEvents)
+        DotcomRenderingDataModel.forLiveblog(liveblog, blocks, request, pageType, filterKeyEvents, forceLive)
       case _ => DotcomRenderingDataModel.forArticle(page, blocks, request, pageType)
     }
 

--- a/common/test/model/dotcomrendering/DotcomRenderingUtilsTest.scala
+++ b/common/test/model/dotcomrendering/DotcomRenderingUtilsTest.scala
@@ -1,0 +1,56 @@
+package model.dotcomrendering.pageElements
+
+import com.gu.contentapi.client.utils.format.{ArticleDesign, InteractiveDesign, LiveBlogDesign, StandardDisplay}
+import model.{ContentFormat, ContentType, DotcomContentType, MetaData}
+import org.scalatest.{FlatSpec, Matchers}
+import model.dotcomrendering.DotcomRenderingUtils
+import org.mockito.Mockito.when
+import org.scalatest.mockito.MockitoSugar
+
+class DotcomRenderingUtilsTest extends FlatSpec with Matchers with MockitoSugar {
+
+  val testContent = mock[ContentType]
+  val testMetadata = mock[MetaData]
+  val formatWithArticleDesign = ContentFormat.defaultContentFormat
+
+  "getModifiedContent" should "ensure an interactive design when the content type is interactive" in {
+    when(testContent.metadata) thenReturn testMetadata
+    when(testMetadata.format) thenReturn Some(formatWithArticleDesign)
+    when(testMetadata.contentType) thenReturn Some(DotcomContentType.Interactive)
+
+    val actual = DotcomRenderingUtils.getModifiedContent(testContent, forceLive = false)
+
+    actual.design should be(InteractiveDesign)
+  }
+
+  it should "ensure an interactive design when the content type is interactive even when we attempt to force a live design" in {
+    when(testContent.metadata) thenReturn testMetadata
+    when(testMetadata.format) thenReturn Some(formatWithArticleDesign)
+    when(testMetadata.contentType) thenReturn Some(DotcomContentType.Interactive)
+
+    val actual = DotcomRenderingUtils.getModifiedContent(testContent, forceLive = true)
+
+    actual.design should be(InteractiveDesign)
+  }
+
+  it should "ensure a live design takes priority when the forceLive flag is set" in {
+    when(testContent.metadata) thenReturn testMetadata
+    when(testMetadata.format) thenReturn Some(formatWithArticleDesign)
+    when(testMetadata.contentType) thenReturn Some(DotcomContentType.Article)
+
+    val actual = DotcomRenderingUtils.getModifiedContent(testContent, forceLive = true)
+
+    actual.design should be(LiveBlogDesign)
+  }
+
+  it should "keep the original design when the content type is not interactive and the forceLive flag is false" in {
+    when(testContent.metadata) thenReturn testMetadata
+    when(testMetadata.format) thenReturn Some(formatWithArticleDesign)
+    when(testMetadata.contentType) thenReturn Some(DotcomContentType.Article)
+
+    val actual = DotcomRenderingUtils.getModifiedContent(testContent, forceLive = false)
+
+    actual should be(formatWithArticleDesign)
+  }
+
+}


### PR DESCRIPTION
## What does this change?

This PR introduces a new parameter for DCR called `live`. When present or set to true it will force the design of a liveblog to be live, even if we are dealing with a deadblog. It will have no effect on other articles. 

## Why
This flag allows us to run automated tests against live blogs without the need to have a special test blog. It's also useful, as an aside, to be able to check how different content might visually change when live vs. dead.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots


**Deadblog**
<img width="1386" alt="Screenshot 2022-02-25 at 10 52 49" src="https://user-images.githubusercontent.com/1229808/155703050-4b3f57c5-7bb0-42bc-a059-7df8c1f29996.png">


**Deadblog with ?live** 
<img width="1388" alt="Screenshot 2022-02-25 at 10 45 16" src="https://user-images.githubusercontent.com/1229808/155702549-60cc6b1c-1b44-4f2c-991e-8eeb5a951978.png">

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
