### PR TITLE
Add spacefinder debug to liveblogs

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/liveblog-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/liveblog-adverts.ts
@@ -6,22 +6,27 @@ import { spaceFiller } from '../../common/modules/article/space-filler';
 import { commercialFeatures } from '../../common/modules/commercial/commercial-features';
 import type {
 	SpacefinderItem,
+	SpacefinderOptions,
 	SpacefinderRules,
 	SpacefinderWriter,
 } from '../../common/modules/spacefinder';
-import { defaultSpacefinderOptions } from '../../common/modules/spacefinder';
 import { addSlot } from './dfp/add-slot';
 
-// We do not want ads to load too high up on the screen. We use this
-// multiplier of screen height to decide where we can load ads from.
-const MIN_GAP_FROM_PAGE_TOP_MULTIPLIER = 1.5;
-
-// We do not want ads to load too close together. We use this multiplier
-// of screen height to ensure the minimum gap in which ads can load.
-const MIN_SPACE_BETWEEN_ADS_MULTIPLIER = 2;
-
-// maximum number of ads to display
+/**
+ * Maximum number of inline ads to display on the page.
+ */
 const MAX_ADS = 8;
+
+/**
+ * Multiplier of screen height that determines the distance from
+ * the top of the page that we can start placing ads.
+ */
+const PAGE_TOP_MULTIPLIER = 1.5;
+
+/**
+ * Multiplier of screen height that sets the minimum distance that two ads can be placed.
+ */
+const AD_SPACE_MULTIPLIER = 2;
 
 let AD_COUNTER = 0;
 let WINDOWHEIGHT: number;
@@ -53,9 +58,7 @@ const getSpaceFillerRules = (
 	const isEnoughSpaceBetweenSlots = (
 		prevSlot: SpacefinderItem,
 		slot: SpacefinderItem,
-	) =>
-		Math.abs(slot.top - prevSlot.top) >
-		windowHeight * MIN_SPACE_BETWEEN_ADS_MULTIPLIER;
+	) => Math.abs(slot.top - prevSlot.top) > windowHeight * AD_SPACE_MULTIPLIER;
 
 	const filterSlot = (slot: SpacefinderItem) => {
 		if (!prevSlot) {
@@ -73,9 +76,7 @@ const getSpaceFillerRules = (
 		slotSelector: ' > .block',
 		fromBottom: shouldUpdate,
 		startAt: shouldUpdate ? firstSlot : undefined,
-		absoluteMinAbove: shouldUpdate
-			? 0
-			: WINDOWHEIGHT * MIN_GAP_FROM_PAGE_TOP_MULTIPLIER,
+		absoluteMinAbove: shouldUpdate ? 0 : WINDOWHEIGHT * PAGE_TOP_MULTIPLIER,
 		minAbove: 0,
 		minBelow: 0,
 		clearContentMeta: 0,
@@ -117,7 +118,7 @@ const insertAds: SpacefinderWriter = async (paras) => {
 };
 
 const fill = (rules: SpacefinderRules) => {
-	const options = { ...defaultSpacefinderOptions, debug: sfdebug === '1' };
+	const options: SpacefinderOptions = { debug: sfdebug === '1' };
 
 	return spaceFiller.fillSpace(rules, insertAds, options).then(() => {
 		if (AD_COUNTER < MAX_ADS) {

--- a/static/src/javascripts/projects/commercial/modules/liveblog-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/liveblog-adverts.ts
@@ -14,11 +14,11 @@ import { addSlot } from './dfp/add-slot';
 
 // We do not want ads to load too high up on the screen. We use this
 // multiplier of screen height to decide where we can load ads from.
-const GAP_BETWEEN_TOP_OF_PAGE_AND_HIGHEST_AD_MULTIPLIER = 1.5;
+const MIN_GAP_FROM_PAGE_TOP_MULTIPLIER = 1.5;
 
-// We do not want ads to load to close together. We use this multiplier
+// We do not want ads to load too close together. We use this multiplier
 // of screen height to ensure the minimum gap in which ads can load.
-const SPACE_BETWEEN_ADS_MULTIPLIER = 2;
+const MIN_SPACE_BETWEEN_ADS_MULTIPLIER = 2;
 
 // maximum number of ads to display
 const MAX_ADS = 8;
@@ -55,7 +55,7 @@ const getSpaceFillerRules = (
 		slot: SpacefinderItem,
 	) =>
 		Math.abs(slot.top - prevSlot.top) >
-		windowHeight * SPACE_BETWEEN_ADS_MULTIPLIER;
+		windowHeight * MIN_SPACE_BETWEEN_ADS_MULTIPLIER;
 
 	const filterSlot = (slot: SpacefinderItem) => {
 		if (!prevSlot) {
@@ -75,7 +75,7 @@ const getSpaceFillerRules = (
 		startAt: shouldUpdate ? firstSlot : undefined,
 		absoluteMinAbove: shouldUpdate
 			? 0
-			: WINDOWHEIGHT * GAP_BETWEEN_TOP_OF_PAGE_AND_HIGHEST_AD_MULTIPLIER,
+			: WINDOWHEIGHT * MIN_GAP_FROM_PAGE_TOP_MULTIPLIER,
 		minAbove: 0,
 		minBelow: 0,
 		clearContentMeta: 0,

--- a/static/src/javascripts/projects/common/modules/spacefinder.ts
+++ b/static/src/javascripts/projects/common/modules/spacefinder.ts
@@ -52,9 +52,9 @@ type SpacefinderRules = {
 type SpacefinderWriter = (paras: HTMLElement[]) => Promise<void>;
 
 type SpacefinderOptions = {
-	waitForLinks: boolean;
-	waitForImages: boolean;
-	waitForInteractives: boolean;
+	waitForLinks?: boolean;
+	waitForImages?: boolean;
+	waitForInteractives?: boolean;
 	debug?: boolean;
 };
 
@@ -80,7 +80,7 @@ const query = (selector: string, context?: HTMLElement | Document) => [
 // to be upgraded
 const LOADING_TIMEOUT = 5_000;
 
-const defaultOptions = {
+const defaultOptions: SpacefinderOptions = {
 	waitForImages: true,
 	waitForLinks: true,
 	waitForInteractives: false,
@@ -448,9 +448,10 @@ const getMeasurements = (
 // SpaceFiller will safely queue up all the various asynchronous DOM actions to avoid any race conditions.
 const findSpace = async (
 	rules: SpacefinderRules,
-	options: SpacefinderOptions = defaultOptions,
+	options?: SpacefinderOptions,
 	exclusions: SpacefinderExclusions = {},
 ): Promise<HTMLElement[]> => {
+	options = { ...defaultOptions, ...options };
 	rules.body =
 		(rules.bodySelector &&
 			document.querySelector<HTMLElement>(rules.bodySelector)) ||
@@ -481,7 +482,6 @@ export const _ = {
 
 export {
 	findSpace,
-	defaultOptions as defaultSpacefinderOptions,
 	SpaceError,
 	SpacefinderRules,
 	SpacefinderWriter,

--- a/static/src/javascripts/projects/common/modules/spacefinder.ts
+++ b/static/src/javascripts/projects/common/modules/spacefinder.ts
@@ -481,6 +481,7 @@ export const _ = {
 
 export {
 	findSpace,
+	defaultOptions as defaultSpacefinderOptions,
 	SpaceError,
 	SpacefinderRules,
 	SpacefinderWriter,

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -418,6 +418,7 @@
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../lib/detect.js",
   "../lib/fastdom-promise.js",
+  "../lib/url.ts",
   "../projects/commercial/modules/dfp/add-slot.ts",
   "../projects/common/modules/article/space-filler.ts",
   "../projects/common/modules/commercial/commercial-features.ts",


### PR DESCRIPTION
## What does this change?

- Adds the Spacefinder debug tool to liveblogs
- Extracted and changed the name of constants to aid clarity

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

![mobile](https://user-images.githubusercontent.com/9574885/178744044-02149a14-cb76-4e85-96c8-aa0fc494f732.png)
![desktop](https://user-images.githubusercontent.com/9574885/178744101-294fddb1-1253-4245-bd52-15cda6e3aa0c.jpg)

## What is the value of this and can you measure success?

This tool helps debugging issues with advert placement on liveblogs.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
