### PR TITLE
fix: Fix certain slideshows not rendering as slideshows.

### DIFF
--- a/common/app/views/fragments/items/facia_cards/dynamoContentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/dynamoContentCard.scala.html
@@ -188,21 +188,23 @@ data-test-id="facia-card"
             case Some(InlineSlideshow(imageElements)) => {
                 <div class="fc-item__media-wrapper">
                     <div class="fc-item__image-container u-responsive-ratio fc-item__slideshow fc-item__slideshow--@imageElements.size">
-                    @imageElements.headOption.map { imageElement =>
-                        @image(
-                            classes = Seq("responsive-img"),
-                            widths = item.mediaWidthsByBreakpoint,
-                            maybePath = Some(imageElement.url),
-                            maybeSrc = if(containerIndex == 0 && index < 4) Some(imageElement.url) else None
-                        )
-                        @imageElements.tail.map { imageElement =>
-                            @image(
+                        @imageElements.headOption.map { imageElement =>
+                            @captionedImage(
                                 classes = Seq("responsive-img "),
                                 widths = item.mediaWidthsByBreakpoint,
-                                maybePath = Some(imageElement.url)
+                                maybePath = Some(imageElement.url),
+                                maybeSrc = if(containerIndex == 0 && index < 4) Some(imageElement.url) else None,
+                                caption = imageElement.caption
                             )
+                            @imageElements.tail.map { imageElement =>
+                                @captionedImage(
+                                    classes = Seq("responsive-img "),
+                                    widths = item.mediaWidthsByBreakpoint,
+                                    maybePath = Some(imageElement.url),
+                                    caption = imageElement.caption
+                                )
+                            }
                         }
-                    }
                     </div>
                 </div>
             }


### PR DESCRIPTION
## What does this change?

Fixes Slideshows on dynamic content cards not rendering correctly. I'm not quite sure what makes a container "dynamic", I believe its something related to what the content of the container is?

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
