### PR TITLE
Unset expiry on puzzles banner switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -440,7 +440,7 @@ trait FeatureSwitches {
     "Enables the puzzles banner on puzzles pages",
     owners = Seq(Owner.withGithub("i-hardy")),
     safeState = Off,
-    sellByDate = LocalDate.of(2022, 3, 31),
+    sellByDate = never,
     exposeClientSide = true,
   )
 


### PR DESCRIPTION
## What does this change?

Sets puzzles banner feature switch to have no expiry date.