### PR TITLE
enhance pinned post with element id

### DIFF
--- a/common/app/model/dotcomrendering/ElementsEnhancer.scala
+++ b/common/app/model/dotcomrendering/ElementsEnhancer.scala
@@ -1,6 +1,6 @@
 package model.dotcomrendering
 
-import play.api.libs.json._
+import play.api.libs.json.{Json, _}
 
 object ElementsEnhancer {
 
@@ -17,8 +17,12 @@ object ElementsEnhancer {
   }
 
   def enhanceObjectWithElementsAtDepth1(obj: JsValue): JsValue = {
-    val elements = obj.as[JsObject].value("elements")
-    obj.as[JsObject] ++ Json.obj("elements" -> enhanceElements(elements))
+    obj.asOpt[JsObject] match {
+      case Some(o) =>
+        val elements = o.value("elements")
+        o ++ Json.obj("elements" -> enhanceElements(elements))
+      case None => obj
+    }
   }
 
   def enhanceObjectsWithElementsAtDepth1(objs: JsValue): IndexedSeq[JsValue] = {

--- a/common/app/model/dotcomrendering/ElementsEnhancer.scala
+++ b/common/app/model/dotcomrendering/ElementsEnhancer.scala
@@ -34,6 +34,7 @@ object ElementsEnhancer {
     obj ++
       Json.obj("blocks" -> enhanceObjectsWithElementsAtDepth1(obj.value("blocks"))) ++
       Json.obj("mainMediaElements" -> enhanceElements(obj.value("mainMediaElements"))) ++
-      Json.obj("keyEvents" -> enhanceObjectsWithElementsAtDepth1(obj.value("keyEvents")))
+      Json.obj("keyEvents" -> enhanceObjectsWithElementsAtDepth1(obj.value("keyEvents"))) ++
+      Json.obj("pinnedPost" -> enhanceObjectWithElementsAtDepth1(obj.value("pinnedPost")))
   }
 }


### PR DESCRIPTION
## What does this change?

Generates elementId for elements inside pinnedPost. This field is required by DCR.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

Fixes #24785
