### PR TITLE
fix: Use absolute links in tableView embed

### DIFF
--- a/sport/app/football/views/tablesList/tableView.scala.html
+++ b/sport/app/football/views/tablesList/tableView.scala.html
@@ -1,5 +1,6 @@
 @import conf.Configuration
 @import model.{Competition, Group, TeamUrl}
+@import common.LinkTo
 @import views.support.RenderClasses
 @import views.support.`package`.Seq2zipWithRowInfo
 @import model.CompetitionDisplayHelpers.cleanTeamName
@@ -10,7 +11,7 @@
     headingLink: Option[String] = None,
     highlightTeamId: Option[String] = None, striped: Boolean = false,
     responsiveFont: Boolean = false, linkToCompetition: Boolean = false,
-    withCrests: Boolean = false)
+    withCrests: Boolean = false)(implicit request: RequestHeader)
 <div class="table__container">
     <table class="@RenderClasses(Map(
             "table" -> true,
@@ -22,7 +23,7 @@
 
         @heading.map{ h=>
             <caption class="table__caption table__caption--top">
-                <a href="@headingLink.getOrElse(competition.url)" class="football-matches__heading">@h</a>
+                <a href="@LinkTo(headingLink.getOrElse(competition.url))" class="football-matches__heading">@h</a>
             </caption>
         }
         <thead>
@@ -51,7 +52,7 @@
                         <span class="team-name" data-abbr="@GuTeamCodes.codeFor(entry.team)">
                             <img class="team-crest" alt="" src="@Configuration.staticSport.path/football/crests/60/@{entry.team.id}.png" />
                             @TeamUrl(entry.team).map{ url =>
-                                <a href="@TeamUrl(entry.team)" data-link-name="View team" class="team-name__long">
+                                <a href="@LinkTo(url)" data-link-name="View team" class="team-name__long">
                                     @cleanTeamName(entry.team.name)
                                 </a>
                             }.getOrElse{
@@ -78,7 +79,7 @@
             <tfoot class="table__caption table__caption--bottom" >
                 <tr>
                     <td colspan="11">
-                        <a href="@{competition.url + "/table"}" data-link-name="full table" class="full-table-link">View full <span class="competition-name">@competition.fullName</span> table</a>
+                        <a href="@LinkTo({competition.url + "/table"})" data-link-name="full table" class="full-table-link">View full <span class="competition-name">@competition.fullName</span> table</a>
                     </td>
                 </tr>
             </tfoot>


### PR DESCRIPTION
## What does this change?

Use absolute links in Football embeds instead of relative links. Relative links causes issues in Apps.

https://user-images.githubusercontent.com/21217225/177816375-e0cfbf83-0e7e-4f19-bb49-5d0358f9f54e.mov

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/21217225/177815645-4a1a2afe-2828-4bc9-b7b8-daec7f8a49e5.png
[after]: https://user-images.githubusercontent.com/21217225/177815555-83b8b065-0a1a-491f-a780-6bc428d1b723.png
