### PR TITLE
Scala 2.13: Refactor `LiveBlogCurrentPage.findPageWithBlock()`

### DIFF
--- a/article/test/model/LiveBlogCurrentPageTest.scala
+++ b/article/test/model/LiveBlogCurrentPageTest.scala
@@ -698,7 +698,7 @@ class LiveBlogCurrentPageTest extends AnyFlatSpec with Matchers {
     val result = LiveBlogCurrentPage.findPageWithBlock(
       pageSize = 2,
       blocks = testFakeBlocks.blocksSequence,
-      isRequestedBlock = "3",
+      requestedBlockId = "3",
       filterKeyEvents = false,
       topicResult = Some(topicResult),
     )


### PR DESCRIPTION
## What does the code that's being refactored do?

`LiveBlogCurrentPage.findPageWithBlock()` is responsible for making sure that a user gets taken to the correct _page_ of a liveblog when they click on a permalink to a liveblog **block**, eg with:

* https://www.theguardian.com/politics/live/2022/aug/01/tory-leadership-race-rishi-sunak-lizz-truss-vote-keir-starmer-uk-politics-live?page=with:block-62e7e89d8f08730a1f7f5579#block-62e7e89d8f08730a1f7f5579 ![image](https://user-images.githubusercontent.com/52038/182650320-be45bfa8-88f3-4a0a-b9d5-db34de155063.png)

...the user is taken to the correct 'page' of the live blog:
* page `3 of 5` for the example above: ![image](https://user-images.githubusercontent.com/52038/182650495-fbda616a-6400-4d3a-92f7-cd3802fd5537.png)

The code was first introduced in January 2016 with https://github.com/guardian/frontend/pull/11700, subsequently updated with https://github.com/guardian/frontend/pull/13566, etc.

## What's the problem?

The existing code compiles without warnings under Scala 2.12, but the Scala 2.13 compiler gives a warning that not _all_ conceivable cases in the pattern-match are handled:

```
frontend/common/app/model/LiveBlogCurrentPage.scala:190:12: match may not be exhaustive.
[warn] It would fail on the following inputs: List(_), Nil
[warn]       .map {
[warn]            ^
```

The warning is unfortunately unwanted noise - as the preceding [`.sliding(3)`](https://www.scala-lang.org/api/2.12.7/scala/collection/immutable/Seq.html#sliding(size:Int):Iterator[Repr]):

https://github.com/guardian/frontend/blob/f90c8a58e6f0941c96392d14fe27e61a4dbaf25b/common/app/model/LiveBlogCurrentPage.scala#L188

...means that the `List` supplied to the case match expression will _always_ have 3 elements, and that's precisely the case that's handled - but there's no way for the compiler to know that - so we as devs need to do _something_ to make the warning go away!

## What's the fix?

Some options:

* Use Scala's [@unchecked](https://www.scala-lang.org/api/2.12.7/scala/unchecked.html) annotation. This is a last resort - turning off compiler checks leaves us exposed to runtime errors and is generally a bad idea!
* Use [`collect()`](https://www.scala-lang.org/api/2.12.7/scala/collection/immutable/Seq.html#collect[B](pf:PartialFunction[A,B]):scala.collection.immutable.Seq[B]) rather than `map()` - this accepts a partial function, rather than a total one, so the compiler error will go away.
* Refactor so that the code no longer needs to assume that a `List` type (which could have _any_ length) has length `3`.

In the end I decided to go with the refactor, because there were a few things about the existing code that could be tweaked:

* Unnecessary work: The method was creating a `LiveBlogCurrentPage` for _every_ page in the liveblog, even though it only ever needed one (the single page that the block actually exists on!), and would eventually throw away the rest.
* The old logic around padding the front & end of the `pages` List with two `None` entries, to allow extracting the `newer` & `older` pages, adds an extra step to the code (and therefore a bit more complexity for humans to understand: _"what are `endedPages`?"_): https://github.com/guardian/frontend/blob/e97894218de96641c6e79a5ca31b247f7ffbd89d/common/app/model/LiveBlogCurrentPage.scala#L181-L191 It can be replaced by just incrementing/decrementing the page index for the one `LiveBlogCurrentPage` we're creating.
* Some variables (like `pinnedBlock`) could be inlined to the point of creation on the `LiveBlogCurrentPage` case class. By using named parameters in constructing the case class, clarity's retained while the code becomes more concise.

## Testing

The code is covered by unit tests in `LiveBlogCurrentPageTest`, with additional test coverage added recently in https://github.com/guardian/frontend/pull/25118.

Here's a video showing that PROD permalinks still work on CODE when this branch is [deployed](https://riffraff.gutools.co.uk/deployment/view/0c4e71e1-6c2f-4c0d-a52d-c3479a4aa095):

https://user-images.githubusercontent.com/52038/182663915-b4bb46ee-8a57-463b-bad4-58a5bcef68e9.mov



See also:

* The Scala 2.13 upgrade PR: https://github.com/guardian/frontend/pull/25190
