### PR TITLE
Call initTrackGpcSignal in commercial-metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@guardian/atom-renderer": "1.2.2",
     "@guardian/automat-modules": "^0.3.8",
     "@guardian/braze-components": "^7.2.0",
-    "@guardian/commercial-core": "^3.4.0",
+    "@guardian/commercial-core": "^3.5.0",
     "@guardian/consent-management-platform": "^10.6.0",
     "@guardian/libs": "^3.6.1",
     "@guardian/shimport": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@guardian/automat-modules": "^0.3.8",
     "@guardian/braze-components": "^7.2.0",
     "@guardian/commercial-core": "^3.4.0",
-    "@guardian/consent-management-platform": "^10.5.0",
+    "@guardian/consent-management-platform": "^10.6.0",
     "@guardian/libs": "^3.6.1",
     "@guardian/shimport": "^1.0.2",
     "@guardian/source-foundations": "^4.0.3",

--- a/static/src/javascripts/bootstraps/standalone.commercial.ts
+++ b/static/src/javascripts/bootstraps/standalone.commercial.ts
@@ -26,6 +26,7 @@ import { init as setAdTestCookie } from '../projects/commercial/modules/set-adte
 import { init as initStickyTopBanner } from '../projects/commercial/modules/sticky-top-banner';
 import { init as initThirdPartyTags } from '../projects/commercial/modules/third-party-tags';
 import { init as initTrackScrollDepth } from '../projects/commercial/modules/track-scroll-depth';
+import { init as initTrackGpcSignal } from '../projects/commercial/modules/track-gpc-signal';
 import { commercialFeatures } from '../projects/common/modules/commercial/commercial-features';
 import type { Modules } from './types';
 
@@ -50,6 +51,8 @@ const commercialExtraModules: Modules = [
 	['cm-comscore', initComscore],
 	['cm-ipsosmori', initIpsosMori],
 	['cm-trackScrollDepth', initTrackScrollDepth],
+	['cm-trackGpcSignal', initTrackGpcSignal],
+
 ];
 
 if (!commercialFeatures.adFree) {

--- a/static/src/javascripts/bootstraps/standalone.commercial.ts
+++ b/static/src/javascripts/bootstraps/standalone.commercial.ts
@@ -25,8 +25,8 @@ import { removeDisabledSlots as closeDisabledSlots } from '../projects/commercia
 import { init as setAdTestCookie } from '../projects/commercial/modules/set-adtest-cookie';
 import { init as initStickyTopBanner } from '../projects/commercial/modules/sticky-top-banner';
 import { init as initThirdPartyTags } from '../projects/commercial/modules/third-party-tags';
-import { init as initTrackScrollDepth } from '../projects/commercial/modules/track-scroll-depth';
 import { init as initTrackGpcSignal } from '../projects/commercial/modules/track-gpc-signal';
+import { init as initTrackScrollDepth } from '../projects/commercial/modules/track-scroll-depth';
 import { commercialFeatures } from '../projects/common/modules/commercial/commercial-features';
 import type { Modules } from './types';
 
@@ -52,7 +52,6 @@ const commercialExtraModules: Modules = [
 	['cm-ipsosmori', initIpsosMori],
 	['cm-trackScrollDepth', initTrackScrollDepth],
 	['cm-trackGpcSignal', initTrackGpcSignal],
-
 ];
 
 if (!commercialFeatures.adFree) {

--- a/static/src/javascripts/projects/commercial/modules/track-gpc-signal.ts
+++ b/static/src/javascripts/projects/commercial/modules/track-gpc-signal.ts
@@ -1,9 +1,7 @@
 import { initTrackGpcSignal } from '@guardian/commercial-core';
-import { log } from '@guardian/libs';
 import { onConsent } from '@guardian/consent-management-platform';
-import type {
-	ConsentState,
-} from '@guardian/consent-management-platform/dist/types';
+import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
+import { log } from '@guardian/libs';
 
 /**
  * Initialise gpc signal tracking

--- a/static/src/javascripts/projects/commercial/modules/track-gpc-signal.ts
+++ b/static/src/javascripts/projects/commercial/modules/track-gpc-signal.ts
@@ -1,0 +1,21 @@
+import { initTrackGpcSignal } from '@guardian/commercial-core';
+import { log } from '@guardian/libs';
+import { onConsent } from '@guardian/consent-management-platform';
+import type {
+	ConsentState,
+} from '@guardian/consent-management-platform/dist/types';
+
+/**
+ * Initialise gpc signal tracking
+ * @returns Promise
+ */
+export const init = async (): Promise<void> => {
+	const consentState: ConsentState = await onConsent();
+
+	if (consentState.canTarget) {
+		initTrackGpcSignal(consentState);
+		log('commercial', 'tracking gpc signal');
+	} else {
+		log('commercial', 'No consent to track gpc signal');
+	}
+};

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -551,6 +551,12 @@
   "../lib/config.js",
   "../projects/common/modules/commercial/geo-utils.js"
  ],
+ "../projects/commercial/modules/track-gpc-signal.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
+  "../../../../node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
+ ],
  "../projects/commercial/modules/track-scroll-depth.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
@@ -747,6 +753,7 @@
   "../projects/commercial/modules/set-adtest-cookie.ts",
   "../projects/commercial/modules/sticky-top-banner.js",
   "../projects/commercial/modules/third-party-tags.ts",
+  "../projects/commercial/modules/track-gpc-signal.ts",
   "../projects/commercial/modules/track-scroll-depth.ts",
   "../projects/common/modules/commercial/commercial-features.ts",
   "../projects/common/modules/commercial/user-features.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1284,10 +1284,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-3.4.0.tgz#30fa768df0ca77ae912a1d55c4de2427d8608654"
   integrity sha512-r/JPn0MpUUOZ/gy0E0NJOBwGDM0fga1nXxXiwY60Ya8S2fOdqrtGJfcnfDOd55wDbQQ0VbRWnO3SO/J6ZA9icw==
 
-"@guardian/consent-management-platform@^10.5.0":
-  version "10.5.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-10.5.0.tgz#5195abd5cf6d940dbdfb7c27b05165913999ed0e"
-  integrity sha512-oxCcHLalyMMIMneolgX7d/n5NM+e7cVYhPwITmYdw2dyM6zpmsZsUENEVnno49HpU0MamD7YzNrhE4HT2w2YIA==
+"@guardian/consent-management-platform@^10.6.0":
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-10.6.0.tgz#18b13a1b6eebc2dcf0d708d12bcd6b93a2c407a3"
+  integrity sha512-U4JvXWV/gG5WwNsooVncYQSf5nroEinVnq2nCIrinQeMyhn6M2syxNnQVqIk/CE05Mh84OpR/ZWvGoz30b2/wA==
   dependencies:
     "@guardian/libs" "1.6.1 - 3.3.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1279,10 +1279,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-7.2.0.tgz#e5e7ba7c19484ebe0e405a93b1c389dae681acef"
   integrity sha512-Y2+XC0bP5mFacwtDlDqlQsbUyQwn4OSlpOTw3+u7t1RhJFw61SDYAER4gOpyJ4t+wQZFdk//LGJUjFqzDfEEuQ==
 
-"@guardian/commercial-core@^3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-3.4.0.tgz#30fa768df0ca77ae912a1d55c4de2427d8608654"
-  integrity sha512-r/JPn0MpUUOZ/gy0E0NJOBwGDM0fga1nXxXiwY60Ya8S2fOdqrtGJfcnfDOd55wDbQQ0VbRWnO3SO/J6ZA9icw==
+"@guardian/commercial-core@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-3.5.0.tgz#860d3bfd2ae078b21e09078a11a44783116e54c1"
+  integrity sha512-wmiJ+mjFTNE3pwYQTuRuZ0jce/GdzAj6HGp11qsQ6SMXuv4B6FW9oae5D24iYkEpjyF+vEjn3DS1/5dNVXEnHA==
 
 "@guardian/consent-management-platform@^10.6.0":
   version "10.6.0"


### PR DESCRIPTION
## What does this change?

- Bumps version of commercial-core to TBD
- calls `initTrackGpcSignal` to Initialise GPC signal tracking is CMP reports `canTarget` as true

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

We'd like to understand the commercial impact of the GPC signal on our platform and track any changes over time.

Depends on:
- https://github.com/guardian/consent-management-platform/pull/606
- https://github.com/guardian/commercial-core/pull/576

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
