### PR TITLE
bump scala versions

### DIFF
--- a/admin/app/model/AdminLifecycle.scala
+++ b/admin/app/model/AdminLifecycle.scala
@@ -81,7 +81,7 @@ class AdminLifecycle(
       if (FrontPressJobSwitch.isSwitchedOn) RefreshFrontsJob.runFrequency(akkaAsync)(LowFrequency)
       Future.successful(())
     }
-
+    //every 2, 17, 32, 47 minutes past the hour, on the 9th second past the minute (e.g 13:02:09, 13:17:09)
     jobs.schedule("RebuildIndexJob", s"9 0/$adminRebuildIndexRateInMinutes * 1/1 * ? *") {
       rebuildIndexJob.run()
     }

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -169,6 +169,8 @@ class GuardianConfiguration extends GuLogging {
     lazy val tagIndexesBucket =
       configuration.getMandatoryStringProperty("tag_indexes.bucket")
 
+    // This shouldn't be > 60 as it's in the context of `0/$adminRebuildIndexRateInMinutes` and `0/60` is invalid
+    // see: https://support.hcltechsw.com/csm?id=kb_article&sysparm_article=KB0091722
     lazy val adminRebuildIndexRateInMinutes =
       configuration.getIntegerProperty("tag_indexes.rebuild_rate_in_minutes").getOrElse(59)
   }

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -170,7 +170,7 @@ class GuardianConfiguration extends GuLogging {
       configuration.getMandatoryStringProperty("tag_indexes.bucket")
 
     lazy val adminRebuildIndexRateInMinutes =
-      configuration.getIntegerProperty("tag_indexes.rebuild_rate_in_minutes").getOrElse(60)
+      configuration.getIntegerProperty("tag_indexes.rebuild_rate_in_minutes").getOrElse(59)
   }
 
   object environment {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -84,6 +84,9 @@ object Dependencies {
     Note: Although frontend compiles and passes all the current tests when jackson is removed, be careful that this
     may break the fronts diagnostics tools. If we try to remove jackson one day after (for instance after other
     dependencies have been upgraded), then do remember to check for regressions.
+
+    The versions are currently set as they are because of:
+    https://github.com/orgs/playframework/discussions/11222
    */
   val jacksonVersion = "2.13.2"
   val jacksonDatabindVersion = "2.13.2.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -57,7 +57,7 @@ object Dependencies {
   val scalaTestPlus = "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.1" % Test
   val scalaUri = "io.lemonlabs" %% "scala-uri" % "3.0.0"
   val seleniumJava = "org.seleniumhq.selenium" % "selenium-java" % "2.44.0"
-  val slf4jExt = "org.slf4j" % "slf4j-ext" % "1.7.25"
+  val slf4jExt = "org.slf4j" % "slf4j-ext" % "1.7.36"
   val jerseyCore = "com.sun.jersey" % "jersey-core" % jerseyVersion
   val jerseyClient = "com.sun.jersey" % "jersey-client" % jerseyVersion
   val w3cSac = "org.w3c.css" % "sac" % "1.3"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -85,13 +85,28 @@ object Dependencies {
     may break the fronts diagnostics tools. If we try to remove jackson one day after (for instance after other
     dependencies have been upgraded), then do remember to check for regressions.
    */
-  val jacksonVersion = "2.11.4"
-  val jacksonDataFormat = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion
+  val jacksonVersion = "2.13.2"
+  val jacksonDatabindVersion = "2.13.2.2"
   val jacksonCore = "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion
-  val jacksonDataType = "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion
-  val jacksonDataTypeJdk8 = "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion
   val jacksonAnnotations = "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion
-  val jackson = Seq(jacksonDataFormat, jacksonCore, jacksonDataType, jacksonAnnotations)
+  val jacksonDataTypeJdk8 = "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion
+  val jacksonDataType = "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion
+  val jacksonDataFormat = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion
+  val jacksonParameterName = "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % jacksonVersion
+  val jackModule = "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion
+  val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
+
+  val jackson =
+    Seq(
+      jacksonCore,
+      jacksonAnnotations,
+      jacksonDataTypeJdk8,
+      jacksonDataType,
+      jacksonDataFormat,
+      jacksonParameterName,
+      jackModule,
+      jacksonDatabind,
+    )
 
   // Web jars
   val bootstrap = "org.webjars" % "bootstrap" % "3.3.7"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
 
 object Dependencies {
   val identityLibVersion = "3.253"
-  val awsVersion = "1.11.240"
+  val awsVersion = "1.12.205"
   val capiVersion = "17.25.0"
   val faciaVersion = "3.3.12"
   val dispatchVersion = "0.13.1"
@@ -47,7 +47,7 @@ object Dependencies {
   val playGoogleAuth = "com.gu.play-googleauth" %% "play-v28" % "2.1.1"
   val playSecretRotation = "com.gu.play-secret-rotation" %% "play-v28" % "0.18"
   val playSecretRotationAwsSdk = "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v1" % "0.18"
-  val quartzScheduler = "org.quartz-scheduler" % "quartz" % "2.2.3"
+  val quartzScheduler = "org.quartz-scheduler" % "quartz" % "2.3.2"
   val redisClient = "net.debasishg" %% "redisclient" % "3.42"
   val rome = "rome" % "rome" % romeVersion
   val romeModules = "org.rometools" % "rome-modules" % romeVersion


### PR DESCRIPTION
## What does this change?

Bumps slf4j 1.7.25 => 1.7.36
Bumps AWS libs 1.11 => 1.12
Bumps quartz-scheduler 2.2.3 => 2.3.2

[Bump jackson](https://github.com/orgs/playframework/discussions/11222)

No-op, this is for security vulnerabilities.