### PR TITLE
Update topic switch description

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -476,7 +476,7 @@ trait FeatureSwitches {
   val AutomaticFilters = Switch(
     SwitchGroup.Feature,
     "automatic-filters",
-    "When ON, displays automatic filters and corresponding UI changes on business live blogs only",
+    "When ON, displays automatic filters and corresponding UI changes",
     owners = Seq(Owner.withEmail("dotcom.platform@guardian.co.uk")),
     safeState = Off,
     sellByDate = never,


### PR DESCRIPTION
## What does this change?

Updates the description for the automatic-filters switch since it now affects multiple liveblogs depending on aws parameter store configuration. 
