### PR TITLE
fix(git.io): resolve links to github.com

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/__vendor/ipsos-mori.js
+++ b/static/src/javascripts/projects/commercial/modules/__vendor/ipsos-mori.js
@@ -1,5 +1,5 @@
 // This is third party code and should not be converted to TypeScript
-// See documentation here: https://git.io/Jy5w8
+// See documentation here: https://github.com/guardian/dotcom-rendering/blob/150fc2d81/dotcom-rendering/docs/architecture/3rd%20party%20technical%20review/002-ipsos-mori.md
 
 export const stub = () => {
 	window.dm = window.dm || { AjaxData: [] };

--- a/static/src/javascripts/projects/commercial/modules/ipsos-mori.ts
+++ b/static/src/javascripts/projects/commercial/modules/ipsos-mori.ts
@@ -21,7 +21,7 @@ const loadIpsosScript = () => {
 
 /**
  * Initialise Ipsos Mori - market research partner
- * documentation on DCR: https://git.io/J9c6g
+ * documentation on DCR: https://github.com/guardian/dotcom-rendering/blob/150fc2d8/dotcom-rendering/docs/architecture/3rd%20party%20technical%20review/002-ipsos-mori.md#L0-L1
  * @returns Promise
  */
 export const init = (): Promise<void> =>

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.ts
@@ -39,7 +39,7 @@ const CONTRIBUTIONS_REMINDER_SIGNED_UP = {
 	daysToLive: 90,
 };
 
-// TODO: isn’t this duplicated from commercial features? https://git.io/JMvcu
+// TODO: isn’t this duplicated from commercial features? https://github.com/guardian/frontend/blob/2a222cfb7/static/src/javascripts/projects/common/modules/commercial/commercial-features.ts#L27
 const forcedAdFreeMode = !!/[#&]noadsaf(&.*)?$/.exec(window.location.hash);
 
 const userHasData = () => {


### PR DESCRIPTION
## What does this change?

`git.io` dies on Friday: https://github.blog/changelog/2022-04-25-git-io-deprecation

Thanks @sndrs for pointing it out.