### PR TITLE
Ei/slot config migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@guardian/atom-renderer": "1.2.2",
     "@guardian/automat-modules": "^0.3.8",
     "@guardian/braze-components": "^7.3.0",
-    "@guardian/commercial-core": "4.5.0",
+    "@guardian/commercial-core": "4.6.0",
     "@guardian/consent-management-platform": "^10.7.1",
     "@guardian/libs": "^3.6.1",
     "@guardian/shimport": "^1.0.2",

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.spec.ts
@@ -1,3 +1,4 @@
+import { createAdSize } from '@guardian/commercial-core';
 import type { PageTargeting } from 'common/modules/commercial/build-page-targeting';
 import {
 	isInAuOrNz as isInAuOrNz_,
@@ -32,9 +33,11 @@ import { _, bids } from './bid-config';
 const mockPageTargeting = {} as unknown as PageTargeting;
 
 const getBidders = () =>
-	bids('dfp-ad--top-above-nav', [[728, 90]], mockPageTargeting).map(
-		(bid) => bid.bidder,
-	);
+	bids(
+		'dfp-ad--top-above-nav',
+		[createAdSize(728, 90)],
+		mockPageTargeting,
+	).map((bid) => bid.bidder);
 
 const {
 	getIndexSiteId,
@@ -129,17 +132,17 @@ describe('getImprovePlacementId', () => {
 
 	const generateTestIds = () => {
 		const prebidSizes: HeaderBiddingSize[][] = [
-			[[300, 250]],
-			[[300, 600]],
-			[[970, 250]],
-			[[728, 90]],
-			[[1, 2]],
+			[createAdSize(300, 250)],
+			[createAdSize(300, 600)],
+			[createAdSize(970, 250)],
+			[createAdSize(728, 90)],
+			[createAdSize(1, 2)],
 		];
 		return prebidSizes.map(getImprovePlacementId);
 	};
 
 	test('should return -1 if no cases match', () => {
-		expect(getImprovePlacementId([[1, 2]])).toBe(-1);
+		expect(getImprovePlacementId([createAdSize(1, 2)])).toBe(-1);
 	});
 
 	test('should return the expected values when geolocated in UK and on desktop device', () => {
@@ -331,8 +334,8 @@ describe('indexExchangeBidders', () => {
 
 	test('should return an IX bidder for every size that the slot can take', () => {
 		const slotSizes: HeaderBiddingSize[] = [
-			[300, 250],
-			[300, 600],
+			createAdSize(300, 250),
+			createAdSize(300, 600),
 		];
 		const bidders: PrebidBidder[] = indexExchangeBidders(slotSizes);
 		expect(bidders).toEqual([
@@ -351,15 +354,15 @@ describe('indexExchangeBidders', () => {
 
 	test('should include methods in the response that generate the correct bid params', () => {
 		const slotSizes: HeaderBiddingSize[] = [
-			[300, 250],
-			[300, 600],
+			createAdSize(300, 250),
+			createAdSize(300, 600),
 		];
 		const bidders: PrebidBidder[] = indexExchangeBidders(slotSizes);
-		expect(bidders[0].bidParams('type', [[1, 2]])).toEqual({
+		expect(bidders[0].bidParams('type', [createAdSize(1, 2)])).toEqual({
 			siteId: '123456',
 			size: [300, 250],
 		});
-		expect(bidders[1].bidParams('type', [[1, 2]])).toEqual({
+		expect(bidders[1].bidParams('type', [createAdSize(1, 2)])).toEqual({
 			siteId: '123456',
 			size: [300, 600],
 		});
@@ -469,10 +472,7 @@ describe('bids', () => {
 		const rightSlotBidders = () =>
 			bids(
 				'dfp-right',
-				[
-					[300, 600],
-					[300, 250],
-				],
+				[createAdSize(300, 600), createAdSize(300, 250)],
 				mockPageTargeting,
 			).map((bid) => bid.bidder);
 		expect(rightSlotBidders()).toEqual(['ix', 'ix', 'adyoulike']);
@@ -515,7 +515,7 @@ describe('bids', () => {
 		isInUk.mockReturnValue(true);
 		const openXBid = bids(
 			'dfp-ad--top-above-nav',
-			[[728, 90]],
+			[createAdSize(728, 90)],
 			mockPageTargeting,
 		)[2];
 		expect(openXBid.params).toEqual({
@@ -530,7 +530,7 @@ describe('bids', () => {
 		isInUsOrCa.mockReturnValue(true);
 		const openXBid = bids(
 			'dfp-ad--top-above-nav',
-			[[728, 90]],
+			[createAdSize(728, 90)],
 			mockPageTargeting,
 		)[2];
 		expect(openXBid.params).toEqual({
@@ -545,7 +545,7 @@ describe('bids', () => {
 		isInAuOrNz.mockReturnValue(true);
 		const openXBid = bids(
 			'dfp-ad--top-above-nav',
-			[[728, 90]],
+			[createAdSize(728, 90)],
 			mockPageTargeting,
 		)[2];
 		expect(openXBid.params).toEqual({
@@ -560,7 +560,7 @@ describe('bids', () => {
 		isInRow.mockReturnValue(true);
 		const openXBid = bids(
 			'dfp-ad--top-above-nav',
-			[[728, 90]],
+			[createAdSize(728, 90)],
 			mockPageTargeting,
 		)[2];
 		expect(openXBid.params).toEqual({
@@ -594,7 +594,7 @@ describe('triplelift adapter', () => {
 
 		const tripleLiftBids = bids(
 			'dfp-ad--top-above-nav',
-			[[728, 90]],
+			[createAdSize(728, 90)],
 			mockPageTargeting,
 		)[1].params;
 		expect(tripleLiftBids).toEqual({
@@ -610,7 +610,7 @@ describe('triplelift adapter', () => {
 
 		const tripleLiftBids = bids(
 			'dfp-ad--inline1',
-			[[300, 250]],
+			[createAdSize(300, 250)],
 			mockPageTargeting,
 		)[1].params;
 		expect(tripleLiftBids).toEqual({
@@ -626,7 +626,7 @@ describe('triplelift adapter', () => {
 
 		const tripleLiftBids = bids(
 			'dfp-ad--top-above-nav',
-			[[320, 50]],
+			[createAdSize(320, 50)],
 			mockPageTargeting,
 		)[1].params;
 		expect(tripleLiftBids).toEqual({
@@ -656,17 +656,17 @@ describe('getXaxisPlacementId', () => {
 
 	const generateTestIds = () => {
 		const prebidSizes: HeaderBiddingSize[][] = [
-			[[300, 250]],
-			[[300, 600]],
-			[[970, 250]],
-			[[728, 90]],
-			[[1, 2]],
+			[createAdSize(300, 250)],
+			[createAdSize(300, 600)],
+			[createAdSize(970, 250)],
+			[createAdSize(728, 90)],
+			[createAdSize(1, 2)],
 		];
 		return prebidSizes.map(getXaxisPlacementId);
 	};
 
 	test('should return -1 if no cases match', () => {
-		expect(getImprovePlacementId([[1, 2]])).toBe(-1);
+		expect(getImprovePlacementId([createAdSize(1, 2)])).toBe(-1);
 	});
 
 	test('should return the expected values for desktop device', () => {

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.ts
@@ -1,3 +1,4 @@
+import { adSizes } from '@guardian/commercial-core';
 import type { Advert } from 'commercial/modules/dfp/Advert';
 import config from '../../../../lib/config';
 import {
@@ -47,10 +48,10 @@ const getSlots = (contentType: string): HeaderBiddingSlot[] => {
 		{
 			key: 'right',
 			sizes: hasShowcase
-				? [[300, 250]]
+				? [[adSizes.mpu.width, adSizes.mpu.height]]
 				: [
-						[300, 600],
-						[300, 250],
+						[adSizes.halfPage.width, adSizes.halfPage.height],
+						[adSizes.mpu.width, adSizes.mpu.height],
 				  ],
 		},
 	];
@@ -58,44 +59,47 @@ const getSlots = (contentType: string): HeaderBiddingSlot[] => {
 		{
 			key: 'top-above-nav',
 			sizes: [
-				[970, 250],
-				[728, 90],
+				[adSizes.billboard.width, adSizes.billboard.height],
+				[adSizes.leaderboard.width, adSizes.leaderboard.height],
 			],
 		},
 		{
 			key: 'inline',
 			sizes: isArticle
 				? [
-						[160, 600],
-						[300, 600],
-						[300, 250],
+						[adSizes.skyscraper.width, adSizes.skyscraper.height],
+						[adSizes.halfPage.width, adSizes.halfPage.height],
+						[adSizes.mpu.width, adSizes.mpu.height],
 				  ]
-				: [[300, 250]],
+				: [[adSizes.mpu.width, adSizes.mpu.height]],
 		},
 		{
 			key: 'inline1',
 			sizes: isArticle
 				? [
-						[300, 250],
-						[620, 350],
+						[adSizes.mpu.width, adSizes.mpu.height],
+						[
+							adSizes.outstreamDesktop.width,
+							adSizes.outstreamDesktop.height,
+						],
 				  ]
-				: [[300, 250]],
+				: [[adSizes.mpu.width, adSizes.mpu.height]],
 		},
 		{
 			key: 'mostpop',
 			sizes: hasExtendedMostPop
 				? [
-						[300, 600],
-						[300, 250],
+						[adSizes.halfPage.width, adSizes.halfPage.height],
+						[adSizes.mpu.width, adSizes.mpu.height],
 				  ]
-				: [[300, 250]],
+				: [[adSizes.mpu.width, adSizes.mpu.height]],
 		},
 		{
 			key: 'comments',
 			sizes: [
-				[160, 600],
-				[300, 250],
-				[300, 600],
+				[adSizes.skyscraper.width, adSizes.skyscraper.height],
+				[adSizes.mpu.width, adSizes.mpu.height],
+				[adSizes.halfPage.width, adSizes.halfPage.height],
 			],
 		},
 		// Banner slots appear on interactives, like on
@@ -104,73 +108,79 @@ const getSlots = (contentType: string): HeaderBiddingSlot[] => {
 			key: 'banner',
 			sizes: [
 				[88, 70],
-				[728, 90],
+				[adSizes.leaderboard.width, adSizes.leaderboard.height],
 				[940, 230],
 				[900, 250],
-				[970, 250],
+				[adSizes.billboard.width, adSizes.billboard.height],
 			],
 		},
 	];
 	const tabletSlots: HeaderBiddingSlot[] = [
 		{
 			key: 'top-above-nav',
-			sizes: [[728, 90]],
+			sizes: [[adSizes.leaderboard.width, adSizes.leaderboard.height]],
 		},
 		{
 			key: 'inline',
-			sizes: [[300, 250]],
+			sizes: [[adSizes.mpu.width, adSizes.mpu.height]],
 		},
 		{
 			key: 'inline1',
 			sizes: isArticle
 				? [
-						[300, 250],
-						[620, 350],
+						[adSizes.mpu.width, adSizes.mpu.height],
+						[
+							adSizes.outstreamDesktop.width,
+							adSizes.outstreamDesktop.height,
+						],
 				  ]
-				: [[300, 250]],
+				: [[adSizes.mpu.width, adSizes.mpu.height]],
 		},
 		{
 			key: 'mostpop',
 			sizes: hasExtendedMostPop
 				? [
-						[300, 600],
-						[300, 250],
-						[728, 90],
+						[adSizes.halfPage.width, adSizes.halfPage.height],
+						[adSizes.mpu.width, adSizes.mpu.height],
+						[adSizes.leaderboard.width, adSizes.leaderboard.height],
 				  ]
-				: [[300, 250]],
+				: [[adSizes.mpu.width, adSizes.mpu.height]],
 		},
 	];
 	const mobileSlots: HeaderBiddingSlot[] = [
 		{
 			key: 'top-above-nav',
-			sizes: [[300, 250]],
+			sizes: [[adSizes.mpu.width, adSizes.mpu.height]],
 		},
 		{
 			key: 'inline',
-			sizes: [[300, 250]],
+			sizes: [[adSizes.mpu.width, adSizes.mpu.height]],
 		},
 		{
 			key: 'inline1',
 			sizes: isArticle
 				? [
-						[300, 197],
-						[300, 250],
+						[
+							adSizes.outstreamMobile.width,
+							adSizes.outstreamMobile.height,
+						],
+						[adSizes.mpu.width, adSizes.mpu.height],
 				  ]
-				: [[300, 250]],
+				: [[adSizes.mpu.width, adSizes.mpu.height]],
 		},
 		{
 			key: 'mostpop',
-			sizes: [[300, 250]],
+			sizes: [[adSizes.mpu.width, adSizes.mpu.height]],
 		},
 	];
 	const mobileStickySlot: HeaderBiddingSlot = {
 		key: 'mobile-sticky',
-		sizes: [[320, 50]],
+		sizes: [[adSizes.mobilesticky.width, adSizes.mobilesticky.height]],
 	};
 
 	const crosswordBannerSlot: HeaderBiddingSlot = {
 		key: 'crossword-banner',
-		sizes: [[728, 90]],
+		sizes: [[adSizes.leaderboard.width, adSizes.leaderboard.height]],
 	};
 
 	const crosswordSlots = isCrossword ? [crosswordBannerSlot] : [];

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.ts
@@ -1,4 +1,4 @@
-import { adSizes } from '@guardian/commercial-core';
+import { adSizes, createAdSize } from '@guardian/commercial-core';
 import type { Advert } from 'commercial/modules/dfp/Advert';
 import config from '../../../../lib/config';
 import {
@@ -48,139 +48,100 @@ const getSlots = (contentType: string): HeaderBiddingSlot[] => {
 		{
 			key: 'right',
 			sizes: hasShowcase
-				? [[adSizes.mpu.width, adSizes.mpu.height]]
-				: [
-						[adSizes.halfPage.width, adSizes.halfPage.height],
-						[adSizes.mpu.width, adSizes.mpu.height],
-				  ],
+				? [adSizes.mpu]
+				: [adSizes.halfPage, adSizes.mpu],
 		},
 	];
 	const desktopSlots: HeaderBiddingSlot[] = [
 		{
 			key: 'top-above-nav',
-			sizes: [
-				[adSizes.billboard.width, adSizes.billboard.height],
-				[adSizes.leaderboard.width, adSizes.leaderboard.height],
-			],
+			sizes: [adSizes.billboard, adSizes.leaderboard],
 		},
 		{
 			key: 'inline',
 			sizes: isArticle
-				? [
-						[adSizes.skyscraper.width, adSizes.skyscraper.height],
-						[adSizes.halfPage.width, adSizes.halfPage.height],
-						[adSizes.mpu.width, adSizes.mpu.height],
-				  ]
-				: [[adSizes.mpu.width, adSizes.mpu.height]],
+				? [adSizes.skyscraper, adSizes.halfPage, adSizes.mpu]
+				: [adSizes.mpu],
 		},
 		{
 			key: 'inline1',
 			sizes: isArticle
-				? [
-						[adSizes.mpu.width, adSizes.mpu.height],
-						[
-							adSizes.outstreamDesktop.width,
-							adSizes.outstreamDesktop.height,
-						],
-				  ]
-				: [[adSizes.mpu.width, adSizes.mpu.height]],
+				? [adSizes.mpu, adSizes.outstreamDesktop]
+				: [adSizes.mpu],
 		},
 		{
 			key: 'mostpop',
 			sizes: hasExtendedMostPop
-				? [
-						[adSizes.halfPage.width, adSizes.halfPage.height],
-						[adSizes.mpu.width, adSizes.mpu.height],
-				  ]
-				: [[adSizes.mpu.width, adSizes.mpu.height]],
+				? [adSizes.halfPage, adSizes.mpu]
+				: [adSizes.mpu],
 		},
 		{
 			key: 'comments',
-			sizes: [
-				[adSizes.skyscraper.width, adSizes.skyscraper.height],
-				[adSizes.mpu.width, adSizes.mpu.height],
-				[adSizes.halfPage.width, adSizes.halfPage.height],
-			],
+			sizes: [adSizes.skyscraper, adSizes.mpu, adSizes.halfPage],
 		},
 		// Banner slots appear on interactives, like on
 		// https://www.theguardian.com/us-news/ng-interactive/2018/nov/06/midterm-elections-2018-live-results-latest-winners-and-seats
 		{
 			key: 'banner',
 			sizes: [
-				[88, 70],
-				[adSizes.leaderboard.width, adSizes.leaderboard.height],
-				[adSizes.cascade.width, adSizes.cascade.height],
-				[900, 250],
-				[adSizes.billboard.width, adSizes.billboard.height],
+				createAdSize(88, 70),
+				adSizes.leaderboard,
+				adSizes.cascade,
+				createAdSize(900, 250),
+				adSizes.billboard,
 			],
 		},
 	];
 	const tabletSlots: HeaderBiddingSlot[] = [
 		{
 			key: 'top-above-nav',
-			sizes: [[adSizes.leaderboard.width, adSizes.leaderboard.height]],
+			sizes: [adSizes.leaderboard],
 		},
 		{
 			key: 'inline',
-			sizes: [[adSizes.mpu.width, adSizes.mpu.height]],
+			sizes: [adSizes.mpu],
 		},
 		{
 			key: 'inline1',
 			sizes: isArticle
-				? [
-						[adSizes.mpu.width, adSizes.mpu.height],
-						[
-							adSizes.outstreamDesktop.width,
-							adSizes.outstreamDesktop.height,
-						],
-				  ]
-				: [[adSizes.mpu.width, adSizes.mpu.height]],
+				? [adSizes.mpu, adSizes.outstreamDesktop]
+				: [adSizes.mpu],
 		},
 		{
 			key: 'mostpop',
 			sizes: hasExtendedMostPop
-				? [
-						[adSizes.halfPage.width, adSizes.halfPage.height],
-						[adSizes.mpu.width, adSizes.mpu.height],
-						[adSizes.leaderboard.width, adSizes.leaderboard.height],
-				  ]
-				: [[adSizes.mpu.width, adSizes.mpu.height]],
+				? [adSizes.halfPage, adSizes.mpu, adSizes.leaderboard]
+				: [adSizes.mpu],
 		},
 	];
 	const mobileSlots: HeaderBiddingSlot[] = [
 		{
 			key: 'top-above-nav',
-			sizes: [[adSizes.mpu.width, adSizes.mpu.height]],
+			sizes: [adSizes.mpu],
 		},
 		{
 			key: 'inline',
-			sizes: [[adSizes.mpu.width, adSizes.mpu.height]],
+			sizes: [adSizes.mpu],
 		},
 		{
 			key: 'inline1',
 			sizes: isArticle
-				? [
-						[
-							adSizes.outstreamMobile.width,
-							adSizes.outstreamMobile.height,
-						],
-						[adSizes.mpu.width, adSizes.mpu.height],
-				  ]
-				: [[adSizes.mpu.width, adSizes.mpu.height]],
+				? [adSizes.outstreamMobile, adSizes.mpu]
+				: [adSizes.mpu],
 		},
 		{
 			key: 'mostpop',
-			sizes: [[adSizes.mpu.width, adSizes.mpu.height]],
+			sizes: [adSizes.mpu],
 		},
 	];
 	const mobileStickySlot: HeaderBiddingSlot = {
 		key: 'mobile-sticky',
-		sizes: [[adSizes.mobilesticky.width, adSizes.mobilesticky.height]],
+		sizes: [adSizes.mobilesticky],
 	};
 
 	const crosswordBannerSlot: HeaderBiddingSlot = {
 		key: 'crossword-banner',
-		sizes: [[adSizes.leaderboard.width, adSizes.leaderboard.height]],
+		sizes: [adSizes.leaderboard],
 	};
 
 	const crosswordSlots = isCrossword ? [crosswordBannerSlot] : [];

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/slot-config.ts
@@ -109,7 +109,7 @@ const getSlots = (contentType: string): HeaderBiddingSlot[] => {
 			sizes: [
 				[88, 70],
 				[adSizes.leaderboard.width, adSizes.leaderboard.height],
-				[940, 230],
+				[adSizes.cascade.width, adSizes.cascade.height],
 				[900, 250],
 				[adSizes.billboard.width, adSizes.billboard.height],
 			],

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/types.d.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/types.d.ts
@@ -1,140 +1,144 @@
-type HeaderBiddingSize = [number, number];
+import type { AdSize } from '@guardian/commercial-core';
 
-type HeaderBiddingSlot = {
-	key:
-		| 'top-above-nav'
-		| 'right'
-		| 'inline1'
-		| 'inline'
-		| 'mostpop'
-		| 'comments'
-		| 'mobile-sticky'
-		| 'banner'
-		| 'crossword-banner';
-	sizes: HeaderBiddingSize[];
-};
+declare global {
+	type HeaderBiddingSize = AdSize;
 
-type PrebidOzoneParams = {
-	publisherId: string;
-	siteId: string;
-	placementId: string;
-	customData?: [Record<string, unknown>];
-	ozoneData?: Record<string, unknown>;
-};
-
-type PrebidSonobiParams = {
-	ad_unit: string;
-	dom_id: string;
-	appNexusTargeting: string;
-	pageViewId: string;
-	render?: string;
-};
-
-type PrebidPubmaticParams = {
-	publisherId: string;
-	adSlot: string;
-};
-
-type PrebidIndexExchangeParams = {
-	siteId: string;
-	size: HeaderBiddingSize;
-};
-
-type PrebidTrustXParams = {
-	uid: string;
-};
-
-type PrebidTripleLiftParams = {
-	inventoryCode: string;
-};
-
-type PrebidImproveParams = {
-	placementId: number;
-	size: {
-		w?: number;
-		h?: number;
-	};
-};
-
-type PrebidXaxisParams = {
-	placementId: number;
-};
-
-type PrebidAppNexusParams = {
-	invCode?: string;
-	member?: string;
-	placementId?: string;
-	keywords: unknown;
-	lotame?: unknown;
-};
-
-type PrebidOpenXParams = {
-	delDomain: string;
-	unit: string;
-	customParams: unknown;
-	lotame?: unknown;
-};
-
-type PrebidAdYouLikeParams = {
-	placement: string;
-};
-
-type PrebidCriteoParams = {
-	networkId: number;
-};
-
-type PrebidSmartParams = {
-	siteId: number;
-	pageId: number;
-	formatId: number;
-};
-
-type BidderCode =
-	| 'adyoulike'
-	| 'and'
-	| 'appnexus'
-	| 'criteo'
-	| 'improvedigital'
-	| 'ix'
-	| 'oxd'
-	| 'ozone'
-	| 'pubmatic'
-	| 'smartadserver'
-	| 'sonobi'
-	| 'triplelift'
-	| 'trustx'
-	| 'xhb';
-
-type PrebidParams =
-	| PrebidAdYouLikeParams
-	| PrebidAppNexusParams
-	| PrebidCriteoParams
-	| PrebidImproveParams
-	| PrebidIndexExchangeParams
-	| PrebidOpenXParams
-	| PrebidOzoneParams
-	| PrebidPubmaticParams
-	| PrebidSmartParams
-	| PrebidSonobiParams
-	| PrebidTripleLiftParams
-	| PrebidTrustXParams
-	| PrebidXaxisParams;
-
-type PrebidBidder = {
-	name: BidderCode;
-	switchName: string;
-	bidParams: (slotId: string, sizes: HeaderBiddingSize[]) => PrebidParams;
-};
-
-type PrebidBid = {
-	bidder: string;
-	params: PrebidParams;
-};
-
-type PrebidMediaTypes = {
-	banner: {
+	type HeaderBiddingSlot = {
+		key:
+			| 'top-above-nav'
+			| 'right'
+			| 'inline1'
+			| 'inline'
+			| 'mostpop'
+			| 'comments'
+			| 'mobile-sticky'
+			| 'banner'
+			| 'crossword-banner';
 		sizes: HeaderBiddingSize[];
 	};
-};
 
-type SlotFlatMap = (slot: HeaderBiddingSlot) => HeaderBiddingSlot[];
+	type PrebidOzoneParams = {
+		publisherId: string;
+		siteId: string;
+		placementId: string;
+		customData?: [Record<string, unknown>];
+		ozoneData?: Record<string, unknown>;
+	};
+
+	type PrebidSonobiParams = {
+		ad_unit: string;
+		dom_id: string;
+		appNexusTargeting: string;
+		pageViewId: string;
+		render?: string;
+	};
+
+	type PrebidPubmaticParams = {
+		publisherId: string;
+		adSlot: string;
+	};
+
+	type PrebidIndexExchangeParams = {
+		siteId: string;
+		size: HeaderBiddingSize;
+	};
+
+	type PrebidTrustXParams = {
+		uid: string;
+	};
+
+	type PrebidTripleLiftParams = {
+		inventoryCode: string;
+	};
+
+	type PrebidImproveParams = {
+		placementId: number;
+		size: {
+			w?: number;
+			h?: number;
+		};
+	};
+
+	type PrebidXaxisParams = {
+		placementId: number;
+	};
+
+	type PrebidAppNexusParams = {
+		invCode?: string;
+		member?: string;
+		placementId?: string;
+		keywords: unknown;
+		lotame?: unknown;
+	};
+
+	type PrebidOpenXParams = {
+		delDomain: string;
+		unit: string;
+		customParams: unknown;
+		lotame?: unknown;
+	};
+
+	type PrebidAdYouLikeParams = {
+		placement: string;
+	};
+
+	type PrebidCriteoParams = {
+		networkId: number;
+	};
+
+	type PrebidSmartParams = {
+		siteId: number;
+		pageId: number;
+		formatId: number;
+	};
+
+	type BidderCode =
+		| 'adyoulike'
+		| 'and'
+		| 'appnexus'
+		| 'criteo'
+		| 'improvedigital'
+		| 'ix'
+		| 'oxd'
+		| 'ozone'
+		| 'pubmatic'
+		| 'smartadserver'
+		| 'sonobi'
+		| 'triplelift'
+		| 'trustx'
+		| 'xhb';
+
+	type PrebidParams =
+		| PrebidAdYouLikeParams
+		| PrebidAppNexusParams
+		| PrebidCriteoParams
+		| PrebidImproveParams
+		| PrebidIndexExchangeParams
+		| PrebidOpenXParams
+		| PrebidOzoneParams
+		| PrebidPubmaticParams
+		| PrebidSmartParams
+		| PrebidSonobiParams
+		| PrebidTripleLiftParams
+		| PrebidTrustXParams
+		| PrebidXaxisParams;
+
+	type PrebidBidder = {
+		name: BidderCode;
+		switchName: string;
+		bidParams: (slotId: string, sizes: HeaderBiddingSize[]) => PrebidParams;
+	};
+
+	type PrebidBid = {
+		bidder: string;
+		params: PrebidParams;
+	};
+
+	type PrebidMediaTypes = {
+		banner: {
+			sizes: HeaderBiddingSize[];
+		};
+	};
+
+	type SlotFlatMap = (slot: HeaderBiddingSlot) => HeaderBiddingSlot[];
+}

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/utils.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/utils.spec.ts
@@ -1,3 +1,4 @@
+import { createAdSize } from '@guardian/commercial-core';
 import type { CountryCode } from '@guardian/libs';
 import { _ } from 'common/modules/commercial/geo-utils';
 import { isInVariantSynchronous as isInVariantSynchronous_ } from 'common/modules/experiments/ab';
@@ -93,18 +94,12 @@ describe('Utils', () => {
 	});
 
 	test('getLargestSize should return only one and the largest size', () => {
-		expect(getLargestSize([[300, 250]])).toEqual([300, 250]);
+		expect(getLargestSize([createAdSize(300, 250)])).toEqual([300, 250]);
 		expect(
-			getLargestSize([
-				[300, 250],
-				[300, 600],
-			]),
+			getLargestSize([createAdSize(300, 250), createAdSize(300, 600)]),
 		).toEqual([300, 600]);
 		expect(
-			getLargestSize([
-				[970, 250],
-				[728, 80],
-			]),
+			getLargestSize([createAdSize(970, 250), createAdSize(728, 80)]),
 		).toEqual([970, 250]);
 	});
 
@@ -301,14 +296,14 @@ describe('Utils', () => {
 	});
 
 	test('shouldIncludeAdYouLike when not in any tests', () => {
-		expect(shouldIncludeAdYouLike([[300, 250]])).toBe(true);
+		expect(shouldIncludeAdYouLike([createAdSize(300, 250)])).toBe(true);
 		expect(
 			shouldIncludeAdYouLike([
-				[300, 600],
-				[300, 250],
+				createAdSize(300, 600),
+				createAdSize(300, 250),
 			]),
 		).toBe(true);
-		expect(shouldIncludeAdYouLike([[728, 90]])).toBe(false);
+		expect(shouldIncludeAdYouLike([createAdSize(728, 90)])).toBe(false);
 	});
 
 	test('removeFalseyValues correctly remove non-truthy values', () => {

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/utils.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/utils.ts
@@ -1,3 +1,4 @@
+import { createAdSize } from '@guardian/commercial-core';
 import { isString } from '@guardian/libs';
 import { once } from 'lodash-es';
 import config from '../../../../lib/config';
@@ -68,22 +69,22 @@ export const stripDfpAdPrefixFrom = (s: string): string =>
 	stripPrefix(s, 'dfp-ad--');
 
 export const containsMpu = (sizes: HeaderBiddingSize[]): boolean =>
-	contains(sizes, [300, 250]);
+	contains(sizes, createAdSize(300, 250));
 
 export const containsDmpu = (sizes: HeaderBiddingSize[]): boolean =>
-	contains(sizes, [300, 600]);
+	contains(sizes, createAdSize(300, 600));
 
 export const containsLeaderboard = (sizes: HeaderBiddingSize[]): boolean =>
-	contains(sizes, [728, 90]);
+	contains(sizes, createAdSize(728, 90));
 
 export const containsBillboard = (sizes: HeaderBiddingSize[]): boolean =>
-	contains(sizes, [970, 250]);
+	contains(sizes, createAdSize(970, 250));
 
 export const containsMpuOrDmpu = (sizes: HeaderBiddingSize[]): boolean =>
 	containsMpu(sizes) || containsDmpu(sizes);
 
 export const containsMobileSticky = (sizes: HeaderBiddingSize[]): boolean =>
-	contains(sizes, [320, 50]);
+	contains(sizes, createAdSize(320, 50));
 
 export const containsLeaderboardOrBillboard = (
 	sizes: HeaderBiddingSize[],
@@ -196,6 +197,6 @@ export const stripTrailingNumbersAbove1 = (s: string): string =>
 	stripSuffix(s, '([2-9]|\\d{2,})');
 
 export const containsWS = (sizes: HeaderBiddingSize[]): boolean =>
-	contains(sizes, [160, 600]);
+	contains(sizes, createAdSize(160, 600));
 
 export const shouldIncludeOnlyA9 = window.location.hash.includes('#only-a9');

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -389,6 +389,7 @@
  ],
  "../projects/commercial/modules/header-bidding/prebid/pubmatic.js": [],
  "../projects/commercial/modules/header-bidding/slot-config.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../lib/config.d.ts",
   "../projects/commercial/modules/dfp/Advert.ts",
   "../projects/commercial/modules/header-bidding/utils.ts"

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -395,6 +395,7 @@
   "../projects/commercial/modules/header-bidding/utils.ts"
  ],
  "../projects/commercial/modules/header-bidding/utils.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../../../../node_modules/@types/lodash-es/index.d.ts",
   "../lib/config.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2084,10 +2084,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-7.3.0.tgz#9c4908fa5d439d85b2024735575435b0a5cd369f"
   integrity sha512-Py2FZ6aHi/inOIF4+4xZqNmbJur3cevtWRMQeFLjNjgN7zR7hMB6Dsd8uurEym6Qd3yxBAGPx/+rS3xVbTKz4w==
 
-"@guardian/commercial-core@4.5.0":
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.5.0.tgz#fdf9073b0e297b969478ea70108a39711ddbc155"
-  integrity sha512-2EuDL1e5HneoZds1UKhkOhXDOSn59+TBEhC0UGxT/oPHJv30ZSF2gbfpubmzd0ktscCT4NeCsb9IAJnitnKV/w==
+"@guardian/commercial-core@4.6.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.6.0.tgz#3d0b08306812ee7ea09a3155ac5ae3b5853afcec"
+  integrity sha512-xRP7hypqAHeK70NAPOXnTkmZSdD6iY4s32212UdcacUGg7I8a0AmE6XYjO0qvkwI2CQqm2wVJqmiIrByffut8g==
 
 "@guardian/consent-management-platform@^10.7.1":
   version "10.7.1"


### PR DESCRIPTION
## What does this change?
Change the slot-config file to use sizes defined in commerical-core - reducing duplication of size definitions
## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
Reducing the duplication of size definitions in the commercial code - trying to keep sizes defined in one place
## Checklist

### Tested

- [X] Locally
- [ ] On CODE (optional)

