### PR TITLE
Temporarily stop putting inline2+ ads in containers

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -155,7 +155,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 								],
 						  }
 						: { desktop: [adSizes.halfPage, adSizes.skyscraper] },
-					!isInline1,
+					false,
 				);
 			});
 		await Promise.all(slots);


### PR DESCRIPTION
## What does this change?

Temporary stop putting inline2+ ads in container divs while we understand a problem this caused.

This change effectively rolls back this PR:

https://github.com/guardian/frontend/pull/24917
