### PR TITLE
Bump Prebid to `2e61e45`

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "object-fit-videos": "^1.0.3",
     "ophan-tracker-js": "1.3.29",
     "preact": "^10.5.13",
-    "prebid.js": "https://github.com/guardian/Prebid.js#f434c6d",
+    "prebid.js": "https://github.com/guardian/Prebid.js#2e61e45",
     "qwery": "3.4.2",
     "rangefix": "^0.2.5",
     "raven-js": "^3.19.1",

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
@@ -323,8 +323,17 @@ const initialise = (window: Window, framework: Framework = 'tcfv2'): void => {
 			bidders: ['ozone'],
 			config: {
 				// Select the ozone granularity, use default if not defined for the size
-				guCustomPriceBucket: ({ width, height }) =>
-					ozonePriceGranularity(width, height) ?? priceGranularity,
+				guCustomPriceBucket: ({ width, height }) => {
+					const granularity =
+						ozonePriceGranularity(width, height) ??
+						priceGranularity;
+					log(
+						'commercial',
+						`Custom Ozone price bucket for size (${width},${height}):`,
+						granularity,
+					);
+					return granularity;
+				},
 			},
 		});
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10174,9 +10174,9 @@ preact@^10.5.13:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.15.tgz#6df94d8afecf3f9e10a742fd8c362ddab464225f"
   integrity sha512-5chK29n6QcJc3m1lVrKQSQ+V7K1Gb8HeQY6FViQ5AxCAEGu3DaHffWNDkC9+miZgsLvbvU9rxbV1qinGHMHzqA==
 
-"prebid.js@https://github.com/guardian/Prebid.js#f434c6d":
+"prebid.js@https://github.com/guardian/Prebid.js#2e61e45":
   version "5.20.0"
-  resolved "https://github.com/guardian/Prebid.js#f434c6d14f65b4bd26baa7f9799ceca0a1bbaafb"
+  resolved "https://github.com/guardian/Prebid.js#2e61e459082036e7a1f82d28a9497979f6872cd8"
   dependencies:
     "@guardian/libs" "^3.1.0"
     babel-plugin-transform-object-assign "^6.22.0"


### PR DESCRIPTION
## What does this change?

Bump Prebid to the build with commit hash `2e61e45`. This introduces the changes detailed in [@guardian/Prebid.js #126](https://github.com/guardian/Prebid.js/pull/126), namely to introduce custom price granularities for bidders that are based on slot size.

Additionally, add some logging when these custom granularities are used by Ozone (which is still part of an AB test, see #24849).

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

This bump should have been included in #24849. Not including it has had the undesired side effect of causing bids that are rounded incorrectly to be lost. Making this change should rectify the rounding issue.

## Tested

- [X] Locally
- [x] On CODE (optional)