### PR TITLE
Revert reverting #24794 and fixes height issue of figures.

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -8,6 +8,7 @@ object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
     LiveblogRendering,
     StickyVideos,
+    SlideshowCaptions,
   )
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -37,5 +38,5 @@ object SlideshowCaptions
       description = "Captions on fronts slideshows",
       owners = Seq(Owner.withGithub("jamesgorrie")),
       sellByDate = LocalDate.of(2022, 6, 2),
-      participationGroup = Perc0C,
+      participationGroup = Perc0B,
     )

--- a/common/app/views/fragments/items/elements/facia_cards/captionedImage.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/captionedImage.scala.html
@@ -1,0 +1,32 @@
+@import layout.WidthsByBreakpoint
+@import model.ImageMedia
+@import implicits.Requests._
+@import experiments.{ActiveExperiments, SlideshowCaptions}
+
+@(
+    classes: Seq[String],
+    widths: WidthsByBreakpoint,
+    maybeImageMedia: Option[ImageMedia] = None,
+    maybePath: Option[String] = None,
+    maybeSrc: Option[String] = None,
+    shouldLazyLoadIndex: Boolean = false,
+    caption: Option[String] = None
+)(implicit request: RequestHeader)
+
+<figure class="fc-item__captioned-image">
+    @image(
+        classes = classes,
+        widths = widths,
+        maybeImageMedia = maybeImageMedia,
+        maybePath = maybePath,
+        maybeSrc = maybeSrc,
+        shouldLazyLoadIndex = shouldLazyLoadIndex
+    )
+    @if(ActiveExperiments.isParticipating(SlideshowCaptions)) {
+        @caption.map { captionText =>
+            <figcaption>
+                @captionText
+            </figcaption>
+        }
+    }
+</figure>

--- a/common/app/views/fragments/items/elements/facia_cards/image.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/image.scala.html
@@ -3,7 +3,6 @@
 @import model.ImageMedia
 @import views.support.{ImageProfile, ImgSrc, RenderClasses, SrcSet}
 @import implicits.Requests._
-@import experiments.{ActiveExperiments, SlideshowCaptions}
 
 @(
     classes: Seq[String],
@@ -12,31 +11,21 @@
     maybePath: Option[String] = None,
     maybeSrc: Option[String] = None,
     shouldLazyLoadIndex: Boolean = false,
-    caption: Option[String] = None
 )(implicit request: RequestHeader)
 
-<figure>
-    <picture>
-        @* IE 9 needs this workaround as per https://scottjehl.github.io/picturefill/ *@
-        <!--[if IE 9]><video style="display: none;"><![endif]-->
-        @widths.breakpoints.map { breakpointWidth =>
-            <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (min-resolution: 120dpi)"
-            sizes="@breakpointWidth.width"
-            srcset="@SrcSet.asSrcSetString(ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia, hidpi = true))" />
-            <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px)"
-            sizes="@breakpointWidth.width"
-            srcset="@SrcSet.asSrcSetString(ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia))" />
-        }
-        <!--[if IE 9]></video><![endif]-->
-        @maybeImageMedia.map(ImgSrc.getFallbackUrl(_)).orElse(maybeSrc).orElse(maybePath.map(ImgSrc(_, ImageProfile(width = widths.desktop.map(_.get))))).map { src =>
-            <img loading="@{ if (Switches.LazyLoadImages.isSwitchedOn && shouldLazyLoadIndex) "lazy" else "auto"}" class="@RenderClasses(classes: _*)" alt="" src="@src"/>
-        }
-    </picture>
-    @if(ActiveExperiments.isParticipating(SlideshowCaptions)) {
-        @caption.map { captionText =>
-            <figcaption>
-                @captionText
-            </figcaption>
-        }
+<picture>
+    @* IE 9 needs this workaround as per https://scottjehl.github.io/picturefill/ *@
+    <!--[if IE 9]><video style="display: none;"><![endif]-->
+    @widths.breakpoints.map { breakpointWidth =>
+        <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (min-resolution: 120dpi)"
+        sizes="@breakpointWidth.width"
+        srcset="@SrcSet.asSrcSetString(ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia, hidpi = true))" />
+        <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px)"
+        sizes="@breakpointWidth.width"
+        srcset="@SrcSet.asSrcSetString(ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia))" />
     }
-</figure>
+    <!--[if IE 9]></video><![endif]-->
+    @maybeImageMedia.map(ImgSrc.getFallbackUrl(_)).orElse(maybeSrc).orElse(maybePath.map(ImgSrc(_, ImageProfile(width = widths.desktop.map(_.get))))).map { src =>
+        <img loading="@{ if (Switches.LazyLoadImages.isSwitchedOn && shouldLazyLoadIndex) "lazy" else "auto"}" class="@RenderClasses(classes: _*)" alt="" src="@src"/>
+    }
+</picture>

--- a/common/app/views/fragments/items/elements/facia_cards/image.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/image.scala.html
@@ -3,6 +3,7 @@
 @import model.ImageMedia
 @import views.support.{ImageProfile, ImgSrc, RenderClasses, SrcSet}
 @import implicits.Requests._
+@import experiments.{ActiveExperiments, SlideshowCaptions}
 
 @(
     classes: Seq[String],
@@ -10,22 +11,32 @@
     maybeImageMedia: Option[ImageMedia] = None,
     maybePath: Option[String] = None,
     maybeSrc: Option[String] = None,
-        shouldLazyLoadIndex: Boolean = false,
+    shouldLazyLoadIndex: Boolean = false,
+    caption: Option[String] = None
 )(implicit request: RequestHeader)
 
-<picture>
-    @* IE 9 needs this workaround as per https://scottjehl.github.io/picturefill/ *@
-    <!--[if IE 9]><video style="display: none;"><![endif]-->
-    @widths.breakpoints.map { breakpointWidth =>
-        <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (min-resolution: 120dpi)"
-        sizes="@breakpointWidth.width"
-        srcset="@SrcSet.asSrcSetString(ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia, hidpi = true))" />
-        <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px)"
-        sizes="@breakpointWidth.width"
-        srcset="@SrcSet.asSrcSetString(ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia))" />
+<figure>
+    <picture>
+        @* IE 9 needs this workaround as per https://scottjehl.github.io/picturefill/ *@
+        <!--[if IE 9]><video style="display: none;"><![endif]-->
+        @widths.breakpoints.map { breakpointWidth =>
+            <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (min-resolution: 120dpi)"
+            sizes="@breakpointWidth.width"
+            srcset="@SrcSet.asSrcSetString(ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia, hidpi = true))" />
+            <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px)"
+            sizes="@breakpointWidth.width"
+            srcset="@SrcSet.asSrcSetString(ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia))" />
+        }
+        <!--[if IE 9]></video><![endif]-->
+        @maybeImageMedia.map(ImgSrc.getFallbackUrl(_)).orElse(maybeSrc).orElse(maybePath.map(ImgSrc(_, ImageProfile(width = widths.desktop.map(_.get))))).map { src =>
+            <img loading="@{ if (Switches.LazyLoadImages.isSwitchedOn && shouldLazyLoadIndex) "lazy" else "auto"}" class="@RenderClasses(classes: _*)" alt="" src="@src"/>
+        }
+    </picture>
+    @if(ActiveExperiments.isParticipating(SlideshowCaptions)) {
+        @caption.map { captionText =>
+            <figcaption>
+                @captionText
+            </figcaption>
+        }
     }
-    <!--[if IE 9]></video><![endif]-->
-    @maybeImageMedia.map(ImgSrc.getFallbackUrl(_)).orElse(maybeSrc).orElse(maybePath.map(ImgSrc(_, ImageProfile(width = widths.desktop.map(_.get))))).map { src =>
-        <img loading="@{ if (Switches.LazyLoadImages.isSwitchedOn && shouldLazyLoadIndex) "lazy" else "auto"}" class="@RenderClasses(classes: _*)" alt="" src="@src"/>
-    }
-</picture>
+</figure>

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -179,15 +179,15 @@ data-test-id="facia-card"
                 <div class="fc-item__media-wrapper">
                     <div class="fc-item__image-container u-responsive-ratio fc-item__slideshow fc-item__slideshow--@imageElements.size">
                         @imageElements.headOption.map { imageElement =>
-                            @image(
-                                classes = Seq("responsive-img"),
+                            @captionedImage(
+                                classes = Seq("responsive-img "),
                                 widths = item.mediaWidthsByBreakpoint,
                                 maybePath = Some(imageElement.url),
                                 maybeSrc = if(containerIndex == 0 && index < 4) Some(imageElement.url) else None,
                                 caption = imageElement.caption
                             )
                             @imageElements.tail.map { imageElement =>
-                                @image(
+                                @captionedImage(
                                     classes = Seq("responsive-img "),
                                     widths = item.mediaWidthsByBreakpoint,
                                     maybePath = Some(imageElement.url),

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -178,21 +178,23 @@ data-test-id="facia-card"
             case Some(InlineSlideshow(imageElements)) => {
                 <div class="fc-item__media-wrapper">
                     <div class="fc-item__image-container u-responsive-ratio fc-item__slideshow fc-item__slideshow--@imageElements.size">
-                    @imageElements.headOption.map { imageElement =>
-                        @image(
-                            classes = Seq("responsive-img"),
-                            widths = item.mediaWidthsByBreakpoint,
-                            maybePath = Some(imageElement.url),
-                            maybeSrc = if(containerIndex == 0 && index < 4) Some(imageElement.url) else None
-                        )
-                        @imageElements.tail.map { imageElement =>
+                        @imageElements.headOption.map { imageElement =>
                             @image(
-                                classes = Seq("responsive-img "),
+                                classes = Seq("responsive-img"),
                                 widths = item.mediaWidthsByBreakpoint,
-                                maybePath = Some(imageElement.url)
+                                maybePath = Some(imageElement.url),
+                                maybeSrc = if(containerIndex == 0 && index < 4) Some(imageElement.url) else None,
+                                caption = imageElement.caption
                             )
+                            @imageElements.tail.map { imageElement =>
+                                @image(
+                                    classes = Seq("responsive-img "),
+                                    widths = item.mediaWidthsByBreakpoint,
+                                    maybePath = Some(imageElement.url),
+                                    caption = imageElement.caption
+                                )
+                            }
                         }
-                    }
                     </div>
                 </div>
             }

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -142,13 +142,6 @@ $fc-item-gutter: $gs-gutter / 4;
 // Wraps all media elements
 .fc-item__media-wrapper {
     box-sizing: border-box;
-
-    figure {
-        position: absolute;
-        width: 100%;
-        height: 100%;
-        margin: 0;
-    }
 }
 
 // Wraps all non-media content
@@ -546,21 +539,11 @@ $block-height: 58px;
     }
 }
 
-.fc-item__slideshow {
-    figure {
-        @include mq($until: tablet) {
-            &:nth-child(1n+2) {
-                display: none;
-            }
-        }
-
-        @include mq(tablet) {
-            animation-timing-function: linear;
-            animation-iteration-count: infinite;
-            animation-direction: normal;
-            opacity: 0;
-        }
-    }
+.fc-item__captioned-image {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    margin: 0;
 
     figcaption {
         @include f-textSans();
@@ -576,6 +559,23 @@ $block-height: 58px;
 
         @include mq($until: tablet) {
             @include font-size(12, 16);
+        }
+    }
+}
+
+.fc-item__slideshow {
+    figure {
+        @include mq($until: tablet) {
+            &:nth-child(1n+2) {
+                display: none;
+            }
+        }
+
+        @include mq(tablet) {
+            animation-timing-function: linear;
+            animation-iteration-count: infinite;
+            animation-direction: normal;
+            opacity: 0;
         }
     }
 }

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -540,15 +540,18 @@ $block-height: 58px;
 }
 
 .fc-item__slideshow {
-    picture {
+    figure {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        margin: 0;
+
         @include mq($until: tablet) {
-            &:nth-child(1n+2) img {
+            &:nth-child(1n+2) {
                 display: none;
             }
         }
-    }
 
-    img {
         @include mq(tablet) {
             animation-timing-function: linear;
             animation-iteration-count: infinite;
@@ -556,8 +559,24 @@ $block-height: 58px;
             opacity: 0;
         }
     }
-}
 
+    figcaption {
+        @include f-textSans();
+        @include font-size(15, 20);
+        font-weight: bold;
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%,  rgba(0, 0, 0, .8) 100%);
+        color: $brightness-100;
+        padding: 60px 8px 8px;
+
+        @include mq($until: tablet) {
+            @include font-size(12, 16);
+        }
+    }
+}
 
 @for $i from 2 through 5 {
     $hangTime: 5;
@@ -579,16 +598,14 @@ $block-height: 58px;
     }
     @include mq(tablet) {
         .fc-item__slideshow--#{$i} {
-            img {
+            figure {
                 animation-duration: #{$totalLoopTime}s;
                 animation-name: fc-item__slideshow--#{$i};
             }
 
             @for $j from 2 through $i {
-                picture:nth-child(#{$j}) {
-                    img {
-                        animation-delay: #{($totalLoopTime / $i) * ($j - 1)}s;
-                    }
+                figure:nth-child(#{$j}) {
+                    animation-delay: #{($totalLoopTime / $i) * ($j - 1)}s;
                 }
             }
         }

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -142,6 +142,13 @@ $fc-item-gutter: $gs-gutter / 4;
 // Wraps all media elements
 .fc-item__media-wrapper {
     box-sizing: border-box;
+
+    figure {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        margin: 0;
+    }
 }
 
 // Wraps all non-media content
@@ -541,11 +548,6 @@ $block-height: 58px;
 
 .fc-item__slideshow {
     figure {
-        position: absolute;
-        width: 100%;
-        height: 100%;
-        margin: 0;
-
         @include mq($until: tablet) {
             &:nth-child(1n+2) {
                 display: none;

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -306,35 +306,21 @@ $fc-item-gutter: $gs-gutter / 4;
 }
 
 .fc-item__slideshow {
-    figure {
-        position: absolute;
-        width: 100%;
-        height: 100%;
-        margin: 0;
-
+    picture {
         @include mq($until: tablet) {
-            &:nth-child(1n+2) {
+            &:nth-child(1n+2) img {
                 display: none;
             }
         }
+    }
 
+    img {
         @include mq(tablet) {
             animation-timing-function: linear;
             animation-iteration-count: infinite;
             animation-direction: normal;
             opacity: 0;
         }
-    }
-
-    figcaption {
-        @include fs-bodyHeading(1);
-        position: absolute;
-        bottom: 0;
-        left: 0;
-        width: 100%;
-        background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%,  rgba(0, 0, 0, .8) 100%);
-        color: $brightness-100;
-        padding: 60px 8px 8px;
     }
 }
 
@@ -358,19 +344,22 @@ $fc-item-gutter: $gs-gutter / 4;
     }
     @include mq(tablet) {
         .fc-item__slideshow--#{$i} {
-            figure {
+            img {
                 animation-duration: #{$totalLoopTime}s;
                 animation-name: fc-item__slideshow--#{$i};
             }
 
             @for $j from 2 through $i {
-                figure:nth-child(#{$j}) {
-                    animation-delay: #{($totalLoopTime / $i) * ($j - 1)}s;
+                picture:nth-child(#{$j}) {
+                    img {
+                        animation-delay: #{($totalLoopTime / $i) * ($j - 1)}s;
+                    }
                 }
             }
         }
     }
 }
+
 
 .fc-item__video-play {
     display: block;

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -306,21 +306,35 @@ $fc-item-gutter: $gs-gutter / 4;
 }
 
 .fc-item__slideshow {
-    picture {
+    figure {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        margin: 0;
+
         @include mq($until: tablet) {
-            &:nth-child(1n+2) img {
+            &:nth-child(1n+2) {
                 display: none;
             }
         }
-    }
 
-    img {
         @include mq(tablet) {
             animation-timing-function: linear;
             animation-iteration-count: infinite;
             animation-direction: normal;
             opacity: 0;
         }
+    }
+
+    figcaption {
+        @include fs-bodyHeading(1);
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%,  rgba(0, 0, 0, .8) 100%);
+        color: $brightness-100;
+        padding: 60px 8px 8px;
     }
 }
 
@@ -344,22 +358,19 @@ $fc-item-gutter: $gs-gutter / 4;
     }
     @include mq(tablet) {
         .fc-item__slideshow--#{$i} {
-            img {
+            figure {
                 animation-duration: #{$totalLoopTime}s;
                 animation-name: fc-item__slideshow--#{$i};
             }
 
             @for $j from 2 through $i {
-                picture:nth-child(#{$j}) {
-                    img {
-                        animation-delay: #{($totalLoopTime / $i) * ($j - 1)}s;
-                    }
+                figure:nth-child(#{$j}) {
+                    animation-delay: #{($totalLoopTime / $i) * ($j - 1)}s;
                 }
             }
         }
     }
 }
-
 
 .fc-item__video-play {
     display: block;


### PR DESCRIPTION
Reverts guardian/frontend#24818 which reverted guardian/frontend#24794

# The Issue

I wrapped all Images on fronts pages with a `<figure>` but only configured the CSS to apply styles to `<figures>` in a Slideshow. This ended up causing any figures on the page *not* in a slideshow to use the browser default styles which includes some margin on the top and bottom of a figure.

I've simplified things a bit by creating a new captionedImage class which is a composite of the image class, this way we're only wrapping images that need to be in figures.
