### PR TITLE
Record cases of spacefinder timing out

### DIFF
--- a/static/src/javascripts/projects/common/modules/spacefinder.ts
+++ b/static/src/javascripts/projects/common/modules/spacefinder.ts
@@ -335,13 +335,20 @@ class SpaceError extends Error {
  */
 const getReady = (rules: SpacefinderRules, options: SpacefinderOptions) =>
 	Promise.race([
-		new Promise((resolve) => window.setTimeout(resolve, LOADING_TIMEOUT)),
+		new Promise((resolve) =>
+			window.setTimeout(() => resolve('timeout'), LOADING_TIMEOUT),
+		),
 		Promise.all([
 			options.waitForImages ? onImagesLoaded(rules) : true,
 			options.waitForLinks ? onRichLinksUpgraded(rules) : true,
 			options.waitForInteractives ? onInteractivesLoaded(rules) : true,
 		]),
-	]);
+	]).then((value) => {
+		if (value === 'timeout') {
+			log('commercial', 'Spacefinder timeout hit');
+			amIUsed('spacefinder.ts', 'SpacefinderTimeoutHit');
+		}
+	});
 
 const getCandidates = (
 	rules: SpacefinderRules,

--- a/static/src/javascripts/projects/common/modules/spacefinder.ts
+++ b/static/src/javascripts/projects/common/modules/spacefinder.ts
@@ -344,7 +344,11 @@ const getReady = (rules: SpacefinderRules, options: SpacefinderOptions) =>
 			options.waitForInteractives ? onInteractivesLoaded(rules) : true,
 		]),
 	]).then((value) => {
-		if (value === 'timeout') {
+		// TODO: remove this conditional once idle loading becomes the default behaviour
+		const isInIdleLoadingVariant =
+			window.guardian.config.tests?.interactivesIdleLoadingVariant;
+
+		if (value === 'timeout' && isInIdleLoadingVariant) {
 			log('commercial', 'Spacefinder timeout hit');
 			amIUsed('spacefinder.ts', 'SpacefinderTimeoutHit');
 		}


### PR DESCRIPTION
## What does this change?

Currently, spacefinder waits a maximum of 5 seconds before running while interactives, rich links and images load. We don't know how frequently this timeout is being hit in practice. This commit adds an `amIUsed` call to track such cases. 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

It will hopefully give us more confidence when making changes to the timeout mechanism, such as this: https://github.com/guardian/frontend/pull/25021

### Tested

- [x] Locally
- [ ] On CODE (optional)

