### PR TITLE
fix(flex): assume flex is broadly supported

### DIFF
--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -22,33 +22,31 @@ $fc-item-gutter: $gs-gutter / 4;
         }
     }
 
-    .has-flex-wrap & {
-        .fc-item__container {
-            flex-wrap: wrap;
-            @if $media-align == right {
-                flex-direction: row-reverse;
-            } @else {
-                flex-direction: row;
-            }
+    .fc-item__container {
+        flex-wrap: wrap;
+        @if $media-align == right {
+            flex-direction: row-reverse;
+        } @else {
+            flex-direction: row;
         }
+    }
 
-        .fc-item__media-wrapper {
-            flex-basis: $media-width;
-        }
+    .fc-item__media-wrapper {
+        flex-basis: $media-width;
+    }
 
-        .fc-item__video-fallback {
-            flex-basis: $media-width;
-        }
+    .fc-item__video-fallback {
+        flex-basis: $media-width;
+    }
 
-        .fc-item__content {
-            flex-basis: (100% - $media-width);
-            // DAMN YOU IE10/11 FLEXWRAP BOX SIZING BUG
-            max-width: (100% - $media-width);
-        }
+    .fc-item__content {
+        flex-basis: (100% - $media-width);
+        // DAMN YOU IE10/11 FLEXWRAP BOX SIZING BUG
+        max-width: (100% - $media-width);
+    }
 
-        .fc-item__footer--horizontal {
-            flex-basis: 100%;
-        }
+    .fc-item__footer--horizontal {
+        flex-basis: 100%;
     }
 
     .has-no-flex-wrap & {
@@ -75,13 +73,8 @@ $fc-item-gutter: $gs-gutter / 4;
     }
 
     @include mq(tablet) {
-        .has-flex & {
-            flex: 1 1 auto;
-        }
-
-        .has-flex-wrap & {
-            display: flex;
-        }
+        display: flex;
+        flex: 1 1 auto;
 
         .has-no-flex-wrap & {
             @include clearfix;
@@ -95,14 +88,12 @@ $fc-item-gutter: $gs-gutter / 4;
     box-sizing: border-box;
 
     @include mq(tablet) {
-        .has-flex-wrap & {
-            flex-direction: column;
-            display: flex;
-            flex: 1 1 auto;
-            // see: http://stackoverflow.com/a/9737602/802472
-            // width:0 fixes child elements with white-space:nowrap below flex
-            width: 0;
-        }
+        flex-direction: column;
+        display: flex;
+        flex: 1 1 auto;
+        // see: http://stackoverflow.com/a/9737602/802472
+        // width:0 fixes child elements with white-space:nowrap below flex
+        width: 0;
     }
 }
 

--- a/static/src/stylesheets/module/facia/_items.scss
+++ b/static/src/stylesheets/module/facia/_items.scss
@@ -28,7 +28,7 @@
     margin-bottom: $gs-baseline;
 
     @include mq(tablet) {
-        .has-flex &:not(.fc-slice__item--mpu-candidate) {
+        &:not(.fc-slice__item--mpu-candidate) {
             display: flex;
         }
     }
@@ -105,7 +105,7 @@
         }
 
         &[class*='fc-item--has-sublinks'] {
-            .has-flex-wrap &.fc-item--has-cutout {
+            &.fc-item--has-cutout {
                 .fc-item__header {
                     padding-right: 0;
                 }
@@ -263,10 +263,8 @@
         @include fc-item--fluid;
         @include fc-item--horizontal(20%);
 
-        .has-flex-wrap & {
-            .fc-item__container {
-                flex-direction: row;
-            }
+        .fc-item__container {
+            flex-direction: row;
         }
 
         .fc-item__header {

--- a/static/src/stylesheets/module/facia/_linkslist.scss
+++ b/static/src/stylesheets/module/facia/_linkslist.scss
@@ -77,16 +77,14 @@
         }
     }
 
-    .has-flex-wrap & {
-        .fc-slice__item {
-            @include mq(tablet) {
-                flex-grow: 0;
-                flex-basis: 50%;
-            }
+    .fc-slice__item {
+        @include mq(tablet) {
+            flex-grow: 0;
+            flex-basis: 50%;
+        }
 
-            @include mq(desktop) {
-                flex-basis: (100% / 3);
-            }
+        @include mq(desktop) {
+            flex-basis: (100% / 3);
         }
     }
 

--- a/static/src/stylesheets/module/facia/_sublinks.scss
+++ b/static/src/stylesheets/module/facia/_sublinks.scss
@@ -34,18 +34,17 @@
 }
 
 @mixin fc-sublinks--horizontal {
-    .has-flex-wrap & {
-        .fc-sublinks {
-            display: flex;
-        }
-        .fc-sublink {
-            flex: 1 1 100%;
+    .fc-sublinks {
+        display: flex;
+    }
+    .fc-sublink {
+        flex: 1 1 100%;
 
-            & + * {
-                margin-left: $gs-gutter;
-            }
+        & + * {
+            margin-left: $gs-gutter;
         }
     }
+
 
     .has-no-flex-wrap & {
         .fc-sublinks {

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--full-media-50.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--full-media-50.scss
@@ -57,22 +57,16 @@ Full item with 50% width media.
     &.fc-item--has-cutout {
         .fc-item__container {
             min-height: gs-height(5) + $gs-baseline * 3;
-
-            .has-flex-wrap & {
-                flex-direction: row;
-            }
+            flex-direction: row;
         }
 
         .fc-item__content {
             width: auto;
             max-width: gs-span(6);
+            flex-basis: auto;
 
             @include mq(desktop) {
                 max-width: gs-span(8);
-            }
-
-            .has-flex-wrap & {
-                flex-basis: auto;
             }
         }
 

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--full-media-75.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--full-media-75.scss
@@ -58,22 +58,16 @@ Full item with 75% width media.
     &.fc-item--has-cutout {
         .fc-item__container {
             min-height: gs-height(5) + $gs-baseline * 3;
-
-            .has-flex-wrap & {
-                flex-direction: row;
-            }
+            flex-direction: row;
         }
 
         .fc-item__content {
             width: auto;
             max-width: gs-span(6);
+            flex-basis: auto;
 
             @include mq(desktop) {
                 max-width: gs-span(8);
-            }
-
-            .has-flex-wrap & {
-                flex-basis: auto;
             }
         }
 

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--half.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--half.scss
@@ -90,7 +90,7 @@ x x x x x x x x x x x x x x x x x x
             display: none;
         }
 
-        .has-flex-wrap &.fc-item--has-cutout {
+        .fc-item--has-cutout {
             .fc-item__content {
                 flex: 0 1 auto;
             }

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--three-quarters-right.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--three-quarters-right.scss
@@ -23,11 +23,8 @@ Three quarter item. Looks like a wide standard, a bit like this:
 @mixin fc-item--three-quarters-right {
 
     @include fc-item--three-quarters;
-
-    .has-flex-wrap & {
-        .fc-item__container {
-            flex-direction: row;
-        }
+    .fc-item__container {
+        flex-direction: row;
     }
 
     // IE10/11 ignore boxsizing on flex-basis'd element.

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--three-quarters.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--three-quarters.scss
@@ -55,10 +55,7 @@ Three quarter item. Looks like a wide standard, a bit like this:
     &.fc-item--has-cutout {
         .fc-item__container {
             min-height: gs-height(7);
-
-            .has-flex-wrap & {
-                flex-direction: row;
-            }
+            flex-direction: row;
         }
 
         .fc-item__header {
@@ -69,13 +66,10 @@ Three quarter item. Looks like a wide standard, a bit like this:
         .fc-item__content {
             width: auto;
             max-width: gs-span(5);
+            flex-basis: auto;
 
             @include mq(desktop) {
                 max-width: gs-span(6);
-            }
-
-            .has-flex-wrap & {
-                flex-basis: auto;
             }
         }
     }


### PR DESCRIPTION
## What does this change?

Assume flex is broadly supported. [Currently supported by at least 98% of browsers](https://caniuse.com/flexbox).

Redo of #24992 

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |


[before]: https://user-images.githubusercontent.com/76776/168795477-9238045b-f460-4441-aaed-ce000acc27d0.png
[after]: https://user-images.githubusercontent.com/76776/168795597-9449ee74-213d-402c-82a7-3f4422d9d8e1.png

## What is the value of this and can you measure success?

For readers with JavaScript disabled, fronts will look better.

## Checklist

### Tested

- [ ] Locally
- [X] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
