### PR TITLE
Scala 2.13: Replace deprecated regex construction

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/TextCleaner.scala
+++ b/common/app/model/dotcomrendering/pageElements/TextCleaner.scala
@@ -81,7 +81,7 @@ object TagLinker {
 
   def keywordRegex(tagName: String): Regex = {
     // whitespace or start of line, then tag name, then whitespace, comma, end of line, full stop or question mark.
-    s"""( |^)($tagName)([ ,$$.?])""".r("start", "tag", "end")
+    s"""(?<start> |^)(?<tag>$tagName)(?<end>[ ,$$.?])""".r
   }
 
   def addLink(
@@ -100,8 +100,7 @@ object TagLinker {
       val keyword = keywords.find(tag => el.html.contains(tag.name))
 
       keyword.map(tag => {
-        // $1 and $3 here are 'start' and 'end' regex match groups.
-        val updatedHtml = keywordRegex(tag.name).replaceFirstIn(el.html, "$1" + link(tag, edition) + "$3")
+        val updatedHtml = keywordRegex(tag.name).replaceFirstIn(el.html, "${start}" + link(tag, edition) + "${end}")
         (TextBlockElement(updatedHtml), terms + tag.name)
       }) getOrElse (el, terms)
     } else {

--- a/common/app/pagepresser/HtmlCleaner.scala
+++ b/common/app/pagepresser/HtmlCleaner.scala
@@ -9,7 +9,7 @@ import scala.collection.JavaConverters._
 
 abstract class HtmlCleaner extends GuLogging {
   lazy val fallbackCacheBustId = Configuration.r2Press.fallbackCachebustId
-  lazy val staticRegEx = """//static.guim.co.uk/static/(\w+)/(.+)(\.\w+)$""".r("cacheBustId", "paths", "extension")
+  lazy val staticRegEx = """//static.guim.co.uk/static/(?<cacheBustId>\w+)/(?<paths>.+)(?<extension>\.\w+)$""".r
   lazy val nonDigitRegEx = """\D+""".r
 
   def canClean(document: Document): Boolean
@@ -158,8 +158,7 @@ abstract class HtmlCleaner extends GuLogging {
 
   def deComboLinks(document: Document): Document = {
     document.getAllElements.asScala.filter(elementContainsCombo).foreach { el =>
-      val combinerRegex = """//combo.guim.co.uk/(\w+)/(.+)(\.\w+)$""".r("cacheBustId", "paths", "extension")
-      val microAppRegex = """^m-(\d+)~(.+)""".r
+      val combinerRegex = """//combo.guim.co.uk/(?<cacheBustId>\w+)/(?<paths>.+)(?<extension>\.\w+)$""".r
       val href = if (el.hasAttr("href")) {
         el.attr("href")
       } else {


### PR DESCRIPTION
The existing code was using the `r(groupNames: String*)` extension method on `String` to create a regex with named capturing groups, but that Scala method was deprecated with Scala 2.13.7:

https://www.scala-lang.org/api/2.13.8/scala/collection/StringOps.html#r(groupNames:String*):scala.util.matching.Regex

The `r(groupNames: String*)` method became unnecessary as Scala adopted Java 8 with Scala 2.12, since Java 7 introduced support for 'Named Capturing Groups' (also called 'inline group names' in related Scala PRs):

> A capturing group can also be assigned a "name", a named-capturing
> group, and then be back-referenced later by the "name".

* https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html#groupname
* https://blog.mrhaki.com/2020/04/java-joy-using-named-capturing-groups.html

The PR that deprecated the `r(groupNames: String*)` method in the Scala standard library: https://github.com/scala/scala/pull/9718 - following on from https://github.com/scala/scala/pull/4990 and https://github.com/scala/bug/issues/9666.

## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
