### PR TITLE
fix: More logical tab order for podcasts

### DIFF
--- a/applications/app/views/fragments/audioBody.scala.html
+++ b/applications/app/views/fragments/audioBody.scala.html
@@ -40,16 +40,6 @@
         @fragments.headTonal(audio, page)
 
         <div class="podcast gs-container">
-            <figure class="podcast__player podcast__section"
-                data-component="main audio"
-                id="audio-component-container"
-                data-media-id="@audio.elements.mainAudio.map(_.properties.id)"
-                data-source="@audio.downloadUrl"
-                data-download-url="@audio.downloadUrl.getOrElse("#")"
-                data-duration="@audio.duration"
-                >
-            </figure>
-
             @for( series <- audio.tags.tags.find(_.properties.podcast.nonEmpty)
             ; podcast <- series.properties.podcast
             ; image <- podcast.image
@@ -124,12 +114,33 @@
                 @fragments.contentMeta(audio, page, false)
             </div>
 
+            <div class="meta__social podcast__share podcast__section" data-component="share">
+                @fragments.social(audio.sharelinks.pageShares)
+                <div class="meta__numbers">
+                    <div class="u-h meta__number js-sharecount">
+                    </div>
+                    <div class="u-h meta__number" data-discussion-id="@audio.content.discussionId" data-commentcount-format="content" data-discussion-closed="@{
+                        !audio.trail.isCommentable
+                    }">
+                    </div>
+                </div>
+            </div>
+
             @if(audio.fields.standfirst.isDefined) {
                 <div class="podcast__standfirst">
                     @fragments.standfirst(audio)
                 </div>
             }
 
+            <figure class="podcast__player podcast__section"
+                    data-component="main audio"
+                    id="audio-component-container"
+                    data-media-id="@audio.elements.mainAudio.map(_.properties.id)"
+                    data-source="@audio.downloadUrl"
+                    data-download-url="@audio.downloadUrl.getOrElse("#")"
+            data-duration="@audio.duration"
+            >
+            </figure>
 
             <div class="from-content-api podcast__body">
                 @if(audio.fields.body.nonEmpty) {
@@ -159,18 +170,6 @@
                     Support The Guardian
                     @fragments.inlineSvg("arrow-right", "icon", List("podcast-support__icon", "podcast__section-icon"))
                 </a>
-            </div>
-
-            <div class="meta__social podcast__share podcast__section" data-component="share">
-                @fragments.social(audio.sharelinks.pageShares)
-                <div class="meta__numbers">
-                    <div class="u-h meta__number js-sharecount">
-                    </div>
-                    <div class="u-h meta__number" data-discussion-id="@audio.content.discussionId" data-commentcount-format="content" data-discussion-closed="@{
-                        !audio.trail.isCommentable
-                    }">
-                    </div>
-                </div>
             </div>
 
             <div class="podcast__submeta podcast__section">


### PR DESCRIPTION
## What does this change?

Updates tab order to be a bit more logical. Order should be top to bottom, left to right.

Closes guardian/dotcom-rendering#5033

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/21217225/181045553-11c2f85c-0596-4f03-abda-05d4a5d37855.png

[after]: https://user-images.githubusercontent.com/21217225/181045233-5eeccbb2-27f1-46d3-8dd4-2d55ccf50793.png
