### PR TITLE
Add Percy visual testing

### DIFF
--- a/cypress/e2e/snapshot-top-above-nav.cy.ts
+++ b/cypress/e2e/snapshot-top-above-nav.cy.ts
@@ -1,0 +1,22 @@
+import { articles, liveblogs } from '../fixtures/pages';
+import { breakpoints } from '../fixtures/breakpoints';
+import '@percy/cypress';
+
+describe('Visually snapshot top-above-nav', () => {
+	[articles[0]].forEach(({ path, adTest }) => {
+		it(`snapshots ${path}`, () => {
+			cy.visit(`${path}?adtest=${adTest}`);
+			cy.allowAllConsent();
+			cy.get('#dfp-ad--top-above-nav').should('exist');
+			cy.findAdSlotIframeBySlotId('dfp-ad--top-above-nav').should(
+				'exist',
+			);
+			cy.hydrate();
+			cy.percySnapshot('top-above-nav', {
+				// TODO decide on the breakpoints we wish to snapshot
+				// widths: breakpoints.map(b => b.width),
+				widths: [740, 1300],
+			});
+		});
+	});
+});

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@cypress/webpack-preprocessor": "^5.12.0",
     "@guardian/eslint-config-typescript": "^0.7.0",
     "@guardian/prettier": "^1.0.0",
-    "@percy/cli": "^1.6.3",
+    "@percy/cli": "^1.6.4",
     "@percy/cypress": "^3.1.2",
     "@types/google.analytics": "^0.0.42",
     "@types/googletag": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@cypress/webpack-preprocessor": "^5.12.0",
     "@guardian/eslint-config-typescript": "^0.7.0",
     "@guardian/prettier": "^1.0.0",
-    "@percy/cli": "^1.6.4",
+    "@percy/cli": "^1.7.2",
     "@percy/cypress": "^3.1.2",
     "@types/google.analytics": "^0.0.42",
     "@types/googletag": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,8 @@
     "@cypress/webpack-preprocessor": "^5.12.0",
     "@guardian/eslint-config-typescript": "^0.7.0",
     "@guardian/prettier": "^1.0.0",
+    "@percy/cli": "^1.6.3",
+    "@percy/cypress": "^3.1.2",
     "@types/google.analytics": "^0.0.42",
     "@types/googletag": "^1.1.3",
     "@types/jest": "^26.0.20",

--- a/package.json
+++ b/package.json
@@ -216,7 +216,8 @@
     "eslint-fix": "eslint --color --fix",
     "test": "jest",
     "cypress:open": "cypress open --e2e --browser=chrome",
-    "cypress:run": "cypress run --spec 'cypress/e2e/**/*'"
+    "cypress:run": "cypress run --spec 'cypress/e2e/**/*'",
+    "cypress:run:percy": "percy exec -- cypress run --spec 'cypress/e2e/**/snapshot-*'"
   },
   "prettier": "@guardian/prettier"
 }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@cypress/webpack-preprocessor": "^5.12.0",
     "@guardian/eslint-config-typescript": "^0.7.0",
     "@guardian/prettier": "^1.0.0",
-    "@percy/cli": "^1.7.2",
+    "@percy/cli": "^1.8.0",
     "@percy/cypress": "^3.1.2",
     "@types/google.analytics": "^0.0.42",
     "@types/googletag": "^1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2449,96 +2449,96 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@percy/cli-build@1.6.3":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@percy/cli-build/-/cli-build-1.6.3.tgz#82c8034a03286b7f1a5bc5542aa615dee1840673"
-  integrity sha512-FPK3HsE+PSW8Xq1oA68kS1ZSsXgxGVKcyctJmHya2Dc7H5XHIyIRTAzsY9qjWGD0OSUGX9jj7j3cZ0QG6LVE5g==
+"@percy/cli-build@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/cli-build/-/cli-build-1.6.4.tgz#965bfeaa069bce1b578589aff6f7bb3fa1f6a7fc"
+  integrity sha512-OC8cPqI+Q12h6P/W93JC5dR2QBKjuNKPs5UmLWYQvkXp24igex0ZeJYZUqvpJrxj4Fm4PTbEmn3SLDo/s86QOg==
   dependencies:
-    "@percy/cli-command" "1.6.3"
+    "@percy/cli-command" "1.6.4"
 
-"@percy/cli-command@1.6.3":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.6.3.tgz#e209cd4410cd8b6a0e130f48258173080bcdce96"
-  integrity sha512-WHICKTVdLW8vFm0emBkR/tV14XKWUfUEKw9UieSuEwIrQmMTPEaY0GxuRk3NrBMj6vkRuJW6yeLCGLVWFlRGlQ==
+"@percy/cli-command@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.6.4.tgz#828cc900717aa53c62d65349ce656285b9c4c8b2"
+  integrity sha512-is7ZFk1GbBajP3c16Pm+QBIyYE7371s5Os8VuTr4vyGOyYtR9s2wKS1EPzoUhKOZRDlJ1fAi4/PQQiZVZqd2IA==
   dependencies:
-    "@percy/config" "1.6.3"
-    "@percy/core" "1.6.3"
-    "@percy/logger" "1.6.3"
+    "@percy/config" "1.6.4"
+    "@percy/core" "1.6.4"
+    "@percy/logger" "1.6.4"
 
-"@percy/cli-config@1.6.3":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.6.3.tgz#72bf5f0b6398569a625844028539164952e100e3"
-  integrity sha512-7qVBGPhMRG+8YV23zNdRjiRlF+AEaspk4SBVu2FU2MrVtCr3+hpeFSoqg3lfzr1Y+7aS3ntYmoifdcsOJ3+vdA==
+"@percy/cli-config@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.6.4.tgz#10b6acae399a4b5b066f45096b63614940a225ef"
+  integrity sha512-kDwuMnrmc1iRtMVQIHoawRxkeaDLLJ+ksx9TLsp+GdEkfXU8rLoxugZh9Aey1/E5R5cjz8Esqi0LB7Ii7qmnZw==
   dependencies:
-    "@percy/cli-command" "1.6.3"
+    "@percy/cli-command" "1.6.4"
 
-"@percy/cli-exec@1.6.3":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@percy/cli-exec/-/cli-exec-1.6.3.tgz#50f140b9805e7d088f79696ab992da60395a7f21"
-  integrity sha512-m42eS7IHN/csILWpskNaKZBkYvTnvAQu99mPFr2467NOBP/HLLjW2ry6qiv/ZwxF6jNbJzBLok8rk2TmiEmeZQ==
+"@percy/cli-exec@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/cli-exec/-/cli-exec-1.6.4.tgz#736882c5d317845c00988200d86d5b2409767d87"
+  integrity sha512-pC5gx5RxJY0baOJ5CyLCwFBVhN0luOm0F9S/EMvRg3CZAWy6IiJMWth3lRYQo7mG7s9AOzcEOyfZ+20YKGc6bQ==
   dependencies:
-    "@percy/cli-command" "1.6.3"
+    "@percy/cli-command" "1.6.4"
     cross-spawn "^7.0.3"
     which "^2.0.2"
 
-"@percy/cli-snapshot@1.6.3":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@percy/cli-snapshot/-/cli-snapshot-1.6.3.tgz#65f32aa17c6cc0a4b00a82c5dd6a471d95323d29"
-  integrity sha512-s2TIaRzibtTpdW9szixwYivoRCKTeqvHLx/7eV3ZiIrDc0t7DY2eylFBFWwUcvlR+jOUC5Yu4o/Ti4I8hZ4mJA==
+"@percy/cli-snapshot@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/cli-snapshot/-/cli-snapshot-1.6.4.tgz#ceb2280644fb6cde6f641736dd85664c4f093a76"
+  integrity sha512-+rN58q/mz05mr94L8FfPqTMGEoLAsq9D28IHZmM94Y5O0mCYqPEpVZgbvkkrz+UfFrqyMtR3WGCqs4mJpE97cA==
   dependencies:
-    "@percy/cli-command" "1.6.3"
+    "@percy/cli-command" "1.6.4"
     yaml "^2.0.0"
 
-"@percy/cli-upload@1.6.3":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@percy/cli-upload/-/cli-upload-1.6.3.tgz#c22f4e3220723b0c3e52da67144e4b60b66b6d96"
-  integrity sha512-spG3/uhAD3DgVFdtHhhX5lx+jnBPu5x2l30gHDHVmi9cyl50upAeNYFx3ROQtuTecXiiZeV024qDJqwvLr94ew==
+"@percy/cli-upload@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/cli-upload/-/cli-upload-1.6.4.tgz#f7f2f177401b70cf6f80827f88073e85ec86694d"
+  integrity sha512-OFZ9xwnJbQpMQRCVVhXKDFmuLEc+tcx9NZ20UNrEpyjlndlfrCBZPBQVrqhonZ1oBhVBRSoRj0iw+BF6YDdboA==
   dependencies:
-    "@percy/cli-command" "1.6.3"
+    "@percy/cli-command" "1.6.4"
     fast-glob "^3.2.11"
     image-size "^1.0.0"
 
-"@percy/cli@^1.6.3":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.6.3.tgz#960181564f2a4aab1fc6b45c3a8fd2cd187b5be0"
-  integrity sha512-LaoH6hR+pw0Zre4MluZc5z+qiNHeIFbnleJSvIdss7B2E6oQh6vfhXdTgrlAhZ/4h8Cmr6HGrRuNPng/b8XAYA==
+"@percy/cli@^1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.6.4.tgz#01e943cc78de42bc05ebbff08f7ac1deeb17ff21"
+  integrity sha512-K1Dgtt7aB/db/oSRdLTCxHZ1AY/gziDrDHxWXRMSgsbf+PunnWe6qUfhxqqLbqlizf8ccp608beKWtys/xKrGw==
   dependencies:
-    "@percy/cli-build" "1.6.3"
-    "@percy/cli-command" "1.6.3"
-    "@percy/cli-config" "1.6.3"
-    "@percy/cli-exec" "1.6.3"
-    "@percy/cli-snapshot" "1.6.3"
-    "@percy/cli-upload" "1.6.3"
-    "@percy/client" "1.6.3"
-    "@percy/logger" "1.6.3"
+    "@percy/cli-build" "1.6.4"
+    "@percy/cli-command" "1.6.4"
+    "@percy/cli-config" "1.6.4"
+    "@percy/cli-exec" "1.6.4"
+    "@percy/cli-snapshot" "1.6.4"
+    "@percy/cli-upload" "1.6.4"
+    "@percy/client" "1.6.4"
+    "@percy/logger" "1.6.4"
 
-"@percy/client@1.6.3":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.6.3.tgz#7d75af3b92e3548fae70239cc16e4a832ae520e6"
-  integrity sha512-/gsfhikO3O36vWHH6TQ4QSVp/i1GkTt7lyPEn51jzKjV9rdQ8hmvxzMk2mleyYDAlZQBwyQaOZdMnhfbphLM2w==
+"@percy/client@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.6.4.tgz#ac7fd6c98144661574dc028587935570c706a7d3"
+  integrity sha512-LbJg/xhrXavHx4ZiijpAq5fpELKszePF0kGMvBHFeEorVjqTPmkZQg1pQW480ND+F/h6sLk15ucU0Aylp2eooA==
   dependencies:
-    "@percy/env" "1.6.3"
-    "@percy/logger" "1.6.3"
+    "@percy/env" "1.6.4"
+    "@percy/logger" "1.6.4"
 
-"@percy/config@1.6.3":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.6.3.tgz#381e2b1f64593b651c90aeca911979cae5867f3f"
-  integrity sha512-BKDykqRoBrjeUHhfYLuTrAnxFYTuOXHc6XKmHuui44buoF5ZaG/2Md5DQpqfGVQ0Jdzumoge/up7PGmxdve1SQ==
+"@percy/config@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.6.4.tgz#31812d1f949f22f6589e87027716d29271822e67"
+  integrity sha512-e9e6CneEs2nmY3kstr5SNaoXT7LRk3Ga/noioSA5HNWPMqKPRwZaMlYLWA0NMSCbVcShMAqbRpa4FEbYTbpGGw==
   dependencies:
-    "@percy/logger" "1.6.3"
+    "@percy/logger" "1.6.4"
     ajv "^8.6.2"
     cosmiconfig "^7.0.0"
     yaml "^2.0.0"
 
-"@percy/core@1.6.3":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.6.3.tgz#a22c12e09d1e43aa6e72494ce94acae7beb8923d"
-  integrity sha512-RwRh8UUARv2gtD32C0NNe6VbBAWhne6IUBN5nMJ2yw6Q7LZqf2oa8kiocxGlyXpMTjYDRZ/FbNT0PqFw5o52gw==
+"@percy/core@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.6.4.tgz#8dc8b78e175b7312ab00ce05043f2b2d07861e09"
+  integrity sha512-p5XP8gcKqeozcJSPZS9ynVfuGV2rM9dYPCjL0GX7KRkjY9vpAO6IfDAFUbcJYbbwy54WiJqFjDMmm8xmTsVniQ==
   dependencies:
-    "@percy/client" "1.6.3"
-    "@percy/config" "1.6.3"
-    "@percy/dom" "1.6.3"
-    "@percy/logger" "1.6.3"
+    "@percy/client" "1.6.4"
+    "@percy/config" "1.6.4"
+    "@percy/dom" "1.6.4"
+    "@percy/logger" "1.6.4"
     content-disposition "^0.5.4"
     cross-spawn "^7.0.3"
     extract-zip "^2.0.1"
@@ -2556,20 +2556,20 @@
   dependencies:
     "@percy/sdk-utils" "^1.3.1"
 
-"@percy/dom@1.6.3":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.6.3.tgz#cd2bf2569ba328f886ba9e026498a060fd980ffc"
-  integrity sha512-V4D/og0AOI1uFb5xtRYuypjmG6PuVwe+eMz10hFThRsxCiRGKlS7QnZUyNQkRwIO/k2r7LnboBpIUzBakSCgzA==
+"@percy/dom@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.6.4.tgz#3a823b2138055ac4a0804d8802e849282adbebd7"
+  integrity sha512-1Ox++5ZpbleaERifm+NTgSgSWKpAFSIxd5x4ZUI6HzNlojDverat6nIFjU+q5Y4Y2DHXn5ihagvODqspOq0Dkw==
 
-"@percy/env@1.6.3":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.6.3.tgz#ab9ff1f3cd85d77be409206d6469fa580efe5164"
-  integrity sha512-YsGQa6i/8Ca+XblRFxAClIo18dEYrU/rZKTZEio4WJ59zjoTskOU3VTgH4a4LX7J3LRpy0+A3v8UiUI4y3Vf8g==
+"@percy/env@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.6.4.tgz#80cb8dd2b44cdce3318cdde752fc183a1553ffa5"
+  integrity sha512-zn/RqbxSOtSnV8rApLtJ7EVzFdPVv+Agwq85/UuTK+2Md5Eb+mnT6TbmkRg/0n7l8d14uiDcRRwRi1+msVefZg==
 
-"@percy/logger@1.6.3":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.6.3.tgz#c13c64c20f9f842fe36266abbddfe9f07cfd2b6a"
-  integrity sha512-900DQ6KmDZVADuVdPARpZHvodALrswLOd/z4x2du484o/hyiNtO2nvO3rzyTCPVI+nreMT82yCy3JqnNwtJaSQ==
+"@percy/logger@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.6.4.tgz#598f1a5de0af9f8e3616a9d12ebf6fedbed5da78"
+  integrity sha512-lFPlVcxRtQyFw+TGzfOgFm4Vc/e8xx3nrrdKopnm22JIiTGH/hYFmq4A9u0e4b6Sp2nDZzWT2W5fxVHZiKDDlg==
 
 "@percy/sdk-utils@^1.3.1":
   version "1.6.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2449,96 +2449,96 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@percy/cli-build@1.6.4":
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/@percy/cli-build/-/cli-build-1.6.4.tgz#965bfeaa069bce1b578589aff6f7bb3fa1f6a7fc"
-  integrity sha512-OC8cPqI+Q12h6P/W93JC5dR2QBKjuNKPs5UmLWYQvkXp24igex0ZeJYZUqvpJrxj4Fm4PTbEmn3SLDo/s86QOg==
+"@percy/cli-build@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@percy/cli-build/-/cli-build-1.7.2.tgz#73276f998de83b5cc1e2cc70c7e157ed5d456c58"
+  integrity sha512-yQlWlVFd305bm6IgoIdgUKkCCVpQTyecnrfTMVjRURaNhCpz4FDXFNc/C0qsuc8QosNu81x7pHbrU5iY82/uXw==
   dependencies:
-    "@percy/cli-command" "1.6.4"
+    "@percy/cli-command" "1.7.2"
 
-"@percy/cli-command@1.6.4":
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.6.4.tgz#828cc900717aa53c62d65349ce656285b9c4c8b2"
-  integrity sha512-is7ZFk1GbBajP3c16Pm+QBIyYE7371s5Os8VuTr4vyGOyYtR9s2wKS1EPzoUhKOZRDlJ1fAi4/PQQiZVZqd2IA==
+"@percy/cli-command@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.7.2.tgz#93b4fab4a01b89bad5bda53bf1ea360d426a08d4"
+  integrity sha512-roTWulBAidSX1ypH23FjVGnCX32YMsb6wUf3EFGNxnEdKYnMsOaH0zvDImJY6izz4NbP+XZ9HfGXu1oVPftoUw==
   dependencies:
-    "@percy/config" "1.6.4"
-    "@percy/core" "1.6.4"
-    "@percy/logger" "1.6.4"
+    "@percy/config" "1.7.2"
+    "@percy/core" "1.7.2"
+    "@percy/logger" "1.7.2"
 
-"@percy/cli-config@1.6.4":
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.6.4.tgz#10b6acae399a4b5b066f45096b63614940a225ef"
-  integrity sha512-kDwuMnrmc1iRtMVQIHoawRxkeaDLLJ+ksx9TLsp+GdEkfXU8rLoxugZh9Aey1/E5R5cjz8Esqi0LB7Ii7qmnZw==
+"@percy/cli-config@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.7.2.tgz#39d5d7c44e3ca113aa1a7464a86a235cf75515ff"
+  integrity sha512-guPC3NxRRXL8AHxHit+QbqOnZlCtgDew/NA4/VwleRsKwyyP1NnQmTdopZFUy84XU157rv5uNF1WhljUAzmlug==
   dependencies:
-    "@percy/cli-command" "1.6.4"
+    "@percy/cli-command" "1.7.2"
 
-"@percy/cli-exec@1.6.4":
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/@percy/cli-exec/-/cli-exec-1.6.4.tgz#736882c5d317845c00988200d86d5b2409767d87"
-  integrity sha512-pC5gx5RxJY0baOJ5CyLCwFBVhN0luOm0F9S/EMvRg3CZAWy6IiJMWth3lRYQo7mG7s9AOzcEOyfZ+20YKGc6bQ==
+"@percy/cli-exec@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@percy/cli-exec/-/cli-exec-1.7.2.tgz#f5f81d4e4bed4caeb65572469b37291354972c39"
+  integrity sha512-TUl4FCnICdBeb12h7ul/DXs++F32mGzD7NDMiaFs2pOCqcoGPwKnEF/pMKIbOTyJpIXC/as/PM4hj1Z5TdUZqg==
   dependencies:
-    "@percy/cli-command" "1.6.4"
+    "@percy/cli-command" "1.7.2"
     cross-spawn "^7.0.3"
     which "^2.0.2"
 
-"@percy/cli-snapshot@1.6.4":
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/@percy/cli-snapshot/-/cli-snapshot-1.6.4.tgz#ceb2280644fb6cde6f641736dd85664c4f093a76"
-  integrity sha512-+rN58q/mz05mr94L8FfPqTMGEoLAsq9D28IHZmM94Y5O0mCYqPEpVZgbvkkrz+UfFrqyMtR3WGCqs4mJpE97cA==
+"@percy/cli-snapshot@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@percy/cli-snapshot/-/cli-snapshot-1.7.2.tgz#07fbe7611ff3a12159471423cfd4fe1d35cd970a"
+  integrity sha512-jaTkCVtceC96JU9kTFmmUfGh0DcGhsirRQSq77EEmdHu3rv1GpzdcytjstHuq6ARUevXl0XHLGQsEp48vQ8ZLA==
   dependencies:
-    "@percy/cli-command" "1.6.4"
+    "@percy/cli-command" "1.7.2"
     yaml "^2.0.0"
 
-"@percy/cli-upload@1.6.4":
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/@percy/cli-upload/-/cli-upload-1.6.4.tgz#f7f2f177401b70cf6f80827f88073e85ec86694d"
-  integrity sha512-OFZ9xwnJbQpMQRCVVhXKDFmuLEc+tcx9NZ20UNrEpyjlndlfrCBZPBQVrqhonZ1oBhVBRSoRj0iw+BF6YDdboA==
+"@percy/cli-upload@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@percy/cli-upload/-/cli-upload-1.7.2.tgz#840faacb084d0ea91a3fd6752086ba848c04efdc"
+  integrity sha512-USKGGxcD9o6H+/j98bm5wvM1aPloOEIcXJYZ9mfGx8YSXC8AjOYFoG+/IqSYrgUIU+Nsc0mChaJ8gB6maDaTOA==
   dependencies:
-    "@percy/cli-command" "1.6.4"
+    "@percy/cli-command" "1.7.2"
     fast-glob "^3.2.11"
     image-size "^1.0.0"
 
-"@percy/cli@^1.6.4":
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.6.4.tgz#01e943cc78de42bc05ebbff08f7ac1deeb17ff21"
-  integrity sha512-K1Dgtt7aB/db/oSRdLTCxHZ1AY/gziDrDHxWXRMSgsbf+PunnWe6qUfhxqqLbqlizf8ccp608beKWtys/xKrGw==
+"@percy/cli@^1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.7.2.tgz#63d6569b3a90dcd960133796f3066fe31e93e4ba"
+  integrity sha512-cjN6qGJBi0U/Tct+6yD9jxH4Hf6d7cBXAySQ6fJHXb1ChXnSB5ULglh4cbIjEuF0Z2/g7M8rYOppnGcTpD5y5A==
   dependencies:
-    "@percy/cli-build" "1.6.4"
-    "@percy/cli-command" "1.6.4"
-    "@percy/cli-config" "1.6.4"
-    "@percy/cli-exec" "1.6.4"
-    "@percy/cli-snapshot" "1.6.4"
-    "@percy/cli-upload" "1.6.4"
-    "@percy/client" "1.6.4"
-    "@percy/logger" "1.6.4"
+    "@percy/cli-build" "1.7.2"
+    "@percy/cli-command" "1.7.2"
+    "@percy/cli-config" "1.7.2"
+    "@percy/cli-exec" "1.7.2"
+    "@percy/cli-snapshot" "1.7.2"
+    "@percy/cli-upload" "1.7.2"
+    "@percy/client" "1.7.2"
+    "@percy/logger" "1.7.2"
 
-"@percy/client@1.6.4":
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.6.4.tgz#ac7fd6c98144661574dc028587935570c706a7d3"
-  integrity sha512-LbJg/xhrXavHx4ZiijpAq5fpELKszePF0kGMvBHFeEorVjqTPmkZQg1pQW480ND+F/h6sLk15ucU0Aylp2eooA==
+"@percy/client@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.7.2.tgz#124604c40e3b16c79f0a243a62f1f27d1ab37ab3"
+  integrity sha512-GjEp3m+WXO2S0iLGwKZs+6zDFkP/V5XJICeou6Q1pOb8N1E3ZhyFfm3+gS2qMwVuf6xIWgxO+RXZxIs2JVJrJw==
   dependencies:
-    "@percy/env" "1.6.4"
-    "@percy/logger" "1.6.4"
+    "@percy/env" "1.7.2"
+    "@percy/logger" "1.7.2"
 
-"@percy/config@1.6.4":
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.6.4.tgz#31812d1f949f22f6589e87027716d29271822e67"
-  integrity sha512-e9e6CneEs2nmY3kstr5SNaoXT7LRk3Ga/noioSA5HNWPMqKPRwZaMlYLWA0NMSCbVcShMAqbRpa4FEbYTbpGGw==
+"@percy/config@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.7.2.tgz#c087bd9dd35c81372b03b51360b91fd2cfd58428"
+  integrity sha512-omING0fj92NG6XVScclkg8l82QUdPw+4YKJjUOHQVqOqyq+7H9A45KtlOk9LVStbVenzRiqH7C+9NhYa+a+/Vg==
   dependencies:
-    "@percy/logger" "1.6.4"
+    "@percy/logger" "1.7.2"
     ajv "^8.6.2"
     cosmiconfig "^7.0.0"
     yaml "^2.0.0"
 
-"@percy/core@1.6.4":
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.6.4.tgz#8dc8b78e175b7312ab00ce05043f2b2d07861e09"
-  integrity sha512-p5XP8gcKqeozcJSPZS9ynVfuGV2rM9dYPCjL0GX7KRkjY9vpAO6IfDAFUbcJYbbwy54WiJqFjDMmm8xmTsVniQ==
+"@percy/core@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.7.2.tgz#95551573a623355e47b026645d1258f75cad8acf"
+  integrity sha512-TsHQbsGtpzEW6bo+BIRkNoIFZrjrWHb9B2pXoMRnG61m6F6KtoL1yOuHhorhrHkCtCtX3A7KXfJtcO9E1oN9RQ==
   dependencies:
-    "@percy/client" "1.6.4"
-    "@percy/config" "1.6.4"
-    "@percy/dom" "1.6.4"
-    "@percy/logger" "1.6.4"
+    "@percy/client" "1.7.2"
+    "@percy/config" "1.7.2"
+    "@percy/dom" "1.7.2"
+    "@percy/logger" "1.7.2"
     content-disposition "^0.5.4"
     cross-spawn "^7.0.3"
     extract-zip "^2.0.1"
@@ -2556,20 +2556,20 @@
   dependencies:
     "@percy/sdk-utils" "^1.3.1"
 
-"@percy/dom@1.6.4":
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.6.4.tgz#3a823b2138055ac4a0804d8802e849282adbebd7"
-  integrity sha512-1Ox++5ZpbleaERifm+NTgSgSWKpAFSIxd5x4ZUI6HzNlojDverat6nIFjU+q5Y4Y2DHXn5ihagvODqspOq0Dkw==
+"@percy/dom@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.7.2.tgz#df12f2d6cd2389a01acd8354fac8496dbbf1e50f"
+  integrity sha512-ipi7SF4nS+/UfHXYLeJTRp25rGvZhRwmGQv6WjAK1HGkl4OJaFJNPbWe0+SCG4zwSsCudeY4lxk5rk05Ev6b1A==
 
-"@percy/env@1.6.4":
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.6.4.tgz#80cb8dd2b44cdce3318cdde752fc183a1553ffa5"
-  integrity sha512-zn/RqbxSOtSnV8rApLtJ7EVzFdPVv+Agwq85/UuTK+2Md5Eb+mnT6TbmkRg/0n7l8d14uiDcRRwRi1+msVefZg==
+"@percy/env@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.7.2.tgz#99fd35eeabedcf3762af2efbba177c7bbc57309a"
+  integrity sha512-exnZsBROCg17bNHqF7CEJVheGVnysZlChSiJHssLcdPGjg2+decefc26UZLA4PuEqgcmYWun5WyGLRPQo62oUQ==
 
-"@percy/logger@1.6.4":
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.6.4.tgz#598f1a5de0af9f8e3616a9d12ebf6fedbed5da78"
-  integrity sha512-lFPlVcxRtQyFw+TGzfOgFm4Vc/e8xx3nrrdKopnm22JIiTGH/hYFmq4A9u0e4b6Sp2nDZzWT2W5fxVHZiKDDlg==
+"@percy/logger@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.7.2.tgz#38b008459f5598d3a8f8708dc68a246473aac8a8"
+  integrity sha512-GSbOqPpjM+UC/0pcm6oTi+KI4u/nbs8Awz0HtFcoxyaNRBptRFUh75zF7qI0zB/HRp8QlZ0z4DayCepfrqqO0A==
 
 "@percy/sdk-utils@^1.3.1":
   version "1.6.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2449,96 +2449,96 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@percy/cli-build@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@percy/cli-build/-/cli-build-1.7.2.tgz#73276f998de83b5cc1e2cc70c7e157ed5d456c58"
-  integrity sha512-yQlWlVFd305bm6IgoIdgUKkCCVpQTyecnrfTMVjRURaNhCpz4FDXFNc/C0qsuc8QosNu81x7pHbrU5iY82/uXw==
+"@percy/cli-build@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli-build/-/cli-build-1.8.0.tgz#58c08e85b56370bfebb6651a9fec2a3a7fe199cf"
+  integrity sha512-Ezp/WVv4edHpx/VVuVKvCKvfsuVjjuCTDiw5SIh6qr31nbx3IBUhWfuTWlU+/y6f6g39fQ7rbS0oKXr+ZtDeww==
   dependencies:
-    "@percy/cli-command" "1.7.2"
+    "@percy/cli-command" "1.8.0"
 
-"@percy/cli-command@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.7.2.tgz#93b4fab4a01b89bad5bda53bf1ea360d426a08d4"
-  integrity sha512-roTWulBAidSX1ypH23FjVGnCX32YMsb6wUf3EFGNxnEdKYnMsOaH0zvDImJY6izz4NbP+XZ9HfGXu1oVPftoUw==
+"@percy/cli-command@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.8.0.tgz#44dc5c229e5d15b2990d13f4a8a086979684e160"
+  integrity sha512-cA/qJL8ZcICZPngqfzaSey9u3ys0y+rz/iTtDwLvFk8W+h6AGcYzGL44VJtdOCT8KBrsU4qpYWiykZegROWQvw==
   dependencies:
-    "@percy/config" "1.7.2"
-    "@percy/core" "1.7.2"
-    "@percy/logger" "1.7.2"
+    "@percy/config" "1.8.0"
+    "@percy/core" "1.8.0"
+    "@percy/logger" "1.8.0"
 
-"@percy/cli-config@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.7.2.tgz#39d5d7c44e3ca113aa1a7464a86a235cf75515ff"
-  integrity sha512-guPC3NxRRXL8AHxHit+QbqOnZlCtgDew/NA4/VwleRsKwyyP1NnQmTdopZFUy84XU157rv5uNF1WhljUAzmlug==
+"@percy/cli-config@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.8.0.tgz#c5cd66589ba89d1c1b16f9e4aa05554cd132c576"
+  integrity sha512-VPwgFYijoWnf3IRQJYLhzN30Bav/g/iFC5YVnu8XajXZg5DtO8TW1vyeOrQAYvK5Fo065dIdoWmw5CqCO5cUww==
   dependencies:
-    "@percy/cli-command" "1.7.2"
+    "@percy/cli-command" "1.8.0"
 
-"@percy/cli-exec@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@percy/cli-exec/-/cli-exec-1.7.2.tgz#f5f81d4e4bed4caeb65572469b37291354972c39"
-  integrity sha512-TUl4FCnICdBeb12h7ul/DXs++F32mGzD7NDMiaFs2pOCqcoGPwKnEF/pMKIbOTyJpIXC/as/PM4hj1Z5TdUZqg==
+"@percy/cli-exec@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli-exec/-/cli-exec-1.8.0.tgz#88bb40bfb2e84bb51a438d2ce7a97d93f394be8a"
+  integrity sha512-Ce6e2kO9ShIDRbW/4QGJZaofy8mgc3U71BGWovJGR2+ChekRnNKKyVIOMgtSkQRZ9Yyt5yYUnVaoLijmoVt4hQ==
   dependencies:
-    "@percy/cli-command" "1.7.2"
+    "@percy/cli-command" "1.8.0"
     cross-spawn "^7.0.3"
     which "^2.0.2"
 
-"@percy/cli-snapshot@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@percy/cli-snapshot/-/cli-snapshot-1.7.2.tgz#07fbe7611ff3a12159471423cfd4fe1d35cd970a"
-  integrity sha512-jaTkCVtceC96JU9kTFmmUfGh0DcGhsirRQSq77EEmdHu3rv1GpzdcytjstHuq6ARUevXl0XHLGQsEp48vQ8ZLA==
+"@percy/cli-snapshot@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli-snapshot/-/cli-snapshot-1.8.0.tgz#d75947564109ce349176cd2aad6ef4ee9e17bc74"
+  integrity sha512-Yz5HKKrDuXB5EMf3Eeo1Sx7aki6VkMMFj8EimDA1WMatW3UC7/pmUmDoxJXkrEJP/CuOIAAi4GKBmDU5/aKHzw==
   dependencies:
-    "@percy/cli-command" "1.7.2"
+    "@percy/cli-command" "1.8.0"
     yaml "^2.0.0"
 
-"@percy/cli-upload@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@percy/cli-upload/-/cli-upload-1.7.2.tgz#840faacb084d0ea91a3fd6752086ba848c04efdc"
-  integrity sha512-USKGGxcD9o6H+/j98bm5wvM1aPloOEIcXJYZ9mfGx8YSXC8AjOYFoG+/IqSYrgUIU+Nsc0mChaJ8gB6maDaTOA==
+"@percy/cli-upload@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli-upload/-/cli-upload-1.8.0.tgz#3bbef12bf163c85e9dfc5310a861e3d56e9f68b2"
+  integrity sha512-d4DRxHZgyL+0pyQVKEh3OHhVYbSxUxHASdsPWsDGZksmOiAyE0VMaeN3m40D/4FbJuylMC2pJ5XaYQv/kCM9Ew==
   dependencies:
-    "@percy/cli-command" "1.7.2"
+    "@percy/cli-command" "1.8.0"
     fast-glob "^3.2.11"
     image-size "^1.0.0"
 
-"@percy/cli@^1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.7.2.tgz#63d6569b3a90dcd960133796f3066fe31e93e4ba"
-  integrity sha512-cjN6qGJBi0U/Tct+6yD9jxH4Hf6d7cBXAySQ6fJHXb1ChXnSB5ULglh4cbIjEuF0Z2/g7M8rYOppnGcTpD5y5A==
+"@percy/cli@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.8.0.tgz#3502c361a3e1db5c7516456308fca7f1ce58eb7f"
+  integrity sha512-7wSYSx4awUvXjenO/jo0yNyFdR+Napj2NX994HDyc2EbCBjnSVPNxRWUGHJxlhWAHB5yv3yjnXhijPm6zb1Kng==
   dependencies:
-    "@percy/cli-build" "1.7.2"
-    "@percy/cli-command" "1.7.2"
-    "@percy/cli-config" "1.7.2"
-    "@percy/cli-exec" "1.7.2"
-    "@percy/cli-snapshot" "1.7.2"
-    "@percy/cli-upload" "1.7.2"
-    "@percy/client" "1.7.2"
-    "@percy/logger" "1.7.2"
+    "@percy/cli-build" "1.8.0"
+    "@percy/cli-command" "1.8.0"
+    "@percy/cli-config" "1.8.0"
+    "@percy/cli-exec" "1.8.0"
+    "@percy/cli-snapshot" "1.8.0"
+    "@percy/cli-upload" "1.8.0"
+    "@percy/client" "1.8.0"
+    "@percy/logger" "1.8.0"
 
-"@percy/client@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.7.2.tgz#124604c40e3b16c79f0a243a62f1f27d1ab37ab3"
-  integrity sha512-GjEp3m+WXO2S0iLGwKZs+6zDFkP/V5XJICeou6Q1pOb8N1E3ZhyFfm3+gS2qMwVuf6xIWgxO+RXZxIs2JVJrJw==
+"@percy/client@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.8.0.tgz#b56206432d5f6d4ee71877f1f277e11178951587"
+  integrity sha512-PMkST2X57m9paTZ22yv8yNeO2X33FeDTnEo99r4TKriiIs5Vm4UKurKYJdztS8OrYh/xl7tx1ATpc6n3vvNkEg==
   dependencies:
-    "@percy/env" "1.7.2"
-    "@percy/logger" "1.7.2"
+    "@percy/env" "1.8.0"
+    "@percy/logger" "1.8.0"
 
-"@percy/config@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.7.2.tgz#c087bd9dd35c81372b03b51360b91fd2cfd58428"
-  integrity sha512-omING0fj92NG6XVScclkg8l82QUdPw+4YKJjUOHQVqOqyq+7H9A45KtlOk9LVStbVenzRiqH7C+9NhYa+a+/Vg==
+"@percy/config@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.8.0.tgz#f0aaff8b04e5b6e3809ba9f41177027ddc4b3db1"
+  integrity sha512-B4cfcNpwqMKKC2US9k+y3sfsgD9JcspNDT+VNPA+9zp1PEbyW5dDe3FQY5bjoLRtQHcNtepBOTMurmWVhjViWw==
   dependencies:
-    "@percy/logger" "1.7.2"
+    "@percy/logger" "1.8.0"
     ajv "^8.6.2"
     cosmiconfig "^7.0.0"
     yaml "^2.0.0"
 
-"@percy/core@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.7.2.tgz#95551573a623355e47b026645d1258f75cad8acf"
-  integrity sha512-TsHQbsGtpzEW6bo+BIRkNoIFZrjrWHb9B2pXoMRnG61m6F6KtoL1yOuHhorhrHkCtCtX3A7KXfJtcO9E1oN9RQ==
+"@percy/core@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.8.0.tgz#a8ce0be3edf7c10dfb6d71825ddaba3b20aaa340"
+  integrity sha512-v6kyC89iXYCWPuuG0XGtBKXVRc92/xZxKZQiehNC6I2/svCAW3GPWWQro8R+HX5ZUqVY6uqPHNdt2oJNKAEJNg==
   dependencies:
-    "@percy/client" "1.7.2"
-    "@percy/config" "1.7.2"
-    "@percy/dom" "1.7.2"
-    "@percy/logger" "1.7.2"
+    "@percy/client" "1.8.0"
+    "@percy/config" "1.8.0"
+    "@percy/dom" "1.8.0"
+    "@percy/logger" "1.8.0"
     content-disposition "^0.5.4"
     cross-spawn "^7.0.3"
     extract-zip "^2.0.1"
@@ -2556,20 +2556,20 @@
   dependencies:
     "@percy/sdk-utils" "^1.3.1"
 
-"@percy/dom@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.7.2.tgz#df12f2d6cd2389a01acd8354fac8496dbbf1e50f"
-  integrity sha512-ipi7SF4nS+/UfHXYLeJTRp25rGvZhRwmGQv6WjAK1HGkl4OJaFJNPbWe0+SCG4zwSsCudeY4lxk5rk05Ev6b1A==
+"@percy/dom@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.8.0.tgz#6bd4bc72fd71c6fd445f2a223d5f860af9b36183"
+  integrity sha512-Q/a5uq3h7xUOZoFEYGhYxaNv6N/wxnQi9K3oaMfa1I8JvBqEVKzuw4izY5Q0OsOmiz78JJFmsLn8IbLh9NuP2w==
 
-"@percy/env@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.7.2.tgz#99fd35eeabedcf3762af2efbba177c7bbc57309a"
-  integrity sha512-exnZsBROCg17bNHqF7CEJVheGVnysZlChSiJHssLcdPGjg2+decefc26UZLA4PuEqgcmYWun5WyGLRPQo62oUQ==
+"@percy/env@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.8.0.tgz#a3c3fa9cb071df0f94b7c197b9235aaf4e62a747"
+  integrity sha512-njfRWRrmyGVOWo1U+Zd8tyniOiNVYWvQvyodHWzqz7AoNz0Zr/+sCs8TsuMfF9QAb3MLcWn4LJoZE09mBIFBwg==
 
-"@percy/logger@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.7.2.tgz#38b008459f5598d3a8f8708dc68a246473aac8a8"
-  integrity sha512-GSbOqPpjM+UC/0pcm6oTi+KI4u/nbs8Awz0HtFcoxyaNRBptRFUh75zF7qI0zB/HRp8QlZ0z4DayCepfrqqO0A==
+"@percy/logger@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.8.0.tgz#e85f60dff1b118644f91f6d73c08a455169f57af"
+  integrity sha512-z1PNQFXDr4+y+a6FPzsZBuMttr0VrRpYSpxRhvhTZTjnLsBvgQ6VP2GxyFlp7E3Y4aG9Lmzau71s2Nlb35Ylgg==
 
 "@percy/sdk-utils@^1.3.1":
   version "1.6.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2449,6 +2449,133 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@percy/cli-build@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@percy/cli-build/-/cli-build-1.6.3.tgz#82c8034a03286b7f1a5bc5542aa615dee1840673"
+  integrity sha512-FPK3HsE+PSW8Xq1oA68kS1ZSsXgxGVKcyctJmHya2Dc7H5XHIyIRTAzsY9qjWGD0OSUGX9jj7j3cZ0QG6LVE5g==
+  dependencies:
+    "@percy/cli-command" "1.6.3"
+
+"@percy/cli-command@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.6.3.tgz#e209cd4410cd8b6a0e130f48258173080bcdce96"
+  integrity sha512-WHICKTVdLW8vFm0emBkR/tV14XKWUfUEKw9UieSuEwIrQmMTPEaY0GxuRk3NrBMj6vkRuJW6yeLCGLVWFlRGlQ==
+  dependencies:
+    "@percy/config" "1.6.3"
+    "@percy/core" "1.6.3"
+    "@percy/logger" "1.6.3"
+
+"@percy/cli-config@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.6.3.tgz#72bf5f0b6398569a625844028539164952e100e3"
+  integrity sha512-7qVBGPhMRG+8YV23zNdRjiRlF+AEaspk4SBVu2FU2MrVtCr3+hpeFSoqg3lfzr1Y+7aS3ntYmoifdcsOJ3+vdA==
+  dependencies:
+    "@percy/cli-command" "1.6.3"
+
+"@percy/cli-exec@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@percy/cli-exec/-/cli-exec-1.6.3.tgz#50f140b9805e7d088f79696ab992da60395a7f21"
+  integrity sha512-m42eS7IHN/csILWpskNaKZBkYvTnvAQu99mPFr2467NOBP/HLLjW2ry6qiv/ZwxF6jNbJzBLok8rk2TmiEmeZQ==
+  dependencies:
+    "@percy/cli-command" "1.6.3"
+    cross-spawn "^7.0.3"
+    which "^2.0.2"
+
+"@percy/cli-snapshot@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@percy/cli-snapshot/-/cli-snapshot-1.6.3.tgz#65f32aa17c6cc0a4b00a82c5dd6a471d95323d29"
+  integrity sha512-s2TIaRzibtTpdW9szixwYivoRCKTeqvHLx/7eV3ZiIrDc0t7DY2eylFBFWwUcvlR+jOUC5Yu4o/Ti4I8hZ4mJA==
+  dependencies:
+    "@percy/cli-command" "1.6.3"
+    yaml "^2.0.0"
+
+"@percy/cli-upload@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@percy/cli-upload/-/cli-upload-1.6.3.tgz#c22f4e3220723b0c3e52da67144e4b60b66b6d96"
+  integrity sha512-spG3/uhAD3DgVFdtHhhX5lx+jnBPu5x2l30gHDHVmi9cyl50upAeNYFx3ROQtuTecXiiZeV024qDJqwvLr94ew==
+  dependencies:
+    "@percy/cli-command" "1.6.3"
+    fast-glob "^3.2.11"
+    image-size "^1.0.0"
+
+"@percy/cli@^1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.6.3.tgz#960181564f2a4aab1fc6b45c3a8fd2cd187b5be0"
+  integrity sha512-LaoH6hR+pw0Zre4MluZc5z+qiNHeIFbnleJSvIdss7B2E6oQh6vfhXdTgrlAhZ/4h8Cmr6HGrRuNPng/b8XAYA==
+  dependencies:
+    "@percy/cli-build" "1.6.3"
+    "@percy/cli-command" "1.6.3"
+    "@percy/cli-config" "1.6.3"
+    "@percy/cli-exec" "1.6.3"
+    "@percy/cli-snapshot" "1.6.3"
+    "@percy/cli-upload" "1.6.3"
+    "@percy/client" "1.6.3"
+    "@percy/logger" "1.6.3"
+
+"@percy/client@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.6.3.tgz#7d75af3b92e3548fae70239cc16e4a832ae520e6"
+  integrity sha512-/gsfhikO3O36vWHH6TQ4QSVp/i1GkTt7lyPEn51jzKjV9rdQ8hmvxzMk2mleyYDAlZQBwyQaOZdMnhfbphLM2w==
+  dependencies:
+    "@percy/env" "1.6.3"
+    "@percy/logger" "1.6.3"
+
+"@percy/config@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.6.3.tgz#381e2b1f64593b651c90aeca911979cae5867f3f"
+  integrity sha512-BKDykqRoBrjeUHhfYLuTrAnxFYTuOXHc6XKmHuui44buoF5ZaG/2Md5DQpqfGVQ0Jdzumoge/up7PGmxdve1SQ==
+  dependencies:
+    "@percy/logger" "1.6.3"
+    ajv "^8.6.2"
+    cosmiconfig "^7.0.0"
+    yaml "^2.0.0"
+
+"@percy/core@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.6.3.tgz#a22c12e09d1e43aa6e72494ce94acae7beb8923d"
+  integrity sha512-RwRh8UUARv2gtD32C0NNe6VbBAWhne6IUBN5nMJ2yw6Q7LZqf2oa8kiocxGlyXpMTjYDRZ/FbNT0PqFw5o52gw==
+  dependencies:
+    "@percy/client" "1.6.3"
+    "@percy/config" "1.6.3"
+    "@percy/dom" "1.6.3"
+    "@percy/logger" "1.6.3"
+    content-disposition "^0.5.4"
+    cross-spawn "^7.0.3"
+    extract-zip "^2.0.1"
+    fast-glob "^3.2.11"
+    micromatch "^4.0.4"
+    mime-types "^2.1.34"
+    path-to-regexp "^6.2.0"
+    rimraf "^3.0.2"
+    ws "^8.0.0"
+
+"@percy/cypress@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@percy/cypress/-/cypress-3.1.2.tgz#a087d3c59a6b155eab5fdb4c237526b9cfacbc22"
+  integrity sha512-JXrGDZbqwkzQd2h5T5D7PvqoucNaiMh4ChPp8cLQiEtRuLHta9nf1lEuXH+jnatGL2j+3jJFIHJ0L7XrgVnvQA==
+  dependencies:
+    "@percy/sdk-utils" "^1.3.1"
+
+"@percy/dom@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.6.3.tgz#cd2bf2569ba328f886ba9e026498a060fd980ffc"
+  integrity sha512-V4D/og0AOI1uFb5xtRYuypjmG6PuVwe+eMz10hFThRsxCiRGKlS7QnZUyNQkRwIO/k2r7LnboBpIUzBakSCgzA==
+
+"@percy/env@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.6.3.tgz#ab9ff1f3cd85d77be409206d6469fa580efe5164"
+  integrity sha512-YsGQa6i/8Ca+XblRFxAClIo18dEYrU/rZKTZEio4WJ59zjoTskOU3VTgH4a4LX7J3LRpy0+A3v8UiUI4y3Vf8g==
+
+"@percy/logger@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.6.3.tgz#c13c64c20f9f842fe36266abbddfe9f07cfd2b6a"
+  integrity sha512-900DQ6KmDZVADuVdPARpZHvodALrswLOd/z4x2du484o/hyiNtO2nvO3rzyTCPVI+nreMT82yCy3JqnNwtJaSQ==
+
+"@percy/sdk-utils@^1.3.1":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@percy/sdk-utils/-/sdk-utils-1.6.3.tgz#3a21fc90578d682c7cc36ecb5487664a026a4ca0"
+  integrity sha512-Q3x88t04BYd9glJYAClm/B0FMhEEIj69ExKQhbCjXWVuH7M5gvRdfImNiZQq5QevgeYcKwhPmO2CEkYhTO5Vig==
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz#a21117b19ee9be70c379ec1877537ef2e1c63301"
@@ -3106,6 +3233,16 @@ ajv@^8.0.1:
   version "8.7.1"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.7.1.tgz#52be6f1736b076074798124293618f132ad07a7e"
   integrity sha512-gPpOObTO1QjbnN1sVMjJcp1TF9nggMfO4MBR5uQl6ZVTOaEPq5i4oq/6R9q2alMMPB3eg53wFv1RuJBLuxf3Hw==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
+ajv@^8.6.2:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
+  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -4801,6 +4938,13 @@ content-disposition@0.5.3:
   dependencies:
     safe-buffer "5.1.2"
 
+content-disposition@^0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.4.tgz#8b82b4efac82512a02bb0b1dcec9d2c5e8eb5bfe"
+  integrity sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==
+  dependencies:
+    safe-buffer "5.2.1"
+
 content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
@@ -4912,6 +5056,17 @@ cosmiconfig@^6.0.0:
     path-type "^4.0.0"
     yaml "^1.7.2"
 
+cosmiconfig@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.1.tgz#714d756522cace867867ccb4474c5d01bbae5d6d"
+  integrity sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==
+  dependencies:
+    "@types/parse-json" "^4.0.0"
+    import-fresh "^3.2.1"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+    yaml "^1.10.0"
+
 cp-file@^6.1.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/cp-file/-/cp-file-6.2.0.tgz#40d5ea4a1def2a9acdd07ba5c0b0246ef73dc10d"
@@ -5014,7 +5169,7 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2:
+cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -6617,7 +6772,7 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-extract-zip@2.0.1:
+extract-zip@2.0.1, extract-zip@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
   integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
@@ -6674,6 +6829,17 @@ fast-glob@^3.1.1:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
   integrity sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
+fast-glob@^3.2.11:
+  version "3.2.11"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
+  integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -7796,6 +7962,13 @@ ignore@^5.0.5, ignore@^5.1.4, ignore@^5.1.8:
   version "5.1.9"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.9.tgz#9ec1a5cbe8e1446ec60d4420060d43aa6e7382fb"
   integrity sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==
+
+image-size@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-1.0.2.tgz#d778b6d0ab75b2737c1556dd631652eb963bc486"
+  integrity sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==
+  dependencies:
+    queue "6.0.2"
 
 immutable@^3:
   version "3.8.2"
@@ -9764,12 +9937,24 @@ mime-db@1.51.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
   integrity sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
 mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.34"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.34.tgz#5a712f9ec1503511a945803640fafe09d3793c24"
   integrity sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==
   dependencies:
     mime-db "1.51.0"
+
+mime-types@^2.1.34:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
 
 mime@1.4.1:
   version "1.4.1"
@@ -10721,6 +10906,11 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
+path-to-regexp@^6.2.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.1.tgz#d54934d6798eb9e5ef14e7af7962c945906918e5"
+  integrity sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -11311,6 +11501,13 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+queue@6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/queue/-/queue-6.0.2.tgz#b91525283e2315c7553d2efa18d83e76432fed65"
+  integrity sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==
+  dependencies:
+    inherits "~2.0.3"
 
 quote-unquote@^1.0.0:
   version "1.0.0"
@@ -12026,7 +12223,7 @@ safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
+safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -14137,6 +14334,11 @@ ws@^7.4.6:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.5.tgz#8b4bc4af518cfabd0473ae4f99144287b33eb881"
   integrity sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==
 
+ws@^8.0.0:
+  version "8.8.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.8.1.tgz#5dbad0feb7ade8ecc99b830c1d77c913d4955ff0"
+  integrity sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==
+
 ws@~7.4.2:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
@@ -14215,10 +14417,15 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@^1.7.2:
+yaml@^1.10.0, yaml@^1.7.2:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+
+yaml@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.1.1.tgz#1e06fb4ca46e60d9da07e4f786ea370ed3c3cfec"
+  integrity sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==
 
 yargs-parser@20.x, yargs-parser@^20.2.2:
   version "20.2.9"


### PR DESCRIPTION
## What does this change?

Adds [Percy](https://percy.io/) to Commercial's Frontend e2e tests.

This will allow us to create visual regression tests for our ad rendering and positioning.

Note: At the moment there is a bug for snapshots in Safari which Browserstack are working to fix.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<img width="1858" alt="Screenshot 2022-08-08 at 17 41 51" src="https://user-images.githubusercontent.com/7014230/183469522-830a60b7-9dcf-4899-b7ff-4cf4047f38d4.png">

