### PR TITLE
Bump identityLibVersion to 3.253

### DIFF
--- a/identity/app/views/support/fragment/ConsentChannel.scala
+++ b/identity/app/views/support/fragment/ConsentChannel.scala
@@ -11,7 +11,7 @@ object ConsentChannel {
   case object PostOptOutConsentChannel extends ConsentChannelBehaviour(Consent.PostOptout.id)
   case object MarketResearchConsentChannel extends ConsentChannelBehaviour(Consent.MarketResearchOptout.id)
   case object ProfilingConsentChannel extends ConsentChannelBehaviour(Consent.ProfilingOptout.id)
-  case object AdvertisingConsentChannel extends ConsentChannelBehaviour(Consent.AdvertisingOptin.id)
+  case object AdvertisingConsentChannel extends ConsentChannelBehaviour(Consent.PersonalisedAdvertising.id)
 
   private val channelsIds = List(
     TextConsentChannel.id,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.240-C5"
+  val identityLibVersion = "3.253"
   val awsVersion = "1.11.240"
   val capiVersion = "17.25.0"
   val faciaVersion = "3.3.12"


### PR DESCRIPTION
Co-authored-by: Joshua Lieberman <@jlieb10>

## What does this change?
As part  for migrating to Scala 2.13, we're bumping `identityLibVersion` to `3.253`.

