### PR TITLE
Make panelTitle part of the rundown panel ID in showcase feeds

### DIFF
--- a/common/app/common/TrailsToShowcase.scala
+++ b/common/app/common/TrailsToShowcase.scala
@@ -263,9 +263,11 @@ object TrailsToShowcase {
       // Make a questionable inference of the panels publication and update times from it's articles and collection update time
       val updateTimes = articles.map(article => Some(article.updated)) :+ collectionLastUpdated
       val updated = updateTimes.flatten.sortBy(_.getMillis).lastOption.getOrElse(published)
+      // to make the rundown panel ID unique when its title is changed, we'll use the title as part of the ID
+      val rundownPanelId = id.concat(s"-${panelTitle.replaceAll(" ","").toLowerCase}")
 
       RundownPanel(
-        guid = id,
+        guid = rundownPanelId,
         panelTitle = panelTitle,
         articleGroup = ArticleGroup(role = Rundown, articles = articles),
         published = published,

--- a/common/app/common/TrailsToShowcase.scala
+++ b/common/app/common/TrailsToShowcase.scala
@@ -263,8 +263,8 @@ object TrailsToShowcase {
       // Make a questionable inference of the panels publication and update times from it's articles and collection update time
       val updateTimes = articles.map(article => Some(article.updated)) :+ collectionLastUpdated
       val updated = updateTimes.flatten.sortBy(_.getMillis).lastOption.getOrElse(published)
-      // to make the rundown panel ID unique when its title is changed, we'll use the title as part of the ID
-      val rundownPanelId = id.concat(s"-${panelTitle.replaceAll(" ","").toLowerCase}")
+      // to make the rundown panel ID unique when its title is changed, we'll use a hash of the title as part of the ID
+      val rundownPanelId = id.concat(s"-${panelTitle.replaceAll(" ","").toLowerCase.hashCode}")
 
       RundownPanel(
         guid = rundownPanelId,

--- a/common/app/common/TrailsToShowcase.scala
+++ b/common/app/common/TrailsToShowcase.scala
@@ -264,7 +264,7 @@ object TrailsToShowcase {
       val updateTimes = articles.map(article => Some(article.updated)) :+ collectionLastUpdated
       val updated = updateTimes.flatten.sortBy(_.getMillis).lastOption.getOrElse(published)
       // to make the rundown panel ID unique when its title is changed, we'll use a hash of the title as part of the ID
-      val rundownPanelId = id.concat(s"-${panelTitle.replaceAll(" ","").toLowerCase.hashCode}")
+      val rundownPanelId = id.concat(s"-${panelTitle.replaceAll(" ", "").toLowerCase.hashCode}")
 
       RundownPanel(
         guid = rundownPanelId,

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -194,8 +194,8 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
 
     val rundownPanel = rundownPanels.head
     val rundownPanelGuid = (rundownPanel \ "guid").head
-    val rundownPanelHash = "rundown-container-id".hashCode
-    rundownPanelGuid.text should be(s"${"rundown-container-id-".concat(rundownPanelHash)}")
+
+    rundownPanelGuid.text should be(s"rundown-container-id--1679333355")
     rundownPanelGuid.attribute("isPermaLink").get.head.text should be("false")
 
     (rundownPanel \ "panel_title").filter(_.prefix == "g").head.text should be("My rundown panel title")
@@ -707,7 +707,8 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
       .get
 
     rundownPanel.`type` should be("RUNDOWN")
-    rundownPanel.guid should be("rundown-container-id") // Guid for rundown item is the container id.
+    // Guid for rundown item is the container id and the hash of the title
+    rundownPanel.guid should be("rundown-container-id--180248192")
     rundownPanel.panelTitle should be("My panel title")
 
     rundownPanel.articleGroup.role shouldBe ("RUNDOWN")

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -194,7 +194,8 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
 
     val rundownPanel = rundownPanels.head
     val rundownPanelGuid = (rundownPanel \ "guid").head
-    rundownPanelGuid.text should be("rundown-container-id")
+    val rundownPanelHash = "rundown-container-id".hashCode
+    rundownPanelGuid.text should be(s"${"rundown-container-id-".concat(rundownPanelHash)}")
     rundownPanelGuid.attribute("isPermaLink").get.head.text should be("false")
 
     (rundownPanel \ "panel_title").filter(_.prefix == "g").head.text should be("My rundown panel title")


### PR DESCRIPTION
## What does this change?
Whenever we change the title of the showcase rundown panel, we should generate a fresh `guid` for it. We can do that by constructing the `guid` from a UUID and the hash of the panel's title.

Note that here we're simply using the entire title prefixed with a hyphen, whitespace removed and converted to lower case, and generating the `hashCode` of that.
 
## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)
- [x] I don't think so (the output is XML - see example below)
 
## Screenshots

Before;
`<guid isPermaLink="false">e2a37110-c46e-466f-8636-565e90ff346c</guid>`

After;
`<guid isPermaLink="false">e2a37110-c46e-466f-8636-565e90ff346c--2130604851</guid>`

## What is the value of this and can you measure success?

This aligns us with the published terms of service and ensures performant responses for showcase consumers

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [x] Other (Google Showcase)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
- [x] N/A

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
