### PR TITLE
Sign in after checkout prompts (header / banner)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@guardian/source-foundations": "^4.0.3",
     "@guardian/source-react-components": "^4.0.2",
     "@guardian/source-react-components-development-kitchen": "^0.0.33",
-    "@guardian/support-dotcom-components": "^1.0.2",
+    "@guardian/support-dotcom-components": "1.0.3",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",
     "bootstrap-sass": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@guardian/source-foundations": "^4.0.3",
     "@guardian/source-react-components": "^4.0.2",
     "@guardian/source-react-components-development-kitchen": "^0.0.33",
-    "@guardian/support-dotcom-components": "1.0.3",
+    "@guardian/support-dotcom-components": "1.0.4",
     "bean": "~1.0.14",
     "bonzo": "~2.0.0",
     "bootstrap-sass": "^3.4.1",

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.spec.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.spec.ts
@@ -9,6 +9,7 @@ import {
 	getDaysSinceLastOneOffContribution,
 	getLastOneOffContributionTimestamp,
 	getLastRecurringContributionDate,
+	getPurchaseInfo,
 	isAdFreeUser,
 	isDigitalSubscriber,
 	isPayingMember,
@@ -652,5 +653,31 @@ describe('isPostAskPauseOneOffContributor', () => {
 		global.Date.now = jest.fn(() => Date.parse('2019-02-01T13:00:30'));
 		setSupportFrontendOneOffContributionCookie(contributionDateTimeEpoch);
 		expect(isPostAskPauseOneOffContributor()).toBe(true);
+	});
+});
+
+describe('getPurchaseInfo', () => {
+	afterEach(() => {
+		removeCookie('GU_CO_COMPLETE');
+	});
+
+	it('returns decoded cookie data', () => {
+		addCookie(
+			'GU_CO_COMPLETE',
+			'%7B%22userType%22%3A%22guest%22%2C%22product%22%3A%22DigitalPack%22%7D',
+		);
+		expect(getPurchaseInfo()).toEqual({
+			userType: 'guest',
+			product: 'DigitalPack',
+		});
+	});
+
+	it('returns undefined if cookie unset', () => {
+		expect(getPurchaseInfo()).toBeUndefined();
+	});
+
+	it('returns undefined if cookie data invalid', () => {
+		addCookie('GU_CO_COMPLETE', 'utter-nonsense');
+		expect(getPurchaseInfo()).toBeUndefined();
 	});
 });

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.ts
@@ -370,10 +370,6 @@ const canShowContributionsReminderFeature = (): boolean => {
 	return Boolean(switches.showContributionReminder) && !signedUpForReminder;
 };
 
-// TODO: remove this once PR in support-dotcom-components is merged and released
-// https://github.com/guardian/support-dotcom-components/pull/665
-// eslint-disable-next-line -- see above
-// @ts-ignore
 type PurchaseInfo = HeaderPayload['targeting']['purchaseInfo'];
 const getPurchaseInfo = (): PurchaseInfo => {
 	const purchaseInfoRaw = getCookie({ name: 'GU_CO_COMPLETE' });
@@ -382,13 +378,12 @@ const getPurchaseInfo = (): PurchaseInfo => {
 		return undefined;
 	}
 
-	let purchaseInfo: PurchaseInfo;
+	let purchaseInfo: PurchaseInfo = undefined;
 
 	try {
-		// TODO: remove this once PR in support-dotcom-components is merged and released
-		// https://github.com/guardian/support-dotcom-components/pull/665
-		// eslint-disable-next-line -- see above
-		purchaseInfo = JSON.parse(decodeURIComponent(purchaseInfoRaw));
+		purchaseInfo = JSON.parse(
+			decodeURIComponent(purchaseInfoRaw),
+		) as PurchaseInfo;
 	} catch {} // eslint-disable-line no-empty -- silently handle error
 
 	return purchaseInfo;

--- a/static/src/javascripts/projects/common/modules/commercial/user-features.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.ts
@@ -1,4 +1,5 @@
 import { getCookie, isObject, removeCookie, setCookie } from '@guardian/libs';
+import type { HeaderPayload } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
 import {
 	AdFreeCookieReasons,
 	adFreeDataIsOld,
@@ -369,6 +370,30 @@ const canShowContributionsReminderFeature = (): boolean => {
 	return Boolean(switches.showContributionReminder) && !signedUpForReminder;
 };
 
+// TODO: remove this once PR in support-dotcom-components is merged and released
+// https://github.com/guardian/support-dotcom-components/pull/665
+// eslint-disable-next-line -- see above
+// @ts-ignore
+type PurchaseInfo = HeaderPayload['targeting']['purchaseInfo'];
+const getPurchaseInfo = (): PurchaseInfo => {
+	const purchaseInfoRaw = getCookie({ name: 'GU_CO_COMPLETE' });
+
+	if (!purchaseInfoRaw) {
+		return undefined;
+	}
+
+	let purchaseInfo: PurchaseInfo;
+
+	try {
+		// TODO: remove this once PR in support-dotcom-components is merged and released
+		// https://github.com/guardian/support-dotcom-components/pull/665
+		// eslint-disable-next-line -- see above
+		purchaseInfo = JSON.parse(decodeURIComponent(purchaseInfoRaw));
+	} catch {} // eslint-disable-line no-empty -- silently handle error
+
+	return purchaseInfo;
+};
+
 export {
 	accountDataUpdateWarning,
 	isAdFreeUser,
@@ -383,6 +408,7 @@ export {
 	getLastOneOffContributionDate,
 	getLastRecurringContributionDate,
 	getDaysSinceLastOneOffContribution,
+	getPurchaseInfo,
 	isPostAskPauseOneOffContributor,
 	readerRevenueRelevantCookies,
 	fakeOneOffContributor,

--- a/static/src/javascripts/projects/common/modules/support/banner.ts
+++ b/static/src/javascripts/projects/common/modules/support/banner.ts
@@ -147,8 +147,6 @@ const buildBannerPayload = async (
 		subscriptionBannerLastClosedAt:
 			(userPrefs.get('subscriptionBannerLastClosedAt') as string) ||
 			undefined,
-		// eslint-disable-next-line -- waiting for guardian/support-dotcom-components#723 to be merged
-		// @ts-ignore
 		signInBannerLastClosedAt:
 			(userPrefs.get('signInBannerLastClosedAt') as string) || undefined,
 		mvtId: getMvtValue() ?? 0,
@@ -162,7 +160,7 @@ const buildBannerPayload = async (
 		contentType,
 		browserId: (await hasCmpConsentForBrowserId()) ? browserId : undefined,
 		purchaseInfo,
-		isSignedIn,
+		isSignedIn: !!isSignedIn,
 	};
 
 	return {
@@ -218,8 +216,6 @@ export const fetchBannerData = async (): Promise<ModuleDataResponse | null> => {
 	const showSignInPrompt =
 		purchaseInfo &&
 		!isSignedIn &&
-		// eslint-disable-next-line -- waiting for guardian/support-dotcom-components#723 to be merged
-		// @ts-ignore
 		!payload.targeting.signInBannerLastClosedAt;
 
 	if (

--- a/static/src/javascripts/projects/common/modules/support/header.ts
+++ b/static/src/javascripts/projects/common/modules/support/header.ts
@@ -6,8 +6,10 @@ import { getMvtValue } from 'common/modules/analytics/mvt-cookie';
 import { submitComponentEvent } from 'common/modules/commercial/acquisitions-ophan';
 import {
 	getLastOneOffContributionDate,
+	getPurchaseInfo,
 	shouldHideSupportMessaging,
 } from 'common/modules/commercial/user-features';
+import { isUserLoggedIn } from 'common/modules/identity/api';
 import {
 	dynamicImport,
 	ModulesVersion,
@@ -31,6 +33,13 @@ const buildHeaderLinksPayload = (): HeaderPayload => {
 			mvtId: getMvtValue() ?? 0,
 			lastOneOffContributionDate:
 				getLastOneOffContributionDate() ?? undefined,
+			// TODO: remove this once PR in support-dotcom-components is merged and released
+			// https://github.com/guardian/support-dotcom-components/pull/665
+			// eslint-disable-next-line -- see above
+			// @ts-ignore
+			// eslint-disable-next-line -- see above
+			purchaseInfo: getPurchaseInfo(),
+			isSignedIn: isUserLoggedIn(),
 		},
 	};
 };

--- a/static/src/javascripts/projects/common/modules/support/header.ts
+++ b/static/src/javascripts/projects/common/modules/support/header.ts
@@ -33,11 +33,6 @@ const buildHeaderLinksPayload = (): HeaderPayload => {
 			mvtId: getMvtValue() ?? 0,
 			lastOneOffContributionDate:
 				getLastOneOffContributionDate() ?? undefined,
-			// TODO: remove this once PR in support-dotcom-components is merged and released
-			// https://github.com/guardian/support-dotcom-components/pull/665
-			// eslint-disable-next-line -- see above
-			// @ts-ignore
-			// eslint-disable-next-line -- see above
 			purchaseInfo: getPurchaseInfo(),
 			isSignedIn: isUserLoggedIn(),
 		},

--- a/static/src/javascripts/projects/common/modules/support/header.ts
+++ b/static/src/javascripts/projects/common/modules/support/header.ts
@@ -62,7 +62,7 @@ export const fetchAndRenderHeaderLinks = async (): Promise<void> => {
 			return;
 		}
 		const { module } = response.data;
-		const Header = await dynamicImport(module.url, 'Header');
+		const Header = await dynamicImport(module.url, module.name);
 
 		const el = document.createElement('div');
 		const container = document.querySelector('.new-header__cta-bar');

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -625,6 +625,7 @@
  ],
  "../projects/common/modules/commercial/user-features.ts": [
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../../../../node_modules/@guardian/support-dotcom-components/dist/dotcom/src/types.d.ts",
   "../lib/config.d.ts",
   "../lib/fetch-json.ts",
   "../lib/manage-ad-free-cookie.ts",

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -707,13 +707,13 @@
  "../projects/common/modules/identity/auth-component-event-params.js": [
   "../lib/url.ts"
  ],
- "../projects/common/modules/mark-candidates.js": [],
+ "../projects/common/modules/spacefinder-debug-tools.js": [],
  "../projects/common/modules/spacefinder.ts": [
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../../../../node_modules/@types/lodash-es/index.d.ts",
   "../lib/fastdom-promise.js",
   "../projects/commercial/sentinel.ts",
-  "../projects/common/modules/mark-candidates.js"
+  "../projects/common/modules/spacefinder-debug-tools.js"
  ],
  "../projects/common/modules/ui/sticky.js": [
   "../../../../node_modules/fastdom/fastdom.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2164,10 +2164,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-3.12.0.tgz#52d11d2fff649e04934033473b3ed7c7bf4a1639"
   integrity sha512-JIFBybaCd69tf+zJZZ7KNLdqaVePOAc36wGFor0I60vc9Ib0jMuzYVffMjMhF6LHSXMdoOcqGwiPdFucObVYAA==
 
-"@guardian/support-dotcom-components@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@guardian/support-dotcom-components/-/support-dotcom-components-1.0.2.tgz#56bfb7cf7aef6d859b6f97b3986188af687f8a16"
-  integrity sha512-NqAxmegwQ1ltBH4EmfXwJHxRXGJzlZMSFDkK+5fkReL4XtACX3ZzR2rMbl7SN5RxSbeSzr5nGElRZ0TWkAYRJw==
+"@guardian/support-dotcom-components@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@guardian/support-dotcom-components/-/support-dotcom-components-1.0.3.tgz#1880eb83191757be4936c0ba838646fc407cc8f2"
+  integrity sha512-KxNhZtH6uS6oO5DOOpBBb0cdcDzHMVkCY8ldwie5R8elBUzISNYfAttOPbFbSBD9juFICMOkbvPe2CWH8kDw7Q==
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2164,10 +2164,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-3.12.0.tgz#52d11d2fff649e04934033473b3ed7c7bf4a1639"
   integrity sha512-JIFBybaCd69tf+zJZZ7KNLdqaVePOAc36wGFor0I60vc9Ib0jMuzYVffMjMhF6LHSXMdoOcqGwiPdFucObVYAA==
 
-"@guardian/support-dotcom-components@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@guardian/support-dotcom-components/-/support-dotcom-components-1.0.3.tgz#1880eb83191757be4936c0ba838646fc407cc8f2"
-  integrity sha512-KxNhZtH6uS6oO5DOOpBBb0cdcDzHMVkCY8ldwie5R8elBUzISNYfAttOPbFbSBD9juFICMOkbvPe2CWH8kDw7Q==
+"@guardian/support-dotcom-components@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@guardian/support-dotcom-components/-/support-dotcom-components-1.0.4.tgz#1d09ce408bcfa435eb2411255688e22a2eede032"
+  integrity sha512-g23KJoJiJVIC75DZW87zyblmNMnjujCgCKntLVLblKoSxIzOBLhzkPUnJqzPtG3aztTPRbqmhLzqgzm6M56/qw==
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"


### PR DESCRIPTION
## What does this change?

Adds support for new header messaging prompting users have contributed to sign in, so that they may get the benefits.

~~This is in draft until https://github.com/guardian/support-dotcom-components/pull/665 has been merged, as the types have changed.~~

Back in draft, now waiting for https://github.com/guardian/support-dotcom-components/pull/723.

Revised Designs here - https://github.com/guardian/support-dotcom-components/pull/738


## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes, PR is https://github.com/guardian/dotcom-rendering/pull/4857

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][
![image](https://user-images.githubusercontent.com/3338808/172574671-8445bce9-8602-4b4e-8d6e-c532ebf7d490.png)
] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

| | Before | After |
|-|-|-|
| Tablet | ![image](https://user-images.githubusercontent.com/3338808/172579492-da66f261-8c66-4f9f-8793-2bfa0c062add.png) | ![image](https://user-images.githubusercontent.com/3338808/172579081-acb1ee0b-14e6-432a-8dde-059f93a93436.png) |
| Large Desktop | ![image](https://user-images.githubusercontent.com/3338808/172579578-59c0072d-ab16-4922-ae5f-6aadcd0cbe9e.png) | ![image](https://user-images.githubusercontent.com/3338808/172578969-c8ac379c-2a86-4d66-b0c3-05b13245614b.png) |


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
