### PR TITLE
Ozone outstream passback

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -136,7 +136,7 @@ const init = (register: RegisterListener): void => {
 						// https://developers.google.com/publisher-tag/reference#googletag.defineSlot
 						const passbackSlot = googletag.defineSlot(
 							slot.getAdUnitPath(),
-							[adSizes.mpu.width, adSizes.mpu.height],
+							mpu,
 							passbackElement.id,
 						);
 						// https://developers.google.com/publisher-tag/guides/ad-sizes#responsive_ads

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -133,11 +133,13 @@ const init = (register: RegisterListener): void => {
 					 * Define and display a new slot
 					 */
 					window.googletag.cmd.push(() => {
+						// https://developers.google.com/publisher-tag/reference#googletag.defineSlot
 						const passbackSlot = googletag.defineSlot(
 							slot.getAdUnitPath(),
 							[adSizes.mpu.width, adSizes.mpu.height],
 							passbackElement.id,
 						);
+						// https://developers.google.com/publisher-tag/guides/ad-sizes#responsive_ads
 						passbackSlot?.defineSizeMapping([
 							[
 								[breakpoints.phablet, 0],
@@ -163,6 +165,7 @@ const init = (register: RegisterListener): void => {
 					 * does not take the height of the child ad element as normal.
 					 * So we set this by hooking into the googletag slotRenderEnded
 					 * event to get the size of the ad loaded.
+					 * https://developers.google.com/publisher-tag/reference#googletag.events.slotrenderendedevent
 					 */
 					googletag
 						.pubads()

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -136,18 +136,18 @@ const init = (register: RegisterListener): void => {
 						// https://developers.google.com/publisher-tag/reference#googletag.defineSlot
 						const passbackSlot = googletag.defineSlot(
 							slot.getAdUnitPath(),
-							mpu,
+							[mpu, outstreamMobile, outstreamDesktop],
 							passbackElement.id,
 						);
 						// https://developers.google.com/publisher-tag/guides/ad-sizes#responsive_ads
 						passbackSlot?.defineSizeMapping([
 							[
 								[breakpoints.phablet, 0],
-								[outstreamDesktop, mpu],
+								[mpu, outstreamDesktop],
 							],
 							[
 								[breakpoints.mobile, 0],
-								[outstreamMobile, mpu],
+								[mpu, outstreamMobile],
 							],
 						]);
 						passbackSlot?.addService(window.googletag.pubads());

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -1,4 +1,6 @@
+import { adSizes } from '@guardian/commercial-core';
 import { log } from '@guardian/libs';
+import { breakpoints } from '@guardian/source-foundations';
 import { adSlotIdPrefix } from '../dfp/dfp-env-globals';
 import type { RegisterListener } from '../messenger';
 
@@ -12,6 +14,16 @@ const getValuesForKeys = (
 ): Array<[string, string[]]> => keys.map((key) => [key, valueFn(key)]);
 
 const labelHeight = 24;
+
+const mpu: [number, number] = [adSizes.mpu.width, adSizes.mpu.height];
+const outstreamDesktop: [number, number] = [
+	adSizes.outstreamDesktop.width,
+	adSizes.outstreamDesktop.height,
+];
+const outstreamMobile: [number, number] = [
+	adSizes.outstreamMobile.width,
+	adSizes.outstreamMobile.height,
+];
 
 /**
  * A listener for 'passback' messages from ad slot iFrames
@@ -123,9 +135,19 @@ const init = (register: RegisterListener): void => {
 					window.googletag.cmd.push(() => {
 						const passbackSlot = googletag.defineSlot(
 							slot.getAdUnitPath(),
-							[300, 250],
+							[adSizes.mpu.width, adSizes.mpu.height],
 							passbackElement.id,
 						);
+						passbackSlot?.defineSizeMapping([
+							[
+								[breakpoints.phablet, 0],
+								[outstreamDesktop, mpu],
+							],
+							[
+								[breakpoints.mobile, 0],
+								[outstreamMobile, mpu],
+							],
+						]);
 						passbackSlot?.addService(window.googletag.pubads());
 						allTargeting.forEach(([key, value]) => {
 							slot.setTargeting(key, value);

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -427,9 +427,7 @@
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/config.d.ts",
   "../projects/commercial/initial-consent-state.ts",
-  "../projects/commercial/modules/__vendor/ipsos-mori.js",
-  "../projects/common/modules/experiments/ab.ts",
-  "../projects/common/modules/experiments/tests/ipsos-mori-australia.ts"
+  "../projects/commercial/modules/__vendor/ipsos-mori.js"
  ],
  "../projects/commercial/modules/liveblog-adverts.ts": [
   "../lib/detect.js",
@@ -472,7 +470,9 @@
   "../projects/commercial/modules/messenger.ts"
  ],
  "../projects/commercial/modules/messenger/passback.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../../../../node_modules/@guardian/source-foundations/dist/types/index.d.ts",
   "../projects/commercial/modules/dfp/dfp-env-globals.ts",
   "../projects/commercial/modules/messenger.ts"
  ],
@@ -663,7 +663,6 @@
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
   "../projects/common/modules/experiments/tests/commercial-gpt-lazy-load.ts",
   "../projects/common/modules/experiments/tests/commercial-lazy-load-margin.ts",
-  "../projects/common/modules/experiments/tests/ipsos-mori-australia.ts",
   "../projects/common/modules/experiments/tests/prebid-price-granularity.ts",
   "../projects/common/modules/experiments/tests/remote-header-test.js",
   "../projects/common/modules/experiments/tests/sign-in-gate-main-control.js",
@@ -695,10 +694,6 @@
   "../lib/noop.ts"
  ],
  "../projects/common/modules/experiments/tests/commercial-lazy-load-margin.ts": [
-  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
-  "../lib/noop.ts"
- ],
- "../projects/common/modules/experiments/tests/ipsos-mori-australia.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
   "../lib/noop.ts"
  ],

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -179,9 +179,7 @@
   "../lib/partition.ts",
   "../projects/commercial/modules/dfp/dfp-env.ts",
   "../projects/commercial/modules/dfp/lazy-load.ts",
-  "../projects/commercial/modules/dfp/load-advert.ts",
-  "../projects/common/modules/experiments/ab.ts",
-  "../projects/common/modules/experiments/tests/commercial-gpt-lazy-load.ts"
+  "../projects/commercial/modules/dfp/load-advert.ts"
  ],
  "../projects/commercial/modules/dfp/empty-advert.ts": [
   "../../../../node_modules/fastdom/fastdom.d.ts",
@@ -210,10 +208,7 @@
   "../projects/commercial/modules/dfp/Advert.ts",
   "../projects/commercial/modules/dfp/dfp-env.ts",
   "../projects/commercial/modules/dfp/get-advert-by-id.ts",
-  "../projects/commercial/modules/dfp/load-advert.ts",
-  "../projects/common/modules/experiments/ab.ts",
-  "../projects/common/modules/experiments/tests/commercial-gpt-lazy-load.ts",
-  "../projects/common/modules/experiments/tests/commercial-lazy-load-margin.ts"
+  "../projects/commercial/modules/dfp/load-advert.ts"
  ],
  "../projects/commercial/modules/dfp/load-advert.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
@@ -575,8 +570,6 @@
  "../projects/common/modules/analytics/shouldCaptureMetrics.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
   "../projects/common/modules/experiments/ab.ts",
-  "../projects/common/modules/experiments/tests/commercial-gpt-lazy-load.ts",
-  "../projects/common/modules/experiments/tests/commercial-lazy-load-margin.ts",
   "../projects/common/modules/experiments/tests/prebid-price-granularity.ts"
  ],
  "../projects/common/modules/article/space-filler.ts": [
@@ -661,8 +654,6 @@
  ],
  "../projects/common/modules/experiments/ab-tests.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
-  "../projects/common/modules/experiments/tests/commercial-gpt-lazy-load.ts",
-  "../projects/common/modules/experiments/tests/commercial-lazy-load-margin.ts",
   "../projects/common/modules/experiments/tests/prebid-price-granularity.ts",
   "../projects/common/modules/experiments/tests/remote-header-test.js",
   "../projects/common/modules/experiments/tests/sign-in-gate-main-control.js",
@@ -689,14 +680,6 @@
   "../projects/common/modules/experiments/ab-utils.ts"
  ],
  "../projects/common/modules/experiments/automatLog.ts": [],
- "../projects/common/modules/experiments/tests/commercial-gpt-lazy-load.ts": [
-  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
-  "../lib/noop.ts"
- ],
- "../projects/common/modules/experiments/tests/commercial-lazy-load-margin.ts": [
-  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
-  "../lib/noop.ts"
- ],
  "../projects/common/modules/experiments/tests/prebid-price-granularity.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
   "../lib/noop.ts"
@@ -721,7 +704,6 @@
   "../../../../node_modules/@types/lodash-es/index.d.ts",
   "../lib/fastdom-promise.js",
   "../lib/mediator.ts",
-  "../lib/noop.ts",
   "../projects/commercial/sentinel.ts",
   "../projects/common/modules/mark-candidates.js"
  ],


### PR DESCRIPTION
## What does this change?

Adds `outstream` ad sizes to the new passback listener introduced in https://github.com/guardian/frontend/pull/24903 & https://github.com/guardian/frontend/pull/24724 .

This allows Ozone to fulfill the passback with a video ad.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [ ] Locally
- [x] On CODE (optional)
