### PR TITLE
move identity project settings into root build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -149,6 +149,8 @@ val identity = application("identity")
       libPhoneNumber,
       supportInternationalisation,
     ),
+    PlayKeys.playDefaultPort := 9009,
+    Test / testOptions += Tests.Argument("-oF"),
   )
 
 val commercial = application("commercial").dependsOn(commonWithTests).aggregate(common)

--- a/identity/build.sbt
+++ b/identity/build.sbt
@@ -1,2 +1,0 @@
-PlayKeys.playDefaultPort := 9009
-Test / testOptions += Tests.Argument("-oF")


### PR DESCRIPTION
## What does this change?

Adds the identity settings to the root identity project settings. This is more in line with how the repo is layed out and helps with a Snyk issue I was having.

In short, Snyk is trying to run again `identity/build.sbt`. This in turn doesn't seem to be carrying the right context i.e. it doesn't have Play in scope. [This is reflected in the Github action error](https://github.com/guardian/frontend/runs/6197541003?check_suite_focus=true#step:6:24).

I've run Snyk locally against this and it works. Hurrah.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

