### PR TITLE
Add "scoreboardUrl" option to DCR cricket endpoint

### DIFF
--- a/sport/app/cricket/controllers/CricketMatchController.scala
+++ b/sport/app/cricket/controllers/CricketMatchController.scala
@@ -3,12 +3,11 @@ package cricket.controllers
 import common._
 import conf.Configuration
 import cricketModel.Match
-import conf.cricketPa.PaFeed.dateFormat
 import conf.cricketPa.{CricketTeam, CricketTeams}
 import jobs.CricketStatsJob
 import model.Cached.RevalidatableResult
 import model._
-import play.api.libs.json.{JsObject, JsValue, Json}
+import play.api.libs.json.{Json}
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 
 case class CricketMatchPage(theMatch: Match, matchId: String, team: CricketTeam) extends StandalonePage {

--- a/sport/app/cricket/controllers/CricketMatchController.scala
+++ b/sport/app/cricket/controllers/CricketMatchController.scala
@@ -38,7 +38,7 @@ class CricketMatchController(cricketStatsJob: CricketStatsJob, val controllerCom
               if (request.isJson && request.forceDCR)
                 JsonComponent(
                   "match" -> Json.toJson(page.theMatch),
-                  "matchUrl" -> (Configuration.site.host + page.metadata.id),
+                  "scoreboardUrl" -> (Configuration.site.host + page.metadata.id),
                 )
               else if (request.isJson)
                 JsonComponent(

--- a/sport/app/cricket/controllers/CricketMatchController.scala
+++ b/sport/app/cricket/controllers/CricketMatchController.scala
@@ -7,7 +7,7 @@ import conf.cricketPa.{CricketTeam, CricketTeams}
 import jobs.CricketStatsJob
 import model.Cached.RevalidatableResult
 import model._
-import play.api.libs.json.{Json}
+import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 
 case class CricketMatchPage(theMatch: Match, matchId: String, team: CricketTeam) extends StandalonePage {

--- a/sport/app/cricket/controllers/CricketMatchController.scala
+++ b/sport/app/cricket/controllers/CricketMatchController.scala
@@ -38,7 +38,7 @@ class CricketMatchController(cricketStatsJob: CricketStatsJob, val controllerCom
               if (request.isJson && request.forceDCR)
                 JsonComponent(
                   "match" -> Json.toJson(page.theMatch),
-                  "scoreboardUrl" -> (Configuration.site.host + page.metadata.id),
+                  "scorecardUrl" -> (Configuration.site.host + page.metadata.id),
                 )
               else if (request.isJson)
                 JsonComponent(

--- a/sport/app/cricket/controllers/CricketMatchController.scala
+++ b/sport/app/cricket/controllers/CricketMatchController.scala
@@ -1,12 +1,14 @@
 package cricket.controllers
 
 import common._
+import conf.Configuration
 import cricketModel.Match
 import conf.cricketPa.PaFeed.dateFormat
 import conf.cricketPa.{CricketTeam, CricketTeams}
 import jobs.CricketStatsJob
 import model.Cached.RevalidatableResult
 import model._
+import play.api.libs.json.{JsObject, JsValue, Json}
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 
 case class CricketMatchPage(theMatch: Match, matchId: String, team: CricketTeam) extends StandalonePage {
@@ -34,7 +36,10 @@ class CricketMatchController(cricketStatsJob: CricketStatsJob, val controllerCom
             val page = CricketMatchPage(matchData, date, team)
             Cached(60) {
               if (request.isJson && request.forceDCR)
-                JsonComponent(page.theMatch)
+                JsonComponent(
+                  "match" -> Json.toJson(page.theMatch),
+                  "matchUrl" -> (Configuration.site.host + page.metadata.id),
+                )
               else if (request.isJson)
                 JsonComponent(
                   "summary" -> cricket.views.html.fragments


### PR DESCRIPTION
## What does this change?

Pass the full scoreboard URL to DCR for the 'View full scorecard' link

<img width="171" alt="image" src="https://user-images.githubusercontent.com/9575458/165554883-d2c2d002-9494-47b1-88e8-d9496f689664.png">

This should not affect anything in production as this time as DCR is not currently consuming this endpoint. 

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes - https://github.com/guardian/dotcom-rendering/pull/4758 will be updated to consume this

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/9575458/165555346-b4442609-8eab-49d8-86da-18157771f7f4.png
[after]: https://user-images.githubusercontent.com/9575458/165556340-992fbc6d-f99e-496e-9e88-d5ebe8874f74.png


## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
