### PR TITLE
Add `im` and `carrot` modes to spacefinder visualiser

### DIFF
--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -76,7 +76,7 @@ class DevParametersHttpRequestHandler(
     "utm_medium", // Google Analytics medium
     "utm_campaign", // Google Analytics campaign
     "utm_term", // Google Analytics term
-    "sfdebug", // enable spacefinder visualiser. '1' = first pass, '2' = second pass
+    "sfdebug", // enable spacefinder visualiser. '1' = inline ads (first pass), '2' = inline ads (second pass), 'im' = inline merchandising ads, 'carrot' = carrot ads
     "rikerdebug", // enable debug logging for Canadian ad setup managed by the Globe and Mail
     "forceSendMetrics", // enable force sending of commercial metrics
     "multiSticky", // enable multiple sticky ads in the right column, for the purpose of qualitative testing

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -217,7 +217,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 			.map((para, i) => {
 				const inlineId = i + (isInline1 ? 1 : 2);
 
-				if (sfdebug) {
+				if (sfdebug == '1' || sfdebug == '2') {
 					para.style.cssText += 'border: thick solid green;';
 				}
 
@@ -353,6 +353,8 @@ const attemptToAddInlineMerchAd = (): Promise<boolean> => {
 		},
 	};
 
+	const enableDebug = sfdebug === 'im';
+
 	const insertAds: SpacefinderWriter = (paras) =>
 		insertAdAtPara(paras[0], 'im', 'im');
 
@@ -360,6 +362,7 @@ const attemptToAddInlineMerchAd = (): Promise<boolean> => {
 		waitForImages: true,
 		waitForLinks: true,
 		waitForInteractives: true,
+		debug: enableDebug,
 	});
 };
 

--- a/static/src/javascripts/projects/commercial/modules/carrot-traffic-driver.ts
+++ b/static/src/javascripts/projects/commercial/modules/carrot-traffic-driver.ts
@@ -1,4 +1,5 @@
 import { createAdSlot } from '@guardian/commercial-core';
+import { getUrlVars } from 'lib/url';
 import { getBreakpoint } from '../../../lib/detect';
 import fastdom from '../../../lib/fastdom-promise';
 import { spaceFiller } from '../../common/modules/article/space-filler';
@@ -8,6 +9,8 @@ import type {
 	SpacefinderWriter,
 } from '../../common/modules/spacefinder';
 import { addSlot } from './dfp/add-slot';
+
+const sfdebug = getUrlVars().sfdebug;
 
 const bodySelector = '.article-body-commercial-selector';
 
@@ -98,11 +101,14 @@ const getRules = (): SpacefinderRules => {
 };
 
 export const initCarrot = (): Promise<boolean> => {
+	const enableDebug = sfdebug === 'carrot';
+
 	if (commercialFeatures.carrotTrafficDriver) {
 		return spaceFiller.fillSpace(getRules(), insertSlot, {
 			waitForImages: true,
 			waitForLinks: true,
 			waitForInteractives: true,
+			debug: enableDebug,
 		});
 	}
 	return Promise.resolve(false);

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -102,6 +102,7 @@
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../lib/detect.js",
   "../lib/fastdom-promise.js",
+  "../lib/url.ts",
   "../projects/commercial/modules/dfp/add-slot.ts",
   "../projects/common/modules/article/space-filler.ts",
   "../projects/common/modules/commercial/commercial-features.ts",


### PR DESCRIPTION
## What does this change?

Adds two new modes to the spacefinder visualiser. 

`sfdebug=im` shows information about inline merch ads
`sfdebug=carrot` shows information about carrot ads

Inline merch example: 

https://www.theguardian.com/science/2022/jul/27/is-russia-killing-off-the-international-space-station-iss

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
![Screenshot 2022-08-01 at 16 46 50](https://user-images.githubusercontent.com/7423751/182188378-09d93389-f27c-4e47-9254-7054bcb3b24c.png)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
