### PR TITLE
Scala 2.13: Refactor cricket match summary template

### DIFF
--- a/sport/app/cricket/views/fragments/cricketMatchSummary.scala.html
+++ b/sport/app/cricket/views/fragments/cricketMatchSummary.scala.html
@@ -25,36 +25,8 @@
                 </tr>
             </thead>
             <tbody>
-                <tr>
-                    <td><b>@theMatch.homeTeam.name</b></td>
-                    <td>@theMatch.homeTeamInnings match {
-                            case firstInnings :: Nil => {
-                                @score(firstInnings) (@firstInnings.overs overs)
-                            }
-                            case firstInnings :: secondInnings :: Nil => {
-                                @miniScore(firstInnings) & @score(secondInnings) (@secondInnings.overs overs)
-                            }
-                            case _ => {
-                                Yet to bat
-                            }
-                        }
-                    </td>
-                </tr>
-                <tr>
-                    <td><b>@theMatch.awayTeam.name</b></td>
-                    <td>@theMatch.awayTeamInnings match {
-                            case firstInnings :: Nil => {
-                                @score(firstInnings) (@firstInnings.overs overs)
-                            }
-                            case firstInnings :: secondInnings :: Nil => {
-                                @miniScore(firstInnings) & @score(secondInnings) (@secondInnings.overs overs)
-                            }
-                            case _ => {
-                                Yet to bat
-                            }
-                        }
-                    </td>
-                </tr>
+                @teamResults(theMatch.homeTeam, theMatch.homeTeamInnings)
+                @teamResults(theMatch.awayTeam, theMatch.awayTeamInnings)
             </tbody>
             <caption class="table__caption table__caption--top" itemprop="name">
                 @theMatch.competitionName, @theMatch.venueName
@@ -71,20 +43,29 @@
 
 </div>
 
-@miniScore(innings: cricketModel.Innings) = {
-    @innings match {
-        case _ if (innings.declared) => { @innings.runsScored - @innings.wickets declared }
-        case _ if (innings.forfeited) => { @innings.runsScored - @innings.wickets forfeited }
-        case _ if (innings.allOut) => { @innings.runsScored }
-        case _ => { @innings.runsScored - @innings.wickets }
-    }
+@teamResults(team: cricketModel.Team, teamInnings: List[cricketModel.Innings]) = {
+    <tr>
+        <td><b>@team.name</b></td>
+        <td>@teamInnings match {
+            case firstInnings :: Nil => {
+                @score(firstInnings) (@firstInnings.overs overs)
+            }
+            case firstInnings :: secondInnings :: Nil => {
+                @score(firstInnings) & @score(secondInnings) (@secondInnings.overs overs)
+            }
+            case _ => {
+                Yet to bat
+            }
+        }
+        </td>
+    </tr>
 }
 
 @score(innings: cricketModel.Innings) = {
-    @innings match {
-        case _ if (!innings.closed) => { @innings.runsScored - @innings.wickets }
-        case _ if (innings.declared) => { @innings.runsScored - @innings.wickets declared }
-        case _ if (innings.forfeited) => { @innings.runsScored - @innings.wickets forfeited }
-        case _ if (innings.allOut) => { @innings.runsScored all out }
+    @innings.runsScored @innings match {
+        case _ if innings.declared => { - @innings.wickets declared }
+        case _ if innings.forfeited => { - @innings.wickets forfeited }
+        case _ if innings.allOut => { all out }
+        case _ => { - @innings.wickets }
     }
 }


### PR DESCRIPTION
This commit removes code duplication and fixes Scala 2.13 compilation issues in the cricket match summary template, which is embedded into the `/sport/cricket/match/.../...-team.json` endpoint, delivering a dynamically loaded HTML chunk summarising the scores on to Cricket articles like [this](https://www.theguardian.com/sport/live/2022/jul/31/england-v-south-africa-third-mens-t20-live-cricket):

![cricket](https://user-images.githubusercontent.com/52038/183131743-91f04387-db87-4665-bb15-6358967548ad.png)
![image](https://user-images.githubusercontent.com/52038/183132141-94dc4170-d8a1-4e3c-bbfd-47fd32c3eafd.png)

_(the corresponding json endpoint for that article is https://api.nextgen.guardianapps.co.uk/sport/cricket/match/2022-07-31/england-cricket-team.json ...you have to work out the date of the article - eg 2022-07-31 - and then transplant it into the url for the json endpoint. [Example payload](https://gist.github.com/rtyley/3b39a3d7fb792dbf13bca3a6ceba8114))_

We're removing the duplication because in general [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) is a good thing, and the intricacies of cricket need as much clarity as possible for non-cricket-following developers! The reason we're looking at this code though (and trying to understand all the cricket-related-logic!) is because of a compilation error under Scala 2.13.

The Scala 2.13 compiler is stricter about non-exhaustive matches in case-pattern-match expression than Scala 2.12 was, and this is actually a good thing - there was recently a bugfix in this bit of code because an unanticipated case in the PA data caused HTTP 500 errors: https://github.com/guardian/frontend/pull/24499

In the case of the `@score()` reusable template block, the Scala 2.13 compiler couldn't verify that all cases were covered - even though `!innings.closed` (meaning the [innings](https://en.wikipedia.org/wiki/Innings#Usage_in_cricket) are ongoing) is the logical complement of (`innings.declared` + `innings.forfeited` + `innings.allOut`), the compiler couldn't verify that without a knowledge of cricket!

https://github.com/guardian/frontend/blob/5a6f2b9b02375863633c4d54a57fe0dee6649ed1/sport/app/cricket/views/fragments/cricketMatchSummary.scala.html#L84-L89

```
[error] /Users/roberto/guardian/frontend/sport/app/cricket/views/fragments/cricketMatchSummary.scala.html:84:6: match may not be exhaustive.
[error]     @innings match {
[error]      ^
```


It's simpler just to catch all the specific 'closed' cases we care about, and then catch the remaining 'open' case with `case _ =>` to very obviously catch everything that _isn't_ closed.
