### PR TITLE
Tighten spacefinder's rich link rule

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -1,7 +1,7 @@
 import { adSizes } from '@guardian/commercial-core';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { spacefinderOkrMegaTest } from 'common/modules/experiments/tests/spacefinder-okr-mega-test';
-import { getBreakpoint, getViewport } from 'lib/detect-viewport';
+import { getBreakpoint, getTweakpoint, getViewport } from 'lib/detect-viewport';
 import { getUrlVars } from 'lib/url';
 import config from '../../../lib/config';
 import fastdom from '../../../lib/fastdom-promise';
@@ -72,9 +72,13 @@ const articleBodySelector = isDotcomRendering
 	: '.js-article__body';
 
 const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
-	const ignoreList = enableRichLinksFix
-		? ' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate):not([data-spacefinder-role="richLink"])'
-		: ' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate)';
+	const tweakpoint = getTweakpoint(getViewport().width);
+	const hasLeftCol = ['leftCol', 'wide'].includes(tweakpoint);
+
+	const ignoreList =
+		enableRichLinksFix && hasLeftCol
+			? ' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate):not([data-spacefinder-role="richLink"])'
+			: ' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate)';
 
 	const isImmersive = config.get('page.isImmersive');
 	const defaultRules: SpacefinderRules = {

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -274,7 +274,7 @@
   "../projects/commercial/modules/dfp/on-slot-load.ts",
   "../projects/commercial/modules/dfp/on-slot-render.ts",
   "../projects/commercial/modules/dfp/on-slot-viewable.ts",
-  "../projects/commercial/modules/dfp/refresh-on-resize.js",
+  "../projects/commercial/modules/dfp/refresh-on-resize.ts",
   "../projects/commercial/modules/messenger.ts",
   "../projects/commercial/modules/messenger/background.js",
   "../projects/commercial/modules/messenger/click.ts",
@@ -325,9 +325,10 @@
   "../projects/common/modules/commercial/commercial-features.ts",
   "../projects/common/modules/commercial/geo-utils.js"
  ],
- "../projects/commercial/modules/dfp/refresh-on-resize.js": [
+ "../projects/commercial/modules/dfp/refresh-on-resize.ts": [
   "../lib/detect.js",
   "../lib/mediator.ts",
+  "../projects/commercial/modules/dfp/Advert.ts",
   "../projects/commercial/modules/dfp/breakpoint-name-to-attribute.ts",
   "../projects/commercial/modules/dfp/dfp-env.ts",
   "../projects/commercial/modules/dfp/load-advert.ts"


### PR DESCRIPTION
## What does this change?

Prevent spacefinder from inserting ads too close to rich links on desktop tweakpoints which _don't_ feature a left column.

@arelra identified this bug whilst working on a separate piece of work: https://github.com/guardian/dotcom-rendering/pull/4506

The bug was introduced in a previous PR, where we relaxed the rules around rich links: https://github.com/guardian/frontend/pull/24690

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![Screenshot 2022-04-08 at 15 15 44](https://user-images.githubusercontent.com/7423751/162462967-cbdf21be-ef2c-412e-8f9e-aae1800a82fb.png) | ![Screenshot 2022-04-08 at 15 14 24](https://user-images.githubusercontent.com/7423751/162463167-44e01661-3b57-4329-966c-a33a19460108.png) |

### Tested

- [x] Locally
- [ ] On CODE (optional)
