### PR TITLE
Listen for `article:sign-in-gate-dismissed`

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -285,5 +285,8 @@ export const init = (): Promise<boolean> => {
 	document.addEventListener('dcr:page:article:redisplayed', () => {
 		void doInit();
 	});
+	document.addEventListener('article:sign-in-gate-dismissed', () => {
+		void doInit();
+	});
 	return doInit();
 };


### PR DESCRIPTION
## What does this change?

Make spacefinder listen for `article:sign-in-gate-dismissed` events. This is because `dcr:page:article:redisplayed` has been renamed `article:sign-in-gate-dismissed` here: https://github.com/guardian/dotcom-rendering/pull/4313

We'll remove the listener for `dcr:page:article:redisplayed` in a [separate PR](https://github.com/guardian/frontend/pull/24789) once these two are merged.