### PR TITLE
Add the ability to show contributors' small byline images in liveblogs

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
@@ -31,6 +31,8 @@ object Tag {
 
   def apply(t: model.Tag): Tag = {
 
+    // We are creating a fallback for small byline images because some contributors have not yet had
+    // larger images taken and uploaded. Once that's done, the aim is to remove the fallback and only use large images.
     val bylineImage: Option[String] = {
       t.properties.contributorLargeImagePath match {
         case Some(bylineLargeImage) => Some(ImgSrc(bylineLargeImage, Item300))

--- a/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
@@ -33,12 +33,11 @@ object Tag {
 
     // We are creating a fallback for small byline images because some contributors have not yet had
     // larger images taken and uploaded. Once that's done, the aim is to remove the fallback and only use large images.
-    val bylineImage: Option[String] = {
+    val bylineImage: Option[String] =
       t.properties.contributorLargeImagePath match {
         case Some(bylineLargeImage) => Some(ImgSrc(bylineLargeImage, Item300))
         case None                   => t.contributorImagePath.map(bylineSmallImage => ImgSrc(bylineSmallImage, Item140))
       }
-    }
 
     Tag(
       t.id,

--- a/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
@@ -10,7 +10,7 @@ import navigation._
 import org.joda.time.DateTime
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
-import views.support.{ImgSrc, Item300}
+import views.support.{ImgSrc, Item140, Item300}
 
 // We have introduced our own set of objects for serializing data to the DotComponents API,
 // because we don't want people changing the core frontend models and as a side effect,
@@ -30,12 +30,20 @@ object Tag {
   implicit val writes = Json.writes[Tag]
 
   def apply(t: model.Tag): Tag = {
+
+    val bylineImage: Option[String] = {
+      t.properties.contributorLargeImagePath match {
+        case Some(bylineLargeImage) => Some(ImgSrc(bylineLargeImage, Item300))
+        case None                   => t.contributorImagePath.map(bylineSmallImage => ImgSrc(bylineSmallImage, Item140))
+      }
+    }
+
     Tag(
       t.id,
       t.properties.tagType,
       t.properties.webTitle,
       t.properties.twitterHandle,
-      t.properties.contributorLargeImagePath.map(src => ImgSrc(src, Item300)),
+      bylineImage,
     )
   }
 }


### PR DESCRIPTION
Fixes issue raised in DCR: https://github.com/guardian/dotcom-rendering/issues/4548

## What does this change?
Small change in the data we send to DCR, so that liveblogs can support contributors' small byline images. 

We're adding this fallback because some contributors have not yet had larger images taken and uploaded. The intention is to remove the fallback once that's done and only use large byline images.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/19683595/165082009-9bae436c-d0a0-46c6-8605-0ebf2c705ec0.png) | ![image](https://user-images.githubusercontent.com/19683595/165081907-a3dc0dee-c7c6-40ec-98b6-1eacc005c9d1.png) |
| ![image](https://user-images.githubusercontent.com/19683595/165082077-c158c982-7f43-4976-9cc1-c9af5a7552d1.png) | ![image](https://user-images.githubusercontent.com/19683595/165082212-a75e1c81-8f90-411e-ac1c-6e5179c5bb9c.png) |

<!-- Please use the following table template to make image comparison easier to parse:

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
