### PR TITLE
Scala 2.13: Add () to empty argument methods

### DIFF
--- a/admin/app/controllers/admin/commercial/AdsDotTextEditController.scala
+++ b/admin/app/controllers/admin/commercial/AdsDotTextEditController.scala
@@ -42,16 +42,18 @@ class AdsDotTextEditController(val controllerComponents: ControllerComponents)(i
       postSave: Call,
   ): Action[AnyContent] =
     Action { implicit request =>
-      AdsTextSellers.form.bindFromRequest.fold(
-        formWithErrors => {
-          NoCache(BadRequest(views.html.commercial.adsDotText(name, saveRoute, formWithErrors)))
-        },
-        adsTextSellers => {
-          S3.putPrivate(s3DotTextKey, adsTextSellers.sellers, "text/plain")
-          log.info(s"Wrote new $name file to $s3DotTextKey")
-          NoCache(Redirect(postSave))
-        },
-      )
+      AdsTextSellers.form
+        .bindFromRequest()
+        .fold(
+          formWithErrors => {
+            NoCache(BadRequest(views.html.commercial.adsDotText(name, saveRoute, formWithErrors)))
+          },
+          adsTextSellers => {
+            S3.putPrivate(s3DotTextKey, adsTextSellers.sellers, "text/plain")
+            log.info(s"Wrote new $name file to $s3DotTextKey")
+            NoCache(Redirect(postSave))
+          },
+        )
     }
 
   def postAdsDotText(): Action[AnyContent] =

--- a/admin/app/controllers/admin/commercial/TakeoverWithEmptyMPUsController.scala
+++ b/admin/app/controllers/admin/commercial/TakeoverWithEmptyMPUsController.scala
@@ -22,15 +22,17 @@ class TakeoverWithEmptyMPUsController(val controllerComponents: ControllerCompon
 
   def create(): Action[AnyContent] =
     Action { implicit request =>
-      TakeoverWithEmptyMPUs.form.bindFromRequest.fold(
-        formWithErrors => {
-          NoCache(BadRequest(views.html.commercial.takeoverWithEmptyMPUsCreate(formWithErrors)))
-        },
-        takeover => {
-          TakeoverWithEmptyMPUs.create(takeover)
-          NoCache(Redirect(routes.TakeoverWithEmptyMPUsController.viewList()))
-        },
-      )
+      TakeoverWithEmptyMPUs.form
+        .bindFromRequest()
+        .fold(
+          formWithErrors => {
+            NoCache(BadRequest(views.html.commercial.takeoverWithEmptyMPUsCreate(formWithErrors)))
+          },
+          takeover => {
+            TakeoverWithEmptyMPUs.create(takeover)
+            NoCache(Redirect(routes.TakeoverWithEmptyMPUsController.viewList()))
+          },
+        )
     }
 
   def remove(url: String): Action[AnyContent] =

--- a/admin/app/controllers/cache/ImageDecacheController.scala
+++ b/admin/app/controllers/cache/ImageDecacheController.scala
@@ -51,7 +51,7 @@ class ImageDecacheController(
 
           ImageServices.clearFastly(originUri, wsClient)
 
-          val decacheRequest: Future[WSResponse] = wsClient.url(s"$originUrl?cachebust=$cacheBust").get
+          val decacheRequest: Future[WSResponse] = wsClient.url(s"$originUrl?cachebust=$cacheBust").get()
           decacheRequest
             .map(_.status)
             .map {

--- a/admin/app/dfp/DataAgent.scala
+++ b/admin/app/dfp/DataAgent.scala
@@ -31,10 +31,10 @@ trait DataAgent[K, V] extends GuLogging with implicits.Strings {
         freshCache
       case Success(_) =>
         log.error("No fresh data loaded so keeping old data")
-        cache.get
+        cache.get()
       case Failure(e) =>
         log.error("Loading of fresh data has failed.", e)
-        cache.get
+        cache.get()
     }
   }
 

--- a/admin/app/football/controllers/PlayerController.scala
+++ b/admin/app/football/controllers/PlayerController.scala
@@ -76,7 +76,7 @@ class PlayerController(val wsClient: WSClient, val controllerComponents: Control
                 client.appearances(playerId, competition.startDate, LocalDate.now(), teamId, competitionId)
             } yield {
               val result = createPlayerCard(cardType, playerId, playerProfile, playerStats, playerAppearances)
-              result.map(renderPlayerCard).getOrElse(renderNotFound)
+              result.map(renderPlayerCard).getOrElse(renderNotFound())
             }
           }
       }
@@ -94,7 +94,7 @@ class PlayerController(val wsClient: WSClient, val controllerComponents: Control
         playerAppearances <- client.appearances(playerId, startDate, LocalDate.now(), teamId)
       } yield {
         val result = createPlayerCard(cardType, playerId, playerProfile, playerStats, playerAppearances)
-        result.map(renderPlayerCard).getOrElse(renderNotFound)
+        result.map(renderPlayerCard).getOrElse(renderNotFound())
       }
     }
 

--- a/admin/app/model/AdminLifecycle.scala
+++ b/admin/app/model/AdminLifecycle.scala
@@ -59,7 +59,7 @@ class AdminLifecycle(
     }
 
     jobs.scheduleEvery("R2PagePressJob", r2PagePressRateInSeconds.seconds) {
-      r2PagePressJob.run
+      r2PagePressJob.run()
     }
 
     //every 2, 17, 32, 47 minutes past the hour, on the 12th second past the minute (e.g 13:02:12, 13:17:12)

--- a/admin/app/tools/AssetMetrics.scala
+++ b/admin/app/tools/AssetMetrics.scala
@@ -91,7 +91,7 @@ object AssetMetricsCache extends GuLogging {
       .sizeMetrics()
       .map { metrics =>
         log.info("Successfully refreshed Asset Metrics data")
-        cache.send(cache.get + (ReportTypes.sizeOfFiles -> metrics))
+        cache.send(cache.get() + (ReportTypes.sizeOfFiles -> metrics))
       }
       .recover {
         case NonFatal(e) =>

--- a/admin/app/views/fragments/formattedChart.scala.html
+++ b/admin/app/views/fragments/formattedChart.scala.html
@@ -5,7 +5,7 @@
 
 <script type="text/javascript">
     function drawChart() {
-        var data = new google.visualization.DataTable(@{Html(chart.asJson.toString)})
+        var data = new google.visualization.DataTable(@{Html(chart.asJson().toString)})
 
         var chart = new google.visualization.LineChart(document.getElementById('@chart.id'));
 

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -127,7 +127,7 @@ GET         /troubleshoot/test                                                  
 # Football admin
 GET         /admin/football                                                                         controllers.admin.SiteController.index
 GET         /admin/football/browse                                                                  controllers.admin.PaBrowserController.browse
-POST        /admin/football/browserRedirect                                                         controllers.admin.PaBrowserController.browserSubstitution
+POST        /admin/football/browserRedirect                                                         controllers.admin.PaBrowserController.browserSubstitution()
 GET         /admin/football/browser/*query                                                          controllers.admin.PaBrowserController.browser(query)
 GET         /admin/football/player                                                                  controllers.admin.PlayerController.playerIndex
 POST        /admin/football/player/card                                                             controllers.admin.PlayerController.redirectToCard

--- a/applications/app/controllers/AtomPageController.scala
+++ b/applications/app/controllers/AtomPageController.scala
@@ -70,30 +70,32 @@ class AtomPageController(
 
   def signup(): Action[AnyContent] =
     Action.async { implicit request =>
-      answersSignupForm.bindFromRequest.fold(
-        formWithErrors => {
-          log.info(s"Form has been submitted with errors: ${formWithErrors.errors}")
-          Future.successful(Cors(NoCache(BadRequest("Invalid email"))))
-        },
-        form => {
-          EmailService
-            .submit(form)(wsClient)
-            .map(_.status match {
-              case 200 | 201 =>
-                Cors(NoCache(Created("Subscribed")))
+      answersSignupForm
+        .bindFromRequest()
+        .fold(
+          formWithErrors => {
+            log.info(s"Form has been submitted with errors: ${formWithErrors.errors}")
+            Future.successful(Cors(NoCache(BadRequest("Invalid email"))))
+          },
+          form => {
+            EmailService
+              .submit(form)(wsClient)
+              .map(_.status match {
+                case 200 | 201 =>
+                  Cors(NoCache(Created("Subscribed")))
 
-              case status =>
-                log.error(s"Error posting to ExactTarget: HTTP $status")
-                Cors(NoCache(InternalServerError("Internal error")))
+                case status =>
+                  log.error(s"Error posting to ExactTarget: HTTP $status")
+                  Cors(NoCache(InternalServerError("Internal error")))
 
-            })
-            .recover {
-              case e: Exception =>
-                log.error(s"Error posting to ExactTarget: ${e.getMessage}")
-                Cors(NoCache(InternalServerError("Internal error")))
-            }
-        },
-      )
+              })
+              .recover {
+                case e: Exception =>
+                  log.error(s"Error posting to ExactTarget: ${e.getMessage}")
+                  Cors(NoCache(InternalServerError("Internal error")))
+              }
+          },
+        )
     }
 
   def renderNoJs(atomType: String, id: String): Action[AnyContent] = render(atomType, id, false, false)

--- a/applications/app/controllers/QuizController.scala
+++ b/applications/app/controllers/QuizController.scala
@@ -49,15 +49,17 @@ class QuizController(
 
   def submit(quizId: String, path: String): Action[AnyContent] =
     Action.async { implicit request =>
-      form.playForm.bindFromRequest.fold(
-        hasErrors = errors => {
-          val errorMessages = errors.errors.flatMap(_.messages.mkString(", ")).mkString(". ")
-          val serverError = s"Problem with quiz form request: $errorMessages"
-          log.error(serverError)
-          Future.successful(InternalServerError(serverError))
-        },
-        success = form => renderQuiz(quizId, path, form),
-      )
+      form.playForm
+        .bindFromRequest()
+        .fold(
+          hasErrors = errors => {
+            val errorMessages = errors.errors.flatMap(_.messages.mkString(", ")).mkString(". ")
+            val serverError = s"Problem with quiz form request: $errorMessages"
+            log.error(serverError)
+            Future.successful(InternalServerError(serverError))
+          },
+          success = form => renderQuiz(quizId, path, form),
+        )
     }
 
   private def renderQuiz(quizId: String, path: String, answers: form.Inputs)(implicit

--- a/applications/app/controllers/SurveyPageController.scala
+++ b/applications/app/controllers/SurveyPageController.scala
@@ -23,7 +23,7 @@ class SurveyPageController(
     Action.async { implicit request =>
       wsClient
         .url(s"https://${Configuration.Survey.formStackAccountName}.formstack.com/forms/$formName")
-        .head
+        .head()
         .map { headResponse =>
           headResponse.status match {
             case 200 =>

--- a/applications/app/pages/CrosswordHtmlPage.scala
+++ b/applications/app/pages/CrosswordHtmlPage.scala
@@ -56,7 +56,7 @@ object CrosswordHtmlPage extends HtmlPage[CrosswordPage] {
         checkModuleSupport(),
         inlineJSBlocking(),
       ),
-      bodyTag(classes = defaultBodyClasses)(
+      bodyTag(classes = defaultBodyClasses())(
         skipToMainContent(),
         survey(),
         pageSkin() when page.metadata.hasPageSkin(request),

--- a/applications/app/pages/IndexHtmlPage.scala
+++ b/applications/app/pages/IndexHtmlPage.scala
@@ -46,7 +46,7 @@ object IndexHtml {
         checkModuleSupport(),
         inlineJSBlocking(),
       ),
-      bodyTag(classes = defaultBodyClasses)(
+      bodyTag(classes = defaultBodyClasses())(
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkin(request),
         guardianHeaderHtml(),

--- a/applications/app/pages/NewsletterHtmlPage.scala
+++ b/applications/app/pages/NewsletterHtmlPage.scala
@@ -45,7 +45,7 @@ object NewsletterHtmlPage extends HtmlPage[NewsletterRoundupPage] {
         checkModuleSupport(),
         inlineJSBlocking(),
       ),
-      bodyTag(classes = defaultBodyClasses)(
+      bodyTag(classes = defaultBodyClasses())(
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkin(request),
         guardianHeaderHtml(),

--- a/applications/app/pages/TagIndexHtmlPage.scala
+++ b/applications/app/pages/TagIndexHtmlPage.scala
@@ -60,7 +60,7 @@ object TagIndexHtmlPage extends HtmlPage[StandalonePage] {
         checkModuleSupport(),
         inlineJSBlocking(),
       ),
-      bodyTag(classes = defaultBodyClasses)(
+      bodyTag(classes = defaultBodyClasses())(
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkin(request),
         guardianHeaderHtml(),

--- a/applications/test/services/InteractivePickerTest.scala
+++ b/applications/test/services/InteractivePickerTest.scala
@@ -11,7 +11,7 @@ import org.scalatest.matchers.should.Matchers
     private[this] val interactives = Set[String](path)
     def isPressed(path: String): Boolean = interactives.contains(path)
   }
-  conf.switches.Switches.InteractivePickerFeature.switchOn
+  conf.switches.Switches.InteractivePickerFeature.switchOn()
 
   "Interactive Picker get rendering tier" should "return PressedInteractive if pressed and switched on" in {
     val testRequest = TestRequest(path)

--- a/article/app/model/KeyEventData.scala
+++ b/article/app/model/KeyEventData.scala
@@ -22,7 +22,7 @@ object KeyEventData {
 
   def apply(blocks: Seq[BodyBlock], timezone: DateTimeZone): Seq[KeyEventData] = {
     val TimelineMaxEntries = 7
-    val timelineBlocks = blocks.sortBy(_.publishedCreatedTimestamp).reverse.take(TimelineMaxEntries)
+    val timelineBlocks = blocks.sortBy(_.publishedCreatedTimestamp()).reverse.take(TimelineMaxEntries)
     timelineBlocks.map { bodyBlock =>
       /*
     Composer should set a default title of `Summary` on summary blocks but instead it allows title to be empty (None).

--- a/article/app/topics/TopicS3Client.scala
+++ b/article/app/topics/TopicS3Client.scala
@@ -26,7 +26,7 @@ final class TopicS3ClientImpl extends TopicS3Client with S3 with GuLogging {
   def getListOfKeys(): Future[List[String]] = {
     getClient { client =>
       Try {
-        val s3ObjectList = client.listObjects(getBucket).getObjectSummaries().asScala.toList
+        val s3ObjectList = client.listObjects(getBucket()).getObjectSummaries().asScala.toList
         s3ObjectList.map(_.getKey)
       } match {
         case Success(value) =>
@@ -42,7 +42,7 @@ final class TopicS3ClientImpl extends TopicS3Client with S3 with GuLogging {
   def getObject(key: String): Future[TopicsApiResponse] = {
     getClient { client =>
       Try {
-        val request = new GetObjectRequest(getBucket, key)
+        val request = new GetObjectRequest(getBucket(), key)
         client.getObject(request).parseToTopicsApiResponse
       }.flatten match {
         case Success(value) =>

--- a/article/app/views/fragments/articleHeaderCommentGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderCommentGarnett.scala.html
@@ -17,7 +17,7 @@
     <div class="content__header tonal__header">
         <div class="u-cf">
             @if(article.content.tags.tags.exists(_.id == "tone/news") || article.content.tags.tags.exists(_.id == "tone/comment")) {
-                @fragments.contentAgeNotice(ageNotice, ariaHidden = true)
+                @fragments.contentAgeNotice(ageNotice(), ariaHidden = true)
             }
 
             <h1 class="content__headline @if(article.content.hasTonalHeaderByline) {content__headline--no-margin-bottom}" articleprop="headline" @langAttributes(article.content)>
@@ -25,7 +25,7 @@
             </h1>
 
             @if(article.content.tags.tags.exists(_.id == "tone/news") || article.content.tags.tags.exists(_.id == "tone/comment")) {
-                @fragments.contentAgeNotice(ageNotice, isHidden = true)
+                @fragments.contentAgeNotice(ageNotice(), isHidden = true)
             }
 
             @if(article.content.hasTonalHeaderByline && article.tags.hasLargeContributorImage) {

--- a/article/app/views/fragments/articleHeaderGarnett.scala.html
+++ b/article/app/views/fragments/articleHeaderGarnett.scala.html
@@ -23,7 +23,7 @@
 
             <div class="u-cf">
                 @if(article.content.tags.tags.exists(_.id == "tone/news") || article.content.tags.tags.exists(_.id == "tone/comment")) {
-                    @fragments.contentAgeNotice(ageNotice, ariaHidden = true)
+                    @fragments.contentAgeNotice(ageNotice(), ariaHidden = true)
                 }
 
                 @if((article.tags.isInterview)){
@@ -55,7 +55,7 @@
 
             <div class="u-cf">
                 @if(article.content.tags.tags.exists(_.id == "tone/news") || article.content.tags.tags.exists(_.id == "tone/comment")) {
-                    @fragments.contentAgeNotice(ageNotice, ariaHidden = true)
+                    @fragments.contentAgeNotice(ageNotice(), ariaHidden = true)
                 }
 
                 @if((article.tags.isInterview)){
@@ -71,7 +71,7 @@
                 </h1>
 
                 @if(article.content.tags.tags.exists(_.id == "tone/news") || article.content.tags.tags.exists(_.id == "tone/comment")) {
-                    @fragments.contentAgeNotice(ageNotice, isHidden = true)
+                    @fragments.contentAgeNotice(ageNotice(), isHidden = true)
                 }
 
                 @if(article.tags.isInterview) {

--- a/article/test/CdnHealthCheckTest.scala
+++ b/article/test/CdnHealthCheckTest.scala
@@ -24,7 +24,7 @@ import org.scalatest.matchers.should.Matchers
     }
 
     // Cache internal healthCheck results before to test endpoints
-    whenReady(controller.runChecks) { _ =>
+    whenReady(controller.runChecks()) { _ =>
       status(controller.healthCheck()(TestRequest("/_healthcheck"))) should be(200)
       status(controller.healthCheck()(TestRequest("/_cdn_healthcheck"))) should be(200)
     }

--- a/commercial/app/model/merchandise/books/BookFinder.scala
+++ b/commercial/app/model/merchandise/books/BookFinder.scala
@@ -34,7 +34,7 @@ object BookAgent extends GuLogging {
       isbn: String,
   )(implicit magentoService: MagentoService, executionContext: ExecutionContext): Option[JsValue] = {
 
-    val bookJson: Option[JsValue] = cache.get.get(isbn)
+    val bookJson: Option[JsValue] = cache.get().get(isbn)
 
     if (bookJson.isEmpty) {
       magentoService.findByIsbn(isbn) onComplete {

--- a/commercial/app/model/merchandise/events/LiveEventAgent.scala
+++ b/commercial/app/model/merchandise/events/LiveEventAgent.scala
@@ -17,7 +17,7 @@ class LiveEventAgent(wsClient: WSClient) extends GuLogging {
 
   private lazy val liveEventAgent = Box[Seq[LiveEvent]](Seq.empty)
 
-  def specificLiveEvent(eventBriteId: String): Option[LiveEvent] = liveEventAgent.get.find(_.eventId == eventBriteId)
+  def specificLiveEvent(eventBriteId: String): Option[LiveEvent] = liveEventAgent.get().find(_.eventId == eventBriteId)
 
   private def updateAvailableMerchandise(
       freshMerchandise: Seq[LiveEvent],

--- a/commercial/conf/routes
+++ b/commercial/conf/routes
@@ -21,7 +21,7 @@ GET         /commercial/books/api/books.json                                comm
 GET         /commercial/api/liveevent.json                                  commercial.controllers.LiveEventsController.getLiveEvent
 
 # Multiple offer merchandising components
-GET         /commercial/api/multi.json                                      commercial.controllers.Multi.getMulti
+GET         /commercial/api/multi.json                                      commercial.controllers.Multi.getMulti()
 
 # Content API merchandising components
 # Attempting to remove ContentApiOffersController, discovered
@@ -30,10 +30,10 @@ GET         /commercial/api/multi.json                                      comm
 GET         /commercial/api/capi-single.json                                commercial.controllers.ContentApiOffersController.nativeJson
 GET         /commercial/api/capi-multiple.json                              commercial.controllers.ContentApiOffersController.nativeJsonMulti
 
-GET         /commercial/api/traffic-driver.json                             commercial.controllers.TrafficDriverController.renderJson
+GET         /commercial/api/traffic-driver.json                             commercial.controllers.TrafficDriverController.renderJson()
 
 # Piggyback pixel from AppNexus, used for resizing mpus
-GET         /commercial/anx/anxresize.js                                    commercial.controllers.PiggybackPixelController.resize
+GET         /commercial/anx/anxresize.js                                    commercial.controllers.PiggybackPixelController.resize()
 
 # Hosted content
 GET         /advertiser-content/:campaignName/:pageName                     commercial.controllers.HostedContentController.renderHostedPage(campaignName, pageName)

--- a/commercial/test/model/events/Fixtures.scala
+++ b/commercial/test/model/events/Fixtures.scala
@@ -321,5 +321,5 @@ object Fixtures {
                                  |}""".stripMargin
 
   lazy val rawEventBriteFeed =
-    scala.io.Source.fromFile("commercial/test/model/events/masterclasses_full_page.json").getLines.mkString
+    scala.io.Source.fromFile("commercial/test/model/events/masterclasses_full_page.json").getLines().mkString
 }

--- a/common/app/common/dfp/DfpAgent.scala
+++ b/common/app/common/dfp/DfpAgent.scala
@@ -24,15 +24,15 @@ object DfpAgent
   private lazy val takeoverWithEmptyMPUsAgent = Box[Seq[TakeoverWithEmptyMPUs]](Nil)
   private lazy val nonRefreshableLineItemsAgent = Box[Seq[Long]](Nil)
 
-  protected def inlineMerchandisingTargetedTags: InlineMerchandisingTagSet = inlineMerchandisingTagsAgent get ()
+  protected def inlineMerchandisingTargetedTags: InlineMerchandisingTagSet = inlineMerchandisingTagsAgent.get()
   protected def targetedHighMerchandisingLineItems: Seq[HighMerchandisingLineItem] =
-    targetedHighMerchandisingLineItemsAgent get ()
-  protected def pageSkinSponsorships: Seq[PageSkinSponsorship] = pageskinnedAdUnitAgent get ()
-  protected def lineItemsBySlot: Map[AdSlot, Seq[GuLineItem]] = lineItemAgent get ()
+    targetedHighMerchandisingLineItemsAgent.get()
+  protected def pageSkinSponsorships: Seq[PageSkinSponsorship] = pageskinnedAdUnitAgent.get()
+  protected def lineItemsBySlot: Map[AdSlot, Seq[GuLineItem]] = lineItemAgent.get()
   protected def takeoversWithEmptyMPUs: Seq[TakeoverWithEmptyMPUs] =
-    takeoverWithEmptyMPUsAgent get ()
+    takeoverWithEmptyMPUsAgent.get()
 
-  def nonRefreshableLineItemIds(): Seq[Long] = nonRefreshableLineItemsAgent get ()
+  def nonRefreshableLineItemIds(): Seq[Long] = nonRefreshableLineItemsAgent.get()
 
   private def stringFromS3(key: String): Option[String] = S3.get(key)(UTF8)
 

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -316,35 +316,37 @@ class EmailSignupController(
     Action.async { implicit request =>
       AllEmailSubmission.increment()
 
-      emailForm.bindFromRequest.fold(
-        formWithErrors => {
-          log.info(s"Form has been submitted with errors: ${formWithErrors.errors}")
-          EmailFormError.increment()
-          Future.successful(respondFooter(InvalidEmail))
-        },
-        form => {
-          log.info(
-            s"Post request received to /email/ - " +
-              s"email: ${form.email}, " +
-              s"ref: ${form.ref}, " +
-              s"refViewId: ${form.refViewId}, " +
-              s"g-recaptcha-response: ${form.googleRecaptchaResponse}, " +
-              s"referer: ${request.headers.get("referer").getOrElse("unknown")}, " +
-              s"user-agent: ${request.headers.get("user-agent").getOrElse("unknown")}, " +
-              s"x-requested-with: ${request.headers.get("x-requested-with").getOrElse("unknown")}",
-          )
+      emailForm
+        .bindFromRequest()
+        .fold(
+          formWithErrors => {
+            log.info(s"Form has been submitted with errors: ${formWithErrors.errors}")
+            EmailFormError.increment()
+            Future.successful(respondFooter(InvalidEmail))
+          },
+          form => {
+            log.info(
+              s"Post request received to /email/ - " +
+                s"email: ${form.email}, " +
+                s"ref: ${form.ref}, " +
+                s"refViewId: ${form.refViewId}, " +
+                s"g-recaptcha-response: ${form.googleRecaptchaResponse}, " +
+                s"referer: ${request.headers.get("referer").getOrElse("unknown")}, " +
+                s"user-agent: ${request.headers.get("user-agent").getOrElse("unknown")}, " +
+                s"x-requested-with: ${request.headers.get("x-requested-with").getOrElse("unknown")}",
+            )
 
-          (for {
-            _ <- validateCaptcha(form, ValidateEmailSignupRecaptchaTokens.isSwitchedOn)
-            result <- submitFormFooter(form)
-          } yield {
-            result
-          }) recover {
-            case _ =>
-              respondFooter(OtherError)
-          }
-        },
-      )
+            (for {
+              _ <- validateCaptcha(form, ValidateEmailSignupRecaptchaTokens.isSwitchedOn)
+              result <- submitFormFooter(form)
+            } yield {
+              result
+            }) recover {
+              case _ =>
+                respondFooter(OtherError)
+            }
+          },
+        )
     }
 
   private def respondFooter(result: SubscriptionResult)(implicit
@@ -430,35 +432,37 @@ class EmailSignupController(
     Action.async { implicit request =>
       AllEmailSubmission.increment()
 
-      emailForm.bindFromRequest.fold(
-        formWithErrors => {
-          log.info(s"Form has been submitted with errors: ${formWithErrors.errors}")
-          EmailFormError.increment()
-          Future.successful(respond(InvalidEmail))
-        },
-        form => {
-          log.info(
-            s"Post request received to /email/ - " +
-              s"email: ${form.email}, " +
-              s"ref: ${form.ref}, " +
-              s"refViewId: ${form.refViewId}, " +
-              s"g-recaptcha-response: ${form.googleRecaptchaResponse}, " +
-              s"referer: ${request.headers.get("referer").getOrElse("unknown")}, " +
-              s"user-agent: ${request.headers.get("user-agent").getOrElse("unknown")}, " +
-              s"x-requested-with: ${request.headers.get("x-requested-with").getOrElse("unknown")}",
-          )
+      emailForm
+        .bindFromRequest()
+        .fold(
+          formWithErrors => {
+            log.info(s"Form has been submitted with errors: ${formWithErrors.errors}")
+            EmailFormError.increment()
+            Future.successful(respond(InvalidEmail))
+          },
+          form => {
+            log.info(
+              s"Post request received to /email/ - " +
+                s"email: ${form.email}, " +
+                s"ref: ${form.ref}, " +
+                s"refViewId: ${form.refViewId}, " +
+                s"g-recaptcha-response: ${form.googleRecaptchaResponse}, " +
+                s"referer: ${request.headers.get("referer").getOrElse("unknown")}, " +
+                s"user-agent: ${request.headers.get("user-agent").getOrElse("unknown")}, " +
+                s"x-requested-with: ${request.headers.get("x-requested-with").getOrElse("unknown")}",
+            )
 
-          (for {
-            _ <- validateCaptcha(form, ValidateEmailSignupRecaptchaTokens.isSwitchedOn)
-            result <- submitForm(form)
-          } yield {
-            result
-          }) recover {
-            case _ =>
-              respond(OtherError)
-          }
-        },
-      )
+            (for {
+              _ <- validateCaptcha(form, ValidateEmailSignupRecaptchaTokens.isSwitchedOn)
+              result <- submitForm(form)
+            } yield {
+              result
+            }) recover {
+              case _ =>
+                respond(OtherError)
+            }
+          },
+        )
     }
 
   private def submitForm(form: EmailForm)(implicit request: Request[AnyContent]) = {

--- a/common/app/experiments/LookedAtExperiments.scala
+++ b/common/app/experiments/LookedAtExperiments.scala
@@ -16,7 +16,7 @@ object LookedAtExperiments {
     request.addAttr(attrKey, new ExperimentsHashMap) // Attach an empty mutable hashmap to a request and return it
 
   def addExperiment(newExperiment: Experiment)(implicit request: RequestHeader): Unit =
-    request.attrs.get(attrKey).foreach(_.put(newExperiment, Unit))
+    request.attrs.get(attrKey).foreach(_.put(newExperiment, ()))
 
   def forRequest(request: RequestHeader): Set[Experiment] =
     request.attrs.get(attrKey).map(_.asScala.keySet.toSet).getOrElse(Set())

--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -115,7 +115,8 @@ object Cached extends implicits.Dates {
       cacheTime.surrogateSeconds.filter(_ => LongCacheSwitch.isSwitchedOn).getOrElse(cacheTime.cacheSeconds)
 
     val etagHeaderString: String = maybeEtag.getOrElse(
-      s""""guRandomEtag${scala.util.Random.nextInt}${scala.util.Random.nextInt}"""", // setting a random tag still helps
+      s""""guRandomEtag${scala.util.Random.nextInt()}${scala.util.Random
+        .nextInt()}"""", // setting a random tag still helps
     )
 
     result.withHeaders(

--- a/common/app/model/CrosswordGridModel.scala
+++ b/common/app/model/CrosswordGridModel.scala
@@ -33,7 +33,7 @@ case class Grid(columns: Int, rows: Int, cells: Map[CrosswordPosition, Cell]) {
 
   def withCrosswordEntry(crosswordEntry: CrosswordEntry): Grid = {
     val entry = Entry.fromCrosswordEntry(crosswordEntry)
-    crosswordEntry.allPositions.foldLeft(this.withEntry(entry)) { (grid, crosswordPosition) =>
+    crosswordEntry.allPositions().foldLeft(this.withEntry(entry)) { (grid, crosswordPosition) =>
       grid.withEditablePosition(crosswordPosition)
     }
   }

--- a/common/app/model/LiveBlogCurrentPage.scala
+++ b/common/app/model/LiveBlogCurrentPage.scala
@@ -114,7 +114,7 @@ object LiveBlogCurrentPage {
   }
 
   private def filterBlocksByTopic(blocks: Seq[BodyBlock], topic: TopicResult) = {
-    blocks.filter(isTopicBlock(topic)).sortBy(_.publishedCreatedTimestamp).reverse
+    blocks.filter(isTopicBlock(topic)).sortBy(_.publishedCreatedTimestamp()).reverse
   }
 
   private def getTopicBlocks(
@@ -141,7 +141,7 @@ object LiveBlogCurrentPage {
       keyEvents <- blocks.requestedBodyBlocks.get(CanonicalLiveBlog.timeline)
       summaries <- blocks.requestedBodyBlocks.get(CanonicalLiveBlog.summary)
     } yield {
-      (keyEvents ++ summaries).sortBy(_.publishedCreatedTimestamp).reverse
+      (keyEvents ++ summaries).sortBy(_.publishedCreatedTimestamp()).reverse
     }
 
     val keyEventsAndSummariesCount = keyEventsAndSummaries.getOrElse(Seq.empty).size

--- a/common/app/views/fragments/audio/containers/flagshipContainer.scala.html
+++ b/common/app/views/fragments/audio/containers/flagshipContainer.scala.html
@@ -43,8 +43,8 @@
     <div class="@RenderClasses(Map(
         ("fc-container__body", true),
         ("fc-container--rolled-up-hide", true),
-        ("fc-show-more--hidden", containerDefinition.addShowMoreClasses),
-        ("js-container--fc-show-more", containerDefinition.addShowMoreClasses),
+        ("fc-show-more--hidden", containerDefinition.addShowMoreClasses()),
+        ("js-container--fc-show-more", containerDefinition.addShowMoreClasses()),
         ("fc-show-more--mobile-only", containerDefinition.hasMobileOnlyShowMore)
     ))"
         data-title="@Localisation(containerDefinition.displayName getOrElse "")"

--- a/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
@@ -31,8 +31,8 @@
     <div class="@RenderClasses(Map(
         ("fc-container__body", true),
         ("fc-container--rolled-up-hide", true),
-        ("fc-show-more--hidden", containerDefinition.addShowMoreClasses),
-        ("js-container--fc-show-more", containerDefinition.addShowMoreClasses),
+        ("fc-show-more--hidden", containerDefinition.addShowMoreClasses()),
+        ("js-container--fc-show-more", containerDefinition.addShowMoreClasses()),
         ("fc-show-more--mobile-only", containerDefinition.hasMobileOnlyShowMore)
     ))"
          data-title="@Localisation(containerDefinition.displayName getOrElse "")"

--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -54,7 +54,7 @@
     @if(showExtras) {
         <div class="meta__extras">
             <div class="meta__social" data-component="share">
-                @fragments.social(item.sharelinks.pageShares, "top", iconModifier = iconModifier)
+                @fragments.social(item.sharelinks.pageShares, "top", iconModifier = iconModifier())
             </div>
                 <div class="meta__numbers">
                     <div class="u-h meta__number js-sharecount">

--- a/common/test/common/ExperimentsTest.scala
+++ b/common/test/common/ExperimentsTest.scala
@@ -11,7 +11,7 @@ import play.api.mvc.RequestHeader
 
 class ExperimentsTest extends AnyFlatSpec with Matchers {
 
-  conf.switches.Switches.ServerSideExperiments.switchOn
+  conf.switches.Switches.ServerSideExperiments.switchOn()
 
   "Experiments" should "not share participation group" in {
     ActiveExperiments.allExperiments.size should be(ActiveExperiments.allExperiments.map(_.participationGroup).size)
@@ -176,9 +176,9 @@ class ExperimentsTest extends AnyFlatSpec with Matchers {
   trait EnabledExperiments {
 
     def apply[T](block: => T): T = {
-      TestCases.experiments.foreach(_.switch.switchOn)
+      TestCases.experiments.foreach(_.switch.switchOn())
       val result = block
-      TestCases.experiments.foreach(_.switch.switchOff)
+      TestCases.experiments.foreach(_.switch.switchOff())
       result
     }
   }

--- a/common/test/conf/CachedHealthCheckTest.scala
+++ b/common/test/conf/CachedHealthCheckTest.scala
@@ -64,7 +64,7 @@ import scala.util.Random
     val controller = new MockController(Helpers.stubControllerComponents())
 
     // Populate the cache and wait for it to finish
-    whenReady(controller.runChecks) { _ =>
+    whenReady(controller.runChecks()) { _ =>
       // Call the /_healthcheck endpoint on this controller
       val healthCheckRequest = FakeRequest(method = "GET", path = "/_healthcheck")
       val response = call(controller.healthCheck(), healthCheckRequest)
@@ -110,7 +110,7 @@ import scala.util.Random
       }
       "results which are never expiring" should {
         "200" in {
-          val resultDate = DateTime.now.minus(scala.util.Random.nextLong) // random date in the past
+          val resultDate = DateTime.now.minus(scala.util.Random.nextLong()) // random date in the past
           val mockResults = List(mockResult(200, resultDate, None))
           getHealthCheck(mockResults, HealthCheckPolicy.All) { response =>
             status(response) should be(200)

--- a/common/test/conf/audio/FlagshipFrontContainerSpec.scala
+++ b/common/test/conf/audio/FlagshipFrontContainerSpec.scala
@@ -11,7 +11,7 @@ class FlagshipFrontContainerSpec extends AnyFlatSpec with Matchers with BeforeAn
   private val formatter =
     DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm").withZone(FlagshipFrontContainer.londonTimezone)
 
-  override def beforeAll: Unit = {
+  override def beforeAll(): Unit = {
     FlagshipFrontContainerSwitch.switchOn()
   }
 

--- a/discussion/app/controllers/CommentsController.scala
+++ b/discussion/app/controllers/CommentsController.scala
@@ -126,41 +126,43 @@ class CommentsController(
     csrfCheck {
       Action.async { implicit request =>
         val scGuU = request.cookies.get("SC_GU_U")
-        userForm.bindFromRequest.fold(
-          formWithErrors =>
-            Future.successful(
-              BadRequest(views.html.discussionComments.reportComment(commentId, reportAbusePage, formWithErrors)),
-            ),
-          userData => {
-            discussionApi
-              .postAbuseReport(userData, scGuU)
-              .map {
-                case success if success.status == 200 =>
-                  NoCache(Redirect(routes.CommentsController.reportAbuseThankYou(commentId)))
-                case error =>
-                  InternalServerError(
-                    views.html.discussionComments.reportComment(
-                      commentId,
-                      reportAbusePage,
-                      userForm.fill(userData),
-                      errorMessage = Some(ReportAbuseFormValidation.genericErrorMessage),
-                    ),
-                  )
-              }
-              .recover({
-                case NonFatal(e) =>
-                  InternalServerError(
-                    views.html.discussionComments.reportComment(
-                      commentId,
-                      reportAbusePage,
-                      userForm.fill(userData),
-                      errorMessage = Some(ReportAbuseFormValidation.genericErrorMessage),
-                    ),
-                  )
-              })
+        userForm
+          .bindFromRequest()
+          .fold(
+            formWithErrors =>
+              Future.successful(
+                BadRequest(views.html.discussionComments.reportComment(commentId, reportAbusePage, formWithErrors)),
+              ),
+            userData => {
+              discussionApi
+                .postAbuseReport(userData, scGuU)
+                .map {
+                  case success if success.status == 200 =>
+                    NoCache(Redirect(routes.CommentsController.reportAbuseThankYou(commentId)))
+                  case error =>
+                    InternalServerError(
+                      views.html.discussionComments.reportComment(
+                        commentId,
+                        reportAbusePage,
+                        userForm.fill(userData),
+                        errorMessage = Some(ReportAbuseFormValidation.genericErrorMessage),
+                      ),
+                    )
+                }
+                .recover({
+                  case NonFatal(e) =>
+                    InternalServerError(
+                      views.html.discussionComments.reportComment(
+                        commentId,
+                        reportAbusePage,
+                        userForm.fill(userData),
+                        errorMessage = Some(ReportAbuseFormValidation.genericErrorMessage),
+                      ),
+                    )
+                })
 
-          },
-        )
+            },
+          )
       }
     }
 

--- a/facia-press/app/frontpress/ToolPressQueueWorker.scala
+++ b/facia-press/app/frontpress/ToolPressQueueWorker.scala
@@ -70,7 +70,7 @@ class ToolPressQueueWorker(liveFapiFrontPress: LiveFapiFrontPress, draftFapiFron
       if (forceConfigUpdate.exists(identity)) {
         ConfigAgent.refreshAndReturn
       } else
-        Future.successful(Unit)
+        Future.successful(())
 
     for {
       _ <- forceConfigUpdateFuture

--- a/facia-press/app/lifecycle/FaciaPressLifecycle.scala
+++ b/facia-press/app/lifecycle/FaciaPressLifecycle.scala
@@ -21,9 +21,9 @@ class FaciaPressLifecycle(
   }
 
   override def start(): Unit = {
-    toolPressQueueWorker.start
+    toolPressQueueWorker.start()
     if (Configuration.faciatool.frontPressCronQueue.isDefined) {
-      frontPressCron.start
+      frontPressCron.start()
     }
   }
 }

--- a/facia/app/pages/FrontHtmlPage.scala
+++ b/facia/app/pages/FrontHtmlPage.scala
@@ -54,7 +54,7 @@ object FrontHtmlPage extends HtmlPage[PressedPage] {
         checkModuleSupport(),
         inlineJSBlocking(),
       ),
-      bodyTag(classes = defaultBodyClasses)(
+      bodyTag(classes = defaultBodyClasses())(
         skipToMainContent(),
         pageSkin() when page.metadata.hasPageSkin(request),
         guardianHeaderHtml(),

--- a/identity/app/controllers/AccountDeletionController.scala
+++ b/identity/app/controllers/AccountDeletionController.scala
@@ -107,7 +107,7 @@ class AccountDeletionController(
   def processAccountDeletionForm: Action[AnyContent] =
     csrfCheck {
       fullAuthWithIdapiUserAction.async { implicit request =>
-        val boundForm = accountDeletionForm.bindFromRequest
+        val boundForm = accountDeletionForm.bindFromRequest()
 
         boundForm.fold(
           formWithErrors =>

--- a/identity/app/form/DateFormData.scala
+++ b/identity/app/form/DateFormData.scala
@@ -10,7 +10,7 @@ trait DateMapping {
 
   def dateMapping(implicit messagesProvider: MessagesProvider): Mapping[DateFormData] =
     mapping(
-      "year" -> optional(number(min = 1800, max = DateTime.now.getYear)),
+      "year" -> optional(number(min = 1800, max = DateTime.now().getYear)),
       "month" -> optional(number(min = 1, max = 12)),
       "day" -> optional(number(min = 1, max = 31)),
     )(DateFormData.apply)(DateFormData.unapply) verifying (

--- a/identity/app/jobs/TorExitNodeList.scala
+++ b/identity/app/jobs/TorExitNodeList.scala
@@ -18,7 +18,7 @@ object TorExitNodeList extends GuLogging {
     val nodes = addresses map { address =>
       val ip = address.getHostAddress
       val url = s"$torNodeListUrl?ip=$ip&port=80"
-      Source.fromURL(url).getLines.toList.filterNot { line => line.startsWith("#") }
+      Source.fromURL(url).getLines().toList.filterNot { line => line.startsWith("#") }
     }
 
     val allNodes = nodes.toList.flatMap { x => x }.toSet

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -5,7 +5,7 @@ GET         /_healthcheck                           controllers.HealthCheck.heal
 
 GET         /google1ec7a89a27d60d47.html            controllers.Assets.at(path = "/public", file = "google1ec7a89a27d60d47.html")
 
-GET         /complete-registration                  controllers.EmailVerificationController.completeRegistration
+GET         /complete-registration                  controllers.EmailVerificationController.completeRegistration()
 POST        /complete-registration                  controllers.EmailVerificationController.resendValidationEmail(returnUrl: String)
 
 ########################################################################################################################

--- a/onward/app/controllers/MostViewedAudioController.scala
+++ b/onward/app/controllers/MostViewedAudioController.scala
@@ -19,7 +19,7 @@ class MostViewedAudioController(
 
   def renderMostViewed(): Action[AnyContent] =
     Action { implicit request =>
-      getMostViewedAudio match {
+      getMostViewedAudio() match {
         case Nil   => Cached(60) { JsonNotFound() }
         case audio => renderMostViewedAudio(audio, "audio")
       }
@@ -27,7 +27,7 @@ class MostViewedAudioController(
 
   def renderMostViewedPodcast(): Action[AnyContent] =
     Action { implicit request =>
-      getMostViewedPodcast match {
+      getMostViewedPodcast() match {
         case Nil     => Cached(60) { JsonNotFound() }
         case podcast => renderMostViewedAudio(podcast, "podcast")
       }

--- a/onward/app/controllers/MostViewedGalleryController.scala
+++ b/onward/app/controllers/MostViewedGalleryController.scala
@@ -39,7 +39,7 @@ class MostViewedGalleryController(
 
   def renderMostViewed(): Action[AnyContent] =
     Action { implicit request =>
-      getMostViewedGallery match {
+      getMostViewedGallery() match {
         case Nil       => Cached(60) { JsonNotFound() }
         case galleries => renderMostViewedGallery(galleries)
       }

--- a/sport/app/cricket/feed/CricketThrottler.scala
+++ b/sport/app/cricket/feed/CricketThrottler.scala
@@ -35,7 +35,7 @@ class CricketThrottlerActor()(implicit materializer: Materializer) extends Actor
     .run()
 
   override def receive: PartialFunction[Any, Unit] = {
-    case toBeThrottled: CricketThrottledTask[Any] => throttler ! TaskWithSender(sender, toBeThrottled.task)
+    case toBeThrottled: CricketThrottledTask[Any] => throttler ! TaskWithSender(sender(), toBeThrottled.task)
     case throttled: TaskWithSender[Any]           => throttled.task() pipeTo throttled.sender
   }
 }

--- a/sport/app/cricket/feed/cricketPaFeed.scala
+++ b/sport/app/cricket/feed/cricketPaFeed.scala
@@ -33,7 +33,7 @@ class PaFeed(wsClient: WSClient, actorSystem: ActorSystem, materializer: Materia
           wsClient
             .url(endpoint)
             .withHttpHeaders(header, xmlContentType)
-            .get
+            .get()
             .map { response =>
               response.status match {
                 case 200 => response.body
@@ -86,7 +86,7 @@ class PaFeed(wsClient: WSClient, actorSystem: ActorSystem, materializer: Materia
             .url(endpoint)
             .withHttpHeaders(header, xmlContentType)
             .withQueryStringParameters(("startDate", start), ("endDate", end))
-            .get
+            .get()
             .map { response =>
               response.status match {
                 case 200 => XML.loadString(response.body) \\ "match" map (content => (content \ "@id").text)

--- a/sport/app/rugby/jobs/RugbyStatsJob.scala
+++ b/sport/app/rugby/jobs/RugbyStatsJob.scala
@@ -48,15 +48,15 @@ class RugbyStatsJob(feed: RugbyFeed) extends GuLogging {
       homeTeamId: String,
       awayTeamId: String,
   ): Option[Match] = {
-    fixturesAndResultsMatches.get.values.find { rugbyMatch =>
+    fixturesAndResultsMatches.get().values.find { rugbyMatch =>
       isValidMatch(year, month, day, homeTeamId, awayTeamId, rugbyMatch)
     }
   }
 
-  def getAllResults(): Seq[Match] = fixturesAndResultsMatches.get.values.toList.filter(_.status == Status.Result)
+  def getAllResults(): Seq[Match] = fixturesAndResultsMatches.get().values.toList.filter(_.status == Status.Result)
 
   def getMatchNavContent(rugbyMatch: Match): Option[MatchNavigation] = {
-    matchNavContent.get.get(rugbyMatch.key)
+    matchNavContent.get().get(rugbyMatch.key)
   }
 
   private def isValidMatch(

--- a/sport/test/FootballTestData.scala
+++ b/sport/test/FootballTestData.scala
@@ -28,7 +28,7 @@ trait FootballTestData {
           }
         }
       }
-      if (TeamMap.teamAgent.get.isEmpty) {
+      if (TeamMap.teamAgent.get().isEmpty) {
         TeamMap.teamAgent.send(old => old ++ FootballTestData.teamTags)
       }
     }


### PR DESCRIPTION
Scala 2.13 is deprecating auto-application of () and gives warnings which are thrown as errors by our sbt settings. For example:

```
[error] /Users/ioanna_kokkini/Projects/frontend/sport/test/FootballTestData.scala:31:29: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method get,
[error] or remove the empty argument list from its definition (Java-defined methods are exempt).
[error] In Scala 3, an unapplied method like this will be eta-expanded into a function.
[error]       if (TeamMap.teamAgent.get.isEmpty) {
[error]
```

Co-authored-by: Roberto Tyley <roberto.tyley@guardian.co.uk>

Pulled from the mega-PR: https://github.com/guardian/frontend/pull/25190
