### PR TITLE
fix: Fix slideshow not rendering on Mobile and fix captions showing o…

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -573,6 +573,12 @@ $block-height: 58px;
         background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%,  rgba(0, 0, 0, .8) 100%);
         color: $brightness-100;
         padding: 60px 8px 8px;
+        
+        &:not(.fc-item__captioned-image-mobile-support) {
+            @include mq($until: tablet) {
+                display: none;
+            }
+        }
     }
 
     .fc-item--has-floating-sublinks & {
@@ -581,12 +587,6 @@ $block-height: 58px;
                 background: linear-gradient(to top, rgba(0, 0, 0, 0) 0%,  rgba(0, 0, 0, .8) 100%);
                 padding: 8px 8px 60px;
                 bottom: inherit;
-            }
-        }
-
-        &:not(.fc-item__captioned-image-mobile-support) {
-            @include mq($until: tablet) {
-                display: none;
             }
         }
     }


### PR DESCRIPTION
## What does this change?

Not quite sure how this happened, seems like Git somehow auto resolved a conflict it shouldn't have and ended up putting the CSS that controls the caption showing on mobile somewhere it shouldn't be.

TLDR: Test merging main into your branch before you merge your branch into main.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
