### PR TITLE
Import ad size mappings from commercial-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@guardian/atom-renderer": "1.2.2",
     "@guardian/automat-modules": "^0.3.8",
     "@guardian/braze-components": "^7.2.0",
-    "@guardian/commercial-core": "^4.1.1",
+    "@guardian/commercial-core": "^4.2.0",
     "@guardian/consent-management-platform": "^10.7.0",
     "@guardian/libs": "^3.6.1",
     "@guardian/shimport": "^1.0.2",

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -61,7 +61,7 @@ const insertAdAtPara = (
 		})
 		.then(() => {
 			const shouldForceDisplay = ['im', 'carrot'].includes(name);
-			addSlot(ad, shouldForceDisplay);
+			addSlot(ad, shouldForceDisplay, sizes);
 		});
 };
 

--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.spec.ts
@@ -1,3 +1,4 @@
+import { createAdSize } from '@guardian/commercial-core';
 import { mocked } from 'ts-jest/utils';
 import { getBreakpoint as getBreakpoint_ } from '../../../lib/detect';
 import fastdom from '../../../lib/fastdom-promise';
@@ -140,16 +141,16 @@ describe('maybeUpgradeSlot', () => {
 
 	it('should upgrade the MPU to a DMPU where necessary', () => {
 		const advert = createTestAdvert({
-			sizes: { desktop: [[300, 250]] },
+			sizes: { desktop: [createAdSize(300, 250)] },
 			slot: { defineSizeMapping: jest.fn() },
 		});
-		expect(advert.sizes.desktop).toEqual([[300, 250]]);
+		expect(advert.sizes.desktop).toEqual([createAdSize(300, 250)]);
 
 		maybeUpgradeSlot(advert, getElement('.js-discussion__ad-slot'));
 		expect(advert.sizes.desktop).toEqual([
-			[300, 250],
-			[300, 600],
-			[160, 600],
+			createAdSize(300, 250),
+			createAdSize(300, 600),
+			createAdSize(160, 600),
 		]);
 		expect(advert.slot.defineSizeMapping).toHaveBeenCalledTimes(1);
 	});
@@ -158,24 +159,24 @@ describe('maybeUpgradeSlot', () => {
 		const advert = createTestAdvert({
 			sizes: {
 				desktop: [
-					[160, 600],
-					[300, 250],
-					[300, 600],
+					createAdSize(160, 600),
+					createAdSize(300, 250),
+					createAdSize(300, 600),
 				],
 			},
 			slot: { defineSizeMapping: jest.fn() },
 		});
 		expect(advert.sizes.desktop).toEqual([
-			[160, 600],
-			[300, 250],
-			[300, 600],
+			createAdSize(160, 600),
+			createAdSize(300, 250),
+			createAdSize(300, 600),
 		]);
 
 		maybeUpgradeSlot(advert, getElement('.js-discussion__ad-slot'));
 		expect(advert.sizes.desktop).toEqual([
-			[160, 600],
-			[300, 250],
-			[300, 600],
+			createAdSize(160, 600),
+			createAdSize(300, 250),
+			createAdSize(300, 600),
 		]);
 		expect(advert.slot.defineSizeMapping).toHaveBeenCalledTimes(0);
 	});
@@ -197,7 +198,7 @@ describe('runSecondStage', () => {
 			'.js-comments .content__main-column',
 		);
 		const advert = createTestAdvert({
-			sizes: { desktop: [[300, 250]] },
+			sizes: { desktop: [createAdSize(300, 250)] },
 			slot: { defineSizeMapping: jest.fn() },
 		});
 		mocked(getAdvertById).mockReturnValue(advert);
@@ -216,7 +217,7 @@ describe('runSecondStage', () => {
 			'.js-comments .content__main-column',
 		);
 		const advert = createTestAdvert({
-			sizes: { desktop: [[300, 250]] },
+			sizes: { desktop: [createAdSize(300, 250)] },
 			slot: { defineSizeMapping: jest.fn() },
 		});
 		mocked(getAdvertById).mockReturnValue(advert);

--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.ts
@@ -72,7 +72,6 @@ const maybeUpgradeSlot = (ad: Advert, adSlot: Element): Advert => {
 	if (!containsDMPU(ad) && ad.sizes.desktop) {
 		const extraSizes: SizeKeys[] = ['halfPage', 'skyscraper'];
 		ad.sizes.desktop.push(
-			// TODO: add getTuple method to commercial-core
 			...extraSizes.map((size) => {
 				const { width, height } = adSizes[size];
 				const tuple = createAdSize(width, height);
@@ -80,7 +79,7 @@ const maybeUpgradeSlot = (ad: Advert, adSlot: Element): Advert => {
 			}),
 		);
 		const sizeMapping = ad.sizes.desktop.map((size) =>
-			!size.width && !size.width
+			!size.width && !size.height
 				? 'fluid'
 				: (size as googletag.SingleSize),
 		);

--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.ts
@@ -1,5 +1,5 @@
 import type { SizeKeys, SizeMapping } from '@guardian/commercial-core';
-import { adSizes, createAdSlot } from '@guardian/commercial-core';
+import { adSizes, createAdSize, createAdSlot } from '@guardian/commercial-core';
 import config from '../../../lib/config';
 import { getBreakpoint } from '../../../lib/detect';
 import fastdom from '../../../lib/fastdom-promise';
@@ -47,24 +47,29 @@ const insertCommentAd = (
 };
 
 const containsDMPU = (ad: Advert): boolean =>
-	ad.sizes.desktop.some(
+	!!ad.sizes.desktop?.some(
 		(el) =>
 			(el[0] === 300 && el[1] === 600) ||
 			(el[0] === 160 && el[1] === 600),
 	);
 
 const maybeUpgradeSlot = (ad: Advert, adSlot: Element): Advert => {
-	if (!containsDMPU(ad)) {
+	if (!containsDMPU(ad) && ad.sizes.desktop) {
 		const extraSizes: SizeKeys[] = ['halfPage', 'skyscraper'];
 		ad.sizes.desktop.push(
 			// TODO: add getTuple method to commercial-core
 			...extraSizes.map((size) => {
 				const { width, height } = adSizes[size];
-				const tuple: AdSizeTuple = [width, height];
+				const tuple = createAdSize(width, height);
 				return tuple;
 			}),
 		);
-		ad.slot.defineSizeMapping([[[0, 0], ad.sizes.desktop]]);
+		const sizeMapping = ad.sizes.desktop.map((size) =>
+			!size.width && !size.width
+				? 'fluid'
+				: (size as googletag.SingleSize),
+		);
+		ad.slot.defineSizeMapping([[[0, 0], sizeMapping]]);
 		void fastdom.mutate(() => {
 			adSlot.setAttribute(
 				'data-desktop',

--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.ts
@@ -1,4 +1,4 @@
-import type { SizeKeys, SizeMapping } from '@guardian/commercial-core';
+import type { SizeKeys } from '@guardian/commercial-core';
 import { adSizes, createAdSize, createAdSlot } from '@guardian/commercial-core';
 import config from '../../../lib/config';
 import { getBreakpoint } from '../../../lib/detect';
@@ -12,10 +12,25 @@ import { getAdvertById } from './dfp/get-advert-by-id';
 import { refreshAdvert } from './dfp/load-advert';
 
 const createCommentSlot = (canBeDmpu: boolean): HTMLElement => {
-	const sizes: SizeMapping = canBeDmpu
-		? { desktop: [adSizes.halfPage, adSizes.skyscraper] }
-		: {};
-	const adSlot = createAdSlot('comments', { sizes });
+	const adSlot = createAdSlot('comments');
+
+	if (!canBeDmpu) {
+		adSlot.setAttribute(
+			'data-desktop',
+			(adSlot.getAttribute('data-desktop') ?? '')
+				.split('|')
+				.filter((size) => !['300,600', '160,600'].includes(size))
+				.join('|'),
+		);
+	}
+
+	adSlot.setAttribute(
+		'data-mobile',
+		(adSlot.getAttribute('data-mobile') ?? '')
+			.split('|')
+			.filter((size) => !['300,600', '160,600'].includes(size))
+			.join('|'),
+	);
 
 	adSlot.classList.add('js-sticky-mpu');
 	return adSlot;

--- a/static/src/javascripts/projects/commercial/modules/comment-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/comment-adverts.ts
@@ -1,5 +1,6 @@
 import type { SizeKeys } from '@guardian/commercial-core';
 import { adSizes, createAdSize, createAdSlot } from '@guardian/commercial-core';
+import { toGoogleTagSize } from 'common/modules/commercial/lib/googletag-ad-size';
 import config from '../../../lib/config';
 import { getBreakpoint } from '../../../lib/detect';
 import fastdom from '../../../lib/fastdom-promise';
@@ -78,11 +79,10 @@ const maybeUpgradeSlot = (ad: Advert, adSlot: Element): Advert => {
 				return tuple;
 			}),
 		);
-		const sizeMapping = ad.sizes.desktop.map((size) =>
-			!size.width && !size.height
-				? 'fluid'
-				: (size as googletag.SingleSize),
-		);
+		const sizeMapping = ad.sizes.desktop.map(
+			toGoogleTagSize,
+		) as googletag.MultiSize;
+
 		ad.slot.defineSizeMapping([[[0, 0], sizeMapping]]);
 		void fastdom.mutate(() => {
 			adSlot.setAttribute(

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.spec.ts
@@ -26,7 +26,7 @@ type MockCommercialCore = {
 	slotSizeMappings: Record<string, unknown>;
 };
 
-const { filterClasses, getAdSizeMapping } = _;
+const { filterClasses, getSlotSizeMapping } = _;
 
 jest.mock('../../../../lib/raven');
 jest.mock('ophan/ng', () => null);
@@ -144,13 +144,22 @@ describe('Advert', () => {
 		expect(ad).toBeDefined();
 		expect(googleSlot.setSafeFrameConfig).not.toBeCalled();
 	});
+
+	it('should throw an error if no size mappings are found or passed in', () => {
+		const slot = document.createElement('div');
+		slot.setAttribute('data-name', 'bad-slot');
+		const createAd = () => new Advert(slot);
+		expect(createAd).toThrow(
+			`Tried to render ad slot 'bad-slot' without any size mappings`,
+		);
+	});
 });
 
 describe('getAdSizeMapping', () => {
 	it.each(['slot', 'mobile-only-slot'])(
 		'getAdSizeMapping(%s) should get the size mapping',
 		(slotName) => {
-			expect(getAdSizeMapping(slotName)).toEqual(
+			expect(getSlotSizeMapping(slotName)).toEqual(
 				slots[slotName as keyof typeof slots],
 			);
 		},
@@ -162,7 +171,9 @@ describe('getAdSizeMapping', () => {
 			const slotName = /inline\d+/.test(value)
 				? 'inline'
 				: (value as CommercialCore.SlotName);
-			expect(getAdSizeMapping(value)).toEqual(slotSizeMappings[slotName]);
+			expect(getSlotSizeMapping(value)).toEqual(
+				slotSizeMappings[slotName],
+			);
 		},
 	);
 });

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.spec.ts
@@ -1,10 +1,48 @@
-import { _, Advert } from './Advert';
+/* eslint-disable import/first -- variables must be available to be used when the mock is hoisted before the imports by jest */
+const slots = {
+	'mobile-only-slot': {
+		mobile: [[300, 50]],
+	},
+	slot: {
+		mobile: [
+			[300, 50],
+			[320, 50],
+		],
+		tablet: [[728, 90]],
+		desktop: [
+			[728, 90],
+			[900, 250],
+			[970, 250],
+		],
+	},
+};
 
-const { filterClasses, createSizeMapping, getAdBreakpointSizes } = _;
+import { slotSizeMappings } from '@guardian/commercial-core';
+import type * as CommercialCore from '@guardian/commercial-core';
+import { _, Advert } from './Advert';
+/* eslint-enable import/first */
+
+type MockCommercialCore = {
+	slotSizeMappings: Record<string, unknown>;
+};
+
+const { filterClasses, getAdSizeMapping } = _;
 
 jest.mock('../../../../lib/raven');
 jest.mock('ophan/ng', () => null);
 
+jest.mock('@guardian/commercial-core', (): MockCommercialCore => {
+	const commercialCore: typeof CommercialCore = jest.requireActual(
+		'@guardian/commercial-core',
+	);
+	return {
+		...commercialCore,
+		slotSizeMappings: {
+			...commercialCore.slotSizeMappings,
+			...slots,
+		},
+	};
+});
 describe('Filter classes', () => {
 	it('should return nil for empty class lists', () => {
 		const result = filterClasses([], []);
@@ -37,9 +75,19 @@ describe('Advert', () => {
 	let googleSlot: googletag.Slot;
 
 	beforeEach(() => {
-		const sizeMapping: Partial<googletag.SizeMappingBuilder> = {
-			build: jest.fn(() => []),
-		};
+		let sizesArray: googletag.SizeMappingArray = [];
+
+		const sizeMapping = {
+			sizes: sizesArray,
+			addSize: jest.fn((width, sizes) => {
+				sizesArray.unshift([width, sizes]);
+			}),
+			build: jest.fn(() => {
+				const tmp = sizesArray;
+				sizesArray = [];
+				return tmp;
+			}),
+		} as unknown as googletag.SizeMappingBuilder;
 
 		//@ts-expect-error - it is a partial mock
 		googleSlot = {
@@ -54,7 +102,7 @@ describe('Advert', () => {
 				return {} as googletag.PubAdsService;
 			},
 			sizeMapping() {
-				return sizeMapping as googletag.SizeMappingBuilder;
+				return sizeMapping;
 			},
 			defineSlot() {
 				return googleSlot;
@@ -98,62 +146,23 @@ describe('Advert', () => {
 	});
 });
 
-describe('createSizeMapping', () => {
-	it('one size', () => {
-		expect(createSizeMapping('300,50')).toEqual([[300, 50]]);
-	});
-	it('multiple sizes', () => {
-		expect(createSizeMapping('300,50|320,50')).toEqual([
-			[300, 50],
-			[320, 50],
-		]);
-		expect(createSizeMapping('300,50|320,50|fluid')).toEqual([
-			[300, 50],
-			[320, 50],
-			'fluid',
-		]);
-	});
-});
+describe('getAdSizeMapping', () => {
+	it.each(['slot', 'mobile-only-slot'])(
+		'getAdSizeMapping(%s) should get the size mapping',
+		(slotName) => {
+			expect(getAdSizeMapping(slotName)).toEqual(
+				slots[slotName as keyof typeof slots],
+			);
+		},
+	);
 
-describe('getAdBreakpointSizes', () => {
-	it('none', () => {
-		const advertNode = document.createElement('div', {});
-		advertNode.setAttribute('data-name', 'name');
-		advertNode.setAttribute('data-something', 'something-else');
-		expect(getAdBreakpointSizes(advertNode)).toEqual({});
-	});
-
-	it('one breakpoint, one size', () => {
-		const advertNode = document.createElement('div', {});
-		advertNode.setAttribute('data-mobile', '300,50');
-		expect(getAdBreakpointSizes(advertNode)).toEqual({
-			mobile: [[300, 50]],
-		});
-	});
-
-	it('one breakpoint, multi-size', () => {
-		const advertNode = document.createElement('div', {});
-		advertNode.setAttribute('data-mobile', '300,50|320,50');
-		expect(getAdBreakpointSizes(advertNode)).toEqual({
-			mobile: [
-				[300, 50],
-				[320, 50],
-			],
-		});
-	});
-
-	it('multiple breakpoints, multi-size', () => {
-		const advertNode = document.createElement('div', {});
-		advertNode.setAttribute('data-mobile', '300,50|320,50');
-		advertNode.setAttribute('data-phablet', '200,200');
-		advertNode.setAttribute('data-desktop', '250,250|fluid');
-		expect(getAdBreakpointSizes(advertNode)).toEqual({
-			mobile: [
-				[300, 50],
-				[320, 50],
-			],
-			phablet: [[200, 200]],
-			desktop: [[250, 250], 'fluid'],
-		});
-	});
+	it.each(['inline1', 'inline10', ...Object.keys(slotSizeMappings)])(
+		'getAdSizeMapping(%s) should get the size mapping for real slots',
+		(value) => {
+			const slotName = /inline\d+/.test(value)
+				? 'inline'
+				: (value as CommercialCore.SlotName);
+			expect(getAdSizeMapping(value)).toEqual(slotSizeMappings[slotName]);
+		},
+	);
 });

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -36,7 +36,7 @@ class Advert {
 	isRendering = false;
 	isLoaded = false;
 	isRendered = false;
-	shouldRefresh = true;
+	shouldRefresh = false;
 	whenLoaded: Promise<boolean>;
 	whenLoadedResolver: Resolver | null = null;
 	whenRendered: Promise<boolean>;

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -56,7 +56,7 @@ class Advert {
 	lineItemId: number | null = null;
 
 	constructor(adSlotNode: HTMLElement, additionalSizes?: SizeMapping) {
-		const sizes = getAdSizeMapping(adSlotNode.dataset.name ?? '') ?? {};
+		const sizes = adSlotNode.dataset.name ? getAdSizeMapping(adSlotNode.dataset.name) : {};
 
 		if (additionalSizes) {
 			(

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -1,5 +1,5 @@
-import { breakpoints } from '../../../../lib/detect';
-import { breakpointNameToAttribute } from './breakpoint-name-to-attribute';
+import { slotSizeMappings } from '@guardian/commercial-core';
+import type { SizeMapping, SlotName } from '@guardian/commercial-core';
 import { defineSlot } from './define-slot';
 
 type Resolver = (x: boolean) => void;
@@ -14,47 +14,21 @@ type Timings = {
 	lazyWaitComplete: number | null;
 };
 
-const stringToTuple = (size: string): AdSizeTuple => {
-	const dimensions = size.split(',', 2).map(Number);
-
-	// Return an outOfPage tuple if the string is not `{number},{number}`
-	if (dimensions.length !== 2 || dimensions.some((n) => isNaN(n)))
-		return [0, 0]; // adSizes.outOfPage
-
-	return [dimensions[0], dimensions[1]];
+const isSlotName = (slotName: string): slotName is SlotName => {
+	return !!(slotName in slotSizeMappings);
 };
 
-/** A breakpoint can have various sizes assigned to it. You can assign either on
- * set of sizes or multiple.
- *
- * One size       - `data-mobile="300,50"`
- * Multiple sizes - `data-mobile="300,50|320,50"`
- */
-const createSizeMapping = (attr: string): AdSize[] =>
-	attr
-		.split('|')
-		.map((size) => (size === 'fluid' ? 'fluid' : stringToTuple(size)));
-
-/** Extract the ad sizes from the breakpoint data attributes of an ad slot
- *
- * @param advertNode The ad slot HTML element that contains the breakpoint attributes
- * @returns A mapping from the breakpoints supported by the slot to an array of ad sizes
- */
-const getAdBreakpointSizes = (advertNode: HTMLElement): AdSizes =>
-	breakpoints.reduce<Record<string, AdSize[]>>((sizes, breakpoint) => {
-		const data = advertNode.getAttribute(
-			`data-${breakpointNameToAttribute(breakpoint.name)}`,
-		);
-		if (data) {
-			sizes[breakpoint.name] = createSizeMapping(data);
-		}
-		return sizes;
-	}, {});
+const getAdSizeMapping = (name: string): SizeMapping | undefined => {
+	const slotName = /inline\d+/.test(name) ? 'inline' : name;
+	if (isSlotName(slotName)) {
+		return slotSizeMappings[slotName];
+	}
+};
 
 class Advert {
 	id: string;
 	node: HTMLElement;
-	sizes: AdSizes;
+	sizes: SizeMapping;
 	size: AdSize | null = null;
 	slot: googletag.Slot;
 	isEmpty: boolean | null = null;
@@ -62,7 +36,7 @@ class Advert {
 	isRendering = false;
 	isLoaded = false;
 	isRendered = false;
-	shouldRefresh = false;
+	shouldRefresh = true;
 	whenLoaded: Promise<boolean>;
 	whenLoadedResolver: Resolver | null = null;
 	whenRendered: Promise<boolean>;
@@ -82,7 +56,7 @@ class Advert {
 	lineItemId: number | null = null;
 
 	constructor(adSlotNode: HTMLElement) {
-		const sizes = getAdBreakpointSizes(adSlotNode);
+		const sizes = getAdSizeMapping(adSlotNode.dataset.name ?? '') ?? {};
 		const slotDefinition = defineSlot(adSlotNode, sizes);
 
 		this.id = adSlotNode.id;
@@ -154,6 +128,5 @@ export { Advert };
 
 export const _ = {
 	filterClasses: Advert.filterClasses,
-	createSizeMapping,
-	getAdBreakpointSizes,
+	getAdSizeMapping,
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -15,7 +15,7 @@ type Timings = {
 };
 
 const isSlotName = (slotName: string): slotName is SlotName => {
-	return !!(slotName in slotSizeMappings);
+	return slotName in slotSizeMappings;
 };
 
 const getAdSizeMapping = (name: string): SizeMapping | undefined => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -29,7 +29,7 @@ class Advert {
 	id: string;
 	node: HTMLElement;
 	sizes: SizeMapping;
-	size: AdSize | null = null;
+	size: AdSize | 'fluid' | null = null;
 	slot: googletag.Slot;
 	isEmpty: boolean | null = null;
 	isLoading = false;

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -1,5 +1,5 @@
 import { slotSizeMappings } from '@guardian/commercial-core';
-import type { SizeMapping, SlotName } from '@guardian/commercial-core';
+import type { AdSize, SizeMapping, SlotName } from '@guardian/commercial-core';
 import { defineSlot } from './define-slot';
 
 type Resolver = (x: boolean) => void;
@@ -55,8 +55,21 @@ class Advert {
 	hasPrebidSize = false;
 	lineItemId: number | null = null;
 
-	constructor(adSlotNode: HTMLElement) {
+	constructor(adSlotNode: HTMLElement, additionalSizes?: SizeMapping) {
 		const sizes = getAdSizeMapping(adSlotNode.dataset.name ?? '') ?? {};
+
+		if (additionalSizes) {
+			(
+				Object.entries(additionalSizes) as Array<
+					[keyof SizeMapping, AdSize[]]
+				>
+			).forEach(([breakpoint, breakPointSizes]) => {
+				sizes[breakpoint] = sizes[breakpoint] ?? [];
+
+				sizes[breakpoint]?.push(...breakPointSizes);
+			});
+		}
+
 		const slotDefinition = defineSlot(adSlotNode, sizes);
 
 		this.id = adSlotNode.id;

--- a/static/src/javascripts/projects/commercial/modules/dfp/add-slot.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/add-slot.ts
@@ -1,11 +1,16 @@
+import type { SizeMapping } from '@guardian/commercial-core';
 import { Advert } from './Advert';
 import { dfpEnv } from './dfp-env';
 import { enableLazyLoad } from './lazy-load';
 import { loadAdvert } from './load-advert';
 import { queueAdvert } from './queue-advert';
 
-const displayAd = (adSlot: HTMLElement, forceDisplay: boolean) => {
-	const advert = new Advert(adSlot);
+const displayAd = (
+	adSlot: HTMLElement,
+	forceDisplay: boolean,
+	additionalSizes?: SizeMapping,
+) => {
+	const advert = new Advert(adSlot, additionalSizes);
 
 	dfpEnv.advertIds[advert.id] = dfpEnv.adverts.push(advert) - 1;
 	if (dfpEnv.shouldLazyLoad() && !forceDisplay) {
@@ -16,11 +21,15 @@ const displayAd = (adSlot: HTMLElement, forceDisplay: boolean) => {
 	}
 };
 
-const addSlot = (adSlot: HTMLElement, forceDisplay: boolean): void => {
+const addSlot = (
+	adSlot: HTMLElement,
+	forceDisplay: boolean,
+	additionalSizes?: SizeMapping,
+): void => {
 	window.googletag.cmd.push(() => {
 		if (!(adSlot.id in dfpEnv.advertIds)) {
 			// dynamically add ad slot
-			displayAd(adSlot, forceDisplay);
+			displayAd(adSlot, forceDisplay, additionalSizes);
 		}
 	});
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
@@ -1,3 +1,7 @@
+/**
+ * @typedef {import('@guardian/commercial-core').AdSize} AdSize
+ * @typedef {import('@guardian/commercial-core').SizeMapping} SizeMapping
+ */
 import { once } from 'lodash-es';
 import config from '../../../../lib/config';
 import { breakpoints } from '../../../../lib/detect';
@@ -11,11 +15,11 @@ const adUnit = once(() => {
 });
 
 /**
- * Builds and assigns the correct size map for a slot based on the breakpoints
- * attached to the element via data attributes.
+ * Builds and assigns the correct size map for a slot based on the breakpoints and sizes from
+ * the size mapping in commercial-core.
  *
  * A new size map is created for a given slot. We then loop through each breakpoint
- * defined in the config, checking if that breakpoint has been set on the slot.
+ * defined in the config, checking if that breakpoint has been defined in the mapping.
  *
  * If it has been defined, then we add that size to the size mapping.
  *
@@ -32,6 +36,12 @@ const buildSizeMapping = (sizes) => {
 	return mapping.build();
 };
 
+/**
+ * Convert our size mappings to googletag compatible ones
+ *
+ * @param {SizeMapping} sizesByBreakpoint
+ * @returns {{ sizeMapping: googletag.SizeMappingArray, sizes: AdSize[] }}
+ */
 const getSizeOpts = (sizesByBreakpoint) => {
 	const sizeMapping = buildSizeMapping(sizesByBreakpoint);
 	// as we're using sizeMapping, pull out all the ad sizes, as an array of arrays
@@ -208,4 +218,4 @@ const defineSlot = (adSlotNode, sizes) => {
 	};
 };
 
-export { defineSlot };
+export { defineSlot, getSizeOpts };

--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
@@ -30,7 +30,7 @@ const buildSizeMapping = (sizes) => {
 	breakpoints
 		.filter((_) => _.name in sizes)
 		.forEach((_) => {
-			mapping.addSize([_.width, 0], sizes[_.name]);
+			mapping.addSize([_.width, 0], sizes[_.name].map((size) => ((!size[0] && !size[1]) ? 'fluid' : size)));
 		});
 
 	return mapping.build();

--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.js
@@ -6,6 +6,7 @@ import { once } from 'lodash-es';
 import config from '../../../../lib/config';
 import { breakpoints } from '../../../../lib/detect';
 import { getUrlVars } from '../../../../lib/url';
+import {toGoogleTagSize} from '../../../common/modules/commercial/lib/googletag-ad-size';
 
 const adUnit = once(() => {
 	const urlVars = getUrlVars();
@@ -30,7 +31,7 @@ const buildSizeMapping = (sizes) => {
 	breakpoints
 		.filter((_) => _.name in sizes)
 		.forEach((_) => {
-			mapping.addSize([_.width, 0], sizes[_.name].map((size) => ((!size[0] && !size[1]) ? 'fluid' : size)));
+			mapping.addSize([_.width, 0], sizes[_.name].map(toGoogleTagSize));
 		});
 
 	return mapping.build();
@@ -218,4 +219,4 @@ const defineSlot = (adSlotNode, sizes) => {
 	};
 };
 
-export { defineSlot, getSizeOpts };
+export { defineSlot, getSizeOpts, toGoogleTagSize };

--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.spec.js
@@ -1,4 +1,5 @@
 import { defineSlot } from './define-slot';
+import { createAdSize } from '@guardian/commercial-core';
 
 beforeEach(() => {
 	const pubAds = {
@@ -35,6 +36,7 @@ describe('Define Slot', () => {
 	it('should call defineSlot with correct params', () => {
 		const slotDiv = document.createElement('div');
 		slotDiv.id = 'dfp-ad--top-above-nav';
+        slotDiv.setAttribute('name', 'top-above-nav');
 		slotDiv.setAttribute('data-tablet', '1,1|2,2|728,90|88,71|fluid');
 		slotDiv.setAttribute(
 			'data-desktop',
@@ -42,16 +44,16 @@ describe('Define Slot', () => {
 		);
 
 		const topAboveNavSizes = {
-			tablet: [[1, 1], [2, 2], [728, 90], [88, 71], 'fluid'],
+			tablet: [createAdSize(1, 1), createAdSize(2, 2), createAdSize(728, 90), createAdSize(88, 71), createAdSize(0,0)],
 			desktop: [
-				[1, 1],
-				[2, 2],
-				[728, 90],
-				[940, 230],
-				[900, 250],
-				[970, 250],
-				[88, 71],
-				'fluid',
+				createAdSize(1, 1),
+				createAdSize(2, 2),
+				createAdSize(728, 90),
+				createAdSize(940, 230),
+				createAdSize(900, 250),
+				createAdSize(970, 250),
+				createAdSize(88, 71),
+				createAdSize(0, 0),
 			],
 		};
 
@@ -60,13 +62,13 @@ describe('Define Slot', () => {
 		expect(window.googletag.defineSlot).toHaveBeenCalledWith(
 			undefined,
 			[
-				[1, 1],
-				[2, 2],
-				[728, 90],
-				[940, 230],
-				[900, 250],
-				[970, 250],
-				[88, 71],
+				createAdSize(1, 1),
+				createAdSize(2, 2),
+				createAdSize(728, 90),
+				createAdSize(940, 230),
+				createAdSize(900, 250),
+				createAdSize(970, 250),
+				createAdSize(88, 71),
 				'fluid',
 			],
 			'dfp-ad--top-above-nav',

--- a/static/src/javascripts/projects/commercial/modules/dfp/load-advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/load-advert.ts
@@ -76,7 +76,12 @@ export const refreshAdvert = (advert: Advert): void => {
 				// force the slot sizes to be the same as advert.size (current)
 				// only when advert.size is an array (forget 'fluid' and other specials)
 				if (Array.isArray(advert.size)) {
-					advert.slot.defineSizeMapping([[[0, 0], [advert.size]]]);
+					const mapping = window.googletag.sizeMapping();
+					mapping.addSize(
+						[0, 0],
+						advert.size as googletag.GeneralSize,
+					);
+					advert.slot.defineSizeMapping(mapping.build());
 				}
 			}
 			window.googletag.pubads().refresh([advert.slot]);

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.ts
@@ -1,3 +1,5 @@
+import type { AdSize } from '@guardian/commercial-core';
+import { createAdSize } from '@guardian/commercial-core';
 import { isString } from '@guardian/libs';
 import { mediator } from '../../../../lib/mediator';
 import reportError from '../../../../lib/report-error';
@@ -35,9 +37,9 @@ const reportEmptyResponse = (
 	}
 };
 
-const sizeEventToAdSize = (size: string | number[]): AdSize => {
+const sizeEventToAdSize = (size: string | number[]): AdSize | 'fluid' => {
 	if (isString(size)) return 'fluid';
-	return [size[0], size[1]];
+	return createAdSize(size[0], size[1]);
 };
 
 export const onSlotRender = (

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
@@ -1,4 +1,5 @@
-import { EventTimer } from '@guardian/commercial-core';
+import type { AdSize } from '@guardian/commercial-core';
+import { createAdSize, EventTimer } from '@guardian/commercial-core';
 import { PREBID_TIMEOUT } from '@guardian/commercial-core/dist/esm/constants';
 import { onConsent } from '@guardian/consent-management-platform';
 import type { Framework } from '@guardian/consent-management-platform/dist/types';
@@ -392,7 +393,7 @@ const initialise = (window: Window, framework: Framework = 'tcfv2'): void => {
 			return;
 		}
 
-		const size: AdSizeTuple = [width, height]; // eg. [300, 250]
+		const size: AdSize = createAdSize(width, height); // eg. [300, 250]
 		const advert = getAdvertById(adUnitCode);
 
 		if (!advert) {

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.spec.js
@@ -1,3 +1,4 @@
+import { adSizes } from '@guardian/commercial-core';
 import config from '../../../../lib/config';
 import { Advert } from '../dfp/Advert';
 
@@ -47,6 +48,7 @@ const slotPrototype = {
 	defineSizeMapping: () => slotPrototype,
 	addService: () => slotPrototype,
 	setTargeting: () => slotPrototype,
+    setSafeFrameConfig: () => slotPrototype
 };
 
 // Mock window.googletag
@@ -58,10 +60,11 @@ window.googletag = {
 	pubads: () => ({}),
 };
 
-const buildAdvert = (id) => {
+const buildAdvert = (id, sizes) => {
 	const elt = document.createElement('div');
 	elt.setAttribute('id', id);
-	return new Advert(elt);
+    elt.setAttribute('data-name', id);
+	return new Advert(elt, sizes);
 };
 
 /* eslint-disable guardian-frontend/no-direct-access-config */
@@ -248,7 +251,7 @@ describe('getPrebidAdSlots', () => {
 
 	test('should return the correct interactive banner slot at breakpoint D', () => {
 		getBreakpointKey.mockReturnValue('D');
-		const dfpAdvert = buildAdvert('dfp-ad--1');
+		const dfpAdvert = buildAdvert('dfp-ad--1', {mobile: [adSizes.mpu]});
 		dfpAdvert.node.setAttribute(
 			'class',
 			'js-ad-slot ad-slot ad-slot--banner-ad ad-slot--banner-ad-desktop ad-slot--rendered',
@@ -286,7 +289,7 @@ describe('getPrebidAdSlots', () => {
 		config.set('switches.mobileStickyPrebid', true);
 		shouldIncludeMobileSticky.mockReturnValue(true);
 		expect(
-			getHeaderBiddingAdSlots(buildAdvert('dfp-ad-mobile-sticky')),
+			getHeaderBiddingAdSlots(buildAdvert('dfp-ad-mobile-sticky', {mobile: [adSizes.mpu]})),
 		).toEqual([
 			{
 				key: 'mobile-sticky',

--- a/static/src/javascripts/projects/common/modules/commercial/lib/googletag-ad-size.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/lib/googletag-ad-size.ts
@@ -1,0 +1,5 @@
+import type { AdSize } from '@guardian/commercial-core';
+
+export const toGoogleTagSize = (size: AdSize): AdSize | 'fluid' => {
+	return size.width === 0 && size.height === 0 ? 'fluid' : size;
+};

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -574,6 +574,7 @@
  ],
  "../projects/common/modules/analytics/shouldCaptureMetrics.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
+  "../lib/url.ts",
   "../projects/common/modules/experiments/ab.ts",
   "../projects/common/modules/experiments/tests/commercial-end-of-quarter-2-test.ts",
   "../projects/common/modules/experiments/tests/commercial-lazy-load-margin-reloaded.ts"

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -222,6 +222,8 @@
   "../projects/commercial/modules/messenger/post-message.ts"
  ],
  "../projects/commercial/modules/dfp/on-slot-render.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/mediator.ts",
   "../lib/report-error.js",
@@ -367,6 +369,7 @@
   "../projects/common/modules/commercial/geo-utils.js"
  ],
  "../projects/commercial/modules/header-bidding/prebid/prebid.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/commercial-core/dist/esm/constants/index.d.ts",
   "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -137,8 +137,8 @@
   "../projects/common/modules/commercial/commercial-features.ts"
  ],
  "../projects/commercial/modules/dfp/Advert.ts": [
-  "../lib/detect.js",
-  "../projects/commercial/modules/dfp/breakpoint-name-to-attribute.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../projects/commercial/modules/dfp/define-slot.js"
  ],
  "../projects/commercial/modules/dfp/add-slot.ts": [

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -121,6 +121,7 @@
   "../projects/commercial/modules/dfp/get-advert-by-id.ts",
   "../projects/commercial/modules/dfp/load-advert.ts",
   "../projects/common/modules/commercial/commercial-features.ts",
+  "../projects/common/modules/commercial/lib/googletag-ad-size.ts",
   "../projects/common/modules/identity/api.ts"
  ],
  "../projects/commercial/modules/comscore.ts": [
@@ -154,7 +155,8 @@
   "../../../../node_modules/lodash-es/lodash.js",
   "../lib/config.js",
   "../lib/detect.js",
-  "../lib/url.ts"
+  "../lib/url.ts",
+  "../projects/common/modules/commercial/lib/googletag-ad-size.ts"
  ],
  "../projects/commercial/modules/dfp/dfp-env-globals.ts": [],
  "../projects/commercial/modules/dfp/dfp-env.ts": [
@@ -616,6 +618,9 @@
  ],
  "../projects/common/modules/commercial/lib/cookie.ts": [
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
+ ],
+ "../projects/common/modules/commercial/lib/googletag-ad-size.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts"
  ],
  "../projects/common/modules/commercial/support-utilities.js": [
   "../lib/geolocation.ts"

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -142,6 +142,7 @@
   "../projects/commercial/modules/dfp/define-slot.js"
  ],
  "../projects/commercial/modules/dfp/add-slot.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../projects/commercial/modules/dfp/Advert.ts",
   "../projects/commercial/modules/dfp/dfp-env.ts",
   "../projects/commercial/modules/dfp/lazy-load.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2084,10 +2084,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-7.2.0.tgz#e5e7ba7c19484ebe0e405a93b1c389dae681acef"
   integrity sha512-Y2+XC0bP5mFacwtDlDqlQsbUyQwn4OSlpOTw3+u7t1RhJFw61SDYAER4gOpyJ4t+wQZFdk//LGJUjFqzDfEEuQ==
 
-"@guardian/commercial-core@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.1.1.tgz#eb569c941d0c179c1b206d8da92f9d2c94ef82cf"
-  integrity sha512-1PwhyYVzRp63Ge1/3XH1pbLf4TYXZg6NKh2hA1I0gmPRAXE0E2/jjSmFQ6cl986rbRP8qn8QdendepinX8Zr/A==
+"@guardian/commercial-core@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.2.0.tgz#c3325c6f5b13c63f6b68700e9af363810f99233f"
+  integrity sha512-hzH7BGo1NvZKE2wkOvAiXvvtqmJeKh4kzmmlqqVHG6lN3rukKNTuYwa9NYtsHIoMokZ8BEMb20J9onDzyDYgjQ==
 
 "@guardian/consent-management-platform@^10.7.0":
   version "10.7.0"
@@ -4318,15 +4318,10 @@ camelcase@^6.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
-caniuse-lite@^1.0.30000998, caniuse-lite@^1.0.30001272, caniuse-lite@^1.0.30001274:
-  version "1.0.30001279"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz#eb06818da481ef5096a3b3760f43e5382ed6b0ce"
-  integrity sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ==
-
-caniuse-lite@^1.0.30001332:
-  version "1.0.30001344"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001344.tgz#8a1e7fdc4db9c2ec79a05e9fd68eb93a761888bb"
-  integrity sha512-0ZFjnlCaXNOAYcV7i+TtdKBp0L/3XEU2MF/x6Du1lrh+SRX4IfzIVL4HNJg5pB2PmFb8rszIGyOvsZnqqRoc2g==
+caniuse-lite@^1.0.30000998, caniuse-lite@^1.0.30001272, caniuse-lite@^1.0.30001274, caniuse-lite@^1.0.30001332:
+  version "1.0.30001355"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001355.tgz"
+  integrity sha512-Sd6pjJHF27LzCB7pT7qs+kuX2ndurzCzkpJl6Qct7LPSZ9jn0bkOA8mdgMgmqnQAWLVOOGjLpc+66V57eLtb1g==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## What does this change?
Instead of reading ad sizes off slot data attributes, load them directly from commercial-core.

A few of the types needed to be updated to use commercial-core ones.

For the moment they're still left as data attributes as it's useful for debugging.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
