### PR TITLE
Stop listening for `dcr:page:article:redisplayed`

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -282,9 +282,6 @@ export const init = (): Promise<boolean> => {
 	// For instance by the signin gate.
 	mediator.on('page:article:redisplayed', doInit);
 	// DCR doesn't have mediator, so listen for CustomEvent
-	document.addEventListener('dcr:page:article:redisplayed', () => {
-		void doInit();
-	});
 	document.addEventListener('article:sign-in-gate-dismissed', () => {
 		void doInit();
 	});


### PR DESCRIPTION
## What does this change?

Stop spacefinder listening for `dcr:page:article:redisplayed`. It was renamed to `article:sign-in-gate-dismissed`.

See:

https://github.com/guardian/dotcom-rendering/pull/4313
https://github.com/guardian/frontend/pull/24786

