### PR TITLE
Ad slots should fallback to data attributes if size mapping is empty

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -1,5 +1,7 @@
-import { slotSizeMappings } from '@guardian/commercial-core';
+import { createAdSize, slotSizeMappings } from '@guardian/commercial-core';
 import type { AdSize, SizeMapping, SlotName } from '@guardian/commercial-core';
+import { breakpoints } from '../../../../lib/detect';
+import { breakpointNameToAttribute } from './breakpoint-name-to-attribute';
 import { defineSlot } from './define-slot';
 
 type Resolver = (x: boolean) => void;
@@ -13,6 +15,41 @@ type Timings = {
 	loadingMethod: number | null;
 	lazyWaitComplete: number | null;
 };
+
+const stringToTuple = (size: string): AdSizeTuple => {
+	const dimensions = size.split(',', 2).map(Number);
+
+	// Return an outOfPage tuple if the string is not `{number},{number}`
+	if (dimensions.length !== 2 || dimensions.some((n) => isNaN(n)))
+		return [0, 0]; // adSizes.outOfPage
+
+	return [dimensions[0], dimensions[1]];
+};
+
+/** A breakpoint can have various sizes assigned to it. You can assign either on
+ * set of sizes or multiple.
+ *
+ * One size       - `data-mobile="300,50"`
+ * Multiple sizes - `data-mobile="300,50|320,50"`
+ */
+const createSizeMapping = (attr: string): AdSize[] =>
+	attr.split('|').map((size) => createAdSize(...stringToTuple(size)));
+
+/** Extract the ad sizes from the breakpoint data attributes of an ad slot
+ *
+ * @param advertNode The ad slot HTML element that contains the breakpoint attributes
+ * @returns A mapping from the breakpoints supported by the slot to an array of ad sizes
+ */
+const getAdBreakpointSizes = (advertNode: HTMLElement): SizeMapping =>
+	breakpoints.reduce<Record<string, AdSize[]>>((sizes, breakpoint) => {
+		const data = advertNode.getAttribute(
+			`data-${breakpointNameToAttribute(breakpoint.name)}`,
+		);
+		if (data) {
+			sizes[breakpoint.name] = createSizeMapping(data);
+		}
+		return sizes;
+	}, {});
 
 const isSlotName = (slotName: string): slotName is SlotName => {
 	return slotName in slotSizeMappings;
@@ -84,21 +121,28 @@ class Advert {
 		adSlotNode: HTMLElement,
 		additionalSizeMapping: SizeMapping = {},
 	) {
+		// Try to used size mappings if available
 		const defaultSizeMappingForSlot = adSlotNode.dataset.name
 			? getSlotSizeMapping(adSlotNode.dataset.name)
 			: {};
 
-		const sizeMapping = mergeSizeMappings(
+		let sizeMapping = mergeSizeMappings(
 			defaultSizeMappingForSlot,
 			additionalSizeMapping,
 		);
 
+		// If the size mapping is empty, use the data attributes to create a size mapping, this is used on some interactives
 		if (isSizeMappingEmpty(sizeMapping)) {
-			throw new Error(
-				`Tried to render ad slot '${
-					adSlotNode.dataset.name ?? ''
-				}' without any size mappings`,
-			);
+			sizeMapping = getAdBreakpointSizes(adSlotNode);
+
+			// If the size mapping is still empty, throw an error as this should never happen
+			if (isSizeMappingEmpty(sizeMapping)) {
+				throw new Error(
+					`Tried to render ad slot '${
+						adSlotNode.dataset.name ?? ''
+					}' without any size mappings`,
+				);
+			}
 		}
 
 		const slotDefinition = defineSlot(adSlotNode, sizeMapping);

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -40,7 +40,9 @@ const createSizeMapping = (attr: string): AdSize[] =>
  * @param advertNode The ad slot HTML element that contains the breakpoint attributes
  * @returns A mapping from the breakpoints supported by the slot to an array of ad sizes
  */
-const getAdBreakpointSizes = (advertNode: HTMLElement): SizeMapping =>
+const getSlotSizeMappingsFromDataAttrs = (
+	advertNode: HTMLElement,
+): SizeMapping =>
 	breakpoints.reduce<Record<string, AdSize[]>>((sizes, breakpoint) => {
 		const data = advertNode.getAttribute(
 			`data-${breakpointNameToAttribute(breakpoint.name)}`,
@@ -131,9 +133,11 @@ class Advert {
 			additionalSizeMapping,
 		);
 
-		// If the size mapping is empty, use the data attributes to create a size mapping, this is used on some interactives
+		/** If the size mapping is empty, use the data attributes to create a size mapping,
+		 * this is used on some interactives e.g. https://www.theguardian.com/education/ng-interactive/2021/sep/11/the-best-uk-universities-2022-rankings
+		 **/
 		if (isSizeMappingEmpty(sizeMapping)) {
-			sizeMapping = getAdBreakpointSizes(adSlotNode);
+			sizeMapping = getSlotSizeMappingsFromDataAttrs(adSlotNode);
 
 			// If the size mapping is still empty, throw an error as this should never happen
 			if (isSizeMappingEmpty(sizeMapping)) {

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -140,6 +140,8 @@
  "../projects/commercial/modules/dfp/Advert.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../lib/detect.js",
+  "../projects/commercial/modules/dfp/breakpoint-name-to-attribute.ts",
   "../projects/commercial/modules/dfp/define-slot.js"
  ],
  "../projects/commercial/modules/dfp/add-slot.ts": [


### PR DESCRIPTION
## What does this change?
#25124 removed reading size mappings from the slots data attributes, but have spotted (https://sentry.io/organizations/the-guardian/issues/3373350782/events/?project=35463&statsPeriod=14d) there are a few interactives where slots are embedded/inserted that seem to use no naming convention for their sizes, and are not displayed, so will have to fallback to the data attributes.

Example: https://www.theguardian.com/education/ng-interactive/2021/sep/11/the-best-uk-universities-2022-rankings

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
