### PR TITLE
update snyk org

### DIFF
--- a/.github/workflows/snyk-pr.yml
+++ b/.github/workflows/snyk-pr.yml
@@ -10,7 +10,7 @@ jobs:
     security:
         uses: guardian/.github/.github/workflows/sbt-node-snyk-pr.yml@main
         with:
-            ORG: guardian-dotcom
+            ORG: guardian-frontend
             SEVERITY_THRESHOLD: critical
         secrets:
             SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -10,6 +10,6 @@ jobs:
     security:
         uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
         with:
-            ORG: guardian-dotcom
+            ORG: guardian-frontend
         secrets:
             SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## What does this change?
Updates the snyk org to `guardian-frontend`.

This is because I thought that this would create the org for us. I then tried to create the org, but I'm not 100% sure I've got all the permissions I need. This uses the current `guardian-frontend` org until I work that out. Then we can then switch to the new one.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)
