### PR TITLE
Add Women's euro 2022 competition & spider data

### DIFF
--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -329,7 +329,7 @@ object CompetitionsProvider {
     Competition("333", "/football/womens-fa-cup", "Women's FA Cup", "Women's FA Cup", "English"),
     Competition(
       "423",
-      "football/women-s-euro-2022",
+      "/football/women-s-euro-2022",
       "Women's Euro 2022",
       "Women's Euro 2022",
       "Internationals",

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -329,8 +329,8 @@ object CompetitionsProvider {
     Competition("333", "/football/womens-fa-cup", "Women's FA Cup", "Women's FA Cup", "English"),
     Competition(
       "423",
-      "/football/womens-euro-2022",
-      "UEFA Women's European Championship 2022",
+      "football/women-s-euro-2022",
+      "Women's Euro 2022",
       "Women's Euro 2022",
       "Internationals",
       showInTeamsList = true,

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -327,6 +327,16 @@ object CompetitionsProvider {
       "European",
     ),
     Competition("333", "/football/womens-fa-cup", "Women's FA Cup", "Women's FA Cup", "English"),
+    Competition(
+      "423",
+      "/football/womens-euro-2022",
+      "UEFA Women's European Championship 2022",
+      "Women's Euro 2022",
+      "Internationals",
+      showInTeamsList = true,
+      tableDividers = List(2),
+      startDate = Some(LocalDate.of(2022, 7, 1)),
+    ),
   )
 }
 

--- a/sport/app/football/model/CompetitionStages.scala
+++ b/sport/app/football/model/CompetitionStages.scala
@@ -182,6 +182,23 @@ object KnockoutSpider {
       ZonedDateTime.of(2021, 7, 7, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Semi-Final     // Match 50
       ZonedDateTime.of(2021, 7, 11, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Final         // Match 51
     ),
+    // Womens Euro 2022
+    "423" -> List(
+      // Group C Winner & Group D Runner up
+      ZonedDateTime.of(2022, 7, 22, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter-Final 3  // 4287727
+      // Group A Winner & Group B Runner Up
+      ZonedDateTime.of(2022, 7, 20, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter-Final 1  // 4287725
+      // Group D Winner & Group C Runner up
+      ZonedDateTime.of(2022, 7, 23, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter-Final 4  // 4287728
+      // Group B Winner & Group A Runner Up
+      ZonedDateTime.of(2022, 7, 21, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Quarter-Final 2  // 4287726
+      // QF Winners 3 & 1
+      ZonedDateTime.of(2022, 7, 26, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Semi-Final 1     // 4287730
+      // QF Winners 4 & 2
+      ZonedDateTime.of(2022, 7, 27, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Semi-Final 2     // 4287731
+      // SM Winners 1 & 2
+      ZonedDateTime.of(2022, 7, 31, 20, 0, 0, 0, ZoneId.of("Europe/London")), // Final            // 4287732
+    ),
   )
 
   // adds a little flex around the match dates in case they aren't listed at exactly the right time

--- a/static/src/stylesheets/module/football/_overview.scss
+++ b/static/src/stylesheets/module/football/_overview.scss
@@ -441,6 +441,11 @@
     }
 }
 
+.football-knockout-chart--3-rounds {
+    .football-round {
+        width: 20%; // 100/5 as there will be 5 columns in the chart
+    }
+}
 .football-knockout-chart--4-rounds,
 .football-knockout-chart--5-rounds {
     .football-round {


### PR DESCRIPTION
Co-Authored-By: Ashleigh Carr <ashcorr20@gmail.com>

## What does this change?

Adds the following for the Womens euros 2022 Competition
- Competition name, ID and tag
- Add stages for spider knockout diagram
- Update CSS for spider diagram to support 3 round competition

For womens euros 2022 we still need (for frontend):
- Cup SVG spider diagram
- Badge for the tournament

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<img width="1306" alt="image" src="https://user-images.githubusercontent.com/9575458/168796819-f8cae966-6937-4013-9749-7fd5ba62238e.png">
<img width="1303" alt="image" src="https://user-images.githubusercontent.com/9575458/168796854-87020cf1-1e72-4dd8-88fe-2c415e9e887b.png">



## What is the value of this and can you measure success?

## Checklist

### Accessibility test checklist

We might want to organise a session with the DAC about making the spider diagram accessible 
<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
