### PR TITLE
fix: Prevent last inline ad from pushing down content

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -1,4 +1,4 @@
-import type { SizeMapping } from '@guardian/commercial-core';
+import type { AdSize, SizeMapping } from '@guardian/commercial-core';
 import { adSizes, createAdSlot } from '@guardian/commercial-core';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { multiStickyRightAds } from 'common/modules/experiments/tests/multi-sticky-right-ads';
@@ -114,6 +114,42 @@ const filterNearbyCandidates =
 		);
 	};
 
+/**
+ * Decide whether we have enough space to add additional sizes for a given advert.
+ * This function ensures we don't insert large height ads at the bottom of articles,
+ * when there's not enough room.
+ *
+ * This is a hotfix to prevent adverts at the bottom of articles pushing down content.
+ * Nudge @chrislomaxjones if you're reading this in 2023
+ */
+const decideAdditionalSizes = async (
+	winningPara: HTMLElement,
+	sizes: AdSize[],
+	isLastInline: boolean,
+): Promise<AdSize[]> => {
+	// If this ad isn't the last inline then return all additional sizes
+	if (!isLastInline) {
+		return sizes;
+	}
+
+	// Compute the vertical distance from the TOP of the winning para to the BOTTOM of the article body
+	const distanceFromBottom = await fastdom.measure(() => {
+		const paraTop = winningPara.getBoundingClientRect().top;
+		const articleBodyBottom = document
+			.querySelector<HTMLElement>(articleBodySelector)
+			?.getBoundingClientRect().bottom;
+
+		return articleBodyBottom
+			? Math.abs(paraTop - articleBodyBottom)
+			: undefined;
+	});
+
+	// Return all of the sizes that will fit in the distance to bottom
+	return sizes.filter((adSize) =>
+		distanceFromBottom ? distanceFromBottom >= adSize.height : false,
+	);
+};
+
 const articleBodySelector = '.article-body-commercial-selector';
 
 const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
@@ -214,8 +250,9 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 
 		const slots = paras
 			.slice(0, isInline1 ? 1 : paras.length)
-			.map((para, i) => {
+			.map(async (para, i) => {
 				const inlineId = i + (isInline1 ? 1 : 2);
+				const isLastInline = i === paras.length - 1;
 
 				if (sfdebug == '1' || sfdebug == '2') {
 					para.style.cssText += 'border: thick solid green;';
@@ -254,7 +291,13 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 									adSizes.outstreamGoogleDesktop,
 								],
 						  }
-						: { desktop: [adSizes.halfPage, adSizes.skyscraper] },
+						: {
+								desktop: await decideAdditionalSizes(
+									para,
+									[adSizes.halfPage, adSizes.skyscraper],
+									isLastInline,
+								),
+						  },
 					containerOptions,
 				);
 			});

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.spec.ts
@@ -80,7 +80,8 @@ describe('getSlots', () => {
 	test('should return the correct slots at breakpoint M without mobile sticky', () => {
 		(shouldIncludeMobileSticky as jest.Mock).mockReturnValue(false);
 		(getBreakpointKey as jest.Mock).mockReturnValue('M');
-		expect(getSlots('Article')).toEqual([
+		config.set('page.contentType', 'Article');
+		expect(getSlots()).toEqual([
 			{
 				key: 'right',
 				sizes: [
@@ -114,7 +115,8 @@ describe('getSlots', () => {
 		(getBreakpointKey as jest.Mock).mockReturnValue('M');
 		config.set('switches.mobileStickyPrebid', true);
 		(shouldIncludeMobileSticky as jest.Mock).mockReturnValue(true);
-		expect(getSlots('Article')).toEqual([
+		config.set('page.contentType', 'Article');
+		expect(getSlots()).toEqual([
 			{
 				key: 'right',
 				sizes: [
@@ -150,7 +152,7 @@ describe('getSlots', () => {
 
 	test('should return the correct slots at breakpoint T', () => {
 		(getBreakpointKey as jest.Mock).mockReturnValue('T');
-		expect(getSlots('Article')).toEqual([
+		expect(getSlots()).toEqual([
 			{
 				key: 'right',
 				sizes: [
@@ -186,7 +188,8 @@ describe('getSlots', () => {
 
 	test('should return the correct slots at breakpoint D on article pages', () => {
 		(getBreakpointKey as jest.Mock).mockReturnValue('D');
-		const desktopSlots = getSlots('Article');
+		config.set('page.contentType', 'Article');
+		const desktopSlots = getSlots();
 		expect(desktopSlots).toContainEqual({
 			key: 'inline',
 			sizes: [
@@ -210,7 +213,8 @@ describe('getSlots', () => {
 
 	test('should return the correct slots at breakpoint T on crossword pages', () => {
 		(getBreakpointKey as jest.Mock).mockReturnValue('T');
-		const tabletSlots = getSlots('Crossword');
+		config.set('page.contentType', 'Crossword');
+		const tabletSlots = getSlots();
 		expect(tabletSlots).toContainEqual({
 			key: 'crossword-banner',
 			sizes: [[728, 90]],
@@ -219,7 +223,8 @@ describe('getSlots', () => {
 
 	test('should return the correct slots at breakpoint D on other pages', () => {
 		(getBreakpointKey as jest.Mock).mockReturnValue('D');
-		const desktopSlots = getSlots('');
+		config.set('page.contentType', '');
+		const desktopSlots = getSlots();
 		expect(desktopSlots).toContainEqual({
 			key: 'inline',
 			sizes: [[300, 250]],

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.spec.ts
@@ -79,9 +79,8 @@ describe('getSlots', () => {
 
 	test('should return the correct slots at breakpoint M without mobile sticky', () => {
 		(shouldIncludeMobileSticky as jest.Mock).mockReturnValue(false);
-		(getBreakpointKey as jest.Mock).mockReturnValue('M');
 		config.set('page.contentType', 'Article');
-		expect(getSlots()).toEqual([
+		expect(getSlots('mobile')).toEqual([
 			{
 				key: 'right',
 				sizes: [
@@ -112,11 +111,10 @@ describe('getSlots', () => {
 	});
 
 	test('should return the correct slots at breakpoint M for US including mobile sticky slot', () => {
-		(getBreakpointKey as jest.Mock).mockReturnValue('M');
 		config.set('switches.mobileStickyPrebid', true);
 		(shouldIncludeMobileSticky as jest.Mock).mockReturnValue(true);
 		config.set('page.contentType', 'Article');
-		expect(getSlots()).toEqual([
+		expect(getSlots('mobile')).toEqual([
 			{
 				key: 'right',
 				sizes: [
@@ -151,8 +149,7 @@ describe('getSlots', () => {
 	});
 
 	test('should return the correct slots at breakpoint T', () => {
-		(getBreakpointKey as jest.Mock).mockReturnValue('T');
-		expect(getSlots()).toEqual([
+		expect(getSlots('tablet')).toEqual([
 			{
 				key: 'right',
 				sizes: [
@@ -187,9 +184,8 @@ describe('getSlots', () => {
 	});
 
 	test('should return the correct slots at breakpoint D on article pages', () => {
-		(getBreakpointKey as jest.Mock).mockReturnValue('D');
 		config.set('page.contentType', 'Article');
-		const desktopSlots = getSlots();
+		const desktopSlots = getSlots('desktop');
 		expect(desktopSlots).toContainEqual({
 			key: 'inline',
 			sizes: [
@@ -212,9 +208,8 @@ describe('getSlots', () => {
 	});
 
 	test('should return the correct slots at breakpoint T on crossword pages', () => {
-		(getBreakpointKey as jest.Mock).mockReturnValue('T');
 		config.set('page.contentType', 'Crossword');
-		const tabletSlots = getSlots();
+		const tabletSlots = getSlots('tablet');
 		expect(tabletSlots).toContainEqual({
 			key: 'crossword-banner',
 			sizes: [[728, 90]],
@@ -222,9 +217,8 @@ describe('getSlots', () => {
 	});
 
 	test('should return the correct slots at breakpoint D on other pages', () => {
-		(getBreakpointKey as jest.Mock).mockReturnValue('D');
 		config.set('page.contentType', '');
-		const desktopSlots = getSlots();
+		const desktopSlots = getSlots('desktop');
 		expect(desktopSlots).toContainEqual({
 			key: 'inline',
 			sizes: [[300, 250]],
@@ -305,6 +299,42 @@ describe('getPrebidAdSlots', () => {
 				key: 'mobile-sticky',
 				sizes: [[320, 50]],
 			},
+		]);
+	});
+
+	test('should return the correct inline slot at breakpoint M when inline is in size mappings', () => {
+		(getBreakpointKey as jest.Mock).mockReturnValue('M');
+		config.set('page.contentType', 'Article');
+		const hbSlots = getHeaderBiddingAdSlots(buildAdvert('inline'));
+
+		expect(hbSlots).toContainEqual(
+			expect.objectContaining({ key: 'inline', sizes: [[300, 250]] }),
+		);
+	});
+
+	test('should return the correct inline slot at breakpoint D when inline is in size mappings', () => {
+		(getBreakpointKey as jest.Mock).mockReturnValue('D');
+		config.set('page.contentType', 'Article');
+
+		const hbSlots = getHeaderBiddingAdSlots(buildAdvert('inline'));
+		expect(hbSlots).toHaveLength(1);
+		expect(hbSlots[0].sizes).toEqual([[300, 250]]);
+	});
+
+	test('should return the correct inline slot at breakpoint D when inline is in size mappings', () => {
+		(getBreakpointKey as jest.Mock).mockReturnValue('D');
+		config.set('page.contentType', 'Article');
+
+		const hbSlots = getHeaderBiddingAdSlots(
+			buildAdvert('inline', {
+				desktop: [adSizes.halfPage, adSizes.skyscraper],
+			}),
+		);
+		expect(hbSlots).toHaveLength(1);
+		expect(hbSlots[0].sizes).toEqual([
+			[160, 600],
+			[300, 600],
+			[300, 250],
 		]);
 	});
 });

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.spec.ts
@@ -312,7 +312,7 @@ describe('getPrebidAdSlots', () => {
 		);
 	});
 
-	test('should return the correct inline slot at breakpoint D when inline is in size mappings', () => {
+	test('should return the correct inline slot at breakpoint D with no additional size mappings', () => {
 		(getBreakpointKey as jest.Mock).mockReturnValue('D');
 		config.set('page.contentType', 'Article');
 
@@ -321,7 +321,7 @@ describe('getPrebidAdSlots', () => {
 		expect(hbSlots[0].sizes).toEqual([[300, 250]]);
 	});
 
-	test('should return the correct inline slot at breakpoint D when inline is in size mappings', () => {
+	test('should return the correct inline slot at breakpoint D with additional size mappings', () => {
 		(getBreakpointKey as jest.Mock).mockReturnValue('D');
 		config.set('page.contentType', 'Article');
 

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.ts
@@ -165,11 +165,11 @@ export const getHeaderBiddingAdSlots = (
 ): HeaderBiddingSlot[] => {
 	const effectiveSlotFlatMap = slotFlatMap ?? ((s) => [s]); // default to identity
 
-	const adSlots = filterByAdvert(
+	const headerBiddingSlots = filterByAdvert(
 		ad,
 		getSlots(config.get('page.contentType', '')),
 	);
-	return adSlots
+	return headerBiddingSlots
 		.map(effectiveSlotFlatMap)
 		.reduce((acc, elt) => acc.concat(elt), []); // the "flat" in "flatMap"
 };

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.ts
@@ -1,6 +1,5 @@
 import { adSizes, createAdSize } from '@guardian/commercial-core';
 import type { Advert } from 'commercial/modules/dfp/Advert';
-import config from '../../../../lib/config';
 import {
 	getBreakpointKey,
 	shouldIncludeMobileSticky,
@@ -34,20 +33,17 @@ const filterByAdvert = (
 	return adUnits;
 };
 
-const getSlots = (contentType: string): HeaderBiddingSlot[] => {
+const getSlots = (): HeaderBiddingSlot[] => {
+	const { contentType, hasShowcaseMainElement } = window.guardian.config.page;
 	const isArticle = contentType === 'Article';
 	const isCrossword = contentType === 'Crossword';
-	const hasShowcase = config.get(
-		'page.hasShowcaseMainElement',
-		false,
-	) as boolean; // TODO : remove type assertion
 	const hasExtendedMostPop =
 		isArticle && window.guardian.config.switches.extendedMostPopular;
 
 	const commonSlots: HeaderBiddingSlot[] = [
 		{
 			key: 'right',
-			sizes: hasShowcase
+			sizes: hasShowcaseMainElement
 				? [adSizes.mpu]
 				: [adSizes.halfPage, adSizes.mpu],
 		},
@@ -165,10 +161,7 @@ export const getHeaderBiddingAdSlots = (
 ): HeaderBiddingSlot[] => {
 	const effectiveSlotFlatMap = slotFlatMap ?? ((s) => [s]); // default to identity
 
-	const headerBiddingSlots = filterByAdvert(
-		ad,
-		getSlots(config.get('page.contentType', '')),
-	);
+	const headerBiddingSlots = filterByAdvert(ad, getSlots());
 	return headerBiddingSlots
 		.map(effectiveSlotFlatMap)
 		.reduce((acc, elt) => acc.concat(elt), []); // the "flat" in "flatMap"

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -394,7 +394,6 @@
  "../projects/commercial/modules/header-bidding/prebid/pubmatic.js": [],
  "../projects/commercial/modules/header-bidding/slot-config.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../lib/config.d.ts",
   "../projects/commercial/modules/dfp/Advert.ts",
   "../projects/commercial/modules/header-bidding/utils.ts"
  ],

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -394,6 +394,7 @@
  "../projects/commercial/modules/header-bidding/prebid/pubmatic.js": [],
  "../projects/commercial/modules/header-bidding/slot-config.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../projects/commercial/modules/dfp/Advert.ts",
   "../projects/commercial/modules/header-bidding/utils.ts"
  ],


### PR DESCRIPTION
**Depends on https://github.com/guardian/frontend/pull/25278**

This one is probably best reviewed commit-by-commit

## What does this change?

Prevent the insertion of adverts that can't fit at the bottom of articles.

For context, we have a Spacefinder rule that disallows adverts from being inserted less than`300px` before the end of the article. This is fine, until we want to insert an ad that is greater than `300px` - aka the "half page" and "skyscraper" sizes.

To remedy this, once we've run Spacefinder we measure the height from the _top_ of the last advert to the _bottom_ of the article body. We then filter out all of the additional ad sizes that can't fit in this space. This allows us to continue inserting MPUs as per Spacefinder's rules, but prevents insertion of larger ads when we don't have room.

This PR also includes some additional plumbing to make this work:
- the ad insertion function now returns the winning element, rather than `void`. We ignore it when we want to use this function as a Spacefinder writer, but when we need to do some extra processing on the winners (as is the case here), its useful to expose them.
- Filter out the larger sizes from the heading bidding slot size configuration for inlines. In the future we should probably be doing this for all slots, but I want to keep the surface area of this PR small.
- Unit tests for the slot configuration changes described above.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/8000415/181486033-67d0c56d-c074-4301-8481-d4e23c524964.png
[after]: https://user-images.githubusercontent.com/8000415/181485778-b48746b7-a705-4178-a2c9-9e2e72a91d6c.png

## What is the value of this and can you measure success?

Prevent issues with advertising slots pushing down content below the article body. Content shouldn't be moved around in response to advertising, so it's important to remediate this.

This represents a temporary fix since, in the future, we may want to restructure the way we insert adverts in the right column

### Tested

- [X] Locally
- [x] On CODE (optional)
