### PR TITLE
fix: Removed black line on certain layouts for slideshows.

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -540,7 +540,6 @@ $block-height: 58px;
 }
 
 .fc-item__captioned-image {
-    position: absolute;
     width: 100%;
     height: 100%;
     margin: 0;


### PR DESCRIPTION

## What does this change?

 - Removes unecessary `position: absolute;` from figures which caused an issue with padding on certain Fronts containers. 

### Before

<img width="713" alt="image" src="https://user-images.githubusercontent.com/21217225/160825235-e18519df-d916-4968-962a-f0a148ab9d0e.png">

### After

<img width="711" alt="image" src="https://user-images.githubusercontent.com/21217225/160825423-d732ab15-c0e1-4275-941d-970f72db21ca.png">
