### PR TITLE
Refactor: use named params for `getTier`

### DIFF
--- a/facia/app/utils/FaciaPicker.scala
+++ b/facia/app/utils/FaciaPicker.scala
@@ -22,7 +22,12 @@ class FaciaPicker extends GuLogging {
     val participatingInTest = ActiveExperiments.isParticipating(FrontRendering)
     val dcrCouldRender = dcrSupportsAllCollectionTypes(faciaPage)
 
-    val tier = getTier(request.forceDCROff, request.forceDCR, participatingInTest, dcrCouldRender)
+    val tier = getTier(
+      forceDCROff = request.forceDCROff,
+      forceDCR = request.forceDCR,
+      participatingInTest = participatingInTest,
+      dcrCouldRender = dcrCouldRender,
+    )
 
     logTier(faciaPage, path, participatingInTest, dcrCouldRender, tier)
 


### PR DESCRIPTION
The params for `getTier` were being passed as positional parameters, but
all four are `boolean` and order matters to the internal logic of
`getTier`, so passing them as named params seems safer.

### Tested

- [x] Locally
- [ ] On CODE (optional)
