### PR TITLE
Remove superfluous Spacefinder rule `fromBottom` from mobile articles

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -181,10 +181,6 @@ const addMobileInlineAds = (): Promise<boolean> => {
 				minAbove: 35,
 				minBelow: 200,
 			},
-			// fromBottom looks like it was mistakenly put in the selectors object where it's ignored by spacefinder
-			// and belongs at the root level of SpacefinderRules.
-			// TODO Investigate the impact of correcting the typo - should mobile inline slots be filled fromBottom?
-			// fromBottom: true,
 		},
 		filter: filterNearbyCandidates(adSizes.mpu.height),
 	};


### PR DESCRIPTION
- @chrislomaxjones noticed that `fromBottom` was (perhaps mistakenly) added to mobile article spacefinder rules in https://github.com/guardian/frontend/pull/20753
- This rule had no effect as it was added to the `selector` object of the spacefinder rules rather than the root level where it would have [reversed spacefinder candidates](https://github.com/guardian/frontend/blob/73031cb6ba235d6696f6a00d79730e57dd817023/static/src/javascripts/projects/common/modules/spacefinder.js#L240) as we do for [liveblog updates](https://github.com/guardian/frontend/blob/a16a3a63ec879ebe14958c7ee302fb98aa639967/static/src/javascripts/projects/commercial/modules/liveblog-adverts.js#L52).
- The rule was commented out in https://github.com/guardian/frontend/pull/24599 as it was causing a ts error

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)