### PR TITLE
Fix define slot Error

### DIFF
--- a/static/src/javascripts/lib/raven.js
+++ b/static/src/javascripts/lib/raven.js
@@ -61,7 +61,7 @@ const sentryOptions = {
 			data?.tags?.tag === 'commercial-sentinel';
 
 		// isInSample is always true if the tag is commercial-sentinel.
-		// Otherwise, sample at .08%
+		// Otherwise, sample at a very small rate.
 		const isInSample = isSentinelLoggingEvent
 			? true
 			: Math.random() < 0.008;

--- a/static/src/javascripts/lib/report-error.js
+++ b/static/src/javascripts/lib/report-error.js
@@ -4,16 +4,13 @@
     is still logged to the console via browsers built-in logging for uncaught
     exceptions. This is optional because sometimes we log errors for tracking
     user data.
-        A sample rate is for when an error is anticipated to be reported highly frequently
-    to the point where we may encroach on our rate limits. A rate of 0.1 will report 1 in every
-    10 errors. A rate of 0.0001 will report 1 in every 10,000 errors.
+        A sample rate is used for highly frequent errors, where logging every
+    one to Sentry may cause us to reach rate limits.
 */
 import raven from './raven';
 
 const reportError = (err, tags, shouldThrow = true, sampleRate = 1) => {
-	if (!isInSample(sampleRate)) return;
-
-	raven.captureException(err, { tags });
+	raven.captureException(err, { tags, sampleRate });
 	if (shouldThrow) {
 		// Flag to ensure it is not reported to Sentry again via global handlers
 		const error = err;
@@ -22,7 +19,4 @@ const reportError = (err, tags, shouldThrow = true, sampleRate = 1) => {
 	}
 };
 
-const isInSample = (sampleRate) => Math.random() <= sampleRate;
-
 export default reportError;
-export { isInSample };

--- a/static/src/javascripts/lib/report-error.js
+++ b/static/src/javascripts/lib/report-error.js
@@ -1,14 +1,18 @@
 /*
-   Report errors to Sentry with optional tags metadata
-   We optionally re-throw the error to halt execution and to ensure the error is
-   still logged to the console via browsers built-in logging for uncaught
-   exceptions. This is optional because sometimes we log errors for tracking
-   user data.
+        Report errors to Sentry with optional tags metadata.
+        We optionally re-throw the error to halt execution and to ensure the error
+    is still logged to the console via browsers built-in logging for uncaught
+    exceptions. This is optional because sometimes we log errors for tracking
+    user data.
+        A sample rate is for when an error is anticipated to be reported highly frequently
+    to the point where we may encroach on our rate limits. A rate of 0.1 will report 1 in every
+    10 errors. A rate of 0.0001 will report 1 in every 10,000 errors.
 */
-
 import raven from './raven';
 
-const reportError = (err, tags, shouldThrow = true) => {
+const reportError = (err, tags, shouldThrow = true, sampleRate = 1) => {
+	if (!isInSample(sampleRate)) return;
+
 	raven.captureException(err, { tags });
 	if (shouldThrow) {
 		// Flag to ensure it is not reported to Sentry again via global handlers
@@ -18,4 +22,7 @@ const reportError = (err, tags, shouldThrow = true) => {
 	}
 };
 
+const isInSample = (sampleRate) => Math.random() <= sampleRate;
+
 export default reportError;
+export { isInSample };

--- a/static/src/javascripts/lib/report-error.js
+++ b/static/src/javascripts/lib/report-error.js
@@ -9,8 +9,8 @@
 */
 import raven from './raven';
 
-const reportError = (err, tags, shouldThrow = true, sampleRate = 1) => {
-	raven.captureException(err, { tags, sampleRate });
+const reportError = (err, tags, shouldThrow = true) => {
+	raven.captureException(err, { tags });
 	if (shouldThrow) {
 		// Flag to ensure it is not reported to Sentry again via global handlers
 		const error = err;

--- a/static/src/javascripts/lib/report-error.spec.js
+++ b/static/src/javascripts/lib/report-error.spec.js
@@ -1,4 +1,4 @@
-import reportError, { isInSample } from './report-error';
+import reportError from './report-error';
 
 jest.mock('raven-js', () => ({
 	config() {
@@ -15,7 +15,7 @@ const fakeRaven = require('raven-js');
 describe('report-error', () => {
 	const error = new Error('Something broke.');
 	const metaData = { test: true };
-	const ravenMetaData = { tags: metaData };
+	const ravenMetaData = { tags: metaData, sampleRate: 1 };
 
 	test('Does not throw an error', () => {
 		expect(() => {
@@ -37,44 +37,5 @@ describe('report-error', () => {
 			error,
 			ravenMetaData,
 		);
-	});
-
-	test('Throws an error if sample rate is GREATER than random number', () => {
-		jest.spyOn(global.Math, 'random').mockReturnValue(0.2);
-		expect(() => {
-			reportError(error, metaData, true, 0.5);
-		}).toThrowError(error);
-	});
-
-	test('Does not throw an error if sample rate is LESS than random number', () => {
-		jest.spyOn(global.Math, 'random').mockReturnValue(0.8);
-		expect(() => {
-			reportError(error, metaData, true, 0.5);
-		}).not.toThrowError(error);
-	});
-
-	describe('isInSample', () => {
-		it.each([0, 0.5, 0.99])(
-			'returns true if sample rate is 1',
-			(randomNumber) => {
-				jest.spyOn(global.Math, 'random').mockReturnValue(randomNumber);
-
-				expect(isInSample(1)).toBe(true);
-			},
-		);
-
-		test('returns TRUE if sample rate is GREATER than random number', () => {
-			const sampleRate = 0.1;
-			jest.spyOn(global.Math, 'random').mockReturnValue(0.08);
-
-			expect(isInSample(sampleRate)).toBe(true);
-		});
-
-		test('returns FALSE if sample rate is LESS than random number', () => {
-			const sampleRate = 0.1;
-			jest.spyOn(global.Math, 'random').mockReturnValue(0.18);
-
-			expect(isInSample(sampleRate)).toBe(false);
-		});
 	});
 });

--- a/static/src/javascripts/lib/report-error.spec.js
+++ b/static/src/javascripts/lib/report-error.spec.js
@@ -15,7 +15,7 @@ const fakeRaven = require('raven-js');
 describe('report-error', () => {
 	const error = new Error('Something broke.');
 	const metaData = { test: true };
-	const ravenMetaData = { tags: metaData, sampleRate: 1 };
+	const ravenMetaData = { tags: metaData };
 
 	test('Does not throw an error', () => {
 		expect(() => {

--- a/static/src/javascripts/lib/report-error.spec.js
+++ b/static/src/javascripts/lib/report-error.spec.js
@@ -1,41 +1,80 @@
-import reportError from './report-error';
+import reportError, { isInSample } from './report-error';
 
 jest.mock('raven-js', () => ({
-    config() {
-        return this;
-    },
-    install() {
-        return this;
-    },
-    captureException: jest.fn(),
+	config() {
+		return this;
+	},
+	install() {
+		return this;
+	},
+	captureException: jest.fn(),
 }));
 
 const fakeRaven = require('raven-js');
 
 describe('report-error', () => {
-    const error = new Error('Something broke.');
-    const metaData = { test: true };
-    const ravenMetaData = { tags: metaData };
+	const error = new Error('Something broke.');
+	const metaData = { test: true };
+	const ravenMetaData = { tags: metaData };
 
-    test('Does not throw an error', () => {
-        expect(() => {
-            reportError(error, metaData, false);
-        }).not.toThrowError(error);
+	test('Does not throw an error', () => {
+		expect(() => {
+			reportError(error, metaData, false);
+		}).not.toThrowError(error);
 
-        expect(fakeRaven.captureException).toHaveBeenCalledWith(
-            error,
-            ravenMetaData
-        );
-    });
+		expect(fakeRaven.captureException).toHaveBeenCalledWith(
+			error,
+			ravenMetaData,
+		);
+	});
 
-    test('Throws an error', () => {
-        expect(() => {
-            reportError(error, metaData);
-        }).toThrowError(error);
+	test('Throws an error', () => {
+		expect(() => {
+			reportError(error, metaData);
+		}).toThrowError(error);
 
-        expect(fakeRaven.captureException).toHaveBeenCalledWith(
-            error,
-            ravenMetaData
-        );
-    });
+		expect(fakeRaven.captureException).toHaveBeenCalledWith(
+			error,
+			ravenMetaData,
+		);
+	});
+
+	test('Throws an error if sample rate is GREATER than random number', () => {
+		jest.spyOn(global.Math, 'random').mockReturnValue(0.2);
+		expect(() => {
+			reportError(error, metaData, true, 0.5);
+		}).toThrowError(error);
+	});
+
+	test('Does not throw an error if sample rate is LESS than random number', () => {
+		jest.spyOn(global.Math, 'random').mockReturnValue(0.8);
+		expect(() => {
+			reportError(error, metaData, true, 0.5);
+		}).not.toThrowError(error);
+	});
+
+	describe('isInSample', () => {
+		it.each([0, 0.5, 0.99])(
+			'returns true if sample rate is 1',
+			(randomNumber) => {
+				jest.spyOn(global.Math, 'random').mockReturnValue(randomNumber);
+
+				expect(isInSample(1)).toBe(true);
+			},
+		);
+
+		test('returns TRUE if sample rate is GREATER than random number', () => {
+			const sampleRate = 0.1;
+			jest.spyOn(global.Math, 'random').mockReturnValue(0.08);
+
+			expect(isInSample(sampleRate)).toBe(true);
+		});
+
+		test('returns FALSE if sample rate is LESS than random number', () => {
+			const sampleRate = 0.1;
+			jest.spyOn(global.Math, 'random').mockReturnValue(0.18);
+
+			expect(isInSample(sampleRate)).toBe(false);
+		});
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -125,7 +125,9 @@ class Advert {
 		} catch {
 			log(
 				'commercial',
-				`Could not create advert. Ad slot: ${adSlotNode.id}`,
+				`Could not create advert. Ad slot: ${
+					adSlotNode.id
+				}. Sizes: ${JSON.stringify(this.sizes)}`,
 			);
 			throw new Error(`Could not define slot for ${adSlotNode.id}`);
 		}

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -4,7 +4,7 @@ import {
 	slotSizeMappings,
 } from '@guardian/commercial-core';
 import type { AdSize, SizeMapping, SlotName } from '@guardian/commercial-core';
-import reportError from 'lib/report-error';
+import { log } from '@guardian/libs';
 import { breakpoints } from '../../../../lib/detect';
 import { breakpointNameToAttribute } from './breakpoint-name-to-attribute';
 import { buildGoogletagSizeMapping, defineSlot } from './define-slot';
@@ -123,10 +123,9 @@ class Advert {
 			this.slot = slotDefinition.slot;
 			this.whenSlotReady = slotDefinition.slotReady;
 		} catch {
-			reportError(
-				new Error(`Could not create advert. Ad slot: ${adSlotNode.id}`),
-				{},
-				false,
+			log(
+				'commercial',
+				`Could not create advert. Ad slot: ${adSlotNode.id}`,
 			);
 			throw new Error(`Could not define slot for ${adSlotNode.id}`);
 		}

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -4,6 +4,7 @@ import {
 	slotSizeMappings,
 } from '@guardian/commercial-core';
 import type { AdSize, SizeMapping, SlotName } from '@guardian/commercial-core';
+import reportError from 'lib/report-error';
 import { breakpoints } from '../../../../lib/detect';
 import { breakpointNameToAttribute } from './breakpoint-name-to-attribute';
 import { buildGoogletagSizeMapping, defineSlot } from './define-slot';
@@ -122,7 +123,12 @@ class Advert {
 			this.slot = slotDefinition.slot;
 			this.whenSlotReady = slotDefinition.slotReady;
 		} catch {
-			throw new Error(`Could not define slot for ${this.id}`);
+			reportError(
+				new Error(`Could not create advert. Ad slot: ${adSlotNode.id}`),
+				{},
+				false,
+			);
+			throw new Error(`Could not define slot for ${adSlotNode.id}`);
 		}
 
 		this.whenLoaded = new Promise((resolve: Resolver) => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -116,11 +116,14 @@ class Advert {
 
 		this.sizes = this.generateSizeMapping(additionalSizeMapping);
 
-		const slotDefinition = defineSlot(adSlotNode, this.sizes);
+		try {
+			const slotDefinition = defineSlot(adSlotNode, this.sizes);
 
-		this.slot = slotDefinition.slot;
-
-		this.whenSlotReady = slotDefinition.slotReady;
+			this.slot = slotDefinition.slot;
+			this.whenSlotReady = slotDefinition.slotReady;
+		} catch {
+			throw new Error(`Could not define slot for ${this.id}`);
+		}
 
 		this.whenLoaded = new Promise((resolve: Resolver) => {
 			this.whenLoadedResolver = resolve;
@@ -228,7 +231,10 @@ class Advert {
 
 		this.sizes = sizeMapping;
 
-		this.slot.defineSizeMapping(buildGoogletagSizeMapping(sizeMapping));
+		const googleMapping = buildGoogletagSizeMapping(sizeMapping);
+		if (googleMapping) {
+			this.slot.defineSizeMapping(googleMapping);
+		}
 	}
 }
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -4,7 +4,6 @@ import {
 	slotSizeMappings,
 } from '@guardian/commercial-core';
 import type { AdSize, SizeMapping, SlotName } from '@guardian/commercial-core';
-import { log } from '@guardian/libs';
 import { breakpoints } from '../../../../lib/detect';
 import { breakpointNameToAttribute } from './breakpoint-name-to-attribute';
 import { buildGoogletagSizeMapping, defineSlot } from './define-slot';
@@ -114,23 +113,12 @@ class Advert {
 	) {
 		this.id = adSlotNode.id;
 		this.node = adSlotNode;
-
 		this.sizes = this.generateSizeMapping(additionalSizeMapping);
 
-		try {
-			const slotDefinition = defineSlot(adSlotNode, this.sizes);
+		const slotDefinition = defineSlot(adSlotNode, this.sizes);
 
-			this.slot = slotDefinition.slot;
-			this.whenSlotReady = slotDefinition.slotReady;
-		} catch {
-			log(
-				'commercial',
-				`Could not create advert. Ad slot: ${
-					adSlotNode.id
-				}. Sizes: ${JSON.stringify(this.sizes)}`,
-			);
-			throw new Error(`Could not define slot for ${adSlotNode.id}`);
-		}
+		this.slot = slotDefinition.slot;
+		this.whenSlotReady = slotDefinition.slotReady;
 
 		this.whenLoaded = new Promise((resolve: Resolver) => {
 			this.whenLoadedResolver = resolve;

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -226,9 +226,9 @@ class Advert {
 
 		this.sizes = sizeMapping;
 
-		const googleMapping = buildGoogletagSizeMapping(sizeMapping);
-		if (googleMapping) {
-			this.slot.defineSizeMapping(googleMapping);
+		const googletagSizeMapping = buildGoogletagSizeMapping(sizeMapping);
+		if (googletagSizeMapping) {
+			this.slot.defineSizeMapping(googletagSizeMapping);
 		}
 	}
 }

--- a/static/src/javascripts/projects/commercial/modules/dfp/add-slot.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/add-slot.ts
@@ -1,4 +1,5 @@
 import type { SizeMapping } from '@guardian/commercial-core';
+import { log } from '@guardian/libs';
 import { Advert } from './Advert';
 import { dfpEnv } from './dfp-env';
 import { enableLazyLoad } from './lazy-load';
@@ -21,10 +22,7 @@ const displayAd = (
 			loadAdvert(advert);
 		}
 	} catch {
-		// TODO: Log using Raven here?? Include slot id in report.
-		// Should we include the invalid mappings so that we can investigate?
-		console.log('Could not create advert');
-		return;
+		log('commercial', `Could not create advert. Ad slot: ${adSlot.id}`);
 	}
 };
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/add-slot.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/add-slot.ts
@@ -10,14 +10,21 @@ const displayAd = (
 	forceDisplay: boolean,
 	additionalSizes?: SizeMapping,
 ) => {
-	const advert = new Advert(adSlot, additionalSizes);
+	try {
+		const advert = new Advert(adSlot, additionalSizes);
 
-	dfpEnv.advertIds[advert.id] = dfpEnv.adverts.push(advert) - 1;
-	if (dfpEnv.shouldLazyLoad() && !forceDisplay) {
-		queueAdvert(advert);
-		enableLazyLoad(advert);
-	} else {
-		loadAdvert(advert);
+		dfpEnv.advertIds[advert.id] = dfpEnv.adverts.push(advert) - 1;
+		if (dfpEnv.shouldLazyLoad() && !forceDisplay) {
+			queueAdvert(advert);
+			enableLazyLoad(advert);
+		} else {
+			loadAdvert(advert);
+		}
+	} catch {
+		// TODO: Log using Raven here?? Include slot id in report.
+		// Should we include the invalid mappings so that we can investigate?
+		console.log('Could not create advert');
+		return;
 	}
 };
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/add-slot.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/add-slot.ts
@@ -1,26 +1,10 @@
 import type { SizeMapping } from '@guardian/commercial-core';
-import { log } from '@guardian/libs';
-import { Advert } from './Advert';
+import type { Advert } from './Advert';
+import { createAdvert } from './create-advert';
 import { dfpEnv } from './dfp-env';
 import { enableLazyLoad } from './lazy-load';
 import { loadAdvert } from './load-advert';
 import { queueAdvert } from './queue-advert';
-
-const createAdvert = (adSlot: HTMLElement, additionalSizes?: SizeMapping) => {
-	try {
-		const advert = new Advert(adSlot, additionalSizes);
-		return advert;
-	} catch {
-		log(
-			'commercial',
-			`Could not create advert. Ad slot: ${
-				adSlot.id
-			}. Additional Sizes: ${JSON.stringify(additionalSizes)}`,
-		);
-
-		return null;
-	}
-};
 
 const displayAd = (advert: Advert, forceDisplay: boolean) => {
 	dfpEnv.advertIds[advert.id] = dfpEnv.adverts.push(advert) - 1;

--- a/static/src/javascripts/projects/commercial/modules/dfp/add-slot.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/add-slot.ts
@@ -22,7 +22,12 @@ const displayAd = (
 			loadAdvert(advert);
 		}
 	} catch {
-		log('commercial', `Could not create advert. Ad slot: ${adSlot.id}`);
+		log(
+			'commercial',
+			`Could not create advert. Ad slot: ${
+				adSlot.id
+			}. Additional Sizes: ${JSON.stringify(additionalSizes)}`,
+		);
 	}
 };
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-advert.ts
@@ -22,7 +22,6 @@ const createAdvert = (
 				feature: 'commercial',
 			},
 			false,
-			1 / 10_000,
 		);
 
 		return null;

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-advert.ts
@@ -1,5 +1,6 @@
 import type { SizeMapping } from '@guardian/commercial-core';
 import { log } from '@guardian/libs';
+import reportError from '../../../../lib/report-error';
 import { Advert } from './Advert';
 
 const createAdvert = (
@@ -10,11 +11,18 @@ const createAdvert = (
 		const advert = new Advert(adSlot, additionalSizes);
 		return advert;
 	} catch {
-		log(
-			'commercial',
-			`Could not create advert. Ad slot: ${
-				adSlot.id
-			}. Additional Sizes: ${JSON.stringify(additionalSizes)}`,
+		const errMsg = `Could not create advert. Ad slot: ${
+			adSlot.id
+		}. Additional Sizes: ${JSON.stringify(additionalSizes)}`;
+
+		log('commercial', errMsg);
+		reportError(
+			new Error(errMsg),
+			{
+				feature: 'commercial',
+			},
+			false,
+			1 / 10_000,
 		);
 
 		return null;

--- a/static/src/javascripts/projects/commercial/modules/dfp/create-advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/create-advert.ts
@@ -1,0 +1,24 @@
+import type { SizeMapping } from '@guardian/commercial-core';
+import { log } from '@guardian/libs';
+import { Advert } from './Advert';
+
+const createAdvert = (
+	adSlot: HTMLElement,
+	additionalSizes?: SizeMapping,
+): Advert | null => {
+	try {
+		const advert = new Advert(adSlot, additionalSizes);
+		return advert;
+	} catch {
+		log(
+			'commercial',
+			`Could not create advert. Ad slot: ${
+				adSlot.id
+			}. Additional Sizes: ${JSON.stringify(additionalSizes)}`,
+		);
+
+		return null;
+	}
+};
+
+export { createAdvert };

--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.spec.ts
@@ -128,6 +128,13 @@ describe('collectSizes', () => {
 			expect(result).toEqual(output);
 		},
 	);
+
+	it('should return an empty array if sizeMappings is null', () => {
+		const sizeMapping = null;
+		const result = collectSizes(sizeMapping);
+
+		expect(result).toEqual([]);
+	});
 });
 
 describe('Define Slot', () => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.ts
@@ -145,9 +145,8 @@ const defineSlot = (
         on slot name, ad unit and sizes. We then add this targeting to the
         slot prior to requesting it from DFP.
 
-        We race the request to IAS with a timeout of 1 second. If the
-        timeout resolves before the request to IAS then the slot is defined
-        without the additional IAS data.
+        We create a timer, such that if the timeout resolves before the request
+		to IAS returns, then the slot is defined without the additional IAS data.
 
         To see debugging output from IAS add the URL param `&iasdebug=true` to the page URL
      */

--- a/static/src/javascripts/projects/commercial/modules/dfp/define-slot.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/define-slot.ts
@@ -29,11 +29,10 @@ const isBreakpoint = (
 /**
  * Builds a googletag size mapping based on the breakpoints and ad sizes from
  * the size mapping in commercial-core and the viewport sizes from source-foundations.
- *
  */
 const buildGoogletagSizeMapping = (
 	sizeMapping: SizeMapping,
-): googletag.SizeMappingArray => {
+): googletag.SizeMappingArray | null => {
 	const mapping = window.googletag.sizeMapping();
 
 	Object.entries(sizeMapping).forEach(([breakpoint, sizes]) => {
@@ -76,12 +75,12 @@ const isSizeInArray = (
  * @returns all the sizes that were present in the size mapping
  */
 const collectSizes = (
-	sizeMapping: googletag.SizeMappingArray,
+	sizeMapping: googletag.SizeMappingArray | null,
 ): googletag.SingleSize[] => {
 	const sizes: googletag.SingleSize[] = [];
 
 	// as we're using sizeMapping, pull out all the ad sizes, as an array of arrays
-	sizeMapping.forEach(([, sizesForBreakpoint]) => {
+	sizeMapping?.forEach(([, sizesForBreakpoint]) => {
 		if (isMultiSize(sizesForBreakpoint)) {
 			sizesForBreakpoint.forEach((size) => {
 				if (!isSizeInArray(size, sizes)) {
@@ -104,6 +103,7 @@ const allowSafeFrameToExpand = (slot: googletag.Slot) => {
 		allowPushExpansion: true,
 		sandbox: true,
 	});
+
 	return slot;
 };
 
@@ -112,11 +112,15 @@ const defineSlot = (
 	sizeMapping: SizeMapping,
 ): { slot: googletag.Slot; slotReady: Promise<void> } => {
 	const slotTarget = adSlotNode.getAttribute('data-name') as SlotName;
+	const id = adSlotNode.id;
 
 	const googletagSizeMapping = buildGoogletagSizeMapping(sizeMapping);
+	if (!googletagSizeMapping) {
+		throw new Error(`Could not define slot for ${id}`);
+	}
+
 	const sizes = collectSizes(googletagSizeMapping);
 
-	const id = adSlotNode.id;
 	let slot: googletag.Slot | null;
 	let slotReady = Promise.resolve();
 
@@ -135,12 +139,13 @@ const defineSlot = (
 	if (!slot) {
 		throw new Error(`Could not define slot for ${id}`);
 	}
+
 	/*
         For each ad slot defined, we request information from IAS, based
         on slot name, ad unit and sizes. We then add this targeting to the
         slot prior to requesting it from DFP.
 
-        We race the request to IAS with a Timeout of 2 seconds. If the
+        We race the request to IAS with a timeout of 1 second. If the
         timeout resolves before the request to IAS then the slot is defined
         without the additional IAS data.
 
@@ -231,6 +236,7 @@ const defineSlot = (
 
 		slotReady = Promise.race([iasTimeout(), iasDataPromise]);
 	}
+
 	const isbn = window.guardian.config.page.isbn;
 
 	if (slotTarget === 'im' && isbn) {

--- a/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.ts
@@ -3,7 +3,8 @@ import { log } from '@guardian/libs';
 import { getBreakpoint } from '../../../../lib/detect';
 import { commercialFeatures } from '../../../common/modules/commercial/commercial-features';
 import { removeDisabledSlots } from '../remove-slots';
-import { Advert } from './Advert';
+import type { Advert } from './Advert';
+import { createAdvert } from './create-advert';
 import { dfpEnv } from './dfp-env';
 import { displayAds } from './display-ads';
 import { displayLazyAds } from './display-lazy-ads';
@@ -62,18 +63,7 @@ const fillAdvertSlots = async (): Promise<void> => {
 				};
 			}
 
-			try {
-				const advert = new Advert(adSlot, additionalSizes);
-				return advert;
-			} catch {
-				log(
-					'commercial',
-					`Could not create advert. Ad slot: ${
-						adSlot.id
-					}. Additional Sizes: ${JSON.stringify(additionalSizes)}`,
-				);
-				return null;
-			}
+			return createAdvert(adSlot, additionalSizes);
 		})
 		.filter((advert): advert is Advert => advert !== null);
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.ts
@@ -68,7 +68,9 @@ const fillAdvertSlots = async (): Promise<void> => {
 			} catch {
 				log(
 					'commercial',
-					`Could not create advert. Ad slot: ${adSlot.id}`,
+					`Could not create advert. Ad slot: ${
+						adSlot.id
+					}. Additional Sizes: ${JSON.stringify(additionalSizes)}`,
 				);
 				return null;
 			}

--- a/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.ts
@@ -66,11 +66,14 @@ const fillAdvertSlots = async (): Promise<void> => {
 				const advert = new Advert(adSlot, additionalSizes);
 				return advert;
 			} catch {
+				log(
+					'commercial',
+					`Could not create advert. Ad slot: ${adSlot.id}`,
+				);
 				return null;
 			}
 		})
-		.filter((advert) => advert !== null)
-		.map((advert) => advert as Advert);
+		.filter((advert): advert is Advert => advert !== null);
 
 	const currentLength = dfpEnv.adverts.length;
 	dfpEnv.adverts = dfpEnv.adverts.concat(adverts);

--- a/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.ts
@@ -61,8 +61,17 @@ const fillAdvertSlots = async (): Promise<void> => {
 					desktop: [adSizes.billboard, createAdSize(900, 250)],
 				};
 			}
-			return new Advert(adSlot, additionalSizes);
-		});
+
+			try {
+				const advert = new Advert(adSlot, additionalSizes);
+				return advert;
+			} catch {
+				return null;
+			}
+		})
+		.filter((advert) => advert !== null)
+		.map((advert) => advert as Advert);
+
 	const currentLength = dfpEnv.adverts.length;
 	dfpEnv.adverts = dfpEnv.adverts.concat(adverts);
 	adverts.forEach((advert, index) => {

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -140,7 +140,6 @@
  "../projects/commercial/modules/dfp/Advert.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/detect.js",
   "../projects/commercial/modules/dfp/breakpoint-name-to-attribute.ts",
   "../projects/commercial/modules/dfp/define-slot.ts"

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -141,11 +141,13 @@
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../lib/detect.js",
+  "../lib/report-error.js",
   "../projects/commercial/modules/dfp/breakpoint-name-to-attribute.ts",
   "../projects/commercial/modules/dfp/define-slot.ts"
  ],
  "../projects/commercial/modules/dfp/add-slot.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../projects/commercial/modules/dfp/Advert.ts",
   "../projects/commercial/modules/dfp/dfp-env.ts",
   "../projects/commercial/modules/dfp/lazy-load.ts",

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -146,14 +146,20 @@
  ],
  "../projects/commercial/modules/dfp/add-slot.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../projects/commercial/modules/dfp/Advert.ts",
+  "../projects/commercial/modules/dfp/create-advert.ts",
   "../projects/commercial/modules/dfp/dfp-env.ts",
   "../projects/commercial/modules/dfp/lazy-load.ts",
   "../projects/commercial/modules/dfp/load-advert.ts",
   "../projects/commercial/modules/dfp/queue-advert.ts"
  ],
  "../projects/commercial/modules/dfp/breakpoint-name-to-attribute.ts": [],
+ "../projects/commercial/modules/dfp/create-advert.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../lib/report-error.js",
+  "../projects/commercial/modules/dfp/Advert.ts"
+ ],
  "../projects/commercial/modules/dfp/define-slot.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/source-foundations/dist/types/index.d.ts",
@@ -189,6 +195,7 @@
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/detect.js",
   "../projects/commercial/modules/dfp/Advert.ts",
+  "../projects/commercial/modules/dfp/create-advert.ts",
   "../projects/commercial/modules/dfp/dfp-env.ts",
   "../projects/commercial/modules/dfp/display-ads.ts",
   "../projects/commercial/modules/dfp/display-lazy-ads.ts",

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -140,8 +140,8 @@
  "../projects/commercial/modules/dfp/Advert.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/detect.js",
-  "../lib/report-error.js",
   "../projects/commercial/modules/dfp/breakpoint-name-to-attribute.ts",
   "../projects/commercial/modules/dfp/define-slot.ts"
  ],


### PR DESCRIPTION
## What is the problem?

No ads will render on a page when there is an error in creating one of the ad slots.

## What does this change?

When an error is thrown when defining an ad slot, this error is now caught where the advert is created so that the next ad slot is processed.

## Why?

When Googletag cannot build a size mapping for an ad slot, an uncaught error is thrown and no ads will render on the entire page. If we catch the error and don't load an ad in that slot, the we can let processing continue and load ads in the other slots in the page.

When there is an invalid size mapping passed to an ad slot, there is no ad loaded for the slot. This makes sense, as Google could not build the ad slot and therefore can't place an ad in that slot. However, we throw an error which is not caught when this happens, which has the end result of no ads loading on the entire page, which does not make sense.

There is a function in `/commercial/modules/dfp/define-slot.ts` called `buildGoogletagSizeMapping` that builds a Googletag size mapping based on the breakpoints and ad sizes from the size mapping in commercial-core. We assume that this function will always return an object of type `googletag.SizeMappingArray`. However, in the case of invalid size mappings being supplied, it is possible that `null` can be returned. When `null` is returned, an uncaught error is thrown in the function collectSizes which will result in no ads being displayed on the page (see screenshots).

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

What happens when now when one or more ads (the right ad slot in this example) fails to load, is that the other ads can still load (top-above-nav here)
![partial-loading](https://user-images.githubusercontent.com/9574885/183610563-c2b714fd-ae02-44ff-aaea-10ae3c3e4b61.jpg)

The error in the console when an ad slot fails to be defined
![No-ads-error](https://user-images.githubusercontent.com/9574885/183610574-de2e093d-dfab-4909-8138-f4b0d57ef2aa.jpg)

The line in define-slot.ts where the error is thrown
![Exception-details](https://user-images.githubusercontent.com/9574885/183610579-73b4890a-96ef-4863-91c5-bd695f4883ff.jpg)

## What is the value of this and can you measure success?

When one or more ad slots fail to be defined, other ads on the page can still be defined and subsequently load. This will increase the number of ads shown on pages where a failure occurs.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
