### PR TITLE
Remove DCR support for rugby liveblogs

### DIFF
--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -369,7 +369,11 @@ object LiveBlogController {
     blog.article.tags.tags.exists(tag => tag.id == "sport/cricket")
   }
 
+  def isRugby(blog: PageWithStoryPackage): Boolean = {
+    blog.article.tags.tags.exists(tag => tag.id == "sport/rugby-union")
+  }
+
   def checkIfSupported(blog: PageWithStoryPackage): Boolean = {
-    isSupportedTheme(blog) && !isCricket(blog)
+    isSupportedTheme(blog) && !isCricket(blog) && !isRugby(blog)
   }
 }


### PR DESCRIPTION
## What does this change?

Rugby liveblogs have logic for getting match stats - We don't know if this is still used, but to be on the safe side we should remove support and manually enable again it when we're happy we support them.
