### PR TITLE
Pre-scala 2.13: upgrade play-googleauth

### DIFF
--- a/admin/app/conf/AdminConfiguration.scala
+++ b/admin/app/conf/AdminConfiguration.scala
@@ -1,7 +1,7 @@
 package conf
 
 import common.GuardianConfiguration
-import conf.Configuration.OAuthCredentialsWithMultipleCallbacks
+import conf.Configuration.{OAuthCredentialsWithMultipleCallbacks, OAuthCredentials}
 import pa.PaClientConfig
 
 case class OmnitureCredentials(userName: String, secret: String)
@@ -54,6 +54,25 @@ object AdminConfiguration {
       oauthSecret,
       configuration.getStringPropertiesSplitByComma("admin.oauth.callbacks"),
     )
+
+  def oauthCredentialsWithSingleCallBack(currentHost: Option[String]): Option[OAuthCredentials] =
+    oauthCredentials.flatMap { cred =>
+      for {
+        callback <- cred.authorizedOauthCallbacks.collectFirst {
+          case defaultHost if currentHost.isEmpty =>
+            defaultHost // if oauthCallbackHost is NOT defined, return the first authorized host in the list
+          case host if host.startsWith(currentHost.get) =>
+            host // if an authorized callback starts with current host, return it
+          // otherwise None will be returned
+        }
+      } yield {
+        Configuration.OAuthCredentials(
+          cred.oauthClientId,
+          cred.oauthSecret,
+          callback,
+        )
+      }
+    }
 
   lazy val omnitureCredentials: Option[OmnitureCredentials] =
     for {

--- a/admin/app/controllers/admin/IndexController.scala
+++ b/admin/app/controllers/admin/IndexController.scala
@@ -1,6 +1,7 @@
 package controllers.admin
 
 import com.gu.googleauth.AuthAction
+import conf.AdminConfiguration
 import model.{ApplicationContext, NoCache}
 import play.api.http.HttpConfiguration
 import play.api.mvc._
@@ -11,7 +12,7 @@ trait AdminAuthController {
 
   case class AdminAuthAction(httpConfiguration: HttpConfiguration)
       extends AuthAction(
-        conf.GoogleAuth(None, httpConfiguration).getConfigOrDie,
+        conf.GoogleAuth(None, httpConfiguration, AdminConfiguration.oauthCredentials).getConfigOrDie,
         routes.OAuthLoginAdminController.login,
         controllerComponents.parsers.default,
       )(controllerComponents.executionContext)

--- a/admin/app/controllers/admin/IndexController.scala
+++ b/admin/app/controllers/admin/IndexController.scala
@@ -12,7 +12,9 @@ trait AdminAuthController {
 
   case class AdminAuthAction(httpConfiguration: HttpConfiguration)
       extends AuthAction(
-        conf.GoogleAuth(None, httpConfiguration, AdminConfiguration.oauthCredentials).getConfigOrDie,
+        conf
+          .GoogleAuth(None, httpConfiguration, AdminConfiguration.oauthCredentialsWithSingleCallBack(None))
+          .getConfigOrDie,
         routes.OAuthLoginAdminController.login,
         controllerComponents.parsers.default,
       )(controllerComponents.executionContext)

--- a/admin/app/controllers/admin/IndexController.scala
+++ b/admin/app/controllers/admin/IndexController.scala
@@ -2,15 +2,16 @@ package controllers.admin
 
 import com.gu.googleauth.AuthAction
 import model.{ApplicationContext, NoCache}
+import play.api.http.HttpConfiguration
 import play.api.mvc._
 
 trait AdminAuthController {
 
   def controllerComponents: ControllerComponents
 
-  object AdminAuthAction
+  case class AdminAuthAction(httpConfiguration: HttpConfiguration)
       extends AuthAction(
-        conf.GoogleAuth.getConfigOrDie,
+        conf.GoogleAuth(None, httpConfiguration).getConfigOrDie,
         routes.OAuthLoginAdminController.login,
         controllerComponents.parsers.default,
       )(controllerComponents.executionContext)

--- a/admin/app/controllers/admin/OAuthLoginAdminController.scala
+++ b/admin/app/controllers/admin/OAuthLoginAdminController.scala
@@ -1,7 +1,7 @@
 package controllers.admin
 
 import com.gu.googleauth.GoogleAuthConfig
-import conf.AdminConfiguration
+import conf.{AdminConfiguration, Configuration}
 import googleAuth.OAuthLoginController
 import model.ApplicationContext
 import play.api.http.HttpConfiguration
@@ -21,12 +21,13 @@ class OAuthLoginAdminController(
       Ok(views.html.auth.login(error))
     }
   override def googleAuthConfig(request: Request[AnyContent]): Option[GoogleAuthConfig] = {
-    val host = Some(s"${if (request.secure) "https" else "http"}://${request.host}")
+    val currentHost = Some(s"${if (request.secure) "https" else "http"}://${request.host}")
+
     conf
       .GoogleAuth(
-        host,
+        currentHost,
         httpConfiguration,
-        AdminConfiguration.oauthCredentials,
+        AdminConfiguration.oauthCredentialsWithSingleCallBack(currentHost),
       )
       .config
   }

--- a/admin/app/controllers/admin/OAuthLoginAdminController.scala
+++ b/admin/app/controllers/admin/OAuthLoginAdminController.scala
@@ -1,6 +1,7 @@
 package controllers.admin
 
 import com.gu.googleauth.GoogleAuthConfig
+import conf.AdminConfiguration
 import googleAuth.OAuthLoginController
 import model.ApplicationContext
 import play.api.http.HttpConfiguration
@@ -21,6 +22,12 @@ class OAuthLoginAdminController(
     }
   override def googleAuthConfig(request: Request[AnyContent]): Option[GoogleAuthConfig] = {
     val host = Some(s"${if (request.secure) "https" else "http"}://${request.host}")
-    conf.GoogleAuth(host, httpConfiguration).config
+    conf
+      .GoogleAuth(
+        host,
+        httpConfiguration,
+        AdminConfiguration.oauthCredentials,
+      )
+      .config
   }
 }

--- a/admin/app/controllers/admin/OAuthLoginAdminController.scala
+++ b/admin/app/controllers/admin/OAuthLoginAdminController.scala
@@ -21,6 +21,6 @@ class OAuthLoginAdminController(
     }
   override def googleAuthConfig(request: Request[AnyContent]): Option[GoogleAuthConfig] = {
     val host = Some(s"${if (request.secure) "https" else "http"}://${request.host}")
-    conf.GoogleAuth(host).config
+    conf.GoogleAuth(host, httpConfiguration).config
   }
 }

--- a/admin/app/controllers/cache/ImageDecacheController.scala
+++ b/admin/app/controllers/cache/ImageDecacheController.scala
@@ -2,11 +2,11 @@ package controllers.cache
 
 import java.net.URI
 import java.util.UUID
-
 import com.gu.googleauth.UserIdentity
-import common.{ImplicitControllerExecutionContext, GuLogging}
+import common.{GuLogging, ImplicitControllerExecutionContext}
 import controllers.admin.AdminAuthController
 import model.{ApplicationContext, NoCache}
+import play.api.http.HttpConfiguration
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc._
@@ -17,6 +17,7 @@ import scala.concurrent.Future.successful
 class ImageDecacheController(
     wsClient: WSClient,
     val controllerComponents: ControllerComponents,
+    val httpConfiguration: HttpConfiguration,
 )(implicit context: ApplicationContext)
     extends BaseController
     with GuLogging
@@ -33,7 +34,7 @@ class ImageDecacheController(
     }
 
   def decache(): Action[AnyContent] =
-    AdminAuthAction.async { implicit request =>
+    AdminAuthAction(httpConfiguration).async { implicit request =>
       getSubmittedImage(request)
         .map(new URI(_))
         .map { imageUri =>

--- a/admin/app/controllers/cache/PageDecacheController.scala
+++ b/admin/app/controllers/cache/PageDecacheController.scala
@@ -1,12 +1,12 @@
 package controllers.cache
 
 import java.net.URI
-
 import com.gu.googleauth.UserIdentity
-import common.{ImplicitControllerExecutionContext, GuLogging}
+import common.{GuLogging, ImplicitControllerExecutionContext}
 import controllers.admin.AdminAuthController
 import model.{ApplicationContext, NoCache}
 import org.apache.commons.codec.digest.DigestUtils
+import play.api.http.HttpConfiguration
 import play.api.libs.ws.WSClient
 import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc._
@@ -17,7 +17,11 @@ import scala.concurrent.Future.successful
 
 case class PrePurgeTestResult(url: String, passed: Boolean)
 
-class PageDecacheController(wsClient: WSClient, val controllerComponents: ControllerComponents)(implicit
+class PageDecacheController(
+    wsClient: WSClient,
+    val controllerComponents: ControllerComponents,
+    val httpConfiguration: HttpConfiguration,
+)(implicit
     context: ApplicationContext,
 ) extends BaseController
     with GuLogging
@@ -35,7 +39,7 @@ class PageDecacheController(wsClient: WSClient, val controllerComponents: Contro
     }
 
   def decacheAjax(): Action[AnyContent] =
-    AdminAuthAction.async { implicit request =>
+    AdminAuthAction(httpConfiguration).async { implicit request =>
       getSubmittedUrlPathMd5(request) match {
         case Some(path) =>
           CdnPurge.soft(wsClient, path, AjaxHost).map(message => NoCache(Ok(views.html.cache.ajaxDecache(message))))
@@ -44,7 +48,7 @@ class PageDecacheController(wsClient: WSClient, val controllerComponents: Contro
     }
 
   def decachePage(): Action[AnyContent] =
-    AdminAuthAction.async { implicit request =>
+    AdminAuthAction(httpConfiguration).async { implicit request =>
       getSubmittedUrlPathMd5(request) match {
         case Some(md5Path) =>
           CdnPurge

--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,8 @@ val common = library("common")
       jSoup,
       json4s,
       playGoogleAuth,
+      playSecretRotation,
+      playSecretRotationAwsSdk,
       quartzScheduler,
       redisClient,
       rome,

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -699,6 +699,10 @@ class GuardianConfiguration extends GuLogging {
     } yield OAuthCredentials(oauthClientId, oauthSecret, oauthCallback)
   }
 
+  object googleOAuth {
+    lazy val playAppSecretParameterName = s"/frontend/${stage.toLowerCase()}/playAppSecret"
+  }
+
   object pngResizer {
     val cacheTimeInSeconds = configuration.getIntegerProperty("png_resizer.image_cache_time").getOrElse(86400)
     val ttlInSeconds = configuration.getIntegerProperty("png_resizer.image_ttl").getOrElse(86400)

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -700,7 +700,7 @@ class GuardianConfiguration extends GuLogging {
   }
 
   object googleOAuth {
-    lazy val playAppSecretParameterName = s"/frontend/${stage.toLowerCase()}/playAppSecret"
+    lazy val playAppSecretParameterName = s"/frontend/${stage.toLowerCase()}/${app.toLowerCase()}/playAppSecret"
   }
 
   object pngResizer {

--- a/common/app/conf/GoogleAuth.scala
+++ b/common/app/conf/GoogleAuth.scala
@@ -1,7 +1,7 @@
 package conf
 
-import com.amazonaws.auth.{AWSCredentialsProviderChain, DefaultAWSCredentialsProviderChain}
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import conf.Configuration.OAuthCredentialsWithMultipleCallbacks
+import com.amazonaws.auth.AWSCredentialsProviderChain
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder
 import com.gu.googleauth.{AntiForgeryChecker, GoogleAuthConfig}
@@ -13,6 +13,7 @@ import java.time.Duration.{ofHours, ofMinutes}
 case class GoogleAuth(
     currentHost: Option[String],
     httpConfiguration: HttpConfiguration,
+    oauthCredentials: Option[OAuthCredentialsWithMultipleCallbacks],
 ) {
   private val securityCredentialsProvider = new AWSCredentialsProviderChain(
     Configuration.aws.mandatoryCredentials,
@@ -33,7 +34,7 @@ case class GoogleAuth(
     )
   }
 
-  val config = AdminConfiguration.oauthCredentials.flatMap { cred =>
+  val config = oauthCredentials.flatMap { cred =>
     for {
       callback <- cred.authorizedOauthCallbacks.collectFirst {
         case defaultHost if currentHost.isEmpty =>

--- a/common/app/conf/GoogleAuth.scala
+++ b/common/app/conf/GoogleAuth.scala
@@ -15,12 +15,12 @@ case class GoogleAuth(
     httpConfiguration: HttpConfiguration,
     oauthCredentials: Option[OAuthCredentials],
 ) {
-  private val securityCredentialsProvider = new AWSCredentialsProviderChain(
+  private val frontendCredentialsProvider = new AWSCredentialsProviderChain(
     Configuration.aws.mandatoryCredentials,
   )
   private val ssmClient = AWSSimpleSystemsManagementClientBuilder
     .standard()
-    .withCredentials(securityCredentialsProvider)
+    .withCredentials(frontendCredentialsProvider)
     .withRegion(Regions.EU_WEST_1)
     .build()
 
@@ -29,7 +29,7 @@ case class GoogleAuth(
 
     new parameterstore.SecretSupplier(
       TransitionTiming(usageDelay = ofMinutes(3), overlapDuration = ofHours(2)),
-      "/frontend/PlayAppSecret",
+      Configuration.googleOAuth.playAppSecretParameterName,
       parameterstore.AwsSdkV1(ssmClient),
     )
   }

--- a/preview/app/controllers/OAuthLoginPreviewController.scala
+++ b/preview/app/controllers/OAuthLoginPreviewController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import com.gu.googleauth.{AntiForgeryChecker, GoogleAuthConfig, UserIdentity}
+import com.gu.googleauth.{GoogleAuthConfig, UserIdentity}
 import conf.Configuration
 import googleAuth.OAuthLoginController
 import model.ApplicationContext

--- a/preview/app/controllers/OAuthLoginPreviewController.scala
+++ b/preview/app/controllers/OAuthLoginPreviewController.scala
@@ -1,18 +1,12 @@
 package controllers
 
-import com.amazonaws.auth.AWSCredentialsProviderChain
-import com.amazonaws.regions.Regions
-import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder
 import com.gu.googleauth.{AntiForgeryChecker, GoogleAuthConfig, UserIdentity}
-import com.gu.play.secretrotation.{SnapshotProvider, TransitionTiming}
 import conf.Configuration
 import googleAuth.OAuthLoginController
 import model.ApplicationContext
 import play.api.http.HttpConfiguration
 import play.api.libs.ws.WSClient
 import play.api.mvc.{Action, AnyContent, ControllerComponents, Request}
-
-import java.time.Duration.{ofHours, ofMinutes}
 
 class OAuthLoginPreviewController(
     val wsClient: WSClient,
@@ -26,35 +20,12 @@ class OAuthLoginPreviewController(
       Ok(views.html.previewAuth(context.applicationIdentity.name, "Dev", UserIdentity.fromRequest(request)))
     }
   override def googleAuthConfig(request: Request[AnyContent]): Option[GoogleAuthConfig] = {
-    val securityCredentialsProvider = new AWSCredentialsProviderChain(
-      Configuration.aws.mandatoryCredentials,
-    )
-    val ssmClient = AWSSimpleSystemsManagementClientBuilder
-      .standard()
-      .withCredentials(securityCredentialsProvider)
-      .withRegion(Regions.EU_WEST_1)
-      .build()
-
-    val secretStateSupplier: SnapshotProvider = {
-      import com.gu.play.secretrotation.aws.parameterstore
-
-      new parameterstore.SecretSupplier(
-        TransitionTiming(usageDelay = ofMinutes(3), overlapDuration = ofHours(2)),
-        "/frontend/PlayAppSecret",
-        parameterstore.AwsSdkV1(ssmClient),
+    conf
+      .GoogleAuth(
+        None,
+        httpConfiguration,
+        Configuration.standalone.oauthCredentials,
       )
-    }
-
-    Configuration.standalone.oauthCredentials.map { cred =>
-      GoogleAuthConfig(
-        cred.oauthClientId, // The client ID from the dev console
-        cred.oauthSecret, // The client secret from the dev console
-        cred.oauthCallback, // The redirect URL Google send users back to (must be the same as
-        // that configured in the developer console)
-        List("guardian.co.uk"), // Google App domain to restrict login
-        antiForgeryChecker =
-          AntiForgeryChecker(secretStateSupplier, AntiForgeryChecker.signatureAlgorithmFromPlay(httpConfiguration)),
-      )
-    }
+      .config
   }
 }

--- a/preview/app/controllers/OAuthLoginPreviewController.scala
+++ b/preview/app/controllers/OAuthLoginPreviewController.scala
@@ -1,12 +1,16 @@
 package controllers
 
-import com.gu.googleauth.{GoogleAuthConfig, UserIdentity}
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder
+import com.gu.googleauth.{AntiForgeryChecker, GoogleAuthConfig, UserIdentity}
+import com.gu.play.secretrotation.{SnapshotProvider, TransitionTiming}
 import conf.Configuration
 import googleAuth.OAuthLoginController
 import model.ApplicationContext
 import play.api.http.HttpConfiguration
 import play.api.libs.ws.WSClient
 import play.api.mvc.{Action, AnyContent, ControllerComponents, Request}
+
+import java.time.Duration.{ofHours, ofMinutes}
 
 class OAuthLoginPreviewController(
     val wsClient: WSClient,
@@ -19,15 +23,26 @@ class OAuthLoginPreviewController(
     Action { request =>
       Ok(views.html.previewAuth(context.applicationIdentity.name, "Dev", UserIdentity.fromRequest(request)))
     }
-  override def googleAuthConfig(request: Request[AnyContent]): Option[GoogleAuthConfig] =
+  override def googleAuthConfig(request: Request[AnyContent]): Option[GoogleAuthConfig] = {
+    val secretStateSupplier: SnapshotProvider = {
+      import com.gu.play.secretrotation.aws.parameterstore
+
+      new parameterstore.SecretSupplier(
+        TransitionTiming(usageDelay = ofMinutes(3), overlapDuration = ofHours(2)),
+        "/Example/PlayAppSecret",
+        parameterstore.AwsSdkV1(AWSSimpleSystemsManagementClientBuilder.defaultClient()),
+      )
+    }
     Configuration.standalone.oauthCredentials.map { cred =>
       GoogleAuthConfig(
         cred.oauthClientId, // The client ID from the dev console
         cred.oauthSecret, // The client secret from the dev console
         cred.oauthCallback, // The redirect URL Google send users back to (must be the same as
         // that configured in the developer console)
-        "guardian.co.uk", // Google App domain to restrict login
-        None,
+        List("guardian.co.uk"), // Google App domain to restrict login
+        antiForgeryChecker =
+          AntiForgeryChecker(secretStateSupplier, AntiForgeryChecker.signatureAlgorithmFromPlay(httpConfiguration)),
       )
     }
+  }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -44,7 +44,9 @@ object Dependencies {
   val macwire = "com.softwaremill.macwire" %% "macros" % "2.3.0" % "provided"
   val mockito = "org.mockito" % "mockito-all" % "1.10.19" % Test
   val paClient = "com.gu" %% "pa-client" % "7.0.5"
-  val playGoogleAuth = "com.gu" %% "play-googleauth" % "0.7.0"
+  val playGoogleAuth = "com.gu.play-googleauth" %% "play-v28" % "2.1.1"
+  val playSecretRotation = "com.gu.play-secret-rotation" %% "play-v28" % "0.18"
+  val playSecretRotationAwsSdk = "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v1" % "0.18"
   val quartzScheduler = "org.quartz-scheduler" % "quartz" % "2.2.3"
   val redisClient = "net.debasishg" %% "redisclient" % "3.42"
   val rome = "rome" % "rome" % romeVersion


### PR DESCRIPTION
Co-authored-by: Ioanna Kokkini <ioanna.kokkini@guardian.co.uk>

## What does this change?
In advance of updating the scala version for `frontend` we want to update as many dependencies as possible to be compatible with both 2.12 and 2.13.

We tried updating frontend scala to 2.13. One of the compilation errors was from play-googleauth. This change bumps the [library](https://github.com/guardian/play-googleauth) to a version greater than 0.7.7. Versions >0.7.7 [can no longer use static play application secrets](https://github.com/guardian/play-googleauth#supported-play-versions). As a result we have introduced the recommended [library](https://github.com/guardian/play-secret-rotation) to handle rotating secrets. Updating to latest play-googleauth and play-secret-rotation introduced binary incompatible errors during compilation. We've chosen the highest versions of these libraries that are compatible with both 2.12 and 2.13 but do not introduce binary incompatible errors during compilation.

The change looks intimidating because it touches the auth flow. We'll provide our understanding to help any reviewers:
- Every app in `frontend` defines a static application secret. The secret is read by the app in the [application.conf](https://github.com/guardian/frontend/blob/main/admin/conf/application.conf#L41). The secret is defined in the ec2 [bootstrap script](https://github.com/guardian/platform/blob/main/provisioning/bootstrap/bootstrap.sh#L47). 
- The app secret is used for [signing session cookies and other built-in utilities](https://www.playframework.com/documentation/2.8.8/ApplicationSecret). With play-googleauth <0.7.7 the app secret was also used as part of the [anti-forgery process](https://github.com/guardian/play-googleauth/blob/65a9dff8512d58b7eb9b91b2b69de4d8b73edaf8/play-v27/src/main/scala/com/gu/googleauth/auth.scala#L147) within the google login flow. 
- We could use the deprecated method and continue to use the static app secret but `frontend` is configured to keep us [honest](https://github.com/guardian/frontend/blob/main/project/ProjectSettings.scala#L30). We'd also invested a lot of time into understanding the flow so were happy to migrate to using a secret from parameter store.
- Only the admin and preview apps authenticate with google. We followed this [guide](https://github.com/guardian/play-secret-rotation/blob/main/aws-parameterstore/README.md) when deciding how to approach the migration.
  - We've created a new application secret in the parameter store. For now this secret is static, we can rotate this as part of a subsequent task.
  - We've updated the relevant parts of the codebase to use this secret from the parameter store as part of the anti-forgery flow.

### How does the anti-forgery process work?
Considering the admin application:
1. We define a login [route](https://github.com/guardian/frontend/blob/main/admin/conf/routes#L10) that is associated with a login [action](https://github.com/guardian/frontend/blob/main/common/app/googleAuth/OAuthLoginController.scala#L31)
2. The login action invokes a [method](https://github.com/guardian/frontend/blob/main/admin/app/controllers/admin/OAuthLoginAdminController.scala#L22) that generates a GoogleAuthConfig object.
3. Instantiating the [GoogleAuthConfig](https://github.com/guardian/play-googleauth/blob/main/play-v27/src/main/scala/com/gu/googleauth/auth.scala#L39) class requires a parameter for anti-forgery checking. In [frontend](https://github.com/guardian/frontend/blob/ik-dl/upgrade-googleauth/admin/app/conf/GoogleAuth.scala#L20) we now define an ssm client, a provider that will get the secret from the parameter store and then use these as part of the [definition](https://github.com/guardian/frontend/blob/ik-dl/upgrade-googleauth/admin/app/conf/GoogleAuth.scala#L52) for our anti-forgery checker.
4. The controller in `frontend` [ensures that a user has a sessionId](https://github.com/guardian/frontend/blob/ik-dl/upgrade-googleauth/common/app/googleAuth/OAuthLoginController.scala#L36). This [entails](https://github.com/guardian/play-googleauth/blob/main/play-v27/src/main/scala/com/gu/googleauth/auth.scala#L98) getting a session id from the request or generating one if it doesn't exist.
5. The controller then [redirects]()https://github.com/guardian/frontend/blob/ik-dl/upgrade-googleauth/common/app/googleAuth/OAuthLoginController.scala#L37 the request. The redirect is [handled](https://github.com/guardian/play-googleauth/blob/main/play-v27/src/main/scala/com/gu/googleauth/auth.scala#L196) and does a number of things before forwarding the request.
-- Importantly, it [generates a token using the sessionId](https://github.com/guardian/play-googleauth/blob/main/play-v27/src/main/scala/com/gu/googleauth/auth.scala#L104). Generating the token involves grabbing the secret from ssm and signing the token with this secret.
6. For the admin app the request is forwarded and handled by [oauth2Callback](https://github.com/guardian/frontend/blob/ik-dl/upgrade-googleauth/common/app/googleAuth/OAuthLoginController.scala#L57). Here we validate that the request includes a sessionId and we then [validate the user identity](https://github.com/guardian/play-googleauth/blob/main/play-v27/src/main/scala/com/gu/googleauth/auth.scala#L218). Validating the user identity involves grabbing the sessionId and token and [ensuring the token has been signed with the expected secret](https://github.com/guardian/play-googleauth/blob/main/play-v27/src/main/scala/com/gu/googleauth/auth.scala#L118).
7. If the verification is successful &rarr; a user is considered valid and can be redirected to the expected page!

### Outstanding questions:
- We can see that apps inside the [ophan](https://github.com/guardian/ophan/blob/dbac4e325bc9547fe45a0ca874f45c64bc170f1b/tracker/conf/application.conf#L4) codebase no longer explicitly set/maintain a static app secret, they have only a dummy one. Can frontend do the same or we use this app secret for purposes other than the google auth flow?

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

N/A

## What is the value of this and can you measure success?

Users can continue to login to the admin and preview apps.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
