### PR TITLE
Contributors for each liveblog block

### DIFF
--- a/common/app/model/dotcomrendering/Contributor.scala
+++ b/common/app/model/dotcomrendering/Contributor.scala
@@ -1,0 +1,9 @@
+package model.dotcomrendering
+
+import play.api.libs.json.Json
+
+case class Contributor(name: String, imageUrl: Option[String])
+
+object Contributor {
+  implicit val writes = Json.writes[Contributor]
+}

--- a/common/app/model/dotcomrendering/DotcomBlocksRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomBlocksRenderingDataModel.scala
@@ -70,10 +70,21 @@ object DotcomBlocksRenderingDataModel {
 
     val calloutsUrl = Option(Configuration.journalism.calloutsUrl);
 
+    val dcrTags = content.tags.tags.map(Tag.apply)
+
     val bodyBlocksDCR: List[Block] = bodyBlocks
       .filter(_.published)
       .map(block =>
-        Block(block, page, shouldAddAffiliateLinks, request, isMainBlock = false, calloutsUrl, contentDateTimes),
+        Block(
+          block,
+          page,
+          shouldAddAffiliateLinks,
+          request,
+          isMainBlock = false,
+          calloutsUrl,
+          contentDateTimes,
+          dcrTags,
+        ),
       )
       .toList
 

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -346,8 +346,10 @@ object DotcomRenderingDataModel {
       .find(_._1 == "calloutsUrl")
       .flatMap(entry => entry._2.asOpt[String])
 
+    val dcrTags = content.tags.tags.map(Tag.apply)
+
     def toDCRBlock(isMainBlock: Boolean = false) = { block: APIBlock =>
-      Block(block, page, shouldAddAffiliateLinks, request, isMainBlock, calloutsUrl, contentDateTimes)
+      Block(block, page, shouldAddAffiliateLinks, request, isMainBlock, calloutsUrl, contentDateTimes, dcrTags)
     }
 
     val mainMediaElements =
@@ -451,7 +453,7 @@ object DotcomRenderingDataModel {
       subMetaKeywordLinks = content.content.submetaLinks.keywords.map(SubMetaLink.apply),
       subMetaSectionLinks =
         content.content.submetaLinks.sectionLabels.map(SubMetaLink.apply).filter(_.title.trim.nonEmpty),
-      tags = content.tags.tags.map(Tag.apply),
+      tags = dcrTags,
       trailText = TextCleaner.sanitiseLinks(edition)(content.trail.fields.trailText.getOrElse("")),
       twitterData = page.getTwitterProperties,
       version = 3,

--- a/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
@@ -49,6 +49,7 @@ case class Block(
     blockFirstPublished: Option[Long],
     blockFirstPublishedDisplay: Option[String],
     title: Option[String],
+    contributors: Seq[Contributor],
     primaryDateLine: String,
     secondaryDateLine: String,
 )
@@ -66,6 +67,7 @@ object Block {
       isMainBlock: Boolean,
       calloutsUrl: Option[String],
       dateTimes: ArticleDateTimes,
+      tags: Seq[Tag],
   ): Block = {
 
     val content = page.item
@@ -87,6 +89,10 @@ object Block {
     val displayedDateTimes = ArticleDateTimes.makeDisplayedDateTimesDCR(dateTimes, request)
     val campaigns = page.getJavascriptConfig.get("campaigns")
 
+    val contributors = block.contributors flatMap { contributorId =>
+      tags.find(_.id == s"profile/$contributorId").map(tag => Contributor(tag.title, tag.bylineImageUrl))
+    }
+
     Block(
       id = block.id,
       elements = DotcomRenderingUtils.blockElementsToPageElements(
@@ -104,6 +110,7 @@ object Block {
       blockLastUpdated = blockLastUpdated,
       blockLastUpdatedDisplay = blockLastUpdatedDisplay,
       title = block.title,
+      contributors = contributors,
       blockFirstPublished = blockFirstPublished,
       blockFirstPublishedDisplay = blockFirstPublishedDisplay,
       primaryDateLine = displayedDateTimes.primaryDateLine,


### PR DESCRIPTION
## What does this change?

Include contributors in the DCR model for each liveblog block. 

At the moment we ignore the contributors property that CAPI returns for each block. This PR will use it and enrich each contributor with a name and image URL based on the associated profile tag. 

The contributors list will be empty if none exist for that block.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<img width="1322" alt="Screenshot 2022-02-25 at 13 53 24" src="https://user-images.githubusercontent.com/1229808/155726901-83669506-aa43-44d4-88ee-5bff719264ea.png">

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
