### PR TITLE
Improve Cypress merchandising tests consistency

### DIFF
--- a/cypress/e2e/inline-slots.cy.ts
+++ b/cypress/e2e/inline-slots.cy.ts
@@ -7,7 +7,7 @@ const pages = [...articles, ...liveblogs].filter(
 
 describe('Slots and iframes load on pages', () => {
 	pages.forEach(({ path, adTest, expectedMinInlineSlotsOnPage }) => {
-		Object.entries(breakpoints).forEach(([breakpoint, width]) => {
+		breakpoints.forEach(({ breakpoint, width }) => {
 			it(`Test ${path} has at least ${expectedMinInlineSlotsOnPage} inline total slots at breakpoint ${breakpoint}`, () => {
 				cy.viewport(width, 500);
 

--- a/cypress/e2e/merchandising-high.cy.ts
+++ b/cypress/e2e/merchandising-high.cy.ts
@@ -3,7 +3,7 @@ import { articles, liveblogs } from '../fixtures/pages';
 
 describe('merchandising-high slot on pages', () => {
 	[...articles, ...liveblogs].forEach(({ path, adTest }) => {
-		Object.entries(breakpoints).forEach(([breakpoint, width]) => {
+		breakpoints.forEach(({ breakpoint, width }) => {
 			it(`Test ${path} has correct slot and iframe at breakpoint ${breakpoint}`, () => {
 				cy.viewport(width, 800);
 

--- a/cypress/e2e/merchandising-high.cy.ts
+++ b/cypress/e2e/merchandising-high.cy.ts
@@ -14,9 +14,12 @@ describe('merchandising-high slot on pages', () => {
 				// Check that the merchandising-high ad slot is on the page
 				cy.get('#dfp-ad--merchandising-high').should('exist');
 
+				// Ensure all lazy loaded items are loaded
+				cy.scrollTo('bottom', { duration: 3000 });
+
 				// creative isn't loaded unless slot is in view
 				cy.get('#dfp-ad--merchandising-high').scrollIntoView({
-					duration: 4000,
+					duration: 3000,
 				});
 
 				// Check that an iframe is placed inside the merchandising-high ad slot

--- a/cypress/e2e/merchandising.cy.ts
+++ b/cypress/e2e/merchandising.cy.ts
@@ -3,7 +3,7 @@ import { articles, liveblogs } from '../fixtures/pages';
 
 describe('merchandising slot on pages', () => {
 	[...articles, ...liveblogs].forEach(({ path, adTest }) => {
-		Object.entries(breakpoints).forEach(([breakpoint, width]) => {
+		breakpoints.forEach(({ breakpoint, width }) => {
 			it(`Test ${path} has correct slot and iframe at breakpoint ${breakpoint}`, () => {
 				cy.viewport(width, 800);
 
@@ -16,7 +16,7 @@ describe('merchandising slot on pages', () => {
 
 				// creative isn't loaded unless slot is in view
 				cy.get('#dfp-ad--merchandising').scrollIntoView({
-					duration: 4000,
+					duration: 3000,
 				});
 
 				// Check that an iframe is placed inside the merchandising ad slot

--- a/cypress/e2e/merchandising.cy.ts
+++ b/cypress/e2e/merchandising.cy.ts
@@ -14,6 +14,9 @@ describe('merchandising slot on pages', () => {
 				// Check that the merchandising ad slot is on the page
 				cy.get('#dfp-ad--merchandising').should('exist');
 
+				// Ensure all lazy loaded items are loaded
+				cy.scrollTo('bottom', { duration: 3000 });
+
 				// creative isn't loaded unless slot is in view
 				cy.get('#dfp-ad--merchandising').scrollIntoView({
 					duration: 3000,

--- a/cypress/e2e/mostpop.cy.ts
+++ b/cypress/e2e/mostpop.cy.ts
@@ -3,7 +3,7 @@ import { articles, liveblogs } from '../fixtures/pages';
 
 describe('mostpop slot on pages', () => {
 	[...articles, ...liveblogs].forEach(({ path, adTest }) => {
-		Object.entries(breakpoints).forEach(([breakpoint, width]) => {
+		breakpoints.forEach(({ breakpoint }) => {
 			it(`Test ${path} has correct slot and iframe at breakpoint ${breakpoint}`, () => {
 				cy.visit(`${path}?adtest=${adTest}`);
 

--- a/cypress/fixtures/breakpoints.ts
+++ b/cypress/fixtures/breakpoints.ts
@@ -1,6 +1,21 @@
-import { breakpoints } from '@guardian/source-foundations'
+import { breakpoints } from '@guardian/source-foundations';
 
-const breakpointsToTest: Array<keyof typeof breakpoints> = ['mobile', 'tablet', 'desktop', 'wide']
-const breakpointWidths = breakpointsToTest.map(b => breakpoints[b])
+type BreakpointKeys = keyof typeof breakpoints;
+type BreakpointSizes = {
+	breakpoint: BreakpointKeys;
+	width: typeof breakpoints[BreakpointKeys];
+};
 
-export { breakpointWidths as breakpoints }
+const breakpointsToTest: Array<keyof typeof breakpoints> = [
+	'mobile',
+	'tablet',
+	'desktop',
+	'wide',
+];
+
+const breakpointSizes: BreakpointSizes[] = breakpointsToTest.map((b) => ({
+	breakpoint: b,
+	width: breakpoints[b],
+}));
+
+export { breakpointSizes as breakpoints };


### PR DESCRIPTION
## What does this change?

1. Reduces the chance of cypress test transient failures on detecting merchandising ad slots by scrolling to the bottom of the page before scrolling to the ad slot.

A theory is that since Cypress is scrolling to the ad slot before the ads are loaded, the viewport sometimes doesn't reach the point where merchandising ad slots load ads due to CLS. If we scroll to the bottom of the page first, we trigger the lazy loading of all ad slots, so that when we scroll to the merch slot, the merch slot will be in the viewport

2. Changed breakpoints object to contain name of the breakpoint to make it easier to see which breakpoint is being tested in the logs

From: `Test {url} has at least 4 inline total slots at breakpoint 2`
To: `Test {url} has at least 4 inline total slots at breakpoint desktop`