### PR TITLE
Add amIused to article-aside-adverts.ts

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-aside-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-aside-adverts.ts
@@ -1,3 +1,4 @@
+import { amIUsed } from 'commercial/sentinel';
 import { $$ } from '../../../lib/$$';
 import config from '../../../lib/config';
 import fastdom from '../../../lib/fastdom-promise';
@@ -60,6 +61,9 @@ export const init = (): Promise<void | boolean> => {
 	if (!adSlotsWithinRightCol.length || !mainCol.get().length) {
 		return Promise.resolve(false);
 	}
+
+	// is this module needed?
+	amIUsed('article-aside-adverts.ts', 'init');
 
 	return fastdom
 		.measure(() => {

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -78,7 +78,8 @@
   "../lib/$$.ts",
   "../lib/config.d.ts",
   "../lib/fastdom-promise.js",
-  "../lib/mediator.ts"
+  "../lib/mediator.ts",
+  "../projects/commercial/sentinel.ts"
  ],
  "../projects/commercial/modules/article-body-adverts.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",


### PR DESCRIPTION
## What does this change?
Add amIused to article-aside-adverts.ts

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)


## What is the value of this and can you measure success?
We suspect that this file is no longer used, deprecated by DCR and never removed, by adding amIUsed we can determine if any obscure pages are still using it.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
