### PR TITLE
Add Relevant Yield cookie sync iframe

### DIFF
--- a/static/vendor/data/amp-iframe.html
+++ b/static/vendor/data/amp-iframe.html
@@ -10,5 +10,10 @@
 			height="0"
 			width="0"
 		></iframe>
+		<iframe
+			src="https://guardian-cdn.relevant-digital.com/static/tags/6214c1072d89bdff800f25f2_cookiesync.html?endpoint=relevant&max_sync_count=5"
+			height="0"
+			width="0"
+		></iframe>
 	</body>
 </html>


### PR DESCRIPTION
## What does this change?

This PR adds an additional iframe that is used by Relevant Yield to perform cookie syncing. This is achieved by adding the cookie sync iframe to the _analytics iframe_: this iframe wraps all the other iframes that are used for analytics on AMP pages, and is fetched in this [DCR component](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/amp/components/AnalyticsIframe.tsx).

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

We're currently running a [test](https://github.com/guardian/dotcom-rendering/pull/4207) on [AMP](https://github.com/guardian/dotcom-rendering/pull/4110) that splits our content into two groups. Each group will hold Prebid auctions with one third party server: **Pubmatic** or **Relevant Yield**.

**Cookie syncing** allows cookies to be shared with DSPs that don't have access to read cookies on the page (since they sit on the other side of the ad exchange). For reference, [this article](https://headerbidding.co/cookie-syncing/#what_is_it) has some good background on cookie syncing.

Currently, Relevant Yield isn't able to compete comparatively since it doesn't have access to the same rich cookie history as Pubmatic - hence bidders are less likely to bid with high CPMs. Adding in cookie sync for RY should increase it's ability to drive through higher-CPM bids.

### Tested

- [X] Locally
- [ ] On CODE (optional)