### PR TITLE
Add Obituaries link to end of UK subnav

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -267,6 +267,7 @@ private object NavLinks {
       science,
       tech,
       globalDevelopment,
+      obituaries,
     ),
   )
   val auNewsPillar = ukNewsPillar.copy(


### PR DESCRIPTION
## What does this change?
Adds `Obituaries` back into the UK subnav #25024. The link was removed in yesterday's #25019 but editorial has changed their mind about this; the rest of the changes from yesterday's PR are still in place.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

Before:
<img width="1307" alt="before" src="https://user-images.githubusercontent.com/37048459/169499433-a4f0be95-731e-47ce-a31e-3edc19c4fd91.png">


After:
<img width="1308" alt="after" src="https://user-images.githubusercontent.com/37048459/169499227-13b25023-2b23-43bf-b21e-e4129f2abbff.png">
