### PR TITLE
Add Australia tags and 0% AB test for Ipsos Mori

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -57,7 +57,7 @@ trait ABTestSwitches {
   Switch(
     ABTests,
     "ab-ipsos-mori-australia",
-    "Use 0% test to check that ipsos mori tagging is working in AU region",
+    "Use 0% AB test to check that ipsos mori tagging is working in AU region",
     owners = Seq(Owner.withGithub("lucymonie")),
     safeState = Off,
     sellByDate = Some(LocalDate.of(2022, 7, 15)),

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -53,4 +53,14 @@ trait ABTestSwitches {
     sellByDate = Some(LocalDate.of(2022, 5, 9)),
     exposeClientSide = true,
   )
+
+  Switch(
+    ABTests,
+    "ipsos-mori-australia",
+    "Use 0% test to check that ipsos mori tagging is working in AU region",
+    owners = Seq(Owner.withGithub("lucymonie")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2022, 7, 15)),
+    exposeClientSide = true,
+  )
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -56,7 +56,7 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ipsos-mori-australia",
+    "ab-ipsos-mori-australia",
     "Use 0% test to check that ipsos mori tagging is working in AU region",
     owners = Seq(Owner.withGithub("lucymonie")),
     safeState = Off,

--- a/common/app/model/IpsosTags.scala
+++ b/common/app/model/IpsosTags.scala
@@ -19,17 +19,23 @@ object IpsosTags {
     "uk/commentisfree" -> "commentisfree",
     "commentisfree" -> "commentisfree", /* Default for comment articles */
     "us/commentisfree" -> "uscommentisfree",
+    "au/commentisfree" -> "commentisfree",
     "community" -> "community",
     "crosswords" -> "crosswords",
-    "uk/culture" -> "culture", /* There is no US or AU culture tag - should these map to culture? */
+    "uk/culture" -> "culture", /* There is no US culture tag - should these map to culture? */
+    "au/culture" -> "culture",
     "education" -> "education",
-    "uk/environment" -> "environment", /* There is no US or AU environment tag - should these map to environment? */
+    "uk/environment" -> "environment", /* There is no US environment tag - should these map to environment? */
     "environment" -> "environment", /* Default for environment articles */
+    "au/environment" -> "environment",
     "fashion" -> "fashion",
+    "au/lifeandstyle/fashion" -> "fashion",
     "fashion/beauty" -> "fashion",
-    "uk/film" -> "film", /* There is no US or AU film tag - should these map to film? */
+    "uk/film" -> "film", /* There is no US film tag - should these map to film? */
     "film" -> "film",
+    "au/film" -> "film",
     "food" -> "food",
+    "au/food" -> "food",
     "football" -> "football",
     "games" -> "games",
     "global-development" -> "globaldevelopment",
@@ -40,7 +46,8 @@ object IpsosTags {
     "inequality" -> "inequality",
     "about" -> "info",
     "law" -> "law",
-    "uk/lifeandstyle" -> "lifeandstyle", /* There is no US or AU lifeandstyle tag - should these map to lifeandstyle? */
+    "uk/lifeandstyle" -> "lifeandstyle", /* There is no US lifeandstyle tag - should these map to lifeandstyle? */
+    "au/lifeandstyle" -> "lifeandstyle",
     "lifeandstyle" -> "lifeandstyle",
     "lifeandstyle/love-and-sex" -> "lifeandstyle",
     "lifeandstyle/women" -> "lifeandstyle",
@@ -48,9 +55,11 @@ object IpsosTags {
     "lifeandstyle/home-and-garden" -> "lifeandstyle",
     "us/lifeandstyle" -> "lifeandstyle",
     "lifeandstyle/home-and-garden" -> "lifeandstyle",
-    "uk/media" -> "media", /* There is no US or AU media tag - should these map to media? */
+    "au/media" -> "media",
+    "uk/media" -> "media", /* There is no US media tag - should these map to media? */
     "membership" -> "membership",
-    "uk/money" -> "money", /* There is no US or AU money tag - should these map to money? */
+    "au/money" -> "money",
+    "uk/money" -> "money", /* There is no US money tag - should these map to money? */
     "money" -> "money",
     "money/debt" -> "money",
     "money/property" -> "money",
@@ -63,11 +72,13 @@ object IpsosTags {
     "observer-food-monthly-awards" -> "ofmawards",
     "observer" -> "observer",
     "politics" -> "politics",
+    "australia-news/australian-politics" -> "politics",
     "public-leaders-network" -> "publicleaders",
     "science" -> "science",
     "small-business-network" -> "smallbusiness",
     "society" -> "society",
     "uk/sport" -> "sport",
+    "au/sport" -> "sport",
     "sport/cricket" -> "cricket",
     "sport/rugby-union" -> "rugbyunion",
     "sport/tennis" -> "tennis",
@@ -76,12 +87,16 @@ object IpsosTags {
     "sport/golf" -> "golf",
     "sport/boxing" -> "boxing",
     "sport/rugbyleague" -> "rugbyleague",
+    "sport/nrl" -> "rugbyleague",
+    "sport/netball" -> "netball",
+    "sport/afl" -> "australianrulesfootball",
     "sport/horse-racing" -> "horseracing",
     "sport/us-sport" -> "ussport",
     "sport" -> "sport", /* Default for sport articles */
     "stage" -> "stage",
     "teacher-network" -> "teachernetwork",
-    "uk/technology" -> "technology", /* There is no US or AU technology tag - should these map to technology? */
+    "uk/technology" -> "technology", /* There is no US technology tag - should these map to technology? */
+    "au/technology" -> "technology",
     "technology" -> "technology", /* Default for technology (including motoring) articles */
     "the-guardian-foundation" -> "foundation",
     "theguardian" -> "theguardian",
@@ -94,25 +109,31 @@ object IpsosTags {
     "au/travel" -> "travel",
     "tv-and-radio" -> "tvandradio",
     "uk/tv-and-radio" -> "tvandradio",
+    "au/tv-and-radio" -> "tvandradio",
     "uk-news" -> "uknews",
     "us-news" -> "us-news",
     "voluntary-sector-network" -> "voluntarysector",
     "world" -> "world",
     "world/coronavirus-outbreak" -> "coronavirusoutbreak",
     "tone/obituaries" -> "obituaries",
+    "australia-news+tone/obituaries" -> "obituaries",
     "tone/recipes" -> "recipes",
     "type/video" -> "video",
     "video" -> "video",
     "documentaries" -> "documentaries",
     "type/podcast" -> "podcasts",
     "podcasts" -> "podcasts",
+    "australia-podcasts" -> "podcasts",
     "inpictures" -> "inpictures",
     "type/gallery" -> "inpictures",
     "publication/guardianweekly" -> "weekly",
     "weekly" -> "weekly",
     "guardian-professional" -> "professional",
     "lifeandstyle/health-and-wellbeing" -> "healthandwellbeing",
+    "au/lifeandstyle/health-and-wellbeing" -> "healthandwellbeing",
     "jobs" -> "jobs",
+    "australia-news/indigenous-australians" -> "indigenous-australians",
+    "guardian-labs-australia" -> "advertisement-features",
   )
 
   // Default to top level `guardian` tag if key is not found

--- a/static/src/javascripts/projects/commercial/modules/ipsos-mori.ts
+++ b/static/src/javascripts/projects/commercial/modules/ipsos-mori.ts
@@ -26,6 +26,7 @@ const loadIpsosScript = (locale: 'au' | 'uk') => {
  * documentation on DCR: [link](https://github.com/guardian/dotcom-rendering/blob/150fc2d81e6a66d9c3336185e874fc8cd0288546/dotcom-rendering/docs/architecture/3rd%20party%20technical%20review/002-ipsos-mori.md)
  * @returns Promise
  */
+
 export const init = (): Promise<void> => {
 	const forceIpsosMoriAustraliaTest = isInVariantSynchronous(
 		ipsosMoriAustralia,
@@ -34,19 +35,16 @@ export const init = (): Promise<void> => {
 
 	return getLocale()
 		.then((locale) => {
-			if (
-				locale === 'GB' ||
-				(locale === 'AU' && forceIpsosMoriAustraliaTest)
-			) {
+			if (locale === 'GB') {
 				return getInitialConsentState();
+			} else if (locale === 'AU' && forceIpsosMoriAustraliaTest) {
+				void loadIpsosScript('au');
 			} else {
 				throw Error('Skipping ipsos process outside GB or AU');
 			}
 		})
 		.then((state) => {
-			if (state.aus) {
-				void loadIpsosScript('au');
-			} else if (getConsentFor('ipsos', state)) {
+			if (!!state && getConsentFor('ipsos', state)) {
 				void loadIpsosScript('uk');
 			} else {
 				throw Error('No consent for ipsos');

--- a/static/src/javascripts/projects/commercial/modules/ipsos-mori.ts
+++ b/static/src/javascripts/projects/commercial/modules/ipsos-mori.ts
@@ -6,13 +6,14 @@ import { ipsosMoriAustralia } from 'common/modules/experiments/tests/ipsos-mori-
 import config from '../../../lib/config';
 import { stub } from './__vendor/ipsos-mori';
 
-const loadIpsosScript = () => {
+const loadIpsosScript = (locale?: string) => {
 	stub();
 
 	const ipsosTag = config.get<string>('page.ipsosTag');
 	if (ipsosTag === undefined) throw Error('Ipsos tag undefined');
+	const dotmetricsLocation = !!locale && locale === 'AU' ? 'au' : 'uk';
 
-	const ipsosSource = `https://uk-script.dotmetrics.net/door.js?d=${document.location.host}&t=${ipsosTag}`;
+	const ipsosSource = `https://${dotmetricsLocation}-script.dotmetrics.net/door.js?d=${document.location.host}&t=${ipsosTag}`;
 
 	return loadScript(ipsosSource, {
 		id: 'ipsos',
@@ -38,7 +39,7 @@ export const init = (): Promise<void> => {
 				return getInitialConsentState();
 			} else if (locale === 'AU' && forceIpsosMoriAustraliaTest) {
 				// Skipping consent step for Australia in 0% test
-				void loadIpsosScript();
+				void loadIpsosScript(locale);
 			} else {
 				throw Error('Skipping ipsos process outside GB or AU');
 			}

--- a/static/src/javascripts/projects/commercial/modules/ipsos-mori.ts
+++ b/static/src/javascripts/projects/commercial/modules/ipsos-mori.ts
@@ -32,34 +32,22 @@ export const init = (): Promise<void> => {
 		'variant',
 	);
 
-	getLocale()
+	return getLocale()
 		.then((locale) => {
 			if (locale === 'GB') {
 				return getInitialConsentState();
-			} else {
-				throw Error('Skipping GB ipsos process outside GB');
-			}
-		})
-		.then((state) => {
-			if (getConsentFor('ipsos', state)) {
-				void loadIpsosScript();
-			} else {
-				throw Error('No consent for ipsos');
-			}
-		})
-		.catch((e) => {
-			log('commercial', '⚠️ Failed to execute ipsos', e);
-		});
-
-	// Australia is handled with a separate call to getLocale because its
-	// initial step doesn't return a consent state and would throw an error
-	getLocale()
-		.then((locale) => {
-			if (locale === 'AU' && forceIpsosMoriAustraliaTest) {
+			} else if (locale === 'AU' && forceIpsosMoriAustraliaTest) {
 				// Skipping consent step for Australia in 0% test
 				void loadIpsosScript();
 			} else {
-				throw Error('Skipping AU ipsos outside AU');
+				throw Error('Skipping ipsos process outside GB or AU');
+			}
+		})
+		.then((state) => {
+			if (!!state && getConsentFor('ipsos', state)) {
+				void loadIpsosScript();
+			} else {
+				throw Error('No consent for ipsos');
 			}
 		})
 		.catch((e) => {

--- a/static/src/javascripts/projects/commercial/modules/ipsos-mori.ts
+++ b/static/src/javascripts/projects/commercial/modules/ipsos-mori.ts
@@ -26,7 +26,6 @@ const loadIpsosScript = (locale: 'au' | 'uk') => {
  * documentation on DCR: [link](https://github.com/guardian/dotcom-rendering/blob/150fc2d81e6a66d9c3336185e874fc8cd0288546/dotcom-rendering/docs/architecture/3rd%20party%20technical%20review/002-ipsos-mori.md)
  * @returns Promise
  */
-
 export const init = (): Promise<void> => {
 	const forceIpsosMoriAustraliaTest = isInVariantSynchronous(
 		ipsosMoriAustralia,
@@ -35,16 +34,19 @@ export const init = (): Promise<void> => {
 
 	return getLocale()
 		.then((locale) => {
-			if (locale === 'GB') {
+			if (
+				locale === 'GB' ||
+				(locale === 'AU' && forceIpsosMoriAustraliaTest)
+			) {
 				return getInitialConsentState();
-			} else if (locale === 'AU' && forceIpsosMoriAustraliaTest) {
-				void loadIpsosScript('au');
 			} else {
 				throw Error('Skipping ipsos process outside GB or AU');
 			}
 		})
 		.then((state) => {
-			if (!!state && getConsentFor('ipsos', state)) {
+			if (state.aus) {
+				void loadIpsosScript('au');
+			} else if (getConsentFor('ipsos', state)) {
 				void loadIpsosScript('uk');
 			} else {
 				throw Error('No consent for ipsos');

--- a/static/src/javascripts/projects/commercial/modules/ipsos-mori.ts
+++ b/static/src/javascripts/projects/commercial/modules/ipsos-mori.ts
@@ -26,7 +26,7 @@ const loadIpsosScript = (locale: 'au' | 'uk') => {
  * documentation on DCR: [link](https://github.com/guardian/dotcom-rendering/blob/150fc2d81e6a66d9c3336185e874fc8cd0288546/dotcom-rendering/docs/architecture/3rd%20party%20technical%20review/002-ipsos-mori.md)
  * @returns Promise
  */
-export const init = (): Promise<void> => {
+export const init = async (): Promise<void> => {
 	const forceIpsosMoriAustraliaTest = isInVariantSynchronous(
 		ipsosMoriAustralia,
 		'variant',
@@ -46,8 +46,10 @@ export const init = (): Promise<void> => {
 		.then((state) => {
 			if (state.aus) {
 				void loadIpsosScript('au');
-			} else if (getConsentFor('ipsos', state)) {
-				void loadIpsosScript('uk');
+			} else if (state.tcfv2) {
+				if (getConsentFor('ipsos', state)) {
+					void loadIpsosScript('uk');
+				}
 			} else {
 				throw Error('No consent for ipsos in GB');
 			}

--- a/static/src/javascripts/projects/commercial/modules/ipsos-mori.ts
+++ b/static/src/javascripts/projects/commercial/modules/ipsos-mori.ts
@@ -49,7 +49,7 @@ export const init = (): Promise<void> => {
 			} else if (getConsentFor('ipsos', state)) {
 				void loadIpsosScript('uk');
 			} else {
-				throw Error('No consent for ipsos in GB or AU');
+				throw Error('No consent for ipsos in GB');
 			}
 		})
 		.catch((e) => {

--- a/static/src/javascripts/projects/commercial/modules/ipsos-mori.ts
+++ b/static/src/javascripts/projects/commercial/modules/ipsos-mori.ts
@@ -49,7 +49,7 @@ export const init = (): Promise<void> => {
 			} else if (getConsentFor('ipsos', state)) {
 				void loadIpsosScript('uk');
 			} else {
-				throw Error('No consent for ipsos');
+				throw Error('No consent for ipsos in GB or AU');
 			}
 		})
 		.catch((e) => {

--- a/static/src/javascripts/projects/commercial/modules/ipsos-mori.ts
+++ b/static/src/javascripts/projects/commercial/modules/ipsos-mori.ts
@@ -46,7 +46,7 @@ export const init = (): Promise<void> => {
 		.then((state) => {
 			if (state.aus) {
 				void loadIpsosScript('au');
-			} else if (getConsentFor('ipsos', consentState)) {
+			} else if (getConsentFor('ipsos', state)) {
 				void loadIpsosScript('uk');
 			} else {
 				throw Error('No consent for ipsos');

--- a/static/src/javascripts/projects/commercial/modules/ipsos-mori.ts
+++ b/static/src/javascripts/projects/commercial/modules/ipsos-mori.ts
@@ -26,7 +26,7 @@ const loadIpsosScript = (locale: 'au' | 'uk') => {
  * documentation on DCR: [link](https://github.com/guardian/dotcom-rendering/blob/150fc2d81e6a66d9c3336185e874fc8cd0288546/dotcom-rendering/docs/architecture/3rd%20party%20technical%20review/002-ipsos-mori.md)
  * @returns Promise
  */
-export const init = async (): Promise<void> => {
+export const init = (): Promise<void> => {
 	const forceIpsosMoriAustraliaTest = isInVariantSynchronous(
 		ipsosMoriAustralia,
 		'variant',
@@ -46,10 +46,8 @@ export const init = async (): Promise<void> => {
 		.then((state) => {
 			if (state.aus) {
 				void loadIpsosScript('au');
-			} else if (state.tcfv2) {
-				if (getConsentFor('ipsos', state)) {
-					void loadIpsosScript('uk');
-				}
+			} else if (getConsentFor('ipsos', state)) {
+				void loadIpsosScript('uk');
 			} else {
 				throw Error('No consent for ipsos in GB');
 			}

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -1,6 +1,7 @@
 import type { ABTest } from '@guardian/ab-core';
 import { commercialGptLazyLoad } from './tests/commercial-gpt-lazy-load';
 import { commercialLazyLoadMargin } from './tests/commercial-lazy-load-margin';
+import { ipsosMoriAustralia } from './tests/ipsos-mori-australia';
 import { prebidPriceGranularity } from './tests/prebid-price-granularity';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
@@ -15,4 +16,5 @@ export const concurrentTests: readonly ABTest[] = [
 	commercialGptLazyLoad,
 	commercialLazyLoadMargin,
 	prebidPriceGranularity,
+	ipsosMoriAustralia,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/ipsos-mori-australia.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/ipsos-mori-australia.ts
@@ -1,0 +1,22 @@
+import type { ABTest } from '@guardian/ab-core';
+import { noop } from '../../../../../lib/noop';
+
+export const ipsosMoriAustralia: ABTest = {
+	id: 'IpsosMoriAustralia',
+	start: '2022-04-28',
+	expiry: '2022-06-30',
+	author: 'Lucy Monie Hall (@lucymonie)',
+	description:
+		'Provide a 0% AB test to check that tagging is working in the AU region',
+	audience: 0,
+	audienceOffset: 0,
+	successMeasure: 'n/a',
+	audienceCriteria: 'n/a',
+	canRun: () => true,
+	variants: [
+		{
+			id: 'variant',
+			test: noop,
+		},
+	],
+};

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -426,7 +426,9 @@
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/config.d.ts",
   "../projects/commercial/initial-consent-state.ts",
-  "../projects/commercial/modules/__vendor/ipsos-mori.js"
+  "../projects/commercial/modules/__vendor/ipsos-mori.js",
+  "../projects/common/modules/experiments/ab.ts",
+  "../projects/common/modules/experiments/tests/ipsos-mori-australia.ts"
  ],
  "../projects/commercial/modules/liveblog-adverts.ts": [
   "../lib/detect.js",
@@ -659,6 +661,7 @@
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
   "../projects/common/modules/experiments/tests/commercial-gpt-lazy-load.ts",
   "../projects/common/modules/experiments/tests/commercial-lazy-load-margin.ts",
+  "../projects/common/modules/experiments/tests/ipsos-mori-australia.ts",
   "../projects/common/modules/experiments/tests/prebid-price-granularity.ts",
   "../projects/common/modules/experiments/tests/remote-header-test.js",
   "../projects/common/modules/experiments/tests/sign-in-gate-main-control.js",
@@ -690,6 +693,10 @@
   "../lib/noop.ts"
  ],
  "../projects/common/modules/experiments/tests/commercial-lazy-load-margin.ts": [
+  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
+  "../lib/noop.ts"
+ ],
+ "../projects/common/modules/experiments/tests/ipsos-mori-australia.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
   "../lib/noop.ts"
  ],


### PR DESCRIPTION
## What does this change?
This adds some Ipsos Mori tag mapping for Australia-specific tag pages and fronts so the correct (more specific) tags are passed rather than the generic `ipsosTag=guardian` tag.

In addition, this adds logic that will run the Ipsos Mori script on pages browsed in the AU geo region, but makes this available only via a 0% AB test. When the region is AU, a localised dotmetrics script is loaded.

To force the variant to show, add the following to any dotcom url: `#ab-IpsosMoriAustralia=variant`

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
The Australian team has indicated that this is a very high priority as a lack of tags will lead to lost ad revenue.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
