### PR TITLE
feat: use flex supports css

### DIFF
--- a/static/src/stylesheets/base/_normalize.scss
+++ b/static/src/stylesheets/base/_normalize.scss
@@ -1,4 +1,4 @@
-/* normalize.css v3.0.0 | MIT License | https://github.com/necolas/normalize.css */
+/* normalize.css v3.0.0 | MIT License | git.io/normalize */
 
 /**
  * Tweaked for theguardian.com: there are some elements we don't use

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -94,7 +94,7 @@
     background-color: $brightness-97;
     border-bottom: 1px solid $brightness-86;
 
-    min-height: 90px + 24px; // https://github.com/guardian/commercial-core/blob/6736d3930be3989a63e5bc0240a4d5bb1c1d9164/src/constants/topAboveNavHeight.ts -- topAboveNavHeight.ts
+    min-height: 90px + 24px; // https://git.io/JK9vs -- topAboveNavHeight.ts
     padding-bottom: $gs-row-height / 2;
     display: flex;
     flex-direction: column;

--- a/static/src/stylesheets/module/email-signup/_form.scss
+++ b/static/src/stylesheets/module/email-signup/_form.scss
@@ -240,8 +240,6 @@
     flex-shrink: 0;
 }
 
-.email-sub__form--thrasher-us-morning-newsletter,
-.email-sub__form--thrasher-morning-mail,
 .email-sub__form--thrasher-first-edition,
 .email-sub__form--thrasher-morning-briefing {
 

--- a/static/src/stylesheets/module/email-signup/_iframe.scss
+++ b/static/src/stylesheets/module/email-signup/_iframe.scss
@@ -273,7 +273,7 @@ body {
         cursor: pointer;
         text-decoration: none;
         font-family: $f-sans-serif-text;
-        font-size: .8rem;
+        font-size: .9rem;
         line-height: 1.5;
         font-weight: 700;
         height: 44px;

--- a/static/src/stylesheets/module/facia-garnett/_items.scss
+++ b/static/src/stylesheets/module/facia-garnett/_items.scss
@@ -71,8 +71,10 @@
     margin-bottom: $gs-baseline;
 
     @include mq(tablet) {
-        .has-flex &:not(.fc-slice__item--mpu-candidate) {
-            display: flex;
+        @supports (display: flex) {
+            &:not(.fc-slice__item--mpu-candidate) {
+                display: flex;
+            }
         }
     }
 

--- a/static/src/stylesheets/module/facia-garnett/_l-list.scss
+++ b/static/src/stylesheets/module/facia-garnett/_l-list.scss
@@ -2,9 +2,11 @@
     width: 100%;
 
     @include mq(tablet) {
-        .has-flex-wrap & {
-            display: flex;
-            flex-wrap: wrap;
+        @supports (flex-wrap: wrap) {
+            & {
+                display: flex;
+                flex-wrap: wrap;
+            }
         }
     }
 }
@@ -12,9 +14,11 @@
 .l-list__item {
     float: left;
 
-    .has-flex-wrap & {
-        flex-grow: 0;
-        flex-basis: 100%;
+    @supports (flex-wrap: wrap) {
+        & {
+            flex-grow: 0;
+            flex-basis: 100%;
+        }
     }
 }
 
@@ -27,8 +31,10 @@
                     width: (100% / $column) * $span;
                     float: left;
 
-                    .has-flex & {
-                        flex: $span 1 auto;
+                    @supports (display: flex) {
+                        & {
+                            flex: $span 1 auto;
+                        }
                     }
                 }
             }
@@ -55,8 +61,10 @@
                     padding-bottom: 0;
                 }
 
-                .has-flex-wrap & {
-                    flex-basis: (100% / $column);
+                @supports (flex-wrap: wrap) {
+                    & {
+                        flex-basis: (100% / $column);
+                    }
                 }
             }
         }

--- a/static/src/stylesheets/module/facia-garnett/_linkslist.scss
+++ b/static/src/stylesheets/module/facia-garnett/_linkslist.scss
@@ -77,15 +77,17 @@
         }
     }
 
-    .has-flex-wrap & {
-        .fc-slice__item {
-            @include mq(tablet) {
-                flex-grow: 0;
-                flex-basis: 50%;
-            }
+    @supports (flex-wrap: wrap) {
+        & {
+            .fc-slice__item {
+                @include mq(tablet) {
+                    flex-grow: 0;
+                    flex-basis: 50%;
+                }
 
-            @include mq(desktop) {
-                flex-basis: (100% / 3);
+                @include mq(desktop) {
+                    flex-basis: (100% / 3);
+                }
             }
         }
     }

--- a/static/src/stylesheets/module/facia-garnett/_slices.scss
+++ b/static/src/stylesheets/module/facia-garnett/_slices.scss
@@ -15,19 +15,21 @@ Hence why a greater depth of selector specificity is needed.
 
 */
 .fc-slice--hl4-h {
-    .has-flex & {
-        flex-direction: row-reverse;
+    @supports (display: flex) {
+        & {
+            flex-direction: row-reverse;
 
-        .fc-slice__item:before {
-            display: none;
-        }
+            .fc-slice__item:before {
+                display: none;
+            }
 
-        .fc-item--half-tablet {
-            @include vertical-item-separator;
+            .fc-item--half-tablet {
+                @include vertical-item-separator;
 
-            .fc-item__standfirst {
-                @include mq(desktop) {
-                    display: none;
+                .fc-item__standfirst {
+                    @include mq(desktop) {
+                        display: none;
+                    }
                 }
             }
         }
@@ -119,11 +121,13 @@ Hence why a greater depth of selector specificity is needed.
 }
 
 .fc-slice--h14-q-q {
-    .has-flex & {
-        flex-direction: row-reverse;
+    @supports (display: flex) {
+        & {
+            flex-direction: row-reverse;
 
-        .fc-slice__item:before {
-            display: none;
+            .fc-slice__item:before {
+                display: none;
+            }
         }
     }
 

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -22,7 +22,7 @@ $fc-item-gutter: $gs-gutter / 4;
         }
     }
 
-    .has-flex-wrap & {
+    @supports(flex-wrap: wrap) {
         .fc-item__container {
             flex-wrap: wrap;
             @if $media-align == right {
@@ -75,12 +75,16 @@ $fc-item-gutter: $gs-gutter / 4;
     }
 
     @include mq(tablet) {
-        .has-flex & {
-            flex: 1 1 auto;
+        @supports (flex: 1 1 auto) {
+            & {
+                flex: 1 1 auto;
+            }
         }
 
-        .has-flex-wrap & {
-            display: flex;
+        @supports (flex-wrap: wrap) {
+            & {
+                display: flex;
+            }
         }
 
         .has-no-flex-wrap & {
@@ -95,13 +99,15 @@ $fc-item-gutter: $gs-gutter / 4;
     box-sizing: border-box;
 
     @include mq(tablet) {
-        .has-flex-wrap & {
-            flex-direction: column;
-            display: flex;
-            flex: 1 1 auto;
-            // see: http://stackoverflow.com/a/9737602/802472
-            // width:0 fixes child elements with white-space:nowrap below flex
-            width: 0;
+        @supports (flex: 1 1 auto) {
+            & {
+                flex-direction: column;
+                display: flex;
+                flex: 1 1 auto;
+                // see: http://stackoverflow.com/a/9737602/802472
+                // width:0 fixes child elements with white-space:nowrap below flex
+                width: 0;
+            }
         }
     }
 }

--- a/static/src/stylesheets/module/facia/_items.scss
+++ b/static/src/stylesheets/module/facia/_items.scss
@@ -28,8 +28,10 @@
     margin-bottom: $gs-baseline;
 
     @include mq(tablet) {
-        .has-flex &:not(.fc-slice__item--mpu-candidate) {
-            display: flex;
+        @supports (display: flex) {
+            &:not(.fc-slice__item--mpu-candidate) {
+                display: flex;
+            }
         }
     }
 
@@ -105,13 +107,15 @@
         }
 
         &[class*='fc-item--has-sublinks'] {
-            .has-flex-wrap &.fc-item--has-cutout {
-                .fc-item__header {
-                    padding-right: 0;
-                }
+            @supports (flex-wrap: wrap) {
+                &.fc-item--has-cutout {
+                    .fc-item__header {
+                        padding-right: 0;
+                    }
 
-                .fc-sublinks {
-                    min-height: gs-height(3) + $gs-baseline;
+                    .fc-sublinks {
+                        min-height: gs-height(3) + $gs-baseline;
+                    }
                 }
             }
         }
@@ -263,9 +267,11 @@
         @include fc-item--fluid;
         @include fc-item--horizontal(20%);
 
-        .has-flex-wrap & {
-            .fc-item__container {
-                flex-direction: row;
+        @supports (display: flex) {
+            & {
+                .fc-item__container {
+                    flex-direction: row;
+                }
             }
         }
 

--- a/static/src/stylesheets/module/facia/_linkslist.scss
+++ b/static/src/stylesheets/module/facia/_linkslist.scss
@@ -77,15 +77,17 @@
         }
     }
 
-    .has-flex-wrap & {
-        .fc-slice__item {
-            @include mq(tablet) {
-                flex-grow: 0;
-                flex-basis: 50%;
-            }
+    @supports (flex-wrap: wrap) {
+        & {
+            .fc-slice__item {
+                @include mq(tablet) {
+                    flex-grow: 0;
+                    flex-basis: 50%;
+                }
 
-            @include mq(desktop) {
-                flex-basis: (100% / 3);
+                @include mq(desktop) {
+                    flex-basis: (100% / 3);
+                }
             }
         }
     }

--- a/static/src/stylesheets/module/facia/_sublinks.scss
+++ b/static/src/stylesheets/module/facia/_sublinks.scss
@@ -34,15 +34,17 @@
 }
 
 @mixin fc-sublinks--horizontal {
-    .has-flex-wrap & {
-        .fc-sublinks {
-            display: flex;
-        }
-        .fc-sublink {
-            flex: 1 1 100%;
+    @supports (display: flex) {
+        & {
+            .fc-sublinks {
+                display: flex;
+            }
+            .fc-sublink {
+                flex: 1 1 100%;
 
-            & + * {
-                margin-left: $gs-gutter;
+                & + * {
+                    margin-left: $gs-gutter;
+                }
             }
         }
     }

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--full-media-50.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--full-media-50.scss
@@ -58,8 +58,10 @@ Full item with 50% width media.
         .fc-item__container {
             min-height: gs-height(5) + $gs-baseline * 3;
 
-            .has-flex-wrap & {
-                flex-direction: row;
+            @supports (display: flex) {
+                & {
+                    flex-direction: row;
+                }
             }
         }
 
@@ -71,8 +73,10 @@ Full item with 50% width media.
                 max-width: gs-span(8);
             }
 
-            .has-flex-wrap & {
-                flex-basis: auto;
+            @supports (flex-wrap: wrap) {
+                & {
+                    flex-basis: auto;
+                }
             }
         }
 

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--full-media-75.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--full-media-75.scss
@@ -59,8 +59,10 @@ Full item with 75% width media.
         .fc-item__container {
             min-height: gs-height(5) + $gs-baseline * 3;
 
-            .has-flex-wrap & {
-                flex-direction: row;
+            @supports (flex-wrap: wrap) {
+                & {
+                    flex-direction: row;
+                }
             }
         }
 
@@ -72,8 +74,10 @@ Full item with 75% width media.
                 max-width: gs-span(8);
             }
 
-            .has-flex-wrap & {
-                flex-basis: auto;
+            @supports (flex-wrap: wrap) {
+                & {
+                    flex-basis: auto;
+                }
             }
         }
 

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--half.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--half.scss
@@ -90,9 +90,11 @@ x x x x x x x x x x x x x x x x x x
             display: none;
         }
 
-        .has-flex-wrap &.fc-item--has-cutout {
-            .fc-item__content {
-                flex: 0 1 auto;
+        @supports (flex-wrap: wrap) {
+            &.fc-item--has-cutout {
+                .fc-item__content {
+                    flex: 0 1 auto;
+                }
             }
         }
     }

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--three-quarters-right.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--three-quarters-right.scss
@@ -24,9 +24,11 @@ Three quarter item. Looks like a wide standard, a bit like this:
 
     @include fc-item--three-quarters;
 
-    .has-flex-wrap & {
-        .fc-item__container {
-            flex-direction: row;
+    @supports (flex-wrap: wrap) {
+        & {
+            .fc-item__container {
+                flex-direction: row;
+            }
         }
     }
 

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--three-quarters.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--three-quarters.scss
@@ -56,8 +56,10 @@ Three quarter item. Looks like a wide standard, a bit like this:
         .fc-item__container {
             min-height: gs-height(7);
 
-            .has-flex-wrap & {
-                flex-direction: row;
+            @supports (flex-wrap: wrap) {
+                & {
+                    flex-direction: row;
+                }
             }
         }
 
@@ -74,8 +76,10 @@ Three quarter item. Looks like a wide standard, a bit like this:
                 max-width: gs-span(6);
             }
 
-            .has-flex-wrap & {
-                flex-basis: auto;
+            @supports (flex-wrap: wrap) {
+                & {
+                    flex-basis: auto;
+                }
             }
         }
     }

--- a/static/src/stylesheets/pasteup/layout/_src.scss
+++ b/static/src/stylesheets/pasteup/layout/_src.scss
@@ -1,7 +1,7 @@
 // ROWS
 @mixin layout-row($class, $detect: false) {
     @if ($detect) {
-        .has-flex {
+        @supports (display: flex) {
             @include flex-row($class);
         }
         .has-no-flex {


### PR DESCRIPTION
## What does this change?

Use the `@supports` css directive so users without javascript but modern browsers get better layouts.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No – but we should think about browser that do no support `flex`
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

See #25014 

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
