### PR TITLE
chore(deps): bump capiVersion

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ import sbt._
 object Dependencies {
   val identityLibVersion = "3.254"
   val awsVersion = "1.12.205"
-  val capiVersion = "19.0.1"
+  val capiVersion = "19.0.3"
   val faciaVersion = "4.0.0"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ import sbt._
 object Dependencies {
   val identityLibVersion = "3.254"
   val awsVersion = "1.12.205"
-  val capiVersion = "19.0.0"
+  val capiVersion = "19.0.1"
   val faciaVersion = "4.0.0"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"


### PR DESCRIPTION
## What does this change?
Bumps the CAPI client to the main version. Mainly to get the new report, but thought I'd fold @rtyley's fixes 

You can see the release notes [here](https://github.com/guardian/content-api-scala-client/releases).

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)
