### PR TITLE
Ei/crossword ad size

### DIFF
--- a/applications/app/views/fragments/crosswords/crosswordContent.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordContent.scala.html
@@ -45,7 +45,7 @@
                         @fragments.commercial.standardAd("right", Seq("mpu-banner-ad"), Map("desktop" -> Seq("300,250", "300,274", "300,600", "fluid")))
                         </div>
                         <div class="crossword-banner hide-until-tablet hide-from-wide" aria-hidden="true">
-                        @fragments.commercial.standardAd("inline1", Seq("crossword-banner"), Map("tablet" -> Seq("1,1", "2,2", "728,90")))
+                        @fragments.commercial.standardAd("crossword-banner", Seq("crossword-banner"), Map())
                         </div>
                     }
                 </div>

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@guardian/atom-renderer": "1.2.2",
     "@guardian/automat-modules": "^0.3.8",
     "@guardian/braze-components": "^7.3.0",
-    "@guardian/commercial-core": "^4.3.0",
+    "@guardian/commercial-core": "4.4.0",
     "@guardian/consent-management-platform": "^10.7.1",
     "@guardian/libs": "^3.6.1",
     "@guardian/shimport": "^1.0.2",

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.spec.js
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.spec.js
@@ -210,7 +210,7 @@ describe('getSlots', () => {
 		getBreakpointKey.mockReturnValue('T');
 		const tabletSlots = getSlots('Crossword');
 		expect(tabletSlots).toContainEqual({
-			key: 'inline1',
+			key: 'crossword-banner',
 			sizes: [[728, 90]],
 		});
 	});

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.ts
@@ -79,8 +79,6 @@ const getSlots = (contentType: string): HeaderBiddingSlot[] => {
 						[300, 250],
 						[620, 350],
 				  ]
-				: isCrossword
-				? [[728, 90]]
 				: [[300, 250]],
 		},
 		{
@@ -129,8 +127,6 @@ const getSlots = (contentType: string): HeaderBiddingSlot[] => {
 						[300, 250],
 						[620, 350],
 				  ]
-				: isCrossword
-				? [[728, 90]]
 				: [[300, 250]],
 		},
 		{
@@ -172,6 +168,13 @@ const getSlots = (contentType: string): HeaderBiddingSlot[] => {
 		sizes: [[320, 50]],
 	};
 
+	const crosswordBannerSlot: HeaderBiddingSlot = {
+		key: 'crossword-banner',
+		sizes: [[728, 90]],
+	};
+
+	const crosswordSlots = isCrossword ? [crosswordBannerSlot] : [];
+
 	switch (getBreakpointKey()) {
 		case 'M':
 			return shouldIncludeMobileSticky() &&
@@ -179,9 +182,9 @@ const getSlots = (contentType: string): HeaderBiddingSlot[] => {
 				? commonSlots.concat([...mobileSlots, mobileStickySlot])
 				: commonSlots.concat(mobileSlots);
 		case 'T':
-			return commonSlots.concat(tabletSlots);
+			return commonSlots.concat(tabletSlots, crosswordSlots);
 		default:
-			return commonSlots.concat(desktopSlots);
+			return commonSlots.concat(desktopSlots, crosswordSlots);
 	}
 };
 

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/types.d.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/types.d.ts
@@ -9,7 +9,8 @@ type HeaderBiddingSlot = {
 		| 'mostpop'
 		| 'comments'
 		| 'mobile-sticky'
-		| 'banner';
+		| 'banner'
+		| 'crossword-banner';
 	sizes: HeaderBiddingSize[];
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2084,10 +2084,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-7.3.0.tgz#9c4908fa5d439d85b2024735575435b0a5cd369f"
   integrity sha512-Py2FZ6aHi/inOIF4+4xZqNmbJur3cevtWRMQeFLjNjgN7zR7hMB6Dsd8uurEym6Qd3yxBAGPx/+rS3xVbTKz4w==
 
-"@guardian/commercial-core@^4.3.0":
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.3.0.tgz#f04bc56d4eedef9feb2a4c844142a7b11082d9bd"
-  integrity sha512-T7aE9kqc0JCNaASh7iHof6+MMOTnoEwinYiIjbJSjMoNRfuMSKIfLpWjZfZ8w58uvOygIx6MJDFTRdyT5J5Fvw==
+"@guardian/commercial-core@4.4.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.4.0.tgz#539d07a69eecde4053d0f1e11d97080aaeed50e5"
+  integrity sha512-rRpdto1O5alkFQ6Z5yYxBaIiwm2GL8H4Vj4qkwKh3qJR0AddOWr+OGRQbkipPZLBw0juz4yh8gTy4eVh8/ml1A==
 
 "@guardian/consent-management-platform@^10.7.1":
   version "10.7.1"


### PR DESCRIPTION
## What does this change?
Adding a new ad type to get rid of ads overlapping crossword comments in tablet view

This ad type will need further work - we need new placement IDs to make sure we get the right ad sizes returned but it should improve the user experience considerably while we make those changes

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
Reducing the overlap of ads on the crossword comments

## Checklist

### Tested

- [X] Locally
- [X] On CODE (optional)


