### PR TITLE
Add a `dcr-fronts` 0% test

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -6,7 +6,7 @@ import java.time.LocalDate
 
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =
-    Set(OfferHttp3, LiveBlogMainMediaPosition, MerchandisingMinHeight)
+    Set(FrontRendering, OfferHttp3, LiveBlogMainMediaPosition, MerchandisingMinHeight)
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -6,14 +6,14 @@ import java.time.LocalDate
 
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =
-    Set(FrontRendering, OfferHttp3, LiveBlogMainMediaPosition, MerchandisingMinHeight)
+    Set(DCRFronts, OfferHttp3, LiveBlogMainMediaPosition, MerchandisingMinHeight)
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
 
-object FrontRendering
+object DCRFronts
     extends Experiment(
-      name = "front-rendering",
+      name = "dcr-fronts",
       description = "Use DCR for fronts",
       owners = Seq(Owner.withGithub("dotcom")),
       sellByDate = LocalDate.of(2023, 6, 2),

--- a/facia/app/utils/FaciaPicker.scala
+++ b/facia/app/utils/FaciaPicker.scala
@@ -1,7 +1,7 @@
 package utils
 
 import common.GuLogging
-import experiments.{ActiveExperiments, FrontRendering}
+import experiments.{ActiveExperiments, DCRFronts}
 import implicits.Requests._
 import model.PressedPage
 import play.api.mvc.RequestHeader
@@ -19,7 +19,7 @@ class FaciaPicker extends GuLogging {
   }
 
   def getTier(faciaPage: PressedPage, path: String)(implicit request: RequestHeader): RenderType = {
-    val participatingInTest = ActiveExperiments.isParticipating(FrontRendering)
+    val participatingInTest = ActiveExperiments.isParticipating(DCRFronts)
     val dcrCouldRender = dcrSupportsAllCollectionTypes(faciaPage)
 
     val tier = getTier(


### PR DESCRIPTION
## What does this change?
This adds the `dcr-fronts` 0% test to force DCR to render front pages. This closes [#5388](https://github.com/guardian/dotcom-rendering/issues/5388)

The test did exist previously but it wasn't in the list of active experiments. It was also called `fronts-rendering` which I've now renamed to `dcr-fronts` to be clear that this is DCR specific.

Note. Opting into this test has not effect until the [dcrCouldRender](https://github.com/guardian/frontend/blob/oliver/turn-on-front-rendering/facia/app/utils/FaciaPicker.scala#L23) property starts to return true for some fronts. Until then the only way to see the dcr version of a front is to use the `?dcr=true` flag.

## Does this change need to be reproduced in dotcom-rendering ?
Nope

## Opting in and out
In: https://www.theguardian.com/opt/in/dcr-fronts
out: https://www.theguardian.com/opt/out/dcr-fronts


