### PR TITLE
Fix dotcom assets when using m.thegulocal.com so that ads load

### DIFF
--- a/nginx/frontend.conf
+++ b/nginx/frontend.conf
@@ -28,7 +28,7 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
     # some urls coming through as /assets/assets/path/to/file.js for some reason
-    rewrite ^/assets(/assets/.*)$ $1 permanent;
+    rewrite ^/assets/assets/(.*)$ /assets/$1 permanent;
 
     location ~* /assets/[A-Za-z\d\-_\.]*\.(js|css) {
       proxy_pass http://127.0.0.1:3030;

--- a/nginx/frontend.conf
+++ b/nginx/frontend.conf
@@ -27,6 +27,15 @@ server {
     proxy_set_header X-GU-ID-Geolocation ip:$remote_addr,country:GB,city:Leeds;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
+    # some urls coming through as /assets/assets/path/to/file.js for some reason
+    rewrite ^/assets(/assets/.*)$ $1 permanent;
+
+    location ~* /assets/[A-Za-z\d\-_\.]*\.(js|css) {
+      proxy_pass http://127.0.0.1:3030;
+      proxy_set_header Host "http://localhost:3030";
+      proxy_set_header "X-Forwarded-Proto" "https";
+    }
+
     location / {
         proxy_pass http://frontend;
         proxy_set_header Host $host;


### PR DESCRIPTION
## What does this change?

Proxies top level assets to localhost:3030 so that dotcom rendered pages now fully work, (including ads)

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
