### PR TITLE
Add Cypress hydrate command

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -46,3 +46,22 @@ Cypress.Commands.add('allowAllConsent', () => {
 		.find(`button[title="${allowAll}"]`, { timeout: 30000 })
 		.click();
 });
+
+Cypress.Commands.add('hydrate', () => {
+	return cy
+		.get('gu-island')
+		.each((el) => {
+			cy.wrap(el)
+				.log(`Scrolling to ${el.attr('name')}`)
+				.scrollIntoView({ duration: 100, timeout: 10000 })
+				.should('have.attr', 'data-gu-ready', 'true', {
+					timeout: 30000,
+				});
+		})
+		.then(() => {
+			cy.scrollTo('top');
+			// Additional wait to ensure layout shift has completed post hydration
+			// eslint-disable-next-line cypress/no-unnecessary-waiting
+			cy.wait(5000);
+		});
+});

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -28,6 +28,8 @@ declare global {
 			allowAllConsent(): void;
 
 			rejectAllConsent(): void;
+
+			hydrate(): Chainable<JQuery<HTMLElement>>;
 		}
 
 		/**


### PR DESCRIPTION
## What does this change?

Adds an e2e utility function that waits for all islands to hydrate.

Preparation for the introduction of visual testing with Percy.

First introduced here: https://github.com/guardian/dotcom-rendering/pull/5256

https://user-images.githubusercontent.com/7014230/177771490-496f7f2b-1316-41cd-b56d-71c62280286b.mp4

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)

