### PR TITLE
Fix line-height of boosted headlines

### DIFF
--- a/static/src/stylesheets/pasteup/typography/_src.scss
+++ b/static/src/stylesheets/pasteup/typography/_src.scss
@@ -17,7 +17,7 @@ $font-scale: (
         5: (font-size: 28, line-height: 32),
         6: (font-size: 34, line-height: 38),
         8: (font-size: 42, line-height: 46),
-        9: (font-size: 50, line-height: 56),
+        9: (font-size: 50, line-height: 58),
         10: (font-size: 70, line-height: 78),
     ),
     bodyHeading: (


### PR DESCRIPTION
## What does this change?

Fix line-height of large, boosted headlines.

Spotted by @Bryony-Szekeres 🕵️‍♀️ 

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/177788397-300eca59-45cc-47fb-9fa6-edd7956de9b5.png
[after]: https://user-images.githubusercontent.com/76776/177788499-7de14d6b-b439-43c7-8ef3-7ddd0b0b42b4.png

## What is the value of this and can you measure success?

The descenders are no longer cropped.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)