### PR TITLE
Weather: fallback to city aliases

### DIFF
--- a/onward/app/weather/WeatherApi.scala
+++ b/onward/app/weather/WeatherApi.scala
@@ -52,7 +52,7 @@ class WeatherApi(wsClient: WSClient, context: ApplicationContext, actorSystem: A
 
   private def searchForCityUrl(countryCode: String, city: String, regionCode: Option[String]): String = {
     val regionPath = regionCode.map(code => s"/$code").getOrElse("")
-    s"$accuWeatherApiUri/locations/v1/cities/$countryCode$regionPath/search.json?q=$city&apikey=$weatherApiKey"
+    s"$accuWeatherApiUri/locations/v1/cities/$countryCode$regionPath/search.json?q=$city&alias=Always&apikey=$weatherApiKey"
   }
 
   private def getJson(url: String): Future[JsValue] = {

--- a/onward/app/weather/controllers/LocationsController.scala
+++ b/onward/app/weather/controllers/LocationsController.scala
@@ -43,7 +43,7 @@ class LocationsController(weatherApi: WeatherApi, val controllerComponents: Cont
           weatherApi.searchForCity(countryCode, city, maybeRegion) map { locations =>
             val cities = CityResponse.fromLocationResponses(locations.filter(_.Country.ID == countryCode).toList)
             cities.headOption.fold {
-              log.warn(s"Could not find $countryCode, $city")
+              log.warn(s"Could not find $countryCode, $city, $maybeRegion")
               Cached(CacheTime.NotFound)(JsonNotFound())
             } { weatherCity =>
               log.info(s"Matched $countryCode, $city, $maybeRegion to ${weatherCity.id}")


### PR DESCRIPTION
## What does this change?

If not official match is found, we want to find the closest matching city. Contrary to [what the docs say][1], this needs to be explicitly set.

[1]: https://developer.accuweather.com/accuweather-locations-api/apis/get/locations/v1/cities/%7BcountryCode%7D/search

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Less failures to get a city’s weather.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
