### PR TITLE
chore: Press /technology/ng-interactive/2018/may/15/the-guardian-app

### DIFF
--- a/common/app/services/dotcomrendering/PressedContent.scala
+++ b/common/app/services/dotcomrendering/PressedContent.scala
@@ -131,6 +131,7 @@ object PressedContent {
     "/lifeandstyle/ng-interactive/2018/apr/21/great-lengths",
     "/technology/ng-interactive/2018/apr/24/bezoss-empire-how-amazon-became-the-worlds-biggest-retailer",
     "/world/2018/apr/26/lynchings-sadism-white-men-why-america-must-atone",
+    "/technology/ng-interactive/2018/may/15/the-guardian-app",
     "/world/ng-interactive/2018/jul/03/thailand-cave-rescue-where-were-the-boys-found-and-how-can-they-be-rescued",
     "/info/ng-interactive/2018/jul/24/working-report",
     "/us-news/2018/jul/30/black-panthers-prison-interviews-african-american-activism",


### PR DESCRIPTION
## What does this change?

Presses https://www.theguardian.com/technology/ng-interactive/2018/may/15/the-guardian-app?dcr=false

This page probably needs to be updated at some point to work on DCR (probably soon!), its already looking a little bit outdated but it seems like its still receiving a fair bit of traffic according to ophan. Pressing is a bit of a temporary patch right now.