### PR TITLE
Add server-side experiment `InteractivesIdleLoading`

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -5,7 +5,7 @@ import experiments.ParticipationGroups._
 import java.time.LocalDate
 
 object ActiveExperiments extends ExperimentsDefinition {
-  override val allExperiments: Set[Experiment] = Set(Inline1ContainerSizing)
+  override val allExperiments: Set[Experiment] = Set(Inline1ContainerSizing, InteractivesIdleLoading)
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
@@ -26,4 +26,14 @@ object Inline1ContainerSizing
       owners = Seq(Owner.withGithub("arelra")),
       sellByDate = LocalDate.of(2022, 5, 31),
       participationGroup = Perc20A,
+    )
+
+object InteractivesIdleLoading
+    extends Experiment(
+      name = "interactives-idle-loading",
+      description =
+        "Tests the impact of loading interactive embeds on page idle instead of when they become visible in the viewport",
+      owners = Seq(Owner.withGithub("simonbyford")),
+      sellByDate = LocalDate.of(2022, 7, 1),
+      participationGroup = Perc10A,
     )


### PR DESCRIPTION
## What does this change?

Adds a server-side AB test to measure the impact of this change:

https://github.com/guardian/dotcom-rendering/pull/4942

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes https://github.com/guardian/dotcom-rendering/pull/4942

### Tested

- [x] Locally
- [x] On CODE (optional)
