### PR TITLE
WIP - Prepare for latest CAPI release - updating interactive format (Attempt 2)

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -2,7 +2,7 @@ package model.dotcomrendering
 
 import com.gu.contentapi.client.model.v1.ElementType.Text
 import com.gu.contentapi.client.model.v1.{Block => APIBlock, BlockElement => ClientBlockElement, Blocks => APIBlocks}
-import com.gu.contentapi.client.utils.format.{InteractiveDesign, LiveBlogDesign}
+import com.gu.contentapi.client.utils.format.{LiveBlogDesign}
 import com.gu.contentapi.client.utils.{AdvertisementFeature, DesignType}
 import common.Edition
 import conf.switches.Switches
@@ -235,13 +235,7 @@ object DotcomRenderingUtils {
   def getModifiedContent(content: ContentType, forceLive: Boolean): ContentFormat = {
     val originalFormat = content.metadata.format.getOrElse(ContentFormat.defaultContentFormat)
 
-    // TODO move to content-api-scala-client once confirmed as correct
-    // behaviour. At the moment we are seeing interactive articles with other
-    // design types due to CAPI format logic. But interactive design should
-    // always take precendent (or so we think).
-    if (content.metadata.contentType.contains(DotcomContentType.Interactive)) {
-      originalFormat.copy(design = InteractiveDesign)
-    } else if (forceLive) {
+    if (forceLive) {
       originalFormat.copy(design = LiveBlogDesign)
     } else {
       originalFormat

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -254,25 +254,26 @@ object ContentFormat {
 
   def parseDesign(s: String): Design =
     s match {
-      case "ArticleDesign"     => ArticleDesign
-      case "MediaDesign"       => MediaDesign
-      case "ReviewDesign"      => ReviewDesign
-      case "AnalysisDesign"    => AnalysisDesign
-      case "CommentDesign"     => CommentDesign
-      case "LetterDesign"      => LetterDesign
-      case "FeatureDesign"     => FeatureDesign
-      case "LiveBlogDesign"    => LiveBlogDesign
-      case "DeadBlogDesign"    => DeadBlogDesign
-      case "RecipeDesign"      => RecipeDesign
-      case "MatchReportDesign" => MatchReportDesign
-      case "InterviewDesign"   => InterviewDesign
-      case "EditorialDesign"   => EditorialDesign
-      case "QuizDesign"        => QuizDesign
-      case "InteractiveDesign" => InteractiveDesign
-      case "PhotoEssayDesign"  => PhotoEssayDesign
-      case "PrintShopDesign"   => PrintShopDesign
-      case "ObituaryDesign"    => ObituaryDesign
-      case _                   => ArticleDesign
+      case "ArticleDesign"             => ArticleDesign
+      case "MediaDesign"               => MediaDesign
+      case "ReviewDesign"              => ReviewDesign
+      case "AnalysisDesign"            => AnalysisDesign
+      case "CommentDesign"             => CommentDesign
+      case "LetterDesign"              => LetterDesign
+      case "FeatureDesign"             => FeatureDesign
+      case "LiveBlogDesign"            => LiveBlogDesign
+      case "DeadBlogDesign"            => DeadBlogDesign
+      case "RecipeDesign"              => RecipeDesign
+      case "MatchReportDesign"         => MatchReportDesign
+      case "InterviewDesign"           => InterviewDesign
+      case "EditorialDesign"           => EditorialDesign
+      case "QuizDesign"                => QuizDesign
+      case "FullPageInteractiveDesign" => FullPageInteractiveDesign
+      case "InteractiveDesign"         => InteractiveDesign
+      case "PhotoEssayDesign"          => PhotoEssayDesign
+      case "PrintShopDesign"           => PrintShopDesign
+      case "ObituaryDesign"            => ObituaryDesign
+      case _                           => ArticleDesign
     }
 
   def parseTheme(s: String): Theme =


### PR DESCRIPTION
## What does this change?
Bumps scanamo, which then in turn allows us to bump capi and facia clients.

We've done these together as the aim was to bump facia client to get captions on slideshow images. To bump facia, we needed to bump capi, which means we needed to bump scanamo as is has a transient dependency on scala-collection-compat@2.1.2, where as we need 2.6.0.

The [browseDependencyTree](https://github.com/sbt/sbt-dependency-graph) plugin was a great way to find this out. Installing it globally will save lot of time in the future.

[This fix](https://github.com/guardian/frontend/pull/24788/commits/23ce33606b5e2c347bf581577a6fa0ebf26a470d) is interesting in the sense of it wasn't failing during tests... not really sure why.

part of: https://github.com/guardian/frontend/issues/24782 https://github.com/guardian/frontend/issues/24740

---

This is Attempt 2 at this PR (Attempt 1: https://github.com/guardian/frontend/pull/24788), where a new version of the CAPI client was released, allowing us to remove some logic that was overwriting the `format.design` for interactive articles
