### PR TITLE
Remove unused getV1EmailSubscriptions method from NewsletterService

### DIFF
--- a/identity/app/services/NewsletterService.scala
+++ b/identity/app/services/NewsletterService.scala
@@ -1,13 +1,7 @@
 package services
 
-import actions.AuthenticatedActions
-import actions.AuthenticatedActions.AuthRequest
-import com.gu.identity.model.{EmailList, EmailNewsletters, Subscriber}
 import idapiclient.{IdApiClient, TrackingData}
-import idapiclient.responses.Error
 import play.api.data._
-import play.api.libs.json._
-import play.api.mvc._
 import utils.SafeLogging
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -15,7 +9,7 @@ import scala.concurrent.{ExecutionContext, Future}
 /**
   * This is the old EmailController converted *as is* to a service to be consumed by EditProfileController
   */
-class NewsletterService(api: IdApiClient, idRequestParser: IdRequestParser, idUrlBuilder: IdentityUrlBuilder)(implicit
+class NewsletterService(api: IdApiClient)(implicit
     executionContext: ExecutionContext,
 ) extends SafeLogging {
 
@@ -38,14 +32,6 @@ class NewsletterService(api: IdApiClient, idRequestParser: IdRequestParser, idUr
       remove: List[String] = List(),
   ): List[String] = {
     (form.data.filter(_._1.startsWith("currentEmailSubscriptions")).map(_._2).filterNot(remove.toSet) ++ add).toList
-  }
-
-  def getV1EmailSubscriptions(
-      form: Form[EmailPrefsData],
-      add: List[String] = List(),
-      remove: List[String] = List(),
-  ): List[String] = {
-    getEmailSubscriptions(form, add, remove).filter(EmailNewsletters.v1ListIds.contains)
   }
 }
 

--- a/identity/test/controllers/ConsentsJourneyControllerTest.scala
+++ b/identity/test/controllers/ConsentsJourneyControllerTest.scala
@@ -45,7 +45,7 @@ import scala.concurrent.Future
     val idRequest = mock[IdentityRequest]
     val trackingData = mock[TrackingData]
     val returnUrlVerifier = mock[ReturnUrlVerifier]
-    val newsletterService = spy(new NewsletterService(api, idRequestParser, idUrlBuilder))
+    val newsletterService = spy(new NewsletterService(api))
     val httpConfiguration = HttpConfiguration.createWithDefaults()
     val newsletterSignupAgent = mock[NewsletterSignupAgent]
 

--- a/identity/test/controllers/ConsentsJourneyControllerTest.scala
+++ b/identity/test/controllers/ConsentsJourneyControllerTest.scala
@@ -3,7 +3,7 @@ package controllers
 import actions.AuthenticatedActions
 import com.gu.identity.cookie.GuUCookieData
 import com.gu.identity.model.Consent.Supporter
-import com.gu.identity.model.{EmailNewsletters, _}
+import com.gu.identity.model._
 import controllers.editprofile.EditProfileController
 import form._
 import idapiclient.{Auth, TrackingData, _}

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -49,7 +49,7 @@ import scala.concurrent.Future
     val idRequest = mock[IdentityRequest]
     val trackingData = mock[TrackingData]
     val returnUrlVerifier = mock[ReturnUrlVerifier]
-    val newsletterService = spy(new NewsletterService(api, idRequestParser, idUrlBuilder))
+    val newsletterService = spy(new NewsletterService(api))
     val httpConfiguration = HttpConfiguration.createWithDefaults()
     val newsletterSignupAgent = mock[NewsletterSignupAgent]
 

--- a/identity/test/controllers/EmailVerificationControllerTest.scala
+++ b/identity/test/controllers/EmailVerificationControllerTest.scala
@@ -38,7 +38,7 @@ class EmailVerificationControllerTest
   val idRequest = mock[IdentityRequest]
   val returnUrlVerifier = mock[ReturnUrlVerifier]
   val signinService = mock[PlaySigninService]
-  val newsletterService = spy(new NewsletterService(api, idRequestParser, idUrlBuilder))
+  val newsletterService = spy(new NewsletterService(api))
 
   val userId: String = "123"
   val user = User("test@example.com", userId, statusFields = StatusFields(userEmailValidated = Some(true)))

--- a/identity/test/controllers/FormstackControllerTest.scala
+++ b/identity/test/controllers/FormstackControllerTest.scala
@@ -38,7 +38,7 @@ class FormstackControllerTest
   val trackingData = mock[TrackingData]
   val authService = mock[AuthenticationService]
   val api = mock[IdApiClient]
-  val newsletterService = spy(new NewsletterService(api, requestParser, idUrlBuilder))
+  val newsletterService = spy(new NewsletterService(api))
 
   val userId = "123"
   val user = User("test@example.com", userId)


### PR DESCRIPTION
## What does this change?

Removes dependency on Newsletter model from the Identity-model. Removes a method and unused variables from NewsletterService. 

This method turned up no usages. Code compiles and builds without it. 

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
