### PR TITLE
Fix issue on liveblogs where refreshing in the middle of the page causes ads to not load

### DIFF
--- a/static/src/javascripts/projects/common/modules/spacefinder.ts
+++ b/static/src/javascripts/projects/common/modules/spacefinder.ts
@@ -429,8 +429,9 @@ const getMeasurements = (
 			result[selector] = selectedElements.map(getDimensions);
 			return result;
 		}, {});
+
 		return {
-			bodyTop: bodyDims?.top ?? 0,
+			bodyTop: bodyDims?.top ? bodyDims.top + window.scrollY : 0,
 			bodyHeight: bodyDims?.height ?? 0,
 			candidates: candidatesWithDims,
 			contentMeta: contentMetaWithDims,

--- a/static/src/javascripts/projects/common/modules/spacefinder.ts
+++ b/static/src/javascripts/projects/common/modules/spacefinder.ts
@@ -414,10 +414,14 @@ const getMeasurements = (
 		: [];
 
 	return fastdom.measure((): Measurements => {
-		const bodyDims =
-			rules.body instanceof Element
-				? rules.body.getBoundingClientRect()
-				: undefined;
+		let bodyDistanceToTopOfPage = 0;
+		let bodyHeight = 0;
+		if (rules.body instanceof Element) {
+			const bodyElement = rules.body.getBoundingClientRect();
+			// bodyElement is relative to the viewport, so we need to add scroll position to get the distance
+			bodyDistanceToTopOfPage = bodyElement.top + window.scrollY;
+			bodyHeight = bodyElement.height;
+		}
 		const candidatesWithDims = candidates.map(getDimensions);
 		const contentMetaWithDims =
 			rules.clearContentMeta && contentMeta
@@ -431,8 +435,8 @@ const getMeasurements = (
 		}, {});
 
 		return {
-			bodyTop: bodyDims?.top ? bodyDims.top + window.scrollY : 0,
-			bodyHeight: bodyDims?.height ?? 0,
+			bodyTop: bodyDistanceToTopOfPage,
+			bodyHeight,
 			candidates: candidatesWithDims,
 			contentMeta: contentMetaWithDims,
 			opponents: opponentsWithDims,


### PR DESCRIPTION
## What does this change?

Spacefinder now uses the correct value for the top of the body element it uses when creating its measurements.

Spacefinder gets the top of the body element when it creates its measurements object with `getBoundingClientRect().top`. The problem is that this calculates `top` to be the height of the body element minus the current scroll position, so we end up with a large negative value for `bodyTop` when we have scrolled far down the page and refresh. This results in Spacefinder thinking the top of the containing body element is about the current scroll position and will not place ads above this point when refreshing the page.

Setting `bodyTop` to equal `bodyDims.top + window.scrollY` makes `bodyTop` reflect the distance from the top of the bodyDims object to the top of the page, which is what we want to use when considering where to place ads.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

Ads will now be served correctly to users who refresh in the middle of the page. 

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
