### PR TITLE
Add `selectedTopics` to DCR model

### DIFF
--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -58,11 +58,11 @@ class LiveBlogController(
       path: String,
       page: Option[String] = None,
       filterKeyEvents: Option[Boolean],
-      selectedTopics: Option[String],
+      topics: Option[String],
   ): Action[AnyContent] = {
     Action.async { implicit request =>
       val filter = shouldFilter(filterKeyEvents)
-      val topMentions = if (filter) None else getTopMentions(path, selectedTopics)
+      val topMentions = if (filter) None else getTopMentions(path, topics)
       val availableTopics = topMentionsService.getTopics(path)
 
       page.map(ParseBlockId.fromPageParam) match {
@@ -73,7 +73,7 @@ class LiveBlogController(
             filter,
             topMentions,
             availableTopics,
-            selectedTopics,
+            selectedTopics = topics,
           ) // we know the id of a block
         case Some(InvalidFormat) =>
           Future.successful(
@@ -88,10 +88,17 @@ class LiveBlogController(
                 filter,
                 Some(value),
                 availableTopics,
-                selectedTopics,
+                selectedTopics = topics,
               ) // no page param
             case None =>
-              renderWithRange(path, CanonicalLiveBlog, filter, None, availableTopics, selectedTopics) // no page param
+              renderWithRange(
+                path,
+                CanonicalLiveBlog,
+                filter,
+                None,
+                availableTopics,
+                selectedTopics = topics,
+              ) // no page param
           }
         }
       }

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -66,7 +66,7 @@ class LiveBlogController(
       val topicList = topMentionsService.getTopics(path)
       page.map(ParseBlockId.fromPageParam) match {
         case Some(ParsedBlockId(id)) =>
-          renderWithRange(path, PageWithBlock(id), filter, topMentions, topicList) // we know the id of a block
+          renderWithRange(path, PageWithBlock(id), filter, topMentions, topicList, topics) // we know the id of a block
         case Some(InvalidFormat) =>
           Future.successful(
             Cached(10)(WithoutRevalidationResult(NotFound)),
@@ -74,8 +74,8 @@ class LiveBlogController(
         case None => {
           topMentions match {
             case Some(value) =>
-              renderWithRange(path, TopicsLiveBlog, filter, Some(value), topicList) // no page param
-            case None => renderWithRange(path, CanonicalLiveBlog, filter, None, topicList) // no page param
+              renderWithRange(path, TopicsLiveBlog, filter, Some(value), topicList, topics) // no page param
+            case None => renderWithRange(path, CanonicalLiveBlog, filter, None, topicList, topics) // no page param
           }
         }
       }
@@ -116,6 +116,7 @@ class LiveBlogController(
       filterKeyEvents: Boolean,
       topMentionResult: Option[TopMentionsResult],
       topics: Option[Seq[TopicWithCount]],
+      activeTopic: Option[String],
   )(implicit
       request: RequestHeader,
   ): Future[Result] = {
@@ -156,7 +157,7 @@ class LiveBlogController(
                 filterKeyEvents,
                 request.forceLive,
                 topics,
-                topMentionResult,
+                activeTopic,
               )
             } else {
               DotcomponentsLogger.logger.logRequest(s"liveblog executing in web", properties, page)

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -156,6 +156,7 @@ class LiveBlogController(
                 filterKeyEvents,
                 request.forceLive,
                 topics,
+                topMentionResult,
               )
             } else {
               DotcomponentsLogger.logger.logRequest(s"liveblog executing in web", properties, page)

--- a/article/app/topmentions/TopMentionsService.scala
+++ b/article/app/topmentions/TopMentionsService.scala
@@ -42,7 +42,6 @@ class TopMentionsService(topMentionsS3Client: TopMentionsS3Client) extends GuLog
       blogId: String,
       topMentionEntity: TopMentionsTopic,
   ): Option[TopMentionsResult] = {
-
     getBlogTopMentions(blogId).flatMap(_.results.find(result => {
       result.`type` == topMentionEntity.`type` && result.name == topMentionEntity.value
     }))

--- a/article/test/DCRFake.scala
+++ b/article/test/DCRFake.scala
@@ -25,6 +25,7 @@ class DCRFake(implicit context: ApplicationContext) extends renderers.DotcomRend
       filterKeyEvents: Boolean,
       forceLive: Boolean,
       topics: Option[Seq[TopicWithCount]],
+      activeTopic: Option[String],
   )(implicit request: RequestHeader): Future[Result] = {
     implicit val ec = ExecutionContext.global
     requestedBlogs.enqueue(article)

--- a/article/test/DCRFake.scala
+++ b/article/test/DCRFake.scala
@@ -24,8 +24,8 @@ class DCRFake(implicit context: ApplicationContext) extends renderers.DotcomRend
       pageType: PageType,
       filterKeyEvents: Boolean,
       forceLive: Boolean,
-      topics: Option[Seq[TopicWithCount]],
-      activeTopic: Option[String],
+      availableTopics: Option[Seq[TopicWithCount]],
+      selectedTopics: Option[String],
   )(implicit request: RequestHeader): Future[Result] = {
     implicit val ec = ExecutionContext.global
     requestedBlogs.enqueue(article)

--- a/article/test/LiveBlogControllerTest.scala
+++ b/article/test/LiveBlogControllerTest.scala
@@ -261,7 +261,7 @@ import scala.concurrent.Future
       path,
       page = None,
       filterKeyEvents = Some(false),
-      selectedTopics = Some("org:Fifa"),
+      topics = Some("org:Fifa"),
     )(fakeRequest)
 
     status(result) should be(200)
@@ -276,7 +276,7 @@ import scala.concurrent.Future
       path,
       page = None,
       filterKeyEvents = Some(true),
-      selectedTopics = Some("org:Fifa"),
+      topics = Some("org:Fifa"),
     )(fakeRequest)
 
     verify(fakeTopMentionsService, times(0)).getTopMentionsByTopic(anyString(), anyObject())

--- a/article/test/LiveBlogControllerTest.scala
+++ b/article/test/LiveBlogControllerTest.scala
@@ -261,7 +261,7 @@ import scala.concurrent.Future
       path,
       page = None,
       filterKeyEvents = Some(false),
-      topics = Some("org:Fifa"),
+      selectedTopics = Some("org:Fifa"),
     )(fakeRequest)
 
     status(result) should be(200)
@@ -276,7 +276,7 @@ import scala.concurrent.Future
       path,
       page = None,
       filterKeyEvents = Some(true),
-      topics = Some("org:Fifa"),
+      selectedTopics = Some("org:Fifa"),
     )(fakeRequest)
 
     verify(fakeTopMentionsService, times(0)).getTopMentionsByTopic(anyString(), anyObject())

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -38,7 +38,7 @@ case class DotcomRenderingDataModel(
     webTitle: String,
     mainMediaElements: List[PageElement],
     main: String,
-    activeTopic: Option[TopMentionsResult],
+    activeTopic: Option[String],
     filterKeyEvents: Boolean,
     topics: Option[Seq[TopicWithCount]],
     pinnedPost: Option[Block],
@@ -102,7 +102,7 @@ object DotcomRenderingDataModel {
   implicit val writes = new Writes[DotcomRenderingDataModel] {
     def writes(model: DotcomRenderingDataModel) = {
       val obj = Json.obj(
-        "activeTopic" -> None,
+        "activeTopic" -> model.activeTopic,
         "version" -> model.version,
         "headline" -> model.headline,
         "standfirst" -> model.standfirst,
@@ -246,7 +246,7 @@ object DotcomRenderingDataModel {
       filterKeyEvents: Boolean,
       forceLive: Boolean,
       topics: Option[Seq[TopicWithCount]] = None,
-      activeTopic: Option[TopMentionsResult] = None,
+      activeTopic: Option[String] = None,
   ): DotcomRenderingDataModel = {
     val pagination = page.currentPage.pagination.map(paginationInfo => {
       Pagination(
@@ -320,7 +320,7 @@ object DotcomRenderingDataModel {
       topics: Option[Seq[TopicWithCount]],
       mostRecentBlockId: Option[String] = None,
       forceLive: Boolean = false,
-      activeTopic: Option[TopMentionsResult] = None,
+      activeTopic: Option[String] = None,
   ): DotcomRenderingDataModel = {
 
     val edition = Edition.edition(request)
@@ -424,10 +424,8 @@ object DotcomRenderingDataModel {
 
     val matchData = makeMatchData(page)
 
-    val newActiveTopic = activeTopic.map(x => println(x))
-
     DotcomRenderingDataModel(
-      activeTopic = None,
+      activeTopic = activeTopic,
       author = author,
       badge = Badges.badgeFor(content).map(badge => DCRBadge(badge.seriesTag, badge.imageUrl)),
       beaconURL = Configuration.debug.beaconUrl,

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -20,6 +20,7 @@ import model.{
   InteractivePage,
   LiveBlogPage,
   PageWithStoryPackage,
+  TopMentionsResult,
   TopicWithCount,
 }
 import navigation._
@@ -37,6 +38,7 @@ case class DotcomRenderingDataModel(
     webTitle: String,
     mainMediaElements: List[PageElement],
     main: String,
+    activeTopic: Option[TopMentionsResult],
     filterKeyEvents: Boolean,
     topics: Option[Seq[TopicWithCount]],
     pinnedPost: Option[Block],
@@ -100,6 +102,7 @@ object DotcomRenderingDataModel {
   implicit val writes = new Writes[DotcomRenderingDataModel] {
     def writes(model: DotcomRenderingDataModel) = {
       val obj = Json.obj(
+        "activeTopic" -> None,
         "version" -> model.version,
         "headline" -> model.headline,
         "standfirst" -> model.standfirst,
@@ -243,6 +246,7 @@ object DotcomRenderingDataModel {
       filterKeyEvents: Boolean,
       forceLive: Boolean,
       topics: Option[Seq[TopicWithCount]] = None,
+      activeTopic: Option[TopMentionsResult] = None,
   ): DotcomRenderingDataModel = {
     val pagination = page.currentPage.pagination.map(paginationInfo => {
       Pagination(
@@ -297,6 +301,7 @@ object DotcomRenderingDataModel {
       topics,
       mostRecentBlockId,
       forceLive,
+      activeTopic,
     )
   }
 
@@ -315,6 +320,7 @@ object DotcomRenderingDataModel {
       topics: Option[Seq[TopicWithCount]],
       mostRecentBlockId: Option[String] = None,
       forceLive: Boolean = false,
+      activeTopic: Option[TopMentionsResult] = None,
   ): DotcomRenderingDataModel = {
 
     val edition = Edition.edition(request)
@@ -418,7 +424,10 @@ object DotcomRenderingDataModel {
 
     val matchData = makeMatchData(page)
 
+    val newActiveTopic = activeTopic.map(x => println(x))
+
     DotcomRenderingDataModel(
+      activeTopic = None,
       author = author,
       badge = Badges.badgeFor(content).map(badge => DCRBadge(badge.seriesTag, badge.imageUrl)),
       beaconURL = Configuration.debug.beaconUrl,

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -22,15 +22,16 @@ import model.{
   NoCache,
   PageWithStoryPackage,
   PressedPage,
+  TopMentionsResult,
   TopicWithCount,
 }
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc.Results.{InternalServerError, NotFound}
 import play.api.mvc.{RequestHeader, Result}
 import play.twirl.api.Html
+
 import java.net.ConnectException
 import java.util.concurrent.TimeoutException
-
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -142,6 +143,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       filterKeyEvents: Boolean,
       forceLive: Boolean = false,
       topics: Option[Seq[TopicWithCount]] = None,
+      activeTopic: Option[TopMentionsResult] = None,
   )(implicit request: RequestHeader): Future[Result] = {
     val dataModel = page match {
       case liveblog: LiveBlogPage =>
@@ -153,6 +155,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
           filterKeyEvents,
           forceLive,
           topics,
+          activeTopic,
         )
       case _ => DotcomRenderingDataModel.forArticle(page, blocks, request, pageType)
     }

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -141,8 +141,8 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       pageType: PageType,
       filterKeyEvents: Boolean,
       forceLive: Boolean = false,
-      topics: Option[Seq[TopicWithCount]] = None,
-      activeTopic: Option[String] = None,
+      availableTopics: Option[Seq[TopicWithCount]] = None,
+      selectedTopics: Option[String] = None,
   )(implicit request: RequestHeader): Future[Result] = {
     val dataModel = page match {
       case liveblog: LiveBlogPage =>
@@ -153,8 +153,8 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
           pageType,
           filterKeyEvents,
           forceLive,
-          topics,
-          activeTopic,
+          availableTopics,
+          selectedTopics,
         )
       case _ => DotcomRenderingDataModel.forArticle(page, blocks, request, pageType)
     }

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -22,7 +22,6 @@ import model.{
   NoCache,
   PageWithStoryPackage,
   PressedPage,
-  TopMentionsResult,
   TopicWithCount,
 }
 import play.api.libs.ws.{WSClient, WSResponse}
@@ -143,7 +142,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       filterKeyEvents: Boolean,
       forceLive: Boolean = false,
       topics: Option[Seq[TopicWithCount]] = None,
-      activeTopic: Option[TopMentionsResult] = None,
+      activeTopic: Option[String] = None,
   )(implicit request: RequestHeader): Future[Result] = {
     val dataModel = page match {
       case liveblog: LiveBlogPage =>


### PR DESCRIPTION
## What does this change?
Updates the DCR model to add activeTopic and passes the topic query param though as its value. This allows us to persist the user's topic state. 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
