### PR TITLE
fix: data-link-name is secondary

### DIFF
--- a/common/app/views/fragments/nav/headerMenu.scala.html
+++ b/common/app/views/fragments/nav/headerMenu.scala.html
@@ -114,7 +114,7 @@
                         <a class="menu-item__title @item.classList.mkString(" ")"
                            href="@item.url"
                            role="menuitem"
-                           data-link-name="nav2 : @item.title">
+                           data-link-name="nav2 : secondary : @item.title">
                             @item.title
                         </a>
                     </li>
@@ -135,7 +135,7 @@
                         <a class="@{"menu-item__title " ++ item.classList.mkString(" ")}"
                            href="@LinkTo { @item.url }"
                            role="menuitem"
-                           data-link-name="nav2 : @item.title">
+                           data-link-name="nav2 : secondary : @item.title">
                             @item.title
                         </a>
                     </li>
@@ -151,7 +151,7 @@
                         <a class="menu-item__title"
                             role="menuitem"
                             href="@LinkTo { @item.url }"
-                            data-link-name="nav2 : @item.title">
+                            data-link-name="nav2 : secondary : @item.title">
                             @item.title
                         </a>
                     </li>
@@ -162,7 +162,7 @@
                     <a class="menu-item__title"
                        href="https://www.facebook.com/theguardian"
                        role="menuitem"
-                       data-link-name="nav2 : facebook">
+                       data-link-name="nav2 : secondary : facebook">
                         @fragments.inlineSvg("share-facebook", "icon", List("menu-item__icon"), isPresentation = true)
                         Facebook
                     </a>
@@ -173,7 +173,7 @@
                     <a class="menu-item__title"
                        href="https://twitter.com/guardian"
                        role="menuitem"
-                       data-link-name="nav2 : twitter">
+                       data-link-name="nav2 : secondary : twitter">
                         @fragments.inlineSvg("share-twitter", "icon", List("menu-item__icon"), isPresentation = true)
                         Twitter
                     </a>


### PR DESCRIPTION
## What does this change?

Sets the mobile navigation as “secondary”.

I think this was a copy-pasta from some other navigation. [DCR does it right](https://github.com/guardian/dotcom-rendering/blob/73fc0a50a7770cd1d09510773690dd6a0f0adb5d/dotcom-rendering/src/web/components/Nav/ExpandedMenu/MoreColumn.tsx#L248).

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Get parity in https://github.com/guardian/dotcom-rendering/issues/4692

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
