### PR TITLE
fix: add 1 to containerIndex

### DIFF
--- a/common/app/views/fragments/commercial/containers/paidContainer.scala.html
+++ b/common/app/views/fragments/commercial/containers/paidContainer.scala.html
@@ -9,7 +9,7 @@
 @import views.support.Commercial.TrackingCodeBuilder.mkInteractionTrackingCode
 @import views.support.Commercial.glabsLink
 
-<div data-id="@containerModel.id" class="fc-container" data-component="labs-container-@containerIndex">
+<div data-id="@containerModel.id" class="fc-container" data-component="labs-container-@{containerIndex + 1}">
     @containerWrapper(
         Seq("legacy", "capi", "paidfor", "tone-paidfor"),
         optKicker = Some(fragments.commercial.paidForMeta(Some(containerModel.id))),

--- a/common/app/views/fragments/commercial/containers/paidContainer.scala.html
+++ b/common/app/views/fragments/commercial/containers/paidContainer.scala.html
@@ -9,7 +9,7 @@
 @import views.support.Commercial.TrackingCodeBuilder.mkInteractionTrackingCode
 @import views.support.Commercial.glabsLink
 
-<div data-id="@containerModel.id" class="fc-container" data-component="labs-container-@{containerIndex + 1}">
+<div data-id="@containerModel.id" class="fc-container" data-component="container-@{containerIndex + 1} | labs">
     @containerWrapper(
         Seq("legacy", "capi", "paidfor", "tone-paidfor"),
         optKicker = Some(fragments.commercial.paidForMeta(Some(containerModel.id))),


### PR DESCRIPTION
## What does this change?

Add 1 to the containerIndex, so it matches other container numbers.

Part of https://github.com/guardian/dotcom-rendering/issues/4698

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No – DCR does it right already, but the name of the container needs to be updated
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

More consistent `data-component` names.

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
