### PR TITLE
fix: Caption text should be 12px when sublinks are displayed

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -583,6 +583,8 @@ $block-height: 58px;
 
     .fc-item--has-floating-sublinks & {
         figcaption {
+            @include font-size(12, 16);
+
             @include mq(tablet) {
                 background: linear-gradient(to top, rgba(0, 0, 0, 0) 0%,  rgba(0, 0, 0, .8) 100%);
                 padding: 8px 8px 60px;


### PR DESCRIPTION
## What does this change?

Changes captions to use 12px font when displayed with sublinks as per figma design.

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/21217225/162466730-5807ca52-6735-4b00-a1bf-118e2f05268c.png
[after]: https://user-images.githubusercontent.com/21217225/162466358-2ef8071f-d81c-48d7-961f-ed784d159d8c.png
### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
