### PR TITLE
Use case matching for Merchandising High position

### DIFF
--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -834,15 +834,14 @@ case class CommercialComponentHigh(isPaidContent: Boolean, isNetworkFront: Boole
 
     if (containers.length >= minContainers) {
 
-      val containerIndex = if (containers.length >= 4) {
-        if (isNetworkFront) {
-          if (MerchandisingHighSection.isSwitchedOn && edition.id.equals(Uk.id)) {
-            4
-          } else {
-            3
-          }
-        } else 2
-      } else 0
+      val merchHighCanBeMoved = MerchandisingHighSection.isSwitchedOn && edition.id.equals(Uk.id)
+
+      val containerIndex = (containers.length >= 4, isNetworkFront, merchHighCanBeMoved) match {
+        case (false, _, _)       => 0
+        case (true, false, _)    => 2
+        case (true, true, false) => 3
+        case (true, true, true)  => 4
+      }
 
       val adSlotHtml = views.html.fragments.commercial.commercialComponentHigh(isPaidContent, hasPageSkin)
 


### PR DESCRIPTION
## What does this change?

Refactor the merchandising-high index logic to use case matching.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No – **not yet!**
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Easier to reason about.

## Checklist

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
