### PR TITLE
fix: Minimum height for crossword banner

### DIFF
--- a/static/src/stylesheets/module/crosswords/_layout.scss
+++ b/static/src/stylesheets/module/crosswords/_layout.scss
@@ -65,7 +65,7 @@
     clear: both;
     margin-top: $gs-baseline;
     // 90px is the height of a leaderboard
-    height: 90px + $mpu-ad-label-height + $gs-row-height / 2;
+    min-height: 90px + $mpu-ad-label-height + $gs-row-height / 2;
 
     @include mq($until: desktop) {
         margin-left: -$gs-gutter;


### PR DESCRIPTION
Co-authored-by: Emma Imber <emma-jo.imber@guardian.co.uk>

## What does this change?

Use a `min-height` rather than `height` for reserving space for crossword banner adverts. 

This will reserve the exact amount of space required for a `90x` height advert, but will also permit larger sizes with a small amount of layout shift (Note these sizes shouldn't be coming through at all, and can be addressed separately - this PR just addresses the overlap).

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Prevent erroneous sizes coming through Prebid from overlapping the comments section. We can then address the Prebid issue separately, which will remediate the layout shift as well.

### Tested

- [X] Locally
- [ ] On CODE (optional)