### PR TITLE
Constrain right ad stickiness to desktop

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -23,8 +23,8 @@ type SlotName = Parameters<typeof createAdSlot>[0];
 
 type ContainerOptions = {
 	sticky?: boolean;
-	heightPx?: number;
 	enableDebug?: boolean;
+	className?: string;
 };
 
 const sfdebug = getUrlVars().sfdebug;
@@ -41,14 +41,12 @@ const wrapSlotInContainer = (
 	options: ContainerOptions = {},
 ) => {
 	const container = document.createElement('div');
-	container.className = 'ad-slot-container ad-slot--offset-right';
+	container.className = `ad-slot-container ad-slot--offset-right ${
+		options.className ?? ''
+	}`;
 
 	if (options.sticky) {
 		ad.style.cssText += 'position: sticky; top: 0;';
-	}
-
-	if (options.heightPx) {
-		container.style.cssText += `height: ${options.heightPx}px;`;
 	}
 
 	if (options.enableDebug) {
@@ -187,7 +185,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 				const containerOptions = stickyContainerHeights
 					? {
 							sticky: true,
-							heightPx: Math.max(stickyContainerHeights[i], 0),
+							className: `ad-slot-container--${i}`,
 							enableDebug,
 					  }
 					: undefined;

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -189,7 +189,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 				articleBodySelector,
 			);
 
-			insertHeightStyles(
+			void insertHeightStyles(
 				stickyContainerHeights.map((height, index) => [
 					getContainerClassname(index),
 					height,

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -189,13 +189,12 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 				articleBodySelector,
 			);
 
-			const heightMapping: Array<[string, number]> =
-				stickyContainerHeights.map((height, i) => [
-					getContainerClassname(i),
+			insertHeightStyles(
+				stickyContainerHeights.map((height, index) => [
+					getContainerClassname(index),
 					height,
-				]);
-
-			insertHeightStyles(heightMapping);
+				]),
+			);
 		}
 
 		const slots = paras

--- a/static/src/javascripts/projects/commercial/modules/sticky-inlines.ts
+++ b/static/src/javascripts/projects/commercial/modules/sticky-inlines.ts
@@ -42,8 +42,7 @@ const insertHeightStyles = (
 	heightMapping: Array<[string, number]>,
 ): Promise<void> => {
 	const heightClasses = heightMapping.reduce(
-		(css, [name, height]) =>
-			css.concat(`.${name} { height: ${height}px; }`),
+		(css, [name, height]) => `${css} .${name} { height: ${height}px; }`,
 		'',
 	);
 

--- a/static/src/javascripts/projects/commercial/modules/sticky-inlines.ts
+++ b/static/src/javascripts/projects/commercial/modules/sticky-inlines.ts
@@ -38,7 +38,9 @@ const articleBottomBufferPx = 100;
  *
  * @param heightMapping The mapping from class name to height value in pixels
  */
-const insertHeightStyles = (heightMapping: Array<[string, number]>): void => {
+const insertHeightStyles = (
+	heightMapping: Array<[string, number]>,
+): Promise<void> => {
 	const heightClasses = heightMapping.reduce(
 		(css, [name, height]) =>
 			css.concat(`.${name} { height: ${height}px; }`),
@@ -52,8 +54,11 @@ const insertHeightStyles = (heightMapping: Array<[string, number]>): void => {
     `;
 
 	const style = document.createElement('style');
-	document.head.appendChild(style);
 	style.appendChild(document.createTextNode(css));
+
+	return fastdom.mutate(() => {
+		document.head.appendChild(style);
+	});
 };
 
 /**

--- a/static/src/javascripts/projects/commercial/modules/sticky-inlines.ts
+++ b/static/src/javascripts/projects/commercial/modules/sticky-inlines.ts
@@ -1,4 +1,5 @@
 import { isUndefined } from '@guardian/libs';
+import { breakpoints } from '@guardian/source-foundations';
 import fastdom from 'lib/fastdom-promise';
 
 /**
@@ -29,6 +30,31 @@ const immersiveBufferPx = 100;
  * The minimum buffer between a right column advert and the bottom of the article body
  */
 const articleBottomBufferPx = 100;
+
+/**
+ * Add a stylesheet to the document that adds height properties for a given set of class names
+ *
+ * Note these are only above on desktop and above
+ *
+ * @param heightMapping The mapping from class name to height value in pixels
+ */
+const insertHeightStyles = (heightMapping: Array<[string, number]>): void => {
+	const heightClasses = heightMapping.reduce(
+		(css, [name, height]) =>
+			css.concat(`.${name} { height: ${height}px; }`),
+		'',
+	);
+
+	const css = `
+        @media (min-width: ${breakpoints.desktop}px) {
+            ${heightClasses}
+        }
+    `;
+
+	const style = document.createElement('style');
+	document.head.appendChild(style);
+	style.appendChild(document.createTextNode(css));
+};
 
 /**
  * Compute the distance between each winning paragraph and subsequent paragraph,
@@ -111,4 +137,4 @@ const computeStickyHeights = async (
 	);
 };
 
-export { computeStickyHeights };
+export { computeStickyHeights, insertHeightStyles };

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -513,6 +513,7 @@
  ],
  "../projects/commercial/modules/sticky-inlines.ts": [
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../../../../node_modules/@guardian/source-foundations/dist/types/index.d.ts",
   "../lib/fastdom-promise.js"
  ],
  "../projects/commercial/modules/sticky-mpu.js": [


### PR DESCRIPTION
## What does this change?

Build upon the work in #25097, by constraining the sticky ads to just **desktop** breakpoints and above.

To achieve this, rather than applying the computed height as a computed property on the container div, we instead construct a stylesheet that is inserted into the document head. This allows us to use a media query that applies a class with the given height to the correct ad slot container, only for desktop above and above.

When applying this method we end with a stylesheet added to the `<head>` that looks like:

```
@media (min-width: 980px) {
            .ad-slot-container-2 { height: 520px; }
            .ad-slot-container-3 { height: 660px; }
            .ad-slot-container-4 { height: 1238px; }
            .ad-slot-container-5 { height: 510px; }
            .ad-slot-container-6 { height: 884px; }
            .ad-slot-container-7 { height: 713px; }
            .ad-slot-container-8 { height: 1351px; }
            .ad-slot-container-9 { height: 576px; }
            .ad-slot-container-10 { height: 561px; }
            .ad-slot-container-11 { height: 1000px; }
}
```

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<details>
  <summary>Before</summary>

  https://user-images.githubusercontent.com/8000415/176215940-cf18fd03-ba39-40d9-8b77-7eff46deb856.mov
</details>

<details>
  <summary>After</summary>

  https://user-images.githubusercontent.com/8000415/176216240-4f56619e-0afb-4303-b86b-b6127ea63d28.mov  
</details>

## What is the value of this and can you measure success?

This fixes an issue that wasn't addressed in the previous PR - that the sticky container height is applied regardless of current viewport width. This causes an obvious issue with the layout on mobile (see the screenshots above).

This can be fixed by applying a media query in place of the computed style. However, since computed styles can't be nested in media queries, it's instead necessary to insert a stylesheet with the sticky heights contained within classes.

### Tested

- [X] Locally
- [x] On CODE (optional)
