### PR TITLE
move top mention model to the common module

### DIFF
--- a/article/app/topmentions/TopMentionsS3Client.scala
+++ b/article/app/topmentions/TopMentionsS3Client.scala
@@ -5,10 +5,11 @@ import com.amazonaws.services.s3.model.{GetObjectRequest, S3Object}
 import com.amazonaws.util.IOUtils
 import common.GuLogging
 import conf.Configuration
+import model.{TopMentionJsonParseException, TopMentionsDetails}
 import play.api.libs.json.{JsError, JsSuccess, Json}
 import services.S3
 import topmentions.S3ObjectImplicits.RichS3Object
-import topmentions.TopMentionsResponse._
+import model.TopMentionsResponse._
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Future

--- a/article/app/topmentions/TopMentionsService.scala
+++ b/article/app/topmentions/TopMentionsService.scala
@@ -1,6 +1,7 @@
 package topmentions
 
 import common.{Box, GuLogging}
+import model.TopMentionsDetails
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/article/test/topmentions/TopMentionsServiceTest.scala
+++ b/article/test/topmentions/TopMentionsServiceTest.scala
@@ -2,6 +2,7 @@ package topmentions
 
 import com.gu.contentapi.client.model.ContentApiError
 import com.gu.contentapi.client.model.v1.ItemResponse
+import model.{TopMentionEntity, TopMentionsDetails, TopMentionsResult}
 import org.scalatest.{BeforeAndAfterAll, GivenWhenThen}
 import org.scalatest.featurespec.AnyFeatureSpec
 import org.scalatest.flatspec.AnyFlatSpec
@@ -9,9 +10,9 @@ import org.scalatest.matchers.should.Matchers
 import test.{ConfiguredTestSuite, WithTestExecutionContext}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
+
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
-
 import scala.concurrent.{Await, Future}
 
 class TopMentionsServiceTest

--- a/common/app/model/TopMentionsModel.scala
+++ b/common/app/model/TopMentionsModel.scala
@@ -1,7 +1,7 @@
-package topmentions
+package model
 
+import model.TopMentionEntity.TopMentionEntity
 import play.api.libs.json.{Format, Json}
-import topmentions.TopMentionEntity.TopMentionEntity
 
 case class TopMentionsResult(
     name: String,


### PR DESCRIPTION
## What does this change?
This PR only moves the TopMentionsModel to the common/model package because we realized that for future PRs we would need to access this model from within common module. e.g. in `DotcomRenderingDataModel`

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
