### PR TITLE
fix bug: month value in signup event timestamps out by one

### DIFF
--- a/common/app/templates/inlineJS/nonBlocking/emailIframeTracking.scala.js
+++ b/common/app/templates/inlineJS/nonBlocking/emailIframeTracking.scala.js
@@ -41,7 +41,7 @@ function to2Digits (v) {return toNDigits(v, 2)}
 function formatTimestampToUTC (inputDate) {
 	const utc = {
 		year: inputDate.getUTCFullYear(),
-		month: inputDate.getUTCMonth(),
+		month: inputDate.getUTCMonth() +1,
 		date: inputDate.getUTCDate(),
 		hours: inputDate.getUTCHours(),
 		minutes: inputDate.getUTCMinutes(),

--- a/static/src/javascripts/projects/common/modules/tracking/utc-date-format.ts
+++ b/static/src/javascripts/projects/common/modules/tracking/utc-date-format.ts
@@ -27,7 +27,7 @@ const to2Digits = (v: number): string => toNDigits(v, 2);
 export const formatTimestampToUTC = (inputDate: Date): string => {
 	const utc = {
 		year: inputDate.getUTCFullYear(),
-		month: inputDate.getUTCMonth(),
+		month: inputDate.getUTCMonth() + 1,
 		date: inputDate.getUTCDate(),
 		hours: inputDate.getUTCHours(),
 		minutes: inputDate.getUTCMinutes(),


### PR DESCRIPTION
## What does this change?
Fixes a bug in the date formatting function for used to generate component event values for ComponentEvents on newsletter sign-up - was using `Date.getUTCMonth` without adding 1 to account for the value being zero-indexed 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
The data team will get the correct month when parsing the timestamps.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
