### PR TITLE
Setup custom price granularity for Criteo

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "object-fit-videos": "^1.0.3",
     "ophan-tracker-js": "1.3.29",
     "preact": "^10.5.13",
-    "prebid.js": "https://github.com/guardian/Prebid.js#d196736",
+    "prebid.js": "https://github.com/guardian/Prebid.js#f434c6d",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
@@ -57,7 +57,7 @@ type UserSync =
 type PbjsConfig = {
 	bidderTimeout: number;
 	timeoutBuffer?: number;
-	priceGranularity: typeof priceGranularity;
+	priceGranularity: PrebidPriceGranularity;
 	userSync: UserSync;
 	consentManagement?: ConsentManagement;
 	realTimeData?: unknown;

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
@@ -285,16 +285,16 @@ const initialise = (window: Window, framework: Framework = 'tcfv2'): void => {
 		pbjsConfig.criteo = {
 			fastBidVersion: 'latest',
 		};
-	}
 
-	// Use a custom price granularity for Criteo
-	// Criteo has a different line item structure and so bids should be rounded to match these
-	window.pbjs.setBidderConfig({
-		bidders: ['criteo'],
-		config: {
-			customPriceBucket: criteoPriceGranularity,
-		},
-	});
+		// Use a custom price granularity for Criteo
+		// Criteo has a different line item structure and so bids should be rounded to match these
+		window.pbjs.setBidderConfig({
+			bidders: ['criteo'],
+			config: {
+				customPriceBucket: criteoPriceGranularity,
+			},
+		});
+	}
 
 	window.pbjs.setConfig(pbjsConfig);
 

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
@@ -12,7 +12,8 @@ import { getAdvertById } from '../../dfp/get-advert-by-id';
 import { getHeaderBiddingAdSlots } from '../slot-config';
 import { stripDfpAdPrefixFrom } from '../utils';
 import { bids } from './bid-config';
-import { priceGranularity } from './price-config';
+import type { PrebidPriceGranularity } from './price-config';
+import { criteoPriceGranularity, priceGranularity } from './price-config';
 import { pubmatic } from './pubmatic';
 
 type CmpApi = 'iab' | 'static';
@@ -143,6 +144,12 @@ declare global {
 				auctionId?: string;
 			}): void;
 			setConfig: (config: PbjsConfig) => void;
+			setBidderConfig: (bidderConfig: {
+				bidders: BidderCode[];
+				config: {
+					customPriceBucket?: PrebidPriceGranularity;
+				};
+			}) => void;
 			getConfig: (item?: string) => PbjsConfig & {
 				dataProviders: Array<{
 					name: string;
@@ -279,6 +286,15 @@ const initialise = (window: Window, framework: Framework = 'tcfv2'): void => {
 			fastBidVersion: 'latest',
 		};
 	}
+
+	// Use a custom price granularity for Criteo
+	// Criteo has a different line item structure and so bids should be rounded to match these
+	window.pbjs.setBidderConfig({
+		bidders: ['criteo'],
+		config: {
+			customPriceBucket: criteoPriceGranularity,
+		},
+	});
 
 	window.pbjs.setConfig(pbjsConfig);
 

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/price-config.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/price-config.spec.ts
@@ -1,7 +1,11 @@
-import { priceGranularity } from './price-config';
+import { criteoPriceGranularity, priceGranularity } from './price-config';
 
 describe('priceGranularity', () => {
-	test('should have correct number of buckets', () => {
+	test('default should have correct number of buckets', () => {
 		expect(priceGranularity.buckets.length).toBe(2);
+	});
+
+	test('criteo should have correct number of buckets', () => {
+		expect(criteoPriceGranularity.buckets.length).toBe(3);
 	});
 });

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/price-config.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/price-config.spec.ts
@@ -2,10 +2,36 @@ import { criteoPriceGranularity, priceGranularity } from './price-config';
 
 describe('priceGranularity', () => {
 	test('default should have correct number of buckets', () => {
-		expect(priceGranularity.buckets.length).toBe(2);
+		expect(priceGranularity).toEqual({
+			buckets: [
+				{
+					max: 100,
+					increment: 0.01,
+				},
+				{
+					max: 500,
+					increment: 1,
+				},
+			],
+		});
 	});
 
 	test('criteo should have correct number of buckets', () => {
-		expect(criteoPriceGranularity.buckets.length).toBe(3);
+		expect(criteoPriceGranularity).toEqual({
+			buckets: [
+				{
+					max: 12,
+					increment: 0.01,
+				},
+				{
+					max: 20,
+					increment: 0.05,
+				},
+				{
+					max: 500,
+					increment: 1,
+				},
+			],
+		});
 	});
 });

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/price-config.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/price-config.ts
@@ -1,4 +1,4 @@
-type PrebidPriceGranularity = {
+export type PrebidPriceGranularity = {
 	buckets: Array<{
 		precision?: number;
 		max: number;
@@ -11,6 +11,23 @@ export const priceGranularity: PrebidPriceGranularity = {
 		{
 			max: 100,
 			increment: 0.01,
+		},
+		{
+			max: 500,
+			increment: 1,
+		},
+	],
+};
+
+export const criteoPriceGranularity: PrebidPriceGranularity = {
+	buckets: [
+		{
+			max: 12,
+			increment: 0.01,
+		},
+		{
+			max: 20,
+			increment: 0.05,
 		},
 		{
 			max: 500,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10107,9 +10107,9 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.15.tgz#6df94d8afecf3f9e10a742fd8c362ddab464225f"
   integrity sha512-5chK29n6QcJc3m1lVrKQSQ+V7K1Gb8HeQY6FViQ5AxCAEGu3DaHffWNDkC9+miZgsLvbvU9rxbV1qinGHMHzqA==
 
-"prebid.js@https://github.com/guardian/Prebid.js#d196736":
+"prebid.js@https://github.com/guardian/Prebid.js#f434c6d":
   version "5.20.0"
-  resolved "https://github.com/guardian/Prebid.js#d196736041aaaa49ce846d4023375e2e1da6dcda"
+  resolved "https://github.com/guardian/Prebid.js#f434c6d14f65b4bd26baa7f9799ceca0a1bbaafb"
   dependencies:
     "@guardian/libs" "^3.1.0"
     babel-plugin-transform-object-assign "^6.22.0"


### PR DESCRIPTION
## What does this change?

Use the foundational work in [guardian/Prebid.js #125](https://github.com/guardian/Prebid.js/pull/125) in order to setup a custom pricing granularity structure for Criteo.

This PR bumps the version of Prebid we use to incorporate this change, and adds a new Criteo price granularity setup that matches the one defined in [commercial-tools](https://github.com/guardian/commercial-tools/blob/main/dfp-line-item-creator/src/main/scala/commercialtools/dfp/model/Config.scala#L30-L36) (private link). This is then passed in as a custom configuration that will overwrite the default price bucket for Criteo.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Criteo has a different line item structure to the generic Prebid line items: it goes up in larger increments from $12. This means that winning bids that don't match these exact increments will not find an eligible line item in GAM. After this change, all Criteo bids should be rounded to a value that has a corresponding GAM line item.

_For example, before this change, a Criteo bid may be received with a CPM of `12.782` and win the auction. This would be rounded using the generic price granularity to `$12.78`. The winning bid would therefore be passed to GAM with price targeting `hb_pb=12.78`. Since Criteo line items go up in increments of 5 cents after 12 dollars, there will be no line item that is eligible for this targeting (the closest line items would be `12.70`, `12.75`, `12.80`, and so on._

_After the change, Criteo bids will be rounded using a new granularity, and so the targeting will be `hb_pb=12.75` and this will find an eligible line item._

### Tested

- [X] Locally
- [X] On CODE (optional)