### PR TITLE
fix: Prevent US paid Youtube player reinitialising itself when trying to mute

### DIFF
--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -365,10 +365,10 @@ const onPlayerReady = (
     const iFrameBehaviourConfig = getIFrameBehaviourConfig(iframe);
     const iFrameBehaviour = getIFrameBehaviour(iFrameBehaviourConfig);
     if (iFrameBehaviour.mutedOnStart) {
-        event.target.mute();
+        youtubePlayer.mute();
     }
     if (iFrameBehaviour.autoplay) {
-        event.target.playVideo();
+        youtubePlayer.playVideo();
     }
 
     if (overlay) {

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.js
@@ -280,8 +280,8 @@ const getIFrameBehaviour = (
 
     if (isUsPaidContentVideo) {
         return {
-            autoplay: isUsPaidContentVideo,
-            mutedOnStart: isUsPaidContentVideo && isAndroid(),
+            autoplay: true,
+            mutedOnStart: isAndroid(),
         };
     }
     return {
@@ -330,14 +330,6 @@ const updateImmersiveButtonPos = () => {
     }
 };
 
-const muteIFrame = (iframe) => {
-    // Mute iFrame in order to autoplay on android mobile devices
-
-    const iframeSrc = new URL(iframe.src);
-    iframeSrc.searchParams.set('mute', '1');
-    iframe.setAttribute('src', iframeSrc.toString());
-};
-
 const onPlayerReady = (
     atomId,
     uniqueAtomId,
@@ -373,7 +365,7 @@ const onPlayerReady = (
     const iFrameBehaviourConfig = getIFrameBehaviourConfig(iframe);
     const iFrameBehaviour = getIFrameBehaviour(iFrameBehaviourConfig);
     if (iFrameBehaviour.mutedOnStart) {
-        muteIFrame(iframe);
+        event.target.mute();
     }
     if (iFrameBehaviour.autoplay) {
         event.target.playVideo();
@@ -532,7 +524,6 @@ export const onVideoContainerNavigation = (atomId) => {
 };
 
 export const _ = {
-    muteIFrame,
     getIFrameBehaviour,
     getIFrameBehaviourConfig,
 };

--- a/static/src/javascripts/projects/common/modules/atoms/youtube.spec.js
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube.spec.js
@@ -3,7 +3,7 @@ import { isAndroid as _isAndroid, isIOS as _isIOS } from 'lib/detect';
 import { isOn as _isOn } from 'common/modules/accessibility/main';
 import config from 'lib/config';
 
-const { muteIFrame, getIFrameBehaviour, getIFrameBehaviourConfig } = _;
+const { getIFrameBehaviour, getIFrameBehaviourConfig } = _;
 
 const isAndroid = _isAndroid;
 const isIOS = _isIOS;
@@ -74,69 +74,6 @@ describe('youtube', () => {
         if (document.body) {
             expect(document.body.innerHTML).toBe(div);
         }
-    });
-
-    describe('muting iframes to trigger autoplay', () => {
-        it('mutes an iframe by amending the src property if no other URL parameters', () => {
-            const docSrc = 'http://www.example.com/q';
-
-            const div = `<div id="outerDiv"><iframe id="iframeId" src="${docSrc}"></iframe></div>`;
-
-            if (document.body) {
-                document.body.innerHTML = div;
-            }
-
-            const iframe = ((document.getElementById(
-                'iframeId'
-            )));
-
-            muteIFrame(iframe);
-
-            if (document.body) {
-                expect(iframe.src).toBe('http://www.example.com/q?mute=1');
-            }
-        });
-
-        it('adds a new parameter to mute iframe if parameters already exist', () => {
-            const docSrc = 'http://www.example.com/q?randomParam=abc';
-
-            const div = `<div id="outerDiv"><iframe id="iframeId" src="${docSrc}"></iframe></div>`;
-
-            if (document.body) {
-                document.body.innerHTML = div;
-            }
-
-            const iframe = ((document.getElementById(
-                'iframeId'
-            )));
-
-            muteIFrame(iframe);
-            if (document.body) {
-                expect(iframe.src).toBe(
-                    'http://www.example.com/q?randomParam=abc&mute=1'
-                );
-            }
-        });
-
-        it("doesn't amend iframe src property if already muted", () => {
-            const docSrc = 'http://www.example.com/q?mute=1';
-
-            const div = `<div id="outerDiv"><iframe id="iframeId" src="${docSrc}"></iframe></div>`;
-
-            if (document.body) {
-                document.body.innerHTML = div;
-            }
-
-            const iframe = ((document.getElementById(
-                'iframeId'
-            )));
-
-            muteIFrame(iframe);
-
-            if (document.body) {
-                expect(iframe.src).toBe('http://www.example.com/q?mute=1');
-            }
-        });
     });
 
     describe(`determining correct youtube iframe behaviour`, () => {
@@ -229,7 +166,7 @@ describe('youtube', () => {
                 },
             });
 
-            docSrc = 'http://www.example.com/q?mute=1';
+            docSrc = 'http://www.example.com/q';
             div = `<div id="outerDiv"><iframe id="iframeId" src="${docSrc}"></iframe></div>`;
             if (document.body) {
                 document.body.innerHTML = div;


### PR DESCRIPTION
Co-authored-by: Dominik Lander <dominik.lander@guardian.co.uk>

## What does this change?

Fix a bug on Paid for US pages when using Android, where the player repeatedly reinitialises itself.

Use the mute function available on the Youtube Player, instead of muting by updating the `src` attribute on the Youtube player iframe. This removes the need for the `muteIFrame` function, so we remove its tests as well.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

This fixes a bug on Android devices where the Youtube Player repeatedly flashes between the player and the overlay.

The suspicion was that updating the iframe `src` attribute causes the player to reinitialise itself. This causes the iframe `src` to be repeatedly updated in a loop, causing the flashing. Removing this logic and using the `event.target.mute()` should alleviate this issue. 

### Tested

- [X] Locally
- [x] On CODE (optional)