### PR TITLE
Revert "Rename `keyEvents` to `timelineBlocks` on DCR model"

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -39,8 +39,7 @@ case class DotcomRenderingDataModel(
     main: String,
     filterKeyEvents: Boolean,
     pinnedPost: Option[Block],
-    keyEvents: List[Block], // TODO remove when timelineBlocks is used in DCR
-    timelineBlocks: List[Block],
+    keyEvents: List[Block],
     mostRecentBlockId: Option[String],
     blocks: List[Block],
     pagination: Option[Pagination],
@@ -108,8 +107,7 @@ object DotcomRenderingDataModel {
         "main" -> model.main,
         "filterKeyEvents" -> model.filterKeyEvents,
         "pinnedPost" -> model.pinnedPost,
-        "keyEvents" -> model.keyEvents, // TODO remove when timelineBlocks is used in DCR
-        "timelineBlocks" -> model.timelineBlocks,
+        "keyEvents" -> model.keyEvents,
         "mostRecentBlockId" -> model.mostRecentBlockId,
         "blocks" -> model.blocks,
         "pagination" -> model.pagination,
@@ -191,8 +189,7 @@ object DotcomRenderingDataModel {
       pageType = pageType,
       hasStoryPackage = page.related.hasStoryPackage,
       pinnedPost = None,
-      keyEvents = Nil, // TODO remove when timelineBlocks is used in DCR
-      timelineBlocks = Nil,
+      keyEvents = Nil,
     )
   }
 
@@ -218,12 +215,11 @@ object DotcomRenderingDataModel {
       pageType = pageType,
       hasStoryPackage = page.related.hasStoryPackage,
       pinnedPost = None,
-      keyEvents = Nil, // TODO remove when timelineBlocks is used in DCR
-      timelineBlocks = Nil,
+      keyEvents = Nil,
     )
   }
 
-  def timelineBlocksFallback(
+  def keyEventsFallback(
       blocks: APIBlocks,
   ): Seq[APIBlock] = {
     blocks.requestedBodyBlocks match {
@@ -259,7 +255,7 @@ object DotcomRenderingDataModel {
     val allTimelineBlocks = blocks.body match {
       case Some(allBlocks) if allBlocks.nonEmpty =>
         allBlocks.filter(block => block.attributes.keyEvent.contains(true) || block.attributes.summary.contains(true))
-      case _ => timelineBlocksFallback(blocks)
+      case _ => keyEventsFallback(blocks)
     }
 
     val timelineBlocks =
@@ -291,7 +287,6 @@ object DotcomRenderingDataModel {
       pageType,
       page.related.hasStoryPackage,
       pinnedPost,
-      timelineBlocks, // TODO remove when timelineBlocks is used in DCR
       timelineBlocks,
       filterKeyEvents,
       mostRecentBlockId,
@@ -309,8 +304,7 @@ object DotcomRenderingDataModel {
       pageType: PageType, // TODO remove as format is better
       hasStoryPackage: Boolean,
       pinnedPost: Option[APIBlock],
-      keyEvents: Seq[APIBlock], // TODO remove when timelineBlocks is used in DCR
-      timelineBlocks: Seq[APIBlock],
+      keyEvents: Seq[APIBlock],
       filterKeyEvents: Boolean = false,
       mostRecentBlockId: Option[String] = None,
       forceLive: Boolean = false,
@@ -387,9 +381,7 @@ object DotcomRenderingDataModel {
         .map(toDCRBlock())
         .toList
 
-    val keyEventsDCR = keyEvents.map(toDCRBlock()) // TODO remove when timelineBlocks is used in DCR
-
-    val timelineBlocksDCR = timelineBlocks.map(toDCRBlock())
+    val keyEventsDCR = keyEvents.map(toDCRBlock())
 
     val pinnedPostDCR = pinnedPost.map(toDCRBlock())
 
@@ -443,8 +435,7 @@ object DotcomRenderingDataModel {
       isSpecialReport = isSpecialReport(page),
       filterKeyEvents = filterKeyEvents,
       pinnedPost = pinnedPostDCR,
-      keyEvents = keyEventsDCR.toList, // TODO remove when timelineBlocks is used in DCR
-      timelineBlocks = timelineBlocksDCR.toList,
+      keyEvents = keyEventsDCR.toList,
       mostRecentBlockId = mostRecentBlockId,
       linkedData = linkedData,
       main = content.fields.main,


### PR DESCRIPTION
Reverts guardian/frontend#25039