### PR TITLE
Add dfpEnv to the window object

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -80,6 +80,7 @@ class Advert {
 	id: string;
 	node: HTMLElement;
 	sizes: SizeMapping;
+	headerBiddingSizes: HeaderBiddingSize[] | null = null;
 	size: AdSize | 'fluid' | null = null;
 	slot: googletag.Slot;
 	isEmpty: boolean | null = null;

--- a/static/src/javascripts/projects/commercial/modules/dfp/dfp-env.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/dfp-env.ts
@@ -20,7 +20,7 @@ interface DfpEnv {
 
 const { switches } = window.guardian.config;
 
-export const dfpEnv: DfpEnv = {
+const dfpEnv: DfpEnv = {
 	/* renderStartTime: integer. Point in time when DFP kicks in */
 	renderStartTime: -1,
 
@@ -67,3 +67,10 @@ export const dfpEnv: DfpEnv = {
 		);
 	},
 };
+
+window.guardian.commercial = window.guardian.commercial ?? {};
+
+// expose this on the window, for use by debugger tools
+window.guardian.commercial.dfpEnv = dfpEnv;
+
+export { dfpEnv };

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
@@ -211,6 +211,7 @@ class PrebidAdUnit {
 		this.code = advert.id;
 		this.bids = bids(advert.id, slot.sizes, pageTargeting);
 		this.mediaTypes = { banner: { sizes: slot.sizes } };
+		advert.headerBiddingSizes = slot.sizes;
 		log('commercial', `PrebidAdUnit ${this.code}`, this.bids);
 	}
 

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -252,6 +252,9 @@ interface Window {
 		// /frontend/common/app/templates/inlineJS/blocking/enableStylesheets.scala.js
 		css: { onLoad: () => void; loaded: boolean };
 		articleCounts?: ArticleCounts;
+		commercial?: {
+			dfpEnv?: DfpEnv;
+		};
 	};
 
 	confiant?: Confiant;


### PR DESCRIPTION
## What does this change?
Adds dfpEnv on the window, nested under `guardian.config.commercial`.

## What is the value of this and can you measure success?

This will allow bookmarklet/extension tools to provide some additional insight into ads on the website.

Also adds headerBiddingSizes to the Advert class so they can be used by the aforementioned tools.

The only tool that needs this so far is a bookmarklet and exists in gist form at the moment https://gist.github.com/Jakeii/748815066e7fc001ad5f7cd050014a87

Example:
<img width="497" alt="Screenshot 2022-07-28 at 10 58 07" src="https://user-images.githubusercontent.com/1731150/181478412-a5b4c3d5-265c-4999-82e6-fa08850044f7.png">


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
