### PR TITLE
add newsletters switch group and migrate switches over

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -443,46 +443,6 @@ trait FeatureSwitches {
     exposeClientSide = false,
   )
 
-  val EmailSignupRecaptcha = Switch(
-    SwitchGroup.Feature,
-    "email-signup-recaptcha",
-    "Enables showing reCAPTCHA when signing up to email newsletters",
-    owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
-    safeState = On,
-    sellByDate = never,
-    exposeClientSide = true,
-  )
-
-  val NewslettersRemoveConfirmationStep = Switch(
-    SwitchGroup.Feature,
-    "newsletters-remove-confirmation-step",
-    "Remove confirmation step when user sign up to a newsletter",
-    owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
-    safeState = On,
-    sellByDate = never,
-    exposeClientSide = false,
-  )
-
-  val ShowNewPrivacyWordingOnEmailSignupEmbeds = Switch(
-    SwitchGroup.Feature,
-    "show-new-privacy-wording-on-email-signup-embeds",
-    "Show new privacy wording on email signup embeds",
-    owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
-    safeState = On,
-    sellByDate = never,
-    exposeClientSide = true,
-  )
-
-  val ValidateEmailSignupRecaptchaTokens = Switch(
-    SwitchGroup.Feature,
-    "validate-email-signup-recaptcha-tokens",
-    "Enables validation of reCAPTCHA tokens on email signup submissions",
-    owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
-    safeState = On,
-    sellByDate = never,
-    exposeClientSide = false,
-  )
-
   val FrontsSlideshowMobileSupport = Switch(
     SwitchGroup.Feature,
     "fronts-slideshow-mobile-support",

--- a/common/app/conf/switches/NewslettersSwitches.scala
+++ b/common/app/conf/switches/NewslettersSwitches.scala
@@ -1,0 +1,48 @@
+package conf.switches
+
+import conf.switches.Expiry.never
+import conf.switches.Owner.group
+
+trait NewslettersSwitches {
+
+  val EmailSignupRecaptcha = Switch(
+    SwitchGroup.Newsletters,
+    "email-signup-recaptcha",
+    "Enables showing reCAPTCHA when signing up to email newsletters",
+    owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
+
+  val NewslettersRemoveConfirmationStep = Switch(
+    SwitchGroup.Newsletters,
+    "newsletters-remove-confirmation-step",
+    "Remove confirmation step when user sign up to a newsletter",
+    owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = false,
+  )
+
+  val ShowNewPrivacyWordingOnEmailSignupEmbeds = Switch(
+    SwitchGroup.Newsletters,
+    "show-new-privacy-wording-on-email-signup-embeds",
+    "Show new privacy wording on email signup embeds",
+    owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = true,
+  )
+
+  val ValidateEmailSignupRecaptchaTokens = Switch(
+    SwitchGroup.Newsletters,
+    "validate-email-signup-recaptcha-tokens",
+    "Enables validation of reCAPTCHA tokens on email signup submissions",
+    owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = false,
+  )
+
+}

--- a/common/app/conf/switches/Switches.scala
+++ b/common/app/conf/switches/Switches.scala
@@ -35,11 +35,12 @@ object SwitchGroup {
   val Facia = SwitchGroup("Facia")
   val Feature = SwitchGroup("Feature")
   val Identity = SwitchGroup("Identity")
+  val Journalism = SwitchGroup("Journalism")
   val Monitoring = SwitchGroup("Monitoring")
   val Performance = SwitchGroup("Performance")
   val ServerSideExperiments = SwitchGroup("Server-side Experiments")
   val Membership = SwitchGroup("Membership")
-  val Journalism = SwitchGroup("Journalism")
+  val Newsletters = SwitchGroup("Newsletters")
   val Privacy = SwitchGroup("Privacy")
   val TX = SwitchGroup("TX")
 }
@@ -177,6 +178,7 @@ object Switches
     with MonitoringSwitches
     with IdentitySwitches
     with JournalismSwitches
+    with NewslettersSwitches
     with TXSwitches {
 
   def all: Seq[Switch] = Switch.allSwitches


### PR DESCRIPTION
## What does this change?

Added new group in switchboard for Newsletters specific switches
Thanks @mxdvl for the idea

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="245" alt="image" src="https://user-images.githubusercontent.com/43961396/177359205-a29bb69b-5a9b-428c-85e9-2c13df58de6e.png"> | <img width="237" alt="image" src="https://user-images.githubusercontent.com/43961396/177359068-b27064d3-ff21-44eb-be16-a1f035924219.png"> |


<img width="874" alt="Screenshot 2022-07-05 at 16 02 40" src="https://user-images.githubusercontent.com/43961396/177358830-8cbc7fef-9936-49f6-b32d-6f84cfbf47f8.png">


## Checklist

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
