### PR TITLE
fix(ab-ophan): remove any type with generics

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/ab-ophan.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-ophan.ts
@@ -4,10 +4,9 @@ import config from '../../../../lib/config';
 import { noop } from '../../../../lib/noop';
 import reportError from '../../../../lib/report-error';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- generics don’t play nice
-type BooleanFunction = (...args: any[]) => boolean;
+type BooleanFunction<Args extends unknown[]> = (...args: Args) => boolean;
 const not =
-	(f: BooleanFunction): BooleanFunction =>
+	<Args extends unknown[]>(f: BooleanFunction<Args>): BooleanFunction<Args> =>
 	(...args) =>
 		!f(...args);
 


### PR DESCRIPTION
## What does this change?

Remove an `any` type. A year ago I couldn’t wrap my head around the correct generic. Now I do.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Better types!

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
