### PR TITLE
Add an experiment which will be used to offer HTTP3

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -5,7 +5,7 @@ import experiments.ParticipationGroups._
 import java.time.LocalDate
 
 object ActiveExperiments extends ExperimentsDefinition {
-  override val allExperiments: Set[Experiment] = Set(InteractivesIdleLoading)
+  override val allExperiments: Set[Experiment] = Set(InteractivesIdleLoading, OfferHttp3)
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
@@ -27,4 +27,13 @@ object InteractivesIdleLoading
       owners = Seq(Owner.withGithub("simonbyford")),
       sellByDate = LocalDate.of(2022, 7, 1),
       participationGroup = Perc10A,
+    )
+
+object OfferHttp3
+    extends Experiment(
+      name = "offer-http3",
+      description = "Offer HTTP3 by providing the header and redirecting URLs to enable loading of assets with HTTP3",
+      owners = Seq(Owner.withGithub("paulmr")),
+      sellByDate = LocalDate.of(2022, 12, 6),
+      participationGroup = Perc0B,
     )


### PR DESCRIPTION
Paired with @AshCorr

## What does this change?

Adds a new experiment, "offer-http3", which will be used in the fastly configuration to provide the `alt-svc` header in the response to offer upgrading of the connection to HTTP3.

Initially this experiement will be opt-in only (0% participation).

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

n/a

## What is the value of this and can you measure success?

Once properly set up, this experiment will allow us to enable HTTP3 on frontend and compare the performance between those who are using it and those who are not. It will also allow us to gather statistics on the availability of HTTP3 support on the client-side.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
