### PR TITLE
Remove unused imports

### DIFF
--- a/admin/app/controllers/admin/OAuthLoginAdminController.scala
+++ b/admin/app/controllers/admin/OAuthLoginAdminController.scala
@@ -1,7 +1,7 @@
 package controllers.admin
 
 import com.gu.googleauth.GoogleAuthConfig
-import conf.{AdminConfiguration, Configuration}
+import conf.AdminConfiguration
 import googleAuth.OAuthLoginController
 import model.ApplicationContext
 import play.api.http.HttpConfiguration

--- a/admin/app/controllers/cache/PageDecacheController.scala
+++ b/admin/app/controllers/cache/PageDecacheController.scala
@@ -10,7 +10,7 @@ import play.api.http.HttpConfiguration
 import play.api.libs.ws.WSClient
 import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc._
-import purge.{AjaxHost, CdnPurge, FastlyService, GuardianHost}
+import purge.{AjaxHost, CdnPurge, GuardianHost}
 
 import scala.concurrent.Future
 import scala.concurrent.Future.successful

--- a/admin/app/football/controllers/PlayerController.scala
+++ b/admin/app/football/controllers/PlayerController.scala
@@ -13,7 +13,6 @@ import football.model.PA
 import scala.concurrent.Future
 import model.{ApplicationContext, Cached, Cors, NoCache}
 import play.api.libs.json.{JsArray, JsObject, JsString}
-import org.joda.time.format.DateTimeFormat
 import play.twirl.api.HtmlFormat
 import play.api.libs.ws.WSClient
 

--- a/admin/app/football/model/PA.scala
+++ b/admin/app/football/model/PA.scala
@@ -2,7 +2,6 @@ package football.model
 
 import pa.{Season, Team}
 import implicits.Collections
-import org.joda.time.DateTime
 
 import java.time.ZoneId
 

--- a/admin/app/tools/DfpLink.scala
+++ b/admin/app/tools/DfpLink.scala
@@ -3,8 +3,6 @@ package tools
 import conf.Configuration.commercial.dfpAccountId
 import conf.Configuration.site
 
-import scala.language.postfixOps
-
 object DfpLink {
 
   def lineItem(lineItemId: Long): String = {

--- a/admin/test/indexes/TagPagesTest.scala
+++ b/admin/test/indexes/TagPagesTest.scala
@@ -2,15 +2,11 @@ package indexes
 
 import com.gu.contentapi.client.model.v1.{TagType, Tag => ApiTag}
 import model.{TagDefinition, TagIndex}
-import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.DoNotDiscover
 import test.WithTestExecutionContext
-
-import scala.language.postfixOps
-import scala.concurrent.duration._
 
 @DoNotDiscover class TagPagesTest extends AnyFlatSpec with Matchers with WithTestExecutionContext with ScalaFutures {
 

--- a/admin/test/package.scala
+++ b/admin/test/package.scala
@@ -1,7 +1,6 @@
 package test
 
 import org.scalatest.Suites
-import org.scalatestplus.play.PortNumber
 
 class AdminTestSuite
     extends Suites(

--- a/applications/app/AppLoader.scala
+++ b/applications/app/AppLoader.scala
@@ -13,10 +13,10 @@ import controllers._
 import dev.{DevAssetsController, DevParametersHttpRequestHandler}
 import http.{CommonFilters, CorsHttpErrorHandler}
 import jobs.{SiteMapJob, SiteMapLifecycle}
-import model.{ApplicationContext, ApplicationIdentity}
+import model.ApplicationIdentity
 import services.ophan.SurgingContentAgentLifecycle
 import play.api.ApplicationLoader.Context
-import play.api.{BuiltInComponentsFromContext, OptionalDevContext}
+import play.api.BuiltInComponentsFromContext
 import play.api.http.{HttpErrorHandler, HttpRequestHandler}
 import play.api.libs.ws.WSClient
 import play.api.mvc.EssentialFilter

--- a/applications/app/controllers/ImageContentController.scala
+++ b/applications/app/controllers/ImageContentController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import com.gu.contentapi.client.model.{Direction, FollowingSearchQuery, SearchQuery, SearchQueryBase}
+import com.gu.contentapi.client.model.{Direction, FollowingSearchQuery, SearchQuery}
 import com.gu.contentapi.client.model.v1.{ItemResponse, Content => ApiContent}
 import common._
 import conf.switches.Switches

--- a/applications/app/controllers/NewspaperController.scala
+++ b/applications/app/controllers/NewspaperController.scala
@@ -4,7 +4,7 @@ import common.{ImplicitControllerExecutionContext, GuLogging}
 import contentapi.ContentApiClient
 import layout.FaciaContainer
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
-import model.{ApplicationContext, Cached, MetaData, SectionId, SimplePage, StandalonePage}
+import model.{ApplicationContext, Cached, MetaData, SectionId, StandalonePage}
 import pages.ContentHtmlPage
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 import services.NewspaperQuery

--- a/applications/app/controllers/Nx1ConfigController.scala
+++ b/applications/app/controllers/Nx1ConfigController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import play.api.libs.json.{Format, Json}
+import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents, RequestHeader}
 import views.support.CamelCase
 import experiments.ActiveExperiments

--- a/applications/app/controllers/YoutubeController.scala
+++ b/applications/app/controllers/YoutubeController.scala
@@ -1,13 +1,11 @@
 package controllers
 
-import com.gu.contentapi.client.model.v1.ItemResponse
 import common._
 import contentapi.ContentApiClient
 import model.{CacheTime, Cached}
 import play.api.libs.ws.WSClient
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}
 
-import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
 class YoutubeController(

--- a/applications/app/pages/ContentHtmlPage.scala
+++ b/applications/app/pages/ContentHtmlPage.scala
@@ -4,7 +4,7 @@ import common.Edition
 import controllers.{ImageContentPage, MediaPage, QuizAnswersPage, TodayNewspaper}
 import html.HtmlPageHelpers._
 import html.{HtmlPage, Styles}
-import model.{ApplicationContext, Audio, AudioAsset, Page}
+import model.{ApplicationContext, Audio, Page}
 import play.api.mvc.RequestHeader
 import play.twirl.api.Html
 import views.html.fragments._
@@ -16,7 +16,6 @@ import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.{newspaperContent, quizAnswerContent}
 import html.HtmlPageHelpers.ContentCSSFile
 import conf.switches.Switches.WeAreHiring
-import views.html.stacked
 
 object ContentHtmlPage extends HtmlPage[Page] {
 

--- a/applications/app/pages/CrosswordHtmlPage.scala
+++ b/applications/app/pages/CrosswordHtmlPage.scala
@@ -1,6 +1,5 @@
 package pages
 
-import common.Edition
 import conf.switches.Switches.WeAreHiring
 import html.HtmlPageHelpers._
 import html.{HtmlPage, Styles}
@@ -22,7 +21,6 @@ import views.html.fragments.page.head.stylesheets.{criticalStyleInline, critical
 import views.html.fragments.page.head._
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import html.HtmlPageHelpers.ContentCSSFile
-import views.html.stacked
 import views.html.fragments.commercial.survey
 
 object CrosswordHtmlPage extends HtmlPage[CrosswordPage] {

--- a/applications/app/pages/GalleryHtmlPage.scala
+++ b/applications/app/pages/GalleryHtmlPage.scala
@@ -1,6 +1,5 @@
 package pages
 
-import common.Edition
 import conf.switches.Switches.WeAreHiring
 import html.{HtmlPage, Styles}
 import html.HtmlPageHelpers._
@@ -14,7 +13,6 @@ import views.html.fragments.page.head.stylesheets.{criticalStyleInline, critical
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.fragments._
 import html.HtmlPageHelpers.{ContentCSSFile}
-import views.html.stacked
 
 object GalleryHtmlPage extends HtmlPage[GalleryPage] {
 

--- a/applications/app/pages/IndexHtmlPage.scala
+++ b/applications/app/pages/IndexHtmlPage.scala
@@ -1,6 +1,5 @@
 package pages
 
-import common.Edition
 import conf.switches.Switches.WeAreHiring
 import html.HtmlPageHelpers._
 import html.{HtmlPage, Styles}
@@ -17,7 +16,6 @@ import views.html.fragments.page.head.stylesheets.{criticalStyleInline, critical
 import views.html.fragments.page.head._
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import html.HtmlPageHelpers.{ContentCSSFile}
-import views.html.stacked
 
 object IndexHtml {
 

--- a/applications/app/pages/InteractiveHtmlPage.scala
+++ b/applications/app/pages/InteractiveHtmlPage.scala
@@ -1,6 +1,5 @@
 package pages
 
-import common.Edition
 import conf.switches.Switches.WeAreHiring
 import model.InteractivePage
 import html.{HtmlPage, Styles}

--- a/applications/app/pages/TagIndexHtmlPage.scala
+++ b/applications/app/pages/TagIndexHtmlPage.scala
@@ -1,6 +1,5 @@
 package pages
 
-import common.Edition
 import conf.switches.Switches.WeAreHiring
 import html.HtmlPageHelpers._
 import html.{HtmlPage, Styles}
@@ -22,7 +21,6 @@ import views.html.fragments.page.head._
 import views.html.fragments.page.{devTakeShot, htmlTag}
 import views.html.preferences.index
 import html.HtmlPageHelpers.{ContentCSSFile}
-import views.html.stacked
 
 object TagIndexHtmlPage extends HtmlPage[StandalonePage] {
 

--- a/applications/test/helpers/FacebookGraphApiTestClient.scala
+++ b/applications/test/helpers/FacebookGraphApiTestClient.scala
@@ -6,7 +6,6 @@ import java.net.URLEncoder
 import play.api.libs.ws.{WSClient, WSResponse}
 import recorder.DefaultHttpRecorder
 import services.FacebookGraphApiClient
-import test.WithTestExecutionContext
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.Duration

--- a/applications/test/package.scala
+++ b/applications/test/package.scala
@@ -2,7 +2,6 @@ package test
 
 import java.util.{List => JList}
 import org.scalatest.Suites
-import org.scalatestplus.play.PortNumber
 import services.{FacebookGraphApiTest, IndexPageTest, InteractivePickerTest, NewspaperControllerTest}
 
 import collection.JavaConverters._

--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -6,23 +6,14 @@ import model.Cached.{CacheableResult, WithoutRevalidationResult}
 import play.api.mvc._
 import services.{GoogleBotMetric, RedirectService}
 import java.net.URLDecoder
-import java.util.concurrent.atomic.AtomicReference
 import javax.ws.rs.core.UriBuilder
 
-import conf.Configuration
-import experiments._
 import model.{CacheTime, Cached}
 import org.apache.http.HttpStatus
-import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
-import play.twirl.api.Html
 import services.RedirectService.{ArchiveRedirect, Destination, PermanentRedirect}
 
-import scala.concurrent.duration._
-import scala.concurrent.{Await, Future}
-import java.lang.System.currentTimeMillis
-
-import metrics.TimingMetric
+import scala.concurrent.Future
 
 class ArchiveController(redirects: RedirectService, val controllerComponents: ControllerComponents, ws: WSClient)
     extends BaseController

--- a/archive/test/package.scala
+++ b/archive/test/package.scala
@@ -2,7 +2,6 @@ package test
 
 import java.util.{List => JList}
 import org.scalatest.Suites
-import org.scalatestplus.play.PortNumber
 
 import collection.JavaConverters._
 

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -5,7 +5,7 @@ import common._
 import contentapi.ContentApiClient
 import implicits.{AmpFormat, EmailFormat, HtmlFormat, JsonFormat}
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
-import model.dotcomrendering.{DotcomRenderingDataModel, DotcomRenderingUtils, PageType}
+import model.dotcomrendering.{DotcomRenderingDataModel, PageType}
 import model.{ContentType, _}
 import pages.{ArticleEmailHtmlPage, ArticleHtmlPage}
 import play.api.libs.json.Json

--- a/article/app/model/ContentFields.scala
+++ b/article/app/model/ContentFields.scala
@@ -2,7 +2,6 @@ package model
 
 import play.api.libs.json.{Json, Writes}
 import play.api.mvc.RequestHeader
-import play.twirl.api.Html
 import views.{BodyProcessor, MainCleaner}
 
 case class ContentFields(fields: Fields, cleanedMainBlockHtml: String, cleanedBodyHtml: String)

--- a/article/app/model/structuredData/LiveBlogPosting.scala
+++ b/article/app/model/structuredData/LiveBlogPosting.scala
@@ -1,7 +1,7 @@
 package model.structuredData
 
 import common.LinkTo
-import model.{Article, Cached}
+import model.Article
 import model.liveblog._
 import org.joda.time.DateTime
 import play.api.libs.json._

--- a/article/app/pages/StoryHtmlPage.scala
+++ b/article/app/pages/StoryHtmlPage.scala
@@ -1,6 +1,5 @@
 package pages
 
-import common.Edition
 import conf.switches.Switches._
 import html.HtmlPageHelpers._
 import html.Styles
@@ -14,7 +13,6 @@ import views.html.fragments.page.body._
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
 import views.html.fragments.page.head._
 import html.HtmlPageHelpers.ContentCSSFile
-import views.html.stacked
 import services.dotcomponents.ArticlePicker.{dcrChecks}
 
 object StoryHtmlPage {

--- a/article/test/LiveBlogControllerTest.scala
+++ b/article/test/LiveBlogControllerTest.scala
@@ -2,7 +2,7 @@ package test
 
 import controllers.LiveBlogController
 import org.mockito.Mockito._
-import org.mockito.Matchers.{any, anyObject, anyString}
+import org.mockito.Matchers.{anyObject, anyString}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import play.api.test._
@@ -11,8 +11,6 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import org.scalatestplus.mockito.MockitoSugar
 import model.{LiveBlogPage, TopicResult, Topic, TopicType}
 import topics.{TopicService}
-
-import scala.concurrent.Future
 
 @DoNotDiscover class LiveBlogControllerTest
     extends AnyFlatSpec

--- a/article/test/package.scala
+++ b/article/test/package.scala
@@ -1,7 +1,6 @@
 package test
 
 import org.scalatest.{Suites, Tag}
-import org.scalatestplus.play.PortNumber
 import services.dotcomponents.ArticlePickerTest
 object ArticleComponents extends Tag("article components")
 

--- a/commercial/app/controllers/Multi.scala
+++ b/commercial/app/controllers/Multi.scala
@@ -5,7 +5,7 @@ import commercial.model.merchandise.books.BestsellersAgent
 import commercial.model.merchandise.events.MasterclassAgent
 import commercial.model.merchandise.jobs.JobsAgent
 import commercial.model.merchandise.travel.TravelOffersAgent
-import commercial.model.merchandise.{MemberPair, Merchandise}
+import commercial.model.merchandise.Merchandise
 import common.{JsonComponent}
 import model.Cached
 import play.api.libs.json.{JsArray, Json}

--- a/commercial/app/model/feeds/FeedParser.scala
+++ b/commercial/app/model/feeds/FeedParser.scala
@@ -5,7 +5,7 @@ import commercial.model.merchandise.events.{LiveEventAgent, MasterclassAgent}
 import commercial.model.merchandise.jobs.JobsAgent
 import commercial.model.merchandise.travel.TravelOffersAgent
 import conf.Configuration
-import commercial.model.merchandise.{Book, Job, LiveEvent, Masterclass, Member, TravelOffer}
+import commercial.model.merchandise.{Book, Job, LiveEvent, Masterclass, TravelOffer}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.Duration

--- a/commercial/app/model/feeds/FeedReader.scala
+++ b/commercial/app/model/feeds/FeedReader.scala
@@ -6,7 +6,7 @@ import conf.switches.Switch
 import play.api.libs.json.{JsValue, Json}
 import play.api.libs.ws.{WSClient, WSRequest, WSResponse, WSSignatureCalculator}
 
-import scala.concurrent.duration.{Duration, _}
+import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}

--- a/commercial/app/model/merchandise/events/LiveEventMembershipInfo.scala
+++ b/commercial/app/model/merchandise/events/LiveEventMembershipInfo.scala
@@ -1,6 +1,5 @@
 package commercial.model.merchandise.events
 
-import play.api.data.validation.ValidationError
 import play.api.libs.json._
 
 case class LiveEventMembershipInfo(id: String, url: String, mainImageUrl: String)

--- a/commercial/app/model/package.scala
+++ b/commercial/app/model/package.scala
@@ -1,6 +1,5 @@
 package commercial
 
-import play.api.data.validation.ValidationError
 import play.api.libs.json._
 
 package object model {

--- a/commercial/test/test/CommercialTestSuite.scala
+++ b/commercial/test/test/CommercialTestSuite.scala
@@ -3,7 +3,6 @@ package commercial.test
 import commercial.model.capi.LookupTest
 import commercial.model.merchandise.{books, events, jobs}
 import org.scalatest.Suites
-import org.scalatestplus.play.PortNumber
 import test.SingleServerSuite
 
 class CommercialTestSuite

--- a/common/app/common/Box.scala
+++ b/common/app/common/Box.scala
@@ -3,7 +3,6 @@ package common
 import java.util.concurrent.atomic.AtomicReference
 
 import scala.concurrent.Future
-import scala.util.{Try, Success, Failure}
 
 abstract class Box[T] {
   def get(): T

--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -1,11 +1,9 @@
 package common
 
-import common.editions.{Au, International, Us}
 import conf.Configuration
 import layout.ContentCard
 import model.Trail
 import org.jsoup.Jsoup
-import play.api.libs.json.Json
 import play.api.mvc.{AnyContent, Request, RequestHeader, Result}
 import play.twirl.api.Html
 import scala.collection.JavaConverters._

--- a/common/app/common/RequestLogger.scala
+++ b/common/app/common/RequestLogger.scala
@@ -4,7 +4,7 @@ import play.api.mvc.{RequestHeader, Result}
 import common.LoggingField._
 import play.api.routing.Router
 
-import scala.util.{Random, Try}
+import scala.util.Random
 
 case class RequestLoggerFields(request: Option[RequestHeader], response: Option[Result], stopWatch: Option[StopWatch]) {
 

--- a/common/app/common/commercial/hosted/ContentUtils.scala
+++ b/common/app/common/commercial/hosted/ContentUtils.scala
@@ -4,7 +4,7 @@ import com.gu.contentapi.client.model.v1.ElementType.Image
 import com.gu.contentapi.client.model.v1.{Asset, Content, Element}
 import conf.Configuration
 import model.{ImageMedia, Element => ModelElement}
-import views.support.{Item300, Item700, Item1200}
+import views.support.Item300
 
 object ContentUtils {
 

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -9,7 +9,6 @@ import com.amazonaws.auth._
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.typesafe.config.{ConfigException, ConfigFactory}
 import common.Environment.{app, awsRegion, stage}
-import conf.switches.Switches
 import conf.{Configuration, Static}
 import org.apache.commons.io.IOUtils
 import services.ParameterStore

--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -10,7 +10,6 @@ import _root_.html.{BrazeEmailFormatter, HtmlTextExtractor}
 import model.CacheTime.RecentlyUpdated
 import model.Cached.RevalidatableResult
 import model.{ApplicationContext, Cached, NoCache}
-import org.apache.commons.lang.exception.ExceptionUtils
 import play.api.Logger
 import play.api.libs.json.{JsObject, JsString}
 import play.api.mvc.{RequestHeader, Result}

--- a/common/app/conf/audio/FlagshipContainer.scala
+++ b/common/app/conf/audio/FlagshipContainer.scala
@@ -2,7 +2,7 @@ package conf.audio
 import conf.switches.Switch
 
 import scala.concurrent.duration._
-import java.time.{Duration, ZonedDateTime, ZoneId, ZoneOffset, DayOfWeek}
+import java.time.{Duration, ZonedDateTime, ZoneId, DayOfWeek}
 
 trait FlagshipContainer {
 

--- a/common/app/conf/switches/PrivacySwitches.scala
+++ b/common/app/conf/switches/PrivacySwitches.scala
@@ -2,7 +2,7 @@ package conf.switches
 
 import conf.switches.Expiry.never
 import conf.switches.Owner.group
-import conf.switches.SwitchGroup.{Privacy, Commercial}
+import conf.switches.SwitchGroup.Commercial
 
 trait PrivacySwitches {
 

--- a/common/app/contentapi/http.scala
+++ b/common/app/contentapi/http.scala
@@ -3,9 +3,6 @@ package contentapi
 import java.net.{InetAddress, URI}
 import java.util.concurrent.TimeoutException
 
-import com.amazonaws.DefaultRequest
-import com.amazonaws.auth.{AWS4Signer, AWSCredentials}
-import com.amazonaws.http.HttpMethodName
 import common.ContentApiMetrics.{ContentApi404Metric, ContentApiErrorMetric, ContentApiRequestsMetric}
 import common.{ContentApiMetrics, GuLogging}
 import conf.Configuration

--- a/common/app/implicits/FaciaContentFrontendHelpers.scala
+++ b/common/app/implicits/FaciaContentFrontendHelpers.scala
@@ -5,7 +5,7 @@ import implicits.Dates._
 import model._
 import model.content.{MediaAssetPlatform, MediaAtom}
 import model.pressed._
-import org.joda.time.{DateTime, Period, PeriodType}
+import org.joda.time.DateTime
 import org.jsoup.Jsoup
 import com.github.nscala_time.time.Implicits._
 import scala.util.Try

--- a/common/app/implicits/WSRequests.scala
+++ b/common/app/implicits/WSRequests.scala
@@ -1,8 +1,7 @@
 package implicits
 
 import common.HttpStatusException
-import conf.Configuration
-import play.api.libs.ws.{WSAuthScheme, WSRequest, WSResponse}
+import play.api.libs.ws.{WSRequest, WSResponse}
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/common/app/layout/CollectionEmail.scala
+++ b/common/app/layout/CollectionEmail.scala
@@ -6,7 +6,6 @@ import model.pressed.{CollectionConfig, PressedContent}
 import com.gu.commercial.branding.ContainerBranding
 import commercial.campaigns.EmailAdvertisements._
 import common.Edition
-import conf.audio.FlagshipEmailContainer
 
 import PartialFunction.condOpt
 

--- a/common/app/layout/FaciaCard.scala
+++ b/common/app/layout/FaciaCard.scala
@@ -5,7 +5,6 @@ import com.gu.commercial.branding.Branding
 import com.gu.contentapi.client.model.{v1 => contentapi}
 import com.gu.contentapi.client.utils.{AdvertisementFeature, DesignType}
 import common.Edition.defaultEdition
-import common.{Edition, LinkTo}
 import implicits.FaciaContentFrontendHelpers.FaciaContentFrontendHelper
 import model._
 import model.pressed._

--- a/common/app/layout/FaciaContainerHeader.scala
+++ b/common/app/layout/FaciaContainerHeader.scala
@@ -2,8 +2,6 @@ package layout
 
 import common.Pagination
 import model.{ApplicationContext, Page, Section, Tag}
-import org.joda.time.LocalDate
-import org.joda.time.format.DateTimeFormat
 import services.ConfigAgent
 
 sealed trait FaciaContainerHeader

--- a/common/app/layout/FaciaWidths.scala
+++ b/common/app/layout/FaciaWidths.scala
@@ -2,7 +2,6 @@ package layout
 
 import cards._
 import BrowserWidth._
-import views.support.ImageProfile
 
 object FaciaWidths {
   private val MediaMobile = Map[CardType, BrowserWidth](

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -1,19 +1,13 @@
 package layout
 
 import common.{Edition, LinkTo}
-import conf.switches.Switches
 import model.PressedPage
 import model.facia.PressedCollection
 import model.meta.{ItemList, ListItem}
-import model.pressed.{CollectionConfig, PressedContent}
-import org.joda.time.DateTime
-import play.api.libs.json.Json
+import model.pressed.PressedContent
 import play.api.mvc.RequestHeader
-import services.CollectionConfigWithId
-import slices.{MostPopular, _}
-import views.support.CutOut
+import slices._
 
-import scala.Function._
 import scala.annotation.tailrec
 
 case class Front(

--- a/common/app/layout/ItemClasses.scala
+++ b/common/app/layout/ItemClasses.scala
@@ -1,10 +1,6 @@
 package layout
 
 import cards.{CardType, ListItem, MediaList, Standard}
-import model.pressed.CollectionConfig
-import play.twirl.api.Html
-import slices.{MobileShowMore, RestrictTo}
-import scala.annotation.tailrec
 
 case class ItemClasses(mobile: CardType, tablet: CardType, desktop: Option[CardType] = None) {
 

--- a/common/app/layout/SnapStuff.scala
+++ b/common/app/layout/SnapStuff.scala
@@ -3,8 +3,6 @@ package layout
 import model.pressed._
 import views.support._
 
-import scala.Function.const
-
 case class SnapStuff(
     dataAttributes: String,
     snapCss: Option[String],

--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -2,10 +2,9 @@ package model
 
 import conf.switches.Switches.LongCacheSwitch
 import org.joda.time.DateTime
-import com.github.nscala_time.time.Implicits._
 import play.api.http.Writeable
 import play.api.mvc._
-import scala.math.{max, min}
+import scala.math.max
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.Duration
 

--- a/common/app/model/CrosswordData.scala
+++ b/common/app/model/CrosswordData.scala
@@ -1,6 +1,6 @@
 package model
 
-import com.gu.contentapi.client.model.v1.{CapiDateTime, Crossword, CrosswordEntry}
+import com.gu.contentapi.client.model.v1.{Crossword, CrosswordEntry}
 import com.gu.contentapi.client.model.{v1 => contentapi}
 import crosswords.CrosswordGridColumnNotation
 import org.joda.time.DateTime

--- a/common/app/model/Section.scala
+++ b/common/app/model/Section.scala
@@ -4,7 +4,7 @@ import com.gu.contentapi.client.model.v1.{Section => ApiSection}
 import common.Pagination
 import common.commercial.CommercialProperties
 import navigation.GuardianFoundationHelper
-import play.api.libs.json.{JsBoolean, JsString, JsValue, Json}
+import play.api.libs.json.{JsString, JsValue, Json}
 
 object Section {
   def make(section: ApiSection, pagination: Option[Pagination] = None): Section = {

--- a/common/app/model/VideoPlayer.scala
+++ b/common/app/model/VideoPlayer.scala
@@ -1,7 +1,7 @@
 package model
 
 import conf.Static
-import views.support.{Video640, VideoProfile}
+import views.support.VideoProfile
 import layout.FaciaCardHeader
 
 case class VideoFaciaProperties(

--- a/common/app/model/dotcomrendering/DotcomBlocksRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomBlocksRenderingDataModel.scala
@@ -6,7 +6,7 @@ import common.Edition
 import common.commercial.EditionAdTargeting.adTargetParamValueWrites
 import conf.Configuration
 import model.dotcomrendering.pageElements.PageElement
-import model.{ContentFormat, ContentPage, LiveBlogPage}
+import model.{ContentFormat, ContentPage}
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
 import views.support.CamelCase

--- a/common/app/model/dotcomrendering/MostPopular.scala
+++ b/common/app/model/dotcomrendering/MostPopular.scala
@@ -1,10 +1,10 @@
 package model.dotcomrendering
 
 import com.github.nscala_time.time.Imports.DateTimeZone
-import com.gu.commercial.branding.{Branding, BrandingType, Sponsored, Logo => CommercialLogo, Dimensions}
+import com.gu.commercial.branding.{Branding, BrandingType, Logo => CommercialLogo, Dimensions}
 import common.{Edition, LinkTo}
 import play.api.mvc.RequestHeader
-import views.support.{ContentOldAgeDescriber, ImageProfile, ImgSrc, Item300, Item460, RemoveOuterParaHtml}
+import views.support.{ImageProfile, ImgSrc, Item300, Item460, RemoveOuterParaHtml}
 import play.api.libs.json._
 import implicits.FaciaContentFrontendHelpers._
 import layout.ContentCard

--- a/common/app/model/dotcomrendering/PageType.scala
+++ b/common/app/model/dotcomrendering/PageType.scala
@@ -1,7 +1,7 @@
 package model.dotcomrendering
 
 import common.Edition
-import model.{ApplicationContext, Content, ContentPage, Page, PageWithStoryPackage}
+import model.{ApplicationContext, Page}
 import play.api.libs.json.{JsBoolean, Json}
 import play.api.mvc.RequestHeader
 import views.support.JavaScriptPage.getMap

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -13,7 +13,7 @@ import com.gu.contentapi.client.model.v1.{
 import com.gu.contentapi.client.model.v1.EmbedTracksType.DoesNotTrack
 import common.{Chronos, Edition}
 import conf.Configuration
-import layout.ContentWidths.{BodyMedia, ImageRoleWidthsByBreakpointMapping, ImmersiveMedia, MainMedia}
+import layout.ContentWidths.{BodyMedia, ImmersiveMedia, MainMedia}
 import model.content._
 import model.dotcomrendering.InteractiveSwitchOver
 import model.{ImageAsset, ImageElement, ImageMedia, VideoAsset}

--- a/common/app/model/dotcomrendering/pageElements/TextCleaner.scala
+++ b/common/app/model/dotcomrendering/pageElements/TextCleaner.scala
@@ -4,12 +4,10 @@ import common.{Edition, LinkTo}
 import conf.Configuration.{affiliateLinks => affiliateLinksConfig}
 import model.{Tag, Tags}
 import org.jsoup.Jsoup
-import play.api.mvc.RequestHeader
 import views.support.AffiliateLinksCleaner
 
 import scala.collection.JavaConverters._
 import scala.util.matching.Regex
-import scala.util.matching.Regex.Match
 
 object TextCleaner {
 

--- a/common/app/model/pressedContent.scala
+++ b/common/app/model/pressedContent.scala
@@ -1,32 +1,9 @@
 package model.pressed
 
 import com.gu.commercial.branding.Branding
-import com.gu.contentapi.client.model.v1.{Content, ElementType}
-import com.gu.contentapi.client.utils.DesignType
-import com.gu.contentapi.client.utils.CapiModelEnrichment.RichContent
-import com.gu.facia.api.utils.FaciaContentUtils
-import com.gu.facia.api.{models => fapi, utils => fapiutils}
-import com.gu.facia.client.models.{Backfill, CollectionConfigJson, CollectionPlatform, Metadata}
-import common.{Edition, HTML}
-import common.commercial.EditionBranding
-import model.content.{Atoms, MediaAtom}
-import model.{
-  CardStylePicker,
-  Commercial,
-  ContentFormat,
-  DotcomContentType,
-  Elements,
-  Fields,
-  ImageMedia,
-  MetaData,
-  Pillar,
-  SectionId,
-  SupportedUrl,
-  Tags,
-  Trail,
-  VideoElement,
-}
-import org.joda.time.DateTime
+import com.gu.facia.api.{models => fapi}
+import common.Edition
+import model.{ContentFormat, Pillar}
 import views.support.ContentOldAgeDescriber
 
 sealed trait PressedContent {

--- a/common/app/navigation/DCRNavigation.scala
+++ b/common/app/navigation/DCRNavigation.scala
@@ -2,7 +2,7 @@ package navigation
 
 import common.Edition
 import model.Page
-import navigation.ReaderRevenueSite.{Support, SupportContribute, SupportGifting, SupportSubscribe, SupporterCTA}
+import navigation.ReaderRevenueSite.{Support, SupportContribute, SupportSubscribe, SupporterCTA}
 import navigation.UrlHelpers._
 import play.api.libs.json.{Json, Writes}
 

--- a/common/app/pagepresser/InteractiveHtmlCleaner.scala
+++ b/common/app/pagepresser/InteractiveHtmlCleaner.scala
@@ -1,6 +1,6 @@
 package pagepresser
 
-import org.jsoup.nodes.{Element, Document}
+import org.jsoup.nodes.Document
 import scala.collection.JavaConverters._
 import scala.io.Source
 

--- a/common/app/pagepresser/NextGenInteractiveHtmlCleaner.scala
+++ b/common/app/pagepresser/NextGenInteractiveHtmlCleaner.scala
@@ -1,6 +1,5 @@
 package pagepresser
 
-import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 
 object NextGenInteractiveHtmlCleaner extends HtmlCleaner with implicits.WSRequests {

--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -2,10 +2,7 @@ package services
 
 import java.io._
 import java.util.zip.{GZIPInputStream, GZIPOutputStream}
-import javax.crypto.Mac
-import javax.crypto.spec.SecretKeySpec
 
-import com.amazonaws.auth.AWSSessionCredentials
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3Client}
 import com.amazonaws.services.s3.model.CannedAccessControlList.{Private, PublicRead}
 import com.amazonaws.services.s3.model._
@@ -13,8 +10,7 @@ import com.amazonaws.util.StringInputStream
 import common.GuLogging
 import conf.Configuration
 import model.PressedPageType
-import org.joda.time.{DateTime, DateTimeZone}
-import play.api.libs.ws.{WSClient, WSRequest}
+import org.joda.time.DateTime
 
 import scala.io.{Codec, Source}
 

--- a/common/app/services/dotcomrendering/InteractiveLibrarian.scala
+++ b/common/app/services/dotcomrendering/InteractiveLibrarian.scala
@@ -1,7 +1,6 @@
 package services.dotcomrendering
 
 import common.GuLogging
-import conf.Configuration
 import play.api.libs.ws.WSClient
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document

--- a/common/app/services/newsletters/GoogleRecaptchaValidationApi.scala
+++ b/common/app/services/newsletters/GoogleRecaptchaValidationApi.scala
@@ -4,7 +4,6 @@ import com.typesafe.scalalogging.LazyLogging
 import conf.Configuration
 import play.api.libs.json.Json
 import play.api.libs.ws.{WSClient, WSResponse}
-import play.api.mvc.{AnyContent, Request}
 import utils.RemoteAddress
 
 import scala.concurrent.Future

--- a/common/app/services/newsletters/NewsletterSignupLifecycle.scala
+++ b/common/app/services/newsletters/NewsletterSignupLifecycle.scala
@@ -4,8 +4,7 @@ import app.LifecycleComponent
 import common.JobScheduler
 import play.api.inject.ApplicationLifecycle
 
-import java.util.concurrent.Executors
-import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService, Future}
+import scala.concurrent.{ExecutionContext, Future}
 
 class NewsletterSignupLifecycle(
     appLifecycle: ApplicationLifecycle,

--- a/common/app/views/support/DropdownMenus.scala
+++ b/common/app/views/support/DropdownMenus.scala
@@ -1,7 +1,6 @@
 package views.support
 
 import conf.Configuration
-import play.twirl.api.Html
 
 object DropdownMenus {
 

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -13,7 +13,6 @@ import com.gu.facia.client.models.{
 }
 import layout._
 import layout.slices._
-import layout.cards
 import model.pressed.{Audio, Gallery, SpecialReport, Video}
 import slices.{Dynamic, DynamicSlowMPU}
 import play.api.mvc.RequestHeader

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -13,7 +13,7 @@ import layout.ContentWidths
 import layout.ContentWidths._
 import model._
 import model.content._
-import model.dotcomrendering.pageElements.{PageElement, TextBlockElement}
+import model.dotcomrendering.pageElements.TextBlockElement
 import navigation.ReaderRevenueSite
 import org.joda.time.DateTime
 import org.jsoup.Jsoup

--- a/common/app/views/support/TrailCssClasses.scala
+++ b/common/app/views/support/TrailCssClasses.scala
@@ -1,6 +1,5 @@
 package views.support
 
-import model.Content
 import model.pressed.{CardStyle, DeadBlog, PressedContent}
 
 object TrailCssClasses {

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -1,14 +1,13 @@
 package views.support
 
 import java.text.DecimalFormat
-import java.util.Locale
 
 import common._
 import model.Cached.WithoutRevalidationResult
 import model._
 import model.pressed.PressedContent
 import org.apache.commons.lang.StringEscapeUtils
-import org.joda.time.format.{DateTimeFormat, ISODateTimeFormat}
+import org.joda.time.format.DateTimeFormat
 import org.joda.time.{DateTime, DateTimeZone, LocalDate}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document

--- a/common/test/CommonTestSuite.scala
+++ b/common/test/CommonTestSuite.scala
@@ -4,7 +4,6 @@ import conf.CachedHealthCheckTest
 import conf.audio.FlagshipFrontContainerSpec
 import navigation.NavigationTest
 import org.scalatest.Suites
-import org.scalatestplus.play.PortNumber
 import renderers.DotcomRenderingServiceTest
 
 class CommonTestSuite

--- a/common/test/layout/WidthsByBreakpointTest.scala
+++ b/common/test/layout/WidthsByBreakpointTest.scala
@@ -1,7 +1,6 @@
 package layout
 
 import layout.ContentWidths._
-import org.scalatest._
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 

--- a/common/test/package.scala
+++ b/common/test/package.scala
@@ -5,7 +5,7 @@ import java.net.URL
 
 import akka.stream.Materializer
 import com.gargoylesoftware.htmlunit.html.HtmlPage
-import com.gargoylesoftware.htmlunit.{BrowserVersion, WebClient, WebResponse}
+import com.gargoylesoftware.htmlunit.{BrowserVersion, WebClient}
 import common.Lazy
 import contentapi._
 import model.{ApplicationContext, ApplicationIdentity}

--- a/discussion/app/AppLoader.scala
+++ b/discussion/app/AppLoader.scala
@@ -18,8 +18,6 @@ import play.api.routing.Router
 import play.api.libs.ws.WSClient
 import router.Routes
 
-import scala.concurrent.ExecutionContext
-
 class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents =
     new BuiltInComponentsFromContext(context) with AppComponents

--- a/discussion/app/discussion/model/Switch.scala
+++ b/discussion/app/discussion/model/Switch.scala
@@ -1,7 +1,7 @@
 package discussion
 package model
 
-import play.api.libs.json.{JsObject, JsValue}
+import play.api.libs.json.JsValue
 
 case class Switch(
     name: String,

--- a/discussion/app/discussion/util/Http.scala
+++ b/discussion/app/discussion/util/Http.scala
@@ -2,7 +2,7 @@ package discussion.util
 
 import common.LoggingField.LogField
 import play.api.libs.ws.{WSClient, WSResponse}
-import play.api.libs.json.{JsValue, Json}
+import play.api.libs.json.JsValue
 import common.{GuLogging, StopWatch}
 import discussion.api.{NotFoundException, OtherException}
 

--- a/discussion/test/package.scala
+++ b/discussion/test/package.scala
@@ -8,7 +8,6 @@ import play.api.libs.ws.WSClient
 import java.io.File
 import scala.concurrent.duration._
 import discussion.api.DiscussionApiLike
-import org.scalatestplus.play.PortNumber
 
 import scala.concurrent.ExecutionContext
 

--- a/facia-press/app/AppLoader.scala
+++ b/facia-press/app/AppLoader.scala
@@ -11,7 +11,6 @@ import model.ApplicationIdentity
 import play.api.ApplicationLoader.Context
 import play.api.routing.Router
 import play.api._
-import play.api.libs.ws.WSClient
 import play.api.mvc.EssentialFilter
 import services.ConfigAgentLifecycle
 import router.Routes

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -10,7 +10,7 @@ import com.gu.facia.api.{FAPI, Response}
 import com.gu.facia.client.ApiClient
 import com.gu.facia.client.models.{Breaking, Canonical, ConfigJson, Metadata, Special}
 import common.LoggingField.LogFieldString
-import common.{LoggingField, _}
+import common._
 import common.commercial.CommercialProperties
 import conf.Configuration
 import conf.switches.Switches

--- a/facia-press/app/frontpress/PressedCollectionDeduplication.scala
+++ b/facia-press/app/frontpress/PressedCollectionDeduplication.scala
@@ -1,11 +1,5 @@
 package frontpress
 
-import layout.slices.Container
-import model.PressedCollectionVersions
-import model.facia.PressedCollection
-import model.pressed.PressedContent
-import com.gu.facia.client.models.{AnyPlatform, WebCollection}
-
 object PressedCollectionDeduplication {
 
   /*

--- a/facia/app/model/OnwardItem.scala
+++ b/facia/app/model/OnwardItem.scala
@@ -1,12 +1,7 @@
 package model
 
-import com.github.nscala_time.time.Imports.DateTimeZone
-import common.{Edition, LinkTo}
 import model.facia.PressedCollection
-import model.pressed.PressedContent
 import play.api.libs.json.Json
-import views.support.{ImageProfile, ImgSrc, Item300, Item460, RemoveOuterParaHtml}
-import implicits.FaciaContentFrontendHelpers._
 import play.api.mvc.RequestHeader
 import model.dotcomrendering.OnwardItem
 

--- a/facia/app/pages/FrontHtmlPage.scala
+++ b/facia/app/pages/FrontHtmlPage.scala
@@ -1,6 +1,5 @@
 package pages
 
-import common.Edition
 import conf.switches.Switches.WeAreHiring
 import html.{HtmlPage, Styles}
 import html.HtmlPageHelpers._
@@ -13,7 +12,6 @@ import views.html.fragments.page.body.{bodyTag, mainContent, skipToMainContent}
 import views.html.fragments.page.head._
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
 import views.html.fragments.page.{devTakeShot, htmlTag}
-import views.html.stacked
 import html.HtmlPageHelpers.{ContentCSSFile, FaciaCSSFile}
 
 object FrontHtmlPage extends HtmlPage[PressedPage] {

--- a/facia/app/utils/TargetedCollections.scala
+++ b/facia/app/utils/TargetedCollections.scala
@@ -12,7 +12,6 @@ import com.gu.facia.client.models.{
 }
 import model.PressedPage
 import model.facia.PressedCollection
-import model.pressed.CollectionConfig
 
 object TargetedCollections {
   // remove all collections with a targeted territory that is not allowed

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -6,7 +6,7 @@ import com.gu.facia.client.models.{ConfigJson, FrontJson}
 import common.editions.{Uk, Us}
 import implicits.FakeRequests
 import concurrent.BlockingOperations
-import play.api.libs.json.{JsArray, JsValue}
+import play.api.libs.json.JsArray
 import play.api.test._
 import play.api.test.Helpers._
 import services.ConfigAgent

--- a/facia/test/package.scala
+++ b/facia/test/package.scala
@@ -6,7 +6,6 @@ import controllers.front.FrontJsonFapiLive
 import model.{PressedPage, PressedPageType}
 import org.fluentlenium.core.domain.FluentWebElement
 import org.scalatest.Suites
-import org.scalatestplus.play.PortNumber
 import play.api.libs.json.Json
 import recorder.HttpRecorder
 import utils.FaciaPickerTest

--- a/facia/test/utils/FaciaPickerTest.scala
+++ b/facia/test/utils/FaciaPickerTest.scala
@@ -1,14 +1,9 @@
 package utils
 
 import common.facia.{FixtureBuilder, PressedCollectionBuilder}
-import model.PressedPage
-import model.facia.PressedCollection
-import experiments.{ExperimentsDefinition, FrontRendering}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.DoNotDiscover
-import org.mockito.Mockito.when
-import test.TestRequest
 
 @DoNotDiscover class FaciaPickerTest extends AnyFlatSpec with Matchers {
 

--- a/identity/app/AppLoader.scala
+++ b/identity/app/AppLoader.scala
@@ -6,7 +6,7 @@ import common.CloudWatchMetricsLifecycle
 import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
 import conf._
 import conf.switches.SwitchboardLifecycle
-import controllers.{Assets, HealthCheck, IdentityControllers}
+import controllers.{HealthCheck, IdentityControllers}
 import dev.DevAssetsController
 import model.ApplicationIdentity
 import play.api.ApplicationLoader.Context
@@ -16,7 +16,7 @@ import play.api.http.HttpErrorHandler
 import play.api.libs.ws.WSClient
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
-import play.filters.csrf.{CSRFAddToken, CSRFCheck, CSRFComponents}
+import play.filters.csrf.CSRFComponents
 import router.Routes
 import services.newsletters.NewsletterSignupLifecycle
 

--- a/identity/app/controllers/DiscardingIdentityCookies.scala
+++ b/identity/app/controllers/DiscardingIdentityCookies.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import java.time.Instant
-import java.time.temporal.{ChronoUnit, TemporalUnit}
+import java.time.temporal.ChronoUnit
 
 import conf.Configuration
 import play.api.mvc.{Cookie, DiscardingCookie, Result}

--- a/identity/app/form/PrivacyMapping.scala
+++ b/identity/app/form/PrivacyMapping.scala
@@ -1,8 +1,7 @@
 package form
 
 import com.gu.identity.model.Consent._
-import com.gu.identity.model.{Consent, StatusFields, User}
-import idapiclient.UserUpdateDTO
+import com.gu.identity.model.{Consent, User}
 import play.api.data.Forms._
 import play.api.data.JodaForms.jodaDate
 import play.api.data.Mapping

--- a/identity/app/idapiclient/IdApiClient.scala
+++ b/identity/app/idapiclient/IdApiClient.scala
@@ -6,9 +6,6 @@ import scala.concurrent.{ExecutionContext, Future}
 import idapiclient.responses.{AccountDeletionResult, CookiesResponse, Error, HttpResponse}
 import conf.IdConfig
 import idapiclient.parser.IdApiJsonBodyParser
-import net.liftweb.json.JsonDSL._
-import net.liftweb.json.compactRender
-import net.liftweb.json.JsonAST.JObject
 import net.liftweb.json.Serialization.write
 import utils.SafeLogging
 import idapiclient.requests.{AutoSignInToken, DeletionBody}

--- a/identity/app/idapiclient/filters/DateRange.scala
+++ b/identity/app/idapiclient/filters/DateRange.scala
@@ -1,7 +1,7 @@
 package client.filters
 
 import org.joda.time.DateTime
-import org.joda.time.format.{ISODateTimeFormat, DateTimeFormatter}
+import org.joda.time.format.ISODateTimeFormat
 
 case class DateRange(from: Option[DateTime] = None, datePath: String, to: Option[DateTime] = None) extends ApiFilter {
   require(from.isDefined || to.isDefined, "Neither from nor to date supplied to date range")

--- a/identity/app/jobs/TorExitNodeList.scala
+++ b/identity/app/jobs/TorExitNodeList.scala
@@ -2,8 +2,7 @@ package jobs
 
 import common.{Box, GuLogging}
 
-import scala.collection.JavaConverters._
-import java.net.{InetAddress, URL}
+import java.net.InetAddress
 
 import scala.io.Source
 

--- a/identity/app/model/Countries.scala
+++ b/identity/app/model/Countries.scala
@@ -2,8 +2,6 @@ package model
 
 import com.gu.i18n.CountryGroup
 
-import scala.collection.immutable
-
 object Countries {
   val all = CountryGroup.countries.map(_.name)
   def withCustom(maybeCountry: Option[String]): List[String] =

--- a/identity/app/pages/IdentityHtmlPage.scala
+++ b/identity/app/pages/IdentityHtmlPage.scala
@@ -2,7 +2,7 @@ package pages
 
 import conf.switches.Switches.WeAreHiring
 import html.HtmlPageHelpers._
-import html.{HtmlPage, Styles}
+import html.Styles
 import model.{ApplicationContext, IdentityPage}
 import play.api.mvc.RequestHeader
 import play.twirl.api.{Html, HtmlFormat}
@@ -12,7 +12,6 @@ import views.html.fragments.page.body._
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
 import views.html.fragments.page.head._
 import html.HtmlPageHelpers.ContentCSSFile
-import views.html.stacked
 
 object IdentityHtmlPage {
 

--- a/identity/test/idapiclient/IdApiTest.scala
+++ b/identity/test/idapiclient/IdApiTest.scala
@@ -11,7 +11,6 @@ import org.mockito.Mockito._
 import org.mockito.Matchers.any
 import org.scalatestplus.mockito.MockitoSugar
 
-import scala.language.postfixOps
 import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 import test.{SingleServerSuite, WithTestExecutionContext, WithTestIdConfig}
 

--- a/identity/test/package.scala
+++ b/identity/test/package.scala
@@ -1,16 +1,12 @@
 package test
 
 import java.io.File
-import common.GuardianConfiguration
-import conf.{IdConfig, IdentityConfiguration}
+import conf.IdConfig
 import controllers.EditProfileControllerTest
 import controllers.ConsentsJourneyControllerTest
 import filters.StrictTransportSecurityHeaderFilterTest
 import org.scalatest.Suites
-import org.scalatestplus.play.PortNumber
-import play.api.i18n.I18nComponents
 import play.api._
-import play.api.http.HttpConfiguration
 import play.api.test.Helpers._
 
 /**

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -1,7 +1,5 @@
 package controllers
 
-import com.github.nscala_time.time.Imports.DateTimeZone
-
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import common._
@@ -11,7 +9,6 @@ import feed.{DayMostPopularAgent, GeoMostPopularAgent, MostPopularAgent}
 import layout.ContentCard
 import model.Cached.RevalidatableResult
 import model._
-import model.pressed.PressedContent
 import model.dotcomrendering.{
   MostPopularGeoResponse,
   MostPopularNx2,
@@ -19,11 +16,9 @@ import model.dotcomrendering.{
   OnwardCollectionResponseDCR,
   OnwardItem,
 }
-import implicits.FaciaContentFrontendHelpers._
 import play.api.libs.json._
 import play.api.mvc._
 import views.support.FaciaToMicroFormat2Helpers._
-import views.support.{ImgSrc, RemoveOuterParaHtml}
 
 import scala.concurrent.Future
 

--- a/onward/app/controllers/RichLinkController.scala
+++ b/onward/app/controllers/RichLinkController.scala
@@ -4,7 +4,7 @@ import common.`package`.convertApiExceptionsWithoutEither
 import common.{Edition, GuLogging, ImplicitControllerExecutionContext, JsonComponent}
 import contentapi.ContentApiClient
 import implicits.Requests
-import model.{ApplicationContext, Cached, Content, ContentFormat, ContentType, ImageAsset}
+import model.{ApplicationContext, Cached, Content, ContentFormat, ContentType}
 import models.dotcomponents.{RichLink, RichLinkTag}
 import model.dotcomrendering.OnwardsUtils
 import play.api.mvc.{Action, AnyContent, ControllerComponents, RequestHeader}

--- a/onward/app/feed/MostPopularAgent.scala
+++ b/onward/app/feed/MostPopularAgent.scala
@@ -2,12 +2,12 @@ package feed
 
 import conf.Configuration
 import contentapi.ContentApiClient
-import com.gu.contentapi.client.model.v1.{Content, ContentFields, ContentType}
+import com.gu.contentapi.client.model.v1.Content
 import common._
 import services.{OphanApi}
 import model.RelatedContentItem
 import play.api.libs.json._
-import play.api.libs.ws.{WSClient, WSResponse}
+import play.api.libs.ws.WSClient
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/onward/app/feed/OnwardJourneyLifecycle.scala
+++ b/onward/app/feed/OnwardJourneyLifecycle.scala
@@ -5,7 +5,6 @@ import app.LifecycleComponent
 import common.{AkkaAsync, JobScheduler}
 import play.api.inject.ApplicationLifecycle
 import scala.concurrent.{ExecutionContext, Future}
-import scala.concurrent.duration._
 
 class OnwardJourneyLifecycle(
     appLifecycle: ApplicationLifecycle,

--- a/onward/app/models/dotcomponents/DotcomponentsOnwardsModels.scala
+++ b/onward/app/models/dotcomponents/DotcomponentsOnwardsModels.scala
@@ -1,7 +1,6 @@
 package models.dotcomponents
 
-import com.gu.contentapi.client.utils.DesignType
-import model.{ContentFormat, DotcomContentType, Pillar, ImageAsset}
+import model.{ContentFormat, DotcomContentType, ImageAsset}
 import play.api.libs.json.Json
 
 // duplicated in dotcomponentsdatamodel

--- a/onward/app/weather/controllers/LocationsController.scala
+++ b/onward/app/weather/controllers/LocationsController.scala
@@ -1,7 +1,6 @@
 package weather.controllers
 
 import common._
-import weather.geo._
 import model.{CacheTime, Cached}
 import weather.models.CityResponse
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents}

--- a/onward/app/weather/models/CityId.scala
+++ b/onward/app/weather/models/CityId.scala
@@ -1,8 +1,5 @@
 package weather.models
 
-import common.{Edition}
-import common.editions.{Au, Us, Uk}
-
 case class City(name: String) extends AnyVal
 
 case class CityId(id: String) extends AnyVal

--- a/onward/app/weather/models/CityResponse.scala
+++ b/onward/app/weather/models/CityResponse.scala
@@ -5,8 +5,6 @@ import common.editions.{Au, Uk, Us}
 import weather.models.accuweather.LocationResponse
 import play.api.libs.json.Json
 
-import scala.collection.immutable
-
 object CityResponse {
   implicit val jsonWrites = Json.writes[CityResponse]
 

--- a/onward/test/package.scala
+++ b/onward/test/package.scala
@@ -1,7 +1,6 @@
 package test
 
 import org.scalatest.Suites
-import org.scalatestplus.play.PortNumber
 
 class OnwardTestSuite
     extends Suites(

--- a/preview/app/controllers/FaciaDraftController.scala
+++ b/preview/app/controllers/FaciaDraftController.scala
@@ -8,7 +8,6 @@ import model.Cached.RevalidatableResult
 import model.{ApplicationContext, PressedPage}
 import play.api.libs.ws.WSClient
 import play.api.mvc._
-import renderers.DotcomRenderingService
 import services.ConfigAgent
 
 import scala.concurrent.Future

--- a/sport/app/conf/SportConfiguration.scala
+++ b/sport/app/conf/SportConfiguration.scala
@@ -1,7 +1,6 @@
 package conf
 
 import common.GuardianConfiguration
-import pa.PaClientConfig
 
 object SportConfiguration {
 

--- a/sport/app/cricket/feed/cricketPaDeserialisation.scala
+++ b/sport/app/cricket/feed/cricketPaDeserialisation.scala
@@ -4,12 +4,10 @@ import common.Chronos
 
 import xml.{NodeSeq, XML}
 import scala.language.postfixOps
-import java.time
-import java.text.SimpleDateFormat
 import cricketModel._
 
-import java.time.{LocalDate, LocalDateTime, ZoneId}
-import java.util.{Date, TimeZone}
+import java.time.LocalDateTime
+import java.util.TimeZone
 
 object Parser {
 

--- a/sport/app/cricket/feed/cricketPaFeed.scala
+++ b/sport/app/cricket/feed/cricketPaFeed.scala
@@ -11,7 +11,6 @@ import play.api.libs.ws.WSClient
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.xml.XML
-import java.util.TimeZone
 
 case class CricketFeedException(message: String) extends RuntimeException(message)
 

--- a/sport/app/cricket/jobs/CricketStatsJob.scala
+++ b/sport/app/cricket/jobs/CricketStatsJob.scala
@@ -1,7 +1,6 @@
 package jobs
 
 import common.{Box, GuLogging}
-import common.Chronos
 import conf.cricketPa.{CricketFeedException, CricketTeam, CricketTeams, PaFeed}
 import cricketModel.Match
 

--- a/sport/app/football/containers/FixturesAndResults.scala
+++ b/sport/app/football/containers/FixturesAndResults.scala
@@ -11,7 +11,7 @@ import play.twirl.api.Html
 import slices.{Fixed, FixedContainers}
 import common.Seqs._
 
-import java.time.{LocalDate, ZoneId}
+import java.time.LocalDate
 import football.views.html.matchList.matchesComponent
 import football.views.html.tablesList.tablesComponent
 import implicits.Requests._

--- a/sport/app/football/controllers/MatchListController.scala
+++ b/sport/app/football/controllers/MatchListController.scala
@@ -7,7 +7,7 @@ import implicits.Requests
 import model.Cached.RevalidatableResult
 import model.{ApplicationContext, Cached, Competition, TeamMap}
 
-import java.time.{LocalDate, LocalDateTime}
+import java.time.LocalDate
 import pa.FootballTeam
 import play.api.mvc.{BaseController, RequestHeader}
 import play.twirl.api.Html

--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -10,7 +10,7 @@ import football.model.{FootballMatchTrail, GuTeamCodes}
 import implicits.{Football, Requests}
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model.{Cached, Competition, Content, ContentType, TeamColours}
-import pa.{FootballMatch, LineUp, LineUpTeam, MatchDayTeam, TeamCodes}
+import pa.{FootballMatch, LineUp, LineUpTeam, MatchDayTeam}
 import play.api.libs.json._
 import play.api.mvc._
 import play.twirl.api.Html

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -8,7 +8,7 @@ import model.{Competition, Table, TeamFixture, TeamNameBuilder}
 import org.joda.time.DateTimeComparator
 import pa.{FootballMatch, _}
 
-import java.time.{Clock, LocalDate, ZoneOffset, ZonedDateTime}
+import java.time.{Clock, LocalDate, ZonedDateTime}
 import java.util.Comparator
 import scala.collection.immutable
 import scala.concurrent.{ExecutionContext, Future}

--- a/sport/app/football/model/CompetitionStages.scala
+++ b/sport/app/football/model/CompetitionStages.scala
@@ -1,6 +1,6 @@
 package football.model
 
-import football.datetime.{DateHelpers, Interval}
+import football.datetime.Interval
 
 import java.time.{ZoneId, ZonedDateTime}
 import model.Competition

--- a/sport/app/football/model/TeamMap.scala
+++ b/sport/app/football/model/TeamMap.scala
@@ -4,7 +4,6 @@ import common._
 import contentapi.ContentApiClient
 import _root_.feed.Competitions
 import implicits.Football
-import org.joda.time.{DateTime, Days}
 import pa._
 
 import java.time.format.DateTimeFormatter

--- a/sport/app/football/model/matches.scala
+++ b/sport/app/football/model/matches.scala
@@ -7,7 +7,7 @@ import model.Competition
 import pa.{FootballMatch, Round}
 
 import java.time.format.DateTimeFormatter
-import java.time.{LocalDate, ZoneId, ZonedDateTime}
+import java.time.{LocalDate, ZonedDateTime}
 
 trait MatchesList extends Football with RichList with implicits.Collections {
 

--- a/sport/app/football/views/support.scala
+++ b/sport/app/football/views/support.scala
@@ -1,6 +1,5 @@
 package views
 
-import pa.{LineUpPlayer, Team}
 import common.GuLogging
 import play.twirl.api.Html
 

--- a/sport/test/football/model/CompetitionTestData.scala
+++ b/sport/test/football/model/CompetitionTestData.scala
@@ -1,6 +1,6 @@
 package football.model
 
-import java.time.{ZonedDateTime, LocalDate}
+import java.time.ZonedDateTime
 import pa._
 import model.Competition
 import java.time.temporal.ChronoUnit

--- a/sport/test/football/model/MatchTestData.scala
+++ b/sport/test/football/model/MatchTestData.scala
@@ -1,6 +1,6 @@
 package football.model
 
-import java.time.{ZonedDateTime, ZoneId, LocalDate}
+import java.time.{ZonedDateTime, ZoneId}
 import pa._
 import feed.Competitions
 import model.Competition

--- a/sport/test/package.scala
+++ b/sport/test/package.scala
@@ -6,7 +6,6 @@ import football.collections.RichListTest
 import football.containers.FixturesAndResultsTest
 import football.model._
 import org.scalatest.Suites
-import org.scalatestplus.play.PortNumber
 import pa.{Http, Response => PaResponse}
 import play.api.libs.ws.WSClient
 import recorder.{DefaultHttpRecorder, HttpRecorder}


### PR DESCRIPTION
## What does this change?
This PR removes unused imports. In order to produce the diff:
`addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.1")` was added in `plugins.sbt`


```
semanticdbEnabled := true, 
semanticdbVersion := scalafixSemanticdb.revision,
scalacOptions += "-Ywarn-unused-import",`
``` 
was added in `ProjectSettings.scala`

and ran `scalafixAll RemoveUnused` in the sbt shell.

