### PR TITLE
Remove `isDotcomRendering` check from spacefinder

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -66,10 +66,7 @@ const filterNearbyCandidates = enableNearbyFilteringFix()
 	? filterNearbyCandidatesFixed
 	: filterNearbyCandidatesBroken;
 
-const isDotcomRendering = config.get<boolean>('isDotcomRendering', false);
-const articleBodySelector = isDotcomRendering
-	? '.article-body-commercial-selector'
-	: '.js-article__body';
+const articleBodySelector = '.article-body-commercial-selector';
 
 const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 	const tweakpoint = getTweakpoint(getViewport().width);
@@ -85,7 +82,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 		bodySelector: articleBodySelector,
 		slotSelector: ' > p',
 		minAbove: isImmersive ? 700 : 300,
-		minBelow: isDotcomRendering ? 300 : 700,
+		minBelow: 300,
 		selectors: {
 			' > h2': {
 				minAbove: 5,
@@ -113,7 +110,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 		bodySelector: articleBodySelector,
 		slotSelector: ' > p',
 		minAbove: isPaidContent ? 1600 : 1000,
-		minBelow: isDotcomRendering ? 300 : 800,
+		minBelow: 300,
 		selectors: {
 			' .ad-slot': adSlotClassSelectorSizes,
 			' [data-spacefinder-role="immersive"]': {

--- a/static/src/javascripts/projects/commercial/modules/carrot-traffic-driver.ts
+++ b/static/src/javascripts/projects/commercial/modules/carrot-traffic-driver.ts
@@ -1,4 +1,3 @@
-import config from '../../../lib/config';
 import { getBreakpoint } from '../../../lib/detect';
 import fastdom from '../../../lib/fastdom-promise';
 import { spaceFiller } from '../../common/modules/article/space-filler';
@@ -10,10 +9,7 @@ import { commercialFeatures } from '../../common/modules/commercial/commercial-f
 import { addSlot } from './dfp/add-slot';
 import { createAdSlot } from './dfp/create-slot';
 
-const isDotcomRendering = config.get('isDotcomRendering', false) as boolean;
-const bodySelector = isDotcomRendering
-	? '.article-body-commercial-selector'
-	: '.js-article__body';
+const bodySelector = '.article-body-commercial-selector';
 
 const wideRules: SpacefinderRules = {
 	bodySelector,

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -105,7 +105,6 @@
   "../projects/common/modules/experiments/tests/spacefinder-okr-mega-test.ts"
  ],
  "../projects/commercial/modules/carrot-traffic-driver.ts": [
-  "../lib/config.d.ts",
   "../lib/detect.js",
   "../lib/fastdom-promise.js",
   "../projects/commercial/modules/dfp/add-slot.ts",


### PR DESCRIPTION
## What does this change?

Remove `isDotcomRendering` check from spacefinder. All articles are rendered by DCR nowadays so we can simplify this logic.

## What is the value of this and can you measure success?

Less dead code.

### Tested

- [ ] Locally
- [ ] On CODE (optional)
