### PR TITLE
Update `youtube-player` to use `ConsentState.canTarget`

### DIFF
--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.ts
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.ts
@@ -179,7 +179,7 @@ describe('create ads config', () => {
 describe('Get Host (no-cookie)', () => {
 	test('`youtube-nocookie.com` with an empty state', () => {
 		const host = youtubePlayer.getHost({
-			state: {
+			consentState: {
 				canTarget: false,
 				framework: null,
 			},
@@ -192,7 +192,7 @@ describe('Get Host (no-cookie)', () => {
 
 	test('`youtube-nocookie.com` with an ad-free', () => {
 		const host = youtubePlayer.getHost({
-			state: {
+			consentState: {
 				aus: { personalisedAdvertising: true },
 				canTarget: true,
 				framework: 'aus',
@@ -206,7 +206,7 @@ describe('Get Host (no-cookie)', () => {
 
 	test('`youtube-nocookie.com` with for other than youtube-media-atom__iframe', () => {
 		const host = youtubePlayer.getHost({
-			state: {
+			consentState: {
 				aus: { personalisedAdvertising: true },
 				canTarget: true,
 				framework: 'aus',
@@ -220,7 +220,7 @@ describe('Get Host (no-cookie)', () => {
 
 	test('`youtube.com` when all three conditions met', () => {
 		const host = youtubePlayer.getHost({
-			state: {
+			consentState: {
 				aus: { personalisedAdvertising: true },
 				canTarget: true,
 				framework: 'aus',

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.ts
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.ts
@@ -76,7 +76,7 @@ const canTargetCCPA = (canTarget: boolean): ConsentState => ({
 	ccpa: {
 		doNotSell: !canTarget,
 	},
-	canTarget: canTarget,
+	canTarget,
 	framework: 'ccpa',
 });
 
@@ -84,7 +84,7 @@ const canTargetAUS = (canTarget: boolean): ConsentState => ({
 	aus: {
 		personalisedAdvertising: canTarget,
 	},
-	canTarget: canTarget,
+	canTarget,
 	framework: 'aus',
 });
 

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.ts
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.spec.ts
@@ -68,7 +68,7 @@ const canTargetTCFv2 = (canTarget: boolean): ConsentState => ({
 		tcString: 'testTcString',
 		addtlConsent: 'testaddtlConsent',
 	},
-	canTarget: true,
+	canTarget,
 	framework: 'tcfv2',
 });
 

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.ts
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.ts
@@ -93,9 +93,9 @@ const onPlayerStateChangeEvent = (
 ) => {
 	if (el) {
 		if (config.get('page.isDev')) {
-			const state = window.YT.PlayerState[event.data];
-			if (state) {
-				console.log(`Player ${el.id} is ${state}`);
+			const playerState = window.YT.PlayerState[event.data];
+			if (playerState) {
+				console.log(`Player ${el.id} is ${playerState}`);
 			}
 		}
 

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.ts
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.ts
@@ -52,22 +52,6 @@ const addVideoStartedClass = (el: HTMLElement | null) => {
 	}
 };
 
-const canTarget = (state: ConsentState): boolean => {
-	if (state.ccpa) {
-		return !state.ccpa.doNotSell;
-	}
-	if (state.aus) {
-		return state.aus.personalisedAdvertising;
-	}
-	if (state.tcfv2) {
-		return (
-			Object.values(state.tcfv2.consents).length > 0 &&
-			Object.values(state.tcfv2.consents).every(Boolean)
-		);
-	}
-	return false;
-};
-
 let resolveInitialConsent: (state: ConsentState) => void;
 const initialConsent = new Promise<ConsentState>((resolve) => {
 	// We don’t need to wait for consent if Ad-Free
@@ -191,7 +175,7 @@ const createAdsConfigEnabled = (
 				cmpVcd: consentState.tcfv2.tcString,
 				cmpGvcd: consentState.tcfv2.addtlConsent,
 			},
-			nonPersonalizedAd: !canTarget(consentState),
+			nonPersonalizedAd: !consentState.canTarget,
 		};
 		log('commercial', 'YouTube Ads Config TCFv2', adsConfigTCFv2);
 		return adsConfigTCFv2;
@@ -200,7 +184,7 @@ const createAdsConfigEnabled = (
 	if (consentState.ccpa || consentState.aus) {
 		const adsConfigCCPA: AdsConfigCCPAorAus = {
 			...adsConfigBasic,
-			restrictedDataProcessor: !canTarget(consentState),
+			restrictedDataProcessor: !consentState.canTarget,
 		};
 		log('commercial', 'YouTube Ads Config CCPA/AUS', adsConfigCCPA);
 		return adsConfigCCPA;
@@ -221,7 +205,7 @@ const getHost = ({
 	adFree: boolean;
 }): YTHost => {
 	if (
-		canTarget(state) &&
+		state.canTarget &&
 		!adFree &&
 		classes.includes('youtube-media-atom__iframe')
 	) {

--- a/static/src/javascripts/projects/common/modules/atoms/youtube-player.ts
+++ b/static/src/javascripts/projects/common/modules/atoms/youtube-player.ts
@@ -52,7 +52,7 @@ const addVideoStartedClass = (el: HTMLElement | null) => {
 	}
 };
 
-let resolveInitialConsent: (state: ConsentState) => void;
+let resolveInitialConsent: (consentState: ConsentState) => void;
 const initialConsent = new Promise<ConsentState>((resolve) => {
 	// We don’t need to wait for consent if Ad-Free
 	if (commercialFeatures.adFree) {
@@ -64,8 +64,8 @@ const initialConsent = new Promise<ConsentState>((resolve) => {
 
 	resolveInitialConsent = resolve;
 });
-onConsentChange((state) => {
-	resolveInitialConsent(state);
+onConsentChange((consentState) => {
+	resolveInitialConsent(consentState);
 });
 
 interface YTPlayerEvent extends Omit<Event, 'target'> {
@@ -196,16 +196,16 @@ const createAdsConfigEnabled = (
 /*eslint curly: ["error", "multi-line"] -- it’s safer to update */
 type YTHost = 'https://www.youtube.com' | 'https://www.youtube-nocookie.com';
 const getHost = ({
-	state,
+	consentState,
 	classes,
 	adFree,
 }: {
-	state: ConsentState;
+	consentState: ConsentState;
 	classes: string[];
 	adFree: boolean;
 }): YTHost => {
 	if (
-		state.canTarget &&
+		consentState.canTarget &&
 		!adFree &&
 		classes.includes('youtube-media-atom__iframe')
 	) {
@@ -248,7 +248,7 @@ const setupPlayer = (
 	// @ts-expect-error -- ts is confused by multiple constructors
 	return new window.YT.Player(el.id, {
 		host: getHost({
-			state: consentState,
+			consentState,
 			classes: [...el.classList.values()],
 			adFree: commercialFeatures.adFree,
 		}),


### PR DESCRIPTION
## What does this change?

- Update `youtube-player` to use `ConsentState.canTarget` as introduced in https://github.com/guardian/consent-management-platform/pull/597
- Fix a small bug in `youtube-player.spec`
- Refactor naming

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

