### PR TITLE
Fix YouTube player when multiple instances of the same video

### DIFF
--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -48,8 +48,12 @@
     }
 
         @for(asset <- activeAsset if playable && !expired) {
-
-            <div id="youtube-@asset.id" data-asset-id="@asset.id" class="youtube-media-atom__iframe"></div>
+            @*
+                Append a UUID to ensure a unqiue DOM id for all YouTube atoms
+                This fixes the scenario when there are muliple instances of the same assetId i.e. the same video on the page.
+                This is most likely to occur in a liveblog where the video can be in a main media position and in a block.
+            *@
+            <div id="youtube-@asset.id-@java.util.UUID.randomUUID.toString" data-asset-id="@asset.id" class="youtube-media-atom__iframe"></div>
 
             @if(mediaWrapper.contains(MediaWrapper.VideoContainer)){
                 <div class="video-overlay">

--- a/common/test/views/fragments/atoms/YoutubeSpec.scala
+++ b/common/test/views/fragments/atoms/YoutubeSpec.scala
@@ -32,8 +32,12 @@ class YoutubeSpec extends MixedPlaySpec {
       val displayCaption = false
       val view = views.html.fragments.atoms
         .youtube(mediaAtom, displayCaption)(FakeRequest())
-      contentAsString(view) must include(
-        """<div id="youtube-assetId" data-asset-id="assetId" class="youtube-media-atom__iframe"></div>""",
+      val contentString = contentAsString(view)
+      contentString must include(
+        """<div id="youtube-assetId-""",
+      )
+      contentString must include(
+        """ data-asset-id="assetId" class="youtube-media-atom__iframe"></div>""",
       )
     }
   }

--- a/common/test/views/support/cleaner/AtomCleanerTest.scala
+++ b/common/test/views/support/cleaner/AtomCleanerTest.scala
@@ -84,7 +84,7 @@ class AtomCleanerTest extends FlatSpec with Matchers with WithTestApplicationCon
   "AtomsCleaner" should "create YouTube template" in {
     Switches.UseAtomsSwitch.switchOn()
     val result: Document = clean(doc)
-    result.select("div").attr("id") shouldBe "youtube-nQuN9CUsdVg"
+    result.select("div").attr("id") should startWith("youtube-nQuN9CUsdVg-")
     result.select("figcaption").html should include("Bird")
   }
 
@@ -115,7 +115,7 @@ class AtomCleanerTest extends FlatSpec with Matchers with WithTestApplicationCon
       ),
     )
 
-    renderAndGetId(atom) should be("youtube-QRplDNMsS4U")
+    renderAndGetId(atom) should startWith("youtube-QRplDNMsS4U")
   }
 
   "Youtube template" should "use latest asset if no active version" in {
@@ -126,7 +126,7 @@ class AtomCleanerTest extends FlatSpec with Matchers with WithTestApplicationCon
       ),
     )
 
-    renderAndGetId(atom) should be(s"youtube-gyVuRflcEKM")
+    renderAndGetId(atom) should startWith(s"youtube-gyVuRflcEKM")
   }
 
   "Youtube template" should "render nothing if there are no assets" in {

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.ts
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.ts
@@ -283,8 +283,7 @@ const setupPlayer = (
 const hasPlayerStarted = (event: YTPlayerEvent) =>
 	event.target.getCurrentTime() > 0;
 
-const getPlayerIframe = (videoId: string) =>
-	document.getElementById(`youtube-${videoId}`);
+const getPlayerIframe = (id: string) => document.getElementById(id);
 
 export const initYoutubePlayer = async (
 	el: HTMLElement,
@@ -296,11 +295,11 @@ export const initYoutubePlayer = async (
 	const consentState = await initialConsent;
 
 	const onPlayerStateChange = (event: YTPlayerEvent) => {
-		onPlayerStateChangeEvent(event, handlers, getPlayerIframe(videoId));
+		onPlayerStateChangeEvent(event, handlers, getPlayerIframe(el.id));
 	};
 
 	const onPlayerReady = (event: YTPlayerEvent) => {
-		const iframe = getPlayerIframe(videoId);
+		const iframe = getPlayerIframe(el.id);
 		if (hasPlayerStarted(event)) {
 			addVideoStartedClass(iframe);
 		}

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.ts
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.ts
@@ -250,6 +250,12 @@ const setupPlayer = (
 		? createAdsConfigDisabled()
 		: createAdsConfigEnabled(consentState);
 
+	/**
+	 * Note:
+	 * This element id must be unique!
+	 * Ensured via the SSR render of youtube.scala.html
+	 */
+
 	// @ts-expect-error -- ts is confused by multiple constructors
 	return new window.YT.Player(el.id, {
 		host: getHost({

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -453,6 +453,11 @@ const initYoutubePlayerForElem = (el) => {
             return;
         }
 
+        /**
+         * Note:
+         * This element id must be unique!
+         * Ensured via the SSR render of youtube.scala.html
+         */
         const iframeId = iframe.id;
 
         const atomId = el.getAttribute('data-media-atom-id') || '';


### PR DESCRIPTION
## What does this change?

### Bug

On Frontend we currently have the following process for creating YouTube atoms:

1. **SSR render placeholder divs**
    
    `youtube.scala.html` will render server-side placeholder divs for each atom using its `assetId` as an id e.g.:
    ```html
    <div id="youtube-@asset.id"  data-asset-id="@asset.id" class="youtube-media-atom__iframe"></div>
    ```
    becomes:
    ```html
    <div id="youtube-VIKeqEySpvQ" data-asset-id="VIKeqEySpvQ" class="youtube-media-atom__iframe"></div>
    ```

2. **Convert placeholder divs to iFrame embeds**
    `youtube-player.js` will attempt, client-side, to convert those placeholder divs to YouTube iFrame embeds
3. **Initialise YouTube player for each iFrame embed**
    `youtube-player.js` will attempt to mount the iFrame and initialise the YouTube player `YT.Player`, requiring a unique DOM element id to do so.

Because we use the atom `assetId` to create the placeholder div id this is **_not_** unique across the page.

When there are multiple instances of the exact same video on a page - a scenario more probable on liveblogs, this causes the following issue:
- the first atom div will have its player initialised correctly.
- however subsequent atom divs for the same video will not initialise their player (step 3 above) as the element id will match the first atom div id in the page, which from `YT.Player`'s point of view has already been initialised.

### Fix

The fix is to append a UUID to the atom div id by the server-side render of `youtube.scala.html`:

```html
<div id="youtube-@asset.id-@java.util.UUID.randomUUID.toString" data-asset-id="@asset.id" class="youtube-media-atom__iframe"></div>
```

This does not have to be stable across renders and is only required to be unique for the lifetime of the page.

## Aside

### Prior Fix

This issue was previously fixed in https://github.com/guardian/frontend/pull/15756 (h/t @akash1810 )

Unfortunately it looks like that fix has been removed or a regression introduced over time. The previous fix worked client-side whereas this fix creates unique ids server-side when the elements are initially rendered.

### DotcomRenderingDataModel

I was hoping to have a unique 'element' id available from the CAPI data model to use for the DOM ids but this is not the case.

However in the case of Dotcom's rendering model (`DotcomRenderingDataModel.scala`) a unique id called `elementId` is generated e.g.:

https://www.theguardian.com/media/2021/jun/25/guardian-journalists-win-orwell-prize-for-video-series-anywhere-but-westminster-john-harris-john-domokos.json?dcr=true

@shtukas pointed me to further details here:

documentation: https://github.com/guardian/frontend/blob/f4c8237babfa16b6efe33006a55084dbf06fe462/common/app/model/dotcomrendering/PageElement-Identifiers.md

PR: https://github.com/guardian/frontend/pull/23562

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes - afaics the same issue exists on DCR but is not currently surfaced as it does not currently render pages (i.e. liveblogs) where this scenario is likely

### Tested

- [x] Locally
- [x] On CODE (optional)

