### PR TITLE
Add feature switch for sticky videos

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -7,6 +7,7 @@ import java.time.LocalDate
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
     LiveblogRendering,
+    StickyVideos,
   )
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -19,4 +20,13 @@ object LiveblogRendering
       owners = Seq(Owner.withGithub("shtukas")),
       sellByDate = LocalDate.of(2022, 6, 2),
       participationGroup = Perc10A,
+    )
+
+object StickyVideos
+    extends Experiment(
+      name = "sticky-videos",
+      description = "Stick videos on live blogs",
+      owners = Seq(Owner.withGithub("joecowton1")),
+      sellByDate = LocalDate.of(2022, 6, 2),
+      participationGroup = Perc0C,
     )


### PR DESCRIPTION
## What does this change?

Adds a feature switch for sticky videos in DCR live blogs. The work to pass the switch value down to the live blog (and specifically the `YoutubeBlockComponent` is [here](https://github.com/guardian/dotcom-rendering/pull/4140).

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

#### Before
<img width="420" alt="Screenshot 2022-03-02 at 18 05 02" src="https://user-images.githubusercontent.com/77005274/156421555-c625c9fe-d990-4b1e-a7e6-acfffb2f8227.png">

#### After
<img width="420" alt="Screenshot 2022-03-02 at 18 03 27" src="https://user-images.githubusercontent.com/77005274/156421602-bda2b634-fede-4171-8b71-ac401f44c6ae.png">



## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
