### PR TITLE
Add newsletters to UK news subnav

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -255,9 +255,10 @@ private object NavLinks {
     List(
       ukNews,
       world,
-      coronavirus,
       climateCrisis,
+      newsletters,
       football,
+      coronavirus,
       ukBusiness,
       ukEnvironment,
       politics,
@@ -266,7 +267,6 @@ private object NavLinks {
       science,
       tech,
       globalDevelopment,
-      obituaries,
     ),
   )
   val auNewsPillar = ukNewsPillar.copy(


### PR DESCRIPTION
## What does this change?
On the UK subnav for News:
- Add Newsletters link
- Move Coronavirus link
- Remove Obituaries link


## Does this change need to be reproduced in dotcom-rendering ?

I've tested this locally on DCR for articles. I haven't been able to test it on DCR-rendered _or_ frontend-rendered fronts. I'm happy to test with these if it's important to do so, but I'll need some pointers on getting Facia running locally. Given the nature of the change, though, I figure it might not be worth doing this.

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="215" alt="before" src="https://user-images.githubusercontent.com/37048459/169300397-0f40adfe-5197-4c82-833e-0a9399978b9a.png"> | <img width="225" alt="after" src="https://user-images.githubusercontent.com/37048459/169291955-c0bbc4c8-fa81-49da-acab-dc763551d5ce.png"> |

Before: 
<img width="1369" alt="before" src="https://user-images.githubusercontent.com/37048459/169300842-ef489cab-8717-49ff-9901-334123b632a8.png">

After:
![after](https://user-images.githubusercontent.com/37048459/169300925-c76f9d4e-bedf-412f-b035-ce4631f82bfc.png)


[before]: https://example.com/before.png
[after]: https://example.com/after.png

## What is the value of this and can you measure success?

This was requested by Editorial. ([See issue](https://github.com/guardian/dotcom-rendering/issues/4928).)

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
- [x] Doesn't change accessibility-related properties.

### Tested

- [x] Locally (**nb.** see qualifications above)
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
