### PR TITLE
Pre-scala 2.13: upgrade scala uri

### DIFF
--- a/common/app/navigation/ReaderRevenueSite.scala
+++ b/common/app/navigation/ReaderRevenueSite.scala
@@ -5,6 +5,7 @@ import conf.Configuration
 import enumeratum.EnumEntry
 
 import scala.collection.immutable.IndexedSeq
+import scala.util.Try
 
 sealed trait ReaderRevenueSite extends EnumEntry {
   val url: String
@@ -14,7 +15,7 @@ object ReaderRevenueSite extends enumeratum.Enum[ReaderRevenueSite] {
 
   override val values: IndexedSeq[ReaderRevenueSite] = findValues
 
-  private def getHost(url: String): Option[String] = Url.parse(url).hostOption.map(_.toString)
+  private def getHost(url: String): Option[String] = Try(Url.parse(url).hostOption).toOption.map(_.toString)
 
   private val hosts: Set[String] = values.flatMap(site => getHost(site.url)).toSet
 

--- a/common/app/navigation/ReaderRevenueSite.scala
+++ b/common/app/navigation/ReaderRevenueSite.scala
@@ -1,11 +1,10 @@
 package navigation
 
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Url
 import conf.Configuration
 import enumeratum.EnumEntry
 
 import scala.collection.immutable.IndexedSeq
-import scala.util.Try
 
 sealed trait ReaderRevenueSite extends EnumEntry {
   val url: String
@@ -15,7 +14,7 @@ object ReaderRevenueSite extends enumeratum.Enum[ReaderRevenueSite] {
 
   override val values: IndexedSeq[ReaderRevenueSite] = findValues
 
-  private def getHost(url: String): Option[String] = Try(Uri.parse(url).host).toOption.flatten
+  private def getHost(url: String): Option[String] = Url.parse(url).hostOption.map(_.toString)
 
   private val hosts: Set[String] = values.flatMap(site => getHost(site.url)).toSet
 

--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -1,7 +1,8 @@
 package navigation
 
-import com.netaporter.uri.config.UriConfig
-import com.netaporter.uri.encoding.PercentEncoder
+import io.lemonlabs.uri.Url
+import io.lemonlabs.uri.config.UriConfig
+import io.lemonlabs.uri.encoding.PercentEncoder
 import navigation.ReaderRevenueSite._
 import play.api.libs.json.Json
 import play.api.mvc.RequestHeader
@@ -67,15 +68,15 @@ object UrlHelpers {
       NavLink("Subscribe", getReaderRevenueUrl(SupportSubscribe, SideMenu), classList = Seq("js-subscribe")),
     )
 
-  private val uriEncoder = UriConfig.default.copy(
-    // The default encoder does not encode double quotes in the querystring
-    queryEncoder = PercentEncoder(PercentEncoder.QUERY_CHARS_TO_ENCODE + '"'),
-  )
-
   def getReaderRevenueUrl(destination: ReaderRevenueSite, position: Position): String = {
     val componentId = getComponentId(destination, position)
     val componentType = getComponentType(position)
 
+    // Implicit - used when parsing url
+    implicit val uriEncoder = UriConfig.default.copy(
+      // The default encoder does not encode double quotes in the querystring
+      queryEncoder = PercentEncoder(PercentEncoder.QUERY_CHARS_TO_ENCODE + '"'),
+    )
     val acquisitionData = Json.obj(
       // GUARDIAN_WEB corresponds to a value in the Thrift enum
       // https://dashboard.ophan.co.uk/docs/thrift/acquisition.html#Enum_AcquisitionSource
@@ -89,12 +90,12 @@ object UrlHelpers {
       ),
     )
 
-    import com.netaporter.uri.dsl._
+    import io.lemonlabs.uri.typesafe.dsl._
 
     // INTCMP is passed as a separate param because people look at it in Google Analytics
     // It's set to the most specific thing (componentId) to maximise its usefulness
     val url = destination.url ? ("INTCMP" -> componentId) & ("acquisitionData" -> acquisitionData.toString)
-    url.toString(uriEncoder)
+    Url.parse(url.toString).toString
   }
 
   def getJobUrl(editionId: String): String =

--- a/common/app/pagepresser/HtmlCleaner.scala
+++ b/common/app/pagepresser/HtmlCleaner.scala
@@ -1,6 +1,5 @@
 package pagepresser
 
-import com.netaporter.uri.Uri.parse
 import common.{GuLogging}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Element, Document}

--- a/common/app/pagepresser/InteractiveHtmlCleaner.scala
+++ b/common/app/pagepresser/InteractiveHtmlCleaner.scala
@@ -1,7 +1,5 @@
 package pagepresser
 
-import com.netaporter.uri.Uri._
-import org.jsoup.Jsoup
 import org.jsoup.nodes.{Element, Document}
 import scala.collection.JavaConverters._
 import scala.io.Source

--- a/common/app/pagepresser/InteractiveImmersiveHtmlCleaner.scala
+++ b/common/app/pagepresser/InteractiveImmersiveHtmlCleaner.scala
@@ -1,10 +1,7 @@
 package pagepresser
 
-import com.netaporter.uri.Uri._
-import org.jsoup.Jsoup
 import org.jsoup.nodes.{Element, Document}
 import scala.collection.JavaConverters._
-import scala.io.Source
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 

--- a/common/app/views/fragments/atoms/youtube.scala.html
+++ b/common/app/views/fragments/atoms/youtube.scala.html
@@ -1,7 +1,4 @@
-@import conf.Configuration.site.host
-@import conf.Configuration.Media
 @import views.support.{RenderClasses, Video700}
-@import com.netaporter.uri.dsl._
 @import model.pressed.CardStyle
 
 @import model.ImageMedia

--- a/common/test/navigation/helpers/UrlHelpersTest.scala
+++ b/common/test/navigation/helpers/UrlHelpersTest.scala
@@ -76,5 +76,11 @@ class UrlHelpersTest extends WordSpec with Matchers {
         UrlHelpers.getComponentType(AmpFooter) should be("ACQUISITIONS_FOOTER")
       }
     }
+
+    "getReaderRevenueUrl" should {
+      "correctly parse urls with double quotes" in {
+        UrlHelpers.getReaderRevenueUrl(SupportSubscribe, Footer) should include("%22")
+      }
+    }
   }
 }

--- a/discussion/app/discussion/api/DiscussionApi.scala
+++ b/discussion/app/discussion/api/DiscussionApi.scala
@@ -1,7 +1,6 @@
 package discussion.api
 
 import java.net.URLEncoder
-import io.lemonlabs.uri.dsl._
 import io.lemonlabs.uri.Url
 import common.GuLogging
 import conf.Configuration
@@ -14,6 +13,7 @@ import play.api.mvc.{Cookie, Headers, RequestHeader}
 import scala.concurrent.duration._
 import conf.switches.Switches._
 import io.lemonlabs.uri.config.{ExcludeNones, UriConfig}
+import io.lemonlabs.uri.typesafe.QueryKey.stringQueryKey
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -25,10 +25,10 @@ trait DiscussionApiLike extends Http with GuLogging {
 
   protected val apiRoot: String
   protected val clientHeaderValue: String
-  protected val defaultParams = List("api-key" -> "dotcom")
+  protected val defaultParams = List("api-key" -> Some("dotcom"))
   protected val pageSize: String = "10"
 
-  def endpointUrl(relativePath: String, params: List[(String, String)] = List()): String = { //Using List for params because order is important for caching reason
+  def endpointUrl(relativePath: String, params: List[(String, Option[String])] = List()): String = { //Using List for params because order is important for caching reason
     implicit val config: UriConfig = UriConfig(renderQuery = ExcludeNones)
     Url.parse(apiRoot + relativePath).addParams(defaultParams ++ params).toString()
   }
@@ -36,7 +36,7 @@ trait DiscussionApiLike extends Http with GuLogging {
   def commentCounts(ids: String)(implicit executionContext: ExecutionContext): Future[Seq[CommentCount]] = {
     def onError(response: WSResponse) =
       s"Discussion API: Error loading comment count ids: $ids status: ${response.status} message: ${response.statusText}"
-    val apiUrl = endpointUrl("/getCommentCounts", List(("short-urls", ids)))
+    val apiUrl = endpointUrl("/getCommentCounts", List(("short-urls", Some(ids))))
 
     getJsonOrError(apiUrl, onError) map { json =>
       json.asInstanceOf[JsObject].fieldSet.toSeq map {
@@ -49,7 +49,7 @@ trait DiscussionApiLike extends Http with GuLogging {
   def commentFor(id: Int, displayThreaded: Option[String] = None)(implicit
       executionContext: ExecutionContext,
   ): Future[Comment] = {
-    val parameters = List("displayResponses" -> "true", "displayThreaded" -> displayThreaded.orNull)
+    val parameters = List("displayResponses" -> Some("true"), "displayThreaded" -> displayThreaded)
     val url = endpointUrl(s"/comment/$id", parameters)
     getCommentJsonForId(id, url)
   }
@@ -57,16 +57,16 @@ trait DiscussionApiLike extends Http with GuLogging {
   def commentsFor(key: DiscussionKey, params: DiscussionParams)(implicit
       executionContext: ExecutionContext,
   ): Future[DiscussionComments] = {
-    val parameters: List[(String, String)] = List(
-      "pageSize" -> params.pageSize,
-      "page" -> params.page,
-      "orderBy" -> params.orderBy,
+    val parameters = List(
+      "pageSize" -> Some(params.pageSize),
+      "page" -> Some(params.page),
+      "orderBy" -> Some(params.orderBy),
       "displayThreaded" -> (params.displayThreaded match {
-        case false => "false"
-        case _     => null
+        case false => Some("false")
+        case _     => None
       }),
-      "showSwitches" -> "true",
-      "maxResponses" -> params.maxResponses.orNull,
+      "showSwitches" -> Some("true"),
+      "maxResponses" -> params.maxResponses,
     )
     val path = s"/discussion/$key" + (if (params.topComments) "/topcomments" else "")
     val url = endpointUrl(path, parameters)
@@ -81,11 +81,11 @@ trait DiscussionApiLike extends Http with GuLogging {
       s"Discussion API: Cannot load comment context, status: ${r.status}, message: ${r.statusText}, response: ${r.body}"
 
     val parameters = List(
-      "pageSize" -> params.pageSize,
-      "orderBy" -> params.orderBy,
+      "pageSize" -> Some(params.pageSize),
+      "orderBy" -> Some(params.orderBy),
       "displayThreaded" -> (params.displayThreaded match {
-        case false => "false"
-        case _     => null
+        case false => Some("false")
+        case _     => None
       }),
     )
     val path = s"/comment/$id/context"
@@ -113,13 +113,13 @@ trait DiscussionApiLike extends Http with GuLogging {
     def onError(r: WSResponse) =
       s"Discussion API: Error loading comments for User $userId, status: ${r.status}, message: ${r.statusText}, response: ${r.body}"
     val parameters = List(
-      "pageSize" -> pageSize,
-      "page" -> page,
-      "orderBy" -> orderBy,
-      "showSwitches" -> "true",
+      "pageSize" -> Some(pageSize),
+      "page" -> Some(page),
+      "orderBy" -> Some(orderBy),
+      "showSwitches" -> Some("true"),
       "displayHighlighted" -> (picks match {
-        case true  => "true"
-        case false => null
+        case true  => Some("true")
+        case false => None
       }),
     )
     val path = s"/profile/$userId/comments"
@@ -135,7 +135,12 @@ trait DiscussionApiLike extends Http with GuLogging {
   ): Future[ProfileComments] = {
     def onError(r: WSResponse) =
       s"Discussion API: Error loading replies for User $userId, status: ${r.status}, message: ${r.statusText}, response: ${r.body}"
-    val parameters = List("pageSize" -> pageSize, "page" -> page, "orderBy" -> "newest", "showSwitches" -> "true")
+    val parameters = List(
+      "pageSize" -> Some(pageSize),
+      "page" -> Some(page),
+      "orderBy" -> Some("newest"),
+      "showSwitches" -> Some("true"),
+    )
     val path = s"/profile/$userId/replies"
     val apiUrl = endpointUrl(path, parameters)
 
@@ -149,7 +154,7 @@ trait DiscussionApiLike extends Http with GuLogging {
   ): Future[ProfileComments] = {
     def onError(r: WSResponse) =
       s"Discussion API: Error loading search User $userId, Query: $q. status: ${r.status}, message: ${r.statusText}, response: ${r.body}"
-    val parameters = List("q" -> URLEncoder.encode(q, "UTF-8"), "page" -> page)
+    val parameters = List("q" -> Some(URLEncoder.encode(q, "UTF-8")), "page" -> Some(page))
     val path = s"/search/profile/$userId"
     val apiUrl = endpointUrl(path, parameters)
 
@@ -163,7 +168,12 @@ trait DiscussionApiLike extends Http with GuLogging {
   ): Future[ProfileDiscussions] = {
     def onError(r: WSResponse) =
       s"Discussion API: Error loading discussions for User $userId, status: ${r.status}, message: ${r.statusText}, response: ${r.body}"
-    val parameters = List("pageSize" -> pageSize, "page" -> page, "orderBy" -> "newest", "showSwitches" -> "true")
+    val parameters = List(
+      "pageSize" -> Some(pageSize),
+      "page" -> Some(page),
+      "orderBy" -> Some("newest"),
+      "showSwitches" -> Some("true"),
+    )
     val path = s"/profile/$userId/discussions"
     val apiUrl = endpointUrl(path, parameters)
 

--- a/discussion/app/discussion/api/DiscussionApi.scala
+++ b/discussion/app/discussion/api/DiscussionApi.scala
@@ -30,7 +30,7 @@ trait DiscussionApiLike extends Http with GuLogging {
 
   def endpointUrl(relativePath: String, params: List[(String, Option[String])] = List()): String = { //Using List for params because order is important for caching reason
     implicit val config: UriConfig = UriConfig(renderQuery = ExcludeNones)
-    Url.parse(apiRoot + relativePath).addParams(defaultParams ++ params).toString()
+    Url.parse(apiRoot + relativePath).addParams(params ++ defaultParams).toString()
   }
 
   def commentCounts(ids: String)(implicit executionContext: ExecutionContext): Future[Seq[CommentCount]] = {

--- a/discussion/app/discussion/api/DiscussionApi.scala
+++ b/discussion/app/discussion/api/DiscussionApi.scala
@@ -49,7 +49,7 @@ trait DiscussionApiLike extends Http with GuLogging {
   def commentFor(id: Int, displayThreaded: Option[String] = None)(implicit
       executionContext: ExecutionContext,
   ): Future[Comment] = {
-    val parameters = List("displayResponses" -> "true", "displayThreaded" -> displayThreaded)
+    val parameters = List("displayResponses" -> "true", "displayThreaded" -> displayThreaded.getOrElse(""))
     val url = endpointUrl(s"/comment/$id", parameters)
     getCommentJsonForId(id, url)
   }
@@ -57,16 +57,16 @@ trait DiscussionApiLike extends Http with GuLogging {
   def commentsFor(key: DiscussionKey, params: DiscussionParams)(implicit
       executionContext: ExecutionContext,
   ): Future[DiscussionComments] = {
-    val parameters = List(
+    val parameters: List[(String, String)] = List(
       "pageSize" -> params.pageSize,
       "page" -> params.page,
       "orderBy" -> params.orderBy,
       "displayThreaded" -> (params.displayThreaded match {
         case false => "false"
-        case _     => None
+        case _     => ""
       }),
       "showSwitches" -> "true",
-      "maxResponses" -> params.maxResponses,
+      "maxResponses" -> params.maxResponses.getOrElse(""),
     )
     val path = s"/discussion/$key" + (if (params.topComments) "/topcomments" else "")
     val url = endpointUrl(path, parameters)
@@ -85,7 +85,7 @@ trait DiscussionApiLike extends Http with GuLogging {
       "orderBy" -> params.orderBy,
       "displayThreaded" -> (params.displayThreaded match {
         case false => "false"
-        case _     => None
+        case _     => ""
       }),
     )
     val path = s"/comment/$id/context"
@@ -119,7 +119,7 @@ trait DiscussionApiLike extends Http with GuLogging {
       "showSwitches" -> "true",
       "displayHighlighted" -> (picks match {
         case true  => "true"
-        case false => None
+        case false => ""
       }),
     )
     val path = s"/profile/$userId/comments"

--- a/discussion/app/discussion/api/DiscussionApi.scala
+++ b/discussion/app/discussion/api/DiscussionApi.scala
@@ -49,7 +49,7 @@ trait DiscussionApiLike extends Http with GuLogging {
   def commentFor(id: Int, displayThreaded: Option[String] = None)(implicit
       executionContext: ExecutionContext,
   ): Future[Comment] = {
-    val parameters = List("displayResponses" -> "true", "displayThreaded" -> displayThreaded.getOrElse(""))
+    val parameters = List("displayResponses" -> "true", "displayThreaded" -> displayThreaded.orNull)
     val url = endpointUrl(s"/comment/$id", parameters)
     getCommentJsonForId(id, url)
   }
@@ -63,10 +63,10 @@ trait DiscussionApiLike extends Http with GuLogging {
       "orderBy" -> params.orderBy,
       "displayThreaded" -> (params.displayThreaded match {
         case false => "false"
-        case _     => ""
+        case _     => null
       }),
       "showSwitches" -> "true",
-      "maxResponses" -> params.maxResponses.getOrElse(""),
+      "maxResponses" -> params.maxResponses.orNull,
     )
     val path = s"/discussion/$key" + (if (params.topComments) "/topcomments" else "")
     val url = endpointUrl(path, parameters)
@@ -85,7 +85,7 @@ trait DiscussionApiLike extends Http with GuLogging {
       "orderBy" -> params.orderBy,
       "displayThreaded" -> (params.displayThreaded match {
         case false => "false"
-        case _     => ""
+        case _     => null
       }),
     )
     val path = s"/comment/$id/context"
@@ -119,7 +119,7 @@ trait DiscussionApiLike extends Http with GuLogging {
       "showSwitches" -> "true",
       "displayHighlighted" -> (picks match {
         case true  => "true"
-        case false => ""
+        case false => null
       }),
     )
     val path = s"/profile/$userId/comments"

--- a/discussion/app/discussion/api/DiscussionApi.scala
+++ b/discussion/app/discussion/api/DiscussionApi.scala
@@ -2,11 +2,11 @@ package discussion.api
 
 import java.net.URLEncoder
 
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.dsl._
+import io.lemonlabs.uri.Url
 import common.GuLogging
 import conf.Configuration
 import discussion.model.{CommentCount, _}
-import discussion.model._
 import discussion.util.Http
 import play.api.libs.json.{JsNull, JsNumber, JsObject}
 import play.api.libs.ws.{WSClient, WSResponse}
@@ -29,7 +29,8 @@ trait DiscussionApiLike extends Http with GuLogging {
   protected val pageSize: String = "10"
 
   def endpointUrl(relativePath: String, params: List[(String, Any)] = List()): String = { //Using List for params because order is important for caching reason
-    (apiRoot + relativePath).addParams(params ++ defaultParams).toString()
+    Url.parse(apiRoot + relativePath).addParams(params ++ defaultParams)
+//      .toString()
   }
 
   def commentCounts(ids: String)(implicit executionContext: ExecutionContext): Future[Seq[CommentCount]] = {

--- a/discussion/app/discussion/api/DiscussionApi.scala
+++ b/discussion/app/discussion/api/DiscussionApi.scala
@@ -1,7 +1,6 @@
 package discussion.api
 
 import java.net.URLEncoder
-
 import io.lemonlabs.uri.dsl._
 import io.lemonlabs.uri.Url
 import common.GuLogging
@@ -14,6 +13,7 @@ import play.api.mvc.{Cookie, Headers, RequestHeader}
 
 import scala.concurrent.duration._
 import conf.switches.Switches._
+import io.lemonlabs.uri.config.{ExcludeNones, UriConfig}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -28,9 +28,9 @@ trait DiscussionApiLike extends Http with GuLogging {
   protected val defaultParams = List("api-key" -> "dotcom")
   protected val pageSize: String = "10"
 
-  def endpointUrl(relativePath: String, params: List[(String, Any)] = List()): String = { //Using List for params because order is important for caching reason
-    Url.parse(apiRoot + relativePath).addParams(params ++ defaultParams)
-//      .toString()
+  def endpointUrl(relativePath: String, params: List[(String, String)] = List()): String = { //Using List for params because order is important for caching reason
+    implicit val config: UriConfig = UriConfig(renderQuery = ExcludeNones)
+    Url.parse(apiRoot + relativePath).addParams(defaultParams ++ params).toString()
   }
 
   def commentCounts(ids: String)(implicit executionContext: ExecutionContext): Future[Seq[CommentCount]] = {

--- a/identity/app/model/ReturnJourney.scala
+++ b/identity/app/model/ReturnJourney.scala
@@ -1,6 +1,6 @@
 package model
 
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Url
 
 import scala.util.Try
 
@@ -8,14 +8,14 @@ object ReturnJourney {
   private val paymentFailureCodes = Set("PF", "PF1", "PF2", "PF3", "PF4", "CCX")
 
   sealed trait Journey {
-    def applies(returnUri: Uri): Boolean
+    def applies(returnUri: Url): Boolean
     val continueCopy: String = "Continue"
   }
 
   // Checks for INTCMP parameter in returnUrl after manage.theguardian redirects to signin with this parameter for payment failure flows
   // If parameter exists and is for payment failure, the 'continue' button reads 'Update your payment method'
   case object PaymentFailure extends Journey {
-    override def applies(returnUri: Uri): Boolean =
+    override def applies(returnUri: Url): Boolean =
       returnUri.query
         .param("INTCMP")
         .exists(paymentFailureCodes.contains)
@@ -25,24 +25,24 @@ object ReturnJourney {
 
   case object Subscriptions extends Journey {
     // e.g. /subscribe/paper/checkout or /subscribe/digital/checkout
-    override def applies(returnUri: Uri): Boolean =
-      returnUri.host.contains("support.theguardian.com") &&
-        returnUri.pathParts.head.part == "subscribe"
+    override def applies(returnUri: Url): Boolean =
+      returnUri.hostOption.contains("support.theguardian.com") &&
+        returnUri.path.parts.head == "subscribe"
 
     override val continueCopy: String = "Back to my subscription"
   }
 
   case object Contributions extends Journey {
     // e.g. /au/contribute or /uk/contribute
-    override def applies(returnUri: Uri): Boolean =
-      returnUri.host.contains("support.theguardian.com") &&
-        returnUri.pathParts.last.part == "contribute"
+    override def applies(returnUri: Url): Boolean =
+      returnUri.hostOption.contains("support.theguardian.com") &&
+        returnUri.path.parts.last == "contribute"
 
     override val continueCopy: String = "Back to my contribution"
   }
 
   case object Other extends Journey {
-    override def applies(returnUri: Uri): Boolean = true
+    override def applies(returnUri: Url): Boolean = true
   }
 
   private val all = List(PaymentFailure, Subscriptions, Contributions, Other)
@@ -50,7 +50,7 @@ object ReturnJourney {
   def apply(returnUrl: Option[String]): Journey =
     (for {
       url <- returnUrl
-      parsedUrl <- Try(Uri.parse(url)).toOption
+      parsedUrl <- Try(Url.parse(url)).toOption
       returnJourney <- all.find(_.applies(parsedUrl))
     } yield returnJourney).getOrElse(Other)
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -54,7 +54,7 @@ object Dependencies {
   val nScalaTime = "com.github.nscala-time" %% "nscala-time" % "2.18.0"
   val scalaTest = "org.scalatest" %% "scalatest" % "3.0.4" % Test
   val scalaTestPlus = "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.1" % Test
-  val scalaUri = "com.netaporter" %% "scala-uri" % "0.4.16"
+  val scalaUri = "io.lemonlabs" %% "scala-uri" % "2.2.2"
   val seleniumJava = "org.seleniumhq.selenium" % "selenium-java" % "2.44.0"
   val slf4jExt = "org.slf4j" % "slf4j-ext" % "1.7.25"
   val jerseyCore = "com.sun.jersey" % "jersey-core" % jerseyVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -54,7 +54,7 @@ object Dependencies {
   val nScalaTime = "com.github.nscala-time" %% "nscala-time" % "2.18.0"
   val scalaTest = "org.scalatest" %% "scalatest" % "3.0.4" % Test
   val scalaTestPlus = "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.1" % Test
-  val scalaUri = "io.lemonlabs" %% "scala-uri" % "2.2.2"
+  val scalaUri = "io.lemonlabs" %% "scala-uri" % "3.0.0"
   val seleniumJava = "org.seleniumhq.selenium" % "selenium-java" % "2.44.0"
   val slf4jExt = "org.slf4j" % "slf4j-ext" % "1.7.25"
   val jerseyCore = "com.sun.jersey" % "jersey-core" % jerseyVersion


### PR DESCRIPTION
## What does this change?
In advance of updating the scala version we want to update as many dependencies as possible to be compatible with both 2.12 and 2.13.

We tried updating frontend scala to 2.13. The first compilation error was from the scala-uri library. We can see that scala-uri is no longer maintained by netaporter, instead by [lemon labs](https://github.com/lemonlabsuk/scala-uri#03x-to-04x):
- [netaporter](https://mvnrepository.com/artifact/com.netaporter/scala-uri) - last version was 0.4.16
- [lemon-labs](https://mvnrepository.com/artifact/io.lemonlabs/scala-uri) - latest is 4.0.1

On scala 2.12 we tried using the latest version of scala-url (4.0.1) but that resulted in further conflicts (cats-core). We downgraded scala-uri until we reached a version that didn't result in any dependency conflicts. The highest version we could get working (without additional dependency updates) was 3.0.0 - we can see in the [version info](https://mvnrepository.com/artifact/io.lemonlabs/scala-uri) that 3.0.0 is compatible with both scala 2.12 and 2.13.

Suggest we revisit further updates to scala-uri version after upgrades to either the scala version or other dependencies.

Note that as part of the change to the library we had to carry out some updates:
- DiscussionApi: the type for params being added to a url is stricter in 3.0.0. This means we need to define all param values as `Option[String]`. We know we maintained the correct order of params because no test database files need updating as a result of our change.
- UrlHelpers: Url.parse takes an implicit `config` param, which we now define in the scope of `getReaderRevenueUrl`. We added a test to confirm that double quotes were still being parsed as expected.
- A number of unused imports were removed (html cleaners + youtube atom)

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

N/A

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
