### PR TITLE
feat: DeeplyReadAgent

### DIFF
--- a/article/app/AppLoader.scala
+++ b/article/app/AppLoader.scala
@@ -1,4 +1,5 @@
 import _root_.commercial.targeting.TargetingLifecycle
+import agents.{DeeplyReadAgent, MostPopularLifecycle}
 import akka.actor.ActorSystem
 import app.{FrontendApplicationLoader, FrontendComponents}
 import com.softwaremill.macwire._
@@ -18,9 +19,8 @@ import play.api.BuiltInComponentsFromContext
 import play.api.http.{HttpErrorHandler, HttpRequestHandler}
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
-import router.Routes
 import services.ophan.SurgingContentAgentLifecycle
-import services.{NewspaperBooksAndSectionsAutoRefresh, OphanApi, SkimLinksCacheLifeCycle, NewsletterService}
+import services.{NewsletterService, NewspaperBooksAndSectionsAutoRefresh, OphanApi, SkimLinksCacheLifeCycle}
 import services.newsletters.{NewsletterApi, NewsletterSignupAgent}
 import jobs.{StoreNavigationLifecycleComponent, TopicLifecycle}
 import topics.{TopicS3Client, TopicS3ClientImpl, TopicService}
@@ -48,6 +48,7 @@ trait AppComponents extends FrontendComponents with ArticleControllers with Topi
   lazy val logbackOperationsPool = wire[LogbackOperationsPool]
 
   lazy val remoteRender = wire[renderers.DotcomRenderingService]
+  lazy val deeplyReadAgent = wire[DeeplyReadAgent]
 
   override lazy val lifecycleComponents = List(
     wire[LogstashLifecycle],
@@ -62,6 +63,7 @@ trait AppComponents extends FrontendComponents with ArticleControllers with Topi
     wire[SkimLinksCacheLifeCycle],
     wire[StoreNavigationLifecycleComponent],
     wire[TopicLifecycle],
+    wire[MostPopularLifecycle],
   )
 
   lazy val router: Router = wire[Routes]

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import agents.DeeplyReadAgent
 import com.gu.contentapi.client.model.v1.{Blocks, ItemResponse, Content => ApiContent}
 import common._
 import contentapi.ContentApiClient
@@ -24,6 +25,7 @@ class ArticleController(
     ws: WSClient,
     remoteRenderer: renderers.DotcomRenderingService = DotcomRenderingService(),
     newsletterService: NewsletterService,
+    deeplyReadAgent: DeeplyReadAgent,
 )(implicit context: ApplicationContext)
     extends BaseController
     with RendersItemResponse
@@ -128,6 +130,7 @@ class ArticleController(
           false,
           newsletter = newsletter,
           topicResult = None,
+          mostPopular = Seq(deeplyReadAgent.getReport()),
         )
       case HtmlFormat | AmpFormat =>
         Future.successful(common.renderHtml(ArticleHtmlPage.html(article), article))

--- a/common/app/agents/MostPopularLifecycle.scala
+++ b/common/app/agents/MostPopularLifecycle.scala
@@ -1,0 +1,18 @@
+package agents
+
+import akka.actor.ActorSystem
+import app.LifecycleComponent
+import common.JobScheduler
+
+import scala.concurrent.ExecutionContext
+
+class MostPopularLifecycle(deeplyReadAgent: DeeplyReadAgent, jobs: JobScheduler)(implicit
+    ec: ExecutionContext,
+    actorSystem: ActorSystem,
+) extends LifecycleComponent {
+
+  override def start(): Unit =
+    jobs.scheduleEveryNMinutes("MostPopularAgentsFrequencyRefreshJob", 5) {
+      deeplyReadAgent.refresh()
+    }
+}

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -97,6 +97,7 @@ case class DotcomRenderingDataModel(
     matchType: Option[DotcomRenderingMatchType],
     isSpecialReport: Boolean, // Indicates whether the page is a special report.
     promotedNewsletter: Option[NewsletterData],
+    mostPopular: Seq[OnwardCollectionResponse] = Seq(),
 )
 
 object DotcomRenderingDataModel {
@@ -170,6 +171,7 @@ object DotcomRenderingDataModel {
         "matchType" -> model.matchType,
         "isSpecialReport" -> model.isSpecialReport,
         "promotedNewsletter" -> model.promotedNewsletter,
+        "mostPopular" -> model.mostPopular,
       )
 
       ElementsEnhancer.enhanceDcrObject(obj)
@@ -340,6 +342,7 @@ object DotcomRenderingDataModel {
       availableTopics: Option[Seq[Topic]],
       newsletter: Option[NewsletterData],
       topicResult: Option[TopicResult],
+      mostPopular: Seq[OnwardCollectionResponse] = Seq(),
   ): DotcomRenderingDataModel = {
 
     val edition = Edition.edition(request)

--- a/common/app/model/dotcomrendering/MostPopular.scala
+++ b/common/app/model/dotcomrendering/MostPopular.scala
@@ -184,10 +184,10 @@ object MostPopularGeoResponse {
 }
 
 /**
- * `MostPopularOnward** was introduced to replace the less flexible [common] `MostPopular`,
- * which is heavily relying on `pressed.PressedContent`,
- * because we want to be able to create MostPopularOnward from trails coming from the `DeeplyReadAgent`
-*/
+  * `MostPopularOnward** was introduced to replace the less flexible [common] `MostPopular`,
+  * which is heavily relying on `pressed.PressedContent`,
+  * because we want to be able to create MostPopularOnward from trails coming from the `DeeplyReadAgent`
+  */
 case class MostPopularOnward(heading: String, section: String, trails: Seq[OnwardItem])
 object MostPopularOnward {
   implicit val mostPopularOnwardWrites = Json.writes[MostPopularOnward]

--- a/common/app/model/dotcomrendering/MostPopular.scala
+++ b/common/app/model/dotcomrendering/MostPopular.scala
@@ -183,13 +183,14 @@ object MostPopularGeoResponse {
   implicit val popularGeoWrites = Json.writes[MostPopularGeoResponse]
 }
 
-// MostPopularNx2 was introduced to replace the less flexible [common] MostPopular
-// which is heavily relying on pressed.PressedContent
-// because we want to be able to create MostPopularNx2 from trails coming from the DeeplyReadAgent
-case class MostPopularNx2(heading: String, section: String, trails: Seq[OnwardItem])
-
-object MostPopularNx2 {
-  implicit val mostPopularNx2Writes = Json.writes[MostPopularNx2]
+/**
+ * `MostPopularOnward** was introduced to replace the less flexible [common] `MostPopular`,
+ * which is heavily relying on `pressed.PressedContent`,
+ * because we want to be able to create MostPopularOnward from trails coming from the `DeeplyReadAgent`
+*/
+case class MostPopularOnward(heading: String, section: String, trails: Seq[OnwardItem])
+object MostPopularOnward {
+  implicit val mostPopularOnwardWrites = Json.writes[MostPopularOnward]
 }
 
 object OnwardsUtils {

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -12,9 +12,9 @@ import model.dotcomrendering.{
   DotcomBlocksRenderingDataModel,
   DotcomFrontsRenderingDataModel,
   DotcomRenderingDataModel,
+  OnwardCollectionResponse,
   PageType,
 }
-
 import services.NewsletterData
 import model.{
   CacheTime,
@@ -157,6 +157,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       availableTopics: Option[Seq[Topic]] = None,
       newsletter: Option[NewsletterData],
       topicResult: Option[TopicResult],
+      mostPopular: Seq[OnwardCollectionResponse],
   )(implicit request: RequestHeader): Future[Result] = {
     val dataModel = page match {
       case liveblog: LiveBlogPage =>
@@ -171,7 +172,8 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
           newsletter,
           topicResult,
         )
-      case _ => DotcomRenderingDataModel.forArticle(page, blocks, request, pageType, newsletter)
+      case _ =>
+        DotcomRenderingDataModel.forArticle(page, blocks, request, pageType, newsletter).copy(mostPopular = mostPopular)
     }
 
     val json = DotcomRenderingDataModel.toJson(dataModel)

--- a/common/app/services/OphanApi.scala
+++ b/common/app/services/OphanApi.scala
@@ -18,6 +18,11 @@ object OphanMostReadItem {
   implicit val jsonReads = Json.reads[OphanMostReadItem]
 }
 
+case class OphanDeeplyReadItem(path: String, benchmarkedAttentionTime: Int)
+object OphanDeeplyReadItem {
+  implicit val jsonReads = Json.reads[OphanDeeplyReadItem]
+}
+
 class OphanApi(wsClient: WSClient)(implicit executionContext: ExecutionContext)
     extends GuLogging
     with implicits.WSRequests {
@@ -105,4 +110,7 @@ class OphanApi(wsClient: WSClient)(implicit executionContext: ExecutionContext)
       Map("hours" -> hours.toString, "count" -> count.toString, "publication-date-from" -> sixMonthsAgo),
     )
   }
+
+  def getDeeplyRead(): Future[Seq[OphanDeeplyReadItem]] =
+    getBody("deeplyread")().map(_.as[Seq[OphanDeeplyReadItem]])
 }

--- a/onward/app/AppLoader.scala
+++ b/onward/app/AppLoader.scala
@@ -18,10 +18,10 @@ import play.api.{BuiltInComponentsFromContext, Environment}
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import play.api.libs.ws.WSClient
-import router.Routes
 import services.OphanApi
 import weather.WeatherApi
 import _root_.commercial.targeting.TargetingLifecycle
+import agents.DeeplyReadAgent
 
 import scala.concurrent.ExecutionContext
 

--- a/onward/app/AppLoader.scala
+++ b/onward/app/AppLoader.scala
@@ -45,6 +45,7 @@ trait OnwardServices {
   lazy val dayMostPopularAgent = wire[DayMostPopularAgent]
   lazy val mostPopularAgent = wire[MostPopularAgent]
   lazy val mostReadAgent = wire[MostReadAgent]
+  lazy val deeplyReadAgent = wire[DeeplyReadAgent]
   lazy val mostPopularSocialAutoRefresh = wire[MostPopularSocialAutoRefresh]
   lazy val mostViewedAudioAgent = wire[MostViewedAudioAgent]
   lazy val mostViewedGalleryAgent = wire[MostViewedGalleryAgent]

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -1,15 +1,23 @@
 package controllers
 
+import agents.DeeplyReadAgent
+
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import common._
 import conf.switches.Switches
 import contentapi.ContentApiClient
-import feed.{DayMostPopularAgent, DeeplyReadAgent, GeoMostPopularAgent, MostPopularAgent}
+import feed.{DayMostPopularAgent, GeoMostPopularAgent, MostPopularAgent}
 import layout.ContentCard
 import model.Cached.RevalidatableResult
 import model._
-import model.dotcomrendering.{MostPopularGeoResponse, MostPopularOnward, OnwardCollectionResponse, OnwardCollectionResponseDCR, OnwardItem}
+import model.dotcomrendering.{
+  MostPopularGeoResponse,
+  MostPopularOnward,
+  OnwardCollectionResponse,
+  OnwardCollectionResponseDCR,
+  OnwardItem,
+}
 import play.api.libs.json._
 import play.api.mvc._
 import views.support.FaciaToMicroFormat2Helpers._
@@ -142,7 +150,7 @@ class MostPopularController(
   }
 
   def jsonResponseNx2(mostPopulars: Seq[MostPopularOnward], mostCards: Map[String, Option[ContentCard]])(implicit
-                                                                                                         request: RequestHeader,
+      request: RequestHeader,
   ): Result = {
     val tabs = mostPopulars.map { nx2 =>
       OnwardCollectionResponse(nx2.heading, nx2.trails)

--- a/onward/app/controllers/OnwardControllers.scala
+++ b/onward/app/controllers/OnwardControllers.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import agents.DeeplyReadAgent
 import akka.actor.ActorSystem
 import com.softwaremill.macwire._
 import weather.controllers.{LocationsController, WeatherController}

--- a/onward/app/controllers/OnwardControllers.scala
+++ b/onward/app/controllers/OnwardControllers.scala
@@ -21,6 +21,7 @@ trait OnwardControllers {
   def geoMostPopularAgent: GeoMostPopularAgent
   def dayMostPopularAgent: DayMostPopularAgent
   def mostPopularAgent: MostPopularAgent
+  def deeplyReadAgent: DeeplyReadAgent
   def mostReadAgent: MostReadAgent
   def mostPopularSocialAutoRefresh: MostPopularSocialAutoRefresh
   def mostViewedVideoAgent: MostViewedVideoAgent

--- a/onward/app/feed/DeeplyReadAgent.scala
+++ b/onward/app/feed/DeeplyReadAgent.scala
@@ -1,0 +1,188 @@
+package feed
+
+import contentapi.ContentApiClient
+import com.gu.contentapi.client.model.v1.Content
+import com.gu.contentapi.client.utils.CapiModelEnrichment.RenderingFormat
+import services.{OphanApi, OphanDeeplyReadItem}
+import play.api.libs.json._
+import common._
+import model.ContentFormat
+import model.dotcomrendering.OnwardItem
+import models._
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NonFatal
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
+
+/*
+  The class DeeplyReadItem is the one that define the answer to the deeply-read.json
+  Note that it's different from OphanDeeplyReadItem which is the one we read from the Ophan Api
+  DeeplyReadItem is an OnwardItem with also a path and benchmarkedAttentionTime
+ */
+case class DeeplyReadItem(
+    path: String,
+    benchmarkedAttentionTime: Int,
+    url: String,
+    linkText: String,
+    showByline: Boolean,
+    byline: Option[String],
+    image: Option[String],
+    ageWarning: Option[String],
+    isLiveBlog: Boolean,
+    pillar: String,
+    designType: String,
+    format: Option[ContentFormat],
+    webPublicationDate: String,
+    headline: String,
+    mediaType: Option[String],
+    shortUrl: String,
+    kickerText: Option[String],
+    starRating: Option[Int],
+    avatarUrl: Option[String],
+)
+object DeeplyReadItem {
+  implicit val jsonWrites = Json.writes[DeeplyReadItem]
+
+  def deeplyReadItemToOnwardItem(item: DeeplyReadItem): OnwardItem = {
+    OnwardItem(
+      url = item.url,
+      linkText = item.linkText,
+      showByline = item.showByline,
+      byline = item.byline,
+      image = item.image,
+      carouselImages = Map("N/A" -> None), // Not implemented for Deeply Read at the moment
+      ageWarning = item.ageWarning,
+      isLiveBlog = item.isLiveBlog,
+      pillar = item.pillar,
+      designType = item.designType,
+      format = item.format.getOrElse(ContentFormat.defaultContentFormat),
+      webPublicationDate = item.webPublicationDate,
+      headline = item.headline,
+      mediaType = item.mediaType,
+      shortUrl = item.shortUrl,
+      kickerText = item.kickerText,
+      starRating = item.starRating,
+      avatarUrl = None,
+      branding = None,
+    )
+  }
+}
+
+class DeeplyReadAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi) extends GuLogging {
+
+  /*
+      We use a mutable map instead of a com.gu.Box, as the latter is a minimal wrapper.
+      Both are used as key value store providing in memory caching.
+
+      This implies that several EC2 instances running this app could be in slightly different states
+      at any point in time. This is not an issue as we have our CDN caching layer in front.
+   */
+
+  private var deeplyReadItems = Box[Map[OphanDeeplyReadItem, Content]](Map.empty)
+
+  def removeStartingSlash(path: String): String = {
+    if (path.startsWith("/")) path.stripPrefix("/") else path
+  }
+
+  def refresh()(implicit ec: ExecutionContext): Future[Seq[Option[(OphanDeeplyReadItem, Content)]]] = {
+    log.info(s"Deeply Read Agent refresh()")
+    /*
+        Here we simply go through the OphanDeeplyReadItem we got from Ophan and for each
+        query CAPI and set the Content for the path.
+     */
+
+    val deeplyReadItemsWithCapi: Future[Seq[Option[(OphanDeeplyReadItem, Content)]]] =
+      ophanApi.getDeeplyRead().flatMap { seq =>
+        log.info(s"ophanItems updated with: ${seq.toArray.size} new items")
+        val eventualMaybeTuples: Seq[Future[Option[(OphanDeeplyReadItem, Content)]]] = seq.map { ophanItem =>
+          log.info(s"CAPI lookup for Ophan deeply read item: ${ophanItem.toString}")
+          val path = removeStartingSlash(ophanItem.path)
+          log.info(s"CAPI Lookup for path: ${path}")
+          val capiItem = contentApiClient
+            .item(path)
+            .showTags("all")
+            .showFields("all")
+            .showReferences("none")
+            .showAtoms("none")
+          val capiResponse = contentApiClient
+            .getResponse(capiItem)
+            .map { res =>
+              res.content.map { c =>
+                log.info(s"Update CAPI data for path: ${path}")
+                println(s"Update CAPI data for path: ${path}")
+                ophanItem -> c
+              }
+            }
+            .recover {
+              case NonFatal(e) =>
+                log.info(s"Error CAPI lookup for path: ${path}. ${e.getMessage}")
+                None
+            }
+          capiResponse
+        }
+        Future.sequence(eventualMaybeTuples)
+
+      // We now perform the atomic update of deeplyReadItems to faithfully reflects the state of the Ophan answer.
+      // It is done as last step of the process because by then the CAPI content has been loaded.
+      }
+    deeplyReadItemsWithCapi.foreach { sequence =>
+      val mapDeeplyReadItems = sequence.filter(_.isDefined).map(_.get).toMap
+      deeplyReadItems.alter(mapDeeplyReadItems)
+    }
+    deeplyReadItemsWithCapi
+  }
+
+  def correctPillar(pillar: String): String = if (pillar == "arts") "culture" else pillar
+
+  def ophanItemToDeeplyReadItem(item: OphanDeeplyReadItem, content: Content): Option[DeeplyReadItem] = {
+
+    val contentFormat: ContentFormat = ContentFormat(content.design, content.theme, content.display)
+
+    // We are doing the pillar correction during the OphanDeeplyReadItem to DeeplyReadItem transformation
+    // Note that we could also do it during the DeeplyReadItem to OnwardItemNx2 transformation
+    for {
+      webPublicationDate <- content.webPublicationDate
+      fields <- content.fields
+      linkText <- fields.trailText
+      pillar <- content.pillarName
+      headline <- fields.headline
+      shortUrl <- fields.shortUrl
+    } yield DeeplyReadItem(
+      path = item.path,
+      benchmarkedAttentionTime = item.benchmarkedAttentionTime,
+      url = content.webUrl,
+      linkText = linkText,
+      showByline = false,
+      byline = fields.byline,
+      image = fields.thumbnail,
+      ageWarning = None,
+      isLiveBlog = fields.liveBloggingNow.getOrElse(false),
+      pillar = correctPillar(pillar.toLowerCase),
+      designType = content.`type`.toString,
+      format = Some(contentFormat),
+      webPublicationDate = webPublicationDate.toString(),
+      headline = headline,
+      mediaType = None,
+      shortUrl = shortUrl,
+      kickerText = None,
+      starRating = None,
+      avatarUrl = None,
+    )
+  }
+
+  def getReport()(implicit ec: ExecutionContext): Seq[DeeplyReadItem] = {
+    if (deeplyReadItems().isEmpty) {
+      // This helps improving the situation if the initial akka driven refresh failed (which happens way to often)
+      // Note that is there was no data in ophanItems the report will be empty, but will at least return data at the next call
+      log.info(s"refresh() from getReport()")
+      refresh()
+    }
+
+    deeplyReadItems()
+      .map(t => ophanItemToDeeplyReadItem(t._1, t._2))
+      .filter(_.isDefined)
+      .map(_.get)
+      .toSeq
+  }
+}

--- a/onward/app/feed/MostPopularAgent.scala
+++ b/onward/app/feed/MostPopularAgent.scala
@@ -4,8 +4,9 @@ import conf.Configuration
 import contentapi.ContentApiClient
 import com.gu.contentapi.client.model.v1.Content
 import common._
-import services.{OphanApi}
+import services.{OphanApi, OphanMostReadItem}
 import model.RelatedContentItem
+import model.dotcomrendering.OnwardItem
 import play.api.libs.json._
 import play.api.libs.ws.WSClient
 

--- a/onward/app/feed/OnwardJourneyLifecycle.scala
+++ b/onward/app/feed/OnwardJourneyLifecycle.scala
@@ -11,6 +11,7 @@ class OnwardJourneyLifecycle(
     jobs: JobScheduler,
     akkaAsync: AkkaAsync,
     mostReadAgent: MostReadAgent,
+    deeplyReadAgent: DeeplyReadAgent,
     geoMostPopularAgent: GeoMostPopularAgent,
     dayMostPopularAgent: DayMostPopularAgent,
     mostPopularAgent: MostPopularAgent,
@@ -40,6 +41,7 @@ class OnwardJourneyLifecycle(
     jobs.scheduleEveryNMinutes("OnwardJourneyAgentsHighFrequencyRefreshJob", 5) {
       mostPopularAgent.refresh()
       geoMostPopularAgent.refresh()
+      deeplyReadAgent.refresh()
     }
 
     jobs.scheduleEveryNMinutes("OnwardJourneyAgentsMediumFrequencyRefreshJob", 30) {

--- a/onward/app/feed/OnwardJourneyLifecycle.scala
+++ b/onward/app/feed/OnwardJourneyLifecycle.scala
@@ -1,9 +1,12 @@
 package feed
 
+import agents.DeeplyReadAgent
+
 import java.util.concurrent.Executors
 import app.LifecycleComponent
 import common.{AkkaAsync, JobScheduler}
 import play.api.inject.ApplicationLifecycle
+
 import scala.concurrent.{ExecutionContext, Future}
 
 class OnwardJourneyLifecycle(

--- a/onward/conf/routes
+++ b/onward/conf/routes
@@ -27,6 +27,7 @@ GET        /most-read/*path.json                      controllers.MostPopularCon
 GET        /most-read-geo.json                        controllers.MostPopularController.renderPopularGeo()
 GET        /most-read-day.json                        controllers.MostPopularController.renderPopularDay(countryCode)
 
+GET        /deeply-read.json                          controllers.MostPopularController.renderDeeplyRead()
 
 GET        /top-stories.json                          controllers.TopStoriesController.renderTopStories()
 GET        /top-stories/trails.json                   controllers.TopStoriesController.renderTrails()


### PR DESCRIPTION
## What does this change?

> **Note**
> Part of https://github.com/guardian/dotcom-rendering/issues/5554

Reinstate the “Deeply Read“ endpoint at [`/deeply-read.json`](https://www.theguardian.com/deeply-read.json).

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
