### PR TITLE
A front page cannot be supported on DCR if it has any unsupported container types

### DIFF
--- a/facia/app/utils/FaciaPicker.scala
+++ b/facia/app/utils/FaciaPicker.scala
@@ -19,24 +19,20 @@ class FaciaPicker extends GuLogging {
     val participatingInTest = ActiveExperiments.isParticipating(FrontRendering)
     val dcrCouldRender = dcrSupportsAllCollectionTypes(faciaPage)
 
-    val tier = decideTier(request.forceDCROff, request.forceDCR, participatingInTest, dcrCouldRender)
+    val tier = getTier(request.forceDCROff, request.forceDCR, participatingInTest, dcrCouldRender)
 
     logTier(faciaPage, path, participatingInTest, dcrCouldRender, tier)
 
     tier
   }
 
-  def decideTier(
+  def getTier(
       forceDCROff: Boolean,
       forceDCR: Boolean,
       participatingInTest: Boolean,
       dcrCouldRender: Boolean,
   ): RenderType = {
-    if (forceDCROff) {
-      LocalRender
-    } else if (forceDCR) {
-      RemoteRender
-    } else if (participatingInTest && dcrCouldRender) {
+    if (forceDCR || participatingInTest && dcrCouldRender && !forceDCROff) {
       RemoteRender
     } else {
       LocalRender

--- a/facia/app/utils/FaciaPicker.scala
+++ b/facia/app/utils/FaciaPicker.scala
@@ -8,6 +8,9 @@ import play.api.mvc.RequestHeader
 
 class FaciaPicker extends GuLogging {
 
+  // To check which collections are supported by DCR and update this set please check:
+  // https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/lib/DecideContainer.tsx
+  // and https://github.com/guardian/dotcom-rendering/issues/4720
   val SUPPORTED_COLLECTIONS: Set[String] =
     Set("dynamic/fast", "dynamic/slow", "fixed/small/slow-IV", "fixed/large/slow-XIV")
 

--- a/facia/test/package.scala
+++ b/facia/test/package.scala
@@ -9,6 +9,7 @@ import org.scalatest.Suites
 import org.scalatestplus.play.PortNumber
 import play.api.libs.json.Json
 import recorder.HttpRecorder
+import utils.FaciaPickerTest
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.io.Codec.UTF8
@@ -60,5 +61,6 @@ class FaciaTestSuite
       new layout.slices.StoryTest,
       new FaciaControllerTest,
       new metadata.FaciaMetaDataTest,
+      new FaciaPickerTest,
     )
     with SingleServerSuite {}

--- a/facia/test/utils/FaciaPickerTest.scala
+++ b/facia/test/utils/FaciaPickerTest.scala
@@ -1,0 +1,78 @@
+package utils
+
+import common.facia.{FixtureBuilder, PressedCollectionBuilder}
+import model.PressedPage
+import model.facia.PressedCollection
+import experiments.{ExperimentsDefinition, FrontRendering}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.DoNotDiscover
+import org.mockito.Mockito.when
+import test.TestRequest
+
+@DoNotDiscover class FaciaPickerTest extends AnyFlatSpec with Matchers {
+
+  "Facia Picker dcrSupportsAllCollectionTypes" should "return false if at least one collection type of the faciaPage collections is not supported" in {
+    val unsupportedPressedCollection =
+      List(
+        PressedCollectionBuilder.mkPressedCollection(collectionType = FaciaPicker.SUPPORTED_COLLECTIONS.head),
+        PressedCollectionBuilder.mkPressedCollection(collectionType = "non-supported-collection-type"),
+      )
+
+    val faciaPage = FixtureBuilder.mkPressedPage(unsupportedPressedCollection)
+    FaciaPicker.dcrSupportsAllCollectionTypes(faciaPage) should be(false)
+  }
+
+  it should "return true if all collection types of a facia page are supported" in {
+    val supportedTypes = FaciaPicker.SUPPORTED_COLLECTIONS.take(3).toList
+    val supportedPressedCollection =
+      List(
+        PressedCollectionBuilder.mkPressedCollection(collectionType = supportedTypes(0)),
+        PressedCollectionBuilder.mkPressedCollection(collectionType = supportedTypes(1)),
+        PressedCollectionBuilder.mkPressedCollection(collectionType = supportedTypes(2)),
+      )
+
+    val faciaPage = FixtureBuilder.mkPressedPage(supportedPressedCollection)
+    FaciaPicker.dcrSupportsAllCollectionTypes(faciaPage) should be(true)
+  }
+
+  "Facia Picker decideTier" should "return LocalRender if dcr=false" in {
+    val forceDCROff = true
+    val forceDCR = false
+    val participatingInTest = true
+    val dcrCouldRender = true
+
+    val tier = FaciaPicker.decideTier(forceDCROff, forceDCR, participatingInTest, dcrCouldRender)
+    tier should be(LocalRender)
+  }
+
+  it should "return RemoteRender if dcr=true" in {
+    val forceDCROff = false
+    val forceDCR = true
+    val participatingInTest = false
+    val dcrCouldRender = false
+
+    val tier = FaciaPicker.decideTier(forceDCROff, forceDCR, participatingInTest, dcrCouldRender)
+    tier should be(RemoteRender)
+  }
+
+  it should "return LocalRender if no flag is provided, participatingInTest is false and dcrCouldRender is true" in {
+    val forceDCROff = false
+    val forceDCR = false
+    val participatingInTest = false
+    val dcrCouldRender = true
+
+    val tier = FaciaPicker.decideTier(forceDCROff, forceDCR, participatingInTest, dcrCouldRender)
+    tier should be(LocalRender)
+  }
+
+  it should "return RemoteRender if no flag is provided and participatingInTest and dcrCouldRender are true" in {
+    val forceDCROff = false
+    val forceDCR = false
+    val participatingInTest = true
+    val dcrCouldRender = true
+
+    val tier = FaciaPicker.decideTier(forceDCROff, forceDCR, participatingInTest, dcrCouldRender)
+    tier should be(RemoteRender)
+  }
+}

--- a/facia/test/utils/FaciaPickerTest.scala
+++ b/facia/test/utils/FaciaPickerTest.scala
@@ -36,13 +36,13 @@ import test.TestRequest
     FaciaPicker.dcrSupportsAllCollectionTypes(faciaPage) should be(true)
   }
 
-  "Facia Picker decideTier" should "return LocalRender if dcr=false" in {
+  "Facia Picker getTier" should "return LocalRender if dcr=false" in {
     val forceDCROff = true
     val forceDCR = false
     val participatingInTest = true
     val dcrCouldRender = true
 
-    val tier = FaciaPicker.decideTier(forceDCROff, forceDCR, participatingInTest, dcrCouldRender)
+    val tier = FaciaPicker.getTier(forceDCROff, forceDCR, participatingInTest, dcrCouldRender)
     tier should be(LocalRender)
   }
 
@@ -52,7 +52,7 @@ import test.TestRequest
     val participatingInTest = false
     val dcrCouldRender = false
 
-    val tier = FaciaPicker.decideTier(forceDCROff, forceDCR, participatingInTest, dcrCouldRender)
+    val tier = FaciaPicker.getTier(forceDCROff, forceDCR, participatingInTest, dcrCouldRender)
     tier should be(RemoteRender)
   }
 
@@ -62,7 +62,7 @@ import test.TestRequest
     val participatingInTest = false
     val dcrCouldRender = true
 
-    val tier = FaciaPicker.decideTier(forceDCROff, forceDCR, participatingInTest, dcrCouldRender)
+    val tier = FaciaPicker.getTier(forceDCROff, forceDCR, participatingInTest, dcrCouldRender)
     tier should be(LocalRender)
   }
 
@@ -72,7 +72,7 @@ import test.TestRequest
     val participatingInTest = true
     val dcrCouldRender = true
 
-    val tier = FaciaPicker.decideTier(forceDCROff, forceDCR, participatingInTest, dcrCouldRender)
+    val tier = FaciaPicker.getTier(forceDCROff, forceDCR, participatingInTest, dcrCouldRender)
     tier should be(RemoteRender)
   }
 }


### PR DESCRIPTION
Closes [#4464](https://github.com/guardian/dotcom-rendering/issues/4464)

## What does this change?

* It adds the first check to `dcrCouldRender`: A front page cannot be supported on DCR if it has any unsupported container types
* Adds `FaciaPickerTest`

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
