### PR TITLE
Switch for AMP content based testing

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -561,4 +561,13 @@ trait PrebidSwitches {
     exposeClientSide = true,
   )
 
+  val ampContentABTesting: Switch = Switch(
+    group = Commercial,
+    name = "amp-content-ab-testing",
+    description = "Enable content based testing on AMP",
+    owners = group(Commercial),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
 }


### PR DESCRIPTION
## What does this change?

Add a switch to enable / disable content based testing on AMP.

For the corresponding functionality that this switch will control, see [DCR #4110](https://github.com/guardian/dotcom-rendering/pull/4110).

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

This will allow us to quickly enable / disable content based testing on AMP, should we choose.

This switch is located with the commercial switches as this content based testing will be used for testing commercial features. Should it become useful elsewhere this switch can be moved to a more appropriate grouo.

### Tested

- [X] Locally
- [ ] On CODE (optional)