### PR TITLE
Add `?dcr` support for cricket match endpoint

### DIFF
--- a/sport/app/cricket/controllers/CricketMatchController.scala
+++ b/sport/app/cricket/controllers/CricketMatchController.scala
@@ -33,7 +33,9 @@ class CricketMatchController(cricketStatsJob: CricketStatsJob, val controllerCom
           cricketStatsJob.findMatch(team, date).map { matchData =>
             val page = CricketMatchPage(matchData, date, team)
             Cached(60) {
-              if (request.isJson)
+              if (request.isJson && request.forceDCR)
+                JsonComponent(page.theMatch)
+              else if (request.isJson)
                 JsonComponent(
                   "summary" -> cricket.views.html.fragments
                     .cricketMatchSummary(page.theMatch, page.metadata.id)

--- a/sport/app/cricket/feed/cricketModel.scala
+++ b/sport/app/cricket/feed/cricketModel.scala
@@ -1,6 +1,81 @@
 package cricketModel
 
+import play.api.libs.json._
 import java.time.LocalDateTime
+
+case class Team(name: String, id: String, home: Boolean, lineup: List[String])
+
+object Team {
+  implicit val writes = Json.writes[Team]
+}
+
+case class InningsBatsman(
+    name: String,
+    order: Int,
+    ballsFaced: Int,
+    runs: Int,
+    fours: Int,
+    sixes: Int,
+    out: Boolean,
+    howOut: String,
+    onStrike: Boolean,
+    nonStrike: Boolean,
+) {
+  lazy val notOut: Boolean = !out
+}
+
+object InningsBatsman {
+  implicit val writes = Json.writes[InningsBatsman]
+}
+
+case class InningsBowler(name: String, order: Int, overs: Int, maidens: Int, runs: Int, wickets: Int)
+
+object InningsBowler {
+  implicit val writes = Json.writes[InningsBowler]
+}
+
+case class InningsWicket(order: Int, name: String, runs: Int)
+
+object InningsWicket {
+  implicit val writes = Json.writes[InningsWicket]
+}
+
+case class Innings(
+    order: Int,
+    battingTeam: String,
+    runsScored: Int,
+    overs: String,
+    declared: Boolean,
+    forfeited: Boolean,
+    description: String,
+    batsmen: List[InningsBatsman],
+    bowlers: List[InningsBowler],
+    fallOfWicket: List[InningsWicket],
+    byes: Int,
+    legByes: Int,
+    noBalls: Int,
+    penalties: Int,
+    wides: Int,
+    extras: Int,
+) {
+  implicit val writes = Json.writes[Innings]
+  lazy val closed = declared || forfeited || allOut
+  lazy val allOut = wickets == 10
+  lazy val wickets = fallOfWicket.length
+
+  lazy val firstIn: Option[InningsBatsman] = batsmen.find(_.notOut)
+  lazy val secondIn: Option[InningsBatsman] = {
+    batsmen.filter(_.notOut) match {
+      case first :: second :: _ => Some(second)
+      case _                    => None
+    }
+  }
+  lazy val lastOut: Option[InningsBatsman] = batsmen.filter(_.out).lastOption
+}
+
+object Innings {
+  implicit val writes = Json.writes[Innings]
+}
 
 case class Match(
     teams: List[Team],
@@ -26,55 +101,6 @@ case class Match(
   def lastOut: Option[InningsBatsman] = lastInnings.flatMap(_.lastOut)
 }
 
-case class Team(name: String, id: String, home: Boolean, lineup: List[String])
-
-case class Innings(
-    order: Int,
-    battingTeam: String,
-    runsScored: Int,
-    overs: String,
-    declared: Boolean,
-    forfeited: Boolean,
-    description: String,
-    batsmen: List[InningsBatsman],
-    bowlers: List[InningsBowler],
-    fallOfWicket: List[InningsWicket],
-    byes: Int,
-    legByes: Int,
-    noBalls: Int,
-    penalties: Int,
-    wides: Int,
-    extras: Int,
-) {
-  lazy val closed = declared || forfeited || allOut
-  lazy val allOut = wickets == 10
-  lazy val wickets = fallOfWicket.length
-
-  lazy val firstIn: Option[InningsBatsman] = batsmen.find(_.notOut)
-  lazy val secondIn: Option[InningsBatsman] = {
-    batsmen.filter(_.notOut) match {
-      case first :: second :: _ => Some(second)
-      case _                    => None
-    }
-  }
-  lazy val lastOut: Option[InningsBatsman] = batsmen.filter(_.out).lastOption
+object Match {
+  implicit val writes = Json.writes[Match]
 }
-
-case class InningsBatsman(
-    name: String,
-    order: Int,
-    ballsFaced: Int,
-    runs: Int,
-    fours: Int,
-    sixes: Int,
-    out: Boolean,
-    howOut: String,
-    onStrike: Boolean,
-    nonStrike: Boolean,
-) {
-  lazy val notOut: Boolean = !out
-}
-
-case class InningsBowler(name: String, order: Int, overs: Int, maidens: Int, runs: Int, wickets: Int)
-
-case class InningsWicket(order: Int, name: String, runs: Int)


### PR DESCRIPTION
## What does this change?

Adds support to send JSON info to for <match>.json?dcr

To achieve this I had too:
1. Add `writes` to data model 
2. Re-order data model to ensure compilation success

Co-authored by: @AshCorr 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No - DCR consumption of the endpoint coming soon 
- [ ] Yes

## Screenshots

<img width="1048" alt="image" src="https://user-images.githubusercontent.com/9575458/162779464-c000a5eb-ca41-4a0e-993d-eb0f26c56836.png">

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
