### PR TITLE
chore: Change caption font size to be 12px on all displays

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -559,11 +559,7 @@ $block-height: 58px;
 
     figcaption {
         @include f-textSans();
-        @include font-size(15, 20);
-
-        @include mq($until: tablet) {
-            @include font-size(12, 16);
-        }
+        @include font-size(12, 16);
 
         font-weight: bold;
         position: absolute;
@@ -589,8 +585,6 @@ $block-height: 58px;
 
     .fc-item--has-floating-sublinks & {
         figcaption {
-            @include font-size(12, 16);
-
             @include mq(tablet) {
                 background: linear-gradient(to top, rgba(0, 0, 0, 0) 0%,  rgba(0, 0, 0, .8) 100%);
                 padding: 8px 8px 60px;


### PR DESCRIPTION
## What does this change?

Changes caption font size to be 12px regardless of display.

Closes #24995

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/21217225/168097666-c00ef197-0e8b-4103-92a3-83ceb6af91be.png

[after]: https://user-images.githubusercontent.com/21217225/168097555-06dc6595-a101-4ad4-b4a5-b9794f6ddae5.png
