### PR TITLE
Replace sticky-videos AB test with switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -516,8 +516,8 @@ trait FeatureSwitches {
 
   val StickyVideos = Switch(
     SwitchGroup.Feature,
-    "live-blogs-sticky-videos",
-    "Enables sticking videos in blogs",
+    "sticky-videos",
+    "Enables sticking videos",
     owners = Seq(Owner.withEmail("dotcom.platform@guardian.co.uk")),
     safeState = Off,
     sellByDate = never,

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -513,4 +513,14 @@ trait FeatureSwitches {
     sellByDate = never,
     exposeClientSide = false,
   )
+
+  val LiveBlogsStickyVideos = Switch(
+    SwitchGroup.Feature,
+    "live-blogs-sticky-videos",
+    "Enables sticking videos in blogs",
+    owners = Seq(Owner.withEmail("dotcom.platform@guardian.co.uk")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -514,7 +514,7 @@ trait FeatureSwitches {
     exposeClientSide = false,
   )
 
-  val LiveBlogsStickyVideos = Switch(
+  val StickyVideos = Switch(
     SwitchGroup.Feature,
     "live-blogs-sticky-videos",
     "Enables sticking videos in blogs",

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -517,7 +517,7 @@ trait FeatureSwitches {
   val StickyVideos = Switch(
     SwitchGroup.Feature,
     "sticky-videos",
-    "Enables sticking videos",
+    "When ON, videos in liveblogs will 'stick' on the screen as the reader scrolls up and down the blog",
     owners = Seq(Owner.withEmail("dotcom.platform@guardian.co.uk")),
     safeState = Off,
     sellByDate = never,

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -7,7 +7,6 @@ import java.time.LocalDate
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] = Set(
     LiveblogRendering,
-    StickyVideos,
   )
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -29,13 +28,4 @@ object FrontRendering
       owners = Seq(Owner.withGithub("dotcom")),
       sellByDate = LocalDate.of(2023, 6, 2),
       participationGroup = Perc0A,
-    )
-
-object StickyVideos
-    extends Experiment(
-      name = "sticky-videos",
-      description = "Stick videos on live blogs",
-      owners = Seq(Owner.withGithub("joecowton1")),
-      sellByDate = LocalDate.of(2022, 6, 2),
-      participationGroup = Perc0C,
     )


### PR DESCRIPTION
## What does this change?

Removes the `sticky-videos` AB test and replaces it with a feature switch. This will allow anyone to quickly turn off the feature if required.

As we're using the same naming `stickyVideos` no changes are required on DCR.

Tested on CODE and working.

### Enabled


<img width="800" alt="Screenshot 2022-04-13 at 14 31 17" src="https://user-images.githubusercontent.com/77005274/163193318-8ada4a70-50d5-49aa-82fb-5a3c50375ac8.png">

### Disabled

<img width="800" alt="Screenshot 2022-04-13 at 14 31 17" src="https://user-images.githubusercontent.com/77005274/163193409-62f1d317-2bea-4404-a34f-43f26b7b068c.png">



