### PR TITLE
Deeply Read Test Switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -34,4 +34,14 @@ trait ABTestSwitches {
     exposeClientSide = true,
   )
 
+  Switch(
+    ABTests,
+    "ab-deeply-read-article-footer",
+    "Test whether adding deeply read articles have negative impact on recirculation",
+    owners = Seq(Owner.withGithub("jlieb10")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2022, 10, 10)),
+    exposeClientSide = true,
+  )
+
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -38,7 +38,7 @@ trait ABTestSwitches {
     ABTests,
     "ab-deeply-read-article-footer",
     "Test whether adding deeply read articles have negative impact on recirculation",
-    owners = Seq(Owner.withGithub("jlieb10")),
+    owners = Seq(Owner.withName("dotcom.platform")),
     safeState = Off,
     sellByDate = Some(LocalDate.of(2022, 10, 10)),
     exposeClientSide = true,

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -1,4 +1,5 @@
 import type { ABTest } from '@guardian/ab-core';
+import { deeplyReadArticleFooterTest } from './tests/deeply-read-article-footer';
 import { multiStickyRightAds } from './tests/multi-sticky-right-ads';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
@@ -11,4 +12,5 @@ export const concurrentTests: readonly ABTest[] = [
 	signInGateMainControl,
 	remoteRRHeaderLinksTest,
 	multiStickyRightAds,
+	deeplyReadArticleFooterTest,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/deeply-read-article-footer.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/deeply-read-article-footer.js
@@ -1,0 +1,28 @@
+export const deeplyReadArticleFooterTest = {
+    id: 'DeeplyReadArticleFooter',
+    start: '2022-08-09',
+    expiry: '2022-10-10',
+    author: 'Joshua Lieberman and Daniel Clifton', 
+    description:
+        'Add new section to the article footer onwards that shows deeply read articles',
+    audience: 1,
+    audienceOffset: 0,
+    successMeasure: 'Recirculation metrics are not worse',
+    audienceCriteria:
+        'all pageviews',
+    dataLinkNames: 'DeeplyReadFooterLinks',
+    idealOutcome:
+        'AV is not worse',
+    showForSensitive: true,
+    canRun: () => true,
+    variants: [
+        {
+            id: 'control',
+            test: () => {},
+        },
+        {
+            id: 'variant',
+            test: () => {},
+        },
+    ],
+};


### PR DESCRIPTION
## What does this change?
Adding a test switch for the forthcoming test of a new onwards journey and UI for Deeply Read articles.

The rest of this work will be carried out on DCR.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
