### PR TITLE
Remove unnecessary method

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.ts
@@ -1,17 +1,8 @@
-import { log } from '@guardian/libs';
 import { once } from 'lodash-es';
 import type { Advert } from './Advert';
 import { dfpEnv } from './dfp-env';
 import { getAdvertById } from './get-advert-by-id';
 import { loadAdvert, refreshAdvert } from './load-advert';
-
-const decideLazyLoadMargin = () => {
-	const lazyLoadMargin = '20%';
-
-	log('commercial', `Using lazy load margin of ${lazyLoadMargin}`);
-
-	return lazyLoadMargin;
-};
 
 const displayAd = (advertId: string) => {
 	const advert = getAdvertById(advertId);
@@ -46,7 +37,7 @@ const onIntersect = (
 const getObserver = once(() => {
 	return Promise.resolve(
 		new window.IntersectionObserver(onIntersect, {
-			rootMargin: `${decideLazyLoadMargin()} 0px`,
+			rootMargin: '20% 0px',
 		}),
 	);
 });

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -203,7 +203,6 @@
   "../projects/commercial/modules/dfp/dfp-env.ts"
  ],
  "../projects/commercial/modules/dfp/lazy-load.ts": [
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../../../../node_modules/@types/lodash-es/index.d.ts",
   "../projects/commercial/modules/dfp/Advert.ts",
   "../projects/commercial/modules/dfp/dfp-env.ts",


### PR DESCRIPTION
## What does this change?

This method/log statement was helpful when we were experimenting with different lazy loading margins. Now we've settled on a value, it just adds complexity and can be removed

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)
