### PR TITLE
Add `RecipeSchemaAtomBlockElement`

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -439,6 +439,15 @@ object QuizAtomBlockElement {
   implicit val QuizAtomBlockElementWrites: Writes[QuizAtomBlockElement] = Json.writes[QuizAtomBlockElement]
 }
 
+case class RecipeSchemaAtomBlockElement(
+    id: String,
+    json: String,
+) extends PageElement
+object RecipeSchemaAtomBlockElement {
+  implicit val RecipeSchemaAtomBlockElementWrites: Writes[RecipeSchemaAtomBlockElement] =
+    Json.writes[RecipeSchemaAtomBlockElement]
+}
+
 case class RichLinkBlockElement(
     url: Option[String],
     text: Option[String],


### PR DESCRIPTION
## What does this change?

A companion to https://github.com/guardian/dotcom-rendering/pull/5272, this adds a `RecipeSchemaAtomBlockElement` class to `PageElement.scala`. Part of an experiment to see before/after SEO performance on a handful of recipe pages with structured data.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes, see https://github.com/guardian/dotcom-rendering/pull/5272
