### PR TITLE
rename model TopicsDetails to TopicsApiResponse

### DIFF
--- a/article/app/topmentions/TopicS3Client.scala
+++ b/article/app/topmentions/TopicS3Client.scala
@@ -5,11 +5,11 @@ import com.amazonaws.services.s3.model.{GetObjectRequest, S3Object}
 import com.amazonaws.util.IOUtils
 import common.GuLogging
 import conf.Configuration
-import model.{TopMentionJsonParseException, TopicsDetails}
+import model.{TopMentionJsonParseException, TopicsApiResponse}
 import play.api.libs.json.{JsError, JsSuccess, Json}
 import services.S3
 import topmentions.S3ObjectImplicits.RichS3Object
-import model.TopMentionsResponse._
+import model.TopicsApiResponse._
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
@@ -17,7 +17,7 @@ import scala.util.{Failure, Success, Try}
 
 trait TopicS3Client {
   def getListOfKeys(): Future[List[String]]
-  def getObject(key: String): Future[TopicsDetails]
+  def getObject(key: String): Future[TopicsApiResponse]
 }
 
 final class TopicS3ClientImpl extends TopicS3Client with S3 with GuLogging {
@@ -39,11 +39,11 @@ final class TopicS3ClientImpl extends TopicS3Client with S3 with GuLogging {
     }
   }
 
-  def getObject(key: String): Future[TopicsDetails] = {
+  def getObject(key: String): Future[TopicsApiResponse] = {
     getClient { client =>
       Try {
         val request = new GetObjectRequest(getBucket, key)
-        client.getObject(request).parseToTopicsDetails
+        client.getObject(request).parseToTopicsApiResponse
       }.flatten match {
         case Success(value) =>
           log.info(s"got topMentionResponse from S3 for key ${key}")
@@ -70,10 +70,10 @@ final class TopicS3ClientImpl extends TopicS3Client with S3 with GuLogging {
 
 object S3ObjectImplicits {
   implicit class RichS3Object(s3Object: S3Object) extends GuLogging {
-    def parseToTopicsDetails: Try[TopicsDetails] = {
+    def parseToTopicsApiResponse: Try[TopicsApiResponse] = {
       val json = Json.parse(asString(s3Object))
 
-      Json.fromJson[TopicsDetails](json) match {
+      Json.fromJson[TopicsApiResponse](json) match {
         case JsSuccess(topMentionResponse, __) =>
           log.debug(s"Parsed TopMentionsDetails from S3 for key ${s3Object.getKey}")
           Success(topMentionResponse)

--- a/article/app/topmentions/TopicService.scala
+++ b/article/app/topmentions/TopicService.scala
@@ -1,13 +1,13 @@
 package topmentions
 
 import common.{Box, GuLogging}
-import model.{TopicsDetails, TopMentionsResult, SelectedTopic, TopicWithCount}
+import model.{TopicsApiResponse, TopMentionsResult, SelectedTopic, TopicWithCount}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class TopicService(topicS3Client: TopicS3Client) extends GuLogging {
 
-  private val topicsDetails = Box[Option[Map[String, TopicsDetails]]](None)
+  private val topicsDetails = Box[Option[Map[String, TopicsApiResponse]]](None)
 
   def refreshTopics()(implicit executionContext: ExecutionContext): Future[Unit] = {
     val retrievedTopMentions = topicS3Client.getListOfKeys().map { key => key.map { retrieveTopicsDetails(_) } }
@@ -24,17 +24,17 @@ class TopicService(topicS3Client: TopicS3Client) extends GuLogging {
       }
   }
 
-  def getBlogTopicsDetails(blogId: String): Option[TopicsDetails] = {
+  def getBlogTopicsApiResponse(blogId: String): Option[TopicsApiResponse] = {
     topicsDetails.get().flatMap(_.get(blogId))
   }
 
   def getTopics(blogId: String): Option[Seq[TopicWithCount]] = {
-    getBlogTopicsDetails(blogId).map(mentions =>
+    getBlogTopicsApiResponse(blogId).map(mentions =>
       mentions.results.map(mention => TopicWithCount(mention.`type`, mention.name, mention.count)),
     )
   }
 
-  def getAllTopics: Option[Map[String, TopicsDetails]] = {
+  def getAllTopics: Option[Map[String, TopicsApiResponse]] = {
     topicsDetails.get()
   }
 
@@ -42,7 +42,7 @@ class TopicService(topicS3Client: TopicS3Client) extends GuLogging {
       blogId: String,
       topMentionEntity: SelectedTopic,
   ): Option[TopMentionsResult] = {
-    getBlogTopicsDetails(blogId).flatMap(_.results.find(result => {
+    getBlogTopicsApiResponse(blogId).flatMap(_.results.find(result => {
       result.`type` == topMentionEntity.`type` && result.name == topMentionEntity.value
     }))
   }

--- a/article/test/topmentions/TopMentionsServiceTest.scala
+++ b/article/test/topmentions/TopMentionsServiceTest.scala
@@ -1,6 +1,6 @@
 package topmentions
 
-import model.{TopicsDetails, TopMentionsResult, SelectedTopic, TopMentionsTopicType, TopicWithCount}
+import model.{TopicsApiResponse, TopMentionsResult, SelectedTopic, TopMentionsTopicType, TopicWithCount}
 import org.scalatest.{BeforeAndAfterAll}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -45,10 +45,10 @@ class TopMentionsServiceTest
     ),
   )
   val successResponse =
-    TopicsDetails(entity_types = Seq(TopMentionsTopicType.Org), results = Seq(topMentionResult), model = "model")
+    TopicsApiResponse(entity_types = Seq(TopMentionsTopicType.Org), results = Seq(topMentionResult), model = "model")
 
   val successMultiResponse =
-    TopicsDetails(entity_types = Seq(TopMentionsTopicType.Org), results = topMentionResults, model = "model")
+    TopicsApiResponse(entity_types = Seq(TopMentionsTopicType.Org), results = topMentionResults, model = "model")
 
   "refreshTopMentions" should "return successful future given getListOfKeys s3 call fails" in {
     when(fakeClient.getListOfKeys()) thenReturn Future.failed(new Throwable(""))

--- a/common/app/model/TopMentionsModel.scala
+++ b/common/app/model/TopMentionsModel.scala
@@ -11,13 +11,13 @@ case class TopMentionsResult(
     count: Int,
     percentage_blocks: Float,
 )
-case class TopicsDetails(entity_types: Seq[TopMentionsTopicType], results: Seq[TopMentionsResult], model: String)
+case class TopicsApiResponse(entity_types: Seq[TopMentionsTopicType], results: Seq[TopMentionsResult], model: String)
 
 case class TopMentionJsonParseException(message: String) extends Exception(message)
 
-object TopMentionsResponse {
+object TopicsApiResponse {
   implicit val TopMentionsResultJf: Format[TopMentionsResult] = Json.format[TopMentionsResult]
-  implicit val TopMentionsDetailsJf: Format[TopicsDetails] = Json.format[TopicsDetails]
+  implicit val TopicsApiResponseJf: Format[TopicsApiResponse] = Json.format[TopicsApiResponse]
 }
 
 case class TopicWithCount(


### PR DESCRIPTION
## What does this change?
This PR renames model `TopicsDetails` to `TopicsApiResponse`