### PR TITLE
Migrate to one Topic type

### DIFF
--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -141,7 +141,7 @@ class LiveBlogController(
       range: BlockRange,
       filterKeyEvents: Boolean,
       topicResult: Option[TopicResult],
-      availableTopics: Option[Seq[AvailableTopic]],
+      availableTopics: Option[Seq[Topic]],
       selectedTopics: Option[String],
   )(implicit
       request: RequestHeader,
@@ -338,7 +338,7 @@ class LiveBlogController(
       blog: LiveBlogPage,
       blocks: Blocks,
       filterKeyEvents: Boolean,
-      availableTopics: Option[Seq[AvailableTopic]],
+      availableTopics: Option[Seq[Topic]],
       selectedTopics: Option[String],
   )(implicit request: RequestHeader): Result = {
     val pageType: PageType = PageType(blog, request, context)
@@ -412,7 +412,7 @@ class LiveBlogController(
 
   def getTopicResult(blogId: String, topic: Option[String]) = {
     val topicResult = for {
-      selectedTopic <- SelectedTopic.fromString(topic)
+      selectedTopic <- Topic.fromString(topic)
       topicResult <- topicService.getSelectedTopic(blogId, selectedTopic)
     } yield topicResult
 

--- a/article/app/topics/TopicService.scala
+++ b/article/app/topics/TopicService.scala
@@ -1,7 +1,7 @@
 package topics
 
 import common.{Box, GuLogging}
-import model.{TopicsApiResponse, TopicResult, SelectedTopic, AvailableTopic}
+import model.{TopicsApiResponse, TopicResult, Topic}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -28,9 +28,9 @@ class TopicService(topicS3Client: TopicS3Client) extends GuLogging {
     topicsDetails.get().flatMap(_.get(blogId))
   }
 
-  def getAvailableTopics(blogId: String): Option[Seq[AvailableTopic]] = {
+  def getAvailableTopics(blogId: String): Option[Seq[Topic]] = {
     getBlogTopicsApiResponse(blogId).map(topicsApiResponse =>
-      topicsApiResponse.results.map(topic => AvailableTopic(topic.`type`, topic.name, topic.count)),
+      topicsApiResponse.results.map(topic => Topic(topic.`type`, topic.name, Some(topic.count))),
     )
   }
 
@@ -40,7 +40,7 @@ class TopicService(topicS3Client: TopicS3Client) extends GuLogging {
 
   def getSelectedTopic(
       blogId: String,
-      topicEntity: SelectedTopic,
+      topicEntity: Topic,
   ): Option[TopicResult] = {
     getBlogTopicsApiResponse(blogId).flatMap(_.results.find(result => {
       result.`type` == topicEntity.`type` && result.name == topicEntity.value

--- a/article/test/DCRFake.scala
+++ b/article/test/DCRFake.scala
@@ -3,12 +3,11 @@ package test
 import com.gu.contentapi.client.model.v1.{Block, Blocks}
 import model.Cached.RevalidatableResult
 import model.dotcomrendering.PageType
-import model.{ApplicationContext, Cached, LiveBlogPage, PageWithStoryPackage, AvailableTopic}
+import model.{ApplicationContext, Cached, LiveBlogPage, PageWithStoryPackage, Topic}
 import play.api.libs.ws.WSClient
 import play.api.mvc.{RequestHeader, Result}
 import play.twirl.api.Html
 
-import scala.collection.mutable
 import scala.collection.mutable.{Queue, ArrayBuffer}
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -25,7 +24,7 @@ class DCRFake(implicit context: ApplicationContext) extends renderers.DotcomRend
       pageType: PageType,
       filterKeyEvents: Boolean,
       forceLive: Boolean,
-      availableTopics: Option[Seq[AvailableTopic]],
+      availableTopics: Option[Seq[Topic]],
       selectedTopics: Option[String],
   )(implicit request: RequestHeader): Future[Result] = {
     implicit val ec = ExecutionContext.global

--- a/article/test/LiveBlogControllerTest.scala
+++ b/article/test/LiveBlogControllerTest.scala
@@ -9,8 +9,8 @@ import play.api.test._
 import play.api.test.Helpers._
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import org.scalatestplus.mockito.MockitoSugar
-import model.{LiveBlogPage, TopicResult, SelectedTopic, TopicType, AvailableTopic, TopicsLiveBlog}
-import topics.{TopicS3Client, TopicService}
+import model.{LiveBlogPage, TopicResult, Topic, TopicType}
+import topics.{TopicService}
 
 import scala.concurrent.Future
 
@@ -40,20 +40,20 @@ import scala.concurrent.Future
     )
 
     val fakeAvailableTopics = Vector(
-      AvailableTopic(TopicType.Gpe, "United Kingdom", 6),
-      AvailableTopic(TopicType.Gpe, "Russia", 4),
-      AvailableTopic(TopicType.Org, "KPMG", 4),
-      AvailableTopic(TopicType.Gpe, "Ukraine", 3),
-      AvailableTopic(TopicType.Gpe, "China", 2),
-      AvailableTopic(TopicType.Gpe, "United States", 2),
-      AvailableTopic(TopicType.Loc, "Europe", 2),
-      AvailableTopic(TopicType.Gpe, "Moscow", 2),
-      AvailableTopic(TopicType.Org, "PZ Cussons", 2),
-      AvailableTopic(TopicType.Person, "Emmanuel Macron", 1),
+      Topic(TopicType.Gpe, "United Kingdom", Some(6)),
+      Topic(TopicType.Gpe, "Russia", Some(4)),
+      Topic(TopicType.Org, "KPMG", Some(4)),
+      Topic(TopicType.Gpe, "Ukraine", Some(3)),
+      Topic(TopicType.Gpe, "China", Some(2)),
+      Topic(TopicType.Gpe, "United States", Some(2)),
+      Topic(TopicType.Loc, "Europe", Some(2)),
+      Topic(TopicType.Gpe, "Moscow", Some(2)),
+      Topic(TopicType.Org, "PZ Cussons", Some(2)),
+      Topic(TopicType.Person, "Emmanuel Macron", Some(1)),
     );
 
     when(
-      fakeTopicService.getSelectedTopic(path, SelectedTopic(TopicType.Org, "Fifa")),
+      fakeTopicService.getSelectedTopic(path, Topic(TopicType.Org, "Fifa")),
     ) thenReturn Some(
       topicResult,
     )

--- a/article/test/topics/TopicServiceTest.scala
+++ b/article/test/topics/TopicServiceTest.scala
@@ -1,6 +1,6 @@
 package topics
 
-import model.{TopicsApiResponse, TopicResult, SelectedTopic, TopicType, AvailableTopic}
+import model.{TopicsApiResponse, TopicResult, Topic, TopicType}
 import org.scalatest.{BeforeAndAfterAll}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -95,7 +95,7 @@ class TopicServiceTest
     val topicService = new TopicService(fakeClient)
     val refreshJob = Await.result(topicService.refreshTopics(), 1.second)
 
-    val result = topicService.getSelectedTopic("key1", SelectedTopic(TopicType.Org, "name1"))
+    val result = topicService.getSelectedTopic("key1", Topic(TopicType.Org, "name1"))
 
     result.get should equal(topicResult)
   }
@@ -107,7 +107,7 @@ class TopicServiceTest
     val topicService = new TopicService(fakeClient)
     val refreshJob = Await.result(topicService.refreshTopics(), 1.second)
 
-    val result = topicService.getSelectedTopic("key1", SelectedTopic(TopicType.Org, "NAME1"))
+    val result = topicService.getSelectedTopic("key1", Topic(TopicType.Org, "NAME1"))
 
     result should equal(None)
   }
@@ -119,7 +119,7 @@ class TopicServiceTest
     val topicService = new TopicService(fakeClient)
     val refreshJob = Await.result(topicService.refreshTopics(), 1.second)
 
-    val result = topicService.getSelectedTopic("key2", SelectedTopic(TopicType.Org, "name1"))
+    val result = topicService.getSelectedTopic("key2", Topic(TopicType.Org, "name1"))
 
     result should equal(None)
   }
@@ -132,7 +132,7 @@ class TopicServiceTest
     val refreshJob = Await.result(topicService.refreshTopics(), 1.second)
 
     val result =
-      topicService.getSelectedTopic("key1", SelectedTopic(TopicType.Person, "Boris"))
+      topicService.getSelectedTopic("key1", Topic(TopicType.Person, "Boris"))
 
     result should equal(None)
   }
@@ -145,7 +145,7 @@ class TopicServiceTest
     val refreshJob = Await.result(topicService.refreshTopics(), 1.second)
 
     val result =
-      topicService.getSelectedTopic("key1", SelectedTopic(TopicType.Org, "someRandomOrg"))
+      topicService.getSelectedTopic("key1", Topic(TopicType.Org, "someRandomOrg"))
 
     result should equal(None)
   }
@@ -156,8 +156,8 @@ class TopicServiceTest
     val expectedTopics =
       Some(
         List(
-          AvailableTopic(TopicType.Org, "name1", 1),
-          AvailableTopic(TopicType.Person, "name2", 10),
+          Topic(TopicType.Org, "name1", Some(1)),
+          Topic(TopicType.Person, "name2", Some(10)),
         ),
       )
 

--- a/common/app/model/TopMentionsModel.scala
+++ b/common/app/model/TopMentionsModel.scala
@@ -20,23 +20,15 @@ object TopicsApiResponse {
   implicit val TopicsApiResponseJf: Format[TopicsApiResponse] = Json.format[TopicsApiResponse]
 }
 
-case class AvailableTopic(
+case class Topic(
     `type`: TopicType,
     value: String,
-    count: Int,
+    count: Option[Int] = None,
 )
 
-object AvailableTopic {
-  implicit val AvailableTopicJf: Format[AvailableTopic] = Json.format[AvailableTopic]
-}
-
-case class SelectedTopic(`type`: TopicType, value: String)
-
-object SelectedTopic extends GuLogging {
-
-  implicit val SelectedTopicJf: Format[SelectedTopic] = Json.format[SelectedTopic]
-
-  def fromString(topic: Option[String]): Option[SelectedTopic] = {
+object Topic extends GuLogging {
+  implicit val TopicJf: Format[Topic] = Json.format[Topic]
+  def fromString(topic: Option[String]): Option[Topic] = {
     topic.flatMap { f =>
       val filterEntity = f.split(":")
       if (filterEntity.length == 2) {
@@ -46,7 +38,7 @@ object SelectedTopic extends GuLogging {
           None
         } else {
           log.debug(s"valid topics query parameter - ${f}")
-          Some(SelectedTopic(entityType.get, filterEntity(1)))
+          Some(Topic(entityType.get, filterEntity(1), None))
         }
       } else {
         log.warn(s"topics query parameter is invalid for ${f}, the format is <type>:<name>")

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -20,7 +20,7 @@ import model.{
   InteractivePage,
   LiveBlogPage,
   PageWithStoryPackage,
-  AvailableTopic,
+  Topic,
 }
 import navigation._
 import play.api.libs.json._
@@ -37,7 +37,7 @@ case class DotcomRenderingDataModel(
     webTitle: String,
     mainMediaElements: List[PageElement],
     main: String,
-    availableTopics: Option[Seq[AvailableTopic]],
+    availableTopics: Option[Seq[Topic]],
     selectedTopics: Option[String],
     filterKeyEvents: Boolean,
     pinnedPost: Option[Block],
@@ -244,7 +244,7 @@ object DotcomRenderingDataModel {
       pageType: PageType,
       filterKeyEvents: Boolean,
       forceLive: Boolean,
-      availableTopics: Option[Seq[AvailableTopic]] = None,
+      availableTopics: Option[Seq[Topic]] = None,
       selectedTopics: Option[String] = None,
   ): DotcomRenderingDataModel = {
     val pagination = page.currentPage.pagination.map(paginationInfo => {
@@ -318,7 +318,7 @@ object DotcomRenderingDataModel {
       filterKeyEvents: Boolean = false,
       mostRecentBlockId: Option[String] = None,
       forceLive: Boolean = false,
-      availableTopics: Option[Seq[AvailableTopic]],
+      availableTopics: Option[Seq[Topic]],
       selectedTopics: Option[String] = None,
   ): DotcomRenderingDataModel = {
 

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -14,16 +14,7 @@ import model.dotcomrendering.{
   DotcomRenderingDataModel,
   PageType,
 }
-import model.{
-  CacheTime,
-  Cached,
-  InteractivePage,
-  LiveBlogPage,
-  NoCache,
-  PageWithStoryPackage,
-  PressedPage,
-  AvailableTopic,
-}
+import model.{CacheTime, Cached, InteractivePage, LiveBlogPage, NoCache, PageWithStoryPackage, PressedPage, Topic}
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc.Results.{InternalServerError, NotFound}
 import play.api.mvc.{RequestHeader, Result}
@@ -141,7 +132,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       pageType: PageType,
       filterKeyEvents: Boolean,
       forceLive: Boolean = false,
-      availableTopics: Option[Seq[AvailableTopic]] = None,
+      availableTopics: Option[Seq[Topic]] = None,
       selectedTopics: Option[String] = None,
   )(implicit request: RequestHeader): Future[Result] = {
     val dataModel = page match {

--- a/common/test/model/TopMentionsModelTest.scala
+++ b/common/test/model/TopMentionsModelTest.scala
@@ -5,38 +5,38 @@ import org.scalatest.matchers.should.Matchers
 
 class TopicsModelTest extends AnyFlatSpec with Matchers {
   "getFilterEntityFromTopicsParam" should "return none when no topic is provided" in {
-    val result = SelectedTopic.fromString(None)
+    val result = Topic.fromString(None)
 
     result should be(None)
   }
 
   it should "return none when an invalid string is provided" in {
     val topic = Some("random string")
-    val result = SelectedTopic.fromString(topic)
+    val result = Topic.fromString(topic)
 
     result should be(None)
   }
 
   it should "return none when the provided topic does not exist as a valid TopicType" in {
     val topic = Some("organization:nhs")
-    val result = SelectedTopic.fromString(topic)
+    val result = Topic.fromString(topic)
 
     result should be(None)
   }
 
   it should "be case insensitive on topic type" in {
     val topics = Seq(
-      TestCase("ORG:someEntityValue", SelectedTopic(TopicType.Org, "someEntityValue")),
-      TestCase("Org:someEntityValue", SelectedTopic(TopicType.Org, "someEntityValue")),
-      TestCase("Product:someEntityValue", SelectedTopic(TopicType.Product, "someEntityValue")),
-      TestCase("PRODUCT:someEntityValue", SelectedTopic(TopicType.Product, "someEntityValue")),
-      TestCase("person:someEntityValue", SelectedTopic(TopicType.Person, "someEntityValue")),
+      TestCase("ORG:someEntityValue", Topic(TopicType.Org, "someEntityValue")),
+      TestCase("Org:someEntityValue", Topic(TopicType.Org, "someEntityValue")),
+      TestCase("Product:someEntityValue", Topic(TopicType.Product, "someEntityValue")),
+      TestCase("PRODUCT:someEntityValue", Topic(TopicType.Product, "someEntityValue")),
+      TestCase("person:someEntityValue", Topic(TopicType.Person, "someEntityValue")),
     )
     topics foreach { topic =>
-      val result = SelectedTopic.fromString(Some(topic.topic))
+      val result = Topic.fromString(Some(topic.topic))
       result should be(Some(topic.result))
     }
   }
 }
 
-case class TestCase(val topic: String, val result: SelectedTopic)
+case class TestCase(val topic: String, val result: Topic)


### PR DESCRIPTION
## What does this change?
This consolidates two types (availableTopic and selectedTopic) into one `Topic` type by making count an optional property that defaults to None to make the code base easier to reason with.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
