### PR TITLE
fix: use same md5 encryption as CAPI

### DIFF
--- a/common/app/model/Badges.scala
+++ b/common/app/model/Badges.scala
@@ -2,9 +2,7 @@ package model
 
 import conf.Static
 import layout.FaciaContainer
-import java.security.MessageDigest
-import java.math.BigInteger
-import scala.util.control.NonFatal
+import org.apache.commons.codec.digest.DigestUtils
 
 trait BaseBadge {
   def maybeThisBadge(tag: String): Option[Badge]
@@ -22,16 +20,8 @@ case class SpecialBadge(salt: String, hashedTag: String, imageUrl: String) exten
       Some(Badge(tag, imageUrl))
     } else None
 
-  private val digest = MessageDigest.getInstance("MD5")
-
   private def md5(input: String): Option[String] = {
-    try {
-      digest.update(input.getBytes(), 0, input.length)
-
-      Option(new BigInteger(1, digest.digest()).toString(16))
-    } catch {
-      case NonFatal(_) => None
-    }
+    Some(DigestUtils.md5Hex(input))
   }
 }
 


### PR DESCRIPTION
## What does this change?

Uses the same [MD5 hash mechanism as CAPI](https://github.com/guardian/content-api-scala-client/blob/main/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala#L156) when looking at report badges.

The two different methods were returning different values. I am still trying to figure out why, but using the same type as the source felt like the right idea to fix this for now.

We should be able to remove this code once we start using tag targeting to see if an tag is a special report or not.