### PR TITLE
Set form colours for new thrasher email sign-up embeds

### DIFF
--- a/static/src/stylesheets/module/email-signup/_form.scss
+++ b/static/src/stylesheets/module/email-signup/_form.scss
@@ -240,6 +240,8 @@
     flex-shrink: 0;
 }
 
+.email-sub__form--thrasher-us-morning-newsletter,
+.email-sub__form--thrasher-morning-mail,
 .email-sub__form--thrasher-first-edition,
 .email-sub__form--thrasher-morning-briefing {
 


### PR DESCRIPTION
## What does this change?

We are creating two new thrashers with built-in sign-up form iframes for the following newsletters:
 - "first thing" (IdentityName: `us-morning-newsletter`)
 - "morning mail" (identityName: `morning-mail`)

This change updates the CSS so the form elements in the thrasher sign-up forms have the same colour scheme as the thrasher for 'first-edition', instead of the default black and white.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots 
localhost:9000/email/form/thrasher/morning-mail
(aqua page background added so white elements in the default are visible)

| Before (default)     | After      |
|-------------|------------|
| <img width="443" alt="Screenshot 2022-04-28 at 08 49 24" src="https://user-images.githubusercontent.com/30567854/165707212-ef5467e0-fb5f-4f98-81fa-89d5ce9d5942.png">| <img width="443" alt="Screenshot 2022-04-28 at 08 48 10" src="https://user-images.githubusercontent.com/30567854/165707241-73762108-87e0-43c9-8bfd-21fd3036e594.png"> |


## What is the value of this and can you measure success?
n/a

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
