### PR TITLE
fix: Correct cron expression for Stale PR action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@ name: "Stale PR Handler"
 
 on:
   schedule:
-    - cron: "0 6 MON-THU * *"
+    - cron: "0 6 * * MON-THU"
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## What does this change?

The last field of the Cron expresion is used for weekday, not the third.

<img width="1155" alt="image" src="https://user-images.githubusercontent.com/21217225/178718121-06c3d275-abd6-4f46-9178-e0cf41acf962.png">

