### PR TITLE
More DCR blogs

### DIFF
--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -366,6 +366,6 @@ object LiveBlogController {
   }
 
   def checkIfSupported(blog: PageWithStoryPackage): Boolean = {
-    isDeadBlog(blog) && isSupportedTheme(blog) && isNotRecent(blog)
+    isDeadBlog(blog) && isSupportedTheme(blog)
   }
 }


### PR DESCRIPTION
## What does this change?
This removes the need for a blog to be older than 2 days before DCR can render it

## Why?
Because we want more liveblog traffic sent to DCR so that we can get better metrics. We measure various things between Frontend and DCR and these tests perform better with more data

## Why not remove the function completely?
Because we send the `recent` property to our logs and it's perhaps useful to keep this data for now