### PR TITLE
Restore Update link text and destinations for single front door test v3

### DIFF
--- a/common/app/navigation/ReaderRevenueSite.scala
+++ b/common/app/navigation/ReaderRevenueSite.scala
@@ -29,6 +29,10 @@ object ReaderRevenueSite extends enumeratum.Enum[ReaderRevenueSite] {
     val url: String = s"${Configuration.id.supportUrl}/subscribe"
   }
 
+  case object SupportGuardianWeekly extends ReaderRevenueSite {
+    val url: String = s"${Configuration.id.supportUrl}/subscribe/weekly"
+  }
+
   case object SupportContribute extends ReaderRevenueSite {
     val url: String = s"${Configuration.id.supportUrl}/contribute"
   }

--- a/common/app/navigation/helpers/UrlHelpers.scala
+++ b/common/app/navigation/helpers/UrlHelpers.scala
@@ -65,7 +65,11 @@ object UrlHelpers {
   def readerRevenueLinks(implicit request: RequestHeader): List[NavLink] =
     List(
       NavLink("Make a contribution", getReaderRevenueUrl(SupportContribute, SideMenu)),
-      NavLink("Subscribe", getReaderRevenueUrl(SupportSubscribe, SideMenu), classList = Seq("js-subscribe")),
+      NavLink(
+        "Print subscriptions",
+        getReaderRevenueUrl(SupportGuardianWeekly, SideMenu),
+        classList = Seq("js-subscribe"),
+      ),
     )
 
   def getReaderRevenueUrl(destination: ReaderRevenueSite, position: Position): String = {

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -83,8 +83,6 @@
                             </ul>
                         }
 
-                        @readerRevenueLinks(Edition(request).id.toLowerCase())
-
                     } else {
                         <div class="colophon__list">
                             @fragments.inlineSvg("guardian-foundation", "logo")

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -4,7 +4,7 @@
 @import views.support.RenderClasses
 @import navigation.NavMenu
 @import navigation.UrlHelpers.{getJobUrl, Header, getReaderRevenueUrl}
-@import navigation.ReaderRevenueSite.{Support, SupportSubscribe, SupportContribute, SupporterCTA}
+@import navigation.ReaderRevenueSite.{Support, SupportSubscribe, SupportGuardianWeekly, SupportContribute, SupporterCTA}
 @import conf.switches.Switches.{IdentityProfileNavigationSwitch, SearchSwitch, AnniversaryLogoHeader}
 
 @defining(NavMenu(page, Edition(request))) { navMenu: NavMenu =>
@@ -48,13 +48,10 @@
             <div class="new-header__top-bar hide-until-mobile">
                 @defining(Edition(request).id.toLowerCase()) { editionId =>
                 @if(!page.metadata.hasSlimHeader) {
-                <div class="top-bar__commercial-items js-supporter-cta is-hidden">
+                <div class="top-bar__commercial-items">
                     <span class="top-bar__item__seperator hide-until-desktop"></span>
-                    <a class="top-bar__item hide-until-desktop"
-                       data-link-name="nav2 : supporter-cta"
-                       data-edition="@{editionId}"
-                       href="@getReaderRevenueUrl(SupporterCTA, Header)">
-                        Subscriptions
+                    <a class="top-bar__item hide-until-desktop" data-link-name="nav2 : supporter-cta" data-edition="@{editionId}" href="@getReaderRevenueUrl(SupportGuardianWeekly, Header)">
+                        Print subscriptions
                     </a>
                 </div>
 


### PR DESCRIPTION
Restores `Update link text and destinations for single front door test v3` changes by reverting the revert guardian/frontend#24968