### PR TITLE
Update Spacefinder rule for immersives

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -92,7 +92,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 				minAbove: 35,
 				minBelow: 400,
 			},
-			' figure.element-immersive': {
+			' [data-spacefinder-role="immersive"]': {
 				minAbove: 0,
 				minBelow: 600,
 			},
@@ -112,7 +112,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 		minBelow: isDotcomRendering ? 300 : 800,
 		selectors: {
 			' .ad-slot': adSlotClassSelectorSizes,
-			' figure.element-immersive': {
+			' [data-spacefinder-role="immersive"]': {
 				minAbove: 0,
 				minBelow: 600,
 			},


### PR DESCRIPTION
## What does this change?

Switch the selector Spacefinder uses to select for immersive figures from `figure.element-immersive` to `[data-spacefinder-role="immersive"]`.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes - [DCR #4380](https://github.com/guardian/dotcom-rendering/pull/4380) has to be merged first.

## What is the value of this and can you measure success?

The `data-spacefinder-role` attribute is more explicit about its purpose and means we don't have to rely on classes/attributs that incidentally identify an element. The basis of this change is detailed [here](https://github.com/guardian/dotcom-rendering/pull/4113).

## Tested

- [X] Locally
- [ ] On CODE (optional)
