### PR TITLE
Add missing case in IndexController

### DIFF
--- a/common/app/controllers/IndexControllerCommon.scala
+++ b/common/app/controllers/IndexControllerCommon.scala
@@ -75,27 +75,26 @@ trait IndexControllerCommon
     path match {
       //if this is a section tag e.g. football/football
       case TagPattern(left, right) if left == right => successful(Cached(60)(redirect(left, request.isRss)))
-      case _ => {
+      case _ =>
         logGoogleBot(request)
         index(Edition(request), path, inferPage(request), request.isRss) map {
-          case Left(model) if model.contents.nonEmpty => renderFaciaFront(model)
           // if no content is returned (as often happens with old/expired/migrated microsites) return 404 rather than an empty page
-          case Left(model) if model.contents.isEmpty =>
-            Cached(60)(
-              WithoutRevalidationResult(
-                Gone(
-                  views.html.gone(
-                    gonePage,
-                    "Sorry - there is no content here",
-                    "This could be, for example, because content associated with it is not yet published, or due to legal reasons such as the expiry of our rights to publish the content.",
+          case Left(model) =>
+            if (model.contents.nonEmpty) renderFaciaFront(model)
+            else
+              Cached(60)(
+                WithoutRevalidationResult(
+                  Gone(
+                    views.html.gone(
+                      gonePage,
+                      "Sorry - there is no content here",
+                      "This could be, for example, because content associated with it is not yet published, or due to legal reasons such as the expiry of our rights to publish the content.",
+                    ),
                   ),
                 ),
-              ),
-            )
+              )
           case Right(other) => RenderOtherStatus(other)
         }
-      }
-
     }
 
   override def canRender(item: ItemResponse): Boolean = item.section.orElse(item.tag).isDefined


### PR DESCRIPTION
Co-authored-by: Roberto Tyley <roberto.tyley@guardian.co.uk>

## What does this change?
Scala 2.13 compiler has become stricter in checkin whether all cases are covered when pattern matching. In this case we are refactoring one of the cases so that the compiler understands our pattern matching is exhaustive.

Warning when switching to Scala 2.13:

```
Projects/frontend/common/app/controllers/IndexControllerCommon.scala:80:78: match may not be exhaustive.
[warn] It would fail on the following input: Left(_)
[warn]         index(Edition(request), path, inferPage(request), request.isRss) map {
[warn]
```

Note: The compiler raises a warning but according to `frontend` project settings `sbt` will raise a warning as an error:
https://github.com/guardian/frontend/blob/main/project/ProjectSettings.scala#L30

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
