### PR TITLE
Fix: Incorrect most recent id causing duplicate blocks

### DIFF
--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -212,13 +212,14 @@ class LiveBlogController(
       _.requestedBodyBlocks.getOrElse(lastUpdateBlockId.around, Seq())
     }
 
-    val filteredBlocks = if (filterKeyEvents) {
-      requestedBlocks.filter(block => block.eventType == KeyEvent || block.eventType == SummaryEvent)
-    } else requestedBlocks
-
-    filteredBlocks.takeWhile { block =>
+    val latestBlocks = requestedBlocks.takeWhile { block =>
       block.id != lastUpdateBlockId.lastUpdate
     }
+
+    if (filterKeyEvents) {
+      latestBlocks.filter(block => block.eventType == KeyEvent || block.eventType == SummaryEvent)
+    } else latestBlocks
+
   }
 
   private[this] def getNewBlocks(


### PR DESCRIPTION
## What does this change?
Changes the order of the new block filter to get the most recent blocks first, then filter by key events. 

