### PR TITLE
Use twirl-compatible comment syntax

### DIFF
--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -7,7 +7,7 @@
 @import conf.switches.Switches.EmailSignupRecaptcha
 @import conf.switches.Switches.ShowNewPrivacyWordingOnEmailSignupEmbeds
 
-//TODO add tones to newsletters API https://trello.com/c/MrlRJPlM/668-add-tones-to-newsletters-api
+@* TODO add tones to newsletters API https://trello.com/c/MrlRJPlM/668-add-tones-to-newsletters-api *@
 @listNamesTones = @{  List(
     "best-of-opinion" -> "comment",
     "best-of-opinion-au" -> "comment",


### PR DESCRIPTION
## What does this change?

* Uses twirl-compatible syntax for the comment, otherwise the comment is rendered as plain text

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

