### PR TITLE
Remove `amIUsed` idle-loading condition

### DIFF
--- a/static/src/javascripts/projects/common/modules/spacefinder.ts
+++ b/static/src/javascripts/projects/common/modules/spacefinder.ts
@@ -344,11 +344,7 @@ const getReady = (rules: SpacefinderRules, options: SpacefinderOptions) =>
 			options.waitForInteractives ? onInteractivesLoaded(rules) : true,
 		]),
 	]).then((value) => {
-		// TODO: remove this conditional once idle loading becomes the default behaviour
-		const isInIdleLoadingVariant =
-			window.guardian.config.tests?.interactivesIdleLoadingVariant;
-
-		if (value === 'timeout' && isInIdleLoadingVariant) {
+		if (value === 'timeout') {
 			log('commercial', 'Spacefinder timeout hit');
 			amIUsed('spacefinder.ts', 'SpacefinderTimeoutHit');
 		}


### PR DESCRIPTION
## What does this change?

Follow up from: https://github.com/guardian/frontend/pull/25095

Previously we only called `amIUsed` on pages where interactives were idle-loaded. This is now the default behaviour for all interactives (see: https://github.com/guardian/dotcom-rendering/pull/5276) so this condition can be removed

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [ ] Locally
- [ ] On CODE (optional)
