### PR TITLE
Remove `inline1ContainerSizing` server side test

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -5,7 +5,7 @@ import experiments.ParticipationGroups._
 import java.time.LocalDate
 
 object ActiveExperiments extends ExperimentsDefinition {
-  override val allExperiments: Set[Experiment] = Set(Inline1ContainerSizing, InteractivesIdleLoading)
+  override val allExperiments: Set[Experiment] = Set(InteractivesIdleLoading)
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
@@ -17,15 +17,6 @@ object FrontRendering
       owners = Seq(Owner.withGithub("dotcom")),
       sellByDate = LocalDate.of(2023, 6, 2),
       participationGroup = Perc0A,
-    )
-
-object Inline1ContainerSizing
-    extends Experiment(
-      name = "inline1-container-sizing",
-      description = "Tests the impact on CLS of fixing the inline1 ad container to full width",
-      owners = Seq(Owner.withGithub("arelra")),
-      sellByDate = LocalDate.of(2022, 5, 31),
-      participationGroup = Perc20A,
     )
 
 object InteractivesIdleLoading


### PR DESCRIPTION
## What does this change?

Remove `inline1ContainerSizing` server side test

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)
