### PR TITLE
fix: gallery expand not showing on mobile

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -103,7 +103,7 @@
                         data-link-name="Launch Gallery Lightbox" data-is-ajax
                         aria-label="Expand image to fullscreen"
                     >
-                        @fragments.inlineSvg("expand-image", "icon", List("centered-icon", "rounded-icon", "gallery__fullscreen", "modern-visible"))
+                        @fragments.inlineSvg("expand-image", "icon", List("centered-icon", "rounded-icon", "gallery__fullscreen", "modern-visible", "gallery-expand"))
                     </a>
                 </div>
             }

--- a/static/src/stylesheets/module/content-garnett/_gallery.scss
+++ b/static/src/stylesheets/module/content-garnett/_gallery.scss
@@ -272,6 +272,10 @@
     }
 }
 
+.gallery-expand {
+    display: block;
+}
+
 .gs-container--gallery {
     @include mq(leftCol) {
         position: static;


### PR DESCRIPTION
## What does this change?

The expand icon was supposed to show on mobile in https://github.com/guardian/frontend/pull/25110 but didn't, this fixes it

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |


[before]: https://user-images.githubusercontent.com/9575458/173611586-9d921f20-8388-4603-8c7d-face50466caa.png
[after]: https://user-images.githubusercontent.com/9575458/173611518-454b8696-0887-4095-b09b-c8e28b16a643.png

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
