### PR TITLE
Replace git.io links with resolved links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,7 +24,7 @@
 
 ### Does this affect other platforms?
 
-- [ ] AMP <!-- AMP question? https://git.io/v9zIE -->
+- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
 - [ ] Apps
 - [ ] Other (please specify)
 
@@ -68,7 +68,7 @@
 - [ ] Locally
 - [ ] On CODE (optional)
 
-<!-- AB test? https://git.io/v1V0x -->
-<!-- Does this PR meet the contributing guidelines? https://git.io/v1VEJ -->
+<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
+<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->
 
 <!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->

--- a/applications/app/controllers/Nx1ConfigController.scala
+++ b/applications/app/controllers/Nx1ConfigController.scala
@@ -14,7 +14,7 @@ import experiments.ActiveExperiments._
 
     - https://www.theguardian.com/switches.json
     - https://www.theguardian.com/tests.json
-    - mark: 2QJfZo - keep these in sync with other instances https://git.io/JkRox
+    - mark: 2QJfZo - keep these in sync with other instances https://github.com/search?q=org%3Aguardian+2QJfZo&type=code
 
   If more metadata is required in the future then do add new routes instead of overloading existing public objects.
 

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -77,7 +77,7 @@ POST       /atom/quiz/:id/*path                                                 
 GET        /atom/youtube/:id.json                                               controllers.YoutubeController.getAtomId(id: String)
 
 # Nx1Config
-# mark: 2QJfZo - keep these in sync with other instances https://git.io/JkRox
+# mark: 2QJfZo - keep these in sync with other instances https://github.com/search?q=org%3Aguardian+2QJfZo&type=code
 GET        /switches.json                                                       controllers.Nx1ConfigController.switches
 GET        /tests.json                                                          controllers.Nx1ConfigController.tests
 

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -358,7 +358,7 @@ POST           /atom/quiz/:id/*path                                             
 GET            /atom/youtube/:id.json                                                                                            controllers.YoutubeController.getAtomId(id: String)
 
 # Nx1Config
-# mark: 2QJfZo - keep these in sync with other instances https://git.io/JkRox
+# mark: 2QJfZo - keep these in sync with other instances https://github.com/search?q=org%3Aguardian+2QJfZo&type=code
 GET            /switches.json                                                       controllers.Nx1ConfigController.switches
 GET            /tests.json                                                          controllers.Nx1ConfigController.tests
 

--- a/setup.sh
+++ b/setup.sh
@@ -90,7 +90,7 @@ install_node() {
 
     curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
     nvm install
-    EXTRA_STEPS+=("Add https://git.io/vKTnK to your .bash_profile")
+    EXTRA_STEPS+=("Add https://gist.github.com/sndrs/5940e9e8a3f506b287233ed65365befb to your .bash_profile")
   else
     if ! nvm_available; then
       source_nvm

--- a/static/src/javascripts/projects/commercial/modules/__vendor/ipsos-mori.js
+++ b/static/src/javascripts/projects/commercial/modules/__vendor/ipsos-mori.js
@@ -1,5 +1,5 @@
 // This is third party code and should not be converted to TypeScript
-// See documentation here: https://git.io/Jy5w8
+// See documentation here: https://github.com/guardian/dotcom-rendering/blob/150fc2d81e6a66d9c3336185e874fc8cd0288546/dotcom-rendering/docs/architecture/3rd%20party%20technical%20review/002-ipsos-mori.md
 
 export const stub = () => {
 	window.dm = window.dm || { AjaxData: [] };

--- a/static/src/javascripts/projects/commercial/modules/ipsos-mori.ts
+++ b/static/src/javascripts/projects/commercial/modules/ipsos-mori.ts
@@ -21,7 +21,7 @@ const loadIpsosScript = () => {
 
 /**
  * Initialise Ipsos Mori - market research partner
- * documentation on DCR: https://git.io/J9c6g
+ * documentation on DCR: [link](https://github.com/guardian/dotcom-rendering/blob/150fc2d81e6a66d9c3336185e874fc8cd0288546/dotcom-rendering/docs/architecture/3rd%20party%20technical%20review/002-ipsos-mori.md)
  * @returns Promise
  */
 export const init = (): Promise<void> =>

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.ts
@@ -39,7 +39,8 @@ const CONTRIBUTIONS_REMINDER_SIGNED_UP = {
 	daysToLive: 90,
 };
 
-// TODO: isn’t this duplicated from commercial features? https://git.io/JMvcu
+// TODO: isn’t this duplicated from commercial features?
+// https://github.com/guardian/frontend/blob/2a222cfb77748aa1140e19adca10bfc688fe6cad/static/src/javascripts/projects/common/modules/commercial/commercial-features.ts
 const forcedAdFreeMode = !!/[#&]noadsaf(&.*)?$/.exec(window.location.hash);
 
 const userHasData = () => {

--- a/static/src/stylesheets/base/_normalize.scss
+++ b/static/src/stylesheets/base/_normalize.scss
@@ -1,4 +1,4 @@
-/* normalize.css v3.0.0 | MIT License | git.io/normalize */
+/* normalize.css v3.0.0 | MIT License | https://github.com/necolas/normalize.css */
 
 /**
  * Tweaked for theguardian.com: there are some elements we don't use

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -94,7 +94,7 @@
     background-color: $brightness-97;
     border-bottom: 1px solid $brightness-86;
 
-    min-height: 90px + 24px; // https://git.io/JK9vs -- topAboveNavHeight.ts
+    min-height: 90px + 24px; // https://github.com/guardian/commercial-core/blob/6736d3930be3989a63e5bc0240a4d5bb1c1d9164/src/constants/topAboveNavHeight.ts -- topAboveNavHeight.ts
     padding-bottom: $gs-row-height / 2;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Co-authored-by: Max Duval <max.duval@theguardian.com>

## What does this change?

Replace git.io links with resolved links as git.io will be deprecated on 2022-04-29:

https://github.blog/changelog/2022-04-25-git-io-deprecation

Used @mxdvl 's guide with the following differences:

```
https://git.io/JkRox -> https://github.com/search?q=org%3Aguardian+2QJfZo&type=code
git.io/normalize -> https://github.com/necolas/normalize.css
```

