### PR TITLE
Add Outstream sizes to Ozone price config

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/price-config.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/price-config.spec.ts
@@ -80,6 +80,8 @@ describe('priceGranularity', () => {
 		[[728, 90], granularityOption2],
 		[[970, 250], granularityOption2],
 		[[300, 250], granularityOption2],
+		[[620, 350], granularityOption2],
+		[[300, 197], granularityOption2],
 	])(
 		'Ozone slot with size %s gives correct granularity',
 		([width, height], expectedGranularity) => {

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/price-config.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/price-config.ts
@@ -72,7 +72,9 @@ export const ozonePriceGranularity = (
 	if (
 		sizeString === adSizes.leaderboard.toString() ||
 		sizeString === adSizes.billboard.toString() ||
-		sizeString === adSizes.mpu.toString()
+		sizeString === adSizes.mpu.toString() ||
+		sizeString === adSizes.outstreamDesktop.toString() ||
+		sizeString === adSizes.outstreamMobile.toString()
 	) {
 		return {
 			buckets: [


### PR DESCRIPTION
## What does this change?

Add the outstream sizes to the Prebid price configuration for Ozone. This is so that these sizes receive a certain set of pricing rules versus other sizes, as defined in our line items ([configured here](https://github.com/guardian/commercial-tools/blob/main/dfp-line-item-creator/src/main/scala/commercialtools/dfp/model/Config.scala#L62-L71)).

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

This will prevent high-CPM Ozone outstream bids from being incorrectly rounded.

As a follow-up it is well worth considering how to make it clearer to do this - is it possible to enforce that new sizes needed to be included at the point we do static analysis?

### Tested

- [X] Locally
- [ ] On CODE (optional)