### PR TITLE
Add support for cricket match urls to DCR data model

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -276,6 +276,18 @@ final case class Content(
       ("contributorBio", JsString(contributorBio.getOrElse(""))),
     )
 
+  def cricketTeam: Option[String] = {
+    if (tags.isCricketLiveBlog && conf.switches.Switches.CricketScoresSwitch.isSwitchedOn) {
+      CricketTeams.teamFor(this).map(_.wordsForUrl)
+    } else None
+  }
+
+  def cricketMatchDate: Option[String] = {
+    if (tags.isCricketLiveBlog && conf.switches.Switches.CricketScoresSwitch.isSwitchedOn) {
+      Some(trail.webPublicationDate.withZone(DateTimeZone.UTC).toString("yyyy-MM-dd"))
+    } else None
+  }
+
   // Dynamic Meta Data may appear on the page for some content. This should be used for conditional metadata.
   def conditionalConfig: Map[String, JsValue] = {
     val rugbyMeta = if (tags.isRugbyMatch && conf.switches.Switches.RugbyScoresSwitch.isSwitchedOn) {
@@ -287,8 +299,8 @@ final case class Content(
 
     val cricketMeta = if (tags.isCricketLiveBlog && conf.switches.Switches.CricketScoresSwitch.isSwitchedOn) {
       List(
-        CricketTeams.teamFor(this).map(_.wordsForUrl).map(wordsForUrl => "cricketTeam" -> JsString(wordsForUrl)),
-        Some(("cricketMatchDate", JsString(trail.webPublicationDate.withZone(DateTimeZone.UTC).toString("yyyy-MM-dd")))),
+        cricketTeam.map(team => "cricketTeam" -> JsString(team)),
+        cricketMatchDate.map(date => "cricketMatchDate" -> JsString(date)),
       )
     } else Nil
 

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -7,7 +7,6 @@ import common.Maps.RichMap
 import common.commercial.EditionCommercialProperties
 import common.{Chronos, Edition, Localisation, RichRequestHeader}
 import conf.Configuration
-import conf.switches.Switches
 import experiments.ActiveExperiments
 import model.dotcomrendering.pageElements.{PageElement, TextCleaner}
 import model.{
@@ -16,7 +15,6 @@ import model.{
   CanonicalLiveBlog,
   ContentFormat,
   ContentPage,
-  DotcomContentType,
   GUDateTimeFormatNew,
   InteractivePage,
   LiveBlogPage,
@@ -25,7 +23,7 @@ import model.{
 import navigation._
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
-import views.support.{AffiliateLinksCleaner, CamelCase, ContentLayout, JavaScriptPage}
+import views.support.{CamelCase, ContentLayout, JavaScriptPage}
 
 // -----------------------------------------------------------------
 // DCR DataModel
@@ -89,6 +87,7 @@ case class DotcomRenderingDataModel(
     contributionsServiceUrl: String,
     badge: Option[DCRBadge],
     matchUrl: Option[String], // Optional url used for match data
+    matchType: Option[DotcomRenderingMatchType],
     isSpecialReport: Boolean, // Indicates whether the page is a special report.
 )
 
@@ -156,6 +155,7 @@ object DotcomRenderingDataModel {
         "contributionsServiceUrl" -> model.contributionsServiceUrl,
         "badge" -> model.badge,
         "matchUrl" -> model.matchUrl,
+        "matchType" -> model.matchType,
         "isSpecialReport" -> model.isSpecialReport,
       )
 
@@ -398,6 +398,8 @@ object DotcomRenderingDataModel {
       modifiedFormat.design == InteractiveDesign && content.trail.webPublicationDate
         .isBefore(Chronos.javaTimeLocalDateTimeToJodaDateTime(InteractiveSwitchOver.date))
 
+    val matchData = DotcomRenderingUtils.makeMatchData(page)
+
     DotcomRenderingDataModel(
       author = author,
       badge = Badges.badgeFor(content).map(badge => DCRBadge(badge.seriesTag, badge.imageUrl)),
@@ -427,7 +429,8 @@ object DotcomRenderingDataModel {
       linkedData = linkedData,
       main = content.fields.main,
       mainMediaElements = mainMediaElements,
-      matchUrl = DotcomRenderingUtils.makeMatchUrl(page),
+      matchUrl = matchData.map(_.matchUrl),
+      matchType = matchData.map(_.matchType),
       nav = Nav(page, edition),
       openGraphData = page.getOpenGraphProperties,
       pageFooter = PageFooter(FooterLinks.getFooterByEdition(Edition(request))),

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -50,14 +50,14 @@ object DotcomRenderingUtils {
   }
 
   def makeCricketMatch(articlePage: ContentPage): Option[DotcomRenderingMatchData] = {
-    val cricketDate = articlePage.getJavascriptConfig.get("cricketMatchDate").map(_.toString)
-    val cricketTeam = articlePage.getJavascriptConfig.get("cricketTeam").map(_.toString)
+    val cricketDate = articlePage.item.content.cricketMatchDate
+    val cricketTeam = articlePage.item.content.cricketTeam
 
     (cricketDate, cricketTeam) match {
       case (Some(date), Some(team)) =>
         Some(
           DotcomRenderingMatchData(
-            s"${Configuration.ajax.url}/sport/cricket/match/${date.replaceAll("\"", "")}/${team.replaceAll("\"", "")}.json?dcr=true",
+            s"${Configuration.ajax.url}/sport/cricket/match/$date/${team}.json?dcr=true",
             CricketMatchType,
           ),
         )


### PR DESCRIPTION

## What does this change?

Adds the ability for `matchUrl` in the DCR data model to include a cricket match URL
Adds an optional property`matchType` as a way to determine the type of a match URL (options are `CricketMatchType` and `FootballMatchType`)

I had considered using `footballMatchUrl` and `cricketMatchUrl` as an alternative to `matchType`, which would have worked equally as well, but would have required more work to ensure that this is backwards compatible with DCR, I think overall `matchType` is a more expandable model for a future where we might have rugby or even other sports (like tennis?!) 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

As DCR does not currently render Cricket liveblogs, it will continue to receive `matchUrl` for footballs blogs & pages as normal, and in a future PR it will be updated to consume `matchType` and render a cricket component for cricket URLs

## Screenshots

**Before:**
Football
<img width="1078" alt="image" src="https://user-images.githubusercontent.com/9575458/164710297-28aceebe-db73-4600-9703-aad9c70e23f4.png">

Cricket (no match URL)
<img width="1035" alt="image" src="https://user-images.githubusercontent.com/9575458/164710586-73421d5e-2139-4513-9e31-85a72ee04228.png">


**After:**
Football
<img width="424" alt="image" src="https://user-images.githubusercontent.com/9575458/164710355-4d568d20-6584-4d8c-8129-3f489b3b18f4.png">
<img width="1032" alt="image" src="https://user-images.githubusercontent.com/9575458/164710336-f619c964-4b4a-4d94-bed4-d4af3e765554.png">

Cricket
<img width="410" alt="image" src="https://user-images.githubusercontent.com/9575458/164710443-85d2c81c-9a16-4556-a14a-688b0511cf3f.png">
<img width="1038" alt="image" src="https://user-images.githubusercontent.com/9575458/164710484-6a082146-2e5e-4126-b317-59c624ae5295.png">



### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
