### PR TITLE
fix(flex): assume flex is broadly supported - and for facia garnett

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_items.scss
+++ b/static/src/stylesheets/module/facia-garnett/_items.scss
@@ -71,7 +71,7 @@
     margin-bottom: $gs-baseline;
 
     @include mq(tablet) {
-        .has-flex &:not(.fc-slice__item--mpu-candidate) {
+        &:not(.fc-slice__item--mpu-candidate) {
             display: flex;
         }
     }

--- a/static/src/stylesheets/module/facia-garnett/_l-list.scss
+++ b/static/src/stylesheets/module/facia-garnett/_l-list.scss
@@ -2,20 +2,16 @@
     width: 100%;
 
     @include mq(tablet) {
-        .has-flex-wrap & {
-            display: flex;
-            flex-wrap: wrap;
-        }
+        display: flex;
+        flex-wrap: wrap;
     }
 }
 
 .l-list__item {
     float: left;
 
-    .has-flex-wrap & {
-        flex-grow: 0;
-        flex-basis: 100%;
-    }
+    flex-grow: 0;
+    flex-basis: 100%;
 }
 
 // We only need this functionality for 2 & 4 column rows.
@@ -27,9 +23,7 @@
                     width: (100% / $column) * $span;
                     float: left;
 
-                    .has-flex & {
-                        flex: $span 1 auto;
-                    }
+                    flex: $span 1 auto;
                 }
             }
         }
@@ -55,9 +49,9 @@
                     padding-bottom: 0;
                 }
 
-                .has-flex-wrap & {
-                    flex-basis: (100% / $column);
-                }
+
+                flex-basis: (100% / $column);
+
             }
         }
     }

--- a/static/src/stylesheets/module/facia-garnett/_linkslist.scss
+++ b/static/src/stylesheets/module/facia-garnett/_linkslist.scss
@@ -77,18 +77,17 @@
         }
     }
 
-    .has-flex-wrap & {
-        .fc-slice__item {
-            @include mq(tablet) {
-                flex-grow: 0;
-                flex-basis: 50%;
-            }
+    .fc-slice__item {
+        @include mq(tablet) {
+            flex-grow: 0;
+            flex-basis: 50%;
+        }
 
-            @include mq(desktop) {
-                flex-basis: (100% / 3);
-            }
+        @include mq(desktop) {
+            flex-basis: (100% / 3);
         }
     }
+
 
     .item--has-cutout {
         padding-bottom: $gs-baseline * 2.5;

--- a/static/src/stylesheets/module/facia-garnett/_slices.scss
+++ b/static/src/stylesheets/module/facia-garnett/_slices.scss
@@ -15,20 +15,18 @@ Hence why a greater depth of selector specificity is needed.
 
 */
 .fc-slice--hl4-h {
-    .has-flex & {
-        flex-direction: row-reverse;
+    flex-direction: row-reverse;
 
-        .fc-slice__item:before {
-            display: none;
-        }
+    .fc-slice__item:before {
+        display: none;
+    }
 
-        .fc-item--half-tablet {
-            @include vertical-item-separator;
+    .fc-item--half-tablet {
+        @include vertical-item-separator;
 
-            .fc-item__standfirst {
-                @include mq(desktop) {
-                    display: none;
-                }
+        .fc-item__standfirst {
+            @include mq(desktop) {
+                display: none;
             }
         }
     }
@@ -119,12 +117,10 @@ Hence why a greater depth of selector specificity is needed.
 }
 
 .fc-slice--h14-q-q {
-    .has-flex & {
-        flex-direction: row-reverse;
+    flex-direction: row-reverse;
 
-        .fc-slice__item:before {
-            display: none;
-        }
+    .fc-slice__item:before {
+        display: none;
     }
 
     .fc-item--standard-tablet {

--- a/static/src/stylesheets/pasteup/layout/_src.scss
+++ b/static/src/stylesheets/pasteup/layout/_src.scss
@@ -1,12 +1,14 @@
 // ROWS
 @mixin layout-row($class, $detect: false) {
     @if ($detect) {
-        .has-flex {
-            @include flex-row($class);
-        }
+
+        @include flex-row($class);
+
+
         .has-no-flex {
             @include no-flex-row($class);
         }
+
     } @else {
         @if ($browser-supports-flexbox) {
             @include flex-row($class);


### PR DESCRIPTION
Fixes: https://github.com/guardian/frontend/issues/25023

This is part 2 of this PR https://github.com/guardian/frontend/pull/25014. Makes the same change in `facia.garnett` and `static/src/stylesheets/pasteup/layout/_src.scss`.

## What does this change?
Assume flex is broadly supported. 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots


| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/19683595/169528466-20a53bba-a31d-4526-accf-6d5e4b31f6c7.png) | ![image](https://user-images.githubusercontent.com/19683595/169527765-ae449a29-90fb-4cb0-b56e-738169ee8c35.png) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
