### PR TITLE
Pass AMP consent messages between parent window and child iframe

### DIFF
--- a/static/vendor/data/amp-iframe.html
+++ b/static/vendor/data/amp-iframe.html
@@ -4,16 +4,36 @@
 			src="https://acdn.adnxs.com/prebid/amp/user-sync/load-cookie-with-consent.html"
 			height="0"
 			width="0"
+			sandbox="allow-scripts allow-same-origin"
 		></iframe>
 		<iframe
 			src="https://guardian.amp.permutive.com/amp-iframe.html?project=d6691a17-6fdb-4d26-85d6-b3dd27f55f08&key=359ba275-5edd-4756-84f8-21a24369ce0b"
 			height="0"
 			width="0"
+			sandbox="allow-scripts allow-same-origin"
 		></iframe>
 		<iframe
 			src="https://guardian-cdn.relevant-digital.com/static/tags/6214c1072d89bdff800f25f2_cookiesync.html?endpoint=relevant&max_sync_count=5"
 			height="0"
 			width="0"
+			sandbox="allow-scripts allow-same-origin"
 		></iframe>
 	</body>
+	<script>
+		const iframes = Array.from(document.getElementsByTagName('iframe'));
+
+		window.addEventListener(
+			'message',
+			(event) => {
+				if (event.data.type === 'send-consent-data') {
+					window.parent.postMessage(event.data, '*');
+				} else {
+					iframes.forEach((iframe) => {
+						iframe.contentWindow.postMessage(event.data, '*');
+					});
+				}
+			},
+			false,
+		);
+	</script>
 </html>


### PR DESCRIPTION
## What does this change?
Prebid scripts are not able to get consent data which is requested via `parent.postMessage` because they are in a nested iframe.

The nested iframe is due to AMP only allowing a single iframe for analytics/ad purposes.

So added some code to pass the messages up and down through the intermediary iframe.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [x] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Changing CAPI versions renders the existing local database files useless -->
<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
