### PR TITLE
Bump identityLibVersion to 3.254

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ package com.gu
 import sbt._
 
 object Dependencies {
-  val identityLibVersion = "3.253"
+  val identityLibVersion = "3.254"
   val awsVersion = "1.12.205"
   val capiVersion = "17.25.0"
   val faciaVersion = "3.3.12"


### PR DESCRIPTION
## What does this change?

Bumping `identityLibVersion` to 3.254. This will remove `Origin Validation Error` vulnerability coming from a previous version of `org.http4s:http4s-server`.



