### PR TITLE
Increase size of price granularity test to 5%

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -50,7 +50,7 @@ trait ABTestSwitches {
     "Test the commercial impact of changing the Prebid Price granularity for Ozone",
     owners = Seq(Owner.withGithub("chrislomaxjones")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2022, 5, 3)),
+    sellByDate = Some(LocalDate.of(2022, 5, 9)),
     exposeClientSide = true,
   )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/prebid-price-granularity.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/prebid-price-granularity.ts
@@ -8,8 +8,8 @@ export const prebidPriceGranularity: ABTest = {
 	author: 'Chris Jones (@chrislomaxjones)',
 	description:
 		'Test the commercial impact of changing Prebid Price granularity for Ozone',
-	audience: 0 / 100,
-	audienceOffset: 0 / 100,
+	audience: 5 / 100,
+	audienceOffset: 25 / 100,
 	successMeasure:
 		'No significant negative impact on CPM when using a granularity that permits fewer line items',
 	audienceCriteria: 'n/a',


### PR DESCRIPTION
## What does this change?

Increase participation in the Prebid price granularity AB test from `0%` to `5%`, adjusting the offset to avoid overlap with other tests. Also, increase the sell by date of the test.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes - See [DCR #4769](https://github.com/guardian/dotcom-rendering/pull/4769).

## What is the value of this and can you measure success?

A 0% was useful to check everything is working as expected. We now increase to 5% in order to begin the test properly. We increase the sell by date so that we can capture data for at least 7 days.

### Tested

- [ ] Locally
- [ ] On CODE (optional)