### PR TITLE
Add topMentionsFilters to DCR model

### DIFF
--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -22,7 +22,6 @@ import renderers.DotcomRenderingService
 import services.CAPILookup
 import services.dotcomponents.DotcomponentsLogger
 import views.support.RenderOtherStatus
-
 import scala.concurrent.Future
 
 case class MinutePage(article: Article, related: RelatedContent) extends PageWithStoryPackage
@@ -81,7 +80,6 @@ class LiveBlogController(
     Action.async { implicit request: Request[AnyContent] =>
       val filter = shouldFilter(filterKeyEvents)
       val range = getRange(lastUpdate, page)
-
       mapModel(path, range, filter) {
         case (blog: LiveBlogPage, _) if rendered.contains(false) => getJsonForFronts(blog)
         case (blog: LiveBlogPage, blocks) if request.forceDCR && lastUpdate.isEmpty =>
@@ -275,7 +273,14 @@ class LiveBlogController(
   )(implicit request: RequestHeader): Result = {
     val pageType: PageType = PageType(blog, request, context)
     val model =
-      DotcomRenderingDataModel.forLiveblog(blog, blocks, request, pageType, filterKeyEvents, request.forceLive)
+      DotcomRenderingDataModel.forLiveblog(
+        blog,
+        blocks,
+        request,
+        pageType,
+        filterKeyEvents,
+        request.forceLive,
+      )
     val json = DotcomRenderingDataModel.toJson(model)
     common.renderJson(json, blog).as("application/json")
   }

--- a/article/app/topmentions/TopMentionsService.scala
+++ b/article/app/topmentions/TopMentionsService.scala
@@ -1,7 +1,7 @@
 package topmentions
 
 import common.{Box, GuLogging}
-import model.{TopMention, TopMentionsDetails}
+import model.{TopMentionFilters, TopMentionsDetails}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -25,13 +25,13 @@ class TopMentionsService(topMentionsS3Client: TopMentionsS3Client) extends GuLog
     topMentions.get().flatMap(_.get(blogId))
   }
 
-  def getTopMentionList(blogId: String): Option[Seq[TopMention]] = {
+  def getTopMentionFilters(blogId: String): Option[Seq[TopMentionFilters]] = {
     getTopMention(blogId).map(mentions =>
-      mentions.results.map(mention => TopMention(mention.name, mention.`type`, mention.count)),
+      mentions.results.map(mention => TopMentionFilters(mention.name, mention.`type`, mention.count)),
     )
   }
 
-  def getAllTopMentions(): Option[Map[String, TopMentionsDetails]] = {
+  def getAllTopMentions: Option[Map[String, TopMentionsDetails]] = {
     topMentions.get()
   }
 

--- a/article/app/topmentions/TopMentionsService.scala
+++ b/article/app/topmentions/TopMentionsService.scala
@@ -1,7 +1,7 @@
 package topmentions
 
 import common.{Box, GuLogging}
-import model.TopMentionsDetails
+import model.{TopMention, TopMentionsDetails}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -23,6 +23,11 @@ class TopMentionsService(topMentionsS3Client: TopMentionsS3Client) extends GuLog
 
   def getTopMention(blogId: String): Option[TopMentionsDetails] = {
     topMentions.get().flatMap(_.get(blogId))
+  }
+
+  def getTopMentionList(blogId: String): Option[Seq[TopMention]] = {
+    val topMention = getTopMention(blogId)
+    topMention.map(x => x.results.map(x => TopMention(x.name, x.`type`, x.count)))
   }
 
   def getAllTopMentions(): Option[Map[String, TopMentionsDetails]] = {

--- a/article/app/topmentions/TopMentionsService.scala
+++ b/article/app/topmentions/TopMentionsService.scala
@@ -26,8 +26,9 @@ class TopMentionsService(topMentionsS3Client: TopMentionsS3Client) extends GuLog
   }
 
   def getTopMentionList(blogId: String): Option[Seq[TopMention]] = {
-    val topMention = getTopMention(blogId)
-    topMention.map(x => x.results.map(x => TopMention(x.name, x.`type`, x.count)))
+    getTopMention(blogId).map(mentions =>
+      mentions.results.map(mention => TopMention(mention.name, mention.`type`, mention.count)),
+    )
   }
 
   def getAllTopMentions(): Option[Map[String, TopMentionsDetails]] = {

--- a/common/app/model/TopMentionsModel.scala
+++ b/common/app/model/TopMentionsModel.scala
@@ -9,6 +9,10 @@ case class TopMention(
     count: Int,
 )
 
+object TopMention {
+  implicit val TopMentionJf: Format[TopMention] = Json.format[TopMention]
+}
+
 case class TopMentionsResult(
     name: String,
     `type`: TopMentionEntity,

--- a/common/app/model/TopMentionsModel.scala
+++ b/common/app/model/TopMentionsModel.scala
@@ -3,14 +3,14 @@ package model
 import model.TopMentionEntity.TopMentionEntity
 import play.api.libs.json.{Format, Json}
 
-case class TopMention(
+case class TopMentionFilters(
     name: String,
     `type`: TopMentionEntity,
     count: Int,
 )
 
-object TopMention {
-  implicit val TopMentionJf: Format[TopMention] = Json.format[TopMention]
+object TopMentionFilters {
+  implicit val TopMentionJf: Format[TopMentionFilters] = Json.format[TopMentionFilters]
 }
 
 case class TopMentionsResult(

--- a/common/app/model/TopMentionsModel.scala
+++ b/common/app/model/TopMentionsModel.scala
@@ -3,6 +3,12 @@ package model
 import model.TopMentionEntity.TopMentionEntity
 import play.api.libs.json.{Format, Json}
 
+case class TopMention(
+    name: String,
+    `type`: TopMentionEntity,
+    count: Int,
+)
+
 case class TopMentionsResult(
     name: String,
     `type`: TopMentionEntity,

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -20,7 +20,7 @@ import model.{
   InteractivePage,
   LiveBlogPage,
   PageWithStoryPackage,
-  TopMention,
+  TopMentionFilters,
 }
 import navigation._
 import play.api.libs.json._
@@ -38,7 +38,7 @@ case class DotcomRenderingDataModel(
     mainMediaElements: List[PageElement],
     main: String,
     filterKeyEvents: Boolean,
-    topMentions: Option[Seq[TopMention]],
+    topMentionFilters: Option[Seq[TopMentionFilters]],
     pinnedPost: Option[Block],
     keyEvents: List[Block],
     mostRecentBlockId: Option[String],
@@ -107,7 +107,7 @@ object DotcomRenderingDataModel {
         "mainMediaElements" -> model.mainMediaElements,
         "main" -> model.main,
         "filterKeyEvents" -> model.filterKeyEvents,
-        "topMentions" -> model.topMentions,
+        "topMentionFilters" -> model.topMentionFilters,
         "pinnedPost" -> model.pinnedPost,
         "keyEvents" -> model.keyEvents,
         "mostRecentBlockId" -> model.mostRecentBlockId,
@@ -192,7 +192,7 @@ object DotcomRenderingDataModel {
       hasStoryPackage = page.related.hasStoryPackage,
       pinnedPost = None,
       keyEvents = Nil,
-      topMentions = None,
+      topMentionFilters = None,
     )
   }
 
@@ -219,7 +219,7 @@ object DotcomRenderingDataModel {
       hasStoryPackage = page.related.hasStoryPackage,
       pinnedPost = None,
       keyEvents = Nil,
-      topMentions = None,
+      topMentionFilters = None,
     )
   }
 
@@ -242,7 +242,7 @@ object DotcomRenderingDataModel {
       pageType: PageType,
       filterKeyEvents: Boolean,
       forceLive: Boolean,
-      topMentions: Option[Seq[TopMention]] = None,
+      topMentions: Option[Seq[TopMentionFilters]] = None,
   ): DotcomRenderingDataModel = {
     val pagination = page.currentPage.pagination.map(paginationInfo => {
       Pagination(
@@ -312,7 +312,7 @@ object DotcomRenderingDataModel {
       pinnedPost: Option[APIBlock],
       keyEvents: Seq[APIBlock],
       filterKeyEvents: Boolean = false,
-      topMentions: Option[Seq[TopMention]],
+      topMentionFilters: Option[Seq[TopMentionFilters]],
       mostRecentBlockId: Option[String] = None,
       forceLive: Boolean = false,
   ): DotcomRenderingDataModel = {
@@ -441,7 +441,7 @@ object DotcomRenderingDataModel {
       isLegacyInteractive = isLegacyInteractive,
       isSpecialReport = isSpecialReport(page),
       filterKeyEvents = filterKeyEvents,
-      topMentions = topMentions,
+      topMentionFilters = topMentionFilters,
       pinnedPost = pinnedPostDCR,
       keyEvents = keyEventsDCR.toList,
       mostRecentBlockId = mostRecentBlockId,

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -20,12 +20,12 @@ import model.{
   InteractivePage,
   LiveBlogPage,
   PageWithStoryPackage,
+  TopMention,
 }
 import navigation._
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
 import views.support.{CamelCase, ContentLayout, JavaScriptPage}
-
 // -----------------------------------------------------------------
 // DCR DataModel
 // -----------------------------------------------------------------
@@ -38,6 +38,7 @@ case class DotcomRenderingDataModel(
     mainMediaElements: List[PageElement],
     main: String,
     filterKeyEvents: Boolean,
+    topMentions: Option[Seq[TopMention]],
     pinnedPost: Option[Block],
     keyEvents: List[Block],
     mostRecentBlockId: Option[String],
@@ -106,6 +107,7 @@ object DotcomRenderingDataModel {
         "mainMediaElements" -> model.mainMediaElements,
         "main" -> model.main,
         "filterKeyEvents" -> model.filterKeyEvents,
+        "topMentions" -> model.topMentions,
         "pinnedPost" -> model.pinnedPost,
         "keyEvents" -> model.keyEvents,
         "mostRecentBlockId" -> model.mostRecentBlockId,
@@ -190,6 +192,7 @@ object DotcomRenderingDataModel {
       hasStoryPackage = page.related.hasStoryPackage,
       pinnedPost = None,
       keyEvents = Nil,
+      topMentions = None,
     )
   }
 
@@ -216,6 +219,7 @@ object DotcomRenderingDataModel {
       hasStoryPackage = page.related.hasStoryPackage,
       pinnedPost = None,
       keyEvents = Nil,
+      topMentions = None,
     )
   }
 
@@ -238,6 +242,7 @@ object DotcomRenderingDataModel {
       pageType: PageType,
       filterKeyEvents: Boolean,
       forceLive: Boolean,
+      topMentions: Option[Seq[TopMention]] = None,
   ): DotcomRenderingDataModel = {
     val pagination = page.currentPage.pagination.map(paginationInfo => {
       Pagination(
@@ -289,6 +294,7 @@ object DotcomRenderingDataModel {
       pinnedPost,
       timelineBlocks,
       filterKeyEvents,
+      topMentions,
       mostRecentBlockId,
       forceLive,
     )
@@ -306,6 +312,7 @@ object DotcomRenderingDataModel {
       pinnedPost: Option[APIBlock],
       keyEvents: Seq[APIBlock],
       filterKeyEvents: Boolean = false,
+      topMentions: Option[Seq[TopMention]],
       mostRecentBlockId: Option[String] = None,
       forceLive: Boolean = false,
   ): DotcomRenderingDataModel = {
@@ -434,6 +441,7 @@ object DotcomRenderingDataModel {
       isLegacyInteractive = isLegacyInteractive,
       isSpecialReport = isSpecialReport(page),
       filterKeyEvents = filterKeyEvents,
+      topMentions = topMentions,
       pinnedPost = pinnedPostDCR,
       keyEvents = keyEventsDCR.toList,
       mostRecentBlockId = mostRecentBlockId,

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -136,7 +136,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
 
     val dataModel = page match {
       case liveblog: LiveBlogPage =>
-        DotcomRenderingDataModel.forLiveblog(liveblog, blocks, request, pageType, filterKeyEvents, forceLive, None)
+        DotcomRenderingDataModel.forLiveblog(liveblog, blocks, request, pageType, filterKeyEvents, forceLive)
       case _ => DotcomRenderingDataModel.forArticle(page, blocks, request, pageType)
     }
 

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -12,11 +12,9 @@ import model.dotcomrendering.{
   DotcomBlocksRenderingDataModel,
   DotcomFrontsRenderingDataModel,
   DotcomRenderingDataModel,
-  DotcomRenderingUtils,
   PageType,
 }
-import model.{CacheTime, Cached, InteractivePage, LiveBlogPage, NoCache, Page, PageWithStoryPackage, PressedPage}
-import play.api.libs.json.Json
+import model.{CacheTime, Cached, InteractivePage, LiveBlogPage, NoCache, PageWithStoryPackage, PressedPage}
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc.Results.{InternalServerError, NotFound}
 import play.api.mvc.{RequestHeader, Result}
@@ -138,7 +136,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
 
     val dataModel = page match {
       case liveblog: LiveBlogPage =>
-        DotcomRenderingDataModel.forLiveblog(liveblog, blocks, request, pageType, filterKeyEvents, forceLive)
+        DotcomRenderingDataModel.forLiveblog(liveblog, blocks, request, pageType, filterKeyEvents, forceLive, None)
       case _ => DotcomRenderingDataModel.forArticle(page, blocks, request, pageType)
     }
 


### PR DESCRIPTION
## What does this change?
Adds an optional topMentionFilters property to the dotcom-rendering model so we create top mention filter buttons on DCR. This PR also adds and method in the top mentions service to map over mentions and create the filter list. 

In order to release this iteratively, and as this is an optional property, this has been implemented as None in this PR. Implementation details will be built out in a seperate PR.

This branch will also require a DCR counterpart PR that receives this new property on DCR.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation) 

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
