### PR TITLE
return last updated block from unfiltered list in render json response

### DIFF
--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -245,7 +245,7 @@ class LiveBlogController(
       lastUpdateBlockId: SinceBlockId,
       filterKeyEvents: Boolean,
       topicResult: Option[TopicResult],
-  ): Seq[BodyBlock] = {
+  ): (Option[BodyBlock], Seq[BodyBlock]) = {
     val requestedBlocks = page.article.fields.blocks.toSeq.flatMap {
       _.requestedBodyBlocks.getOrElse(lastUpdateBlockId.around, Seq())
     }
@@ -254,12 +254,14 @@ class LiveBlogController(
       block.id != lastUpdateBlockId.lastUpdate
     }
 
-    if (filterKeyEvents) {
+    val filteredBlocks = if (filterKeyEvents) {
       latestBlocks.filter(block => block.eventType == KeyEvent || block.eventType == SummaryEvent)
     } else if (topicResult.isDefined) {
       latestBlocks.filter(block => topicResult.get.blocks.contains(block.id))
     } else latestBlocks
 
+    // the last block is picked from the unfiltered list
+    (latestBlocks.headOption, filteredBlocks)
   }
 
   private[this] def getNewBlocks(
@@ -298,7 +300,7 @@ class LiveBlogController(
       requestedBodyBlocks: scala.collection.Map[String, Seq[Block]],
       topicResult: Option[TopicResult],
   )(implicit request: RequestHeader): Future[Result] = {
-    val newBlocks = getNewBlocks(page, lastUpdateBlockId, filterKeyEvents, topicResult)
+    val (lastNewBlock, newBlocks) = getNewBlocks(page, lastUpdateBlockId, filterKeyEvents, topicResult)
     val newCapiBlocks = getNewBlocks(requestedBodyBlocks, lastUpdateBlockId, filterKeyEvents, topicResult)
 
     val timelineHtml = views.html.liveblog.keyEvents(
@@ -322,7 +324,7 @@ class LiveBlogController(
       val livePageJson = isLivePage.filter(_ == true).map { _ =>
         "html" -> blocksHtml
       }
-      val mostRecent = newBlocks.headOption.map { block =>
+      val mostRecent = lastNewBlock.map { block =>
         "mostRecentBlockId" -> s"block-${block.id}"
       }
 

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -300,7 +300,7 @@ class LiveBlogController(
       requestedBodyBlocks: scala.collection.Map[String, Seq[Block]],
       topicResult: Option[TopicResult],
   )(implicit request: RequestHeader): Future[Result] = {
-    val (lastNewBlock, newBlocks) = getNewBlocks(page, lastUpdateBlockId, filterKeyEvents, topicResult)
+    val (newestBlock, newBlocks) = getNewBlocks(page, lastUpdateBlockId, filterKeyEvents, topicResult)
     val newCapiBlocks = getNewBlocks(requestedBodyBlocks, lastUpdateBlockId, filterKeyEvents, topicResult)
 
     val timelineHtml = views.html.liveblog.keyEvents(
@@ -324,7 +324,7 @@ class LiveBlogController(
       val livePageJson = isLivePage.filter(_ == true).map { _ =>
         "html" -> blocksHtml
       }
-      val mostRecent = lastNewBlock.map { block =>
+      val mostRecent = newestBlock.map { block =>
         "mostRecentBlockId" -> s"block-${block.id}"
       }
 


### PR DESCRIPTION
## What does this change?
This PR fixes a bug for liveblog render json api route (liveblog polling endpoint) where `mostRecentBlockId` field in the renderJson response wouldn't have any value because when the number of new filtered blocks is 0, even when we have had new blocks. This happens when the new blocks are filtered based on the filter category (e.g. `key events` & top mention topics), but non of the newly posted blocks are relevant to the filter category, so the list would be empty in the response. 

But in the mentioned scenario, we would still need to keep track of the very last block no matter if it is relevant to the filter topic or not. This way, next time DCR calls the `renderJson` endpoint, it'd call it with the correct `lastUpdate` query param. 

DCR part of the fix: https://github.com/guardian/dotcom-rendering/pull/5350

This change was tested locally and the updates are now working properly. 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
