### PR TITLE
Add containers to all inline ads

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -228,7 +228,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 					para,
 					`inline${inlineId}`,
 					'inline',
-					`inline`,
+					'inline',
 					isInline1
 						? {
 								phablet: [

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -178,9 +178,11 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 		const includeStickyContainers =
 			includeContainer &&
 			// Check if query parameter required for qualitative testing has been provided
-			(getUrlVars().multiSticky ||
+			!!(
+				getUrlVars().multiSticky ??
 				// Otherwise check for participation in AB test
-				isInVariantSynchronous(multiStickyRightAds, 'variant'));
+				isInVariantSynchronous(multiStickyRightAds, 'variant')
+			);
 
 		if (includeStickyContainers) {
 			const stickyContainerHeights = await computeStickyHeights(
@@ -205,19 +207,22 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 					para.style.cssText += 'border: thick solid green;';
 				}
 
-				const containerOptions = includeStickyContainers
-					? {
-							sticky: true,
-							className: getStickyContainerClassname(i),
-							enableDebug,
-					  }
-					: {
-							sticky: false,
-							className: isInline1
-								? ''
-								: ' offset-right ad-slot-container--offset-right',
-							enableDebug,
-					  };
+				let containerClasses = '';
+
+				if (includeStickyContainers) {
+					containerClasses += getStickyContainerClassname(i);
+				}
+
+				if (!isInline1) {
+					containerClasses +=
+						' offset-right ad-slot-container--offset-right';
+				}
+
+				const containerOptions = {
+					sticky: includeStickyContainers,
+					className: containerClasses,
+					enableDebug,
+				};
 
 				return insertAdAtPara(
 					para,

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -53,9 +53,8 @@ const wrapSlotInContainer = (
 	options: ContainerOptions = {},
 ) => {
 	const container = document.createElement('div');
-	container.className = `ad-slot-container ad-slot--offset-right ${
-		options.className ?? ''
-	}`;
+
+	container.className = `ad-slot-container ${options.className ?? ''}`;
 
 	if (options.sticky) {
 		ad.style.cssText += 'position: sticky; top: 0;';
@@ -75,18 +74,15 @@ const insertAdAtPara = (
 	type: SlotName,
 	classes?: string,
 	sizes?: SizeMapping,
-	includeContainer?: boolean,
 	containerOptions: ContainerOptions = {},
 ): Promise<void> => {
 	const ad = createAdSlot(type, {
 		name,
-		classes: includeContainer ? '' : classes,
+		classes: '',
 		sizes,
 	});
 
-	const node = includeContainer
-		? wrapSlotInContainer(ad, containerOptions)
-		: ad;
+	const node = wrapSlotInContainer(ad, containerOptions);
 
 	return fastdom
 		.mutate(() => {
@@ -221,7 +217,9 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 					para,
 					`inline${inlineId}`,
 					'inline',
-					`inline${isInline1 ? '' : ' offset-right'}`,
+					`inline${
+						isInline1 ? '' : ' offset-right ad-slot--offset-right'
+					}`,
 					isInline1
 						? {
 								phablet: [
@@ -234,7 +232,6 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 								],
 						  }
 						: { desktop: [adSizes.halfPage, adSizes.skyscraper] },
-					includeContainer,
 					containerOptions,
 				);
 			});

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -80,7 +80,7 @@ const insertAdAtPara = (
 ): Promise<void> => {
 	const ad = createAdSlot(type, {
 		name,
-		classes: '',
+		classes,
 		sizes,
 	});
 
@@ -225,9 +225,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 					para,
 					`inline${inlineId}`,
 					'inline',
-					`inline${
-						isInline1 ? '' : ' offset-right ad-slot--offset-right'
-					}`,
+					`inline`,
 					isInline1
 						? {
 								phablet: [

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -215,7 +215,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 
 				if (!isInline1) {
 					containerClasses +=
-						' offset-right ad-slot-container--offset-right';
+						' offset-right ad-slot--offset-right ad-slot-container--offset-right';
 				}
 
 				const containerOptions = {

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -178,11 +178,9 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 		const includeStickyContainers =
 			includeContainer &&
 			// Check if query parameter required for qualitative testing has been provided
-			!!(
-				getUrlVars().multiSticky ??
+			(!!getUrlVars().multiSticky ||
 				// Otherwise check for participation in AB test
-				isInVariantSynchronous(multiStickyRightAds, 'variant')
-			);
+				isInVariantSynchronous(multiStickyRightAds, 'variant'));
 
 		if (includeStickyContainers) {
 			const stickyContainerHeights = await computeStickyHeights(

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -54,9 +54,7 @@ const wrapSlotInContainer = (
 ) => {
 	const container = document.createElement('div');
 
-	container.className = `ad-slot-container--article ${
-		options.className ?? ''
-	}`;
+	container.className = `ad-slot-container ${options.className ?? ''}`;
 
 	if (options.sticky) {
 		ad.style.cssText += 'position: sticky; top: 0;';
@@ -217,7 +215,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 							sticky: false,
 							className: isInline1
 								? ''
-								: ' offset-right ad-slot--offset-right',
+								: ' offset-right ad-slot-container--offset-right',
 							enableDebug,
 					  };
 

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -46,7 +46,7 @@ const adSlotClassSelectorSizes = {
  * @param i Index of winning paragraph
  * @returns The classname for container
  */
-const getContainerClassname = (i: number) => `ad-slot-container-${i + 2}`;
+const getStickyContainerClassname = (i: number) => `ad-slot-container-${i + 2}`;
 
 const wrapSlotInContainer = (
 	ad: HTMLElement,
@@ -54,7 +54,9 @@ const wrapSlotInContainer = (
 ) => {
 	const container = document.createElement('div');
 
-	container.className = `ad-slot-container ${options.className ?? ''}`;
+	container.className = `ad-slot-container--article ${
+		options.className ?? ''
+	}`;
 
 	if (options.sticky) {
 		ad.style.cssText += 'position: sticky; top: 0;';
@@ -190,7 +192,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 
 			void insertHeightStyles(
 				stickyContainerHeights.map((height, index) => [
-					getContainerClassname(index),
+					getStickyContainerClassname(index),
 					height,
 				]),
 			);
@@ -208,10 +210,16 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 				const containerOptions = includeStickyContainers
 					? {
 							sticky: true,
-							className: getContainerClassname(i),
+							className: getStickyContainerClassname(i),
 							enableDebug,
 					  }
-					: undefined;
+					: {
+							sticky: false,
+							className: isInline1
+								? ''
+								: ' offset-right ad-slot--offset-right',
+							enableDebug,
+					  };
 
 				return insertAdAtPara(
 					para,

--- a/static/src/javascripts/projects/commercial/modules/liveblog-adverts.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/liveblog-adverts.spec.ts
@@ -89,10 +89,12 @@ describe('Liveblog Dynamic Adverts', () => {
 		);
 		return init().then(() => {
 			expect(
-				document.querySelector('.x1')?.nextElementSibling?.id,
+				document.querySelector('.x1')?.nextElementSibling
+					?.firstElementChild?.id,
 			).toEqual('dfp-ad--inline1');
 			expect(
-				document.querySelector('.x12')?.nextElementSibling?.id,
+				document.querySelector('.x12')?.nextElementSibling
+					?.firstElementChild?.id,
 			).toEqual('dfp-ad--inline2');
 			expect(
 				document.querySelector('.js-liveblog-body')?.children.length,

--- a/static/src/javascripts/projects/commercial/modules/liveblog-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/liveblog-adverts.ts
@@ -97,7 +97,7 @@ const getSlotName = (isMobile: boolean, slotCounter: number): string => {
 const insertAdAtPara = (para: Node): Promise<void> => {
 	const isMobile = getBreakpoint() === 'mobile';
 	const container: HTMLElement = document.createElement('div');
-	container.className = `ad-slot-container--liveblog`;
+	container.className = `ad-slot-container`;
 
 	const ad = createAdSlot('inline', {
 		name: getSlotName(isMobile, AD_COUNTER),

--- a/static/src/javascripts/projects/commercial/modules/liveblog-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/liveblog-adverts.ts
@@ -109,6 +109,7 @@ const insertAdAtPara = (para: Node): Promise<void> => {
 	return fastdom
 		.mutate(() => {
 			if (para.parentNode) {
+				/* ads are inserted after the block on liveblogs */
 				para.parentNode.insertBefore(container, para.nextSibling);
 			}
 		})

--- a/static/src/javascripts/projects/commercial/modules/liveblog-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/liveblog-adverts.ts
@@ -97,7 +97,7 @@ const getSlotName = (isMobile: boolean, slotCounter: number): string => {
 const insertAdAtPara = (para: Node): Promise<void> => {
 	const isMobile = getBreakpoint() === 'mobile';
 	const container: HTMLElement = document.createElement('div');
-	container.className = `ad-slot-container ad-slot--liveblog-inline`;
+	container.className = `ad-slot-container--liveblog`;
 
 	const ad = createAdSlot('inline', {
 		name: getSlotName(isMobile, AD_COUNTER),

--- a/static/src/javascripts/projects/commercial/modules/liveblog-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/liveblog-adverts.ts
@@ -109,7 +109,7 @@ const insertAdAtPara = (para: Node): Promise<void> => {
 	return fastdom
 		.mutate(() => {
 			if (para.parentNode) {
-				para.parentNode.insertBefore(container, para);
+				para.parentNode.insertBefore(container, para.nextSibling);
 			}
 		})
 		.then(() => {

--- a/static/src/javascripts/projects/commercial/modules/liveblog-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/liveblog-adverts.ts
@@ -94,23 +94,36 @@ const getSlotName = (isMobile: boolean, slotCounter: number): string => {
 	return `inline${slotCounter + 1}`;
 };
 
-const insertAds: SpacefinderWriter = async (paras) => {
+const insertAdAtPara = (para: Node): Promise<void> => {
 	const isMobile = getBreakpoint() === 'mobile';
+	const container: HTMLElement = document.createElement('div');
+	container.className = `ad-slot-container ad-slot--liveblog-inline`;
+
+	const ad = createAdSlot('inline', {
+		name: getSlotName(isMobile, AD_COUNTER),
+		classes: 'liveblog-inline',
+	});
+
+	container.appendChild(ad);
+
+	return fastdom
+		.mutate(() => {
+			if (para.parentNode) {
+				para.parentNode.insertBefore(container, para);
+			}
+		})
+		.then(() => {
+			addSlot(ad, false);
+		});
+};
+
+const insertAds: SpacefinderWriter = async (paras) => {
 	const fastdomPromises = [];
 	for (let i = 0; i < paras.length && AD_COUNTER < MAX_ADS; i += 1) {
 		const para = paras[i];
 		if (para.parentNode) {
-			const adSlot = createAdSlot('inline', {
-				name: getSlotName(isMobile, AD_COUNTER),
-				classes: 'liveblog-inline',
-			});
-			// insert the ad slot container into the DOM
-			const result = fastdom.mutate(() => {
-				para.parentNode?.insertBefore(adSlot, para.nextSibling);
-			});
+			const result = insertAdAtPara(para);
 			fastdomPromises.push(result);
-			// load and display the advert via GAM
-			addSlot(adSlot, false);
 			AD_COUNTER += 1;
 		}
 	}

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -694,6 +694,10 @@
  "../projects/common/modules/experiments/tests/remote-header-test.js": [],
  "../projects/common/modules/experiments/tests/sign-in-gate-main-control.js": [],
  "../projects/common/modules/experiments/tests/sign-in-gate-main-variant.js": [],
+ "../projects/common/modules/experiments/utils.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
+ ],
  "../projects/common/modules/identity/api.ts": [
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/config.d.ts",

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -694,10 +694,6 @@
  "../projects/common/modules/experiments/tests/remote-header-test.js": [],
  "../projects/common/modules/experiments/tests/sign-in-gate-main-control.js": [],
  "../projects/common/modules/experiments/tests/sign-in-gate-main-variant.js": [],
- "../projects/common/modules/experiments/utils.ts": [
-  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
- ],
  "../projects/common/modules/identity/api.ts": [
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/config.d.ts",


### PR DESCRIPTION
## What does this change?
We have been having issues with 'expanding' adverts escaping their slots (see below before image(s). We have added containers to all inline slots to align and constrain their widths.

This has allowed us to also clean up a lot of container and slot CSS in DCR.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes https://github.com/guardian/dotcom-rendering/pull/5382

## Screenshots


| Before      | After      |
|-------------|------------|
| <img width="910" alt="image" src="https://user-images.githubusercontent.com/1731150/178730529-d2f1d0e8-efb9-4cda-9eaf-22db89d71264.png"> | |
![Screenshot 2022-07-13 at 13 14 03](https://user-images.githubusercontent.com/1731150/178730902-bd437109-6e15-45ed-8def-c7ac1c8f8739.png) | ![Screenshot 2022-07-13 at 13 15 05](https://user-images.githubusercontent.com/1731150/178731136-a3cb3b4b-6a7a-464e-8886-be9923873502.png) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png



## What is the value of this and can you measure success?


### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
