### PR TITLE
Fix daily article count for today

### DIFF
--- a/static/src/javascripts/projects/common/modules/support/articleCount.ts
+++ b/static/src/javascripts/projects/common/modules/support/articleCount.ts
@@ -14,7 +14,7 @@ export interface DailyArticleCount {
 
 type DailyArticleHistory = DailyArticleCount[];
 
-const today = Math.floor(Date.now() / 86400000); // 1 day in ms
+export const today = Math.floor(Date.now() / 86400000); // 1 day in ms
 
 const isDailyArticleHistory = (data: any): data is DailyArticleHistory =>
 	Array.isArray(data);
@@ -87,4 +87,18 @@ export const getArticleCounts = async (
 	}
 
 	return window.guardian.articleCounts;
+};
+
+export const getArticleCountToday = (
+	articleCounts: ArticleCounts | undefined,
+): number | undefined => {
+	const latest = articleCounts?.dailyArticleHistory[0];
+	if (latest) {
+		if (latest.day === today) {
+			return articleCounts.dailyArticleHistory[0].count;
+		}
+		// article counting is enabled, but none so far today
+		return 0;
+	}
+	return undefined;
 };

--- a/static/src/javascripts/projects/common/modules/support/articleCount.ts
+++ b/static/src/javascripts/projects/common/modules/support/articleCount.ts
@@ -14,9 +14,9 @@ export interface DailyArticleCount {
 
 type DailyArticleHistory = DailyArticleCount[];
 
-export const today = Math.floor(Date.now() / 86400000); // 1 day in ms
+export const today = Math.floor(Date.now() / 86_400_000); // 1 day in ms
 
-const isDailyArticleHistory = (data: any): data is DailyArticleHistory =>
+const isDailyArticleHistory = (data: unknown): data is DailyArticleHistory =>
 	Array.isArray(data);
 
 const getDailyArticleHistory = (): DailyArticleHistory | undefined => {

--- a/static/src/javascripts/projects/common/modules/support/banner.ts
+++ b/static/src/javascripts/projects/common/modules/support/banner.ts
@@ -15,7 +15,10 @@ import { getMvtValue } from 'common/modules/analytics/mvt-cookie';
 import { submitComponentEvent } from 'common/modules/commercial/acquisitions-ophan';
 import { getVisitCount } from 'common/modules/commercial/contributions-utilities';
 import { shouldHideSupportMessaging } from 'common/modules/commercial/user-features';
-import { getArticleCounts } from 'common/modules/support/articleCount';
+import {
+	getArticleCounts,
+	getArticleCountToday,
+} from 'common/modules/support/articleCount';
 import {
 	buildTagIds,
 	dynamicImport,
@@ -121,7 +124,7 @@ const buildBannerPayload = async (): Promise<BannerPayload> => {
 
 	const articleCounts = await getArticleCounts(pageId, keywordIds, isFront);
 	const weeklyArticleHistory = articleCounts?.weeklyArticleHistory;
-	const articleCountToday = articleCounts?.dailyArticleHistory[0]?.count;
+	const articleCountToday = getArticleCountToday(articleCounts);
 
 	const targeting: BannerTargeting = {
 		alreadyVisitedCount: getVisitCount(),


### PR DESCRIPTION
Currently this may use e.g. yesterday's count if the browser hasn't yet landed on an article

[DCR change](https://github.com/guardian/dotcom-rendering/pull/4312)