### PR TITLE
Check whether AB test switches begin `ab-`

### DIFF
--- a/common/test/conf/switches/SwitchesTest.scala
+++ b/common/test/conf/switches/SwitchesTest.scala
@@ -8,8 +8,16 @@ class SwitchesTest extends FlatSpec with Matchers with AppendedClues {
 
   private val SwitchNamePattern = """([a-z\d-]+)""".r
 
-  private def forAllSwitches(test: Switch => Unit): Unit = {
-    Switches.all foreach { switch => test(switch) withClue s"(switch: '${switch.name}')" }
+  private val abSwitchNamePattern = """ab-([a-z\d-]+)""".r
+
+  private def forAllSwitches(test: Switch => Unit, switches: Iterable[Switch] = Switches.all): Unit = {
+    switches foreach { switch => test(switch) withClue s"(switch: '${switch.name}')" }
+  }
+
+  private def forAllABTestSwitches(test: Switch => Unit): Unit = {
+    Switches.grouped.find(_._1.name == "A/B Tests") foreach {
+      case (_, switches) => forAllSwitches(test, switches)
+    }
   }
 
   private val testSwitchGroup = new SwitchGroup("category")
@@ -86,5 +94,9 @@ class SwitchesTest extends FlatSpec with Matchers with AppendedClues {
       day == SATURDAY || day == SUNDAY
     }
     forAllSwitches(switch => switch.sellByDate.exists(isWeekend) shouldBe false)
+  }
+
+  "AB test switches" should "begin with ab-" in {
+    forAllABTestSwitches(switch => switch.name should fullyMatch regex abSwitchNamePattern)
   }
 }


### PR DESCRIPTION
## What does this change?

Add an additional unit test that checks that each of the switches in the AB test group have the prefix `ab-`, as well as only being composed of alphanumeric characters and `-`.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

It isn't clear from the switch definition that AB tests must be named in this way. If they're not named in this way they won't be detected as runnable tests in the client-side code.

Adding this test will catch misnamed switches and hopefully make the contract clearer (in the same way we don't allow tests to expire on weekends, for example).

### Tested

- [X] Locally
- [ ] On CODE (optional)

I tested this by adding an AB test switch locally with an incorrect name and checked the test failed using the following commands

```
$ make sbt
$ project common
$ test:testOnly *SwitchesTest
```