### PR TITLE
Remove fronts cypress tests

### DIFF
--- a/cypress/e2e/consent.cy.ts
+++ b/cypress/e2e/consent.cy.ts
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-import { fronts } from '../fixtures/pages';
+import { articles } from '../fixtures/pages';
 import { fakeLogOut, fakeLogin } from '../lib/util';
 import { AdFreeCookieReasons } from 'lib/manage-ad-free-cookie';
 
@@ -68,243 +68,241 @@ describe('tcfv2 consent', () => {
 		cy.clearLocalStorage();
 	});
 
-	[fronts[0]].forEach(({ path, adTest }) => {
-		it(`Test ${path} hides slots when consent is denied`, () => {
-			cy.visit(`${path}?adtest=${adTest}`);
+	const { path, adTest } = articles[0];
+	it(`Test ${path} hides slots when consent is denied`, () => {
+		cy.visit(`${path}?adtest=${adTest}`);
 
-			cy.rejectAllConsent();
+		cy.rejectAllConsent();
 
-			cy.get(`[data-name="top-above-nav"]`).should('not.exist');
+		cy.get(`[data-name="top-above-nav"]`).should('not.exist');
 
-			cy.getCookie('GU_AF1').should('not.be.empty');
+		cy.getCookie('GU_AF1').should('not.be.empty');
 
-			expectAdFree([AdFreeCookieReasons.ConsentOptOut]);
+		expectAdFree([AdFreeCookieReasons.ConsentOptOut]);
 
-			cy.reload();
+		cy.reload();
 
-			expectAdFree([AdFreeCookieReasons.ConsentOptOut]);
+		expectAdFree([AdFreeCookieReasons.ConsentOptOut]);
 
-			cy.get(`[data-name="top-above-nav"]`).should('not.exist');
+		cy.get(`[data-name="top-above-nav"]`).should('not.exist');
 
-			// Check the banner still shows support message
-			cy.get('.new-header__cta-bar div')
-				.shadow()
-				.find('h2')
-				.should('contain', 'Support the Guardian');
-		});
+		// Check the banner still shows support message
+		cy.get('[name="ReaderRevenueLinks"]')
+			.find('h2')
+			.should('contain', 'Support the Guardian');
+	});
 
-		it(`Test ${path} shows ad slots when reconsented`, () => {
-			cy.visit(`${path}?adtest=${adTest}`);
+	it(`Test ${path} shows ad slots when reconsented`, () => {
+		cy.visit(`${path}?adtest=${adTest}`);
 
-			cy.rejectAllConsent();
+		cy.rejectAllConsent();
 
-			// prevent support banner so we can click privacy settings button
-			localStorage.setItem(
-				'gu.prefs.engagementBannerLastClosedAt',
-				`{"value":"${new Date().toISOString()}"}`,
+		// prevent support banner so we can click privacy settings button
+		localStorage.setItem(
+			'gu.prefs.engagementBannerLastClosedAt',
+			`{"value":"${new Date().toISOString()}"}`,
+		);
+
+		cy.reload();
+
+		reconsent();
+
+		cy.reload();
+
+		expectAdFree([]);
+
+		adsShouldShow();
+	});
+
+	it(`Test ${path} reject all, login as subscriber, log out should not show ads`, () => {
+		fakeLogin(true);
+
+		cy.visit(`${path}?adtest=${adTest}`);
+
+		cy.rejectAllConsent();
+
+		expectAdFree([
+			AdFreeCookieReasons.ConsentOptOut,
+			AdFreeCookieReasons.Subscriber,
+		]);
+
+		fakeLogOut();
+
+		cy.reload();
+
+		expectAdFree([AdFreeCookieReasons.ConsentOptOut]);
+
+		adsShouldNotShow();
+	});
+
+	it(`Test ${path} reject all, login as non-subscriber, log out should not show ads`, () => {
+		fakeLogin(false);
+
+		cy.visit(`${path}?adtest=${adTest}`);
+
+		cy.rejectAllConsent();
+
+		expectAdFree([AdFreeCookieReasons.ConsentOptOut]);
+
+		fakeLogOut();
+
+		expectAdFree([AdFreeCookieReasons.ConsentOptOut]);
+
+		adsShouldNotShow();
+	});
+
+	it(`Test ${path} reject all, login as non-subscriber, reconsent should show ads`, () => {
+		cy.visit(`${path}?adtest=${adTest}`);
+
+		cy.rejectAllConsent();
+
+		fakeLogin(false);
+
+		// prevent support banner so we can click privacy settings button
+		localStorage.setItem(
+			'gu.prefs.engagementBannerLastClosedAt',
+			`{"value":"${new Date().toISOString()}"}`,
+		);
+
+		cy.reload();
+
+		expectAdFree([AdFreeCookieReasons.ConsentOptOut]);
+
+		adsShouldNotShow();
+
+		reconsent();
+
+		expectAdFree([]);
+
+		cy.reload();
+
+		adsShouldShow();
+	});
+
+	it(`Test ${path} accept all, login as subscriber, subscription expires, should show ads`, () => {
+		fakeLogin(true);
+
+		cy.visit(`${path}?adtest=${adTest}`);
+
+		cy.allowAllConsent();
+
+		expectAdFree([AdFreeCookieReasons.Subscriber]);
+
+		cy.setCookie(
+			'gu_user_features_expiry',
+			String(new Date().getTime() - 1000),
+		);
+
+		localStorage.setItem(
+			'gu.ad_free_cookie_reason',
+			`{"subscriber": ${new Date().getTime() - 1000}}`,
+		);
+
+		// to intercept response
+		fakeLogin(false);
+
+		cy.reload();
+
+		expectAdFree([]);
+
+		// reload twice so server is not sent ad free cookie
+		cy.reload();
+
+		adsShouldShow();
+	});
+
+	it(`Test ${path} reject all, login as subscriber, subscription expires, should not show ads`, () => {
+		fakeLogin(true);
+
+		cy.visit(`${path}?adtest=${adTest}`);
+
+		cy.rejectAllConsent();
+
+		expectAdFree([
+			AdFreeCookieReasons.ConsentOptOut,
+			AdFreeCookieReasons.Subscriber,
+		]);
+
+		cy.setCookie(
+			'gu_user_features_expiry',
+			String(new Date().getTime() - 1000),
+		);
+
+		localStorage.setItem(
+			'gu.ad_free_cookie_reason',
+			`{"subscriber": ${new Date().getTime() - 1000}}`,
+		);
+
+		// to intercept response
+		fakeLogin(false);
+
+		cy.reload();
+
+		expectAdFree([AdFreeCookieReasons.ConsentOptOut]);
+
+		// reload twice so server is not sent ad free cookie
+		cy.reload();
+
+		adsShouldNotShow();
+	});
+
+	it(`Test ${path} reject all, cookie/reason expires, cookie should renew expiry and remain`, () => {
+		cy.visit(`${path}?adtest=${adTest}`);
+
+		cy.rejectAllConsent();
+
+		expectAdFree([AdFreeCookieReasons.ConsentOptOut]);
+
+		const expiredTimestamp = new Date().getTime() - 1000;
+
+		cy.setCookie('GU_AF1', String(expiredTimestamp));
+
+		localStorage.setItem(
+			'gu.ad_free_cookie_reason',
+			`{"consent_opt_out": ${expiredTimestamp}}`,
+		);
+
+		cy.reload();
+
+		expectAdFree([AdFreeCookieReasons.ConsentOptOut]);
+
+		// expiries should update
+
+		cy.then(() =>
+			expect(
+				Number(
+					JSON.parse(
+						localStorage.getItem('gu.ad_free_cookie_reason') ||
+							'{}',
+					).consent_opt_out,
+				),
+			).to.be.greaterThan(expiredTimestamp),
+		);
+
+		cy.getCookie('GU_AF1')
+			.should('have.property', 'value')
+			.then((value) =>
+				expect(Number(value)).to.be.greaterThan(expiredTimestamp),
 			);
+	});
 
-			cy.reload();
+	it(`Test ${path} allow all, logged in, if localstorage reason is missing, keep ad free, don't show ads`, () => {
+		fakeLogin(true);
 
-			reconsent();
+		cy.setCookie('GU_AF1', String(new Date().getTime() + 100000));
 
-			cy.reload();
+		cy.visit(`${path}?adtest=${adTest}`);
 
-			expectAdFree([]);
+		cy.allowAllConsent();
 
-			adsShouldShow();
-		});
+		cy.wait('@userData');
 
-		it(`Test ${path} reject all, login as subscriber, log out should not show ads`, () => {
-			fakeLogin(true);
+		cy.then(() => localStorage.removeItem('gu.ad_free_cookie_reason'));
 
-			cy.visit(`${path}?adtest=${adTest}`);
+		cy.reload();
 
-			cy.rejectAllConsent();
+		cy.getCookie('GU_AF1').should('exist');
 
-			expectAdFree([
-				AdFreeCookieReasons.ConsentOptOut,
-				AdFreeCookieReasons.Subscriber,
-			]);
-
-			fakeLogOut();
-
-			cy.reload();
-
-			expectAdFree([AdFreeCookieReasons.ConsentOptOut]);
-
-			adsShouldNotShow();
-		});
-
-		it(`Test ${path} reject all, login as non-subscriber, log out should not show ads`, () => {
-			fakeLogin(false);
-
-			cy.visit(`${path}?adtest=${adTest}`);
-
-			cy.rejectAllConsent();
-
-			expectAdFree([AdFreeCookieReasons.ConsentOptOut]);
-
-			fakeLogOut();
-
-			expectAdFree([AdFreeCookieReasons.ConsentOptOut]);
-
-			adsShouldNotShow();
-		});
-
-		it(`Test ${path} reject all, login as non-subscriber, reconsent should show ads`, () => {
-			cy.visit(`${path}?adtest=${adTest}`);
-
-			cy.rejectAllConsent();
-
-			fakeLogin(false);
-
-			// prevent support banner so we can click privacy settings button
-			localStorage.setItem(
-				'gu.prefs.engagementBannerLastClosedAt',
-				`{"value":"${new Date().toISOString()}"}`,
-			);
-
-			cy.reload();
-
-			expectAdFree([AdFreeCookieReasons.ConsentOptOut]);
-
-			adsShouldNotShow();
-
-			reconsent();
-
-			expectAdFree([]);
-
-			cy.reload();
-
-			adsShouldShow();
-		});
-
-		it(`Test ${path} accept all, login as subscriber, subscription expires, should show ads`, () => {
-			fakeLogin(true);
-
-			cy.visit(`${path}?adtest=${adTest}`);
-
-			cy.allowAllConsent();
-
-			expectAdFree([AdFreeCookieReasons.Subscriber]);
-
-			cy.setCookie(
-				'gu_user_features_expiry',
-				String(new Date().getTime() - 1000),
-			);
-
-			localStorage.setItem(
-				'gu.ad_free_cookie_reason',
-				`{"subscriber": ${new Date().getTime() - 1000}}`,
-			);
-
-			// to intercept response
-			fakeLogin(false);
-
-			cy.reload();
-
-			expectAdFree([]);
-
-			// reload twice so server is not sent ad free cookie
-			cy.reload();
-
-			adsShouldShow();
-		});
-
-		it(`Test ${path} reject all, login as subscriber, subscription expires, should not show ads`, () => {
-			fakeLogin(true);
-
-			cy.visit(`${path}?adtest=${adTest}`);
-
-			cy.rejectAllConsent();
-
-			expectAdFree([
-				AdFreeCookieReasons.ConsentOptOut,
-				AdFreeCookieReasons.Subscriber,
-			]);
-
-			cy.setCookie(
-				'gu_user_features_expiry',
-				String(new Date().getTime() - 1000),
-			);
-
-			localStorage.setItem(
-				'gu.ad_free_cookie_reason',
-				`{"subscriber": ${new Date().getTime() - 1000}}`,
-			);
-
-			// to intercept response
-			fakeLogin(false);
-
-			cy.reload();
-
-			expectAdFree([AdFreeCookieReasons.ConsentOptOut]);
-
-			// reload twice so server is not sent ad free cookie
-			cy.reload();
-
-			adsShouldNotShow();
-		});
-
-		it(`Test ${path} reject all, cookie/reason expires, cookie should renew expiry and remain`, () => {
-			cy.visit(`${path}?adtest=${adTest}`);
-
-			cy.rejectAllConsent();
-
-			expectAdFree([AdFreeCookieReasons.ConsentOptOut]);
-
-			const expiredTimestamp = new Date().getTime() - 1000;
-
-			cy.setCookie('GU_AF1', String(expiredTimestamp));
-
-			localStorage.setItem(
-				'gu.ad_free_cookie_reason',
-				`{"consent_opt_out": ${expiredTimestamp}}`,
-			);
-
-			cy.reload();
-
-			expectAdFree([AdFreeCookieReasons.ConsentOptOut]);
-
-			// expiries should update
-
-			cy.then(() =>
-				expect(
-					Number(
-						JSON.parse(
-							localStorage.getItem('gu.ad_free_cookie_reason') ||
-								'{}',
-						).consent_opt_out,
-					),
-				).to.be.greaterThan(expiredTimestamp),
-			);
-
-			cy.getCookie('GU_AF1')
-				.should('have.property', 'value')
-				.then((value) =>
-					expect(Number(value)).to.be.greaterThan(expiredTimestamp),
-				);
-		});
-
-		it(`Test ${path} allow all, logged in, if localstorage reason is missing, keep ad free, don't show ads`, () => {
-			fakeLogin(true);
-
-			cy.setCookie('GU_AF1', String(new Date().getTime() + 100000));
-
-			cy.visit(`${path}?adtest=${adTest}`);
-
-			cy.allowAllConsent();
-
-			cy.wait('@userData');
-
-			cy.then(() => localStorage.removeItem('gu.ad_free_cookie_reason'));
-
-			cy.reload();
-
-			cy.getCookie('GU_AF1').should('exist');
-
-			cy.get('#dfp-ad--top-above-nav').should('not.exist');
-		});
+		cy.get('#dfp-ad--top-above-nav').should('not.exist');
 	});
 });

--- a/cypress/e2e/targeting.cy.ts
+++ b/cypress/e2e/targeting.cy.ts
@@ -1,11 +1,11 @@
-import { allPages, fronts } from '../fixtures/pages';
+import { allPages, articles } from '../fixtures/pages';
 import { bidderURLs, wins } from '../fixtures/prebid';
 
 const gamUrl = 'https://securepubads.g.doubleclick.net/gampad/ads?**';
 
 describe('GAM targeting', () => {
 	it(`checks that a request is made`, () => {
-		const { path, adTest } = fronts[0];
+		const { path, adTest } = articles[0];
 		cy.visit(`${path}?adtest=${adTest}`);
 
 		cy.allowAllConsent();
@@ -16,7 +16,7 @@ describe('GAM targeting', () => {
 	});
 
 	it(`checks the gdpr_consent param`, () => {
-		const { path, adTest } = fronts[0];
+		const { path, adTest } = articles[0];
 		cy.visit(`${path}?adtest=${adTest}`);
 
 		cy.allowAllConsent();
@@ -30,28 +30,29 @@ describe('GAM targeting', () => {
 		cy.wait('@gamRequest', { timeout: 30000 });
 	});
 
-	fronts.forEach(({ path, section, adTest }) => {
-		it(`checks custom params on the ${section} front`, () => {
-			cy.visit(`${path}?adtest=${adTest}`);
+	// front tests are disabled for the moment
+	// fronts.forEach(({ path, section, adTest }) => {
+	// 	it.skip(`checks custom params on the ${section} front`, () => {
+	// 		cy.visit(`${path}?adtest=${adTest}`);
 
-			cy.allowAllConsent();
+	// 		cy.allowAllConsent();
 
-			cy.intercept({ url: gamUrl }, function (req) {
-				const url = new URL(req.url);
+	// 		cy.intercept({ url: gamUrl }, function (req) {
+	// 			const url = new URL(req.url);
 
-				const custParams = decodeURIComponent(
-					url.searchParams.get('cust_params') || '',
-				);
-				const decodedCustParams = new URLSearchParams(custParams);
+	// 			const custParams = decodeURIComponent(
+	// 				url.searchParams.get('cust_params') || '',
+	// 			);
+	// 			const decodedCustParams = new URLSearchParams(custParams);
 
-				expect(decodedCustParams.get('s')).to.equal(section); // s: section
-				expect(decodedCustParams.get('urlkw')).to.contain(section); // urlkw: url keywords. urlkw is an array.
-				expect(decodedCustParams.get('sens')).to.equal('f'); // not sensitive content
-			}).as('gamRequest');
+	// 			expect(decodedCustParams.get('s')).to.equal(section); // s: section
+	// 			expect(decodedCustParams.get('urlkw')).to.contain(section); // urlkw: url keywords. urlkw is an array.
+	// 			expect(decodedCustParams.get('sens')).to.equal('f'); // not sensitive content
+	// 		}).as('gamRequest');
 
-			cy.wait('@gamRequest', { timeout: 30000 });
-		});
-	});
+	// 		cy.wait('@gamRequest', { timeout: 30000 });
+	// 	});
+	// });
 
 	it(`checks sensitive content is marked as sensitive`, () => {
 		const sensitivePage = allPages.find(
@@ -117,7 +118,7 @@ describe('Prebid targeting', () => {
 	});
 
 	it(`prebid winner should display ad and send targeting to GAM`, () => {
-		const { path } = fronts[0];
+		const { path } = articles[0];
 
 		interceptGamRequest();
 

--- a/cypress/fixtures/pages/index.ts
+++ b/cypress/fixtures/pages/index.ts
@@ -2,6 +2,6 @@ import { fronts } from './fronts';
 import { articles } from './articles';
 import { liveblogs } from './liveblogs';
 
-const allPages = [...fronts, ...articles, ...liveblogs];
+const allPages = [...articles, ...liveblogs];
 
-export { articles, fronts, liveblogs, allPages };
+export { articles, liveblogs, allPages };


### PR DESCRIPTION
## What does this change?
Removes the fronts cypress tests for the moment, as we will initially start with only article/liveblog test pages, to make running in CI easier.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)