### PR TITLE
Remove use of `data-spacefinder-component`

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -73,7 +73,7 @@ const articleBodySelector = isDotcomRendering
 
 const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 	const ignoreList = enableRichLinksFix
-		? ' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate):not([data-spacefinder-component="rich-link"])'
+		? ' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate):not([data-spacefinder-role="rich-link"])'
 		: ' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate)';
 
 	const isImmersive = config.get('page.isImmersive');
@@ -115,10 +115,6 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 			' figure.element-immersive': {
 				minAbove: 0,
 				minBelow: 600,
-			},
-			' [data-spacefinder-component="numbered-list-title"]': {
-				minAbove: 25,
-				minBelow: 0,
 			},
 		},
 		filter: filterNearbyCandidates(adSizes.halfPage.height),


### PR DESCRIPTION
## What does this change?

Remove use of the `data-spacefinder-component` attribute when Spacefinder selects elements.

In the case of rich links, we instead use `data-spacefinder-role` which is added by DCR (see [DCR #4113](https://github.com/guardian/dotcom-rendering/pull/4113)).

In the case of numbered list titles, these are no longer added to any figures and so can safely be removed.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes - See [DCR #4354](https://github.com/guardian/dotcom-rendering/pull/4354), which needs merging after this.

## What is the value of this and can you measure success?

Previously we'd add an `data-spacefinder-component` attribute to each figure element we needed Spacefinder to know about.

Instead, we aim for a more declarative approach, where we use the `role` and `type` already defined by the renderer in order to select for figures in articles.

### Tested

- [X] Locally
- [ ] On CODE (optional)