### PR TITLE
Pre-scala 2.13: Update scalatest, scalacheck and scalatestplus.play

### DIFF
--- a/admin/test/controllers/DeploysRadiatorControllerTest.scala
+++ b/admin/test/controllers/DeploysRadiatorControllerTest.scala
@@ -2,7 +2,9 @@ package controllers.admin
 
 import controllers.Helpers.DeploysTestHttpRecorder
 import model.deploys._
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import play.api.libs.json.JsArray
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc.ControllerComponents
@@ -14,7 +16,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 @DoNotDiscover class DeploysControllerTest
-    extends WordSpec
+    extends AnyWordSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/admin/test/dfp/DfpApiValidationTest.scala
+++ b/admin/test/dfp/DfpApiValidationTest.scala
@@ -4,10 +4,11 @@ import concurrent.BlockingOperations
 import common.dfp.{GuAdUnit, GuLineItem, GuTargeting, Sponsorship}
 import com.google.api.ads.admanager.axis.v202108._
 import org.joda.time.DateTime
-import org.scalatest._
 import akka.actor.ActorSystem
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class DfpApiValidationTest extends FlatSpec with Matchers {
+class DfpApiValidationTest extends AnyFlatSpec with Matchers {
 
   private def lineItem(adUnitIds: Seq[String]): GuLineItem = {
     val adUnits = adUnitIds.map(adUnitId => {

--- a/admin/test/dfp/DfpDataCacheJobTest.scala
+++ b/admin/test/dfp/DfpDataCacheJobTest.scala
@@ -3,11 +3,13 @@ package dfp
 import common.dfp.{GuLineItem, GuTargeting, Sponsorship}
 import org.joda.time.DateTime
 import org.scalatest._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 import test._
 
 class DfpDataCacheJobTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with SingleServerSuite
     with BeforeAndAfterAll

--- a/admin/test/dfp/ReaderTest.scala
+++ b/admin/test/dfp/ReaderTest.scala
@@ -2,9 +2,10 @@ package dfp
 
 import com.google.api.ads.admanager.axis.utils.v202108.StatementBuilder
 import dfp.Reader.read
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ReaderTest extends FlatSpec with Matchers {
+class ReaderTest extends AnyFlatSpec with Matchers {
 
   "load" should "load a single page of results" in {
     val stmtBuilder = new StatementBuilder()

--- a/admin/test/football/PlayerControllerTest.scala
+++ b/admin/test/football/PlayerControllerTest.scala
@@ -1,15 +1,16 @@
 package football
 
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FreeSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import play.api.libs.json.{JsObject, JsString}
 import play.api.mvc.AnyContentAsFormUrlEncoded
 import play.api.test._
 import play.api.test.Helpers._
-import football.services.PaFootballClient
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 import test.{ConfiguredTestSuite, WithMaterializer, WithTestWsClient}
 
 @DoNotDiscover class PlayerControllerTest
-    extends FreeSpec
+    extends AnyFreeSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/admin/test/football/SiteControllerTest.scala
+++ b/admin/test/football/SiteControllerTest.scala
@@ -1,12 +1,14 @@
 package football
 
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import play.api.test._
 import play.api.test.Helpers._
 import test.{ConfiguredTestSuite, WithMaterializer, WithTestWsClient}
 
 @DoNotDiscover class SiteControllerTest
-    extends FreeSpec
+    extends AnyFreeSpec
     with ConfiguredTestSuite
     with Matchers
     with WithMaterializer

--- a/admin/test/football/TablesControllerTest.scala
+++ b/admin/test/football/TablesControllerTest.scala
@@ -2,7 +2,9 @@ package football
 
 import _root_.controllers.admin.TablesController
 import football.model.PA
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import play.api.mvc.AnyContentAsFormUrlEncoded
 import play.api.test._
 import play.api.test.Helpers._
@@ -13,7 +15,7 @@ import scala.annotation.tailrec
 import scala.language.postfixOps
 
 @DoNotDiscover class TablesControllerTest
-    extends FreeSpec
+    extends AnyFreeSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/admin/test/indexes/TagPagesTest.scala
+++ b/admin/test/indexes/TagPagesTest.scala
@@ -4,14 +4,16 @@ import com.gu.contentapi.client.model.v1.{TagType, Tag => ApiTag}
 import model.{TagDefinition, TagIndex}
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.DoNotDiscover
 import play.api.libs.iteratee.Enumerator
 import test.WithTestExecutionContext
 
 import scala.language.postfixOps
 import scala.concurrent.duration._
 
-@DoNotDiscover class TagPagesTest extends FlatSpec with Matchers with WithTestExecutionContext with ScalaFutures {
+@DoNotDiscover class TagPagesTest extends AnyFlatSpec with Matchers with WithTestExecutionContext with ScalaFutures {
 
   val tagPages = new TagPages
 

--- a/admin/test/package.scala
+++ b/admin/test/package.scala
@@ -1,6 +1,7 @@
 package test
 
 import org.scalatest.Suites
+import org.scalatestplus.play.PortNumber
 
 class AdminTestSuite
     extends Suites(
@@ -12,6 +13,4 @@ class AdminTestSuite
       new pagepresser.InteractiveHtmlCleanerTest,
       new controllers.admin.DeploysControllerTest,
     )
-    with SingleServerSuite {
-  override lazy val port: Int = 19015
-}
+    with SingleServerSuite {}

--- a/admin/test/pagepresser/HtmlCleanerTest.scala
+++ b/admin/test/pagepresser/HtmlCleanerTest.scala
@@ -1,11 +1,14 @@
 package pagepresser
 
 import org.jsoup.Jsoup
-import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.DoNotDiscover
 import test.ConfiguredTestSuite
+
 import scala.io.Source
 
-@DoNotDiscover class HtmlCleanerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class HtmlCleanerTest extends AnyFlatSpec with Matchers with ConfiguredTestSuite {
 
   "BasicHtmlCleaner" should "remove ad slots from a page that will be pressed" in {
     val originalSource =

--- a/admin/test/pagepresser/InteractiveHtmlCleanerTest.scala
+++ b/admin/test/pagepresser/InteractiveHtmlCleanerTest.scala
@@ -1,12 +1,14 @@
 package pagepresser
 
 import org.jsoup.Jsoup
-import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.DoNotDiscover
 import test.ConfiguredTestSuite
 
 import scala.io.Source
 
-@DoNotDiscover class InteractiveHtmlCleanerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class InteractiveHtmlCleanerTest extends AnyFlatSpec with Matchers with ConfiguredTestSuite {
 
   "InteractiveHtmlCleaner" should "remove all non-interactive scripts and re-write jQuery when pressing a page" in {
     val originalSource = Source.fromInputStream(

--- a/admin/test/services/ParameterStoreServiceTest.scala
+++ b/admin/test/services/ParameterStoreServiceTest.scala
@@ -2,12 +2,13 @@ package services
 
 import akka.actor.ActorSystem
 import concurrent.BlockingOperations
-import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
 import org.mockito.Mockito._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 
-class ParameterStoreServiceTest extends FlatSpec with ScalaFutures with Matchers with MockitoSugar {
+class ParameterStoreServiceTest extends AnyFlatSpec with ScalaFutures with Matchers with MockitoSugar {
 
   "findParameterBySubstring" should "retrieve a parameter from the parameter store by substring" in {
     val actorSystem = ActorSystem()

--- a/applications/test/AllIndexControllerTest.scala
+++ b/applications/test/AllIndexControllerTest.scala
@@ -1,13 +1,15 @@
 package test
 
-import contentapi.{ContentApiClient, SectionsLookUp}
+import contentapi.SectionsLookUp
 import controllers.AllIndexController
 import org.joda.time.DateTimeZone
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import play.api.test.Helpers._
 
 @DoNotDiscover class AllIndexControllerTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/applications/test/AllIndexTemplateTest.scala
+++ b/applications/test/AllIndexTemplateTest.scala
@@ -1,6 +1,8 @@
 package test
 
-import org.scalatest.{DoNotDiscover, FlatSpec, Ignore, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{DoNotDiscover, Ignore}
 
 /*
   I'm getting endless timeouts trying to run this locally and as a result am missing the
@@ -8,7 +10,7 @@ import org.scalatest.{DoNotDiscover, FlatSpec, Ignore, Matchers}
   Temporarily ignoring the navigation interaction parts of the test to see if we can move
   this on.
  */
-@DoNotDiscover @Ignore class AllIndexTemplateTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover @Ignore class AllIndexTemplateTest extends AnyFlatSpec with Matchers with ConfiguredTestSuite {
   it should "render the /all page and navigate backwards and forwards" in goTo("/world/2019/jan/31/all") { browser =>
     import browser._
 
@@ -25,7 +27,7 @@ import org.scalatest.{DoNotDiscover, FlatSpec, Ignore, Matchers}
   }
 }
 
-@DoNotDiscover class AllIndexTemplateTestLite extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class AllIndexTemplateTestLite extends AnyFlatSpec with Matchers with ConfiguredTestSuite {
   it should "render the /all page and the correct Older and Newer button links for 2019 Jan 31" in goTo(
     "/world/2019/jan/31/all",
   ) { browser =>

--- a/applications/test/CrosswordDataTest.scala
+++ b/applications/test/CrosswordDataTest.scala
@@ -1,14 +1,16 @@
 package test
 
 import controllers.CrosswordPageController
-import model.{Entry, CrosswordData}
+import model.{CrosswordData, Entry}
 import org.joda.time.DateTime
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Millis, Span}
 
 @DoNotDiscover class CrosswordDataTest
-    extends FreeSpec
+    extends AnyFreeSpec
     with Matchers
     with ConfiguredTestSuite
     with ScalaFutures

--- a/applications/test/CrosswordPageMetaDataTest.scala
+++ b/applications/test/CrosswordPageMetaDataTest.scala
@@ -2,10 +2,12 @@ package test
 
 import controllers.CrosswordPageController
 import metadata.MetaDataMatcher
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 
 @DoNotDiscover class CrosswordPageMetaDataTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/applications/test/GalleryControllerTest.scala
+++ b/applications/test/GalleryControllerTest.scala
@@ -1,11 +1,13 @@
 package test
 
 import controllers.GalleryController
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.test.Helpers._
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 
 @DoNotDiscover class GalleryControllerTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/applications/test/GalleryTemplateTest.scala
+++ b/applications/test/GalleryTemplateTest.scala
@@ -1,10 +1,13 @@
 package test
 
 import conf.switches.Switches.FacebookShareUseTrailPicFirstSwitch
-import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.DoNotDiscover
+import org.scalatest.matchers.should.Matchers
+
 import scala.collection.JavaConverters._
 
-@DoNotDiscover class GalleryTemplateTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class GalleryTemplateTest extends AnyFlatSpec with Matchers with ConfiguredTestSuite {
 
   it should "render gallery headline" in goTo("/news/gallery/2012/may/02/picture-desk-live-kabul-burma") { browser =>
     browser.el("h1").text should be("Picture desk live: the day's best news images")

--- a/applications/test/ImageContentControllerTest.scala
+++ b/applications/test/ImageContentControllerTest.scala
@@ -1,11 +1,13 @@
 package test
 
 import controllers.ImageContentController
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.test.Helpers._
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 
 @DoNotDiscover class ImageContentControllerTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/applications/test/ImageContentTemplateTest.scala
+++ b/applications/test/ImageContentTemplateTest.scala
@@ -1,9 +1,10 @@
 package test
-import scala.collection.JavaConverters._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
+import org.scalatest.DoNotDiscover
 
-@DoNotDiscover class ImageContentTemplateTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class ImageContentTemplateTest extends AnyFlatSpec with Matchers with ConfiguredTestSuite {
 
   it should "render a cartoon" in goTo("/commentisfree/cartoon/2013/jul/15/iain-duncan-smith-benefits-cap") { browser =>
     import browser._

--- a/applications/test/IndexControllerTest.scala
+++ b/applications/test/IndexControllerTest.scala
@@ -2,12 +2,14 @@ package test
 
 import contentapi.SectionsLookUp
 import controllers.IndexController
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.test._
 import play.api.test.Helpers._
-import org.scalatest.{DoNotDiscover, BeforeAndAfterAll, Matchers, FlatSpec}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 
 @DoNotDiscover class IndexControllerTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with BeforeAndAfterAll
     with ConfiguredTestSuite

--- a/applications/test/IndexFeatureTest.scala
+++ b/applications/test/IndexFeatureTest.scala
@@ -2,13 +2,16 @@ package test
 
 import play.api.test.TestBrowser
 import org.scalatest._
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
+
 import scala.collection.JavaConverters._
 
-@DoNotDiscover class IndexFeatureTest extends FeatureSpec with GivenWhenThen with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class IndexFeatureTest extends AnyFeatureSpec with GivenWhenThen with Matchers with ConfiguredTestSuite {
 
-  feature("Section") {
+  Feature("Section") {
 
-    feature("Sponsorships") {
+    Feature("Sponsorships") {
 
       def testFrontSponsorship(browser: TestBrowser, sponsorshipType: String): Assertion = {
         import browser._
@@ -31,7 +34,7 @@ import scala.collection.JavaConverters._
         *
        * If they fail often, might need to look into setting up a reliable data source
         */
-      scenario("Advertisement Feature Front") {
+      Scenario("Advertisement Feature Front") {
 
         Given("I am on an advertisement feature front")
         goTo("/visa-partner-zone") { browser =>
@@ -40,7 +43,7 @@ import scala.collection.JavaConverters._
 
       }
 
-      scenario("Sponsored Front") {
+      Scenario("Sponsored Front") {
 
         Given("I am on ansponsored front")
         goTo("/sustainable-business/role-business-development") { browser =>
@@ -49,7 +52,7 @@ import scala.collection.JavaConverters._
 
       }
 
-      scenario("Foundation Supported Front") {
+      Scenario("Foundation Supported Front") {
 
         Given("I am on a foundation supported front")
         goTo("/global-development") { browser =>

--- a/applications/test/IndexMetaDataTest.scala
+++ b/applications/test/IndexMetaDataTest.scala
@@ -4,12 +4,14 @@ import contentapi.SectionsLookUp
 import controllers.IndexController
 import metadata.MetaDataMatcher
 import org.jsoup.Jsoup
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import play.api.libs.json._
 import play.api.test.Helpers._
 
 @DoNotDiscover class IndexMetaDataTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/applications/test/InteractiveControllerTest.scala
+++ b/applications/test/InteractiveControllerTest.scala
@@ -2,15 +2,17 @@ package test
 
 import controllers.InteractiveController
 import play.api.test.Helpers._
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers, PrivateMethodTester}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, PrivateMethodTester}
 import conf.Configuration.interactive.cdnPath
 import play.api.libs.ws.WSClient
 import com.gu.contentapi.client.model.v1.Blocks
 import model.dotcomrendering.PageType
-import model.{InteractivePage}
-import play.twirl.api.Html
+import model.InteractivePage
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.mvc.{RequestHeader, Result, Results}
-import scala.concurrent.{ExecutionContext, Future}
+
+import scala.concurrent.Future
 
 class DCRFake() extends renderers.DotcomRenderingService {
   override def getInteractive(
@@ -24,7 +26,7 @@ class DCRFake() extends renderers.DotcomRenderingService {
 }
 
 @DoNotDiscover class InteractiveControllerTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/applications/test/InteractiveTemplateTest.scala
+++ b/applications/test/InteractiveTemplateTest.scala
@@ -1,9 +1,12 @@
 package test
 
-import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.DoNotDiscover
+import org.scalatest.matchers.should.Matchers
+
 import scala.collection.JavaConverters._
 
-@DoNotDiscover class InteractiveTemplateTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class InteractiveTemplateTest extends AnyFlatSpec with Matchers with ConfiguredTestSuite {
 
   "Interactive html template" should "show the twitter card meta-data" in goTo(
     "/us-news/ng-interactive/2015/apr/13/marco-rubio-campaign-resume-guardian?dcr=false",

--- a/applications/test/LatestIndexControllerTest.scala
+++ b/applications/test/LatestIndexControllerTest.scala
@@ -1,11 +1,13 @@
 package test
 
 import controllers.LatestIndexController
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import play.api.test.Helpers._
 
 @DoNotDiscover class LatestIndexControllerTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/applications/test/MediaControllerTest.scala
+++ b/applications/test/MediaControllerTest.scala
@@ -2,12 +2,15 @@ package test
 
 import controllers.MediaController
 import play.api.test.Helpers._
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import org.jsoup.Jsoup
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
 import scala.util.matching.Regex
 
 @DoNotDiscover class MediaControllerTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/applications/test/MediaFeatureTest.scala
+++ b/applications/test/MediaFeatureTest.scala
@@ -1,16 +1,18 @@
 package test
 
-import scala.collection.JavaConverters._
-import org.scalatest.{DoNotDiscover, Matchers, GivenWhenThen, FeatureSpec}
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
 
-@DoNotDiscover class MediaFeatureTest extends FeatureSpec with GivenWhenThen with Matchers with ConfiguredTestSuite {
-  feature("Media (video)") {
+import org.scalatest.{DoNotDiscover, GivenWhenThen}
+
+@DoNotDiscover class MediaFeatureTest extends AnyFeatureSpec with GivenWhenThen with Matchers with ConfiguredTestSuite {
+  Feature("Media (video)") {
 
     info("In order to experience all the wonderful videos the Guardian publish")
     info("As a sighted Guardian reader")
     info("I want to view a version of the video optimised for my browser")
 
-    scenario("Load HTML5 video formats") {
+    Scenario("Load HTML5 video formats") {
       Given("I am on a video page")
       goTo("/film/video/2013/aug/14/chloe-grace-moretz-kick-ass-2-video") { browser =>
         import browser._
@@ -22,7 +24,7 @@ import org.scalatest.{DoNotDiscover, Matchers, GivenWhenThen, FeatureSpec}
       }
     }
 
-    scenario("Have correct canonical url when 410 encountered") {
+    Scenario("Have correct canonical url when 410 encountered") {
       Given("I am on a video page")
       goTo("/world/video/2008/dec/11/guantanamo-bay") { browser =>
         import browser._
@@ -30,7 +32,7 @@ import org.scalatest.{DoNotDiscover, Matchers, GivenWhenThen, FeatureSpec}
       }
     }
 
-    scenario("Include Guardian byline") {
+    Scenario("Include Guardian byline") {
       goTo("/film/video/2013/aug/14/chloe-grace-moretz-kick-ass-2-video") { browser =>
         import browser._
         el(".byline").html().toString should include("Ben Child")
@@ -39,7 +41,7 @@ import org.scalatest.{DoNotDiscover, Matchers, GivenWhenThen, FeatureSpec}
       }
     }
 
-    scenario("Include non Guardian byline") {
+    Scenario("Include non Guardian byline") {
       goTo("/lifeandstyle/australia-food-blog/video/2014/feb/03/chia-mango-sorbet-video-recipe") { browser =>
         browser.$(".byline").first().text() should be(
           "Guy Turland and Mark Alston, Source: Bondi Harvest Pty Ltd",
@@ -47,7 +49,7 @@ import org.scalatest.{DoNotDiscover, Matchers, GivenWhenThen, FeatureSpec}
       }
     }
 
-    scenario("The content is marked up with the correct schema") {
+    Scenario("The content is marked up with the correct schema") {
       goTo("/uk-news/video/2014/aug/06/qatar-airlines-flight-escorted-raf-fighter-jet-bomb-hoax-video") { browser =>
         import browser._
 
@@ -64,7 +66,7 @@ import org.scalatest.{DoNotDiscover, Matchers, GivenWhenThen, FeatureSpec}
       }
     }
 
-    scenario("Twitter cards should appear in video article meta data") {
+    Scenario("Twitter cards should appear in video article meta data") {
       goTo("/world/video/2014/nov/05/easyjet-flight-aborts-landing-last-minute-video") { browser =>
         import browser._
         el("meta[name='twitter:site']").attribute("content") should be("@guardian")

--- a/applications/test/NewspaperControllerTest.scala
+++ b/applications/test/NewspaperControllerTest.scala
@@ -1,19 +1,21 @@
 package services
 
 import controllers.NewspaperController
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import play.api.test.Helpers._
 import test.{
   ConfiguredTestSuite,
   TestRequest,
   WithMaterializer,
-  WithTestContentApiClient,
   WithTestApplicationContext,
+  WithTestContentApiClient,
   WithTestWsClient,
 }
 
 @DoNotDiscover class NewspaperControllerTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/applications/test/SectionTemplateTest.scala
+++ b/applications/test/SectionTemplateTest.scala
@@ -1,14 +1,15 @@
 package test
 
 import java.net.URI
-
 import org.fluentlenium.core.domain.FluentWebElement
-import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.DoNotDiscover
 import play.api.test.TestBrowser
 
 import scala.collection.JavaConverters._
 
-@DoNotDiscover class SectionTemplateTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class SectionTemplateTest extends AnyFlatSpec with Matchers with ConfiguredTestSuite {
 
   it should "render front title" in goTo("/uk-news") { browser =>
     browser.el("[data-test-id=header-title]").text should be("UK news")

--- a/applications/test/ShareLinksTest.scala
+++ b/applications/test/ShareLinksTest.scala
@@ -1,12 +1,13 @@
 package test
 
 import com.gu.contentapi.client.model.v1.ItemResponse
-import contentapi.ContentApiClient
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import org.scalatest.concurrent.{Futures, ScalaFutures}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 @DoNotDiscover class ShareLinksTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with Futures

--- a/applications/test/TagFeatureTest.scala
+++ b/applications/test/TagFeatureTest.scala
@@ -1,16 +1,19 @@
 package test
 
-import org.scalatest.{DoNotDiscover, FeatureSpec, GivenWhenThen, Matchers}
+import org.scalatest.{DoNotDiscover, GivenWhenThen}
 import services.IndexPagePagination
+
 import collection.JavaConverters._
 import conf.switches.Switches
-import org.fluentlenium.core.domain.{FluentWebElement, FluentList}
+import org.fluentlenium.core.domain.{FluentList, FluentWebElement}
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
 
-@DoNotDiscover class TagFeatureTest extends FeatureSpec with GivenWhenThen with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class TagFeatureTest extends AnyFeatureSpec with GivenWhenThen with Matchers with ConfiguredTestSuite {
 
-  feature("Tag Series, Blogs and Contributors Pages trail size") {
+  Feature("Tag Series, Blogs and Contributors Pages trail size") {
 
-    scenario("Tag Series, Blogs and Contributors pages should show 50 trails (includes leadContent if present)") {
+    Scenario("Tag Series, Blogs and Contributors pages should show 50 trails (includes leadContent if present)") {
 
       Given("I visit a tag page")
 
@@ -21,9 +24,9 @@ import org.fluentlenium.core.domain.{FluentWebElement, FluentList}
     }
   }
 
-  feature("Contributor pages") {
+  Feature("Contributor pages") {
 
-    scenario("Should display the profile images") {
+    Scenario("Should display the profile images") {
 
       Given("I visit the 'Jemima Kiss' contributor page")
       Switches.ImageServerSwitch.switchOn()
@@ -35,7 +38,7 @@ import org.fluentlenium.core.domain.{FluentWebElement, FluentList}
       }
     }
 
-    scenario("Should not not display profiles where they don't exist") {
+    Scenario("Should not not display profiles where they don't exist") {
 
       Given("I visit the 'Sam Jones' contributor page")
       goTo("/profile/samjones") { browser =>
@@ -47,9 +50,9 @@ import org.fluentlenium.core.domain.{FluentWebElement, FluentList}
     }
   }
 
-  feature("Tag Pages") {
+  Feature("Tag Pages") {
 
-    scenario("Pagination") {
+    Scenario("Pagination") {
 
       /*
       This test is consistently failing locally, and thus does not generate the required data/database/xxx file

--- a/applications/test/TagTemplateTest.scala
+++ b/applications/test/TagTemplateTest.scala
@@ -1,8 +1,10 @@
 package test
 
-import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.DoNotDiscover
+import org.scalatest.matchers.should.Matchers
 
-@DoNotDiscover class TagTemplateTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class TagTemplateTest extends AnyFlatSpec with Matchers with ConfiguredTestSuite {
 
   it should "render tag headline" in goTo("/world/turkey") { browser =>
     browser.el("[data-test-id=header-title]").text should be("Turkey")

--- a/applications/test/common/CombinerControllerTest.scala
+++ b/applications/test/common/CombinerControllerTest.scala
@@ -2,19 +2,21 @@ package common
 
 import contentapi.SectionsLookUp
 import controllers.IndexController
+import org.scalatest.flatspec.AnyFlatSpec
 import play.api.test.Helpers._
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
+import org.scalatest.matchers.should.Matchers
 import test.{
   ConfiguredTestSuite,
   TestRequest,
   WithMaterializer,
-  WithTestContentApiClient,
   WithTestApplicationContext,
+  WithTestContentApiClient,
   WithTestWsClient,
 }
 
 @DoNotDiscover class CombinerControllerTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/applications/test/common/CombinerFeatureTest.scala
+++ b/applications/test/common/CombinerFeatureTest.scala
@@ -1,14 +1,21 @@
 package common
 
-import org.scalatest.{DoNotDiscover, FeatureSpec, GivenWhenThen, Matchers}
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{DoNotDiscover, GivenWhenThen}
 import test.ConfiguredTestSuite
+
 import collection.JavaConverters._
 
-@DoNotDiscover class CombinerFeatureTest extends FeatureSpec with GivenWhenThen with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class CombinerFeatureTest
+    extends AnyFeatureSpec
+    with GivenWhenThen
+    with Matchers
+    with ConfiguredTestSuite {
 
-  feature("Combiner pages") {
+  Feature("Combiner pages") {
 
-    scenario("Should combine 2 tags") {
+    Scenario("Should combine 2 tags") {
 
       Given("I visit a combiner page")
 
@@ -20,7 +27,7 @@ import collection.JavaConverters._
       }
     }
 
-    scenario("Should combine a section with a tag") {
+    Scenario("Should combine a section with a tag") {
 
       Given("I visit a combiner page")
 
@@ -33,7 +40,7 @@ import collection.JavaConverters._
       }
     }
 
-    scenario("Tags in same section") {
+    Scenario("Tags in same section") {
 
       Given("I visit a combiner page with tags in the same section")
 
@@ -45,7 +52,7 @@ import collection.JavaConverters._
       }
     }
 
-    scenario("Series combiner in the same section") {
+    Scenario("Series combiner in the same section") {
 
       Given("I visit a combiner page with a series tag in the same seciton")
 

--- a/applications/test/package.scala
+++ b/applications/test/package.scala
@@ -1,9 +1,9 @@
 package test
 
 import java.util.{List => JList}
-
 import org.scalatest.Suites
-import services.{FacebookGraphApiTest, IndexPageTest, NewspaperControllerTest, InteractivePickerTest}
+import org.scalatestplus.play.PortNumber
+import services.{FacebookGraphApiTest, IndexPageTest, InteractivePickerTest, NewspaperControllerTest}
 
 import collection.JavaConverters._
 
@@ -44,6 +44,4 @@ class ApplicationsTestSuite
       new FacebookGraphApiTest,
       new InteractivePickerTest,
     )
-    with SingleServerSuite {
-  override lazy val port: Int = 19003
-}
+    with SingleServerSuite {}

--- a/applications/test/services/FacebookGraphApiTest.scala
+++ b/applications/test/services/FacebookGraphApiTest.scala
@@ -2,11 +2,13 @@ package services
 
 import helpers.FacebookGraphApiTestClient
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import test.{ConfiguredTestSuite, WithMaterializer, WithTestExecutionContext, WithTestWsClient}
 
 @DoNotDiscover class FacebookGraphApiTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/applications/test/services/IndexPageGroupingTest.scala
+++ b/applications/test/services/IndexPageGroupingTest.scala
@@ -2,18 +2,19 @@ package services
 
 import java.time.ZoneOffset
 import java.util.UUID
-
 import model.{Content, ContentType}
 import org.joda.time.{DateTime, DateTimeZone, LocalDate}
-import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.DoNotDiscover
 import contentapi.FixtureTemplates.emptyApiContent
 import IndexPageGrouping.fromContent
 import common.JodaTime._
 import test.ConfiguredTestSuite
 import implicits.Dates.jodaToJavaInstant
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichOffsetDateTime
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-@DoNotDiscover class IndexPageGroupingTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class IndexPageGroupingTest extends AnyFlatSpec with Matchers with ConfiguredTestSuite {
   val timeZone = DateTimeZone.forOffsetHours(0)
 
   def makeFixture(dateTime: DateTime): ContentType =

--- a/applications/test/services/InteractivePickerTest.scala
+++ b/applications/test/services/InteractivePickerTest.scala
@@ -1,11 +1,11 @@
 package services
 
-import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
-import test.{ConfiguredTestSuite, TestRequest}
-import implicits.HtmlFormat
-import play.api.test.Helpers._
+import org.scalatest.DoNotDiscover
+import test.TestRequest
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-@DoNotDiscover class InteractivePickerTest extends FlatSpec with Matchers {
+@DoNotDiscover class InteractivePickerTest extends AnyFlatSpec with Matchers {
   val path = "/lifeandstyle/ng-interactive/2016/mar/12/stephen-collins-cats-cartoon"
   object MockPressedInteractives {
     private[this] val interactives = Set[String](path)

--- a/applications/test/services/NewspaperQueryTest.scala
+++ b/applications/test/services/NewspaperQueryTest.scala
@@ -2,10 +2,12 @@ package services
 
 import org.joda.time.{DateTime, DateTimeZone}
 import org.scalatest._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, WithTestWsClient}
 
 @DoNotDiscover class NewspaperQueryTest
-    extends FreeSpec
+    extends AnyFreeSpec
     with Matchers
     with ConfiguredTestSuite
     with implicits.Dates

--- a/archive/test/ArchiveControllerTest.scala
+++ b/archive/test/ArchiveControllerTest.scala
@@ -2,18 +2,18 @@ package test
 
 import conf.Configuration
 import controllers.ArchiveController
-import model.{ApplicationContext, ApplicationIdentity}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.mvc.Result
 import play.api.test.Helpers._
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
-import play.api.Environment
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 
 import scala.concurrent.Future
 import services.RedirectService
 import services.RedirectService.{ArchiveRedirect, PermanentRedirect}
 
 @DoNotDiscover class ArchiveControllerTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with WithTestExecutionContext

--- a/archive/test/package.scala
+++ b/archive/test/package.scala
@@ -2,6 +2,7 @@ package test
 
 import java.util.{List => JList}
 import org.scalatest.Suites
+import org.scalatestplus.play.PortNumber
 
 import collection.JavaConverters._
 
@@ -16,6 +17,4 @@ class ArchiveTestSuite
     extends Suites(
       new ArchiveControllerTest,
     )
-    with SingleServerSuite {
-  override lazy val port: Int = 19004
-}
+    with SingleServerSuite {}

--- a/article/test/AnalyticsFeatureTest.scala
+++ b/article/test/AnalyticsFeatureTest.scala
@@ -1,18 +1,21 @@
 package test
 
-import org.scalatest.{DoNotDiscover, Matchers, GivenWhenThen, FeatureSpec}
+import org.scalatest.{DoNotDiscover, GivenWhenThen}
+
 import collection.JavaConverters._
 import org.fluentlenium.core.domain.FluentWebElement
 import conf.Configuration
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
 
 @DoNotDiscover class AnalyticsFeatureTest
-    extends FeatureSpec
+    extends AnyFeatureSpec
     with GivenWhenThen
     with Matchers
     with ConfiguredTestSuite {
   implicit val config = Configuration
 
-  feature("Analytics") {
+  Feature("Analytics") {
 
     conf.switches.Switches.EnableDiscussionSwitch.switchOff()
     // Feature
@@ -23,7 +26,7 @@ import conf.Configuration
 
     // Scenarios
 
-    scenario("Ensure all clicked links are recorded by Analytics") {
+    Scenario("Ensure all clicked links are recorded by Analytics") {
       Given("I am on an article entitled 'Olympic opening ceremony will recreate countryside with real animals'")
       goTo("/sport/2012/jun/12/london-2012-olympic-opening-ceremony") { browser =>
         Then("all links on the page should be decorated with the Omniture meta-data attribute")
@@ -33,7 +36,7 @@ import conf.Configuration
 
     }
 
-    scenario("Ophan tracks user actions")(pending)
+    Scenario("Ophan tracks user actions")(pending)
 
   }
 

--- a/article/test/ArticleControllerTest.scala
+++ b/article/test/ArticleControllerTest.scala
@@ -2,13 +2,15 @@ package test
 
 import controllers.ArticleController
 import org.apache.commons.codec.digest.DigestUtils
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
+import org.scalatest.matchers.should.Matchers
 import play.api.test.Helpers._
 import play.api.test._
 
 @DoNotDiscover class ArticleControllerTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with MockitoSugar

--- a/article/test/CdnHealthCheckTest.scala
+++ b/article/test/CdnHealthCheckTest.scala
@@ -1,13 +1,14 @@
 package test
 
 import controllers.HealthCheck
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import play.api.test.Helpers._
-import play.api.test.Helpers
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 @DoNotDiscover class CdnHealthCheckTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with ScalaFutures

--- a/article/test/LiveBlogControllerTest.scala
+++ b/article/test/LiveBlogControllerTest.scala
@@ -1,13 +1,14 @@
 package test
 
 import controllers.LiveBlogController
-import experiments.{ActiveExperiments}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.test._
 import play.api.test.Helpers._
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 
 @DoNotDiscover class LiveBlogControllerTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/article/test/MainMediaWidthsTest.scala
+++ b/article/test/MainMediaWidthsTest.scala
@@ -1,7 +1,6 @@
 package test
 
 import java.time.ZoneOffset
-
 import com.gu.contentapi.client.model.v1.{Content => ApiContent, Element => ApiElement, Tag => ApiTag, _}
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichOffsetDateTime
 import implicits.Dates.jodaToJavaInstant
@@ -11,8 +10,10 @@ import org.scalatest._
 import org.scalatest.concurrent.Eventually
 import views.MainMediaWidths
 import model.{Article, Content}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-@DoNotDiscover class MainMediaWidthsTest extends FreeSpec with Matchers with Eventually with ConfiguredTestSuite {
+@DoNotDiscover class MainMediaWidthsTest extends AnyFreeSpec with Matchers with Eventually with ConfiguredTestSuite {
   "should return correct widths" in {
     val item = ApiContent(
       id = "foo/2012/jan/07/bar",

--- a/article/test/PublicationControllerTest.scala
+++ b/article/test/PublicationControllerTest.scala
@@ -1,16 +1,17 @@
 package test
 
-import contentapi.ContentApiClient
 import controllers.{ArticleController, PublicationController}
 import model.TagDefinition
-import org.scalatest.mockito.MockitoSugar
 import org.mockito.Mockito._
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import services.{NewspaperBookSectionTagAgent, NewspaperBookTagAgent}
 
 @DoNotDiscover class PublicationControllerTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with MockitoSugar

--- a/article/test/model/KeyEventDataTest.scala
+++ b/article/test/model/KeyEventDataTest.scala
@@ -3,9 +3,10 @@ package model
 import common.Edition
 import model.liveblog.{BlockAttributes, Blocks, BodyBlock}
 import org.joda.time.DateTime
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class KeyEventDataTest extends FlatSpec with Matchers {
+class KeyEventDataTest extends AnyFlatSpec with Matchers {
   def fakeBlock(
       publicationOrder: Int,
       isKeyEvent: Boolean = false,

--- a/article/test/model/LiveBlogCurrentPageTest.scala
+++ b/article/test/model/LiveBlogCurrentPageTest.scala
@@ -3,9 +3,11 @@ package model
 import model.liveblog.BodyBlock.{KeyEvent, SummaryEvent}
 import model.liveblog._
 import org.joda.time.DateTime
-import org.scalatest.{Assertion, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.Assertion
 
-class LiveBlogCurrentPageTest extends FlatSpec with Matchers {
+class LiveBlogCurrentPageTest extends AnyFlatSpec with Matchers {
 
   def fakeBlock(
       publicationOrder: Int,

--- a/article/test/model/ParseBlockIdTest.scala
+++ b/article/test/model/ParseBlockIdTest.scala
@@ -1,9 +1,10 @@
 package model
 
 import model.ParseBlockId.{InvalidFormat, ParsedBlockId}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ParseBlockIdTest extends FlatSpec with Matchers {
+class ParseBlockIdTest extends AnyFlatSpec with Matchers {
 
   it should "parse a with" in {
     val result = ParseBlockId.fromPageParam("with:block-asdf")

--- a/article/test/package.scala
+++ b/article/test/package.scala
@@ -1,7 +1,8 @@
 package test
 
 import org.scalatest.{Suites, Tag}
-import services.dotcomponents.{ArticlePickerTest}
+import org.scalatestplus.play.PortNumber
+import services.dotcomponents.ArticlePickerTest
 object ArticleComponents extends Tag("article components")
 
 class ArticleTestSuite
@@ -14,6 +15,4 @@ class ArticleTestSuite
       new LiveBlogControllerTest,
       new ArticlePickerTest,
     )
-    with SingleServerSuite {
-  override lazy val port: Int = 19005
-}
+    with SingleServerSuite {}

--- a/article/test/services/dotcomponents/ArticlePickerTest.scala
+++ b/article/test/services/dotcomponents/ArticlePickerTest.scala
@@ -1,10 +1,11 @@
 package services.dotcomponents
 
-import model.{PageWithStoryPackage}
-import org.scalatest.{DoNotDiscover, FlatSpec, FunSuite, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.DoNotDiscover
 import test.TestRequest
 
-@DoNotDiscover class ArticlePickerTest extends FlatSpec with Matchers {
+@DoNotDiscover class ArticlePickerTest extends AnyFlatSpec with Matchers {
 
   "Article Picker decideTier" should "return LocalRenderArticle if forceDCROff and dcr cannot render" in {
     val testRequest = TestRequest("article-path?dcr=false")

--- a/commercial/test/model/CapiAgentTest.scala
+++ b/commercial/test/model/CapiAgentTest.scala
@@ -1,10 +1,12 @@
 package commercial.model.capi
 
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterAll
 import test._
 
 class CapiAgentTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with SingleServerSuite
     with BeforeAndAfterAll

--- a/commercial/test/model/LookupTest.scala
+++ b/commercial/test/model/LookupTest.scala
@@ -1,13 +1,15 @@
 package commercial.model.capi
 
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, WithTestWsClient}
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
 @DoNotDiscover class LookupTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/commercial/test/model/books/BookTest.scala
+++ b/commercial/test/model/books/BookTest.scala
@@ -1,11 +1,13 @@
 package commercial.model.merchandise.books
 
 import commercial.model.merchandise.Book
-import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.DoNotDiscover
 import play.api.libs.json.Json
 import test.ConfiguredTestSuite
 
-@DoNotDiscover class BookTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class BookTest extends AnyFlatSpec with Matchers with ConfiguredTestSuite {
 
   private val json = Json.parse(
     """{"sku":"9780001712768",

--- a/commercial/test/model/books/MagentoBestsellersFeedTest.scala
+++ b/commercial/test/model/books/MagentoBestsellersFeedTest.scala
@@ -1,12 +1,14 @@
 package commercial.model.merchandise.books
 
 import commercial.model.merchandise.Book
-import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.DoNotDiscover
 import test.ConfiguredTestSuite
 
 import scala.xml.XML
 
-@DoNotDiscover class MagentoBestsellersFeedTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class MagentoBestsellersFeedTest extends AnyFlatSpec with Matchers with ConfiguredTestSuite {
 
   private val xmlStr =
     """<BestSellers><Category>General</Category>

--- a/commercial/test/model/books/MagentoExceptionTest.scala
+++ b/commercial/test/model/books/MagentoExceptionTest.scala
@@ -1,10 +1,12 @@
 package commercial.model.merchandise.books
 
-import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.DoNotDiscover
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.Json
 import test.ConfiguredTestSuite
 
-@DoNotDiscover class MagentoExceptionTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class MagentoExceptionTest extends AnyFlatSpec with Matchers with ConfiguredTestSuite {
 
   "apply" should "create a MagentoException from json" in {
     val json = Json.parse("""{"messages":{"error":[{"code":404,"message":"Resource not found."}]}}""")

--- a/commercial/test/model/events/EventbriteMasterclassFeedParsingTest.scala
+++ b/commercial/test/model/events/EventbriteMasterclassFeedParsingTest.scala
@@ -2,10 +2,11 @@ package commercial.model.merchandise.events
 
 import commercial.model.merchandise.Masterclass
 import commercial.model.merchandise.events.Eventbrite.Response
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json._
 
-class EventbriteMasterclassFeedParsingTest extends FlatSpec with Matchers {
+class EventbriteMasterclassFeedParsingTest extends AnyFlatSpec with Matchers {
 
   "MasterClassFeedParser" should "parse out a list of Event JsValues" in {
     val eventBriteFeed: JsValue = Json.parse(Fixtures.rawEventBriteFeed)

--- a/commercial/test/model/events/SingleEventbriteMasterclassParsingTest.scala
+++ b/commercial/test/model/events/SingleEventbriteMasterclassParsingTest.scala
@@ -2,10 +2,12 @@ package commercial.model.merchandise.events
 
 import commercial.model.merchandise.Masterclass
 import commercial.model.merchandise.events.Eventbrite.{Event, Venue}
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues
 import play.api.libs.json._
 
-class SingleEventbriteMasterclassParsingTest extends FlatSpec with Matchers with OptionValues {
+class SingleEventbriteMasterclassParsingTest extends AnyFlatSpec with Matchers with OptionValues {
 
   "MasterClass companion object" should
     "not create a masterclass object if there isn't at link to the Guardian with the words 'Click here'" in {

--- a/commercial/test/model/jobs/JobTest.scala
+++ b/commercial/test/model/jobs/JobTest.scala
@@ -1,10 +1,12 @@
 package commercial.model.merchandise.jobs
 
 import commercial.model.merchandise.Job
-import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.DoNotDiscover
+import org.scalatest.matchers.should.Matchers
 import test.ConfiguredTestSuite
 
-@DoNotDiscover class JobTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class JobTest extends AnyFlatSpec with Matchers with ConfiguredTestSuite {
 
   "mainIndustry" should "give a value for jobs" in {
     val job = Job(1, "title", "desc", None, "recruiter", None, "logo", Seq(218), "Unpaid Voluntary Work")

--- a/commercial/test/model/jobs/JobsFeedTest.scala
+++ b/commercial/test/model/jobs/JobsFeedTest.scala
@@ -1,12 +1,12 @@
 package commercial.model.merchandise.jobs
 
 import commercial.model.merchandise.Job
-
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.xml.XML
 
-class JobsFeedTest extends FlatSpec with Matchers {
+class JobsFeedTest extends AnyFlatSpec with Matchers {
 
   "parse" should "parse all jobs in XML feed" in {
     val jobs = JobsFeed.parse(XML.loadString(Fixtures.xml))

--- a/commercial/test/model/travel/TravelOfferTest.scala
+++ b/commercial/test/model/travel/TravelOfferTest.scala
@@ -2,11 +2,12 @@ package commercial.model.merchandise.travel
 
 import commercial.model.merchandise.TravelOffer
 import org.joda.time.DateTime
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.xml.Elem
 
-class TravelOfferTest extends FlatSpec with Matchers {
+class TravelOfferTest extends AnyFlatSpec with Matchers {
 
   private val xml: Elem =
     <product vibeid="a08878776d1429a5109064d64b5fda05"

--- a/commercial/test/test/CommercialTestSuite.scala
+++ b/commercial/test/test/CommercialTestSuite.scala
@@ -3,6 +3,7 @@ package commercial.test
 import commercial.model.capi.LookupTest
 import commercial.model.merchandise.{books, events, jobs}
 import org.scalatest.Suites
+import org.scalatestplus.play.PortNumber
 import test.SingleServerSuite
 
 class CommercialTestSuite
@@ -15,6 +16,4 @@ class CommercialTestSuite
       new LookupTest,
       new books.BookTest,
     )
-    with SingleServerSuite {
-  override lazy val port: Int = 19006
-}
+    with SingleServerSuite {}

--- a/common/test/CommonTestSuite.scala
+++ b/common/test/CommonTestSuite.scala
@@ -4,6 +4,7 @@ import conf.CachedHealthCheckTest
 import conf.audio.FlagshipFrontContainerSpec
 import navigation.NavigationTest
 import org.scalatest.Suites
+import org.scalatestplus.play.PortNumber
 import renderers.DotcomRenderingServiceTest
 
 class CommonTestSuite
@@ -13,6 +14,4 @@ class CommonTestSuite
       new FlagshipFrontContainerSpec,
       new DotcomRenderingServiceTest,
     )
-    with SingleServerSuite {
-  override lazy val port: Int = 19016
-}
+    with SingleServerSuite {}

--- a/common/test/common/Assets/AssetsTest.scala
+++ b/common/test/common/Assets/AssetsTest.scala
@@ -1,15 +1,16 @@
 package common.Assets
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 
-class AssetsTest extends FlatSpec with Matchers with GuiceOneAppPerSuite {
+class AssetsTest extends AnyFlatSpec with Matchers with GuiceOneAppPerSuite {
   "Static" should "collect asset maps" in {
     val static = new Assets("simon says", "assets/testassets.map", true)
 
-    static("zen1").toString should be("simon says" + "no snowflake ever falls in the wrong place.")
-    static("zen2").toString should be("simon says" + "water which is too pure has no fish.")
-    static("zen3").toString should be("simon says" + "the quieter you become the more you are able to hear.")
+    static("zen1") should be("simon says" + "no snowflake ever falls in the wrong place.")
+    static("zen2") should be("simon says" + "water which is too pure has no fish.")
+    static("zen3") should be("simon says" + "the quieter you become the more you are able to hear.")
   }
 
 }

--- a/common/test/common/BoxTest.scala
+++ b/common/test/common/BoxTest.scala
@@ -1,8 +1,9 @@
 package common
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class BoxSpec extends FlatSpec with Matchers {
+class BoxSpec extends AnyFlatSpec with Matchers {
   "Box" should "return the initial value" in {
     val box = Box(5)
     box() should be(5)

--- a/common/test/common/CommonPackageTest.scala
+++ b/common/test/common/CommonPackageTest.scala
@@ -3,14 +3,16 @@ package common
 import com.fasterxml.jackson.core.JsonParseException
 import com.gu.contentapi.client.model.v1._
 import model.SimpleContentPage
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsValue
 import play.api.test.Helpers._
 import play.twirl.api.Html
 import test.{TestRequest, WithTestApplicationContext}
+
 import scala.concurrent.Future
 
-class CommonPackageTest extends FlatSpec with Matchers with WithTestApplicationContext {
+class CommonPackageTest extends AnyFlatSpec with Matchers with WithTestApplicationContext {
 
   trait PackageTestScope {
     val article = model.Content(

--- a/common/test/common/CryptoTest.scala
+++ b/common/test/common/CryptoTest.scala
@@ -1,8 +1,9 @@
 package common
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CryptoTest extends FlatSpec with Matchers {
+class CryptoTest extends AnyFlatSpec with Matchers {
 
   val privateKey = "6FA3BE741DE87141F90EB3E67EB51976"
   val message = "Les sanglots longs des violons de l'automne blessent mon cœur d'une langueur monotone."

--- a/common/test/common/EditionTest.scala
+++ b/common/test/common/EditionTest.scala
@@ -1,12 +1,12 @@
 package common
 
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import play.api.test.FakeRequest
 import common.editions.{Uk, Us}
+import org.scalatest.flatspec.AnyFlatSpec
 import play.api.mvc.Cookie
 
-class EditionTest extends FlatSpec with Matchers {
+class EditionTest extends AnyFlatSpec with Matchers {
 
   "Edition" should "resolve correct edition from header" in {
 

--- a/common/test/common/ExperimentsTest.scala
+++ b/common/test/common/ExperimentsTest.scala
@@ -1,13 +1,15 @@
 package experiments
 
 import conf.switches.Owner
+
 import java.time.LocalDate
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
 import test.TestRequest
 import ParticipationGroups._
+import org.scalatest.flatspec.AnyFlatSpec
 import play.api.mvc.RequestHeader
 
-class ExperimentsTest extends FlatSpec with Matchers {
+class ExperimentsTest extends AnyFlatSpec with Matchers {
 
   conf.switches.Switches.ServerSideExperiments.switchOn
 

--- a/common/test/common/ExternalLinksTest.scala
+++ b/common/test/common/ExternalLinksTest.scala
@@ -1,9 +1,11 @@
 package common
 
-import org.scalatest.{Inspectors, Matchers, FlatSpec}
+import org.scalatest.{Inspectors}
+import org.scalatest.matchers.should.Matchers
 import ExternalLinks.external
+import org.scalatest.flatspec.AnyFlatSpec
 
-class ExternalLinksTest extends FlatSpec with Matchers with Inspectors {
+class ExternalLinksTest extends AnyFlatSpec with Matchers with Inspectors {
   val testPaths = Seq(
     "/sport/cycling",
     "/cities/2014/nov/24/equal-streets-happier-healthier-mumbai",

--- a/common/test/common/HtmlCleanerTest.scala
+++ b/common/test/common/HtmlCleanerTest.scala
@@ -1,13 +1,13 @@
 package common
 
 import org.jsoup.Jsoup
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
 import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
+import pagepresser.InteractiveImmersiveHtmlCleaner
 
-import pagepresser.{InteractiveImmersiveHtmlCleaner}
-
-class InteractiveImmersiveHtmlCleanerTest extends FlatSpec with Matchers {
+class InteractiveImmersiveHtmlCleanerTest extends AnyFlatSpec with Matchers {
   val now = LocalDateTime.parse("2021-08-26T10:15:30")
 
   "InteractiveImmersiveHtmlCleaner" should "only clean interactive immersives" in {

--- a/common/test/common/InlineStylesTest.scala
+++ b/common/test/common/InlineStylesTest.scala
@@ -1,12 +1,13 @@
 package common
 
 import org.jsoup.Jsoup
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.twirl.api.Html
 
 import scala.collection.immutable.ListMap
 
-class InlineStylesTest extends FlatSpec with Matchers {
+class InlineStylesTest extends AnyFlatSpec with Matchers {
   val stub: ListMap[String, String] = ListMap.empty
 
   // https://www.w3.org/TR/css3-selectors/#specificity

--- a/common/test/common/IsoDateTest.scala
+++ b/common/test/common/IsoDateTest.scala
@@ -1,10 +1,10 @@
 package common
 
-import model._
 import org.joda.time.DateTime
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class IsoDateTest extends FlatSpec with Matchers with implicits.Dates {
+class IsoDateTest extends AnyFlatSpec with Matchers with implicits.Dates {
 
   "Iso Date Parser" should "parse" in {
     "2013-11-11T23:02:18.311Z".parseISODateTime should be(

--- a/common/test/common/JsonComponentTest.scala
+++ b/common/test/common/JsonComponentTest.scala
@@ -1,18 +1,17 @@
 package common
 
 import conf.switches.Switches.AutoRefreshSwitch
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 import play.twirl.api.Html
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.api.libs.json.Json._
-import play.api.libs.json.{JsObject, Writes}
 import test.WithTestExecutionContext
 
 import scala.concurrent.Future
 
-class JsonComponentTest extends FlatSpec with Matchers with WithTestExecutionContext {
+class JsonComponentTest extends AnyFlatSpec with Matchers with WithTestExecutionContext {
 
   "JsonComponent" should "build json output with standard name" in {
     AutoRefreshSwitch.switchOn()

--- a/common/test/common/LinkToTest.scala
+++ b/common/test/common/LinkToTest.scala
@@ -1,11 +1,12 @@
 package common
 
-import org.scalatest.{FlatSpec, Matchers}
-import common.editions.{Au, Us, International, Uk}
+import org.scalatest.matchers.should.Matchers
+import common.editions.{Au, International, Uk, Us}
+import org.scalatest.flatspec.AnyFlatSpec
 import test._
 import play.api.test.FakeRequest
 
-class LinkToTest extends FlatSpec with Matchers with implicits.FakeRequests {
+class LinkToTest extends AnyFlatSpec with Matchers with implicits.FakeRequests {
 
   implicit val edition = Uk
   implicit val editions = Seq(Uk, Us, Au)

--- a/common/test/common/MapsTest.scala
+++ b/common/test/common/MapsTest.scala
@@ -1,9 +1,10 @@
 package common
 
-import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.matchers.should.Matchers
 import Maps._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class MapsTest extends FlatSpec with Matchers {
+class MapsTest extends AnyFlatSpec with Matchers {
   "insertWith" should "just insert v if k is not present in map" in {
     insertWith(Map.empty[String, Int], "a", 3)(_ + _) shouldEqual Map("a" -> 3)
   }

--- a/common/test/common/ModelOrResultTest.scala
+++ b/common/test/common/ModelOrResultTest.scala
@@ -1,21 +1,21 @@
 package common
 
 import java.time.ZoneOffset
-
 import com.gu.contentapi.client.model.v1.{Content, ItemResponse, Section, Tag, TagType}
 import org.joda.time.DateTime
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
 import play.api.mvc.RequestHeader
 import play.api.test.Helpers._
 import test.{TestRequest, WithTestExecutionContext}
 import implicits.Dates.jodaToJavaInstant
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichOffsetDateTime
+import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.concurrent.Future
 
 private object TestModel
 
-class ModelOrResultTest extends FlatSpec with Matchers with WithTestExecutionContext {
+class ModelOrResultTest extends AnyFlatSpec with Matchers with WithTestExecutionContext {
 
   val offsetDate = jodaToJavaInstant(new DateTime()).atOffset(ZoneOffset.UTC)
 

--- a/common/test/common/PaginationTest.scala
+++ b/common/test/common/PaginationTest.scala
@@ -1,8 +1,9 @@
 package common
 
-import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class PaginationTest extends FlatSpec with Matchers {
+class PaginationTest extends AnyFlatSpec with Matchers {
 
   it should "return the correct set of pages for pagination navigation" in {
     Pagination(1, 10, 1000).pages should be(List(1, 2, 3, 4))

--- a/common/test/common/RelativePathEscaperTest.scala
+++ b/common/test/common/RelativePathEscaperTest.scala
@@ -1,10 +1,10 @@
 package common
 
-import conf.Static
-import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 
-class RelativePathEscaperTest extends FlatSpec with Matchers with GuiceOneAppPerSuite {
+class RelativePathEscaperTest extends AnyFlatSpec with Matchers with GuiceOneAppPerSuite {
   "RelativePathEscaper" should "escape javascript paths in Static.js.curl" in {
     val curlJs = common.Assets.js.curl
     val escapedCurlJs = RelativePathEscaper.escapeLeadingDotPaths(curlJs)

--- a/common/test/common/RequestLoggerTest.scala
+++ b/common/test/common/RequestLoggerTest.scala
@@ -1,11 +1,11 @@
 package common
 
 import common.LoggingField._
-import org.scalatest.{FlatSpec, Matchers}
-import play.api.mvc.{ResponseHeader, Result}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.test.FakeRequest
 
-class RequestLoggerTest extends FlatSpec with Matchers {
+class RequestLoggerTest extends AnyFlatSpec with Matchers {
 
   "RequestLogger with no request, response or stopwatch" should "have no fields" in {
     val fields = RequestLoggerFields(request = None, response = None, stopWatch = None)

--- a/common/test/common/Retry.scala
+++ b/common/test/common/Retry.scala
@@ -1,9 +1,11 @@
 package common
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
 import scala.util.{Failure, Success}
 
-class RetryTest extends FlatSpec with Matchers {
+class RetryTest extends AnyFlatSpec with Matchers {
   val onFail = (_: Throwable, _: Int) => ()
 
   it should "execute code once even if n is 0" in {

--- a/common/test/common/SeqsTest.scala
+++ b/common/test/common/SeqsTest.scala
@@ -1,9 +1,10 @@
 package common
 
-import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.matchers.should.Matchers
 import Seqs._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class SeqsTest extends FlatSpec with Matchers {
+class SeqsTest extends AnyFlatSpec with Matchers {
   "isDescending" should "return true for descending lists" in {
     Seq(3, 3, 3, 2, 1, 0, -2).isDescending shouldEqual true
   }

--- a/common/test/common/StringsTest.scala
+++ b/common/test/common/StringsTest.scala
@@ -1,9 +1,10 @@
 package common
 
 import common.Strings./
-import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class StringsTest extends FlatSpec with Matchers {
+class StringsTest extends AnyFlatSpec with Matchers {
   "/.unapply" should "return None if the string does not contain a slash" in {
     /.unapply("Hello") shouldEqual None
   }

--- a/common/test/common/StripHtmlTagsAndUnescapeEntitiesTest.scala
+++ b/common/test/common/StripHtmlTagsAndUnescapeEntitiesTest.scala
@@ -1,10 +1,10 @@
 package common
 
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import views.support.StripHtmlTagsAndUnescapeEntities
 
-class StripHtmlTagsAndUnescapeEntitiesTest extends FlatSpec with Matchers {
+class StripHtmlTagsAndUnescapeEntitiesTest extends AnyFlatSpec with Matchers {
 
   "Strip HTML tags and unescape entities" should "unescape entities" in {
 

--- a/common/test/common/TagLinkerTest.scala
+++ b/common/test/common/TagLinkerTest.scala
@@ -1,7 +1,6 @@
 package common
 
 import java.time.ZoneOffset
-
 import com.gu.contentapi.client.model.v1.{ContentFields, TagType, Content => ApiContent, Tag => ApiTag}
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichOffsetDateTime
 import common.editions.Uk
@@ -11,14 +10,15 @@ import model.{Article, Content}
 import org.joda.time.DateTime
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.test.FakeRequest
 import views.support.TagLinker
 
 import scala.collection.JavaConverters._
 
-class TagLinkerTest extends FlatSpec with Matchers with GuiceOneAppPerSuite {
+class TagLinkerTest extends AnyFlatSpec with Matchers with GuiceOneAppPerSuite {
 
   implicit val edition = Uk
   implicit val request = FakeRequest("GET", "/")

--- a/common/test/common/TrailsToRssTest.scala
+++ b/common/test/common/TrailsToRssTest.scala
@@ -14,7 +14,8 @@ import com.gu.contentapi.client.utils.CapiModelEnrichment.RichOffsetDateTime
 import implicits.Dates.jodaToJavaInstant
 import model._
 import org.joda.time.DateTime
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.test.FakeRequest
 
@@ -23,7 +24,7 @@ import java.util.UUID
 import scala.util.Try
 import scala.xml._
 
-class TrailsToRssTest extends FlatSpec with Matchers with GuiceOneAppPerSuite {
+class TrailsToRssTest extends AnyFlatSpec with Matchers with GuiceOneAppPerSuite {
 
   val request = FakeRequest()
 

--- a/common/test/common/TrailsToShowcaseTest.scala
+++ b/common/test/common/TrailsToShowcaseTest.scala
@@ -9,14 +9,15 @@ import implicits.Dates.jodaToJavaInstant
 import model.pressed._
 import model.{ImageAsset, ImageMedia}
 import org.joda.time.DateTime
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.test.FakeRequest
 
 import java.time.ZoneOffset
 import scala.collection.JavaConverters._
 import scala.xml.{Node, XML}
 
-class TrailsToShowcaseTest extends FlatSpec with Matchers {
+class TrailsToShowcaseTest extends AnyFlatSpec with Matchers {
 
   val request = FakeRequest()
 

--- a/common/test/common/WitnessCleanerTest.scala
+++ b/common/test/common/WitnessCleanerTest.scala
@@ -1,12 +1,11 @@
 package common
 
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import views.support.{WitnessCleaner, withJsoup}
 import play.twirl.api.Html
-import conf.switches.Switches
+import org.scalatest.flatspec.AnyFlatSpec
 
-class WitnessCleanerTest extends FlatSpec with Matchers {
+class WitnessCleanerTest extends AnyFlatSpec with Matchers {
 
   "Witness cleaner" should "not remove video embeds" in {
 

--- a/common/test/common/commercial/ContainerModelTest.scala
+++ b/common/test/common/commercial/ContainerModelTest.scala
@@ -3,9 +3,11 @@ package common.commercial
 import common.facia.PressedCollectionBuilder.mkPressedCollection
 import common.editions.Uk
 import model.facia.PressedCollection
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues
 
-class ContainerModelTest extends FlatSpec with Matchers with OptionValues {
+class ContainerModelTest extends AnyFlatSpec with Matchers with OptionValues {
 
   def fromUkPressedCollection: (PressedCollection) => ContainerModel = {
     ContainerModel.fromPressedCollection(Uk)

--- a/common/test/common/commercial/hosted/ColourTest.scala
+++ b/common/test/common/commercial/hosted/ColourTest.scala
@@ -1,12 +1,13 @@
 package common.commercial.hosted
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /*
  * For colours, see http://www.colorhexa.com/<hexcode>
  * eg. http://www.colorhexa.com/2ec869
  */
-class ColourTest extends FlatSpec with Matchers {
+class ColourTest extends AnyFlatSpec with Matchers {
 
   "isDark" should "be true for Zootropolis green" in {
     val zootropolisColour = Colour("#2ec869")

--- a/common/test/common/dfp/GuLineItemTest.scala
+++ b/common/test/common/dfp/GuLineItemTest.scala
@@ -3,9 +3,10 @@ package common.dfp
 import common.dfp.AdSize.leaderboardSize
 import org.joda.time.DateTime
 import org.joda.time.DateTime.now
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class GuLineItemTest extends FlatSpec with Matchers {
+class GuLineItemTest extends AnyFlatSpec with Matchers {
 
   private val defaultCreativePlaceholders =
     Seq(GuCreativePlaceholder(leaderboardSize, targeting = None))

--- a/common/test/common/dfp/HighMerchandisingLineItemTest.scala
+++ b/common/test/common/dfp/HighMerchandisingLineItemTest.scala
@@ -2,9 +2,10 @@ package common.dfp
 
 import common.{Edition, editions}
 import model.{Tag, TagProperties}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class HighMerchandisingLineItemTest extends FlatSpec with Matchers {
+class HighMerchandisingLineItemTest extends AnyFlatSpec with Matchers {
 
   private object TestAgent extends HighMerchandiseComponentAgent {
     override protected def targetedHighMerchandisingLineItems: Seq[HighMerchandisingLineItem] = {

--- a/common/test/common/dfp/InlineMerchandiseComponentAgentTest.scala
+++ b/common/test/common/dfp/InlineMerchandiseComponentAgentTest.scala
@@ -2,9 +2,10 @@ package common.dfp
 
 import com.gu.contentapi.client.model.v1.{Tag => ApiTag, TagType => ApiTagType}
 import model.Tag
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class InlineMerchandiseComponentAgentTest extends FlatSpec with Matchers {
+class InlineMerchandiseComponentAgentTest extends AnyFlatSpec with Matchers {
 
   private def toTag(tagType: ApiTagType, tagId: String, sectionId: Option[String] = None): Tag = {
     Tag.make(

--- a/common/test/common/dfp/PageSkinTest.scala
+++ b/common/test/common/dfp/PageSkinTest.scala
@@ -1,8 +1,9 @@
 package common.dfp
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class PageSkinTest extends FlatSpec with Matchers {
+class PageSkinTest extends AnyFlatSpec with Matchers {
 
   "isValidAdUnit" should "be false for a keyword page that's been replaced by a pressed front" in {
     // keyword pages should be targeted by keyword instead of by ad unit

--- a/common/test/common/dfp/PageskinAdAgentTest.scala
+++ b/common/test/common/dfp/PageskinAdAgentTest.scala
@@ -4,14 +4,15 @@ import com.gu.commercial.display.{AdTargetParam, KeywordParam, SeriesParam}
 import com.gu.contentapi.client.model.v1.{Tag, TagType}
 import common.Edition.defaultEdition
 import common.commercial.{CommercialProperties, EditionAdTargeting}
-import common.editions.{Au, Uk, Us}
+import common.editions.{Uk}
 import conf.Configuration.commercial.dfpAdUnitGuRoot
 import model.MetaData
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.test.FakeRequest
 import play.api.test.Helpers.GET
 
-class PageskinAdAgentTest extends FlatSpec with Matchers {
+class PageskinAdAgentTest extends AnyFlatSpec with Matchers {
   val keywordParamSet: Set[AdTargetParam] = KeywordParam.fromItemId("sport-keyword").toSet
   val commercialProperties = CommercialProperties(
     editionBrandings = Set.empty,

--- a/common/test/common/dfp/TakeoverWithEmptyMPUsTest.scala
+++ b/common/test/common/dfp/TakeoverWithEmptyMPUsTest.scala
@@ -1,9 +1,10 @@
 package common.dfp
 
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.data.validation.{Invalid, Valid}
 
-class TakeoverWithEmptyMPUsTest extends FlatSpec with Matchers {
+class TakeoverWithEmptyMPUsTest extends AnyFlatSpec with Matchers {
 
   "TakeoverWithEmptyMPUs" should "recognise as valid urls that are at least 1 directory deep" in {
     TakeoverWithEmptyMPUs.mustBeAtLeastOneDirectoryDeep("http://www.theguardian.com/uk") should equal(Valid)

--- a/common/test/common/facia/PressedCollectionTest.scala
+++ b/common/test/common/facia/PressedCollectionTest.scala
@@ -1,8 +1,9 @@
 package common.facia
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class PressedCollectionTest extends FlatSpec with Matchers {
+class PressedCollectionTest extends AnyFlatSpec with Matchers {
   "withoutTrailTextOnTail" should "remove trail text from curated and backfill content, leaving the curated head" in {
     val pressedCollection = PressedCollectionBuilder.mkPressedCollection()
     val withoutTrailText = pressedCollection.withoutTrailTextOnTail

--- a/common/test/concurrent/BlockingOperationsTest.scala
+++ b/common/test/concurrent/BlockingOperationsTest.scala
@@ -2,9 +2,10 @@ package concurrent
 
 import akka.actor.ActorSystem
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class BlockingOperationsTest extends FlatSpec with Matchers with ScalaFutures {
+class BlockingOperationsTest extends AnyFlatSpec with Matchers with ScalaFutures {
   val system = ActorSystem()
 
   "BlockingOperations" should "execute blocks in a thread pool" in {

--- a/common/test/conf/CachedHealthCheckTest.scala
+++ b/common/test/conf/CachedHealthCheckTest.scala
@@ -1,19 +1,21 @@
 package conf
 
 import org.joda.time.DateTime
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, Matchers, WordSpec}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
+import org.scalatest.matchers.should.Matchers
 import play.api.mvc.{ControllerComponents, Result}
 import play.api.test.{FakeRequest, Helpers}
 import play.api.test.Helpers._
-import test.{ConfiguredTestSuite, WithMaterializer, WithTestExecutionContext, WithTestWsClient}
+import test.{ConfiguredTestSuite, WithMaterializer, WithTestWsClient}
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.wordspec.AnyWordSpec
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.util.Random
 
 @DoNotDiscover class CachedHealthCheckTest
-    extends WordSpec
+    extends AnyWordSpec
     with Matchers
     with ConfiguredTestSuite
     with ScalaFutures

--- a/common/test/conf/audio/FlagshipFrontContainerSpec.scala
+++ b/common/test/conf/audio/FlagshipFrontContainerSpec.scala
@@ -1,10 +1,13 @@
 package conf.audio
 import conf.switches.Switches.FlagshipFrontContainerSwitch
-import java.time.{ZonedDateTime, DayOfWeek}
-import java.time.format.DateTimeFormatter
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class FlagshipFrontContainerSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
+import java.time.{DayOfWeek, ZonedDateTime}
+import java.time.format.DateTimeFormatter
+import org.scalatest.{BeforeAndAfterAll}
+
+class FlagshipFrontContainerSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
   private val formatter =
     DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm").withZone(FlagshipFrontContainer.londonTimezone)
 

--- a/common/test/conf/switches/SwitchesTest.scala
+++ b/common/test/conf/switches/SwitchesTest.scala
@@ -1,10 +1,13 @@
 package conf.switches
 
+import org.scalatest.flatspec.AnyFlatSpec
+
 import java.time.DayOfWeek.{SATURDAY, SUNDAY}
 import java.time.LocalDate
-import org.scalatest.{AppendedClues, FlatSpec, Matchers}
+import org.scalatest.AppendedClues
+import org.scalatest.matchers.should.Matchers
 
-class SwitchesTest extends FlatSpec with Matchers with AppendedClues {
+class SwitchesTest extends AnyFlatSpec with Matchers with AppendedClues {
 
   private val SwitchNamePattern = """([a-z\d-]+)""".r
 

--- a/common/test/html/BrazeEmailFormatterTest.scala
+++ b/common/test/html/BrazeEmailFormatterTest.scala
@@ -1,9 +1,10 @@
 package html
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.twirl.api.Html
 
-class BrazeEmailFormatterTest extends FlatSpec with Matchers {
+class BrazeEmailFormatterTest extends AnyFlatSpec with Matchers {
 
   "HtmlLinkUtimInsertion" should "insert utm code place holders into an HTML string" in {
     val rawHtml =

--- a/common/test/html/HtmlTextExtractorTest.scala
+++ b/common/test/html/HtmlTextExtractorTest.scala
@@ -1,9 +1,10 @@
 package html
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.twirl.api.Html
 
-class HtmlTextExtractorTest extends FlatSpec with Matchers {
+class HtmlTextExtractorTest extends AnyFlatSpec with Matchers {
 
   "HtmlTextExtractor" should "extract text from html" in {
     val rawHtml =

--- a/common/test/layout/CollectionEmailTest.scala
+++ b/common/test/layout/CollectionEmailTest.scala
@@ -1,9 +1,11 @@
 package layout
 
 import common.facia.FixtureBuilder
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
 
-class CollectionEmailTest extends FlatSpec with Matchers with OptionValues {
+class CollectionEmailTest extends AnyFlatSpec with Matchers with OptionValues {
 
   it should "respect the maxItemsToDisplay property if set" in {
     val pressedPage = FixtureBuilder.mkPressedPage(

--- a/common/test/layout/DayHeadlineTest.scala
+++ b/common/test/layout/DayHeadlineTest.scala
@@ -1,9 +1,12 @@
 package layout
 
-import java.time.LocalDate
-import org.scalatest.{OptionValues, Matchers, FlatSpec}
+import org.scalatest.flatspec.AnyFlatSpec
 
-class DayHeadlineTest extends FlatSpec with Matchers with OptionValues {
+import java.time.LocalDate
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
+
+class DayHeadlineTest extends AnyFlatSpec with Matchers with OptionValues {
   "urlFragmentFormatString" should "produce url paths that work with all urls" in {
     DayHeadline(LocalDate.of(1987, 2, 5)).urlFragment.value shouldEqual "1987/feb/05"
   }

--- a/common/test/layout/FrontTest.scala
+++ b/common/test/layout/FrontTest.scala
@@ -11,12 +11,13 @@ import contentapi.FixtureTemplates.emptyApiContent
 import implicits.Dates.jodaToJavaInstant
 import model.pressed.{LatestSnap, PressedContent}
 import org.joda.time.DateTime
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import services.FaciaContentConvert
 import slices._
 
-class FrontTest extends FlatSpec with Matchers with GuiceOneAppPerSuite {
+class FrontTest extends AnyFlatSpec with Matchers with GuiceOneAppPerSuite {
   def trailWithUrl(theUrl: String): PressedContent = {
     FaciaContentConvert.contentToFaciaContent(emptyApiContent.copy(id = theUrl, webUrl = theUrl))
   }

--- a/common/test/layout/PaidCardTest.scala
+++ b/common/test/layout/PaidCardTest.scala
@@ -2,9 +2,11 @@ package layout
 
 import common.facia.FixtureBuilder.mkPressedContent
 import model.pressed.{FreeHtmlKicker, ItemKicker, KickerProperties}
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
 
-class PaidCardTest extends FlatSpec with Matchers with OptionValues {
+class PaidCardTest extends AnyFlatSpec with Matchers with OptionValues {
 
   private def mkKicker(): ItemKicker =
     FreeHtmlKicker(

--- a/common/test/layout/SliceWithCardsTest.scala
+++ b/common/test/layout/SliceWithCardsTest.scala
@@ -1,19 +1,23 @@
 package layout
 
 import java.time.ZoneOffset
-
 import com.gu.contentapi.client.model.v1.{Content => ApiContent}
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichOffsetDateTime
 import implicits.Dates.jodaToJavaInstant
 import model.pressed.CollectionConfig
 import org.joda.time.DateTime
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import services.FaciaContentConvert
 import slices.DesktopBehaviour
 
-class SliceWithCardsTest extends FlatSpec with Matchers with GeneratorDrivenPropertyChecks with GuiceOneAppPerSuite {
+class SliceWithCardsTest
+    extends AnyFlatSpec
+    with Matchers
+    with ScalaCheckDrivenPropertyChecks
+    with GuiceOneAppPerSuite {
   val NumberOfFixtures = 40
 
   def nthApiContent(n: Int): ApiContent =

--- a/common/test/layout/TagHistogramTest.scala
+++ b/common/test/layout/TagHistogramTest.scala
@@ -3,9 +3,10 @@ package layout
 import com.gu.contentapi.client.model.v1.Tag
 import contentapi.FixtureTemplates
 import model.{Content, Trail}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class TagHistogramTest extends FlatSpec with Matchers {
+class TagHistogramTest extends AnyFlatSpec with Matchers {
   def tag(id: String): Tag =
     FixtureTemplates.emptyTag.copy(id = id)
 

--- a/common/test/layout/WidthsByBreakpointTest.scala
+++ b/common/test/layout/WidthsByBreakpointTest.scala
@@ -2,8 +2,10 @@ package layout
 
 import layout.ContentWidths._
 import org.scalatest._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class WidthsByBreakpointTest extends FreeSpec with Matchers {
+class WidthsByBreakpointTest extends AnyFreeSpec with Matchers {
   "ContentWidths" - {
     "getWidthsFromContentElement" - {
       "inline" - {

--- a/common/test/layout/slices/DynamicContainerTest.scala
+++ b/common/test/layout/slices/DynamicContainerTest.scala
@@ -1,15 +1,16 @@
 package layout.slices
 
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
-import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.OptionValues._
 import common.Seqs._
 import layout.slices.ArbitraryStories._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 /** Tests for common behaviour between the Dynamic Fast and Dynamic Slow containers -- this is mostly respecting error
   * conditions and the optional first slice, which appears for the same size combinations for either container.
   */
-trait DynamicContainerTest extends FlatSpec with Matchers with GeneratorDrivenPropertyChecks {
+trait DynamicContainerTest extends AnyFlatSpec with Matchers with ScalaCheckDrivenPropertyChecks {
   val slicesFor: Seq[Story] => Option[Seq[Slice]]
 
   "slicesFor" should "return None for a non-descending list of groups" in {

--- a/common/test/layout/slices/StoryTest.scala
+++ b/common/test/layout/slices/StoryTest.scala
@@ -1,14 +1,16 @@
 package layout.slices
 
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
-import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
-import ArbitraryStories._
+import layout.slices.ArbitraryStories.arbitraryStories
+import org.scalatest.DoNotDiscover
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import test.ConfiguredTestSuite
 
 @DoNotDiscover class StoryTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
-    with GeneratorDrivenPropertyChecks
+    with ScalaCheckDrivenPropertyChecks
     with ConfiguredTestSuite {
   "segmentByGroup" should "preserve order" in {
     forAll { stories: Seq[Story] =>

--- a/common/test/metadata/MetaDataMatcher.scala
+++ b/common/test/metadata/MetaDataMatcher.scala
@@ -2,7 +2,7 @@ package metadata
 
 import model.meta.Logo
 import org.jsoup.Jsoup
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json._
 import play.api.mvc.Result
 import play.api.test.Helpers._

--- a/common/test/metrics/DurationMetricTest.scala
+++ b/common/test/metrics/DurationMetricTest.scala
@@ -1,10 +1,11 @@
 package metrics
 
 import com.amazonaws.services.cloudwatch.model.StandardUnit
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
 import org.joda.time.DateTime
+import org.scalatest.flatspec.AnyFlatSpec
 
-class DurationMetricTest extends FlatSpec with Matchers {
+class DurationMetricTest extends AnyFlatSpec with Matchers {
 
   "DurationMetric" should "start off empty" in {
     val durationMetric: DurationMetric = DurationMetric("TestMetric", StandardUnit.Count)

--- a/common/test/model/AdSuffixHandlingForFrontsTest.scala
+++ b/common/test/model/AdSuffixHandlingForFrontsTest.scala
@@ -1,8 +1,9 @@
 package model
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class AdSuffixHandlingForFrontsTest extends FlatSpec with Matchers {
+class AdSuffixHandlingForFrontsTest extends AnyFlatSpec with Matchers {
   val NetworkFronts = MetaData.make(id = "", section = None, webTitle = "")
 
   val SectionFront = MetaData.make(id = "", section = Some(SectionId.fromId("business")), webTitle = "")

--- a/common/test/model/CachedTest.scala
+++ b/common/test/model/CachedTest.scala
@@ -1,18 +1,17 @@
 package model
 
 import java.time.ZoneOffset
-
 import com.gu.contentapi.client.model.v1.{ContentFields, Content => ApiContent}
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichOffsetDateTime
 import conf.switches.Switches.LongCacheSwitch
-import implicits.Dates.jodaToJavaInstant
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import org.joda.time.DateTime
 import com.github.nscala_time.time.Imports._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.mvc.Results
 
-class CachedTest extends FlatSpec with Matchers with Results with implicits.Dates {
+class CachedTest extends AnyFlatSpec with Matchers with Results with implicits.Dates {
 
   "Cached" should "cache live content for 5 seconds" in {
     LongCacheSwitch.switchOff()

--- a/common/test/model/ContentTest.scala
+++ b/common/test/model/ContentTest.scala
@@ -1,23 +1,24 @@
 package model
 
-import java.time.{OffsetDateTime, ZoneOffset}
-
+import java.time.ZoneOffset
 import com.gu.contentapi.client.model.v1.{Content => ApiContent, Element => ApiElement, Tag => ApiTag, _}
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichOffsetDateTime
 import model.content.MediaAtom
 import org.joda.time.DateTime
-import org.scalatest.mockito.MockitoSugar
 import org.mockito.Mockito._
-import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import views.support.JavaScriptPage
 import common.Edition
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.json.JsBoolean
 import play.api.test.FakeRequest
 import play.api.test.Helpers.GET
 
 class ContentTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with GuiceOneAppPerSuite
     with implicits.Dates

--- a/common/test/model/CorsTest.scala
+++ b/common/test/model/CorsTest.scala
@@ -1,14 +1,14 @@
 package model
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
 import play.api.mvc.AnyContentAsEmpty
 import play.api.mvc.Results.NoContent
 import play.api.test.{FakeHeaders, FakeRequest}
 import play.api.test.Helpers._
 import model.Cors.isWhitelisted
-import org.scalacheck.Prop.True
+import org.scalatest.flatspec.AnyFlatSpec
 
-class CorsTest extends FlatSpec with Matchers {
+class CorsTest extends AnyFlatSpec with Matchers {
   "Cors Helper" should "not provide Cors response headers for unsupported origins" in {
     // This test is here to show that we really do accept any origin outside of the whitelist. We should change this policy.
     val fakeHeaders = FakeHeaders(List("Origin" -> "unknown.origin.com"))

--- a/common/test/model/DateTimeTest.scala
+++ b/common/test/model/DateTimeTest.scala
@@ -1,13 +1,12 @@
 package model
 
 import common.Edition
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.joda.time.DateTime
-import com.gu.contentapi.client.model.v1.{Content => ApiContent}
 import com.github.nscala_time.time.Imports._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class DateTimeTest extends FlatSpec with Matchers with implicits.Dates {
+class DateTimeTest extends AnyFlatSpec with Matchers with implicits.Dates {
 
   //http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3.1
 

--- a/common/test/model/ElementsTest.scala
+++ b/common/test/model/ElementsTest.scala
@@ -13,10 +13,11 @@ import com.gu.contentapi.client.model.v1.{
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichOffsetDateTime
 import contentapi.FixtureTemplates
 import org.joda.time.DateTime
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 
-class ElementsTest extends FlatSpec with Matchers with GuiceOneAppPerSuite {
+class ElementsTest extends AnyFlatSpec with Matchers with GuiceOneAppPerSuite {
 
   "Elements" should "find the biggest crop of the main picture" in {
 

--- a/common/test/model/MetaDataTest.scala
+++ b/common/test/model/MetaDataTest.scala
@@ -1,14 +1,15 @@
 package model
 
-import java.time.{OffsetDateTime, ZoneOffset}
-import com.gu.contentapi.client.model.v1.{CapiDateTime, ContentFields, TagType, Content => ApiContent, Tag => ApiTag}
+import java.time.ZoneOffset
+import com.gu.contentapi.client.model.v1.{ContentFields, TagType, Content => ApiContent, Tag => ApiTag}
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichOffsetDateTime
 import implicits.Dates.jodaToJavaInstant
-import org.scalatest.{FlatSpec, Matchers}
 import org.joda.time.DateTime
 import common.Chronos
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class MetaDataTest extends FlatSpec with Matchers {
+class MetaDataTest extends AnyFlatSpec with Matchers {
 
   def testMetaData(id: String, section: String): MetaData = {
     MetaData.make(id, section = Some(SectionId.fromId(section)), webTitle = "t")

--- a/common/test/model/SeoDataTest.scala
+++ b/common/test/model/SeoDataTest.scala
@@ -1,8 +1,9 @@
 package model
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class SeoDataTest extends FlatSpec with Matchers {
+class SeoDataTest extends AnyFlatSpec with Matchers {
 
   "SeoData" should "handle an path that has an edition" in {
     val seoData: SeoData = SeoData.fromPath("uk/culture")

--- a/common/test/model/TagIndexPageTest.scala
+++ b/common/test/model/TagIndexPageTest.scala
@@ -1,9 +1,10 @@
 package model
 
 import common.ResourcesHelper
-import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class TagIndexPageTest extends FlatSpec with Matchers with ResourcesHelper {
+class TagIndexPageTest extends AnyFlatSpec with Matchers with ResourcesHelper {
   val fixture = slurpJsonOrDie[TagIndex]("c.json")
 
   val cuba = TagDefinition(

--- a/common/test/model/UrlsTest.scala
+++ b/common/test/model/UrlsTest.scala
@@ -1,15 +1,15 @@
 package model
 
 import java.time.ZoneOffset
-
 import com.gu.contentapi.client.model.v1.{TagType, Content => ApiContent, Tag => ApiTag}
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichOffsetDateTime
 import implicits.Dates.jodaToJavaInstant
 import org.joda.time.DateTime
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 
-class UrlsTest extends FlatSpec with Matchers with GuiceOneAppPerSuite {
+class UrlsTest extends AnyFlatSpec with Matchers with GuiceOneAppPerSuite {
 
   val offsetDate = jodaToJavaInstant(new DateTime()).atOffset(ZoneOffset.UTC)
 

--- a/common/test/model/dotcomrendering/DotcomRenderingUtilsTest.scala
+++ b/common/test/model/dotcomrendering/DotcomRenderingUtilsTest.scala
@@ -5,10 +5,11 @@ import com.gu.contentapi.client.utils.format.LiveBlogDesign
 import model.dotcomrendering.DotcomRenderingUtils
 import model.{CanonicalLiveBlog, ContentFormat, ContentType, DotcomContentType, MetaData}
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 
-class DotcomRenderingUtilsTest extends FlatSpec with Matchers with MockitoSugar {
+class DotcomRenderingUtilsTest extends AnyFlatSpec with Matchers with MockitoSugar {
 
   val testContent = mock[ContentType]
   val testMetadata = mock[MetaData]

--- a/common/test/model/dotcomrendering/pageElements/PageElementTest.scala
+++ b/common/test/model/dotcomrendering/pageElements/PageElementTest.scala
@@ -2,10 +2,11 @@ package model.dotcomrendering.pageElements
 
 import com.gu.contentapi.client.model.v1.EmbedTracking
 import com.gu.contentapi.client.model.v1.EmbedTracksType.{DoesNotTrack, EnumUnknownEmbedTracksType, Tracks, Unknown}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
 import model.dotcomrendering.pageElements.PageElement.containsThirdPartyTracking
+import org.scalatest.flatspec.AnyFlatSpec
 
-class PageElementTest extends FlatSpec with Matchers {
+class PageElementTest extends AnyFlatSpec with Matchers {
   "PageElement" should "classify capi tracking value correctly" in {
     containsThirdPartyTracking(None) should equal(false)
     containsThirdPartyTracking(Some(EmbedTracking(DoesNotTrack))) should equal(false)

--- a/common/test/model/dotcomrendering/pageElements/TextCleanerTest.scala
+++ b/common/test/model/dotcomrendering/pageElements/TextCleanerTest.scala
@@ -6,9 +6,10 @@ import common.editions
 import common.editions.Uk
 import conf.Configuration
 import model.dotcomrendering.pageElements.{TagLinker, TextBlockElement, TextCleaner}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class TextCleanerTest extends FlatSpec with Matchers {
+class TextCleanerTest extends AnyFlatSpec with Matchers {
 
   val host = Configuration.site.host
 

--- a/common/test/navigation/AuthenticationComponentEventTest.scala
+++ b/common/test/navigation/AuthenticationComponentEventTest.scala
@@ -1,9 +1,10 @@
 package navigation
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
 import AuthenticationComponentEvent._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class AuthenticationComponentEventTest extends FlatSpec with Matchers {
+class AuthenticationComponentEventTest extends AnyFlatSpec with Matchers {
 
   "createAuthenticationComponentEventTuple" should "create a component event tuple with the parameters passed" in {
     createAuthenticationComponentEventTuple(

--- a/common/test/navigation/NavigationTest.scala
+++ b/common/test/navigation/NavigationTest.scala
@@ -3,13 +3,15 @@ package navigation
 import common.editions._
 import NavLinks._
 import com.gu.contentapi.client.model.v1.ItemResponse
-import model.{Content, ContentPage, ContentType, Page, MetaData}
+import model.{Content, ContentPage, ContentType, MetaData, Page}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import test.{ConfiguredTestSuite, WithMaterializer, WithTestContentApiClient, WithTestWsClient}
 
 @DoNotDiscover class NavigationTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/common/test/navigation/helpers/UrlHelpersTest.scala
+++ b/common/test/navigation/helpers/UrlHelpersTest.scala
@@ -1,12 +1,12 @@
 package navigation.helpers
 
-import org.scalatest.{WordSpec, Matchers}
-import test.TestRequest
-import navigation.ReaderRevenueSite.{Support, SupportContribute, SupportSubscribe, SupportGifting, SupporterCTA}
+import navigation.ReaderRevenueSite.{Support, SupportContribute, SupportGifting, SupportSubscribe, SupporterCTA}
 import navigation.UrlHelpers
 import navigation.UrlHelpers.{AmpFooter, AmpHeader, Footer, Header}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class UrlHelpersTest extends WordSpec with Matchers {
+class UrlHelpersTest extends AnyWordSpec with Matchers {
 
   "UrlHelpers" can {
     "getComponentId" should {

--- a/common/test/renderers/DotcomRenderingServiceTest.scala
+++ b/common/test/renderers/DotcomRenderingServiceTest.scala
@@ -1,23 +1,22 @@
 package renderers
 
-import model.{MetaData, Page, CacheTime}
-import model.dotcomrendering.PageType
-import org.apache.commons.codec.digest.DigestUtils
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers, PrivateMethodTester}
-import play.api.test.Helpers._
-import play.api.test._
+import model.{CacheTime}
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, PrivateMethodTester}
+import org.scalatest.matchers.should.Matchers
 import test.{ConfiguredTestSuite, TestRequest, WithMaterializer, WithTestWsClient}
 import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
-import play.api.mvc.{RequestHeader, Result, Results}
+import play.api.mvc.{Result}
 import conf.Configuration
 import org.mockito.Matchers.any
 import org.mockito.Mockito.when
-import scala.concurrent.{ExecutionContext, Future}
+
+import scala.concurrent.{Future}
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpec
 
 @DoNotDiscover class DotcomRenderingServiceTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with MockitoSugar

--- a/common/test/services/IndexPageTest.scala
+++ b/common/test/services/IndexPageTest.scala
@@ -6,14 +6,16 @@ import model.{Section, Tags}
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
+import org.scalatest.matchers.should.Matchers
 import layout.slices.Fixed
+import org.scalatest.flatspec.AnyFlatSpec
 import test._
 
 import scala.concurrent.Future
 
 @DoNotDiscover class IndexPageTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/common/test/services/ShouldServeFrontTest.scala
+++ b/common/test/services/ShouldServeFrontTest.scala
@@ -3,14 +3,17 @@ package services
 import com.gu.facia.client.models.{Branded, CollectionConfigJson, ConfigJson, FrontJson}
 import model.{ApplicationContext, ApplicationIdentity}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
 import play.api.Environment
 import test.WithTestApplicationContext
+
 import scala.concurrent.duration._
 import scala.concurrent.Await
 
 class ShouldServeFrontTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with WithTestApplicationContext
     with ScalaFutures

--- a/common/test/views/support/CamelCaseTest.scala
+++ b/common/test/views/support/CamelCaseTest.scala
@@ -1,9 +1,10 @@
 package views.support
 
 import CamelCase.fromHyphenated
-import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CamelCaseTest extends FlatSpec with Matchers {
+class CamelCaseTest extends AnyFlatSpec with Matchers {
   "fromHyphenated" should "create a camel case string" in {
     fromHyphenated("once-upon-a-time") shouldEqual "onceUponATime"
     fromHyphenated("hello-world") shouldEqual "helloWorld"

--- a/common/test/views/support/CommercialTest.scala
+++ b/common/test/views/support/CommercialTest.scala
@@ -1,10 +1,12 @@
 package views.support
 
 import model.{MetaData, SectionId}
-import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers, OptionValues}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.{BeforeAndAfterEach, OptionValues}
+import org.scalatest.matchers.should.Matchers
 import views.support.Commercial.topAboveNavSlot
 
-class CommercialTest extends FlatSpec with Matchers with OptionValues with BeforeAndAfterEach {
+class CommercialTest extends AnyFlatSpec with Matchers with OptionValues with BeforeAndAfterEach {
 
   private def metaDataFromId(pageId: String): MetaData =
     MetaData.make(

--- a/common/test/views/support/ContentFooterContainersLayoutTest.scala
+++ b/common/test/views/support/ContentFooterContainersLayoutTest.scala
@@ -3,10 +3,11 @@ package views.support
 import com.gu.contentapi.client.model.v1.{ContentFields, TagType}
 import contentapi.FixtureTemplates.{emptyApiContent, emptyTag}
 import model.{RelatedContent, RelatedContentItem}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.twirl.api.Html
 
-class ContentFooterContainersLayoutTest extends FlatSpec with Matchers {
+class ContentFooterContainersLayoutTest extends AnyFlatSpec with Matchers {
 
   private def contentItem(
       showInRelatedContent: Boolean = true,

--- a/common/test/views/support/GUDateTimeFormatNewTest.scala
+++ b/common/test/views/support/GUDateTimeFormatNewTest.scala
@@ -3,9 +3,10 @@ package views.support
 import common.editions
 import model.GUDateTimeFormatNew
 import org.joda.time.DateTime
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class GUDateTimeFormatNewTest extends FreeSpec with Matchers {
+class GUDateTimeFormatNewTest extends AnyFreeSpec with Matchers {
   val date = DateTime.parse("2019-05-08T10:26:11.000+10:00")
   "formatDateTimeForDisplayGivenEdition" - {
     "correctly handles Australian to US timezone conversion" in {

--- a/common/test/views/support/ImgSrcTest.scala
+++ b/common/test/views/support/ImgSrcTest.scala
@@ -1,19 +1,18 @@
 package views.support
 
 import java.time.ZoneOffset
-
 import com.gu.contentapi.client.model.v1.{Asset, AssetType, Content, Element, ElementType, Tag, TagType}
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichOffsetDateTime
-import common.Environment.stage
 import conf.Configuration
 import conf.switches.Switches.ImageServerSwitch
 import implicits.Dates.jodaToJavaInstant
 import model.{ImageAsset, ImageMedia}
 import org.joda.time.DateTime
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 
-class ImgSrcTest extends FlatSpec with Matchers with GuiceOneAppPerSuite {
+class ImgSrcTest extends AnyFlatSpec with Matchers with GuiceOneAppPerSuite {
 
   lazy val imageHost = Configuration.images.host
 

--- a/common/test/views/support/TemplatesTest.scala
+++ b/common/test/views/support/TemplatesTest.scala
@@ -7,12 +7,12 @@ import com.gu.contentapi.client.model.v1.{
   Tag => ApiTag,
   _,
 }
-import common.Edition
 import common.editions.Uk
 import conf.Configuration
 import model._
 import org.jsoup.Jsoup
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.mvc.RequestHeader
 import play.api.test.FakeRequest
 import test.TestRequest
@@ -21,7 +21,7 @@ import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import scala.collection.JavaConverters._
 import scala.xml.XML
 
-class TemplatesTest extends FlatSpec with Matchers with GuiceOneAppPerSuite {
+class TemplatesTest extends AnyFlatSpec with Matchers with GuiceOneAppPerSuite {
 
   "RemoveOuterPara" should "remove outer paragraph tags" in {
     RemoveOuterParaHtml(" <P> foo <b>bar</b> </p> ").body should be(" foo <b>bar</b> ")

--- a/common/test/views/support/TitleTest.scala
+++ b/common/test/views/support/TitleTest.scala
@@ -1,18 +1,18 @@
 package views.support
 
 import java.time.ZoneOffset
-
 import com.gu.contentapi.client.model.v1.{TagType, Content => ApiContent, Tag => ApiTag}
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichOffsetDateTime
 import common.Pagination
 import implicits.Dates.jodaToJavaInstant
 import model._
 import org.joda.time.DateTime
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.test.FakeRequest
 
-class TitleTest extends FlatSpec with Matchers with GuiceOneAppPerSuite {
+class TitleTest extends AnyFlatSpec with Matchers with GuiceOneAppPerSuite {
 
   implicit val request = FakeRequest()
 

--- a/common/test/views/support/TrackingCodeBuilderTest.scala
+++ b/common/test/views/support/TrackingCodeBuilderTest.scala
@@ -13,11 +13,13 @@ import layout.{
   PaidCard,
 }
 import model.pressed
-import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.should.Matchers
 import play.api.test.FakeRequest
 import views.support.Commercial.TrackingCodeBuilder
 
-class TrackingCodeBuilderTest extends FlatSpec with Matchers with BeforeAndAfterEach {
+class TrackingCodeBuilderTest extends AnyFlatSpec with Matchers with BeforeAndAfterEach {
 
   private def mkBranding(sponsorName: String) =
     Branding(

--- a/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
+++ b/common/test/views/support/cleaner/AffiliateLinksCleanerTest.scala
@@ -1,10 +1,11 @@
 package views.support.cleaner
 import conf.Configuration
 import org.joda.time.DateTime
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import views.support.AffiliateLinksCleaner._
 
-class AffiliateLinksCleanerTest extends FlatSpec with Matchers {
+class AffiliateLinksCleanerTest extends AnyFlatSpec with Matchers {
 
   "linkToSkimLink" should "correctly convert a link to a skimlink" in {
     val link = "https://www.piratendating.nl/"

--- a/common/test/views/support/cleaner/AtomCleanerTest.scala
+++ b/common/test/views/support/cleaner/AtomCleanerTest.scala
@@ -7,11 +7,12 @@ import model.content._
 import model.{ImageAsset, ImageMedia}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import test.{TestRequest, WithTestApplicationContext}
 import views.support.AtomsCleaner
 
-class AtomCleanerTest extends FlatSpec with Matchers with WithTestApplicationContext with FakeRequests {
+class AtomCleanerTest extends AnyFlatSpec with Matchers with WithTestApplicationContext with FakeRequests {
 
   val asset: Asset = Asset(
     AssetType.Image,

--- a/common/test/views/support/cleaner/CmpParamCleanerTest.scala
+++ b/common/test/views/support/cleaner/CmpParamCleanerTest.scala
@@ -2,9 +2,10 @@ package views.support.cleaner
 
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CmpParamCleanerTest extends FlatSpec with Matchers {
+class CmpParamCleanerTest extends AnyFlatSpec with Matchers {
 
   "CmpParamCleaner" should "attach an element-pass-cmp class to formstack iframes" in {
     val doc =

--- a/common/test/views/support/cleaner/CommercialMPUForFrontsTest.scala
+++ b/common/test/views/support/cleaner/CommercialMPUForFrontsTest.scala
@@ -1,11 +1,12 @@
 package views.support.cleaner
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
 import StringCleaner._
+import org.scalatest.flatspec.AnyFlatSpec
 import play.api.test.FakeRequest
 import views.support.CommercialMPUForFronts
 
-class CommercialMPUForFrontsTest extends FlatSpec with Matchers {
+class CommercialMPUForFrontsTest extends AnyFlatSpec with Matchers {
 
   def getFileContent(filePath: String): String = {
     val source = scala.io.Source.fromInputStream(getClass.getResourceAsStream(filePath))

--- a/common/test/views/support/cleaner/StyleCleanerTest.scala
+++ b/common/test/views/support/cleaner/StyleCleanerTest.scala
@@ -1,9 +1,10 @@
 package views.support.cleaner
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
 import StringCleaner._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class StyleCleanerTest extends FlatSpec with Matchers {
+class StyleCleanerTest extends AnyFlatSpec with Matchers {
 
   def ignoreWhiteSpaces(s: String): String = s.replaceAll("\\s", "")
 

--- a/common/test/views/support/cleaner/VideoEmbedCleanerTest.scala
+++ b/common/test/views/support/cleaner/VideoEmbedCleanerTest.scala
@@ -2,13 +2,12 @@ package views.support.cleaner
 
 import com.gu.contentapi.client.model.v1.{Content => ApiContent}
 import model.{Article, Content}
-import org.jsoup.nodes.Element
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.scalatest.{FlatSpec, Matchers}
-import scala.collection.JavaConverters._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class VideoEmbedCleanerTest extends FlatSpec with Matchers {
+class VideoEmbedCleanerTest extends AnyFlatSpec with Matchers {
 
   val contentApi = ApiContent(
     id = "foo/2012/jan/07/bar",

--- a/discussion/test/CommentCountControllerTest.scala
+++ b/discussion/test/CommentCountControllerTest.scala
@@ -1,11 +1,13 @@
 package test
 
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
+import org.scalatest.matchers.should.Matchers
 import play.api.test.Helpers._
 import controllers.CommentCountController
+import org.scalatest.flatspec.AnyFlatSpec
 
 @DoNotDiscover class CommentCountControllerTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/discussion/test/CommentPageControllerTest.scala
+++ b/discussion/test/CommentPageControllerTest.scala
@@ -1,12 +1,14 @@
 package test
 
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
+import org.scalatest.matchers.should.Matchers
 import play.api.test.Helpers._
 import controllers.CommentsController
 import discussion.model.DiscussionKey
+import org.scalatest.flatspec.AnyFlatSpec
 
 @DoNotDiscover class CommentPageControllerTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/discussion/test/ProfileTest.scala
+++ b/discussion/test/ProfileTest.scala
@@ -1,10 +1,12 @@
 package test
 
-import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.DoNotDiscover
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.Json
 import discussion.model.Profile
+import org.scalatest.flatspec.AnyFlatSpec
 
-@DoNotDiscover class ProfileTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class ProfileTest extends AnyFlatSpec with Matchers with ConfiguredTestSuite {
 
   "Profile" should "parse JSON Profile with no optional fields" in {
     val jsonStr = """{"userProfile": {

--- a/discussion/test/controllers/DiscussionApiPluginIntegrationTest.scala
+++ b/discussion/test/controllers/DiscussionApiPluginIntegrationTest.scala
@@ -4,6 +4,8 @@ import conf.Configuration
 import discussion.api.DiscussionApiLike
 import discussion.model.Comment
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 import test.{ConfiguredTestSuite, WithMaterializer, WithTestExecutionContext, WithTestWsClient}
 
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -12,7 +14,7 @@ import scala.concurrent.duration._
 import play.api.libs.ws.{WSClient, WSResponse}
 
 @DoNotDiscover class DiscussionApiPluginIntegrationTest
-    extends FlatSpecLike
+    extends AnyFlatSpecLike
     with Matchers
     with BeforeAndAfterAll
     with ConfiguredTestSuite

--- a/discussion/test/controllers/ProfileActivityControllerTest.scala
+++ b/discussion/test/controllers/ProfileActivityControllerTest.scala
@@ -1,12 +1,14 @@
 package controllers
 
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
+import org.scalatest.matchers.should.Matchers
 import play.api.test.Helpers._
 import play.api.test.FakeRequest
 import test.{ConfiguredTestSuite, DiscussionApiStub, WithMaterializer, WithTestWsClient}
 
 @DoNotDiscover class ProfileActivityControllerTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/discussion/test/discussion/DiscussionApiTest.scala
+++ b/discussion/test/discussion/DiscussionApiTest.scala
@@ -2,7 +2,8 @@ package discussion
 
 import discussion.api.{DiscussionApiLike, DiscussionParams}
 import discussion.model.DiscussionKey
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FreeSpec}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc.Headers
 import test.{ConfiguredTestSuite, WithMaterializer, WithTestExecutionContext, WithTestWsClient}
@@ -12,7 +13,7 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 
 @DoNotDiscover class DiscussionApiTest
-    extends FreeSpec
+    extends AnyFreeSpec
     with ConfiguredTestSuite
     with BeforeAndAfterAll
     with WithMaterializer

--- a/discussion/test/discussion/model/CommentTest.scala
+++ b/discussion/test/discussion/model/CommentTest.scala
@@ -1,10 +1,12 @@
 package discussion.model
 
-import org.scalatest.{DoNotDiscover, Matchers, FreeSpec}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.DoNotDiscover
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json._
 import test.ConfiguredTestSuite
 
-@DoNotDiscover class CommentTest extends FreeSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class CommentTest extends AnyFreeSpec with Matchers with ConfiguredTestSuite {
 
   "A comment with Json" in {
     val json: JsValue = Json.parse(aCommentJson)

--- a/discussion/test/discussion/model/DiscussionKeyTest.scala
+++ b/discussion/test/discussion/model/DiscussionKeyTest.scala
@@ -1,9 +1,10 @@
 package discussion.model
 
-import org.scalatest.{DoNotDiscover, FreeSpec}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.DoNotDiscover
 import test.ConfiguredTestSuite
 
-@DoNotDiscover class DiscussionKeyTest extends FreeSpec with ConfiguredTestSuite {
+@DoNotDiscover class DiscussionKeyTest extends AnyFreeSpec with ConfiguredTestSuite {
 
   "DiscussionKey" - {
 

--- a/discussion/test/package.scala
+++ b/discussion/test/package.scala
@@ -4,10 +4,11 @@ import conf.Configuration
 import org.scalatest.Suites
 import recorder.DefaultHttpRecorder
 import play.api.libs.ws.WSClient
-import java.io.File
 
+import java.io.File
 import scala.concurrent.duration._
 import discussion.api.DiscussionApiLike
+import org.scalatestplus.play.PortNumber
 
 import scala.concurrent.ExecutionContext
 
@@ -38,6 +39,4 @@ class DiscussionTestSuite
       new CommentCountControllerTest,
       new ProfileTest,
     )
-    with SingleServerSuite {
-  override lazy val port: Int = 19008
-}
+    with SingleServerSuite {}

--- a/facia-press/test/frontpress/FaciaPressDeduplicationTest.scala
+++ b/facia-press/test/frontpress/FaciaPressDeduplicationTest.scala
@@ -1,9 +1,10 @@
 package frontpress
 
+import org.scalatest.flatspec.AnyFlatSpec
 import testdata.FaciaPressDeduplicationTestData
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
 
-class FaciaPressDeduplicationTest extends FlatSpec with Matchers with FaciaPressDeduplicationTestData {
+class FaciaPressDeduplicationTest extends AnyFlatSpec with Matchers with FaciaPressDeduplicationTestData {
 
   var sequence = List(
     PressedCollectionVisibility(collection0, 0),

--- a/facia-press/test/frontpress/FapiFrontPressTest.scala
+++ b/facia-press/test/frontpress/FapiFrontPressTest.scala
@@ -8,8 +8,9 @@ import com.gu.facia.api.models.Collection
 import common.GuLogging
 import model.pressed.EnrichedContent
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{AsyncFlatSpec, Matchers}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.json.{JsValue, Json}
 import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 

--- a/facia-press/test/frontpress/PressedCollectionVisibilityTest.scala
+++ b/facia-press/test/frontpress/PressedCollectionVisibilityTest.scala
@@ -2,10 +2,11 @@ package frontpress
 
 import helpers.FaciaTestData
 import model.facia.PressedCollection
-import org.scalatest.{FlatSpec, Matchers}
 import com.gu.facia.client.models.{AnyPlatform, AppCollection, CollectionPlatform, WebCollection}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class PressedCollectionVisibilityTest extends FlatSpec with Matchers with FaciaTestData {
+class PressedCollectionVisibilityTest extends AnyFlatSpec with Matchers with FaciaTestData {
 
   trait PressedCollectionVisibilityScope {
     val collections: List[PressedCollection] = ukFaciaPage.collections.map { collection =>

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -16,15 +16,16 @@ import helpers.FaciaTestData
 import org.mockito.Mockito.when
 import org.mockito.Matchers.any
 import org.mockito.Matchers.anyString
-import org.scalatest.mockito.MockitoSugar
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
-import play.api.libs.typedmap.TypedKey
 import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 
 @DoNotDiscover class FaciaControllerTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with FaciaTestData
     with Matchers
     with ConfiguredTestSuite

--- a/facia/test/FaciaFeatureTest.scala
+++ b/facia/test/FaciaFeatureTest.scala
@@ -2,13 +2,14 @@ package test
 
 import org.scalatest._
 import play.api.test.TestBrowser
-import org.fluentlenium.core.domain.FluentWebElement
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
 
-@DoNotDiscover class FaciaFeatureTest extends FeatureSpec with GivenWhenThen with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class FaciaFeatureTest extends AnyFeatureSpec with GivenWhenThen with Matchers with ConfiguredTestSuite {
 
-  feature("Facia") {
+  Feature("Facia") {
 
-    feature("Sponsorships") {
+    Feature("Sponsorships") {
 
       def testFrontSponsorship(browser: TestBrowser, sponsorshipType: String): Assertion = {
         import browser._
@@ -47,7 +48,7 @@ import org.fluentlenium.core.domain.FluentWebElement
         *
        * If they fail often, might need to look into setting up a reliable data source
         */
-      scenario("Advertisement Feature Front") {
+      Scenario("Advertisement Feature Front") {
 
         Given("I am on an advertisement feature front")
         goTo("/sustainable-business/hm-partner-zone") { browser =>
@@ -56,7 +57,7 @@ import org.fluentlenium.core.domain.FluentWebElement
 
       }
 
-      scenario("Advertisement Feature Container") {
+      Scenario("Advertisement Feature Container") {
 
         Given("I am on a front with an advertisement feature container")
         goTo("/lifeandstyle/live-better") { browser =>
@@ -65,7 +66,7 @@ import org.fluentlenium.core.domain.FluentWebElement
 
       }
 
-      scenario("Sponsored Front") {
+      Scenario("Sponsored Front") {
 
         Given("I am on a sponsored front")
         goTo("/lifeandstyle/live-better") { browser =>
@@ -74,7 +75,7 @@ import org.fluentlenium.core.domain.FluentWebElement
 
       }
 
-      scenario("Sponsored Container") {
+      Scenario("Sponsored Container") {
 
         Given("I am on a front with a sponsored container")
         goTo("/lifeandstyle/live-better") { browser =>
@@ -83,7 +84,7 @@ import org.fluentlenium.core.domain.FluentWebElement
 
       }
 
-      scenario("Foundation Supported Front") {
+      Scenario("Foundation Supported Front") {
 
         Given("I am on a foundation supported front")
         goTo("/global-development") { browser =>
@@ -92,7 +93,7 @@ import org.fluentlenium.core.domain.FluentWebElement
 
       }
 
-      scenario("Foundation Supported Container") {
+      Scenario("Foundation Supported Container") {
 
         Given("I am on a front with a foundation supported container")
         goTo("/global-development") { browser =>

--- a/facia/test/FaciaMetaDataTest.scala
+++ b/facia/test/FaciaMetaDataTest.scala
@@ -6,8 +6,10 @@ import concurrent.BlockingOperations
 import conf.Configuration
 import controllers.FaciaControllerImpl
 import org.jsoup.Jsoup
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.json._
 import play.api.test.Helpers._
 import services.ConfigAgent
@@ -17,7 +19,7 @@ import scala.concurrent.Await
 import test._
 
 @DoNotDiscover class FaciaMetaDataTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/facia/test/controllers/front/FaciaDefaultsTest.scala
+++ b/facia/test/controllers/front/FaciaDefaultsTest.scala
@@ -1,10 +1,12 @@
 package controllers.front
 
-import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
+import org.scalatest.DoNotDiscover
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json._
 import test.ConfiguredTestSuite
 
-@DoNotDiscover class FaciaDefaultsTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class FaciaDefaultsTest extends AnyFlatSpec with Matchers with ConfiguredTestSuite {
 
   "FaciaDefaults" should "parse correctly" in {
     Json.parse(FaciaDefaults.defaultJson).isInstanceOf[JsValue] should be(true)

--- a/facia/test/controllers/front/FrontHeadlineTest.scala
+++ b/facia/test/controllers/front/FrontHeadlineTest.scala
@@ -3,13 +3,15 @@ package controllers.front
 import akka.util.Timeout
 import common.facia.FixtureBuilder
 import model.Cached.RevalidatableResult
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 import play.api.test.Helpers
+
 import scala.concurrent.duration._
 import scala.concurrent.Future
 import scala.language.postfixOps
 
-class FrontHeadlineTest extends FunSuite with Matchers {
+class FrontHeadlineTest extends AnyFunSuite with Matchers {
   implicit val timeout: Timeout = Timeout(5 seconds)
 
   test("renderEmailHeadline extracts headline from pressed page") {

--- a/facia/test/model/FaciaPageTest.scala
+++ b/facia/test/model/FaciaPageTest.scala
@@ -1,9 +1,11 @@
 package model
 
-import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.DoNotDiscover
 import test.ConfiguredTestSuite
 
-@DoNotDiscover class FaciaPageTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class FaciaPageTest extends AnyFlatSpec with Matchers with ConfiguredTestSuite {
 
   private def toPressedPage(id: String): PressedPage = {
     PressedPage(id, SeoData.empty, FrontProperties.empty, Nil)

--- a/facia/test/package.scala
+++ b/facia/test/package.scala
@@ -1,12 +1,12 @@
 package test
 
 import java.io.File
-
 import concurrent.BlockingOperations
 import controllers.front.FrontJsonFapiLive
 import model.{PressedPage, PressedPageType}
 import org.fluentlenium.core.domain.FluentWebElement
 import org.scalatest.Suites
+import org.scalatestplus.play.PortNumber
 import play.api.libs.json.Json
 import recorder.HttpRecorder
 
@@ -61,6 +61,4 @@ class FaciaTestSuite
       new FaciaControllerTest,
       new metadata.FaciaMetaDataTest,
     )
-    with SingleServerSuite {
-  override lazy val port: Int = 19009
-}
+    with SingleServerSuite {}

--- a/facia/test/utils/TargetedCollectionsTest.scala
+++ b/facia/test/utils/TargetedCollectionsTest.scala
@@ -2,10 +2,10 @@ package utils
 
 import com.gu.facia.client.models.NZTerritory
 import helpers.FaciaTestData
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers._
+import metadata.MetaDataMatcher.{be, contain, not, convertToAnyShouldWrapper}
+import org.scalatest.flatspec.AnyFlatSpec
 
-class TargetedCollectionsTest extends FlatSpec with FaciaTestData {
+class TargetedCollectionsTest extends AnyFlatSpec with FaciaTestData {
 
   behavior of "FrontUtilsTest"
 

--- a/identity/test/actions/AuthenticatedActionsTest.scala
+++ b/identity/test/actions/AuthenticatedActionsTest.scala
@@ -1,28 +1,25 @@
 package actions
 
 import java.net.URLEncoder
-
 import actions.AuthenticatedActions.AuthRequest
-import com.gu.identity.model.{StatusFields, Subscriber, User}
-import conf.switches.Switches
+import com.gu.identity.model.{StatusFields, User}
 import idapiclient.{Auth, IdApiClient, ScGuRp, ScGuU}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{Matchers, WordSpecLike}
 import org.mockito.Matchers.any
 import play.api.mvc.{AnyContent, _}
-import play.api.test.{FakeRequest, Helpers, Injecting}
+import play.api.test.{FakeRequest, Helpers}
 import services._
 import test.{WithTestExecutionContext, WithTestIdConfig}
 import idapiclient.Response
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.test.Helpers._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.Future
 
 class AuthenticatedActionsTest
-    extends WordSpecLike
+    extends AnyWordSpecLike
     with MockitoSugar
     with ScalaFutures
     with Matchers

--- a/identity/test/clients/DiscussionClientTest.scala
+++ b/identity/test/clients/DiscussionClientTest.scala
@@ -1,11 +1,11 @@
 package clients
 
 import conf.IdentityConfiguration
+import metadata.MetaDataMatcher.convertToAnyShouldWrapper
 import org.mockito.Matchers.any
 import org.mockito.Mockito._
-import org.scalatest.AsyncFlatSpec
-import org.scalatest.Matchers._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.json.Json
 import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 

--- a/identity/test/controllers/ConsentsJourneyControllerTest.scala
+++ b/identity/test/controllers/ConsentsJourneyControllerTest.scala
@@ -1,23 +1,24 @@
 package controllers
 
 import actions.AuthenticatedActions
-import com.gu.identity.cookie.GuUCookieData
 import com.gu.identity.model.Consent.Supporter
 import com.gu.identity.model._
 import controllers.editprofile.EditProfileController
 import form._
 import idapiclient.{Auth, TrackingData, _}
-import model.{Countries, PhoneNumbers}
+import model.PhoneNumbers
 import org.mockito.Mockito._
 import org.mockito.{ArgumentCaptor, Matchers => MockitoMatchers}
 import MockitoMatchers._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest._
 import org.scalatestplus.play.ConfiguredServer
 import _root_.play.api.http.HttpConfiguration
 import _root_.play.api.mvc._
 import _root_.play.api.test.Helpers._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar
 import services._
 import services.newsletters.NewsletterSignupAgent
 import test._
@@ -25,7 +26,7 @@ import test._
 import scala.concurrent.Future
 
 @DoNotDiscover class ConsentsJourneyControllerTest
-    extends WordSpec
+    extends AnyWordSpec
     with WithTestExecutionContext
     with Matchers
     with MockitoSugar

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -1,26 +1,21 @@
 package controllers
 
 import actions.AuthenticatedActions
-import com.gu.identity.cookie.GuUCookieData
-import com.gu.identity.model.Consent.Supporter
 import com.gu.identity.model._
 import form._
 import idapiclient.{TrackingData, _}
-import idapiclient.Auth
-import idapiclient.responses.Error
-import model.{Countries, PhoneNumbers}
+import model.PhoneNumbers
 import controllers.editprofile.EditProfileController
-import org.joda.time.format.ISODateTimeFormat
 import org.mockito.Mockito._
-import org.mockito.{ArgumentCaptor, Matchers => MockitoMatchers}
+import org.mockito.{Matchers => MockitoMatchers}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{DoNotDiscover, Matchers, OptionValues, WordSpec}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{DoNotDiscover, OptionValues}
 import org.scalatestplus.play.ConfiguredServer
 import _root_.play.api.http.HttpConfiguration
 import _root_.play.api.mvc._
-import _root_.play.api.test.FakeRequest
-import _root_.play.api.test.Helpers._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar
 import services._
 import services.newsletters.NewsletterSignupAgent
 import test._
@@ -29,7 +24,7 @@ import scala.concurrent.Future
 
 //TODO test form validation and population of form fields.
 @DoNotDiscover class EditProfileControllerTest
-    extends WordSpec
+    extends AnyWordSpec
     with WithTestExecutionContext
     with Matchers
     with MockitoSugar

--- a/identity/test/controllers/EmailVerificationControllerTest.scala
+++ b/identity/test/controllers/EmailVerificationControllerTest.scala
@@ -2,16 +2,15 @@ package controllers
 
 import actions.AuthenticatedActions
 import com.gu.identity.model.{StatusFields, User}
-import idapiclient.responses.{CookieResponse, CookiesResponse, Error}
-import idapiclient.{Auth, IdApiClient, ScGuU, TrackingData}
+import idapiclient.{IdApiClient, ScGuU, TrackingData}
 import model.PhoneNumbers
-import org.joda.time.DateTime
 import org.mockito.AdditionalAnswers.returnsFirstArg
-import org.mockito.Matchers.{any, anyString, anyVararg, eq => eql}
+import org.mockito.Matchers.{any, anyString, anyVararg}
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{Matchers, path}
-import play.api.mvc.{ControllerComponents, Cookie, Request, RequestHeader}
+import org.scalatest.freespec.PathAnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.mvc.{ControllerComponents, Request, RequestHeader}
 import play.api.test.Helpers._
 import services._
 import test._
@@ -19,7 +18,7 @@ import test._
 import scala.concurrent.Future
 
 class EmailVerificationControllerTest
-    extends path.FreeSpec
+    extends PathAnyFreeSpec
     with Matchers
     with WithTestExecutionContext
     with WithTestApplicationContext

--- a/identity/test/controllers/FormstackControllerTest.scala
+++ b/identity/test/controllers/FormstackControllerTest.scala
@@ -1,7 +1,6 @@
 package controllers
 
 import actions.AuthenticatedActions
-import com.gu.identity.cookie.GuUCookieData
 import com.gu.identity.model.User
 import conf.FrontendIdentityCookieDecoder
 import conf.switches.Switches
@@ -10,8 +9,9 @@ import idapiclient.responses.Error
 import idapiclient.{IdApiClient, ScGuU, TrackingData}
 import org.mockito.{Matchers => MockitoMatchers}
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{Matchers, path}
+import org.scalatest.freespec.PathAnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.RequestHeader
 import play.api.test.Helpers._
 import services._
@@ -20,7 +20,7 @@ import test.{Fake, TestRequest, WithTestApplicationContext, WithTestExecutionCon
 import scala.concurrent.{ExecutionContext, Future}
 
 class FormstackControllerTest
-    extends path.FreeSpec
+    extends PathAnyFreeSpec
     with Matchers
     with WithTestApplicationContext
     with WithTestExecutionContext

--- a/identity/test/controllers/PublicProfileControllerTest.scala
+++ b/identity/test/controllers/PublicProfileControllerTest.scala
@@ -6,8 +6,9 @@ import idapiclient.{Auth, _}
 import org.joda.time.DateTime
 import org.mockito.Mockito._
 import org.mockito.{Matchers => MockitoMatchers}
-import org.scalatest._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatest.freespec.PathAnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.RequestHeader
 import play.api.test.Helpers._
 import services._
@@ -17,7 +18,7 @@ import scala.concurrent.Future
 import scala.util.Left
 
 class PublicProfileControllerTest
-    extends path.FreeSpec
+    extends PathAnyFreeSpec
     with Matchers
     with WithTestApplicationContext
     with MockitoSugar {

--- a/identity/test/filters/StrictTransportSecurityHeaderFilterTest.scala
+++ b/identity/test/filters/StrictTransportSecurityHeaderFilterTest.scala
@@ -2,7 +2,9 @@ package filters
 
 import akka.stream.Materializer
 import http.StrictTransportSecurityHeaderFilter
-import org.scalatest.{DoNotDiscover, FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.DoNotDiscover
 import play.api.mvc.{RequestHeader, Result}
 import play.api.test.FakeRequest
 import play.api.mvc.Results._
@@ -12,7 +14,7 @@ import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 
 @DoNotDiscover class StrictTransportSecurityHeaderFilterTest
-    extends FunSuite
+    extends AnyFunSuite
     with Matchers
     with ConfiguredTestSuite
     with WithTestExecutionContext {

--- a/identity/test/form/TelephoneNumberMappingTest.scala
+++ b/identity/test/form/TelephoneNumberMappingTest.scala
@@ -1,9 +1,9 @@
 package form
 
-import com.google.i18n.phonenumbers.PhoneNumberUtil
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class TelephoneNumberMappingTest extends WordSpec with Matchers {
+class TelephoneNumberMappingTest extends AnyWordSpec with Matchers {
 
   "Telephone Number Form Data" should {
     "be valid if neither country code or local number is provided" in {

--- a/identity/test/formstack/FormstackApiTest.scala
+++ b/identity/test/formstack/FormstackApiTest.scala
@@ -1,14 +1,15 @@
 package formstack
 
-import org.scalatest.{Matchers, path}
-import org.scalatest.mockito.MockitoSugar
 import org.mockito.Mockito._
 import org.mockito.{Matchers => MockitoMatchers}
+import org.scalatest.freespec.PathAnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 import test.WithTestExecutionContext
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class FormstackApiTest extends path.FreeSpec with Matchers with MockitoSugar with WithTestExecutionContext {
+class FormstackApiTest extends PathAnyFreeSpec with Matchers with MockitoSugar with WithTestExecutionContext {
   val httpClient = mock[WsFormstackHttp]
   val formstackApi = new FormstackApi(httpClient)
 

--- a/identity/test/idapiclient/IdApiTest.scala
+++ b/identity/test/idapiclient/IdApiTest.scala
@@ -1,6 +1,5 @@
 package idapiclient
 
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.play.PlaySpec
 
@@ -10,6 +9,7 @@ import idapiclient.parser.IdApiJsonBodyParser
 import idapiclient.responses.Error
 import org.mockito.Mockito._
 import org.mockito.Matchers.any
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.language.postfixOps
 import play.api.libs.ws.{WSClient, WSRequest, WSResponse}

--- a/identity/test/idapiclient/filters/DateRangeTest.scala
+++ b/identity/test/idapiclient/filters/DateRangeTest.scala
@@ -1,11 +1,11 @@
 package client.filters
 
-import org.scalatest.Matchers
-import org.scalatest.FunSuite
 import org.joda.time.format.ISODateTimeFormat
 import org.joda.time.DateTime
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class DateRangeTest extends FunSuite with Matchers {
+class DateRangeTest extends AnyFunSuite with Matchers {
   val dateTimeFormatter = ISODateTimeFormat.dateTime()
   val from = DateTime.now()
   val to = DateTime.now()

--- a/identity/test/idapiclient/filters/ElemMatchTest.scala
+++ b/identity/test/idapiclient/filters/ElemMatchTest.scala
@@ -1,9 +1,9 @@
 package client.filters
 
-import org.scalatest.FunSuite
-import org.scalatest.Matchers
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class ElemMatchTest extends FunSuite with Matchers {
+class ElemMatchTest extends AnyFunSuite with Matchers {
   test("should add elemMatch with a single filter") {
     val elemMatch = ElemMatch("arrayPath", List(ElemMatchFilter("fieldPath", "value")))
     elemMatch.parameters should contain(("elemMatch", "arrayPath"))

--- a/identity/test/idapiclient/filters/OrderByTest.scala
+++ b/identity/test/idapiclient/filters/OrderByTest.scala
@@ -1,9 +1,9 @@
 package client.filters
 
-import org.scalatest.FunSuite
-import org.scalatest.Matchers
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class OrderByTest extends FunSuite with Matchers {
+class OrderByTest extends AnyFunSuite with Matchers {
   test("should apply order by") {
     OrderBy("field").parameters should contain(("orderBy", "field"))
   }

--- a/identity/test/idapiclient/filters/PaginationTest.scala
+++ b/identity/test/idapiclient/filters/PaginationTest.scala
@@ -1,9 +1,9 @@
 package client.filters
 
-import org.scalatest.FunSuite
-import org.scalatest.Matchers
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class PaginationTest extends FunSuite with Matchers {
+class PaginationTest extends AnyFunSuite with Matchers {
   test("should apply page number") {
     Pagination(2).parameters should contain(("page", "2"))
   }

--- a/identity/test/idapiclient/filters/ValueFilterTest.scala
+++ b/identity/test/idapiclient/filters/ValueFilterTest.scala
@@ -1,9 +1,9 @@
 package client.filters
 
-import org.scalatest.FunSuite
-import org.scalatest.Matchers
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class ValueFilterTest extends FunSuite with Matchers {
+class ValueFilterTest extends AnyFunSuite with Matchers {
   test("value filter should return correct querystring params") {
     ValueFilter("testName", "testVal").parameters should contain(("filter", "testName:testVal"))
   }

--- a/identity/test/idapiclient/parser/JsonBodyParserTest.scala
+++ b/identity/test/idapiclient/parser/JsonBodyParserTest.scala
@@ -1,12 +1,12 @@
 package idapiclient.parser
 
-import org.scalatest.path
 import net.liftweb.json.JsonAST.JValue
 import idapiclient.responses.{Error, HttpResponse}
-import org.scalatest.Matchers
 import net.liftweb.json.DefaultFormats
+import org.scalatest.freespec.PathAnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class JsonBodyParserTest extends path.FreeSpec with Matchers {
+class JsonBodyParserTest extends PathAnyFreeSpec with Matchers {
   case class TestType(test: String)
 
   val testErrors = List(Error("Test error", "Test description"))

--- a/identity/test/model/PhoneNumbersTest.scala
+++ b/identity/test/model/PhoneNumbersTest.scala
@@ -1,8 +1,9 @@
 package model
 
-import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class PhoneNumbersTest extends FlatSpec with Matchers {
+class PhoneNumbersTest extends AnyFlatSpec with Matchers {
 
   behavior of "PhoneNumbers"
 

--- a/identity/test/package.scala
+++ b/identity/test/package.scala
@@ -1,13 +1,13 @@
 package test
 
 import java.io.File
-
 import common.GuardianConfiguration
 import conf.{IdConfig, IdentityConfiguration}
 import controllers.EditProfileControllerTest
 import controllers.ConsentsJourneyControllerTest
 import filters.StrictTransportSecurityHeaderFilterTest
 import org.scalatest.Suites
+import org.scalatestplus.play.PortNumber
 import play.api.i18n.I18nComponents
 import play.api._
 import play.api.http.HttpConfiguration
@@ -39,9 +39,7 @@ class IdentityTestSuite
       new StrictTransportSecurityHeaderFilterTest,
       new ConsentsJourneyControllerTest,
     )
-    with SingleServerSuite {
-  override lazy val port: Int = 19010
-}
+    with SingleServerSuite {}
 
 trait WithTestIdConfig {
   class IdentityConfigurationStub extends IdConfig {

--- a/identity/test/services/DiscussionApiServiceTest.scala
+++ b/identity/test/services/DiscussionApiServiceTest.scala
@@ -1,10 +1,10 @@
 package services
 
 import clients.{DiscussionClient, DiscussionProfile, DiscussionProfileResponse, DiscussionProfileStats}
+import metadata.MetaDataMatcher.convertToAnyShouldWrapper
 import org.mockito.Mockito._
-import org.scalatest.AsyncFlatSpec
-import org.scalatest.Matchers._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.Future
 

--- a/identity/test/services/IdentityUrlBuilderTest.scala
+++ b/identity/test/services/IdentityUrlBuilderTest.scala
@@ -1,13 +1,13 @@
 package services
 
-import org.scalatest.path
-import org.scalatest.Matchers
-import org.scalatest.mockito.MockitoSugar
 import org.mockito.Mockito._
 import idapiclient.TrackingData
+import org.scalatest.freespec.PathAnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 import test.WithTestIdConfig
 
-class IdentityUrlBuilderTest extends path.FreeSpec with Matchers with MockitoSugar with WithTestIdConfig {
+class IdentityUrlBuilderTest extends PathAnyFreeSpec with Matchers with MockitoSugar with WithTestIdConfig {
   val idRequest = mock[IdentityRequest]
   val omnitureTracking = mock[TrackingData]
   when(idRequest.trackingData) thenReturn omnitureTracking

--- a/identity/test/services/MembersDataApiServiceTest.scala
+++ b/identity/test/services/MembersDataApiServiceTest.scala
@@ -1,15 +1,16 @@
 package services
 
 import conf.IdentityConfiguration
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.AsyncFlatSpec
+import metadata.MetaDataMatcher.{convertToAnyShouldWrapper, include}
 import org.scalatest.EitherValues
-import org.scalatest.Matchers._
 import org.mockito.Mockito._
 import org.mockito.Matchers._
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 import play.api.mvc.{Cookie, Cookies}
 import play.api.libs.json.Json
+
 import scala.concurrent.Future
 
 class MembersDataApiServiceTest extends AsyncFlatSpec with EitherValues with MockitoSugar {
@@ -80,7 +81,7 @@ class MembersDataApiServiceTest extends AsyncFlatSpec with EitherValues with Moc
 
     val futureEither = MdapiService.getUserContentAccess(cookies)
     futureEither map { either => either.isRight shouldBe true }
-    futureEither map { either => either.right.value shouldEqual ContentAccess(true, true, false, true, false, true) }
+    futureEither map { either => either.value shouldEqual ContentAccess(true, true, false, true, false, true) }
   }
 
   it should "return MdapiServiceException if unable to extract ContentAccess from json response" in {

--- a/identity/test/services/ReturnUrlVerifierTest.scala
+++ b/identity/test/services/ReturnUrlVerifierTest.scala
@@ -1,12 +1,12 @@
 package services
 
-import org.scalatest.FunSuite
-import org.scalatest.Matchers
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.{FakeHeaders, FakeRequest}
 import test.WithTestIdConfig
 
-class ReturnUrlVerifierTest extends FunSuite with Matchers with WithTestIdConfig {
+class ReturnUrlVerifierTest extends AnyFunSuite with Matchers with WithTestIdConfig {
 
   val domain = testIdConfig.domain
 

--- a/identity/test/utils/RemoteAddressTest.scala
+++ b/identity/test/utils/RemoteAddressTest.scala
@@ -1,12 +1,12 @@
 package utils
 
-import org.scalatest.FunSuite
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import org.scalatest.Matchers
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 import play.api.mvc.AnyContentAsEmpty
 
-class RemoteAddressTest extends FunSuite with Matchers {
+class RemoteAddressTest extends AnyFunSuite with Matchers {
   object TestRemoteAddress extends RemoteAddress
 
   val xFor = "X-Forwarded-For"

--- a/identity/test/utils/ThirdPartyConditionsTest.scala
+++ b/identity/test/utils/ThirdPartyConditionsTest.scala
@@ -1,9 +1,10 @@
 package utils
 
-import org.scalatest.{FunSuite, Matchers}
 import ThirdPartyConditions._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class ThirdPartyConditionsTest extends FunSuite with Matchers {
+class ThirdPartyConditionsTest extends AnyFunSuite with Matchers {
 
   test("validation of group code returns Some for a valid group code") {
     val thirdPartyConditions = List("GRS")

--- a/onward/test/MostPopularControllerTest.scala
+++ b/onward/test/MostPopularControllerTest.scala
@@ -2,13 +2,15 @@ package test
 
 import controllers.MostPopularController
 import feed.{DayMostPopularAgent, GeoMostPopularAgent, MostPopularAgent}
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import play.api.test._
 import play.api.test.Helpers._
 import services.OphanApi
 
 @DoNotDiscover class MostPopularControllerTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/onward/test/MostPopularFeatureTest.scala
+++ b/onward/test/MostPopularFeatureTest.scala
@@ -1,15 +1,17 @@
 package test
 
-import collection.JavaConverters._
-import org.scalatest.{DoNotDiscover, Matchers, GivenWhenThen, FeatureSpec}
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
+
+import org.scalatest.{DoNotDiscover, GivenWhenThen}
 
 @DoNotDiscover class MostPopularFeatureTest
-    extends FeatureSpec
+    extends AnyFeatureSpec
     with GivenWhenThen
     with Matchers
     with ConfiguredTestSuite {
 
-  feature("Most popular") {
+  Feature("Most popular") {
 
     // Feature
 
@@ -23,7 +25,7 @@ import org.scalatest.{DoNotDiscover, Matchers, GivenWhenThen, FeatureSpec}
 
     // Scenarios
 
-    scenario("Most popular for a section") {
+    Scenario("Most popular for a section") {
 
       Given("I am on a page in the 'World' section")
       goTo("/most-read/world") { browser =>

--- a/onward/test/MostViewedVideoTest.scala
+++ b/onward/test/MostViewedVideoTest.scala
@@ -2,12 +2,14 @@ package test
 
 import controllers.MostViewedVideoController
 import feed.MostViewedVideoAgent
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import play.api.test.Helpers._
 import services.OphanApi
 
 @DoNotDiscover class MostViewedVideoTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/onward/test/NavigationControllerTest.scala
+++ b/onward/test/NavigationControllerTest.scala
@@ -1,12 +1,14 @@
 package test
 
 import controllers.NavigationController
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.test._
 import play.api.test.Helpers._
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 
 @DoNotDiscover class NavigationControllerTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/onward/test/OnwardContentCardControllerTest.scala
+++ b/onward/test/OnwardContentCardControllerTest.scala
@@ -1,12 +1,14 @@
 package test
 
-import controllers.{RecommendedContentCardController, RichLinkController}
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import controllers.RichLinkController
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import play.api.test.Helpers.{contentAsString, contentType, _}
 import play.api.test._
 
 @DoNotDiscover class OnwardContentCardControllerTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/onward/test/RecommendedContentCardControllerTest.scala
+++ b/onward/test/RecommendedContentCardControllerTest.scala
@@ -1,10 +1,12 @@
 package test
 import controllers.RecommendedContentCardController
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
+import org.scalatest.matchers.should.Matchers
 import play.api.test.Helpers._
 
 @DoNotDiscover class RecommendedContentCardControllerTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/onward/test/RelatedControllerTest.scala
+++ b/onward/test/RelatedControllerTest.scala
@@ -2,13 +2,15 @@ package test
 
 import controllers.RelatedController
 import feed.MostReadAgent
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.test._
 import play.api.test.Helpers._
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import services.OphanApi
 
 @DoNotDiscover class RelatedControllerTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/onward/test/RelatedFeatureTest.scala
+++ b/onward/test/RelatedFeatureTest.scala
@@ -1,10 +1,16 @@
 package test
 
-import org.scalatest.{DoNotDiscover, Matchers, GivenWhenThen, FeatureSpec}
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{DoNotDiscover, GivenWhenThen}
 
-@DoNotDiscover class RelatedFeatureTest extends FeatureSpec with GivenWhenThen with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class RelatedFeatureTest
+    extends AnyFeatureSpec
+    with GivenWhenThen
+    with Matchers
+    with ConfiguredTestSuite {
 
-  feature("Related links") {
+  Feature("Related links") {
 
     // Feature
 
@@ -18,7 +24,7 @@ import org.scalatest.{DoNotDiscover, Matchers, GivenWhenThen, FeatureSpec}
 
     // Features
 
-    scenario("Shows related links for each article") {
+    Scenario("Shows related links for each article") {
 
       Given("there is an article 'Woman tortured during burglary tells of waterboarding ordeal'")
       goTo("/related/uk/2012/aug/07/woman-torture-burglary-waterboard-surrey") { browser =>

--- a/onward/test/RichLinkControllerTest.scala
+++ b/onward/test/RichLinkControllerTest.scala
@@ -1,11 +1,13 @@
 package test
 
 import controllers.RichLinkController
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
+import org.scalatest.matchers.should.Matchers
 import play.api.test.Helpers._
 
 @DoNotDiscover class RichLinkControllerTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/onward/test/SeriesControllerTest.scala
+++ b/onward/test/SeriesControllerTest.scala
@@ -1,11 +1,13 @@
 package test
 
 import controllers.SeriesController
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
+import org.scalatest.matchers.should.Matchers
 import play.api.test.Helpers._
 
 @DoNotDiscover class SeriesControllerTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/onward/test/TopStoriesControllerTest.scala
+++ b/onward/test/TopStoriesControllerTest.scala
@@ -1,12 +1,14 @@
 package test
 
 import controllers.TopStoriesController
+import org.scalatest.flatspec.AnyFlatSpec
 import play.api.test._
 import play.api.test.Helpers._
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
+import org.scalatest.matchers.should.Matchers
 
 @DoNotDiscover class TopStoriesControllerTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/onward/test/VideoInSectionTest.scala
+++ b/onward/test/VideoInSectionTest.scala
@@ -2,11 +2,13 @@ package test
 
 import conf.Configuration
 import controllers.MediaInSectionController
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
+import org.scalatest.matchers.should.Matchers
 import play.api.test.Helpers._
 
 @DoNotDiscover class VideoInSectionTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterAll

--- a/onward/test/business/ModelsTest.scala
+++ b/onward/test/business/ModelsTest.scala
@@ -1,9 +1,10 @@
 package business
 
 import common.ResourcesHelper
-import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ModelsTest extends FlatSpec with Matchers with ResourcesHelper {
+class ModelsTest extends AnyFlatSpec with Matchers with ResourcesHelper {
   "models" should "correctly deserialize" in {
     val json = slurpJsonOrDie[Indices]("business-indices.json")
 

--- a/onward/test/controllers/ChangeEditionControllerTest.scala
+++ b/onward/test/controllers/ChangeEditionControllerTest.scala
@@ -1,12 +1,13 @@
 package controllers
 
-import conf.switches.Switches
+import org.scalatest.flatspec.AnyFlatSpec
 import play.api.test.Helpers.{cookies => playCookies, _}
-import org.scalatest.{BeforeAndAfterEach, DoNotDiscover, Matchers, FlatSpec}
+import org.scalatest.{BeforeAndAfterEach, DoNotDiscover}
+import org.scalatest.matchers.should.Matchers
 import test.{ConfiguredTestSuite, TestRequest}
 
 @DoNotDiscover class ChangeEditionControllerTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with BeforeAndAfterEach {

--- a/onward/test/model/TopStoriesFeatureTest.scala
+++ b/onward/test/model/TopStoriesFeatureTest.scala
@@ -1,17 +1,19 @@
 package model
 
-import org.scalatest.{DoNotDiscover, Matchers, GivenWhenThen, FeatureSpec}
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{DoNotDiscover, GivenWhenThen}
 import test.ConfiguredTestSuite
 
 @DoNotDiscover class TopStoriesFeatureTest
-    extends FeatureSpec
+    extends AnyFeatureSpec
     with GivenWhenThen
     with Matchers
     with ConfiguredTestSuite {
 
-  feature("Latest top stories") {
+  Feature("Latest top stories") {
 
-    scenario("Shows latest links when on a page in the UK edition") {
+    Scenario("Shows latest links when on a page in the UK edition") {
 
       Given("I am on any page in the UK edition")
       goTo("/top-stories") { browser =>
@@ -24,7 +26,7 @@ import test.ConfiguredTestSuite
       }
     }
 
-    scenario("Shows latest links for a section in US edition") {
+    Scenario("Shows latest links for a section in US edition") {
       Given("I am on any page in the US edition")
       US("/top-stories") { browser =>
         import browser._

--- a/onward/test/package.scala
+++ b/onward/test/package.scala
@@ -1,7 +1,7 @@
 package test
 
-import controllers._
 import org.scalatest.Suites
+import org.scalatestplus.play.PortNumber
 
 class OnwardTestSuite
     extends Suites(
@@ -18,6 +18,4 @@ class OnwardTestSuite
       new RichLinkControllerTest,
       new NavigationControllerTest,
     )
-    with SingleServerSuite {
-  override lazy val port: Int = 19011
-}
+    with SingleServerSuite {}

--- a/onward/test/weather/WeatherApiTest.scala
+++ b/onward/test/weather/WeatherApiTest.scala
@@ -1,17 +1,19 @@
 package weather
 
 import akka.actor.ActorSystem
-import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
 import play.api.libs.json.{JsString, JsValue}
 import org.mockito.Mockito._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.Future
 import scala.language.postfixOps
 
-class WeatherApiTest extends FlatSpec with ScalaFutures with Matchers with MockitoSugar {
+class WeatherApiTest extends AnyFlatSpec with ScalaFutures with Matchers with MockitoSugar {
   val actorSystem = ActorSystem()
 
   "retryWeatherRequest" should "return for a successful future" in {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -55,6 +55,8 @@ object Dependencies {
   val nScalaTime = "com.github.nscala-time" %% "nscala-time" % "2.30.0"
   val scalaTest = "org.scalatest" %% "scalatest" % "3.2.11" % Test
   val scalaTestPlus = "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test
+  val scalaTestPlusMockito = "org.scalatestplus" %% "mockito-3-4" % "3.3.0.0-SNAP3" % Test
+  val scalaTestPlusScalacheck = "org.scalatestplus" %% "scalacheck-1-15" % "3.2.11.0" % Test
   val scalaUri = "io.lemonlabs" %% "scala-uri" % "3.0.0"
   val seleniumJava = "org.seleniumhq.selenium" % "selenium-java" % "2.44.0"
   val slf4jExt = "org.slf4j" % "slf4j-ext" % "1.7.36"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -51,10 +51,10 @@ object Dependencies {
   val redisClient = "net.debasishg" %% "redisclient" % "3.42"
   val rome = "rome" % "rome" % romeVersion
   val romeModules = "org.rometools" % "rome-modules" % romeVersion
-  val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.13.5" % Test
+  val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.16.0" % Test
   val nScalaTime = "com.github.nscala-time" %% "nscala-time" % "2.30.0"
-  val scalaTest = "org.scalatest" %% "scalatest" % "3.0.4" % Test
-  val scalaTestPlus = "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.1" % Test
+  val scalaTest = "org.scalatest" %% "scalatest" % "3.2.11" % Test
+  val scalaTestPlus = "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test
   val scalaUri = "io.lemonlabs" %% "scala-uri" % "3.0.0"
   val seleniumJava = "org.seleniumhq.selenium" % "selenium-java" % "2.44.0"
   val slf4jExt = "org.slf4j" % "slf4j-ext" % "1.7.36"

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -71,6 +71,8 @@ object ProjectSettings {
     libraryDependencies ++= Seq(
       scalaTest,
       scalaTestPlus,
+      scalaTestPlusMockito,
+      scalaTestPlusScalacheck,
       mockito,
     ),
     // These settings are needed for forking, which in turn is needed for concurrent restrictions.

--- a/sport/test/CompetitionAgentTest.scala
+++ b/sport/test/CompetitionAgentTest.scala
@@ -2,14 +2,17 @@ package test
 
 import feed.CompetitionsService
 import model.Competition
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
-import org.scalatest.concurrent.{ScalaFutures, Eventually}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Millis, Span}
-import java.time.{ZonedDateTime, Clock, LocalDate}
+
+import java.time.{Clock, LocalDate, ZonedDateTime}
 import java.time.ZoneId
 
 @DoNotDiscover class CompetitionAgentTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with ConfiguredTestSuite
     with Matchers
     with implicits.Football

--- a/sport/test/FixturesFeatureTest.scala
+++ b/sport/test/FixturesFeatureTest.scala
@@ -1,19 +1,22 @@
 package test
 
-import org.scalatest.{DoNotDiscover, FeatureSpec, GivenWhenThen, Matchers}
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{DoNotDiscover, GivenWhenThen}
+
 import collection.JavaConverters._
 import tools.MatchListFeatureTools
 
 @DoNotDiscover class FixturesFeatureTest
-    extends FeatureSpec
+    extends AnyFeatureSpec
     with GivenWhenThen
     with Matchers
     with MatchListFeatureTools
     with ConfiguredTestSuite {
 
-  feature("Football Fixtures") {
+  Feature("Football Fixtures") {
 
-    scenario("Visit the fixtures page") {
+    Scenario("Visit the fixtures page") {
 
       Given("I visit the fixtures page")
 
@@ -31,7 +34,7 @@ import tools.MatchListFeatureTools
       }
     }
 
-    scenario("Next fixtures") {
+    Scenario("Next fixtures") {
       Given("I am on the fixtures page")
       goTo("/football/fixtures") { browser =>
         import browser._
@@ -46,7 +49,7 @@ import tools.MatchListFeatureTools
       }
     }
 
-    scenario("Link tracking") {
+    Scenario("Link tracking") {
       Given("I visit the fixtures page")
       goTo("/football/fixtures/2012/oct/20") { browser =>
         import browser._

--- a/sport/test/LeagueTablesFeatureTest.scala
+++ b/sport/test/LeagueTablesFeatureTest.scala
@@ -4,9 +4,11 @@ import football.controllers.LeagueTableController
 import play.api.test._
 import play.api.test.Helpers._
 import org.scalatest._
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
 
 @DoNotDiscover class LeagueTablesFeatureTest
-    extends FeatureSpec
+    extends AnyFeatureSpec
     with GivenWhenThen
     with Matchers
     with ConfiguredTestSuite
@@ -18,9 +20,9 @@ import org.scalatest._
     with WithTestApplicationContext
     with WithTestWsClient {
 
-  feature("League Tables") {
+  Feature("League Tables") {
 
-    scenario("Visit 'all tables' page") {
+    Scenario("Visit 'all tables' page") {
       Given("I visit the a all tables page")
 
       goTo("/football/tables") { browser =>
@@ -46,7 +48,7 @@ import org.scalatest._
       }
     }
 
-    scenario("Visit 'competition table' page") {
+    Scenario("Visit 'competition table' page") {
       Given("I visit the a competition league table page")
 
       goTo("/football/premierleague/table") { browser =>
@@ -63,7 +65,7 @@ import org.scalatest._
       }
     }
 
-    scenario("Should redirect when no competition table data found") {
+    Scenario("Should redirect when no competition table data found") {
       val leagueTableController =
         new LeagueTableController(testCompetitionsService, play.api.test.Helpers.stubControllerComponents())
       val result = leagueTableController.renderCompetition("sfgsfgsfg")(FakeRequest())

--- a/sport/test/LiveMatchesFeatureTest.scala
+++ b/sport/test/LiveMatchesFeatureTest.scala
@@ -1,18 +1,20 @@
 package test
 
-import org.scalatest.{DoNotDiscover, FeatureSpec, GivenWhenThen, Matchers}
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{DoNotDiscover, GivenWhenThen}
 import tools.MatchListFeatureTools
 
 @DoNotDiscover class LiveMatchesFeatureTest
-    extends FeatureSpec
+    extends AnyFeatureSpec
     with GivenWhenThen
     with Matchers
     with MatchListFeatureTools
     with ConfiguredTestSuite {
 
-  feature("Live Matches") {
+  Feature("Live Matches") {
 
-    scenario("Visit the live matches") {
+    Scenario("Visit the live matches") {
 
       Given("I visit the live matches page")
 
@@ -33,7 +35,7 @@ import tools.MatchListFeatureTools
       }
     }
 
-    scenario("Competition fixtures filter") {
+    Scenario("Competition fixtures filter") {
 
       Given("I am on the premier league live matches page")
       goTo("/football/premierleague/live") { browser =>

--- a/sport/test/MatchFeatureTest.scala
+++ b/sport/test/MatchFeatureTest.scala
@@ -1,14 +1,16 @@
 package test
 
-import org.scalatest.{DoNotDiscover, FeatureSpec, GivenWhenThen, Matchers}
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{DoNotDiscover, GivenWhenThen}
 
 import scala.collection.JavaConverters._
 
-@DoNotDiscover class MatchFeatureTest extends FeatureSpec with GivenWhenThen with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class MatchFeatureTest extends AnyFeatureSpec with GivenWhenThen with Matchers with ConfiguredTestSuite {
 
-  feature("MatchPage") {
+  Feature("MatchPage") {
 
-    scenario("Visit match page") {
+    Scenario("Visit match page") {
 
       Given("I visit a match page")
 

--- a/sport/test/ResultsFeatureTest.scala
+++ b/sport/test/ResultsFeatureTest.scala
@@ -1,19 +1,22 @@
 package test
 
-import org.scalatest.{DoNotDiscover, FeatureSpec, GivenWhenThen, Matchers}
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{DoNotDiscover, GivenWhenThen}
+
 import collection.JavaConverters._
 import tools.MatchListFeatureTools
 
 @DoNotDiscover class ResultsFeatureTest
-    extends FeatureSpec
+    extends AnyFeatureSpec
     with GivenWhenThen
     with Matchers
     with MatchListFeatureTools
     with ConfiguredTestSuite {
 
-  feature("Football Results") {
+  Feature("Football Results") {
 
-    scenario("Visit the results page") {
+    Scenario("Visit the results page") {
 
       Given("I visit the results page")
 
@@ -44,7 +47,7 @@ import tools.MatchListFeatureTools
       }
     }
 
-    scenario("Next results") {
+    Scenario("Next results") {
       Given("I am on the results page")
       goTo("/football/results") { browser =>
         import browser._
@@ -59,7 +62,7 @@ import tools.MatchListFeatureTools
       }
     }
 
-    scenario("Competition results filter") { // filter has been removed and will be re-implemented differently
+    Scenario("Competition results filter") { // filter has been removed and will be re-implemented differently
 
       Given("I am on the the results page")
       goTo("/football/results") { browser =>
@@ -82,7 +85,7 @@ import tools.MatchListFeatureTools
       }
     }
 
-    scenario("Link tracking") {
+    Scenario("Link tracking") {
       Given("I visit the results page")
       goTo("/football/results") { browser =>
         import browser._

--- a/sport/test/controllers/CompetitionListControllerTest.scala
+++ b/sport/test/controllers/CompetitionListControllerTest.scala
@@ -1,12 +1,14 @@
 package test
 
 import football.controllers.CompetitionListController
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.test._
 import play.api.test.Helpers._
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 
 @DoNotDiscover class CompetitionListControllerTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with ConfiguredTestSuite
     with Matchers
     with FootballTestData

--- a/sport/test/controllers/FixturesControllerTest.scala
+++ b/sport/test/controllers/FixturesControllerTest.scala
@@ -4,9 +4,11 @@ import football.controllers.FixturesController
 import play.api.test._
 import play.api.test.Helpers._
 import org.scalatest._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 @DoNotDiscover class FixturesControllerTest
-    extends FreeSpec
+    extends AnyFreeSpec
     with ConfiguredTestSuite
     with Matchers
     with FootballTestData

--- a/sport/test/controllers/LeagueTableControllerTest.scala
+++ b/sport/test/controllers/LeagueTableControllerTest.scala
@@ -1,12 +1,14 @@
 package test
 
 import football.controllers.LeagueTableController
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.test._
 import play.api.test.Helpers._
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 
 @DoNotDiscover class LeagueTableControllerTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with ConfiguredTestSuite
     with Matchers
     with FootballTestData

--- a/sport/test/controllers/MatchControllerTest.scala
+++ b/sport/test/controllers/MatchControllerTest.scala
@@ -1,11 +1,13 @@
 package test
 
 import football.controllers.MatchController
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.test.Helpers._
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 
 @DoNotDiscover class MatchControllerTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with ConfiguredTestSuite
     with Matchers
     with BeforeAndAfterAll

--- a/sport/test/controllers/MoreOnMatchFeatureTest.scala
+++ b/sport/test/controllers/MoreOnMatchFeatureTest.scala
@@ -2,11 +2,13 @@ package test
 
 import org.scalatest._
 import football.controllers.MoreOnMatchController
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.test.Helpers._
 import play.api.test.FakeRequest
 
 @DoNotDiscover class MoreOnMatchFeatureTest
-    extends FeatureSpec
+    extends AnyFeatureSpec
     with GivenWhenThen
     with Matchers
     with ConfiguredTestSuite
@@ -23,9 +25,9 @@ import play.api.test.FakeRequest
     play.api.test.Helpers.stubControllerComponents(),
   )
 
-  feature("Match Nav") {
+  Feature("Match Nav") {
 
-    scenario("View content related to a match") {
+    Scenario("View content related to a match") {
 
       Given("I visit a match page")
 
@@ -48,7 +50,7 @@ import play.api.test.FakeRequest
       }
     }
 
-    scenario("Non-existant match pages return status 404") {
+    Scenario("Non-existant match pages return status 404") {
 
       Given("I visit a non-existant match page")
 
@@ -64,9 +66,9 @@ import play.api.test.FakeRequest
     }
   }
 
-  feature("More on match") {
+  Feature("More on match") {
 
-    scenario("View content related to a match") {
+    Scenario("View content related to a match") {
 
       Given("I visit a match page")
 
@@ -88,7 +90,7 @@ import play.api.test.FakeRequest
       }
     }
 
-    scenario("Non-existant match pages return status 404") {
+    Scenario("Non-existant match pages return status 404") {
 
       Given("I visit a non-existant match page")
 

--- a/sport/test/controllers/ResultsControllerTest.scala
+++ b/sport/test/controllers/ResultsControllerTest.scala
@@ -2,7 +2,9 @@ package controllers
 
 import akka.stream.Materializer
 import football.controllers.ResultsController
-import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -11,7 +13,7 @@ import test._
 import scala.concurrent.Future
 
 @DoNotDiscover class ResultsControllerTest
-    extends WordSpec
+    extends AnyWordSpec
     with ConfiguredTestSuite
     with Matchers
     with FootballTestData

--- a/sport/test/football/collections/RichListTest.scala
+++ b/sport/test/football/collections/RichListTest.scala
@@ -1,9 +1,11 @@
 package football.collections
 
-import org.scalatest.{DoNotDiscover, Matchers, FunSuite}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.DoNotDiscover
+import org.scalatest.matchers.should.Matchers
 import test.ConfiguredTestSuite
 
-@DoNotDiscover class RichListTest extends FunSuite with Matchers with RichList with ConfiguredTestSuite {
+@DoNotDiscover class RichListTest extends AnyFunSuite with Matchers with RichList with ConfiguredTestSuite {
   test("Should group simple List correctly") {
     val l = List(1, 1, 2, 3, 3, 3, 4, 5, 5)
     l.segment() should equal(

--- a/sport/test/football/containers/FixturesAndResultsTest.scala
+++ b/sport/test/football/containers/FixturesAndResultsTest.scala
@@ -1,10 +1,12 @@
 package football.containers
 
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import test._
 
 @DoNotDiscover class FixturesAndResultsTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ConfiguredTestSuite
     with WithTestApplicationContext

--- a/sport/test/football/feed/CompetitionsTest.scala
+++ b/sport/test/football/feed/CompetitionsTest.scala
@@ -1,15 +1,16 @@
 package football.feed
 
 import java.time.{Clock, Duration, ZoneId, ZonedDateTime}
-
 import feed.Competitions
 import org.scalatest._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 import pa.FootballMatch
-import test.FootballTestData.{competitions, result, liveMatch, fixture}
+import test.FootballTestData.{competitions, fixture, liveMatch, result}
 
 case class TestCase(isLive: Boolean, startTimeDelta: Duration, expectedStatus: Boolean)
 
-class CompetitionsTest extends FreeSpec with Matchers with OptionValues {
+class CompetitionsTest extends AnyFreeSpec with Matchers with OptionValues {
   "Competitions" - {
     Seq(
       TestCase(false, Duration.ofSeconds(1), true),

--- a/sport/test/football/model/CompetitionStageTest.scala
+++ b/sport/test/football/model/CompetitionStageTest.scala
@@ -3,12 +3,15 @@ package football.model
 import org.scalatest._
 import pa.{Round, Stage}
 import org.scalatest.matchers.{BePropertyMatchResult, BePropertyMatcher}
+
 import java.time.ZonedDateTime
 import implicits.Collections
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 import test._
 
 @DoNotDiscover class CompetitionStageTest
-    extends FreeSpec
+    extends AnyFreeSpec
     with Matchers
     with OptionValues
     with CompetitionTestData

--- a/sport/test/football/model/FixturesListTest.scala
+++ b/sport/test/football/model/FixturesListTest.scala
@@ -1,14 +1,17 @@
 package football.model
 
-import org.scalatest.{DoNotDiscover, OptionValues, FreeSpec, Matchers}
+import org.scalatest.{DoNotDiscover, OptionValues}
 import implicits.Football
 import pa.{Fixture, FootballMatch, MatchDay}
 import model.Competition
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 import test.ConfiguredTestSuite
+
 import java.time.format.DateTimeFormatter
 
 @DoNotDiscover class FixturesListTest
-    extends FreeSpec
+    extends AnyFreeSpec
     with Matchers
     with MatchTestData
     with Football

--- a/sport/test/football/model/MatchDayListTest.scala
+++ b/sport/test/football/model/MatchDayListTest.scala
@@ -2,10 +2,12 @@ package football.model
 
 import org.scalatest._
 import implicits.Football
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 import test.ConfiguredTestSuite
 
 @DoNotDiscover class MatchDayListTest
-    extends FreeSpec
+    extends AnyFreeSpec
     with Matchers
     with MatchTestData
     with Football

--- a/sport/test/football/model/ResultsListTest.scala
+++ b/sport/test/football/model/ResultsListTest.scala
@@ -2,12 +2,14 @@ package football.model
 
 import org.scalatest._
 import implicits.Football
-import pa.{FootballMatch, Result, MatchDay}
+import pa.{FootballMatch, MatchDay, Result}
 import model.Competition
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 import test.ConfiguredTestSuite
 
 @DoNotDiscover class ResultsListTest
-    extends FreeSpec
+    extends AnyFreeSpec
     with Matchers
     with MatchTestData
     with Football

--- a/sport/test/football/model/TeamColoursTest.scala
+++ b/sport/test/football/model/TeamColoursTest.scala
@@ -1,11 +1,13 @@
 package football.model
 
-import org.scalatest.{DoNotDiscover, FreeSpec, Matchers}
+import org.scalatest.DoNotDiscover
 import model.TeamColours
-import pa.{Official, LineUpTeam}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import pa.{LineUpTeam, Official}
 import test.ConfiguredTestSuite
 
-@DoNotDiscover class TeamColoursTest extends FreeSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class TeamColoursTest extends AnyFreeSpec with Matchers with ConfiguredTestSuite {
   "home team colour" - {
     "should be left as-is if it is the same as the away team" in {
       TeamColours(fakeTeam("#333333"), fakeTeam("#333333")).home should equal("#333333")

--- a/sport/test/package.scala
+++ b/sport/test/package.scala
@@ -1,12 +1,12 @@
 package test
 
 import java.io.File
-
 import conf.{FootballClient, SportConfiguration}
 import football.collections.RichListTest
 import football.containers.FixturesAndResultsTest
 import football.model._
 import org.scalatest.Suites
+import org.scalatestplus.play.PortNumber
 import pa.{Http, Response => PaResponse}
 import play.api.libs.ws.WSClient
 import recorder.{DefaultHttpRecorder, HttpRecorder}
@@ -36,9 +36,7 @@ class SportTestSuite
       new ResultsFeatureTest,
       new FixturesAndResultsTest,
     )
-    with SingleServerSuite {
-  override lazy val port: Int = 19013
-}
+    with SingleServerSuite {}
 
 trait WithTestFootballClient {
   self: WithTestExecutionContext =>

--- a/sport/test/rugby/feed/PAFeedTest.scala
+++ b/sport/test/rugby/feed/PAFeedTest.scala
@@ -1,7 +1,8 @@
 package rugby.feed
 
 import org.joda.time.DateTime
-import org.scalatest.{AsyncFlatSpec, Matchers}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
 import rugby.model.{Match, Stage, Status, Team}
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/sport/test/rugby/model/PAMatchParserTest.scala
+++ b/sport/test/rugby/model/PAMatchParserTest.scala
@@ -1,12 +1,13 @@
 package rugby.model
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import rugby.feed.{JsonParseException, PAMatchesResponse}
 
 import scala.io.Source
 import scala.util.Try
 
-class PAMatchParserTest extends FlatSpec with Matchers {
+class PAMatchParserTest extends AnyFlatSpec with Matchers {
 
   behavior of "PA Match parser"
 

--- a/sport/test/tools/MatchListFeatureTools.scala
+++ b/sport/test/tools/MatchListFeatureTools.scala
@@ -1,10 +1,11 @@
 package tools
 
-import org.fluentlenium.core.domain.{FluentWebElement, FluentList}
+import org.fluentlenium.core.domain.{FluentList, FluentWebElement}
 import org.openqa.selenium.interactions.Actions
 import play.api.test.TestBrowser
+
 import collection.JavaConverters._
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 
 trait MatchListFeatureTools extends Matchers {
 


### PR DESCRIPTION
Closes #24933 

As part of the upgrade to Scala 2.13 these dependencies are now compatible with both 2.12 and 2.13

## What does this change?

### Dependencies

In `Dependencies.scala`:
* Updates / Adds the following dependencies:

| Dependency                                         | Before   | After             |
|----------------------------------------------------|----------|-------------------|
| `"org.scalacheck" %% "scalacheck" %`               | `1.13.5` | `1.16.0`          |
| `"org.scalatest" %% "scalatest"`                   | `3.0.4`  | `3.2.11`          |
| `"org.scalatestplus.play" %% "scalatestplus-play"` | `3.1.1`  | `5.1.0`           |
| `"org.scalatestplus" %% "mockito-3-4"`             |          | `"3.3.0.0-SNAP3"` |
| `"org.scalatestplus" %% "scalacheck-1-15"`         |          | `"3.2.11.0"`      |

* `org.scalatestplus.mockito-3-4` had to be added to have access to `MockitoSugar`. It is now imported from `org.scalatestplus.mockito.MockitoSugar`

* `org.scalatestplus.scalacheck-1-15` had to be added because instead of using `GeneratorDrivenPropertyChecks` we are now using `ScalaCheckDrivenPropertyChecks`. The first was removed (`scalatest` recommendation here:  https://github.com/scalatest/scalatest/issues/1735). The second is now imported from `org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks` (e.g. `common/test/layout/slices/DynamicContainerTest.scala`).


### Renaming / Re-importing

After the above dependencies are upgraded / added, the following changes had to be made in the test files:

| Class    | Renamed to  | Re-imported from                   |
|----------|-------------|------------------------------------|
| WordSpec | AnyWordSpec | org.scalatest.wordspec.AnyWordSpec |
| WordSpecLike | AnyWordSpecLike | org.scalatest.wordspec.AnyWordSpecLike |
| FlatSpec | AnyFlatSpec | org.scalatest.flatspec.AnyFlatSpec |
| FreeSpec | AnyFreeSpec | org.scalatest.freespec.AnyFreeSpec |
| FeatureSpec | AnyFeatureSpec | org.scalatest.featurespec.AnyFeatureSpec |
| FlatSpecLike | AnyFlatSpecLike | org.scalatest.flatspec.AnyFlatSpecLike |
| FunSuite | AnyFunSuite | org.scalatest.funsuite.AnyFunSuite |
| WordSpec | AnyWordSpec | org.scalatest.wordspec.AnyWordSpec |
| path.FreeSpec | PathAnyFreeSpec | org.scalatest.freespec.PathAnyFreeSpec |
| Matchers | Same name | org.scalatest.matchers.should.Matchers |

because the previous classes were renamed in `scalatest:3.1.0` (https://www.scalatest.org/release_notes/3.1.0) and removed in `scalatest:3.2.0` (https://www.scalatest.org/release_notes/3.2.0).


### Deprecated functions

* `feature` is deprecated. We're now using `Feature`
* `scenario` is deprecated. We're now using `Scenario`
Doc here: https://javadoc.io/doc/org.scalatest/scalatest-featurespec_2.12/3.2.11/org/scalatest/featurespec/AnyFeatureSpec.html

* In `identity/test/services/MembersDataApiServiceTest.scala` `either.right` was replaced by `either.value` because the `.right.value` syntax on `Either` is deprecated and will be removed. We should use `.value`: https://javadoc.io/doc/org.scalatest/scalatest-core_2.12/latest/org/scalatest/EitherValues.html

### Remove overriding the port in test suites that implement `SingleServerSuite`

Overriding the port was introduced by this PR: https://github.com/guardian/frontend/pull/14736. However, in the new `scalatestplus-play` version it cannot be overriden as it's `final`: https://github.com/playframework/scalatestplus-play/blob/main/module/src/main/scala/org/scalatestplus/play/ServerProvider.scala#L48. At the moment, there does not seem to be any other option for configuring the port: https://github.com/playframework/scalatestplus-play/pull/123

Test are passing after this bit of code gets removed. There seems to be automatic allocation of ports (in a range of 24000 -2^16) so it seems reasonable to not replace the `port` override with new code that configures it. 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
