### PR TITLE
Use browserId for banner targeting

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@guardian/shimport": "^1.0.2",
     "@guardian/source-foundations": "^4.0.0-rc.4",
     "@guardian/source-react-components": "^4.0.0-rc.2",
-    "@guardian/support-dotcom-components": "^1.0.1",
+    "@guardian/support-dotcom-components": "^1.0.2",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",
     "bootstrap-sass": "^3.4.1",

--- a/static/src/javascripts/projects/common/modules/support/articleCount.ts
+++ b/static/src/javascripts/projects/common/modules/support/articleCount.ts
@@ -5,7 +5,7 @@ import {
 } from '@guardian/support-dotcom-components';
 import type { WeeklyArticleHistory } from '@guardian/support-dotcom-components/dist/shared/src/types/targeting';
 import { storageKeyDailyArticleCount } from 'common/modules/onward/history';
-import { getArticleCountConsent } from 'common/modules/support/supportMessaging';
+import { hasCmpConsentForArticleCount } from 'common/modules/support/supportMessaging';
 
 export interface DailyArticleCount {
 	day: number;
@@ -60,7 +60,7 @@ export const getArticleCounts = async (
 	keywordIds: string,
 	isFront: boolean,
 ): Promise<ArticleCounts | undefined> => {
-	const hasConsentedToArticleCounts = await getArticleCountConsent();
+	const hasConsentedToArticleCounts = await hasCmpConsentForArticleCount();
 	if (!hasConsentedToArticleCounts) return undefined;
 
 	if (!isFront && !window.guardian.articleCounts) {

--- a/static/src/javascripts/projects/common/modules/support/banner.ts
+++ b/static/src/javascripts/projects/common/modules/support/banner.ts
@@ -22,7 +22,8 @@ import {
 import {
 	buildTagIds,
 	dynamicImport,
-	getArticleCountConsent,
+	hasCmpConsentForArticleCount,
+	hasCmpConsentForBrowserId,
 	isHosted,
 	ModulesVersion,
 	supportDotcomComponentsUrl,
@@ -126,6 +127,8 @@ const buildBannerPayload = async (): Promise<BannerPayload> => {
 	const weeklyArticleHistory = articleCounts?.weeklyArticleHistory;
 	const articleCountToday = getArticleCountToday(articleCounts);
 
+	const browserId = window.guardian.config.ophan.browserId;
+
 	const targeting: BannerTargeting = {
 		alreadyVisitedCount: getVisitCount(),
 		shouldHideReaderRevenue: shouldHideReaderRevenue,
@@ -141,11 +144,12 @@ const buildBannerPayload = async (): Promise<BannerPayload> => {
 		countryCode: getCountryCode(),
 		weeklyArticleHistory: weeklyArticleHistory,
 		articleCountToday: articleCountToday,
-		hasOptedOutOfArticleCount: !(await getArticleCountConsent()),
+		hasOptedOutOfArticleCount: !(await hasCmpConsentForArticleCount()),
 		modulesVersion: ModulesVersion,
 		sectionId: section,
 		tagIds: buildTagIds(),
 		contentType,
+		browserId: (await hasCmpConsentForBrowserId()) ? browserId : undefined,
 	};
 
 	return {

--- a/static/src/javascripts/projects/common/modules/support/epic.ts
+++ b/static/src/javascripts/projects/common/modules/support/epic.ts
@@ -24,7 +24,7 @@ import {
 	buildKeywordTags,
 	buildSeriesTag,
 	dynamicImport,
-	getArticleCountConsent,
+	hasCmpConsentForArticleCount,
 	isHosted,
 	ModulesVersion,
 	supportDotcomComponentsUrl,
@@ -82,7 +82,7 @@ const buildEpicPayload = async (): Promise<EpicPayload> => {
 		countryCode,
 		epicViewLog: getEpicViewLog(storage.local),
 		weeklyArticleHistory: weeklyArticleHistory,
-		hasOptedOutOfArticleCount: !(await getArticleCountConsent()),
+		hasOptedOutOfArticleCount: !(await hasCmpConsentForArticleCount()),
 		modulesVersion: ModulesVersion,
 		url: window.location.origin + window.location.pathname,
 	};

--- a/static/src/javascripts/projects/common/modules/support/supportMessaging.ts
+++ b/static/src/javascripts/projects/common/modules/support/supportMessaging.ts
@@ -79,8 +79,9 @@ const removeArticleCountsFromLocalStorage = (): void => {
 };
 
 const REQUIRED_CONSENTS_FOR_ARTICLE_COUNT = [1, 3, 7];
+const REQUIRED_CONSENTS_FOR_BROWSER_ID = [1, 3, 5, 7];
 
-export const getArticleCountConsent = (): Promise<boolean> => {
+export const hasCmpConsentForArticleCount = (): Promise<boolean> => {
 	if (hasOptedOutOfArticleCount()) {
 		return Promise.resolve(false);
 	}
@@ -103,3 +104,18 @@ export const getArticleCountConsent = (): Promise<boolean> => {
 		});
 	});
 };
+
+export const hasCmpConsentForBrowserId = (): Promise<boolean> =>
+	new Promise((resolve) => {
+		onConsentChange(({ ccpa, tcfv2, aus }) => {
+			if (ccpa || aus) {
+				resolve(true);
+			} else if (tcfv2) {
+				const hasRequiredConsents =
+					REQUIRED_CONSENTS_FOR_BROWSER_ID.every(
+						(consent) => tcfv2.consents[consent],
+					);
+				resolve(hasRequiredConsents);
+			}
+		});
+	});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1349,10 +1349,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-3.12.0.tgz#52d11d2fff649e04934033473b3ed7c7bf4a1639"
   integrity sha512-JIFBybaCd69tf+zJZZ7KNLdqaVePOAc36wGFor0I60vc9Ib0jMuzYVffMjMhF6LHSXMdoOcqGwiPdFucObVYAA==
 
-"@guardian/support-dotcom-components@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@guardian/support-dotcom-components/-/support-dotcom-components-1.0.1.tgz#a6f51ce1c93efbaac705989a9d63a601bbf80328"
-  integrity sha512-zoxBAQIRUiz3iMi+wgutSi36igLjpGUI66JT+ByxHgFkTELiqsflG6Htn1ynYy4j5q80LyEIwahLqtuFFWq+YQ==
+"@guardian/support-dotcom-components@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@guardian/support-dotcom-components/-/support-dotcom-components-1.0.2.tgz#56bfb7cf7aef6d859b6f97b3986188af687f8a16"
+  integrity sha512-NqAxmegwQ1ltBH4EmfXwJHxRXGJzlZMSFDkK+5fkReL4XtACX3ZzR2rMbl7SN5RxSbeSzr5nGElRZ0TWkAYRJw==
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"


### PR DESCRIPTION
Send `browserId` to `support-dotcom-components` for banner targeting, if the user has consented. This will mean we can run tests [using propensity models](https://github.com/guardian/support-dotcom-components/pull/658).

The `hasCmpConsentForBrowserId` function is copied from DCR: https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/lib/contributions.ts#L185

I also renamed the existing `getArticleCountConsent` to `hasCmpConsentForArticleCount`. It's consistent with DCR and clearer about the return type.

[DCR PR](https://github.com/guardian/dotcom-rendering/pull/4344)