### PR TITLE
Add `inline1` outstream sizes to Prebid

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.spec.js
@@ -77,17 +77,15 @@ describe('getSlots', () => {
 	test('should return the correct slots at breakpoint M without mobile sticky', () => {
 		shouldIncludeMobileSticky.mockReturnValue(false);
 		getBreakpointKey.mockReturnValue('M');
-		expect(getSlots('Article')).toEqual([
+        const slots = getSlots('Article');
+        console.log(slots);
+		expect(slots).toEqual([
 			{
 				key: 'right',
 				sizes: [
 					[300, 600],
 					[300, 250],
 				],
-			},
-			{
-				key: 'inline1',
-				sizes: [[300, 250]],
 			},
 			{
 				key: 'top-above-nav',
@@ -97,6 +95,13 @@ describe('getSlots', () => {
 				key: 'inline',
 				sizes: [[300, 250]],
 			},
+            {
+                key: 'inline1',
+                sizes: [
+                    [300, 197],
+                    [300, 250]
+                ],
+            },
 			{
 				key: 'mostpop',
 				sizes: [[300, 250]],
@@ -117,10 +122,6 @@ describe('getSlots', () => {
 				],
 			},
 			{
-				key: 'inline1',
-				sizes: [[300, 250]],
-			},
-			{
 				key: 'top-above-nav',
 				sizes: [[300, 250]],
 			},
@@ -128,6 +129,13 @@ describe('getSlots', () => {
 				key: 'inline',
 				sizes: [[300, 250]],
 			},
+            {
+                key: 'inline1',
+                sizes: [
+                    [300, 197],
+                    [300, 250]
+                ],
+            },
 			{
 				key: 'mostpop',
 				sizes: [[300, 250]],
@@ -150,17 +158,20 @@ describe('getSlots', () => {
 				],
 			},
 			{
-				key: 'inline1',
-				sizes: [[300, 250]],
-			},
-			{
-				key: 'top-above-nav',
+                key: 'top-above-nav',
 				sizes: [[728, 90]],
 			},
 			{
-				key: 'inline',
+                key: 'inline',
 				sizes: [[300, 250]],
 			},
+            {
+                key: 'inline1',
+                sizes: [
+                    [550, 310],
+                    [620, 350]
+                ],
+            },
 			{
 				key: 'mostpop',
 				sizes: [

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.spec.js
@@ -77,9 +77,7 @@ describe('getSlots', () => {
 	test('should return the correct slots at breakpoint M without mobile sticky', () => {
 		shouldIncludeMobileSticky.mockReturnValue(false);
 		getBreakpointKey.mockReturnValue('M');
-        const slots = getSlots('Article');
-        console.log(slots);
-		expect(slots).toEqual([
+		expect(getSlots('Article')).toEqual([
 			{
 				key: 'right',
 				sizes: [
@@ -168,6 +166,7 @@ describe('getSlots', () => {
             {
                 key: 'inline1',
                 sizes: [
+                    [300, 250],
                     [550, 310],
                     [620, 350]
                 ],
@@ -196,7 +195,7 @@ describe('getSlots', () => {
 		});
         expect(desktopSlots).toContainEqual({
             key: 'inline1',
-            sizes: [[550, 310], [620, 350]],
+            sizes: [[300, 250], [550, 310], [620, 350]],
         });
 		expect(desktopSlots).not.toContainEqual({
 			key: 'inline',

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.spec.js
@@ -194,6 +194,10 @@ describe('getSlots', () => {
 				[300, 250],
 			],
 		});
+        expect(desktopSlots).toContainEqual({
+            key: 'inline1',
+            sizes: [[550, 310], [620, 350]],
+        });
 		expect(desktopSlots).not.toContainEqual({
 			key: 'inline',
 			sizes: [[300, 250]],

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.ts
@@ -53,10 +53,6 @@ const getSlots = (contentType: string): HeaderBiddingSlot[] => {
 						[300, 250],
 				  ],
 		},
-		{
-			key: 'inline1',
-			sizes: isCrossword ? [[728, 90]] : [[300, 250]],
-		},
 	];
 	const desktopSlots: HeaderBiddingSlot[] = [
 		{
@@ -83,6 +79,8 @@ const getSlots = (contentType: string): HeaderBiddingSlot[] => {
 						[550, 310],
 						[620, 350],
 				  ]
+				: isCrossword
+				? [[728, 90]]
 				: [[300, 250]],
 		},
 		{
@@ -131,6 +129,8 @@ const getSlots = (contentType: string): HeaderBiddingSlot[] => {
 						[550, 310],
 						[620, 350],
 				  ]
+				: isCrossword
+				? [[728, 90]]
 				: [[300, 250]],
 		},
 		{

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.ts
@@ -76,6 +76,7 @@ const getSlots = (contentType: string): HeaderBiddingSlot[] => {
 			key: 'inline1',
 			sizes: isArticle
 				? [
+						[300, 250],
 						[550, 310],
 						[620, 350],
 				  ]
@@ -126,6 +127,7 @@ const getSlots = (contentType: string): HeaderBiddingSlot[] => {
 			key: 'inline1',
 			sizes: isArticle
 				? [
+						[300, 250],
 						[550, 310],
 						[620, 350],
 				  ]

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.ts
@@ -77,6 +77,15 @@ const getSlots = (contentType: string): HeaderBiddingSlot[] => {
 				: [[300, 250]],
 		},
 		{
+			key: 'inline1',
+			sizes: isArticle
+				? [
+						[550, 310],
+						[620, 350],
+				  ]
+				: [[300, 250]],
+		},
+		{
 			key: 'mostpop',
 			sizes: hasExtendedMostPop
 				? [
@@ -116,6 +125,15 @@ const getSlots = (contentType: string): HeaderBiddingSlot[] => {
 			sizes: [[300, 250]],
 		},
 		{
+			key: 'inline1',
+			sizes: isArticle
+				? [
+						[550, 310],
+						[620, 350],
+				  ]
+				: [[300, 250]],
+		},
+		{
 			key: 'mostpop',
 			sizes: hasExtendedMostPop
 				? [
@@ -134,6 +152,15 @@ const getSlots = (contentType: string): HeaderBiddingSlot[] => {
 		{
 			key: 'inline',
 			sizes: [[300, 250]],
+		},
+		{
+			key: 'inline1',
+			sizes: isArticle
+				? [
+						[300, 197],
+						[300, 250],
+				  ]
+				: [[300, 250]],
 		},
 		{
 			key: 'mostpop',


### PR DESCRIPTION
## What does this change?

Add `inline1`  outstream (aka video) sizes to Prebid.

This allows Ozone to bid on that slot via prebid.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [x] On CODE (optional)
