### PR TITLE
Update CAPI & FAPI clients to latest versions (also remove hack required for Lightbox)

### DIFF
--- a/facia-press/test/frontpress/FaciaClientTest.scala
+++ b/facia-press/test/frontpress/FaciaClientTest.scala
@@ -1,0 +1,31 @@
+package frontpress
+
+import com.gu.contentapi.client.ContentApiClient
+import com.gu.contentapi.client.model.SearchQuery
+import org.scalatest.flatspec._
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+
+class FaciaClientTest extends AsyncFlatSpec with Matchers with MockitoSugar {
+
+  "FAPI Client" should "send a CAPI client request without a runtime error like java.lang.NoSuchMethodError" in {
+    // The FAPI client uses the Content API client. If this test fails with a java.lang.NoSuchMethodError, the
+    // versions of FAPI client and CAPI client we are using are incompatible - the FAPI client will have been
+    // compiled against a different version of the CAPI client.
+
+    val mockContentApiClient = mock[ContentApiClient]
+
+    // This is only exercising the code to send the request, not recieve the result, but it's enough to trigger the
+    // java.lang.NoSuchMethodError seen in https://github.com/guardian/frontend/pull/25139#issuecomment-1163407402
+    noException shouldBe thrownBy(
+      com.gu.facia.api.contentapi.ContentApi.getHydrateResponse(
+        mockContentApiClient,
+        Seq(
+          SearchQuery().tag("profile/roberto-tyley"),
+          SearchQuery().tag("stage/comedy"),
+        ),
+      ),
+    )
+  }
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,8 +5,8 @@ import sbt._
 object Dependencies {
   val identityLibVersion = "3.254"
   val awsVersion = "1.12.205"
-  val capiVersion = "18.0.1"
-  val faciaVersion = "3.3.12"
+  val capiVersion = "19.0.0"
+  val faciaVersion = "4.0.0"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"


### PR DESCRIPTION
## What does this change?

The latest version of the CAPI client (v19) includes https://github.com/guardian/content-api-scala-client/pull/359, which we can use to replace the pagination code based on [`play-iteratees`](https://github.com/playframework/play-iteratees) (introduced in July 2014 with https://github.com/guardian/frontend/pull/5199), currently blocking the [Scala 2.13 upgrade for Frontend](https://github.com/guardian/frontend/issues/24817).

The updated CAPI client is binary-incompatible with previous versions of the CAPI client, meaning we also need to update the FAPI client - as it also uses CAPI, and needs to be compiled against the same CAPI version. A similar PR, updating FAPI & CAPI in Ophan is at https://github.com/guardian/ophan/pull/4719, and has been successfully deployed. Like there, we're adding a `FaciaClientTest` that will break at build time rather than runtime if our versions of the FAPI & CAPI clients are incompatible.

The updates to the CAPI client also support `previous`/`next` search functionality, as used by the Lightbox, meaning that the small `ContentApiNavQuery` hack for the Lightbox (introduced here: https://github.com/guardian/frontend/pull/20462) can now be removed.

## Screenshots

The next/previous functionality in lightboxes (eg on [this article](https://www.theguardian.com/commentisfree/picture/2022/may/22/brian-adcock-on-the-looming-sue-gray-report-cartoon)) from https://github.com/guardian/frontend/pull/20462 continues to work:

https://user-images.githubusercontent.com/52038/176659959-1bba3f4e-cea7-4c75-8927-42b06a209da3.mov

## Checklist

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [x] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [ ] Locally
- [x] On CODE (optional)
