### PR TITLE
Fix fluid ads refreshing

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/should-refresh.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/should-refresh.spec.ts
@@ -1,5 +1,5 @@
 import { adSizes, createAdSize } from '@guardian/commercial-core';
-import type { AdSize, AdSizeString } from '@guardian/commercial-core';
+import type { AdSize } from '@guardian/commercial-core';
 import { Advert } from './Advert';
 import { _, shouldRefresh } from './should-refresh';
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/should-refresh.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/should-refresh.spec.ts
@@ -1,0 +1,103 @@
+import { adSizes, createAdSize } from '@guardian/commercial-core';
+import type { AdSize, AdSizeString } from '@guardian/commercial-core';
+import { Advert } from './Advert';
+import { _, shouldRefresh } from './should-refresh';
+
+const { outstreamSizes } = _;
+
+export const toAdSizeString = (size: AdSize): AdSize | 'fluid' => {
+	return size[0] === 0 && size[1] === 0 ? (size.toString() as 'fluid') : size;
+};
+
+describe('shouldRefresh', () => {
+	let googleSlot: googletag.Slot;
+
+	beforeEach(() => {
+		let sizesArray: googletag.SizeMappingArray = [];
+
+		const sizeMapping = {
+			sizes: sizesArray,
+			addSize: jest.fn((width, sizes) => {
+				sizesArray.unshift([width, sizes]);
+			}),
+			build: jest.fn(() => {
+				const tmp = sizesArray;
+				sizesArray = [];
+				return tmp;
+			}),
+		} as unknown as googletag.SizeMappingBuilder;
+
+		//@ts-expect-error - it is a partial mock
+		googleSlot = {
+			defineSizeMapping: jest.fn(() => googleSlot),
+			setSafeFrameConfig: jest.fn(() => googleSlot),
+			setTargeting: jest.fn(() => googleSlot),
+			addService: jest.fn(() => googleSlot),
+		};
+
+		const partialGoogletag: Partial<typeof googletag> = {
+			pubads() {
+				return {} as googletag.PubAdsService;
+			},
+			sizeMapping() {
+				return sizeMapping;
+			},
+			defineSlot() {
+				return googleSlot;
+			},
+		};
+
+		// @ts-expect-error -- we’re making it a partial
+		window.googletag = partialGoogletag;
+	});
+
+	it('should return false for fluid ads', () => {
+		const slot = document.createElement('div');
+		slot.setAttribute('data-name', 'inline');
+		const advert = new Advert(slot);
+		advert.size = toAdSizeString(createAdSize(0, 0));
+		const result = shouldRefresh(advert);
+		expect(result).toBe(false);
+	});
+
+	it('should return true for non-fluid ads', () => {
+		const slot = document.createElement('div');
+		slot.setAttribute('data-name', 'inline');
+		const advert = new Advert(slot);
+		advert.size = adSizes.halfPage;
+		const result = shouldRefresh(advert);
+		expect(result).toBe(true);
+	});
+
+	outstreamSizes.forEach((size) => {
+		it(`should return false for outstream ${size}`, () => {
+			const slot = document.createElement('div');
+			slot.setAttribute('data-name', 'inline');
+			const advert = new Advert(slot);
+			const [width, height] = size.split(',');
+			advert.size = createAdSize(Number(width), Number(height));
+			const result = shouldRefresh(advert);
+			expect(result).toBe(false);
+		});
+	});
+
+	it('if config.hasPageSkin is true ads should not refresh', () => {
+		window.guardian.config.page.hasPageSkin = true;
+
+		const slot = document.createElement('div');
+		slot.setAttribute('data-name', 'inline');
+		const advert = new Advert(slot);
+		advert.size = adSizes.halfPage;
+		const result = shouldRefresh(advert);
+		expect(result).toBe(false);
+	});
+
+	it('if eventLineItemId is in nonRefreshableLineItemIds should not refresh', () => {
+		const slot = document.createElement('div');
+		slot.setAttribute('data-name', 'inline');
+		const advert = new Advert(slot);
+		advert.size = adSizes.halfPage;
+		const result = shouldRefresh(advert, [123], 123);
+		expect(result).toBe(false);
+	});
+});

--- a/static/src/javascripts/projects/commercial/modules/dfp/should-refresh.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/should-refresh.spec.ts
@@ -5,7 +5,7 @@ import { _, shouldRefresh } from './should-refresh';
 
 const { outstreamSizes } = _;
 
-export const toAdSizeString = (size: AdSize): AdSize | 'fluid' => {
+const toAdSizeString = (size: AdSize): AdSize | 'fluid' => {
 	return size[0] === 0 && size[1] === 0 ? (size.toString() as 'fluid') : size;
 };
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/should-refresh.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/should-refresh.ts
@@ -1,6 +1,5 @@
 import type { AdSizeString } from '@guardian/commercial-core';
 import { adSizes } from '@guardian/commercial-core';
-import config from '../../../../lib/config';
 import type { Advert } from './Advert';
 
 const outstreamSizes = [
@@ -34,7 +33,7 @@ export const shouldRefresh = (
 	const sizeString = advert.size?.toString();
 
 	// Fluid adverts should not refresh
-	const isFluid = sizeString === '0,0';
+	const isFluid = sizeString === 'fluid';
 	if (isFluid) return false;
 
 	// Outstream adverts should not refresh
@@ -49,8 +48,12 @@ export const shouldRefresh = (
 	if (isNonRefreshableLineItem) return false;
 
 	// If we have a pageskin then don't refresh
-	if (config.get('page.hasPageSkin')) return false;
+	if (window.guardian.config.page.hasPageSkin) return false;
 
 	// If none of the other conditions are met then the advert should refresh
 	return true;
+};
+
+export const _ = {
+	outstreamSizes,
 };

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -338,7 +338,6 @@
  "../projects/commercial/modules/dfp/should-refresh.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../lib/config.d.ts",
   "../projects/commercial/modules/dfp/Advert.ts"
  ],
  "../projects/commercial/modules/dfp/track-ad-render.ts": [


### PR DESCRIPTION
## What does this change?
`adSize.toString()` now returns 'fluid' instead of '0,0', this broke `should-refresh.ts`, we updated the string, and added some unit tests.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)
