### PR TITLE
Add cypress targeting test

### DIFF
--- a/cypress/integration/right-slot.spec.ts
+++ b/cypress/integration/right-slot.spec.ts
@@ -1,11 +1,5 @@
 import { articles, liveblogs } from '../fixtures/pages';
 
-// Don't fail tests when uncaught exceptions occur
-// This is because scripts loaded on the page and unrelated to these tests can cause this
-Cypress.on('uncaught:exception', (err, runnable) => {
-	return false;
-});
-
 describe('right slot on pages', () => {
 	[...articles, ...liveblogs].forEach(({ path, adTest }) => {
 		it(`Test ${path} has right slot and iframe`, () => {

--- a/cypress/integration/slots.spec.ts
+++ b/cypress/integration/slots.spec.ts
@@ -1,11 +1,5 @@
 import { getStage, getTestUrl } from '../lib/util';
 
-// Don't fail tests when uncaught exceptions occur
-// This is because scripts loaded on the page and unrelated to these tests can cause this
-Cypress.on('uncaught:exception', (err, runnable) => {
-	return false;
-});
-
 const stage = getStage();
 
 const pages = [
@@ -49,13 +43,14 @@ describe('Slots and iframes load on pages', () => {
 					expectedMinTotalSlotsOnPage,
 				);
 
-				[...(Array(expectedMinInlineSlotsOnPage).keys())]
-					.forEach((item, i) => {
+				[...Array(expectedMinInlineSlotsOnPage).keys()].forEach(
+					(item, i) => {
 						cy.get(`[data-name="inline${i + 1}"]`).should(
 							'have.length',
 							1,
 						);
-					});
+					},
+				);
 
 				cy.get(`[data-name="right"]`).should('have.length', 1);
 

--- a/cypress/integration/targeting.spec.ts
+++ b/cypress/integration/targeting.spec.ts
@@ -1,0 +1,38 @@
+import { pages } from '../fixtures/pages';
+
+const interceptGamRequest = () => {
+	return cy.intercept(
+		{
+			url: 'https://securepubads.g.doubleclick.net/gampad/ads?**',
+		},
+		function (req) {
+			const url = new URL(req.url);
+
+			expect(url.searchParams.get('gdpr_consent')).to.not.be.undefined;
+
+			const custParams = decodeURIComponent(
+				url.searchParams.get('cust_params') || '',
+			);
+			const decodedCustParams = new URLSearchParams(custParams);
+			expect(decodedCustParams.get('consent_tcfv2')).to.equal('t');
+		},
+	);
+};
+
+describe('targeting', () => {
+	it(`intercepts GAM request`, () => {
+		const { path, adTest } = pages[0];
+
+		cy.visit(`${path}?adtest=${adTest}`);
+
+		// Click "Yes, I'm happy" on the sourcepoint banner to obtain consent
+		cy.getIframeBody('sp_message_iframe_').find('.btn-primary').click();
+
+		// Check that the top-above-nav ad slot is on the page
+		cy.get('#dfp-ad--top-above-nav').should('exist');
+
+		interceptGamRequest().as('gamRequest');
+
+		cy.wait('@gamRequest', { timeout: 30000 });
+	});
+});

--- a/cypress/integration/top-above-nav.spec.ts
+++ b/cypress/integration/top-above-nav.spec.ts
@@ -1,11 +1,5 @@
 import { pages } from '../fixtures/pages';
 
-// Don't fail tests when uncaught exceptions occur
-// This is because scripts loaded on the page and unrelated to these tests can cause this
-Cypress.on('uncaught:exception', (err, runnable) => {
-	return false;
-});
-
 describe('top-above-nav on pages', () => {
 	pages.forEach(({ path, adTest }) => {
 		it(`Test ${path} has top-above-nav slot and iframe`, () => {

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -16,16 +16,40 @@
 // https://docs.cypress.io/guides/tooling/typescript-support#Types-for-custom-commands
 declare global {
 	namespace Cypress {
-	  interface Chainable {
-		/**
-		 * Custom command to select DOM element by data-cy attribute.
-		 * @example cy.getIframeBody('sp_message_iframe_')
-		 */
-		 getIframeBody(selector: string): Chainable<Element>
-	  }
+		interface Chainable {
+			/**
+			 * Custom command to select DOM element by data-cy attribute.
+			 * @example cy.getIframeBody('sp_message_iframe_')
+			 */
+			getIframeBody(selector: string): Chainable<Element>;
+		}
 	}
-  }
-
+}
 
 // Import commands.js using ES2015 syntax:
 import './commands';
+
+Cypress.on('uncaught:exception', (err, runnable) => {
+	// don't break our tests if sourcepoint code breaks
+	if (/wrapperMessagingWithoutDetection/.test(err.stack || '')) {
+		console.warn(err);
+		return false;
+	}
+
+	// When we set the `GU_U` cookie this is causing the commercial bundle to try and do
+	// something with the url which is failing in Cypress with a malformed URI error
+	if (err.message.includes('URI malformed')) {
+		// This error is unrelated to the test in question so return  false to prevent
+		// this commercial error from failing this test
+		return false;
+	}
+
+	// We don't want to throw an error if the consent framework isn't loaded in the tests
+	// https://github.com/guardian/consent-management-platform/blob/main/src/onConsentChange.ts#L34
+	if (err.message.includes('no IAB consent framework found on the page')) {
+		console.warn(err);
+		return false;
+	}
+
+	return true;
+});


### PR DESCRIPTION
## What does this change?

- Created a Cypress test to ensure that the GAM network request has correct GDPR consent parameters
- Tidied the Cypress files: Moved common function to `support/index.ts` so it is run before all tests.