### PR TITLE
WIP - add consumer for capi firehose

### DIFF
--- a/article/app/AppLoader.scala
+++ b/article/app/AppLoader.scala
@@ -41,6 +41,8 @@ trait AppComponents extends FrontendComponents with ArticleControllers {
 
   lazy val remoteRender = wire[renderers.DotcomRenderingService]
 
+  lazy val kinesisConsumerService = wire[capiFirehoseConsumer.KinesisConsumerService]
+
   override lazy val lifecycleComponents = List(
     wire[LogstashLifecycle],
     wire[NewspaperBooksAndSectionsAutoRefresh],

--- a/article/app/AppLoader.scala
+++ b/article/app/AppLoader.scala
@@ -1,6 +1,7 @@
 import _root_.commercial.targeting.TargetingLifecycle
 import akka.actor.ActorSystem
 import app.{FrontendApplicationLoader, FrontendComponents}
+import capiFirehoseConsumer.FirehoseConsumerLifecycle
 import com.softwaremill.macwire._
 import common.Assets.DiscussionExternalAssetsLifecycle
 import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
@@ -52,6 +53,7 @@ trait AppComponents extends FrontendComponents with ArticleControllers {
     wire[DiscussionExternalAssetsLifecycle],
     wire[SkimLinksCacheLifeCycle],
     wire[StoreNavigationLifecycleComponent],
+    wire[FirehoseConsumerLifecycle],
   )
 
   lazy val router: Router = wire[Routes]

--- a/article/app/capiFirehoseConsumer/CrierStreamReader.scala
+++ b/article/app/capiFirehoseConsumer/CrierStreamReader.scala
@@ -1,0 +1,25 @@
+package capiFirehoseConsumer
+
+import com.gu.contentapi.client.model.v1.Content
+import com.gu.contentapi.firehose.client.StreamListener
+import com.gu.contentatom.thrift.Atom
+import com.gu.crier.model.event.v1.RetrievableContent
+import common.GuLogging
+
+class CrierStreamReader extends GuLogging with StreamListener {
+  override def contentUpdate(content: Content): Unit = {
+    log.info(s"CrierStreamReader read content update for ${content.id}")
+  }
+
+  override def contentRetrievableUpdate(content: RetrievableContent): Unit = {
+    log.info(s"CrierStreamReader read content retrievable update for ${content.id}")
+  }
+
+  override def contentTakedown(contentId: String): Unit = {
+    log.info(s"CrierStreamReader read content takedown for ${contentId}")
+  }
+
+  override def atomUpdate(atom: Atom): Unit = {
+    log.info(s"CrierStreamReader read atom update for ${atom.id}")
+  }
+}

--- a/article/app/capiFirehoseConsumer/FirehoseConsumerLifecycle.scala
+++ b/article/app/capiFirehoseConsumer/FirehoseConsumerLifecycle.scala
@@ -1,35 +1,27 @@
 package capiFirehoseConsumer
 
 import app.LifecycleComponent
-import com.gu.contentapi.firehose.ContentApiFirehoseConsumer
 import common.GuLogging
-import conf.Configuration
 import play.api.inject.ApplicationLifecycle
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class FirehoseConsumerLifecycle(appLifecycle: ApplicationLifecycle)(implicit ec: ExecutionContext)
+class FirehoseConsumerLifecycle(
+    appLifecycle: ApplicationLifecycle,
+    kinesisConsumerService: KinesisConsumerService,
+)(implicit ec: ExecutionContext)
     extends LifecycleComponent
     with GuLogging {
 
   appLifecycle.addStopHook { () =>
     Future {
       log.info("shutting down listener for crier events")
-      contentApiFirehoseConsumer.shutdown()
+      kinesisConsumerService.shutdown
     }
   }
 
-  // Crier consumer
-  val crierStreamReader = new CrierStreamReader
-
-  val contentApiFirehoseConsumer = new ContentApiFirehoseConsumer(
-    kinesisStreamReaderConfig = Configuration.contentApi.kinesisStreamReaderConfig,
-    streamListener = crierStreamReader,
-    filterProductionMonitoring = true,
-  )
-
   override def start(): Unit = {
     log.info("starting listener for crier events")
-    contentApiFirehoseConsumer.start()
+    kinesisConsumerService.start
   }
 }

--- a/article/app/capiFirehoseConsumer/FirehoseConsumerLifecycle.scala
+++ b/article/app/capiFirehoseConsumer/FirehoseConsumerLifecycle.scala
@@ -1,0 +1,35 @@
+package capiFirehoseConsumer
+
+import app.LifecycleComponent
+import com.gu.contentapi.firehose.ContentApiFirehoseConsumer
+import common.GuLogging
+import conf.Configuration
+import play.api.inject.ApplicationLifecycle
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class FirehoseConsumerLifecycle(appLifecycle: ApplicationLifecycle)(implicit ec: ExecutionContext)
+    extends LifecycleComponent
+    with GuLogging {
+
+  appLifecycle.addStopHook { () =>
+    Future {
+      log.info("shutting down listener for crier events")
+      contentApiFirehoseConsumer.shutdown()
+    }
+  }
+
+  // Crier consumer
+  val crierStreamReader = new CrierStreamReader
+
+  val contentApiFirehoseConsumer = new ContentApiFirehoseConsumer(
+    kinesisStreamReaderConfig = Configuration.contentApi.kinesisStreamReaderConfig,
+    streamListener = crierStreamReader,
+    filterProductionMonitoring = true,
+  )
+
+  override def start(): Unit = {
+    log.info("starting listener for crier events")
+    contentApiFirehoseConsumer.start()
+  }
+}

--- a/article/app/capiFirehoseConsumer/KinesisConsumerService.scala
+++ b/article/app/capiFirehoseConsumer/KinesisConsumerService.scala
@@ -1,0 +1,38 @@
+package capiFirehoseConsumer
+
+import com.gu.contentapi.firehose.ContentApiFirehoseConsumer
+import com.gu.contentapi.firehose.kinesis.KinesisStreamReaderConfig
+import conf.Configuration
+
+class KinesisConsumerService {
+
+  private[this] def kinesisStreamReaderConfig: KinesisStreamReaderConfig =
+    KinesisStreamReaderConfig(
+      streamName = Configuration.contentApi.indexStream,
+      app = "frontend",
+      stage = "live",
+      mode = Configuration.environment.stage,
+      suffix = None,
+      kinesisCredentialsProvider = Configuration.contentApi.capiKinesisCredsProvider,
+      dynamoCredentialsProvider = Configuration.contentApi.dynamoCredsProvider,
+      awsRegion = Configuration.aws.region,
+    )
+
+  // Crier consumer
+  private[this] def crierStreamReader = new CrierStreamReader
+
+  private[this] def contentApiFirehoseConsumer =
+    new ContentApiFirehoseConsumer(
+      kinesisStreamReaderConfig = kinesisStreamReaderConfig,
+      streamListener = crierStreamReader,
+      filterProductionMonitoring = true,
+    )
+
+  def start: Unit = {
+    contentApiFirehoseConsumer.start()
+  }
+
+  def shutdown = {
+    contentApiFirehoseConsumer.shutdown()
+  }
+}

--- a/article/test/FakeKinesisConsumer.scala
+++ b/article/test/FakeKinesisConsumer.scala
@@ -1,0 +1,9 @@
+import conf.Configuration
+import capiFirehoseConsumer.KinesisConsumerService
+import com.gu.contentapi.firehose.ContentApiFirehoseConsumer
+
+class FakeKinesisConsumer extends KinesisConsumerService {
+  override def start = {}
+
+  override def shutdown = {}
+}

--- a/article/test/TestAppLoader.scala
+++ b/article/test/TestAppLoader.scala
@@ -1,4 +1,5 @@
 import app.FrontendComponents
+import com.softwaremill.macwire.wire
 import play.api.ApplicationLoader.Context
 import play.api.BuiltInComponentsFromContext
 import renderers.DotcomRenderingService
@@ -12,6 +13,7 @@ trait TestComponents extends WithTestContentApiClient {
 
   // Relying on DCR output for tests is always a mistake.
   override lazy val remoteRender: DotcomRenderingService = new DCRFake()
+  override lazy val kinesisConsumerService = new FakeKinesisConsumer()
 }
 
 class TestAppLoader extends AppLoader {

--- a/build.sbt
+++ b/build.sbt
@@ -58,6 +58,7 @@ val common = library("common")
       identityModel,
       capiAws,
       okhttp,
+      contentApiFirehoseClient,
     ) ++ jackson,
   )
   .settings(

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -234,7 +234,9 @@ class GuardianConfiguration extends GuLogging {
     }
 
     lazy val capiCrierRoleArn: String =
-      configuration.getStringProperty("aws.capiCrierRoleArn").getOrElse(sys.error("Missing aws.crierRoleArn parameter"))
+      configuration
+        .getStringProperty("content.api.crierRoleArn")
+        .getOrElse(sys.error("Missing content.api.crierRoleArn parameter"))
 
     lazy val capiKinesisCredsProvider = new AWSCredentialsProviderChain(
       new EnvironmentVariableCredentialsProvider(),
@@ -258,12 +260,12 @@ class GuardianConfiguration extends GuLogging {
       configuration.getIntegerProperty("content.api.nextPreviousPageSize").getOrElse(50)
 
     lazy val indexStream: String = configuration
-      .getStringProperty("aws.kinesis.indexStream")
-      .getOrElse(sys.error("Missing aws.kinesis.indexStream parameter"))
+      .getStringProperty("content.api.kinesis.indexStream")
+      .getOrElse(sys.error("Missing content.api.kinesis.indexStream parameter"))
 
     lazy val kinesisStreamReaderConfig: KinesisStreamReaderConfig = KinesisStreamReaderConfig(
       streamName = indexStream,
-      app = "support-apple-news",
+      app = "frontend",
       stage = "live",
       mode = stage,
       suffix = None,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -62,6 +62,7 @@ object Dependencies {
   val jerseyClient = "com.sun.jersey" % "jersey-client" % jerseyVersion
   val w3cSac = "org.w3c.css" % "sac" % "1.3"
   val libPhoneNumber = "com.googlecode.libphonenumber" % "libphonenumber" % "8.10.0"
+  val contentApiFirehoseClient = "com.gu" %% "content-api-firehose-client" % "0.12"
 
   val logback2 = "net.logstash.logback" % "logstash-logback-encoder" % "4.6"
   // logback2  to prevent "error: reference to logback is ambiguous;"


### PR DESCRIPTION
## What does this change?
This PR is still in progress. It adds a consumer for the CAPI firehose stream so that we can get informed when a liveblog is created/updated/deleted and as a result make a call to the data science api to retrieve the filter data for the liveblog and update the in-memory cached data OR delete the cached data when a liveblog becomes deadblog or is taken down. 

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
