### PR TITLE
fix: Duplicated size mappings on inline adverts

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@guardian/atom-renderer": "1.2.2",
     "@guardian/automat-modules": "^0.3.8",
     "@guardian/braze-components": "^7.3.0",
-    "@guardian/commercial-core": "4.4.0",
+    "@guardian/commercial-core": "4.5.0",
     "@guardian/consent-management-platform": "^10.7.1",
     "@guardian/libs": "^3.6.1",
     "@guardian/shimport": "^1.0.2",

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -1,4 +1,8 @@
-import { createAdSize, slotSizeMappings } from '@guardian/commercial-core';
+import {
+	concatSizeMappings,
+	createAdSize,
+	slotSizeMappings,
+} from '@guardian/commercial-core';
 import type { AdSize, SizeMapping, SlotName } from '@guardian/commercial-core';
 import { breakpoints } from '../../../../lib/detect';
 import { breakpointNameToAttribute } from './breakpoint-name-to-attribute';
@@ -65,23 +69,6 @@ const getSlotSizeMapping = (name: string): SizeMapping => {
 	return {};
 };
 
-const mergeSizeMappings = (
-	sizeMapping: SizeMapping,
-	additionalSizeMapping: SizeMapping,
-): SizeMapping => {
-	const mergedSizeMapping = sizeMapping;
-	(
-		Object.entries(additionalSizeMapping) as Array<
-			[keyof SizeMapping, AdSize[]]
-		>
-	).forEach(([breakpoint, breakPointSizes]) => {
-		mergedSizeMapping[breakpoint] = mergedSizeMapping[breakpoint] ?? [];
-
-		mergedSizeMapping[breakpoint]?.push(...breakPointSizes);
-	});
-	return mergedSizeMapping;
-};
-
 const isSizeMappingEmpty = (sizeMapping: SizeMapping): boolean => {
 	return (
 		Object.keys(sizeMapping).length === 0 ||
@@ -128,7 +115,7 @@ class Advert {
 			? getSlotSizeMapping(adSlotNode.dataset.name)
 			: {};
 
-		let sizeMapping = mergeSizeMappings(
+		let sizeMapping = concatSizeMappings(
 			defaultSizeMappingForSlot,
 			additionalSizeMapping,
 		);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2084,10 +2084,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-7.3.0.tgz#9c4908fa5d439d85b2024735575435b0a5cd369f"
   integrity sha512-Py2FZ6aHi/inOIF4+4xZqNmbJur3cevtWRMQeFLjNjgN7zR7hMB6Dsd8uurEym6Qd3yxBAGPx/+rS3xVbTKz4w==
 
-"@guardian/commercial-core@4.4.0":
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.4.0.tgz#539d07a69eecde4053d0f1e11d97080aaeed50e5"
-  integrity sha512-rRpdto1O5alkFQ6Z5yYxBaIiwm2GL8H4Vj4qkwKh3qJR0AddOWr+OGRQbkipPZLBw0juz4yh8gTy4eVh8/ml1A==
+"@guardian/commercial-core@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.5.0.tgz#fdf9073b0e297b969478ea70108a39711ddbc155"
+  integrity sha512-2EuDL1e5HneoZds1UKhkOhXDOSn59+TBEhC0UGxT/oPHJv30ZSF2gbfpubmzd0ktscCT4NeCsb9IAJnitnKV/w==
 
 "@guardian/consent-management-platform@^10.7.1":
   version "10.7.1"


### PR DESCRIPTION
Necessary for https://github.com/guardian/frontend/pull/25271.

## What does this change?

- Bump the version of `commercial-core` to 4.5.0.
- Use the `concatSizeMappings` function that was refactored and exported in [commercial-core #126](https://github.com/guardian/commercial-core/pull/626) as a replacement for a similar implementation in Frontend.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

This should fix a bug where `slotSizeMappings` was accumulating values as merges which mutate the underlying value were being performed using its elements.

This causes sizes to be accumulated on each merge and will cause size mappings to be duplicated across slots e.g. inlines further down the page will get the Teads size mapping. 

> **Note**
> This currently doesn't cause any issues in production, since the merges don't change the effective set of size mappings. However, the fix is necessary for https://github.com/guardian/frontend/pull/25271.

#### Before

For an inline slot on an article that appears down the page (so some merges have occurred before its time to determine its size mappings):

```json
{ "defaultSizeMappings": [
  [1, 1],
  [2, 2],
  [300, 250],
  [300, 274],
  [0, 0],
  [620, 350],
  [550, 310],
  [300, 600],
  [160, 600]
]}
```

#### After

```json
{ "defaultSizeMappings": [
  [1, 1],
  [2, 2],
  [300, 250],
  [300, 274],
  [0, 0]
]}
```

### Tested

- [x] Locally
- [ ] On CODE (optional)