### PR TITLE
fix: filter out cancelled newsletters

### DIFF
--- a/common/app/services/newsletters/NewsletterSignupAgent.scala
+++ b/common/app/services/newsletters/NewsletterSignupAgent.scala
@@ -47,7 +47,6 @@ class NewsletterSignupAgent(newsletterApi: NewsletterApi) extends GuLogging {
 
     newsletterApi.getNewsletters() map {
       case Right(allNewsletters) =>
-
         val supportedNewsletters = allNewsletters.filterNot(_.cancelled)
 
         newslettersAgent.alter(Right(supportedNewsletters))

--- a/common/app/services/newsletters/NewsletterSignupLifecycle.scala
+++ b/common/app/services/newsletters/NewsletterSignupLifecycle.scala
@@ -30,8 +30,6 @@ class NewsletterSignupLifecycle(
     newsletterSignupAgent.refresh()
     jobs.scheduleEveryNMinutes("NewsletterSignupAgentLowFrequencyRefreshJob", 60) {
       newsletterSignupAgent.refresh()
-      Future.successful(())
     }
   }
-
 }

--- a/common/app/services/newsletters/model/NewsletterResponse.scala
+++ b/common/app/services/newsletters/model/NewsletterResponse.scala
@@ -19,6 +19,7 @@ case class NewsletterResponse(
     signupPage: Option[String],
     restricted: Boolean,
     paused: Boolean,
+    cancelled: Boolean,
     emailConfirmation: Boolean,
     group: String,
 )


### PR DESCRIPTION
## What does this change?

The newsletters API is going to start returning cancelled newsletters in the response due to a requirement to have access to this data. Some issues were found with this update where the [all newsletters page](https://m.code.dev-theguardian.com/email-newsletters) was displaying the cancelled newsletters so we need to prevent these from displaying before releasing to prod.

There is a similar PR in `identity` for this work: https://github.com/guardian/identity/pull/2132/files.

The reason we have to filter out cancelled newsletters on the "client" side of the "api" is that newsletters isn't a proper API and just serves a JSON from an s3 bucket through fastly. If/when newsletters API becomes a full API, we can add filtering params for this in the call itself but for now this is just to ensure that the change to include cancelled newsletters as default in newsletters does not affect other parts of the system.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |
| ![before2][] | cancelled section no longer appears |

[before]: https://user-images.githubusercontent.com/43961396/180186111-8831b604-bcca-41a8-8732-fa1f54e035a7.png
[after]: https://user-images.githubusercontent.com/43961396/180186118-e7e5e033-c9b6-47ae-9a2e-f123c73f04cb.png
[before2]: https://user-images.githubusercontent.com/43961396/180186590-28ca1ff0-3d6d-43a5-9680-ea6278b127a2.png


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
