### PR TITLE
Ji/using large byline image

### DIFF
--- a/common/app/model/dotcomrendering/Contributor.scala
+++ b/common/app/model/dotcomrendering/Contributor.scala
@@ -2,7 +2,7 @@ package model.dotcomrendering
 
 import play.api.libs.json.Json
 
-case class Contributor(name: String, imageUrl: Option[String])
+case class Contributor(name: String, imageUrl: Option[String], largeImageUrl: Option[String])
 
 object Contributor {
   implicit val writes = Json.writes[Contributor]

--- a/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
@@ -29,14 +29,13 @@ case class Tag(
 object Tag {
   implicit val writes = Json.writes[Tag]
 
-  // TODO: In second PR we will set bylineImageUrl to t.properties.bylineImageUrl.map(src => ImgSrc(src, Item300)),
   def apply(t: model.Tag): Tag = {
     Tag(
       t.id,
       t.properties.tagType,
       t.properties.webTitle,
       t.properties.twitterHandle,
-      t.properties.contributorLargeImagePath.map(src => ImgSrc(src, Item300)),
+      t.properties.bylineImageUrl.map(src => ImgSrc(src, Item300)),
       t.properties.contributorLargeImagePath.map(src => ImgSrc(src, Item300)),
     )
   }

--- a/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
@@ -95,7 +95,9 @@ object Block {
     val campaigns = page.getJavascriptConfig.get("campaigns")
 
     val contributors = block.contributors flatMap { contributorId =>
-      tags.find(_.id == s"profile/$contributorId").map(tag => Contributor(tag.title, tag.bylineImageUrl))
+      tags
+        .find(_.id == s"profile/$contributorId")
+        .map(tag => Contributor(tag.title, tag.bylineImageUrl, tag.bylineLargeImageUrl))
     }
 
     Block(


### PR DESCRIPTION
Closes [#4548](https://github.com/guardian/dotcom-rendering/issues/4548)
Follows: 
https://github.com/guardian/frontend/pull/24944
https://github.com/guardian/dotcom-rendering/pull/4742

## What does this change?

* In `DotcomRenderingSupportTypes.Tag` it sets `bylineImageUrl` to be the small byline image and `bylineLargeImageUrl` to be the large byline image.
* In `Contributor` tag read from blogs it adds a `largeImageUrl` property.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

DCR is handling the new properties in this PR that will go first: https://github.com/guardian/dotcom-rendering/pull/4742

## Why?
The requirement is to only small byline images in blogs and not in articles.

## Screenshots
|                                    | Before | After |
|------------------------------------|----------------------------------------|--------------------------------------|
| Blog  / Author with small byline image | ![image](https://user-images.githubusercontent.com/19683595/165354623-39cb17bd-cdf8-421e-9e1e-941d9427b7c3.png) | ![image](https://user-images.githubusercontent.com/19683595/165356140-2d35a50d-305c-489b-b44c-a8f66db82540.png) |
| Blog  / Author with large byline image | ![image](https://user-images.githubusercontent.com/19683595/165354757-5e562d08-2270-451b-be2f-ee5617d97df6.png) | ![image](https://user-images.githubusercontent.com/19683595/165354757-5e562d08-2270-451b-be2f-ee5617d97df6.png)|
| Article / Author with large byline image | ![image](https://user-images.githubusercontent.com/19683595/165354196-cd3d4139-d48a-4b48-8641-7470445cc247.png) | ![image](https://user-images.githubusercontent.com/19683595/165354196-cd3d4139-d48a-4b48-8641-7470445cc247.png)|
| Article / Author with small byline image | ![image](https://user-images.githubusercontent.com/19683595/165354285-5743fba2-682e-43e4-8dd0-dc9c59fd462f.png) | ![image](https://user-images.githubusercontent.com/19683595/165354340-9181966c-8d3b-435e-a70f-bccff8c1f2d3.png) |

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
