### PR TITLE
chore(deps): bump @guardian/consent-management-platform from 10.2.2 to 10.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@guardian/automat-modules": "^0.3.8",
     "@guardian/braze-components": "^5.3.0",
     "@guardian/commercial-core": "^3.0.0",
-    "@guardian/consent-management-platform": "^10.2.2",
+    "@guardian/consent-management-platform": "^10.3.1",
     "@guardian/libs": "^3.6.1",
     "@guardian/shimport": "^1.0.2",
     "@guardian/source-foundations": "^4.0.0-rc.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1284,10 +1284,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-3.0.0.tgz#8b2040e89b4dd8e317563938552776da4ced5bee"
   integrity sha512-wB3y5p6eyuuekEK27S4OZ8vnVRMJ1tcHwi1SwmfIsYNEZLwYJRv3UxsLlTEeUmH8YAnYNgIEzJ390GfQ8iaVeA==
 
-"@guardian/consent-management-platform@^10.2.2":
-  version "10.2.2"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-10.2.2.tgz#bffa22192c68b308574d6c6abfb22277058d3e32"
-  integrity sha512-lLdVTrDhxtf9BC3S2PNLMJf7/cR0Zo5RnfstWaynGerwOILwM8Ppl5xdHX/i6RdZrt2O4Z7GuB6mxhNAeAw27A==
+"@guardian/consent-management-platform@^10.3.1":
+  version "10.3.1"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-10.3.1.tgz#09e744ee81a54fe1ab7d0ed58b125ffb59cb0934"
+  integrity sha512-nW+YyQyOwbltiaEgIPtruNys0ZsxlQAJdWsgq+ENcJDvRdjJJPIOqoCY/cL3P3sqL2pwvKttANhSzM6aM0wJlw==
   dependencies:
     "@guardian/libs" "1.6.1 - 3.3.0"
 


### PR DESCRIPTION
## What does this change?

Bumps the CMP to 10.3.1 to incorporate changes from:
- https://github.com/guardian/consent-management-platform/pull/562

## Why?

Stays up to date with the most current version of the CMP & allows safe transition between vendor-ids when required.

Updated in DCR: https://github.com/guardian/dotcom-rendering/pull/4192