### PR TITLE
E2e tests run on various viewport sizes

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -13,4 +13,7 @@ export default defineConfig({
       return require('./cypress/plugins/index.ts').default(on, config)
     },
   },
+  // Test files like merchandising.cy.ts that take a few minutes to run exceed the memory limit
+  // causing the browser to crash. https://github.com/cypress-io/cypress/issues/1906
+  "numTestsKeptInMemory": 0
 })

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     },
   },
   // Test files like merchandising.cy.ts that take a few minutes to run exceed the memory limit
-  // causing the browser to crash. https://github.com/cypress-io/cypress/issues/1906
+  // causing the browser to crash. Since we're not using snapshots at the moment, work around the
+  // issue by not saving tests to memory. https://github.com/cypress-io/cypress/issues/1906
   "numTestsKeptInMemory": 0
 })

--- a/cypress/e2e/inline-slots.cy.ts
+++ b/cypress/e2e/inline-slots.cy.ts
@@ -1,25 +1,30 @@
 import { liveblogs, articles } from '../fixtures/pages';
+import { breakpoints } from '../fixtures/breakpoints';
 
 const pages = [...articles, ...liveblogs].filter(a => 'expectedMinInlineSlotsOnPage' in a);
 
 describe('Slots and iframes load on pages', () => {
 	pages.forEach(({ path, adTest, expectedMinInlineSlotsOnPage }) => {
-		it(`Test ${path} has at least ${expectedMinInlineSlotsOnPage} inline total slots`, () => {
-			cy.visit(`${path}?adtest=${adTest}`);
+		Object.entries(breakpoints).forEach(([breakpoint, width]) => {
+			it(`Test ${path} has at least ${expectedMinInlineSlotsOnPage} inline total slots at breakpoint ${breakpoint}`, () => {
+				cy.viewport(width, 500)
 
-			// Click "Yes, I'm happy" on the sourcepoint banner to obtain consent
-			cy.getIframeBody('sp_message_iframe_').find('.btn-primary').click();
-
-			cy.scrollTo('bottom', { duration: 5000 });
-
-			[...Array(expectedMinInlineSlotsOnPage).keys()].forEach(
-				(item, i) => {
-					cy.get(`[data-name="inline${i + 1}"]`).should(
-						'have.length',
-						1,
-					);
-				},
-			);
-		});
+				cy.visit(`${path}?adtest=${adTest}`);
+	
+				// Click "Yes, I'm happy" on the sourcepoint banner to obtain consent
+				cy.getIframeBody('sp_message_iframe_').find('.btn-primary').click();
+	
+				cy.scrollTo('bottom', { duration: 5000 });
+	
+				[...Array(expectedMinInlineSlotsOnPage).keys()].forEach(
+					(item, i) => {
+						cy.get(`[data-name="inline${i + 1}"]`).should(
+							'have.length',
+							1,
+						);
+					},
+				);
+			});
+		})
 	});
 });

--- a/cypress/e2e/merchandising-high.cy.ts
+++ b/cypress/e2e/merchandising-high.cy.ts
@@ -1,7 +1,7 @@
 import { breakpoints } from '../fixtures/breakpoints';
 import { articles, liveblogs } from '../fixtures/pages';
 
-describe('merchandising slot on pages', () => {
+describe('merchandising-high slot on pages', () => {
 	[...articles, ...liveblogs].forEach(({ path, adTest }) => {
 		Object.entries(breakpoints).forEach(([breakpoint, width]) => {
 			it(`Test ${path} has correct slot and iframe at breakpoint ${breakpoint}`, () => {
@@ -12,14 +12,16 @@ describe('merchandising slot on pages', () => {
 				// Click "Yes, I'm happy" on the sourcepoint banner to obtain consent
 				cy.getIframeBody('sp_message_iframe_').find('.btn-primary').click();
 
-				// Check that the merchandising ad slot is on the page
-				cy.get('#dfp-ad--merchandising').should('exist');
+				// Check that the merchandising-high ad slot is on the page
+				cy.get('#dfp-ad--merchandising-high').should('exist');
 
 				// creative isn't loaded unless slot is in view
-				cy.get('#dfp-ad--merchandising').scrollIntoView({duration: 4000});
+				cy.get('#dfp-ad--merchandising-high').scrollIntoView({duration: 4000});
 
-				// Check that an iframe is placed inside the merchandising ad slot
-				cy.get('#dfp-ad--merchandising').find('iframe', {timeout: 10000}).should('exist');
+				// Check that an iframe is placed inside the merchandising-high ad slot
+				cy.get('#dfp-ad--merchandising-high')
+					.find('iframe')
+					.should('exist');
 			});
 		});
 	});

--- a/cypress/e2e/mostpop.cy.ts
+++ b/cypress/e2e/mostpop.cy.ts
@@ -1,21 +1,24 @@
+import { breakpoints } from '../fixtures/breakpoints';
 import { articles, liveblogs } from '../fixtures/pages';
 
 describe('mostpop slot on pages', () => {
 	[...articles, ...liveblogs].forEach(({ path, adTest }) => {
-		it(`Test ${path} has correct slot and iframe`, () => {
-			cy.visit(`${path}?adtest=${adTest}`);
-
-			// Click "Yes, I'm happy" on the sourcepoint banner to obtain consent
-			cy.getIframeBody('sp_message_iframe_').find('.btn-primary').click();
-
-			// Check that the mostpop ad slot is on the page
-			cy.get('#dfp-ad--mostpop').should('exist');
-
-			// creative isn't loaded unless slot is in view
-			cy.get('#dfp-ad--mostpop').scrollIntoView();
-
-			// Check that an iframe is placed inside the ad slot
-			cy.get('#dfp-ad--mostpop').find('iframe').should('exist');
+		Object.entries(breakpoints).forEach(([breakpoint, width]) => {
+			it(`Test ${path} has correct slot and iframe at breakpoint ${breakpoint}`, () => {
+				cy.visit(`${path}?adtest=${adTest}`);
+	
+				// Click "Yes, I'm happy" on the sourcepoint banner to obtain consent
+				cy.getIframeBody('sp_message_iframe_').find('.btn-primary').click();
+	
+				// Check that the mostpop ad slot is on the page
+				cy.get('#dfp-ad--mostpop').should('exist');
+	
+				// creative isn't loaded unless slot is in view
+				cy.get('#dfp-ad--mostpop').scrollIntoView();
+	
+				// Check that an iframe is placed inside the ad slot
+				cy.get('#dfp-ad--mostpop').find('iframe').should('exist');
+			});
 		});
 	});
 });

--- a/cypress/e2e/right-slot.cy.ts
+++ b/cypress/e2e/right-slot.cy.ts
@@ -1,4 +1,4 @@
-import { breakpoints } from '../fixtures/breakpoints';
+import { breakpoints } from '@guardian/source-foundations';
 import { articles, liveblogs } from '../fixtures/pages';
 
 describe('right slot on pages', () => {

--- a/cypress/e2e/right-slot.cy.ts
+++ b/cypress/e2e/right-slot.cy.ts
@@ -1,10 +1,11 @@
+import { breakpoints } from '../fixtures/breakpoints';
 import { articles, liveblogs } from '../fixtures/pages';
 
 describe('right slot on pages', () => {
 	[...articles, ...liveblogs].forEach(({ path, adTest }) => {
 		it(`Test ${path} has correct slot and iframe`, () => {
-			// width has to be > 1300px in order for the right column to appear on liveblogs
-			cy.viewport(1301, 1000);
+			// viewport width has to be >= 1300px in order for the right column to appear on liveblogs
+			cy.viewport(breakpoints['wide'], 1000);
 
 			cy.visit(`${path}?adtest=${adTest}`);
 

--- a/cypress/fixtures/breakpoints.ts
+++ b/cypress/fixtures/breakpoints.ts
@@ -1,0 +1,10 @@
+import { breakpoints } from '@guardian/source-foundations'
+
+const breakpointsToTest = ['mobile', 'tablet', 'desktop', 'wide']
+const breakpointsWidths = Object.fromEntries(
+	Object.entries(breakpoints).filter(
+		([key, _]) => breakpointsToTest.includes(key)
+	)
+ );
+
+export { breakpointsWidths as breakpoints }

--- a/cypress/fixtures/breakpoints.ts
+++ b/cypress/fixtures/breakpoints.ts
@@ -1,10 +1,6 @@
 import { breakpoints } from '@guardian/source-foundations'
 
-const breakpointsToTest = ['mobile', 'tablet', 'desktop', 'wide']
-const breakpointsWidths = Object.fromEntries(
-	Object.entries(breakpoints).filter(
-		([key, _]) => breakpointsToTest.includes(key)
-	)
- );
+const breakpointsToTest: Array<keyof typeof breakpoints> = ['mobile', 'tablet', 'desktop', 'wide']
+const breakpointWidths = breakpointsToTest.map(b => breakpoints[b])
 
-export { breakpointsWidths as breakpoints }
+export { breakpointWidths as breakpoints }


### PR DESCRIPTION
## What does this change?
- Updates commercial end-to-end cypress tests so that they load pages at various viewport sizes ('mobile', 'tablet', 'desktop', 'wide') rather than just desktop.
- Split `merchandising.cy.ts` into two files, testing merchandising and merchandising-high slots separately.
- update cypress config, setting `numTestsKeptInMemory` to 0. This will let us run tests like `merchandising.cy.ts` that take a few minutes to complete without the browsers crashing.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
- Since ad behaviour varies by breakpoint, ads on different viewport sizes can fail independently. This change extends our test coverage by rerunning tests at various viewport sizes.

### Tested

- [x] Locally
- [ ] On CODE (N/A)