### PR TITLE
Add basic JSON-LD Structure to interactives articles (DCR)

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -178,7 +178,7 @@ object DotcomRenderingDataModel {
       page = page,
       request = request,
       pagination = None,
-      linkedData = Nil, // TODO
+      linkedData = LinkedData.forInteractive(page),
       mainBlock = blocks.main,
       bodyBlocks = blocks.body.getOrElse(Nil),
       pageType = pageType,

--- a/common/app/model/dotcomrendering/LinkedData.scala
+++ b/common/app/model/dotcomrendering/LinkedData.scala
@@ -73,7 +73,7 @@ object LinkedData {
       WebPage(
         `@id` = article.metadata.webUrl,
         potentialAction =
-          PotentialAction(target = "android-app://com.guardian/" + article.metadata.webUrl.replace("://", "/")),
+          Some(PotentialAction(target = "android-app://com.guardian/" + article.metadata.webUrl.replace("://", "/"))),
       ),
     )
   }
@@ -109,8 +109,9 @@ object LinkedData {
           ),
           WebPage(
             `@id` = article.metadata.webUrl,
-            potentialAction =
+            potentialAction = Some(
               PotentialAction(target = "android-app://com.guardian/" + article.metadata.webUrl.replace("://", "/")),
+            ),
           ),
         )
       }
@@ -123,8 +124,6 @@ object LinkedData {
     List(
       WebPage(
         `@id` = article.metadata.webUrl,
-        potentialAction =
-          PotentialAction(target = "android-app://com.guardian/" + article.metadata.webUrl.replace("://", "/")),
       ),
     )
   }
@@ -212,7 +211,7 @@ case class WebPage(
     `@type`: String = "WebPage",
     `@context`: String = "https://schema.org",
     `@id`: String,
-    potentialAction: PotentialAction,
+    potentialAction: Option[PotentialAction] = None,
 ) extends LinkedData
 
 object WebPage {

--- a/common/app/model/dotcomrendering/LinkedData.scala
+++ b/common/app/model/dotcomrendering/LinkedData.scala
@@ -1,7 +1,7 @@
 package model.dotcomrendering
 
 import com.gu.contentapi.client.model.v1.{Block => CAPIBlock}
-import model.{Article, LiveBlogPage}
+import model.{Article, InteractivePage, LiveBlogPage}
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
 import play.api.libs.functional.syntax._
@@ -115,6 +115,18 @@ object LinkedData {
         )
       }
     }
+  }
+
+  def forInteractive(
+      article: InteractivePage,
+  ): List[LinkedData] = {
+    List(
+      WebPage(
+        `@id` = article.metadata.webUrl,
+        potentialAction =
+          PotentialAction(target = "android-app://com.guardian/" + article.metadata.webUrl.replace("://", "/")),
+      ),
+    )
   }
 
   private[this] def getImages(article: Article, fallbackLogo: String): List[String] = {


### PR DESCRIPTION
## What does this change?

Adds basic 'WebPage' schema.org data to Interactives for DCR

This is a great starting point for eventually adding more data for interactives!

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No - DCR Already supports the linked data type, we just need to provide it
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/9575458/160433600-b7557dcb-821d-4e29-a77b-dc4b93328637.png
[after]: https://user-images.githubusercontent.com/9575458/160433483-6d9b4e7d-797d-4713-b61c-5797f6ca0af3.png


## What is the value of this and can you measure success?

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
