### PR TITLE
fix: remove unused test switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -46,16 +46,6 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-scroll-depth",
-    "Send scroll depth tracking data",
-    owners = Seq(Owner.withEmail("dotcom.platform@theguardian.com")),
-    safeState = Off,
-    sellByDate = Some(LocalDate.of(2022, 7, 5)),
-    exposeClientSide = true,
-  )
-
-  Switch(
-    ABTests,
     "ab-multi-sticky-right-ads",
     "Test the commercial and performance impact of sticky ads in the right column",
     owners = Seq(Owner.withGithub("chrislomaxjones")),


### PR DESCRIPTION
## What does this change?

Remove unused AB Test from #25125

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

The `ab-scroll-depth` experiment did not take place and the switch has expired.