### PR TITLE
chore(deps):bump @guardian/consent-management-platform from 10.3.1 to 10.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@guardian/automat-modules": "^0.3.8",
     "@guardian/braze-components": "^7.1.0",
     "@guardian/commercial-core": "^3.2.1",
-    "@guardian/consent-management-platform": "^10.3.1",
+    "@guardian/consent-management-platform": "^10.4.0",
     "@guardian/libs": "^3.6.1",
     "@guardian/shimport": "^1.0.2",
     "@guardian/source-foundations": "^4.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1284,10 +1284,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-3.2.1.tgz#15073e5718c12b12cc0973a36bf54b8ee5e3c2ef"
   integrity sha512-e8Fs8h33oL9eRjluQHqDe4p4UkeuYrOAEI9x5nUBNMShwgv2ef9n0pPo7P0epe0gxJYKmm52J/IHsP+nbesVrQ==
 
-"@guardian/consent-management-platform@^10.3.1":
-  version "10.3.1"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-10.3.1.tgz#09e744ee81a54fe1ab7d0ed58b125ffb59cb0934"
-  integrity sha512-nW+YyQyOwbltiaEgIPtruNys0ZsxlQAJdWsgq+ENcJDvRdjJJPIOqoCY/cL3P3sqL2pwvKttANhSzM6aM0wJlw==
+"@guardian/consent-management-platform@^10.4.0":
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-10.4.0.tgz#2b3972374812efce569421a57949509d306e0e48"
+  integrity sha512-+j6LN0fgn/RUk1oJUkVJl/78dc7SXRB5iT/nPXUIFz64fO/Ge/wTQEUGfvwrhv0YxWBTKxHcCwgBOL4Wfk341g==
   dependencies:
     "@guardian/libs" "1.6.1 - 3.3.0"
 


### PR DESCRIPTION
## What does this change?

Bumps the CMP to 10.4.0 to incorporate changes from:
- https://github.com/guardian/consent-management-platform/pull/593

## Why?

Stays up to date with the most current version of the CMP.
