### PR TITLE
Increase spacefinder minAbove for articles without main image, or with a showcase image

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -31,6 +31,11 @@ const sfdebug = getUrlVars().sfdebug;
 
 const isPaidContent = config.get<boolean>('page.isPaidContent', false);
 
+const hasImages = !!window.guardian.config.page.lightboxImages?.images.length;
+
+const hasShowcaseMainElement =
+	window.guardian.config.page.hasShowcaseMainElement;
+
 const adSlotClassSelectorSizes = {
 	minAbove: 500,
 	minBelow: 500,
@@ -147,11 +152,22 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 		filter: filterNearbyCandidates(adSizes.mpu.height),
 	};
 
+	let minAbove = 1000;
+
+	if (isPaidContent) {
+		minAbove += 600;
+	}
+
+	/* On old articles without a main image or articles with a showcase main image, inline2 can sometimes overlap the most viewed articles */
+	if (!hasImages || hasShowcaseMainElement) {
+		minAbove += 100;
+	}
+
 	// For any other inline
 	const relaxedRules: SpacefinderRules = {
 		bodySelector: articleBodySelector,
 		slotSelector: ' > p',
-		minAbove: isPaidContent ? 1600 : 1000,
+		minAbove,
 		minBelow: 300,
 		selectors: {
 			' .ad-slot': adSlotClassSelectorSizes,

--- a/static/src/javascripts/projects/common/modules/spacefinder-debug-tools.js
+++ b/static/src/javascripts/projects/common/modules/spacefinder-debug-tools.js
@@ -1,4 +1,4 @@
-export const markCandidates = (exclusions, winners, options) => {
+const markCandidates = (exclusions, winners, options) => {
 	if (!options?.debug) return winners;
 
 	const colours = {
@@ -105,3 +105,23 @@ export const markCandidates = (exclusions, winners, options) => {
 
 	return winners;
 };
+
+const debugMinAbove = (body, minAbove) => {
+	body.style.position = 'relative';
+
+	const minAboveIndicator = document.createElement('div');
+
+	minAboveIndicator.style.cssText = `
+		position: absolute;
+		top: ${minAbove}px;
+		width: 100%;
+		background-color: red;
+		height: 5px;
+	`;
+
+	minAboveIndicator.innerHTML = `<div style="position: absolute; right: 0px; background-color: rgba(255, 255, 255, 0.97); padding: 10px; border-radius: 0px 0px 0px 10px; font-family: sans-serif; font-size: 0.7rem;">Threshold for slot to be too close to top (minAbove: ${minAbove}px)</div>`;
+
+	body.appendChild(minAboveIndicator);
+};
+
+export { markCandidates, debugMinAbove };

--- a/static/src/javascripts/projects/common/modules/spacefinder.ts
+++ b/static/src/javascripts/projects/common/modules/spacefinder.ts
@@ -4,7 +4,7 @@ import { log } from '@guardian/libs';
 import { memoize } from 'lodash-es';
 import { amIUsed } from 'commercial/sentinel';
 import fastdom from '../../../lib/fastdom-promise';
-import { markCandidates } from './mark-candidates';
+import { debugMinAbove, markCandidates } from './spacefinder-debug-tools';
 
 type RuleSpacing = {
 	minAbove: number;
@@ -85,24 +85,6 @@ const defaultOptions: SpacefinderOptions = {
 	waitForLinks: true,
 	waitForInteractives: false,
 	debug: false,
-};
-
-const debugMinAbove = (body: HTMLElement, minAbove: number): void => {
-	body.style.position = 'relative';
-
-	const minAboveIndicator = document.createElement('div');
-
-	minAboveIndicator.style.cssText = `
-		position: absolute;
-		top: ${minAbove}px;
-		width: 100%;
-		background-color: red;
-		height: 5px;
-	`;
-
-	minAboveIndicator.innerHTML = `<div style="position: absolute; right: 0px; background-color: rgba(255, 255, 255, 0.97); padding: 10px; border-radius: 0px 0px 0px 10px; font-family: sans-serif; font-size: 0.7rem;">Threshold for slot to be too close to top (minAbove: ${minAbove}px)</div>`;
-
-	body.appendChild(minAboveIndicator);
 };
 
 const isIframe = (node: Node): node is HTMLIFrameElement =>

--- a/static/src/javascripts/projects/common/modules/spacefinder.ts
+++ b/static/src/javascripts/projects/common/modules/spacefinder.ts
@@ -87,6 +87,24 @@ const defaultOptions: SpacefinderOptions = {
 	debug: false,
 };
 
+const debugMinAbove = (body: HTMLElement, minAbove: number): void => {
+	body.style.position = 'relative';
+
+	const minAboveIndicator = document.createElement('div');
+
+	minAboveIndicator.style.cssText = `
+		position: absolute;
+		top: ${minAbove}px;
+		width: 100%;
+		background-color: red;
+		height: 5px;
+	`;
+
+	minAboveIndicator.innerHTML = `<div style="position: absolute; right: 0px; background-color: rgba(255, 255, 255, 0.97); padding: 10px; border-radius: 0px 0px 0px 10px; font-family: sans-serif; font-size: 0.8rem;">minAbove: ${minAbove}px</div>`;
+
+	body.appendChild(minAboveIndicator);
+};
+
 const isIframe = (node: Node): node is HTMLIFrameElement =>
 	node instanceof HTMLIFrameElement;
 
@@ -456,6 +474,10 @@ const findSpace = async (
 		(rules.bodySelector &&
 			document.querySelector<HTMLElement>(rules.bodySelector)) ||
 		document;
+
+	if (options.debug && rules.minAbove && rules.body instanceof HTMLElement) {
+		debugMinAbove(rules.body, rules.minAbove);
+	}
 
 	await getReady(rules, options);
 

--- a/static/src/javascripts/projects/common/modules/spacefinder.ts
+++ b/static/src/javascripts/projects/common/modules/spacefinder.ts
@@ -100,7 +100,7 @@ const debugMinAbove = (body: HTMLElement, minAbove: number): void => {
 		height: 5px;
 	`;
 
-	minAboveIndicator.innerHTML = `<div style="position: absolute; right: 0px; background-color: rgba(255, 255, 255, 0.97); padding: 10px; border-radius: 0px 0px 0px 10px; font-family: sans-serif; font-size: 0.8rem;">minAbove: ${minAbove}px</div>`;
+	minAboveIndicator.innerHTML = `<div style="position: absolute; right: 0px; background-color: rgba(255, 255, 255, 0.97); padding: 10px; border-radius: 0px 0px 0px 10px; font-family: sans-serif; font-size: 0.7rem;">Threshold for slot to be too close to top (minAbove: ${minAbove}px)</div>`;
 
 	body.appendChild(minAboveIndicator);
 };

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -79,6 +79,10 @@ interface Config {
 
 type Edition = string; // https://github.com/guardian/frontend/blob/b952f6b9/common/app/views/support/JavaScriptPage.scala#L79
 
+interface LightboxImages {
+	images: Array<{ src: string }>;
+}
+
 interface PageConfig extends CommercialPageConfig {
 	ajaxUrl: string; // https://github.com/guardian/frontend/blob/33db7bbd/common/app/views/support/JavaScriptPage.scala#L72
 	assetsPath: string;
@@ -89,6 +93,7 @@ interface PageConfig extends CommercialPageConfig {
 	frontendAssetsFullURL?: string; // only in DCR
 	hasInlineMerchandise: boolean;
 	hasPageSkin: boolean; // https://github.com/guardian/frontend/blob/b952f6b9/common/app/views/support/JavaScriptPage.scala#L48
+	hasShowcaseMainElement: boolean;
 	host: string;
 	isDev: boolean; // https://github.com/guardian/frontend/blob/33db7bbd/common/app/views/support/JavaScriptPage.scala#L73
 	isFront: boolean; // https://github.com/guardian/frontend/blob/201cc764/common/app/model/meta.scala#L352
@@ -99,6 +104,7 @@ interface PageConfig extends CommercialPageConfig {
 	isSensitive: boolean;
 	keywordIds: string;
 	keywords: string;
+	lightboxImages?: LightboxImages;
 	nonRefreshableLineItemIds?: number[];
 	pageId: string;
 	publication: string;


### PR DESCRIPTION
## What does this change?
These 2 types of articles have an issue where inline2 is overlapping most viewed, increasing minAbove for them will prevent it happening.

Also added a line to show minAbove in spacefinder debug.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots


| Before      | After      |
|-------------|------------|
| ![Screenshot 2022-07-21 at 10 28 21](https://user-images.githubusercontent.com/1731150/180180498-0323a596-fe20-4938-a316-dc3eacfe33f0.png) | ![Screenshot 2022-07-21 at 10 31 25](https://user-images.githubusercontent.com/1731150/180181022-145c0abf-82ae-429b-8ad3-5045c6aa8477.png)
 |

## What is the value of this and can you measure success?

## Checklist

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
