### PR TITLE
Send json data to DCR /Cards endpoint when show more button gets clicked

### DIFF
--- a/common/app/model/CollectionConfig.scala
+++ b/common/app/model/CollectionConfig.scala
@@ -1,7 +1,8 @@
 package model.pressed
 
 import com.gu.facia.api.{models => fapi}
-import com.gu.facia.client.models.{Backfill, CollectionConfigJson, Metadata, CollectionPlatform}
+import com.gu.facia.client.models.{Backfill, CollectionConfigJson, CollectionPlatform, Metadata}
+import model.PressedCollectionFormat
 
 final case class CollectionConfig(
     displayName: Option[String],
@@ -25,6 +26,8 @@ final case class CollectionConfig(
 )
 
 object CollectionConfig {
+  implicit val collectionConfigFormat = PressedCollectionFormat.collectionConfigFormat
+
   def make(config: fapi.CollectionConfig): CollectionConfig = {
     CollectionConfig(
       displayName = config.displayName,

--- a/common/app/model/DisplayHints.scala
+++ b/common/app/model/DisplayHints.scala
@@ -1,10 +1,13 @@
 package model.pressed
 
 import com.gu.facia.api.{models => fapi}
+import model.PressedCollectionFormat
 
 final case class DisplayHints(maxItemsToDisplay: Option[Int])
 
 object DisplayHints {
+  implicit val displayHintsFormat = PressedCollectionFormat.displayHintsFormat
+
   def make(displayHints: fapi.DisplayHints): DisplayHints = {
     DisplayHints(displayHints.maxItemsToDisplay)
   }

--- a/common/app/model/PressedPage.scala
+++ b/common/app/model/PressedPage.scala
@@ -85,14 +85,19 @@ case object LiteAdFreeType extends PressedPageType {
   override def suffix = ".lite.adfree"
 }
 
+case object FullDCRType extends PressedPageType {
+  override def suffix = ".full.dcr"
+}
+
 case class PressedCollectionVersions(
     lite: PressedCollection,
     full: PressedCollection,
     liteAdFree: PressedCollection,
     fullAdFree: PressedCollection,
+    fullDCR: PressedCollection,
 )
 
-case class PressedPageVersions(lite: PressedPage, full: PressedPage, liteAdFree: PressedPage, fullAdFree: PressedPage)
+case class PressedPageVersions(lite: PressedPage, full: PressedPage, liteAdFree: PressedPage, fullAdFree: PressedPage, fullDCR: PressedPage)
 
 object PressedPageVersions {
   def fromPressedCollections(
@@ -102,10 +107,11 @@ object PressedPageVersions {
       pressedCollections: List[PressedCollectionVersions],
   ): PressedPageVersions = {
     PressedPageVersions(
-      PressedPage(id, seoData, frontProperties, pressedCollections.map(_.lite)).filterEmpty,
-      PressedPage(id, seoData, frontProperties, pressedCollections.map(_.full)).filterEmpty,
-      PressedPage(id, seoData, frontProperties, pressedCollections.map(_.liteAdFree)).filterEmpty,
-      PressedPage(id, seoData, frontProperties, pressedCollections.map(_.fullAdFree)).filterEmpty,
+      lite = PressedPage(id, seoData, frontProperties, pressedCollections.map(_.lite)).filterEmpty,
+      full = PressedPage(id, seoData, frontProperties, pressedCollections.map(_.full)).filterEmpty,
+      liteAdFree = PressedPage(id, seoData, frontProperties, pressedCollections.map(_.liteAdFree)).filterEmpty,
+      fullAdFree = PressedPage(id, seoData, frontProperties, pressedCollections.map(_.fullAdFree)).filterEmpty,
+      fullDCR = PressedPage(id, seoData, frontProperties, pressedCollections.map(_.fullDCR)).filterEmpty,
     )
   }
 }

--- a/common/app/model/PressedPage.scala
+++ b/common/app/model/PressedPage.scala
@@ -97,7 +97,13 @@ case class PressedCollectionVersions(
     fullDCR: PressedCollection,
 )
 
-case class PressedPageVersions(lite: PressedPage, full: PressedPage, liteAdFree: PressedPage, fullAdFree: PressedPage, fullDCR: PressedPage)
+case class PressedPageVersions(
+    lite: PressedPage,
+    full: PressedPage,
+    liteAdFree: PressedPage,
+    fullAdFree: PressedPage,
+    fullDCR: PressedPage,
+)
 
 object PressedPageVersions {
   def fromPressedCollections(

--- a/common/app/model/dotcomrendering/DotcomCardsRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomCardsRenderingDataModel.scala
@@ -1,9 +1,9 @@
 package model.dotcomrendering
 
-import model.pressed.PressedContent
+import model.pressed.{CollectionConfig, PressedContent}
 import play.api.libs.json.Json
 
-case class DotcomCardsRenderingDataModel(cards: List[PressedContent], startIndex: Int)
+case class DotcomCardsRenderingDataModel(cards: List[PressedContent], startIndex: Int, config: CollectionConfig)
 
 object DotcomCardsRenderingDataModel {
   implicit val writes = Json.writes[DotcomCardsRenderingDataModel]

--- a/common/app/model/dotcomrendering/DotcomCardsRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomCardsRenderingDataModel.scala
@@ -3,7 +3,7 @@ package model.dotcomrendering
 import model.pressed.{CollectionConfig, PressedContent}
 import play.api.libs.json.Json
 
-case class DotcomCardsRenderingDataModel(cards: List[PressedContent], startIndex: Int, config: CollectionConfig)
+case class DotcomCardsRenderingDataModel(cards: List[PressedContent], config: CollectionConfig)
 
 object DotcomCardsRenderingDataModel {
   implicit val writes = Json.writes[DotcomCardsRenderingDataModel]

--- a/common/app/model/dotcomrendering/DotcomCardsRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomCardsRenderingDataModel.scala
@@ -3,7 +3,7 @@ package model.dotcomrendering
 import model.pressed.PressedContent
 import play.api.libs.json.Json
 
-case class DotcomCardsRenderingDataModel(cards: List[PressedContent])
+case class DotcomCardsRenderingDataModel(cards: List[PressedContent], startIndex: Int)
 
 object DotcomCardsRenderingDataModel {
   implicit val writes = Json.writes[DotcomCardsRenderingDataModel]

--- a/common/app/model/dotcomrendering/DotcomCardsRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomCardsRenderingDataModel.scala
@@ -1,0 +1,15 @@
+package model.dotcomrendering
+
+import model.pressed.PressedContent
+import play.api.libs.json.Json
+
+case class DotcomCardsRenderingDataModel(cards: List[PressedContent])
+
+object DotcomCardsRenderingDataModel {
+  implicit val writes = Json.writes[DotcomCardsRenderingDataModel]
+
+  def toJson(model: DotcomCardsRenderingDataModel): String = {
+    val jsValue = Json.toJson(model)
+    Json.stringify(DotcomRenderingUtils.withoutNull(jsValue))
+  }
+}

--- a/common/app/model/dotcomrendering/DotcomFrontsRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomFrontsRenderingDataModel.scala
@@ -6,6 +6,7 @@ import common.commercial.EditionCommercialProperties
 import conf.Configuration
 import experiments.ActiveExperiments
 import model.PressedPage
+import model.pressed.PressedContent
 import navigation.{FooterLinks, Nav}
 import play.api.libs.json.{JsObject, JsValue, Json}
 import play.api.mvc.RequestHeader

--- a/common/app/model/facia/PressedCollection.scala
+++ b/common/app/model/facia/PressedCollection.scala
@@ -30,8 +30,8 @@ case class PressedCollection(
     config: CollectionConfig,
     hasMore: Boolean,
     targetedTerritory: Option[TargetedTerritory],
-    liteCuratedLength: Option[Int],
-    liteBackfillLength: Option[Int],
+    liteCuratedLength: Option[Int] = None,
+    liteBackfillLength: Option[Int] = None,
 ) {
 
   lazy val isEmpty: Boolean = curated.isEmpty && backfill.isEmpty && treats.isEmpty
@@ -70,7 +70,11 @@ case class PressedCollection(
     val liteCurated = curated.take(visible)
     val liteBackfill = backfill.take(visible - liteCurated.length)
     val hasMore = curatedPlusBackfillDeduplicated.length > visible
-    copy(hasMore = hasMore, liteCuratedLength = Some(liteCurated.length), liteBackfillLength = Some(liteBackfill.length))
+    copy(
+      hasMore = hasMore,
+      liteCuratedLength = Some(liteCurated.length),
+      liteBackfillLength = Some(liteBackfill.length),
+    )
   }
 
   lazy val collectionConfigWithId = CollectionConfigWithId(id, config)

--- a/common/app/model/facia/PressedCollection.scala
+++ b/common/app/model/facia/PressedCollection.scala
@@ -30,6 +30,8 @@ case class PressedCollection(
     config: CollectionConfig,
     hasMore: Boolean,
     targetedTerritory: Option[TargetedTerritory],
+    liteCuratedLength: Option[Int],
+    liteBackfillLength: Option[Int],
 ) {
 
   lazy val isEmpty: Boolean = curated.isEmpty && backfill.isEmpty && treats.isEmpty
@@ -62,6 +64,13 @@ case class PressedCollection(
   def full(visible: Int): PressedCollection = {
     val hasMore = curatedPlusBackfillDeduplicated.length > visible
     copy(hasMore = hasMore)
+  }
+
+  def fullDCR(visible: Int): PressedCollection = {
+    val liteCurated = curated.take(visible)
+    val liteBackfill = backfill.take(visible - liteCurated.length)
+    val hasMore = curatedPlusBackfillDeduplicated.length > visible
+    copy(hasMore = hasMore, liteCuratedLength = Some(liteCurated.length), liteBackfillLength = Some(liteBackfill.length))
   }
 
   lazy val collectionConfigWithId = CollectionConfigWithId(id, config)

--- a/common/app/model/pressedContent.scala
+++ b/common/app/model/pressedContent.scala
@@ -3,7 +3,7 @@ package model.pressed
 import com.gu.commercial.branding.Branding
 import com.gu.facia.api.{models => fapi}
 import common.Edition
-import model.{ContentFormat, Pillar}
+import model.{ContentFormat, Pillar, PressedContentFormat}
 import views.support.ContentOldAgeDescriber
 
 sealed trait PressedContent {

--- a/common/app/model/pressedContent.scala
+++ b/common/app/model/pressedContent.scala
@@ -45,6 +45,8 @@ sealed trait PressedContent {
 }
 
 object PressedContent {
+  implicit val pressedContentFormat = PressedContentFormat.format
+
   def make(content: fapi.FaciaContent): PressedContent =
     content match {
       case curatedContent: fapi.CuratedContent => CuratedContent.make(curatedContent)

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -27,7 +27,7 @@ import model.{
   Topic,
   TopicResult,
 }
-import model.pressed.PressedContent
+import model.pressed.{CollectionConfig, PressedContent}
 import play.api.libs.json.Json
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc.Results.{InternalServerError, NotFound}
@@ -210,8 +210,9 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       ws: WSClient,
       cards: List[PressedContent],
       startIndex: Int,
+      config: CollectionConfig,
   )(implicit request: RequestHeader): Future[Result] = {
-    val dataModel = DotcomCardsRenderingDataModel(cards, startIndex)
+    val dataModel = DotcomCardsRenderingDataModel(cards, startIndex, config)
 
     val json = DotcomCardsRenderingDataModel.toJson(dataModel)
     post(ws, json, Configuration.rendering.baseURL + "/Cards", CacheTime.Facia)

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -10,6 +10,7 @@ import http.{HttpPreconnections, ResultWithPreconnectPreload}
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model.dotcomrendering.{
   DotcomBlocksRenderingDataModel,
+  DotcomCardsRenderingDataModel,
   DotcomFrontsRenderingDataModel,
   DotcomRenderingDataModel,
   PageType,
@@ -20,11 +21,14 @@ import model.{
   InteractivePage,
   LiveBlogPage,
   NoCache,
+  Page,
   PageWithStoryPackage,
   PressedPage,
   Topic,
   TopicResult,
 }
+import model.pressed.PressedContent
+import play.api.libs.json.Json
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc.Results.{InternalServerError, NotFound}
 import play.api.mvc.{RequestHeader, Result}
@@ -200,6 +204,17 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
 
     val json = DotcomFrontsRenderingDataModel.toJson(dataModel)
     post(ws, json, Configuration.rendering.baseURL + "/Front", CacheTime.Facia)
+  }
+
+  def getCards(
+      ws: WSClient,
+      cards: List[PressedContent],
+      startIndex: Int,
+  )(implicit request: RequestHeader): Future[Result] = {
+    val dataModel = DotcomCardsRenderingDataModel(cards, startIndex)
+
+    val json = DotcomCardsRenderingDataModel.toJson(dataModel)
+    post(ws, json, Configuration.rendering.baseURL + "/Cards", CacheTime.Facia)
   }
 
   def getInteractive(

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -209,13 +209,12 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
   def getCards(
       ws: WSClient,
       cards: List[PressedContent],
-      startIndex: Int,
       config: CollectionConfig,
   )(implicit request: RequestHeader): Future[Result] = {
-    val dataModel = DotcomCardsRenderingDataModel(cards, startIndex, config)
+    val dataModel = DotcomCardsRenderingDataModel(cards, config)
 
     val json = DotcomCardsRenderingDataModel.toJson(dataModel)
-    post(ws, json, Configuration.rendering.baseURL + "/Cards", CacheTime.Facia)
+    post(ws, json, Configuration.rendering.baseURL + "/ShowMore", CacheTime.Facia)
   }
 
   def getInteractive(

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -265,6 +265,7 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
         putPressedPage(path, pressedFronts.lite, LiteType)
         putPressedPage(path, pressedFronts.fullAdFree, FullAdFreeType)
         putPressedPage(path, pressedFronts.liteAdFree, LiteAdFreeType)
+        putPressedPage(path, pressedFronts.fullDCR, FullDCRType)
       }
       .fold(
         e => {
@@ -306,6 +307,7 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
       case LiteType       => FaciaPressMetrics.FrontPressContentSizeLite
       case LiteAdFreeType => FaciaPressMetrics.FrontPressContentSizeLite
       case FullAdFreeType => FaciaPressMetrics.FrontPressContentSize
+      case FullDCRType    => FaciaPressMetrics.FrontPressContentSize
     }
 
     metric.recordSample(json.getBytes.length, new DateTime())

--- a/facia-press/app/frontpress/PressedCollectionVisibility.scala
+++ b/facia-press/app/frontpress/PressedCollectionVisibility.scala
@@ -10,10 +10,11 @@ case class PressedCollectionVisibility(pressedCollection: PressedCollection, vis
     copy(pressedCollection = pressedCollection.withoutTrailTextOnTail)
   lazy val pressedCollectionVersions: PressedCollectionVersions = {
     PressedCollectionVersions(
-      pressedCollection.lite(visible),
-      pressedCollection.full(visible),
-      pressedCollection.adFree.lite(visible),
-      pressedCollection.adFree.full(visible),
+      lite = pressedCollection.lite(visible),
+      full = pressedCollection.full(visible),
+      liteAdFree = pressedCollection.adFree.lite(visible),
+      fullAdFree = pressedCollection.adFree.full(visible),
+      fullDCR = pressedCollection.fullDCR(visible),
     )
   }
 }

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -354,11 +354,15 @@ trait FaciaController
     Action.async { implicit request =>
       frontJsonFapi.get(path, fullRequestType).flatMap {
         case Some(pressedPage) =>
-          val matchedCollection = pressedPage.collections.filter(_.id == collectionId).head
-          val pressedContent = matchedCollection.curated
-
-          val model = DotcomCardsRenderingDataModel(pressedContent)
-          val json = DotcomCardsRenderingDataModel.toJson(model)
+          if (request.forceDCR) {
+            // TODO: Use Option?
+            //  TODO: Concatenate curated with backfill
+            // TODO: Do we need to add anything else?
+            // TODO: Work out the actual startIndex
+            val matchedCollection = pressedPage.collections.filter(_.id == collectionId).head
+            val pressedContent = matchedCollection.curated
+            remoteRenderer.getCards(ws, pressedContent, 2)
+          }
 
           val containers = Front.fromPressedPage(pressedPage, Edition(request), adFree = request.isAdFree).containers
           val maybeResponse =

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -360,7 +360,7 @@ trait FaciaController
 
             val matchedCollection = pressedPage.collections.filter(_.id == collectionId).head
 
-            // TODO: length is Option because not all types oof pressedCollection have the property, but
+            // TODO: length is Option because not all types of pressedCollection have the property, but
             //  pressedCollections coming from *DCR* pressedPages *should* have the length prop. If they don't
             //  then something has gone wrong. How should we surface this? (Default value of 0 avoids a crash
             //  but it covers over the bug.)
@@ -372,7 +372,6 @@ trait FaciaController
             ) ++ matchedCollection.backfill.takeRight(matchedCollection.backfill.length - liteBackfillLength)
             val startIndex = liteCuratedLength + liteBackfillLength
 
-            // todo: Is this the right return value already, or do we need to process it?
             remoteRenderer.getCards(ws = ws, cards = pressedContent, startIndex = startIndex)
 
           case None => successful(Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound)))

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -374,7 +374,7 @@ trait FaciaController
 
                 val config = collection.config
 
-                remoteRenderer.getCards(ws = ws, cards = pressedContent, startIndex = startIndex, config = config)
+                remoteRenderer.getCards(ws = ws, cards = pressedContent, config = config)
 
               }) getOrElse successful(Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound)))
 

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -355,9 +355,12 @@ trait FaciaController
       if (request.forceDCR) {
         frontJsonFapi.get(path, fullDCRRequestType).flatMap {
           case Some(pressedPage) =>
-            // TODO: Use Option?
             // TODO: Do we need to add anything else?
 
+            // TODO: The issue here is that .head will throw an error if the collection isn't found
+            //  I can't work out how to extend the 'for' structure below to this, though.
+            //  If the collection isn't found, will we need a new 'path', or will one of the other return
+            //  values cover this already?
             val matchedCollection = pressedPage.collections.filter(_.id == collectionId).head
 
             // TODO: length is Option because not all types of pressedCollection have the property, but
@@ -372,6 +375,9 @@ trait FaciaController
             ) ++ matchedCollection.backfill.takeRight(matchedCollection.backfill.length - liteBackfillLength)
             val startIndex = liteCuratedLength + liteBackfillLength
 
+            // TODO we also need to handle the case where this doesn't work
+            //  - Are there importantly different failure cases to handle, or can we return a generic fallback response,
+            //    given that DCR doesn't really do anything with the response in the case of failure?)
             remoteRenderer.getCards(ws = ws, cards = pressedContent, startIndex = startIndex)
 
           case None => successful(Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound)))

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -366,17 +366,19 @@ trait FaciaController
             //  but it covers over the bug.)
             val liteCuratedLength = matchedCollection.liteCuratedLength match {
               case Some(n: Int) => n
-              case None => 0
+              case None         => 0
             }
             val liteBackfillLength = matchedCollection.liteBackfillLength match {
               case Some(n: Int) => n
-              case None => 0
+              case None         => 0
             }
-            val pressedContent = matchedCollection.curated.takeRight(matchedCollection.curated.length - liteCuratedLength) ++ matchedCollection.backfill.takeRight(matchedCollection.backfill.length - liteBackfillLength)
+            val pressedContent = matchedCollection.curated.takeRight(
+              matchedCollection.curated.length - liteCuratedLength,
+            ) ++ matchedCollection.backfill.takeRight(matchedCollection.backfill.length - liteBackfillLength)
             val startIndex = liteCuratedLength + liteBackfillLength
 
             // todo: Is this the right return value already, or do we need to process it?
-            remoteRenderer.getCards(ws=ws, cards=pressedContent, startIndex=startIndex)
+            remoteRenderer.getCards(ws = ws, cards = pressedContent, startIndex = startIndex)
           }
 
           val containers = Front.fromPressedPage(pressedPage, Edition(request), adFree = request.isAdFree).containers

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -375,10 +375,12 @@ trait FaciaController
             ) ++ matchedCollection.backfill.takeRight(matchedCollection.backfill.length - liteBackfillLength)
             val startIndex = liteCuratedLength + liteBackfillLength
 
+            val config = matchedCollection.config
+
             // TODO we also need to handle the case where this doesn't work
             //  - Are there importantly different failure cases to handle, or can we return a generic fallback response,
             //    given that DCR doesn't really do anything with the response in the case of failure?)
-            remoteRenderer.getCards(ws = ws, cards = pressedContent, startIndex = startIndex)
+            remoteRenderer.getCards(ws = ws, cards = pressedContent, startIndex = startIndex, config = config)
 
           case None => successful(Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound)))
         }

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -356,11 +356,11 @@ trait FaciaController
         frontJsonFapi.get(path, fullDCRRequestType).flatMap {
           case Some(pressedPage) =>
             val matchedCollection = pressedPage.collections.find(_.id == collectionId)
-
-            // TODO: length is Option because not all types of pressedCollection have the property, but
-            //  pressedCollections coming from *DCR* pressedPages *should* have the length prop. If they don't
-            //  then something has gone wrong. How should we surface this? (Default value of 0 avoids a crash
-            //  but it covers over the bug.)
+            // nb: length is an Option because not all types of pressedCollection have the property, but
+            //  pressedCollections coming from 'fullDCR' pressedPages *should* have the length prop. If they don't
+            //  then something has gone wrong. Narrowing the types and parsing the Collection
+            //  might be preferable to setting a default, but was deemed too time-consuming for
+            //  the time being.
             matchedCollection
               .map(collection => {
 
@@ -377,10 +377,6 @@ trait FaciaController
                 remoteRenderer.getCards(ws = ws, cards = pressedContent, startIndex = startIndex, config = config)
 
               }) getOrElse successful(Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound)))
-
-          // TODO we also need to handle the case where this doesn't work
-          //  - Are there importantly different failure cases to handle, or can we return a generic fallback response,
-          //    given that DCR doesn't really do anything with the response in the case of failure?)
 
           case None => successful(Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound)))
         }

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -20,9 +20,10 @@ import implicits.GUHeaders
 import pages.{FrontEmailHtmlPage, FrontHtmlPage}
 import utils.{FaciaPicker, RemoteRender, TargetedCollections}
 import conf.Configuration
+import model.dotcomrendering.DotcomCardsRenderingDataModel.toJson
 import play.api.libs.ws.WSClient
 import renderers.DotcomRenderingService
-import model.dotcomrendering.{DotcomFrontsRenderingDataModel, PageType}
+import model.dotcomrendering.{DotcomCardsRenderingDataModel, DotcomFrontsRenderingDataModel, PageType}
 
 import scala.concurrent.Future
 import scala.concurrent.Future.successful
@@ -353,6 +354,12 @@ trait FaciaController
     Action.async { implicit request =>
       frontJsonFapi.get(path, fullRequestType).flatMap {
         case Some(pressedPage) =>
+          val matchedCollection = pressedPage.collections.filter(_.id == collectionId).head
+          val pressedContent = matchedCollection.curated
+
+          val model = DotcomCardsRenderingDataModel(pressedContent)
+          val json = DotcomCardsRenderingDataModel.toJson(model)
+
           val containers = Front.fromPressedPage(pressedPage, Edition(request), adFree = request.isAdFree).containers
           val maybeResponse =
             for {


### PR DESCRIPTION
## Use case

* Given a front is rendered by DCR 
* When a user clicks a show more button 
<img width="1407" alt="Screenshot 2022-06-23 at 11 30 27" src="https://user-images.githubusercontent.com/19683595/175279152-4522dd9f-a346-493e-8185-e67026432b98.png">

* DCR calls facia endpoint `/*path/show-more/*id.json?dcr=true`:

<img width="1738" alt="Screenshot 2022-06-23 at 11 54 38" src="https://user-images.githubusercontent.com/19683595/175283343-78be6e29-d629-42f5-997b-218fafb2171d.png">

* And frontend returns JSON to DCR `/Cards` endpoint:
```
{
    cards: 
    startIndex: 
    config:
}
```

Related DCR PR: https://github.com/guardian/dotcom-rendering/pull/5116
Related DCR Issue: https://github.com/guardian/dotcom-rendering/issues/4604

## What does this change?

This PR:
* Adds a new type of `fullDCR` `PressedCollection` in `facia-press`. When `/*path/show-more/*id.json?dcr=true` gets hit, `FaciaController.renderShowMore` method will request `pressed.v2.full.dcr.json` from the `aws-frondend-store` S3 bucket. The current purpose of the `fullDCR` version is to persist data about which cards are visible 'above the fold' in a given container, but the intention is that other DCR-specific content may eventually be added here, too.
* Adds a `DotcomCardsRenderingDataModel` 
* Adds a `getCards` method in `DotcomRenderingService`. It converts a list of `PressedContent` and a `startIndex` to json and makes a POST request to DCR `/Cards` endpoint to send the data

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

Not 'reproduced' as such, but this change should be deployed alongside the corresponding [DCR PR](Related DCR PR: https://github.com/guardian/dotcom-rendering/pull/5116).

## Screenshots

| Before      | After      |
|-------------|------------|
|facia-press stores in S3|
| <img width="1234" alt="image" src="https://user-images.githubusercontent.com/19683595/175288295-ab0665cd-eb0f-4026-b8da-fb6c839fc3af.png"> | <img width="1228" alt="image" src="https://user-images.githubusercontent.com/19683595/175288376-cc16a48b-d25b-4784-91f1-81f383bbbe2d.png"> |
|`/*path/show-more/*id.json?dcr=true` returns|
| <img width="1777" alt="Screenshot 2022-06-23 at 12 38 12" src="https://user-images.githubusercontent.com/19683595/175290142-e69a21e3-5207-473a-aa73-0aaab3bca035.png"> | <img width="884" alt="image" src="https://user-images.githubusercontent.com/19683595/175289601-a381bac3-bb2a-4ed2-b798-fac8b274fd5f.png"> TODO: Add html key |


[before]: https://example.com/before.png
[after]: https://example.com/after.png

## What is the value of this and can you measure success?

Part of the Fronts migration -- supporting existing behaviour in DCR.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it
- [x] No, all DCR Fronts containers are currently ad-free.

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->

### TODO
* Add unit tests
* Test e2e in CODE: Facia Tool --> frontend --> DCR