### PR TITLE
Upgrade targeting-client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ val common = library("common")
       awsCore,
       awsCloudwatch,
       awsDynamodb,
+      awsKinesis,
       awsS3,
       awsSns,
       awsSts,

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ val common = library("common")
       awsCore,
       awsCloudwatch,
       awsDynamodb,
+      awsEc2,
       awsKinesis,
       awsS3,
       awsSns,

--- a/common/app/common/Logback/KinesisAdapter.scala
+++ b/common/app/common/Logback/KinesisAdapter.scala
@@ -1,20 +1,19 @@
 package common.Logback
 
-import java.util.concurrent.{ThreadFactory, ThreadPoolExecutor}
+import java.util.concurrent.ThreadPoolExecutor
 import akka.actor.ActorSystem
 import akka.dispatch.MessageDispatcher
 import akka.pattern.CircuitBreaker
 import ch.qos.logback.classic.spi.ILoggingEvent
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.AWSCredentialsProvider
-import com.amazonaws.client.builder.AwsAsyncClientBuilder
 import com.amazonaws.retry.{PredefinedRetryPolicies, RetryPolicy}
-import com.amazonaws.services.kinesis.{AmazonKinesisAsync, AmazonKinesisAsyncClient}
-import com.amazonaws.services.kinesis.AmazonKinesisAsyncClient.asyncBuilder
+import com.amazonaws.services.kinesis.AmazonKinesisAsyncClient
 import com.gu.logback.appender.kinesis.KinesisAppender
 
 import scala.concurrent.duration._
 import scala.concurrent.Future
+import scala.annotation.nowarn
 
 // LogbackOperationsPool must be wired as a singleton
 class LogbackOperationsPool(val actorSystem: ActorSystem) {
@@ -32,6 +31,7 @@ class SafeBlockingKinesisAppender(logbackOperations: LogbackOperationsPool) exte
     resetTimeout = 10.seconds,
   )(logbackOperations.logbackOperations)
 
+  @nowarn
   override protected def createClient(
       credentials: AWSCredentialsProvider,
       configuration: ClientConfiguration,
@@ -46,13 +46,6 @@ class SafeBlockingKinesisAppender(logbackOperations: LogbackOperationsPool) exte
         true,
       ),
     )
-
-    // Trying to get rid of the deprecated class
-//    AmazonKinesisAsyncClient.asyncBuilder
-//      .withCredentials(credentials)
-//      .withClientConfiguration(configuration)
-//      .withExecutorFactory(ThreadFactory)
-//      .build()
 
     new AmazonKinesisAsyncClient(credentials, configuration, executor)
   }

--- a/common/app/common/Logback/KinesisAdapter.scala
+++ b/common/app/common/Logback/KinesisAdapter.scala
@@ -1,16 +1,18 @@
 package common.Logback
 
-import java.util.concurrent.ThreadPoolExecutor
-
+import java.util.concurrent.{ThreadFactory, ThreadPoolExecutor}
 import akka.actor.ActorSystem
 import akka.dispatch.MessageDispatcher
 import akka.pattern.CircuitBreaker
 import ch.qos.logback.classic.spi.ILoggingEvent
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.client.builder.AwsAsyncClientBuilder
 import com.amazonaws.retry.{PredefinedRetryPolicies, RetryPolicy}
-import com.amazonaws.services.kinesis.AmazonKinesisAsyncClient
+import com.amazonaws.services.kinesis.{AmazonKinesisAsync, AmazonKinesisAsyncClient}
+import com.amazonaws.services.kinesis.AmazonKinesisAsyncClient.asyncBuilder
 import com.gu.logback.appender.kinesis.KinesisAppender
+
 import scala.concurrent.duration._
 import scala.concurrent.Future
 
@@ -44,6 +46,14 @@ class SafeBlockingKinesisAppender(logbackOperations: LogbackOperationsPool) exte
         true,
       ),
     )
+
+    // Trying to get rid of the deprecated class
+//    AmazonKinesisAsyncClient.asyncBuilder
+//      .withCredentials(credentials)
+//      .withClientConfiguration(configuration)
+//      .withExecutorFactory(ThreadFactory)
+//      .build()
+
     new AmazonKinesisAsyncClient(credentials, configuration, executor)
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -67,7 +67,7 @@ object Dependencies {
   // logback2  to prevent "error: reference to logback is ambiguous;"
 
   val kinesisLogbackAppender = "com.gu" % "kinesis-logback-appender" % "1.4.0"
-  val targetingClient = "com.gu" %% "targeting-client" % "1.1.0"
+  val targetingClient = "com.gu" %% "targeting-client" % "1.1.2"
   val scanamo = "org.scanamo" %% "scanamo" % "1.0.0-M11"
   val enumeratumPlayJson = "com.beachape" %% "enumeratum-play-json" % "1.7.0"
   val commercialShared = "com.gu" %% "commercial-shared" % "6.1.6"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,6 +16,7 @@ object Dependencies {
   val awsCore = "com.amazonaws" % "aws-java-sdk-core" % awsVersion
   val awsCloudwatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsVersion
   val awsDynamodb = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion
+  val awsEc2 = "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion
   val awsKinesis = "com.amazonaws" % "aws-java-sdk-kinesis" % awsVersion
   val awsS3 = "com.amazonaws" % "aws-java-sdk-s3" % awsVersion
   val awsSes = "com.amazonaws" % "aws-java-sdk-ses" % awsVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -66,7 +66,7 @@ object Dependencies {
   // logback2  to prevent "error: reference to logback is ambiguous;"
 
   val kinesisLogbackAppender = "com.gu" % "kinesis-logback-appender" % "1.4.0"
-  val targetingClient = "com.gu" %% "targeting-client-play26" % "0.14.7"
+  val targetingClient = "com.gu" %% "targeting-client" % "1.1.0"
   val scanamo = "org.scanamo" %% "scanamo" % "1.0.0-M11"
   val enumeratumPlayJson = "com.beachape" %% "enumeratum-play-json" % "1.7.0"
   val commercialShared = "com.gu" %% "commercial-shared" % "6.1.6"


### PR DESCRIPTION
## What does this change?

In advance of updating the Scala version we want to update as many dependencies as possible to be compatible with both 2.12 and 2.13.

This change bumps [targeting-client](https://index.scala-lang.org/guardian/grid/targeting-client/1.1.0?binaryVersion=_2.13) to the latest version which is compatible with both 2.12 and 2.13.

As part of this PR `aws-java-sdk-kinesis` and `aws-java-sdk-ec2` had also to change from `1.11.26` to `1.11.240`.


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
