### PR TITLE
Update social card image used for Observer Reviews

### DIFF
--- a/common/app/views/support/ImageProfile.scala
+++ b/common/app/views/support/ImageProfile.scala
@@ -238,7 +238,7 @@ object OpenGraphImage extends OverlayBase64 {
       shouldUpscale: Boolean = false,
   ): ShareImage = {
     val image = rating match {
-      case x if 0 to 5 contains x => s"overlay-base64=${overlayUrlBase64(s"tg-review-$x.png")}"
+      case x if 0 to 5 contains x => s"overlay-base64=${overlayUrlBase64(s"to-review-$x.png")}"
       case _                      => s"overlay-base64=${overlayUrlBase64("to-default.png")}"
     }
     new ShareImage(image, shouldIncludeOverlay, shouldUpscale)


### PR DESCRIPTION
## What does this change?
Due to a three year old copy and paste typo in the codebase, we've been generating the wrong images for social media on Observer reviews. They should show The Observer logo and star rating, but show The Guardian logo and star rating.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
|![image](https://user-images.githubusercontent.com/3300789/161067729-1cd2bcc4-1690-4e7f-8411-ce6125d3d110.png)|![image](https://user-images.githubusercontent.com/3300789/161067782-49ee2daf-214a-402f-b8ce-b7f74e42379f.png)|

## What is the value of this and can you measure success?
Accurate branding for the Observer -- probably not directly measurable

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [X] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
