### PR TITLE
Fix `top-above-nav` test

### DIFF
--- a/cypress/integration/top-above-nav.spec.js
+++ b/cypress/integration/top-above-nav.spec.js
@@ -48,7 +48,7 @@ describe('top-above-nav on pages', () => {
 			cy.visit(`${path}?adtest=${adTest}`);
 
 			// Click "Yes, I'm happy" on the sourcepoint banner to obtain consent
-			getIframeBody('sp_message_iframe_597005')
+			getIframeBody('sp_message_iframe_')
 				.find('.btn-primary')
 				.click();
 

--- a/cypress/lib/iframe.js
+++ b/cypress/lib/iframe.js
@@ -3,7 +3,6 @@
 export const getIframeBody = (iframeIdPrefix) => {
 	// Retrieve the iframe element on the page
 	const iframe = cy
-		//`[data-cy^="youtube-overlay-NtN-a6inr1E"]`
 		.get(`iframe[id^="${iframeIdPrefix}"]`)
 		.its('0.contentDocument')
 		.should('exist');

--- a/cypress/lib/iframe.js
+++ b/cypress/lib/iframe.js
@@ -1,9 +1,10 @@
 /// <reference types="cypress" />
 
-export const getIframeBody = (iframeId) => {
+export const getIframeBody = (iframeIdPrefix) => {
 	// Retrieve the iframe element on the page
 	const iframe = cy
-		.get(`iframe#${iframeId}`)
+		//`[data-cy^="youtube-overlay-NtN-a6inr1E"]`
+		.get(`iframe[id^="${iframeIdPrefix}"]`)
 		.its('0.contentDocument')
 		.should('exist');
 


### PR DESCRIPTION
## What does this change?
- The id of the sourcepoint banner can change over time and has changed since this test was initially created. 
- After this change, the banner is selected by its id's prefix (`sp_message_iframe_`) rather than the entire value (e.g. `sp_message_iframe_597005`)