### PR TITLE
Scala 2.13: Natural arg-order calling storeJsonBody

### DIFF
--- a/commercial/app/controllers/PrebidAnalyticsController.scala
+++ b/commercial/app/controllers/PrebidAnalyticsController.scala
@@ -13,8 +13,6 @@ class PrebidAnalyticsController(val controllerComponents: ControllerComponents) 
 
   def insert(): Action[String] =
     Action(parse.text) { implicit request =>
-      val stream = Analytics.storeJsonBody(Switches.prebidAnalytics, prebidAnalyticsStream, log) _
-
-      stream(request.body)
+      Analytics.storeJsonBody(Switches.prebidAnalytics, prebidAnalyticsStream, log)(request.body)
     }
 }


### PR DESCRIPTION
Scala 2.13 doesn't like the way the code was previously calling `commercial.controllers.Analytics.storeJsonBody()` - effectively, the first 3 arguments, then the last 2 implicit arguments, and then the _middle_ non-implicit `analytics: String` argument. Although this worked in Scala 2.12, in Scala 2.13, this error was raised:

```
/Users/ioanna_kokkini/Projects/frontend/commercial/app/controllers/PrebidAnalyticsController.scala:16:43: Cannot find any HTTP Request here
[error]       val stream = Analytics.storeJsonBody(Switches.prebidAnalytics, prebidAnalyticsStream, log) _
[error]
```

["Cannot find any HTTP Request here"](https://github.com/playframework/playframework/blob/59c907fae50481b5c2b8c4313f3aedd39d293d62/core/play/src/main/scala/play/api/mvc/Request.scala#L27-L28) comes from the implicit `play.api.mvc.Request` not being found by the Scala 2.13 compiler, which I guess was confused by the method parameter order!

The fix is to just inline the code a bit, and supply the _middle_ `analytics: String` argument in it's natural 2nd position,
and allow the compiler to then find the last pair of implicit arguments.
