### PR TITLE
remove insert tracking event and use data-component for pinned post

### DIFF
--- a/article/app/views/liveblog/pinnedBlock.scala.html
+++ b/article/app/views/liveblog/pinnedBlock.scala.html
@@ -6,7 +6,7 @@
 @*
 * This template is to wrap pinned posts
 *@
-<div id="pinned-block" class="pinned-block" data-block-id="@block.id">
+<div id="pinned-block" class="pinned-block" data-block-id="@block.id" data-component="pinned-post">
     <input id="pinned-block-button" class="pinned-block__button" type="checkbox" aria-controls="pinned-block" />
     <label for="pinned-block-button" class="pinned-block__label pinned-block__label--collapsed pinned-block__label--expanded">
         @fragments.inlineSvg("plus", "icon", List("pinned-block__label-icon--expand"))

--- a/static/src/javascripts/bootstraps/enhanced/liveblog.js
+++ b/static/src/javascripts/bootstraps/enhanced/liveblog.js
@@ -108,9 +108,6 @@ const trackPinnedPostDuration = (pinnedBlock) => {
 const initTracking = () => {
 	const pinnedBlock = document.getElementById('pinned-block');
 	if (pinnedBlock) {
-		const pinnedBlockId = cleanId(pinnedBlock.dataset.blockId);
-		ophan.record(componentEvent(pinnedBlockId, 'INSERT'));
-
         trackPinnedPostDuration(pinnedBlock);
 	}
 };


### PR DESCRIPTION
## What does this change?
This PR follows a change that was done for pinned-post tracking in DCR in https://github.com/guardian/dotcom-rendering/pull/4242
It is removing the `INSERT` tracking event for pinned post. This event was used to track the page views that had a pinned post. 

Instead, data-component is used on the pinned post component. This attribute will be detected by the `tracker-js` script and on every page view one request is made to ophan for all the components in the page that have `data-component` attribute. 

The main advantage is that we don't need to make individual call to ophan to track the page views containing pinned-post. Instead we can just add this information to an existing call that's supposed to send all `renderedComponents` to ophan as a list in one call.  something like this:
![image](https://user-images.githubusercontent.com/15894063/158399754-8d42c3ee-2ed5-4bf7-866c-8d23a9efa74b.png)


## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
