### PR TITLE
Dblatcher/newsletters page component event

### DIFF
--- a/applications/app/views/signup/newsletterContent.scala.html
+++ b/applications/app/views/signup/newsletterContent.scala.html
@@ -38,10 +38,20 @@
                 <div class="signup-confirmation is-hidden js-signup-confirmation">
                     <div class="signup-confirmation__success-headline-container">
                         @fragments.inlineSvg("envelope", "icon")
-                        <h3 class="signup-confirmation--success">@Html(emailListing.emailEmbed.successHeadline)</h3>
+                        <h3 class="signup-confirmation--heading">@Html(emailListing.emailEmbed.successHeadline)</h3>
                     </div>
                     <div class="newsletter-card__content">
-                        <p class="signup-confirmation--success-description">@Html(emailListing.emailEmbed.successDescription)</p>
+                        <p class="signup-confirmation--description">@Html(emailListing.emailEmbed.successDescription)</p>
+                    </div>
+                </div>
+
+                <div class="signup-confirmation is-hidden js-signup-fail-message">
+                    <div class="signup-confirmation__success-headline-container">
+                        @fragments.inlineSvg("cross", "icon")
+                        <h3 class="signup-confirmation--heading">Sign up failed</h3>
+                    </div>
+                    <div class="newsletter-card__content">
+                        <p class="signup-confirmation--description">Please try again or contact <a href="mailto:customer.help@@theguardian.com" target="_blank">customer.help@@theguardian.com</a></p>
                     </div>
                 </div>
 

--- a/common/app/templates/inlineJS/nonBlocking/emailIframeTracking.scala.js
+++ b/common/app/templates/inlineJS/nonBlocking/emailIframeTracking.scala.js
@@ -25,6 +25,38 @@ function getClickEventData (element) {
     }
 }
 
+ function toNDigits (value, requiredLength) {
+	const valueString = value.toString();
+
+	if (valueString.length < requiredLength) {
+		return `${'0'.repeat(
+			requiredLength - valueString.length
+		)}${valueString}`;
+	}
+	return valueString;
+};
+
+function to2Digits (v) {return toNDigits(v, 2)}
+
+function formatTimestampToUTC (inputDate) {
+	const utc = {
+		year: inputDate.getUTCFullYear(),
+		month: inputDate.getUTCMonth(),
+		date: inputDate.getUTCDate(),
+		hours: inputDate.getUTCHours(),
+		minutes: inputDate.getUTCMinutes(),
+		seconds: inputDate.getUTCSeconds(),
+		milliseconds: inputDate.getUTCMilliseconds(),
+	};
+
+	const date = `${utc.year}-${to2Digits(utc.month)}-${to2Digits(utc.date)}`;
+	const time = `${to2Digits(utc.hours)}:${to2Digits(utc.minutes)}:${to2Digits(utc.seconds)}`;
+	const microSeconds = toNDigits(utc.milliseconds * 1000, 6);
+
+	return `${date} ${time}.${microSeconds} UTC`;
+};
+
+
 function buildComponentEventData (formElement, actionType, actionDescription) {
     return {
         componentEvent: {
@@ -33,7 +65,7 @@ function buildComponentEventData (formElement, actionType, actionDescription) {
                 id: formElement.getAttribute('data-component'),
             },
             action: actionType,
-            value: [actionDescription,formElement.getAttribute('data-email-list-name')].join(),
+            value: [actionDescription,formElement.getAttribute('data-email-list-name'), formatTimestampToUTC(new Date())].join(),
         }
     }
 };

--- a/common/app/templates/inlineJS/nonBlocking/emailIframeTracking.scala.js
+++ b/common/app/templates/inlineJS/nonBlocking/emailIframeTracking.scala.js
@@ -57,15 +57,21 @@ function formatTimestampToUTC (inputDate) {
 };
 
 
-function buildComponentEventData (formElement, actionType, actionDescription) {
+function buildComponentEventData (formElement, action, eventDescription) {
+    const value = JSON.stringify({
+		eventDescription,
+		newsletterId: formElement.getAttribute('data-email-list-name'),
+		timestamp: formatTimestampToUTC(new Date()),
+	});
+
     return {
         componentEvent: {
             component: {
                 componentType: 'NEWSLETTER_SUBSCRIPTION',
                 id: formElement.getAttribute('data-component'),
             },
-            action: actionType,
-            value: [actionDescription,formElement.getAttribute('data-email-list-name'), formatTimestampToUTC(new Date())].join(),
+            action,
+            value,
         }
     }
 };

--- a/static/src/javascripts/bootstraps/enhanced/newsletters.js
+++ b/static/src/javascripts/bootstraps/enhanced/newsletters.js
@@ -12,6 +12,7 @@ const classes = {
 	signupButton: 'js-newsletter-signup-button',
 	styleSignup: 'newsletter-card__lozenge--submit',
 	signupConfirm: 'js-signup-confirmation',
+	failureMessage: 'js-signup-fail-message',
 	previewButton: 'js-newsletter-preview',
 	card: 'newsletter-card',
 };
@@ -72,12 +73,15 @@ const validate = (form) => {
 	return typeof emailAddress === 'string' && emailAddress.indexOf('@') > -1;
 };
 
-const addSubscriptionMessage = (buttonEl) => {
+const addConfirmationMessage = (buttonEl, isSuccess) => {
 	const meta = $.ancestor(buttonEl, classes.wrapper);
 	fastdom.mutate(() => {
 		$(buttonEl.form).addClass('is-hidden');
 		$(`.${classes.previewButton}`, meta).addClass('is-hidden');
-		$(`.${classes.signupConfirm}`, meta).removeClass('is-hidden');
+		$(
+			`.${isSuccess ? classes.signupConfirm : classes.failureMessage}`,
+			meta,
+		).removeClass('is-hidden');
 	});
 };
 
@@ -142,18 +146,18 @@ const submitForm = (form, buttonEl) => {
 		},
 	}).then((response) => {
 		if (response.ok) {
-			addSubscriptionMessage(buttonEl);
-            if (cardElement) {
-                const confirmEventData = buildComponentEventData(
-                    cardElement,
-                    'SUBSCRIBE',
-                    'submission-confirmed',
-                );
-                ophan.record(confirmEventData);
-                console.log(confirmEventData.componentEvent);
-            }
+			addConfirmationMessage(buttonEl, true);
+			if (cardElement) {
+				const confirmEventData = buildComponentEventData(
+					cardElement,
+					'SUBSCRIBE',
+					'submission-confirmed',
+				);
+				ophan.record(confirmEventData);
+				console.log(confirmEventData.componentEvent);
+			}
 		} else {
-			//TO DO - USER FEEDBACK!!!
+			addConfirmationMessage(buttonEl, false);
 			response
 				.text()
 				.then((errorText) => {
@@ -169,7 +173,7 @@ const submitForm = (form, buttonEl) => {
 				})
 				.catch((e) => {
 					console.warn(e);
-                    if (cardElement) {
+					if (cardElement) {
 						const failEventData = buildComponentEventData(
 							cardElement,
 							'CLOSE',

--- a/static/src/javascripts/bootstraps/enhanced/newsletters.js
+++ b/static/src/javascripts/bootstraps/enhanced/newsletters.js
@@ -2,6 +2,7 @@ import fastdom from 'fastdom';
 import $ from 'lib/$';
 import config from 'lib/config';
 import { getUserFromCookie, getUserFromApi } from 'common/modules/identity/api';
+import { formatTimestampToUTC } from 'common/modules/tracking/utc-date-format';
 import ophan from 'ophan/ng';
 
 const classes = {
@@ -29,53 +30,6 @@ const inputs = {
 	dummy: 'name',
 };
 
-/**
- * Pads a number with the required number of leading
- * zeros to be of a required length in string form
- * @param {number} v an integer value below 10**n
- * @param {number} n the required length of the string
- * @returns a string of the required length representing the number
- */
-const toNDigits = (v, n) => {
-	const s = v.toString();
-
-	if (s.length < n) {
-		return `${'0'.repeat(n - s.length)}${s}`;
-	}
-	return s;
-};
-
-const to2Digits = (v) => toNDigits(v, 2);
-
-/**
- * Converts a Date to a string in the format used by the data team
- * IE yyy-MM-dd hh:mm:ss.ssssss UTC
- *
- * There **should** be a better way to do this.
- *
- * @param {Date} inputDate
- * @returns {string} The formatted date string
- */
-const formatTimestampToUTC = (inputDate) => {
-	const utc = {
-		year: inputDate.getUTCFullYear(),
-		month: inputDate.getUTCMonth(),
-		date: inputDate.getUTCDate(),
-		hours: inputDate.getUTCHours(),
-		minutes: inputDate.getUTCMinutes(),
-		seconds: inputDate.getUTCSeconds(),
-		milliseconds: inputDate.getUTCMilliseconds(),
-	};
-
-	const date = `${utc.year}-${to2Digits(utc.month)}-${to2Digits(utc.date)}`;
-	const time = `${to2Digits(utc.hours)}:${to2Digits(utc.minutes)}:${to2Digits(
-		utc.seconds,
-	)}`;
-	const microSeconds = toNDigits(utc.milliseconds * 1000, 6);
-
-	return `${date} ${time}.${microSeconds} UTC`;
-};
-
 const buildComponentEventData = (
 	cardElement,
 	actionType,
@@ -93,7 +47,11 @@ const buildComponentEventData = (
 				id: cardElement.getAttribute('data-component'),
 			},
 			action: actionType,
-			value: [actionDescription, listName, formatTimestampToUTC(new Date())].join(),
+			value: [
+				actionDescription,
+				listName,
+				formatTimestampToUTC(new Date()),
+			].join(),
 		},
 	};
 };

--- a/static/src/javascripts/bootstraps/enhanced/newsletters.js
+++ b/static/src/javascripts/bootstraps/enhanced/newsletters.js
@@ -122,6 +122,17 @@ const submitForm = (form, buttonEl) => {
 		formQueryString += `&g-recaptcha-response=${googleRecaptchaResponse}`;
 	}
 
+    const cardElement = findContainingCard(form);
+	if (cardElement) {
+		const eventData = buildComponentEventData(
+			cardElement,
+			'SUBSCRIBE',
+			'form-submission',
+		);
+		ophan.record(eventData);
+		console.log(eventData);
+	}
+
 	return fetch(`${config.get('page.ajaxUrl')}/email`, {
 		method: 'POST',
 		body: formQueryString,

--- a/static/src/javascripts/bootstraps/enhanced/newsletters.js
+++ b/static/src/javascripts/bootstraps/enhanced/newsletters.js
@@ -30,6 +30,9 @@ const inputs = {
 	dummy: 'name',
 };
 
+let lastEventDataSent = undefined;
+let lastEventDataSentTimestamp = 0;
+
 const buildComponentEventData = (cardElement, action, eventDescription) => {
 	const listNameInput = cardElement.querySelector('input[name=listName]');
 	const newsletterId = listNameInput
@@ -69,8 +72,6 @@ const findContainingCard = (originalElement) => {
 	return undefined;
 };
 
-let lastEventDataSent = undefined;
-let lastEventDataSentTimestamp = 0;
 
 const sendTracking = (element, eventType, eventExtraDetail) => {
 	const cardElement = findContainingCard(element);
@@ -132,7 +133,6 @@ const sendTracking = (element, eventType, eventExtraDetail) => {
 	ophan.record(eventData);
 	lastEventDataSent = eventData;
 	lastEventDataSentTimestamp = now;
-	console.log(eventData.componentEvent);
 };
 
 const hideInputAndShowPreview = (el) => {
@@ -225,7 +225,6 @@ const submitForm = (form, buttonEl) => {
 					sendTracking(form, trackingEvents.fail, errorText);
 				})
 				.catch((e) => {
-					console.warn(e);
 					sendTracking(form, trackingEvents.fail, '[no error text]');
 				});
 		}

--- a/static/src/javascripts/bootstraps/enhanced/newsletters.js
+++ b/static/src/javascripts/bootstraps/enhanced/newsletters.js
@@ -164,6 +164,17 @@ const createSubscriptionFormEventHandlers = (buttonEl) => {
 const showCaptcha = (form, callback) => {
 	const captchaContainer = $('.grecaptcha_container', form).get(0);
 
+	// The first captcha id will be "0" (falsy in js) so check for type
+	if (typeof form.captchaId === 'undefined') {
+		form.captchaId = grecaptcha.render(captchaContainer, {
+			sitekey: window.guardian.config.page.googleRecaptchaSiteKey,
+			callback: callback,
+			size: 'invisible',
+		});
+	}
+
+	grecaptcha.execute(form.captchaId);
+
 	const cardElement = findContainingCard(form);
 	if (cardElement) {
 		const eventData = buildComponentEventData(
@@ -172,15 +183,8 @@ const showCaptcha = (form, callback) => {
 			'open-captcha',
 		);
 		ophan.record(eventData);
-		console.log(eventData);
+		console.log(eventData.componentEvent);
 	}
-
-	const captchaId = grecaptcha.render(captchaContainer, {
-		sitekey: window.guardian.config.page.googleRecaptchaSiteKey,
-		callback: callback,
-		size: 'invisible',
-	});
-	grecaptcha.execute(captchaId);
 };
 
 const modifyFormForSignedIn = (el) => {

--- a/static/src/javascripts/bootstraps/enhanced/newsletters.js
+++ b/static/src/javascripts/bootstraps/enhanced/newsletters.js
@@ -3,180 +3,228 @@ import fastdom from 'fastdom';
 import $ from 'lib/$';
 import config from 'lib/config';
 import { getUserFromCookie, getUserFromApi } from 'common/modules/identity/api';
+import ophan from 'ophan/ng';
 
 const classes = {
-    wrapper: 'js-newsletter-meta',
-    signupForm: 'js-email-sub__form',
-    textInput: 'js-newsletter-card__text-input',
-    signupButton: 'js-newsletter-signup-button',
-    styleSignup: 'newsletter-card__lozenge--submit',
-    signupConfirm: 'js-signup-confirmation',
-    previewButton: 'js-newsletter-preview',
+	wrapper: 'js-newsletter-meta',
+	signupForm: 'js-email-sub__form',
+	textInput: 'js-newsletter-card__text-input',
+	signupButton: 'js-newsletter-signup-button',
+	styleSignup: 'newsletter-card__lozenge--submit',
+	signupConfirm: 'js-signup-confirmation',
+	previewButton: 'js-newsletter-preview',
+	card: 'newsletter-card',
 };
 
 const inputs = {
-    email: 'email',
-    dummy: 'name',
+	email: 'email',
+	dummy: 'name',
+};
+
+const buildComponentEventData = (
+	cardElement,
+	actionType,
+	actionDescription,
+) => {
+	const listNameInput = cardElement.querySelector('input[name=listName]');
+	const listName = listNameInput
+		? listNameInput.value
+		: '[unknown list name]';
+
+	return {
+		componentEvent: {
+			component: {
+				componentType: 'NEWSLETTER_SUBSCRIPTION',
+				id: cardElement.getAttribute('data-component'),
+			},
+			action: actionType,
+			value: [actionDescription, listName].join(),
+		},
+	};
+};
+
+const isNewsletterCard = (element) =>
+	element.hasAttribute('data-component') &&
+	element.classList.contains(classes.card);
+
+const findContainingCard = (originalElement) => {
+	let element = originalElement;
+	while (element.parentElement) {
+		if (isNewsletterCard(element)) {
+			return element;
+		}
+		element = element.parentElement;
+	}
+	return undefined;
 };
 
 const hideInputAndShowPreview = (el) => {
-    fastdom.mutate(() => {
-        $(`.${classes.textInput}`, el).addClass('is-hidden');
-        $(`.${classes.signupButton}`, el).removeClass(classes.styleSignup);
-        $(`.${classes.previewButton}`, el).removeClass('is-hidden');
-    });
+	fastdom.mutate(() => {
+		$(`.${classes.textInput}`, el).addClass('is-hidden');
+		$(`.${classes.signupButton}`, el).removeClass(classes.styleSignup);
+		$(`.${classes.previewButton}`, el).removeClass('is-hidden');
+	});
 };
 
 const validate = (form) => {
-    // simplistic email address validation
-    const emailAddress = $(`.${classes.textInput}`, form).val();
-    return typeof emailAddress === 'string' && emailAddress.indexOf('@') > -1;
+	// simplistic email address validation
+	const emailAddress = $(`.${classes.textInput}`, form).val();
+	return typeof emailAddress === 'string' && emailAddress.indexOf('@') > -1;
 };
 
 const addSubscriptionMessage = (buttonEl) => {
-    const meta = $.ancestor(buttonEl, classes.wrapper);
-    fastdom.mutate(() => {
-        $(buttonEl.form).addClass('is-hidden');
-        $(`.${classes.previewButton}`, meta).addClass('is-hidden');
-        $(`.${classes.signupConfirm}`, meta).removeClass('is-hidden');
-    });
+	const meta = $.ancestor(buttonEl, classes.wrapper);
+	fastdom.mutate(() => {
+		$(buttonEl.form).addClass('is-hidden');
+		$(`.${classes.previewButton}`, meta).addClass('is-hidden');
+		$(`.${classes.signupConfirm}`, meta).removeClass('is-hidden');
+	});
 };
 
 const modifyDataLinkName = (modifier) => (el) => {
-    const firstStageName = el.getAttribute('data-link-name') || "undefined-data-link-name"
-    el.setAttribute('data-link-name', firstStageName + modifier)
-}
+	const firstStageName =
+		el.getAttribute('data-link-name') || 'undefined-data-link-name';
+	el.setAttribute('data-link-name', firstStageName + modifier);
+};
 
-const modifyLinkNamesForSecondStage = (el) => modifyDataLinkName('-second-stage')(el)
+const modifyLinkNamesForSecondStage = (el) =>
+	modifyDataLinkName('-second-stage')(el);
 
-const modifyLinkNamesForSignedInUser = (el) => modifyDataLinkName('-signed-in')(el)
+const modifyLinkNamesForSignedInUser = (el) =>
+	modifyDataLinkName('-signed-in')(el);
 
-const submitForm = (
-    form,
-    buttonEl
-) => {
-    const dummyEmail = encodeURIComponent(
-        $(`input[name="${inputs.dummy}"]`, form).val()
-    ); // Used as a 'bot-bait', see https://stackoverflow.com/a/34623588/2823715
-    const email = encodeURIComponent(
-        $(`input[name="${inputs.email}"]`, form).val()
-    );
-    const listName = encodeURIComponent(
-        $('input[name="listName"]', form).val()
-    );
-    const csrfToken = encodeURIComponent(
-        $('input[name="csrfToken"]', form).val()
-    );
-    const ref = encodeURIComponent(
-        window.location.href
-    );
-    const refViewId = encodeURIComponent(
-        config.get('ophan.pageViewId')
-    );
-    const googleRecaptchaResponse = encodeURIComponent(
-        $('[name="g-recaptcha-response"]', form).val()
-    );
+const submitForm = (form, buttonEl) => {
+	const dummyEmail = encodeURIComponent(
+		$(`input[name="${inputs.dummy}"]`, form).val(),
+	); // Used as a 'bot-bait', see https://stackoverflow.com/a/34623588/2823715
+	const email = encodeURIComponent(
+		$(`input[name="${inputs.email}"]`, form).val(),
+	);
+	const listName = encodeURIComponent(
+		$('input[name="listName"]', form).val(),
+	);
+	const csrfToken = encodeURIComponent(
+		$('input[name="csrfToken"]', form).val(),
+	);
+	const ref = encodeURIComponent(window.location.href);
+	const refViewId = encodeURIComponent(config.get('ophan.pageViewId'));
+	const googleRecaptchaResponse = encodeURIComponent(
+		$('[name="g-recaptcha-response"]', form).val(),
+	);
 
-    let formQueryString = `${inputs.email}=${email}`;
-    formQueryString += `&csrfToken=${csrfToken}`;
-    formQueryString += `&listName=${listName}`;
-    formQueryString += `&ref=${ref}`;
-    formQueryString += `&refViewId=${refViewId}`;
-    formQueryString += `&${inputs.dummy}=${dummyEmail}`;
-    if (window.guardian.config.switches.emailSignupRecaptcha) {
-        formQueryString += `&g-recaptcha-response=${googleRecaptchaResponse}`
-    }
+	let formQueryString = `${inputs.email}=${email}`;
+	formQueryString += `&csrfToken=${csrfToken}`;
+	formQueryString += `&listName=${listName}`;
+	formQueryString += `&ref=${ref}`;
+	formQueryString += `&refViewId=${refViewId}`;
+	formQueryString += `&${inputs.dummy}=${dummyEmail}`;
+	if (window.guardian.config.switches.emailSignupRecaptcha) {
+		formQueryString += `&g-recaptcha-response=${googleRecaptchaResponse}`;
+	}
 
-    return fetch(`${config.get('page.ajaxUrl')}/email`, {
-        method: 'POST',
-        body: formQueryString,
-        headers: {
-            Accept: 'application/json',
-            'Content-Type': 'application/x-www-form-urlencoded',
-        },
-    }).then(response => {
-        if (response.ok) {
-            addSubscriptionMessage(buttonEl);
-        }
-    });
+	return fetch(`${config.get('page.ajaxUrl')}/email`, {
+		method: 'POST',
+		body: formQueryString,
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/x-www-form-urlencoded',
+		},
+	}).then((response) => {
+		if (response.ok) {
+			addSubscriptionMessage(buttonEl);
+		}
+	});
 };
 
 const createSubscriptionFormEventHandlers = (buttonEl) => {
-    bean.on(buttonEl, 'click', event => {
-        event.preventDefault();
-        const form = buttonEl.form;
-        if (validate(form)) {
-            if (window.guardian.config.switches.emailSignupRecaptcha) {
-                showCaptcha(form, () => submitForm(form, buttonEl))
-            } else {
-                submitForm(form, buttonEl);
-            }
-        }
-    });
+	bean.on(buttonEl, 'click', (event) => {
+		event.preventDefault();
+		const form = buttonEl.form;
+		if (validate(form)) {
+			if (window.guardian.config.switches.emailSignupRecaptcha) {
+				showCaptcha(form, () => submitForm(form, buttonEl));
+			} else {
+				submitForm(form, buttonEl);
+			}
+		}
+	});
 };
 
 const showCaptcha = (form, callback) => {
-    const captchaContainer = $('.grecaptcha_container', form).get(0)
-    const captchaId = grecaptcha.render(captchaContainer, {
-        sitekey: window.guardian.config.page.googleRecaptchaSiteKey,
-        callback: callback,
-        size: 'invisible'
-    })
-    grecaptcha.execute(captchaId)
-}
+	const captchaContainer = $('.grecaptcha_container', form).get(0);
+
+	const cardElement = findContainingCard(form);
+	if (cardElement) {
+		const eventData = buildComponentEventData(
+			cardElement,
+			'EXPAND',
+			'open-captcha',
+		);
+		ophan.record(eventData);
+		console.log(eventData);
+	}
+
+	const captchaId = grecaptcha.render(captchaContainer, {
+		sitekey: window.guardian.config.page.googleRecaptchaSiteKey,
+		callback: callback,
+		size: 'invisible',
+	});
+	grecaptcha.execute(captchaId);
+};
 
 const modifyFormForSignedIn = (el) => {
-    modifyLinkNamesForSignedInUser(el);
-    createSubscriptionFormEventHandlers(el);
-}
+	modifyLinkNamesForSignedInUser(el);
+	createSubscriptionFormEventHandlers(el);
+};
 
 const showSignupForm = (buttonEl) => {
-    const form = buttonEl.form;
-    const meta = $.ancestor(buttonEl, 'js-newsletter-meta');
-    fastdom.mutate(() => {
-        $(`.${classes.textInput}`, form)
-            .removeClass('is-hidden')
-            .focus();
-        $(`.${classes.signupButton}`, form).addClass(classes.styleSignup);
-        $(`.${classes.previewButton}`, meta).addClass('is-hidden');
-        modifyLinkNamesForSecondStage(buttonEl)
-        createSubscriptionFormEventHandlers(buttonEl);
-    });
+	const form = buttonEl.form;
+	const meta = $.ancestor(buttonEl, 'js-newsletter-meta');
+	fastdom.mutate(() => {
+		$(`.${classes.textInput}`, form).removeClass('is-hidden').focus();
+		$(`.${classes.signupButton}`, form).addClass(classes.styleSignup);
+		$(`.${classes.previewButton}`, meta).addClass('is-hidden');
+		modifyLinkNamesForSecondStage(buttonEl);
+		createSubscriptionFormEventHandlers(buttonEl);
+	});
 };
 
 const updatePageForLoggedIn = (emailAddress, el) => {
-    fastdom.mutate(() => {
-        hideInputAndShowPreview(el);
-        $(`.${classes.textInput}`, el).val(emailAddress);
-    });
+	fastdom.mutate(() => {
+		hideInputAndShowPreview(el);
+		$(`.${classes.textInput}`, el).val(emailAddress);
+	});
 };
 
 const showSecondStageSignup = (buttonEl) => {
-    fastdom.mutate(() => {
-        buttonEl.setAttribute('type', 'button');
-        bean.on(buttonEl, 'click', () => {
-            showSignupForm(buttonEl);
-        });
-    });
+	fastdom.mutate(() => {
+		buttonEl.setAttribute('type', 'button');
+		bean.on(buttonEl, 'click', () => {
+			showSignupForm(buttonEl);
+		});
+	});
 };
 
 const enhanceNewsletters = () => {
-    if (getUserFromCookie() !== null) {
-        // email address is not stored in the cookie, gotta go to the Api
-        getUserFromApi(userFromId => {
-            if (userFromId && userFromId.primaryEmailAddress) {
-                updatePageForLoggedIn(userFromId.primaryEmailAddress);
-                $.forEachElement(`.${classes.signupButton}`, modifyFormForSignedIn);
-            }
-        });
-    } else {
-        hideInputAndShowPreview();
-        $.forEachElement(`.${classes.signupButton}`, showSecondStageSignup);
-    }
+	if (getUserFromCookie() !== null) {
+		// email address is not stored in the cookie, gotta go to the Api
+		getUserFromApi((userFromId) => {
+			if (userFromId && userFromId.primaryEmailAddress) {
+				updatePageForLoggedIn(userFromId.primaryEmailAddress);
+				$.forEachElement(
+					`.${classes.signupButton}`,
+					modifyFormForSignedIn,
+				);
+			}
+		});
+	} else {
+		hideInputAndShowPreview();
+		$.forEachElement(`.${classes.signupButton}`, showSecondStageSignup);
+	}
 };
 
 const init = () => {
-    enhanceNewsletters();
+	enhanceNewsletters();
 };
 
 export { init };

--- a/static/src/javascripts/bootstraps/enhanced/newsletters.js
+++ b/static/src/javascripts/bootstraps/enhanced/newsletters.js
@@ -210,9 +210,13 @@ const updatePageForLoggedIn = (emailAddress, el) => {
 const showSecondStageSignup = (buttonEl) => {
 	fastdom.mutate(() => {
 		buttonEl.setAttribute('type', 'button');
-		bean.on(buttonEl, 'click', () => {
-			showSignupForm(buttonEl);
-		});
+		buttonEl.addEventListener(
+			'click',
+			() => {
+				showSignupForm(buttonEl);
+			},
+			{ once: true },
+		);
 	});
 };
 

--- a/static/src/javascripts/bootstraps/enhanced/newsletters.js
+++ b/static/src/javascripts/bootstraps/enhanced/newsletters.js
@@ -144,6 +144,8 @@ const modifyLinkNamesForSignedInUser = (el) =>
 	modifyDataLinkName('-signed-in')(el);
 
 const submitForm = (form, buttonEl) => {
+	buttonEl.setAttribute('disabled', 'true');
+
 	const dummyEmail = encodeURIComponent(
 		$(`input[name="${inputs.dummy}"]`, form).val(),
 	); // Used as a 'bot-bait', see https://stackoverflow.com/a/34623588/2823715
@@ -203,6 +205,11 @@ const submitForm = (form, buttonEl) => {
 const createSubscriptionFormEventHandlers = (buttonEl) => {
 	buttonEl.addEventListener('click', (event) => {
 		event.preventDefault();
+
+		if (buttonEl.getAttribute('disabled') === true) {
+			return;
+		}
+
 		const form = buttonEl.form;
 		if (validate(form)) {
 			if (window.guardian.config.switches.emailSignupRecaptcha) {

--- a/static/src/javascripts/projects/common/modules/tracking/utc-date-format.ts
+++ b/static/src/javascripts/projects/common/modules/tracking/utc-date-format.ts
@@ -1,0 +1,45 @@
+/**
+ * Pads a number with the required number of leading
+ * zeros to be of a required length in string form
+ * @param {number} value a non-negative integer value less than 10**requiredLength
+ * @param {number} requiredLength
+ * @returns a string of the required length representing the number
+ */
+const toNDigits = (value: number, requiredLength: number): string => {
+	const valueString = value.toString();
+
+	if (valueString.length < requiredLength) {
+		return `${'0'.repeat(
+			requiredLength - valueString.length,
+		)}${valueString}`;
+	}
+	return valueString;
+};
+
+const to2Digits = (v: number): string => toNDigits(v, 2);
+
+/**
+ * Converts a Date to a string in the format used by the data team
+ * IE yyy-MM-dd hh:mm:ss.ssssss UTC
+ *
+ * There **should** be a better way to do this.
+ */
+export const formatTimestampToUTC = (inputDate: Date): string => {
+	const utc = {
+		year: inputDate.getUTCFullYear(),
+		month: inputDate.getUTCMonth(),
+		date: inputDate.getUTCDate(),
+		hours: inputDate.getUTCHours(),
+		minutes: inputDate.getUTCMinutes(),
+		seconds: inputDate.getUTCSeconds(),
+		milliseconds: inputDate.getUTCMilliseconds(),
+	};
+
+	const date = `${utc.year}-${to2Digits(utc.month)}-${to2Digits(utc.date)}`;
+	const time = `${to2Digits(utc.hours)}:${to2Digits(utc.minutes)}:${to2Digits(
+		utc.seconds,
+	)}`;
+	const microSeconds = toNDigits(utc.milliseconds * 1000, 6);
+
+	return `${date} ${time}.${microSeconds} UTC`;
+};

--- a/static/src/stylesheets/module/signup/_newsletters.scss
+++ b/static/src/stylesheets/module/signup/_newsletters.scss
@@ -288,7 +288,7 @@
         align-items: center;
     }
 
-    .signup-confirmation--success {
+    .signup-confirmation--heading {
         @include fs-textSans(3);
         margin-bottom: 0;
         font-weight: 700;
@@ -296,7 +296,7 @@
         display: inline;
     }
 
-    .signup-confirmation--success-description {
+    .signup-confirmation--description {
         @include fs-textSans(3);
         color: $brightness-7;
         display: inline;


### PR DESCRIPTION
## What does this change?
This PR make the all newsletters page (/email-newsletters) sent `ComponentEvents` via Ophan to give the data team more reliable information about how many sign-ups can for each newsletter can be attributed to the page. It currently only tracks button clicks, which do not reliably translate into sign-ups.
As requested by the data team, the `componentEvent.value` is a stringified JSON object including a timestamp in UTC format.

Also the PR : 
 - makes the page display user feedback if the sign-up fails. Currently, if the sign-up fails (e.g. network error, backend validation failed) there is no feedback (IE to the user, the button did nothing)
 - stops the page attempting to render a captcha widget in the same container more than once - currently, this would lead to an unhandled error if the user opened a captcha, dismissed it, then tried to open it again. 
- update the `ComponentEvents` sent from embed iframes to use  the same format for the `componentEvent.value`

### What is not good?
 - The `formatTimestampToUTC` function is duplicated because the scripts in the embed iframes use non-blocking inline JS, which (I think) can't `import` or `require` any code from modules. 
 - `formatTimestampToUTC` is not elegant -  I'm not sure if there is a better way to build the string using `Date.toLocaleString` but I couldn't find the right combination of options make it work.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

The `sendtracking` function in the `SecureSignupIframe.importable` component (not currently being used in production) will need to be updated so the event data values sent to Ophan matches the format used the all newsletters page.

## What is the value of this and can you measure success?
The data team will be able to more accurately track how many sign-ups can be attributed to the page.

## Flowchart - all newsletter page tracking

<img width="609" alt="Screenshot 2022-06-28 at 12 24 26" src="https://user-images.githubusercontent.com/30567854/176168426-bb3196de-7882-43b5-afba-9ae8d4f59c72.png">

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
