### PR TITLE
chore: update world cup 2018 => world cup 2022

### DIFF
--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -177,13 +177,13 @@ object CompetitionsProvider {
     ),
     Competition(
       "700",
-      "/football/world-cup-2018",
-      "World Cup 2018",
-      "World Cup 2018",
+      "/football/world-cup-2022",
+      "World Cup 2022",
+      "World Cup 2022",
       "Internationals",
       showInTeamsList = true,
       tableDividers = List(2),
-      startDate = Some(LocalDate.of(2018, 6, 1)),
+      startDate = Some(LocalDate.of(2022, 11, 1)),
     ),
     Competition(
       "750",


### PR DESCRIPTION
## What does this change?
Updates the label of competition 700, which is recycled for any "World cup `nnnn`", to `World Cup 2022`. This has been confirmed with PA and CP.

## Before
<img width="936" alt="Screenshot 2022-05-31 at 14 22 26" src="https://user-images.githubusercontent.com/31692/171183623-e38cb615-5fc0-404a-99f3-6b9e7899cca6.png">
<img width="963" alt="Screenshot 2022-05-31 at 14 22 36" src="https://user-images.githubusercontent.com/31692/171183653-81e6ee55-c087-4ac5-81af-43d3ddbaf785.png">

## After 
<img width="932" alt="Screenshot 2022-05-31 at 14 14 53" src="https://user-images.githubusercontent.com/31692/171183680-32380dce-8483-4e80-948c-56f0fadd8ab9.png">
<img width="969" alt="Screenshot 2022-05-31 at 14 15 01" src="https://user-images.githubusercontent.com/31692/171183693-9a733ca6-7a05-4c2e-a7f9-4019ba6b84d9.png">

