### PR TITLE
Improve Digital should receive Prebid sizes

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
@@ -69,6 +69,9 @@ type PbjsConfig = {
 	criteo?: {
 		fastBidVersion: 'latest' | 'none' | `${number}`;
 	};
+	improvedigital?: {
+		usePrebidSizes?: boolean;
+	};
 };
 
 type PbjsEvent = 'bidWon';
@@ -334,8 +337,6 @@ const initialise = (window: Window, framework: Framework = 'tcfv2'): void => {
 		});
 	}
 
-	window.pbjs.setConfig(pbjsConfig);
-
 	if (config.get<boolean>('switches.prebidAnalytics', false)) {
 		window.pbjs.enableAnalytics([
 			{
@@ -383,7 +384,13 @@ const initialise = (window: Window, framework: Framework = 'tcfv2'): void => {
 			],
 			suppressEmptyKeys: true,
 		};
+
+		pbjsConfig.improvedigital = {
+			usePrebidSizes: true,
+		};
 	}
+
+	window.pbjs.setConfig(pbjsConfig);
 
 	// Adjust slot size when prebid ad loads
 	window.pbjs.onEvent('bidWon', (data) => {


### PR DESCRIPTION
## What does this change?

This PR adds a flag to our Prebid configuration for Improve Digital (one of our SSPs) that ensures they receive the size of the slot for a given bid.

<details open>
<summary>Example diff of a request to Improve Digital</summary>

```diff
 {
   "cur": ["USD"],
   "ext": {
     "improvedigital": { "sdk": { "name": "pbjs", "version": "6.26.0" } }
   },
  "device": { "w": 1100, "h": 1096 },
   "regs": { "ext": { "gdpr": 1 } },
   "user": {
     "ext": {
       "consent": "...,
       "consented_providers_settings": {
         "consented_providers": [
           2090, 1577, 46, 70, 1301, 1843, 108, 1878, 440, 1097, 3119, 196, 202,
           89, 89, 2918, 149, 338, 1205, 1415, 415, 2035, 486, 494, 505, 482,
           2677, 981, 1456
         ]
       }
     }
   },
   "tmax": 1500,
   "site": {
     "page": "http://localhost:9000/food/2020/oct/20/were-like-athletes-the-secret-lives-of-giant-vegetable-growers?pbtest=improvedigital",
     "domain": "localhost"
   },
  "source": { "ext": {}, "tid": "8558aa2d-0114-46ca-ab84-9d7ab1479012" },
   "imp": [
     {
      "id": "28a085e5c8ddd6",
       "secure": 0,
       "ext": { "bidder": { "placementId": 1116396 } },
-      "banner": {}
+      "banner": {
+        "format": [
+          { "w": 300, "h": 250 },
+          { "w": 620, "h": 350 }
+        ]
+      }
     }
   ],
  "id": "43f101faf8585b"
 }
```
</details>

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Why?

This ensures we don't get back creatives that won't fit in certain slots. This fixes a bug where double MPU (300x600) adverts were being placed in `inline1` slots, which causes them to overlap onto the rest of the page.

### Tested

- [X] Locally
- [ ] On CODE (optional)
