### PR TITLE
Remove play-iteratees

### DIFF
--- a/admin/app/indexes/ContentApiTagsEnumerator.scala
+++ b/admin/app/indexes/ContentApiTagsEnumerator.scala
@@ -8,7 +8,6 @@ import scala.concurrent.{ExecutionContext, Future}
 import com.gu.contentapi.client.model.v1.{Tag, TagsResponse}
 
 import scala.concurrent.duration._
-import play.api.libs.iteratee.{Enumeratee, Enumerator}
 
 class ContentApiTagsEnumerator(contentApiClient: ContentApiClient)(implicit executionContext: ExecutionContext)
     extends GuLogging {
@@ -16,35 +15,13 @@ class ContentApiTagsEnumerator(contentApiClient: ContentApiClient)(implicit exec
   val MaxNumberRetries = 5
   val MaxPageSize = 1000
 
-  def enumeratePages(getPage: Int => Future[TagsResponse]): Enumerator[Tag] = {
-    def getPageWithRetries(page: Int, retriesRemaining: Int = MaxNumberRetries): Future[TagsResponse] =
-      if (retriesRemaining == 0)
-        getPage(page)
-      else
-        getPage(page) recoverWith {
-          case error: Throwable =>
-            log.error(s"Error getting tag page $page, $retriesRemaining retries remaining", error)
-            getPageWithRetries(page, retriesRemaining - 1)
-        }
-
-    Enumerator
-      .unfoldM(Option(1)) {
-        case Some(nextPage) =>
-          getPageWithRetries(nextPage) map { response =>
-            val next = if (response.pages == response.currentPage) None else Some(response.currentPage + 1)
-
-            Some(next, response.results)
-          }
-
-        case None => Future.successful(None)
-      }
-      .flatMap(Enumerator.apply(_: _*))
+  def enumerateTagType(tagType: String): Future[Seq[Tag]] = {
+    val tagQuery = contentApiClient.tags.tagType(tagType).pageSize(MaxPageSize)
+    contentApiClient.thriftClient.paginateAccum(tagQuery)(
+      { r: TagsResponse => r.results.filter(isSuitableTag) },
+      { (a: Seq[Tag], b: Seq[Tag]) => a ++ b },
+    )
   }
-
-  def enumerateTagType(tagType: String): Enumerator[Tag] =
-    enumeratePages { page =>
-      contentApiClient.getResponse(contentApiClient.tags.tagType(tagType).pageSize(MaxPageSize).page(page))
-    }
 
   implicit class RichTag(tag: Tag) {
     def isSectionTag: Boolean =
@@ -54,9 +31,9 @@ class ContentApiTagsEnumerator(contentApiClient: ContentApiClient)(implicit exec
       }
   }
 
-  def enumerateTagTypeFiltered(tagType: String): Enumerator[Tag] =
-    enumerateTagType(tagType) through Enumeratee.filter({ tag =>
-      /** Believe it or not, we actually have tags whose titles start with HTML tags ... */
-      !tag.id.startsWith("weather/") && asAscii(tag.webTitle).charAt(0).isLetterOrDigit
-    })
+  private def isSuitableTag(tag: Tag): Boolean = {
+
+    /** Believe it or not, we actually have tags whose titles start with HTML tags ... */
+    !tag.id.startsWith("weather/") && asAscii(tag.webTitle).charAt(0).isLetterOrDigit
+  }
 }

--- a/admin/app/indexes/TagPages.scala
+++ b/admin/app/indexes/TagPages.scala
@@ -127,7 +127,7 @@ class TagPages(implicit executionContext: ExecutionContext) extends GuLogging {
   def invalidSectionsFilter(tag: Tag): Boolean = tag.sectionId.exists(TagPages.validSections.contains)
   def publicationsFilter(tag: Tag): Boolean = tagHeadKey(tag.id).exists(TagPages.publications.contains)
 
-//  val byWebTitle = mappedByKey(tag => alphaIndexKey(tag.webTitle))
+  def byWebTitle(tags: Set[Tag]): Map[String, Set[Tag]] = tags.groupBy(tag => alphaIndexKey(tag.webTitle))
 //
 //  val byContributorNameOrder = mappedByKey { tag =>
 //    alphaIndexKey(tag.lastName orElse tag.firstName getOrElse tag.webTitle)

--- a/admin/app/indexes/TagPages.scala
+++ b/admin/app/indexes/TagPages.scala
@@ -1,11 +1,9 @@
 package indexes
 
-import common.GuLogging
-import common.Maps._
 import com.gu.contentapi.client.model.v1.Tag
-import model.{TagDefinition, TagIndex}
+import common.GuLogging
 import common.StringEncodings.asAscii
-import play.api.libs.iteratee.{Enumeratee, Iteratee}
+import model.{TagDefinition, TagIndex}
 
 import scala.concurrent.ExecutionContext
 import scala.util.Try
@@ -103,10 +101,10 @@ class TagPages(implicit executionContext: ExecutionContext) extends GuLogging {
     id.split("/").headOption
   }
 
-  private def mappedByKey(key: Tag => String) =
-    Iteratee.fold[Tag, Map[String, Set[Tag]]](Map.empty) { (acc, tag) =>
-      insertWith(acc, key(tag), Set(tag))(_ union _)
-    }
+//  private def mappedByKey(key: Tag => String) =
+//    Iteratee.fold[Tag, Map[String, Set[Tag]]](Map.empty) { (acc, tag) =>
+//      insertWith(acc, key(tag), Set(tag))(_ union _)
+//    }
 
   def asciiLowerWebTitle(tag: Tag): String =
     asAscii(tag.webTitle).toLowerCase
@@ -126,17 +124,17 @@ class TagPages(implicit executionContext: ExecutionContext) extends GuLogging {
         )
     }
 
-  val invalidSectionsFilter = Enumeratee.filter[Tag](_.sectionId.exists(TagPages.validSections.contains))
-  val publicationsFilter = Enumeratee.filter[Tag](t => tagHeadKey(t.id).exists(TagPages.publications.contains))
+  def invalidSectionsFilter(tag: Tag): Boolean = tag.sectionId.exists(TagPages.validSections.contains)
+  def publicationsFilter(tag: Tag): Boolean = tagHeadKey(tag.id).exists(TagPages.publications.contains)
 
-  val byWebTitle = mappedByKey(tag => alphaIndexKey(tag.webTitle))
-
-  val byContributorNameOrder = mappedByKey { tag =>
-    alphaIndexKey(tag.lastName orElse tag.firstName getOrElse tag.webTitle)
-  }
-
-  val bySection = invalidSectionsFilter &>> mappedByKey(_.sectionId.get)
-
-  val byPublication = publicationsFilter &>> mappedByKey(tag => tagHeadKey(tag.id).getOrElse("publication"))
+//  val byWebTitle = mappedByKey(tag => alphaIndexKey(tag.webTitle))
+//
+//  val byContributorNameOrder = mappedByKey { tag =>
+//    alphaIndexKey(tag.lastName orElse tag.firstName getOrElse tag.webTitle)
+//  }
+//
+//  val bySection = invalidSectionsFilter &>> mappedByKey(_.sectionId.get)
+//
+//  val byPublication = publicationsFilter &>> mappedByKey(tag => tagHeadKey(tag.id).getOrElse("publication"))
 
 }

--- a/admin/app/indexes/TagPages.scala
+++ b/admin/app/indexes/TagPages.scala
@@ -101,11 +101,6 @@ class TagPages(implicit executionContext: ExecutionContext) extends GuLogging {
     id.split("/").headOption
   }
 
-//  private def mappedByKey(key: Tag => String) =
-//    Iteratee.fold[Tag, Map[String, Set[Tag]]](Map.empty) { (acc, tag) =>
-//      insertWith(acc, key(tag), Set(tag))(_ union _)
-//    }
-
   def asciiLowerWebTitle(tag: Tag): String =
     asAscii(tag.webTitle).toLowerCase
 
@@ -126,15 +121,6 @@ class TagPages(implicit executionContext: ExecutionContext) extends GuLogging {
 
   def invalidSectionsFilter(tag: Tag): Boolean = tag.sectionId.exists(TagPages.validSections.contains)
   def publicationsFilter(tag: Tag): Boolean = tagHeadKey(tag.id).exists(TagPages.publications.contains)
-
   def byWebTitle(tags: Set[Tag]): Map[String, Set[Tag]] = tags.groupBy(tag => alphaIndexKey(tag.webTitle))
-//
-//  val byContributorNameOrder = mappedByKey { tag =>
-//    alphaIndexKey(tag.lastName orElse tag.firstName getOrElse tag.webTitle)
-//  }
-//
-//  val bySection = invalidSectionsFilter &>> mappedByKey(_.sectionId.get)
-//
-//  val byPublication = publicationsFilter &>> mappedByKey(tag => tagHeadKey(tag.id).getOrElse("publication"))
 
 }

--- a/admin/app/jobs/RebuildIndexJob.scala
+++ b/admin/app/jobs/RebuildIndexJob.scala
@@ -47,7 +47,7 @@ class RebuildIndexJob(contentApiClient: ContentApiClient)(implicit executionCont
     } yield {
       val tags = (keywords ++ series).toSet
       val tagsBySection: Map[String, Set[Tag]] = tags.filter(tagPages.invalidSectionsFilter).groupBy(_.sectionId.get)
-      val tagsByWebTitle: Map[String, Set[Tag]] = tags.groupBy(tag => tagPages.alphaIndexKey(tag.webTitle))
+      val tagsByWebTitle: Map[String, Set[Tag]] = tagPages.byWebTitle(tags)
 
       blocking {
         saveToS3("keywords", tagPages.toPages(tagsByWebTitle)(alphaTitle, tagPages.asciiLowerWebTitle))

--- a/admin/test/indexes/TagPagesTest.scala
+++ b/admin/test/indexes/TagPagesTest.scala
@@ -7,7 +7,6 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.DoNotDiscover
-import play.api.libs.iteratee.Enumerator
 import test.WithTestExecutionContext
 
 import scala.language.postfixOps
@@ -78,14 +77,10 @@ import scala.concurrent.duration._
     val advertisingTag = tagFixture("Advertising")
     val otherDigitalSolutionsTag = tagFixture("Other digital solutions")
 
+    val tags = Set(activateTag, archivedSpeakersTag, blogTag, advertisingTag, otherDigitalSolutionsTag)
+
     tagPages.toPages(
-      Enumerator(
-        activateTag,
-        archivedSpeakersTag,
-        blogTag,
-        advertisingTag,
-        otherDigitalSolutionsTag,
-      ).run(tagPages.byWebTitle).futureValue(Timeout(1 second)),
+      tagPages.byWebTitle(tags),
     )(_.toUpperCase, tagPages.asciiLowerWebTitle) shouldEqual Seq(
       TagIndex(
         "a",

--- a/build.sbt
+++ b/build.sbt
@@ -124,7 +124,6 @@ val admin = application("admin")
       awsElasticloadbalancing,
       awsSes,
       scalaUri,
-      playIteratees,
     ),
     RoutesKeys.routesImport += "bindables._",
     RoutesKeys.routesImport += "org.joda.time.LocalDate",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -76,7 +76,6 @@ object Dependencies {
   val playJson = "com.typesafe.play" %% "play-json" % playJsonVersion
   val playJsonExtensions = "ai.x" %% "play-json-extensions" % playJsonExtensionsVersion
   val playJsonJoda = "com.typesafe.play" %% "play-json-joda" % playJsonVersion
-  val playIteratees = "com.typesafe.play" %% "play-iteratees" % "2.6.1"
   val atomRenderer = "com.gu" %% "atom-renderer" % "1.2.0"
   val supportInternationalisation = "com.gu" %% "support-internationalisation" % "0.13"
   val capiAws = "com.gu" %% "content-api-client-aws" % "0.7"


### PR DESCRIPTION
## What does this change?
As part of the Scala 2.13 upgrade we need to remove the `play-iteratees` library because it is no longer supported and there is no 2.13 version. We're replacing it with the `paginateAccum` CAPI client method. The `play-iteratees` library was used to fully list all `keyword` & `series` tags, for two purposes:

* creating index pages - Index pages help Google crawl our site, so they're good for SEO - they were first introduced with https://github.com/guardian/frontend/pull/5199 in July 2014
* detecting when redirects should occur away from legacy urls in `PublicationController` (this functionality was introduced with https://github.com/guardian/frontend/pull/11150) https://github.com/guardian/frontend/blob/6b1adeef122e1612cc39ea0869fc94d5ac2585eb/article/app/controllers/PublicationController.scala#L58

### Index pages

* https://www.theguardian.com/index/contributors ![image](https://user-images.githubusercontent.com/52038/176932142-fe59b562-112a-49de-aae7-1ede59baf5f7.png)
* https://www.theguardian.com/index/contributors/b ![image](https://user-images.githubusercontent.com/52038/176932601-616aae0c-d4f5-41f1-82e8-d817bc9018a5.png)

* https://www.theguardian.com/index/subjects ![image](https://user-images.githubusercontent.com/52038/176932099-f87b8452-4639-4255-a0af-5832d4ce0b59.png)
* https://www.theguardian.com/index/subjects/b ![image](https://user-images.githubusercontent.com/52038/176932516-d1957ff3-3e39-4d27-89ef-96a60fc33595.png)




## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
