### PR TITLE
Update link text and destinations for single front door test v2

### DIFF
--- a/common/app/navigation/ReaderRevenueSite.scala
+++ b/common/app/navigation/ReaderRevenueSite.scala
@@ -29,6 +29,10 @@ object ReaderRevenueSite extends enumeratum.Enum[ReaderRevenueSite] {
     val url: String = s"${Configuration.id.supportUrl}/subscribe"
   }
 
+  case object SupportGuardianWeekly extends ReaderRevenueSite {
+    val url: String = s"${Configuration.id.supportUrl}/subscribe/weekly"
+  }
+
   case object SupportContribute extends ReaderRevenueSite {
     val url: String = s"${Configuration.id.supportUrl}/contribute"
   }

--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -64,7 +64,11 @@ object UrlHelpers {
   def readerRevenueLinks(implicit request: RequestHeader): List[NavLink] =
     List(
       NavLink("Make a contribution", getReaderRevenueUrl(SupportContribute, SideMenu)),
-      NavLink("Subscribe", getReaderRevenueUrl(SupportSubscribe, SideMenu), classList = Seq("js-subscribe")),
+      NavLink(
+        "Print subscriptions",
+        getReaderRevenueUrl(SupportGuardianWeekly, SideMenu),
+        classList = Seq("js-subscribe"),
+      ),
     )
 
   private val uriEncoder = UriConfig.default.copy(

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -87,7 +87,6 @@
                             </ul>
                         }
 
-                        @readerRevenueLinks(Edition(request).id.toLowerCase())
 
                     } else {
                         <div class="colophon__list">

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -1,3 +1,4 @@
+@import navigation.ReaderRevenueSite.SupportGuardianWeekly
 @()(implicit page: model.Page, request: RequestHeader)
 
 @import common.{LinkTo, Edition}
@@ -48,13 +49,10 @@
             <div class="new-header__top-bar hide-until-mobile">
                 @defining(Edition(request).id.toLowerCase()) { editionId =>
                 @if(!page.metadata.hasSlimHeader) {
-                <div class="top-bar__commercial-items js-supporter-cta is-hidden">
+                <div class="top-bar__commercial-items">
                     <span class="top-bar__item__seperator hide-until-desktop"></span>
-                    <a class="top-bar__item hide-until-desktop"
-                       data-link-name="nav2 : supporter-cta"
-                       data-edition="@{editionId}"
-                       href="@getReaderRevenueUrl(SupporterCTA, Header)">
-                        Subscriptions
+                    <a class="top-bar__item hide-until-desktop" data-link-name="nav2 : supporter-cta" data-edition="@{editionId}" href="@getReaderRevenueUrl(SupportGuardianWeekly, Header)">
+                        Print subscriptions
                     </a>
                 </div>
 


### PR DESCRIPTION
## What does this change?
To support the new product proposition work we are going to run an ABC test to measure the effect of the current contribute/subscribe split messaging vs a single 'support the guardian' call to action. This will be done in combination with bringing forward the existing ‘Supporter Newsletter’ & reduced support asks benefits to contributors on the support site.

This PR facilitates that by 
-  Hide Supporter Revenue links in the footer
- Update "Subscriptions" link in desktop navigation
- Update "Subscriptions" link in mobile navigation

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)
PR here: https://github.com/guardian/dotcom-rendering/pull/4218

## Screenshots
| Before      | After      |
|-------------|------------|
| ![before](https://user-images.githubusercontent.com/181371/149518422-8701f408-5742-4dfc-83d8-ff6493079107.png) | ![after](https://user-images.githubusercontent.com/181371/149518417-a3e61dff-022a-434e-b1f7-524549214335.png)|

## What is the value of this and can you measure success?
The value will be that we will gain insight into whether a single consistent support ask is better than two different asks and whether bringing forward benefits in the journey is beneficial.

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
