### PR TITLE
Give priority to webUrl from PressedProperties over href

### DIFF
--- a/common/app/model/SupportedUrl.scala
+++ b/common/app/model/SupportedUrl.scala
@@ -13,28 +13,16 @@ object SupportedUrl {
 
   def fromFaciaContent(fc: PressedContent): String =
     fc match {
-      case curatedContent: CuratedContent =>
-        s"/${curatedContent.properties.webUrl
-          .map(webUrl => webUrl.replaceFirst("^[a-zA-Z]+://www.theguardian.com/", ""))
-          .orElse(curatedContent.properties.href)
-          .getOrElse(fc.card.id)}"
+      case curatedContent: CuratedContent => s"/${curatedContent.properties.href.getOrElse(fc.card.id)}"
       case supportingCuratedContent: SupportingCuratedContent =>
         s"/${supportingCuratedContent.properties.webUrl
           .map(webUrl => webUrl.replaceFirst("^[a-zA-Z]+://www.theguardian.com/", ""))
           .orElse(supportingCuratedContent.properties.href)
           .getOrElse(fc.card.id)}"
-      case linkSnap: LinkSnap =>
-        linkSnap.properties.webUrl
-          .map(webUrl => webUrl.replaceFirst("^[a-zA-Z]+://www.theguardian.com/", ""))
-          .orElse(linkSnap.properties.href)
-          .getOrElse(linkSnap.card.id)
+      case linkSnap: LinkSnap => linkSnap.properties.href.getOrElse(linkSnap.card.id)
       case latestSnap: LatestSnap =>
         latestSnap.properties.maybeContent
           .map(content => s"/${content.metadata.id}")
-          .orElse(
-            latestSnap.properties.webUrl
-              .map(webUrl => webUrl.replaceFirst("^[a-zA-Z]+://www.theguardian.com/", "")),
-          )
           .orElse(latestSnap.properties.href)
           .getOrElse(s"/${latestSnap.card.id}")
     }

--- a/common/app/model/SupportedUrl.scala
+++ b/common/app/model/SupportedUrl.scala
@@ -15,7 +15,7 @@ object SupportedUrl {
     fc match {
       case curatedContent: CuratedContent =>
         s"/${curatedContent.properties.webUrl
-          .map(webUrl => webUrl.replaceFirst("^[a-zA-Z]+://www.theguardian.com/", ""))
+          .map(_.replaceFirst("^https?://www.theguardian.com/", ""))
           .orElse(curatedContent.properties.href)
           .getOrElse(fc.card.id)}"
       case supportingCuratedContent: SupportingCuratedContent =>

--- a/common/app/model/SupportedUrl.scala
+++ b/common/app/model/SupportedUrl.scala
@@ -13,13 +13,28 @@ object SupportedUrl {
 
   def fromFaciaContent(fc: PressedContent): String =
     fc match {
-      case curatedContent: CuratedContent => s"/${curatedContent.properties.href.getOrElse(fc.card.id)}"
+      case curatedContent: CuratedContent =>
+        s"/${curatedContent.properties.webUrl
+          .map(webUrl => webUrl.replaceFirst("^[a-zA-Z]+://www.theguardian.com/", ""))
+          .orElse(curatedContent.properties.href)
+          .getOrElse(fc.card.id)}"
       case supportingCuratedContent: SupportingCuratedContent =>
-        s"/${supportingCuratedContent.properties.href.getOrElse(fc.card.id)}"
-      case linkSnap: LinkSnap => linkSnap.properties.href.getOrElse(linkSnap.card.id)
+        s"/${supportingCuratedContent.properties.webUrl
+          .map(webUrl => webUrl.replaceFirst("^[a-zA-Z]+://www.theguardian.com/", ""))
+          .orElse(supportingCuratedContent.properties.href)
+          .getOrElse(fc.card.id)}"
+      case linkSnap: LinkSnap =>
+        linkSnap.properties.webUrl
+          .map(webUrl => webUrl.replaceFirst("^[a-zA-Z]+://www.theguardian.com/", ""))
+          .orElse(linkSnap.properties.href)
+          .getOrElse(linkSnap.card.id)
       case latestSnap: LatestSnap =>
         latestSnap.properties.maybeContent
           .map(content => s"/${content.metadata.id}")
+          .orElse(
+            latestSnap.properties.webUrl
+              .map(webUrl => webUrl.replaceFirst("^[a-zA-Z]+://www.theguardian.com/", "")),
+          )
           .orElse(latestSnap.properties.href)
           .getOrElse(s"/${latestSnap.card.id}")
     }

--- a/common/app/model/SupportedUrl.scala
+++ b/common/app/model/SupportedUrl.scala
@@ -13,12 +13,13 @@ object SupportedUrl {
 
   def fromFaciaContent(fc: PressedContent): String =
     fc match {
-      case curatedContent: CuratedContent => s"/${curatedContent.properties.href.getOrElse(fc.card.id)}"
-      case supportingCuratedContent: SupportingCuratedContent =>
-        s"/${supportingCuratedContent.properties.webUrl
+      case curatedContent: CuratedContent =>
+        s"/${curatedContent.properties.webUrl
           .map(webUrl => webUrl.replaceFirst("^[a-zA-Z]+://www.theguardian.com/", ""))
-          .orElse(supportingCuratedContent.properties.href)
+          .orElse(curatedContent.properties.href)
           .getOrElse(fc.card.id)}"
+      case supportingCuratedContent: SupportingCuratedContent =>
+        s"/${supportingCuratedContent.properties.href.getOrElse(fc.card.id)}"
       case linkSnap: LinkSnap => linkSnap.properties.href.getOrElse(linkSnap.card.id)
       case latestSnap: LatestSnap =>
         latestSnap.properties.maybeContent


### PR DESCRIPTION
Fixes #25092 

## What does this change?

When constructing the `SupportedUrl` from the facia content we want to use the following in this order:

1. `pressedProperties.webUrl` (added in this PR)
2. `pressedProperties.href`
3. `pressedContent.card.id`

## Why?

The Ophan team is working on "evolving URLs", a new feature which will allow staff to change the path of a piece of content through Composer. The current change addresses SEO concerns and results in fronts reflecting the new path. 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
Piece with evolved URL: changed from /jun/01 -> /jun/06 : https://www.theguardian.com/politics/2022/jun/06/who-are-the-main-contenders-to-replace-boris-johnson

![Screenshot 2022-06-13 at 11 13 57](https://user-images.githubusercontent.com/19683595/173402667-3516d137-7844-4fb8-bfef-58049a08c775.png)

### Before

Front links to: https://www.theguardian.com/politics/2022/jun/01/who-are-the-main-contenders-to-replace-boris-johnson
![Screenshot 2022-06-13 at 11 14 14](https://user-images.githubusercontent.com/19683595/173402676-e1277d97-b747-4146-a3fb-743726ceaf68.png)


### After

Front links to: https://www.theguardian.com/politics/2022/jun/06/who-are-the-main-contenders-to-replace-boris-johnson
![Screenshot 2022-06-13 at 20 55 04](https://user-images.githubusercontent.com/19683595/173434739-ba6c5024-a66f-4489-acf6-a2dcf77bab89.png)


<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
