### PR TITLE
Introduce new `20%` lazy load margin

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -33,4 +33,15 @@ trait ABTestSwitches {
     sellByDate = Some(LocalDate.of(2022, 6, 9)),
     exposeClientSide = true,
   )
+
+  Switch(
+    ABTests,
+    "ab-commercial-end-of-quarter-2-test",
+    "Check whether all changes made this quarter when combined lead to revenue uplift",
+    owners = Seq(Owner.withGithub("chrislomaxjones")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2022, 7, 5)),
+    exposeClientSide = true,
+  )
+
 }

--- a/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.spec.ts
@@ -1,7 +1,7 @@
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import type { Advert } from './Advert';
 import { dfpEnv } from './dfp-env';
-import { getAdvertById as getAdvertById_ } from './get-advert-by-id';
+import { getAdvertById } from './get-advert-by-id';
 import { enableLazyLoad } from './lazy-load';
 import { loadAdvert } from './load-advert';
 
@@ -22,16 +22,11 @@ jest.mock('../../../../lib/config', () => ({
 
 jest.mock('./Advert', () => jest.fn(() => ({ advert: jest.fn() })));
 
-jest.mock('./get-advert-by-id', () => ({
-	getAdvertById: jest.fn(),
-}));
+jest.mock('./get-advert-by-id');
 
 jest.mock('./load-advert', () => ({
-	refreshAdvert: jest.fn(),
 	loadAdvert: jest.fn(),
 }));
-
-const getAdvertById = getAdvertById_;
 
 describe('enableLazyLoad', () => {
 	const windowIntersectionObserver = window.IntersectionObserver;

--- a/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.spec.ts
@@ -1,8 +1,16 @@
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import type { Advert } from './Advert';
 import { dfpEnv } from './dfp-env';
 import { getAdvertById as getAdvertById_ } from './get-advert-by-id';
 import { enableLazyLoad } from './lazy-load';
 import { loadAdvert } from './load-advert';
+
+jest.mock('lodash-es', () => ({
+	...jest.requireActual('lodash-es'),
+	// Mock `once` as the identity function so we can re-run `enableLazyLoad`
+	// and generate different intersection observers
+	once: jest.fn().mockImplementation(<T>(f: T) => f),
+}));
 
 jest.mock('../../../common/modules/experiments/ab', () => ({
 	isInVariantSynchronous: jest.fn(),
@@ -52,7 +60,22 @@ describe('enableLazyLoad', () => {
 		expect(windowIntersectionObserver).toBe(undefined);
 	});
 
-	it('should create an observer if lazyLoadObserve is true', () => {
+	it('should create a 20% observer if lazyLoadObserve is true and not in control of test', () => {
+		// Mock being in variant / not in test
+		(isInVariantSynchronous as jest.Mock).mockReturnValue(false);
+		dfpEnv.lazyLoadObserve = true;
+		enableLazyLoad(testAdvert as unknown as Advert);
+		expect(loadAdvert).not.toHaveBeenCalled();
+		expect(
+			window.IntersectionObserver as jest.Mock,
+		).toHaveBeenNthCalledWith(1, expect.anything(), {
+			rootMargin: '20% 0px',
+		});
+	});
+
+	it('should create a 200px observer if lazyLoadObserve is true and in control of test', () => {
+		// Mock being in control of test
+		(isInVariantSynchronous as jest.Mock).mockReturnValue(true);
 		dfpEnv.lazyLoadObserve = true;
 		enableLazyLoad(testAdvert as unknown as Advert);
 		expect(loadAdvert).not.toHaveBeenCalled();

--- a/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.ts
@@ -1,8 +1,23 @@
+import { log } from '@guardian/libs';
 import { once } from 'lodash-es';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { commercialEndOfQuarter2Test } from 'common/modules/experiments/tests/commercial-end-of-quarter-2-test';
 import type { Advert } from './Advert';
 import { dfpEnv } from './dfp-env';
 import { getAdvertById } from './get-advert-by-id';
 import { loadAdvert, refreshAdvert } from './load-advert';
+
+const decideLazyLoadMargin = () => {
+	const enableNewLazyLoadMargin = !isInVariantSynchronous(
+		commercialEndOfQuarter2Test,
+		'control',
+	);
+
+	const lazyLoadMargin = enableNewLazyLoadMargin ? '20%' : '200px';
+	log('commercial', `Using lazy load margin of ${lazyLoadMargin}`);
+
+	return lazyLoadMargin;
+};
 
 const displayAd = (advertId: string) => {
 	const advert = getAdvertById(advertId);
@@ -37,7 +52,7 @@ const onIntersect = (
 const getObserver = once(() => {
 	return Promise.resolve(
 		new window.IntersectionObserver(onIntersect, {
-			rootMargin: '200px 0px',
+			rootMargin: `${decideLazyLoadMargin()} 0px`,
 		}),
 	);
 });

--- a/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
@@ -1,10 +1,12 @@
 import type { ABTest } from '@guardian/ab-core';
 import { isInABTestSynchronous } from '../experiments/ab';
+import { commercialEndOfQuarter2Test } from '../experiments/tests/commercial-end-of-quarter-2-test';
 import { prebidPriceGranularity } from '../experiments/tests/prebid-price-granularity';
 
 const defaultClientSideTests: ABTest[] = [
 	/* linter, please keep this array multi-line */
 	prebidPriceGranularity,
+	commercialEndOfQuarter2Test,
 ];
 
 const serverSideTests: ServerSideABTest[] = [];

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -1,4 +1,5 @@
 import type { ABTest } from '@guardian/ab-core';
+import { commercialEndOfQuarter2Test } from './tests/commercial-end-of-quarter-2-test';
 import { prebidPriceGranularity } from './tests/prebid-price-granularity';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
@@ -11,4 +12,5 @@ export const concurrentTests: readonly ABTest[] = [
 	signInGateMainControl,
 	remoteRRHeaderLinksTest,
 	prebidPriceGranularity,
+	commercialEndOfQuarter2Test,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-end-of-quarter-2-test.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-end-of-quarter-2-test.ts
@@ -10,9 +10,9 @@ export const commercialEndOfQuarter2Test: ABTest = {
 	audienceOffset: 0 / 100,
 	audienceCriteria: 'All pageviews',
 	successMeasure:
-		'Enabling all changes leads to an increase in inline programmatic revenue per 1000 pageviews',
+		'Enabling all changes leads to an increase in revenue per 1000 pageviews',
 	description:
-		'Check whether all changes made this quarter when combined lead to an increase in inline programmatic revenue per 1000 pageviews',
+		'Check whether all changes made this quarter when combined lead to an increase in revenue per 1000 pageviews',
 	variants: [
 		{ id: 'control', test: noop },
 		{ id: 'variant', test: noop },

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-end-of-quarter-2-test.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-end-of-quarter-2-test.ts
@@ -1,0 +1,21 @@
+import type { ABTest } from '@guardian/ab-core';
+import { noop } from '../../../../../lib/noop';
+
+export const commercialEndOfQuarter2Test: ABTest = {
+	id: 'CommercialEndOfQuarter2Test',
+	author: 'Chris Jones (@chrislomaxjones)',
+	start: '2022-05-30',
+	expiry: '2022-07-05',
+	audience: 10 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria: 'All pageviews',
+	successMeasure:
+		'Enabling all changes leads to an increase in inline programmatic revenue per 1000 pageviews',
+	description:
+		'Check whether all changes made this quarter when combined lead to an increase in inline programmatic revenue per 1000 pageviews',
+	variants: [
+		{ id: 'control', test: noop },
+		{ id: 'variant', test: noop },
+	],
+	canRun: () => true,
+};

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -205,11 +205,14 @@
   "../projects/commercial/modules/dfp/dfp-env.ts"
  ],
  "../projects/commercial/modules/dfp/lazy-load.ts": [
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../../../../node_modules/@types/lodash-es/index.d.ts",
   "../projects/commercial/modules/dfp/Advert.ts",
   "../projects/commercial/modules/dfp/dfp-env.ts",
   "../projects/commercial/modules/dfp/get-advert-by-id.ts",
-  "../projects/commercial/modules/dfp/load-advert.ts"
+  "../projects/commercial/modules/dfp/load-advert.ts",
+  "../projects/common/modules/experiments/ab.ts",
+  "../projects/common/modules/experiments/tests/commercial-end-of-quarter-2-test.ts"
  ],
  "../projects/commercial/modules/dfp/load-advert.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
@@ -571,6 +574,7 @@
  "../projects/common/modules/analytics/shouldCaptureMetrics.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
   "../projects/common/modules/experiments/ab.ts",
+  "../projects/common/modules/experiments/tests/commercial-end-of-quarter-2-test.ts",
   "../projects/common/modules/experiments/tests/prebid-price-granularity.ts"
  ],
  "../projects/common/modules/article/space-filler.ts": [
@@ -655,6 +659,7 @@
  ],
  "../projects/common/modules/experiments/ab-tests.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
+  "../projects/common/modules/experiments/tests/commercial-end-of-quarter-2-test.ts",
   "../projects/common/modules/experiments/tests/prebid-price-granularity.ts",
   "../projects/common/modules/experiments/tests/remote-header-test.js",
   "../projects/common/modules/experiments/tests/sign-in-gate-main-control.js",
@@ -681,6 +686,10 @@
   "../projects/common/modules/experiments/ab-utils.ts"
  ],
  "../projects/common/modules/experiments/automatLog.ts": [],
+ "../projects/common/modules/experiments/tests/commercial-end-of-quarter-2-test.ts": [
+  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
+  "../lib/noop.ts"
+ ],
  "../projects/common/modules/experiments/tests/prebid-price-granularity.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
   "../lib/noop.ts"


### PR DESCRIPTION
## What does this change?

Roll out a new lazy load margin of `20%` (previously `200px`).

This also introduces a new AB Test `CommercialEndOfQuarter2Test` which we will use to test all accumulated changes throughout the quarter (not just related to lazy loading) against a control with none of these changes enabled. This lazy load changed is enabled for all pageviews **not in the control group of the end of quarter test** (that is, the variant of the test and non-participants). This implies that the change will be rolled out to 100% whilst the test is not switched on.

The table below summarises the behaviour of the test:

|                 |                 **Behaviour**                 |
|:---------------:|:---------------------------------------------:|
|   **Control**   |               200px lazy loading              |
|   **Variant**   | 20% lazy loading |
| **Not in test** | 20% lazy loading |


See more context about the history of AB testing this change in these PRs:
- #24770
- #24839
- #25006 

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes - [DCR #5092](https://github.com/guardian/dotcom-rendering/pull/5092)

## What is the value of this and can you measure success?

Based on the findings from our previous AB testing we decided to roll out _variant 1_ to 100% of the audience. Rather than simply change the hardcoded value, we're leaving it switchable so that we can enable it in the variant at the end of the quarter and disable it in the control (and leave it enabled for everyone else).

### Tested

- [x] Locally
- [x] On CODE (optional)

**Notes on testing**

Locally I added logging of the form below to test that the two groups had values of approximately 200px or 20% (the first value is `px` and second is `%` in the log line).

```ts
log(
	'commercial',
	'lazyload',
	entry.intersectionRect.top - window.innerHeight,
	((entry.intersectionRect.top - window.innerHeight) /
		window.innerHeight) *
		100
);
```

On CODE I checked the test setup was working (notintest, force into variant and control, both on FE and DCR) and that in each group the expected value was emitted (see table above for expected values).


