### PR TITLE
Remove logic that serves blogs from frontend - all being served by DCR

### DIFF
--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -124,8 +124,8 @@ class LiveBlogController(
                 "isDead" -> isDeadBlog.toString,
                 "isLiveBlog" -> "true",
               )
-            val remoteRendering =
-              shouldRemoteRender(request.forceDCROff)
+            val remoteRendering = !request.forceDCROff
+
             if (remoteRendering) {
               DotcomponentsLogger.logger.logRequest(s"liveblog executing in dotcomponents", properties, page)
               val pageType: PageType = PageType(blog, request, context)
@@ -143,14 +143,6 @@ class LiveBlogController(
       }
 
     }
-  }
-
-  def shouldRemoteRender(
-      forceDCROff: Boolean,
-  ): Boolean = {
-    // ?dcr=false, so never render DCR
-    if (forceDCROff) false
-    else true
   }
 
   private[this] def getRange(lastUpdate: Option[String], page: Option[String]): BlockRange = {
@@ -174,7 +166,7 @@ class LiveBlogController(
       filterKeyEvents: Boolean,
       requestedBodyBlocks: scala.collection.Map[String, Seq[Block]] = Map.empty,
   )(implicit request: RequestHeader): Future[Result] = {
-    val remoteRender = shouldRemoteRender(request.forceDCROff)
+    val remoteRender = !request.forceDCROff
 
     range match {
       case SinceBlockId(lastBlockId) =>

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -109,12 +109,11 @@ class LiveBlogController(
           case (minute: MinutePage, HtmlFormat) =>
             Future.successful(common.renderHtml(MinuteHtmlPage.html(minute), minute))
           case (blog: LiveBlogPage, HtmlFormat) =>
-            val dcrCouldRender = LiveBlogController.checkIfSupported(blog)
-            val isRecent = !LiveBlogController.isNotRecent(blog)
+            val dcrCouldRender = true
             val theme = blog.article.content.metadata.format.getOrElse(ContentFormat.defaultContentFormat).theme
             val design = blog.article.content.metadata.format.getOrElse(ContentFormat.defaultContentFormat).design
             val display = blog.article.content.metadata.format.getOrElse(ContentFormat.defaultContentFormat).display
-            val isDeadBlog = LiveBlogController.isDeadBlog(blog)
+            val isDeadBlog = !blog.article.fields.isLive
             val properties =
               Map(
                 "participatingInTest" -> "false",
@@ -122,12 +121,11 @@ class LiveBlogController(
                 "theme" -> theme.toString,
                 "design" -> design.toString,
                 "display" -> display.toString,
-                "isRecent" -> isRecent.toString,
                 "isDead" -> isDeadBlog.toString,
                 "isLiveBlog" -> "true",
               )
             val remoteRendering =
-              shouldRemoteRender(request.forceDCROff, request.forceDCR, dcrCouldRender)
+              shouldRemoteRender(request.forceDCROff)
             if (remoteRendering) {
               DotcomponentsLogger.logger.logRequest(s"liveblog executing in dotcomponents", properties, page)
               val pageType: PageType = PageType(blog, request, context)
@@ -149,16 +147,10 @@ class LiveBlogController(
 
   def shouldRemoteRender(
       forceDCROff: Boolean,
-      forceDCR: Boolean,
-      dcrCouldRender: Boolean,
   ): Boolean = {
     // ?dcr=false, so never render DCR
     if (forceDCROff) false
-    // ?dcr=true, so always render DCR
-    else if (forceDCR) true
-    // DCR supports this blog
-    else if (dcrCouldRender) true
-    else false
+    else true
   }
 
   private[this] def getRange(lastUpdate: Option[String], page: Option[String]): BlockRange = {
@@ -182,8 +174,7 @@ class LiveBlogController(
       filterKeyEvents: Boolean,
       requestedBodyBlocks: scala.collection.Map[String, Seq[Block]] = Map.empty,
   )(implicit request: RequestHeader): Future[Result] = {
-    val dcrCouldRender = LiveBlogController.checkIfSupported(liveblog)
-    val remoteRender = shouldRemoteRender(request.forceDCROff, request.forceDCR, dcrCouldRender)
+    val remoteRender = shouldRemoteRender(request.forceDCROff)
 
     range match {
       case SinceBlockId(lastBlockId) =>
@@ -341,32 +332,5 @@ class LiveBlogController(
 
   def shouldFilter(filterKeyEvents: Option[Boolean]): Boolean = {
     filterKeyEvents.getOrElse(false)
-  }
-}
-
-object LiveBlogController {
-  private def isSupportedTheme(blog: PageWithStoryPackage): Boolean = {
-    blog.article.content.metadata.format.getOrElse(ContentFormat.defaultContentFormat).theme match {
-      case NewsPillar      => true
-      case CulturePillar   => true
-      case LifestylePillar => true
-      case SportPillar     => true
-      case _               => false
-    }
-  }
-
-  def isDeadBlog(blog: PageWithStoryPackage): Boolean = !blog.article.fields.isLive
-
-  def isNotRecent(blog: PageWithStoryPackage): Boolean = {
-    val twoDaysAgo = new DateTime(DateTimeZone.UTC).minusDays(2)
-    blog.article.fields.lastModified.isBefore(twoDaysAgo)
-  }
-
-  def isRugby(blog: PageWithStoryPackage): Boolean = {
-    blog.article.tags.tags.exists(tag => tag.id == "sport/rugby-union")
-  }
-
-  def checkIfSupported(blog: PageWithStoryPackage): Boolean = {
-    isSupportedTheme(blog) && !isRugby(blog)
   }
 }

--- a/article/app/pages/StoryHtmlPage.scala
+++ b/article/app/pages/StoryHtmlPage.scala
@@ -16,7 +16,6 @@ import views.html.fragments.page.head._
 import html.HtmlPageHelpers.ContentCSSFile
 import views.html.stacked
 import services.dotcomponents.ArticlePicker.{dcrChecks}
-import controllers.LiveBlogController.{checkIfSupported}
 
 object StoryHtmlPage {
 
@@ -33,8 +32,7 @@ object StoryHtmlPage {
 
   def htmlDcrCouldRender(implicit pageWithStoryPackage: PageWithStoryPackage, request: RequestHeader): Html = {
     if (pageWithStoryPackage.item.tags.isLiveBlog) {
-      val thisDcrCouldRender: Boolean = checkIfSupported(pageWithStoryPackage)
-      Html(s"<script>window.guardian.config.page.dcrCouldRender = $thisDcrCouldRender</script>")
+      Html(s"<script>window.guardian.config.page.dcrCouldRender = true</script>")
     } else {
       val thisDcrCouldRender: Boolean = dcrChecks(pageWithStoryPackage, request).values.forall(identity)
       Html(s"<script>window.guardian.config.page.dcrCouldRender = $thisDcrCouldRender</script>")

--- a/article/test/LiveBlogControllerTest.scala
+++ b/article/test/LiveBlogControllerTest.scala
@@ -173,24 +173,23 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
   it should "use dcr if no dcr param is passed" in {
     val forceDCROff = false
 
-    val shouldRemoteRender =
-      liveBlogController.shouldRemoteRender(forceDCROff)
+    val shouldRemoteRender = !forceDCROff
+
     shouldRemoteRender should be(true)
   }
 
   it should "use DCR if the parameter dcr=true is passed" in {
     val forceDCROff = false
 
-    val shouldRemoteRender =
-      liveBlogController.shouldRemoteRender(forceDCROff)
+    val shouldRemoteRender = !forceDCROff
     shouldRemoteRender should be(true)
   }
 
   it should "use frontend if the parameter dcr=false is passed" in {
     val forceDCROff = true
 
-    val shouldRemoteRender =
-      liveBlogController.shouldRemoteRender(forceDCROff)
+    val shouldRemoteRender = !forceDCROff
+
     shouldRemoteRender should be(false)
   }
 

--- a/article/test/LiveBlogControllerTest.scala
+++ b/article/test/LiveBlogControllerTest.scala
@@ -172,52 +172,26 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 
   it should "use dcr if no dcr param is passed" in {
     val forceDCROff = false
-    val forceDCR = false
-    val dcrCanRender = true
 
     val shouldRemoteRender =
-      liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, dcrCanRender)
+      liveBlogController.shouldRemoteRender(forceDCROff)
     shouldRemoteRender should be(true)
   }
 
   it should "use DCR if the parameter dcr=true is passed" in {
     val forceDCROff = false
-    val forceDCR = true
-    val dcrCanRender = true
 
     val shouldRemoteRender =
-      liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, dcrCanRender)
+      liveBlogController.shouldRemoteRender(forceDCROff)
     shouldRemoteRender should be(true)
   }
 
   it should "use frontend if the parameter dcr=false is passed" in {
     val forceDCROff = true
-    val forceDCR = false
-    val dcrCanRender = true
 
     val shouldRemoteRender =
-      liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, dcrCanRender)
+      liveBlogController.shouldRemoteRender(forceDCROff)
     shouldRemoteRender should be(false)
-  }
-
-  it should "use frontend if DCR cant render" in {
-    val forceDCROff = false
-    val forceDCR = false
-    val dcrCanRender = false
-
-    val shouldRemoteRender =
-      liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, dcrCanRender)
-    shouldRemoteRender should be(false)
-  }
-
-  it should "use DCR if dcrCanRender is false and dcr=true" in {
-    val forceDCROff = false
-    val forceDCR = true
-    val dcrCanRender = false
-
-    val shouldRemoteRender =
-      liveBlogController.shouldRemoteRender(forceDCROff, forceDCR, dcrCanRender)
-    shouldRemoteRender should be(true)
   }
 
   it should "filter when the filter parameter is true" in {


### PR DESCRIPTION
co-authored-by: Olly Namey <olly.namey@theguardian.com>

## What does this change?
We no longer need to serve any blogs through frontend, so we've ripped out the code that, in certain instances, serves blogs by frontend. We are at 100%, finally!

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes (please indicate your plans for DCR Implementation)

(Already done the corresponding DCR work)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
