### PR TITLE
Force sending of Commercial metrics

### DIFF
--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -77,6 +77,7 @@ class DevParametersHttpRequestHandler(
     "utm_term", // Google Analytics term
     "sfdebug", // enable spacefinder visualiser. '1' = first pass, '2' = second pass
     "rikerdebug", // enable debug logging for Canadian ad setup managed by the Globe and Mail
+    "forceSendMetrics", // enable force sending of commercial metrics
   )
 
   val playBugs = Seq("") // (Play 2.5 bug?) request.queryString is returning an empty string when empty

--- a/static/src/javascripts/bootstraps/standalone.commercial.ts
+++ b/static/src/javascripts/bootstraps/standalone.commercial.ts
@@ -93,9 +93,10 @@ const loadFrontendBundle = async (): Promise<void> => {
 		'commercial/commercial-metrics'
 	);
 
-	commercialExtraModules.push(
-		['cm-commercial-metrics', commercialMetrics.init], // In DCR, see App.tsx
-	);
+	commercialExtraModules.push([
+		'cm-commercial-metrics',
+		commercialMetrics.init,
+	]);
 
 	return;
 };

--- a/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.ts
+++ b/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.ts
@@ -3,7 +3,6 @@ import {
 	bypassCommercialMetricsSampling as switchOffSampling,
 } from '@guardian/commercial-core';
 import { loadScript, log } from '@guardian/libs';
-import { setForceSendMetrics } from '../../../common/modules/analytics/forceSendMetrics';
 import { getAdvertById } from '../dfp/get-advert-by-id';
 import { refreshAdvert } from '../dfp/load-advert';
 import { stripDfpAdPrefixFrom } from '../header-bidding/utils';
@@ -49,7 +48,6 @@ const maybeRefreshBlockedSlotOnce: ConfiantCallback = (
 	const eventTimer = EventTimer.get();
 	eventTimer.trigger(`${stripDfpAdPrefixFrom(advert.id)}-blockedByConfiant`);
 
-	setForceSendMetrics(true);
 	void switchOffSampling();
 
 	advert.slot.setTargeting('confiant', String(blockingType));

--- a/static/src/javascripts/projects/common/modules/analytics/forceSendMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/forceSendMetrics.ts
@@ -1,5 +1,0 @@
-export let forceSendMetrics = window.location.hash === '#forceSendMetrics';
-
-export const setForceSendMetrics = (val: boolean): void => {
-	forceSendMetrics = val;
-};

--- a/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
@@ -12,8 +12,8 @@ const serverSideTests: ServerSideABTest[] = [];
 /**
  * Function to check whether metrics should be captured for the current page
  * @param tests - optional array of ABTest to check against.
- * @returns {boolean} whether the user is in a one of a set of client or server-side tests
- * for which we want to always capture metrics.
+ * @returns {boolean} whether the user is in one of a set of client or server-side tests
+ * for which we want to always capture metrics or if we should force metrics.
  */
 const shouldCaptureMetrics = (tests = defaultClientSideTests): boolean => {
 	const userInClientSideTest = tests.some((test) =>
@@ -25,7 +25,10 @@ const shouldCaptureMetrics = (tests = defaultClientSideTests): boolean => {
 		Object.keys(window.guardian.config.tests).some((test) =>
 			String(serverSideTests).includes(test),
 		);
-	return userInClientSideTest || userInServerSideTest;
+
+	const forceSendMetrics = window.location.hash === '#forceSendMetrics';
+
+	return userInClientSideTest || userInServerSideTest || forceSendMetrics;
 };
 
 export { shouldCaptureMetrics };

--- a/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
@@ -1,4 +1,5 @@
 import type { ABTest } from '@guardian/ab-core';
+import { getUrlVars } from 'lib/url';
 import { isInABTestSynchronous } from '../experiments/ab';
 import { commercialEndOfQuarter2Test } from '../experiments/tests/commercial-end-of-quarter-2-test';
 
@@ -26,7 +27,7 @@ const shouldCaptureMetrics = (tests = defaultClientSideTests): boolean => {
 			String(serverSideTests).includes(test),
 		);
 
-	const forceSendMetrics = window.location.hash === '#forceSendMetrics';
+	const forceSendMetrics = Boolean(getUrlVars().forceSendMetrics);
 
 	return userInClientSideTest || userInServerSideTest || forceSendMetrics;
 };

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -77,8 +77,7 @@
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../projects/commercial/modules/dfp/get-advert-by-id.ts",
   "../projects/commercial/modules/dfp/load-advert.ts",
-  "../projects/commercial/modules/header-bidding/utils.ts",
-  "../projects/common/modules/analytics/forceSendMetrics.ts"
+  "../projects/commercial/modules/header-bidding/utils.ts"
  ],
  "../projects/commercial/modules/article-aside-adverts.ts": [
   "../lib/$$.ts",
@@ -556,7 +555,6 @@
  "../projects/commercial/sentinel.ts": [
   "../lib/config.d.ts"
  ],
- "../projects/common/modules/analytics/forceSendMetrics.ts": [],
  "../projects/common/modules/analytics/google.ts": [
   "../../../../node_modules/web-vitals/dist/modules/index.d.ts",
   "../lib/config.d.ts",


### PR DESCRIPTION
## What does this change?

This allows the user to forcefully send commercial metrics by adjusting the URL.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Allows us to check what commercial metrics are sent on production frontend

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
