### PR TITLE
Provide story package data in the DCR request to avoid second call in the client

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -3,7 +3,6 @@ package model.dotcomrendering
 import com.gu.contentapi.client.model.v1.{Block => APIBlock, Blocks => APIBlocks}
 import com.gu.contentapi.client.utils.AdvertisementFeature
 import com.gu.contentapi.client.utils.format.{ImmersiveDisplay, InteractiveDesign}
-import services.NewsletterData
 import common.Maps.RichMap
 import common.commercial.EditionCommercialProperties
 import common.{Chronos, Edition, Localisation, RichRequestHeader}
@@ -11,22 +10,11 @@ import conf.Configuration
 import experiments.ActiveExperiments
 import model.dotcomrendering.DotcomRenderingUtils._
 import model.dotcomrendering.pageElements.{PageElement, TextCleaner}
-import model.{
-  ArticleDateTimes,
-  Badges,
-  CanonicalLiveBlog,
-  ContentFormat,
-  ContentPage,
-  GUDateTimeFormatNew,
-  InteractivePage,
-  LiveBlogPage,
-  PageWithStoryPackage,
-  Topic,
-  TopicResult,
-}
+import model.{ArticleDateTimes, Badges, CanonicalLiveBlog, ContentFormat, ContentPage, GUDateTimeFormatNew, InteractivePage, LiveBlogPage, PageWithStoryPackage, Topic, TopicResult}
 import navigation._
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
+import services.NewsletterData
 import views.support.{CamelCase, ContentLayout, JavaScriptPage}
 // -----------------------------------------------------------------
 // DCR DataModel
@@ -78,6 +66,7 @@ case class DotcomRenderingDataModel(
     contentType: String,
     hasRelated: Boolean,
     hasStoryPackage: Boolean,
+    storyPackage: Option[OnwardCollectionResponse],
     beaconURL: String,
     isCommentable: Boolean,
     commercialProperties: Map[String, EditionCommercialProperties],
@@ -150,6 +139,7 @@ object DotcomRenderingDataModel {
         "contentType" -> model.contentType,
         "hasRelated" -> model.hasRelated,
         "hasStoryPackage" -> model.hasStoryPackage,
+        "storyPackage" -> model.storyPackage,
         "beaconURL" -> model.beaconURL,
         "isCommentable" -> model.isCommentable,
         "commercialProperties" -> model.commercialProperties,
@@ -198,6 +188,7 @@ object DotcomRenderingDataModel {
       bodyBlocks = blocks.body.getOrElse(Nil),
       pageType = pageType,
       hasStoryPackage = page.related.hasStoryPackage,
+      storyPackage = getStoryPackage(page.related.faciaItems, request),
       pinnedPost = None,
       keyEvents = Nil,
       availableTopics = None,
@@ -228,6 +219,7 @@ object DotcomRenderingDataModel {
       bodyBlocks = blocks.body.getOrElse(Nil),
       pageType = pageType,
       hasStoryPackage = page.related.hasStoryPackage,
+      storyPackage = getStoryPackage(page.related.faciaItems, request),
       pinnedPost = None,
       keyEvents = Nil,
       availableTopics = None,
@@ -306,6 +298,7 @@ object DotcomRenderingDataModel {
       bodyBlocks,
       pageType,
       page.related.hasStoryPackage,
+      getStoryPackage(page.related.faciaItems, request), //todo
       pinnedPost,
       timelineBlocks,
       filterKeyEvents,
@@ -326,6 +319,7 @@ object DotcomRenderingDataModel {
       bodyBlocks: Seq[APIBlock],
       pageType: PageType, // TODO remove as format is better
       hasStoryPackage: Boolean,
+      storyPackage: Option[OnwardCollectionResponse],
       pinnedPost: Option[APIBlock],
       keyEvents: Seq[APIBlock],
       filterKeyEvents: Boolean = false,
@@ -457,6 +451,7 @@ object DotcomRenderingDataModel {
       guardianBaseURL = Configuration.site.host,
       hasRelated = content.content.showInRelated,
       hasStoryPackage = hasStoryPackage,
+      storyPackage = storyPackage,
       headline = content.trail.headline,
       isAdFreeUser = views.support.Commercial.isAdFree(request),
       isCommentable = content.trail.isCommentable,

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -10,7 +10,19 @@ import conf.Configuration
 import experiments.ActiveExperiments
 import model.dotcomrendering.DotcomRenderingUtils._
 import model.dotcomrendering.pageElements.{PageElement, TextCleaner}
-import model.{ArticleDateTimes, Badges, CanonicalLiveBlog, ContentFormat, ContentPage, GUDateTimeFormatNew, InteractivePage, LiveBlogPage, PageWithStoryPackage, Topic, TopicResult}
+import model.{
+  ArticleDateTimes,
+  Badges,
+  CanonicalLiveBlog,
+  ContentFormat,
+  ContentPage,
+  GUDateTimeFormatNew,
+  InteractivePage,
+  LiveBlogPage,
+  PageWithStoryPackage,
+  Topic,
+  TopicResult,
+}
 import navigation._
 import play.api.libs.json._
 import play.api.mvc.RequestHeader

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -10,7 +10,7 @@ import conf.switches.Switches
 import conf.{Configuration, Static}
 import model.content.Atom
 import model.dotcomrendering.pageElements.{DisclaimerBlockElement, PageElement, TextCleaner}
-import model.pressed.SpecialReport
+import model.pressed.{PressedContent, SpecialReport}
 import model.{
   ArticleDateTimes,
   CanonicalLiveBlog,
@@ -288,6 +288,23 @@ object DotcomRenderingUtils {
     if (block.attributes.summary.contains(true) && block.title.isEmpty) {
       block.copy(title = Some("Summary"))
     } else block
+  }
+
+  def getStoryPackage(
+      faciaItems: Seq[PressedContent],
+      requestHeader: RequestHeader,
+  ): Option[OnwardCollectionResponse] = {
+    faciaItems match {
+      case Nil => None
+      case _ =>
+        Some(
+          OnwardCollectionResponse(
+            heading = "More on this story",
+            trails =
+              faciaItems.map(faciaItem => OnwardItem.pressedContentToOnwardItem(faciaItem)(requestHeader)).take(10),
+          ),
+        )
+    }
   }
 
 }


### PR DESCRIPTION
## What does this change?

Adding a new parameter to the DCR rendering model called "storyPackage". This will contain all the data needed to render the "More on this story" section and avoid a separate call from the client. 

### Tested

- [x] On CODE (optional)
