### PR TITLE
feat: Add new switch to disable slideshows and captions on mobile displays

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -504,4 +504,13 @@ trait FeatureSwitches {
     exposeClientSide = false,
   )
 
+  val FrontsSlideshowMobileSupport = Switch(
+    SwitchGroup.Feature,
+    "fronts-slideshow-mobile-support",
+    "Enables using captions and slideshows on fronts mobile displays",
+    owners = Seq(Owner.withEmail("dotcom.platform@guardian.co.uk")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = false,
+  )
 }

--- a/common/app/views/fragments/items/elements/facia_cards/captionedImage.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/captionedImage.scala.html
@@ -2,6 +2,7 @@
 @import model.ImageMedia
 @import implicits.Requests._
 @import experiments.{ActiveExperiments, SlideshowCaptions}
+@import conf.switches.Switches.FrontsSlideshowMobileSupport
 
 @(
     classes: Seq[String],
@@ -24,7 +25,7 @@
     )
     @if(ActiveExperiments.isParticipating(SlideshowCaptions)) {
         @caption.map { captionText =>
-            <figcaption>
+            <figcaption class="@if(FrontsSlideshowMobileSupport.isSwitchedOn) {fc-item__captioned-image-mobile-support}">
                 @captionText
             </figcaption>
         }

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -11,6 +11,7 @@
 @import views.html.fragments.inlineSvg
 @import views.support.{CutOut, GetClasses, RemoveOuterParaHtml, RenderClasses, Video640}
 @import model.ContentDesignType.RichContentDesignType
+@import conf.switches.Switches.FrontsSlideshowMobileSupport
 
 @import Function.const
 
@@ -177,7 +178,7 @@ data-test-id="facia-card"
 
             case Some(InlineSlideshow(imageElements)) => {
                 <div class="fc-item__media-wrapper">
-                    <div class="fc-item__image-container u-responsive-ratio fc-item__slideshow fc-item__slideshow--@imageElements.size">
+                    <div class="fc-item__image-container u-responsive-ratio fc-item__slideshow fc-item__slideshow--@imageElements.size @if(FrontsSlideshowMobileSupport.isSwitchedOn) {fc-item__slideshow-mobile-support}">
                         @imageElements.headOption.map { imageElement =>
                             @captionedImage(
                                 classes = Seq("responsive-img "),

--- a/common/app/views/fragments/items/facia_cards/dynamoContentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/dynamoContentCard.scala.html
@@ -10,6 +10,7 @@
 @import views.html.fragments.inlineSvg
 @import views.support.{CutOut, GetClasses, RemoveOuterParaHtml, RenderClasses, Video640}
 @import model.ContentDesignType.RichContentDesignType
+@import conf.switches.Switches.FrontsSlideshowMobileSupport
 
 @import Function.const
 
@@ -187,7 +188,7 @@ data-test-id="facia-card"
 
             case Some(InlineSlideshow(imageElements)) => {
                 <div class="fc-item__media-wrapper">
-                    <div class="fc-item__image-container u-responsive-ratio fc-item__slideshow fc-item__slideshow--@imageElements.size">
+                    <div class="fc-item__image-container u-responsive-ratio fc-item__slideshow fc-item__slideshow--@imageElements.size @if(FrontsSlideshowMobileSupport.isSwitchedOn) {fc-item__slideshow-mobile-support}">
                         @imageElements.headOption.map { imageElement =>
                             @captionedImage(
                                 classes = Seq("responsive-img "),

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -4,6 +4,19 @@ $fc-item-gutter: $gs-gutter / 4;
    ==========================================================================
 */
 
+@mixin fc-slideshow-movement($totalLoopTime, $slideshowSize) {
+    figure {
+        animation-duration: #{$totalLoopTime}s;
+        animation-name: fc-item__slideshow--#{$slideshowSize};
+    }
+
+    @for $imageIndex from 2 through $slideshowSize {
+        figure:nth-child(#{$imageIndex}) {
+            animation-delay: #{($totalLoopTime / $slideshowSize) * ($imageIndex - 1)}s;
+        }
+    }
+}
+
 @mixin fs-headline-quote($level) {
     .fc-item__title--quoted .inline-garnett-quote__svg {
         height: get-font-size(headline, $level);
@@ -559,11 +572,32 @@ $block-height: 58px;
         @include mq($until: tablet) {
             @include font-size(12, 16);
         }
+
+        &:not(.fc-item__captioned-image-mobile-support) {
+            @include mq($until: tablet) {
+                display: none;
+            }
+        }
     }
 }
 
 .fc-item__slideshow {
-    figure {
+    &:not(.fc-item__slideshow-mobile-support) figure {
+        @include mq($until: tablet) {
+            &:nth-child(1n+2) {
+                display: none;
+            }
+        }
+
+        @include mq(tablet) {
+            animation-timing-function: linear;
+            animation-iteration-count: infinite;
+            animation-direction: normal;
+            opacity: 0;
+        }
+    }
+
+    &.fc-item__slideshow-mobile-support figure {
         animation-timing-function: linear;
         animation-iteration-count: infinite;
         animation-direction: normal;
@@ -589,17 +623,13 @@ $block-height: 58px;
             opacity: 0;
         }
     }
-
     .fc-item__slideshow--#{$i} {
-        figure {
-            animation-duration: #{$totalLoopTime}s;
-            animation-name: fc-item__slideshow--#{$i};
+        @include mq(tablet) {
+            @include fc-slideshow-movement($totalLoopTime, $i)
         }
 
-        @for $j from 2 through $i {
-            figure:nth-child(#{$j}) {
-                animation-delay: #{($totalLoopTime / $i) * ($j - 1)}s;
-            }
+        &.fc-item__slideshow-mobile-support {
+            @include fc-slideshow-movement($totalLoopTime, $i)
         }
     }
 }


### PR DESCRIPTION
## What does this change?

Re-adds breakpoints to mobile displays for slideshows and captions but makes it configurable through a switch.

## Checklist
### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
