### PR TITLE
Rename `keyEvents` to `timelineBlocks` on DCR model

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -39,8 +39,8 @@ case class DotcomRenderingDataModel(
     main: String,
     filterKeyEvents: Boolean,
     pinnedPost: Option[Block],
-    keyEvents: List[Block], // TODO remove when timeline is used in DCR
-    timeline: List[Block],
+    keyEvents: List[Block], // TODO remove when timelineBlocks is used in DCR
+    timelineBlocks: List[Block],
     mostRecentBlockId: Option[String],
     blocks: List[Block],
     pagination: Option[Pagination],
@@ -108,8 +108,8 @@ object DotcomRenderingDataModel {
         "main" -> model.main,
         "filterKeyEvents" -> model.filterKeyEvents,
         "pinnedPost" -> model.pinnedPost,
-        "keyEvents" -> model.keyEvents, // TODO remove when timeline is used in DCR
-        "timeline" -> model.timeline,
+        "keyEvents" -> model.keyEvents, // TODO remove when timelineBlocks is used in DCR
+        "timelineBlocks" -> model.timelineBlocks,
         "mostRecentBlockId" -> model.mostRecentBlockId,
         "blocks" -> model.blocks,
         "pagination" -> model.pagination,
@@ -191,8 +191,8 @@ object DotcomRenderingDataModel {
       pageType = pageType,
       hasStoryPackage = page.related.hasStoryPackage,
       pinnedPost = None,
-      keyEvents = Nil, // TODO remove when timeline is used in DCR
-      timeline = Nil,
+      keyEvents = Nil, // TODO remove when timelineBlocks is used in DCR
+      timelineBlocks = Nil,
     )
   }
 
@@ -218,12 +218,12 @@ object DotcomRenderingDataModel {
       pageType = pageType,
       hasStoryPackage = page.related.hasStoryPackage,
       pinnedPost = None,
-      keyEvents = Nil, // TODO remove when timeline is used in DCR
-      timeline = Nil,
+      keyEvents = Nil, // TODO remove when timelineBlocks is used in DCR
+      timelineBlocks = Nil,
     )
   }
 
-  def timelineFallback(
+  def timelineBlocksFallback(
       blocks: APIBlocks,
   ): Seq[APIBlock] = {
     blocks.requestedBodyBlocks match {
@@ -259,7 +259,7 @@ object DotcomRenderingDataModel {
     val allTimelineBlocks = blocks.body match {
       case Some(allBlocks) if allBlocks.nonEmpty =>
         allBlocks.filter(block => block.attributes.keyEvent.contains(true) || block.attributes.summary.contains(true))
-      case _ => timelineFallback(blocks)
+      case _ => timelineBlocksFallback(blocks)
     }
 
     val timelineBlocks =
@@ -291,7 +291,7 @@ object DotcomRenderingDataModel {
       pageType,
       page.related.hasStoryPackage,
       pinnedPost,
-      timelineBlocks, // TODO remove when timeline is used in DCR
+      timelineBlocks, // TODO remove when timelineBlocks is used in DCR
       timelineBlocks,
       filterKeyEvents,
       mostRecentBlockId,
@@ -309,8 +309,8 @@ object DotcomRenderingDataModel {
       pageType: PageType, // TODO remove as format is better
       hasStoryPackage: Boolean,
       pinnedPost: Option[APIBlock],
-      keyEvents: Seq[APIBlock], // TODO remove when timeline is used in DCR
-      timeline: Seq[APIBlock],
+      keyEvents: Seq[APIBlock], // TODO remove when timelineBlocks is used in DCR
+      timelineBlocks: Seq[APIBlock],
       filterKeyEvents: Boolean = false,
       mostRecentBlockId: Option[String] = None,
       forceLive: Boolean = false,
@@ -387,9 +387,9 @@ object DotcomRenderingDataModel {
         .map(toDCRBlock())
         .toList
 
-    val keyEventsDCR = keyEvents.map(toDCRBlock()) // TODO remove when timeline is used in DCR
+    val keyEventsDCR = keyEvents.map(toDCRBlock()) // TODO remove when timelineBlocks is used in DCR
 
-    val timelineDCR = timeline.map(toDCRBlock())
+    val timelineBlocksDCR = timelineBlocks.map(toDCRBlock())
 
     val pinnedPostDCR = pinnedPost.map(toDCRBlock())
 
@@ -443,8 +443,8 @@ object DotcomRenderingDataModel {
       isSpecialReport = isSpecialReport(page),
       filterKeyEvents = filterKeyEvents,
       pinnedPost = pinnedPostDCR,
-      keyEvents = keyEventsDCR.toList, // TODO remove when timeline is used in DCR
-      timeline = timelineDCR.toList,
+      keyEvents = keyEventsDCR.toList, // TODO remove when timelineBlocks is used in DCR
+      timelineBlocks = timelineBlocksDCR.toList,
       mostRecentBlockId = mostRecentBlockId,
       linkedData = linkedData,
       main = content.fields.main,

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -39,7 +39,8 @@ case class DotcomRenderingDataModel(
     main: String,
     filterKeyEvents: Boolean,
     pinnedPost: Option[Block],
-    keyEvents: List[Block],
+    keyEvents: List[Block], // TODO remove when timeline is used in DCR
+    timeline: List[Block],
     mostRecentBlockId: Option[String],
     blocks: List[Block],
     pagination: Option[Pagination],
@@ -107,7 +108,8 @@ object DotcomRenderingDataModel {
         "main" -> model.main,
         "filterKeyEvents" -> model.filterKeyEvents,
         "pinnedPost" -> model.pinnedPost,
-        "keyEvents" -> model.keyEvents,
+        "keyEvents" -> model.keyEvents, // TODO remove when timeline is used in DCR
+        "timeline" -> model.timeline,
         "mostRecentBlockId" -> model.mostRecentBlockId,
         "blocks" -> model.blocks,
         "pagination" -> model.pagination,
@@ -189,7 +191,8 @@ object DotcomRenderingDataModel {
       pageType = pageType,
       hasStoryPackage = page.related.hasStoryPackage,
       pinnedPost = None,
-      keyEvents = Nil,
+      keyEvents = Nil, // TODO remove when timeline is used in DCR
+      timeline = Nil,
     )
   }
 
@@ -215,11 +218,12 @@ object DotcomRenderingDataModel {
       pageType = pageType,
       hasStoryPackage = page.related.hasStoryPackage,
       pinnedPost = None,
-      keyEvents = Nil,
+      keyEvents = Nil, // TODO remove when timeline is used in DCR
+      timeline = Nil,
     )
   }
 
-  def keyEventsFallback(
+  def timelineFallback(
       blocks: APIBlocks,
   ): Seq[APIBlock] = {
     blocks.requestedBodyBlocks match {
@@ -255,7 +259,7 @@ object DotcomRenderingDataModel {
     val allTimelineBlocks = blocks.body match {
       case Some(allBlocks) if allBlocks.nonEmpty =>
         allBlocks.filter(block => block.attributes.keyEvent.contains(true) || block.attributes.summary.contains(true))
-      case _ => keyEventsFallback(blocks)
+      case _ => timelineFallback(blocks)
     }
 
     val timelineBlocks =
@@ -287,6 +291,7 @@ object DotcomRenderingDataModel {
       pageType,
       page.related.hasStoryPackage,
       pinnedPost,
+      timelineBlocks, // TODO remove when timeline is used in DCR
       timelineBlocks,
       filterKeyEvents,
       mostRecentBlockId,
@@ -304,7 +309,8 @@ object DotcomRenderingDataModel {
       pageType: PageType, // TODO remove as format is better
       hasStoryPackage: Boolean,
       pinnedPost: Option[APIBlock],
-      keyEvents: Seq[APIBlock],
+      keyEvents: Seq[APIBlock], // TODO remove when timeline is used in DCR
+      timeline: Seq[APIBlock],
       filterKeyEvents: Boolean = false,
       mostRecentBlockId: Option[String] = None,
       forceLive: Boolean = false,
@@ -381,7 +387,9 @@ object DotcomRenderingDataModel {
         .map(toDCRBlock())
         .toList
 
-    val keyEventsDCR = keyEvents.map(toDCRBlock())
+    val keyEventsDCR = keyEvents.map(toDCRBlock()) // TODO remove when timeline is used in DCR
+
+    val timelineDCR = timeline.map(toDCRBlock())
 
     val pinnedPostDCR = pinnedPost.map(toDCRBlock())
 
@@ -435,7 +443,8 @@ object DotcomRenderingDataModel {
       isSpecialReport = isSpecialReport(page),
       filterKeyEvents = filterKeyEvents,
       pinnedPost = pinnedPostDCR,
-      keyEvents = keyEventsDCR.toList,
+      keyEvents = keyEventsDCR.toList, // TODO remove when timeline is used in DCR
+      timeline = timelineDCR.toList,
       mostRecentBlockId = mostRecentBlockId,
       linkedData = linkedData,
       main = content.fields.main,


### PR DESCRIPTION
## What does this change?

We're sending an array of timeline events containing both key events and summary events to DCR as a field called `keyEvents`. To remove any confusion, this PR creates an identical replacement field called `timelineBlocks`. Once we use this in DCR we can remove `keyEvents`.

