### PR TITLE
Update the switch description for `automatic-filters`

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -476,7 +476,7 @@ trait FeatureSwitches {
   val AutomaticFilters = Switch(
     SwitchGroup.Feature,
     "automatic-filters",
-    "When ON, displays automatic filters and corresponding UI changes on business live blogs only",
+    "When ON, displays automatic filters (Topics) on live blogs",
     owners = Seq(Owner.withEmail("dotcom.platform@guardian.co.uk")),
     safeState = Off,
     sellByDate = never,


### PR DESCRIPTION
## What does this change?
We now show topics on more than just business blogs so I've changed the description to reflect this