### PR TITLE
Remove superfluous use of `implicits.Collections`

### DIFF
--- a/commercial/app/controllers/Multi.scala
+++ b/commercial/app/controllers/Multi.scala
@@ -18,7 +18,6 @@ class Multi(
     jobsAgent: JobsAgent,
     val controllerComponents: ControllerComponents,
 ) extends BaseController
-    with implicits.Collections
     with implicits.Requests {
 
   private def multiSample(

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -416,7 +416,7 @@ case class GuCreativeTemplate(
   lazy val isForApps: Boolean = name.startsWith("apps - ") || name.startsWith("as ") || name.startsWith("qc ")
 }
 
-object GuCreativeTemplate extends implicits.Collections {
+object GuCreativeTemplate {
 
   implicit val guCreativeTemplateFormats: Format[GuCreativeTemplate] = Json.format[GuCreativeTemplate]
 }

--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -23,7 +23,7 @@ import scala.concurrent.duration.{Duration, MILLISECONDS}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
-object QueryDefaults extends implicits.Collections {
+object QueryDefaults {
   // NOTE - do NOT add body to this list
   val trailFieldsList = List[String](
     "byline",

--- a/common/app/implicits/Collections.scala
+++ b/common/app/implicits/Collections.scala
@@ -22,18 +22,6 @@ trait Collections {
       builder.result
     }
   }
-
-  // A non-inlined implementation of drop while. This is needed because scala 2.11
-  // currently throws warnings (fatal warnings are on) when using standard drop while.
-  // https://issues.scala-lang.org/browse/SI-7529
-  implicit class List2DropWhile[A](list: List[A]) {
-    def safeDropWhile(p: A => Boolean): List[A] = {
-      def loop(xs: List[A]): List[A] =
-        if (xs.isEmpty || !p(xs.head)) xs
-        else loop(xs.tail)
-      loop(list)
-    }
-  }
 }
 
 object CollectionsOps extends Collections

--- a/common/app/layout/ContainerLayout.scala
+++ b/common/app/layout/ContainerLayout.scala
@@ -23,7 +23,7 @@ case class ContainerLayout(
   def hasShowMore: Boolean = hasDesktopShowMore || hasMobileShowMore
 }
 
-object ContainerLayout extends implicits.Collections {
+object ContainerLayout {
   def apply(
       sliceDefinitions: Seq[Slice],
       items: Seq[PressedContent],

--- a/common/app/layout/TagHistogram.scala
+++ b/common/app/layout/TagHistogram.scala
@@ -1,6 +1,5 @@
 package layout
 
-import implicits.Collections
 import model.Trail
 import model.pressed.PressedContent
 import implicits.FaciaContentFrontendHelpers.FaciaContentFrontendHelper
@@ -13,7 +12,7 @@ case class TagHistogram(frequencyById: Map[String, Int], numberOfItems: Int) {
       frequencyById.get(id) map { _.toDouble / numberOfItems } getOrElse 0d
 }
 
-object TagHistogram extends Collections {
+object TagHistogram {
   def fromTrails(trails: Seq[Trail]): TagHistogram =
     TagHistogram(
       trails.foldLeft(Map.empty[String, Int]) {

--- a/common/app/services/IndexPageGrouping.scala
+++ b/common/app/services/IndexPageGrouping.scala
@@ -3,7 +3,6 @@ package services
 import common.Chronos
 import common.JodaTime._
 import common.Maps.RichMapSeq
-import implicits.Collections
 import implicits.Dates._
 import layout.{DateHeadline, DayHeadline, MonthHeadline}
 import model.Content
@@ -11,7 +10,7 @@ import org.joda.time.{DateTimeZone, LocalDate}
 
 case class TrailAndDate(trail: Content, date: LocalDate)
 
-object IndexPageGrouping extends Collections {
+object IndexPageGrouping {
   val MinimumPerDayPopOutFrequency = 2
 
   def fromContent(trails: Seq[Content], timezone: DateTimeZone): Seq[IndexPageGrouping] = {

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -31,7 +31,6 @@ trait FaciaController
     extends BaseController
     with GuLogging
     with ImplicitControllerExecutionContext
-    with implicits.Collections
     with implicits.Requests {
 
   val frontJsonFapi: FrontJsonFapi

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -348,7 +348,6 @@ class CompetitionsService(val footballClient: FootballClient, competitionDefinit
     with LiveMatches
     with Lineups
     with GuLogging
-    with implicits.Collections
     with implicits.Football {
 
   private implicit val dateOrdering = Ordering.comparatorToOrdering(

--- a/sport/app/football/model/matches.scala
+++ b/sport/app/football/model/matches.scala
@@ -9,7 +9,7 @@ import pa.{FootballMatch, Round}
 import java.time.format.DateTimeFormatter
 import java.time.{LocalDate, ZonedDateTime}
 
-trait MatchesList extends Football with RichList with implicits.Collections {
+trait MatchesList extends Football with RichList {
 
   val competitions: Seq[Competition]
 
@@ -48,7 +48,7 @@ trait MatchesList extends Football with RichList with implicits.Collections {
   lazy val relevantMatches: List[(FootballMatch, Competition)] = {
     val startDate = date
     val matchDates = allRelevantMatches.map { case (fMatch, _) => fMatch.date.toLocalDate }.distinct
-    val eligibleDates = matchDates.safeDropWhile(dateComesFirstInList(_, startDate)).take(daysToDisplay)
+    val eligibleDates = matchDates.dropWhile(dateComesFirstInList(_, startDate)).take(daysToDisplay)
     allRelevantMatches.filter {
       case (fMatch, _) =>
         eligibleDates.contains(fMatch.date.toLocalDate)
@@ -75,7 +75,7 @@ trait MatchesList extends Football with RichList with implicits.Collections {
     }
 
   lazy val nextPage: Option[String] = {
-    val nextMatchDate = matchDates.safeDropWhile(dateComesFirstInList(_, date)).drop(daysToDisplay).headOption
+    val nextMatchDate = matchDates.dropWhile(dateComesFirstInList(_, date)).drop(daysToDisplay).headOption
     nextMatchDate.map(s"$baseUrl/more/" + _.format(DateTimeFormatter.ofPattern("yyyy/MMM/dd")))
   }
   lazy val previousPage: Option[String] = {

--- a/sport/app/football/model/model.scala
+++ b/sport/app/football/model/model.scala
@@ -18,8 +18,7 @@ case class Competition(
     showInTeamsList: Boolean = false,
     tableDividers: List[Int] = Nil,
     finalMatchSVG: Option[String] = None,
-) extends implicits.Collections
-    with implicits.Football {
+) extends implicits.Football {
 
   lazy val hasMatches = matches.nonEmpty
   lazy val hasLiveMatches = matches.exists(_.isLive)

--- a/sport/test/football/model/CompetitionStageTest.scala
+++ b/sport/test/football/model/CompetitionStageTest.scala
@@ -5,7 +5,6 @@ import pa.{Round, Stage}
 import org.scalatest.matchers.{BePropertyMatchResult, BePropertyMatcher}
 
 import java.time.ZonedDateTime
-import implicits.Collections
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import test._
@@ -15,7 +14,6 @@ import test._
     with Matchers
     with OptionValues
     with CompetitionTestData
-    with Collections
     with FootballTestData
     with WithTestFootballClient
     with BeforeAndAfterAll


### PR DESCRIPTION
## What does this change?

In the course of upgrading the Frontend codebase to Scala 2.13 (see https://github.com/guardian/frontend/pull/25190) we came across the `implicits.Collections` class, and had trouble updating it for Scala 2.13: https://github.com/guardian/frontend/pull/25190#discussion_r913972996

It turns out that we will be able to _delete_ this class with the Scala 2.13 upgrade, rather than have to update it, which is nice! To reduce the size of the Scala 2.13 upgrade PR, we're **removing superfluous use `implicits.Collections`** in this pre-upgrade PR.

### What is `implicits.Collections` ?

[`implicits.Collections`](https://github.com/guardian/frontend/blob/4c1a4cb7859d30c0d6ed1e52f5edf7034b3e53fc/common/app/implicits/Collections.scala) is currently used to add two additional methods to standard Scala collections:

* `distinctBy()` - introduced November 2012 with https://github.com/guardian/frontend/pull/263. Surprisingly, Scala 2.13 has [a new built-in method](https://www.scala-lang.org/api/2.13.x/scala/collection/Seq.html#distinctBy[B](f:A=%3EB):C) that is called the same thing and is called the same way! So the Frontend implementation can be deleted when the Scala 2.13 upgrade occurs.
* `safeDropWhile()` - introduced January 2015 with https://github.com/guardian/frontend/pull/7706 to handle a problem
  with the Scala 2.11 compiler: https://github.com/scala/bug/issues/7529 The issue is no longer present in Scala 2.12, so the method could have been removed with the Scala 2.12 upgrade performed November 2017 with https://github.com/guardian/frontend/pull/18218

This pre-upgrade PR deletes the unnecessary `safeDropWhile()` method, and removes several unnecessary references to `implicits.Collections`.

