### PR TITLE
Fetch non-refreshable line items from CODE when running frontend locally

### DIFF
--- a/commercial/app/controllers/nonRefreshableLineItemsController.scala
+++ b/commercial/app/controllers/nonRefreshableLineItemsController.scala
@@ -2,7 +2,7 @@ package commercial.controllers
 
 import common.JsonComponent
 import common.dfp.DfpAgent
-import model.Cached
+import model.{Cached, Cors}
 import play.api.libs.json.Json
 import play.api.mvc._
 
@@ -16,8 +16,14 @@ class nonRefreshableLineItemsController(val controllerComponents: ControllerComp
     Action { implicit request =>
       val nonRefreshableLineItems: Seq[Long] = DfpAgent.nonRefreshableLineItemIds()
       val json = Json.toJson(nonRefreshableLineItems)
-      Cached(15.minutes) {
-        JsonComponent(json)
-      }
+
+      Cors(
+        Cached(15.minutes) {
+          JsonComponent(json)
+        },
+        None,
+        None,
+        Seq("localhost"),
+      )
     }
 }

--- a/static/src/javascripts/projects/commercial/modules/dfp/non-refreshable-line-items.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/non-refreshable-line-items.ts
@@ -2,10 +2,10 @@ import { memoize } from 'lodash-es';
 import reportError from 'lib/report-error';
 
 export const fetchNonRefreshableLineItemIds = async (): Promise<number[]> => {
-	// Use the CODE environment's non-refreshable line item file for CODE and local testing
-	const fileHost = window.guardian.config.page.isProd
-		? 'https://www.theguardian.com'
-		: 'https://m.code.dev-theguardian.com';
+	// When the env is CODE or local, use the CODE env's non-refreshable line items file
+	const { host, isProd } = window.guardian.config.page;
+	const fileHost = isProd ? host : 'https://m.code.dev-theguardian.com';
+
 	const fileLocation = new URL(
 		'/commercial/non-refreshable-line-items.json',
 		fileHost,

--- a/static/src/javascripts/projects/commercial/modules/dfp/non-refreshable-line-items.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/non-refreshable-line-items.ts
@@ -6,9 +6,12 @@ export const fetchNonRefreshableLineItemIds = async (): Promise<number[]> => {
 	const fileHost = window.guardian.config.page.isProd
 		? 'https://www.theguardian.com'
 		: 'https://m.code.dev-theguardian.com';
-	const fileLocation = `${fileHost}/commercial/non-refreshable-line-items.json`;
+	const fileLocation = new URL(
+		'/commercial/non-refreshable-line-items.json',
+		fileHost,
+	);
 
-	const response = await window.fetch(fileLocation);
+	const response = await fetch(fileLocation.toString());
 
 	if (response.ok) {
 		const json: unknown = await response.json();

--- a/static/src/javascripts/projects/commercial/modules/dfp/non-refreshable-line-items.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/non-refreshable-line-items.ts
@@ -2,9 +2,13 @@ import { memoize } from 'lodash-es';
 import reportError from 'lib/report-error';
 
 export const fetchNonRefreshableLineItemIds = async (): Promise<number[]> => {
-	const response = await window.fetch(
-		'/commercial/non-refreshable-line-items.json',
-	);
+	// Use the CODE environment's non-refreshable line item file for CODE and local testing
+	const fileHost = window.guardian.config.page.isProd
+		? 'https://www.theguardian.com'
+		: 'https://m.code.dev-theguardian.com';
+	const fileLocation = `${fileHost}/commercial/non-refreshable-line-items.json`;
+
+	const response = await window.fetch(fileLocation);
 
 	if (response.ok) {
 		const json: unknown = await response.json();

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -79,34 +79,34 @@ interface Config {
 type Edition = string; // https://github.com/guardian/frontend/blob/b952f6b9/common/app/views/support/JavaScriptPage.scala#L79
 
 interface PageConfig extends CommercialPageConfig {
-	edition: Edition;
-	isDev: boolean; // https://github.com/guardian/frontend/blob/33db7bbd/common/app/views/support/JavaScriptPage.scala#L73
-	isSensitive: boolean;
-	isFront: boolean; // https://github.com/guardian/frontend/blob/201cc764/common/app/model/meta.scala#L352
 	ajaxUrl: string; // https://github.com/guardian/frontend/blob/33db7bbd/common/app/views/support/JavaScriptPage.scala#L72
-	isHosted: boolean; // https://github.com/guardian/frontend/blob/66afe02e/common/app/common/commercial/hosted/HostedMetadata.scala#L37
-	hasPageSkin: boolean; //https://github.com/guardian/frontend/blob/b952f6b9/common/app/views/support/JavaScriptPage.scala#L48
 	assetsPath: string;
-	frontendAssetsFullURL?: string; // only in DCR
-	nonRefreshableLineItemIds?: number[];
-	section: string;
-	isPaidContent: boolean;
-	videoDuration: number;
-	source: string;
-	pageId: string;
 	authorIds: string;
 	blogIds: string;
 	contentType: string;
+	edition: Edition;
+	frontendAssetsFullURL?: string; // only in DCR
+	hasInlineMerchandise: boolean;
+	hasPageSkin: boolean; // https://github.com/guardian/frontend/blob/b952f6b9/common/app/views/support/JavaScriptPage.scala#L48
+	isDev: boolean; // https://github.com/guardian/frontend/blob/33db7bbd/common/app/views/support/JavaScriptPage.scala#L73
+	isFront: boolean; // https://github.com/guardian/frontend/blob/201cc764/common/app/model/meta.scala#L352
+	isHosted: boolean; // https://github.com/guardian/frontend/blob/66afe02e/common/app/common/commercial/hosted/HostedMetadata.scala#L37
+	isPaidContent: boolean;
+	isSensitive: boolean;
 	keywordIds: string;
 	keywords: string;
-	toneIds: string;
+	nonRefreshableLineItemIds?: number[];
+	pageId: string;
 	publication: string;
-	seriesId: string;
+	section: string;
 	series: string;
-	sponsorshipType: string;
-	tones: string;
-	hasInlineMerchandise: boolean;
+	seriesId: string;
 	shouldHideReaderRevenue?: boolean;
+	source: string;
+	sponsorshipType: string;
+	toneIds: string;
+	tones: string;
+	videoDuration: number;
 }
 
 interface Ophan {

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -92,6 +92,7 @@ interface PageConfig extends CommercialPageConfig {
 	isFront: boolean; // https://github.com/guardian/frontend/blob/201cc764/common/app/model/meta.scala#L352
 	isHosted: boolean; // https://github.com/guardian/frontend/blob/66afe02e/common/app/common/commercial/hosted/HostedMetadata.scala#L37
 	isPaidContent: boolean;
+	isProd: boolean; // https://github.com/guardian/frontend/blob/33db7bbd/common/app/views/support/JavaScriptPage.scala
 	isSensitive: boolean;
 	keywordIds: string;
 	keywords: string;

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -88,6 +88,7 @@ interface PageConfig extends CommercialPageConfig {
 	frontendAssetsFullURL?: string; // only in DCR
 	hasInlineMerchandise: boolean;
 	hasPageSkin: boolean; // https://github.com/guardian/frontend/blob/b952f6b9/common/app/views/support/JavaScriptPage.scala#L48
+	host: string;
 	isDev: boolean; // https://github.com/guardian/frontend/blob/33db7bbd/common/app/views/support/JavaScriptPage.scala#L73
 	isFront: boolean; // https://github.com/guardian/frontend/blob/201cc764/common/app/model/meta.scala#L352
 	isHosted: boolean; // https://github.com/guardian/frontend/blob/66afe02e/common/app/common/commercial/hosted/HostedMetadata.scala#L37


### PR DESCRIPTION
## What is the problem?

When running frontend locally, the request for the non-refreshable line items file fails (see screenshot below). This is because it is looking for the file at `${host}/commercial/non-refreshable-line-items` which 404s since the [file is generated](https://github.com/guardian/frontend/blob/main/docs/05-commercial/04-non-refreshable-line-items.md) and does not exist when running locally. This file _is_ generated for PROD and CODE environments.

## What does this change?

- When frontend is NOT running in production, the CODE env version of the non-refreshable line items file is used
- Adding CORS so that local env can access the file in CODE

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-----------|------------|
| ![error](https://user-images.githubusercontent.com/9574885/168101808-ffa874d3-40eb-4d64-8cbd-4b1d30cc920d.png)| No Error!

## What is the value of this and can you measure success?

This fixes a bug when running locally. This alone provides no immediate value to the user.

## Tested

- [x] Locally
- [x] On CODE

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
