### PR TITLE
feat: Enable DCR Liveblog rendering for all users

### DIFF
--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -5,7 +5,6 @@ import com.gu.contentapi.client.utils.format.{CulturePillar, LifestylePillar, Ne
 import common.`package`.{convertApiExceptions => _, renderFormat => _}
 import common.{JsonComponent, RichRequestHeader, _}
 import contentapi.ContentApiClient
-import experiments.{ActiveExperiments, LiveblogRendering}
 import implicits.{AmpFormat, HtmlFormat}
 import model.Cached.WithoutRevalidationResult
 import model.LiveBlogHelpers._
@@ -111,7 +110,6 @@ class LiveBlogController(
             Future.successful(common.renderHtml(MinuteHtmlPage.html(minute), minute))
           case (blog: LiveBlogPage, HtmlFormat) =>
             val dcrCouldRender = LiveBlogController.checkIfSupported(blog)
-            val participatingInTest = ActiveExperiments.isParticipating(LiveblogRendering)
             val isRecent = !LiveBlogController.isNotRecent(blog)
             val theme = blog.article.content.metadata.format.getOrElse(ContentFormat.defaultContentFormat).theme
             val design = blog.article.content.metadata.format.getOrElse(ContentFormat.defaultContentFormat).design
@@ -119,7 +117,7 @@ class LiveBlogController(
             val isDeadBlog = LiveBlogController.isDeadBlog(blog)
             val properties =
               Map(
-                "participatingInTest" -> participatingInTest.toString,
+                "participatingInTest" -> "false",
                 "dcrCouldRender" -> dcrCouldRender.toString,
                 "theme" -> theme.toString,
                 "design" -> design.toString,
@@ -129,7 +127,7 @@ class LiveBlogController(
                 "isLiveBlog" -> "true",
               )
             val remoteRendering =
-              shouldRemoteRender(request.forceDCROff, request.forceDCR, participatingInTest, dcrCouldRender)
+              shouldRemoteRender(request.forceDCROff, request.forceDCR, dcrCouldRender)
             if (remoteRendering) {
               DotcomponentsLogger.logger.logRequest(s"liveblog executing in dotcomponents", properties, page)
               val pageType: PageType = PageType(blog, request, context)
@@ -152,15 +150,14 @@ class LiveBlogController(
   def shouldRemoteRender(
       forceDCROff: Boolean,
       forceDCR: Boolean,
-      participatingInTest: Boolean,
       dcrCouldRender: Boolean,
   ): Boolean = {
     // ?dcr=false, so never render DCR
     if (forceDCROff) false
     // ?dcr=true, so always render DCR
     else if (forceDCR) true
-    // User is in the test and dcr supports this blog . No param passed
-    else if (participatingInTest && dcrCouldRender) true
+    // DCR supports this blog
+    else if (dcrCouldRender) true
     else false
   }
 
@@ -186,8 +183,7 @@ class LiveBlogController(
       requestedBodyBlocks: scala.collection.Map[String, Seq[Block]] = Map.empty,
   )(implicit request: RequestHeader): Future[Result] = {
     val dcrCouldRender = LiveBlogController.checkIfSupported(liveblog)
-    val participating = ActiveExperiments.isParticipating(LiveblogRendering)
-    val remoteRender = shouldRemoteRender(request.forceDCROff, request.forceDCR, participating, dcrCouldRender)
+    val remoteRender = shouldRemoteRender(request.forceDCROff, request.forceDCR, dcrCouldRender)
 
     range match {
       case SinceBlockId(lastBlockId) =>

--- a/article/app/model/LiveBlogHelpers.scala
+++ b/article/app/model/LiveBlogHelpers.scala
@@ -2,7 +2,6 @@ package model
 
 import com.gu.contentapi.client.model.v1.ItemResponse
 import common.`package`._
-import experiments.{ActiveExperiments, LiveblogRendering}
 import model.liveblog.BodyBlock
 import model.ParseBlockId.ParsedBlockId
 import org.joda.time.DateTime

--- a/article/test/LiveBlogControllerTest.scala
+++ b/article/test/LiveBlogControllerTest.scala
@@ -169,71 +169,54 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
     content should include("56d071d2e4b0bd5a0524cc66")
   }
 
-  it should "use DCR if the parameter dcr=true is passed" in {
+  it should "use dcr if no dcr param is passed" in {
     val forceDCROff = false
-    val forceDCR = true
-    val participatingInTest = false
+    val forceDCR = false
     val dcrCanRender = true
 
     val shouldRemoteRender =
-      liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, participatingInTest, dcrCanRender)
+      liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, dcrCanRender)
+    shouldRemoteRender should be(true)
+  }
+
+  it should "use DCR if the parameter dcr=true is passed" in {
+    val forceDCROff = false
+    val forceDCR = true
+    val dcrCanRender = true
+
+    val shouldRemoteRender =
+      liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, dcrCanRender)
     shouldRemoteRender should be(true)
   }
 
   it should "use frontend if the parameter dcr=false is passed" in {
     val forceDCROff = true
     val forceDCR = false
-    val participatingInTest = false
     val dcrCanRender = true
 
     val shouldRemoteRender =
-      liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, participatingInTest, dcrCanRender)
+      liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, dcrCanRender)
     shouldRemoteRender should be(false)
-
   }
 
-  it should "use dcr if the user is in the test and no dcr param is included" in {
+  it should "use frontend if DCR cant render" in {
     val forceDCROff = false
     val forceDCR = false
-    val participatingInTest = true
-    val dcrCanRender = true
+    val dcrCanRender = false
 
     val shouldRemoteRender =
-      liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, participatingInTest, dcrCanRender)
-    shouldRemoteRender should be(true)
-  }
-
-  it should " use frontend if it can render but not in test" in {
-    val forceDCROff = false
-    val forceDCR = false
-    val participatingInTest = false
-    val dcrCanRender = true
-
-    val shouldRemoteRender =
-      liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, participatingInTest, dcrCanRender)
+      liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, dcrCanRender)
     shouldRemoteRender should be(false)
   }
 
   it should "use DCR if dcrCanRender is false and dcr=true" in {
     val forceDCROff = false
     val forceDCR = true
-    val participatingInTest = true
     val dcrCanRender = false
 
     val shouldRemoteRender =
-      liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, participatingInTest, dcrCanRender)
+      liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, dcrCanRender)
     shouldRemoteRender should be(true)
-  }
-
-  it should "use frontend if dcrCanRender is false no param is passed" in {
-    val forceDCROff = false
-    val forceDCR = false
-    val participatingInTest = true
-    val dcrCanRender = false
-
-    val shouldRemoteRender =
-      liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, participatingInTest, dcrCanRender)
-    shouldRemoteRender should be(false)
   }
 
   it should "filter when the filter parameter is true" in {

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -5,21 +5,10 @@ import experiments.ParticipationGroups._
 import java.time.LocalDate
 
 object ActiveExperiments extends ExperimentsDefinition {
-  override val allExperiments: Set[Experiment] = Set(
-    LiveblogRendering,
-  )
+  override val allExperiments: Set[Experiment] = Set()
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
-
-object LiveblogRendering
-    extends Experiment(
-      name = "liveblog-rendering",
-      description = "Use DCR for liveblogs",
-      owners = Seq(Owner.withGithub("shtukas")),
-      sellByDate = LocalDate.of(2022, 6, 2),
-      participationGroup = Perc50,
-    )
 
 object FrontRendering
     extends Experiment(


### PR DESCRIPTION
## What does this change?

Rolls out liveblogs to 100% of users!

Closes guardian/dotcom-rendering#4655