### PR TITLE
Updates description and title of newsletter signup page

### DIFF
--- a/common/app/staticpages/StaticPages.scala
+++ b/common/app/staticpages/StaticPages.scala
@@ -43,7 +43,10 @@ object StaticPages {
       MetaData.make(
         id = id,
         section = Option(SectionId(value = "newsletter-signup-page")),
-        webTitle = "Guardian newsletters: sign up",
+        webTitle = "Sign up for our free newsletters",
+        description = Some(
+          "Scroll less and understand more about the subjects you care about with the Guardian's brilliant email newsletters, free to your inbox.",
+        ),
         contentType = Some(DotcomContentType.Signup),
         iosType = None,
         shouldGoogleIndex = true,

--- a/common/app/staticpages/StaticPages.scala
+++ b/common/app/staticpages/StaticPages.scala
@@ -43,7 +43,7 @@ object StaticPages {
       MetaData.make(
         id = id,
         section = Option(SectionId(value = "newsletter-signup-page")),
-        webTitle = "Sign up for our free newsletters",
+        webTitle = "Guardian newsletters: Sign up for our free newsletters",
         description = Some(
           "Scroll less and understand more about the subjects you care about with the Guardian's brilliant email newsletters, free to your inbox.",
         ),

--- a/common/app/views/support/Title.scala
+++ b/common/app/views/support/Title.scala
@@ -9,6 +9,7 @@ import play.twirl.api.Html
 object Title {
   val SectionsToIgnore = Set(
     "global",
+    "newsletter-signup-page",
   )
 
   def apply(page: Page)(implicit request: RequestHeader): Html =

--- a/common/app/views/support/Title.scala
+++ b/common/app/views/support/Title.scala
@@ -7,6 +7,8 @@ import play.api.mvc.RequestHeader
 import play.twirl.api.Html
 
 object Title {
+  // Sections added to this list won't be included in the page title.
+  // for example if we wanted `Page Title | The Guardian` instead of `Page Title | Section Name | The Guardian`
   val SectionsToIgnore = Set(
     "global",
     "newsletter-signup-page",


### PR DESCRIPTION
## What does this change?

As per #25036 updates title and description of the newsletter signup page to improve the google search results.

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |
| There isn't a description tag. | ![after2][] |

[before]: https://user-images.githubusercontent.com/21217225/169862214-bb43d895-c364-4199-b780-1597e1db5dae.png
[after]: https://user-images.githubusercontent.com/21217225/169862145-b3518a05-08be-48f2-9e5d-18363f0e3b50.png
[after2]: https://user-images.githubusercontent.com/21217225/169861997-e89e3dd8-0fdb-4f5d-81f9-69da1903fac6.png

