### PR TITLE
Add NewsArticle json-ld type for Interactives

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -178,7 +178,11 @@ object DotcomRenderingDataModel {
       page = page,
       request = request,
       pagination = None,
-      linkedData = LinkedData.forInteractive(page),
+      linkedData = LinkedData.forInteractive(
+        interactive = page.item,
+        baseURL = Configuration.amp.baseUrl,
+        fallbackLogo = Configuration.images.fallbackLogo,
+      ),
       mainBlock = blocks.main,
       bodyBlocks = blocks.body.getOrElse(Nil),
       pageType = pageType,

--- a/common/app/model/dotcomrendering/LinkedData.scala
+++ b/common/app/model/dotcomrendering/LinkedData.scala
@@ -1,7 +1,7 @@
 package model.dotcomrendering
 
 import com.gu.contentapi.client.model.v1.{Block => CAPIBlock}
-import model.{Article, InteractivePage, LiveBlogPage}
+import model.{Article, ImageMedia, Interactive, LiveBlogPage, Tags}
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
 import play.api.libs.functional.syntax._
@@ -44,13 +44,13 @@ object LinkedData {
       )
 
     val article = liveblog.article
-    val authors = getAuthors(article)
+    val authors = getAuthors(article.tags)
 
     List(
       LiveBlogPosting(
         `@id` = baseURL + article.metadata.id,
-        image = getImages(article, fallbackLogo),
-        author = getAuthors(article),
+        image = getImagesForArticle(article, fallbackLogo),
+        author = authors,
         datePublished = article.trail.webPublicationDate.toString(),
         dateModified = article.fields.lastModified.toString(),
         headline = article.trail.headline,
@@ -60,7 +60,7 @@ object LinkedData {
         liveBlogUpdate = blocks.map(block => {
           BlogPosting(
             `@id` = block.id,
-            image = getImages(article, fallbackLogo),
+            image = getImagesForArticle(article, fallbackLogo),
             author = authors,
             datePublished = article.trail.webPublicationDate.toString(),
             dateModified = article.fields.lastModified.toString(),
@@ -84,7 +84,7 @@ object LinkedData {
       fallbackLogo: String,
   ): List[LinkedData] = {
 
-    val authors = getAuthors(article)
+    val authors = getAuthors(article.tags)
 
     article match {
       case filmReview if article.content.imdb.isDefined && article.tags.isReview => {
@@ -100,7 +100,7 @@ object LinkedData {
         List(
           NewsArticle(
             `@id` = baseURL + "/" + article.metadata.id,
-            image = getImages(article, fallbackLogo),
+            image = getImagesForArticle(article, fallbackLogo),
             author = authors,
             datePublished = article.trail.webPublicationDate.toString(),
             dateModified = article.fields.lastModified.toString(),
@@ -119,19 +119,49 @@ object LinkedData {
   }
 
   def forInteractive(
-      article: InteractivePage,
+      interactive: Interactive,
+      baseURL: String,
+      fallbackLogo: String,
   ): List[LinkedData] = {
+    val authors = getAuthors(interactive.tags)
+
     List(
+      NewsArticle(
+        `@id` = baseURL + "/" + interactive.metadata.id,
+        image = getImagesForInteractive(interactive, fallbackLogo),
+        author = authors,
+        datePublished = interactive.trail.webPublicationDate.toString(),
+        dateModified = interactive.fields.lastModified.toString(),
+        headline = interactive.trail.headline,
+        mainEntityOfPage = interactive.metadata.webUrl,
+      ),
       WebPage(
-        `@id` = article.metadata.webUrl,
+        `@id` = interactive.metadata.webUrl,
+        potentialAction = Some(
+          PotentialAction(target = "android-app://com.guardian/" + interactive.metadata.webUrl.replace("://", "/")),
+        ),
       ),
     )
   }
 
-  private[this] def getImages(article: Article, fallbackLogo: String): List[String] = {
+  private[this] def getImagesForArticle(
+      article: Article,
+      fallbackLogo: String,
+  ): List[String] = getImages(article.trail.trailPicture, article.content.openGraphImage, fallbackLogo)
+
+  private[this] def getImagesForInteractive(
+      article: Interactive,
+      fallbackLogo: String,
+  ): List[String] = getImages(article.trail.trailPicture, article.content.openGraphImage, fallbackLogo)
+
+  private[this] def getImages(
+      trailPicture: Option[ImageMedia],
+      openGraphImage: String,
+      fallbackLogo: String,
+  ): List[String] = {
     val mainImageURL = {
       val main = for {
-        elem <- article.trail.trailPicture
+        elem <- trailPicture
         master <- elem.masterImage
         url <- master.url
       } yield url
@@ -143,22 +173,22 @@ object LinkedData {
     // gif images so we can't guarantee they will be large enough to pass Google
     // structured data requirements (1200px). This should affect very few
     // articles in practice.
-    val openGraphImage = {
-      val preferred = article.content.openGraphImage
+    val preferredOpenGraphImage = {
+      val preferred = openGraphImage
       if (preferred.endsWith(".gif")) ImgSrc(fallbackLogo, Item1200)
       else preferred
     }
 
     List(
-      openGraphImage,
+      preferredOpenGraphImage,
       ImgSrc(mainImageURL, OneByOne),
       ImgSrc(mainImageURL, FourByThree),
       ImgSrc(mainImageURL, Item1200),
     )
   }
 
-  def getAuthors(article: Article): List[Person] = {
-    val authors = article.tags.contributors.map(contributor => {
+  def getAuthors(tags: Tags): List[Person] = {
+    val authors = tags.contributors.map(contributor => {
       Person(
         name = contributor.name,
         sameAs = Some(contributor.metadata.webUrl),


### PR DESCRIPTION
## What does this change?

Part of https://github.com/guardian/frontend/issues/24821
Follows up on https://github.com/guardian/frontend/pull/24823

Adds 'NewsArticle' schema.org type ~ bringing interactives closer inline with articles!

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No - DCR automatically consumes this data
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |


[before]: https://user-images.githubusercontent.com/9575458/161094906-35e00dca-69e0-4531-bd39-2284798d849b.png
[after]: https://user-images.githubusercontent.com/9575458/161094774-2c98c903-d419-4cde-90a2-90df26fc8df0.png

## What is the value of this and can you measure success?

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
