### PR TITLE
feat: Port the stale PR action from dotcom-rendering

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@ name: "Stale PR Handler"
 
 on:
   schedule:
-    - cron: "0 6 * * *"
+    - cron: "0 6 MON-THU * *"
 
 permissions:
   pull-requests: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,31 @@
+name: "Stale PR Handler"
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+
+permissions:
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v5
+        id: stale
+        # Read about options here: https://github.com/actions/stale#all-options
+        with:
+          # never automatically mark issues as stale
+          days-before-issue-stale: -1
+          
+          days-before-stale: 30
+          stale-pr-message: >
+            "This PR is stale because it has been open 30 days with no activity.
+            Unless a comment is added or the “stale” label removed, this will be closed in 3 days"
+          
+          days-before-close: 3
+          close-pr-message: 'This PR was closed because it has been stalled for 3 days with no activity.'
+          
+          delete-branch: true
+          
+          exempt-pr-labels: "dependencies"


### PR DESCRIPTION
## What does this change?

This is an action we've been using for a while in @guardian/dotcom-rendering which automatically closes any PR's that haven't seen any activity for a while.

It's currently configured to label any PR thats had no activity for 30+ days with "Stale" and then close the PR 3 days later if theres still been no activity. It also deletes the PR branch but they can be restored from a local copy or from the Github branches page (if its been deleted fairly recently)

## Why?

This action will hopefully remind people that they have PR's open that might need some love and care and/or close any PR's that aren't necessary anymore making it easier for reviewers to see what needs reviewing.
