### PR TITLE
Fix measure-timing.js for when there are multiple measurements

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/measure-timing.js
+++ b/static/src/javascripts/projects/commercial/modules/measure-timing.js
@@ -5,7 +5,6 @@ export const measureTiming = (name) => {
 		const endKey = `${name}-end`;
 
 		const start = () => {
-			clear();
 			perf.mark(startKey);
 		};
 

--- a/static/src/javascripts/projects/commercial/modules/measure-timing.js
+++ b/static/src/javascripts/projects/commercial/modules/measure-timing.js
@@ -5,6 +5,7 @@ export const measureTiming = (name) => {
 		const endKey = `${name}-end`;
 
 		const start = () => {
+			clear();
 			perf.mark(startKey);
 		};
 
@@ -21,6 +22,8 @@ export const measureTiming = (name) => {
 
 		const clear = () => {
 			perf.clearMarks(startKey);
+			perf.clearMarks(endKey);
+			perf.clearMeasures(name);
 		};
 
 		return {


### PR DESCRIPTION
## What does this change?

In measureTiming.js:
`window.performance` is used to measure time between a start and end event. `performance.mark` is used to create a timestampt in the browser's performance entry with a given name (e.g performance.mark('start');)

`performance.measure` is used to measure the time difference between 2 keys.

`performance.getEntriesByName` is used to get the list of all measurements with a specific name. So everytime a new measurement is made `perf.measure('myPerf', 'myPerf-start', 'myPerf-end');`, an item with name 'myPerf' will be added to this list.

In the measureTiming code, it is getting the first item measureEntries[0] so the result would always be the value of the first 'myPerf' measurement, even when there are multiple 'myPerf' measurement

## Changes: 
Updates the clear function in initPerf, so that when clear is called, all the marked keys and the measures that was taken as part of the current initPerf instance will be cleared from the browser performance entry.

This way if the consumer wants to measure time multiple times with the same name, they can decide if they want to clear the marked keys and measurements.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
