### PR TITLE
Remove old newsletter model

### DIFF
--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -1,10 +1,10 @@
-@import services.newsletters.NewsletterResponse
 @import views.support.`package`.Seq2zipWithRowInfo
 @import staticpages.NewsletterRoundupPage
 @import conf.switches.Switches.EmailSignupRecaptcha
 @import conf.switches.Switches.ShowNewPrivacyWordingOnEmailSignupEmbeds
 @import common.LinkTo
 
+@import services.newsletters.model.NewsletterResponse
 @(signupPage: NewsletterRoundupPage)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @manageEmailsUrl = @{

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -4,11 +4,7 @@ import com.typesafe.scalalogging.LazyLogging
 import common.EmailSubsciptionMetrics._
 import common.{GuLogging, ImplicitControllerExecutionContext, LinkTo}
 import conf.Configuration
-import conf.switches.Switches.{
-  EmailSignupRecaptcha,
-  NewslettersRemoveConfirmationStep,
-  ValidateEmailSignupRecaptchaTokens,
-}
+import conf.switches.Switches.{EmailSignupRecaptcha, NewslettersRemoveConfirmationStep, ValidateEmailSignupRecaptchaTokens}
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model._
 import play.api.data.Forms._
@@ -119,7 +115,8 @@ class EmailSignupController(
   def renderPage(): Action[AnyContent] =
     Action { implicit request =>
       emailEmbedAgent.getNewsletterByName("today-uk") match {
-        case Right(Some(result)) => Cached(60)(RevalidatableResult.Ok(views.html.emailLanding(emailLandingPage, result)))
+        case Right(Some(result)) =>
+          Cached(60)(RevalidatableResult.Ok(views.html.emailLanding(emailLandingPage, result)))
         case _ => Cached(15.minute)(WithoutRevalidationResult(NoContent))
       }
     }

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -118,7 +118,10 @@ class EmailSignupController(
 
   def renderPage(): Action[AnyContent] =
     Action { implicit request =>
-      Cached(60)(RevalidatableResult.Ok(views.html.emailLanding(emailLandingPage)))
+      emailEmbedAgent.getNewsletterByName("today-uk") match {
+        case Right(Some(result)) => Cached(60)(RevalidatableResult.Ok(views.html.emailLanding(emailLandingPage, result)))
+        case _ => Cached(15.minute)(WithoutRevalidationResult(NoContent))
+      }
     }
 
   def renderFooterForm(listName: String): Action[AnyContent] =

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -4,7 +4,11 @@ import com.typesafe.scalalogging.LazyLogging
 import common.EmailSubsciptionMetrics._
 import common.{GuLogging, ImplicitControllerExecutionContext, LinkTo}
 import conf.Configuration
-import conf.switches.Switches.{EmailSignupRecaptcha, NewslettersRemoveConfirmationStep, ValidateEmailSignupRecaptchaTokens}
+import conf.switches.Switches.{
+  EmailSignupRecaptcha,
+  NewslettersRemoveConfirmationStep,
+  ValidateEmailSignupRecaptchaTokens,
+}
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model._
 import play.api.data.Forms._

--- a/common/app/services/newsletters/NewsletterApi.scala
+++ b/common/app/services/newsletters/NewsletterApi.scala
@@ -1,40 +1,13 @@
 package services.newsletters
 
-import com.gu.identity.model.{EmailEmbed, NewsletterIllustration}
 import common.{BadConfigurationException, GuLogging}
 import conf.Configuration._
-import play.api.libs.json.{JsError, JsSuccess, JsValue, Json}
+import play.api.libs.json.{JsError, JsSuccess, JsValue}
 import play.api.libs.ws.WSClient
+import services.newsletters.model.NewsletterResponse
 
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}
-
-case class NewsletterResponse(
-    identityName: String,
-    name: String,
-    brazeNewsletterName: String,
-    brazeSubscribeAttributeName: String,
-    brazeSubscribeEventNamePrefix: String,
-    theme: String,
-    description: String,
-    frequency: String,
-    listIdV1: Int,
-    listId: Int,
-    exampleUrl: Option[String],
-    emailEmbed: EmailEmbed,
-    illustration: Option[NewsletterIllustration] = None,
-    signupPage: Option[String],
-    restricted: Boolean,
-    paused: Boolean,
-    emailConfirmation: Boolean,
-    group: String,
-)
-
-object NewsletterResponse {
-  implicit val emailEmbedReads = Json.reads[EmailEmbed]
-  implicit val newsletterIllustrationReads = Json.reads[NewsletterIllustration]
-  implicit val newsletterResponseReads = Json.reads[NewsletterResponse]
-}
 
 object GroupedNewslettersResponse {
   type GroupedNewslettersResponse = List[(String, List[NewsletterResponse])]

--- a/common/app/services/newsletters/NewsletterSignupAgent.scala
+++ b/common/app/services/newsletters/NewsletterSignupAgent.scala
@@ -2,6 +2,7 @@ package services.newsletters
 
 import common.{Box, GuLogging}
 import services.newsletters.GroupedNewslettersResponse.GroupedNewslettersResponse
+import services.newsletters.model.NewsletterResponse
 
 import scala.concurrent.ExecutionContext
 

--- a/common/app/services/newsletters/model/EmailEmbed.scala
+++ b/common/app/services/newsletters/model/EmailEmbed.scala
@@ -1,0 +1,11 @@
+package services.newsletters.model
+
+case class EmailEmbed(
+    name: String,
+    title: String,
+    description: String,
+    successHeadline: String,
+    successDescription: String,
+    hexCode: String,
+    imageUrl: Option[String],
+)

--- a/common/app/services/newsletters/model/NewsletterIllustration.scala
+++ b/common/app/services/newsletters/model/NewsletterIllustration.scala
@@ -1,0 +1,5 @@
+package services.newsletters.model
+
+case class NewsletterIllustration(
+    circle: Option[String],
+)

--- a/common/app/services/newsletters/model/NewsletterResponse.scala
+++ b/common/app/services/newsletters/model/NewsletterResponse.scala
@@ -1,0 +1,30 @@
+package services.newsletters.model
+
+import play.api.libs.json.Json
+
+case class NewsletterResponse(
+    identityName: String,
+    name: String,
+    brazeNewsletterName: String,
+    brazeSubscribeAttributeName: String,
+    brazeSubscribeEventNamePrefix: String,
+    theme: String,
+    description: String,
+    frequency: String,
+    listIdV1: Int,
+    listId: Int,
+    exampleUrl: Option[String],
+    emailEmbed: EmailEmbed,
+    illustration: Option[NewsletterIllustration] = None,
+    signupPage: Option[String],
+    restricted: Boolean,
+    paused: Boolean,
+    emailConfirmation: Boolean,
+    group: String,
+)
+
+object NewsletterResponse {
+  implicit val emailEmbedReads = Json.reads[EmailEmbed]
+  implicit val newsletterIllustrationReads = Json.reads[NewsletterIllustration]
+  implicit val newsletterResponseReads = Json.reads[NewsletterResponse]
+}

--- a/common/app/staticpages/StaticPages.scala
+++ b/common/app/staticpages/StaticPages.scala
@@ -1,7 +1,7 @@
 package staticpages
 
 import model.{DotcomContentType, MetaData, SectionId, SimplePage, StandalonePage}
-import services.newsletters.{GroupedNewslettersResponse, NewsletterResponse}
+import services.newsletters.model.NewsletterResponse
 
 case class NewsletterRoundupPage(
     metadata: MetaData,

--- a/common/app/views/emailFragment.scala.html
+++ b/common/app/views/emailFragment.scala.html
@@ -1,4 +1,4 @@
-@import services.newsletters.NewsletterResponse
+@import services.newsletters.model.NewsletterResponse
 @(page: model.Page, emailType: String, emailNewsletter: NewsletterResponse)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @emailEmbed(page) {

--- a/common/app/views/emailFragmentThrasher.scala.html
+++ b/common/app/views/emailFragmentThrasher.scala.html
@@ -1,4 +1,4 @@
-@import services.newsletters.NewsletterResponse
+@import services.newsletters.model.NewsletterResponse
 @(page: model.Page, emailNewsletter: NewsletterResponse)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @emailEmbed(page) {

--- a/common/app/views/emailLanding.scala.html
+++ b/common/app/views/emailLanding.scala.html
@@ -1,6 +1,6 @@
-@(page: model.Page)(implicit request: RequestHeader, context: model.ApplicationContext)
+@import services.newsletters.model.NewsletterResponse
+@(page: model.Page, guardianTodayUk: NewsletterResponse)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @mainLegacy(page){ }{
-    @fragments.emailLandingBody()
+    @fragments.emailLandingBody(guardianTodayUk)
 }
-

--- a/common/app/views/emailSubscriptionSuccessResult.scala.html
+++ b/common/app/views/emailSubscriptionSuccessResult.scala.html
@@ -1,5 +1,5 @@
 
-@import services.newsletters.NewsletterResponse
+@import services.newsletters.model.NewsletterResponse
 @(page: model.Page, emailNewsletter: NewsletterResponse, listName: String)(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @electionNewsletters = @{List("minute-us", "us-morning-newsletter", "today-us", "green-light")}

--- a/common/app/views/fragments/email/signup/result/emailResultNewDesign.scala.html
+++ b/common/app/views/fragments/email/signup/result/emailResultNewDesign.scala.html
@@ -1,4 +1,4 @@
-@import services.newsletters.NewsletterResponse
+@import services.newsletters.model.NewsletterResponse
 @(listName: String, emailNewsletter: NewsletterResponse, resultHtml: Html)(implicit request: RequestHeader)
 
 @emailEmbedData = @{emailNewsletter.emailEmbed}

--- a/common/app/views/fragments/email/signup/result/emailSuccess.scala.html
+++ b/common/app/views/fragments/email/signup/result/emailSuccess.scala.html
@@ -1,4 +1,4 @@
-@import com.gu.identity.model.EmailEmbed
+@import services.newsletters.model.EmailEmbed
 @(emailEmbedData: EmailEmbed)
 <div class="email-sub email-sub--article">
     <div class="email-sub__message">

--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -1,5 +1,4 @@
-@import com.gu.identity.model.EmailNewsletters._
-@import com.gu.identity.model.EmailEmbed
+@import services.newsletters.model.EmailEmbed
 @(  componentClass: String,
     listName:String,
     emailEmbedData: EmailEmbed)(implicit request: RequestHeader)
@@ -8,22 +7,23 @@
 @import conf.switches.Switches.EmailSignupRecaptcha
 @import conf.switches.Switches.ShowNewPrivacyWordingOnEmailSignupEmbeds
 
+//TODO add tones to newsletters API https://trello.com/c/MrlRJPlM/668-add-tones-to-newsletters-api
 @listNamesTones = @{  List(
-    bestOfOpinionUK.identityName -> "comment",
-    bestOfOpinionAUS.identityName -> "comment",
-    bestOfOpinionUS.identityName -> "comment",
-    bookmarks.identityName -> "review",
-    theFiver.identityName -> "feature",
-    theLongRead.identityName -> "feature",
-    documentaries.identityName -> "plaindark",
-    theFlyer.identityName -> "feature",
-    theBreakdown.identityName -> "feature",
-    theSpin.identityName -> "feature",
-    filmToday.identityName -> "media",
-    sleeveNotes.identityName -> "review",
-    theObserverFoodMonthly.identityName -> "feature",
-    firstDogOnTheMoon.identityName -> "media",
-    fashionStatement.identityName -> "media"
+    "best-of-opinion" -> "comment",
+    "best-of-opinion-au" -> "comment",
+    "best-of-opinion-us" -> "comment",
+    "bookmarks" -> "review",
+    "the-fiver" -> "feature",
+    "the-long-read" -> "feature",
+    "documentaries" -> "plaindark",
+    "the-flyer" -> "feature",
+    "the-breakdown" -> "feature",
+    "the-spin" -> "feature",
+    "film-today" -> "media",
+    "sleeve-notes" -> "review",
+    "observer-food" -> "feature",
+    "first-dog" -> "media",
+    "fashion-statement" -> "media"
 ).toMap: Map[String, String] }
 
 @formId = @{ componentClass + "-email-sub-form" }

--- a/common/app/views/fragments/email/signup/subscription/thrasherEmailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/thrasherEmailSignUp.scala.html
@@ -1,5 +1,4 @@
-@import com.gu.identity.model.EmailNewsletters._
-@import com.gu.identity.model.EmailEmbed
+@import services.newsletters.model.EmailEmbed
 @(
     listName:String,
     emailEmbedData: EmailEmbed,
@@ -7,8 +6,6 @@
 
 @import common.LinkTo
 @import conf.switches.Switches.EmailSignupRecaptcha
-@import conf.switches.Switches.NewslettersRemoveConfirmationStep
-
 
 @wrapperClass = @{ "email-sub email-sub--thrasher-embed" }
 @wrapperToneClass = @{ "email-sub--thrasher-embed" }

--- a/common/app/views/fragments/emailLandingBody.scala.html
+++ b/common/app/views/fragments/emailLandingBody.scala.html
@@ -1,6 +1,5 @@
-@import com.gu.identity.model.EmailNewsletters
-@import com.gu.identity.model.EmailEmbed
-@()(implicit request: RequestHeader)
+@import services.newsletters.model.NewsletterResponse
+@(guardianTodayUk: NewsletterResponse)(implicit request: RequestHeader)
 @import views.support.RenderClasses
 
 <div>
@@ -13,8 +12,8 @@
             <div class="gs-container u-cf">
                 @fragments.email.signup.subscription.emailSignUp(
                     "landing",
-                    EmailNewsletters.guardianTodayUk.identityName,
-                    EmailNewsletters.guardianTodayUk.emailEmbed
+                    guardianTodayUk.identityName,
+                    guardianTodayUk.emailEmbed
                 )
             </div>
         </div>

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -1,18 +1,13 @@
 @(showNav: Boolean = true)(implicit page: model.Page, request: RequestHeader)
 
+@import common.editions.{Au, International, Uk, Us}
+@import common.{Edition, LinkTo}
+@import conf.switches.Switches.EmailInlineInFooterSwitch
+@import navigation.ReaderRevenueSite.{SupportContribute, SupportSubscribe}
+@import navigation.UrlHelpers.{Footer, getReaderRevenueUrl}
+@import navigation.{FooterLink, FooterLinks, NavMenu}
 @import org.joda.time.DateTime
-@import common.Edition
-@import common.LinkTo
-@import navigation.NavMenu
-@import navigation.{FooterLinks, FooterLink}
-@import navigation.ReaderRevenueSite.{Support, SupportSubscribe, SupportContribute}
-@import navigation.UrlHelpers.{getReaderRevenueUrl, Footer, AmpFooter}
-@import common.editions.{Au, Uk, Us, International}
-@import model.Page
-@import conf.switches.Switches.{ EmailInlineInFooterSwitch }
-@import com.gu.identity.model.EmailNewsletters
-@import model.NoCache
-@import views.support.{RenderClasses}
+@import views.support.RenderClasses
 
 @footerListItem(link: FooterLink) = {
     <li class="colophon__item">
@@ -50,6 +45,7 @@
                             </a>
                         </li>
                     }
+                </ul>
             }
         </div>
 
@@ -60,16 +56,16 @@
                     <div class="footer__email-container js-footer__email-container">
                     @currentEdition match {
                         case Uk => {
-                            @fragments.email.signup.emailIframe(EmailNewsletters.guardianTodayUk.identityName, "footer-daily-email-uk")
+                            @fragments.email.signup.emailIframe("today-uk", "footer-daily-email-uk")
                         }
                         case Us => {
-                            @fragments.email.signup.emailIframe(EmailNewsletters.guardianTodayUs.identityName, "footer-daily-email-us")
+                            @fragments.email.signup.emailIframe("today-us", "footer-daily-email-us")
                         }
                         case Au => {
-                            @fragments.email.signup.emailIframe(EmailNewsletters.guardianTodayAu.identityName, "footer-daily-email-au")
+                            @fragments.email.signup.emailIframe("today-au", "footer-daily-email-au")
                         }
                         case International => {
-                            @fragments.email.signup.emailIframe(EmailNewsletters.guardianTodayUk.identityName, "footer-daily-email-int")
+                            @fragments.email.signup.emailIframe("today-uk", "footer-daily-email-int")
                         }
                     }
                     </div>

--- a/identity/app/views/completeConsents.scala.html
+++ b/identity/app/views/completeConsents.scala.html
@@ -1,6 +1,6 @@
 @import services.EmailPrefsData
 
-@import services.newsletters.NewsletterResponse
+@import services.newsletters.model.NewsletterResponse
 @(
     idRequest: services.IdentityRequest,
     idUrlBuilder: services.IdentityUrlBuilder,

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -5,7 +5,7 @@
 @import controllers.editprofile.ProfileForms
 @import _root_.utils.ConsentsJourneyType._
 
-@import services.newsletters.NewsletterResponse
+@import services.newsletters.model.NewsletterResponse
 @(
     user: com.gu.identity.model.User,
     forms: ProfileForms,

--- a/identity/app/views/fragments/emailListCategories.scala.html
+++ b/identity/app/views/fragments/emailListCategories.scala.html
@@ -1,7 +1,7 @@
 @import _root_.form.IdFormHelpers.nonInputFields
 @import services.EmailPrefsData
 @import views.support.`package`.Seq2zipWithRowInfo
-@import services.newsletters.NewsletterResponse
+@import services.newsletters.model.NewsletterResponse
 
 @(
     emailPrefsForm: Form[EmailPrefsData],

--- a/identity/app/views/fragments/newsletterSwitch.scala.html
+++ b/identity/app/views/fragments/newsletterSwitch.scala.html
@@ -1,10 +1,9 @@
 @import common.LinkTo
 @import _root_.form.IdFormHelpers.nonInputFields
 @import views.support.fragment.Switch._
-@import services.newsletters.NewsletterResponse
 
 @* Editorial Newsletter switch/checkbox *@
-
+@import services.newsletters.model.NewsletterResponse
 @(
     emailPrefsForm: Form[_],
     emailSubscriptions: List[String],

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -1,8 +1,6 @@
 @import services.EmailPrefsData
 
-@import com.gu.identity.model.User
-@import com.gu.identity.model.EmailNewsletter
-@import services.newsletters.NewsletterResponse
+@import services.newsletters.model.NewsletterResponse
 @(
     page: model.Page,
     emailPrefsForm: Form[EmailPrefsData],

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -9,7 +9,6 @@ import idapiclient.{TrackingData, _}
 import idapiclient.Auth
 import idapiclient.responses.Error
 import model.{Countries, PhoneNumbers}
-import com.gu.identity.model.EmailNewsletters
 import controllers.editprofile.EditProfileController
 import org.joda.time.format.ISODateTimeFormat
 import org.mockito.Mockito._


### PR DESCRIPTION
## What does this change?

This is replacing references to the old Identity newsletters model with references to the new Newsletters API, which should now be the source of truth. Some of these are no longer needed and another PR will follow to delete these, but we want to unblock work that is waiting for these references to be updated. 

Trello: https://trello.com/c/cgSF0EJ2/651-remove-references-in-frontend-to-old-newsletter-model-that-lives-in-identity

There should be no visible change to any email sign up page/embed. 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)
