### PR TITLE
Remove unused CommentShare switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -330,17 +330,6 @@ trait FeatureSwitches {
     exposeClientSide = true,
   )
 
-  // Owner: Maria Livia Chiorean
-  val SharingComments = Switch(
-    SwitchGroup.Feature,
-    "sharing-comments",
-    "When ON, the user will be able to share comments",
-    owners = Seq(Owner.withGithub("marialivia16")),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true,
-  )
-
   // Owner: Sam Cutler / Editorial Tools
   val Targeting = Switch(
     SwitchGroup.Feature,

--- a/discussion/app/views/fragments/comment.scala.html
+++ b/discussion/app/views/fragments/comment.scala.html
@@ -1,6 +1,5 @@
 @import common.Edition
 @import conf.Configuration
-@import conf.switches.Switches.SharingComments
 @import discussion.model.Comment
 @import views.support.{GuDateFormatLegacy, RenderClasses}
 @import views.support.`package`.withJsoup


### PR DESCRIPTION
## What does this change?

In #25065, we removed the comment share feature. However we're now left with this feature switch that does nothing.

This change tidies away the switch. Assuming we don't need to revert the change 😅  (#25072)
