### PR TITLE
Support small byline images only for blogs

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
@@ -10,7 +10,7 @@ import navigation._
 import org.joda.time.DateTime
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
-import views.support.{ImgSrc, Item140, Item300}
+import views.support.{ImgSrc, Item300, Item640}
 
 // We have introduced our own set of objects for serializing data to the DotComponents API,
 // because we don't want people changing the core frontend models and as a side effect,
@@ -24,35 +24,20 @@ case class Tag(
     title: String,
     twitterHandle: Option[String],
     bylineImageUrl: Option[String],
-    isLargeBylineImage: Option[Boolean],
+    bylineLargeImageUrl: Option[String],
 )
-
-case class BylineImage(imageUrl: String, isLargeImage: Boolean)
 
 object Tag {
   implicit val writes = Json.writes[Tag]
 
   def apply(t: model.Tag): Tag = {
-
-    // We are creating a fallback for small byline images because some contributors have not yet had
-    // larger images taken and uploaded. Once that's done, the aim is to remove the fallback and only use large images.
-    val bylineImage: Option[BylineImage] =
-      t.properties.contributorLargeImagePath match {
-        case Some(bylineLargeImage) =>
-          Some(BylineImage(imageUrl = ImgSrc(bylineLargeImage, Item300), isLargeImage = true))
-        case None =>
-          t.contributorImagePath.map(bylineSmallImage =>
-            BylineImage(imageUrl = ImgSrc(bylineSmallImage, Item140), isLargeImage = false),
-          )
-      }
-
     Tag(
       t.id,
       t.properties.tagType,
       t.properties.webTitle,
       t.properties.twitterHandle,
-      bylineImage.map(_.imageUrl),
-      bylineImage.map(_.isLargeImage),
+      t.properties.bylineImageUrl.map(src => ImgSrc(src, Item300)),
+      t.properties.contributorLargeImagePath.map(src => ImgSrc(src, Item640)),
     )
   }
 }

--- a/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
@@ -10,7 +10,7 @@ import navigation._
 import org.joda.time.DateTime
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
-import views.support.{ImgSrc, Item300}
+import views.support.{ImgSrc, Item140, Item300}
 
 // We have introduced our own set of objects for serializing data to the DotComponents API,
 // because we don't want people changing the core frontend models and as a side effect,
@@ -24,18 +24,35 @@ case class Tag(
     title: String,
     twitterHandle: Option[String],
     bylineImageUrl: Option[String],
+    isLargeBylineImage: Option[Boolean],
 )
+
+case class BylineImage(imageUrl: String, isLargeImage: Boolean)
 
 object Tag {
   implicit val writes = Json.writes[Tag]
 
   def apply(t: model.Tag): Tag = {
+
+    // We are creating a fallback for small byline images because some contributors have not yet had
+    // larger images taken and uploaded. Once that's done, the aim is to remove the fallback and only use large images.
+    val bylineImage: Option[BylineImage] =
+      t.properties.contributorLargeImagePath match {
+        case Some(bylineLargeImage) =>
+          Some(BylineImage(imageUrl = ImgSrc(bylineLargeImage, Item300), isLargeImage = true))
+        case None =>
+          t.contributorImagePath.map(bylineSmallImage =>
+            BylineImage(imageUrl = ImgSrc(bylineSmallImage, Item140), isLargeImage = false),
+          )
+      }
+
     Tag(
       t.id,
       t.properties.tagType,
       t.properties.webTitle,
       t.properties.twitterHandle,
-      t.properties.contributorLargeImagePath.map(src => ImgSrc(src, Item300)),
+      bylineImage.map(_.imageUrl),
+      bylineImage.map(_.isLargeImage),
     )
   }
 }

--- a/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
@@ -2,7 +2,6 @@ package model.dotcomrendering
 
 import com.gu.contentapi.client.model.v1.{Block => APIBlock}
 import com.gu.contentapi.client.utils.format.ImmersiveDisplay
-import common.Edition
 import common.commercial.{CommercialProperties, EditionCommercialProperties, PrebidIndexSite}
 import model.dotcomrendering.pageElements.PageElement
 import model.{ArticleDateTimes, ContentPage, GUDateTimeFormatNew}
@@ -10,7 +9,7 @@ import navigation._
 import org.joda.time.DateTime
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
-import views.support.{ImgSrc, Item300, Item640}
+import views.support.{ImgSrc, Item300}
 
 // We have introduced our own set of objects for serializing data to the DotComponents API,
 // because we don't want people changing the core frontend models and as a side effect,

--- a/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
@@ -30,14 +30,15 @@ case class Tag(
 object Tag {
   implicit val writes = Json.writes[Tag]
 
+  // TODO: In second PR we will set bylineImageUrl to t.properties.bylineImageUrl.map(src => ImgSrc(src, Item300)),
   def apply(t: model.Tag): Tag = {
     Tag(
       t.id,
       t.properties.tagType,
       t.properties.webTitle,
       t.properties.twitterHandle,
-      t.properties.bylineImageUrl.map(src => ImgSrc(src, Item300)),
-      t.properties.contributorLargeImagePath.map(src => ImgSrc(src, Item640)),
+      t.properties.contributorLargeImagePath.map(src => ImgSrc(src, Item300)),
+      t.properties.contributorLargeImagePath.map(src => ImgSrc(src, Item300)),
     )
   }
 }


### PR DESCRIPTION
Co-authored-by: James Gorrie <james.gorrie@guardian.co.uk>

## What does this change?
It adds `bylineLargeImageUrl` in the `Tag` model we send to DCR. For now, it will be the same as the existing `bylineImageUrl` but will be changed in a separate PR.


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

Not reproduced but we are making considerations how to handle it in a later PR.

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://git.io/v1V0x -->
<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
