### PR TITLE
Revert "Remove comment share feature"

### DIFF
--- a/discussion/app/views/fragments/comment.scala.html
+++ b/discussion/app/views/fragments/comment.scala.html
@@ -115,6 +115,10 @@
                             Reply
                         </a>
 
+                        @if(SharingComments.isSwitchedOn) {
+                            @commentShare(comment)
+                        }
+
                         <span class="d-comment__action-separator d-staff-required">|</span>
 
                         <button class="u-button-reset d-comment__action d-comment__action--pick d-staff-required" role="button"

--- a/discussion/app/views/fragments/commentShare.scala.html
+++ b/discussion/app/views/fragments/commentShare.scala.html
@@ -1,0 +1,39 @@
+@import _root_.model.{Facebook, ShareLinks, SharePlatform, Twitter}
+@import discussion.model.Comment
+@import org.apache.commons.lang.StringEscapeUtils
+@import org.jsoup.Jsoup
+@import org.jsoup.safety.Whitelist
+
+@(comment: Comment)
+
+<div class="d-comment__action d-comment__action--share">
+
+    <div class="sharing-text">@fragments.inlineSvg("share", "icon", List("comment-share-icon")) <span>Share</span></div>
+
+    <div class="sharing-buttons" data-link-name="comment social">
+    @defining(s"${comment.webUrl}") { permalink =>
+        @defining(StringEscapeUtils.unescapeHtml(Jsoup.clean(comment.body.replaceAll("<blockquote>.*</blockquote>", ""), Whitelist.none()))) { commentBody =>
+            @shareLink(permalink, Facebook, "", Some(s"""${comment.profile.displayName} commented: "$commentBody""""))
+
+            @* Twitter allows 140 characters. We need 2 for the quotes and 24 for the URL. *@
+            @defining(if(commentBody.length <= 114) s""""$commentBody"""" else s""""${commentBody.take(111)}..."""") { commentText =>
+                @shareLink(permalink, Twitter, commentText, None)
+            }
+        }
+    }
+
+    @shareLink(permalink: String, platform: SharePlatform, text: String, quote: Option[String]) = {
+
+        <a href="@ShareLinks.createShareLinkForComment(platform = platform, href = permalink, text = text, quote = quote).href"
+        target="_blank"
+        class="social__action social-icon-wrapper"
+        data-link-name="social-comment : @{platform.css}">
+            <span class="inline-icon__fallback button">
+                @platform.userMessage</span>
+            @fragments.inlineSvg(s"share-${platform.css}", "icon", List("rounded-icon", "social-icon", "centered-icon", s"social-icon--${platform.css}", s"comment-${platform.css}-icon"))
+            <span class="u-h">@platform.text</span>
+        </a>
+    }
+
+    </div>
+</div>

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -838,6 +838,9 @@ $comment-recommend-button-size: 19px;
         .d-comment__action-pick {
             display: none;
         }
+        .d-comment__action--share {
+            margin: 0;
+        }
     }
 }
 
@@ -906,6 +909,38 @@ $comment-recommend-button-size: 19px;
     .d-comment__action-separator {
         display: inline-block;
     }
+}
+
+.d-comment__action--share {
+    vertical-align: middle;
+    margin-left: $gs-gutter / 4;
+
+    &:hover {
+        .sharing-text span:nth-child(2) {
+            text-decoration: underline;
+        }
+
+        .comment-facebook-icon,
+        .comment-twitter-icon {
+            transform: scale(1);
+            cursor: pointer;
+            vertical-align: middle;
+        }
+
+        .comment-facebook-icon {
+            transition: all .2s ease-in-out;
+        }
+
+        .comment-twitter-icon {
+            transition: all .2s .1s ease-in-out;
+        }
+    }
+}
+
+.sharing-text {
+    cursor: pointer;
+    display: inline-block;
+    margin-right: $gs-gutter / 4;
 }
 
 .comment-share-icon {


### PR DESCRIPTION
Reverts guardian/frontend#25065

I raised this because the layout looks broken as a result of this change. 

![Screenshot 2022-06-01 at 09 30 25](https://user-images.githubusercontent.com/5931528/171366827-640d65a7-dc97-4cdc-8f77-794cb85647f2.png)

However this may be a caching issue. Please stand by.

![maxresdefault](https://user-images.githubusercontent.com/5931528/171365994-c3190db2-8966-4507-a300-5fcff61bdbc5.jpg)
