### PR TITLE
Ad passback handler

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/prepare-googletag.ts
@@ -19,6 +19,7 @@ import { init as disableRefresh } from '../messenger/disable-refresh';
 import { init as initGetPageTargeting } from '../messenger/get-page-targeting';
 import { init as initGetPageUrl } from '../messenger/get-page-url';
 import { init as getStyles } from '../messenger/get-stylesheet';
+import { init as passback } from '../messenger/passback';
 import { init as resize } from '../messenger/resize';
 import { init as scroll } from '../messenger/scroll';
 import { init as type } from '../messenger/type';
@@ -41,6 +42,7 @@ initMessenger(
 	sendClick,
 	background,
 	disableRefresh,
+	passback,
 );
 
 const setDfpListeners = (): void => {

--- a/static/src/javascripts/projects/commercial/modules/messenger.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger.ts
@@ -169,7 +169,7 @@ const toStandardMessage = (
  */
 const getIframe = (
 	message: StandardMessage,
-	messageEventSouce: MessageEventSource | null,
+	messageEventSource: MessageEventSource | null,
 ): HTMLIFrameElement | undefined => {
 	if (message.slotId) {
 		const container = document.getElementById(`dfp-ad--${message.slotId}`);
@@ -177,10 +177,10 @@ const getIframe = (
 	} else if (message.iframeId) {
 		const el = document.getElementById(message.iframeId);
 		return el instanceof HTMLIFrameElement ? el : undefined;
-	} else if (messageEventSouce) {
+	} else if (messageEventSource) {
 		const iframes = document.querySelectorAll<HTMLIFrameElement>('iframe');
 		return Array.from(iframes).find(
-			(iframe) => iframe.contentWindow === messageEventSouce,
+			(iframe) => iframe.contentWindow === messageEventSource,
 		);
 	}
 };

--- a/static/src/javascripts/projects/commercial/modules/messenger.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger.ts
@@ -12,6 +12,7 @@ type MessageType =
 	| 'get-page-url'
 	| 'get-styles'
 	| 'measure-ad-load'
+	| 'passback'
 	| 'resize'
 	| 'set-ad-height'
 	| 'scroll'

--- a/static/src/javascripts/projects/commercial/modules/messenger.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger.ts
@@ -165,7 +165,7 @@ const toStandardMessage = (
  * - using the iframeId from the incoming message
  * - checking message event.source (i.e. window) against all page level iframe contentWindows
  *
- * Listeners can use then use the iFrame to determine the slot making the postMessage call
+ * Listeners can then use the iFrame to determine the slot making the postMessage call
  */
 const getIframe = (
 	message: StandardMessage,

--- a/static/src/javascripts/projects/commercial/modules/messenger.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger.ts
@@ -158,9 +158,14 @@ const toStandardMessage = (
 });
 
 /**
- * Retrieve a reference to the calling iframe via it's ID.
+ * Retrieve a reference to the calling iFrame
  *
- * Incoming messages contain the ID of the iframe into which the source window is embedded.
+ * Attempts the following strategies to find the correct iframe:
+ * - using the slotId from the incoming message
+ * - using the iframeId from the incoming message
+ * - checking message event.source (i.e. window) against all page level iframe contentWindows
+ *
+ * Listeners can use then use the iFrame to determine the slot making the postMessage call
  */
 const getIframe = (
 	message: StandardMessage,

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -6,16 +6,27 @@ type PassbackMessagePayload = {
 	source: string;
 };
 
+/**
+ * A listener for 'passback' messages from ad slot iFrames
+ * Ad providers will invoke 'passback' to tell us they have not filled this slot
+ * In which case we need to refresh the slot with another ad
+ */
 const init = (register: RegisterListener): void => {
 	register('passback', (messagePayload, ret, iframe) => {
 		window.googletag.cmd.push(function () {
 			const payload = messagePayload as PassbackMessagePayload;
 			const { slotId: slotIdFromMessage, source } = payload;
+			/**
+			 * Attempt to get the slotId from the calling iFrame as provided by messenger
+			 */
 			const slotIdFromIframe =
 				iframe?.closest<HTMLDivElement>('.ad-slot')?.dataset.name;
 			const slotId = slotIdFromMessage || slotIdFromIframe;
 			if (slotId) {
 				const slotIdWithPrefix = `${adSlotIdPrefix}${slotId}`;
+				/**
+				 * Find the live slot object from googletag
+				 */
 				const slot = window.googletag
 					.pubads()
 					.getSlots()
@@ -27,6 +38,10 @@ const init = (register: RegisterListener): void => {
 						[[640, 480], [[300, 250]]],
 						[[0, 0], []],
 					]);
+					/**
+					 * Set passback targeting param so the passback line item can negatively target
+					 * This ensures that passback line items do not match for this request
+					 */
 					slot.setTargeting('passback', [source]);
 					slot.setTargeting('slot', slotId);
 					window.googletag.pubads().refresh([slot]);

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -1,31 +1,36 @@
 import { adSlotIdPrefix } from '../dfp/dfp-env-globals';
 import type { RegisterListener } from '../messenger';
 
-type PassbackPayload = {
+type PassbackMessagePayload = {
 	slotId: string;
 	source: string;
 };
 
 const init = (register: RegisterListener): void => {
-	register('passback', (payloadFromCreative) => {
+	register('passback', (messagePayload, ret, iframe) => {
 		window.googletag.cmd.push(function () {
-			const payload = payloadFromCreative as PassbackPayload;
-			const { slotId, source } = payload;
-			const slotIdWithPrefix = `${adSlotIdPrefix}${slotId}`;
-			const slot = window.googletag
-				.pubads()
-				.getSlots()
-				.find((s) => s.getSlotElementId() === slotIdWithPrefix);
-			if (slot) {
-				// TODO use size mappings frrom commercial-core
-				slot.defineSizeMapping([
-					[[1024, 768], [[300, 250]]],
-					[[640, 480], [[300, 250]]],
-					[[0, 0], []],
-				]);
-				slot.setTargeting('passback', [source]);
-				slot.setTargeting('slot', slotId);
-				window.googletag.pubads().refresh([slot]);
+			const payload = messagePayload as PassbackMessagePayload;
+			const { slotId: slotIdFromMessage, source } = payload;
+			const slotIdFromIframe =
+				iframe?.closest<HTMLDivElement>('.ad-slot')?.dataset.name;
+			const slotId = slotIdFromMessage || slotIdFromIframe;
+			if (slotId) {
+				const slotIdWithPrefix = `${adSlotIdPrefix}${slotId}`;
+				const slot = window.googletag
+					.pubads()
+					.getSlots()
+					.find((s) => s.getSlotElementId() === slotIdWithPrefix);
+				if (slot) {
+					// TODO use size mappings frrom commercial-core
+					slot.defineSizeMapping([
+						[[1024, 768], [[300, 250]]],
+						[[640, 480], [[300, 250]]],
+						[[0, 0], []],
+					]);
+					slot.setTargeting('passback', [source]);
+					slot.setTargeting('slot', slotId);
+					window.googletag.pubads().refresh([slot]);
+				}
 			}
 		});
 	});

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -2,7 +2,6 @@ import { adSlotIdPrefix } from '../dfp/dfp-env-globals';
 import type { RegisterListener } from '../messenger';
 
 type PassbackMessagePayload = {
-	slotId: string;
 	source: string;
 };
 
@@ -14,14 +13,12 @@ type PassbackMessagePayload = {
 const init = (register: RegisterListener): void => {
 	register('passback', (messagePayload, ret, iframe) => {
 		window.googletag.cmd.push(function () {
-			const payload = messagePayload as PassbackMessagePayload;
-			const { slotId: slotIdFromMessage, source } = payload;
+			const { source } = messagePayload as PassbackMessagePayload;
 			/**
 			 * Attempt to get the slotId from the calling iFrame as provided by messenger
 			 */
-			const slotIdFromIframe =
+			const slotId =
 				iframe?.closest<HTMLDivElement>('.ad-slot')?.dataset.name;
-			const slotId = slotIdFromMessage || slotIdFromIframe;
 			if (slotId) {
 				const slotIdWithPrefix = `${adSlotIdPrefix}${slotId}`;
 				/**

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -1,21 +1,25 @@
 import { adSlotIdPrefix } from '../dfp/dfp-env-globals';
 import type { RegisterListener } from '../messenger';
 
-const slotId = `${adSlotIdPrefix}inline1`;
+type PassbackPayload = {
+	slotId: string;
+};
 
 const init = (register: RegisterListener): void => {
-	register('passback', () => {
+	register('passback', (payloadFromCreative) => {
 		window.googletag.cmd.push(function () {
-			const slot = window.googletag.defineSlot(
-				'/59666047/theguardian.com/x-passback/teads',
-				[300, 250],
-				slotId,
-			);
+			const payload = payloadFromCreative as PassbackPayload;
+			const { slotId } = payload;
+			const slotIdWithPrefix = `${adSlotIdPrefix}${slotId}`;
+			const slot = window.googletag
+				.pubads()
+				.getSlots()
+				.find((s) => s.getSlotElementId() === slotIdWithPrefix);
 			if (slot) {
-				slot.addService(googletag.pubads());
+				slot.defineSizeMapping([[[300, 250], []]]);
 				slot.setTargeting('passback', ['teads']);
-				window.googletag.enableServices();
-				window.googletag.display(slotId);
+				slot.setTargeting('slot', slotId);
+				window.googletag.pubads().refresh([slot]);
 			}
 		});
 	});

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -1,7 +1,7 @@
 import { adSlotIdPrefix } from '../dfp/dfp-env-globals';
 import type { RegisterListener } from '../messenger';
 
-const slotId = `${adSlotIdPrefix}-inline1`;
+const slotId = `${adSlotIdPrefix}inline1`;
 
 const init = (register: RegisterListener): void => {
 	register('passback', () => {

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -1,0 +1,24 @@
+import { adSlotIdPrefix } from '../dfp/dfp-env-globals';
+import type { RegisterListener } from '../messenger';
+
+const slotId = `${adSlotIdPrefix}-inline1`;
+
+const init = (register: RegisterListener): void => {
+	register('passback', () => {
+		window.googletag.cmd.push(function () {
+			const slot = window.googletag.defineSlot(
+				'/59666047/theguardian.com/x-passback/teads',
+				[300, 250],
+				slotId,
+			);
+			if (slot) {
+				slot.addService(googletag.pubads());
+				slot.setTargeting('passback', ['teads']);
+				window.googletag.enableServices();
+				window.googletag.display(slotId);
+			}
+		});
+	});
+};
+
+export { init };

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -3,13 +3,14 @@ import type { RegisterListener } from '../messenger';
 
 type PassbackPayload = {
 	slotId: string;
+	source: string;
 };
 
 const init = (register: RegisterListener): void => {
 	register('passback', (payloadFromCreative) => {
 		window.googletag.cmd.push(function () {
 			const payload = payloadFromCreative as PassbackPayload;
-			const { slotId } = payload;
+			const { slotId, source } = payload;
 			const slotIdWithPrefix = `${adSlotIdPrefix}${slotId}`;
 			const slot = window.googletag
 				.pubads()
@@ -22,7 +23,7 @@ const init = (register: RegisterListener): void => {
 					[[640, 480], [[300, 250]]],
 					[[0, 0], []],
 				]);
-				slot.setTargeting('passback', ['teads']);
+				slot.setTargeting('passback', [source]);
 				slot.setTargeting('slot', slotId);
 				window.googletag.pubads().refresh([slot]);
 			}

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -45,12 +45,10 @@ const init = (register: RegisterListener): void => {
 					.getSlots()
 					.find((s) => s.getSlotElementId() === slotIdWithPrefix);
 				if (slot) {
-					// TODO use size mappings frrom commercial-core
-					slot.defineSizeMapping([
-						[[1024, 768], [[300, 250]]],
-						[[640, 480], [[300, 250]]],
-						[[0, 0], []],
-					]);
+					/**
+					 * All viewports >= 0x0 use fixed size 300x250
+					 */
+					slot.defineSizeMapping([[[0, 0], [[300, 250]]]]);
 					/**
 					 * Set passback targeting param so the passback line item can negatively target
 					 * This ensures that passback line items do not match for this request

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -16,7 +16,12 @@ const init = (register: RegisterListener): void => {
 				.getSlots()
 				.find((s) => s.getSlotElementId() === slotIdWithPrefix);
 			if (slot) {
-				slot.defineSizeMapping([[[300, 250], []]]);
+				// TODO use size mappings frrom commercial-core
+				slot.defineSizeMapping([
+					[[1024, 768], [[300, 250]]],
+					[[640, 480], [[300, 250]]],
+					[[0, 0], []],
+				]);
 				slot.setTargeting('passback', ['teads']);
 				slot.setTargeting('slot', slotId);
 				window.googletag.pubads().refresh([slot]);

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -279,6 +279,7 @@
   "../projects/commercial/modules/messenger/get-page-url.ts",
   "../projects/commercial/modules/messenger/get-stylesheet.js",
   "../projects/commercial/modules/messenger/measure-ad-load.ts",
+  "../projects/commercial/modules/messenger/passback.ts",
   "../projects/commercial/modules/messenger/resize.ts",
   "../projects/commercial/modules/messenger/scroll.js",
   "../projects/commercial/modules/messenger/type.ts",
@@ -461,6 +462,10 @@
  "../projects/commercial/modules/messenger/measure-ad-load.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../projects/commercial/modules/messenger.ts"
+ ],
+ "../projects/commercial/modules/messenger/passback.ts": [
+  "../projects/commercial/modules/dfp/dfp-env-globals.ts",
   "../projects/commercial/modules/messenger.ts"
  ],
  "../projects/commercial/modules/messenger/post-message.ts": [],

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -465,6 +465,7 @@
   "../projects/commercial/modules/messenger.ts"
  ],
  "../projects/commercial/modules/messenger/passback.ts": [
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../projects/commercial/modules/dfp/dfp-env-globals.ts",
   "../projects/commercial/modules/messenger.ts"
  ],

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -159,7 +159,7 @@
  "../projects/commercial/modules/dfp/create-slot.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../projects/commercial/modules/dfp/dfp-env.ts"
+  "../projects/commercial/modules/dfp/dfp-env-globals.ts"
  ],
  "../projects/commercial/modules/dfp/define-slot.js": [
   "../../../../node_modules/lodash-es/lodash.js",
@@ -167,6 +167,7 @@
   "../lib/detect.js",
   "../lib/url.ts"
  ],
+ "../projects/commercial/modules/dfp/dfp-env-globals.ts": [],
  "../projects/commercial/modules/dfp/dfp-env.ts": [
   "../lib/config.d.ts",
   "../lib/url.ts",
@@ -734,7 +735,7 @@
   "../projects/commercial/modules/article-body-adverts.ts",
   "../projects/commercial/modules/comment-adverts.ts",
   "../projects/commercial/modules/comscore.ts",
-  "../projects/commercial/modules/dfp/dfp-env.ts",
+  "../projects/commercial/modules/dfp/dfp-env-globals.ts",
   "../projects/commercial/modules/dfp/prepare-a9.js",
   "../projects/commercial/modules/dfp/prepare-googletag.ts",
   "../projects/commercial/modules/dfp/prepare-permutive.js",


### PR DESCRIPTION
## What does this change?

Currently when (third-party) passback scripts run in an iFrame they directly control and load passback adverts themselves.

We therefore have little control over passback ad loading and cannot make improvements without involving third parties.

This PR adds a new passback flow to simplify the integration for third-parties and to give us control over ad loading.

## 📖 Terms

### What is a Passback Ad?

For certain ad slots (e.g. `inline1`) we allow ad providers (e.g. [Teads](https://www.teads.com/)) first choice of whether they wish to fulfil the ad slot.

A passback is when the ad provider chooses not to fulfil the slot and 'passes back' the slot to retry fulfilment.

### What is Messenger?

`messenger` provides a cross-window communication method between ads (that live inside iFrames) and the commercial runtime that lives on the main window.

The ad iFrame and the commercial runtime communicate by:
- sending messages via `postMessage`
- listening for messages via an `onmessage` listener e.g. `window.addEventListener("message", ... )`.

More background on `postMessage` [here](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage).

### What is googletag?

`googletag` aka [Google Publisher Tag](https://developers.google.com/publisher-tag/guides/get-started) is the client-side library that we use to define ad slots and make requests for adverts.

### What is GAM?

`GAM` aka [Google Ad Manager](https://admanager.google.com/) is an ad-exchange platform that matches ads to targeting information.

## 🏗️ This Change

This change inverts control of the current process by changing the passback script's responsibility from loading the passback ad to instead simply firing a cross-window 'passback' message.

The passback script (which executes inside the ad iFrame) will now fire a `postMessage` of type 'passback' e.g.:

```js
<script type="text/javascript">
    top.window.postMessage(JSON.stringify({
        id: "someId",
        type: "passback",
        value: {
          source: "teads"
        }
    }), "*");
</script>
```

A passback listener will then fire on receipt of this message and use _our_ main window `googletag` instance to refresh the ad.

This approach gives us control of the ad loading process rather giving control to a third party script.

### Changes to `messenger`

A new strategy has been added to `messenger.js` `getIframe()` (h/t @ashishpuliyel) to auto-detect the calling iFrame.

The new strategy finds the originating iFrame element by comparing `event.source` (i.e. the iFrame window of the message sender) to the window of every page level iFrame.[contentWindow](https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/contentWindow).

Previously the originating `postMessage` had to explicitly set `slotId` or `iframeId` to allow detection.

### New `passback` listener

The new `passback` listener uses the iFrame passed by `messenger` to determine the `slotId` that sent the postMessage.

Once we have the `slotId` we can [find the slot](https://developers.google.com/publisher-tag/reference#googletag.Service_getSlots), apply settings and perform the refresh.

### Before

```mermaid
sequenceDiagram
%%{config: { 'useMaxWidth': false} }%%
autonumber
Page->>Ad Slot: Render Ad Slot
loop All Adverts
    googletag->>googletag: Display Ad
end
googletag->>GAM: Request Advert
GAM->>googletag: Passback Script
googletag->>Ad iFrame: Create iFrame
alt Passback script fulfills
    Ad iFrame->>Ad iFrame: Load Advert
else Passback script passes back
    Ad iFrame->>Ad iFrame: Load googletag
    Ad iFrame->>GAM: Request New Advert
    GAM->>Ad iFrame: New Advert
    Ad iFrame->>Ad iFrame: Load Advert
end
Ad iFrame-->>Ad Slot: Ad Rendered
```

### After

```mermaid
sequenceDiagram
%%{config: { 'useMaxWidth': false} }%%
autonumber
Page->>Ad Slot: Render Ad Slot
loop All Adverts
    googletag->>googletag: Display Ad
end
googletag->>GAM: Request Advert
GAM->>googletag: Passback Script
googletag->>Ad iFrame: Create iFrame
alt Passback script fulfills
    Ad iFrame->>Ad iFrame: Load Advert
else Passback script passes back
    Ad iFrame->>Messenger: passback postMessage
end
Messenger->>Passback Listener: Invoke Listener
Passback Listener->>googletag: Request Slot Refresh
googletag->>GAM: Request Advert
GAM->>googletag: New Advert
googletag->>googletag: Load Advert
googletag-->>Ad Slot: Ad Rendered
```

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [x] On CODE (optional)
