### PR TITLE
Ad passback method to hold the initial iFrame and create a new slot

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -157,7 +157,7 @@ const init = (register: RegisterListener): void => {
 									size.getHeight() + labelHeight
 								}px`;
 								/**
-								 * In liuei of https://github.com/guardian/dotcom-rendering/pull/4506
+								 * In lieu of https://github.com/guardian/dotcom-rendering/pull/4506
 								 * which changes inline1 to take the full width of the column, the ad
 								 * will float right so we have to set the ad width.
 								 */

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -62,6 +62,8 @@ const init = (register: RegisterListener): void => {
 				if (slotElement) {
 					// TODO: this should be promoted to default styles for inline1
 					slotElement.style.position = 'relative';
+					// Remove any outstream styling for this slot
+					slotElement.classList.remove('ad-slot--outstream');
 				}
 			}
 

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -88,7 +88,7 @@ const init = (register: RegisterListener): void => {
 					 */
 					const passbackElement = document.createElement('div');
 					passbackElement.id = `${slotIdWithPrefix}--passback`;
-					passbackElement.className = `js-ad-slot ad-slot`;
+					passbackElement.classList.add('ad-slot', 'js-ad-slot');
 					passbackElement.setAttribute('aria-hidden', 'true');
 					slotElement.insertAdjacentElement(
 						'beforeend',

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -52,6 +52,10 @@ const init = (register: RegisterListener): void => {
 				if (iFrameContainer) {
 					iFrameContainer.style.visibility = 'hidden';
 				}
+				if (slotElement) {
+					// TODO: this should be promoted to default styles for inline1
+					slotElement.style.position = 'relative';
+				}
 			}
 
 			if (slotId && source) {
@@ -90,6 +94,12 @@ const init = (register: RegisterListener): void => {
 					passbackElement.id = `${slotIdWithPrefix}--passback`;
 					passbackElement.classList.add('ad-slot', 'js-ad-slot');
 					passbackElement.setAttribute('aria-hidden', 'true');
+					// position absolute to position over the container slot
+					passbackElement.style.position = 'absolute';
+					// account for the ad label
+					passbackElement.style.top = '24px';
+					// take the full width so it will center horizontally
+					passbackElement.style.width = '100%';
 					slotElement.insertAdjacentElement(
 						'beforeend',
 						passbackElement,

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -19,8 +19,8 @@ const labelHeight = 24;
 
 /**
  * A listener for 'passback' messages from ad slot iFrames
- * Ad providers will invoke 'passback' to tell us they have not filled this slot
- * In which case we need to create a 'passback' slot with another ad
+ * Ad providers will postMessage a 'passback' message to tell us they have not filled this slot
+ * In which case we create a 'passback' slot with another ad
  */
 const init = (register: RegisterListener): void => {
 	register('passback', (messagePayload, ret, iframe) => {

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -59,7 +59,7 @@ const init = (register: RegisterListener): void => {
 					 */
 					iFrameContainer.style.visibility = 'hidden';
 					/**
-					 * In liuei of https://github.com/guardian/dotcom-rendering/pull/4506
+					 * In lieu of https://github.com/guardian/dotcom-rendering/pull/4506
 					 * which changes inline1 to take the full width of the column, the ad
 					 * will float right. In which case we have to remove the initial
 					 * iFrame from document flow and set the width once known.

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -9,11 +9,7 @@ type PassbackMessagePayload = {
 const getValuesForKeys = (
 	keys: string[],
 	valueFn: (key: string) => string[],
-): Array<[string, string[]]> =>
-	keys.reduce((acc: Array<[string, string[]]>, key: string) => {
-		acc.push([key, valueFn(key)]);
-		return acc;
-	}, []);
+): Array<[string, string[]]> => keys.map((key) => [key, valueFn(key)]);
 
 const labelHeight = 24;
 

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -20,7 +20,7 @@ const labelHeight = 24;
 /**
  * A listener for 'passback' messages from ad slot iFrames
  * Ad providers will invoke 'passback' to tell us they have not filled this slot
- * In which case we need to refresh the slot with another ad
+ * In which case we need to create a 'passback' slot with another ad
  */
 const init = (register: RegisterListener): void => {
 	register('passback', (messagePayload, ret, iframe) => {
@@ -51,13 +51,20 @@ const init = (register: RegisterListener): void => {
 				const iFrameContainer =
 					iframe.closest<HTMLDivElement>('.ad-slot__content');
 
-				/**
-				 * Keep the initial iFrame which contains ad provider code
-				 * to detect passbacks.
-				 * Maintain its initial size by setting visibility to prevent CLS.
-				 */
 				if (iFrameContainer) {
+					/**
+					 * Keep the initial outstream iFrame so they can detect passbacks.
+					 * Maintain the iFrame initial size by setting visibility to prevent CLS.
+					 * In a full width column we only then need to resize height.
+					 */
 					iFrameContainer.style.visibility = 'hidden';
+					/**
+					 * In liuei of https://github.com/guardian/dotcom-rendering/pull/4506
+					 * which changes inline1 to take the full width of the column, the ad
+					 * will float right. In which case we have to remove the initial
+					 * iFrame from document flow and set the width once known.
+					 */
+					// iFrameContainer.style.display = 'none';
 				}
 				if (slotElement) {
 					// TODO: this should be promoted to default styles for inline1
@@ -149,6 +156,12 @@ const init = (register: RegisterListener): void => {
 								slotElement.style.height = `${
 									size.getHeight() + labelHeight
 								}px`;
+								/**
+								 * In liuei of https://github.com/guardian/dotcom-rendering/pull/4506
+								 * which changes inline1 to take the full width of the column, the ad
+								 * will float right so we have to set the ad width.
+								 */
+								// slotElement.style.width = `${size.getWidth()}px`;
 							}
 						});
 


### PR DESCRIPTION
## Why this change?

The passback method introduced in https://github.com/guardian/frontend/pull/24724 replaces the initial ad provider iFrame with the passback ad iFrame - as per normal googletag rendering behaviour.

However we have had feedback from our ad partners that in the event of a passback they still wish to hold their iFrame open in order to allow their script to independently verify that a passback has occurred. 

## Terms

### Passback Ad

For certain ad slots (e.g. `inline1`) we allow ad providers (e.g. [Teads](https://www.teads.com/)) first choice of whether they wish to fulfil the ad slot.

A passback is when the ad provider chooses not to fulfil the slot and 'passes back' the slot to us to retry fulfilment.

### Ad Slot

An ad slot is an object that defines metadata about the ad we wish to render and is represented by:

1. A [googletag slot](https://developers.google.com/publisher-tag/reference#googletag.Slot)
2. In the DOM by a _container_ that will hold an ad iFrame. We instruct [googletag](https://developers.google.com/publisher-tag/guides/get-started) to insert an ad into a given slot. The ad will be inserted into the slot as an iFrame. So we have this (simplified) structure:
    ```html
    <div id="dfp-ad--inline1" ... > <!-- slot inserted by us -->
      <iframe ...> <!-- inserted by googletag -->
    ```

We have very limited control over the styling of an ad iFrame so our positional control is normally applied at the slot level.

### Initial iFrame

This is the iFrame initially inserted by the ad provider that has first choice for the slot. The provider may decide not to fulfil the slot and 'passback' control to us.

### Passback iFrame

This is the iFrame created by the passback slot to show another ad in the event of a passback. It is separate and distinct from the initial iFrame.

## This Change

This change is to test a new method that keeps the initial iFrame open _and_ attempts to minimise any [CLS](https://web.dev/cls/) as follows:

1. #### Hide the initial iFrame

    Set the initial iFrame to `visibility: hidden` to:
    - keep the iFrame active
    - maintain the initial slot dimensions to limit container resizing (i.e. layout shift) and to not undo the full-width approach introduced in:
        https://github.com/guardian/dotcom-rendering/pull/4506
        
1. #### Create a new slot

    - copy the targeting over from the previous slot in googletag including prebid auction results
    - define an entirely new ad slot and display it
    - the new slot is created _inside_ the `dfp-ad--inline1` ad slot as `dfp-ad--inline1--passback` to give the following:
      ```html
      <div id="dfp-ad--inline1" ... > <!-- slot inserted by us -->
          <iframe ...> <!-- initial iFrame inserted by googletag -->
          <div id="dfp-ad--inline1--passback" ... > <!-- slot inserted by us -->
              <iframe ...> <!-- passback iFrame inserted by googletag -->
          </div>
      </div>
      ```
    
1. #### Position and size the new passback ad slot

    - overlay the new passback slot over the initial iFrame using `position: absolute` to avoid CLS e.g.:
    - resize the container height to match the displayed passback ad height using the [slotRenderEnded](https://developers.google.com/publisher-tag/reference#googletag.events.slotrenderendedevent) event
    
        | normal flow      |
        | :--- |
        | <img width="352" alt="Screenshot 2022-04-20 at 13 35 39" src="https://user-images.githubusercontent.com/7014230/166714894-45eb2711-0b27-4945-b345-40d5839beb88.png"> |
        
        vs

        | overlay      | adjust height |
        | :--- | :--- |
        | <img width="527" alt="Screenshot 2022-04-20 at 13 37 35" src="https://user-images.githubusercontent.com/7014230/166717611-b3cdfe47-61e1-4ba9-9b2e-99f003e34080.png"> | <img width="399" alt="Screenshot 2022-04-20 at 13 37 57-2" src="https://user-images.githubusercontent.com/7014230/166717462-2873fbf0-a8f0-4d24-b22b-e4f469d97c4f.png"> |


Todo:

- Use fastdom to reduce layout thrashing?

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)
