### PR TITLE
Fix spacefinder immersive bug

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -83,7 +83,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 				minAbove: 35,
 				minBelow: 400,
 			},
-			' figure.element--immersive': {
+			' figure.element-immersive': {
 				minAbove: 0,
 				minBelow: 600,
 			},
@@ -103,7 +103,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 		minBelow: isDotcomRendering ? 300 : 800,
 		selectors: {
 			' .ad-slot': adSlotClassSelectorSizes,
-			' figure.element--immersive': {
+			' figure.element-immersive': {
 				minAbove: 0,
 				minBelow: 600,
 			},


### PR DESCRIPTION
## What does this change?

Immersives have the class `element--immersive` applied on frontend and `element-immersive` on DCR. Spacefinder was using the frontend definition, which broke ad placement on DCR. Now all articles are being rendered by DCR, we can safely switch to the DCR definition.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![[before]](https://user-images.githubusercontent.com/7423751/155710007-562c0f3b-8796-45ca-ae21-e0a0dca8514d.png) | ![[after]](https://user-images.githubusercontent.com/7423751/155710202-e3c1c3fd-dc51-4504-a528-461968e7326a.png) |

