### PR TITLE
Enable cricket liveblogs in DCR

### DIFF
--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -362,15 +362,11 @@ object LiveBlogController {
     blog.article.fields.lastModified.isBefore(twoDaysAgo)
   }
 
-  def isCricket(blog: PageWithStoryPackage): Boolean = {
-    blog.article.tags.tags.exists(tag => tag.id == "sport/cricket")
-  }
-
   def isRugby(blog: PageWithStoryPackage): Boolean = {
     blog.article.tags.tags.exists(tag => tag.id == "sport/rugby-union")
   }
 
   def checkIfSupported(blog: PageWithStoryPackage): Boolean = {
-    isSupportedTheme(blog) && !isCricket(blog) && !isRugby(blog)
+    isSupportedTheme(blog) && !isRugby(blog)
   }
 }


### PR DESCRIPTION
## What does this change?

Removes the check for cricket liveblogs because we now support them! https://github.com/guardian/dotcom-rendering/pull/4758

Closes https://github.com/guardian/dotcom-rendering/issues/4384
