### PR TITLE
Set panel title as g:panel tag content when available

### DIFF
--- a/common/app/common/ShowcaseRSSModules.scala
+++ b/common/app/common/ShowcaseRSSModules.scala
@@ -46,7 +46,7 @@ object RssAtomModule {
 
 case class GPanel(
     `type`: String,
-    content: Option[String],
+    content: String,
 )
 
 trait GModule extends com.sun.syndication.feed.module.Module with Serializable with Cloneable {
@@ -180,7 +180,7 @@ class GModuleGenerator extends ModuleGenerator {
         gModule.getPanel.foreach { panel =>
           val panelElement = new org.jdom.Element("panel", NS)
           panelElement.setAttribute(new Attribute("type", panel.`type`))
-          panelElement.addContent(panel.content.getOrElse(""))
+          panelElement.addContent(panel.content)
           element.addContent(panelElement)
         }
         gModule.getPanelTitle.foreach { panelTitle =>

--- a/common/app/common/ShowcaseRSSModules.scala
+++ b/common/app/common/ShowcaseRSSModules.scala
@@ -44,12 +44,17 @@ object RssAtomModule {
   val URI = "http://www.w3.org/2005/Atom"
 }
 
+case class GPanel(
+  `type`: String,
+  content: Option[String]
+)
+
 trait GModule extends com.sun.syndication.feed.module.Module with Serializable with Cloneable {
   override def getUri: String = GModule.URI
 
-  def getPanel: Option[String]
+  def getPanel: Option[GPanel]
 
-  def setPanel(panel: Option[String])
+  def setPanel(panel: Option[GPanel])
 
   def getPanelTitle: Option[String]
 
@@ -69,15 +74,15 @@ trait GModule extends com.sun.syndication.feed.module.Module with Serializable w
 }
 
 class GModuleImpl() extends GModule {
-  private var panel: Option[String] = None
+  private var panel: Option[GPanel] = None
   private var panelTitle: Option[String] = None
   private var overline: Option[String] = None
   private var articleGroup: Option[GArticleGroup] = None
   private var bulletList: Option[GBulletList] = None
 
-  override def getPanel: Option[String] = panel
+  override def getPanel: Option[GPanel] = panel
 
-  override def setPanel(panel: Option[String]): Unit = this.panel = panel
+  override def setPanel(panel: Option[GPanel]): Unit = this.panel = panel
 
   override def getPanelTitle: Option[String] = panelTitle
 
@@ -174,7 +179,8 @@ class GModuleGenerator extends ModuleGenerator {
       case gModule: GModule =>
         gModule.getPanel.foreach { panel =>
           val panelElement = new org.jdom.Element("panel", NS)
-          panelElement.setAttribute(new Attribute("type", panel))
+          panelElement.setAttribute(new Attribute("type", panel.`type`))
+          panelElement.addContent(panel.content.getOrElse(""))
           element.addContent(panelElement)
         }
         gModule.getPanelTitle.foreach { panelTitle =>

--- a/common/app/common/ShowcaseRSSModules.scala
+++ b/common/app/common/ShowcaseRSSModules.scala
@@ -45,8 +45,8 @@ object RssAtomModule {
 }
 
 case class GPanel(
-  `type`: String,
-  content: Option[String]
+    `type`: String,
+    content: Option[String],
 )
 
 trait GModule extends com.sun.syndication.feed.module.Module with Serializable with Cloneable {

--- a/common/app/common/TrailsToShowcase.scala
+++ b/common/app/common/TrailsToShowcase.scala
@@ -603,7 +603,7 @@ object TrailsToShowcase {
     setEntryDates(singleStoryPanel, entry)
 
     val gModule = new GModuleImpl()
-    gModule.setPanel(Some(singleStoryPanel.`type`))
+    gModule.setPanel(Some(GPanel(singleStoryPanel.`type`, singleStoryPanel.panelTitle)))
     gModule.setPanelTitle(singleStoryPanel.panelTitle)
     gModule.setOverline(singleStoryPanel.overline)
     gModule.setBulletList(singleStoryPanel.bulletList.map(asGBulletList))
@@ -632,7 +632,7 @@ object TrailsToShowcase {
     setEntryDates(rundownPanel, entry)
 
     val gModule = new GModuleImpl()
-    gModule.setPanel(Some(rundownPanel.`type`))
+    gModule.setPanel(Some(GPanel(rundownPanel.`type`, Some(rundownPanel.panelTitle))))
     gModule.setPanelTitle(Some(rundownPanel.panelTitle))
     gModule.setArticleGroup(Some(asGArticleGroup(rundownPanel.articleGroup)))
     addModuleTo(entry, gModule)

--- a/common/app/common/TrailsToShowcase.scala
+++ b/common/app/common/TrailsToShowcase.scala
@@ -603,7 +603,7 @@ object TrailsToShowcase {
     setEntryDates(singleStoryPanel, entry)
 
     val gModule = new GModuleImpl()
-    gModule.setPanel(Some(GPanel(singleStoryPanel.`type`, singleStoryPanel.panelTitle)))
+    gModule.setPanel(Some(GPanel(singleStoryPanel.`type`, singleStoryPanel.title)))
     gModule.setPanelTitle(singleStoryPanel.panelTitle)
     gModule.setOverline(singleStoryPanel.overline)
     gModule.setBulletList(singleStoryPanel.bulletList.map(asGBulletList))
@@ -632,7 +632,7 @@ object TrailsToShowcase {
     setEntryDates(rundownPanel, entry)
 
     val gModule = new GModuleImpl()
-    gModule.setPanel(Some(GPanel(rundownPanel.`type`, Some(rundownPanel.panelTitle))))
+    gModule.setPanel(Some(GPanel(rundownPanel.`type`, rundownPanel.panelTitle)))
     gModule.setPanelTitle(Some(rundownPanel.panelTitle))
     gModule.setArticleGroup(Some(asGArticleGroup(rundownPanel.articleGroup)))
     addModuleTo(entry, gModule)

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -398,7 +398,11 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     authorsEmail should be(Some("Trail byline"))
 
     val gModule = entry.getModule(GModule.URI).asInstanceOf[GModule]
-    gModule.getPanel should be(Some("SINGLE_STORY"))
+    val gPanel = gModule.getPanel
+    gPanel shouldNot be(None)
+    gPanel.get.`type` should be("SINGLE_STORY")
+    gPanel.get.content should be(Some("My panel title"))
+
     gModule.getPanelTitle should be(Some("My panel title"))
     gModule.getOverline should be(Some("A kicker"))
     gModule.getArticleGroup.nonEmpty should be(true)
@@ -760,7 +764,11 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     val mediaModule = entry.getModule("http://search.yahoo.com/mrss/").asInstanceOf[MediaEntryModule]
     mediaModule should be(null)
     val gModule = entry.getModule(GModule.URI).asInstanceOf[GModule]
-    gModule.getPanel should be(Some("RUNDOWN"))
+    val gPanel = gModule.getPanel
+    gPanel shouldNot be(None)
+    gPanel.get.`type` should be("RUNDOWN")
+    gPanel.get.content should be(Some("Rundown panel title"))
+
     gModule.getPanelTitle should be(Some("Rundown panel title"))
 
     val articleGroup = gModule.getArticleGroup.get

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -401,7 +401,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     val gPanel = gModule.getPanel
     gPanel shouldNot be(None)
     gPanel.get.`type` should be("SINGLE_STORY")
-    gPanel.get.content should be(Some("My panel title"))
+    gPanel.get.content should be("My unique headline")
 
     gModule.getPanelTitle should be(Some("My panel title"))
     gModule.getOverline should be(Some("A kicker"))
@@ -767,7 +767,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     val gPanel = gModule.getPanel
     gPanel shouldNot be(None)
     gPanel.get.`type` should be("RUNDOWN")
-    gPanel.get.content should be(Some("Rundown panel title"))
+    gPanel.get.content should be("Rundown panel title")
 
     gModule.getPanelTitle should be(Some("Rundown panel title"))
 


### PR DESCRIPTION
## What does this change?

Showcase `g:panel` tags are supposed to have a value (despite the docs saying this is optional). `RUNDOWN` and `SINGLE_STORY` panels will now have `g:panel` tags with the value of `panel.panelTitle` and `panel.title` respectively. This is not as confusing to read in the code as it is to explain here - sorry!

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No (or I assume not anyway as showcase feeds are XML only)
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
(After example captured from local run, whilst Before is from PROD)
Before:
```
<g:panel type="RUNDOWN"/>
<g:panel_title>Evening briefing | Wednesday 16 March</g:panel_title>
```
After:
```
<g:panel type="RUNDOWN">The hidden toll of surviving disaster on an oil rig</g:panel>
<g:panel_title>The hidden toll of surviving disaster on an oil rig</g:panel_title>
```

```
<g:panel type="SINGLE_STORY">How Papua New Guinea’s Covid strategy went so wrong</g:panel>
```

## What is the value of this and can you measure success?

Corrects the showcase schema

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [x] Other (Showcase)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
- [x] N/A

### Tested

- [x] Locally
- [ ] On CODE (optional)

@blishen has also manually tested the results of this change in the showcase preview tools and it looked fine there.

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
