### PR TITLE
fix(a11y): make tab order logical on podcasts

### DIFF
--- a/applications/app/views/fragments/audioBody.scala.html
+++ b/applications/app/views/fragments/audioBody.scala.html
@@ -59,25 +59,6 @@
                 </div>
             }
 
-            @if(audio.fields.standfirst.isDefined) {
-                <div class="podcast__standfirst">
-                    @fragments.standfirst(audio)
-                </div>
-            }
-
-            <div class="podcast__byline">
-                @fragments.contentMeta(audio, page, false)
-            </div>
-
-            <div class="from-content-api podcast__body">
-                @if(audio.fields.body.nonEmpty) {
-                    @Html(audio.fields.body)
-                }
-                @audio.elements.images.map{ img =>
-                    @fragments.imageFigure(img.images)
-                }
-            </div>
-
             <div class="podcast__meta podcast__section">
                 <div class="podcast__meta-heading podcast__section-heading">More ways to listen</div>
                 <ul class="podcast__meta-items">
@@ -137,6 +118,26 @@
                         </li>
                     }
                 </ul>
+            </div>
+
+            <div class="podcast__byline">
+                @fragments.contentMeta(audio, page, false)
+            </div>
+
+            @if(audio.fields.standfirst.isDefined) {
+                <div class="podcast__standfirst">
+                    @fragments.standfirst(audio)
+                </div>
+            }
+
+
+            <div class="from-content-api podcast__body">
+                @if(audio.fields.body.nonEmpty) {
+                    @Html(audio.fields.body)
+                }
+                @audio.elements.images.map{ img =>
+                    @fragments.imageFigure(img.images)
+                }
             </div>
 
             <div class="podcast__secondary podcast__section">


### PR DESCRIPTION
## What does this change?

Reorder DOM nodes so that tab order matches visual order.

Fixes https://github.com/guardian/dotcom-rendering/issues/4463

Co-authored-by: Ashleigh Carr <ashcorr20@gmail.com>
Co-authored-by: Oliver Lloyd <oliverlloyd@users.noreply.github.com>

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/173557562-9721c872-1b58-41ea-8ac0-1059cdef0552.png
[after]: https://user-images.githubusercontent.com/76776/173557509-90eb12cf-a04d-4d13-86c2-766c0f12d81f.png

## What is the value of this and can you measure success?

Keyboard users tend to find inconsistencies between tab order and visual order disorientating and frustrating.

## Tested

- [ ] Locally
- [X] In CODE