### PR TITLE
fix: Fix the json endpoint for fronts

### DIFF
--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -200,7 +200,8 @@ trait FaciaController
       case Some((faciaPage, _)) if nonHtmlEmail(request) =>
         successful(Cached(CacheTime.RecentlyUpdated)(renderEmail(faciaPage)))
       case Some((faciaPage: PressedPage, targetedTerritories))
-          if FaciaPicker.getTier(faciaPage, path)(request) == RemoteRender =>
+          if FaciaPicker.getTier(faciaPage, path)(request) == RemoteRender
+            && !request.isJson =>
         val pageType = PageType(faciaPage, request, context)
         withVaryHeader(remoteRenderer.getFront(ws, faciaPage, pageType)(request), targetedTerritories)
       case Some((faciaPage: PressedPage, targetedTerritories)) =>


### PR DESCRIPTION
## What does this change?

- Makes sure that the request isn't a JSON request before rendering with DCR.

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
