### PR TITLE
Extend both lazy load tests to the first of May

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -40,7 +40,7 @@ trait ABTestSwitches {
     "Test various margins at which ads are lazily-loaded in order to find the optimal one",
     owners = Seq(Owner.withGithub("zekehuntergreen")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2022, 5, 1)),
+    sellByDate = Some(LocalDate.of(2022, 5, 2)),
     exposeClientSide = true,
   )
 
@@ -50,7 +50,7 @@ trait ABTestSwitches {
     "This test enables GPT enableLazyLoad as an alternative to our custom lazy loading",
     owners = Seq(Owner.withGithub("zekehuntergreen")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2022, 5, 1)),
+    sellByDate = Some(LocalDate.of(2022, 5, 2)),
     exposeClientSide = true,
   )
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -40,7 +40,7 @@ trait ABTestSwitches {
     "Test various margins at which ads are lazily-loaded in order to find the optimal one",
     owners = Seq(Owner.withGithub("zekehuntergreen")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2022, 4, 14)),
+    sellByDate = Some(LocalDate.of(2022, 5, 1)),
     exposeClientSide = true,
   )
 
@@ -50,7 +50,7 @@ trait ABTestSwitches {
     "This test enables GPT enableLazyLoad as an alternative to our custom lazy loading",
     owners = Seq(Owner.withGithub("zekehuntergreen")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2022, 4, 12)),
+    sellByDate = Some(LocalDate.of(2022, 5, 1)),
     exposeClientSide = true,
   )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-gpt-lazy-load.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-gpt-lazy-load.ts
@@ -5,7 +5,7 @@ export const commercialGptLazyLoad: ABTest = {
 	id: 'CommercialGptLazyLoad',
 	start: '2022-03-29',
 	// The test should run for ten days
-	expiry: '2022-04-12',
+	expiry: '2022-05-01',
 	author: 'Zeke Hunter-Green',
 	description:
 		'This test compares GPT enableLazyLoad to our custom-built lazy load solution',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-lazy-load-margin.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-lazy-load-margin.ts
@@ -5,7 +5,7 @@ export const commercialLazyLoadMargin: ABTest = {
 	id: 'CommercialLazyLoadMargin',
 	start: '2022-03-29',
 	// test should be in place for a minimum of 16 days
-	expiry: '2022-04-19',
+	expiry: '2022-05-01',
 	author: 'Zeke Hunter-Green',
 	description:
 		'Test various margins at which ads are lazily-loaded in order to find the optimal one',


### PR DESCRIPTION
## What does this change?
- extends expiry date of both lazy load tests to the first of March

## Why?
- The GPT test needs to run for more than 10 days since the relevant data is being collected more slowly than expected
- There's no harm in adding more time to the test duration than we'll end up needing

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes https://github.com/guardian/dotcom-rendering/pull/4512
