### PR TITLE
Update link to modern slavery act report 2022

### DIFF
--- a/common/app/navigation/FooterLinks.scala
+++ b/common/app/navigation/FooterLinks.scala
@@ -106,7 +106,7 @@ object FooterLinks {
     allWriters("uk"),
     FooterLink(
       "Modern Slavery Act",
-      "https://uploads.guim.co.uk/2021/07/27/STL_&_GMG_Modern_Slavery_Act_Statement_2021.pdf",
+      "https://uploads.guim.co.uk/2022/07/20/STL_Modern_Slavery_Statement_2022.pdf",
       "uk : footer : modern slavery act statement",
     ),
     digitalNewspaperArchive,


### PR DESCRIPTION
## What does this change?

Updates the link to the latest 2022 report

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No - footer links are passed to DCR in data model
- [ ] Yes (please indicate your plans for DCR Implementation)
