### PR TITLE
feat(nav): add women's euros 2022 to football navigation

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -104,6 +104,7 @@ private object NavLinks {
     "Football",
     "/football",
     children = List(
+      NavLink("Women's Euro 2022", "/football/women-s-euro-2022", Some("football/women-s-euro-2022")),
       NavLink("Live scores", "/football/live", Some("football/live")),
       NavLink("Tables", "/football/tables", Some("football/tables")),
       NavLink("Fixtures", "/football/fixtures", Some("football/fixtures")),


### PR DESCRIPTION
## What does this change?
Adds '[Women's Euro 2022](https://www.theguardian.com/football/women-s-euro-2022)' in first place on the [Football](https://www.theguardian.com/football) navigation bar.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="530" alt="Screenshot 2022-07-04 at 09 11 51" src="https://user-images.githubusercontent.com/31692/177111722-34f1de3f-eb0c-480c-be13-2e7900867f86.png"> | <img width="528" alt="Screenshot 2022-07-04 at 09 11 57" src="https://user-images.githubusercontent.com/31692/177111750-ae02a866-4492-4bb3-9bfe-feea5eb2313e.png"> |

