### PR TITLE
Prototyping - Liveblog auto filters

### DIFF
--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -295,7 +295,7 @@ class LiveBlogController(
   )(implicit request: RequestHeader): Result = {
     val pageType: PageType = PageType(blog, request, context)
     val model =
-      DotcomRenderingDataModel.forLiveblog(blog, blocks, request, pageType, filterKeyEvents, request.forceLive)
+      DotcomRenderingDataModel.forLiveblog(blog, blocks, request, pageType, filterKeyEvents, request.forceLive, automaticFilterData = None) // TODO
     val json = DotcomRenderingDataModel.toJson(model)
     common.renderJson(json, blog).as("application/json")
   }

--- a/article/test/DCRFake.scala
+++ b/article/test/DCRFake.scala
@@ -31,7 +31,7 @@ class DCRFake(implicit context: ApplicationContext) extends renderers.DotcomRend
   override def getFilters(
       ws: WSClient,
       liveblogId: String,
-      timeout: Duration = 60.seconds,
+      timeout: Duration = Duration(60, java.util.concurrent.TimeUnit.SECONDS),
   )(implicit request: RequestHeader): Future[Option[FilterData]] = {
     Future.successful(None)
   }

--- a/article/test/DCRFake.scala
+++ b/article/test/DCRFake.scala
@@ -2,12 +2,14 @@ package test
 
 import com.gu.contentapi.client.model.v1.{Block, Blocks}
 import model.Cached.RevalidatableResult
-import model.dotcomrendering.PageType
+import model.dotcomrendering.{FilterData, PageType}
 import model.{ApplicationContext, Cached, LiveBlogPage, PageWithStoryPackage}
+import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
 import play.api.mvc.{RequestHeader, Result}
 import play.twirl.api.Html
 
+import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
 
 // It is always a mistake to rely on actual DCR output for tests.
@@ -24,6 +26,14 @@ class DCRFake(implicit context: ApplicationContext) extends renderers.DotcomRend
     Future(
       Cached(article)(RevalidatableResult.Ok(Html("FakeRemoteRender has found you out if you rely on this markup!"))),
     )
+  }
+
+  override def getFilters(
+      ws: WSClient,
+      liveblogId: String,
+      timeout: Duration = 60.seconds,
+  )(implicit request: RequestHeader): Future[Option[FilterData]] = {
+    Future.successful(None)
   }
 
   override def getBlocks(ws: WSClient, page: LiveBlogPage, blocks: Seq[Block])(implicit

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -39,6 +39,7 @@ case class DotcomRenderingDataModel(
     mainMediaElements: List[PageElement],
     main: String,
     filterKeyEvents: Boolean,
+    automaticFilterData: Option[FilterData],
     pinnedPost: Option[Block],
     keyEvents: List[Block],
     mostRecentBlockId: Option[String],
@@ -95,6 +96,7 @@ case class DotcomRenderingDataModel(
 object DotcomRenderingDataModel {
 
   implicit val pageElementWrites = PageElement.pageElementWrites
+  implicit val automaticFilterDataWrites = FilterData.filterDataWrites
 
   implicit val writes = new Writes[DotcomRenderingDataModel] {
     def writes(model: DotcomRenderingDataModel) = {
@@ -106,6 +108,7 @@ object DotcomRenderingDataModel {
         "mainMediaElements" -> model.mainMediaElements,
         "main" -> model.main,
         "filterKeyEvents" -> model.filterKeyEvents,
+        "automaticFilterData" -> model.automaticFilterData,
         "pinnedPost" -> model.pinnedPost,
         "keyEvents" -> model.keyEvents,
         "mostRecentBlockId" -> model.mostRecentBlockId,
@@ -189,6 +192,7 @@ object DotcomRenderingDataModel {
       hasStoryPackage = page.related.hasStoryPackage,
       pinnedPost = None,
       keyEvents = Nil,
+      automaticFilterData = None,
     )
   }
 
@@ -215,6 +219,7 @@ object DotcomRenderingDataModel {
       hasStoryPackage = page.related.hasStoryPackage,
       pinnedPost = None,
       keyEvents = Nil,
+      automaticFilterData = None,
     )
   }
 
@@ -237,6 +242,7 @@ object DotcomRenderingDataModel {
       pageType: PageType,
       filterKeyEvents: Boolean,
       forceLive: Boolean,
+      automaticFilterData: Option[FilterData],
   ): DotcomRenderingDataModel = {
     val pagination = page.currentPage.pagination.map(paginationInfo => {
       Pagination(
@@ -289,6 +295,7 @@ object DotcomRenderingDataModel {
       filterKeyEvents,
       mostRecentBlockId,
       forceLive,
+      automaticFilterData,
     )
   }
 
@@ -306,6 +313,7 @@ object DotcomRenderingDataModel {
       filterKeyEvents: Boolean = false,
       mostRecentBlockId: Option[String] = None,
       forceLive: Boolean = false,
+      automaticFilterData: Option[FilterData],
   ): DotcomRenderingDataModel = {
 
     val edition = Edition.edition(request)
@@ -421,6 +429,7 @@ object DotcomRenderingDataModel {
       isLegacyInteractive = isLegacyInteractive,
       isSpecialReport = DotcomRenderingUtils.isSpecialReport(page),
       filterKeyEvents = filterKeyEvents,
+      automaticFilterData = automaticFilterData,
       pinnedPost = pinnedPostDCR,
       keyEvents = keyEventsDCR.toList,
       mostRecentBlockId = mostRecentBlockId,

--- a/common/app/model/dotcomrendering/FilterData.scala
+++ b/common/app/model/dotcomrendering/FilterData.scala
@@ -1,0 +1,23 @@
+package model.dotcomrendering
+
+import model.dotcomrendering.pageElements.PageElement
+import play.api.libs.json.{Json, Writes}
+
+case class Filter(name: String,
+                  `type`: String,
+                  count: Int,
+                  blocks: Seq[String],
+                  percentage_blocks: Int)
+
+object Filter {
+  val filterWrites: Writes[Filter] = Json.writes[Filter]
+}
+
+case class FilterData(results: Seq[Filter],
+                      model: String,
+                      entityType: Seq[String]) {
+}
+
+object FilterData {
+  val filterDataWrites: Writes[FilterData] = Json.writes[FilterData]
+}

--- a/common/app/model/dotcomrendering/FilterData.scala
+++ b/common/app/model/dotcomrendering/FilterData.scala
@@ -1,23 +1,17 @@
 package model.dotcomrendering
 
-import model.dotcomrendering.pageElements.PageElement
-import play.api.libs.json.{Json, Writes}
+import play.api.libs.json.{Format, Json, Writes}
 
-case class Filter(name: String,
-                  `type`: String,
-                  count: Int,
-                  blocks: Seq[String],
-                  percentage_blocks: Int)
+case class Filter(name: String, `type`: String, count: Int, blocks: Seq[String], percentage_blocks: Int)
 
 object Filter {
   val filterWrites: Writes[Filter] = Json.writes[Filter]
+  implicit val filterFormat: Format[Filter] = Json.format[Filter]
 }
 
-case class FilterData(results: Seq[Filter],
-                      model: String,
-                      entityType: Seq[String]) {
-}
+case class FilterData(results: Seq[Filter], model: String, entityType: Seq[String]) {}
 
 object FilterData {
   val filterDataWrites: Writes[FilterData] = Json.writes[FilterData]
+  implicit val filterDataFormat: Format[FilterData] = Json.format[FilterData]
 }

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -46,7 +46,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     resetTimeout = Configuration.rendering.timeout * 4,
   )
 
-  private[this] def getFilters(
+  def getFilters(
       ws: WSClient,
       liveblogId: String,
       timeout: Duration = 60.seconds,

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -119,7 +119,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
 
     val dataModel = page match {
       case liveblog: LiveBlogPage =>
-        DotcomRenderingDataModel.forLiveblog(liveblog, blocks, request, pageType, filterKeyEvents, forceLive = false)
+        DotcomRenderingDataModel.forLiveblog(liveblog, blocks, request, pageType, filterKeyEvents, forceLive = false, automaticFilterData = None) // TODO
       case _ => DotcomRenderingDataModel.forArticle(page, blocks, request, pageType)
     }
     val json = DotcomRenderingDataModel.toJson(dataModel)


### PR DESCRIPTION
## What does this change?
This PR is an experiment to add some filtering data to the post data passed to DCR so that DCR can then add filters on a liveblog based on them. 

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
