### PR TITLE
Tiny code clean-up

### DIFF
--- a/common/app/common/RequestLogger.scala
+++ b/common/app/common/RequestLogger.scala
@@ -9,7 +9,7 @@ import scala.util.{Random, Try}
 case class RequestLoggerFields(request: Option[RequestHeader], response: Option[Result], stopWatch: Option[StopWatch]) {
 
   private lazy val requestHeadersFields: List[LogField] = {
-    val whitelistedHeaderNames = Set(
+    val allowListedHeaderNames = Set(
       "Host",
       "From",
       "Origin",
@@ -33,9 +33,9 @@ case class RequestLoggerFields(request: Option[RequestHeader], response: Option[
       }
       .getOrElse(Map.empty[String, String])
 
-    val whitelistedHeaders = allHeadersFields.filterKeys(whitelistedHeaderNames.contains)
+    val allowListedHeaders = allHeadersFields.filterKeys(allowListedHeaderNames.contains)
     val guardianSpecificHeaders = allHeadersFields.filterKeys(_.toUpperCase.startsWith("X-GU-"))
-    (whitelistedHeaders ++ guardianSpecificHeaders).toList.map(t => LogFieldString(s"req.header.${t._1}", t._2))
+    (allowListedHeaders ++ guardianSpecificHeaders).toList.map(t => LogFieldString(s"req.header.${t._1}", t._2))
   }
   private lazy val customFields: List[LogField] = {
     val requestHeaders: List[LogField] = request

--- a/common/app/common/RequestLogger.scala
+++ b/common/app/common/RequestLogger.scala
@@ -25,6 +25,7 @@ case class RequestLoggerFields(request: Option[RequestHeader], response: Option[
       "Fastly-Digest",
       "Accept-Encoding", // TODO remove if seen after 2021/09/03
     )
+
     val allHeadersFields = request
       .map {
         _.headers.toMap.map {
@@ -35,7 +36,11 @@ case class RequestLoggerFields(request: Option[RequestHeader], response: Option[
 
     val allowListedHeaders = allHeadersFields.filterKeys(allowListedHeaderNames.contains)
     val guardianSpecificHeaders = allHeadersFields.filterKeys(_.toUpperCase.startsWith("X-GU-"))
-    (allowListedHeaders ++ guardianSpecificHeaders).toList.map(t => LogFieldString(s"req.header.${t._1}", t._2))
+
+    (allowListedHeaders ++ guardianSpecificHeaders).toList.map {
+      case (headerName, headerValue) =>
+        LogFieldString(s"req.header.${headerName}", headerValue)
+    }
   }
   private lazy val customFields: List[LogField] = {
     val requestHeaders: List[LogField] = request


### PR DESCRIPTION
## What does this change?

Nothing! 

Little code clean up in `RequestLoggerFields`, I was going to add a line here to log a new header but realised I don't need to ... maybe the little clean up is useful to keep.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Reviewers like the look of the change.

### Tested

- [X] Locally
- [ ] On CODE (optional)
