### PR TITLE
Fix: dedup backfill against trails from the same collection

### DIFF
--- a/facia-press/app/frontpress/PressedCollectionDeduplication.scala
+++ b/facia-press/app/frontpress/PressedCollectionDeduplication.scala
@@ -1,5 +1,7 @@
 package frontpress
 
+import model.pressed.PressedContent
+
 object PressedCollectionDeduplication {
 
   /*
@@ -38,6 +40,10 @@ object PressedCollectionDeduplication {
     !collectionIsMostPopular(collectionV: PressedCollectionVisibility)
   }
 
+  def getHeaderURLsFromTrailsList(pCVs: List[PressedContent]): Seq[String] = {
+    pCVs.map(pressedContent => pressedContent.header.url)
+  }
+
   def getHeaderURLsFromCuratedAndBackfilledAtDepth(pCVs: Seq[PressedCollectionVisibility], depth: Int): Seq[String] = {
     pCVs.flatMap { collection =>
       (collection.pressedCollection.curated ++ collection.pressedCollection.backfill)
@@ -51,7 +57,10 @@ object PressedCollectionDeduplication {
       collectionV: PressedCollectionVisibility,
   ): PressedCollectionVisibility = {
     // Essentially deduplicate the backfill of collectionV using header values values from accum's elements curated and backfill
-    val accumulatedHeaderURLsForDeduplication: Seq[String] = getHeaderURLsFromCuratedAndBackfilledAtDepth(accum, 10)
+    val accumulatedHeaderURLsForDeduplication: Seq[String] =
+      getHeaderURLsFromCuratedAndBackfilledAtDepth(accum, 10) ++ getHeaderURLsFromTrailsList(
+        collectionV.pressedCollection.curated,
+      )
     val newBackfill = collectionV.pressedCollection.backfill.filter(pressedContent =>
       !accumulatedHeaderURLsForDeduplication.contains(pressedContent.header.url),
     )

--- a/facia-press/app/frontpress/PressedCollectionDeduplication.scala
+++ b/facia-press/app/frontpress/PressedCollectionDeduplication.scala
@@ -56,13 +56,18 @@ object PressedCollectionDeduplication {
       accum: Seq[PressedCollectionVisibility],
       collectionV: PressedCollectionVisibility,
   ): PressedCollectionVisibility = {
-    // Essentially deduplicate the backfill of collectionV using header values values from accum's elements curated and backfill
-    val accumulatedHeaderURLsForDeduplication: Seq[String] =
+    // `accum` accumulates the deduplicated collections that have been processed so far from this batch.
+    // The idea is that if a card has already appeared in a collection 'higher up on the page', then it should be
+    // removed from later collections, unless it was curated for the later collection (see comments at top of page).
+    // Because it's possible for there to be overlap *within* a container between the curated and backfill
+    // cards, we also add the current collection's curated cards to the list of URLs to deduplicate the current
+    // container's backfill cards against.
+    val headerURLsToDeduplicateAgainst: Seq[String] =
       getHeaderURLsFromCuratedAndBackfilledAtDepth(accum, 10) ++ getHeaderURLsFromTrailsList(
         collectionV.pressedCollection.curated,
       )
     val newBackfill = collectionV.pressedCollection.backfill.filter(pressedContent =>
-      !accumulatedHeaderURLsForDeduplication.contains(pressedContent.header.url),
+      !headerURLsToDeduplicateAgainst.contains(pressedContent.header.url),
     )
     collectionV.copy(
       pressedCollection = collectionV.pressedCollection.copy(

--- a/facia-press/app/testdata/FaciaPressDeduplicationTestData.scala
+++ b/facia-press/app/testdata/FaciaPressDeduplicationTestData.scala
@@ -118,4 +118,22 @@ trait FaciaPressDeduplicationTestData {
     ),
   )
 
+  // -----------------------------------------------------
+  // Comment for FaciaPressDeduplicationTest:
+  // collection4 is used to test that backfills are deduped against curated
+  // from the same collection, as well as previous collections.
+  // -----------------------------------------------------
+  val collection4 = collectionFromCuratedAndBackfilled(
+    List(
+      "link99",
+      "link98",
+      "link97",
+    ).map(id => pressedContentFromId(id)),
+    List(
+      "link97",
+      "link96",
+      "link95",
+    ).map(id => pressedContentFromId(id)),
+  )
+
 }

--- a/facia-press/test/frontpress/FaciaPressDeduplicationTest.scala
+++ b/facia-press/test/frontpress/FaciaPressDeduplicationTest.scala
@@ -11,6 +11,7 @@ class FaciaPressDeduplicationTest extends AnyFlatSpec with Matchers with FaciaPr
     PressedCollectionVisibility(collection1, 0),
     PressedCollectionVisibility(collection2, 0),
     PressedCollectionVisibility(collection3, 0),
+    PressedCollectionVisibility(collection4, 0),
   )
   // Note that the integer (0) passed as second argument of PressedCollectionVisibility.apply is irrelevant. We use
   // it because the current version of PressedCollectionDeduplication.deduplication still takes PressedCollectionVisibility
@@ -35,5 +36,11 @@ class FaciaPressDeduplicationTest extends AnyFlatSpec with Matchers with FaciaPr
 
   it should "not deduplicate Most Popular containers" in {
     newSequence(3).pressedCollection.backfill.size shouldBe sequence(3).pressedCollection.backfill.size
+  }
+
+  it should "deduplicate backfill within a single container" in {
+    newSequence(4).pressedCollection.backfill.size shouldBe 2
+    newSequence(4).pressedCollection.backfill(0).header.url shouldEqual "/link96"
+    newSequence(4).pressedCollection.backfill(1).header.url shouldEqual "/link95"
   }
 }


### PR DESCRIPTION
## What does this change?

In the deduping logic for facia-press, it adds the urls from the current collection's `curated` list to the list of urls against which the `backfill` for the current collection is deduped.

Prior to this, backfill trails for a collection were only being checked against the trails which were present in the collections which had been processed earlier on in the deduping process (e.g. earlier on in the page, if the collection is part of a front). So if a trail was present in both the `curated` and `backfill` lists for a collection, but not in any of the prior collections that had been deduped already, then it would not be removed.

Also adds a test case for this scenario.

Closes #25249.

## Screenshots

| Before | After |
| --- | --- |
| <img width="1334" alt="image" src="https://user-images.githubusercontent.com/37048459/182858370-3fbc71e9-0a01-4de5-9bad-af21e9e1bda6.png"> | <img width="1319" alt="image" src="https://user-images.githubusercontent.com/37048459/182858679-19754330-425e-483a-9c70-a1acf2ffb0d4.png"> |
| Two cards missing from bottom row | The right number of cards, with no duplicates |


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)