### PR TITLE
When there are no article ads, log why

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.spec.ts
@@ -31,6 +31,7 @@ const resetPrebid = () => {
 describe('initialise', () => {
 	beforeEach(() => {
 		resetPrebid();
+		config.set('switches.commercial', true);
 		config.set('switches.consentManagement', true);
 		config.set('switches.prebidUserSync', true);
 		config.set('switches.prebidAppNexus', true);

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.ts
@@ -21,13 +21,13 @@ function adsDisabledLogger(
 			`Adverts are not shown because ${condition} = ${value.toString()}`,
 		);
 
-	Object.entries(trueConditions).forEach(
-		([condition, value]) => !value && noAdsLog(condition, value),
-	);
+	for (const [condition, value] of Object.entries(trueConditions)) {
+		if (!value) noAdsLog(condition, value);
+	}
 
-	Object.entries(falseConditions).forEach(
-		([condition, value]) => value && noAdsLog(condition, value),
-	);
+	for (const [condition, value] of Object.entries(falseConditions)) {
+		if (value) noAdsLog(condition, value);
+	}
 }
 
 // Having a constructor means we can easily re-instantiate the object in a test
@@ -68,10 +68,7 @@ class CommercialFeatures {
 		const isIdentityPage =
 			config.get('page.contentType') === 'Identity' ||
 			config.get('page.section') === 'identity'; // needed for pages under profile.* subdomain
-		const switches = config.get<Record<string, boolean | undefined>>(
-			'switches',
-			{},
-		);
+		const switches = config.get<Record<string, boolean>>('switches', {});
 		const isWidePage = getBreakpoint() === 'wide';
 		const supportsSticky =
 			document.documentElement.classList.contains('has-sticky');
@@ -90,7 +87,7 @@ class CommercialFeatures {
 		this.youtubeAdvertising = !this.adFree && !sensitiveContent;
 
 		const dfpAdvertisingTrueConditions = {
-			'switches.commercial': !!switches.commercial,
+			'switches.commercial': switches.commercial,
 			externalAdvertising,
 		};
 

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.ts
@@ -18,7 +18,7 @@ function adsDisabledLogger(
 	const noAdsLog = (condition: string, value: boolean): void =>
 		log(
 			'commercial',
-			`Adverts are not shown because ${condition} = ${value.toString()}`,
+			`Adverts are not shown because ${condition} = ${String(value)}`,
 		);
 
 	for (const [condition, value] of Object.entries(trueConditions)) {

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.ts
@@ -8,12 +8,12 @@ import { isAdFreeUser } from './user-features';
 /**
  * Logs the reason why adverts are disabled on an article
  *
- * @param ifFalse - ads are disabled if these are false
  * @param ifTrue - ads are disabled if these are true
+ * @param ifFalse - ads are disabled if these are false
  */
 function articleAdsDisabledLogger(
-	ifFalse: Record<string, boolean>,
 	ifTrue: Record<string, boolean>,
+	ifFalse: Record<string, boolean>,
 ): void {
 	const adsDisabledBecause: Record<string, boolean> = {};
 

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.ts
@@ -1,3 +1,5 @@
+import { log } from '@guardian/libs';
+import { pickBy } from 'lodash-es';
 import defaultConfig from '../../../../lib/config';
 import { getBreakpoint } from '../../../../lib/detect';
 import { isUserLoggedIn } from '../identity/api';
@@ -81,6 +83,28 @@ class CommercialFeatures {
 			!isLiveBlog &&
 			!isHosted &&
 			!newRecipeDesign;
+
+		if (isArticle && !this.articleBodyAdverts) {
+			const articleBodyAdvertsFalseIfTrue: Record<string, boolean> = {
+				forceAdFree,
+				isAdFreeUser: isAdFreeUser(),
+				sensitiveContent,
+				isMinuteArticle,
+				isLiveBlog,
+				isHosted,
+				newRecipeDesign: !!newRecipeDesign,
+			};
+
+			const articleBodyAdvertsFalseIfFalse: Record<string, boolean> = {
+				'switches.commercial': switches.commercial,
+				externalAdvertising: externalAdvertising,
+			};
+
+			log('commercial', 'articleBodyAdverts = false because:', {
+				...pickBy(articleBodyAdvertsFalseIfTrue, (v) => v),
+				...pickBy(articleBodyAdvertsFalseIfFalse, (v) => !v),
+			});
+		}
 
 		this.carrotTrafficDriver =
 			!this.adFree &&

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.ts
@@ -68,7 +68,10 @@ class CommercialFeatures {
 		const isIdentityPage =
 			config.get('page.contentType') === 'Identity' ||
 			config.get('page.section') === 'identity'; // needed for pages under profile.* subdomain
-		const switches = config.get<Record<string, boolean>>('switches', {});
+		const switches = config.get<Record<string, boolean | undefined>>(
+			'switches',
+			{},
+		);
 		const isWidePage = getBreakpoint() === 'wide';
 		const supportsSticky =
 			document.documentElement.classList.contains('has-sticky');
@@ -87,7 +90,7 @@ class CommercialFeatures {
 		this.youtubeAdvertising = !this.adFree && !sensitiveContent;
 
 		const dfpAdvertisingTrueConditions = {
-			'switches.commercial': switches.commercial,
+			'switches.commercial': !!switches.commercial,
 			externalAdvertising,
 		};
 

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -1,92 +1,4 @@
 {
- "../../../../../commercial-core/dist/cjs/ad-sizes.d.ts": [],
- "../../../../../commercial-core/dist/cjs/ad-targeting-youtube.d.ts": [
-  "../../../../../commercial-core/dist/cjs/types.d.ts",
-  "../../../../../commercial-core/node_modules/@guardian/consent-management-platform/dist/types/index.d.ts"
- ],
- "../../../../../commercial-core/dist/cjs/constants/index.d.ts": [
-  "../../../../../commercial-core/dist/cjs/constants/prebid-timeout.d.ts",
-  "../../../../../commercial-core/dist/cjs/constants/top-above-nav-height.d.ts"
- ],
- "../../../../../commercial-core/dist/cjs/constants/prebid-timeout.d.ts": [],
- "../../../../../commercial-core/dist/cjs/constants/top-above-nav-height.d.ts": [],
- "../../../../../commercial-core/dist/cjs/detect-ad-blocker.d.ts": [],
- "../../../../../commercial-core/dist/cjs/event-timer.d.ts": [],
- "../../../../../commercial-core/dist/cjs/index.d.ts": [
-  "../../../../../commercial-core/dist/cjs/ad-sizes.d.ts",
-  "../../../../../commercial-core/dist/cjs/ad-targeting-youtube.d.ts",
-  "../../../../../commercial-core/dist/cjs/constants/index.d.ts",
-  "../../../../../commercial-core/dist/cjs/detect-ad-blocker.d.ts",
-  "../../../../../commercial-core/dist/cjs/event-timer.d.ts",
-  "../../../../../commercial-core/dist/cjs/permutive.d.ts",
-  "../../../../../commercial-core/dist/cjs/send-commercial-metrics.d.ts",
-  "../../../../../commercial-core/dist/cjs/targeting/content.d.ts",
-  "../../../../../commercial-core/dist/cjs/targeting/personalised.d.ts",
-  "../../../../../commercial-core/dist/cjs/targeting/pick-targeting-values.d.ts",
-  "../../../../../commercial-core/dist/cjs/targeting/session.d.ts",
-  "../../../../../commercial-core/dist/cjs/targeting/shared.d.ts",
-  "../../../../../commercial-core/dist/cjs/targeting/viewport.d.ts",
-  "../../../../../commercial-core/dist/cjs/third-party-tags/facebook-pixel.d.ts",
-  "../../../../../commercial-core/dist/cjs/third-party-tags/ias.d.ts",
-  "../../../../../commercial-core/dist/cjs/third-party-tags/inizio.d.ts",
-  "../../../../../commercial-core/dist/cjs/third-party-tags/permutive.d.ts",
-  "../../../../../commercial-core/dist/cjs/third-party-tags/remarketing.d.ts",
-  "../../../../../commercial-core/dist/cjs/third-party-tags/twitter-uwt.d.ts",
-  "../../../../../commercial-core/dist/cjs/track-scroll-depth.d.ts",
-  "../../../../../commercial-core/dist/cjs/types.d.ts"
- ],
- "../../../../../commercial-core/dist/cjs/permutive.d.ts": [],
- "../../../../../commercial-core/dist/cjs/send-commercial-metrics.d.ts": [],
- "../../../../../commercial-core/dist/cjs/targeting/content.d.ts": [
-  "../../../../../commercial-core/dist/cjs/targeting/shared.d.ts",
-  "../../../../../commercial-core/dist/cjs/types.d.ts"
- ],
- "../../../../../commercial-core/dist/cjs/targeting/personalised.d.ts": [
-  "../../../../../commercial-core/dist/cjs/types.d.ts",
-  "../../../../../commercial-core/node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",
-  "../../../../../commercial-core/node_modules/@guardian/consent-management-platform/dist/types/tcfv2/index.d.ts"
- ],
- "../../../../../commercial-core/dist/cjs/targeting/pick-targeting-values.d.ts": [
-  "../../../../../commercial-core/node_modules/type-fest/index.d.ts",
-  "../../../../../commercial-core/node_modules/type-fest/index.d.ts"
- ],
- "../../../../../commercial-core/dist/cjs/targeting/session.d.ts": [
-  "../../../../../commercial-core/dist/cjs/types.d.ts",
-  "../../../../../commercial-core/node_modules/@guardian/ab-core/dist/index.d.ts",
-  "../../../../../commercial-core/node_modules/@guardian/libs/dist/types/index.d.ts"
- ],
- "../../../../../commercial-core/dist/cjs/targeting/shared.d.ts": [],
- "../../../../../commercial-core/dist/cjs/targeting/viewport.d.ts": [
-  "../../../../../commercial-core/dist/cjs/types.d.ts"
- ],
- "../../../../../commercial-core/dist/cjs/third-party-tags/facebook-pixel.d.ts": [
-  "../../../../../commercial-core/dist/cjs/types.d.ts"
- ],
- "../../../../../commercial-core/dist/cjs/third-party-tags/ias.d.ts": [
-  "../../../../../commercial-core/dist/cjs/types.d.ts"
- ],
- "../../../../../commercial-core/dist/cjs/third-party-tags/inizio.d.ts": [
-  "../../../../../commercial-core/dist/cjs/types.d.ts"
- ],
- "../../../../../commercial-core/dist/cjs/third-party-tags/permutive.d.ts": [
-  "../../../../../commercial-core/dist/cjs/types.d.ts"
- ],
- "../../../../../commercial-core/dist/cjs/third-party-tags/remarketing.d.ts": [
-  "../../../../../commercial-core/dist/cjs/types.d.ts"
- ],
- "../../../../../commercial-core/dist/cjs/third-party-tags/twitter-uwt.d.ts": [
-  "../../../../../commercial-core/dist/cjs/types.d.ts"
- ],
- "../../../../../commercial-core/dist/cjs/track-scroll-depth.d.ts": [],
- "../../../../../commercial-core/dist/cjs/types.d.ts": [
-  "../../../../../commercial-core/node_modules/@guardian/consent-management-platform/dist/types/index.d.ts"
- ],
- "../../../../../commercial-core/dist/esm/constants/index.d.ts": [
-  "../../../../../commercial-core/dist/esm/constants/prebid-timeout.d.ts",
-  "../../../../../commercial-core/dist/esm/constants/top-above-nav-height.d.ts"
- ],
- "../../../../../commercial-core/dist/esm/constants/prebid-timeout.d.ts": [],
- "../../../../../commercial-core/dist/esm/constants/top-above-nav-height.d.ts": [],
  "../lib/$$.ts": [
   "../../../../node_modules/csstype/index.d.ts"
  ],
@@ -145,7 +57,7 @@
   "../projects/common/modules/commercial/user-features.ts"
  ],
  "../projects/commercial/commercial-metrics.ts": [
-  "../../../../../commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../projects/common/modules/analytics/shouldCaptureMetrics.ts"
  ],
  "../projects/commercial/initial-consent-state.ts": [
@@ -161,7 +73,7 @@
   "../projects/common/modules/commercial/commercial-features.ts"
  ],
  "../projects/commercial/modules/ad-verification/prepare-ad-verification.ts": [
-  "../../../../../commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../projects/commercial/modules/dfp/get-advert-by-id.ts",
   "../projects/commercial/modules/dfp/load-advert.ts",
@@ -175,7 +87,7 @@
   "../lib/mediator.ts"
  ],
  "../projects/commercial/modules/article-body-adverts.ts": [
-  "../../../../../commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../lib/config.d.ts",
   "../lib/detect-viewport.ts",
   "../lib/fastdom-promise.js",
@@ -199,7 +111,8 @@
   "../projects/common/modules/spacefinder.ts"
  ],
  "../projects/commercial/modules/comment-adverts.ts": [
-  "../../../../../commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../lib/config.d.ts",
   "../lib/detect.js",
   "../lib/fastdom-promise.js",
@@ -240,7 +153,8 @@
  ],
  "../projects/commercial/modules/dfp/breakpoint-name-to-attribute.ts": [],
  "../projects/commercial/modules/dfp/create-slot.ts": [
-  "../../../../../commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../projects/commercial/modules/dfp/dfp-env-globals.ts"
  ],
  "../projects/commercial/modules/dfp/define-slot.js": [
@@ -301,7 +215,7 @@
   "../projects/common/modules/experiments/tests/commercial-lazy-load-margin.ts"
  ],
  "../projects/commercial/modules/dfp/load-advert.ts": [
-  "../../../../../commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../projects/commercial/modules/dfp/Advert.ts",
   "../projects/commercial/modules/header-bidding/a9/a9.ts",
   "../projects/commercial/modules/header-bidding/prebid/prebid.ts",
@@ -420,7 +334,7 @@
   "../lib/fastdom-promise.js"
  ],
  "../projects/commercial/modules/dfp/render-advert.ts": [
-  "../../../../../commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../lib/$$.ts",
   "../lib/fastdom-promise.js",
   "../lib/report-error.js",
@@ -430,7 +344,8 @@
   "../projects/commercial/modules/sticky-mpu.js"
  ],
  "../projects/commercial/modules/dfp/should-refresh.ts": [
-  "../../../../../commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../lib/config.d.ts",
   "../projects/commercial/modules/dfp/Advert.ts"
  ],
@@ -465,8 +380,8 @@
   "../projects/common/modules/commercial/geo-utils.js"
  ],
  "../projects/commercial/modules/header-bidding/prebid/prebid.ts": [
-  "../../../../../commercial-core/dist/cjs/index.d.ts",
-  "../../../../../commercial-core/dist/esm/constants/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/esm/constants/index.d.ts",
   "../../../../node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/config.d.ts",
@@ -484,7 +399,7 @@
   "../projects/common/modules/experiments/tests/prebid-price-granularity.ts"
  ],
  "../projects/commercial/modules/header-bidding/prebid/price-config.ts": [
-  "../../../../../commercial-core/dist/cjs/index.d.ts"
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts"
  ],
  "../projects/commercial/modules/header-bidding/prebid/pubmatic.js": [],
  "../projects/commercial/modules/header-bidding/slot-config.ts": [
@@ -549,7 +464,7 @@
  ],
  "../projects/commercial/modules/messenger/get-stylesheet.js": [],
  "../projects/commercial/modules/messenger/measure-ad-load.ts": [
-  "../../../../../commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../projects/commercial/modules/messenger.ts"
  ],
@@ -619,7 +534,8 @@
   "../projects/common/modules/commercial/commercial-features.ts"
  ],
  "../projects/commercial/modules/third-party-tags.ts": [
-  "../../../../../commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
   "../lib/config.d.ts",
   "../lib/fastdom-promise.js",
@@ -637,7 +553,7 @@
   "../projects/common/modules/commercial/geo-utils.js"
  ],
  "../projects/commercial/modules/track-scroll-depth.ts": [
-  "../../../../../commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../projects/common/modules/commercial/enhanced-consent.ts"
  ],
@@ -666,7 +582,8 @@
  ],
  "../projects/common/modules/async-call-merger.ts": [],
  "../projects/common/modules/commercial/build-page-targeting.ts": [
-  "../../../../../commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
   "../../../../node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",
   "../../../../node_modules/@guardian/consent-management-platform/dist/types/tcfv2/index.d.ts",
@@ -683,7 +600,6 @@
   "../projects/common/modules/identity/api.ts"
  ],
  "../projects/common/modules/commercial/commercial-features.ts": [
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/config.d.ts",
   "../lib/detect.js",
   "../projects/common/modules/commercial/user-features.ts",
@@ -817,7 +733,7 @@
   "../types/dates.ts"
  ],
  "standalone.commercial.ts": [
-  "../../../../../commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/report-error.js",
   "../lib/robust.js",

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -600,6 +600,8 @@
   "../projects/common/modules/identity/api.ts"
  ],
  "../projects/common/modules/commercial/commercial-features.ts": [
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../../../../node_modules/@types/lodash-es/index.d.ts",
   "../lib/config.d.ts",
   "../lib/detect.js",
   "../projects/common/modules/commercial/user-features.ts",

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -1,4 +1,92 @@
 {
+ "../../../../../commercial-core/dist/cjs/ad-sizes.d.ts": [],
+ "../../../../../commercial-core/dist/cjs/ad-targeting-youtube.d.ts": [
+  "../../../../../commercial-core/dist/cjs/types.d.ts",
+  "../../../../../commercial-core/node_modules/@guardian/consent-management-platform/dist/types/index.d.ts"
+ ],
+ "../../../../../commercial-core/dist/cjs/constants/index.d.ts": [
+  "../../../../../commercial-core/dist/cjs/constants/prebid-timeout.d.ts",
+  "../../../../../commercial-core/dist/cjs/constants/top-above-nav-height.d.ts"
+ ],
+ "../../../../../commercial-core/dist/cjs/constants/prebid-timeout.d.ts": [],
+ "../../../../../commercial-core/dist/cjs/constants/top-above-nav-height.d.ts": [],
+ "../../../../../commercial-core/dist/cjs/detect-ad-blocker.d.ts": [],
+ "../../../../../commercial-core/dist/cjs/event-timer.d.ts": [],
+ "../../../../../commercial-core/dist/cjs/index.d.ts": [
+  "../../../../../commercial-core/dist/cjs/ad-sizes.d.ts",
+  "../../../../../commercial-core/dist/cjs/ad-targeting-youtube.d.ts",
+  "../../../../../commercial-core/dist/cjs/constants/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/detect-ad-blocker.d.ts",
+  "../../../../../commercial-core/dist/cjs/event-timer.d.ts",
+  "../../../../../commercial-core/dist/cjs/permutive.d.ts",
+  "../../../../../commercial-core/dist/cjs/send-commercial-metrics.d.ts",
+  "../../../../../commercial-core/dist/cjs/targeting/content.d.ts",
+  "../../../../../commercial-core/dist/cjs/targeting/personalised.d.ts",
+  "../../../../../commercial-core/dist/cjs/targeting/pick-targeting-values.d.ts",
+  "../../../../../commercial-core/dist/cjs/targeting/session.d.ts",
+  "../../../../../commercial-core/dist/cjs/targeting/shared.d.ts",
+  "../../../../../commercial-core/dist/cjs/targeting/viewport.d.ts",
+  "../../../../../commercial-core/dist/cjs/third-party-tags/facebook-pixel.d.ts",
+  "../../../../../commercial-core/dist/cjs/third-party-tags/ias.d.ts",
+  "../../../../../commercial-core/dist/cjs/third-party-tags/inizio.d.ts",
+  "../../../../../commercial-core/dist/cjs/third-party-tags/permutive.d.ts",
+  "../../../../../commercial-core/dist/cjs/third-party-tags/remarketing.d.ts",
+  "../../../../../commercial-core/dist/cjs/third-party-tags/twitter-uwt.d.ts",
+  "../../../../../commercial-core/dist/cjs/track-scroll-depth.d.ts",
+  "../../../../../commercial-core/dist/cjs/types.d.ts"
+ ],
+ "../../../../../commercial-core/dist/cjs/permutive.d.ts": [],
+ "../../../../../commercial-core/dist/cjs/send-commercial-metrics.d.ts": [],
+ "../../../../../commercial-core/dist/cjs/targeting/content.d.ts": [
+  "../../../../../commercial-core/dist/cjs/targeting/shared.d.ts",
+  "../../../../../commercial-core/dist/cjs/types.d.ts"
+ ],
+ "../../../../../commercial-core/dist/cjs/targeting/personalised.d.ts": [
+  "../../../../../commercial-core/dist/cjs/types.d.ts",
+  "../../../../../commercial-core/node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",
+  "../../../../../commercial-core/node_modules/@guardian/consent-management-platform/dist/types/tcfv2/index.d.ts"
+ ],
+ "../../../../../commercial-core/dist/cjs/targeting/pick-targeting-values.d.ts": [
+  "../../../../../commercial-core/node_modules/type-fest/index.d.ts",
+  "../../../../../commercial-core/node_modules/type-fest/index.d.ts"
+ ],
+ "../../../../../commercial-core/dist/cjs/targeting/session.d.ts": [
+  "../../../../../commercial-core/dist/cjs/types.d.ts",
+  "../../../../../commercial-core/node_modules/@guardian/ab-core/dist/index.d.ts",
+  "../../../../../commercial-core/node_modules/@guardian/libs/dist/types/index.d.ts"
+ ],
+ "../../../../../commercial-core/dist/cjs/targeting/shared.d.ts": [],
+ "../../../../../commercial-core/dist/cjs/targeting/viewport.d.ts": [
+  "../../../../../commercial-core/dist/cjs/types.d.ts"
+ ],
+ "../../../../../commercial-core/dist/cjs/third-party-tags/facebook-pixel.d.ts": [
+  "../../../../../commercial-core/dist/cjs/types.d.ts"
+ ],
+ "../../../../../commercial-core/dist/cjs/third-party-tags/ias.d.ts": [
+  "../../../../../commercial-core/dist/cjs/types.d.ts"
+ ],
+ "../../../../../commercial-core/dist/cjs/third-party-tags/inizio.d.ts": [
+  "../../../../../commercial-core/dist/cjs/types.d.ts"
+ ],
+ "../../../../../commercial-core/dist/cjs/third-party-tags/permutive.d.ts": [
+  "../../../../../commercial-core/dist/cjs/types.d.ts"
+ ],
+ "../../../../../commercial-core/dist/cjs/third-party-tags/remarketing.d.ts": [
+  "../../../../../commercial-core/dist/cjs/types.d.ts"
+ ],
+ "../../../../../commercial-core/dist/cjs/third-party-tags/twitter-uwt.d.ts": [
+  "../../../../../commercial-core/dist/cjs/types.d.ts"
+ ],
+ "../../../../../commercial-core/dist/cjs/track-scroll-depth.d.ts": [],
+ "../../../../../commercial-core/dist/cjs/types.d.ts": [
+  "../../../../../commercial-core/node_modules/@guardian/consent-management-platform/dist/types/index.d.ts"
+ ],
+ "../../../../../commercial-core/dist/esm/constants/index.d.ts": [
+  "../../../../../commercial-core/dist/esm/constants/prebid-timeout.d.ts",
+  "../../../../../commercial-core/dist/esm/constants/top-above-nav-height.d.ts"
+ ],
+ "../../../../../commercial-core/dist/esm/constants/prebid-timeout.d.ts": [],
+ "../../../../../commercial-core/dist/esm/constants/top-above-nav-height.d.ts": [],
  "../lib/$$.ts": [
   "../../../../node_modules/csstype/index.d.ts"
  ],
@@ -57,7 +145,7 @@
   "../projects/common/modules/commercial/user-features.ts"
  ],
  "../projects/commercial/commercial-metrics.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/index.d.ts",
   "../projects/common/modules/analytics/shouldCaptureMetrics.ts"
  ],
  "../projects/commercial/initial-consent-state.ts": [
@@ -73,7 +161,7 @@
   "../projects/common/modules/commercial/commercial-features.ts"
  ],
  "../projects/commercial/modules/ad-verification/prepare-ad-verification.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../projects/commercial/modules/dfp/get-advert-by-id.ts",
   "../projects/commercial/modules/dfp/load-advert.ts",
@@ -87,7 +175,7 @@
   "../lib/mediator.ts"
  ],
  "../projects/commercial/modules/article-body-adverts.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/index.d.ts",
   "../lib/config.d.ts",
   "../lib/detect-viewport.ts",
   "../lib/fastdom-promise.js",
@@ -111,8 +199,7 @@
   "../projects/common/modules/spacefinder.ts"
  ],
  "../projects/commercial/modules/comment-adverts.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/index.d.ts",
   "../lib/config.d.ts",
   "../lib/detect.js",
   "../lib/fastdom-promise.js",
@@ -153,8 +240,7 @@
  ],
  "../projects/commercial/modules/dfp/breakpoint-name-to-attribute.ts": [],
  "../projects/commercial/modules/dfp/create-slot.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/index.d.ts",
   "../projects/commercial/modules/dfp/dfp-env-globals.ts"
  ],
  "../projects/commercial/modules/dfp/define-slot.js": [
@@ -215,7 +301,7 @@
   "../projects/common/modules/experiments/tests/commercial-lazy-load-margin.ts"
  ],
  "../projects/commercial/modules/dfp/load-advert.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/index.d.ts",
   "../projects/commercial/modules/dfp/Advert.ts",
   "../projects/commercial/modules/header-bidding/a9/a9.ts",
   "../projects/commercial/modules/header-bidding/prebid/prebid.ts",
@@ -334,7 +420,7 @@
   "../lib/fastdom-promise.js"
  ],
  "../projects/commercial/modules/dfp/render-advert.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/index.d.ts",
   "../lib/$$.ts",
   "../lib/fastdom-promise.js",
   "../lib/report-error.js",
@@ -344,8 +430,7 @@
   "../projects/commercial/modules/sticky-mpu.js"
  ],
  "../projects/commercial/modules/dfp/should-refresh.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/index.d.ts",
   "../lib/config.d.ts",
   "../projects/commercial/modules/dfp/Advert.ts"
  ],
@@ -380,8 +465,8 @@
   "../projects/common/modules/commercial/geo-utils.js"
  ],
  "../projects/commercial/modules/header-bidding/prebid/prebid.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/commercial-core/dist/esm/constants/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/index.d.ts",
+  "../../../../../commercial-core/dist/esm/constants/index.d.ts",
   "../../../../node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/config.d.ts",
@@ -399,7 +484,7 @@
   "../projects/common/modules/experiments/tests/prebid-price-granularity.ts"
  ],
  "../projects/commercial/modules/header-bidding/prebid/price-config.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts"
+  "../../../../../commercial-core/dist/cjs/index.d.ts"
  ],
  "../projects/commercial/modules/header-bidding/prebid/pubmatic.js": [],
  "../projects/commercial/modules/header-bidding/slot-config.ts": [
@@ -464,7 +549,7 @@
  ],
  "../projects/commercial/modules/messenger/get-stylesheet.js": [],
  "../projects/commercial/modules/messenger/measure-ad-load.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../projects/commercial/modules/messenger.ts"
  ],
@@ -534,8 +619,7 @@
   "../projects/common/modules/commercial/commercial-features.ts"
  ],
  "../projects/commercial/modules/third-party-tags.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
   "../lib/config.d.ts",
   "../lib/fastdom-promise.js",
@@ -553,7 +637,7 @@
   "../projects/common/modules/commercial/geo-utils.js"
  ],
  "../projects/commercial/modules/track-scroll-depth.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../projects/common/modules/commercial/enhanced-consent.ts"
  ],
@@ -582,8 +666,7 @@
  ],
  "../projects/common/modules/async-call-merger.ts": [],
  "../projects/common/modules/commercial/build-page-targeting.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
   "../../../../node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",
   "../../../../node_modules/@guardian/consent-management-platform/dist/types/tcfv2/index.d.ts",
@@ -601,7 +684,6 @@
  ],
  "../projects/common/modules/commercial/commercial-features.ts": [
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../../../../node_modules/@types/lodash-es/index.d.ts",
   "../lib/config.d.ts",
   "../lib/detect.js",
   "../projects/common/modules/commercial/user-features.ts",
@@ -735,7 +817,7 @@
   "../types/dates.ts"
  ],
  "standalone.commercial.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/report-error.js",
   "../lib/robust.js",

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -1,4 +1,92 @@
 {
+ "../../../../../commercial-core/dist/cjs/ad-sizes.d.ts": [],
+ "../../../../../commercial-core/dist/cjs/ad-targeting-youtube.d.ts": [
+  "../../../../../commercial-core/dist/cjs/types.d.ts",
+  "../../../../../commercial-core/node_modules/@guardian/consent-management-platform/dist/types/index.d.ts"
+ ],
+ "../../../../../commercial-core/dist/cjs/constants/index.d.ts": [
+  "../../../../../commercial-core/dist/cjs/constants/prebid-timeout.d.ts",
+  "../../../../../commercial-core/dist/cjs/constants/top-above-nav-height.d.ts"
+ ],
+ "../../../../../commercial-core/dist/cjs/constants/prebid-timeout.d.ts": [],
+ "../../../../../commercial-core/dist/cjs/constants/top-above-nav-height.d.ts": [],
+ "../../../../../commercial-core/dist/cjs/detect-ad-blocker.d.ts": [],
+ "../../../../../commercial-core/dist/cjs/event-timer.d.ts": [],
+ "../../../../../commercial-core/dist/cjs/index.d.ts": [
+  "../../../../../commercial-core/dist/cjs/ad-sizes.d.ts",
+  "../../../../../commercial-core/dist/cjs/ad-targeting-youtube.d.ts",
+  "../../../../../commercial-core/dist/cjs/constants/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/detect-ad-blocker.d.ts",
+  "../../../../../commercial-core/dist/cjs/event-timer.d.ts",
+  "../../../../../commercial-core/dist/cjs/permutive.d.ts",
+  "../../../../../commercial-core/dist/cjs/send-commercial-metrics.d.ts",
+  "../../../../../commercial-core/dist/cjs/targeting/content.d.ts",
+  "../../../../../commercial-core/dist/cjs/targeting/personalised.d.ts",
+  "../../../../../commercial-core/dist/cjs/targeting/pick-targeting-values.d.ts",
+  "../../../../../commercial-core/dist/cjs/targeting/session.d.ts",
+  "../../../../../commercial-core/dist/cjs/targeting/shared.d.ts",
+  "../../../../../commercial-core/dist/cjs/targeting/viewport.d.ts",
+  "../../../../../commercial-core/dist/cjs/third-party-tags/facebook-pixel.d.ts",
+  "../../../../../commercial-core/dist/cjs/third-party-tags/ias.d.ts",
+  "../../../../../commercial-core/dist/cjs/third-party-tags/inizio.d.ts",
+  "../../../../../commercial-core/dist/cjs/third-party-tags/permutive.d.ts",
+  "../../../../../commercial-core/dist/cjs/third-party-tags/remarketing.d.ts",
+  "../../../../../commercial-core/dist/cjs/third-party-tags/twitter-uwt.d.ts",
+  "../../../../../commercial-core/dist/cjs/track-scroll-depth.d.ts",
+  "../../../../../commercial-core/dist/cjs/types.d.ts"
+ ],
+ "../../../../../commercial-core/dist/cjs/permutive.d.ts": [],
+ "../../../../../commercial-core/dist/cjs/send-commercial-metrics.d.ts": [],
+ "../../../../../commercial-core/dist/cjs/targeting/content.d.ts": [
+  "../../../../../commercial-core/dist/cjs/targeting/shared.d.ts",
+  "../../../../../commercial-core/dist/cjs/types.d.ts"
+ ],
+ "../../../../../commercial-core/dist/cjs/targeting/personalised.d.ts": [
+  "../../../../../commercial-core/dist/cjs/types.d.ts",
+  "../../../../../commercial-core/node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",
+  "../../../../../commercial-core/node_modules/@guardian/consent-management-platform/dist/types/tcfv2/index.d.ts"
+ ],
+ "../../../../../commercial-core/dist/cjs/targeting/pick-targeting-values.d.ts": [
+  "../../../../../commercial-core/node_modules/type-fest/index.d.ts",
+  "../../../../../commercial-core/node_modules/type-fest/index.d.ts"
+ ],
+ "../../../../../commercial-core/dist/cjs/targeting/session.d.ts": [
+  "../../../../../commercial-core/dist/cjs/types.d.ts",
+  "../../../../../commercial-core/node_modules/@guardian/ab-core/dist/index.d.ts",
+  "../../../../../commercial-core/node_modules/@guardian/libs/dist/types/index.d.ts"
+ ],
+ "../../../../../commercial-core/dist/cjs/targeting/shared.d.ts": [],
+ "../../../../../commercial-core/dist/cjs/targeting/viewport.d.ts": [
+  "../../../../../commercial-core/dist/cjs/types.d.ts"
+ ],
+ "../../../../../commercial-core/dist/cjs/third-party-tags/facebook-pixel.d.ts": [
+  "../../../../../commercial-core/dist/cjs/types.d.ts"
+ ],
+ "../../../../../commercial-core/dist/cjs/third-party-tags/ias.d.ts": [
+  "../../../../../commercial-core/dist/cjs/types.d.ts"
+ ],
+ "../../../../../commercial-core/dist/cjs/third-party-tags/inizio.d.ts": [
+  "../../../../../commercial-core/dist/cjs/types.d.ts"
+ ],
+ "../../../../../commercial-core/dist/cjs/third-party-tags/permutive.d.ts": [
+  "../../../../../commercial-core/dist/cjs/types.d.ts"
+ ],
+ "../../../../../commercial-core/dist/cjs/third-party-tags/remarketing.d.ts": [
+  "../../../../../commercial-core/dist/cjs/types.d.ts"
+ ],
+ "../../../../../commercial-core/dist/cjs/third-party-tags/twitter-uwt.d.ts": [
+  "../../../../../commercial-core/dist/cjs/types.d.ts"
+ ],
+ "../../../../../commercial-core/dist/cjs/track-scroll-depth.d.ts": [],
+ "../../../../../commercial-core/dist/cjs/types.d.ts": [
+  "../../../../../commercial-core/node_modules/@guardian/consent-management-platform/dist/types/index.d.ts"
+ ],
+ "../../../../../commercial-core/dist/esm/constants/index.d.ts": [
+  "../../../../../commercial-core/dist/esm/constants/prebid-timeout.d.ts",
+  "../../../../../commercial-core/dist/esm/constants/top-above-nav-height.d.ts"
+ ],
+ "../../../../../commercial-core/dist/esm/constants/prebid-timeout.d.ts": [],
+ "../../../../../commercial-core/dist/esm/constants/top-above-nav-height.d.ts": [],
  "../lib/$$.ts": [
   "../../../../node_modules/csstype/index.d.ts"
  ],
@@ -57,7 +145,7 @@
   "../projects/common/modules/commercial/user-features.ts"
  ],
  "../projects/commercial/commercial-metrics.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/index.d.ts",
   "../projects/common/modules/analytics/shouldCaptureMetrics.ts"
  ],
  "../projects/commercial/initial-consent-state.ts": [
@@ -73,7 +161,7 @@
   "../projects/common/modules/commercial/commercial-features.ts"
  ],
  "../projects/commercial/modules/ad-verification/prepare-ad-verification.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../projects/commercial/modules/dfp/get-advert-by-id.ts",
   "../projects/commercial/modules/dfp/load-advert.ts",
@@ -87,7 +175,7 @@
   "../lib/mediator.ts"
  ],
  "../projects/commercial/modules/article-body-adverts.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/index.d.ts",
   "../lib/config.d.ts",
   "../lib/detect-viewport.ts",
   "../lib/fastdom-promise.js",
@@ -111,8 +199,7 @@
   "../projects/common/modules/spacefinder.ts"
  ],
  "../projects/commercial/modules/comment-adverts.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/index.d.ts",
   "../lib/config.d.ts",
   "../lib/detect.js",
   "../lib/fastdom-promise.js",
@@ -153,8 +240,7 @@
  ],
  "../projects/commercial/modules/dfp/breakpoint-name-to-attribute.ts": [],
  "../projects/commercial/modules/dfp/create-slot.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/index.d.ts",
   "../projects/commercial/modules/dfp/dfp-env-globals.ts"
  ],
  "../projects/commercial/modules/dfp/define-slot.js": [
@@ -215,7 +301,7 @@
   "../projects/common/modules/experiments/tests/commercial-lazy-load-margin.ts"
  ],
  "../projects/commercial/modules/dfp/load-advert.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/index.d.ts",
   "../projects/commercial/modules/dfp/Advert.ts",
   "../projects/commercial/modules/header-bidding/a9/a9.ts",
   "../projects/commercial/modules/header-bidding/prebid/prebid.ts",
@@ -334,7 +420,7 @@
   "../lib/fastdom-promise.js"
  ],
  "../projects/commercial/modules/dfp/render-advert.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/index.d.ts",
   "../lib/$$.ts",
   "../lib/fastdom-promise.js",
   "../lib/report-error.js",
@@ -344,8 +430,7 @@
   "../projects/commercial/modules/sticky-mpu.js"
  ],
  "../projects/commercial/modules/dfp/should-refresh.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/index.d.ts",
   "../lib/config.d.ts",
   "../projects/commercial/modules/dfp/Advert.ts"
  ],
@@ -380,8 +465,8 @@
   "../projects/common/modules/commercial/geo-utils.js"
  ],
  "../projects/commercial/modules/header-bidding/prebid/prebid.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/commercial-core/dist/esm/constants/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/index.d.ts",
+  "../../../../../commercial-core/dist/esm/constants/index.d.ts",
   "../../../../node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/config.d.ts",
@@ -399,7 +484,7 @@
   "../projects/common/modules/experiments/tests/prebid-price-granularity.ts"
  ],
  "../projects/commercial/modules/header-bidding/prebid/price-config.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts"
+  "../../../../../commercial-core/dist/cjs/index.d.ts"
  ],
  "../projects/commercial/modules/header-bidding/prebid/pubmatic.js": [],
  "../projects/commercial/modules/header-bidding/slot-config.ts": [
@@ -464,7 +549,7 @@
  ],
  "../projects/commercial/modules/messenger/get-stylesheet.js": [],
  "../projects/commercial/modules/messenger/measure-ad-load.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../projects/commercial/modules/messenger.ts"
  ],
@@ -534,8 +619,7 @@
   "../projects/common/modules/commercial/commercial-features.ts"
  ],
  "../projects/commercial/modules/third-party-tags.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
   "../lib/config.d.ts",
   "../lib/fastdom-promise.js",
@@ -553,7 +637,7 @@
   "../projects/common/modules/commercial/geo-utils.js"
  ],
  "../projects/commercial/modules/track-scroll-depth.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../projects/common/modules/commercial/enhanced-consent.ts"
  ],
@@ -582,8 +666,7 @@
  ],
  "../projects/common/modules/async-call-merger.ts": [],
  "../projects/common/modules/commercial/build-page-targeting.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
   "../../../../node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",
   "../../../../node_modules/@guardian/consent-management-platform/dist/types/tcfv2/index.d.ts",
@@ -600,6 +683,7 @@
   "../projects/common/modules/identity/api.ts"
  ],
  "../projects/common/modules/commercial/commercial-features.ts": [
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/config.d.ts",
   "../lib/detect.js",
   "../projects/common/modules/commercial/user-features.ts",
@@ -733,7 +817,7 @@
   "../types/dates.ts"
  ],
  "standalone.commercial.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../../commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/report-error.js",
   "../lib/robust.js",

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -600,6 +600,7 @@
   "../projects/common/modules/identity/api.ts"
  ],
  "../projects/common/modules/commercial/commercial-features.ts": [
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/config.d.ts",
   "../lib/detect.js",
   "../projects/common/modules/commercial/user-features.ts",


### PR DESCRIPTION
## What does this change?
Logs the reason why there are no article ads, reasons include:

The following are true
- `forceAdFree`
- `isAdFreeUser`
- `sensitiveContent`
- `isMinuteArticle`
- `isLiveBlog`
- `isHosted`
- `newRecipeDesign`

Or the following are false
- `switches.commercial`
- `externalAdvertising`

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
<img width="414" alt="Screenshot 2022-04-28 at 13 58 31" src="https://user-images.githubusercontent.com/1731150/165757457-82fae3f4-3748-4860-a99a-e5a2dfa61066.png">

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
