### PR TITLE
Extend Prebid price test switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -30,7 +30,7 @@ trait ABTestSwitches {
     "Test the commercial impact of changing the Prebid Price granularity for Ozone",
     owners = Seq(Owner.withGithub("chrislomaxjones")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2022, 6, 9)),
+    sellByDate = Some(LocalDate.of(2022, 6, 15)),
     exposeClientSide = true,
   )
 


### PR DESCRIPTION
## What does this change?

Extend the switch for the Prebid price granularity test by one week. Note this leaves the AB test itself unextended, since its switched off and we're removing it in #25059 (draft as of writing).

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Why

This will prevent the switch expiry causing the build to go red, before we eventually remove the switch in #25059.

### Tested

- [ ] Locally
- [ ] On CODE (optional)
