### PR TITLE
chore(deps): bump faciaVersion to 4.0.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val identityLibVersion = "3.254"
   val awsVersion = "1.12.205"
   val capiVersion = "19.0.3"
-  val faciaVersion = "4.0.0"
+  val faciaVersion = "4.0.1"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"


### PR DESCRIPTION
## What does this change?
Bumps facia => `4.0.1` as per [this comment](https://github.com/guardian/frontend/pull/25201#discussion_r915751065) (thanks @rtyley).

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)
