### PR TITLE
feat: add basic, do nothing, deeply read agent

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import agents.DeeplyReadAgent
 import com.gu.contentapi.client.model.v1.{Blocks, ItemResponse, Content => ApiContent}
 import common._
 import contentapi.ContentApiClient
@@ -24,6 +25,7 @@ class ArticleController(
     ws: WSClient,
     remoteRenderer: renderers.DotcomRenderingService = DotcomRenderingService(),
     newsletterService: NewsletterService,
+    deeplyReadAgent: DeeplyReadAgent,
 )(implicit context: ApplicationContext)
     extends BaseController
     with RendersItemResponse
@@ -31,6 +33,9 @@ class ArticleController(
     with ImplicitControllerExecutionContext {
 
   val capiLookup: CAPILookup = new CAPILookup(contentApiClient)
+  val mostPopular = Seq(
+    deeplyReadAgent.onwardsJourneyResponse,
+  )
 
   private def isSupported(c: ApiContent) = c.isArticle || c.isLiveBlog || c.isSudoku
   override def canRender(i: ItemResponse): Boolean = i.content.exists(isSupported)
@@ -128,6 +133,7 @@ class ArticleController(
           false,
           newsletter = newsletter,
           topicResult = None,
+          mostPopular = mostPopular,
         )
       case HtmlFormat | AmpFormat =>
         Future.successful(common.renderHtml(ArticleHtmlPage.html(article), article))

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -133,7 +133,7 @@ class ArticleController(
           false,
           newsletter = newsletter,
           topicResult = None,
-          mostPopular = mostPopular,
+          mostPopular = Some(mostPopular),
         )
       case HtmlFormat | AmpFormat =>
         Future.successful(common.renderHtml(ArticleHtmlPage.html(article), article))

--- a/article/app/controllers/ArticleControllers.scala
+++ b/article/app/controllers/ArticleControllers.scala
@@ -1,12 +1,13 @@
 package controllers
 
+import agents.DeeplyReadAgent
 import com.softwaremill.macwire._
 import contentapi.ContentApiClient
 import model.ApplicationContext
 import play.api.libs.ws.WSClient
 import play.api.mvc.ControllerComponents
 import renderers.DotcomRenderingService
-import services.{NewspaperBookSectionTagAgent, NewspaperBookTagAgent, NewsletterService}
+import services.{NewsletterService, NewspaperBookSectionTagAgent, NewspaperBookTagAgent}
 import services.newsletters.NewsletterSignupAgent
 import topics.{TopicS3Client, TopicService}
 
@@ -26,4 +27,5 @@ trait ArticleControllers {
   lazy val articleController = wire[ArticleController]
   lazy val liveBlogController = wire[LiveBlogController]
   lazy val newsletterService = wire[NewsletterService]
+  lazy val deeplyReadAgent = wire[DeeplyReadAgent]
 }

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -188,7 +188,7 @@ class LiveBlogController(
                 availableTopics,
                 newsletter = None,
                 topicResult,
-                mostPopular = mostPopular,
+                mostPopular = Some(mostPopular),
               )
             } else {
               DotcomponentsLogger.logger.logRequest(s"liveblog executing in web", properties, page)

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import agents.DeeplyReadAgent
 import com.gu.contentapi.client.model.v1.{Block, Blocks, ItemResponse, Content => ApiContent}
 import common.`package`.{convertApiExceptions => _, renderFormat => _}
 import common.{JsonComponent, RichRequestHeader, _}
@@ -21,6 +22,7 @@ import services.{CAPILookup, NewsletterService}
 import services.dotcomponents.DotcomponentsLogger
 import topics.TopicService
 import views.support.RenderOtherStatus
+
 import scala.concurrent.Future
 
 case class MinutePage(article: Article, related: RelatedContent) extends PageWithStoryPackage
@@ -32,12 +34,16 @@ class LiveBlogController(
     remoteRenderer: renderers.DotcomRenderingService = DotcomRenderingService(),
     newsletterService: NewsletterService,
     topicService: TopicService,
+    deeplyReadAgent: DeeplyReadAgent,
 )(implicit context: ApplicationContext)
     extends BaseController
     with GuLogging
     with ImplicitControllerExecutionContext {
 
   val capiLookup: CAPILookup = new CAPILookup(contentApiClient)
+  val mostPopular = Seq(
+    deeplyReadAgent.onwardsJourneyResponse,
+  )
 
   // we support liveblogs and also articles, so that minutes work
   private def isSupported(c: ApiContent) = c.isLiveBlog || c.isArticle
@@ -182,6 +188,7 @@ class LiveBlogController(
                 availableTopics,
                 newsletter = None,
                 topicResult,
+                mostPopular = mostPopular,
               )
             } else {
               DotcomponentsLogger.logger.logRequest(s"liveblog executing in web", properties, page)

--- a/article/test/ArticleControllerTest.scala
+++ b/article/test/ArticleControllerTest.scala
@@ -1,5 +1,6 @@
 package test
 
+import agents.DeeplyReadAgent
 import controllers.ArticleController
 import org.apache.commons.codec.digest.DigestUtils
 import org.scalatest.flatspec.AnyFlatSpec
@@ -31,6 +32,7 @@ import services.newsletters.{NewsletterApi, NewsletterSignupAgent}
     wsClient,
     new DCRFake(),
     new NewsletterService(new NewsletterSignupAgent(new NewsletterApi(wsClient))),
+    new DeeplyReadAgent(),
   )
 
   "Article Controller" should "200 when content type is article" in {

--- a/article/test/DCRFake.scala
+++ b/article/test/DCRFake.scala
@@ -28,7 +28,7 @@ class DCRFake(implicit context: ApplicationContext) extends renderers.DotcomRend
       availableTopics: Option[Seq[Topic]],
       newsletter: Option[NewsletterData],
       topicResult: Option[TopicResult],
-      mostPopular: Seq[OnwardCollectionResponse],
+      mostPopular: Option[Seq[OnwardCollectionResponse]],
   )(implicit request: RequestHeader): Future[Result] = {
     implicit val ec = ExecutionContext.global
     requestedBlogs.enqueue(article)

--- a/article/test/DCRFake.scala
+++ b/article/test/DCRFake.scala
@@ -2,7 +2,7 @@ package test
 
 import com.gu.contentapi.client.model.v1.{Block, Blocks}
 import model.Cached.RevalidatableResult
-import model.dotcomrendering.PageType
+import model.dotcomrendering.{OnwardCollectionResponse, PageType}
 import model.{ApplicationContext, Cached, LiveBlogPage, PageWithStoryPackage, Topic, TopicResult}
 import play.api.libs.ws.WSClient
 import play.api.mvc.{RequestHeader, Result}
@@ -28,6 +28,7 @@ class DCRFake(implicit context: ApplicationContext) extends renderers.DotcomRend
       availableTopics: Option[Seq[Topic]],
       newsletter: Option[NewsletterData],
       topicResult: Option[TopicResult],
+      mostPopular: Seq[OnwardCollectionResponse],
   )(implicit request: RequestHeader): Future[Result] = {
     implicit val ec = ExecutionContext.global
     requestedBlogs.enqueue(article)

--- a/article/test/LiveBlogControllerTest.scala
+++ b/article/test/LiveBlogControllerTest.scala
@@ -1,5 +1,6 @@
 package test
 
+import agents.DeeplyReadAgent
 import controllers.LiveBlogController
 import org.mockito.Mockito._
 import org.mockito.Matchers.{anyObject, anyString}
@@ -9,8 +10,8 @@ import play.api.test._
 import play.api.test.Helpers._
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover}
 import org.scalatestplus.mockito.MockitoSugar
-import model.{LiveBlogPage, TopicResult, Topic, TopicType}
-import topics.{TopicService}
+import model.{LiveBlogPage, Topic, TopicResult, TopicType}
+import topics.TopicService
 import services.NewsletterService
 import services.newsletters.{NewsletterApi, NewsletterSignupAgent}
 
@@ -71,6 +72,7 @@ import services.newsletters.{NewsletterApi, NewsletterSignupAgent}
       fakeDcr,
       new NewsletterService(new NewsletterSignupAgent(new NewsletterApi(wsClient))),
       fakeTopicService,
+      new DeeplyReadAgent,
     )
   }
 

--- a/article/test/PublicationControllerTest.scala
+++ b/article/test/PublicationControllerTest.scala
@@ -1,5 +1,6 @@
 package test
 
+import agents.DeeplyReadAgent
 import controllers.{ArticleController, PublicationController}
 import model.TagDefinition
 import org.mockito.Mockito._
@@ -38,6 +39,7 @@ import services.newsletters.{NewsletterApi, NewsletterSignupAgent}
       wsClient,
       new DCRFake(),
       new NewsletterService(new NewsletterSignupAgent(new NewsletterApi(wsClient))),
+      new DeeplyReadAgent(),
     )
   lazy val publicationController =
     new PublicationController(bookAgent, bookSectionAgent, articleController, controllerComponents)

--- a/common/app/agents/DeeplyReadAgent.scala
+++ b/common/app/agents/DeeplyReadAgent.scala
@@ -1,0 +1,14 @@
+package agents
+
+import common.{Box, GuLogging}
+import model.dotcomrendering.{OnwardCollectionResponse, OnwardItem}
+
+class DeeplyReadAgent extends GuLogging {
+  private val trailsBox = Box[Seq[OnwardItem]](Seq())
+  def onwardsJourneyResponse = {
+    OnwardCollectionResponse(
+      heading = "Deeply read",
+      trails = trailsBox.get(),
+    )
+  }
+}

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -97,6 +97,7 @@ case class DotcomRenderingDataModel(
     matchType: Option[DotcomRenderingMatchType],
     isSpecialReport: Boolean, // Indicates whether the page is a special report.
     promotedNewsletter: Option[NewsletterData],
+    mostPopular: Seq[OnwardCollectionResponse],
 )
 
 object DotcomRenderingDataModel {
@@ -170,6 +171,7 @@ object DotcomRenderingDataModel {
         "matchType" -> model.matchType,
         "isSpecialReport" -> model.isSpecialReport,
         "promotedNewsletter" -> model.promotedNewsletter,
+        "mostPopular" -> model.mostPopular,
       )
 
       ElementsEnhancer.enhanceDcrObject(obj)
@@ -340,6 +342,7 @@ object DotcomRenderingDataModel {
       availableTopics: Option[Seq[Topic]],
       newsletter: Option[NewsletterData],
       topicResult: Option[TopicResult],
+      mostPopular: Seq[OnwardCollectionResponse] = Seq(),
   ): DotcomRenderingDataModel = {
 
     val edition = Edition.edition(request)
@@ -512,6 +515,7 @@ object DotcomRenderingDataModel {
       webTitle = content.metadata.webTitle,
       webURL = content.metadata.webUrl,
       promotedNewsletter = newsletter,
+      mostPopular = mostPopular,
     )
   }
 }

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -97,7 +97,7 @@ case class DotcomRenderingDataModel(
     matchType: Option[DotcomRenderingMatchType],
     isSpecialReport: Boolean, // Indicates whether the page is a special report.
     promotedNewsletter: Option[NewsletterData],
-    mostPopular: Seq[OnwardCollectionResponse],
+    mostPopular: Option[Seq[OnwardCollectionResponse]],
 )
 
 object DotcomRenderingDataModel {
@@ -342,7 +342,7 @@ object DotcomRenderingDataModel {
       availableTopics: Option[Seq[Topic]],
       newsletter: Option[NewsletterData],
       topicResult: Option[TopicResult],
-      mostPopular: Seq[OnwardCollectionResponse] = Seq(),
+      mostPopular: Option[Seq[OnwardCollectionResponse]] = None,
   ): DotcomRenderingDataModel = {
 
     val edition = Edition.edition(request)

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -12,9 +12,9 @@ import model.dotcomrendering.{
   DotcomBlocksRenderingDataModel,
   DotcomFrontsRenderingDataModel,
   DotcomRenderingDataModel,
+  OnwardCollectionResponse,
   PageType,
 }
-
 import services.NewsletterData
 import model.{
   CacheTime,
@@ -157,6 +157,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       availableTopics: Option[Seq[Topic]] = None,
       newsletter: Option[NewsletterData],
       topicResult: Option[TopicResult],
+      mostPopular: Seq[OnwardCollectionResponse],
   )(implicit request: RequestHeader): Future[Result] = {
     val dataModel = page match {
       case liveblog: LiveBlogPage =>
@@ -174,7 +175,9 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       case _ => DotcomRenderingDataModel.forArticle(page, blocks, request, pageType, newsletter)
     }
 
-    val json = DotcomRenderingDataModel.toJson(dataModel)
+    val modelWithAgentData = dataModel.copy(mostPopular = mostPopular)
+
+    val json = DotcomRenderingDataModel.toJson(modelWithAgentData)
     post(ws, json, Configuration.rendering.baseURL + "/Article", page.metadata.cacheTime)
   }
 

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -157,7 +157,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       availableTopics: Option[Seq[Topic]] = None,
       newsletter: Option[NewsletterData],
       topicResult: Option[TopicResult],
-      mostPopular: Seq[OnwardCollectionResponse],
+      mostPopular: Option[Seq[OnwardCollectionResponse]],
   )(implicit request: RequestHeader): Future[Result] = {
     val dataModel = page match {
       case liveblog: LiveBlogPage =>

--- a/common/test/agents/DeeplyReadAgentTest.scala
+++ b/common/test/agents/DeeplyReadAgentTest.scala
@@ -1,0 +1,12 @@
+package agents
+
+import model.dotcomrendering.OnwardCollectionResponse
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class DeeplyReadAgentTest extends AnyFlatSpec with Matchers {
+  "DeeplyReadAgent" should "initialise with trails being an empty Seq" in {
+    val agent = new DeeplyReadAgent()
+    agent.onwardsJourneyResponse.trails shouldBe Seq.empty
+  }
+}


### PR DESCRIPTION
Co-authored-by: Ioanna Kokkini [ioannakok@users.noreply.github.com](mailto:oliverlloyd@users.noreply.github.com)

Part of: https://github.com/guardian/dotcom-rendering/issues/5664

Adds the `DeeplyRead` agent data (currently empty) to the `DotcomRenderingDataModel.model` when posting to DCR.

This PR aims to decide on the model we should use to interface with DCR.

It also simply implements attaching that data to the model, which we will refine as patterns become more apparent by adding more examples (which we know are coming).

## DCR interface

### Naming

We have use `MostPopular` to indicate that section of the page in DCR, which can then be populated with different types of data e.g.
- Deeply read
- Most viewed
- Most viewed in section
- ...

Instead of coming up with a new name, which feels like it would just proliferate things further, this further defines things, is more intentional, and hopefully moves in a direction of less ambiguity.

Adding it to the `mostPopular` prop indicates to DCR this is where is should go on the page. I image we could use something similar for `onwards`.

![mostPopular](https://user-images.githubusercontent.com/31692/183665379-aef1dc9a-707a-4180-bb57-808d3d66a177.png)

### Return type

As DCR already knows how to render `OnwardCollectionResponse` so we are using this.

## Most comments & shared

<img width="790" alt="Screenshot 2022-08-09 at 16 47 00" src="https://user-images.githubusercontent.com/31692/183698509-c03e3d1d-ce42-4897-8005-849213da8650.png">

As we know the plan is to remove these as soon as we have a better alternative (Deeply read), we didn't want to add this to the model. 

In the short run, if this model is something we want to support, we could have a `mostPopularSupporting` or similar, as we call this [`MostViewedFooterSecondTierItem` in DCR](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/components/MostViewedFooterData.importable.tsx#L97-L109).

---

## Getting the data onto the model

This is the least important as part of this PR and is likely to change as it doesn't affect the interface with DCR.

1. route
1. [`ArticleController` fetches `deeplyReadData`](https://github.com/guardian/frontend/pull/25358/files#diff-226a2f55912aeab5d0800fe01df264dd358642019223e3b4676940359360a3a6R36-R38)
2. [`deeplyReadData` is passed to `DotcomRenderingService.getArticle`](https://github.com/guardian/frontend/pull/25358/files#diff-226a2f55912aeab5d0800fe01df264dd358642019223e3b4676940359360a3a6R136)

At this point we explored two options:
1. `deeplyReadData` is passed to `DotcomRenderingDataModel.forArticle` and other similar methods, and drilled through those methods
1. we [copy the data onto the model fetched from `DotcomRenderingDataModel.forArticle`](https://github.com/guardian/frontend/pull/25358/files#diff-ac3fa093b0a96194d7a5ece8dc0f4bacc42719c718cd8e2a5f700f53230f4d88R178)

The latter seemed simpler better reflects what we are doing which attaching request level, rather than item level data to send to DCR, and avoided massive code changes from prop drilling.

Global information like this seems to have been done by [calculating it on the `DotcomRenderingDataModel.apply`](https://github.com/guardian/frontend/blob/main/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala#L344-L447), but including the agent at this level felt like too much of a coupling.

Another option to explore would be to create a new model, `DotcomRenderingGlobalData` or similar, and stitch them together before `post`ing it to DCR. I think a clearer pattern will become more obvious adding some more examples, as we know we're going to. This implementation shouldn't affect how we interface with DCR. 