### PR TITLE
Introduce `CommercialLazyLoadMarginReloaded` test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -34,4 +34,13 @@ trait ABTestSwitches {
     exposeClientSide = true,
   )
 
+  Switch(
+    ABTests,
+    "ab-commercial-lazy-load-margin-reloaded",
+    "Test various margins at which ads are lazily-loaded in order to find the optimal one",
+    owners = Seq(Owner.withGithub("simonbyford")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2022, 7, 11)),
+    exposeClientSide = true,
+  )
 }

--- a/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.spec.ts
@@ -85,6 +85,7 @@ describe('enableLazyLoad', () => {
 		// Mock being in variant / not in test
 		(isInVariantSynchronous as jest.Mock)
 			.mockReturnValueOnce(false)
+			.mockReturnValueOnce(false)
 			.mockReturnValueOnce(true);
 		dfpEnv.lazyLoadObserve = true;
 		enableLazyLoad(testAdvert as unknown as Advert);

--- a/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.spec.ts
@@ -55,7 +55,7 @@ describe('enableLazyLoad', () => {
 		expect(windowIntersectionObserver).toBe(undefined);
 	});
 
-	it('should create a 20% observer if lazyLoadObserve is true and not in control of test', () => {
+	it('should create a 20% observer if lazyLoadObserve is true and not in control of commercialEndOfQuarter2Test', () => {
 		// Mock being in variant / not in test
 		(isInVariantSynchronous as jest.Mock).mockReturnValue(false);
 		dfpEnv.lazyLoadObserve = true;
@@ -68,9 +68,9 @@ describe('enableLazyLoad', () => {
 		});
 	});
 
-	it('should create a 200px observer if lazyLoadObserve is true and in control of test', () => {
+	it('should create a 200px observer if lazyLoadObserve is true and in control of commercialEndOfQuarter2Test', () => {
 		// Mock being in control of test
-		(isInVariantSynchronous as jest.Mock).mockReturnValue(true);
+		(isInVariantSynchronous as jest.Mock).mockReturnValueOnce(true);
 		dfpEnv.lazyLoadObserve = true;
 		enableLazyLoad(testAdvert as unknown as Advert);
 		expect(loadAdvert).not.toHaveBeenCalled();
@@ -78,6 +78,21 @@ describe('enableLazyLoad', () => {
 			window.IntersectionObserver as jest.Mock,
 		).toHaveBeenNthCalledWith(1, expect.anything(), {
 			rootMargin: '200px 0px',
+		});
+	});
+
+	it('should create a 0% observer if lazyLoadObserve is true and not in control of commercialEndOfQuarter2Test and in variant-1 of commercialLazyLoadMarginReloaded', () => {
+		// Mock being in variant / not in test
+		(isInVariantSynchronous as jest.Mock)
+			.mockReturnValueOnce(false)
+			.mockReturnValueOnce(true);
+		dfpEnv.lazyLoadObserve = true;
+		enableLazyLoad(testAdvert as unknown as Advert);
+		expect(loadAdvert).not.toHaveBeenCalled();
+		expect(
+			window.IntersectionObserver as jest.Mock,
+		).toHaveBeenNthCalledWith(1, expect.anything(), {
+			rootMargin: '0% 0px',
 		});
 	});
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.ts
@@ -2,10 +2,24 @@ import { log } from '@guardian/libs';
 import { once } from 'lodash-es';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { commercialEndOfQuarter2Test } from 'common/modules/experiments/tests/commercial-end-of-quarter-2-test';
+import { commercialLazyLoadMarginReloaded } from 'common/modules/experiments/tests/commercial-lazy-load-margin-reloaded';
 import type { Advert } from './Advert';
 import { dfpEnv } from './dfp-env';
 import { getAdvertById } from './get-advert-by-id';
 import { loadAdvert, refreshAdvert } from './load-advert';
+
+const lazyLoadMargins = {
+	'variant-1': '0%',
+	'variant-2': '10%',
+	'variant-3': '20%',
+	'variant-4': '30%',
+	'variant-5': '40%',
+	'variant-6': '50%',
+	'variant-7': '60%',
+	'variant-8': '70%',
+} as const;
+
+type LazyLoadMarginTestVariant = keyof typeof lazyLoadMargins;
 
 const decideLazyLoadMargin = () => {
 	const enableNewLazyLoadMargin = !isInVariantSynchronous(
@@ -13,7 +27,23 @@ const decideLazyLoadMargin = () => {
 		'control',
 	);
 
-	const lazyLoadMargin = enableNewLazyLoadMargin ? '20%' : '200px';
+	const lazyLoadMarginReloadedTestVariant = Object.keys(lazyLoadMargins).find(
+		(variantName) => {
+			return isInVariantSynchronous(
+				commercialLazyLoadMarginReloaded,
+				variantName,
+			);
+		},
+	) as LazyLoadMarginTestVariant | undefined;
+
+	let lazyLoadMargin;
+
+	if (lazyLoadMarginReloadedTestVariant) {
+		lazyLoadMargin = lazyLoadMargins[lazyLoadMarginReloadedTestVariant];
+	} else {
+		lazyLoadMargin = enableNewLazyLoadMargin ? '20%' : '200px';
+	}
+
 	log('commercial', `Using lazy load margin of ${lazyLoadMargin}`);
 
 	return lazyLoadMargin;

--- a/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.ts
@@ -9,14 +9,14 @@ import { getAdvertById } from './get-advert-by-id';
 import { loadAdvert, refreshAdvert } from './load-advert';
 
 const lazyLoadMargins = {
+	control: '20%',
 	'variant-1': '0%',
 	'variant-2': '10%',
-	'variant-3': '20%',
-	'variant-4': '30%',
-	'variant-5': '40%',
-	'variant-6': '50%',
-	'variant-7': '60%',
-	'variant-8': '70%',
+	'variant-3': '30%',
+	'variant-4': '40%',
+	'variant-5': '50%',
+	'variant-6': '60%',
+	'variant-7': '70%',
 } as const;
 
 type LazyLoadMarginTestVariant = keyof typeof lazyLoadMargins;

--- a/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
@@ -1,10 +1,12 @@
 import type { ABTest } from '@guardian/ab-core';
 import { isInABTestSynchronous } from '../experiments/ab';
 import { commercialEndOfQuarter2Test } from '../experiments/tests/commercial-end-of-quarter-2-test';
+import { commercialLazyLoadMarginReloaded } from '../experiments/tests/commercial-lazy-load-margin-reloaded';
 
 const defaultClientSideTests: ABTest[] = [
 	/* linter, please keep this array multi-line */
 	commercialEndOfQuarter2Test,
+	commercialLazyLoadMarginReloaded,
 ];
 
 const serverSideTests: ServerSideABTest[] = [];

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -1,5 +1,6 @@
 import type { ABTest } from '@guardian/ab-core';
 import { commercialEndOfQuarter2Test } from './tests/commercial-end-of-quarter-2-test';
+import { commercialLazyLoadMarginReloaded } from './tests/commercial-lazy-load-margin-reloaded';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
@@ -11,4 +12,5 @@ export const concurrentTests: readonly ABTest[] = [
 	signInGateMainControl,
 	remoteRRHeaderLinksTest,
 	commercialEndOfQuarter2Test,
+	commercialLazyLoadMarginReloaded,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-lazy-load-margin-reloaded.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-lazy-load-margin-reloaded.ts
@@ -1,0 +1,57 @@
+import type { ABTest } from '@guardian/ab-core';
+import { noop } from '../../../../../lib/noop';
+
+export const commercialLazyLoadMarginReloaded: ABTest = {
+	id: 'CommercialLazyLoadMarginReloaded',
+	start: '2022-06-20',
+	expiry: '2022-07-04',
+	author: 'Simon Byford',
+	description:
+		'Once again test various margins at which ads are lazily-loaded in order to find the optimal one, this time using values between 0% and 70% of the viewport height',
+	audience: 10 / 100,
+	audienceOffset: 10 / 100,
+	successMeasure: 'Ad ratio, viewability, and CLS remain constant or improve',
+	audienceCriteria: 'n/a',
+	dataLinkNames: 'n/a',
+	idealOutcome:
+		'One of the variants shows a marked improvement in all of the metrics that we are considering',
+	canRun: () => true,
+	variants: [
+		{
+			id: 'control',
+			test: noop,
+		},
+		{
+			id: 'variant-1',
+			test: noop,
+		},
+		{
+			id: 'variant-2',
+			test: noop,
+		},
+		{
+			id: 'variant-3',
+			test: noop,
+		},
+		{
+			id: 'variant-4',
+			test: noop,
+		},
+		{
+			id: 'variant-5',
+			test: noop,
+		},
+		{
+			id: 'variant-6',
+			test: noop,
+		},
+		{
+			id: 'variant-7',
+			test: noop,
+		},
+		{
+			id: 'variant-8',
+			test: noop,
+		},
+	],
+};

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-lazy-load-margin-reloaded.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-lazy-load-margin-reloaded.ts
@@ -8,7 +8,7 @@ export const commercialLazyLoadMarginReloaded: ABTest = {
 	author: 'Simon Byford',
 	description:
 		'Once again test various margins at which ads are lazily-loaded in order to find the optimal one, this time using values between 0% and 70% of the viewport height',
-	audience: 10 / 100,
+	audience: 20 / 100,
 	audienceOffset: 10 / 100,
 	successMeasure: 'Ad ratio, viewability, and CLS remain constant or improve',
 	audienceCriteria: 'n/a',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-lazy-load-margin-reloaded.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-lazy-load-margin-reloaded.ts
@@ -18,10 +18,6 @@ export const commercialLazyLoadMarginReloaded: ABTest = {
 	canRun: () => true,
 	variants: [
 		{
-			id: 'control',
-			test: noop,
-		},
-		{
 			id: 'variant-1',
 			test: noop,
 		},

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-lazy-load-margin-reloaded.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-lazy-load-margin-reloaded.ts
@@ -18,6 +18,10 @@ export const commercialLazyLoadMarginReloaded: ABTest = {
 	canRun: () => true,
 	variants: [
 		{
+			id: 'control',
+			test: noop,
+		},
+		{
 			id: 'variant-1',
 			test: noop,
 		},
@@ -43,10 +47,6 @@ export const commercialLazyLoadMarginReloaded: ABTest = {
 		},
 		{
 			id: 'variant-7',
-			test: noop,
-		},
-		{
-			id: 'variant-8',
 			test: noop,
 		},
 	],

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -569,7 +569,8 @@
  "../projects/common/modules/analytics/shouldCaptureMetrics.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
   "../projects/common/modules/experiments/ab.ts",
-  "../projects/common/modules/experiments/tests/commercial-end-of-quarter-2-test.ts"
+  "../projects/common/modules/experiments/tests/commercial-end-of-quarter-2-test.ts",
+  "../projects/common/modules/experiments/tests/commercial-lazy-load-margin-reloaded.ts"
  ],
  "../projects/common/modules/article/space-filler.ts": [
   "../lib/raven.js",

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -203,7 +203,8 @@
   "../projects/commercial/modules/dfp/get-advert-by-id.ts",
   "../projects/commercial/modules/dfp/load-advert.ts",
   "../projects/common/modules/experiments/ab.ts",
-  "../projects/common/modules/experiments/tests/commercial-end-of-quarter-2-test.ts"
+  "../projects/common/modules/experiments/tests/commercial-end-of-quarter-2-test.ts",
+  "../projects/common/modules/experiments/tests/commercial-lazy-load-margin-reloaded.ts"
  ],
  "../projects/commercial/modules/dfp/load-advert.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
@@ -653,6 +654,7 @@
  "../projects/common/modules/experiments/ab-tests.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
   "../projects/common/modules/experiments/tests/commercial-end-of-quarter-2-test.ts",
+  "../projects/common/modules/experiments/tests/commercial-lazy-load-margin-reloaded.ts",
   "../projects/common/modules/experiments/tests/remote-header-test.js",
   "../projects/common/modules/experiments/tests/sign-in-gate-main-control.js",
   "../projects/common/modules/experiments/tests/sign-in-gate-main-variant.js"
@@ -679,6 +681,10 @@
  ],
  "../projects/common/modules/experiments/automatLog.ts": [],
  "../projects/common/modules/experiments/tests/commercial-end-of-quarter-2-test.ts": [
+  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
+  "../lib/noop.ts"
+ ],
+ "../projects/common/modules/experiments/tests/commercial-lazy-load-margin-reloaded.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
   "../lib/noop.ts"
  ],


### PR DESCRIPTION
## What does this change?

Following on from the success of the previous experiment `CommercialLazyLoadMargin` ([PR](https://github.com/guardian/frontend/pull/24839)) we are introducing a new experiment with different margins. These are:

| Variant   | Margin |
|-----------|--------|
| `control` | 20% of the viewport height    |
| `variant-1` | 0% of the viewport height     |
| `variant-2` | 10% of the viewport height    |
| `variant-3` | 30% of the viewport height    |
| `variant-4` | 40% of the viewport height    |
| `variant-5` | 50% of the viewport height    |
| `variant-6` | 60% of the viewport height    |
| `variant-7` | 70% of the viewport height    |

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes [(please indicate your plans for DCR Implementation)](https://github.com/guardian/dotcom-rendering/pull/5185)

## Screenshots

![173536495-3bb0058e-501d-4ed3-b9be-7493c89cea19](https://user-images.githubusercontent.com/7423751/173537001-ec3e5a99-700c-49d8-b46b-b543c4b15195.png)

## What is the value of this and can you measure success?

### Tested

- [x] Locally
- [x] On CODE (optional)