### PR TITLE
fix: Set cache duration to 900 seconds for DCR rendered fronts pages

### DIFF
--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -76,13 +76,13 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       ws: WSClient,
       payload: String,
       endpoint: String,
-      cached: CacheTime,
+      cacheTime: CacheTime,
       timeout: Duration = Configuration.rendering.timeout,
   )(implicit request: RequestHeader): Future[Result] = {
     def handler(response: WSResponse): Result = {
       response.status match {
         case 200 =>
-          Cached(cached)(RevalidatableResult.Ok(Html(response.body)))
+          Cached(cacheTime)(RevalidatableResult.Ok(Html(response.body)))
             .withHeaders("X-GU-Dotcomponents" -> "true")
             .withPreconnect(HttpPreconnections.defaultUrls)
         case 400 =>

--- a/common/test/renderers/DotcomRenderingServiceTest.scala
+++ b/common/test/renderers/DotcomRenderingServiceTest.scala
@@ -1,6 +1,6 @@
 package renderers
 
-import model.{MetaData, Page}
+import model.{MetaData, Page, CacheTime}
 import model.dotcomrendering.PageType
 import org.apache.commons.codec.digest.DigestUtils
 import org.scalatest.mockito.MockitoSugar
@@ -55,7 +55,7 @@ import org.scalatest.concurrent.ScalaFutures
         wsMock,
         payload,
         "https://endpoint.com",
-        fakePage(),
+        CacheTime.Default,
         Configuration.rendering.timeout,
         request,
       ),

--- a/common/test/renderers/DotcomRenderingServiceTest.scala
+++ b/common/test/renderers/DotcomRenderingServiceTest.scala
@@ -31,13 +31,6 @@ import org.scalatest.concurrent.ScalaFutures
   val articleUrl = "politics/2021/oct/07/coronavirus-report-warned-of-impact-on-uk-four-years-before-pandemic"
   val post = PrivateMethod[Future[Result]]('post)
   val request = TestRequest()
-  private case class fakePage() extends Page {
-    override val metadata = MetaData.make(
-      id = "",
-      section = None,
-      webTitle = "",
-    )
-  }
   private val wsMock = mock[WSClient]
   private val wsResponseMock = mock[WSResponse]
   private val wsRequestMock = mock[WSRequest]


### PR DESCRIPTION
## What does this change?

- Previously all fronts pages were given a cache time of 900 seconds, when adding the DCR cache pages we instead relied on the page metadata for the cache time which may not be correct. This PR forces DCR rendered fronts pages to also use the standard 900 second cache time.

We use 900 seconds for Fronts as we have a lambda function set up to automatically clear the cache when the Front is updated.

## Screenshots

### Before

<img width="534" alt="image" src="https://user-images.githubusercontent.com/21217225/161966015-8708c4b7-b60c-4938-8357-c6d56a3d334d.png">


### After 
<img width="537" alt="image" src="https://user-images.githubusercontent.com/21217225/161965873-1e5bd00c-1a08-4edb-879e-ec8e28493106.png">

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
