### PR TITLE
Update article counts before using them

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -28,9 +28,7 @@ import {
     logHistory,
     logSummary,
     showInMegaNav,
-    incrementDailyArticleCount,
 } from 'common/modules/onward/history';
-import { incrementWeeklyArticleCount } from '@guardian/support-dotcom-components';
 import { initAccessibilityPreferences } from 'common/modules/ui/accessibility-prefs';
 import { initClickstream } from 'common/modules/ui/clickstream';
 import { init as initDropdowns } from 'common/modules/ui/dropdowns';
@@ -54,7 +52,6 @@ import { signInGate } from 'common/modules/identity/sign-in-gate';
 import { brazeBanner } from 'common/modules/commercial/braze/brazeBanner';
 import { readerRevenueBanner } from 'common/modules/commercial/reader-revenue-banner';
 import { puzzlesBanner } from 'common/modules/commercial/puzzles-banner';
-import { getArticleCountConsent } from 'common/modules/support/supportMessaging';
 import { init as initGoogleAnalytics } from 'common/modules/tracking/google-analytics';
 
 const initialiseTopNavItems = () => {
@@ -165,16 +162,6 @@ const updateHistory = () => {
         }
 
         logHistory(page);
-    }
-};
-
-const updateArticleCounts = async () => {
-    const page = config.get('page');
-    const hasConsentedToArticleCounts = await getArticleCountConsent();
-
-    if (page && !page.isFront && hasConsentedToArticleCounts) {
-        incrementDailyArticleCount(page);
-        incrementWeeklyArticleCount(storage.local, page.pageId, page.keywordIds.split(','));
     }
 };
 
@@ -337,7 +324,6 @@ const init = () => {
         ['c-user-features', refreshUserFeatures],
         ['c-membership', initMembership],
         ['c-banner-picker', initialiseBanner],
-        ['c-increment-article-counts', updateArticleCounts],
         ['c-reader-revenue-dev-utils', initReaderRevenueDevUtils],
         ['c-add-privacy-settings-link', addPrivacySettingsLink],
         ['c-load-google-analytics', loadGoogleAnalytics],

--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -473,8 +473,8 @@ const showInMegaNavEnable = (bool) => {
     saveSummary(summary);
 };
 
-const incrementDailyArticleCount = (pageConfig) => {
-    if (!pageConfig.isFront && !getCookie(ARTICLES_VIEWED_OPT_OUT_COOKIE.name)) {
+const incrementDailyArticleCount = (isFront) => {
+    if (!isFront && !getCookie(ARTICLES_VIEWED_OPT_OUT_COOKIE.name)) {
         const dailyCount = storage.local.get(storageKeyDailyArticleCount) || [];
 
         if (dailyCount[0] && dailyCount[0].day && dailyCount[0].day === today) {
@@ -496,6 +496,8 @@ const incrementDailyArticleCount = (pageConfig) => {
         storage.local.set(storageKeyDailyArticleCount, dailyCount);
     }
 };
+
+const getDailyArticleHistory = () => storage.local.get(storageKeyDailyArticleCount) || [];
 
 const getArticleViewCountForDays = (days) => {
     const dailyCount = storage.local.get(storageKeyDailyArticleCount) || [];
@@ -528,6 +530,7 @@ export {
     mostViewedSeries,
     incrementDailyArticleCount,
     getArticleViewCountForDays,
+    getDailyArticleHistory,
     getMondayFromDate,
     storageKeyDailyArticleCount,
 };

--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -8,9 +8,6 @@ import { storage } from '@guardian/libs';
 import { getPath } from 'lib/url';
 import isObject from 'lodash/isObject';
 
-import {getCookie} from "lib/cookies";
-import { ARTICLES_VIEWED_OPT_OUT_COOKIE } from "common/modules/commercial/user-features";
-
 const editions = ['uk', 'us', 'au'];
 
 const editionalised = [
@@ -473,47 +470,6 @@ const showInMegaNavEnable = (bool) => {
     saveSummary(summary);
 };
 
-const incrementDailyArticleCount = (isFront) => {
-    if (!isFront && !getCookie(ARTICLES_VIEWED_OPT_OUT_COOKIE.name)) {
-        const dailyCount = storage.local.get(storageKeyDailyArticleCount) || [];
-
-        if (dailyCount[0] && dailyCount[0].day && dailyCount[0].day === today) {
-            dailyCount[0].count += 1;
-        } else {
-            // New day
-            dailyCount.unshift({ day: today, count: 1 });
-
-            // Remove any days older than 60
-            const cutOff = today - 60;
-            const firstOldDayIndex = dailyCount.findIndex(
-                c => c.day && c.day < cutOff
-            );
-            if (firstOldDayIndex > 0) {
-                dailyCount.splice(firstOldDayIndex);
-            }
-        }
-
-        storage.local.set(storageKeyDailyArticleCount, dailyCount);
-    }
-};
-
-const getDailyArticleHistory = () => storage.local.get(storageKeyDailyArticleCount) || [];
-
-const getArticleViewCountForDays = (days) => {
-    const dailyCount = storage.local.get(storageKeyDailyArticleCount) || [];
-    const cutOff = today - days;
-
-    const firstOldDayIndex = dailyCount.findIndex(
-        c => c.day && c.day <= cutOff
-    );
-    const dailyCountWindow =
-        firstOldDayIndex >= 0
-            ? dailyCount.slice(0, firstOldDayIndex)
-            : dailyCount;
-
-    return dailyCountWindow.reduce((acc, current) => current.count + acc, 0);
-};
-
 export {
     logHistory,
     logSummary,
@@ -528,9 +484,6 @@ export {
     reset,
     seriesSummary,
     mostViewedSeries,
-    incrementDailyArticleCount,
-    getArticleViewCountForDays,
-    getDailyArticleHistory,
     getMondayFromDate,
     storageKeyDailyArticleCount,
 };

--- a/static/src/javascripts/projects/common/modules/onward/history.spec.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.spec.js
@@ -9,9 +9,7 @@ import {
     reset,
     seriesSummary,
     mostViewedSeries,
-    getArticleViewCountForDays,
     _,
-    incrementDailyArticleCount,
     getMondayFromDate,
 } from 'common/modules/onward/history';
 import { getCookie as getCookie_ } from 'lib/cookies';
@@ -53,7 +51,6 @@ jest.mock('raven-js', () => ({
 const contains = [['/p/3kvgc', 1], ['/p/3kx8f', 1], ['/p/3kx7e', 1]];
 
 const today = Math.floor(Date.now() / 86400000); // 1 day in ms
-const startOfThisWeek = getMondayFromDate(new Date());
 
 const pageConfig = {
     pageId: '/p/3jbcb',
@@ -376,49 +373,5 @@ describe('history', () => {
 
         expect(getContributors().length).toEqual(1);
         expect(getContributors()[0][0]).toEqual('Finbarr Saunders');
-    });
-
-    // dailyArticleCount tests
-    it('gets article count for today only', () => {
-        const counts = [{ day: today, count: 1 }, { day: today - 1, count: 1 }];
-        storageStub.local.set('gu.history.dailyArticleCount', counts);
-
-        expect(getArticleViewCountForDays(1)).toEqual(1);
-    });
-
-    it('gets article count for 2 days', () => {
-        const counts = [{ day: today, count: 1 }, { day: today - 1, count: 1 }];
-        storageStub.local.set('gu.history.dailyArticleCount', counts);
-
-        expect(getArticleViewCountForDays(2)).toEqual(2);
-    });
-
-    it('increments the daily article count', () => {
-        const counts = [{ day: today, count: 1 }];
-        storageStub.local.set('gu.history.dailyArticleCount', counts);
-
-        incrementDailyArticleCount(pageConfig);
-
-        expect(getArticleViewCountForDays(1)).toEqual(2);
-    });
-
-    it('increments the yearly article count', () => {
-        const counts = [{ day: today, count: 1 }];
-        storageStub.local.set('gu.history.dailyArticleCount', counts);
-
-        incrementDailyArticleCount(pageConfig);
-
-        expect(getArticleViewCountForDays(1)).toEqual(2);
-    });
-
-    it('removes old daily history while incrementing the article count', () => {
-        const counts = [{ day: today - 70, count: 9 }];
-        storageStub.local.set('gu.history.dailyArticleCount', counts);
-
-        incrementDailyArticleCount(pageConfig);
-
-        expect(storageStub.local.get('gu.history.dailyArticleCount')).toEqual([
-            { day: today, count: 1 },
-        ]);
     });
 });

--- a/static/src/javascripts/projects/common/modules/support/articleCount.spec.ts
+++ b/static/src/javascripts/projects/common/modules/support/articleCount.spec.ts
@@ -1,0 +1,39 @@
+import {storage} from '@guardian/libs';
+import {incrementDailyArticleCount} from 'common/modules/support/articleCount';
+
+jest.mock('raven-js', () => ({
+	config() {
+		return this;
+	},
+	install() {
+		return this;
+	},
+	captureException: jest.fn(),
+}));
+
+const today = Math.floor(Date.now() / 86400000); // 1 day in ms
+
+describe('history', () => {
+	afterEach(() => {
+		storage.local.remove('gu.history.dailyArticleCount');
+	});
+
+	it('creates daily history if empty', () => {
+		incrementDailyArticleCount();
+
+		expect(storage.local.get('gu.history.dailyArticleCount')).toEqual([
+			{ day: today, count: 1 },
+		]);
+	});
+
+	it('removes old daily history while incrementing the article count', () => {
+		const counts = [{ day: today - 70, count: 9 }];
+		storage.local.set('gu.history.dailyArticleCount', counts);
+
+		incrementDailyArticleCount();
+
+		expect(storage.local.get('gu.history.dailyArticleCount')).toEqual([
+			{ day: today, count: 1 },
+		]);
+	});
+});

--- a/static/src/javascripts/projects/common/modules/support/articleCount.spec.ts
+++ b/static/src/javascripts/projects/common/modules/support/articleCount.spec.ts
@@ -1,5 +1,5 @@
-import {storage} from '@guardian/libs';
-import {incrementDailyArticleCount} from 'common/modules/support/articleCount';
+import { storage } from '@guardian/libs';
+import { incrementDailyArticleCount } from 'common/modules/support/articleCount';
 
 jest.mock('raven-js', () => ({
 	config() {

--- a/static/src/javascripts/projects/common/modules/support/articleCount.spec.ts
+++ b/static/src/javascripts/projects/common/modules/support/articleCount.spec.ts
@@ -36,4 +36,19 @@ describe('articleCount', () => {
 			{ day: today, count: 1 },
 		]);
 	});
+
+	it('increments the daily article count', () => {
+		const counts = [
+			{ day: today, count: 9 },
+			{ day: today - 1, count: 2 },
+		];
+		storage.local.set('gu.history.dailyArticleCount', counts);
+
+		incrementDailyArticleCount();
+
+		expect(storage.local.get('gu.history.dailyArticleCount')).toEqual([
+			{ day: today, count: 10 },
+			{ day: today - 1, count: 2 },
+		]);
+	});
 });

--- a/static/src/javascripts/projects/common/modules/support/articleCount.spec.ts
+++ b/static/src/javascripts/projects/common/modules/support/articleCount.spec.ts
@@ -13,7 +13,7 @@ jest.mock('raven-js', () => ({
 
 const today = Math.floor(Date.now() / 86400000); // 1 day in ms
 
-describe('history', () => {
+describe('articleCount', () => {
 	afterEach(() => {
 		storage.local.remove('gu.history.dailyArticleCount');
 	});

--- a/static/src/javascripts/projects/common/modules/support/articleCount.ts
+++ b/static/src/javascripts/projects/common/modules/support/articleCount.ts
@@ -16,11 +16,14 @@ type DailyArticleHistory = DailyArticleCount[];
 
 const today = Math.floor(Date.now() / 86400000); // 1 day in ms
 
+const isDailyArticleHistory = (data: any): data is DailyArticleHistory =>
+	Array.isArray(data);
+
 const getDailyArticleHistory = (): DailyArticleHistory | undefined => {
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- reading from local storage
 	const item = storage.local.get(storageKeyDailyArticleCount);
-	if (item) {
-		return item as DailyArticleHistory;
+	if (isDailyArticleHistory(item)) {
+		return item;
 	}
 	return undefined;
 };

--- a/static/src/javascripts/projects/common/modules/support/articleCount.ts
+++ b/static/src/javascripts/projects/common/modules/support/articleCount.ts
@@ -4,12 +4,8 @@ import {
 	incrementWeeklyArticleCount,
 } from '@guardian/support-dotcom-components';
 import type { WeeklyArticleHistory } from '@guardian/support-dotcom-components/dist/shared/src/types/targeting';
-import {
-	getDailyArticleHistory,
-	incrementDailyArticleCount,
-} from 'common/modules/onward/history';
 import { getArticleCountConsent } from 'common/modules/support/supportMessaging';
-// TODO - migrate daily article count history code to this file (and TS)
+import {storageKeyDailyArticleCount} from "common/modules/onward/history";
 
 export interface DailyArticle {
 	day: number;
@@ -17,6 +13,39 @@ export interface DailyArticle {
 }
 
 type DailyArticleHistory = DailyArticle[];
+
+const today = Math.floor(Date.now() / 86400000); // 1 day in ms
+
+const getDailyArticleHistory = (): DailyArticleHistory | undefined => {
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- reading from local storage
+	const item = storage.local.get(storageKeyDailyArticleCount);
+	if (item) {
+		return item as DailyArticleHistory;
+	}
+	return undefined;
+};
+
+export const incrementDailyArticleCount = (): void => {
+	const dailyCount = getDailyArticleHistory() ?? [];
+
+	if (dailyCount[0]?.day === today) {
+		dailyCount[0].count += 1;
+	} else {
+		// New day
+		dailyCount.unshift({ day: today, count: 1 });
+
+		// Remove any days older than 60
+		const cutOff = today - 60;
+		const firstOldDayIndex = dailyCount.findIndex(
+			(c) => c.day && c.day < cutOff,
+		);
+		if (firstOldDayIndex > 0) {
+			dailyCount.splice(firstOldDayIndex);
+		}
+	}
+
+	storage.local.set(storageKeyDailyArticleCount, dailyCount);
+};
 
 export interface ArticleCounts {
 	weeklyArticleHistory: WeeklyArticleHistory;
@@ -38,10 +67,12 @@ export const getArticleCounts = async (
 			keywordIds.split(','),
 		);
 
-		incrementDailyArticleCount(isFront);
+		incrementDailyArticleCount();
 
-		const weeklyArticleHistory = getWeeklyArticleHistory(storage.local);
-		const dailyArticleHistory = getDailyArticleHistory();
+		const weeklyArticleHistory =
+			getWeeklyArticleHistory(storage.local) ?? [];
+		const dailyArticleHistory: DailyArticleHistory =
+			getDailyArticleHistory() ?? [];
 		window.guardian.articleCounts = {
 			weeklyArticleHistory,
 			dailyArticleHistory,

--- a/static/src/javascripts/projects/common/modules/support/articleCount.ts
+++ b/static/src/javascripts/projects/common/modules/support/articleCount.ts
@@ -7,12 +7,12 @@ import type { WeeklyArticleHistory } from '@guardian/support-dotcom-components/d
 import { storageKeyDailyArticleCount } from 'common/modules/onward/history';
 import { getArticleCountConsent } from 'common/modules/support/supportMessaging';
 
-export interface DailyArticle {
+export interface DailyArticleCount {
 	day: number;
 	count: number;
 }
 
-type DailyArticleHistory = DailyArticle[];
+type DailyArticleHistory = DailyArticleCount[];
 
 const today = Math.floor(Date.now() / 86400000); // 1 day in ms
 

--- a/static/src/javascripts/projects/common/modules/support/articleCount.ts
+++ b/static/src/javascripts/projects/common/modules/support/articleCount.ts
@@ -1,0 +1,52 @@
+import { storage } from '@guardian/libs';
+import {
+	getWeeklyArticleHistory,
+	incrementWeeklyArticleCount,
+} from '@guardian/support-dotcom-components';
+import type { WeeklyArticleHistory } from '@guardian/support-dotcom-components/dist/shared/src/types/targeting';
+import {
+	getDailyArticleHistory,
+	incrementDailyArticleCount,
+} from 'common/modules/onward/history';
+import { getArticleCountConsent } from 'common/modules/support/supportMessaging';
+// TODO - migrate daily article count history code to this file (and TS)
+
+export interface DailyArticle {
+	day: number;
+	count: number;
+}
+
+type DailyArticleHistory = DailyArticle[];
+
+export interface ArticleCounts {
+	weeklyArticleHistory: WeeklyArticleHistory;
+	dailyArticleHistory: DailyArticleHistory;
+}
+
+export const getArticleCounts = async (
+	pageId: string,
+	keywordIds: string,
+	isFront: boolean,
+): Promise<ArticleCounts | undefined> => {
+	const hasConsentedToArticleCounts = await getArticleCountConsent();
+	if (!hasConsentedToArticleCounts) return undefined;
+
+	if (!isFront && !window.guardian.articleCounts) {
+		incrementWeeklyArticleCount(
+			storage.local,
+			pageId,
+			keywordIds.split(','),
+		);
+
+		incrementDailyArticleCount(isFront);
+
+		const weeklyArticleHistory = getWeeklyArticleHistory(storage.local);
+		const dailyArticleHistory = getDailyArticleHistory();
+		window.guardian.articleCounts = {
+			weeklyArticleHistory,
+			dailyArticleHistory,
+		};
+	}
+
+	return window.guardian.articleCounts;
+};

--- a/static/src/javascripts/projects/common/modules/support/articleCount.ts
+++ b/static/src/javascripts/projects/common/modules/support/articleCount.ts
@@ -4,8 +4,8 @@ import {
 	incrementWeeklyArticleCount,
 } from '@guardian/support-dotcom-components';
 import type { WeeklyArticleHistory } from '@guardian/support-dotcom-components/dist/shared/src/types/targeting';
+import { storageKeyDailyArticleCount } from 'common/modules/onward/history';
 import { getArticleCountConsent } from 'common/modules/support/supportMessaging';
-import {storageKeyDailyArticleCount} from "common/modules/onward/history";
 
 export interface DailyArticle {
 	day: number;

--- a/static/src/javascripts/projects/common/modules/support/articleCount.ts
+++ b/static/src/javascripts/projects/common/modules/support/articleCount.ts
@@ -61,6 +61,7 @@ export const getArticleCounts = async (
 	if (!hasConsentedToArticleCounts) return undefined;
 
 	if (!isFront && !window.guardian.articleCounts) {
+		// This is an article and the counts have not been initialised yet
 		incrementWeeklyArticleCount(
 			storage.local,
 			pageId,
@@ -68,11 +69,14 @@ export const getArticleCounts = async (
 		);
 
 		incrementDailyArticleCount();
+	}
 
+	if (!window.guardian.articleCounts) {
 		const weeklyArticleHistory =
 			getWeeklyArticleHistory(storage.local) ?? [];
 		const dailyArticleHistory: DailyArticleHistory =
 			getDailyArticleHistory() ?? [];
+
 		window.guardian.articleCounts = {
 			weeklyArticleHistory,
 			dailyArticleHistory,

--- a/static/src/javascripts/projects/common/modules/support/banner.ts
+++ b/static/src/javascripts/projects/common/modules/support/banner.ts
@@ -113,10 +113,7 @@ const getArticleCountToday = (
 	articleCounts: ArticleCounts | undefined,
 ): number | undefined => {
 	if (articleCounts) {
-		return (
-			articleCounts.dailyArticleHistory[0] &&
-			articleCounts.dailyArticleHistory[0].count
-		);
+		return articleCounts.dailyArticleHistory[0]?.count;
 	}
 	return undefined;
 };

--- a/static/src/javascripts/projects/common/modules/support/banner.ts
+++ b/static/src/javascripts/projects/common/modules/support/banner.ts
@@ -15,7 +15,6 @@ import { getMvtValue } from 'common/modules/analytics/mvt-cookie';
 import { submitComponentEvent } from 'common/modules/commercial/acquisitions-ophan';
 import { getVisitCount } from 'common/modules/commercial/contributions-utilities';
 import { shouldHideSupportMessaging } from 'common/modules/commercial/user-features';
-import type { ArticleCounts } from 'common/modules/support/articleCount';
 import { getArticleCounts } from 'common/modules/support/articleCount';
 import {
 	buildTagIds,
@@ -109,15 +108,6 @@ export const renderBanner = (
 		});
 };
 
-const getArticleCountToday = (
-	articleCounts: ArticleCounts | undefined,
-): number | undefined => {
-	if (articleCounts) {
-		return articleCounts.dailyArticleHistory[0]?.count;
-	}
-	return undefined;
-};
-
 const buildBannerPayload = async (): Promise<BannerPayload> => {
 	const {
 		contentType,
@@ -131,7 +121,7 @@ const buildBannerPayload = async (): Promise<BannerPayload> => {
 
 	const articleCounts = await getArticleCounts(pageId, keywordIds, isFront);
 	const weeklyArticleHistory = articleCounts?.weeklyArticleHistory;
-	const articleCountToday = getArticleCountToday(articleCounts);
+	const articleCountToday = articleCounts?.dailyArticleHistory[0]?.count;
 
 	const targeting: BannerTargeting = {
 		alreadyVisitedCount: getVisitCount(),

--- a/static/src/javascripts/projects/common/modules/support/banner.ts
+++ b/static/src/javascripts/projects/common/modules/support/banner.ts
@@ -1,9 +1,8 @@
 import { mountDynamic } from '@guardian/automat-modules';
-import { log, storage } from '@guardian/libs';
+import { log } from '@guardian/libs';
 import {
 	getBanner,
 	getPuzzlesBanner,
-	getWeeklyArticleHistory,
 } from '@guardian/support-dotcom-components';
 import type {
 	BannerPayload,
@@ -16,7 +15,8 @@ import { getMvtValue } from 'common/modules/analytics/mvt-cookie';
 import { submitComponentEvent } from 'common/modules/commercial/acquisitions-ophan';
 import { getVisitCount } from 'common/modules/commercial/contributions-utilities';
 import { shouldHideSupportMessaging } from 'common/modules/commercial/user-features';
-import { getArticleViewCountForDays } from 'common/modules/onward/history';
+import type { ArticleCounts } from 'common/modules/support/articleCount';
+import { getArticleCounts } from 'common/modules/support/articleCount';
 import {
 	buildTagIds,
 	dynamicImport,
@@ -109,9 +109,32 @@ export const renderBanner = (
 		});
 };
 
+const getArticleCountToday = (
+	articleCounts: ArticleCounts | undefined,
+): number | undefined => {
+	if (articleCounts) {
+		return (
+			articleCounts.dailyArticleHistory[0] &&
+			articleCounts.dailyArticleHistory[0].count
+		);
+	}
+	return undefined;
+};
+
 const buildBannerPayload = async (): Promise<BannerPayload> => {
-	const { contentType, section, shouldHideReaderRevenue, isPaidContent } =
-		window.guardian.config.page;
+	const {
+		contentType,
+		section,
+		shouldHideReaderRevenue,
+		isPaidContent,
+		pageId,
+		keywordIds,
+		isFront,
+	} = window.guardian.config.page;
+
+	const articleCounts = await getArticleCounts(pageId, keywordIds, isFront);
+	const weeklyArticleHistory = articleCounts?.weeklyArticleHistory;
+	const articleCountToday = getArticleCountToday(articleCounts);
 
 	const targeting: BannerTargeting = {
 		alreadyVisitedCount: getVisitCount(),
@@ -126,8 +149,8 @@ const buildBannerPayload = async (): Promise<BannerPayload> => {
 			undefined,
 		mvtId: getMvtValue() ?? 0,
 		countryCode: getCountryCode(),
-		weeklyArticleHistory: getWeeklyArticleHistory(storage.local),
-		articleCountToday: getArticleViewCountForDays(1) as number,
+		weeklyArticleHistory: weeklyArticleHistory,
+		articleCountToday: articleCountToday,
 		hasOptedOutOfArticleCount: !(await getArticleCountConsent()),
 		modulesVersion: ModulesVersion,
 		sectionId: section,

--- a/static/src/javascripts/projects/common/modules/support/epic.ts
+++ b/static/src/javascripts/projects/common/modules/support/epic.ts
@@ -4,7 +4,6 @@ import {
 	getEpic,
 	getEpicViewLog,
 	getLiveblogEpic,
-	getWeeklyArticleHistory,
 } from '@guardian/support-dotcom-components';
 import type {
 	EpicPayload,
@@ -20,6 +19,7 @@ import {
 	isRecurringContributor,
 	shouldHideSupportMessaging,
 } from 'common/modules/commercial/user-features';
+import { getArticleCounts } from 'common/modules/support/articleCount';
 import {
 	buildKeywordTags,
 	buildSeriesTag,
@@ -52,10 +52,20 @@ const getEpicElement = (): HTMLDivElement => {
 };
 
 const buildEpicPayload = async (): Promise<EpicPayload> => {
-	const { contentType, section, shouldHideReaderRevenue, isPaidContent } =
-		window.guardian.config.page;
+	const {
+		contentType,
+		section,
+		shouldHideReaderRevenue,
+		isPaidContent,
+		pageId,
+		keywordIds,
+		isFront,
+	} = window.guardian.config.page;
 
 	const countryCode = getCountryCode();
+
+	const articleCounts = await getArticleCounts(pageId, keywordIds, isFront);
+	const weeklyArticleHistory = articleCounts?.weeklyArticleHistory;
 
 	const targeting: EpicTargeting = {
 		contentType: contentType,
@@ -71,7 +81,7 @@ const buildEpicPayload = async (): Promise<EpicPayload> => {
 		mvtId: getMvtValue() ?? 0,
 		countryCode,
 		epicViewLog: getEpicViewLog(storage.local),
-		weeklyArticleHistory: getWeeklyArticleHistory(storage.local),
+		weeklyArticleHistory: weeklyArticleHistory,
 		hasOptedOutOfArticleCount: !(await getArticleCountConsent()),
 		modulesVersion: ModulesVersion,
 		url: window.location.origin + window.location.pathname,

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -204,12 +204,12 @@ type WeeklyArticleLog = {
 };
 type WeeklyArticleHistory = WeeklyArticleLog[];
 
-interface DailyArticle {
+interface DailyArticleCount {
 	day: number;
 	count: number;
 }
 
-type DailyArticleHistory = DailyArticle[];
+type DailyArticleHistory = DailyArticleCount[];
 
 interface ArticleCounts {
 	weeklyArticleHistory: WeeklyArticleHistory;

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -1,3 +1,5 @@
+import type { ArticleCounts } from 'common/modules/support/articleCount';
+
 type ServerSideABTest = `${string}${'Variant' | 'Control'}`;
 
 declare const twttr: {
@@ -207,6 +209,7 @@ interface Window {
 		adBlockers: AdBlockers;
 		// /frontend/common/app/templates/inlineJS/blocking/enableStylesheets.scala.js
 		css: { onLoad: () => void; loaded: boolean };
+		articleCounts?: ArticleCounts;
 	};
 
 	confiant?: Confiant;

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -1,5 +1,3 @@
-import type { ArticleCounts } from 'common/modules/support/articleCount';
-
 type ServerSideABTest = `${string}${'Variant' | 'Control'}`;
 
 declare const twttr: {
@@ -197,6 +195,26 @@ type AdBlockers = {
 	active: boolean | undefined;
 	onDetect: function[];
 };
+
+type TagCounts = Record<string, number>;
+type WeeklyArticleLog = {
+	week: number;
+	count: number;
+	tags?: TagCounts;
+};
+type WeeklyArticleHistory = WeeklyArticleLog[];
+
+interface DailyArticle {
+	day: number;
+	count: number;
+}
+
+type DailyArticleHistory = DailyArticle[];
+
+interface ArticleCounts {
+	weeklyArticleHistory: WeeklyArticleHistory;
+	dailyArticleHistory: DailyArticleHistory;
+}
 
 interface Window {
 	// eslint-disable-next-line id-denylist -- this *is* the guardian object

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -196,6 +196,10 @@ type AdBlockers = {
 	onDetect: function[];
 };
 
+/**
+ *  All article history types here are duplicated from elsewhere.
+ *  This is because adding imports to this file causes typechecking to break for every use of window.guardian in the codebase.
+ */
 type TagCounts = Record<string, number>;
 type WeeklyArticleLog = {
 	week: number;


### PR DESCRIPTION
### Existing behaviour:
On page load, `common.js` updates the article counts in local storage.
These counts are used for requests to [SDC](https://github.com/guardian/support-dotcom-components) for the epic and banner.
There is a race condition here, and in fact the article counts are always updated after the requests are made to SDC. It should be the other way round.

### New behaviour
It now closely follows the logic in DCR: https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/lib/article-count.ts#L21
The article counts are no longer initialised from `common.js` on page load. Instead, each place which needs the article counts (epic and banner) makes a call to `getArticleCounts`, which takes care of updating the counts only once per page view. It uses `window.guardian` to do this.