### PR TITLE
Fix podcast right ad slot

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -20,10 +20,6 @@
     margin-bottom: $gs-baseline * 2;
 }
 
-.ad-slot--dark {
-    background-color: lighten($brightness-7,  2.5%);
-}
-
 .ad-slot--right,
 .ad-slot--comments {
     position: sticky;
@@ -269,6 +265,10 @@
     @include mq(tablet, leftCol) {
         clear: left;
     }
+}
+
+.ad-slot--dark {
+    background-color: lighten($brightness-7,  2.5%);
 }
 
 .ad-slot--container-inline:not(.ad-slot--fluid):not(.ad-slot--gc):not(.ad-slot--mostpop) {

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -612,3 +612,9 @@
 .bz-custom-container ~ #bannerandheader > .top-banner-ad-container {
     display: none;
 }
+
+.podcast__secondary .ad-slot--right {
+    @include mq($until: desktop) {
+        display: none;
+    }
+}


### PR DESCRIPTION
## What does this change?
The label was coloured incorrectly on dark podcast (all podcast?) pages, now fixed.

The slot is now hidden on < desktop breakpoint sizes, inline with article pages.

Example: https://www.theguardian.com/news/audio/2022/aug/08/the-tory-leadership-race-and-the-ghost-of-margaret-thatcher-podcast

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |


[before]: https://user-images.githubusercontent.com/1731150/183390804-0840770a-3bbc-4c9f-8cd3-6fa579f38467.png
[after]: https://user-images.githubusercontent.com/1731150/183390412-a2fb582b-48b4-4407-9e4b-6c3842b352e6.png

## What is the value of this and can you measure success?
Label is actually readable on dark pages/podcasts
The right slot was not expected to ever be displayed on mobile, so now it isn't.

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
