### PR TITLE
Bypass metric sampling in AB test definition

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -13,6 +13,7 @@ import { init as initAcquisitionsLinkEnrichment } from 'common/modules/commercia
 import { fetchAndRenderHeaderLinks } from "common/modules/support/header";
 import { fetchAndRenderEpic } from "common/modules/support/epic";
 import { coreVitals } from 'common/modules/analytics/coreVitals';
+import { init as initCommercialMetrics } from 'commercial/commercial-metrics';
 
 const bootEnhanced = () => {
     const bootstrapContext = (featureName, bootstrap) => {
@@ -41,9 +42,12 @@ const bootEnhanced = () => {
             },
         ],
 
-        //
+        ['core-web-vitals', coreVitals],
+
+        ['commercial-metrics', initCommercialMetrics],
+
         // A/B tests
-                [
+        [
             'ab-tests',
             () => {
                 catchErrorsWithContext([
@@ -56,8 +60,6 @@ const bootEnhanced = () => {
                 ]);
             },
         ],
-
-        ['core-web-vitals', coreVitals],
 
         ['enrich-acquisition-links', initAcquisitionsLinkEnrichment],
 

--- a/static/src/javascripts/bootstraps/standalone.commercial.ts
+++ b/static/src/javascripts/bootstraps/standalone.commercial.ts
@@ -83,25 +83,6 @@ if (!commercialFeatures.adFree) {
 }
 
 /**
- * Load modules that are specific to `frontend`.
- */
-const loadFrontendBundle = async (): Promise<void> => {
-	if (isDotcomRendering) return;
-
-	const commercialMetrics = await import(
-		/* webpackChunkName: "frontend" */
-		'commercial/commercial-metrics'
-	);
-
-	commercialExtraModules.push([
-		'cm-commercial-metrics',
-		commercialMetrics.init,
-	]);
-
-	return;
-};
-
-/**
  * Load modules specific to `dotcom-rendering`.
  * Not sure if this is needed. Currently no separate chunk is created
  * Introduced by @tomrf1
@@ -184,7 +165,6 @@ const bootCommercial = async (): Promise<void> => {
 	};
 
 	try {
-		await loadFrontendBundle();
 		await loadDcrBundle();
 
 		const allModules: Array<Parameters<typeof loadModules>> = [

--- a/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
@@ -1,12 +1,10 @@
 import type { ABTest } from '@guardian/ab-core';
 import { getUrlVars } from 'lib/url';
 import { isInABTestSynchronous } from '../experiments/ab';
-import { commercialEndOfQuarter2Test } from '../experiments/tests/commercial-end-of-quarter-2-test';
 import { commercialLazyLoadMarginReloaded } from '../experiments/tests/commercial-lazy-load-margin-reloaded';
 
 const defaultClientSideTests: ABTest[] = [
 	/* linter, please keep this array multi-line */
-	commercialEndOfQuarter2Test,
 	commercialLazyLoadMarginReloaded,
 ];
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/commercial-end-of-quarter-2-test.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/commercial-end-of-quarter-2-test.ts
@@ -1,5 +1,5 @@
 import type { ABTest } from '@guardian/ab-core';
-import { noop } from '../../../../../lib/noop';
+import { bypassMetricsSampling } from '../utils';
 
 export const commercialEndOfQuarter2Test: ABTest = {
 	id: 'CommercialEndOfQuarter2Test',
@@ -14,8 +14,11 @@ export const commercialEndOfQuarter2Test: ABTest = {
 	description:
 		'Check whether all changes made this quarter when combined lead to an increase in revenue per 1000 pageviews',
 	variants: [
-		{ id: 'control', test: noop },
-		{ id: 'variant', test: noop },
+		{
+			id: 'control',
+			test: bypassMetricsSampling,
+		},
+		{ id: 'variant', test: bypassMetricsSampling },
 	],
 	canRun: () => true,
 };

--- a/static/src/javascripts/projects/common/modules/experiments/utils.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/utils.ts
@@ -1,0 +1,10 @@
+import { bypassCommercialMetricsSampling } from '@guardian/commercial-core';
+import { bypassCoreWebVitalsSampling } from '@guardian/libs';
+
+export const bypassMetricsSampling = (): void => {
+	console.log('overriding commercial sampling');
+	void bypassCommercialMetricsSampling();
+
+	console.log('overriding CWV sampling');
+	bypassCoreWebVitalsSampling();
+};

--- a/static/src/javascripts/projects/common/modules/experiments/utils.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/utils.ts
@@ -2,9 +2,6 @@ import { bypassCommercialMetricsSampling } from '@guardian/commercial-core';
 import { bypassCoreWebVitalsSampling } from '@guardian/libs';
 
 export const bypassMetricsSampling = (): void => {
-	console.log('overriding commercial sampling');
 	void bypassCommercialMetricsSampling();
-
-	console.log('overriding CWV sampling');
 	bypassCoreWebVitalsSampling();
 };


### PR DESCRIPTION
## What does this change?
- Currently we maintain three different lists of ab tests for which we sample commercial metrics and core web vitals at 100%
- This is a proof of concept to instead bypass the sampling rate in the `test` property of the `ABTest` itself.
- For testing I'm using this quarter's commercial mega test `CommercialEndOfQuarter2Test` as the guinea pig

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes https://github.com/guardian/dotcom-rendering/pull/5228

## What is the value of this and can you measure success?
- This refactor should make the AB testing code simpler and easier write and read. A developer who wants to create a new AB test that overrides sampling can change a line of code in the AB test definition itself rather than having to track down and understand
   - frontend's [`shouldCaptureMetrics`](https://github.com/guardian/frontend/blob/41f5b3297a1d2b30d1c46d3e41dc19d0d718dfe6/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts#L19)
   - DCR's [`CoreVitals`](https://github.com/guardian/dotcom-rendering/blob/e8f45d2c27d726efd80d97182d94a0e699538529/dotcom-rendering/src/web/components/CoreVitals.importable.tsx#L10)
   - DCR's [`CommercialMetrics`](https://github.com/guardian/dotcom-rendering/blob/e8f45d2c27d726efd80d97182d94a0e699538529/dotcom-rendering/src/web/components/CommercialMetrics.importable.tsx#L17)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
