### PR TITLE
Add MerchandisingMinHeight experiment

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -6,7 +6,7 @@ import java.time.LocalDate
 
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =
-    Set(OfferHttp3, LiveBlogMainMediaPosition)
+    Set(OfferHttp3, LiveBlogMainMediaPosition, MerchandisingMinHeight)
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
@@ -36,4 +36,13 @@ object LiveBlogMainMediaPosition
       owners = Seq(Owner.withGithub("abeddow91")),
       sellByDate = LocalDate.of(2022, 10, 7),
       participationGroup = Perc50,
+    )
+
+object MerchandisingMinHeight
+    extends Experiment(
+      name = "merchandising-min-height",
+      description = "Test whether there are negative effects of setting a min-height on both merchandising slots",
+      owners = Seq(Owner.withGithub("domlander")),
+      sellByDate = LocalDate.of(2022, 9, 2),
+      participationGroup = Perc0C,
     )


### PR DESCRIPTION
## What does this change?

This adds an experiment `merchandising-min-height` which will be used as a server-side AB test to test that adding a minimum height to the merchandising ad slots does not have a negative effect on user experience in US and AUS regions.

## Does this change need to be reproduced in dotcom-rendering?

[DCR PR](https://github.com/guardian/dotcom-rendering/pull/5561)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
