### PR TITLE
Replace key event carousel switch with 0% AB test

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -503,16 +503,6 @@ trait FeatureSwitches {
     exposeClientSide = true,
   )
 
-  val KeyEventsCarousel = Switch(
-    SwitchGroup.Feature,
-    "key-events-carousel",
-    "When ON, shows the new key events timeline carousel and hides the old key events timeline",
-    owners = Seq(Owner.withEmail("dotcom.platform@guardian.co.uk")),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true,
-  )
-
   val NewsletterOnwards = Switch(
     SwitchGroup.Feature,
     "newsletter-onwards",

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -41,7 +41,7 @@ object OfferHttp3
 object KeyEventsCarousel
     extends Experiment(
       name = "key-events-carousel",
-      description = "Displays key events carousel on live blogs and hides old key events container",
+      description = "When ON, live blog key events are displayed in a carousel",
       owners = Seq(Owner.withGithub("abeddow91")),
       sellByDate = LocalDate.of(2022, 9, 13),
       participationGroup = Perc0C,

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -41,8 +41,8 @@ object OfferHttp3
 object KeyEventsCarousel
     extends Experiment(
       name = "key-events-carousel",
-      description = "Displays key events inside a carousel",
+      description = "Displays key events carousel on live blogs and hides old key events container",
       owners = Seq(Owner.withGithub("abeddow91")),
-      sellByDate = LocalDate.of(2022, 7, 13),
+      sellByDate = LocalDate.of(2022, 9, 13),
       participationGroup = Perc0C,
     )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -5,7 +5,7 @@ import experiments.ParticipationGroups._
 import java.time.LocalDate
 
 object ActiveExperiments extends ExperimentsDefinition {
-  override val allExperiments: Set[Experiment] = Set(InteractivesIdleLoading, OfferHttp3)
+  override val allExperiments: Set[Experiment] = Set(InteractivesIdleLoading, OfferHttp3, KeyEventsCarousel)
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
@@ -36,4 +36,13 @@ object OfferHttp3
       owners = Seq(Owner.withGithub("paulmr")),
       sellByDate = LocalDate.of(2022, 12, 6),
       participationGroup = Perc0B,
+    )
+
+object KeyEventsCarousel
+    extends Experiment(
+      name = "key-events-carousel",
+      description = "Displays key events inside a carousel",
+      owners = Seq(Owner.withGithub("abeddow91")),
+      sellByDate = LocalDate.of(2022, 7, 13),
+      participationGroup = Perc0C,
     )


### PR DESCRIPTION
## What does this change?
Editorial would like to test the key events carousel before it is rolled out. This PR removes the exisiting key events carousel switch and replaces it with an opt-in 0% AB test.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
