### PR TITLE
No advertising for Internet Explorer

### DIFF
--- a/static/src/javascripts/lib/detect.js
+++ b/static/src/javascripts/lib/detect.js
@@ -270,7 +270,7 @@ const adblockInUse = getAdblockInUse();
 
 const getReferrer = () => document.referrer || '';
 
-const getUserAgent = (() => {
+const getUserAgent = () => {
 	if (!navigator && !navigator.userAgent) {
 		return '';
 	}
@@ -312,7 +312,9 @@ const getUserAgent = (() => {
 		browser: M[0],
 		version: M[1],
 	};
-})();
+};
+
+const userAgent = getUserAgent();
 
 const isGoogleProxy = () =>
 	!!(
@@ -330,6 +332,7 @@ export {
 	hasPushStateSupport,
 	getBreakpoint,
 	getUserAgent,
+	userAgent,
 	getViewport,
 	isIOS,
 	applePayApiAvailable,

--- a/static/src/javascripts/lib/detect.js
+++ b/static/src/javascripts/lib/detect.js
@@ -1,5 +1,6 @@
 import config from './config';
 import { mediator } from './mediator';
+import { isObject, isString } from '@guardian/libs';
 
 // These should match those defined in:
 //   stylesheets/_vars.scss
@@ -316,6 +317,20 @@ const getUserAgent = () => {
 
 const userAgent = getUserAgent();
 
+/**
+ * Determine whether current browser is a version of Internet Explorer
+ */
+const isInternetExplorer = () => {
+	const userAgent = getUserAgent();
+
+	return (
+		// IE 10 and IE 11
+		(isString(userAgent) && userAgent.startsWith('IE')) ||
+		// IE 9 and below
+		(isObject(userAgent) && userAgent.browser === 'MSIE')
+	);
+};
+
 const isGoogleProxy = () =>
 	!!(
 		navigator &&
@@ -333,6 +348,7 @@ export {
 	getBreakpoint,
 	getUserAgent,
 	userAgent,
+	isInternetExplorer,
 	getViewport,
 	isIOS,
 	applePayApiAvailable,

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.ts
@@ -1,6 +1,6 @@
 import { log } from '@guardian/libs';
 import defaultConfig from '../../../../lib/config';
-import { getBreakpoint } from '../../../../lib/detect';
+import { getBreakpoint, getUserAgent } from '../../../../lib/detect';
 import { isUserLoggedIn } from '../identity/api';
 import userPrefs from '../user-prefs';
 import { isAdFreeUser } from './user-features';
@@ -76,6 +76,11 @@ class CommercialFeatures {
 			config.get('page.showNewRecipeDesign') &&
 			config.get('tests.abNewRecipeDesign');
 
+		// Determine if running an unsupported browser
+		const isInternetExplorer =
+			typeof getUserAgent === 'string' && getUserAgent.startsWith('IE');
+		const isUnsupportedBrowser = isInternetExplorer;
+
 		this.isSecureContact = [
 			'help/ng-interactive/2017/mar/17/contact-the-guardian-securely',
 			'help/2016/sep/19/how-to-contact-the-guardian-securely',
@@ -95,6 +100,7 @@ class CommercialFeatures {
 			sensitiveContent,
 			isIdentityPage,
 			adFree: this.adFree,
+			isUnsupportedBrowser,
 		};
 
 		this.dfpAdvertising =

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.ts
@@ -1,6 +1,6 @@
 import { log } from '@guardian/libs';
 import defaultConfig from '../../../../lib/config';
-import { getBreakpoint, getUserAgent } from '../../../../lib/detect';
+import { getBreakpoint, isInternetExplorer } from '../../../../lib/detect';
 import { isUserLoggedIn } from '../identity/api';
 import userPrefs from '../user-prefs';
 import { isAdFreeUser } from './user-features';
@@ -76,10 +76,8 @@ class CommercialFeatures {
 			config.get('page.showNewRecipeDesign') &&
 			config.get('tests.abNewRecipeDesign');
 
-		// Determine if running an unsupported browser
-		const isInternetExplorer =
-			typeof getUserAgent === 'string' && getUserAgent.startsWith('IE');
-		const isUnsupportedBrowser = isInternetExplorer;
+		// TODO Convert detect.js to TypeScript
+		const isUnsupportedBrowser = (isInternetExplorer as () => boolean)();
 
 		this.isSecureContact = [
 			'help/ng-interactive/2017/mar/17/contact-the-guardian-securely',

--- a/static/src/javascripts/projects/common/modules/navigation/navigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/navigation.js
@@ -1,7 +1,7 @@
 import bean from 'bean';
 import fastdom from 'lib/fastdom-promise';
 import { mediator } from 'lib/mediator';
-import { isIOS, getUserAgent } from 'lib/detect';
+import { isIOS, userAgent } from 'lib/detect';
 import $ from 'lib/$';
 
 const jsEnableFooterNav = () =>
@@ -88,8 +88,8 @@ const initNavigation = () => {
 
     if (
         isIOS() &&
-        typeof getUserAgent === 'object' &&
-        parseInt(getUserAgent.version, 10) > 5
+        typeof userAgent === 'object' &&
+        parseInt(userAgent.version, 10) > 5
     ) {
         // crashes mobile safari < 6, so we add it here after detection
         modifications.push(addOverflowScrollTouch());

--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -1,7 +1,7 @@
 import fastdom from 'fastdom';
 import $ from 'lib/$';
 import { getCookie, addCookie } from 'lib/cookies';
-import { isIOS, isAndroid, getBreakpoint, getUserAgent } from 'lib/detect';
+import { isIOS, isAndroid, getBreakpoint, userAgent } from 'lib/detect';
 import template from 'lodash/template';
 import { loadCssPromise } from 'lib/load-css-promise';
 import { Message, hasUserAcknowledgedBanner } from 'common/modules/ui/message';
@@ -54,7 +54,7 @@ const messageCode = isIOS() ? 'ios' : 'android';
 
 const canUseSmartBanner = () =>
     config.get('switches.smartAppBanner') &&
-    getUserAgent.browser === 'Safari' &&
+    userAgent.browser === 'Safari' &&
     isIOS();
 
 const canShow = () =>

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -10,6 +10,7 @@
   "../../../../node_modules/@guardian/source-foundations/dist/types/index.d.ts"
  ],
  "../lib/detect.js": [
+  "../../../../node_modules/@guardian/libs/dist/cjs/index.js",
   "../lib/config.js",
   "../lib/mediator.ts"
  ],


### PR DESCRIPTION
## What does this change?

This PR adds a new check `isUnsupportedBrowser` to the set of commercial features. We use this new flag to disable advertising if set to `true`, which occurs when an Internet Explorer user agent is detected.

Additionally, this adds some tests to check this logic against some sample user agents.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

The commercial code runs inconsistently on Internet Explorer, with some features supported and others badly broken. Since IE is not a great contributor to advertising revenue (lots of the ads don't load in the first place), it makes sense to consider it unsupported from a commercial perspective and not attempt to show ads at all.

### Tested

- [X] Locally
- [ ] On CODE (optional) - **TODO**
