### PR TITLE
Move caption to fix tab order

### DIFF
--- a/sport/app/football/views/tablesList/tableView.scala.html
+++ b/sport/app/football/views/tablesList/tableView.scala.html
@@ -19,6 +19,12 @@
             "table--striped" -> striped,
             "table--responsive-font" -> responsiveFont
         ))">
+
+        @heading.map{ h=>
+            <caption class="table__caption table__caption--top">
+                <a href="@headingLink.getOrElse(competition.url)" class="football-matches__heading">@h</a>
+            </caption>
+        }
         <thead>
             <tr>
                 <th class="table-column--sub"><abbr title="Position">P</abbr></th>
@@ -68,11 +74,6 @@
             }
         </tbody>
 
-        @heading.map{ h=>
-            <caption class="table__caption table__caption--top">
-                <a href="@headingLink.getOrElse(competition.url)" class="football-matches__heading">@h</a>
-            </caption>
-        }
         @if(linkToCompetition){
             <tfoot class="table__caption table__caption--bottom" >
                 <tr>


### PR DESCRIPTION
Co-authored-by: Oliver Lloyd <oliverlloyd@users.noreply.github.com>
Co-authored-by: Max Duval <max.duval@theguardian.com>
Co-authored-by: Joshua <jlieb10@users.noreply.github.com>

## What does this change?

Moves the `<caption>` element in football tables in order to produce a more semantic tab order.

Closes https://github.com/guardian/dotcom-rendering/issues/4459

## Tested locally?

- [x] Yes
