### PR TITLE
fix: put score in football result in results table

### DIFF
--- a/sport/app/football/views/fragments/teamForm.scala.html
+++ b/sport/app/football/views/fragments/teamForm.scala.html
@@ -11,7 +11,7 @@
             data-score="@result.self.score.get"
             data-score-foe="@result.foe.score.get"
             title="Won @result.self.score.get-@result.foe.score.get against @cleanTeamName(result.foe.name)">
-            <span class="u-h">Won against @cleanTeamName(result.foe.name)</span>
+            <span class="u-h">Won @result.self.score.get-@result.foe.score.get against @cleanTeamName(result.foe.name)</span>
         </span>
     }
     @if(result.drew) {
@@ -21,7 +21,7 @@
             data-score="@result.self.score.get"
             data-score-foe="@result.foe.score.get"
             title="Drew @result.self.score.get-@result.foe.score.get with @cleanTeamName(result.foe.name)">
-            <span class="u-h">Drew with @cleanTeamName(result.foe.name)</span>
+            <span class="u-h">Drew @result.self.score.get-@result.foe.score.get with @cleanTeamName(result.foe.name)</span>
         </span>
     }
     @if(result.lost) {
@@ -31,7 +31,7 @@
             data-score="@result.self.score.get"
             data-score-foe="@result.foe.score.get"
             title="Lost @result.self.score.get-@result.foe.score.get to @cleanTeamName(result.foe.name)">
-            <span class="u-h">Lost to @cleanTeamName(result.foe.name)</span>
+            <span class="u-h">Lost @result.self.score.get-@result.foe.score.get to @cleanTeamName(result.foe.name)</span>
         </span>
     }
 }


### PR DESCRIPTION
## What does this change?
Part of: https://github.com/guardian/dotcom-rendering/issues/4448

Adds the score content to the table cell to give more useful information to people who use screen readers.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<img width="660" alt="Screenshot 2022-05-31 at 15 38 08" src="https://user-images.githubusercontent.com/31692/171202139-49d2baaf-2c59-4707-adbd-d97f974c5c7f.png">
