### PR TITLE
Immersives for all ✊ 

### DIFF
--- a/common/app/layout/ContentWidths.scala
+++ b/common/app/layout/ContentWidths.scala
@@ -64,7 +64,16 @@ object ContentWidths {
       tablet = Some(140.px),
     ) // desktop, leftCol and wide are also 140px
 
-    override val immersive = BodyMedia.inline
+    override val immersive = WidthsByBreakpoint(
+      mobile = Some(480.px),
+      mobileLandscape = Some(660.px),
+      phablet = Some(740.px),
+      tablet = Some(980.px),
+      desktop = Some(1140.px),
+      leftCol = Some(1300.px),
+      wide = Some(1900.px),
+    )
+
     override val halfwidth = BodyMedia.inline
   }
 


### PR DESCRIPTION
## What?
This fixes https://github.com/guardian/dotcom-rendering/issues/5107 by removing the override that used to exist forcing in body images to use sources for the `inline` weighting, instead of the `immersive` weighting value that was chosen in Composer.

## Why?
Because DCR (unlike Frontend) does actually render these `immersive` images using the weighting chosen in Composer so if we don't pass down the right sources then the quality of the image suffers.

### Should DCR be rendering `immersive` images in non Immersive articles?
If a particular weighting is chosen in Composer then that decision should be respected. If we want to disallow particular weightings for different article types then that might be a change we make to Composer but the rendering tier is the wrong place to make that change.

It is true that [there are issues](https://github.com/guardian/dotcom-rendering/issues/5108) with immersive images overlapping content in the right column. These issues may well have been the reason the override was put in place. But as long as DCR is supporting this functionality then we should provide it with the sources it needs.