### PR TITLE
Fix accessibility for expanding image in galleries

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -86,21 +86,26 @@
             @defining(
                 if(image.width >= image.height) {"--landscape"} else {"--portrait"}
             ) { orientation =>
-                <a class="gallery__img-container gallery__img-container@orientation js-gallerythumbs"
+                <div class="gallery__img-container gallery__img-container@orientation"
                     @*
                      * This ensures that the image height never goes above 96vh
                      *@
-                    style="max-width: calc(@image.ratioDouble * 96vh)"
-                    href="@LinkTo{@page.item.metadata.url#img-@rowInfo.rowNum}"
-                    data-link-name="Launch Gallery Lightbox" data-is-ajax>
+                    style="max-width: calc(@image.ratioDouble * 96vh)">
                     @fragments.image(
                         imageElement.images,
                         Seq("gallery__img", s"gallery__img$orientation"),
                         GalleryMedia.inline,
                         image.altText.getOrElse("")
                     )
-                    @fragments.inlineSvg("expand-image", "icon", List("centered-icon", "rounded-icon", "gallery__fullscreen", "modern-visible", "hide-until-tablet"))
-                </a>
+                    <a href="@LinkTo{@page.item.metadata.url#img-@rowInfo.rowNum}"
+                        class="js-gallerythumbs gallery__fullscreen-container"
+                        tabindex="0"
+                        data-link-name="Launch Gallery Lightbox" data-is-ajax
+                        aria-label="Expand image to fullscreen"
+                    >
+                        @fragments.inlineSvg("expand-image", "icon", List("centered-icon", "rounded-icon", "gallery__fullscreen", "modern-visible"))
+                    </a>
+                </div>
             }
         </figure>
     </li>

--- a/static/src/stylesheets/module/content-garnett/_gallery.scss
+++ b/static/src/stylesheets/module/content-garnett/_gallery.scss
@@ -237,15 +237,20 @@
     }
 }
 
-.article__fullscreen,
-.gallery__fullscreen {
+.gallery__fullscreen-container {
     top: 0;
     right: 0;
     width: 44px;
     height: 44px;
-    background-color: rgba(51, 51, 51, .6);
     margin: $gs-gutter/2;
     position: absolute;
+}
+
+.article__fullscreen,
+.gallery__fullscreen {
+    background-color: rgba(51, 51, 51, .6);
+    width: 44px;
+    height: 44px;
 
     .element--thumbnail & {
         width: 33px;
@@ -264,19 +269,6 @@
     }
     @if $old-ie {
         display: none;
-    }
-}
-
-@include mq(desktop) {
-    .article__fullscreen,
-    .gallery__fullscreen {
-        opacity: 0;
-        transition: opacity .15s ease-out;
-    }
-
-    .article__img-container:hover .article__fullscreen,
-    .gallery__img-container:hover .gallery__fullscreen {
-        opacity: 1;
     }
 }
 


### PR DESCRIPTION
Part of https://github.com/guardian/dotcom-rendering/issues/4460

- Always visible so it's clear to all users that images can be expanded
- Link only on the icon & not the whole image
- Added a label so its clear what the link does

Co-Authored-By: James Gorrie <jamesgorrie@users.noreply.github.com>
Co-Authored-By: Ioanna Kokkini <ioannakok@users.noreply.github.com>

## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

|  | Before      | After      |
|------------|-------------|------------|
| Default | ![before][] | ![after][] |
| Active Link | ![before1][] | ![after1][] |
| Voice Control | ![before2][] | ![after2][] |

[before]: https://user-images.githubusercontent.com/9575458/173559724-4e197429-63b6-49ef-82ef-06afae276bce.png
[after]: https://user-images.githubusercontent.com/9575458/173559641-f9464039-caaa-4782-863c-7ae7e73a9306.png

[before1]: https://user-images.githubusercontent.com/9575458/173560270-339e13f7-ecf5-4dff-8fd6-b5afe8c8b373.png
[after1]: https://user-images.githubusercontent.com/9575458/173560111-6058af1d-b81f-4d44-ab96-46c6762fc5e5.png

[before2]: https://user-images.githubusercontent.com/9575458/173561474-274c624c-4b22-4d59-9715-f61098156ef6.jpg
[after2]: https://user-images.githubusercontent.com/9575458/173561450-a3cdf7ac-c342-4395-9dca-b774e4fb60cc.jpg

## Checklist

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
