### PR TITLE
Adds focus trap to lightbox.js

### DIFF
--- a/static/src/javascripts/projects/common/modules/gallery/lightbox.js
+++ b/static/src/javascripts/projects/common/modules/gallery/lightbox.js
@@ -56,7 +56,7 @@ class GalleryLightbox {
             });
         };
 
-        const galleryLightboxHtml = `<dialog class="overlay gallery-lightbox gallery-lightbox--hover">
+        const galleryLightboxHtml = `<dialog class="overlay gallery-lightbox gallery-lightbox--closed gallery-lightbox--hover">
                 <div class="gallery-lightbox__sidebar">
                     ${generateButtonHTML('close')}
                     <div class="gallery-lightbox__progress  gallery-lightbox__progress--sidebar">

--- a/static/src/javascripts/projects/common/modules/gallery/lightbox.js
+++ b/static/src/javascripts/projects/common/modules/gallery/lightbox.js
@@ -357,9 +357,12 @@ class GalleryLightbox {
     }
 
     show() {
-        // `showModal` ensures that we focus trap the user within the `dialogue` container
-        // visually show/hide functionality is still controlled via css and classnames
-        // in the `this.hide` method, we close the modal
+        /**
+         * Using `showModal` ensures that we trap focus inside the modal `dialogue`
+         * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/showModal}
+         *
+         * Visually, show/hide functionality is still controlled via css and classnames in the `this.hide` method
+         */
         this.$lightboxEl.get(0).showModal();
 
         const $body = bonzo(document.body);

--- a/static/src/javascripts/projects/common/modules/gallery/lightbox.js
+++ b/static/src/javascripts/projects/common/modules/gallery/lightbox.js
@@ -56,7 +56,7 @@ class GalleryLightbox {
             });
         };
 
-        const galleryLightboxHtml = `<div class="overlay gallery-lightbox gallery-lightbox--closed gallery-lightbox--hover">
+        const galleryLightboxHtml = `<dialog class="overlay gallery-lightbox gallery-lightbox--hover">
                 <div class="gallery-lightbox__sidebar">
                     ${generateButtonHTML('close')}
                     <div class="gallery-lightbox__progress  gallery-lightbox__progress--sidebar">
@@ -71,7 +71,7 @@ class GalleryLightbox {
                 <div class="js-gallery-swipe gallery-lightbox__swipe-container">
                     <ul class="gallery-lightbox__content js-gallery-content"></ul>
                 </div>
-            </div>`;
+            </dialog>`;
 
         // ELEMENT BINDINGS
         this.lightboxEl = bonzo.create(galleryLightboxHtml);
@@ -357,6 +357,11 @@ class GalleryLightbox {
     }
 
     show() {
+        // `showModal` ensures that we focus trap the user within the `dialogue` container
+        // visually show/hide functionality is still controlled via css and classnames
+        // in the `this.hide` method, we close the modal
+        this.$lightboxEl.get(0).showModal();
+
         const $body = bonzo(document.body);
         this.bodyScrollPosition = $body.scrollTop();
         $body.addClass('has-overlay');
@@ -385,6 +390,7 @@ class GalleryLightbox {
                 $body.scrollTop(this.bodyScrollPosition);
             }
             this.$lightboxEl.removeClass('gallery-lightbox--open');
+            this.$lightboxEl.get(0).close();
             mediator.emit('ui:images:vh');
         }, 1);
     }

--- a/static/src/javascripts/projects/common/views/content/block-sharing.html
+++ b/static/src/javascripts/projects/common/views/content/block-sharing.html
@@ -12,3 +12,4 @@
             <%=shareButtons%>
         </div>
 </li>
+=

--- a/static/src/javascripts/projects/common/views/content/block-sharing.html
+++ b/static/src/javascripts/projects/common/views/content/block-sharing.html
@@ -12,4 +12,3 @@
             <%=shareButtons%>
         </div>
 </li>
-=

--- a/static/src/javascripts/projects/common/views/content/share-button.html
+++ b/static/src/javascripts/projects/common/views/content/share-button.html
@@ -1,4 +1,4 @@
-<a class="rounded-icon block-share__item block-share__item--<%=css%> js-blockshare-link" href="<%=url%>" target="_blank" data-link-name="social <%=css%>">
+<a class="rounded-icon block-share__item block-share__item--<%=css%> js-blockshare-link" href="<%=url%>" target="_blank" data-link-name="social <%=css%>" tabindex="-1">
     <span class="u-h"><%=text%></span>
     <%= icon %>
 </a>


### PR DESCRIPTION
## What does this change?

- changes container for lightbox from `div` => `dialog` to get all the nice focus trap functionality from that. A nice thing we learnt was you can use `showModal` or `show`. `showModal` set the focus trap, `show` doesn't.
- We've set the `tabindex` on the share buttons to `-1` as _all_ the images are included in the DOM of the `dialog`, along with their share buttons, see the video for details. This might not be a long term solution, but it works until we revisit this.

## being able to tab into slides without loaded images
https://user-images.githubusercontent.com/31692/173605588-7ae98d64-5a18-4860-a33d-d1fb1604b60c.mov

## being focus trapped 
https://user-images.githubusercontent.com/31692/173605658-bf0a4387-8a92-49db-9baa-7440a09f99ae.mov

## Alternatives we tried
- We tried setting non-selected slides to hidden, this doesn't work as we need to support swiping. The currently implementation requires that the DOM is not hidden.
- Use the [`inert`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert) attribute on the non-selected slides, which worked, but decided against it due to [lack of device support](https://caniuse.com/mdn-api_htmlelement_inert).

Closes https://github.com/guardian/dotcom-rendering/issues/4460