### PR TITLE
Add captions to slideshow pressed data type

### DIFF
--- a/common/app/implicits/FaciaContentFrontendHelpers.scala
+++ b/common/app/implicits/FaciaContentFrontendHelpers.scala
@@ -50,7 +50,14 @@ object FaciaContentFrontendHelpers {
         case Some(ImageSlideshow(assets)) =>
           Option {
             assets.flatMap(asset =>
-              Try(FaciaImageElement(asset.imageSrc, asset.imageSrcWidth.toInt, asset.imageSrcHeight.toInt)).toOption,
+              Try(
+                FaciaImageElement(
+                  asset.imageSrc,
+                  asset.imageSrcWidth.toInt,
+                  asset.imageSrcHeight.toInt,
+                  asset.imageCaption,
+                ),
+              ).toOption,
             )
           }
         case _ => None

--- a/common/app/model/Image.scala
+++ b/common/app/model/Image.scala
@@ -20,11 +20,17 @@ object Cutout {
     Cutout(imageSrc = cutout.imageSrc, imageSrcHeight = cutout.imageSrcHeight, imageSrcWidth = cutout.imageSrcWidth)
 }
 
-final case class Replace(imageSrc: String, imageSrcWidth: String, imageSrcHeight: String) extends Image
+final case class Replace(imageSrc: String, imageSrcWidth: String, imageSrcHeight: String, imageCaption: Option[String])
+    extends Image
 
 object Replace {
   def make(replace: fapi.Replace): Replace =
-    Replace(imageSrc = replace.imageSrc, imageSrcHeight = replace.imageSrcHeight, imageSrcWidth = replace.imageSrcWidth)
+    Replace(
+      imageSrc = replace.imageSrc,
+      imageSrcHeight = replace.imageSrcHeight,
+      imageSrcWidth = replace.imageSrcWidth,
+      imageCaption = replace.imageCaption,
+    )
 
 }
 

--- a/common/app/model/ImageElement.scala
+++ b/common/app/model/ImageElement.scala
@@ -1,4 +1,4 @@
 package model
 
 /** Used in overrides from Facia press */
-case class FaciaImageElement(url: String, width: Int, height: Int)
+case class FaciaImageElement(url: String, width: Int, height: Int, caption: Option[String])

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -33,7 +33,7 @@ class TrailsToShowcaseTest extends FlatSpec with Matchers {
     ImageMedia(Seq(asset))
   }
 
-  val replacedImage = Replace("http://localhost/replaced-image.jpg", "1200", "1000")
+  val replacedImage = Replace("http://localhost/replaced-image.jpg", "1200", "1000", None)
 
   val smallImageMedia: ImageMedia = {
     val asset = ImageAsset(


### PR DESCRIPTION
## What does this change?

Adds the caption to types for pressed slideshows.

Expanding on https://github.com/guardian/frontend/pull/24788

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |


[before]: https://user-images.githubusercontent.com/9575458/159255525-f1ccd3f7-6954-46d1-aaee-233c10947c90.png
[after]: https://user-images.githubusercontent.com/9575458/159255398-026c23ea-a280-482e-b5f4-c53f73323f39.png


## What is the value of this and can you measure success?

## Checklist

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
