### PR TITLE
Add slash to liveblog schema id

### DIFF
--- a/common/app/model/dotcomrendering/LinkedData.scala
+++ b/common/app/model/dotcomrendering/LinkedData.scala
@@ -48,7 +48,7 @@ object LinkedData {
 
     List(
       LiveBlogPosting(
-        `@id` = baseURL + article.metadata.id,
+        `@id` = baseURL + "/" + article.metadata.id,
         image = getImagesForArticle(article, fallbackLogo),
         author = authors,
         datePublished = article.trail.webPublicationDate.toString(),


### PR DESCRIPTION
Co-authored-by: James Gorrie <jamesgorrie@users.noreply.github.com>

## What does this change?

Adds a forward slash to the `@id` property in LiveBloog schemas, to make a valid URL. Part of #25237 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

