### PR TITLE
Sticky ads in the right column: `0%` AB test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -54,4 +54,14 @@ trait ABTestSwitches {
     exposeClientSide = true,
   )
 
+  Switch(
+    ABTests,
+    "ab-multi-sticky-right-ads",
+    "Test the commercial and performance impact of sticky ads in the right column",
+    owners = Seq(Owner.withGithub("chrislomaxjones")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2022, 7, 4)),
+    exposeClientSide = true,
+  )
+
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -60,7 +60,7 @@ trait ABTestSwitches {
     "Test the commercial and performance impact of sticky ads in the right column",
     owners = Seq(Owner.withGithub("chrislomaxjones")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2022, 7, 4)),
+    sellByDate = Some(LocalDate.of(2022, 8, 2)),
     exposeClientSide = true,
   )
 

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -172,7 +172,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 		const stickyContainerHeights =
 			includeContainer &&
 			isInVariantSynchronous(multiStickyRightAds, 'variant')
-				? computeStickyHeight(paras, articleBodySelector)
+				? await computeStickyHeight(paras, articleBodySelector)
 				: undefined;
 
 		const slots = paras

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -1,5 +1,7 @@
 import type { SizeMapping } from '@guardian/commercial-core';
 import { adSizes, createAdSlot } from '@guardian/commercial-core';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { multiStickyRightAds } from 'common/modules/experiments/tests/multi-sticky-right-ads';
 import { getBreakpoint, getTweakpoint, getViewport } from 'lib/detect-viewport';
 import { getUrlVars } from 'lib/url';
 import config from '../../../lib/config';
@@ -15,8 +17,15 @@ import type {
 import { initCarrot } from './carrot-traffic-driver';
 import { addSlot } from './dfp/add-slot';
 import { trackAdRender } from './dfp/track-ad-render';
+import { computeStickyHeight } from './sticky-inlines';
 
 type SlotName = Parameters<typeof createAdSlot>[0];
+
+type ContainerOptions = {
+	sticky?: boolean;
+	heightPx?: number;
+	enableDebug?: boolean;
+};
 
 const sfdebug = getUrlVars().sfdebug;
 
@@ -27,6 +36,29 @@ const adSlotClassSelectorSizes = {
 	minBelow: 500,
 };
 
+const wrapSlotInContainer = (
+	ad: HTMLElement,
+	options: ContainerOptions = {},
+) => {
+	const container = document.createElement('div');
+	container.className = 'ad-slot-container ad-slot--offset-right';
+
+	if (options.sticky) {
+		ad.style.cssText += 'position: sticky; top: 10px;';
+	}
+
+	if (options.heightPx) {
+		container.style.cssText += `height: ${options.heightPx}px;`;
+	}
+
+	if (options.enableDebug) {
+		container.style.cssText += 'outline: 2px solid red;';
+	}
+
+	container.appendChild(ad);
+	return container;
+};
+
 const insertAdAtPara = (
 	para: Node,
 	name: string,
@@ -34,6 +66,7 @@ const insertAdAtPara = (
 	classes?: string,
 	sizes?: SizeMapping,
 	includeContainer?: boolean,
+	containerOptions: ContainerOptions = {},
 ): Promise<void> => {
 	const ad = createAdSlot(type, {
 		name,
@@ -41,17 +74,9 @@ const insertAdAtPara = (
 		sizes,
 	});
 
-	let node: HTMLElement;
-
-	if (includeContainer) {
-		const container = document.createElement('div');
-		container.className = `ad-slot-container ad-slot--offset-right`;
-		container.appendChild(ad);
-
-		node = container;
-	} else {
-		node = ad;
-	}
+	const node = includeContainer
+		? wrapSlotInContainer(ad, containerOptions)
+		: ad;
 
 	return fastdom
 		.mutate(() => {
@@ -134,16 +159,38 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 
 	const rules = isInline1 ? defaultRules : relaxedRules;
 
+	const enableDebug =
+		(sfdebug === '1' && isInline1) || (sfdebug === '2' && !isInline1);
+
 	const insertAds: SpacefinderWriter = async (paras) => {
+		// Include containers on the non-inline1 pass
+		// i.e. inline2, inline3, etc...
+		const includeContainer = !isInline1;
+
+		// Make ads sticky in containers if using containers and in sticky test variant
+		// Compute the height of containers in which ads will remain sticky
+		const stickyContainerHeights =
+			includeContainer &&
+			isInVariantSynchronous(multiStickyRightAds, 'variant')
+				? computeStickyHeight(paras, articleBodySelector)
+				: undefined;
+
 		const slots = paras
 			.slice(0, isInline1 ? 1 : paras.length)
 			.map((para, i) => {
 				const inlineId = i + (isInline1 ? 1 : 2);
-				const includeContainer = !isInline1;
 
 				if (sfdebug) {
 					para.style.cssText += 'border: thick solid green;';
 				}
+
+				const containerOptions = stickyContainerHeights
+					? {
+							sticky: true,
+							heightPx: Math.max(stickyContainerHeights[i], 0),
+							enableDebug,
+					  }
+					: undefined;
 
 				return insertAdAtPara(
 					para,
@@ -163,13 +210,11 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 						  }
 						: { desktop: [adSizes.halfPage, adSizes.skyscraper] },
 					includeContainer,
+					containerOptions,
 				);
 			});
 		await Promise.all(slots);
 	};
-
-	const enableDebug =
-		(sfdebug === '1' && isInline1) || (sfdebug === '2' && !isInline1);
 
 	return spaceFiller.fillSpace(rules, insertAds, {
 		waitForImages: true,

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -44,7 +44,7 @@ const wrapSlotInContainer = (
 	container.className = 'ad-slot-container ad-slot--offset-right';
 
 	if (options.sticky) {
-		ad.style.cssText += 'position: sticky; top: 10px;';
+		ad.style.cssText += 'position: sticky; top: 0;';
 	}
 
 	if (options.heightPx) {

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -17,7 +17,7 @@ import type {
 import { initCarrot } from './carrot-traffic-driver';
 import { addSlot } from './dfp/add-slot';
 import { trackAdRender } from './dfp/track-ad-render';
-import { computeStickyHeight } from './sticky-inlines';
+import { computeStickyHeights } from './sticky-inlines';
 
 type SlotName = Parameters<typeof createAdSlot>[0];
 
@@ -172,7 +172,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 		const stickyContainerHeights =
 			includeContainer &&
 			isInVariantSynchronous(multiStickyRightAds, 'variant')
-				? await computeStickyHeight(paras, articleBodySelector)
+				? await computeStickyHeights(paras, articleBodySelector)
 				: undefined;
 
 		const slots = paras

--- a/static/src/javascripts/projects/commercial/modules/sticky-inlines.ts
+++ b/static/src/javascripts/projects/commercial/modules/sticky-inlines.ts
@@ -34,7 +34,7 @@ const articleBottomBufferPx = 100;
  * Compute the distance between each winning paragraph and subsequent paragraph,
  * taking into account elements that extend into the right column
  */
-const computeStickyHeight = async (
+const computeStickyHeights = async (
 	winners: HTMLElement[],
 	articleBodySelector: string,
 ): Promise<number[]> => {
@@ -111,4 +111,4 @@ const computeStickyHeight = async (
 	);
 };
 
-export { computeStickyHeight };
+export { computeStickyHeights };

--- a/static/src/javascripts/projects/commercial/modules/sticky-inlines.ts
+++ b/static/src/javascripts/projects/commercial/modules/sticky-inlines.ts
@@ -1,0 +1,111 @@
+import { isUndefined } from '@guardian/libs';
+
+/**
+ * Represents an element that has some presence in the right column that we need to account for
+ */
+type RightColItem = {
+	/**
+	 * The kind of elements that extend into the right column:
+	 * - `figure`: Immersive figures (images, interactives) can extend into the right column
+	 * - `winningPara`: Paragraphs that win Spacefinder will have an ad placed in the right column
+	 */
+	kind: 'figure' | 'winningPara';
+	top: number;
+	element: HTMLElement;
+};
+
+/**
+ * The minimum buffer between two adverts (aka winning paragraphs) in the right column
+ */
+const paragraphBufferPx = 600;
+
+/**
+ * The minimum buffer between a right column advert and an immersive element
+ */
+const immersiveBufferPx = 100;
+
+/**
+ * The minimum buffer between a right column advert and the bottom of the article body
+ */
+const articleBottomBufferPx = 100;
+
+/**
+ * Compute the distance between each winning paragraph and subsequent paragraph,
+ * taking into account elements that extend into the right column
+ */
+const computeStickyHeight = (
+	winners: HTMLElement[],
+	articleBodySelector: string,
+): number[] => {
+	// Immersive figures can extend into the right column
+	// Therefore we have to take them into account when we can compute how far an ad can be sticky for
+	const immersiveFigures = [
+		...document.querySelectorAll<HTMLElement>(
+			'[data-spacefinder-role="immersive"]',
+		),
+	];
+
+	const figures: RightColItem[] = immersiveFigures.map((element) => ({
+		kind: 'figure',
+		top: element.getBoundingClientRect().top,
+		element,
+	}));
+
+	const winningParas: RightColItem[] = winners.map((element) => ({
+		kind: 'winningPara',
+		top: element.getBoundingClientRect().top,
+		element,
+	}));
+
+	return (
+		// Concat the set of figures and winning paragraphs in the article
+		[...figures, ...winningParas]
+			// Sort so they appear in order of their top coordinates
+			.sort((first, second) => first.top - second.top)
+			// Step through each one by one, measuring the height we can make the container of the ad slot
+			.map((current, index, items) => {
+				// We don't care about computing the distance *from* figures
+				// These will be filtered out in the next step
+				if (current.kind === 'figure') {
+					return undefined;
+				}
+
+				// Retrieve the next element to which we'll extend the container height
+				// This can be undefined if there is no next item
+				const next = items[index + 1] as RightColItem | undefined;
+
+				// If there is no `next` element we've reached the final element in the article body
+				// In this case we want to make the sticky distance extend until the bottom of the article body,
+				// minus a small constant buffer
+				if (next === undefined) {
+					const articleBodyElement =
+						document.querySelector<HTMLElement>(
+							articleBodySelector,
+						);
+
+					const articleBodyElementHeightBottom =
+						articleBodyElement?.getBoundingClientRect().bottom ?? 0;
+
+					return (
+						articleBodyElementHeightBottom -
+						current.top -
+						articleBottomBufferPx
+					);
+				}
+
+				// Choose height of buffer depending on the kind of element we're measuring to
+				const buffer =
+					next.kind === 'winningPara'
+						? paragraphBufferPx
+						: immersiveBufferPx;
+
+				// Compute the distance from the top of the current element to the top of the next element, minus the buffer
+				return Math.floor(next.top - current.top - buffer);
+			})
+			// Remove the figures marked as undefined
+			// In effect keeping only the heights for winning paragraphs
+			.filter((height): height is number => !isUndefined(height))
+	);
+};
+
+export { computeStickyHeight };

--- a/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
@@ -3,11 +3,13 @@ import { getUrlVars } from 'lib/url';
 import { isInABTestSynchronous } from '../experiments/ab';
 import { commercialEndOfQuarter2Test } from '../experiments/tests/commercial-end-of-quarter-2-test';
 import { commercialLazyLoadMarginReloaded } from '../experiments/tests/commercial-lazy-load-margin-reloaded';
+import { multiStickyRightAds } from '../experiments/tests/multi-sticky-right-ads';
 
 const defaultClientSideTests: ABTest[] = [
 	/* linter, please keep this array multi-line */
 	commercialEndOfQuarter2Test,
 	commercialLazyLoadMarginReloaded,
+	multiStickyRightAds,
 ];
 
 const serverSideTests: ServerSideABTest[] = [];

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -1,6 +1,7 @@
 import type { ABTest } from '@guardian/ab-core';
 import { commercialEndOfQuarter2Test } from './tests/commercial-end-of-quarter-2-test';
 import { commercialLazyLoadMarginReloaded } from './tests/commercial-lazy-load-margin-reloaded';
+import { multiStickyRightAds } from './tests/multi-sticky-right-ads';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
@@ -13,4 +14,5 @@ export const concurrentTests: readonly ABTest[] = [
 	remoteRRHeaderLinksTest,
 	commercialEndOfQuarter2Test,
 	commercialLazyLoadMarginReloaded,
+	multiStickyRightAds,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/multi-sticky-right-ads.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/multi-sticky-right-ads.ts
@@ -1,0 +1,21 @@
+import type { ABTest } from '@guardian/ab-core';
+import { noop } from '../../../../../lib/noop';
+
+export const multiStickyRightAds: ABTest = {
+	id: 'MultiStickyRightAds',
+	author: 'Chris Jones (@chrislomaxjones)',
+	start: '2022-06-9',
+	expiry: '2022-08-02',
+	audience: 0 / 100,
+	audienceOffset: 50 / 100,
+	audienceCriteria: 'All pageviews',
+	successMeasure:
+		'Sticky ads in the right column leads to an increase in revenue per 1000 pageviews with no significant impact on page health / performance',
+	description:
+		'Test the commercial and performance impact of sticky ads in the right column',
+	variants: [
+		{ id: 'control', test: noop },
+		{ id: 'variant', test: noop },
+	],
+	canRun: () => true,
+};

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -96,8 +96,11 @@
   "../projects/commercial/modules/carrot-traffic-driver.ts",
   "../projects/commercial/modules/dfp/add-slot.ts",
   "../projects/commercial/modules/dfp/track-ad-render.ts",
+  "../projects/commercial/modules/sticky-inlines.ts",
   "../projects/common/modules/article/space-filler.ts",
   "../projects/common/modules/commercial/commercial-features.ts",
+  "../projects/common/modules/experiments/ab.ts",
+  "../projects/common/modules/experiments/tests/multi-sticky-right-ads.ts",
   "../projects/common/modules/spacefinder.ts"
  ],
  "../projects/commercial/modules/carrot-traffic-driver.ts": [
@@ -508,6 +511,10 @@
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/url.ts"
  ],
+ "../projects/commercial/modules/sticky-inlines.ts": [
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../lib/fastdom-promise.js"
+ ],
  "../projects/commercial/modules/sticky-mpu.js": [
   "../lib/config.js",
   "../lib/fastdom-promise.js",
@@ -566,9 +573,11 @@
  ],
  "../projects/common/modules/analytics/shouldCaptureMetrics.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
+  "../lib/url.ts",
   "../projects/common/modules/experiments/ab.ts",
   "../projects/common/modules/experiments/tests/commercial-end-of-quarter-2-test.ts",
-  "../projects/common/modules/experiments/tests/commercial-lazy-load-margin-reloaded.ts"
+  "../projects/common/modules/experiments/tests/commercial-lazy-load-margin-reloaded.ts",
+  "../projects/common/modules/experiments/tests/multi-sticky-right-ads.ts"
  ],
  "../projects/common/modules/article/space-filler.ts": [
   "../lib/raven.js",
@@ -654,6 +663,7 @@
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
   "../projects/common/modules/experiments/tests/commercial-end-of-quarter-2-test.ts",
   "../projects/common/modules/experiments/tests/commercial-lazy-load-margin-reloaded.ts",
+  "../projects/common/modules/experiments/tests/multi-sticky-right-ads.ts",
   "../projects/common/modules/experiments/tests/remote-header-test.js",
   "../projects/common/modules/experiments/tests/sign-in-gate-main-control.js",
   "../projects/common/modules/experiments/tests/sign-in-gate-main-variant.js"
@@ -684,6 +694,10 @@
   "../lib/noop.ts"
  ],
  "../projects/common/modules/experiments/tests/commercial-lazy-load-margin-reloaded.ts": [
+  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
+  "../lib/noop.ts"
+ ],
+ "../projects/common/modules/experiments/tests/multi-sticky-right-ads.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
   "../lib/noop.ts"
  ],


### PR DESCRIPTION
## What does this change?

Add a `0%` AB test for introducing stickiness to the right-column ads inserted by Spacefinder (on desktop and above). We refer to these ads here as _inline2+_ (differentiating from the inline1 outstream ad that won't have this behaviour).

The test will work as follows:
- The control will experience the non-sticky behaviour.
- The variant will experience the sticky behaviour.
- Non-participants will experience the non-sticky behaviour.

To introduce this sticky behaviour, we use the existing container divs that wrap inline2+ ads on the page, and make the ads sticky _within_ these containers. It is then necessary to compute the height of the container such that it extends as far as possible without "bumping" into any other elements in the right column (other ads, immersive images, immersive figures). We also include additional buffers that we can use to offset things from each other when they stick in the right.

See the diagrams below for a visual explanation of how the container heights are computed (click to enlarge):

| ![image](https://user-images.githubusercontent.com/8000415/172895371-7ccdc90b-7b3f-4d00-966c-f3995788be18.png) | ![image](https://user-images.githubusercontent.com/8000415/172895464-7d37dd02-42c4-4540-a834-046f5a10a6ab.png) |
|-|-|

The algorithm to compute the heights works roughly as follows:
- Assemble an array of all of the winning Spacefinder paragraphs and all of the immersive figures in the article.
- Sort these elements by their `top` coordinates (so they're in the same order they appear on the page).
- For each winning paragraph, compute the height from the top of the current paragraph until the top of the next element in the list. This forms the height of the sticky container, minus some buffers. Treat the final paragraph in the array as a special case.

Further, we add additional `outline` styling to the containers when in the Spacefinder debug mode pass 2.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes - [DCR PR](https://github.com/guardian/dotcom-rendering/pull/5194).

## Screenshots

![](https://user-images.githubusercontent.com/8000415/173618631-087c59be-0e71-45b7-9b3b-72f59ab4b659.png)

https://user-images.githubusercontent.com/8000415/174572653-1baaa195-d588-46ed-ab39-890401f7b060.mov

## What is the value of this and can you measure success?

We'd like to run this test to see the commercial, page performance and UX impact of introduce stickiness to the ads in the right column. By running this experiment we should be able to determine whether introducing this stickiness has a commercial benefit without adversely affecting the experience of reading articles.

We initially make this a `0%` test so that we don't expose the functionality to anyone until we're ready, and so we can follow up with subsequent work.

### Tested

- [X] Locally
- [ ] On CODE (optional)

## Todo

Since this is a `0%` test, it's safe to introduce features in subsequent PRs without affecting the experience of visitors to the site. It also allows us to start testing this in production as early as possible.

- [ ] Remove sticky container heights when not on Desktop
- [ ] We could run multiple variants, each with different buffer heights?
- [ ] Increase audience size when test is ready
