### PR TITLE
Fix casing of `richLink` Spacefiner role

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -73,7 +73,7 @@ const articleBodySelector = isDotcomRendering
 
 const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 	const ignoreList = enableRichLinksFix
-		? ' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate):not([data-spacefinder-role="rich-link"])'
+		? ' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate):not([data-spacefinder-role="richLink"])'
 		: ' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate)';
 
 	const isImmersive = config.get('page.isImmersive');


### PR DESCRIPTION
## What does this change?

Switch casing of rich link role attribute, from `rich-link` to `richLink`.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

This causes a bug where we don't correctly add rich links to the Spacefinder ignore list.

### Follow up

Could we prevent this kind of error in the future with automated tests?

### Tested

- [X] Locally
- [ ] On CODE (optional)