### PR TITLE
Revert "feat(nav): add women's euros 2022 to football navigation"

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -104,7 +104,6 @@ private object NavLinks {
     "Football",
     "/football",
     children = List(
-      NavLink("Women's Euro 2022", "/football/women-s-euro-2022", Some("football/women-s-euro-2022")),
       NavLink("Live scores", "/football/live", Some("football/live")),
       NavLink("Tables", "/football/tables", Some("football/tables")),
       NavLink("Fixtures", "/football/fixtures", Some("football/fixtures")),


### PR DESCRIPTION
Closes https://github.com/guardian/frontend/issues/25347 by reverting guardian/frontend#25177 and thus removing the link to the Women's Euros page from the nav bar.

This is following a request from CP