### PR TITLE
Update AB test configuration 

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -30,7 +30,7 @@ trait ABTestSwitches {
     "Check whether fixing a bug in spacefinder's nearby candidate filtering mechanism leads to revenue uplift",
     owners = Seq(Owner.withGithub("simonbyford")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2022, 3, 7)),
+    sellByDate = Some(LocalDate.of(2022, 4, 1)),
     exposeClientSide = true,
   )
 
@@ -40,7 +40,7 @@ trait ABTestSwitches {
     "Check whether fixing spacefinder's ability to detect when images have loaded leads to revenue uplift",
     owners = Seq(Owner.withGithub("simonbyford")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2022, 2, 28)),
+    sellByDate = Some(LocalDate.of(2022, 4, 1)),
     exposeClientSide = true,
   )
 
@@ -50,7 +50,7 @@ trait ABTestSwitches {
     "Check whether ignoring rich links in spacefinder on desktop leads to revenue uplift",
     owners = Seq(Owner.withGithub("simonbyford")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2022, 3, 21)),
+    sellByDate = Some(LocalDate.of(2022, 4, 1)),
     exposeClientSide = true,
   )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/spacefinder-okr-3-rich-links.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/spacefinder-okr-3-rich-links.ts
@@ -6,7 +6,7 @@ export const spacefinderOkr3RichLinks: ABTest = {
 	author: 'Simon Byford (@simonbyford)',
 	start: '2022-02-28',
 	expiry: '2022-03-21',
-	audience: 10 / 100,
+	audience: 20 / 100,
 	audienceOffset: 30 / 100,
 	audienceCriteria: 'All pageviews',
 	successMeasure:


### PR DESCRIPTION
## What does this change?

2 small changes to AB test configuration:

- increase the size of the `SpacefinderOkr3RichLinks` test to be 20% of the audience, as per Sara's guidance
- push forward AB test switch expiries into April. We need these switches to remain in place until the end of the quarter. Also, if we let them expire, they cause build failures which we want to avoid

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes - https://github.com/guardian/dotcom-rendering/pull/4116

![Screenshot 2022-03-01 at 09 29 47](https://user-images.githubusercontent.com/7423751/156143101-7d7c3089-6f95-4550-a50e-402536f10c42.png)

