### PR TITLE
Sticky right ads: specify a `min-height`

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/sticky-inlines.ts
+++ b/static/src/javascripts/projects/commercial/modules/sticky-inlines.ts
@@ -42,7 +42,7 @@ const insertHeightStyles = (
 	heightMapping: Array<[string, number]>,
 ): Promise<void> => {
 	const heightClasses = heightMapping.reduce(
-		(css, [name, height]) => `${css} .${name} { height: ${height}px; }`,
+		(css, [name, height]) => `${css} .${name} { min-height: ${height}px; }`,
 		'',
 	);
 


### PR DESCRIPTION
## What does this change?

Apply `min-height` rather than `height` to sticky containers.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| <img width="1432" alt="Screenshot 2022-07-13 at 11 20 22" src="https://user-images.githubusercontent.com/8000415/178711488-6a1d6ed7-54a2-4b21-8c33-d191ba09b449.png"> |  <img width="1527" alt="Screenshot 2022-07-13 at 11 53 52" src="https://user-images.githubusercontent.com/8000415/178717630-6baee3ae-e779-40b5-9f4d-1d0402e57e4f.png"> |

## What is the value of this and can you measure success?

This fixes an issue that arises when a sticky container is measured to be smaller than the height of the ad itself. This can cause an advert to overlap with content that comes after the article body.

Applying a minimum height rather than just a height ensures that the sticky container is at least as tall as the advert itself.

Note this does not address the placement of sticky adverts themselves. So we're still rendering a double MPU at the bottom of the article, and possibly pushing content down. This can be addressed separately.

### Tested

- [x] Locally
- [x] On CODE (optional)
