### PR TITLE
Scala 2.13: Fix ambiguous overloaded JsonComponent method

### DIFF
--- a/admin/app/controllers/admin/CommercialController.scala
+++ b/admin/app/controllers/admin/CommercialController.scala
@@ -126,7 +126,7 @@ class CommercialController(
       val lineItems: Seq[GuLineItem] = Store.getDfpLineItemsReport().lineItems filter (_.orderId.toString == orderId)
 
       Cached(5.minutes) {
-        JsonComponent(Json.toJson(lineItems))
+        JsonComponent.fromWritable(lineItems)
       }
     }
 
@@ -144,7 +144,7 @@ class CommercialController(
         }) getOrElse Nil
 
       Cached(5.minutes) {
-        JsonComponent(Json.toJson(previewUrls))
+        JsonComponent.fromWritable(previewUrls)
       }
     }
 

--- a/admin/app/football/controllers/PlayerController.scala
+++ b/admin/app/football/controllers/PlayerController.scala
@@ -152,7 +152,7 @@ class PlayerController(val wsClient: WSClient, val controllerComponents: Control
             ),
           ),
         )
-        Cached(600)(JsonComponent(responseJson))
+        Cached(600)(JsonComponent.fromWritable(responseJson))
       }
     }
 }

--- a/applications/app/controllers/GalleryController.scala
+++ b/applications/app/controllers/GalleryController.scala
@@ -39,7 +39,7 @@ class GalleryController(contentApiClient: ContentApiClient, val controllerCompon
       val index = request.getIntParameter("index") getOrElse 1
       lookup(path, index, isTrail = false) map {
         case Right(other) => RenderOtherStatus(other)
-        case Left(model)  => Cached(model) { JsonComponent(model.gallery.lightbox.javascriptConfig) }
+        case Left(model)  => Cached(model) { JsonComponent.fromWritable(model.gallery.lightbox.javascriptConfig) }
       }
     }
 

--- a/applications/app/controllers/ImageContentController.scala
+++ b/applications/app/controllers/ImageContentController.scala
@@ -65,7 +65,7 @@ class ImageContentController(
             case _                     => None
           },
         )
-        Cached(CacheTime.Default)(JsonComponent(JsArray(lightboxJson)))
+        Cached(CacheTime.Default)(JsonComponent.fromWritable(JsArray(lightboxJson)))
       }
     }
 }

--- a/applications/app/controllers/MediaController.scala
+++ b/applications/app/controllers/MediaController.scala
@@ -33,7 +33,7 @@ class MediaController(contentApiClient: ContentApiClient, val controllerComponen
         case Left(model)  => MediaInfo(expired = false, shouldHideAdverts = model.media.content.shouldHideAdverts)
         case Right(other) => MediaInfo(expired = other.header.status == GONE, shouldHideAdverts = true)
       } map { mediaInfo =>
-        Cached(60)(JsonComponent(withRefreshStatus(Json.toJson(mediaInfo).as[JsObject])))
+        Cached(60)(JsonComponent.fromWritable(withRefreshStatus(Json.toJson(mediaInfo).as[JsObject])))
       }
     }
 

--- a/commercial/app/controllers/ContentApiOffersController.scala
+++ b/commercial/app/controllers/ContentApiOffersController.scala
@@ -62,11 +62,11 @@ class ContentApiOffersController(
         case Nil => Cached(componentNilMaxAge) { jsonFormat.nilResult }
         case content if isMulti =>
           Cached(1.hour) {
-            JsonComponent(CapiMultiple.fromContent(content, Edition(request)))
+            JsonComponent.fromWritable(CapiMultiple.fromContent(content, Edition(request)))
           }
         case first :: _ =>
           Cached(1.hour) {
-            JsonComponent(CapiSingle.fromContent(first, Edition(request)))
+            JsonComponent.fromWritable(CapiSingle.fromContent(first, Edition(request)))
           }
       }
 

--- a/commercial/app/controllers/JobsController.scala
+++ b/commercial/app/controllers/JobsController.scala
@@ -20,7 +20,7 @@ class JobsController(jobsAgent: JobsAgent, val controllerComponents: ControllerC
   def getJobs: Action[AnyContent] =
     Action { implicit request =>
       Cached(60.seconds) {
-        JsonComponent(jobSample(specificIds, segment))
+        JsonComponent.fromWritable(jobSample(specificIds, segment))
       }
     }
 }

--- a/commercial/app/controllers/LiveEventsController.scala
+++ b/commercial/app/controllers/LiveEventsController.scala
@@ -16,7 +16,7 @@ class LiveEventsController(liveEventAgent: LiveEventAgent, val controllerCompone
         for {
           id <- specificId
           event <- liveEventAgent.specificLiveEvent(id)
-        } yield Cached(componentMaxAge) { JsonComponent(event) }
+        } yield Cached(componentMaxAge) { JsonComponent.fromWritable(event) }
       } getOrElse Cached(componentNilMaxAge) { jsonFormat.nilResult }
     }
 }

--- a/commercial/app/controllers/Multi.scala
+++ b/commercial/app/controllers/Multi.scala
@@ -72,7 +72,7 @@ class Multi(
 
       if (offerTypes.size == contents.size) {
         Cached(componentMaxAge) {
-          JsonComponent(JsArray((offerTypes zip contents).map {
+          JsonComponent.fromWritable(JsArray((offerTypes zip contents).map {
             case (contentType, content) =>
               Json.obj(
                 "type" -> contentType,

--- a/commercial/app/controllers/TrafficDriverController.scala
+++ b/commercial/app/controllers/TrafficDriverController.scala
@@ -44,7 +44,7 @@ class TrafficDriverController(
         case None => Cached(componentNilMaxAge) { jsonFormat.nilResult }
         case Some(content) =>
           Cached(60.seconds) {
-            JsonComponent(TrafficDriver.fromContent(content, Edition(request)))
+            JsonComponent.fromWritable(TrafficDriver.fromContent(content, Edition(request)))
           }
       }
 

--- a/commercial/app/controllers/TravelOffersController.scala
+++ b/commercial/app/controllers/TravelOffersController.scala
@@ -19,9 +19,8 @@ class TravelOffersController(travelOffersAgent: TravelOffersAgent, val controlle
 
   def getTravel: Action[AnyContent] =
     Action { implicit request =>
-      val json = Json.toJson(travelSample(specificIds, segment))
       Cached(60.seconds) {
-        JsonComponent(json)
+        JsonComponent.fromWritable(travelSample(specificIds, segment))
       }
     }
 }

--- a/commercial/app/controllers/nonRefreshableLineItemsController.scala
+++ b/commercial/app/controllers/nonRefreshableLineItemsController.scala
@@ -15,11 +15,9 @@ class nonRefreshableLineItemsController(val controllerComponents: ControllerComp
   def getIds: Action[AnyContent] =
     Action { implicit request =>
       val nonRefreshableLineItems: Seq[Long] = DfpAgent.nonRefreshableLineItemIds()
-      val json = Json.toJson(nonRefreshableLineItems)
-
       Cors(
         Cached(15.minutes) {
-          JsonComponent(json)
+          JsonComponent.fromWritable(nonRefreshableLineItems)
         },
         None,
         None,

--- a/common/app/common/JsonComponent.scala
+++ b/common/app/common/JsonComponent.scala
@@ -14,7 +14,7 @@ object JsonComponent extends Results with implicits.Requests {
 
   def withRefreshStatus(obj: JsObject): JsValue = obj + ("refreshStatus" -> toJson(AutoRefreshSwitch.isSwitchedOn))
 
-  def apply[A](value: A)(implicit request: RequestHeader, writes: Writes[A]): RevalidatableResult =
+  def fromWritable[A](value: A)(implicit request: RequestHeader, writes: Writes[A]): RevalidatableResult =
     resultFor(
       request,
       Json.stringify(Json.toJson(value)),

--- a/common/test/common/JsonComponentTest.scala
+++ b/common/test/common/JsonComponentTest.scala
@@ -61,7 +61,7 @@ class JsonComponentTest extends AnyFlatSpec with Matchers with WithTestExecution
 
     val result = Future {
       implicit val request = FakeRequest("GET", "http://foo.bar.com/data.json")
-      JsonComponent(JsonComponent.withRefreshStatus(obj("name" -> "foo"))).result
+      JsonComponent.fromWritable(JsonComponent.withRefreshStatus(obj("name" -> "foo"))).result
     }
 
     contentType(result) should be(Some("application/json"))

--- a/discussion/app/controllers/CommentCountController.scala
+++ b/discussion/app/controllers/CommentCountController.scala
@@ -17,7 +17,7 @@ class CommentCountController(val discussionApi: DiscussionApiLike, val controlle
       val counts = discussionApi.commentCounts(shortUrls)
       counts map { counts =>
         Cached(300) {
-          JsonComponent(
+          JsonComponent.fromWritable(
             JsObject(Seq("counts" -> JsArray(counts.map(_.toJson)))),
           )
         }

--- a/onward/app/controllers/CardController.scala
+++ b/onward/app/controllers/CardController.scala
@@ -57,7 +57,7 @@ class CardController(
                   // To test a story that has no image:
                   // /cards/opengraph/http%3A%2F%2Fwww.theguardian.com%2Fmedia%2Fgreenslade%2F2013%2Faug%2F22%2Fjournalist-safety-egypt.json
 
-                  JsonComponent(
+                  JsonComponent.fromWritable(
                     withRefreshStatus(
                       Json
                         .toJson(
@@ -92,7 +92,7 @@ class CardController(
                   val firstParagraph = fragment.select("#mw-content-text > p").first
                   firstParagraph.select(".reference").remove()
 
-                  JsonComponent(
+                  JsonComponent.fromWritable(
                     withRefreshStatus(
                       Json
                         .toJson(

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -138,7 +138,7 @@ class MostPopularController(
       OnwardItem.contentCardToOnwardItem(contentCard)
     }
     val response = OnwardCollectionResponseDCR(tabs, mostCommented, mostShared)
-    Cached(900)(JsonComponent(response))
+    Cached(900)(JsonComponent.fromWritable(response))
   }
 
   def jsonResponseNx2(mostPopulars: Seq[MostPopularNx2], mostCards: Map[String, Option[ContentCard]])(implicit
@@ -154,7 +154,7 @@ class MostPopularController(
       OnwardItem.contentCardToOnwardItem(contentCard)
     }
     val response = OnwardCollectionResponseDCR(tabs, mostCommented, mostShared)
-    Cached(900)(JsonComponent(response))
+    Cached(900)(JsonComponent.fromWritable(response))
   }
 
   def jsonResponse(mostPopular: MostPopular, countryCode: String)(implicit request: RequestHeader): Result = {
@@ -163,7 +163,7 @@ class MostPopularController(
       heading = mostPopular.heading,
       trails = mostPopular.trails.map(OnwardItem.pressedContentToOnwardItem).take(10),
     )
-    Cached(900)(JsonComponent(data))
+    Cached(900)(JsonComponent.fromWritable(data))
   }
 
   def renderPopularDay(countryCode: String): Action[AnyContent] =

--- a/onward/app/controllers/NavigationController.scala
+++ b/onward/app/controllers/NavigationController.scala
@@ -24,7 +24,7 @@ class NavigationController(val controllerComponents: ControllerComponents) exten
       Edition.byId(editionId) match {
         case Some(edition) =>
           val menu = SimpleMenu(edition)
-          Cached(900)(JsonComponent(menu))
+          Cached(900)(JsonComponent.fromWritable(menu))
         case None =>
           Cached(60) {
             val json = Json.toJson(ApiError("Invalid edition ID.", 400)).toString()

--- a/onward/app/controllers/PopularInTag.scala
+++ b/onward/app/controllers/PopularInTag.scala
@@ -40,7 +40,7 @@ class PopularInTag(
       val numberOfCards = if (trails.faciaItems.length == 5 || trails.faciaItems.length == 6) 4 else 8
 
       if (request.forceDCR) {
-        JsonComponent(
+        JsonComponent.fromWritable(
           OnwardCollectionResponse(
             heading = "Related content",
             trails = trails.items.map(_.faciaContent).map(OnwardItem.pressedContentToOnwardItem).take(numberOfCards),

--- a/onward/app/controllers/RelatedController.scala
+++ b/onward/app/controllers/RelatedController.scala
@@ -62,7 +62,7 @@ class RelatedController(
           trails = trails.map(_.faciaContent).map(OnwardItem.pressedContentToOnwardItem).take(10),
         )
 
-        JsonComponent(data)
+        JsonComponent.fromWritable(data)
       } else if (request.isJson) {
         val html = views.html.fragments.containers.facia_cards.container(
           onwardContainer(containerTitle, relatedTrails.map(_.faciaContent)),

--- a/onward/app/controllers/RichLinkController.scala
+++ b/onward/app/controllers/RichLinkController.scala
@@ -40,7 +40,7 @@ class RichLinkController(contentApiClient: ContentApiClient, controllerComponent
             pillar = OnwardsUtils.normalisePillar(content.metadata.pillar),
             format = content.metadata.format.getOrElse(ContentFormat.defaultContentFormat),
           )
-          Cached(900)(JsonComponent(richLink)(request, RichLink.writes))
+          Cached(900)(JsonComponent.fromWritable(richLink)(request, RichLink.writes))
         case Some(content) => renderContent(richLinkHtml(content), richLinkBodyHtml(content))
         case None          => NotFound
       }

--- a/onward/app/controllers/SeriesController.scala
+++ b/onward/app/controllers/SeriesController.scala
@@ -32,7 +32,9 @@ class SeriesController(
     Action.async { implicit request =>
       if (request.forceDCR) {
         lookup(Edition(request), seriesId).map { mseries =>
-          mseries.map { series => JsonComponent(SeriesStoriesDCR.fromSeries(series)).result }.getOrElse(NotFound)
+          mseries
+            .map { series => JsonComponent.fromWritable(SeriesStoriesDCR.fromSeries(series)).result }
+            .getOrElse(NotFound)
         }
       } else {
         lookup(Edition(request), seriesId) map { series =>

--- a/onward/app/controllers/StocksController.scala
+++ b/onward/app/controllers/StocksController.scala
@@ -13,12 +13,12 @@ class StocksController(stocksData: StocksData, val controllerComponents: Control
     Action { implicit request =>
       // Decommissioned, see marker: 7dde429f00b1
       if (false && StocksWidgetSwitch.isSwitchedOff) {
-        Cached(1.minute)(JsonComponent(Stocks(Seq.empty)))
+        Cached(1.minute)(JsonComponent.fromWritable(Stocks(Seq.empty)))
       } else {
         stocksData.get match {
           case None => InternalServerError("Business data not loaded")
           case Some(stocks) =>
-            Cached(1.minute)(JsonComponent(stocks))
+            Cached(1.minute)(JsonComponent.fromWritable(stocks))
         }
       }
     }

--- a/onward/app/controllers/StoryPackageController.scala
+++ b/onward/app/controllers/StoryPackageController.scala
@@ -30,7 +30,7 @@ class StoryPackageController(val contentApiClient: ContentApiClient, val control
   def render(path: String): Action[AnyContent] =
     Action.async { implicit request =>
       getRelatedContent(path).map(items => {
-        val json = JsonComponent(
+        val json = JsonComponent.fromWritable(
           OnwardCollectionResponse(
             heading = "More on this story",
             trails = items.map(_.faciaContent).map(OnwardItem.pressedContentToOnwardItem).take(10),

--- a/onward/app/weather/controllers/LocationsController.scala
+++ b/onward/app/weather/controllers/LocationsController.scala
@@ -18,7 +18,7 @@ class LocationsController(weatherApi: WeatherApi, val controllerComponents: Cont
   def findCity(query: String): Action[AnyContent] =
     Action.async { implicit request =>
       weatherApi.searchForLocations(query) map { locations =>
-        Cached(7.days)(JsonComponent(CityResponse.fromLocationResponses(locations.toList)))
+        Cached(7.days)(JsonComponent.fromWritable(CityResponse.fromLocationResponses(locations.toList)))
       }
     }
 
@@ -58,7 +58,7 @@ class LocationsController(weatherApi: WeatherApi, val controllerComponents: Cont
               // We do this as AccuWeather writes "New York, New York" if no region is specified, where as we
               // just get "New York" from Fastly.
               val weatherCityWithoutRegion = weatherCity.copy(city = city)
-              Cached(1 hour)(JsonComponent(weatherCityWithoutRegion))
+              Cached(1 hour)(JsonComponent.fromWritable(weatherCityWithoutRegion))
             }
           }
 
@@ -67,7 +67,7 @@ class LocationsController(weatherApi: WeatherApi, val controllerComponents: Cont
             cityFromRequestEdition.fold {
               Cached(CacheTime.NotFound)(JsonNotFound())
             } { city =>
-              Cached(1 hour)(JsonComponent(city))
+              Cached(1 hour)(JsonComponent.fromWritable(city))
             },
           )
       }

--- a/sport/app/football/controllers/MatchController.scala
+++ b/sport/app/football/controllers/MatchController.scala
@@ -170,7 +170,7 @@ class MatchController(
         page map { page =>
           if (request.forceDCR) {
             Cached(30) {
-              JsonComponent(Json.toJson(NsAnswer.makeFromFootballMatch(theMatch, page.lineUp)))
+              JsonComponent.fromWritable(NsAnswer.makeFromFootballMatch(theMatch, page.lineUp))
             }
           } else {
             val htmlResponse = () =>

--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -268,17 +268,15 @@ class MoreOnMatchController(
               filtered <- related map { _ filter hasExactlyTwoTeams }
             } yield {
               Cached(if (theMatch.isLive) 10 else 300) {
-                JsonComponent(
-                  Json.toJson(
-                    NxAnswer.makeFromFootballMatch(
-                      request,
-                      theMatch,
-                      filtered,
-                      lineup,
-                      competition,
-                      theMatch.isResult,
-                      theMatch.isLive,
-                    ),
+                JsonComponent.fromWritable(
+                  NxAnswer.makeFromFootballMatch(
+                    request,
+                    theMatch,
+                    filtered,
+                    lineup,
+                    competition,
+                    theMatch.isResult,
+                    theMatch.isLive,
                   ),
                 )
               }


### PR DESCRIPTION
_Don't worry, this PR looks big but it's **only a rename of a method** that's called in quite a few places!_

The Frontend codebase compiles just fine under Scala 2.12 right now, but if we switch to the Scala 2.13 compiler (ie for https://github.com/guardian/frontend/pull/25190) it suddenly starts giving a lot of _'ambiguous reference to overloaded definition'_ errors, eg here:

https://github.com/guardian/frontend/blob/5e17a2fc5c885c0da0fc7d202662e5acce6bb2db/sport/app/football/controllers/MoreOnMatchController.scala#L396-L397

```
[error] ambiguous reference to overloaded definition
[error] both method apply in object JsonComponent of type (items: (String, Any)*)(implicit request: play.api.mvc.RequestHeader): model.Cached.RevalidatableResult
[error] and  method apply in object JsonComponent of type [A](value: A)(implicit request: play.api.mvc.RequestHeader, writes: play.api.libs.json.Writes[A]): model.Cached.RevalidatableResult
[error] match argument types ((String, play.api.libs.json.JsArray)) and expected result type model.Cached.CacheableResult
```

...the Scala compiler is saying it can't work out which of these 2 methods we're trying to call:

A) This one that accepts any type `T` at all, so long as an instance of [`play.api.libs.json.Writes[T]`](https://www.playframework.com/documentation/2.8.x/ScalaJsonCombinators#Writes) is available:
https://github.com/guardian/frontend/blob/5a6d14885ad2bcfae7d6bbcc5a7ffdac1add3451/common/app/common/JsonComponent.scala#L17-L21

B) This one that accepts multiple `(String, Any)` pairs: https://github.com/guardian/frontend/blob/5a6d14885ad2bcfae7d6bbcc5a7ffdac1add3451/common/app/common/JsonComponent.scala#L36-L39

Why does the code only fail under Scala 2.13?
---------------------------------------------

The Scala 2.12 compiler was unfortunately being too slack on ambiguity, and Scala 2.13 is actually being much more sensible! Under Scala 2.12, the compiler would arbitrarily _prefer_ the 'B' varargs method that takes `(String, Any)` pairs, even though the 'A' method would have been a valid choice if only a single pair was passed in (and there wasn't any reasonable way for a programmer to guess which method it was going to choose). It shouldn't have made such an arbitrary choice - and Scala 2.13 corrects that.

You can see the arbitrary nature of Scala 2.12's choice of method here, in [this online example](https://scastie.scala-lang.org/rtyley/5HdzJGVqSU6QgIUfTg6nLA/8):

![image](https://user-images.githubusercontent.com/52038/181229409-1f57dd4b-7488-46ce-94c5-15d18a7290dc.png)

When you have both the 'pairs' & 'writes' versions of the methods available- so `foo()` is overloaded- there is no good reason why Scala 2.12 should pick either - but it always picks the 'pairs' one.

What's the fix?
---------------

We need to remove the ambiguity, and make certain that when we call `JsonComponent` there's only ever exactly 1 method that matches our invocation! We can do that by renaming one of the two `apply()` methods.

We could rename either method, but it's actually preferable to change method A (that uses `Writes[T]`). That's because if we were to rename B, and then fix all the compilation errors, we _wouldn't_ see places where the Scala 2.12 compiler was originally choosing B, but can still choose A - the compiler will just start using the the A method without raising a compilation error. Unless we realise that, we'll actually be unintentionally switching parts of our codebase from using B to A... potentially changing the results?

If we rename 'A', then the resulting compilation errors across the codebase will be *ALL* places that 'A' was getting called - because the Scala 2.12 compiler only called the 'A' method when it had no choice, ie when the `(String, Any)` form of method 'B' was not available.
