### PR TITLE
Extend newsletters feature switches

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -449,7 +449,7 @@ trait FeatureSwitches {
     "Enables showing reCAPTCHA when signing up to email newsletters",
     owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
     safeState = On,
-    sellByDate = LocalDate.of(2022, 10, 5),
+    sellByDate = never,
     exposeClientSide = true,
   )
 
@@ -459,7 +459,7 @@ trait FeatureSwitches {
     "Remove confirmation step when user sign up to a newsletter",
     owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
     safeState = On,
-    sellByDate = LocalDate.of(2022, 10, 5),
+    sellByDate = never,
     exposeClientSide = false,
   )
 
@@ -469,7 +469,7 @@ trait FeatureSwitches {
     "Show new privacy wording on email signup embeds",
     owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
     safeState = On,
-    sellByDate = LocalDate.of(2022, 10, 5),
+    sellByDate = never,
     exposeClientSide = true,
   )
 
@@ -479,7 +479,7 @@ trait FeatureSwitches {
     "Enables validation of reCAPTCHA tokens on email signup submissions",
     owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
     safeState = On,
-    sellByDate = LocalDate.of(2022, 10, 5),
+    sellByDate = never,
     exposeClientSide = false,
   )
 

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -448,7 +448,7 @@ trait FeatureSwitches {
     "email-signup-recaptcha",
     "Enables showing reCAPTCHA when signing up to email newsletters",
     owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
-    safeState = Off,
+    safeState = On,
     sellByDate = LocalDate.of(2022, 10, 5),
     exposeClientSide = true,
   )
@@ -458,7 +458,7 @@ trait FeatureSwitches {
     "newsletters-remove-confirmation-step",
     "Remove confirmation step when user sign up to a newsletter",
     owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
-    safeState = Off,
+    safeState = On,
     sellByDate = LocalDate.of(2022, 10, 5),
     exposeClientSide = false,
   )
@@ -468,7 +468,7 @@ trait FeatureSwitches {
     "show-new-privacy-wording-on-email-signup-embeds",
     "Show new privacy wording on email signup embeds",
     owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
-    safeState = Off,
+    safeState = On,
     sellByDate = LocalDate.of(2022, 10, 5),
     exposeClientSide = true,
   )
@@ -478,7 +478,7 @@ trait FeatureSwitches {
     "validate-email-signup-recaptcha-tokens",
     "Enables validation of reCAPTCHA tokens on email signup submissions",
     owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
-    safeState = Off,
+    safeState = On,
     sellByDate = LocalDate.of(2022, 10, 5),
     exposeClientSide = false,
   )

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -447,7 +447,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "email-signup-recaptcha",
     "Enables showing reCAPTCHA when signing up to email newsletters",
-    owners = Seq(Owner.withGithub("georgeblahblah")),
+    owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
     safeState = Off,
     sellByDate = LocalDate.of(2022, 10, 5),
     exposeClientSide = true,

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -449,7 +449,7 @@ trait FeatureSwitches {
     "Enables showing reCAPTCHA when signing up to email newsletters",
     owners = Seq(Owner.withGithub("georgeblahblah")),
     safeState = Off,
-    sellByDate = LocalDate.of(2022, 7, 5),
+    sellByDate = LocalDate.of(2022, 10, 5),
     exposeClientSide = true,
   )
 
@@ -459,7 +459,7 @@ trait FeatureSwitches {
     "Remove confirmation step when user sign up to a newsletter",
     owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
     safeState = Off,
-    sellByDate = LocalDate.of(2022, 7, 5),
+    sellByDate = LocalDate.of(2022, 10, 5),
     exposeClientSide = false,
   )
 
@@ -469,7 +469,7 @@ trait FeatureSwitches {
     "Show new privacy wording on email signup embeds",
     owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
     safeState = Off,
-    sellByDate = LocalDate.of(2022, 7, 5),
+    sellByDate = LocalDate.of(2022, 10, 5),
     exposeClientSide = true,
   )
 
@@ -479,7 +479,7 @@ trait FeatureSwitches {
     "Enables validation of reCAPTCHA tokens on email signup submissions",
     owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
     safeState = Off,
-    sellByDate = LocalDate.of(2022, 7, 5),
+    sellByDate = LocalDate.of(2022, 10, 5),
     exposeClientSide = false,
   )
 


### PR DESCRIPTION
## What does this change?

* Extend newsletters feature switches to `2022-10-5`
* Update owner of email-signup-recaptcha switch to newsletters email
* Update safe state of newsletters switches to On

