### PR TITLE
Remove dead blog check for liveblog rendering in DCR test

### DIFF
--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -366,6 +366,6 @@ object LiveBlogController {
   }
 
   def checkIfSupported(blog: PageWithStoryPackage): Boolean = {
-    isDeadBlog(blog) && isSupportedTheme(blog)
+    isSupportedTheme(blog)
   }
 }

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -19,7 +19,7 @@ object LiveblogRendering
       description = "Use DCR for liveblogs",
       owners = Seq(Owner.withGithub("shtukas")),
       sellByDate = LocalDate.of(2022, 6, 2),
-      participationGroup = Perc10A,
+      participationGroup = Perc1A,
     )
 
 object StickyVideos


### PR DESCRIPTION
## What does this change?
* Removes deadblog check from `LiveBlogController.checkIfSupported`
* Drop liveblog test to 1%

This is more an experiment to see if I understand how we release stuff and be able to chat to the data folk confidently. 

[We set the value on `window.guardian.page.config.dcrCouldRender`](https://github.com/guardian/frontend/blob/main/article/app/pages/StoryHtmlPage.scala#L34-L42)

[This is read from `getExperienceValue`](https://github.com/guardian/frontend/blob/main/common/app/views/fragments/analytics/google.scala.html#L49-L56)

[Which is then sent to GA in `dimension43` as `dcrCouldRender`](https://github.com/guardian/frontend/blob/main/common/app/views/fragments/analytics/google.scala.html#L124).

[We add it to ophan via `experiences.dcrCouldRender`](https://github.com/guardian/frontend/blob/main/static/src/javascripts/lib/capture-ophan-info.js#L43-L45).

[We use it in content targetting via `eligibleForDCR`](https://github.com/guardian/frontend/blob/main/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.ts#L286-L288). I can't see where this is used.


Fixes https://github.com/guardian/dotcom-rendering/issues/4179