### PR TITLE
Update Identity library from 3.240-C5 to 3.253

### DIFF
--- a/identity/app/views/support/fragment/ConsentChannel.scala
+++ b/identity/app/views/support/fragment/ConsentChannel.scala
@@ -11,7 +11,7 @@ object ConsentChannel {
   case object PostOptOutConsentChannel extends ConsentChannelBehaviour(Consent.PostOptout.id)
   case object MarketResearchConsentChannel extends ConsentChannelBehaviour(Consent.MarketResearchOptout.id)
   case object ProfilingConsentChannel extends ConsentChannelBehaviour(Consent.ProfilingOptout.id)
-  case object AdvertisingConsentChannel extends ConsentChannelBehaviour(Consent.AdvertisingOptin.id)
+  case object PersonalisedAdvertisingConsentChannel extends ConsentChannelBehaviour(Consent.PersonalisedAdvertising.id)
 
   private val channelsIds = List(
     TextConsentChannel.id,
@@ -19,7 +19,7 @@ object ConsentChannel {
     PostOptOutConsentChannel.id,
     MarketResearchConsentChannel.id,
     ProfilingConsentChannel.id,
-    AdvertisingConsentChannel.id,
+    PersonalisedAdvertisingConsentChannel.id,
   )
 
   private val productIds = List(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.240-C5"
+  val identityLibVersion = "3.253"
   val awsVersion = "1.11.240"
   val capiVersion = "17.25.0"
   val faciaVersion = "3.3.12"


### PR DESCRIPTION
## What does this change?

This update removes the dependency on the EmailNewsletters object from the old identity-model, as this dependency has been fully replaced by the newsletter api

More context available here: https://github.com/guardian/identity/pull/1875

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Checklist

CODE checks 

- [x] profile.code.dev-theguardian.com/consents/thank-you  displays correctly and works if email comms selected
- [x] profile.code.dev-theguardian.com/complete-consents displays correctly and signs up user to newsletters if checked
- [ ] [Booksmarks newsletter sign up](https://m.code.dev-theguardian.com/books/ng-interactive/2022/mar/21/sign-up-for-bookmarks-discover-new-books-in-our-weekly-email) - email received/ MMA? (signed in user)
- [x] m.code.dev-theguardian.com/email-newsletters - subscription works for signed in user and is reflected in MMA
- [x] m.code.dev-theguardian.com/email-newsletters - subscription works for NON signed in user 
- [ ]  [Bookmarks newsletter sign up](https://m.code.dev-theguardian.com/books/ng-interactive/2022/mar/21/sign-up-for-bookmarks-discover-new-books-in-our-weekly-email) - email received/ MMA? (NON signed in user) 

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
