### PR TITLE
slow sideshow to 5 seconds

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -560,7 +560,7 @@ $block-height: 58px;
 
 
 @for $i from 2 through 5 {
-    $hangTime: 4;
+    $hangTime: 5;
     $fadeTime: 1;
     $totalLoopTime: $i * ($hangTime + $fadeTime);
     @keyframes fc-item__slideshow--#{$i} {

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -325,7 +325,7 @@ $fc-item-gutter: $gs-gutter / 4;
 }
 
 @for $i from 2 through 5 {
-    $hangTime: 4;
+    $hangTime: 5;
     $fadeTime: 1;
     $totalLoopTime: $i * ($hangTime + $fadeTime);
     @keyframes fc-item__slideshow--#{$i} {


### PR DESCRIPTION
## What does this change?
Slows the slideshow rate to wait 5 seconds on an image.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
### Before

https://user-images.githubusercontent.com/31692/157018060-4f6d7a7c-caa1-41af-8b12-6eb19cde9bc3.mov

### After

https://user-images.githubusercontent.com/31692/157018091-4c10b30e-27e7-4a7d-885a-ea38cfb39f40.mov

