### PR TITLE
Add block- prefix to mostRecentBlockId

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -260,11 +260,7 @@ object DotcomRenderingDataModel {
         .getOrElse(blocks.body.fold(Seq.empty[APIBlock])(_.filter(_.attributes.pinned.contains(true))))
         .headOption
 
-    val mostRecentBlockId = blocks.requestedBodyBlocks
-      .flatMap(_.get(CanonicalLiveBlog.firstPage))
-      .getOrElse(blocks.body.getOrElse(Seq.empty))
-      .headOption
-      .map(_.id)
+    val mostRecentBlockId = DotcomRenderingUtils.getMostRecentBlockId(blocks)
 
     apply(
       page,

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -248,4 +248,12 @@ object DotcomRenderingUtils {
     }
   }
 
+  def getMostRecentBlockId(blocks: APIBlocks): Option[String] = {
+    blocks.requestedBodyBlocks
+      .flatMap(_.get(CanonicalLiveBlog.firstPage))
+      .getOrElse(blocks.body.getOrElse(Seq.empty))
+      .headOption
+      .map(block => s"block-${block.id}")
+  }
+
 }

--- a/common/test/model/dotcomrendering/DotcomRenderingUtilsTest.scala
+++ b/common/test/model/dotcomrendering/DotcomRenderingUtilsTest.scala
@@ -1,11 +1,13 @@
 package model.dotcomrendering.pageElements
 
 import com.gu.contentapi.client.utils.format.{ArticleDesign, InteractiveDesign, LiveBlogDesign, StandardDisplay}
-import model.{ContentFormat, ContentType, DotcomContentType, MetaData}
+import model.{CanonicalLiveBlog, ContentFormat, ContentType, DotcomContentType, MetaData}
 import org.scalatest.{FlatSpec, Matchers}
 import model.dotcomrendering.DotcomRenderingUtils
 import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
+import com.gu.contentapi.client.model.v1.Blocks
+import com.gu.contentapi.client.model.v1.Block
 
 class DotcomRenderingUtilsTest extends FlatSpec with Matchers with MockitoSugar {
 
@@ -53,4 +55,60 @@ class DotcomRenderingUtilsTest extends FlatSpec with Matchers with MockitoSugar 
     actual should be(formatWithArticleDesign)
   }
 
+  "getMostRecentBlockID" should "return the most recent block when the first page is requested" in {
+    val testBlocks = mock[Blocks]
+    val testBlock1 = mock[Block]
+    val testBlock2 = mock[Block]
+
+    when(testBlock1.id) thenReturn "testBlockId123"
+    when(testBlocks.requestedBodyBlocks) thenReturn Some(
+      Map(CanonicalLiveBlog.firstPage -> Seq(testBlock1, testBlock2)),
+    )
+
+    val actual = DotcomRenderingUtils.getMostRecentBlockId(testBlocks)
+
+    actual should be(Some("block-testBlockId123"))
+  }
+
+  it should "return the most recent block when an older page is requested" in {
+    val testBlocks = mock[Blocks]
+    val testBlock1 = mock[Block]
+    val testBlock2 = mock[Block]
+
+    when(testBlock1.id) thenReturn "testBlockId123"
+    when(testBlocks.requestedBodyBlocks) thenReturn None
+    when(testBlocks.body) thenReturn Some(Seq(testBlock1, testBlock2))
+
+    val actual = DotcomRenderingUtils.getMostRecentBlockId(testBlocks)
+
+    actual should be(Some("block-testBlockId123"))
+  }
+
+  it should "return nothing if for whatever reason the blog is empty" in {
+    val testBlocks = mock[Blocks]
+    val testBlock1 = mock[Block]
+    val testBlock2 = mock[Block]
+
+    when(testBlock1.id) thenReturn "testBlockId123"
+    when(testBlocks.requestedBodyBlocks) thenReturn None
+    when(testBlocks.body) thenReturn None
+
+    val actual = DotcomRenderingUtils.getMostRecentBlockId(testBlocks)
+
+    actual should be(None)
+  }
+
+  it should "add block- in front of the block id" in {
+    val testBlocks = mock[Blocks]
+    val testBlock1 = mock[Block]
+    val testBlock2 = mock[Block]
+
+    when(testBlock1.id) thenReturn "testBlockId123"
+    when(testBlocks.requestedBodyBlocks) thenReturn None
+    when(testBlocks.body) thenReturn Some(Seq(testBlock1, testBlock2))
+
+    val actual = DotcomRenderingUtils.getMostRecentBlockId(testBlocks)
+
+    actual should be(Some("block-testBlockId123"))
+  }
 }


### PR DESCRIPTION
## What does this change?

Adds a block prefix to the mostRecentBlockId field to keep this in line with the response we construct for updates polling (https://github.com/guardian/frontend/blob/main/article/app/controllers/LiveBlogController.scala#L284)

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
