### PR TITLE
Passback updates

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -111,138 +111,136 @@ const init = (register: RegisterListener): void => {
 					.getSlots()
 					.find((s) => s.getSlotElementId() === slotIdWithPrefix);
 
-				if (initialSlot) {
-					/**
-					 * Copy the targeting from the initial slot
-					 */
-					const pageTargeting = getValuesForKeys(
-						window.googletag.pubads().getTargetingKeys(),
-						(key) => window.googletag.pubads().getTargeting(key),
-					);
-					const slotTargeting = getValuesForKeys(
-						initialSlot.getTargetingKeys(),
-						(key) => initialSlot.getTargeting(key),
-					);
+				if (!initialSlot) {
 					log(
 						'commercial',
-						'Passback: initial inline1 targeting',
-						Object.fromEntries([
-							...pageTargeting,
-							...slotTargeting,
-						]),
+						'Passback: cannot determine the googletag slot from the slotId',
 					);
-
-					/**
-					 * Create the targeting for the new passback slot
-					 */
-					const passbackTargeting: Array<[string, string[]]> = [
-						...pageTargeting,
-						...slotTargeting,
-						['passback', [getPassbackValue(source)]],
-						['slot', ['inline1']],
-					];
-
-					/**
-					 * Create a new passback ad slot element
-					 */
-					const passbackElement = document.createElement('div');
-					passbackElement.id = `${slotIdWithPrefix}--passback`;
-					passbackElement.classList.add('ad-slot', 'js-ad-slot');
-					passbackElement.setAttribute('aria-hidden', 'true');
-					// position absolute to position over the container slot
-					passbackElement.style.position = 'absolute';
-					// account for the ad label
-					passbackElement.style.top = `${labelHeight}px`;
-					// take the full width so it will center horizontally
-					passbackElement.style.width = '100%';
-
-					void fastdom
-						.mutate(() => {
-							slotElement.insertAdjacentElement(
-								'beforeend',
-								passbackElement,
-							);
-						})
-						.then(() => {
-							/**
-							 * Define and display the new passback slot
-							 */
-							window.googletag.cmd.push(() => {
-								// https://developers.google.com/publisher-tag/reference#googletag.defineSlot
-								const passbackSlot = googletag.defineSlot(
-									initialSlot.getAdUnitPath(),
-									[mpu, outstreamMobile, outstreamDesktop],
-									passbackElement.id,
-								);
-								if (passbackSlot) {
-									// https://developers.google.com/publisher-tag/guides/ad-sizes#responsive_ads
-									passbackSlot.defineSizeMapping([
-										[
-											[breakpoints.phablet, 0],
-											[mpu, outstreamDesktop],
-										],
-										[
-											[breakpoints.mobile, 0],
-											[mpu, outstreamMobile],
-										],
-									]);
-									passbackSlot.addService(
-										window.googletag.pubads(),
-									);
-									passbackTargeting.forEach(
-										([key, value]) => {
-											passbackSlot.setTargeting(
-												key,
-												value,
-											);
-										},
-									);
-									log(
-										'commercial',
-										'Passback: passback inline1 targeting map',
-										passbackSlot.getTargetingMap(),
-									);
-									googletag.display(passbackElement.id);
-								}
-							});
-
-							/**
-							 * Resize the container height once the passback has loaded.
-							 * We need to do this because the passback ad is absolutely
-							 * positioned in order to not add layout shift. So it is
-							 * taken out of normal document flow and the parent container
-							 * does not take the height of the child ad element as normal.
-							 * We set the height by hooking into the googletag slotRenderEnded
-							 * event which provides the size of the loaded ad.
-							 * https://developers.google.com/publisher-tag/reference#googletag.events.slotrenderendedevent
-							 */
-							googletag
-								.pubads()
-								.addEventListener(
-									'slotRenderEnded',
-									function (
-										event: googletag.events.SlotRenderEndedEvent,
-									) {
-										const slotId =
-											event.slot.getSlotElementId();
-										if (slotId === passbackElement.id) {
-											const size = event.size;
-											if (Array.isArray(size)) {
-												const height = size[1];
-												slotElement.style.height = `${
-													height + labelHeight
-												}px`;
-											}
-										}
-									},
-								);
-
-							log(
-								'commercial',
-								`Passback: from ${source} creating slot: ${passbackElement.id}`,
-							);
-						});
+					return;
 				}
+
+				/**
+				 * Copy the targeting from the initial slot
+				 */
+				const pageTargeting = getValuesForKeys(
+					window.googletag.pubads().getTargetingKeys(),
+					(key) => window.googletag.pubads().getTargeting(key),
+				);
+				const slotTargeting = getValuesForKeys(
+					initialSlot.getTargetingKeys(),
+					(key) => initialSlot.getTargeting(key),
+				);
+				log(
+					'commercial',
+					'Passback: initial inline1 targeting',
+					Object.fromEntries([...pageTargeting, ...slotTargeting]),
+				);
+
+				/**
+				 * Create the targeting for the new passback slot
+				 */
+				const passbackTargeting: Array<[string, string[]]> = [
+					...pageTargeting,
+					...slotTargeting,
+					['passback', [getPassbackValue(source)]],
+					['slot', ['inline1']],
+				];
+
+				/**
+				 * Create a new passback ad slot element
+				 */
+				const passbackElement = document.createElement('div');
+				passbackElement.id = `${slotIdWithPrefix}--passback`;
+				passbackElement.classList.add('ad-slot', 'js-ad-slot');
+				passbackElement.setAttribute('aria-hidden', 'true');
+				// position absolute to position over the container slot
+				passbackElement.style.position = 'absolute';
+				// account for the ad label
+				passbackElement.style.top = `${labelHeight}px`;
+				// take the full width so it will center horizontally
+				passbackElement.style.width = '100%';
+
+				void fastdom
+					.mutate(() => {
+						slotElement.insertAdjacentElement(
+							'beforeend',
+							passbackElement,
+						);
+					})
+					.then(() => {
+						/**
+						 * Define and display the new passback slot
+						 */
+						window.googletag.cmd.push(() => {
+							// https://developers.google.com/publisher-tag/reference#googletag.defineSlot
+							const passbackSlot = googletag.defineSlot(
+								initialSlot.getAdUnitPath(),
+								[mpu, outstreamMobile, outstreamDesktop],
+								passbackElement.id,
+							);
+							if (passbackSlot) {
+								// https://developers.google.com/publisher-tag/guides/ad-sizes#responsive_ads
+								passbackSlot.defineSizeMapping([
+									[
+										[breakpoints.phablet, 0],
+										[mpu, outstreamDesktop],
+									],
+									[
+										[breakpoints.mobile, 0],
+										[mpu, outstreamMobile],
+									],
+								]);
+								passbackSlot.addService(
+									window.googletag.pubads(),
+								);
+								passbackTargeting.forEach(([key, value]) => {
+									passbackSlot.setTargeting(key, value);
+								});
+								log(
+									'commercial',
+									'Passback: passback inline1 targeting map',
+									passbackSlot.getTargetingMap(),
+								);
+								googletag.display(passbackElement.id);
+							}
+						});
+
+						/**
+						 * Resize the container height once the passback has loaded.
+						 * We need to do this because the passback ad is absolutely
+						 * positioned in order to not add layout shift. So it is
+						 * taken out of normal document flow and the parent container
+						 * does not take the height of the child ad element as normal.
+						 * We set the height by hooking into the googletag slotRenderEnded
+						 * event which provides the size of the loaded ad.
+						 * https://developers.google.com/publisher-tag/reference#googletag.events.slotrenderendedevent
+						 */
+						googletag
+							.pubads()
+							.addEventListener(
+								'slotRenderEnded',
+								function (
+									event: googletag.events.SlotRenderEndedEvent,
+								) {
+									const slotId =
+										event.slot.getSlotElementId();
+									if (slotId === passbackElement.id) {
+										const size = event.size;
+										if (Array.isArray(size)) {
+											const height = size[1];
+											slotElement.style.height = `${
+												height + labelHeight
+											}px`;
+										}
+									}
+								},
+							);
+
+						log(
+							'commercial',
+							`Passback: from ${source} creating slot: ${passbackElement.id}`,
+						);
+					});
 			});
 		});
 	});

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -232,14 +232,13 @@ const init = (register: RegisterListener): void => {
 									'Passback: passback inline1 targeting map',
 									passbackSlot.getTargetingMap(),
 								);
+								log(
+									'commercial',
+									`Passback: from ${source} displaying slot: ${passbackElement.id}`,
+								);
 								googletag.display(passbackElement.id);
 							}
 						});
-
-						log(
-							'commercial',
-							`Passback: from ${source} creating slot: ${passbackElement.id}`,
-						);
 					});
 			});
 		});

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -1,7 +1,7 @@
 import { adSizes } from '@guardian/commercial-core';
 import { log } from '@guardian/libs';
 import { breakpoints } from '@guardian/source-foundations';
-import { getBreakpoint } from 'lib/detect';
+import { getBreakpoint, getViewport } from 'lib/detect-viewport';
 import fastdom from '../../../../lib/fastdom-promise';
 import { adSlotIdPrefix } from '../dfp/dfp-env-globals';
 import type { RegisterListener } from '../messenger';
@@ -26,7 +26,7 @@ const getValuesForKeys = (
 ): Array<[string, string[]]> => keys.map((key) => [key, valueFn(key)]);
 
 const getPassbackValue = (source: string): string => {
-	const isMobile = (getBreakpoint() as string).startsWith('mobile');
+	const isMobile = getBreakpoint(getViewport().width) === 'mobile';
 	// e.g. 'teadsdesktop' or 'teadsmobile';
 	return `${source}${isMobile ? 'mobile' : 'desktop'}`;
 };

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -49,15 +49,16 @@ const init = (register: RegisterListener): void => {
 				);
 			}
 			/**
-			 * Get the slotId from the calling iFrame as provided by messenger
+			 * Determine the slot from the calling iFrame as provided by messenger
 			 */
 			const slotElement = iframe?.closest<HTMLDivElement>('.ad-slot');
 			const slotId = slotElement?.dataset.name;
 			if (!slotId) {
 				log(
 					'commercial',
-					'Passback: cannot determine the calling iFrame',
+					'Passback: cannot determine the slot from the calling iFrame',
 				);
+				return;
 			}
 
 			log(
@@ -77,12 +78,11 @@ const init = (register: RegisterListener): void => {
 					 */
 					iFrameContainer.style.visibility = 'hidden';
 				}
-				if (slotElement) {
-					// TODO: this should be promoted to default styles for inline1
-					slotElement.style.position = 'relative';
-					// Remove any outstream styling for this slot
-					slotElement.classList.remove('ad-slot--outstream');
-				}
+
+				// TODO: this should be promoted to default styles for inline1
+				slotElement.style.position = 'relative';
+				// Remove any outstream styling for this slot
+				slotElement.classList.remove('ad-slot--outstream');
 			}
 
 			if (slotId && source) {

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -88,7 +88,7 @@ const init = (register: RegisterListener): void => {
 				return;
 			}
 
-			const updatePreviousSlotPromise = fastdom.mutate(() => {
+			const updateInitialSlotPromise = fastdom.mutate(() => {
 				/**
 				 * Keep the initial outstream iFrame so they can detect passbacks.
 				 * Maintain the iFrame initial size by setting visibility hidden to prevent CLS.
@@ -101,7 +101,7 @@ const init = (register: RegisterListener): void => {
 				slotElement.classList.remove('ad-slot--outstream');
 			});
 
-			void updatePreviousSlotPromise.then(() => {
+			void updateInitialSlotPromise.then(() => {
 				const slotIdWithPrefix = `${adSlotIdPrefix}${slotId}`;
 				/**
 				 * Find the initial slot object from googletag

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -127,14 +127,14 @@ const init = (register: RegisterListener): void => {
 								passbackElement,
 							);
 						})
-						.then(() => passbackElement);
+						.then(() => passbackElement.id);
 				},
 			);
 
 			/**
 			 * Create and display the new passback slot
 			 */
-			void createNewSlotElementPromise.then((passbackElement) => {
+			void createNewSlotElementPromise.then((passbackElementId) => {
 				/**
 				 * Find the initial slot object from googletag
 				 */
@@ -196,7 +196,7 @@ const init = (register: RegisterListener): void => {
 							event: googletag.events.SlotRenderEndedEvent,
 						) {
 							const slotId = event.slot.getSlotElementId();
-							if (slotId === passbackElement.id) {
+							if (slotId === passbackElementId) {
 								const size = event.size;
 								if (Array.isArray(size)) {
 									const height = size[1];
@@ -218,7 +218,7 @@ const init = (register: RegisterListener): void => {
 					const passbackSlot = googletag.defineSlot(
 						initialSlot.getAdUnitPath(),
 						[mpu, outstreamMobile, outstreamDesktop],
-						passbackElement.id,
+						passbackElementId,
 					);
 					if (passbackSlot) {
 						// https://developers.google.com/publisher-tag/guides/ad-sizes#responsive_ads
@@ -243,9 +243,9 @@ const init = (register: RegisterListener): void => {
 						);
 						log(
 							'commercial',
-							`Passback: from ${source} displaying slot: ${passbackElement.id}`,
+							`Passback: from ${source} displaying slot: ${passbackElementId}`,
 						);
-						googletag.display(passbackElement.id);
+						googletag.display(passbackElementId);
 					}
 				});
 			});

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -98,7 +98,7 @@ const init = (register: RegisterListener): void => {
 			 */
 			const updateInitialSlotPromise = fastdom.mutate(() => {
 				iFrameContainer.style.visibility = 'hidden';
-				// TODO: this should be promoted to default styles for inline1
+				// TODO: this should be promoted to default styles for the initial slot
 				slotElement.style.position = 'relative';
 				// Remove any outstream styling for this slot
 				slotElement.classList.remove('ad-slot--outstream');
@@ -164,7 +164,7 @@ const init = (register: RegisterListener): void => {
 				);
 				log(
 					'commercial',
-					'Passback: initial inline1 targeting',
+					'Passback: initial slot targeting',
 					Object.fromEntries([...pageTargeting, ...slotTargeting]),
 				);
 
@@ -175,7 +175,7 @@ const init = (register: RegisterListener): void => {
 					...pageTargeting,
 					...slotTargeting,
 					['passback', [getPassbackValue(source)]],
-					['slot', ['inline1']],
+					['slot', [slotId]],
 				];
 
 				/**
@@ -238,7 +238,7 @@ const init = (register: RegisterListener): void => {
 						});
 						log(
 							'commercial',
-							'Passback: passback inline1 targeting map',
+							'Passback: passback slot targeting map',
 							passbackSlot.getTargetingMap(),
 						);
 						log(

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -50,10 +50,18 @@ const init = (register: RegisterListener): void => {
 				return;
 			}
 
+			if (!iframe) {
+				log(
+					'commercial',
+					'Passback: iframe has not been passed by messenger',
+				);
+				return;
+			}
+
 			/**
 			 * Determine the slot from the calling iFrame as provided by messenger
 			 */
-			const slotElement = iframe?.closest<HTMLDivElement>('.ad-slot');
+			const slotElement = iframe.closest<HTMLDivElement>('.ad-slot');
 			const slotId = slotElement?.dataset.name;
 			if (!slotId) {
 				log(
@@ -68,24 +76,22 @@ const init = (register: RegisterListener): void => {
 				`Passback: from ${source} for slot ${String(slotId)}`,
 			);
 
-			if (iframe) {
-				const iFrameContainer =
-					iframe.closest<HTMLDivElement>('.ad-slot__content');
+			const iFrameContainer =
+				iframe.closest<HTMLDivElement>('.ad-slot__content');
 
-				if (iFrameContainer) {
-					/**
-					 * Keep the initial outstream iFrame so they can detect passbacks.
-					 * Maintain the iFrame initial size by setting visibility hidden to prevent CLS.
-					 * In a full width column we then just need to resize the height.
-					 */
-					iFrameContainer.style.visibility = 'hidden';
-				}
-
-				// TODO: this should be promoted to default styles for inline1
-				slotElement.style.position = 'relative';
-				// Remove any outstream styling for this slot
-				slotElement.classList.remove('ad-slot--outstream');
+			if (iFrameContainer) {
+				/**
+				 * Keep the initial outstream iFrame so they can detect passbacks.
+				 * Maintain the iFrame initial size by setting visibility hidden to prevent CLS.
+				 * In a full width column we then just need to resize the height.
+				 */
+				iFrameContainer.style.visibility = 'hidden';
 			}
+
+			// TODO: this should be promoted to default styles for inline1
+			slotElement.style.position = 'relative';
+			// Remove any outstream styling for this slot
+			slotElement.classList.remove('ad-slot--outstream');
 
 			if (slotId && source) {
 				const slotIdWithPrefix = `${adSlotIdPrefix}${slotId}`;

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -5,20 +5,7 @@ import { getBreakpoint } from 'lib/detect';
 import { adSlotIdPrefix } from '../dfp/dfp-env-globals';
 import type { RegisterListener } from '../messenger';
 
-type PassbackMessagePayload = {
-	source: string;
-};
-
-const getValuesForKeys = (
-	keys: string[],
-	valueFn: (key: string) => string[],
-): Array<[string, string[]]> => keys.map((key) => [key, valueFn(key)]);
-
-const getPassbackValue = (source: string): string => {
-	const isMobile = (getBreakpoint() as string).startsWith('mobile');
-	// e.g. 'teadsdesktop' or 'teadsmobile';
-	return `${source}${isMobile ? 'mobile' : 'desktop'}`;
-};
+type PassbackMessagePayload = { source: string };
 
 const labelHeight = 24;
 
@@ -31,6 +18,17 @@ const outstreamMobile: [number, number] = [
 	adSizes.outstreamMobile.width,
 	adSizes.outstreamMobile.height,
 ];
+
+const getValuesForKeys = (
+	keys: string[],
+	valueFn: (key: string) => string[],
+): Array<[string, string[]]> => keys.map((key) => [key, valueFn(key)]);
+
+const getPassbackValue = (source: string): string => {
+	const isMobile = (getBreakpoint() as string).startsWith('mobile');
+	// e.g. 'teadsdesktop' or 'teadsmobile';
+	return `${source}${isMobile ? 'mobile' : 'desktop'}`;
+};
 
 /**
  * A listener for 'passback' messages from ad slot iFrames

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -191,9 +191,11 @@ const init = (register: RegisterListener): void => {
 										const size = event.size;
 										if (Array.isArray(size)) {
 											const height = size[1];
-											slotElement.style.height = `${
-												height + labelHeight
-											}px`;
+											void fastdom.mutate(() => {
+												slotElement.style.height = `${
+													height + labelHeight
+												}px`;
+											});
 										}
 									}
 								},

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -47,7 +47,9 @@ const init = (register: RegisterListener): void => {
 					'commercial',
 					'Passback: postMessage does not have source set',
 				);
+				return;
 			}
+
 			/**
 			 * Determine the slot from the calling iFrame as provided by messenger
 			 */

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -79,14 +79,20 @@ const init = (register: RegisterListener): void => {
 			const iFrameContainer =
 				iframe.closest<HTMLDivElement>('.ad-slot__content');
 
-			if (iFrameContainer) {
-				/**
-				 * Keep the initial outstream iFrame so they can detect passbacks.
-				 * Maintain the iFrame initial size by setting visibility hidden to prevent CLS.
-				 * In a full width column we then just need to resize the height.
-				 */
-				iFrameContainer.style.visibility = 'hidden';
+			if (!iFrameContainer) {
+				log(
+					'commercial',
+					'Passback: cannot determine the iFrameContainer from the calling iFrame',
+				);
+				return;
 			}
+
+			/**
+			 * Keep the initial outstream iFrame so they can detect passbacks.
+			 * Maintain the iFrame initial size by setting visibility hidden to prevent CLS.
+			 * In a full width column we then just need to resize the height.
+			 */
+			iFrameContainer.style.visibility = 'hidden';
 
 			// TODO: this should be promoted to default styles for inline1
 			slotElement.style.position = 'relative';

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -8,7 +8,7 @@ import type { RegisterListener } from '../messenger';
 
 type PassbackMessagePayload = { source: string };
 
-const labelHeight = 24;
+const adLabelHeight = 24;
 
 const mpu: [number, number] = [adSizes.mpu.width, adSizes.mpu.height];
 const outstreamDesktop: [number, number] = [
@@ -116,7 +116,7 @@ const init = (register: RegisterListener): void => {
 					// position absolute to position over the container slot
 					passbackElement.style.position = 'absolute';
 					// account for the ad label
-					passbackElement.style.top = `${labelHeight}px`;
+					passbackElement.style.top = `${adLabelHeight}px`;
 					// take the full width so it will center horizontally
 					passbackElement.style.width = '100%';
 
@@ -199,11 +199,20 @@ const init = (register: RegisterListener): void => {
 							if (slotId === passbackElementId) {
 								const size = event.size;
 								if (Array.isArray(size)) {
-									const height = size[1];
+									const adHeight = size[1];
+									log(
+										'commercial',
+										`Passback: ad height is ${adHeight}`,
+									);
 									void fastdom.mutate(() => {
-										slotElement.style.height = `${
-											height + labelHeight
+										const slotHeight = `${
+											adHeight + adLabelHeight
 										}px`;
+										log(
+											'commercial',
+											`Passback: setting height of passback slot to ${slotHeight}`,
+										);
+										slotElement.style.height = slotHeight;
 									});
 								}
 							}

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -1,6 +1,7 @@
 import { adSizes } from '@guardian/commercial-core';
 import { log } from '@guardian/libs';
 import { breakpoints } from '@guardian/source-foundations';
+import { getBreakpoint } from 'lib/detect';
 import { adSlotIdPrefix } from '../dfp/dfp-env-globals';
 import type { RegisterListener } from '../messenger';
 
@@ -12,6 +13,12 @@ const getValuesForKeys = (
 	keys: string[],
 	valueFn: (key: string) => string[],
 ): Array<[string, string[]]> => keys.map((key) => [key, valueFn(key)]);
+
+const getPassbackValue = (source: string): string => {
+	const isMobile = (getBreakpoint() as string).startsWith('mobile');
+	// e.g. 'teadsdesktop' or 'teadsmobile';
+	return `${source}${isMobile ? 'mobile' : 'desktop'}`;
+};
 
 const labelHeight = 24;
 
@@ -117,7 +124,7 @@ const init = (register: RegisterListener): void => {
 					const passbackTargeting: Array<[string, string[]]> = [
 						...pageTargeting,
 						...slotTargeting,
-						['passback', [source]],
+						['passback', [getPassbackValue(source)]],
 						['slot', ['inline1']],
 					];
 

--- a/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/passback.ts
@@ -77,7 +77,7 @@ const init = (register: RegisterListener): void => {
 
 			log(
 				'commercial',
-				`Passback: from ${source} for slot ${slotIdWithPrefix}`,
+				`Passback: from source '${source}' for slot '${slotIdWithPrefix}'`,
 			);
 
 			const iFrameContainer =
@@ -252,7 +252,7 @@ const init = (register: RegisterListener): void => {
 						);
 						log(
 							'commercial',
-							`Passback: from ${source} displaying slot: ${passbackElementId}`,
+							`Passback: displaying slot '${passbackElementId}'`,
 						);
 						googletag.display(passbackElementId);
 					}

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -461,7 +461,7 @@
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../../../../node_modules/@guardian/source-foundations/dist/types/index.d.ts",
-  "../lib/detect.js",
+  "../lib/detect-viewport.ts",
   "../lib/fastdom-promise.js",
   "../projects/commercial/modules/dfp/dfp-env-globals.ts",
   "../projects/commercial/modules/messenger.ts"

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -461,6 +461,8 @@
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../../../../node_modules/@guardian/source-foundations/dist/types/index.d.ts",
+  "../lib/detect.js",
+  "../lib/fastdom-promise.js",
   "../projects/commercial/modules/dfp/dfp-env-globals.ts",
   "../projects/commercial/modules/messenger.ts"
  ],


### PR DESCRIPTION
## What does this change?

Updates the passback listener with:

- new value for the `passback` targeting parameter based on the breakpoint e.g. `teadsdesktop` or `teadsmobile`
- early returns if the required iframe or elements are not found
- reorder `slotRenderEnded` listener registration
- wrap dom mutations with fastdom
- readability and logging improvements

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [x] On CODE (optional)

