### PR TITLE
Add test for getTopics method

### DIFF
--- a/article/test/topmentions/TopMentionsServiceTest.scala
+++ b/article/test/topmentions/TopMentionsServiceTest.scala
@@ -2,7 +2,7 @@ package topmentions
 
 import com.gu.contentapi.client.model.ContentApiError
 import com.gu.contentapi.client.model.v1.ItemResponse
-import model.{TopMentionsDetails, TopMentionsResult, TopMentionsTopic, TopMentionsTopicType}
+import model.{TopMentionsDetails, TopMentionsResult, TopMentionsTopic, TopMentionsTopicType, TopicWithCount}
 import model.TopMentionsTopicType.TopMentionsTopicType
 import org.scalatest.{BeforeAndAfterAll, GivenWhenThen}
 import org.scalatest.featurespec.AnyFeatureSpec
@@ -31,8 +31,28 @@ class TopMentionsServiceTest
       count = 1,
       percentage_blocks = 1.2f,
     )
+
+  val topMentionResults = Seq(
+    TopMentionsResult(
+      name = "name1",
+      `type` = TopMentionsTopicType.Org,
+      blocks = Seq("blockId1"),
+      count = 1,
+      percentage_blocks = 1.2f,
+    ),
+    TopMentionsResult(
+      name = "name2",
+      `type` = TopMentionsTopicType.Person,
+      blocks = Seq("blockId1"),
+      count = 10,
+      percentage_blocks = 1.2f,
+    ),
+  )
   val successResponse =
     TopMentionsDetails(entity_types = Seq(TopMentionsTopicType.Org), results = Seq(topMentionResult), model = "model")
+
+  val successMultiResponse =
+    TopMentionsDetails(entity_types = Seq(TopMentionsTopicType.Org), results = topMentionResults, model = "model")
 
   "refreshTopMentions" should "return successful future given getListOfKeys s3 call fails" in {
     when(fakeClient.getListOfKeys()) thenReturn Future.failed(new Throwable(""))
@@ -131,5 +151,35 @@ class TopMentionsServiceTest
       topMentionService.getTopMentionsByTopic("key1", TopMentionsTopic(TopMentionsTopicType.Org, "someRandomOrg"))
 
     result should equal(None)
+  }
+
+  "getTopics" should "return a list of topics given a blog id" in {
+    when(fakeClient.getListOfKeys()) thenReturn Future.successful(List("key1"))
+    when(fakeClient.getObject("key1")) thenReturn Future.successful(successMultiResponse)
+    val expectedTopics =
+      Some(
+        List(
+          TopicWithCount(TopMentionsTopicType.Org, "name1", 1),
+          TopicWithCount(TopMentionsTopicType.Person, "name2", 10),
+        ),
+      )
+
+    val topMentionService = new TopMentionsService(fakeClient)
+    val refreshJob = Await.result(topMentionService.refreshTopMentions(), 1.second)
+    val topicList =
+      topMentionService.getTopics("key1")
+
+    topicList should equal(expectedTopics)
+  }
+
+  "getTopics" should "return none given a blog id that doesn't exist in cache" in {
+    when(fakeClient.getListOfKeys()) thenReturn Future.successful(List("key1"))
+    when(fakeClient.getObject("key1")) thenReturn Future.successful(successMultiResponse)
+    val topMentionService = new TopMentionsService(fakeClient)
+
+    val topicList =
+      topMentionService.getTopics("key1")
+
+    topicList should equal(None)
   }
 }


### PR DESCRIPTION
## What does this change?
Adds tests for the `getTopics` function which, when given a blog id, returns a list of topics with count.
## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
