### PR TITLE
Scala 2.13: Fix `weaker access privileges` compile error

### DIFF
--- a/common/app/common/ShowcaseRSSModules.scala
+++ b/common/app/common/ShowcaseRSSModules.scala
@@ -13,23 +13,19 @@ import org.joda.time.format.ISODateTimeFormat
 import java.util
 import scala.collection.JavaConverters._
 
-trait RssAtomModule extends com.sun.syndication.feed.module.Module with Serializable with Cloneable {
+class RssAtomModule extends com.sun.syndication.feed.module.Module with Serializable {
   override def getUri: String = RssAtomModule.URI
-  def getUpdated: Option[DateTime]
-  def setUpdated(updated: Option[DateTime]): Unit
-}
 
-class RssAtomModuleImpl extends RssAtomModule {
   private var updated: Option[DateTime] = None
 
-  override def getUpdated: Option[DateTime] = updated
+  def getUpdated: Option[DateTime] = updated
 
-  override def setUpdated(updated: Option[DateTime]): Unit = this.updated = updated
+  def setUpdated(updated: Option[DateTime]): Unit = this.updated = updated
 
   override def getInterface: Class[_] = classOf[RssAtomModule]
 
-  override def clone: Object = {
-    val module = new RssAtomModuleImpl
+  override def clone(): Object = {
+    val module = new RssAtomModule
     module.copyFrom(this)
     module
   }
@@ -49,61 +45,39 @@ case class GPanel(
     content: String,
 )
 
-trait GModule extends com.sun.syndication.feed.module.Module with Serializable with Cloneable {
+class GModule extends com.sun.syndication.feed.module.Module with Serializable with Cloneable {
   override def getUri: String = GModule.URI
 
-  def getPanel: Option[GPanel]
-
-  def setPanel(panel: Option[GPanel]): Unit
-
-  def getPanelTitle: Option[String]
-
-  def setPanelTitle(panelTitle: Option[String]): Unit
-
-  def getOverline: Option[String]
-
-  def setOverline(overline: Option[String]): Unit
-
-  def getArticleGroup: Option[GArticleGroup]
-
-  def setArticleGroup(articleGroup: Option[GArticleGroup]): Unit
-
-  def getBulletList: Option[GBulletList]
-
-  def setBulletList(bulletList: Option[GBulletList]): Unit
-}
-
-class GModuleImpl() extends GModule {
   private var panel: Option[GPanel] = None
   private var panelTitle: Option[String] = None
   private var overline: Option[String] = None
   private var articleGroup: Option[GArticleGroup] = None
   private var bulletList: Option[GBulletList] = None
 
-  override def getPanel: Option[GPanel] = panel
+  def getPanel: Option[GPanel] = panel
 
-  override def setPanel(panel: Option[GPanel]): Unit = this.panel = panel
+  def setPanel(panel: Option[GPanel]): Unit = this.panel = panel
 
-  override def getPanelTitle: Option[String] = panelTitle
+  def getPanelTitle: Option[String] = panelTitle
 
-  override def setPanelTitle(panelTitle: Option[String]): Unit = this.panelTitle = panelTitle
+  def setPanelTitle(panelTitle: Option[String]): Unit = this.panelTitle = panelTitle
 
-  override def getOverline: Option[String] = overline
+  def getOverline: Option[String] = overline
 
-  override def setOverline(overline: Option[String]): Unit = this.overline = overline
+  def setOverline(overline: Option[String]): Unit = this.overline = overline
 
-  override def getArticleGroup: Option[GArticleGroup] = articleGroup
+  def getArticleGroup: Option[GArticleGroup] = articleGroup
 
-  override def setArticleGroup(articleGroup: Option[GArticleGroup]): Unit = this.articleGroup = articleGroup
+  def setArticleGroup(articleGroup: Option[GArticleGroup]): Unit = this.articleGroup = articleGroup
 
-  override def getBulletList: Option[GBulletList] = bulletList
+  def getBulletList: Option[GBulletList] = bulletList
 
-  override def setBulletList(bulletList: Option[GBulletList]): Unit = this.bulletList = bulletList
+  def setBulletList(bulletList: Option[GBulletList]): Unit = this.bulletList = bulletList
 
   override def getInterface: Class[_] = classOf[GModule]
 
   override def clone: Object = {
-    val gModule = new GModuleImpl
+    val gModule = new GModule
     gModule.copyFrom(this)
     gModule
   }
@@ -240,7 +214,7 @@ class GModuleGenerator extends ModuleGenerator {
             pubDateElement.addContent(DateParser.formatRFC822(article.published.toDate))
             articleElement.addContent(pubDateElement)
 
-            val rssAtomModule = new RssAtomModuleImpl()
+            val rssAtomModule = new RssAtomModule()
             rssAtomModule.setUpdated(Some(article.updated))
             rssAtomModuleGenerator.generate(rssAtomModule, articleElement)
 

--- a/common/app/common/TrailsToShowcase.scala
+++ b/common/app/common/TrailsToShowcase.scala
@@ -602,7 +602,7 @@ object TrailsToShowcase {
 
     setEntryDates(singleStoryPanel, entry)
 
-    val gModule = new GModuleImpl()
+    val gModule = new GModule()
     gModule.setPanel(Some(GPanel(singleStoryPanel.`type`, singleStoryPanel.title)))
     gModule.setPanelTitle(singleStoryPanel.panelTitle)
     gModule.setOverline(singleStoryPanel.overline)
@@ -631,7 +631,7 @@ object TrailsToShowcase {
 
     setEntryDates(rundownPanel, entry)
 
-    val gModule = new GModuleImpl()
+    val gModule = new GModule()
     gModule.setPanel(Some(GPanel(rundownPanel.`type`, rundownPanel.panelTitle)))
     gModule.setPanelTitle(Some(rundownPanel.panelTitle))
     gModule.setArticleGroup(Some(asGArticleGroup(rundownPanel.articleGroup)))
@@ -656,8 +656,8 @@ object TrailsToShowcase {
   }
 
   private def setEntryDates(panel: Panel, entry: SyndEntryImpl): Unit = {
-    def atomDatesModuleFor(updated: Option[DateTime]): RssAtomModuleImpl = {
-      val atomModule = new RssAtomModuleImpl
+    def atomDatesModuleFor(updated: Option[DateTime]): RssAtomModule = {
+      val atomModule = new RssAtomModule
       atomModule.setUpdated(updated)
       atomModule
     }


### PR DESCRIPTION
Compiling Frontend under Scala 2.13, we see two identical compilation errors against the `RssAtomModule` & `GModule` traits, which both extend the `com.sun.syndication.feed.module.Module` interface from ROME (used for processing RSS). The error is this:

> weaker access privileges in overriding `def clone()`: Object (defined in trait Module) override should be **`public`**;
> (note that `def clone()`: Object (defined in trait Module) is abstract, and is therefore overridden by concrete **`protected`**[package lang] `def clone()`: Object (defined in class Object))

`com.sun.syndication.feed.module.Module` is a Java interface that specifies `clone()` should be *public*:

```
public Object clone() throws CloneNotSupportedException;
```

...but it's just an interface, not a class - and so the `java.lang.Object.clone()` method, which is assigned `protected` as an access modifier, is _more_ protected than the `Module` interface dictates - but it's the only `clone()` method available on our trait, whether that's `RssAtomModule` or `GModule`.

This is a horrible little problem and various people have encountered it over the years:

* https://github.com/scala/bug/issues/3946
* https://bugs.openjdk.org/browse/JDK-6946211

How to fix?
-----------

There is a fairly good suggestion at https://stackoverflow.com/a/8619704/438886 - just define a concrete `clone()` method in the trait, with a guard implementation that throws a `CloneNotSupportedException` - your concrete subclasses can override the method with whatever implementation they like. It's a bit of a hack, but it works.

However, looking at the code of these two traits and their solitary implementations:

* `RssAtomModule` with its implementation `RssAtomModuleImpl`
* `GModule` with `GModuleImpl`

...there's no reason to separate the functionality here into a separate trait and class. It's not being used to facilitate testing, and each trait has only a single implementation. Sometimes a trait can be a nice way to decide exactly what limited public API you want people to think about when they use your code, but I don't think that's the case here. Totally fine to just unite each trait & class into a simple class, reducing unnecessary boilerplate, and removing the need to have a dummy `public` clone method!

The compilation errors in full:

```
[error] /Users/roberto/guardian/frontend/common/app/common/ShowcaseRSSModules.scala:16:7: weaker access privileges in overriding
[error] def clone(): Object (defined in trait Module)
[error]   override should be public;
[error]   (note that def clone(): Object (defined in trait Module) is abstract,
[error]   and is therefore overridden by concrete protected[package lang] def clone(): Object (defined in class Object))
[error] trait RssAtomModule extends com.sun.syndication.feed.module.Module with Serializable with Cloneable {
[error]       ^
[error] /Users/roberto/guardian/frontend/common/app/common/ShowcaseRSSModules.scala:52:7: weaker access privileges in overriding
[error] def clone(): Object (defined in trait Module)
[error]   override should be public;
[error]   (note that def clone(): Object (defined in trait Module) is abstract,
[error]   and is therefore overridden by concrete protected[package lang] def clone(): Object (defined in class Object))
[error] trait GModule extends com.sun.syndication.feed.module.Module with Serializable with Cloneable {
[error]       ^
```
