### PR TITLE
Convert AB Test to feature switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -512,4 +512,14 @@ trait FeatureSwitches {
     sellByDate = never,
     exposeClientSide = true,
   )
+
+  val AutomaticFilters = Switch(
+    SwitchGroup.Feature,
+    "automatic-filters",
+    "When ON, displays automatic filters and corresponding UI changes on business live blogs only",
+    owners = Seq(Owner.withEmail("dotcom.platform@guardian.co.uk")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
 }

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -6,7 +6,7 @@ import java.time.LocalDate
 
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =
-    Set(InteractivesIdleLoading, OfferHttp3, KeyEventsCarousel, AutomaticFilters)
+    Set(InteractivesIdleLoading, OfferHttp3, KeyEventsCarousel)
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
@@ -46,13 +46,4 @@ object KeyEventsCarousel
       owners = Seq(Owner.withGithub("abeddow91")),
       sellByDate = LocalDate.of(2022, 9, 13),
       participationGroup = Perc0C,
-    )
-
-object AutomaticFilters
-    extends Experiment(
-      name = "automatic-filters",
-      description = "When ON, tests automatic filters on business live blogs only",
-      owners = Seq(Owner.withGithub("joecowton1")),
-      sellByDate = LocalDate.of(2022, 12, 6),
-      participationGroup = Perc0D,
     )


### PR DESCRIPTION
## What does this change?

Removes the AB test for automatic filters and adds a feature switch for automatic filters.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

