### PR TITLE
Add firstPublishedDisplayNoTimezone to DCR data model

### DIFF
--- a/common/app/model/DatesAndTimes.scala
+++ b/common/app/model/DatesAndTimes.scala
@@ -119,7 +119,9 @@ object GUDateTimeFormatNew {
       case _ => date.toString(DateTimeFormat.forPattern("HH.mm z").withZone(timezone))
     }
   }
-  def dateTimeToLiveBlogDisplay(dateTime: DateTime, timezone: DateTimeZone): String = {
-    dateTime.toString(DateTimeFormat.forPattern("HH:mm z").withZone(timezone))
+  def formatTimeForDisplayNoTimezone(dateTime: DateTime, request: RequestHeader): String = {
+    val edition = Edition(request)
+    val timezone = edition.timezone
+    dateTime.toString(DateTimeFormat.forPattern("HH.mm").withZone(timezone))
   }
 }

--- a/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
@@ -2,6 +2,7 @@ package model.dotcomrendering
 
 import com.gu.contentapi.client.model.v1.{Block => APIBlock}
 import com.gu.contentapi.client.utils.format.ImmersiveDisplay
+import common.Edition
 import common.commercial.{CommercialProperties, EditionCommercialProperties, PrebidIndexSite}
 import model.dotcomrendering.pageElements.PageElement
 import model.{ArticleDateTimes, ContentPage, GUDateTimeFormatNew}
@@ -48,6 +49,7 @@ case class Block(
     blockLastUpdatedDisplay: Option[String],
     blockFirstPublished: Option[Long],
     blockFirstPublishedDisplay: Option[String],
+    blockFirstPublishedDisplayNoTimezone: Option[String],
     title: Option[String],
     contributors: Seq[Contributor],
     primaryDateLine: String,
@@ -81,6 +83,8 @@ object Block {
     val blockFirstPublished = block.firstPublishedDate.map(_.dateTime)
     val blockFirstPublishedDisplay =
       blockFirstPublished.map(dt => GUDateTimeFormatNew.formatTimeForDisplay(new DateTime(dt), request))
+    val blockFirstPublishedDisplayNoTimezone =
+      blockFirstPublished.map(dt => GUDateTimeFormatNew.formatTimeForDisplayNoTimezone(new DateTime(dt), request))
 
     val blockLastUpdated = block.lastModifiedDate.map(_.dateTime)
     val blockLastUpdatedDisplay =
@@ -113,6 +117,7 @@ object Block {
       contributors = contributors,
       blockFirstPublished = blockFirstPublished,
       blockFirstPublishedDisplay = blockFirstPublishedDisplay,
+      blockFirstPublishedDisplayNoTimezone = blockFirstPublishedDisplayNoTimezone,
       primaryDateLine = displayedDateTimes.primaryDateLine,
       secondaryDateLine = displayedDateTimes.secondaryDateLine,
     )


### PR DESCRIPTION
## What does this change?

Part of https://github.com/guardian/dotcom-rendering/issues/4501

Provide a firstPublishedDisplay without the appended timezone to go on liveblocks:
<img width="147" alt="image" src="https://user-images.githubusercontent.com/9575458/161550475-a0ef7717-e589-4f7e-a053-c6ea07c3ebb0.png">

The live-block time is an exception in DCR where editionalised time does not receive a timezone appended at the end (confirmed with design); so creating a new field in the data model made more sense than updating an existing one, as this makes the inconsistency clear and reasoned.

Replaces current logic in DCR removing the timezone from the existing data: https://github.com/guardian/dotcom-rendering/pull/4500

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes - DCR Will be updated to consume the new data

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/9575458/161549929-dccf6065-e49b-4dcb-b5ab-446230249f98.png
[after]: https://user-images.githubusercontent.com/9575458/161549806-bf71e12a-94cf-4d98-ba82-c2d1b4431b18.png

## What is the value of this and can you measure success?

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
