### PR TITLE
Consider list items in spacefinder

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -78,7 +78,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 	const isImmersive = config.get('page.isImmersive');
 	const defaultRules: SpacefinderRules = {
 		bodySelector: articleBodySelector,
-		slotSelector: ' > p',
+		slotSelector: ['p'],
 		minAbove: isImmersive ? 700 : 300,
 		minBelow: isDotcomRendering ? 300 : 700,
 		selectors: {
@@ -106,7 +106,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 	// For any other inline
 	const relaxedRules: SpacefinderRules = {
 		bodySelector: articleBodySelector,
-		slotSelector: ' > p',
+		slotSelector: ['p'],
 		minAbove: isPaidContent ? 1600 : 1000,
 		minBelow: isDotcomRendering ? 300 : 800,
 		selectors: {
@@ -162,7 +162,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 const addMobileInlineAds = (): Promise<boolean> => {
 	const rules: SpacefinderRules = {
 		bodySelector: articleBodySelector,
-		slotSelector: ' > p',
+		slotSelector: ['p'],
 		minAbove: 200,
 		minBelow: 200,
 		selectors: {
@@ -223,7 +223,7 @@ const attemptToAddInlineMerchAd = (): Promise<boolean> => {
 
 	const rules: SpacefinderRules = {
 		bodySelector: articleBodySelector,
-		slotSelector: ' > p',
+		slotSelector: ['p'],
 		minAbove: 300,
 		minBelow: 0,
 		selectors: {

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -55,6 +55,16 @@ const insertAdAtPara = (
 		});
 };
 
+const isInRichLinksVariant = isInVariantSynchronous(
+	spacefinderOkr3RichLinks,
+	'variant',
+);
+
+const enableListItemsFix = isInVariantSynchronous(
+	spacefinderOkrMegaTest,
+	'variant',
+);
+
 const enableNearbyFilteringFix = () =>
 	!isInVariantSynchronous(spacefinderOkrMegaTest, 'control');
 
@@ -68,17 +78,18 @@ const articleBodySelector = isDotcomRendering
 	: '.js-article__body';
 
 const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
-	const ignoreList = isInVariantSynchronous(
-		spacefinderOkr3RichLinks,
-		'variant',
-	)
-		? ' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate):not([data-spacefinder-component="rich-link"])'
-		: ' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate)';
+	let ignoreList = ' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate)';
+
+	if (isInRichLinksVariant) {
+		ignoreList += ':not([data-spacefinder-component="rich-link"])';
+	} else if (enableListItemsFix) {
+		ignoreList += ':not(ul)';
+	}
 
 	const isImmersive = config.get('page.isImmersive');
 	const defaultRules: SpacefinderRules = {
 		bodySelector: articleBodySelector,
-		slotSelector: ['p'],
+		slotSelector: enableListItemsFix ? ['p', 'ul li'] : ['p'],
 		minAbove: isImmersive ? 700 : 300,
 		minBelow: isDotcomRendering ? 300 : 700,
 		selectors: {
@@ -106,7 +117,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 	// For any other inline
 	const relaxedRules: SpacefinderRules = {
 		bodySelector: articleBodySelector,
-		slotSelector: ['p'],
+		slotSelector: enableListItemsFix ? ['p', 'ul li'] : ['p'],
 		minAbove: isPaidContent ? 1600 : 1000,
 		minBelow: isDotcomRendering ? 300 : 800,
 		selectors: {
@@ -160,9 +171,15 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 };
 
 const addMobileInlineAds = (): Promise<boolean> => {
+	let ignoreList = ' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate)';
+
+	if (enableListItemsFix) {
+		ignoreList += ':not(ul)';
+	}
+
 	const rules: SpacefinderRules = {
 		bodySelector: articleBodySelector,
-		slotSelector: ['p'],
+		slotSelector: enableListItemsFix ? ['p', 'ul li'] : ['p'],
 		minAbove: 200,
 		minBelow: 200,
 		selectors: {
@@ -171,7 +188,7 @@ const addMobileInlineAds = (): Promise<boolean> => {
 				minBelow: 250,
 			},
 			' .ad-slot': adSlotClassSelectorSizes,
-			' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate)': {
+			[ignoreList]: {
 				minAbove: 35,
 				minBelow: 200,
 			},

--- a/static/src/javascripts/projects/commercial/modules/carrot-traffic-driver.ts
+++ b/static/src/javascripts/projects/commercial/modules/carrot-traffic-driver.ts
@@ -17,7 +17,7 @@ const bodySelector = isDotcomRendering
 
 const wideRules: SpacefinderRules = {
 	bodySelector,
-	slotSelector: ' > p',
+	slotSelector: ['p'],
 	minAbove: 500,
 	minBelow: 400,
 	clearContentMeta: 0,

--- a/static/src/javascripts/projects/commercial/modules/liveblog-adverts.js
+++ b/static/src/javascripts/projects/commercial/modules/liveblog-adverts.js
@@ -48,7 +48,7 @@ const getSpaceFillerRules = (windowHeight, update) => {
 
 	return {
 		bodySelector: '.js-liveblog-body',
-		slotSelector: ' > .block',
+		slotSelector: ['.block'],
 		fromBottom: shouldUpdate,
 		startAt: shouldUpdate ? firstSlot : null,
 		absoluteMinAbove: shouldUpdate ? 0 : WINDOWHEIGHT * OFFSET,

--- a/static/src/javascripts/projects/common/modules/article/rich-links.js
+++ b/static/src/javascripts/projects/common/modules/article/rich-links.js
@@ -96,7 +96,7 @@ const upgradeRichLink = (el) => {
 
 const getSpacefinderRules = () => ({
     bodySelector: '.js-article__body',
-    slotSelector: ' > p',
+    slotSelector: ['p'],
     minAbove: 200,
     minBelow: 250,
     clearContentMeta: 50,

--- a/static/src/javascripts/projects/common/modules/article/space-filler.ts
+++ b/static/src/javascripts/projects/common/modules/article/space-filler.ts
@@ -16,7 +16,8 @@ type SpacefinderItem = {
 type SpacefinderRules = {
 	bodySelector: string;
 	body?: Node;
-	slotSelector: string;
+	// array of selectors for direct descendants of bodySelector to be considered as candidates
+	slotSelector: string[];
 	// minimum from slot to top of page
 	absoluteMinAbove?: number;
 	// minimum from para to top of article

--- a/static/src/javascripts/projects/common/modules/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/spacefinder.js
@@ -216,7 +216,11 @@ const getReady = (rules, options) =>
 	]).then(() => rules);
 
 const getCandidates = (rules, exclusions) => {
-	let candidates = query(rules.bodySelector + rules.slotSelector);
+	let combinedSelector = rules.slotSelector
+		.map((selector) => `${rules.bodySelector} > ${selector}`)
+		.join();
+	let candidates = query(combinedSelector);
+
 	let result;
 	if (rules.fromBottom) {
 		candidates.reverse();


### PR DESCRIPTION
## What does this change?

Some articles are comprised of list items (`<li>`) instead of paragraphs (`<p>`). These include "what we know so far" articles, for example:

https://www.theguardian.com/world/2022/feb/26/russian-forces-advance-inside-ukraine-what-we-know-so-far
https://www.theguardian.com/world/2022/feb/27/russian-banks-excluded-from-swift-what-we-know-so-far
https://www.theguardian.com/uk-news/2021/nov/15/liverpool-hospital-taxi-explosion-what-we-know-so-far
https://www.theguardian.com/us-news/2020/oct/05/donald-trump-and-covid-what-we-know-so-far
https://www.theguardian.com/uk-news/2017/may/23/manchester-arena-attack-what-we-know-so-far

Because spacefinder only sees paragraphs, none of these articles contain any inline ads.

This PR adds support for multiple `slotSelector` values by accepting an array instead of a single value. This enables us to select both paragraphs and list items as potential candidates for inline ad insertion.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Higher chance of inline ads appearing on articles containing lists.

## A/B test 

After some discussion it was decided that because articles containing lists are quite rare, it won't be possible to validate this change via an AB test in the same way as we have for other changes. This is because we'd struggle to reach the required sample size for statistical significance. 

Instead, we'll just enable this change for members of the `variant` group in the `SpacefinderOkrMegaTest` which we plan to run at the end of the quarter. 

More info about `SpacefinderOkrMegaTest` here: https://github.com/guardian/frontend/pull/24726

### Tested

- [x] Locally
- [x] On CODE (optional)

## Screenshots

| Before      | After (just inline2+)      | After(inline1 & inline2+)
|-------------|------------|------------|
| ![[before]](https://user-images.githubusercontent.com/7423751/155978669-8098569a-dbc9-4361-bdbc-a9bbe7af3f42.png) | ![[after]](https://user-images.githubusercontent.com/7423751/155978674-9f00bef8-155c-4bb9-9c10-7fbe24c6914a.png) | ![[after]](https://user-images.githubusercontent.com/7423751/155978683-c0b68d2a-e541-4c0a-bccc-c5a66250c388.png)
