### PR TITLE
Dblatcher/adjust thrasher sign up embed style

### DIFF
--- a/common/app/views/fragments/email/signup/subscription/thrasherEmailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/thrasherEmailSignUp.scala.html
@@ -9,32 +9,27 @@
 @import conf.switches.Switches.EmailSignupRecaptcha
 @import conf.switches.Switches.NewslettersRemoveConfirmationStep
 
-@componentClass = @{"thrasher-embed"}
-@formId = @{ componentClass + "-email-sub-form" }
-@inputId = @{ componentClass + "-email-sub-input" }
-@dummyInputId = @{ componentClass + "-email-sub-input-name" }
 
-@wrapperClass = @{ "email-sub" + " email-sub--" + componentClass  }
-@wrapperToneClass = @{ "email-sub--" + componentClass }
-@formClass = @{ "email-sub__form" + " email-sub__form--" + componentClass + " email-sub__form--thrasher-" + listName }
+@wrapperClass = @{ "email-sub email-sub--thrasher-embed" }
+@wrapperToneClass = @{ "email-sub--thrasher-embed" }
 
 
-@form = {
-    <form action="@LinkTo(s"/email")" method="post" id="@formId" class="@formClass" data-email-form-type="@componentClass" data-email-list-name="@listName">
+<div class="@wrapperClass @wrapperToneClass js-ab-embed-old-design">
+    <form action="@LinkTo(s"/email")" method="post" id="thrasher-embed-email-sub-form" class="email-sub__form email-sub__form--thrasher-embed email-sub__form--thrasher-@listName" data-email-form-type="thrasher-embed" data-email-list-name="@listName">
         @helper.CSRF.formField
         <div class="email-sub__form-wrapper">
 
-            <label class="email-sub__thrasher-embed-label" for="@inputId">Enter your email</label>
+            <label class="email-sub__thrasher-embed-label" for="thrasher-embed-email-sub-input">Enter your email</label>
             <div class="email-sub__thrasher-embed-row">
-                <input class="email-sub__thrasher-embed-input" type="email" name="email" id="@inputId" />
-                <button type="submit" class="email-sub__thrasher-embed-button" id="email-embed-signup-button--old" data-component="email-signup-button @componentClass-@listName" data-link-name="@componentClass | @listName">
+                <input class="email-sub__thrasher-embed-input" type="email" name="email" id="thrasher-embed-email-sub-input" />
+                <button type="submit" class="email-sub__thrasher-embed-button" id="email-embed-signup-button--old" data-component="email-signup-button thrasher-embed-@listName" data-link-name="thrasher-embed | @listName">
                     <span>Sign up</span>
                     @fragments.inlineSvg("arrow-right", "icon", Seq("email-sub__thrasher-embed-icon"))
                 </button>
             </div>
 
             <label aria-hidden="true">
-                <input tabindex="-1" class="email-sub__text-input u-h" autocomplete="off" type="text" name="name" id="@dummyInputId" placeholder="Name" />
+                <input tabindex="-1" class="email-sub__text-input u-h" autocomplete="off" type="text" name="name" id="thrasher-embed-email-sub-input-name" placeholder="Name" />
             </label>
             <input class="email-sub__listname-input" type="hidden" name="listName" value="@listName" />
             <input class="email-sub__ref-input" type="hidden" name="ref" id="email-sub__ref-input" value="" />
@@ -45,11 +40,6 @@
             }
         </div>
     </form>
-}
-
-
-<div class="@wrapperClass @wrapperToneClass js-ab-embed-old-design">
-    @form
 </div>
 
 <script>

--- a/static/src/stylesheets/module/email-signup/_form.scss
+++ b/static/src/stylesheets/module/email-signup/_form.scss
@@ -222,8 +222,8 @@
     @include fs-textSans(3, true);
     margin-right: 8px;
     flex: 1;
-    max-width: 18.5rem;
-    min-width: 7rem;
+    max-width: 296px;
+    min-width: 112px;
 }
 
 .email-sub__thrasher-embed-button {

--- a/static/src/stylesheets/module/email-signup/_form.scss
+++ b/static/src/stylesheets/module/email-signup/_form.scss
@@ -204,6 +204,7 @@
 
 .email-sub__thrasher-embed-label {
     @include fs-textSans(1, true);
+    font-size: 15px;
     font-weight: 700;
     color: $brightness-100;
     display: block;
@@ -213,13 +214,13 @@
 .email-sub__thrasher-embed-row {
     display: flex;
     justify-content: flex-start;
-    align-items: center;
+    height: 36px;
+    align-items: stretch;
 }
 
 .email-sub__thrasher-embed-input {
     @include fs-textSans(3, true);
-    margin-right: 4px;
-    margin-bottom: 4px;
+    margin-right: 8px;
     flex: 1;
     max-width: 18.5rem;
     min-width: 7rem;
@@ -227,6 +228,7 @@
 
 .email-sub__thrasher-embed-button {
     @include fs-textSans(1, false);
+    font-size: 17px;
     position: relative;
     border: 0;
     border-radius: 1000px;
@@ -234,8 +236,7 @@
     background-color: $brightness-100;
     color: $brightness-7;
     font-weight: 700;
-    margin-bottom: 4px;
-    flex-basis: 6rem;
+    flex-basis: 118px;
     flex-shrink: 0;
 }
 


### PR DESCRIPTION
## What does this change?
Increases the size of the form elements and label on the thrasher embed form so that they match the design document (did require manually setting some font sizes instead of using the typography mixins).

Also simplified the thrasherEmailSignUp template by not using a series of 'ComponentClass' variables for attributes. 

I kept the wrapperToneClass and wrapperClass variables for the sake of consistency with related templates, even though the values are constant in this template.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
Please ignore the teleporter button on the 'before' image.


| Before      | After      |
|-------------|------------|
| ![www theguardian com_email_form_thrasher_4156 (1)](https://user-images.githubusercontent.com/30567854/156555795-80d04d02-45b6-4396-bbf5-02ed8bf20900.png) | ![localhost_3000_email_form_thrasher_4156](https://user-images.githubusercontent.com/30567854/156555810-32742fe4-21d9-4e5d-887f-a37b66027f36.png)|


## What is the value of this and can you measure success?
Improves the appearance of the form embed in context. Matches the dimension given in the  design document.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?
- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?
- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist
- [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [X] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

