### PR TITLE
Add container to `inline2+` ad slots

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -35,11 +35,13 @@ const insertAdAtPara = (
 	type: string,
 	classes?: string,
 	sizes?: SizeMappings,
+	includeContainer?: boolean,
 ): Promise<void> => {
 	const ad = createAdSlot(type, {
 		name,
 		classes,
 		sizes,
+		includeContainer,
 	});
 
 	return fastdom
@@ -153,6 +155,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 								],
 						  }
 						: { desktop: [adSizes.halfPage, adSizes.skyscraper] },
+					!isInline1,
 				);
 			});
 		await Promise.all(slots);

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slot.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slot.ts
@@ -15,6 +15,7 @@ type CreateSlotOptions = {
 	classes?: string;
 	name?: string;
 	sizes?: Record<string, AdSize[] | undefined>; // allow an empty object
+	includeContainer?: boolean;
 };
 
 const commonSizeMappings: SizeMappings = {
@@ -160,6 +161,7 @@ const createAdSlotElement = (
 	name: string,
 	attrs: Record<string, string>,
 	classes: string[],
+	includeContainer: boolean,
 ): HTMLElement => {
 	const id = `${adSlotIdPrefix}${name}`;
 
@@ -179,13 +181,23 @@ const createAdSlotElement = (
 	// The 'main' adSlot
 	const adSlot = document.createElement('div');
 	adSlot.id = id;
-	adSlot.className = `js-ad-slot ad-slot ${classes.join(' ')}`;
+	adSlot.className = `js-ad-slot ad-slot ${
+		includeContainer ? '' : classes.join(' ')
+	}`;
 	adSlot.setAttribute('data-link-name', `ad slot ${name}`);
 	adSlot.setAttribute('data-name', name);
 	adSlot.setAttribute('aria-hidden', 'true');
 	Object.keys(attrs).forEach((attr) => {
 		adSlot.setAttribute(attr, attrs[attr]);
 	});
+
+	if (includeContainer) {
+		const container = document.createElement('div');
+		container.className = `ad-slot-container ${classes.join(' ')}`;
+		container.appendChild(adSlot);
+
+		return container;
+	}
 
 	return adSlot;
 };
@@ -270,6 +282,7 @@ export const createAdSlot = (
 ): HTMLElement => {
 	const adSlotConfig = adSlotConfigs[type];
 	const slotName = options.name ?? adSlotConfig.name ?? type;
+	const includeContainer = options.includeContainer ?? false;
 
 	const sizeMappings = concatSizeMappings(
 		adSlotConfig.sizeMappings,
@@ -290,5 +303,6 @@ export const createAdSlot = (
 		slotName,
 		createDataAttributes(attributes),
 		createClasses(slotName, options.classes),
+		includeContainer,
 	);
 };


### PR DESCRIPTION
## What does this change?

Wrap `inline2+` ad slots in a container div. This will hopefully stop Google performing [ad expansion](https://support.google.com/admanager/answer/9117822?hl=en).

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes - we apply the `max-size` in [this PR](https://github.com/guardian/dotcom-rendering/pull/4688)

## What is the value of this and can you measure success?

Stop bad ad expansions like this:

<img width="1096" alt="Screenshot 2022-04-21 at 11 25 23" src="https://user-images.githubusercontent.com/7423751/164436934-0e932025-43a7-4022-8a60-7eccf22fbe02.png">

### Tested

- [x] Locally
- [ ] On CODE - TODO