### PR TITLE
Add container to `inline2+` ad slots (again)

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -36,15 +36,26 @@ const insertAdAtPara = (
 ): Promise<void> => {
 	const ad = createAdSlot(type, {
 		name,
-		classes,
+		classes: includeContainer ? '' : classes,
 		sizes,
-		includeContainer,
 	});
+
+	let node: HTMLElement;
+
+	if (includeContainer) {
+		const container = document.createElement('div');
+		container.className = `ad-slot-container ad-slot--offset-right`;
+		container.appendChild(ad);
+
+		node = container;
+	} else {
+		node = ad;
+	}
 
 	return fastdom
 		.mutate(() => {
 			if (para.parentNode) {
-				para.parentNode.insertBefore(ad, para);
+				para.parentNode.insertBefore(node, para);
 			}
 		})
 		.then(() => {
@@ -127,6 +138,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 			.slice(0, isInline1 ? 1 : paras.length)
 			.map((para, i) => {
 				const inlineId = i + (isInline1 ? 1 : 2);
+				const includeContainer = !isInline1;
 
 				if (sfdebug) {
 					para.style.cssText += 'border: thick solid green;';
@@ -149,7 +161,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 								],
 						  }
 						: { desktop: [adSizes.halfPage, adSizes.skyscraper] },
-					false,
+					includeContainer,
 				);
 			});
 		await Promise.all(slots);

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-slot.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-slot.ts
@@ -15,7 +15,6 @@ type CreateSlotOptions = {
 	classes?: string;
 	name?: string;
 	sizes?: Record<string, AdSize[] | undefined>; // allow an empty object
-	includeContainer?: boolean;
 };
 
 const commonSizeMappings: SizeMappings = {
@@ -161,7 +160,6 @@ const createAdSlotElement = (
 	name: string,
 	attrs: Record<string, string>,
 	classes: string[],
-	includeContainer: boolean,
 ): HTMLElement => {
 	const id = `${adSlotIdPrefix}${name}`;
 
@@ -181,23 +179,13 @@ const createAdSlotElement = (
 	// The 'main' adSlot
 	const adSlot = document.createElement('div');
 	adSlot.id = id;
-	adSlot.className = `js-ad-slot ad-slot ${
-		includeContainer ? '' : classes.join(' ')
-	}`;
+	adSlot.className = `js-ad-slot ad-slot ${classes.join(' ')}`;
 	adSlot.setAttribute('data-link-name', `ad slot ${name}`);
 	adSlot.setAttribute('data-name', name);
 	adSlot.setAttribute('aria-hidden', 'true');
 	Object.keys(attrs).forEach((attr) => {
 		adSlot.setAttribute(attr, attrs[attr]);
 	});
-
-	if (includeContainer) {
-		const container = document.createElement('div');
-		container.className = `ad-slot-container ${classes.join(' ')}`;
-		container.appendChild(adSlot);
-
-		return container;
-	}
 
 	return adSlot;
 };
@@ -282,7 +270,6 @@ export const createAdSlot = (
 ): HTMLElement => {
 	const adSlotConfig = adSlotConfigs[type];
 	const slotName = options.name ?? adSlotConfig.name ?? type;
-	const includeContainer = options.includeContainer ?? false;
 
 	const sizeMappings = concatSizeMappings(
 		adSlotConfig.sizeMappings,
@@ -303,6 +290,5 @@ export const createAdSlot = (
 		slotName,
 		createDataAttributes(attributes),
 		createClasses(slotName, options.classes),
-		includeContainer,
 	);
 };


### PR DESCRIPTION
## What does this change?

Second attempt at adding a container div to `inline2+` ad slots. It follows on from a previous attempt:

https://github.com/guardian/frontend/pull/24917

Unfortunately this caused a GPT issue which broke `inline2+` ads and was quickly disabled in this PR:

https://github.com/guardian/frontend/pull/24930

The issue occurred because we passed the container div into `loadAdvert` instead of the ad element itself.

The fix is to move the responsibility of adding a container div from `createAdSlot` into `insertAdAtPara`.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![Screenshot 2022-04-27 at 10 20 47](https://user-images.githubusercontent.com/7423751/165486508-d5521bb1-7403-4cb9-bfa0-a36998ae150d.png) | ![Screenshot 2022-04-27 at 10 21 29](https://user-images.githubusercontent.com/7423751/165486501-e4c3c94b-85a0-4da3-8dca-cbfcaa8d034b.png) |

## What is the value of this and can you measure success?

Fixes dodgy ad expansions _and_ doesn't break all `inline2+` ads (hopefully)

### Tested

- [x] Locally
- [x] On CODE 