### PR TITLE
Switch: `newsletter-onwards`

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -533,4 +533,14 @@ trait FeatureSwitches {
     sellByDate = never,
     exposeClientSide = true,
   )
+
+  val NewsletterOnwards = Switch(
+    SwitchGroup.Feature,
+    "newsletter-onwards",
+    "When ON, we replace the standard related stories onwards container with a dedicated one for Newsletters",
+    owners = Seq(Owner.withEmail("dotcom.platform@guardian.co.uk")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
 }


### PR DESCRIPTION
## What does this change?
Adds a new feature switch `newsletter-onwards`

## Why?
Because we are going to showcase newsletters at the bottom of articles but we first want a way to turn this on and off