### PR TITLE
fix: use `unknown` type in predicate

### DIFF
--- a/static/src/javascripts/projects/common/modules/support/articleCount.ts
+++ b/static/src/javascripts/projects/common/modules/support/articleCount.ts
@@ -16,7 +16,7 @@ type DailyArticleHistory = DailyArticleCount[];
 
 const today = Math.floor(Date.now() / 86400000); // 1 day in ms
 
-const isDailyArticleHistory = (data: any): data is DailyArticleHistory =>
+const isDailyArticleHistory = (data: unknown): data is DailyArticleHistory =>
 	Array.isArray(data);
 
 const getDailyArticleHistory = (): DailyArticleHistory | undefined => {


### PR DESCRIPTION
## What does this change?

Use `unknown` instead of `any`.