### PR TITLE
Measure scroll depth

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@guardian/atom-renderer": "1.2.2",
     "@guardian/automat-modules": "^0.3.8",
     "@guardian/braze-components": "^5.3.0",
-    "@guardian/commercial-core": "^3.0.0",
+    "@guardian/commercial-core": "^3.1.0",
     "@guardian/consent-management-platform": "^10.3.1",
     "@guardian/libs": "^3.6.1",
     "@guardian/shimport": "^1.0.2",

--- a/static/src/javascripts/bootstraps/standalone.commercial.ts
+++ b/static/src/javascripts/bootstraps/standalone.commercial.ts
@@ -25,6 +25,7 @@ import { removeDisabledSlots as closeDisabledSlots } from '../projects/commercia
 import { init as setAdTestCookie } from '../projects/commercial/modules/set-adtest-cookie';
 import { init as initStickyTopBanner } from '../projects/commercial/modules/sticky-top-banner';
 import { init as initThirdPartyTags } from '../projects/commercial/modules/third-party-tags';
+import { init as initTrackScrollDepth } from '../projects/commercial/modules/track-scroll-depth';
 import { commercialFeatures } from '../projects/common/modules/commercial/commercial-features';
 import type { Modules } from './types';
 
@@ -48,6 +49,7 @@ const commercialExtraModules: Modules = [
 	['cm-closeDisabledSlots', closeDisabledSlots],
 	['cm-comscore', initComscore],
 	['cm-ipsosmori', initIpsosMori],
+	['cm-trackScrollDepth', initTrackScrollDepth],
 ];
 
 if (!commercialFeatures.adFree) {

--- a/static/src/javascripts/projects/commercial/modules/track-scroll-depth.ts
+++ b/static/src/javascripts/projects/commercial/modules/track-scroll-depth.ts
@@ -1,0 +1,22 @@
+import { initTrackScrollDepth } from '@guardian/commercial-core';
+import { log } from '@guardian/libs';
+import { getEnhancedConsent } from 'common/modules/commercial/enhanced-consent';
+
+/**
+ * Initisalise scroll depth / velocity tracking if user has consented to relevant purposes.
+ * @returns Promise
+ */
+export const init = async (): Promise<void> => {
+	const state = await getEnhancedConsent();
+	if (
+		// Purpose 8 - Measure content performance
+		(state.framework == 'tcfv2' && state.tcfv2?.consents[8]) ||
+		state.canTarget
+	) {
+		initTrackScrollDepth();
+		log('commercial', 'tracking scroll depth');
+	} else {
+		log('commercial', 'No consent to track scroll depth');
+	}
+	return Promise.resolve();
+};

--- a/static/src/javascripts/projects/commercial/modules/track-scroll-depth.ts
+++ b/static/src/javascripts/projects/commercial/modules/track-scroll-depth.ts
@@ -18,5 +18,4 @@ export const init = async (): Promise<void> => {
 	} else {
 		log('commercial', 'No consent to track scroll depth');
 	}
-	return Promise.resolve();
 };

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -541,6 +541,11 @@
   "../lib/config.js",
   "../projects/common/modules/commercial/geo-utils.js"
  ],
+ "../projects/commercial/modules/track-scroll-depth.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../projects/common/modules/commercial/enhanced-consent.ts"
+ ],
  "../projects/common/modules/analytics/forceSendMetrics.ts": [],
  "../projects/common/modules/analytics/google.ts": [
   "../../../../node_modules/web-vitals/dist/modules/index.d.ts",
@@ -745,6 +750,7 @@
   "../projects/commercial/modules/set-adtest-cookie.ts",
   "../projects/commercial/modules/sticky-top-banner.js",
   "../projects/commercial/modules/third-party-tags.ts",
+  "../projects/commercial/modules/track-scroll-depth.ts",
   "../projects/common/modules/commercial/commercial-features.ts",
   "../projects/common/modules/commercial/user-features.ts",
   "types.ts"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1279,10 +1279,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-5.3.0.tgz#abe79666e5636ad2a0064cb2f227a64239231d2f"
   integrity sha512-3tljnI79cIR2e3RrnXMc0liSPAuFjezDZ50MCpXw9Y3KX8jD92AqWDAfjsC0XrpGj946ZB149Z/EarhrSRQ/hg==
 
-"@guardian/commercial-core@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-3.0.0.tgz#8b2040e89b4dd8e317563938552776da4ced5bee"
-  integrity sha512-wB3y5p6eyuuekEK27S4OZ8vnVRMJ1tcHwi1SwmfIsYNEZLwYJRv3UxsLlTEeUmH8YAnYNgIEzJ390GfQ8iaVeA==
+"@guardian/commercial-core@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-3.1.0.tgz#23b5927d9781b58d26b850b87f837886a3e008c6"
+  integrity sha512-CoX9lLZSju7KFN6JcF5hBtNqZfSYV+bnYZ4M4NKly5rO+y/ew/dKLuZrFqfIMxH2TcltQV6yoDwq3B3K8JgOtQ==
 
 "@guardian/consent-management-platform@^10.3.1":
   version "10.3.1"


### PR DESCRIPTION
## What does this change?
- Bumps version of commercial-core to 3.1.0
- calls `initTrackScrollDepth` to Initialise scroll depth tracking if the user has consented to [purpose 8](https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/#Purpose_8__Measure_content_performance), "measure content performance"

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?
As part of an investigation into lazy loading ads using scroll velocity rather than the distance between the viewport and slot alone, we'd like to gather data about user scroll depth / velocity.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
