### PR TITLE
Extend Prebid price granularity AB test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/prebid-price-granularity.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/prebid-price-granularity.ts
@@ -4,7 +4,7 @@ import { noop } from '../../../../../lib/noop';
 export const prebidPriceGranularity: ABTest = {
 	id: 'PrebidPriceGranularity',
 	start: '2022-04-05',
-	expiry: '2022-05-03',
+	expiry: '2022-06-09',
 	author: 'Chris Jones (@chrislomaxjones)',
 	description:
 		'Test the commercial impact of changing Prebid Price granularity for Ozone',


### PR DESCRIPTION
## What does this change?

Extend the price granularity AB test. The test should conclude faster than this expiry, but it now matches the one set for the switch.