### PR TITLE
ensure Summary title on empty summary posts in DCR

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -2,12 +2,13 @@ package model.dotcomrendering
 
 import com.gu.contentapi.client.model.v1.{Block => APIBlock, Blocks => APIBlocks}
 import com.gu.contentapi.client.utils.AdvertisementFeature
-import com.gu.contentapi.client.utils.format.{ImmersiveDisplay, InteractiveDesign, LiveBlogDesign}
+import com.gu.contentapi.client.utils.format.{ImmersiveDisplay, InteractiveDesign}
 import common.Maps.RichMap
 import common.commercial.EditionCommercialProperties
 import common.{Chronos, Edition, Localisation, RichRequestHeader}
 import conf.Configuration
 import experiments.ActiveExperiments
+import model.dotcomrendering.DotcomRenderingUtils._
 import model.dotcomrendering.pageElements.{PageElement, TextCleaner}
 import model.{
   ArticleDateTimes,
@@ -165,7 +166,7 @@ object DotcomRenderingDataModel {
 
   def toJson(model: DotcomRenderingDataModel): String = {
     val jsValue = Json.toJson(model)
-    Json.stringify(DotcomRenderingUtils.withoutNull(jsValue))
+    Json.stringify(withoutNull(jsValue))
   }
 
   def forInteractive(
@@ -249,16 +250,16 @@ object DotcomRenderingDataModel {
       )
     })
 
-    val bodyBlocks = DotcomRenderingUtils.blocksForLiveblogPage(page, blocks)
+    val bodyBlocks = blocksForLiveblogPage(page, blocks).map(ensureSummaryTitle)
 
-    val allKeyEvents = blocks.body match {
+    val allTimelineBlocks = blocks.body match {
       case Some(allBlocks) if allBlocks.nonEmpty =>
         allBlocks.filter(block => block.attributes.keyEvent.contains(true) || block.attributes.summary.contains(true))
       case _ => keyEventsFallback(blocks)
     }
 
-    val keyEvents: Seq[APIBlock] =
-      allKeyEvents.sortBy(block => block.firstPublishedDate.orElse(block.createdDate).map(_.dateTime)).reverse
+    val timelineBlocks =
+      orderBlocks(allTimelineBlocks).map(ensureSummaryTitle)
 
     val linkedData = LinkedData.forLiveblog(
       liveblog = page,
@@ -267,13 +268,14 @@ object DotcomRenderingDataModel {
       fallbackLogo = Configuration.images.fallbackLogo,
     )
 
-    val pinnedPost: Option[APIBlock] =
+    val pinnedPost =
       blocks.requestedBodyBlocks
         .flatMap(_.get("body:pinned"))
         .getOrElse(blocks.body.fold(Seq.empty[APIBlock])(_.filter(_.attributes.pinned.contains(true))))
         .headOption
+        .map(ensureSummaryTitle)
 
-    val mostRecentBlockId = DotcomRenderingUtils.getMostRecentBlockId(blocks)
+    val mostRecentBlockId = getMostRecentBlockId(blocks)
 
     apply(
       page,
@@ -285,7 +287,7 @@ object DotcomRenderingDataModel {
       pageType,
       page.related.hasStoryPackage,
       pinnedPost,
-      keyEvents,
+      timelineBlocks,
       filterKeyEvents,
       mostRecentBlockId,
       forceLive,
@@ -336,7 +338,7 @@ object DotcomRenderingDataModel {
     val config = Config(
       switches = switches,
       abTests = ActiveExperiments.getJsMap(request),
-      ampIframeUrl = DotcomRenderingUtils.assetURL("data/vendor/amp-iframe.html"),
+      ampIframeUrl = assetURL("data/vendor/amp-iframe.html"),
       googletagUrl = Configuration.googletag.jsLocation,
       stage = common.Environment.stage,
       frontendAssetsFullURL = Configuration.assets.fullURL(common.Environment.stage),
@@ -355,7 +357,16 @@ object DotcomRenderingDataModel {
     val dcrTags = content.tags.tags.map(Tag.apply)
 
     def toDCRBlock(isMainBlock: Boolean = false) = { block: APIBlock =>
-      Block(block, page, shouldAddAffiliateLinks, request, isMainBlock, calloutsUrl, contentDateTimes, dcrTags)
+      Block(
+        block = block,
+        page = page,
+        shouldAddAffiliateLinks = shouldAddAffiliateLinks,
+        request = request,
+        isMainBlock = isMainBlock,
+        calloutsUrl = calloutsUrl,
+        dateTimes = contentDateTimes,
+        tags = dcrTags,
+      )
     }
 
     val mainMediaElements =
@@ -392,13 +403,13 @@ object DotcomRenderingDataModel {
       )
     }
 
-    val modifiedFormat = DotcomRenderingUtils.getModifiedContent(content, forceLive)
+    val modifiedFormat = getModifiedContent(content, forceLive)
 
     val isLegacyInteractive =
       modifiedFormat.design == InteractiveDesign && content.trail.webPublicationDate
         .isBefore(Chronos.javaTimeLocalDateTimeToJodaDateTime(InteractiveSwitchOver.date))
 
-    val matchData = DotcomRenderingUtils.makeMatchData(page)
+    val matchData = makeMatchData(page)
 
     DotcomRenderingDataModel(
       author = author,
@@ -421,7 +432,7 @@ object DotcomRenderingDataModel {
       isCommentable = content.trail.isCommentable,
       isImmersive = isImmersive,
       isLegacyInteractive = isLegacyInteractive,
-      isSpecialReport = DotcomRenderingUtils.isSpecialReport(page),
+      isSpecialReport = isSpecialReport(page),
       filterKeyEvents = filterKeyEvents,
       pinnedPost = pinnedPostDCR,
       keyEvents = keyEventsDCR.toList,
@@ -437,7 +448,7 @@ object DotcomRenderingDataModel {
       pageId = content.metadata.id,
       pageType = pageType, // TODO this info duplicates what is already elsewhere in format?
       pagination = pagination,
-      pillar = DotcomRenderingUtils.findPillar(content.metadata.pillar, content.metadata.designType),
+      pillar = findPillar(content.metadata.pillar, content.metadata.designType),
       publication = content.content.publication,
       sectionLabel = Localisation(content.content.sectionLabelName.getOrElse(""))(request),
       sectionName = content.metadata.section.map(_.value),
@@ -458,7 +469,7 @@ object DotcomRenderingDataModel {
       webPublicationDate = content.trail.webPublicationDate.toString,
       webPublicationDateDisplay =
         GUDateTimeFormatNew.formatDateTimeForDisplay(content.trail.webPublicationDate, request),
-      webPublicationSecondaryDateDisplay = DotcomRenderingUtils.secondaryDateString(content, request),
+      webPublicationSecondaryDateDisplay = secondaryDateString(content, request),
       webTitle = content.metadata.webTitle,
       webURL = content.metadata.webUrl,
     )

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -287,12 +287,8 @@ object DotcomRenderingUtils {
 
   def ensureSummaryTitle(block: APIBlock): APIBlock = {
     if (block.attributes.summary.contains(true) && block.title.isEmpty) {
-      val out = block.copy(title = Some("Summary"))
-      println(">>>> out", out)
-      out
-    } else {
-      block
-    }
+      block.copy(title = Some("Summary"))
+    } else block
   }
 
 }

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -21,7 +21,6 @@ import model.{
   LiveBlogPage,
   Pillar,
 }
-
 import org.joda.time.format.DateTimeFormat
 import play.api.libs.json._
 import play.api.mvc.RequestHeader

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -282,4 +282,17 @@ object DotcomRenderingUtils {
       .map(block => s"block-${block.id}")
   }
 
+  def orderBlocks(blocks: Seq[APIBlock]): Seq[APIBlock] =
+    blocks.sortBy(block => block.firstPublishedDate.orElse(block.createdDate).map(_.dateTime)).reverse
+
+  def ensureSummaryTitle(block: APIBlock): APIBlock = {
+    if (block.attributes.summary.contains(true) && block.title.isEmpty) {
+      val out = block.copy(title = Some("Summary"))
+      println(">>>> out", out)
+      out
+    } else {
+      block
+    }
+  }
+
 }

--- a/common/test/model/dotcomrendering/DotcomRenderingUtilsTest.scala
+++ b/common/test/model/dotcomrendering/DotcomRenderingUtilsTest.scala
@@ -1,14 +1,12 @@
 package model.dotcomrendering.pageElements
 
-import com.gu.contentapi.client.utils.format.{ArticleDesign, InteractiveDesign, LiveBlogDesign, StandardDisplay}
-import model.{CanonicalLiveBlog, ContentFormat, ContentType, DotcomContentType, MetaData}
-import org.scalatest.{FlatSpec, Matchers}
+import com.gu.contentapi.client.model.v1.{Block, BlockAttributes, Blocks}
+import com.gu.contentapi.client.utils.format.LiveBlogDesign
 import model.dotcomrendering.DotcomRenderingUtils
-import org.mockito.Mockito.{verify, verifyZeroInteractions, when}
+import model.{CanonicalLiveBlog, ContentFormat, ContentType, DotcomContentType, MetaData}
+import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
-import com.gu.contentapi.client.model.v1.Blocks
-import com.gu.contentapi.client.model.v1.Block
-import com.gu.contentapi.client.model.v1.BlockAttributes
+import org.scalatest.{FlatSpec, Matchers}
 
 class DotcomRenderingUtilsTest extends FlatSpec with Matchers with MockitoSugar {
 
@@ -117,7 +115,8 @@ class DotcomRenderingUtilsTest extends FlatSpec with Matchers with MockitoSugar 
 
   it should "not change the title of a summary post with a title" in {
     val testBlock1 = mock[Block]
-    val summaryBlockAttributes: BlockAttributes = BlockAttributes(Some(false), Some(true), Some("I have a title"), Some(false), None)
+    val summaryBlockAttributes: BlockAttributes =
+      BlockAttributes(Some(false), Some(true), Some("I have a title"), Some(false), None)
 
     when(testBlock1.title) thenReturn Some("I have a title")
     when(testBlock1.attributes) thenReturn summaryBlockAttributes

--- a/common/test/model/dotcomrendering/DotcomRenderingUtilsTest.scala
+++ b/common/test/model/dotcomrendering/DotcomRenderingUtilsTest.scala
@@ -4,10 +4,11 @@ import com.gu.contentapi.client.utils.format.{ArticleDesign, InteractiveDesign, 
 import model.{CanonicalLiveBlog, ContentFormat, ContentType, DotcomContentType, MetaData}
 import org.scalatest.{FlatSpec, Matchers}
 import model.dotcomrendering.DotcomRenderingUtils
-import org.mockito.Mockito.when
+import org.mockito.Mockito.{verify, verifyZeroInteractions, when}
 import org.scalatest.mockito.MockitoSugar
 import com.gu.contentapi.client.model.v1.Blocks
 import com.gu.contentapi.client.model.v1.Block
+import com.gu.contentapi.client.model.v1.BlockAttributes
 
 class DotcomRenderingUtilsTest extends FlatSpec with Matchers with MockitoSugar {
 
@@ -15,7 +16,7 @@ class DotcomRenderingUtilsTest extends FlatSpec with Matchers with MockitoSugar 
   val testMetadata = mock[MetaData]
   val formatWithArticleDesign = ContentFormat.defaultContentFormat
 
-  it should "ensure a live design takes priority when the forceLive flag is set" in {
+  "getModifiedContent" should "ensure a live design takes priority when the forceLive flag is set" in {
     when(testContent.metadata) thenReturn testMetadata
     when(testMetadata.format) thenReturn Some(formatWithArticleDesign)
     when(testMetadata.contentType) thenReturn Some(DotcomContentType.Article)
@@ -90,5 +91,37 @@ class DotcomRenderingUtilsTest extends FlatSpec with Matchers with MockitoSugar 
     val actual = DotcomRenderingUtils.getMostRecentBlockId(testBlocks)
 
     actual should be(Some("block-testBlockId123"))
+  }
+
+  "ensureSummaryTitle" should "add a title to summary posts without a title" in {
+    val testBlock1 = mock[Block]
+    val testBlock2 = mock[Block]
+    val summaryBlockAttributes = BlockAttributes(Some(false), Some(true), None, Some(false), None)
+
+    when(testBlock1.title) thenReturn None
+    when(testBlock1.attributes) thenReturn summaryBlockAttributes
+    when(testBlock1.copy(title = Some("Summary"))) thenReturn testBlock2
+
+    DotcomRenderingUtils.ensureSummaryTitle(testBlock1) should be(testBlock2)
+  }
+
+  it should "not a title to a non summary posts without a title" in {
+    val testBlock1 = mock[Block]
+    val summaryBlockAttributes = BlockAttributes(Some(true), Some(false), None, Some(false), None)
+
+    when(testBlock1.title) thenReturn None
+    when(testBlock1.attributes) thenReturn summaryBlockAttributes
+
+    DotcomRenderingUtils.ensureSummaryTitle(testBlock1).title should be(None)
+  }
+
+  it should "not change the title of a summary post with a title" in {
+    val testBlock1 = mock[Block]
+    val summaryBlockAttributes: BlockAttributes = BlockAttributes(Some(false), Some(true), Some("I have a title"), Some(false), None)
+
+    when(testBlock1.title) thenReturn Some("I have a title")
+    when(testBlock1.attributes) thenReturn summaryBlockAttributes
+
+    DotcomRenderingUtils.ensureSummaryTitle(testBlock1).title should be(Some("I have a title"))
   }
 }


### PR DESCRIPTION
## What does this change?
Ensures all summary posts on a liveblog have a title, and defaults those that do not to "Summary". 

This should be fixed in Composer such that CAPI is the source of truth for titles: 
https://trello.com/c/12DyqrCD/228-composer-set-default-summary-subheader-in-composer

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/1229808/165140877-47c7bab2-41e6-44d8-8927-4abd99367a94.png
[after]: https://user-images.githubusercontent.com/1229808/165140788-f71a354f-8b78-440b-99a2-067d15932fec.png

### Tested

- [x] Locally
- [ ] On CODE (optional)
