### PR TITLE
Fix ad label max-height

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -43,6 +43,7 @@
     @include font-size(12, 20);
     position: relative;
     height: $mpu-ad-label-height;
+    max-height: $mpu-ad-label-height;
     background-color: $brightness-97;
     padding: 0 ($gs-baseline/3)*2;
     border-top: 1px solid $brightness-86;


### PR DESCRIPTION
## What does this change?

We have seen issues where the ad label has its width and height set to that of its related advert.

Until we track down the cause of this we have decided to add a `max-height` to the ad label.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes: https://github.com/guardian/dotcom-rendering/pull/4681

## Screenshots

<img width="112" alt="Screenshot 2022-04-20 at 16 53 03" src="https://user-images.githubusercontent.com/7014230/164277242-c6d42dcc-3003-44fd-b932-694ae187d845.png">

### Tested

- [ ] Locally
- [x] On CODE (optional)
