### PR TITLE
Add word-break: break-word css from leftCol in container header description

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_container.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container.scss
@@ -284,6 +284,7 @@ $header-image-size-desktop: 100px;
         width: $left-column;
         float: left;
         margin-top: 0;
+        word-break: break-word;
     }
 
     @include mq(wide) {


### PR DESCRIPTION
## What does this change?
Adds `word-break: break-word` in `.fc-container__header__description` class from `leftCol` breakpoint.

We're making this change to improve the crosswords front in `wide` and `leftCol` breakpoints.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
| Before (wide)    | After |
|------------------|-------|
| ![Screenshot 2022-08-01 at 10 51 59](https://user-images.githubusercontent.com/19683595/182138042-09be3fe6-ad34-450b-8a20-81ee8c504458.png) | ![image](https://user-images.githubusercontent.com/19683595/182138328-ae588b58-670c-4c2b-9645-8e5f7ddf4000.png) |
| Before (leftCol) | After |
|  ![Screenshot 2022-08-01 at 11 01 02](https://user-images.githubusercontent.com/19683595/182138083-5ea2fbb8-f2b9-41a4-aff4-0c2e117a8297.png) |  ![Screenshot 2022-08-01 at 11 17 33](https://user-images.githubusercontent.com/19683595/182138227-d043374d-b934-4895-a757-208321938a8d.png) |


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
