### PR TITLE
Various a11y improvements for Front container Show/Hide

### DIFF
--- a/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
@@ -36,7 +36,8 @@
         ("fc-show-more--mobile-only", containerDefinition.hasMobileOnlyShowMore)
     ))"
          data-title="@Localisation(containerDefinition.displayName getOrElse "")"
-         data-id="@containerDefinition.dataId">
+         data-id="@containerDefinition.dataId"
+         id="container-@containerDefinition.dataId">
 
         @for(sliceWithCards <- containerLayout.slices) {
             @slice(sliceWithCards, containerDefinition.index, frontProperties = Some(frontProperties), containerDefinition.displayName, frontId, containerDefinition.isStoryPackage)

--- a/common/app/views/fragments/containers/facia_cards/standardHeaderMeta.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/standardHeaderMeta.scala.html
@@ -25,7 +25,7 @@
                                 <img class="badge-slot__img" src="@badge.imageUrl" alt="" />
                             </div>
                         }
-                        <h2 class="fc-container__title__text">@Localisation(title)</h2>
+                        <h2 id="container-header-@containerDefinition.dataId" class="fc-container__title__text">@Localisation(title)</h2>
                     </a>
                     }.getOrElse {
                         <h2 tabindex="0">@Localisation(title)</h2>

--- a/static/src/javascripts/projects/facia/modules/ui/container-toggle.js
+++ b/static/src/javascripts/projects/facia/modules/ui/container-toggle.js
@@ -11,9 +11,9 @@ const toggleText = {
     displayed: 'Hide',
 };
 
-const btnTmpl = ({ text, dataLink }) => `
-    <button class="fc-container__toggle" data-link-name="${dataLink}">
-        <span class="fc-container__toggle__text">${text}</span>
+const btnTmpl = ({ text, dataLink, id }) => `
+    <button class="fc-container__toggle" data-link-name="${dataLink}" aria-expanded="true" aria-controls="container-${id}" aria-labelledby="container-header-${id} container-state-${id}">
+        <span class="fc-container__toggle__text" id="container-state-${id}">${text}</span>
     </button>
 `;
 
@@ -26,6 +26,7 @@ export class ContainerToggle {
                 btnTmpl({
                     text: 'Hide',
                     dataLink: 'Show',
+                    id: this.$container.attr('data-id'),
                 })
             )
         );
@@ -64,6 +65,10 @@ export class ContainerToggle {
             this.$button.attr(
                 'data-link-name',
                 toggleText[this.state === 'displayed' ? 'hidden' : 'displayed']
+            );
+            this.$button.attr(
+                'aria-expanded',
+                this.state === 'displayed' ? 'true' : 'false'
             );
             this.buttonText().text(toggleText[this.state]);
         });


### PR DESCRIPTION
## What does this change?

- adds `aria-controls` attribute to Show/Hide button to indicate which container is being controlled
- adds `aria-labelledby` to add more context when a screen reader announces a button
- adds `aria-expanded` to tell screen readers what the current state of the container is

### Known issues

Seems to suffer the same issue as the Q&A atom where screen readers don't announce the when the button is pressed, only tested on MacOs Voiceover

Partial fix #24843 