### PR TITLE
Pre-scala 2.13: inline Box

### DIFF
--- a/admin/app/dfp/AdvertiserAgent.scala
+++ b/admin/app/dfp/AdvertiserAgent.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.gu.Box
+import common.Box
 import common.dfp.GuAdvertiser
 import concurrent.BlockingOperations
 

--- a/admin/app/dfp/CreativeTemplateAgent.scala
+++ b/admin/app/dfp/CreativeTemplateAgent.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.gu.Box
+import common.Box
 import common.dfp.GuCreativeTemplate
 import concurrent.BlockingOperations
 

--- a/admin/app/dfp/DataAgent.scala
+++ b/admin/app/dfp/DataAgent.scala
@@ -1,7 +1,6 @@
 package dfp
 
-import com.gu.Box
-import common.GuLogging
+import common.{Box, GuLogging}
 import concurrent.BlockingOperations
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/admin/app/dfp/OrderAgent.scala
+++ b/admin/app/dfp/OrderAgent.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.gu.Box
+import common.Box
 import common.dfp.GuOrder
 import concurrent.BlockingOperations
 

--- a/admin/app/jobs/CommercialDfpReporting.scala
+++ b/admin/app/jobs/CommercialDfpReporting.scala
@@ -7,8 +7,7 @@ import com.google.api.ads.admanager.axis.v202108.Column.{AD_SERVER_IMPRESSIONS, 
 import com.google.api.ads.admanager.axis.v202108.DateRangeType.CUSTOM_DATE
 import com.google.api.ads.admanager.axis.v202108.Dimension.{CUSTOM_CRITERIA, DATE}
 import com.google.api.ads.admanager.axis.v202108._
-import com.gu.Box
-import common.{AkkaAsync, JobScheduler, GuLogging}
+import common.{AkkaAsync, Box, JobScheduler, GuLogging}
 import dfp.DfpApi
 import play.api.inject.ApplicationLifecycle
 

--- a/admin/app/model/abtests/AbTests.scala
+++ b/admin/app/model/abtests/AbTests.scala
@@ -6,7 +6,7 @@ import org.joda.time.DateTime
 
 import scala.concurrent.{ExecutionContext, Future}
 import awswrappers.cloudwatch._
-import com.gu.Box
+import common.Box
 
 object AbTests {
   private val abTests = Box[Map[String, Seq[String]]](Map.empty)

--- a/admin/app/tools/AssetMetrics.scala
+++ b/admin/app/tools/AssetMetrics.scala
@@ -2,8 +2,7 @@ package tools
 
 import awswrappers.cloudwatch._
 import com.amazonaws.services.cloudwatch.model._
-import com.gu.Box
-import common.GuLogging
+import common.{Box, GuLogging}
 import org.joda.time.DateTime
 import tools.CloudWatch._
 

--- a/admin/app/tools/LoadBalancer.scala
+++ b/admin/app/tools/LoadBalancer.scala
@@ -1,8 +1,7 @@
 package tools
 
-import common.GuLogging
+import common.{Box, GuLogging}
 import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancingClient
-import com.gu.Box
 
 import scala.collection.JavaConverters._
 

--- a/applications/app/jobs/SitemapLifecycle.scala
+++ b/applications/app/jobs/SitemapLifecycle.scala
@@ -1,7 +1,6 @@
 package jobs
 
 import app.LifecycleComponent
-import com.gu.Box
 import common._
 import contentapi.ContentApiClient
 import services.{NewsSiteMap, VideoSiteMap}

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,6 @@ val common = library("common")
   .settings(
     Test / javaOptions += "-Dconfig.file=common/conf/test.conf",
     libraryDependencies ++= Seq(
-      guBox,
       apacheCommonsLang,
       awsCore,
       awsCloudwatch,

--- a/commercial/app/model/capi/CapiAgent.scala
+++ b/commercial/app/model/capi/CapiAgent.scala
@@ -1,7 +1,6 @@
 package commercial.model.capi
 
-import com.gu.Box
-import common.GuLogging
+import common.{Box, GuLogging}
 import contentapi.ContentApiClient
 import model.ContentType
 

--- a/commercial/app/model/merchandise/MerchandiseAgent.scala
+++ b/commercial/app/model/merchandise/MerchandiseAgent.scala
@@ -1,8 +1,7 @@
 package commercial.model.merchandise
 
-import com.gu.Box
 import commercial.model.Segment
-import common.GuLogging
+import common.{Box, GuLogging}
 
 import scala.concurrent.Future
 import scala.util.Random

--- a/commercial/app/model/merchandise/books/BookFinder.scala
+++ b/commercial/app/model/merchandise/books/BookFinder.scala
@@ -3,10 +3,9 @@ package commercial.model.merchandise.books
 import akka.actor.ActorSystem
 import akka.pattern.CircuitBreaker
 import akka.util.Timeout
-import com.gu.Box
 import commercial.model.feeds.{FeedParseException, FeedReadException, FeedReader, FeedRequest}
 import commercial.model.merchandise.Book
-import common.GuLogging
+import common.{Box, GuLogging}
 import conf.Configuration
 import conf.switches.Switches.BookLookupSwitch
 import play.api.libs.json._

--- a/commercial/app/model/merchandise/events/LiveEventAgent.scala
+++ b/commercial/app/model/merchandise/events/LiveEventAgent.scala
@@ -2,9 +2,8 @@ package commercial.model.merchandise.events
 
 import java.lang.System._
 
-import com.gu.Box
 import commercial.model.feeds._
-import common.GuLogging
+import common.{Box, GuLogging}
 import conf.Configuration
 import commercial.model.merchandise.LiveEvent
 import play.api.libs.json.JsValue

--- a/commercial/app/model/merchandise/jobs/Industries.scala
+++ b/commercial/app/model/merchandise/jobs/Industries.scala
@@ -1,6 +1,6 @@
 package commercial.model.merchandise.jobs
 
-import com.gu.Box
+import common.Box
 import commercial.model.capi.Lookup
 import contentapi.ContentApiClient
 

--- a/common/app/commercial/targeting/CampaignAgent.scala
+++ b/common/app/commercial/targeting/CampaignAgent.scala
@@ -1,6 +1,5 @@
 package commercial.targeting
 
-import com.gu.Box
 import common._
 import com.gu.targeting.client.{Campaign, CampaignCache}
 import conf.Configuration

--- a/common/app/common/Assets/DiscussionAssets.scala
+++ b/common/app/common/Assets/DiscussionAssets.scala
@@ -1,8 +1,7 @@
 package common.Assets
 
 import app.LifecycleComponent
-import com.gu.Box
-import common.{GuLogging, GuardianConfiguration, JobScheduler}
+import common.{Box, GuLogging, GuardianConfiguration, JobScheduler}
 import conf.switches.Switches
 import play.api.libs.ws.{WSClient, WSResponse}
 

--- a/common/app/common/AutoRefresh.scala
+++ b/common/app/common/AutoRefresh.scala
@@ -5,7 +5,6 @@ import akka.actor.{ActorSystem, Cancellable}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
-import com.gu.Box
 
 /** Simple class for repeatedly updating a value on a schedule */
 abstract class AutoRefresh[A](initialDelay: FiniteDuration, interval: FiniteDuration) extends GuLogging {

--- a/common/app/common/Box.scala
+++ b/common/app/common/Box.scala
@@ -1,0 +1,46 @@
+package common
+
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.concurrent.Future
+import scala.util.{Try, Success, Failure}
+
+abstract class Box[T] {
+  def get(): T
+  def apply(): T
+
+  def send(t: T): Unit
+  def send(f: T => T): Unit
+
+  def alter(t: T): Future[T]
+  def alter(t: T => T): Future[T]
+  def modify(f: T => Try[T]): Future[T]
+
+  def map[A](f: T => A): Box[A]
+  def flatMap[A](f: T => Box[A]): Box[A]
+}
+
+object Box {
+  def apply[T](initialValue: T): Box[T] = new AtomicRefBox[T](initialValue)
+}
+
+private class AtomicRefBox[T](t: T) extends Box[T] {
+  private val ref: AtomicReference[T] = new AtomicReference[T](t)
+
+  def apply(): T = ref.get()
+  def get(): T = ref.get()
+
+  def send(t: T): Unit = ref.set(t)
+  def send(f: T => T): Unit = ref.updateAndGet(t => f(t))
+
+  def alter(t: T): Future[T] = Future.successful(ref.updateAndGet(_ => t))
+  def alter(f: T => T): Future[T] = Future.successful(ref.updateAndGet(_ => f(t)))
+  def modify(f: T => Try[T]): Future[T] =
+    f(t) match {
+      case Success(v) => Future.successful(ref.updateAndGet(_ => v))
+      case Failure(e) => Future.failed(e)
+    }
+
+  def map[A](f: T => A): Box[A] = new AtomicRefBox[A](f(get()))
+  def flatMap[A](f: T => Box[A]): Box[A] = f(get())
+}

--- a/common/app/common/Box.scala
+++ b/common/app/common/Box.scala
@@ -20,7 +20,13 @@ object Box {
   def apply[T](initialValue: T): Box[T] = new AtomicRefBox[T](initialValue)
 }
 
+// Note the omission of modify, map and flatMap
+// (https://github.com/guardian/box/blob/master/src/main/scala/com/gu/Box.scala#L38).
+// These functions aren't used in frontend and the modify function had not been
+// implemented correctly in the Box library.
 private class AtomicRefBox[T](initialValue: T) extends Box[T] {
+  // Note the name of this initial value. This has a different name those in
+  // the methods below to ensure the correct scope of named variables.
   private val ref: AtomicReference[T] = new AtomicReference[T](initialValue)
 
   def apply(): T = ref.get()

--- a/common/app/common/Box.scala
+++ b/common/app/common/Box.scala
@@ -14,18 +14,14 @@ abstract class Box[T] {
 
   def alter(t: T): Future[T]
   def alter(t: T => T): Future[T]
-  def modify(f: T => Try[T]): Future[T]
-
-  def map[A](f: T => A): Box[A]
-  def flatMap[A](f: T => Box[A]): Box[A]
 }
 
 object Box {
   def apply[T](initialValue: T): Box[T] = new AtomicRefBox[T](initialValue)
 }
 
-private class AtomicRefBox[T](t: T) extends Box[T] {
-  private val ref: AtomicReference[T] = new AtomicReference[T](t)
+private class AtomicRefBox[T](initialValue: T) extends Box[T] {
+  private val ref: AtomicReference[T] = new AtomicReference[T](initialValue)
 
   def apply(): T = ref.get()
   def get(): T = ref.get()
@@ -34,13 +30,5 @@ private class AtomicRefBox[T](t: T) extends Box[T] {
   def send(f: T => T): Unit = ref.updateAndGet(t => f(t))
 
   def alter(t: T): Future[T] = Future.successful(ref.updateAndGet(_ => t))
-  def alter(f: T => T): Future[T] = Future.successful(ref.updateAndGet(_ => f(t)))
-  def modify(f: T => Try[T]): Future[T] =
-    f(t) match {
-      case Success(v) => Future.successful(ref.updateAndGet(_ => v))
-      case Failure(e) => Future.failed(e)
-    }
-
-  def map[A](f: T => A): Box[A] = new AtomicRefBox[A](f(get()))
-  def flatMap[A](f: T => Box[A]): Box[A] = f(get())
+  def alter(f: T => T): Future[T] = Future.successful(ref.updateAndGet(t => f(t)))
 }

--- a/common/app/common/dfp/DfpAgent.scala
+++ b/common/app/common/dfp/DfpAgent.scala
@@ -1,6 +1,6 @@
 package common.dfp
 
-import com.gu.Box
+import common.Box
 import conf.Configuration.commercial._
 import conf.Configuration.environment
 import play.api.libs.json.Json

--- a/common/app/common/jobs.scala
+++ b/common/app/common/jobs.scala
@@ -8,7 +8,6 @@ import play.api.Mode.Test
 import scala.collection.mutable
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
-import com.gu.Box
 import scala.util.{Failure, Success}
 
 object JobsState {

--- a/common/app/conf/HealthCheck.scala
+++ b/common/app/conf/HealthCheck.scala
@@ -5,7 +5,6 @@ import common._
 import org.joda.time.DateTime
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc._
-import com.gu.Box
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.util.control.NonFatal

--- a/common/app/conf/switches/Switches.scala
+++ b/common/app/conf/switches/Switches.scala
@@ -1,7 +1,6 @@
 package conf.switches
 
 import java.util.concurrent.TimeoutException
-import com.gu.Box
 import common._
 import java.time.{LocalDate, ZoneId}
 import java.time.Duration

--- a/common/app/contentapi/SectionsLookUp.scala
+++ b/common/app/contentapi/SectionsLookUp.scala
@@ -1,8 +1,7 @@
 package contentapi
 
-import com.gu.Box
 import com.gu.contentapi.client.model.v1.Section
-import common.GuLogging
+import common.{Box, GuLogging}
 
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success}

--- a/common/app/metrics/FrontendMetrics.scala
+++ b/common/app/metrics/FrontendMetrics.scala
@@ -159,7 +159,7 @@ final case class SamplerMetric(override val name: String, override val metricUni
   }
 
   def recordSample(sampleValue: Double, sampleTime: DateTime): Future[List[SampledDataPoint]] =
-    dataPoints.alter(SampledDataPoint(sampleValue, sampleTime) :: _)
+    dataPoints.alter(SampledDataPoint(sampleValue, sampleTime) :: dataPoints.get())
 
   override def isEmpty: Boolean = dataPoints.get().isEmpty
 }

--- a/common/app/metrics/FrontendMetrics.scala
+++ b/common/app/metrics/FrontendMetrics.scala
@@ -127,7 +127,7 @@ final case class DurationMetric(override val name: String, override val metricUn
   }
 
   // Public for tests.
-  def record(dataPoint: DurationDataPoint): Unit = dataPoints.alter(dataPoint :: _)
+  def record(dataPoint: DurationDataPoint): Unit = dataPoints.alter(dataPoint :: dataPoints.get())
 
   def recordDuration(timeInMillis: Double): Unit = record(DurationDataPoint(timeInMillis, Option(DateTime.now)))
 

--- a/common/app/metrics/FrontendMetrics.scala
+++ b/common/app/metrics/FrontendMetrics.scala
@@ -127,7 +127,7 @@ final case class DurationMetric(override val name: String, override val metricUn
   }
 
   // Public for tests.
-  def record(dataPoint: DurationDataPoint): Unit = dataPoints.alter(dataPoint :: dataPoints.get())
+  def record(dataPoint: DurationDataPoint): Unit = dataPoints.alter(dataPoint :: _)
 
   def recordDuration(timeInMillis: Double): Unit = record(DurationDataPoint(timeInMillis, Option(DateTime.now)))
 
@@ -159,7 +159,7 @@ final case class SamplerMetric(override val name: String, override val metricUni
   }
 
   def recordSample(sampleValue: Double, sampleTime: DateTime): Future[List[SampledDataPoint]] =
-    dataPoints.alter(SampledDataPoint(sampleValue, sampleTime) :: dataPoints.get())
+    dataPoints.alter(SampledDataPoint(sampleValue, sampleTime) :: _)
 
   override def isEmpty: Boolean = dataPoints.get().isEmpty
 }

--- a/common/app/metrics/FrontendMetrics.scala
+++ b/common/app/metrics/FrontendMetrics.scala
@@ -2,9 +2,8 @@ package metrics
 
 import java.util.concurrent.atomic.AtomicLong
 
-import com.gu.Box
 import com.amazonaws.services.cloudwatch.model.StandardUnit
-import common.{FaciaPressMetrics, StopWatch}
+import common.{Box, StopWatch}
 import model.diagnostics.CloudWatch
 import org.joda.time.DateTime
 import scala.concurrent.Future

--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -2,7 +2,6 @@ package services
 
 import akka.util.Timeout
 import app.LifecycleComponent
-import com.gu.Box
 import com.gu.facia.api.models.{Front, _}
 import com.gu.facia.client.ApiClient
 import com.gu.facia.client.models.{ConfigJson, FrontJson}

--- a/common/app/services/newsletters/NewsletterSignupAgent.scala
+++ b/common/app/services/newsletters/NewsletterSignupAgent.scala
@@ -1,7 +1,6 @@
 package services.newsletters
 
-import com.gu.Box
-import common.GuLogging
+import common.{Box, GuLogging}
 import services.newsletters.GroupedNewslettersResponse.GroupedNewslettersResponse
 
 import scala.concurrent.ExecutionContext

--- a/common/app/services/ophan/SurgingContentAgent.scala
+++ b/common/app/services/ophan/SurgingContentAgent.scala
@@ -1,7 +1,6 @@
 package services.ophan
 
 import app.LifecycleComponent
-import com.gu.Box
 import com.gu.commercial.display.SurgeLookupService
 import common._
 import org.joda.time.DateTime

--- a/common/test/common/BoxTest.scala
+++ b/common/test/common/BoxTest.scala
@@ -1,0 +1,16 @@
+package common
+
+import org.scalatest._
+
+class BoxSpec extends FlatSpec with Matchers {
+  "Box" should "return the initial value" in {
+    val box = Box(5)
+    box() should be(5)
+  }
+
+  "Box" should "return the updated" in {
+    val box = Box(5)
+    box.send(2)
+    box() should be(2)
+  }
+}

--- a/common/test/metrics/DurationMetricTest.scala
+++ b/common/test/metrics/DurationMetricTest.scala
@@ -2,6 +2,7 @@ package metrics
 
 import com.amazonaws.services.cloudwatch.model.StandardUnit
 import org.scalatest.{FlatSpec, Matchers}
+import org.joda.time.DateTime
 
 class DurationMetricTest extends FlatSpec with Matchers {
 
@@ -43,5 +44,45 @@ class DurationMetricTest extends FlatSpec with Matchers {
     val dataPoints = durationMetric.getAndResetDataPoints
     dataPoints.length should be(7)
     dataPoints.splitAt(4)._1 should be(allMetrics)
+  }
+
+  "SamplerMetric" should "start off empty" in {
+    val samplerMetric: SamplerMetric = SamplerMetric("TestMetric", StandardUnit.Count)
+
+    samplerMetric.getAndResetDataPoints should be(List())
+  }
+
+  it should "record some samples" in {
+    val samplerMetric: SamplerMetric = SamplerMetric("TestMetric", StandardUnit.Count)
+
+    samplerMetric.recordSample(1000, DateTime.now())
+    samplerMetric.recordSample(1000, DateTime.now())
+    samplerMetric.recordSample(1000, DateTime.now())
+
+    val storedDatapoints = samplerMetric.getAndResetDataPoints
+
+    storedDatapoints.length should be(3)
+    storedDatapoints.forall(_.value == 1000) should be(true)
+
+    samplerMetric.getAndResetDataPoints.length should be(0)
+  }
+
+  it should "add recorded samples to the head of the list" in {
+    val samplerMetric: SamplerMetric = SamplerMetric("TestMetric", StandardUnit.Count)
+
+    val sampleOne = SampledDataPoint(10.00, DateTime.now())
+    val sampleTwo = SampledDataPoint(11.00, DateTime.now())
+    val sampleThree = SampledDataPoint(12.00, DateTime.now())
+    val sampleFour = SampledDataPoint(13.00, DateTime.now())
+    val allSamples = List(sampleOne, sampleTwo, sampleThree, sampleFour)
+
+    samplerMetric.recordSample(10.00, DateTime.now())
+    samplerMetric.recordSample(10.00, DateTime.now())
+    samplerMetric.recordSample(10.00, DateTime.now())
+    allSamples.map((sample) => samplerMetric.recordSample(sample.value, sample.sampleTime))
+
+    val samples = samplerMetric.getAndResetDataPoints
+    samples.length should be(7)
+    samples.splitAt(4)._1 should be(allSamples.reverse)
   }
 }

--- a/identity/app/jobs/TorExitNodeList.scala
+++ b/identity/app/jobs/TorExitNodeList.scala
@@ -1,11 +1,9 @@
 package jobs
 
-import common.GuLogging
+import common.{Box, GuLogging}
 
 import scala.collection.JavaConverters._
 import java.net.{InetAddress, URL}
-
-import com.gu.Box
 
 import scala.io.Source
 

--- a/onward/app/feed/MostPopularAgent.scala
+++ b/onward/app/feed/MostPopularAgent.scala
@@ -1,6 +1,5 @@
 package feed
 
-import com.gu.Box
 import conf.Configuration
 import contentapi.ContentApiClient
 import com.gu.contentapi.client.model.v1.{Content, ContentFields, ContentType}

--- a/onward/app/feed/MostReadAgent.scala
+++ b/onward/app/feed/MostReadAgent.scala
@@ -1,6 +1,5 @@
 package feed
 
-import com.gu.Box
 import common._
 import services.OphanApi
 

--- a/onward/app/feed/MostViewedAudioAgent.scala
+++ b/onward/app/feed/MostViewedAudioAgent.scala
@@ -1,6 +1,5 @@
 package feed
 
-import com.gu.Box
 import contentapi.ContentApiClient
 import common._
 import model.RelatedContentItem

--- a/onward/app/feed/MostViewedGalleryAgent.scala
+++ b/onward/app/feed/MostViewedGalleryAgent.scala
@@ -1,6 +1,5 @@
 package feed
 
-import com.gu.Box
 import contentapi.ContentApiClient
 import common._
 import model.RelatedContentItem

--- a/onward/app/feed/MostViewedVideoAgent.scala
+++ b/onward/app/feed/MostViewedVideoAgent.scala
@@ -1,6 +1,5 @@
 package feed
 
-import com.gu.Box
 import com.gu.contentapi.client
 import common._
 import common.editions.Uk

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,6 @@ object Dependencies {
   val jerseyVersion = "1.19.4"
   val playJsonVersion = "2.6.3"
   val playJsonExtensionsVersion = "0.42.0"
-  val guBox = "com.gu" %% "box" % "0.1.0"
   val apacheCommonsLang = "org.apache.commons" % "commons-lang3" % "3.11"
   val awsCore = "com.amazonaws" % "aws-java-sdk-core" % awsVersion
   val awsCloudwatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsVersion

--- a/sport/app/cricket/jobs/CricketStatsJob.scala
+++ b/sport/app/cricket/jobs/CricketStatsJob.scala
@@ -1,7 +1,6 @@
 package jobs
 
-import com.gu.Box
-import common.GuLogging
+import common.{Box, GuLogging}
 import common.Chronos
 import conf.cricketPa.{CricketFeedException, CricketTeam, CricketTeams, PaFeed}
 import cricketModel.Match

--- a/sport/app/football/feed/agent.scala
+++ b/sport/app/football/feed/agent.scala
@@ -1,6 +1,5 @@
 package feed
 
-import com.gu.Box
 import pa._
 import conf.FootballClient
 import common._

--- a/sport/app/football/model/TeamMap.scala
+++ b/sport/app/football/model/TeamMap.scala
@@ -3,7 +3,6 @@ package model
 import common._
 import contentapi.ContentApiClient
 import _root_.feed.Competitions
-import com.gu.Box
 import implicits.Football
 import org.joda.time.{DateTime, Days}
 import pa._

--- a/sport/app/rugby/jobs/RugbyStatsJob.scala
+++ b/sport/app/rugby/jobs/RugbyStatsJob.scala
@@ -1,7 +1,6 @@
 package rugby.jobs
 
-import com.gu.Box
-import common.GuLogging
+import common.{Box, GuLogging}
 import org.joda.time.format.{DateTimeFormat, DateTimeFormatter}
 import rugby.feed.{Event, MatchNavigation, PARugbyAPIException, RugbyFeed}
 import rugby.model._


### PR DESCRIPTION
## What does this change?
In advance of updating the scala version we want to update as many dependencies as possible to be compatible with both 2.12 and 2.13.

We tried updating frontend scala to 2.13. One of the compilation errors was from com.gu.box. Given [box](https://github.com/guardian/box) is just a very thin wrapper of `AtomicReference`, and only used by a handful of repos, it's been suggested to inline it. 

In this PR we remove Box as a dependency and define it in `common`. Most of the changes relate to updated imports.

One specific error caused me a bit of confusion:
- Inlining Box resulted in a failing test in [DurationMetricTest](https://github.com/guardian/frontend/blob/dlawes/update-guBox/common/test/metrics/DurationMetricTest.scala#L45) --> the test failed because the list length was not expected (ref: https://teamcity.gutools.co.uk/viewLog.html?buildId=752344&buildTypeId=dotcom_master&tab=buildLog&branch_dotcom=dlawes%2Fupdate-guBox&_focus=15032)
- I could see that [FrontendMetrics](https://github.com/guardian/frontend/blob/dlawes/update-guBox/common/app/metrics/FrontendMetrics.scala#L130) was still attempting to add new data points to the head of the list, but the existing data points could not be resolved (`unbound placeholder parameter error`).
- I noticed an equivalent function in the same file: https://github.com/guardian/frontend/blob/dlawes/update-guBox/common/app/metrics/FrontendMetrics.scala#L162. This was not covered by tests; I added tests and saw it was also failing.

^^ to resolve the failing tests we had to update the methods defined in the Box class. There was actually an error in the library itself (around variable names and scopes), which meant that we were only ever altering or modifying the original value for our ref, never the latest. Now that these methods in the local Box class are updated (or removed, if not being used), our tests pass.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

N/A

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
