### PR TITLE
Remove <dc:date> elements from encoded xml result

### DIFF
--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -274,6 +274,10 @@ trait FaciaController
       singleStoryPanels = singleStoryPanelOutcomes.flatMap(_.toOption),
       maybeRundownPanel = rundownPanelOutcome.toOption,
     )
+    // Google doesn't like <dc:date> elements in the showcase feed so we're going to remove them with a
+    // tightly-focussed regex replacement. The <dc:date> values are added in the depths of the Rome
+    // library which is not easy to intercept at that point. We can use this technique until we can figure
+    // out a better way. In the meantime it'll stop the validator from complaining at us.
     val dcDateRegEx = """<dc:date>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d+Z</dc:date>""".r
     val showcaseWithoutDcDates = dcDateRegEx.replaceAllIn(showcase, "")
     RevalidatableResult(Ok(showcaseWithoutDcDates).as("text/xml; charset=utf-8"), showcaseWithoutDcDates)

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -274,7 +274,9 @@ trait FaciaController
       singleStoryPanels = singleStoryPanelOutcomes.flatMap(_.toOption),
       maybeRundownPanel = rundownPanelOutcome.toOption,
     )
-    RevalidatableResult(Ok(showcase).as("text/xml; charset=utf-8"), showcase)
+    val dcDateRegEx = """<dc:date>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d+Z</dc:date>""".r
+    val showcaseWithoutDcDates = dcDateRegEx.replaceAllIn(showcase, "")
+    RevalidatableResult(Ok(showcaseWithoutDcDates).as("text/xml; charset=utf-8"), showcaseWithoutDcDates)
   }
 
   def renderFrontPress(path: String): Action[AnyContent] =


### PR DESCRIPTION
## What does this change?
Our showcase feed causes the validator to complain due to the presence of `<dc:date>` elements in the response, as it only wants to receive `<pubDate>` elements. These `<dc:date>`elements are inserted by the Rome library in a way that is difficult for us to intercept elegantly. This PR applies a blunt instrument approach to removing those elements to buy us some time to investigate a better method of handling them.

It only affects showcase renderings from Facia so nothing else is affected as a result of this. 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

**Before**
```
<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:g="http://schemas.google.com/pcn/2020" version="2.0">
<channel>
<title>The Guardian</title>
<link>https://www.theguardian.com/au-showcase</link>
<description>Latest Au Showcase news, comment and analysis from the Guardian, the world's leading liberal voice</description>
<language>en-gb</language>
<copyright>Guardian News &amp; Media Limited or its affiliated companies. All rights reserved. 2022</copyright>
<pubDate>Thu, 28 Apr 2022 12:04:44 GMT</pubDate>
**<dc:date>2022-04-28T12:04:44Z</dc:date>**
<dc:language>en-gb</dc:language>
<dc:rights>Guardian News &amp; Media Limited or its affiliated companies. All rights reserved. 2022</dc:rights>
<image>
<title>The Guardian</title>
<url>https://assets.guim.co.uk/images/guardian-logo-rss.c45beb1bafa34b347ac333af2e6fe23f.png</url>
<link>https://www.theguardian.com</link>
</image>
<item>
<title>Macron’s appeal to unity succeeds but far right makes strong showing</title>
<link>https://www.theguardian.com/world/2022/apr/25/macrons-appeal-to-unity-succeeds-but-far-right-makes-strong-showing</link>
<pubDate>Mon, 25 Apr 2022 04:00:41 GMT</pubDate>
<author>Angelique Chrisafis in Paris</author>
<guid isPermaLink="false">https://www.theguardian.com/world/2022/apr/25/macrons-appeal-to-unity-succeeds-but-far-right-makes-strong-showing</guid>
**<dc:date>2022-04-25T04:00:41Z</dc:date>**
<atom:updated>2022-04-25T04:00:41Z</atom:updated>
<g:panel type="SINGLE_STORY">Macron’s appeal to unity succeeds but far right makes strong showing</g:panel>
<g:panel_title>French presidential election 2022</g:panel_title>
<g:overline>Analysis</g:overline>
<g:bullet_list>
<g:list_item>France's president belatedly realised rationality wasn’t enough to win</g:list_item>
<g:list_item>Now, he needs to heal a ‘fractured’ society’s sense of injustice</g:list_item>
</g:bullet_list>
<media:content url="https://media.guim.co.uk/11c6543eb8bdc60412ad30e1971354e7318f6422/0_43_8640_5184/master/8640.jpg"/>
</item>
```

**After** (captured from localhost)
```
<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:g="http://schemas.google.com/pcn/2020" version="2.0">
<channel>
<title>The Guardian</title>
<link>https://www.theguardian.com/au-showcase</link>
<description>Latest Au Showcase news, comment and analysis from the Guardian, the world's leading liberal voice</description>
<language>en-gb</language>
<copyright>Guardian News &amp; Media Limited or its affiliated companies. All rights reserved. 2022</copyright>
<pubDate>Thu, 28 Apr 2022 11:52:48 GMT</pubDate>
<dc:language>en-gb</dc:language>
<dc:rights>Guardian News &amp; Media Limited or its affiliated companies. All rights reserved. 2022</dc:rights>
<image>
<title>The Guardian</title>
<url>https://assets.guim.co.uk/images/guardian-logo-rss.c45beb1bafa34b347ac333af2e6fe23f.png</url>
<link>https://www.theguardian.com</link>
</image>
<item>
<title>Old-world wines v new: what’s the difference?</title>
<link>https://www.theguardian.com/food/2022/feb/04/old-world-wines-v-new-whats-the-difference-fiona-beckett</link>
<pubDate>Fri, 04 Feb 2022 14:00:29 GMT</pubDate>
<author>Fiona Beckett</author>
<guid isPermaLink="false">https://www.theguardian.com/food/2022/feb/04/old-world-wines-v-new-whats-the-difference-fiona-beckett</guid>
<atom:updated>2022-02-08T00:00:04+11:00</atom:updated>
<g:panel type="SINGLE_STORY">Old-world wines v new: what’s the difference?</g:panel>
<g:bullet_list>
<g:list_item>More eclectic tastes and globalism have blurred the distinctions between old- and new</g:list_item>
<g:list_item>new-world styles could these days pass for old, and vice versa</g:list_item>
</g:bullet_list>
<media:content url="https://media.guim.co.uk/83c945026b0a1157ad47c5b561cc88d10c0e1c32/0_137_5156_3095/master/5156.jpg"/>
</item>
```

## What is the value of this and can you measure success?

We have been assured that these elements do not prevent the generation of showcase content, but whenever there is a question regarding the state of the service, we're always told to remove them, so that's what we're doing here.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [x] Other (Google Showcase)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
- [x] Not applicable

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
