### PR TITLE
Iframe parent component param

### DIFF
--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -28,6 +28,8 @@ GET        /crosswords/lookup                                                   
 # Email paths
 GET        /email/form/$emailType<plain|plaindark|plaintone>/$listId<[0-9]+>         controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
 GET        /email/form/$emailType<plain|plaindark|plaintone>/:listName               controllers.EmailSignupController.renderFormFromName(emailType: String, listName: String)
+GET        /email/form/$emailType<plain|plaindark|plaintone>/:parentComponent/$listId<[0-9]+>         controllers.EmailSignupController.renderFormWithParentComponent(emailType: String, listId: Int, parentComponent:String)
+GET        /email/form/$emailType<plain|plaindark|plaintone>/:parentComponent/:listName               controllers.EmailSignupController.renderFormFromNameWithParentComponent(emailType: String, listName: String, parentComponent: String)
 GET        /email/form/footer/:listName                                              controllers.EmailSignupController.renderFooterForm(listName: String)
 GET        /email/form/thrasher/$listId<[0-9]+>                                      controllers.EmailSignupController.renderThrasherForm(listId: Int)
 GET        /email/form/thrasher/:listName                                            controllers.EmailSignupController.renderThrasherFormFromName(listName: String)

--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -98,7 +98,7 @@ class CanonicalLink {
     "index",
     "page",
     "filterKeyEvents",
-    "iframe_location",
+    "iframe_parent_component",
   )
 
   def apply(implicit request: RequestHeader, webUrl: String): String = {

--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -98,6 +98,7 @@ class CanonicalLink {
     "index",
     "page",
     "filterKeyEvents",
+    "iframe_location",
   )
 
   def apply(implicit request: RequestHeader, webUrl: String): String = {

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -194,6 +194,7 @@ class EmailSignupController(
     csrfAddToken {
       Action { implicit request =>
         val identityNewsletter = emailEmbedAgent.getNewsletterById(listId)
+        val iframeLocation = request.getQueryString("iframe_location")
 
         identityNewsletter match {
           case Right(Some(newsletter)) =>
@@ -203,6 +204,7 @@ class EmailSignupController(
                   emailLandingPage,
                   emailType,
                   newsletter,
+                  iframeLocation,
                 ),
               ),
             )
@@ -228,6 +230,7 @@ class EmailSignupController(
     csrfAddToken {
       Action { implicit request =>
         val identityNewsletter = emailEmbedAgent.getNewsletterByName(listName)
+        val iframeLocation = request.getQueryString("iframe_location")
         identityNewsletter match {
           case Right(Some(newsletter)) =>
             Cached(1.hour)(
@@ -236,6 +239,7 @@ class EmailSignupController(
                   emailLandingPage,
                   emailType,
                   newsletter,
+                  iframeLocation,
                 ),
               ),
             )

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -190,11 +190,15 @@ class EmailSignupController(
       }
     }
 
-  def renderForm(emailType: String, listId: Int): Action[AnyContent] =
+  def renderFormWithParentComponent (emailType: String, listId: Int, parentComponent: String): Action[AnyContent] =
+    csrfAddToken {
+      return renderForm(emailType,listId, Option(parentComponent))
+    }
+
+  def renderForm(emailType: String, listId: Int, iframeParentComponent: Option[String] = None): Action[AnyContent] =
     csrfAddToken {
       Action { implicit request =>
         val identityNewsletter = emailEmbedAgent.getNewsletterById(listId)
-        val iframeParentComponent = request.getQueryString("iframe_parent_component")
 
         identityNewsletter match {
           case Right(Some(newsletter)) =>
@@ -226,11 +230,16 @@ class EmailSignupController(
     log.error(s"Newsletter not found: Couldn't find $newsletterName")
   }
 
-  def renderFormFromName(emailType: String, listName: String): Action[AnyContent] =
+
+  def renderFormFromNameWithParentComponent (emailType: String, listName: String, parentComponent: String): Action[AnyContent] =
+    csrfAddToken {
+      return renderFormFromName(emailType,listName, Option(parentComponent))
+    }
+
+  def renderFormFromName(emailType: String, listName: String, iframeParentComponent:Option[String] = None): Action[AnyContent] =
     csrfAddToken {
       Action { implicit request =>
         val identityNewsletter = emailEmbedAgent.getNewsletterByName(listName)
-        val iframeParentComponent = request.getQueryString("iframe_parent_component")
         identityNewsletter match {
           case Right(Some(newsletter)) =>
             Cached(1.hour)(

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -194,7 +194,7 @@ class EmailSignupController(
     csrfAddToken {
       Action { implicit request =>
         val identityNewsletter = emailEmbedAgent.getNewsletterById(listId)
-        val iframeLocation = request.getQueryString("iframe_location")
+        val iframeParentComponent = request.getQueryString("iframe_parent_component")
 
         identityNewsletter match {
           case Right(Some(newsletter)) =>
@@ -204,7 +204,7 @@ class EmailSignupController(
                   emailLandingPage,
                   emailType,
                   newsletter,
-                  iframeLocation,
+                  iframeParentComponent,
                 ),
               ),
             )
@@ -230,7 +230,7 @@ class EmailSignupController(
     csrfAddToken {
       Action { implicit request =>
         val identityNewsletter = emailEmbedAgent.getNewsletterByName(listName)
-        val iframeLocation = request.getQueryString("iframe_location")
+        val iframeParentComponent = request.getQueryString("iframe_parent_component")
         identityNewsletter match {
           case Right(Some(newsletter)) =>
             Cached(1.hour)(
@@ -239,7 +239,7 @@ class EmailSignupController(
                   emailLandingPage,
                   emailType,
                   newsletter,
-                  iframeLocation,
+                  iframeParentComponent,
                 ),
               ),
             )

--- a/common/app/views/emailFragment.scala.html
+++ b/common/app/views/emailFragment.scala.html
@@ -1,12 +1,12 @@
 @import services.newsletters.model.NewsletterResponse
-@(page: model.Page, emailType: String, emailNewsletter: NewsletterResponse, iframeLocation: Option[String])(implicit request: RequestHeader, context: model.ApplicationContext)
+@(page: model.Page, emailType: String, emailNewsletter: NewsletterResponse, iframeParentComponent: Option[String])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @emailEmbed(page) {
     @fragments.email.signup.subscription.emailSignUp(
         emailType,
         emailNewsletter.identityName,
         emailNewsletter.emailEmbed,
-        iframeLocation,
+        iframeParentComponent,
     )
 }
 

--- a/common/app/views/emailFragment.scala.html
+++ b/common/app/views/emailFragment.scala.html
@@ -1,11 +1,12 @@
 @import services.newsletters.model.NewsletterResponse
-@(page: model.Page, emailType: String, emailNewsletter: NewsletterResponse)(implicit request: RequestHeader, context: model.ApplicationContext)
+@(page: model.Page, emailType: String, emailNewsletter: NewsletterResponse, iframeLocation: Option[String])(implicit request: RequestHeader, context: model.ApplicationContext)
 
 @emailEmbed(page) {
     @fragments.email.signup.subscription.emailSignUp(
         emailType,
         emailNewsletter.identityName,
         emailNewsletter.emailEmbed,
+        iframeLocation,
     )
 }
 

--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -1,7 +1,8 @@
 @import services.newsletters.model.EmailEmbed
 @(  componentClass: String,
     listName:String,
-    emailEmbedData: EmailEmbed)(implicit request: RequestHeader)
+    emailEmbedData: EmailEmbed,
+    iframeLocation: Option[String])(implicit request: RequestHeader)
 
 @import common.LinkTo
 @import conf.switches.Switches.EmailSignupRecaptcha
@@ -35,13 +36,17 @@
 @formClass = @{ "email-sub__form" + " email-sub__form--" + componentClass }
 @headerClass = @{"email-sub__header" + " email-sub__header--" + componentClass  }
 
+@locationSuffix = @{ if (iframeLocation.nonEmpty) " " + iframeLocation.getOrElse("") else "" }
+@buttonDataComponent = @{ "email-signup-button " + componentClass + "-" + listName + locationSuffix }
+@formDataComponent = @{ "email-signup-form " + componentClass + "-" + listName + locationSuffix }
+
 @form = {
-    <form action="@LinkTo(s"/email")" method="post" id="@formId" class="@formClass" data-email-form-type="@componentClass" data-email-list-name="@listName">
+    <form action="@LinkTo(s"/email")" method="post" id="@formId" class="@formClass" data-email-form-type="@componentClass" data-email-list-name="@listName" data-component="@formDataComponent" data-link-name="@componentClass | @listName">
         @helper.CSRF.formField
         <div class="email-sub__form-wrapper" tabindex="-1">
             <div class="email-sub__inline-label">
 
-                <input class="email-sub__text-input" type="email" name="email" id="@inputId" />
+                <input class="email-sub__text-input" required="" type="email" name="email" id="@inputId" />
                 <label class="email-sub__label" for="@inputId">@fragments.inlineSvg("envelope", "icon", Seq("label__icon"))Enter your email address</label>
                 <label aria-hidden="true">
                     <input tabindex="-1" class="email-sub__text-input u-h" autocomplete="off" type="text" name="name" id="@dummyInputId" placeholder="Name" />
@@ -52,7 +57,7 @@
                 <input class="email-sub__refviewid-input" type="hidden" name="refViewId" id="email-sub__refviewid-input" value="" />
 
             </div>
-            <button type="submit" class="email-sub__submit-button button button--tertiary button--large" id="email-embed-signup-button--old" data-component="email-signup-button @componentClass-@listName" data-link-name="@componentClass | @listName">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
+            <button type="submit" class="email-sub__submit-button button button--tertiary button--large" id="email-embed-signup-button--old" data-component="@buttonDataComponent" data-link-name="@componentClass | @listName">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))Sign up</button>
             @if(EmailSignupRecaptcha.isSwitchedOn && ShowNewPrivacyWordingOnEmailSignupEmbeds.isSwitchedOn) {
                 @fragments.email.signup.recaptchaContainer()
                 @fragments.email.signup.recaptchaTerms(fragments.email.signup.privacyNoticeContent())

--- a/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/subscription/emailSignUp.scala.html
@@ -2,7 +2,7 @@
 @(  componentClass: String,
     listName:String,
     emailEmbedData: EmailEmbed,
-    iframeLocation: Option[String])(implicit request: RequestHeader)
+    iframeParentComponent: Option[String])(implicit request: RequestHeader)
 
 @import common.LinkTo
 @import conf.switches.Switches.EmailSignupRecaptcha
@@ -36,9 +36,9 @@
 @formClass = @{ "email-sub__form" + " email-sub__form--" + componentClass }
 @headerClass = @{"email-sub__header" + " email-sub__header--" + componentClass  }
 
-@locationSuffix = @{ if (iframeLocation.nonEmpty) " " + iframeLocation.getOrElse("") else "" }
-@buttonDataComponent = @{ "email-signup-button " + componentClass + "-" + listName + locationSuffix }
-@formDataComponent = @{ "email-signup-form " + componentClass + "-" + listName + locationSuffix }
+@parentSuffix = @{ if (iframeParentComponent.nonEmpty) " " + iframeParentComponent.getOrElse("") else "" }
+@buttonDataComponent = @{ "email-signup-button " + componentClass + "-" + listName + parentSuffix }
+@formDataComponent = @{ "email-signup-form " + componentClass + "-" + listName + parentSuffix }
 
 @form = {
     <form action="@LinkTo(s"/email")" method="post" id="@formId" class="@formClass" data-email-form-type="@componentClass" data-email-list-name="@listName" data-component="@formDataComponent" data-link-name="@componentClass | @listName">

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -30,6 +30,8 @@ GET            /crosswords/lookup                                               
 # Email paths
 GET        /email/form/$emailType<plain|plaindark|plaintone>/$listId<[0-9]+>         controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
 GET        /email/form/$emailType<plain|plaindark|plaintone>/:listName               controllers.EmailSignupController.renderFormFromName(emailType: String, listName: String)
+GET        /email/form/$emailType<plain|plaindark|plaintone>/:parentComponent/$listId<[0-9]+>         controllers.EmailSignupController.renderFormWithParentComponent(emailType: String, listId: Int, parentComponent:String)
+GET        /email/form/$emailType<plain|plaindark|plaintone>/:parentComponent/:listName               controllers.EmailSignupController.renderFormFromNameWithParentComponent(emailType: String, listName: String, parentComponent: String)
 GET        /email/form/footer/:listName                                              controllers.EmailSignupController.renderFooterForm(listName: String)
 GET        /email/form/thrasher/$listId<[0-9]+>                                      controllers.EmailSignupController.renderThrasherForm(listId: Int)
 GET        /email/form/thrasher/:listName                                            controllers.EmailSignupController.renderThrasherFormFromName(listName: String)

--- a/preview/conf/routes
+++ b/preview/conf/routes
@@ -176,6 +176,8 @@ GET        /sharecount/*path.json                                               
 # Email paths
 GET        /email/form/$emailType<plain|plaindark|plaintone>/$listId<[0-9]+>         controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
 GET        /email/form/$emailType<plain|plaindark|plaintone>/:listName               controllers.EmailSignupController.renderFormFromName(emailType: String, listName: String)
+GET        /email/form/$emailType<plain|plaindark|plaintone>/:parentComponent/$listId<[0-9]+>         controllers.EmailSignupController.renderFormWithParentComponent(emailType: String, listId: Int, parentComponent:String)
+GET        /email/form/$emailType<plain|plaindark|plaintone>/:parentComponent/:listName               controllers.EmailSignupController.renderFormFromNameWithParentComponent(emailType: String, listName: String, parentComponent: String)
 GET        /email/form/footer/:listName                                              controllers.EmailSignupController.renderFooterForm(listName: String)
 GET        /email/form/thrasher/$listId<[0-9]+>                                      controllers.EmailSignupController.renderThrasherForm(listId: Int)
 GET        /email/form/thrasher/:listName                                            controllers.EmailSignupController.renderThrasherFormFromName(listName: String)


### PR DESCRIPTION
## What does this change?
The Marketing Tools team is adding newsletter signup in the Epics and intends to use the same iframes that are used in the newsletter sign-up embeds. So the tracking events can distinguish between interactions with an iframe in an epic and interactions with an iframe in an embed, this PR:
 - adds a supported query param "iframe_parent_component"
 - passes the value of that param to the email sign-up form template to be used within the `data-component` attributes which set the tracking event payload posted to ophan

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
When Marketing Tools implement sign-ups in epics, they will be able to add the param to the iframe src URL, so clicks from the epic can be separated from clicks from embeds.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
