### PR TITLE
feat: Move slideshow captions to top left when Sublinks are displayed

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -561,14 +561,14 @@ $block-height: 58px;
         color: $brightness-100;
         padding: 60px 8px 8px;
     }
-}
 
-.fc-item--has-floating-sublinks .fc-item__captioned-image {
-    figcaption {
-        @include mq(tablet) {
-            background: linear-gradient(to top, rgba(0, 0, 0, 0) 0%,  rgba(0, 0, 0, .8) 100%);
-            padding: 8px 8px 60px;
-            bottom: inherit;
+    .fc-item--has-floating-sublinks & {
+        figcaption {
+            @include mq(tablet) {
+                background: linear-gradient(to top, rgba(0, 0, 0, 0) 0%,  rgba(0, 0, 0, .8) 100%);
+                padding: 8px 8px 60px;
+                bottom: inherit;
+            }
         }
     }
 }

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -547,6 +547,11 @@ $block-height: 58px;
     figcaption {
         @include f-textSans();
         @include font-size(15, 20);
+
+        @include mq($until: tablet) {
+            @include font-size(12, 16);
+        }
+
         font-weight: bold;
         position: absolute;
         bottom: 0;
@@ -555,9 +560,15 @@ $block-height: 58px;
         background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%,  rgba(0, 0, 0, .8) 100%);
         color: $brightness-100;
         padding: 60px 8px 8px;
+    }
+}
 
-        @include mq($until: tablet) {
-            @include font-size(12, 16);
+.fc-item--has-floating-sublinks .fc-item__captioned-image {
+    figcaption {
+        @include mq(tablet) {
+            background: linear-gradient(to top, rgba(0, 0, 0, 0) 0%,  rgba(0, 0, 0, .8) 100%);
+            padding: 8px 8px 60px;
+            bottom: inherit;
         }
     }
 }


### PR DESCRIPTION
## What does this change?

 - Move captions to the top left if there are sublinks on a slideshow.
 - Always display captions in the bottom left on displays smaller than tablets

## Screenshots

![2022-04-06 11 23 54](https://user-images.githubusercontent.com/21217225/161956359-e5fbed6e-8a56-4e96-bf7e-9183c82c7e3e.gif)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
