### PR TITLE
Add css in the container header description so that content does not overflow

### DIFF
--- a/static/src/stylesheets/module/facia-garnett/_container.scss
+++ b/static/src/stylesheets/module/facia-garnett/_container.scss
@@ -284,6 +284,8 @@ $header-image-size-desktop: 100px;
         width: $left-column;
         float: left;
         margin-top: 0;
+        word-break: normal;
+        overflow-wrap: anywhere;
     }
 
     @include mq(wide) {


### PR DESCRIPTION
Replaces https://github.com/guardian/frontend/pull/25317 because the previous PR did not keep up with the branch when I force pushed.

## What does this change?
Adds 
```
word-break: normal;
overflow-wrap: anywhere;
```
in `.fc-container__header__description` class from leftCol breakpoint.

We're making this change to improve the crosswords front in leftCol breakpoint.
Related to this issue: https://github.com/guardian/frontend/issues/25314. This change improves the front but the issue will remain open for Design and Editorial to discuss how this container should look like. 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![Screenshot 2022-08-01 at 14 54 23](https://user-images.githubusercontent.com/19683595/182334060-28b149a6-769c-4464-9906-c90766029b32.png)| ![Screenshot 2022-08-01 at 14 55 30](https://user-images.githubusercontent.com/19683595/182334065-c3c64da7-14b3-498e-bb07-7646b27369b9.png) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
