### PR TITLE
fix: Fix newsletter service

### DIFF
--- a/common/app/model/dotcomrendering/ElementsEnhancer.scala
+++ b/common/app/model/dotcomrendering/ElementsEnhancer.scala
@@ -40,6 +40,6 @@ object ElementsEnhancer {
       Json.obj("mainMediaElements" -> enhanceElements(obj.value("mainMediaElements"))) ++
       Json.obj("keyEvents" -> enhanceObjectsWithElementsAtDepth1(obj.value("keyEvents"))) ++
       Json.obj("pinnedPost" -> enhanceObjectWithElementsAtDepth1(obj.value("pinnedPost"))) ++
-      Json.obj("promotedNewsletter" -> enhanceObjectWithElementsAtDepth1(obj.value("promotedNewsletter")))
+      Json.obj("promotedNewsletter" -> obj.value("promotedNewsletter"))
   }
 }

--- a/common/app/services/NewsletterService.scala
+++ b/common/app/services/NewsletterService.scala
@@ -25,7 +25,7 @@ object NewsletterData {
 
 class NewsletterService(newsletterSignupAgent: NewsletterSignupAgent) {
   private val EMBED_TAG_PREFIX = "campaign/email/"
-  private val EMBED_TAG_TYPE = "campaign"
+  private val EMBED_TAG_TYPE = "Campaign"
 
   private def findNewsletterTag(tags: List[Tag]) = {
     tags.find(t => t.properties.tagType.equals(EMBED_TAG_TYPE) && t.properties.id.startsWith(EMBED_TAG_PREFIX))


### PR DESCRIPTION
## What does this change?
Fixes the capitalisation of the TagType value in the newsletter service.
Fixes the json value used in ElementEnhancer

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
newsletter data ("promotedNewsletter") will appear in the JSON for this article (includes tag "campaign/email/pushing-buttons"):
http://localhost:9000/games/2022/jul/12/pushing-buttons-is-it-game-over-for-gaming-pandemic-boom.json?dcr=true

``` "promotedNewsletter":{"identityName":"pushing-buttons","name":"Pushing Buttons","theme":"culture","description":"Keza MacDonald's weekly look at the world of gaming","frequency":"Weekly","listId":6017,"group":"Culture","successDescription":"Thanks for subscribing!"} ```


## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
