### PR TITLE
Add `rikerdebug` to list of accepted URL parameters

### DIFF
--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -76,6 +76,7 @@ class DevParametersHttpRequestHandler(
     "utm_campaign", // Google Analytics campaign
     "utm_term", // Google Analytics term
     "sfdebug", // enable spacefinder visualiser. '1' = first pass, '2' = second pass
+    "rikerdebug", // enable debug logging for Canadian ad setup managed by the Globe and Mail
   )
 
   val playBugs = Seq("") // (Play 2.5 bug?) request.queryString is returning an empty string when empty


### PR DESCRIPTION
## What does this change?
- In Canada, we use [Multiple Customer Management](https://support.google.com/admanager/answer/9611105?hl=en) to allow the Globe and Mail to manage our advertising inventory.
- Users in Canada will have a single line item for each ad slot whose creative fetches a Globe and Mail [script](https://tgamriker.s3.ca-central-1.amazonaws.com/V8MZV_theguardian.com.js) called "riker tag" which handles prebid, permutive, and targeting, then displays an ad from the Globe and Mail's GAM network.
- Including the URL parameter `rikerdebug=true` enables this script's logging. This change adds the parameter to the list of accepted commercial parameters.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<img width="942" alt="Screenshot 2022-03-25 at 17 31 27" src="https://user-images.githubusercontent.com/17057932/160172115-f99ad0f2-3007-4fe8-a0dd-d2b118a19841.png">


## What is the value of this and can you measure success?
Seeing riker logs will make it easier to debug any issues with Canadian advertising on local machines.

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)
