### PR TITLE
refactor(weather): pick best city

### DIFF
--- a/onward/app/weather/WeatherApi.scala
+++ b/onward/app/weather/WeatherApi.scala
@@ -50,9 +50,8 @@ class WeatherApi(wsClient: WSClient, context: ApplicationContext, actorSystem: A
     s"$accuWeatherApiUri/locations/v1/cities/geoposition/search.json?q=$latitudeLongitude&apikey=$weatherApiKey"
   }
 
-  private def searchForCityUrl(countryCode: String, city: String, regionCode: Option[String]): String = {
-    val regionPath = regionCode.map(code => s"/$code").getOrElse("")
-    s"$accuWeatherApiUri/locations/v1/cities/$countryCode$regionPath/search.json?q=$city&alias=Always&apikey=$weatherApiKey"
+  private def searchForCityUrl(countryCode: String, city: String): String = {
+    s"$accuWeatherApiUri/locations/v1/cities/$countryCode/search.json?q=$city&alias=Always&apikey=$weatherApiKey"
   }
 
   private def getJson(url: String): Future[JsValue] = {
@@ -99,8 +98,8 @@ class WeatherApi(wsClient: WSClient, context: ApplicationContext, actorSystem: A
       Json.fromJson[Seq[LocationResponse]](r).get
     })
 
-  def searchForCity(countryCode: String, city: String, regionCode: Option[String]) =
-    getJson(searchForCityUrl(countryCode, city, regionCode)).map({ r =>
+  def searchForCity(countryCode: String, city: String) =
+    getJson(searchForCityUrl(countryCode, city)).map({ r =>
       Json.fromJson[Seq[LocationResponse]](r).get
     })
 

--- a/onward/app/weather/controllers/LocationsController.scala
+++ b/onward/app/weather/controllers/LocationsController.scala
@@ -40,8 +40,17 @@ class LocationsController(weatherApi: WeatherApi, val controllerComponents: Cont
 
       (maybeCountry, maybeCity) match {
         case (Some(countryCode), Some(city)) =>
-          weatherApi.searchForCity(countryCode, city, maybeRegion) map { locations =>
-            val cities = CityResponse.fromLocationResponses(locations.filter(_.Country.ID == countryCode).toList)
+          weatherApi.searchForCity(countryCode, city) map { locations =>
+            val cities = CityResponse.fromLocationResponses(
+              locations
+                .filter(_.Country.ID == countryCode)
+                .sortBy(_.AdministrativeArea.ID match {
+                  // We want to get cities within a matching region to come up first
+                  case region if maybeRegion.contains(region) => 0
+                  case _                                      => 1
+                })
+                .toList,
+            )
             cities.headOption.fold {
               log.warn(s"Could not find $countryCode, $city, $maybeRegion")
               Cached(CacheTime.NotFound)(JsonNotFound())


### PR DESCRIPTION
## What does this change?

Stop looking for a region, because there are many cities which we don’t get a match for when providing the administrative region.

If there are multiple matches, order cities in a matching regions before others.

```scala
val apiResponse = Seq(
  ("London", "ON", "CA"),
  ("London", "OH", "US"),
  ("London", "LON", "GB")
)

val maybeRegion = Some("LON")

val sortedApiResponse = apiResponse.sortBy(_._2 match {
  case region if Some(region) == maybeRegion => 0
  case _                                     => 1
})

println(apiResponse); // List((London,ON,CA), (London,OH,US), (London,LON,GB))
println(sortedApiResponse); // List((London,LON,GB), (London,ON,CA), (London,OH,US))
```
[Try it for yourself](https://scastie.scala-lang.org/2S7wcAgTSjKTZGyeaxdBbw).

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

We should get a lot more matches. I ran some numbers in GB to see when we get results with or without a region ([source](https://gist.github.com/mxdvl/c81c016a319ca353c70a9cfc7ac390e6)). Here are the cases where we get a different results:

```js
[
  { city: "crowthorne", without_region: "331531", with_region: undefined },
  { city: "bournemouth", without_region: "326983", with_region: undefined },
  { city: "poole", without_region: "330357", with_region: undefined },
  { city: "kingsmead", without_region: "2522683", with_region: undefined },
  { city: "gatwick", without_region: "1-713134_1_AL", with_region: undefined },
  { city: "hayes", without_region: "323264", with_region: undefined },
  { city: "roberton", without_region: "710036", with_region: "2531408" }
]
```

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
