### PR TITLE
Extend `ab-multi-sticky-right-ads` experiment

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -30,7 +30,7 @@ trait ABTestSwitches {
     "Test the commercial and performance impact of sticky ads in the right column",
     owners = Seq(Owner.withGithub("chrislomaxjones")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2022, 8, 2)),
+    sellByDate = Some(LocalDate.of(2022, 10, 4)),
     exposeClientSide = true,
   )
 


### PR DESCRIPTION
## What does this change?

Extends `ab-multi-sticky-right-ads` experiment. This needs to remain active for further testing so punt the `sellByDate` another 2 months into the future

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes - https://github.com/guardian/dotcom-rendering/pull/5555
