### PR TITLE
YouTube player - don't show ads for pages with sensitive content

### DIFF
--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.ts
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.ts
@@ -246,7 +246,7 @@ const setupPlayer = (
 	 * empty array.
 	 */
 
-	const adsConfig = commercialFeatures.adFree
+	const adsConfig = !commercialFeatures.youtubeAdvertising
 		? createAdsConfigDisabled()
 		: createAdsConfigEnabled(consentState);
 

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.ts
@@ -20,6 +20,7 @@ class CommercialFeatures {
 	adFree: boolean;
 	comscore: boolean;
 	launchpad: boolean;
+	youtubeAdvertising: boolean;
 
 	constructor(config = defaultConfig) {
 		// this is used for SpeedCurve tests
@@ -56,6 +57,8 @@ class CommercialFeatures {
 
 		// Feature switches
 		this.adFree = !!forceAdFree || isAdFreeUser();
+
+		this.youtubeAdvertising = !this.adFree && !sensitiveContent;
 
 		this.dfpAdvertising =
 			forceAds ||


### PR DESCRIPTION
## What does this change?

Although ads are switched off at a page level for sensitive content via:

`window.guardian.config.page.shouldHideAdverts`

For live blog YouTube videos, ads are still (incorrectly) shown.

This change expands the check in `youtube-player` by adding `commercialFeatures.youtubeAdvertising` which encompasses `adFree` and `shouldHideAdverts`.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (although this is more urgent for Frontend live blogs atm, will follow up for articles)

## Screenshots

Before:

<img width="320" alt="Screenshot 2022-02-25 at 15 34 17" src="https://user-images.githubusercontent.com/7014230/155744054-d59c94b3-71da-4ae6-874d-5cb618fbac7c.png">

### Tested

- [ ] Locally
- [X] On CODE (optional)
