### PR TITLE
feat: Add LogFieldList to GuLogging for logging out lists

### DIFF
--- a/common/app/common/GuLogging.scala
+++ b/common/app/common/GuLogging.scala
@@ -59,14 +59,14 @@ object LoggingField {
   case class LogFieldDouble(name: String, value: Double) extends LogField
   case class LogFieldLong(name: String, value: Long) extends LogField
   case class LogFieldBoolean(name: String, value: Boolean) extends LogField
-  case class LogFieldList(name: String, value: List[String]) extends LogField
+  case class LogFieldArray(name: String, value: Array[String]) extends LogField
 
   implicit def tupleToLogFieldInt(t: (String, Int)): LogFieldInt = LogFieldInt(t._1, t._2)
   implicit def tupleToLogFieldString(t: (String, String)): LogFieldString = LogFieldString(t._1, t._2)
   implicit def tupleToLogFieldDouble(t: (String, Double)): LogFieldDouble = LogFieldDouble(t._1, t._2)
   implicit def tupleToLogFieldLong(t: (String, Long)): LogFieldLong = LogFieldLong(t._1, t._2)
   implicit def tupleToLogFieldBoolean(t: (String, Boolean)): LogFieldBoolean = LogFieldBoolean(t._1, t._2)
-  implicit def tupleToLogFieldList(t: (String, List[String])): LogFieldList = LogFieldList(t._1, t._2)
+  implicit def tupleToLogFieldList(t: (String, Array[String])): LogFieldArray = LogFieldArray(t._1, t._2)
 
   def customFieldMarkers(fields: List[LogField]): LogstashMarker = {
     val fieldsMap = fields
@@ -76,10 +76,11 @@ object LoggingField {
         case LogFieldDouble(n, v)  => (n, v)
         case LogFieldLong(n, v)    => (n, v)
         case LogFieldBoolean(n, v) => (n, v)
-        case LogFieldList(n, v)    => (n, v)
+        case LogFieldArray(n, v)   => (n, v)
       }
       .toMap
       .asJava
+
     appendEntries(fieldsMap)
   }
 }

--- a/common/app/common/GuLogging.scala
+++ b/common/app/common/GuLogging.scala
@@ -59,12 +59,14 @@ object LoggingField {
   case class LogFieldDouble(name: String, value: Double) extends LogField
   case class LogFieldLong(name: String, value: Long) extends LogField
   case class LogFieldBoolean(name: String, value: Boolean) extends LogField
+  case class LogFieldList(name: String, value: List[String]) extends LogField
 
   implicit def tupleToLogFieldInt(t: (String, Int)): LogFieldInt = LogFieldInt(t._1, t._2)
   implicit def tupleToLogFieldString(t: (String, String)): LogFieldString = LogFieldString(t._1, t._2)
   implicit def tupleToLogFieldDouble(t: (String, Double)): LogFieldDouble = LogFieldDouble(t._1, t._2)
   implicit def tupleToLogFieldLong(t: (String, Long)): LogFieldLong = LogFieldLong(t._1, t._2)
   implicit def tupleToLogFieldBoolean(t: (String, Boolean)): LogFieldBoolean = LogFieldBoolean(t._1, t._2)
+  implicit def tupleToLogFieldList(t: (String, List[String])): LogFieldList = LogFieldList(t._1, t._2)
 
   def customFieldMarkers(fields: List[LogField]): LogstashMarker = {
     val fieldsMap = fields
@@ -74,6 +76,7 @@ object LoggingField {
         case LogFieldDouble(n, v)  => (n, v)
         case LogFieldLong(n, v)    => (n, v)
         case LogFieldBoolean(n, v) => (n, v)
+        case LogFieldList(n, v)    => (n, v)
       }
       .toMap
       .asJava

--- a/facia/app/utils/DotcomFrontsLogger.scala
+++ b/facia/app/utils/DotcomFrontsLogger.scala
@@ -25,9 +25,9 @@ case class DotcomFrontsLogger() extends GuLogging {
         "front.id",
         faciaPage.id,
       ),
-      LogFieldList(
+      LogFieldArray(
         "front.collections.array",
-        faciaPage.collections.map(_.collectionType),
+        faciaPage.collections.map(_.collectionType).toArray,
       ),
     )
   }

--- a/facia/app/utils/DotcomFrontsLogger.scala
+++ b/facia/app/utils/DotcomFrontsLogger.scala
@@ -25,9 +25,9 @@ case class DotcomFrontsLogger() extends GuLogging {
         "front.id",
         faciaPage.id,
       ),
-      LogFieldString(
+      LogFieldList(
         "front.collections",
-        faciaPage.collections.map(_.collectionType).mkString(", "),
+        faciaPage.collections.map(_.collectionType),
       ),
     )
   }

--- a/facia/app/utils/DotcomFrontsLogger.scala
+++ b/facia/app/utils/DotcomFrontsLogger.scala
@@ -26,7 +26,7 @@ case class DotcomFrontsLogger() extends GuLogging {
         faciaPage.id,
       ),
       LogFieldList(
-        "front.collections",
+        "front.collections.array",
         faciaPage.collections.map(_.collectionType),
       ),
     )


### PR DESCRIPTION
# What does this change?

- Adds a new LogFieldList type to GuLogging for logging lists to ELK.
- Changes `front.collections` to a list type

# Why?
So we can do more interesting things with this data, like group by terms