### PR TITLE
rename TopicService methods

### DIFF
--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -413,7 +413,7 @@ class LiveBlogController(
   def getTopMentions(blogId: String, topics: Option[String]) = {
     val topMentionsResult = for {
       topMentionTopic <- TopMentionsTopic.fromString(topics)
-      topMentions <- topMentionsService.getTopMentionsByTopic(blogId, topMentionTopic)
+      topMentions <- topMentionsService.getBlogSelectedTopic(blogId, topMentionTopic)
     } yield topMentions
 
     topMentionsResult match {

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -413,7 +413,7 @@ class LiveBlogController(
   def getTopMentions(blogId: String, topics: Option[String]) = {
     val topMentionsResult = for {
       topMentionTopic <- TopMentionsTopic.fromString(topics)
-      topMentions <- topMentionsService.getBlogSelectedTopic(blogId, topMentionTopic)
+      topMentions <- topMentionsService.getSelectedTopicDetails(blogId, topMentionTopic)
     } yield topMentions
 
     topMentionsResult match {

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -413,7 +413,7 @@ class LiveBlogController(
   def getTopMentions(blogId: String, topics: Option[String]) = {
     val topMentionsResult = for {
       topMentionTopic <- TopMentionsTopic.fromString(topics)
-      topMentions <- topMentionsService.getSelectedTopicDetails(blogId, topMentionTopic)
+      topMentions <- topMentionsService.getSelectedTopic(blogId, topMentionTopic)
     } yield topMentions
 
     topMentionsResult match {

--- a/article/app/jobs/TopicLifecycle.scala
+++ b/article/app/jobs/TopicLifecycle.scala
@@ -27,14 +27,14 @@ class TopicLifecycle(
 
     // refresh top mentions when app starts
     akkaAsync.after1s {
-      topMentionService.refreshTopMentions()
+      topMentionService.refreshTopics()
     }
   }
 
   private def scheduleJobs(): Unit = {
     // This job runs every 2 minutes
     jobs.scheduleEvery("TopMentionsAgentRefreshJob", 2.minutes) {
-      topMentionService.refreshTopMentions()
+      topMentionService.refreshTopics()
     }
   }
 

--- a/article/app/topmentions/TopicService.scala
+++ b/article/app/topmentions/TopicService.scala
@@ -24,12 +24,12 @@ class TopicService(topMentionsS3Client: TopMentionsS3Client) extends GuLogging {
       }
   }
 
-  def getBlogTopics(blogId: String): Option[TopMentionsDetails] = {
+  def getBlogTopicsDetails(blogId: String): Option[TopMentionsDetails] = {
     topMentions.get().flatMap(_.get(blogId))
   }
 
   def getTopics(blogId: String): Option[Seq[TopicWithCount]] = {
-    getBlogTopics(blogId).map(mentions =>
+    getBlogTopicsDetails(blogId).map(mentions =>
       mentions.results.map(mention => TopicWithCount(mention.`type`, mention.name, mention.count)),
     )
   }
@@ -42,7 +42,7 @@ class TopicService(topMentionsS3Client: TopMentionsS3Client) extends GuLogging {
       blogId: String,
       topMentionEntity: TopMentionsTopic,
   ): Option[TopMentionsResult] = {
-    getBlogTopics(blogId).flatMap(_.results.find(result => {
+    getBlogTopicsDetails(blogId).flatMap(_.results.find(result => {
       result.`type` == topMentionEntity.`type` && result.name == topMentionEntity.value
     }))
   }

--- a/article/app/topmentions/TopicService.scala
+++ b/article/app/topmentions/TopicService.scala
@@ -10,7 +10,7 @@ class TopicService(topMentionsS3Client: TopMentionsS3Client) extends GuLogging {
   private val topMentions = Box[Option[Map[String, TopMentionsDetails]]](None)
 
   def refreshTopics()(implicit executionContext: ExecutionContext): Future[Unit] = {
-    val retrievedTopMentions = topMentionsS3Client.getListOfKeys().map { key => key.map { retrieveTopMention(_) } }
+    val retrievedTopMentions = topMentionsS3Client.getListOfKeys().map { key => key.map { retrieveTopicsDetails(_) } }
 
     retrievedTopMentions
       .flatMap(Future.sequence(_))
@@ -38,7 +38,7 @@ class TopicService(topMentionsS3Client: TopMentionsS3Client) extends GuLogging {
     topMentions.get()
   }
 
-  def getTopMentionsByTopic(
+  def getBlogSelectedTopic(
       blogId: String,
       topMentionEntity: TopMentionsTopic,
   ): Option[TopMentionsResult] = {
@@ -47,7 +47,7 @@ class TopicService(topMentionsS3Client: TopMentionsS3Client) extends GuLogging {
     }))
   }
 
-  private def retrieveTopMention(key: String)(implicit executionContext: ExecutionContext) = {
+  private def retrieveTopicsDetails(key: String)(implicit executionContext: ExecutionContext) = {
     topMentionsS3Client.getObject(key).map { res => key -> res }
   }
 }

--- a/article/app/topmentions/TopicService.scala
+++ b/article/app/topmentions/TopicService.scala
@@ -24,12 +24,12 @@ class TopicService(topMentionsS3Client: TopMentionsS3Client) extends GuLogging {
       }
   }
 
-  def getBlogTopMentions(blogId: String): Option[TopMentionsDetails] = {
+  def getBlogTopics(blogId: String): Option[TopMentionsDetails] = {
     topMentions.get().flatMap(_.get(blogId))
   }
 
   def getTopics(blogId: String): Option[Seq[TopicWithCount]] = {
-    getBlogTopMentions(blogId).map(mentions =>
+    getBlogTopics(blogId).map(mentions =>
       mentions.results.map(mention => TopicWithCount(mention.`type`, mention.name, mention.count)),
     )
   }
@@ -42,7 +42,7 @@ class TopicService(topMentionsS3Client: TopMentionsS3Client) extends GuLogging {
       blogId: String,
       topMentionEntity: TopMentionsTopic,
   ): Option[TopMentionsResult] = {
-    getBlogTopMentions(blogId).flatMap(_.results.find(result => {
+    getBlogTopics(blogId).flatMap(_.results.find(result => {
       result.`type` == topMentionEntity.`type` && result.name == topMentionEntity.value
     }))
   }

--- a/article/app/topmentions/TopicService.scala
+++ b/article/app/topmentions/TopicService.scala
@@ -38,7 +38,7 @@ class TopicService(topicS3Client: TopicS3Client) extends GuLogging {
     topMentions.get()
   }
 
-  def getSelectedTopicDetails(
+  def getSelectedTopic(
       blogId: String,
       topMentionEntity: TopMentionsTopic,
   ): Option[TopMentionsResult] = {

--- a/article/app/topmentions/TopicService.scala
+++ b/article/app/topmentions/TopicService.scala
@@ -38,7 +38,7 @@ class TopicService(topicS3Client: TopicS3Client) extends GuLogging {
     topMentions.get()
   }
 
-  def getBlogSelectedTopic(
+  def getSelectedTopicDetails(
       blogId: String,
       topMentionEntity: TopMentionsTopic,
   ): Option[TopMentionsResult] = {

--- a/article/app/topmentions/TopicService.scala
+++ b/article/app/topmentions/TopicService.scala
@@ -34,7 +34,7 @@ class TopicService(topMentionsS3Client: TopMentionsS3Client) extends GuLogging {
     )
   }
 
-  def getAllTopMentions: Option[Map[String, TopMentionsDetails]] = {
+  def getAllTopics: Option[Map[String, TopMentionsDetails]] = {
     topMentions.get()
   }
 

--- a/article/app/topmentions/TopicService.scala
+++ b/article/app/topmentions/TopicService.scala
@@ -9,7 +9,7 @@ class TopicService(topMentionsS3Client: TopMentionsS3Client) extends GuLogging {
 
   private val topMentions = Box[Option[Map[String, TopMentionsDetails]]](None)
 
-  def refreshTopMentions()(implicit executionContext: ExecutionContext): Future[Unit] = {
+  def refreshTopics()(implicit executionContext: ExecutionContext): Future[Unit] = {
     val retrievedTopMentions = topMentionsS3Client.getListOfKeys().map { key => key.map { retrieveTopMention(_) } }
 
     retrievedTopMentions

--- a/article/test/LiveBlogControllerTest.scala
+++ b/article/test/LiveBlogControllerTest.scala
@@ -53,7 +53,7 @@ import scala.concurrent.Future
     );
 
     when(
-      fakeTopMentionsService.getSelectedTopicDetails(path, TopMentionsTopic(TopMentionsTopicType.Org, "Fifa")),
+      fakeTopMentionsService.getSelectedTopic(path, TopMentionsTopic(TopMentionsTopicType.Org, "Fifa")),
     ) thenReturn Some(
       topMentionResult,
     )
@@ -324,7 +324,7 @@ import scala.concurrent.Future
       topics = Some("org:Fifa"),
     )(fakeRequest)
 
-    verify(fakeTopMentionsService, times(0)).getSelectedTopicDetails(anyString(), anyObject())
+    verify(fakeTopMentionsService, times(0)).getSelectedTopic(anyString(), anyObject())
     status(result) should be(200)
   }
 

--- a/article/test/LiveBlogControllerTest.scala
+++ b/article/test/LiveBlogControllerTest.scala
@@ -53,7 +53,7 @@ import scala.concurrent.Future
     );
 
     when(
-      fakeTopMentionsService.getBlogSelectedTopic(path, TopMentionsTopic(TopMentionsTopicType.Org, "Fifa")),
+      fakeTopMentionsService.getSelectedTopicDetails(path, TopMentionsTopic(TopMentionsTopicType.Org, "Fifa")),
     ) thenReturn Some(
       topMentionResult,
     )
@@ -324,7 +324,7 @@ import scala.concurrent.Future
       topics = Some("org:Fifa"),
     )(fakeRequest)
 
-    verify(fakeTopMentionsService, times(0)).getBlogSelectedTopic(anyString(), anyObject())
+    verify(fakeTopMentionsService, times(0)).getSelectedTopicDetails(anyString(), anyObject())
     status(result) should be(200)
   }
 

--- a/article/test/LiveBlogControllerTest.scala
+++ b/article/test/LiveBlogControllerTest.scala
@@ -53,7 +53,7 @@ import scala.concurrent.Future
     );
 
     when(
-      fakeTopMentionsService.getTopMentionsByTopic(path, TopMentionsTopic(TopMentionsTopicType.Org, "Fifa")),
+      fakeTopMentionsService.getBlogSelectedTopic(path, TopMentionsTopic(TopMentionsTopicType.Org, "Fifa")),
     ) thenReturn Some(
       topMentionResult,
     )
@@ -324,7 +324,7 @@ import scala.concurrent.Future
       topics = Some("org:Fifa"),
     )(fakeRequest)
 
-    verify(fakeTopMentionsService, times(0)).getTopMentionsByTopic(anyString(), anyObject())
+    verify(fakeTopMentionsService, times(0)).getBlogSelectedTopic(anyString(), anyObject())
     status(result) should be(200)
   }
 

--- a/article/test/topmentions/TopMentionsServiceTest.scala
+++ b/article/test/topmentions/TopMentionsServiceTest.scala
@@ -54,7 +54,7 @@ class TopMentionsServiceTest
     when(fakeClient.getListOfKeys()) thenReturn Future.failed(new Throwable(""))
     val topMentionService = new TopicService(fakeClient)
 
-    Await.result(topMentionService.refreshTopMentions(), 1.second)
+    Await.result(topMentionService.refreshTopics(), 1.second)
     val results = topMentionService.getAllTopMentions
 
     results should be(None)
@@ -67,7 +67,7 @@ class TopMentionsServiceTest
 
     val topMentionService = new TopicService(fakeClient)
 
-    val refreshJob = Await.result(topMentionService.refreshTopMentions(), 1.second)
+    val refreshJob = Await.result(topMentionService.refreshTopics(), 1.second)
     val results = topMentionService.getAllTopMentions
 
     refreshJob shouldBe a[Unit]
@@ -80,7 +80,7 @@ class TopMentionsServiceTest
 
     val topMentionService = new TopicService(fakeClient)
 
-    val refreshJob = Await.result(topMentionService.refreshTopMentions(), 1.second)
+    val refreshJob = Await.result(topMentionService.refreshTopics(), 1.second)
     val results = topMentionService.getAllTopMentions
 
     refreshJob shouldBe a[Unit]
@@ -93,7 +93,7 @@ class TopMentionsServiceTest
     when(fakeClient.getObject("key1")) thenReturn Future.successful(successResponse)
 
     val topMentionService = new TopicService(fakeClient)
-    val refreshJob = Await.result(topMentionService.refreshTopMentions(), 1.second)
+    val refreshJob = Await.result(topMentionService.refreshTopics(), 1.second)
 
     val result = topMentionService.getTopMentionsByTopic("key1", TopMentionsTopic(TopMentionsTopicType.Org, "name1"))
 
@@ -105,7 +105,7 @@ class TopMentionsServiceTest
     when(fakeClient.getObject("key1")) thenReturn Future.successful(successResponse)
 
     val topMentionService = new TopicService(fakeClient)
-    val refreshJob = Await.result(topMentionService.refreshTopMentions(), 1.second)
+    val refreshJob = Await.result(topMentionService.refreshTopics(), 1.second)
 
     val result = topMentionService.getTopMentionsByTopic("key1", TopMentionsTopic(TopMentionsTopicType.Org, "NAME1"))
 
@@ -117,7 +117,7 @@ class TopMentionsServiceTest
     when(fakeClient.getObject("key1")) thenReturn Future.successful(successResponse)
 
     val topMentionService = new TopicService(fakeClient)
-    val refreshJob = Await.result(topMentionService.refreshTopMentions(), 1.second)
+    val refreshJob = Await.result(topMentionService.refreshTopics(), 1.second)
 
     val result = topMentionService.getTopMentionsByTopic("key2", TopMentionsTopic(TopMentionsTopicType.Org, "name1"))
 
@@ -129,7 +129,7 @@ class TopMentionsServiceTest
     when(fakeClient.getObject("key1")) thenReturn Future.successful(successResponse)
 
     val topMentionService = new TopicService(fakeClient)
-    val refreshJob = Await.result(topMentionService.refreshTopMentions(), 1.second)
+    val refreshJob = Await.result(topMentionService.refreshTopics(), 1.second)
 
     val result = topMentionService.getTopMentionsByTopic("key1", TopMentionsTopic(TopMentionsTopicType.Person, "Boris"))
 
@@ -141,7 +141,7 @@ class TopMentionsServiceTest
     when(fakeClient.getObject("key1")) thenReturn Future.successful(successResponse)
 
     val topMentionService = new TopicService(fakeClient)
-    val refreshJob = Await.result(topMentionService.refreshTopMentions(), 1.second)
+    val refreshJob = Await.result(topMentionService.refreshTopics(), 1.second)
 
     val result =
       topMentionService.getTopMentionsByTopic("key1", TopMentionsTopic(TopMentionsTopicType.Org, "someRandomOrg"))
@@ -161,7 +161,7 @@ class TopMentionsServiceTest
       )
 
     val topMentionService = new TopicService(fakeClient)
-    val refreshJob = Await.result(topMentionService.refreshTopMentions(), 1.second)
+    val refreshJob = Await.result(topMentionService.refreshTopics(), 1.second)
     val topicList =
       topMentionService.getTopics("key1")
 

--- a/article/test/topmentions/TopMentionsServiceTest.scala
+++ b/article/test/topmentions/TopMentionsServiceTest.scala
@@ -95,7 +95,7 @@ class TopMentionsServiceTest
     val topMentionService = new TopicService(fakeClient)
     val refreshJob = Await.result(topMentionService.refreshTopics(), 1.second)
 
-    val result = topMentionService.getSelectedTopicDetails("key1", TopMentionsTopic(TopMentionsTopicType.Org, "name1"))
+    val result = topMentionService.getSelectedTopic("key1", TopMentionsTopic(TopMentionsTopicType.Org, "name1"))
 
     result.get should equal(topMentionResult)
   }
@@ -107,7 +107,7 @@ class TopMentionsServiceTest
     val topMentionService = new TopicService(fakeClient)
     val refreshJob = Await.result(topMentionService.refreshTopics(), 1.second)
 
-    val result = topMentionService.getSelectedTopicDetails("key1", TopMentionsTopic(TopMentionsTopicType.Org, "NAME1"))
+    val result = topMentionService.getSelectedTopic("key1", TopMentionsTopic(TopMentionsTopicType.Org, "NAME1"))
 
     result should equal(None)
   }
@@ -119,7 +119,7 @@ class TopMentionsServiceTest
     val topMentionService = new TopicService(fakeClient)
     val refreshJob = Await.result(topMentionService.refreshTopics(), 1.second)
 
-    val result = topMentionService.getSelectedTopicDetails("key2", TopMentionsTopic(TopMentionsTopicType.Org, "name1"))
+    val result = topMentionService.getSelectedTopic("key2", TopMentionsTopic(TopMentionsTopicType.Org, "name1"))
 
     result should equal(None)
   }
@@ -132,7 +132,7 @@ class TopMentionsServiceTest
     val refreshJob = Await.result(topMentionService.refreshTopics(), 1.second)
 
     val result =
-      topMentionService.getSelectedTopicDetails("key1", TopMentionsTopic(TopMentionsTopicType.Person, "Boris"))
+      topMentionService.getSelectedTopic("key1", TopMentionsTopic(TopMentionsTopicType.Person, "Boris"))
 
     result should equal(None)
   }
@@ -145,7 +145,7 @@ class TopMentionsServiceTest
     val refreshJob = Await.result(topMentionService.refreshTopics(), 1.second)
 
     val result =
-      topMentionService.getSelectedTopicDetails("key1", TopMentionsTopic(TopMentionsTopicType.Org, "someRandomOrg"))
+      topMentionService.getSelectedTopic("key1", TopMentionsTopic(TopMentionsTopicType.Org, "someRandomOrg"))
 
     result should equal(None)
   }

--- a/article/test/topmentions/TopMentionsServiceTest.scala
+++ b/article/test/topmentions/TopMentionsServiceTest.scala
@@ -55,7 +55,7 @@ class TopMentionsServiceTest
     val topMentionService = new TopicService(fakeClient)
 
     Await.result(topMentionService.refreshTopics(), 1.second)
-    val results = topMentionService.getAllTopMentions
+    val results = topMentionService.getAllTopics
 
     results should be(None)
   }
@@ -68,7 +68,7 @@ class TopMentionsServiceTest
     val topMentionService = new TopicService(fakeClient)
 
     val refreshJob = Await.result(topMentionService.refreshTopics(), 1.second)
-    val results = topMentionService.getAllTopMentions
+    val results = topMentionService.getAllTopics
 
     refreshJob shouldBe a[Unit]
     results should be(None)
@@ -81,7 +81,7 @@ class TopMentionsServiceTest
     val topMentionService = new TopicService(fakeClient)
 
     val refreshJob = Await.result(topMentionService.refreshTopics(), 1.second)
-    val results = topMentionService.getAllTopMentions
+    val results = topMentionService.getAllTopics
 
     refreshJob shouldBe a[Unit]
     results.isDefined should be(true)

--- a/article/test/topmentions/TopMentionsServiceTest.scala
+++ b/article/test/topmentions/TopMentionsServiceTest.scala
@@ -95,7 +95,7 @@ class TopMentionsServiceTest
     val topMentionService = new TopicService(fakeClient)
     val refreshJob = Await.result(topMentionService.refreshTopics(), 1.second)
 
-    val result = topMentionService.getBlogSelectedTopic("key1", TopMentionsTopic(TopMentionsTopicType.Org, "name1"))
+    val result = topMentionService.getSelectedTopicDetails("key1", TopMentionsTopic(TopMentionsTopicType.Org, "name1"))
 
     result.get should equal(topMentionResult)
   }
@@ -107,7 +107,7 @@ class TopMentionsServiceTest
     val topMentionService = new TopicService(fakeClient)
     val refreshJob = Await.result(topMentionService.refreshTopics(), 1.second)
 
-    val result = topMentionService.getBlogSelectedTopic("key1", TopMentionsTopic(TopMentionsTopicType.Org, "NAME1"))
+    val result = topMentionService.getSelectedTopicDetails("key1", TopMentionsTopic(TopMentionsTopicType.Org, "NAME1"))
 
     result should equal(None)
   }
@@ -119,7 +119,7 @@ class TopMentionsServiceTest
     val topMentionService = new TopicService(fakeClient)
     val refreshJob = Await.result(topMentionService.refreshTopics(), 1.second)
 
-    val result = topMentionService.getBlogSelectedTopic("key2", TopMentionsTopic(TopMentionsTopicType.Org, "name1"))
+    val result = topMentionService.getSelectedTopicDetails("key2", TopMentionsTopic(TopMentionsTopicType.Org, "name1"))
 
     result should equal(None)
   }
@@ -131,7 +131,8 @@ class TopMentionsServiceTest
     val topMentionService = new TopicService(fakeClient)
     val refreshJob = Await.result(topMentionService.refreshTopics(), 1.second)
 
-    val result = topMentionService.getBlogSelectedTopic("key1", TopMentionsTopic(TopMentionsTopicType.Person, "Boris"))
+    val result =
+      topMentionService.getSelectedTopicDetails("key1", TopMentionsTopic(TopMentionsTopicType.Person, "Boris"))
 
     result should equal(None)
   }
@@ -144,7 +145,7 @@ class TopMentionsServiceTest
     val refreshJob = Await.result(topMentionService.refreshTopics(), 1.second)
 
     val result =
-      topMentionService.getBlogSelectedTopic("key1", TopMentionsTopic(TopMentionsTopicType.Org, "someRandomOrg"))
+      topMentionService.getSelectedTopicDetails("key1", TopMentionsTopic(TopMentionsTopicType.Org, "someRandomOrg"))
 
     result should equal(None)
   }

--- a/article/test/topmentions/TopMentionsServiceTest.scala
+++ b/article/test/topmentions/TopMentionsServiceTest.scala
@@ -95,7 +95,7 @@ class TopMentionsServiceTest
     val topMentionService = new TopicService(fakeClient)
     val refreshJob = Await.result(topMentionService.refreshTopics(), 1.second)
 
-    val result = topMentionService.getTopMentionsByTopic("key1", TopMentionsTopic(TopMentionsTopicType.Org, "name1"))
+    val result = topMentionService.getBlogSelectedTopic("key1", TopMentionsTopic(TopMentionsTopicType.Org, "name1"))
 
     result.get should equal(topMentionResult)
   }
@@ -107,7 +107,7 @@ class TopMentionsServiceTest
     val topMentionService = new TopicService(fakeClient)
     val refreshJob = Await.result(topMentionService.refreshTopics(), 1.second)
 
-    val result = topMentionService.getTopMentionsByTopic("key1", TopMentionsTopic(TopMentionsTopicType.Org, "NAME1"))
+    val result = topMentionService.getBlogSelectedTopic("key1", TopMentionsTopic(TopMentionsTopicType.Org, "NAME1"))
 
     result should equal(None)
   }
@@ -119,7 +119,7 @@ class TopMentionsServiceTest
     val topMentionService = new TopicService(fakeClient)
     val refreshJob = Await.result(topMentionService.refreshTopics(), 1.second)
 
-    val result = topMentionService.getTopMentionsByTopic("key2", TopMentionsTopic(TopMentionsTopicType.Org, "name1"))
+    val result = topMentionService.getBlogSelectedTopic("key2", TopMentionsTopic(TopMentionsTopicType.Org, "name1"))
 
     result should equal(None)
   }
@@ -131,7 +131,7 @@ class TopMentionsServiceTest
     val topMentionService = new TopicService(fakeClient)
     val refreshJob = Await.result(topMentionService.refreshTopics(), 1.second)
 
-    val result = topMentionService.getTopMentionsByTopic("key1", TopMentionsTopic(TopMentionsTopicType.Person, "Boris"))
+    val result = topMentionService.getBlogSelectedTopic("key1", TopMentionsTopic(TopMentionsTopicType.Person, "Boris"))
 
     result should equal(None)
   }
@@ -144,7 +144,7 @@ class TopMentionsServiceTest
     val refreshJob = Await.result(topMentionService.refreshTopics(), 1.second)
 
     val result =
-      topMentionService.getTopMentionsByTopic("key1", TopMentionsTopic(TopMentionsTopicType.Org, "someRandomOrg"))
+      topMentionService.getBlogSelectedTopic("key1", TopMentionsTopic(TopMentionsTopicType.Org, "someRandomOrg"))
 
     result should equal(None)
   }


### PR DESCRIPTION
## What does this change?
This PR renames methods in `TopicService`
- `refreshTopMentions` to `refreshTopics`
- `getBlogTopMentions` to `getBlogTopicsDetails`
- `getAllTopMentions` to `getAllTopics`
- `getTopMentionsByTopic` to `getSelectedTopic`
- `retrieveTopMention` to `retrieveTopicsDetails`