### PR TITLE
Press Northern Ireland assembly election results interactive

### DIFF
--- a/common/app/services/dotcomrendering/PressedContent.scala
+++ b/common/app/services/dotcomrendering/PressedContent.scala
@@ -95,6 +95,7 @@ object PressedContent {
     "/world/ng-interactive/2017/jan/17/missing-flight-mh370-a-visual-guide-to-the-parts-and-debris-found-so-far",
     "/artanddesign/2017/jan/28/charisma-droids-todays-robots-da-vinci-michelangelo-science-museum-robots",
     "/lifeandstyle/ng-interactive/2017/feb/19/the-5th-annual-ofm-50-what-we-love-about-food-in-2017",
+    "/uk-news/ng-interactive/2017/mar/03/northern-ireland-assembly-election-latest-results",
     "/info/ng-interactive/2017/mar/06/sign-up-for-the-sleeve-notes-email",
     "/lifeandstyle/2017/mar/25/parkour-free-runner-killed-on-paris-metro-sport-mustang-wanted",
     "/us-news/2017/apr/25/trump-supporters-elect-again-100-days",


### PR DESCRIPTION
## What does this change?
After a request from visuals it adds `/uk-news/ng-interactive/2017/mar/03/northern-ireland-assembly-election-latest-results` to the list of pressed content.

