### PR TITLE
Prevent elements inserted by the spacefinder visualiser affecting ad placement

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -121,8 +121,8 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 	const hasLeftCol = ['leftCol', 'wide'].includes(tweakpoint);
 
 	const ignoreList = hasLeftCol
-		? ' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate):not([data-spacefinder-role="richLink"])'
-		: ' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate)';
+		? ' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate):not(.sfdebug):not([data-spacefinder-role="richLink"])'
+		: ' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate):not(.sfdebug)';
 
 	const isImmersive = config.get('page.isImmersive');
 	const defaultRules: SpacefinderRules = {
@@ -280,10 +280,11 @@ const addMobileInlineAds = (): Promise<boolean> => {
 				minBelow: 250,
 			},
 			' .ad-slot': adSlotClassSelectorSizes,
-			' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate)': {
-				minAbove: 35,
-				minBelow: 200,
-			},
+			' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate):not(.sfdebug)':
+				{
+					minAbove: 35,
+					minBelow: 200,
+				},
 		},
 		filter: filterNearbyCandidates(adSizes.mpu.height),
 	};
@@ -344,10 +345,11 @@ const attemptToAddInlineMerchAd = (): Promise<boolean> => {
 				minBelow: 250,
 			},
 			' .ad-slot': adSlotClassSelectorSizes,
-			' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate)': {
-				minAbove: 200,
-				minBelow: 400,
-			},
+			' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate):not(.sfdebug)':
+				{
+					minAbove: 200,
+					minBelow: 400,
+				},
 		},
 	};
 

--- a/static/src/javascripts/projects/commercial/modules/carrot-traffic-driver.ts
+++ b/static/src/javascripts/projects/commercial/modules/carrot-traffic-driver.ts
@@ -39,10 +39,11 @@ const wideRules: SpacefinderRules = {
 			minAbove: 50,
 			minBelow: 50,
 		},
-		' > *:not(p):not(h2):not(blockquote):not(#sign-in-gate)': {
-			minAbove: 50,
-			minBelow: 50,
-		},
+		' > *:not(p):not(h2):not(blockquote):not(#sign-in-gate):not(.sfdebug)':
+			{
+				minAbove: 50,
+				minBelow: 50,
+			},
 		' .ad-slot': {
 			minAbove: 100,
 			minBelow: 100,

--- a/static/src/javascripts/projects/common/modules/spacefinder-debug-tools.js
+++ b/static/src/javascripts/projects/common/modules/spacefinder-debug-tools.js
@@ -27,7 +27,7 @@ const markCandidates = (exclusions, winners, options) => {
 
 	const addDistanceExplainer = (element, text) => {
 		const explainer = document.createElement('div');
-		explainer.className = 'distanceExplainer';
+		explainer.className = 'distanceExplainer sfdebug';
 		explainer.appendChild(document.createTextNode(text));
 		explainer.style.cssText = `
             position:absolute;
@@ -66,6 +66,7 @@ const markCandidates = (exclusions, winners, options) => {
 
 	const addExplainer = (element, text) => {
 		const explainer = document.createElement('div');
+		explainer.className = 'sfdebug';
 		explainer.appendChild(document.createTextNode(text));
 		explainer.style.cssText = `
             position:absolute;
@@ -110,6 +111,7 @@ const debugMinAbove = (body, minAbove) => {
 	body.style.position = 'relative';
 
 	const minAboveIndicator = document.createElement('div');
+	minAboveIndicator.className = 'sfdebug';
 
 	minAboveIndicator.style.cssText = `
 		position: absolute;
@@ -119,7 +121,7 @@ const debugMinAbove = (body, minAbove) => {
 		height: 5px;
 	`;
 
-	minAboveIndicator.innerHTML = `<div style="position: absolute; right: 0px; background-color: rgba(255, 255, 255, 0.97); padding: 10px; border-radius: 0px 0px 0px 10px; font-family: sans-serif; font-size: 0.7rem;">Threshold for slot to be too close to top (minAbove: ${minAbove}px)</div>`;
+	minAboveIndicator.innerHTML = `<div class="sfdebug" style="position: absolute; right: 0px; background-color: rgba(255, 255, 255, 0.97); padding: 10px; border-radius: 0px 0px 0px 10px; font-family: sans-serif; font-size: 0.7rem;">Threshold for slot to be too close to top (minAbove: ${minAbove}px)</div>`;
 
 	body.appendChild(minAboveIndicator);
 };


### PR DESCRIPTION
## What does this change?

When enabled, the spacefinder visualiser inserts a bunch of stuff into the DOM, for example "explainer" labels and [this line](https://github.com/guardian/frontend/pull/25261). 

This is a potential issue because spacefinder runs multiple times per page load (for inline1, inline2+, inline mech, etc.) and any DOM elements inserted in one run are then taken into account when deciding where to place ads in subsequent runs.

The fix is to apply a class (I picked `sfdebug`) to anything inserted by the spacefinder visualiser and then explicitly ignore such elements in spacefinder.

For example:

| Visualiser disabled  |  Visualiser enabled  | Visualiser enabled (after fix)  |           
|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
|    ![Screenshot 2022-08-02 at 10 04 18](https://user-images.githubusercontent.com/7423751/182336951-545ac56a-6fc2-49b8-ba58-d083edf68520.png) https://www.theguardian.com/world/2022/aug/02/world-one-miscalculation-away-from-nuclear-annihilation-un-chief-says  |  ![Screenshot 2022-08-02 at 10 03 50](https://user-images.githubusercontent.com/7423751/182336969-aa1fd204-575b-486d-854a-24cd3b56bdfd.png)   https://www.theguardian.com/world/2022/aug/02/world-one-miscalculation-away-from-nuclear-annihilation-un-chief-says?sfdebug=1 | ![Screenshot 2022-08-02 at 10 16 15](https://user-images.githubusercontent.com/7423751/182339456-537537d1-b33d-49bb-b99b-086c81cc4375.png) https://www.theguardian.com/world/2022/aug/02/world-one-miscalculation-away-from-nuclear-annihilation-un-chief-says?sfdebug=1 |




## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
