### PR TITLE
add prod and code to riff-raff allowedStages

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -2,7 +2,9 @@ stacks:
 - frontend
 regions:
 - eu-west-1
-
+allowedStages:
+  - CODE
+  - PROD
 templates:
   frontend:
     type: autoscaling


### PR DESCRIPTION
## What does this change?

Adds the `allowedStages` to `riff-raff` to avoid being able to deploy to unsupported stages. And quite nicely simplifies the UI.

[There more in the documentation](https://riffraff.gutools.co.uk/docs/reference/riff-raff.yaml.md).

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)
