### PR TITLE
fix(a11): weather widget logical tab order

### DIFF
--- a/onward/app/views/weatherFragments/cityWeather.scala.html
+++ b/onward/app/views/weatherFragments/cityWeather.scala.html
@@ -4,6 +4,22 @@
 
 @defining(weatherResponse.temperatureForEdition(Edition(request))) { temp =>
     <aside class="weather js-weather" aria-label="Today's weather forecast for <%=city%>">
+        <div class="weather__location">
+            <div class="search-tool js-search-tool">
+                <div class="search-tool__form u-cf">
+                    <label class="u-h" for="editlocation">Edit your location</label>
+                    <input id="editlocation" class="search-tool__input js-search-tool-input" type="text" data-link-name="weather-edit-location" value="<%=city%>" aria-label="enter location" />
+                    @fragments.inlineSvg("search-36", "icon", List("weather__search-icon", "weather__edit-location"), None, true)
+                    <button class="search-tool__btn">@fragments.inlineSvg("search-36", "icon") <span class="u-h">
+                        Search for city</span></button>
+                </div>
+                <ul class="u-unstyled search-tool__list js-search-tool-list"></ul>
+            </div>
+            <button class="weather__close-location js-close-location meta-button u-h" data-link-name="weather-close-location"
+            href="#close-change-location" aria-label="stop editing location"><span class="u-h">
+                Close change location</span> @fragments.inlineSvg("close", "icon", List("weather__close-icon"))
+            </button>
+        </div>
         <div class="u-unstyled forecast__item forecast__item--current js-weather-current" aria-label="@(s"The weather now: ${math.round(temp.Value)}°${temp.Unit}, ${weatherResponse.WeatherText.toLowerCase()}")">
             <div class="weather__time" aria-hidden="true">
                 <span class="weather__time-value">Now</span>
@@ -23,22 +39,6 @@
             </div>
             <a href=@weatherResponse.Link&partner=web_guardian_adc
             target=”_blank” data-link-name="weather-view-full-forecast">View full forecast</a>
-        </div>
-        <div class="weather__location">
-            <div class="search-tool js-search-tool">
-                <div class="search-tool__form u-cf">
-                    <label class="u-h" for="editlocation">Edit your location</label>
-                    <input id="editlocation" class="search-tool__input js-search-tool-input" type="text" data-link-name="weather-edit-location" value="<%=city%>" aria-label="enter location" />
-                    @fragments.inlineSvg("search-36", "icon", List("weather__search-icon", "weather__edit-location"), None, true)
-                    <button class="search-tool__btn">@fragments.inlineSvg("search-36", "icon") <span class="u-h">
-                        Search for city</span></button>
-                </div>
-                <ul class="u-unstyled search-tool__list js-search-tool-list"></ul>
-            </div>
-            <button class="weather__close-location js-close-location meta-button u-h" data-link-name="weather-close-location"
-            href="#close-change-location" aria-label="stop editing location"><span class="u-h">
-                Close change location</span> @fragments.inlineSvg("close", "icon", List("weather__close-icon"))
-            </button>
         </div>
     </aside>
 }

--- a/static/src/stylesheets/module/_weather.scss
+++ b/static/src/stylesheets/module/_weather.scss
@@ -141,7 +141,6 @@ $weather-large-size: 50px;
 
 .weather__location {
     box-sizing: border-box;
-    order: -1;
     position: relative;
     width: 100%;
     border-top: 1px solid $brightness-86;


### PR DESCRIPTION
## What does this change?

Stop using flex ordering and rely on the natural order of the the DOM for the location search.
On mobile breakpoints, the search is now at the top, which is more consistent.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

It looks the same, but it performs differently on desktop!

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |
| ![before-mobile][] | ![after-mobile][] |

[before]: https://user-images.githubusercontent.com/76776/179724369-ccc8ddd9-a6b2-44b1-9d55-55fd621b2080.png
[after]: https://user-images.githubusercontent.com/76776/179724369-ccc8ddd9-a6b2-44b1-9d55-55fd621b2080.png

[before-mobile]: https://user-images.githubusercontent.com/76776/179725300-5f0adbef-47a9-43bc-93c8-a22b9abd498f.png
[after-mobile]: https://user-images.githubusercontent.com/76776/179724768-ed844e1b-4cf5-4585-a294-da96dac7b26c.png

## What is the value of this and can you measure success?

Resolves https://github.com/guardian/dotcom-rendering/issues/4494

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [X] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
