### PR TITLE
Fix ad slots not removed for fronts on mobile and mostpop

### DIFF
--- a/static/src/javascripts/bootstraps/standalone.commercial.ts
+++ b/static/src/javascripts/bootstraps/standalone.commercial.ts
@@ -3,6 +3,7 @@ import { log } from '@guardian/libs';
 import reportError from '../lib/report-error';
 import { catchErrorsWithContext } from '../lib/robust';
 import { initAdblockAsk } from '../projects/commercial/adblock-ask';
+import { adFreeSlotRemove } from '../projects/commercial/modules/ad-free-slot-remove';
 import { init as prepareAdVerification } from '../projects/commercial/modules/ad-verification/prepare-ad-verification';
 import { init as initArticleAsideAdverts } from '../projects/commercial/modules/article-aside-adverts';
 import { init as initArticleBodyAdverts } from '../projects/commercial/modules/article-body-adverts';
@@ -46,6 +47,7 @@ const commercialBaseModules: Modules = [];
 
 // remaining modules not necessary to load an ad
 const commercialExtraModules: Modules = [
+	['cm-adFreeSlotRemoveFronts', adFreeSlotRemove],
 	['cm-manageAdFreeCookieOnConsentChange', manageAdFreeCookieOnConsentChange],
 	['cm-closeDisabledSlots', closeDisabledSlots],
 	['cm-comscore', initComscore],

--- a/static/src/javascripts/projects/commercial/modules/ad-free-slot-remove.ts
+++ b/static/src/javascripts/projects/commercial/modules/ad-free-slot-remove.ts
@@ -1,0 +1,17 @@
+import { once } from 'lodash-es';
+import { commercialFeatures } from '../../common/modules/commercial/commercial-features';
+import { removeSlots } from './remove-slots';
+
+/**
+ * If the user is ad-free, remove all ad slots on the page,
+ * as the ad slots are still left on the page on fronts, and mostpop on articles
+ */
+const adFreeSlotRemove = once(() => {
+	if (!commercialFeatures.adFree) {
+		return Promise.resolve();
+	}
+
+	return removeSlots();
+});
+
+export { adFreeSlotRemove };

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -67,6 +67,11 @@
   "../projects/common/modules/analytics/shouldCaptureMetrics.ts"
  ],
  "../projects/commercial/modules/__vendor/ipsos-mori.js": [],
+ "../projects/commercial/modules/ad-free-slot-remove.ts": [
+  "../../../../node_modules/@types/lodash-es/index.d.ts",
+  "../projects/commercial/modules/remove-slots.ts",
+  "../projects/common/modules/commercial/commercial-features.ts"
+ ],
  "../projects/commercial/modules/ad-verification/prepare-ad-verification.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
@@ -718,6 +723,7 @@
   "../lib/robust.js",
   "../projects/commercial/adblock-ask.ts",
   "../projects/commercial/commercial-metrics.ts",
+  "../projects/commercial/modules/ad-free-slot-remove.ts",
   "../projects/commercial/modules/ad-verification/prepare-ad-verification.ts",
   "../projects/commercial/modules/article-aside-adverts.ts",
   "../projects/commercial/modules/article-body-adverts.ts",


### PR DESCRIPTION
## What does this change?
We had removed/repurposed a seemingly redundant file as part of #25091, however there were some cases where it was still needed.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
