### PR TITLE
Prebid price granularity AB test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -53,4 +53,14 @@ trait ABTestSwitches {
     sellByDate = Some(LocalDate.of(2022, 5, 2)),
     exposeClientSide = true,
   )
+
+  Switch(
+    ABTests,
+    "ab-prebid-price-granularity",
+    "Test the commercial impact of changing the Prebid Price granularity for Ozone",
+    owners = Seq(Owner.withGithub("chrislomaxjones")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2022, 5, 3)),
+    exposeClientSide = true,
+  )
 }

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.spec.ts
@@ -19,15 +19,7 @@ jest.mock('../../dfp/get-advert-by-id', () => ({
 }));
 
 jest.mock('../../../../common/modules/experiments/ab', () => ({
-	/**
-	 * Mock defaults to being in control for all tests
-	 * @example
-	 * isInVariantSynchronous(testId, 'control'); // => true
-	 * isInVariantSynchronous(testId, 'variant'); // => false
-	 */
-	isInVariantSynchronous: jest.fn(
-		(_testId, variantId) => variantId !== 'variant',
-	),
+	isInVariantSynchronous: jest.fn(),
 }));
 
 const resetPrebid = () => {

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.spec.ts
@@ -19,8 +19,14 @@ jest.mock('../../dfp/get-advert-by-id', () => ({
 }));
 
 jest.mock('../../../../common/modules/experiments/ab', () => ({
+	/**
+	 * Mock defaults to being in control for all tests
+	 * @example
+	 * isInVariantSynchronous(testId, 'control'); // => true
+	 * isInVariantSynchronous(testId, 'variant'); // => false
+	 */
 	isInVariantSynchronous: jest.fn(
-		(_testId, variantId) => variantId === 'variant',
+		(_testId, variantId) => variantId !== 'variant',
 	),
 }));
 

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
@@ -273,8 +273,6 @@ const initialise = (window: Window, framework: Framework = 'tcfv2'): void => {
 		},
 	);
 
-	// This creates an 'unsealed' object. Flows
-	// allows dynamic assignment.
 	window.pbjs.bidderSettings = {};
 
 	if (window.guardian.config.switches.consentManagement) {

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
@@ -156,8 +156,8 @@ declare global {
 				config: {
 					customPriceBucket?: PrebidPriceGranularity;
 					/**
-					 * This is a custom property that has been added to select
-					 * a price bucket based on the width and height of the slot
+					 * This is a custom property that has been added to our fork of prebid.js
+					 * to select a price bucket based on the width and height of the slot
 					 */
 					guCustomPriceBucket?: (bid: {
 						width: number;

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
@@ -6,6 +6,8 @@ import type { Advert } from 'commercial/modules/dfp/Advert';
 import type { PageTargeting } from 'common/modules/commercial/build-page-targeting';
 import { getPageTargeting } from 'common/modules/commercial/build-page-targeting';
 import { getEnhancedConsent } from 'common/modules/commercial/enhanced-consent';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { prebidPriceGranularity } from 'common/modules/experiments/tests/prebid-price-granularity';
 import config from '../../../../../lib/config';
 import { dfpEnv } from '../../dfp/dfp-env';
 import { getAdvertById } from '../../dfp/get-advert-by-id';
@@ -13,7 +15,11 @@ import { getHeaderBiddingAdSlots } from '../slot-config';
 import { stripDfpAdPrefixFrom } from '../utils';
 import { bids } from './bid-config';
 import type { PrebidPriceGranularity } from './price-config';
-import { criteoPriceGranularity, priceGranularity } from './price-config';
+import {
+	criteoPriceGranularity,
+	ozonePriceGranularity,
+	priceGranularity,
+} from './price-config';
 import { pubmatic } from './pubmatic';
 
 type CmpApi = 'iab' | 'static';
@@ -122,6 +128,7 @@ type BidderSettings = {
 	standard?: never; // prevent overriding the default settings
 	xhb?: Partial<BidderSetting<XaxisBidResponse>>;
 	improvedigital?: Partial<BidderSetting>;
+	ozone?: Partial<BidderSetting>;
 };
 
 declare global {
@@ -148,6 +155,14 @@ declare global {
 				bidders: BidderCode[];
 				config: {
 					customPriceBucket?: PrebidPriceGranularity;
+					/**
+					 * This is a custom property that has been added to select
+					 * a price bucket based on the width and height of the slot
+					 */
+					guCustomPriceBucket?: (bid: {
+						width: number;
+						height: number;
+					}) => PrebidPriceGranularity;
 				};
 			}) => void;
 			getConfig: (item?: string) => PbjsConfig & {
@@ -258,6 +273,10 @@ const initialise = (window: Window, framework: Framework = 'tcfv2'): void => {
 		},
 	);
 
+	// This creates an 'unsealed' object. Flows
+	// allows dynamic assignment.
+	window.pbjs.bidderSettings = {};
+
 	if (window.guardian.config.switches.consentManagement) {
 		pbjsConfig.consentManagement = consentManagement();
 	}
@@ -296,6 +315,33 @@ const initialise = (window: Window, framework: Framework = 'tcfv2'): void => {
 		});
 	}
 
+	if (
+		window.guardian.config.switches.prebidOzone &&
+		isInVariantSynchronous(prebidPriceGranularity, 'variant')
+	) {
+		// When in the variant of the test use a custom price granularity for Ozone
+		// The variant line items will have a separate structure
+		window.pbjs.setBidderConfig({
+			bidders: ['ozone'],
+			config: {
+				// Select the ozone granularity, use default if not defined for the size
+				guCustomPriceBucket: ({ width, height }) =>
+					ozonePriceGranularity(width, height) ?? priceGranularity,
+			},
+		});
+
+		// Add key-value targeting to only match line items setup for variant of test
+		// Line items in control must negatively target this value
+		window.pbjs.bidderSettings.ozone = {
+			adserverTargeting: [
+				{
+					key: 'hb_ab_test',
+					val: () => 'variant',
+				},
+			],
+		};
+	}
+
 	window.pbjs.setConfig(pbjsConfig);
 
 	if (config.get<boolean>('switches.prebidAnalytics', false)) {
@@ -309,10 +355,6 @@ const initialise = (window: Window, framework: Framework = 'tcfv2'): void => {
 			},
 		]);
 	}
-
-	// This creates an 'unsealed' object. Flows
-	// allows dynamic assignment.
-	window.pbjs.bidderSettings = {};
 
 	if (config.get<boolean>('switches.prebidXaxis', false)) {
 		window.pbjs.bidderSettings.xhb = {

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/price-config.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/price-config.spec.ts
@@ -1,4 +1,8 @@
-import { criteoPriceGranularity, priceGranularity } from './price-config';
+import {
+	criteoPriceGranularity,
+	ozonePriceGranularity,
+	priceGranularity,
+} from './price-config';
 
 describe('priceGranularity', () => {
 	test('default should have correct buckets', () => {
@@ -34,4 +38,54 @@ describe('priceGranularity', () => {
 			],
 		});
 	});
+
+	const granularityOption1 = {
+		buckets: [
+			{
+				max: 10,
+				increment: 0.01,
+			},
+			{
+				max: 15,
+				increment: 0.1,
+			},
+			{
+				max: 50,
+				increment: 1,
+			},
+		],
+	};
+
+	const granularityOption2 = {
+		buckets: [
+			{
+				max: 12,
+				increment: 0.01,
+			},
+			{
+				max: 20,
+				increment: 0.1,
+			},
+			{
+				max: 50,
+				increment: 1,
+			},
+		],
+	};
+
+	test.each([
+		[[100, 100], undefined],
+		[[160, 600], granularityOption1],
+		[[300, 600], granularityOption1],
+		[[728, 90], granularityOption2],
+		[[970, 250], granularityOption2],
+		[[300, 250], granularityOption2],
+	])(
+		'Ozone slot with size %d,%d gives correct granularity',
+		([width, height], expectedGranularity) => {
+			expect(ozonePriceGranularity(width, height)).toEqual(
+				expectedGranularity,
+			);
+		},
+	);
 });

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/price-config.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/price-config.spec.ts
@@ -1,7 +1,7 @@
 import { criteoPriceGranularity, priceGranularity } from './price-config';
 
 describe('priceGranularity', () => {
-	test('default should have correct number of buckets', () => {
+	test('default should have correct buckets', () => {
 		expect(priceGranularity).toEqual({
 			buckets: [
 				{
@@ -16,7 +16,7 @@ describe('priceGranularity', () => {
 		});
 	});
 
-	test('criteo should have correct number of buckets', () => {
+	test('criteo should have correct buckets', () => {
 		expect(criteoPriceGranularity).toEqual({
 			buckets: [
 				{

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/price-config.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/price-config.spec.ts
@@ -81,7 +81,7 @@ describe('priceGranularity', () => {
 		[[970, 250], granularityOption2],
 		[[300, 250], granularityOption2],
 	])(
-		'Ozone slot with size %d,%d gives correct granularity',
+		'Ozone slot with size %s gives correct granularity',
 		([width, height], expectedGranularity) => {
 			expect(ozonePriceGranularity(width, height)).toEqual(
 				expectedGranularity,

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/price-config.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/price-config.ts
@@ -1,3 +1,5 @@
+import { adSizes } from '@guardian/commercial-core';
+
 export type PrebidPriceGranularity = {
 	buckets: Array<{
 		precision?: number;
@@ -43,48 +45,52 @@ export const ozonePriceGranularity = (
 	width: number,
 	height: number,
 ): PrebidPriceGranularity | undefined => {
-	switch ([width, height].join(',')) {
-		case '160,600':
-		case '300,600': {
-			return {
-				buckets: [
-					{
-						max: 10,
-						increment: 0.01,
-					},
-					{
-						max: 15,
-						increment: 0.1,
-					},
-					{
-						max: 50,
-						increment: 1,
-					},
-				],
-			};
-		}
-		case '728,90':
-		case '970,250':
-		case '300,250': {
-			return {
-				buckets: [
-					{
-						max: 12,
-						increment: 0.01,
-					},
-					{
-						max: 20,
-						increment: 0.1,
-					},
-					{
-						max: 50,
-						increment: 1,
-					},
-				],
-			};
-		}
-		default: {
-			return undefined;
-		}
+	const sizeString = [width, height].join(',');
+
+	if (
+		sizeString === adSizes.skyscraper.toString() ||
+		sizeString === adSizes.halfPage.toString()
+	) {
+		return {
+			buckets: [
+				{
+					max: 10,
+					increment: 0.01,
+				},
+				{
+					max: 15,
+					increment: 0.1,
+				},
+				{
+					max: 50,
+					increment: 1,
+				},
+			],
+		};
 	}
+
+	if (
+		sizeString === adSizes.leaderboard.toString() ||
+		sizeString === adSizes.billboard.toString() ||
+		sizeString === adSizes.mpu.toString()
+	) {
+		return {
+			buckets: [
+				{
+					max: 12,
+					increment: 0.01,
+				},
+				{
+					max: 20,
+					increment: 0.1,
+				},
+				{
+					max: 50,
+					increment: 1,
+				},
+			],
+		};
+	}
+
+	return undefined;
 };

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/price-config.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/price-config.ts
@@ -35,3 +35,56 @@ export const criteoPriceGranularity: PrebidPriceGranularity = {
 		},
 	],
 };
+
+/**
+ * Compute the price granularity for Ozone based on the width and height of the slot
+ */
+export const ozonePriceGranularity = (
+	width: number,
+	height: number,
+): PrebidPriceGranularity | undefined => {
+	switch ([width, height].join(',')) {
+		case '160,600':
+		case '300,600': {
+			return {
+				buckets: [
+					{
+						max: 10,
+						increment: 0.01,
+					},
+					{
+						max: 15,
+						increment: 0.1,
+					},
+					{
+						max: 50,
+						increment: 1,
+					},
+				],
+			};
+		}
+		case '728,90':
+		case '970,250':
+		case '300,250': {
+			return {
+				buckets: [
+					{
+						max: 12,
+						increment: 0.01,
+					},
+					{
+						max: 20,
+						increment: 0.1,
+					},
+					{
+						max: 50,
+						increment: 1,
+					},
+				],
+			};
+		}
+		default: {
+			return undefined;
+		}
+	}
+};

--- a/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
@@ -2,6 +2,7 @@ import type { ABTest } from '@guardian/ab-core';
 import { isInABTestSynchronous } from '../experiments/ab';
 import { commercialGptLazyLoad } from '../experiments/tests/commercial-gpt-lazy-load';
 import { commercialLazyLoadMargin } from '../experiments/tests/commercial-lazy-load-margin';
+import { prebidPriceGranularity } from '../experiments/tests/prebid-price-granularity';
 import { spacefinderOkrMegaTest } from '../experiments/tests/spacefinder-okr-mega-test';
 
 const defaultClientSideTests: ABTest[] = [
@@ -9,6 +10,7 @@ const defaultClientSideTests: ABTest[] = [
 	spacefinderOkrMegaTest,
 	commercialGptLazyLoad,
 	commercialLazyLoadMargin,
+	prebidPriceGranularity,
 ];
 
 const serverSideTests: ServerSideABTest[] = [];

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -1,6 +1,7 @@
 import type { ABTest } from '@guardian/ab-core';
 import { commercialGptLazyLoad } from './tests/commercial-gpt-lazy-load';
 import { commercialLazyLoadMargin } from './tests/commercial-lazy-load-margin';
+import { prebidPriceGranularity } from './tests/prebid-price-granularity';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
@@ -15,4 +16,5 @@ export const concurrentTests: readonly ABTest[] = [
 	spacefinderOkrMegaTest,
 	commercialGptLazyLoad,
 	commercialLazyLoadMargin,
+	prebidPriceGranularity,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/prebid-price-granularity.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/prebid-price-granularity.ts
@@ -1,0 +1,27 @@
+import type { ABTest } from '@guardian/ab-core';
+import { noop } from '../../../../../lib/noop';
+
+export const prebidPriceGranularity: ABTest = {
+	id: 'PrebidPriceGranularity',
+	start: '2022-04-05',
+	expiry: '2022-05-03',
+	author: 'Chris Jones (@chrislomaxjones)',
+	description:
+		'Test the commercial impact of changing Prebid Price granularity for Ozone',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	successMeasure:
+		'No significant negative impact on CPM when using a granularity that permits fewer line items',
+	audienceCriteria: 'n/a',
+	canRun: () => true,
+	variants: [
+		{
+			id: 'control',
+			test: noop,
+		},
+		{
+			id: 'variant',
+			test: noop,
+		},
+	],
+};

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -404,7 +404,9 @@
   "../projects/common/modules/experiments/ab.ts",
   "../projects/common/modules/experiments/tests/prebid-price-granularity.ts"
  ],
- "../projects/commercial/modules/header-bidding/prebid/price-config.ts": [],
+ "../projects/commercial/modules/header-bidding/prebid/price-config.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts"
+ ],
  "../projects/commercial/modules/header-bidding/prebid/pubmatic.js": [],
  "../projects/commercial/modules/header-bidding/slot-config.ts": [
   "../lib/config.d.ts",

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -1,4 +1,5 @@
 {
+ "../../../../../Prebid.js/build/dist/prebid.js": [],
  "../lib/$$.ts": [
   "../../../../node_modules/csstype/index.d.ts"
  ],
@@ -299,11 +300,11 @@
   "../lib/report-error.js"
  ],
  "../projects/commercial/modules/dfp/prepare-prebid.ts": [
+  "../../../../../Prebid.js/build/dist/prebid.js",
   "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
   "../../../../node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../../../../node_modules/@types/lodash-es/index.d.ts",
-  "../../../../node_modules/prebid.js/build/dist/prebid.js",
   "../lib/config.d.ts",
   "../lib/detect-google-proxy.ts",
   "../projects/commercial/modules/dfp/dfp-env.ts",
@@ -399,7 +400,9 @@
   "../projects/commercial/modules/header-bidding/slot-config.ts",
   "../projects/commercial/modules/header-bidding/utils.ts",
   "../projects/common/modules/commercial/build-page-targeting.ts",
-  "../projects/common/modules/commercial/enhanced-consent.ts"
+  "../projects/common/modules/commercial/enhanced-consent.ts",
+  "../projects/common/modules/experiments/ab.ts",
+  "../projects/common/modules/experiments/tests/prebid-price-granularity.ts"
  ],
  "../projects/commercial/modules/header-bidding/prebid/price-config.ts": [],
  "../projects/commercial/modules/header-bidding/prebid/pubmatic.js": [],
@@ -574,6 +577,7 @@
   "../projects/common/modules/experiments/ab.ts",
   "../projects/common/modules/experiments/tests/commercial-gpt-lazy-load.ts",
   "../projects/common/modules/experiments/tests/commercial-lazy-load-margin.ts",
+  "../projects/common/modules/experiments/tests/prebid-price-granularity.ts",
   "../projects/common/modules/experiments/tests/spacefinder-okr-mega-test.ts"
  ],
  "../projects/common/modules/article/space-filler.ts": [
@@ -659,6 +663,7 @@
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
   "../projects/common/modules/experiments/tests/commercial-gpt-lazy-load.ts",
   "../projects/common/modules/experiments/tests/commercial-lazy-load-margin.ts",
+  "../projects/common/modules/experiments/tests/prebid-price-granularity.ts",
   "../projects/common/modules/experiments/tests/remote-header-test.js",
   "../projects/common/modules/experiments/tests/sign-in-gate-main-control.js",
   "../projects/common/modules/experiments/tests/sign-in-gate-main-variant.js",
@@ -690,6 +695,10 @@
   "../lib/noop.ts"
  ],
  "../projects/common/modules/experiments/tests/commercial-lazy-load-margin.ts": [
+  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
+  "../lib/noop.ts"
+ ],
+ "../projects/common/modules/experiments/tests/prebid-price-granularity.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
   "../lib/noop.ts"
  ],


### PR DESCRIPTION
## What does this change

This PR adds a 0% AB test for testing a new proposed line item setup for an SSP called Ozone.

Specifically, that means using a different [price granularity](https://docs.prebid.org/dev-docs/examples/custom-price-buckets.html) specifically for the Ozone bidder. Visitors to the website in the variant group of the test will have this different pricing structure applied to Ozone, whereas those in the control or not participating will experience no change. Additionally, the granularity will vary depending on the size of the ad. The different price structures are summarised in the table below:

<table>
<tr><th>160x600, 300x600</th><th>728x90, 970x250, 300x250</th></tr>
<tr><td>

| Increments | Bucket Start | Bucket End |
|:----------:|:------------:|:----------:|
|    $0.01   |     $0.01    |    $9.99   |
|    $0.10   |    $10.00    |   $14.95   |
|    $1.00   |      $15     |     $49    |
|      -     |      $50     |      -     |

</td><td>

| Increments | Bucket Start | Bucket End |
|:----------:|:------------:|:----------:|
|    $0.01   |     $0.01    |   $11.99   |
|    $0.10   |    $12.00    |   $19.95   |
|    $1.00   |      $20     |     $49    |
|      -     |      $50     |      -     |

</td></tr> </table>

We previously had one granularity across all bidders. This was changed in #24886, where we added a custom granularity for Criteo. We extend this functionality to allow a custom granularity to selected by Ozone based on the size of the ad - a change introduced in [@guardian/Prebid.js #126](https://github.com/guardian/Prebid.js/pull/126).

These new price buckets will correspond to a new set of line items that will run in parallel with the existing ones. These line items will be generated in a subsequent PR.

#### How will the variant target the new set of line items?

We add key-value targeting `hb_ab_test=variant` to all winning Ozone bids in the variant. This is so they can target the new set of line items. If we apply negative targeting to this key-value, this should make this line items eligible only in the variant group.

## Does this change need to be reproduced in dotcom-rendering?

- [ ] No
- [X] Yes - There is a corresponding [DCR PR](https://github.com/guardian/dotcom-rendering/pull/4529).

## Why

We'd like to reduce the number of automated line items in Google Ad Manager. To do this, we need to increase the size of the price increments in our granularities. In doing so, we may find we lose revenue, meaning there is a trade-off between how much we can reduce our line items without affecting our revenue. To measure the impact, we run this experiment with a proposed new line item setup and will measure to see if there is any significant change in revenue per 1000 pageviews.

#### Why Ozone?

We intend to reduce the line item count across all our SSPs, but for the purpose of the test we'll just be using Ozone. Running the new and old set of line items in parallel would push us over our limit, hence why we will use one SSP for the test.

#### Why a 0% test?

This allows the variant functionality to be tested in production by manually opting oneself into the test, without affecting visitors to the site. Once sample sizes and so on have been agreed we can increase participation to the correct percentage in a separate PR.
