### PR TITLE
Bump `commercial-core`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@guardian/atom-renderer": "1.2.2",
     "@guardian/automat-modules": "^0.3.8",
     "@guardian/braze-components": "^7.2.0",
-    "@guardian/commercial-core": "^3.2.1",
+    "@guardian/commercial-core": "^3.4.0",
     "@guardian/consent-management-platform": "^10.5.0",
     "@guardian/libs": "^3.6.1",
     "@guardian/shimport": "^1.0.2",

--- a/static/src/javascripts/projects/commercial/commercial-metrics.ts
+++ b/static/src/javascripts/projects/commercial/commercial-metrics.ts
@@ -2,6 +2,7 @@ import {
 	initCommercialMetrics,
 	bypassCommercialMetricsSampling as switchOffSampling,
 } from '@guardian/commercial-core';
+import { log } from '@guardian/libs';
 import { shouldCaptureMetrics } from '../common/modules/analytics/shouldCaptureMetrics';
 
 const { isDev } = window.guardian.config.page;
@@ -24,12 +25,16 @@ const init = (): Promise<void> => {
 					adBlockerInUse: adBlockers.active,
 			  };
 
-	initCommercialMetrics(args);
-
-	if (shouldCaptureMetrics()) {
-		// TODO: rename upstream
-		switchOffSampling();
-	}
+	initCommercialMetrics(args)
+		.then(() => {
+			if (shouldCaptureMetrics()) {
+				// TODO: rename upstream
+				void switchOffSampling();
+			}
+		})
+		.catch((error) =>
+			log('commercial', 'Error initialising commercial metrics', error),
+		);
 
 	return Promise.resolve();
 };

--- a/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.ts
+++ b/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.ts
@@ -50,7 +50,7 @@ const maybeRefreshBlockedSlotOnce: ConfiantCallback = (
 	eventTimer.trigger(`${stripDfpAdPrefixFrom(advert.id)}-blockedByConfiant`);
 
 	setForceSendMetrics(true);
-	switchOffSampling();
+	void switchOffSampling();
 
 	advert.slot.setTargeting('confiant', String(blockingType));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1279,10 +1279,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-7.2.0.tgz#e5e7ba7c19484ebe0e405a93b1c389dae681acef"
   integrity sha512-Y2+XC0bP5mFacwtDlDqlQsbUyQwn4OSlpOTw3+u7t1RhJFw61SDYAER4gOpyJ4t+wQZFdk//LGJUjFqzDfEEuQ==
 
-"@guardian/commercial-core@^3.2.1":
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-3.2.1.tgz#15073e5718c12b12cc0973a36bf54b8ee5e3c2ef"
-  integrity sha512-e8Fs8h33oL9eRjluQHqDe4p4UkeuYrOAEI9x5nUBNMShwgv2ef9n0pPo7P0epe0gxJYKmm52J/IHsP+nbesVrQ==
+"@guardian/commercial-core@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-3.4.0.tgz#30fa768df0ca77ae912a1d55c4de2427d8608654"
+  integrity sha512-r/JPn0MpUUOZ/gy0E0NJOBwGDM0fga1nXxXiwY60Ya8S2fOdqrtGJfcnfDOd55wDbQQ0VbRWnO3SO/J6ZA9icw==
 
 "@guardian/consent-management-platform@^10.5.0":
   version "10.5.0"


### PR DESCRIPTION
## What does this change?

Bumps `commercial-core` to `3.4.0`.

## Why?

To pull in changes to commercial-core which require consent to be given before sending commercial metrics:

https://github.com/guardian/commercial-core/pull/535

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes https://github.com/guardian/dotcom-rendering/pull/4821

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
