### PR TITLE
Scala 2.13: Replace deprecated procedure syntax with explicit ': Unit ='

### DIFF
--- a/admin/app/controllers/cache/ImageServices.scala
+++ b/admin/app/controllers/cache/ImageServices.scala
@@ -26,7 +26,7 @@ object ImageServices {
   // clear both the origin CDN and Fastly IO service (either i.guim.co.uk or i.guimcode.co.uk)
   private def fastlyServiceIdsforOrigin(host: String): Seq[String] = Seq(fastlyOriginCdns(host), fastlyIOService)
 
-  def clearFastly(originUri: URI, wsClient: WSClient) {
+  def clearFastly(originUri: URI, wsClient: WSClient): Unit = {
     fastlyServiceIdsforOrigin(originUri.getHost).foreach { serviceId =>
       // This works because the "path" is set as a Surrogate Key for images in i.guim.co.uk
       // https://www.fastly.com/blog/surrogate-keys-part-1/

--- a/admin/app/jobs/AnalyticsSanityCheckJob.scala
+++ b/admin/app/jobs/AnalyticsSanityCheckJob.scala
@@ -36,7 +36,7 @@ class AnalyticsSanityCheckJob(ophanApi: OphanApi) extends GuLogging {
     },
   )
 
-  def run()(implicit executionContext: ExecutionContext) {
+  def run()(implicit executionContext: ExecutionContext): Unit = {
 
     val fRawPageViews: Future[GetMetricStatisticsResult] = CloudWatchStats.rawPageViews()
     val fGooglePageViews = CloudWatchStats.googleAnalyticsPageViews()

--- a/admin/app/jobs/FastlyCloudwatchLoadJob.scala
+++ b/admin/app/jobs/FastlyCloudwatchLoadJob.scala
@@ -44,7 +44,7 @@ class FastlyCloudwatchLoadJob(fastlyStatisticService: FastlyStatisticService) ex
     }
   }
 
-  def run()(implicit executionContext: ExecutionContext) {
+  def run()(implicit executionContext: ExecutionContext): Unit = {
     log.info("Loading statistics from Fastly to CloudWatch.")
     fastlyStatisticService.fetch().map { statistics =>
       val fresh: List[FastlyStatistic] = statistics filter { statistic =>

--- a/admin/app/jobs/RebuildIndexJob.scala
+++ b/admin/app/jobs/RebuildIndexJob.scala
@@ -15,7 +15,7 @@ class RebuildIndexJob(contentApiClient: ContentApiClient)(implicit executionCont
   val contentApiTagsEnumerator = new ContentApiTagsEnumerator(contentApiClient)
   val tagPages = new TagPages
 
-  def saveToS3(parentKey: String, tagPages: Seq[TagIndex]) {
+  def saveToS3(parentKey: String, tagPages: Seq[TagIndex]): Unit = {
     val s3StopWatch = new StopWatch
 
     tagPages foreach { tagPage =>
@@ -114,7 +114,7 @@ class RebuildIndexJob(contentApiClient: ContentApiClient)(implicit executionCont
     }
   }
 
-  def run() {
+  def run(): Unit = {
     rebuildKeywordIndexes().withErrorLogging andThen {
       case _ =>
         rebuildContributorIndex().withErrorLogging andThen {

--- a/admin/app/model/abtests/AbTestJob.scala
+++ b/admin/app/model/abtests/AbTestJob.scala
@@ -8,7 +8,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 
 object AbTestJob extends GuLogging {
-  def run()(implicit executionContext: ExecutionContext) {
+  def run()(implicit executionContext: ExecutionContext): Unit = {
 
     log.info("Downloading abtests info from CloudWatch")
 

--- a/admin/app/model/abtests/AbTests.scala
+++ b/admin/app/model/abtests/AbTests.scala
@@ -15,7 +15,7 @@ object AbTests {
     abTests.get()
   }
 
-  def update(testVariants: Map[String, Seq[String]]) {
+  def update(testVariants: Map[String, Seq[String]]): Unit = {
     abTests.send(testVariants)
   }
 

--- a/admin/app/tools/LoadBalancer.scala
+++ b/admin/app/tools/LoadBalancer.scala
@@ -38,7 +38,7 @@ object LoadBalancer extends GuLogging {
 
   private val agent = Box(loadBalancers)
 
-  def refresh() {
+  def refresh(): Unit = {
     log.info("starting refresh LoadBalancer ELB DNS names")
     credentials.foreach { credentials =>
       val client = AmazonElasticLoadBalancingClient

--- a/admin/app/tools/charts/charts.scala
+++ b/admin/app/tools/charts/charts.scala
@@ -24,7 +24,7 @@ class ChartTable(private val labels: Seq[String]) {
   def column(label: String): ChartColumn = datapoints(label)
   def allColumns: Seq[ChartColumn] = datapoints.values.toSeq
 
-  def addColumn(label: String, data: ChartColumn) {
+  def addColumn(label: String, data: ChartColumn): Unit = {
     datapoints += ((label, data))
   }
 

--- a/archive/app/services/ArchiveMetrics.scala
+++ b/archive/app/services/ArchiveMetrics.scala
@@ -21,7 +21,7 @@ class ArchiveMetrics(appLifecycle: ApplicationLifecycle, jobs: JobScheduler)(imp
     }
   }
 
-  private def report() {
+  private def report(): Unit = {
     CloudWatch.putMetrics("ArchiveMetrics", List(GoogleBotMetric.Googlebot404Count), List.empty)
   }
 

--- a/common/app/common/AutoRefresh.scala
+++ b/common/app/common/AutoRefresh.scala
@@ -24,7 +24,7 @@ abstract class AutoRefresh[A](initialDelay: FiniteDuration, interval: FiniteDura
     } yield Future.successful(a)).getOrElse(refresh())
 
   class Task(implicit executionContext: ExecutionContext) extends Runnable {
-    def run() {
+    def run(): Unit = {
       refresh().onComplete {
         case Success(a) =>
           log.debug(s"Updated AutoRefresh: $a")

--- a/common/app/common/ShowcaseRSSModules.scala
+++ b/common/app/common/ShowcaseRSSModules.scala
@@ -16,7 +16,7 @@ import scala.collection.JavaConverters._
 trait RssAtomModule extends com.sun.syndication.feed.module.Module with Serializable with Cloneable {
   override def getUri: String = RssAtomModule.URI
   def getUpdated: Option[DateTime]
-  def setUpdated(updated: Option[DateTime])
+  def setUpdated(updated: Option[DateTime]): Unit
 }
 
 class RssAtomModuleImpl extends RssAtomModule {
@@ -54,23 +54,23 @@ trait GModule extends com.sun.syndication.feed.module.Module with Serializable w
 
   def getPanel: Option[GPanel]
 
-  def setPanel(panel: Option[GPanel])
+  def setPanel(panel: Option[GPanel]): Unit
 
   def getPanelTitle: Option[String]
 
-  def setPanelTitle(panelTitle: Option[String])
+  def setPanelTitle(panelTitle: Option[String]): Unit
 
   def getOverline: Option[String]
 
-  def setOverline(overline: Option[String])
+  def setOverline(overline: Option[String]): Unit
 
   def getArticleGroup: Option[GArticleGroup]
 
-  def setArticleGroup(articleGroup: Option[GArticleGroup])
+  def setArticleGroup(articleGroup: Option[GArticleGroup]): Unit
 
   def getBulletList: Option[GBulletList]
 
-  def setBulletList(bulletList: Option[GBulletList])
+  def setBulletList(bulletList: Option[GBulletList]): Unit
 }
 
 class GModuleImpl() extends GModule {

--- a/common/app/common/dfp/DfpAgent.scala
+++ b/common/app/common/dfp/DfpAgent.scala
@@ -36,13 +36,13 @@ object DfpAgent
 
   private def stringFromS3(key: String): Option[String] = S3.get(key)(UTF8)
 
-  private def update[T](agent: Box[Seq[T]])(freshData: => Seq[T]) {
+  private def update[T](agent: Box[Seq[T]])(freshData: => Seq[T]): Unit = {
     if (freshData.nonEmpty) {
       agent send freshData
     }
   }
 
-  def refresh()(implicit executionContext: ExecutionContext) {
+  def refresh()(implicit executionContext: ExecutionContext): Unit = {
 
     def grabPageSkinSponsorshipsFromStore(key: String): Seq[PageSkinSponsorship] = {
       val reportOption: Option[PageSkinSponsorshipReport] = for {
@@ -76,7 +76,7 @@ object DfpAgent
       } yield lineItems
     }
 
-    def updateInlineMerchandisingTargetedTags(freshData: InlineMerchandisingTagSet) {
+    def updateInlineMerchandisingTargetedTags(freshData: InlineMerchandisingTagSet): Unit = {
       inlineMerchandisingTagsAgent send { oldData =>
         if (freshData.nonEmpty) freshData else oldData
       }

--- a/common/app/common/jobs.scala
+++ b/common/app/common/jobs.scala
@@ -18,7 +18,7 @@ object JobsState {
 
 class FunctionJob extends Job with GuLogging {
   import JobsState._
-  def execute(context: JobExecutionContext) {
+  def execute(context: JobExecutionContext): Unit = {
     val name = context.getJobDetail.getKey.getName
     val f = jobs(name)
     if (outstanding.get()(name) > 0) {
@@ -102,7 +102,7 @@ class JobScheduler(context: ApplicationContext) extends GuLogging {
     }
   }
 
-  def deschedule(name: String) {
+  def deschedule(name: String): Unit = {
     log.info(s"Descheduling $name")
     jobs.remove(name)
     scheduler.deleteJob(new JobKey(name))

--- a/common/app/common/management.scala
+++ b/common/app/common/management.scala
@@ -5,8 +5,8 @@ import java.util.concurrent.atomic.AtomicBoolean
 import scala.io.Source
 
 trait Switchable {
-  def switchOn()
-  def switchOff()
+  def switchOn(): Unit
+  def switchOff(): Unit
   def isSwitchedOn: Boolean
   def isSwitchedOff: Boolean = !isSwitchedOn
 

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -227,7 +227,7 @@ class CloudWatchMetricsLifecycle(
       )
     }
 
-  private def report() {
+  private def report(): Unit = {
     val allMetrics: List[FrontendMetric] = this.systemMetrics ::: this.appMetrics.metrics
 
     CloudWatch.putMetrics(applicationMetricsNamespace, allMetrics, applicationDimension)

--- a/common/app/contentapi/SectionsLookUpLifecycle.scala
+++ b/common/app/contentapi/SectionsLookUpLifecycle.scala
@@ -21,13 +21,13 @@ class SectionsLookUpLifecycle(
     }
   }
 
-  private def scheduleJobs() {
+  private def scheduleJobs(): Unit = {
     jobs.schedule("SectionsLookUpJob", "0 * * * * ?") {
       sectionsLookUp.refresh()
     }
   }
 
-  private def descheduleJobs() {
+  private def descheduleJobs(): Unit = {
     jobs.deschedule("SectionsLookUpJob")
   }
 

--- a/common/app/implicits/AutomaticResourceManagement.scala
+++ b/common/app/implicits/AutomaticResourceManagement.scala
@@ -3,7 +3,7 @@ package implicits
 import language.reflectiveCalls
 
 trait AutomaticResourceManagement {
-  def withCloseable[T <: { def close() }](closeable: T): {
+  def withCloseable[T <: { def close(): Unit }](closeable: T): {
     def apply[S](body: (T) => S): S
   } =
     new {
@@ -15,7 +15,7 @@ trait AutomaticResourceManagement {
         }
     }
 
-  def withDisposable[T <: { def dispose() }](disposable: T): {
+  def withDisposable[T <: { def dispose(): Unit }](disposable: T): {
     def apply[S](body: (T) => S): S
   } =
     new {

--- a/common/app/model/diagnostics/CloudWatch.scala
+++ b/common/app/model/diagnostics/CloudWatch.scala
@@ -23,10 +23,10 @@ trait CloudWatch extends GuLogging {
   }
 
   trait LoggingAsyncHandler extends AsyncHandler[PutMetricDataRequest, PutMetricDataResult] with GuLogging {
-    def onError(exception: Exception) {
+    def onError(exception: Exception): Unit = {
       log.info(s"CloudWatch PutMetricDataRequest error: ${exception.getMessage}}")
     }
-    def onSuccess(request: PutMetricDataRequest, result: PutMetricDataResult) {
+    def onSuccess(request: PutMetricDataRequest, result: PutMetricDataResult): Unit = {
       log.info("CloudWatch PutMetricDataRequest - success")
     }
   }

--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -78,7 +78,7 @@ trait S3 extends GuLogging {
       new DateTime(result.getObjectMetadata.getLastModified)
     }
 
-  def putPublic(key: String, value: String, contentType: String) {
+  def putPublic(key: String, value: String, contentType: String): Unit = {
     put(key: String, value: String, contentType: String, PublicRead)
   }
 
@@ -87,11 +87,11 @@ trait S3 extends GuLogging {
     client.foreach(_.putObject(request))
   }
 
-  def putPrivate(key: String, value: String, contentType: String) {
+  def putPrivate(key: String, value: String, contentType: String): Unit = {
     put(key: String, value: String, contentType: String, Private)
   }
 
-  def putPrivateGzipped(key: String, value: String, contentType: String) {
+  def putPrivateGzipped(key: String, value: String, contentType: String): Unit = {
     putGzipped(key, value, contentType, Private)
   }
 
@@ -100,7 +100,12 @@ trait S3 extends GuLogging {
       Source.fromInputStream(new GZIPInputStream(result.getObjectContent)).mkString
     }
 
-  private def putGzipped(key: String, value: String, contentType: String, accessControlList: CannedAccessControlList) {
+  private def putGzipped(
+      key: String,
+      value: String,
+      contentType: String,
+      accessControlList: CannedAccessControlList,
+  ): Unit = {
     lazy val request = {
       val metadata = new ObjectMetadata()
 
@@ -129,7 +134,7 @@ trait S3 extends GuLogging {
     }
   }
 
-  private def put(key: String, value: String, contentType: String, accessControlList: CannedAccessControlList) {
+  private def put(key: String, value: String, contentType: String, accessControlList: CannedAccessControlList): Unit = {
     val metadata = new ObjectMetadata()
     metadata.setCacheControl("no-cache,no-store")
     metadata.setContentType(contentType)

--- a/common/app/views/support/cleaner/VideoEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/VideoEmbedCleaner.scala
@@ -148,12 +148,12 @@ case class VideoEmbedCleaner(article: Article, maxEmbedHeight: Int = 812) extend
     document
   }
 
-  private def addVimeoDntFlag(iframe: Element) {
+  private def addVimeoDntFlag(iframe: Element): Unit = {
     val src = iframe.attr("src")
     iframe.attr("src", src ++ (if (src.contains("?")) "&" else "?") ++ "dnt=true")
   }
 
-  private def wrapIframe(container: Element, iframe: Element) {
+  private def wrapIframe(container: Element, iframe: Element): Unit = {
     // Has no id to get data from capi so try and get from iframe
     val videoWidth = iframe.attr("width")
     val videoHeight = iframe.attr("height")
@@ -167,7 +167,7 @@ case class VideoEmbedCleaner(article: Article, maxEmbedHeight: Int = 812) extend
     }
   }
 
-  private def wrapCustom(container: Element, width: Float, height: Float) {
+  private def wrapCustom(container: Element, width: Float, height: Float): Unit = {
     val aspectRatio = width / height
     val maxWidth = maxEmbedHeight * aspectRatio
     val paddingBottom = (1 / aspectRatio) * 100
@@ -176,8 +176,8 @@ case class VideoEmbedCleaner(article: Article, maxEmbedHeight: Int = 812) extend
     )
   }
 
-  private def wrapHD(container: Element) {
-    container.wrap(s"""<div class="embed-video-wrapper u-responsive-ratio u-responsive-ratio--hd"></div>""")
+  private def wrapHD(container: Element): Unit = {
+    container.wrap("""<div class="embed-video-wrapper u-responsive-ratio u-responsive-ratio--hd"></div>""")
   }
 
   def findVideoApiElement(id: String): Option[VideoElement] = article.elements.bodyVideos.find(_.properties.id == id)

--- a/common/test/conf/audio/FlagshipFrontContainerSpec.scala
+++ b/common/test/conf/audio/FlagshipFrontContainerSpec.scala
@@ -11,7 +11,7 @@ class FlagshipFrontContainerSpec extends AnyFlatSpec with Matchers with BeforeAn
   private val formatter =
     DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm").withZone(FlagshipFrontContainer.londonTimezone)
 
-  override def beforeAll {
+  override def beforeAll: Unit = {
     FlagshipFrontContainerSwitch.switchOn()
   }
 

--- a/common/test/metadata/MetaDataMatcher.scala
+++ b/common/test/metadata/MetaDataMatcher.scala
@@ -14,7 +14,7 @@ object MetaDataMatcher extends Matchers {
   lazy val appId = "409128287"
   val iosDomain = "ios-app://"
 
-  def ensureOrganisation(result: Future[Result]) {
+  def ensureOrganisation(result: Future[Result]): Unit = {
     status(result) should be(200)
     val stringResult = contentAsString(result)
     val body = Jsoup.parseBodyFragment(stringResult)
@@ -31,7 +31,7 @@ object MetaDataMatcher extends Matchers {
     socialNetworks.size should be(4)
   }
 
-  def ensureWebPage(result: Future[Result], articleUrl: String) {
+  def ensureWebPage(result: Future[Result], articleUrl: String): Unit = {
     val body = Jsoup.parseBodyFragment(contentAsString(result))
     status(result) should be(200)
 
@@ -43,14 +43,14 @@ object MetaDataMatcher extends Matchers {
     (appIndexer \ "potentialAction" \ "target").as[String] should include(articleUrl)
   }
 
-  def ensureDeepLink(result: Future[Result]) {
+  def ensureDeepLink(result: Future[Result]): Unit = {
     val body = Jsoup.parseBodyFragment(contentAsString(result))
     status(result) should be(200)
     val script = body.getElementsByAttributeValueStarting("href", iosDomain)
     script.size() should be(1)
   }
 
-  def ensureNoDeepLink(result: Future[Result]) {
+  def ensureNoDeepLink(result: Future[Result]): Unit = {
     val body = Jsoup.parseBodyFragment(contentAsString(result))
     status(result) should be(200)
     val script = body.getElementsByAttributeValueStarting("href", iosDomain)
@@ -65,7 +65,7 @@ object MetaDataMatcher extends Matchers {
     script.size() should be(0)
   }
 
-  def ensureOldArticleMessage(result: Future[Result], articleUrl: String) {
+  def ensureOldArticleMessage(result: Future[Result], articleUrl: String): Unit = {
     val body = Jsoup.parseBodyFragment(contentAsString(result))
     status(result) should be(200)
 
@@ -73,7 +73,7 @@ object MetaDataMatcher extends Matchers {
     elements.size() should be(2)
   }
 
-  def ensureNoOldArticleMessage(result: Future[Result], articleUrl: String) {
+  def ensureNoOldArticleMessage(result: Future[Result], articleUrl: String): Unit = {
     val body = Jsoup.parseBodyFragment(contentAsString(result))
     status(result) should be(200)
 

--- a/facia-press/app/frontpress/JsonQueueWorker.scala
+++ b/facia-press/app/frontpress/JsonQueueWorker.scala
@@ -22,7 +22,7 @@ final private[frontpress] class ConsecutiveErrorsRecorder {
     errorCount.set(0)
   }
 
-  def recordError() {
+  def recordError(): Unit = {
     errorCount.addAndGet(1)
   }
 
@@ -39,7 +39,7 @@ object DateTimeRecorder {
 final private[frontpress] class DateTimeRecorder {
   @volatile private var lastTime: Option[DateTime] = None
 
-  def refresh() {
+  def refresh(): Unit = {
     lastTime = Some(DateTime.now())
   }
 
@@ -128,7 +128,7 @@ abstract class JsonQueueWorker[A: Reads]()(implicit executionContext: ExecutionC
     getRequest.map(_ => ())
   }
 
-  final private def next() {
+  final private def next(): Unit = {
     getAndProcess onComplete {
       case _ if started => next()
       case _            => log.info("Stopping worker...")
@@ -137,7 +137,7 @@ abstract class JsonQueueWorker[A: Reads]()(implicit executionContext: ExecutionC
 
   final private var started = false
 
-  final def start() {
+  final def start(): Unit = {
     synchronized {
       if (started) {
         log.warn("Attempted to start queue worker but queue worker is already started")

--- a/facia-press/app/frontpress/StatusNotification.scala
+++ b/facia-press/app/frontpress/StatusNotification.scala
@@ -26,10 +26,10 @@ object StatusNotification {
   lazy val partitionKey: String = "facia-tool-updates"
 
   object KinesisLoggingAsyncHandler extends AsyncHandler[PutRecordRequest, PutRecordResult] {
-    def onError(exception: Exception) {
+    def onError(exception: Exception): Unit = {
       log.error(s"Kinesis PutRecord request error: ${exception.getMessage}}")
     }
-    def onSuccess(request: PutRecordRequest, result: PutRecordResult) {
+    def onSuccess(request: PutRecordRequest, result: PutRecordResult): Unit = {
       log.info(s"Kinesis status notification sent to stream:${request.getStreamName}")
     }
   }

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -63,7 +63,7 @@ import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
     wsClient
   }
 
-  override def beforeAll() {
+  override def beforeAll(): Unit = {
     val refresh = ConfigAgent.refreshWith(
       ConfigJson(
         fronts = Map(

--- a/facia/test/FaciaMetaDataTest.scala
+++ b/facia/test/FaciaMetaDataTest.scala
@@ -32,7 +32,7 @@ import test._
   lazy val blockingOperations = new BlockingOperations(actorSystem)
   lazy val fapi = new TestFrontJsonFapi(blockingOperations)
 
-  override def beforeAll() {
+  override def beforeAll(): Unit = {
     val refresh = ConfigAgent.refreshWith(
       ConfigJson(
         fronts =

--- a/identity/app/conf/IdentityLifecycle.scala
+++ b/identity/app/conf/IdentityLifecycle.scala
@@ -21,13 +21,13 @@ class IdentityLifecycle(
     }
   }
 
-  private def scheduleJobs() {
+  private def scheduleJobs(): Unit = {
     jobs.schedule("TorExitNodeRefeshJob", "0 0/30 * * * ?") {
       TorExitNodeList.run()
     }
   }
 
-  private def descheduleJobs() {
+  private def descheduleJobs(): Unit = {
     jobs.deschedule("TorExitNodeRefeshJob")
   }
 

--- a/identity/app/http/HeaderLoggingFilter.scala
+++ b/identity/app/http/HeaderLoggingFilter.scala
@@ -8,7 +8,7 @@ import utils.SafeLogging
 import scala.concurrent.Future
 
 class HeaderLoggingFilter(implicit val mat: Materializer) extends Filter with SafeLogging {
-  def logHeaders(rh: RequestHeader) {
+  def logHeaders(rh: RequestHeader): Unit = {
     val keys: Set[String] = rh.headers.keys filterNot { name =>
       "Cookie" == name || "User-Agent" == name || "Authorization" == name
     }

--- a/identity/app/jobs/TorExitNodeList.scala
+++ b/identity/app/jobs/TorExitNodeList.scala
@@ -12,7 +12,7 @@ object TorExitNodeList extends GuLogging {
   private val torExitNodeAgent = Box[Set[String]](Set.empty)
   private val torNodeListUrl = "https://check.torproject.org/cgi-bin/TorBulkExitList.py"
 
-  def run() {
+  def run(): Unit = {
     log.info("Updating tor list for current list for %s".format("profile.theguardian.com"))
     val addresses = InetAddress.getAllByName("profile.theguardian.com")
 

--- a/sport/app/cricket/conf/context.scala
+++ b/sport/app/cricket/conf/context.scala
@@ -24,7 +24,7 @@ class CricketLifecycle(
     }
   }
 
-  private def scheduleJobs() {
+  private def scheduleJobs(): Unit = {
     jobs.scheduleEvery("CricketAgentRefreshCurrentMatches", 5.minutes) {
       Future(cricketStatsJob.run(fromDate = LocalDate.now, matchesToFetch = 1))
     }
@@ -33,12 +33,12 @@ class CricketLifecycle(
     }
   }
 
-  private def descheduleJobs() {
+  private def descheduleJobs(): Unit = {
     jobs.deschedule("CricketAgentRefreshCurrentMatches")
     jobs.deschedule("CricketAgentRefreshHistoricalMatches")
   }
 
-  override def start() {
+  override def start(): Unit = {
     descheduleJobs()
     scheduleJobs()
 

--- a/sport/app/football/conf/context.scala
+++ b/sport/app/football/conf/context.scala
@@ -29,7 +29,7 @@ class FootballLifecycle(
     }
   }
 
-  private def scheduleJobs() {
+  private def scheduleJobs(): Unit = {
     competitionsService.competitionIds.zipWithIndex foreach {
       case (id, index) =>
         //stagger fixtures and results refreshes to avoid timeouts
@@ -64,7 +64,7 @@ class FootballLifecycle(
     }
   }
 
-  private def descheduleJobs() {
+  private def descheduleJobs(): Unit = {
     competitionsService.competitionIds foreach { id =>
       jobs.deschedule(s"CompetitionAgentRefreshJob_$id")
     }

--- a/sport/test/FootballTestData.scala
+++ b/sport/test/FootballTestData.scala
@@ -19,7 +19,7 @@ trait FootballTestData {
   }
 
   implicit class TestCompetitionsService(competitionsService: CompetitionsService) {
-    def loadTestData() {
+    def loadTestData(): Unit = {
       if (competitionsService.matches.isEmpty) {
         competitionsService.competitionAgents.foreach { agent =>
           FootballTestData.competitions.filter(_.id == agent.competition.id).map { comp =>


### PR DESCRIPTION
## What does this change?
We're trying to fix as many syntax errors as possible while we're still in Scala 2.12. For this PR, we added: `addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.1")` in `plugins.sbt` and ran `scalafixAll ProcedureSyntax` in the `sbt` shell. 
