### PR TITLE
fix: Remove incorrect dynamo sublink styles

### DIFF
--- a/static/src/stylesheets/inline/story-package-garnett.scss
+++ b/static/src/stylesheets/inline/story-package-garnett.scss
@@ -447,7 +447,6 @@ $block-height: 58px; // Note: duplicated from _item.scss
                 margin-bottom: 0;
 
                 @include mq($from: tablet) {
-                    background-color: rgba(0, 0, 0, .8);
                     border-left: 0;
                     border-bottom: 0;
                     max-width: 33%;
@@ -456,7 +455,6 @@ $block-height: 58px; // Note: duplicated from _item.scss
 
             .fc-sublink__title,
             &.fc-item--type-live.fc-item--pillar-news .fc-sublink__link {
-                color: #ffffff;
                 font-weight: 800;
 
                 &:before {


### PR DESCRIPTION
## What does this change?

 - Removes incorrect styles from floating sublinks in Fronts

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/21217225/172156901-015b902f-c601-4c11-b0e1-b3d9b22512e0.png
[after]: https://user-images.githubusercontent.com/21217225/172181221-f5e143cd-c5b4-4d5e-be03-7cb2e35185d9.png
 