### PR TITLE
Add toSeq in sequences to ensure immutability

### DIFF
--- a/admin/app/dfp/DataMapper.scala
+++ b/admin/app/dfp/DataMapper.scala
@@ -46,7 +46,7 @@ class DataMapper(
           CustomTarget(
             customTargetingService.targetingKey(session)(criterion.getKeyId),
             criterion.getOperator.getValue,
-            criterion.getValueIds map (valueId =>
+            criterion.getValueIds.toSeq map (valueId =>
               customTargetingService.targetingValue(session)(criterion.getKeyId, valueId),
             ),
           )
@@ -54,7 +54,7 @@ class DataMapper(
         val targets = criteria.getChildren collect {
           case criterion: CustomCriteria => criterion
         } map toCustomTarget
-        CustomTargetSet(criteria.getLogicalOperator.getValue, targets)
+        CustomTargetSet(criteria.getLogicalOperator.getValue, targets.toIndexedSeq)
       }
 
       criteriaSets.getChildren
@@ -105,7 +105,7 @@ class DataMapper(
       GuCreativePlaceholder(AdSize(size.getWidth, size.getHeight), targeting)
     }
 
-    placeholders sortBy { placeholder =>
+    placeholders.toIndexedSeq sortBy { placeholder =>
       val size = placeholder.size
       (size.width, size.height)
     }

--- a/admin/app/dfp/SessionWrapper.scala
+++ b/admin/app/dfp/SessionWrapper.scala
@@ -140,7 +140,7 @@ private[dfp] class SessionWrapper(dfpSession: AdManagerSession) {
     options.setExportFormat(ExportFormat.CSV_DUMP)
     options.setUseGzipCompression(true)
     val charSource: CharSource = reportDownloader.getReportAsCharSource(options)
-    charSource.readLines().asScala
+    charSource.readLines().asScala.toSeq
   }
 
   object lineItemCreativeAssociations {
@@ -164,7 +164,7 @@ private[dfp] class SessionWrapper(dfpSession: AdManagerSession) {
 
     def create(licas: Seq[LineItemCreativeAssociation]): Seq[LineItemCreativeAssociation] = {
       logAroundCreate(typeName) {
-        licaService.createLineItemCreativeAssociations(licas.toArray)
+        licaService.createLineItemCreativeAssociations(licas.toArray).toIndexedSeq
       }
     }
 
@@ -193,7 +193,7 @@ private[dfp] class SessionWrapper(dfpSession: AdManagerSession) {
 
     def create(creatives: Seq[Creative]): Seq[Creative] = {
       logAroundCreate(typeName) {
-        creativeService.createCreatives(creatives.toArray)
+        creativeService.createCreatives(creatives.toArray).toIndexedSeq
       }
     }
   }

--- a/admin/app/indexes/ContentApiTagsEnumerator.scala
+++ b/admin/app/indexes/ContentApiTagsEnumerator.scala
@@ -18,7 +18,7 @@ class ContentApiTagsEnumerator(contentApiClient: ContentApiClient)(implicit exec
   def enumerateTagType(tagType: String): Future[Seq[Tag]] = {
     val tagQuery = contentApiClient.tags.tagType(tagType).pageSize(MaxPageSize)
     contentApiClient.thriftClient.paginateAccum(tagQuery)(
-      { r: TagsResponse => r.results.filter(isSuitableTag) },
+      { r: TagsResponse => r.results.filter(isSuitableTag).toSeq },
       { (a: Seq[Tag], b: Seq[Tag]) => a ++ b },
     )
   }

--- a/admin/app/model/abtests/AbTestJob.scala
+++ b/admin/app/model/abtests/AbTestJob.scala
@@ -27,7 +27,7 @@ object AbTestJob extends GuLogging {
       val testVariants = switches.foldLeft(Map.empty[String, Seq[String]])((acc, switch) => {
         if (tests.isDefinedAt(switch)) {
           // Update map with a list of variants for the ab-test switch.
-          acc.updated(switch, tests(switch).map(_._2))
+          acc.updated(switch, tests(switch).map(_._2).toSeq)
         } else {
           acc
         }

--- a/applications/app/controllers/AllIndexController.scala
+++ b/applications/app/controllers/AllIndexController.scala
@@ -148,7 +148,7 @@ class AllIndexController(
           .map(section =>
             IndexPage(
               page = Section.make(section),
-              contents = item.results.getOrElse(Nil).map(IndexPageItem(_)),
+              contents = item.results.getOrElse(Nil).map(IndexPageItem(_)).toSeq,
               Tags(Nil),
               date,
               tzOverride = None,
@@ -159,7 +159,7 @@ class AllIndexController(
               val tag = Tag.make(apitag)
               IndexPage(
                 page = tag,
-                contents = item.results.getOrElse(Nil).map(IndexPageItem(_)),
+                contents = item.results.getOrElse(Nil).map(IndexPageItem(_)).toSeq,
                 Tags(List(tag)),
                 date,
                 tzOverride = None,

--- a/applications/app/controllers/LatestIndexController.scala
+++ b/applications/app/controllers/LatestIndexController.scala
@@ -80,7 +80,7 @@ class LatestIndexController(contentApiClient: ContentApiClient, val controllerCo
           .map(section =>
             IndexPage(
               page = Section.make(section),
-              contents = item.results.getOrElse(Nil).map(IndexPageItem(_)),
+              contents = item.results.getOrElse(Nil).map(IndexPageItem(_)).toSeq,
               tags = Tags(Nil),
               date = DateTime.now,
               tzOverride = None,
@@ -90,7 +90,7 @@ class LatestIndexController(contentApiClient: ContentApiClient, val controllerCo
             item.tag.map(tag =>
               IndexPage(
                 page = Tag.make(tag),
-                contents = item.results.getOrElse(Nil).map(IndexPageItem(_)),
+                contents = item.results.getOrElse(Nil).map(IndexPageItem(_)).toSeq,
                 tags = Tags(Nil),
                 date = DateTime.now,
                 tzOverride = None,

--- a/applications/app/services/NewspaperQuery.scala
+++ b/applications/app/services/NewspaperQuery.scala
@@ -77,13 +77,13 @@ class NewspaperQuery(contentApiClient: ContentApiClient) extends Dates with GuLo
           None,
           Some(FRONT_PAGE_DISPLAY_NAME),
           Some(newspaperDate.toString(dateForFrontPagePattern)),
-          content,
+          content.toSeq,
           0,
           snaps,
         )
       }
 
-      val unorderedBookSections = createBookSections(otherContent)
+      val unorderedBookSections = createBookSections(otherContent.toSeq)
       val orderedBookSections = orderByPageNumber(unorderedBookSections)
 
       val bookSectionContainers = orderedBookSections.map { list =>

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -123,7 +123,14 @@ class LiveBlogController(
         case (blog: LiveBlogPage, blocks) if request.forceDCR && lastUpdate.isEmpty =>
           Future.successful(renderGuuiJson(blog, blocks, filter, availableTopics, topicResult))
         case (blog: LiveBlogPage, blocks) =>
-          getJson(blog, range, isLivePage, filter, blocks.requestedBodyBlocks.getOrElse(Map.empty), topicResult)
+          getJson(
+            blog,
+            range,
+            isLivePage,
+            filter,
+            blocks.requestedBodyBlocks.getOrElse(Map.empty).map(entry => (entry._1, entry._2.toSeq)),
+            topicResult,
+          )
         case (minute: MinutePage, _) =>
           Future.successful(common.renderJson(views.html.fragments.minuteBody(minute), minute))
         case _ =>

--- a/commercial/app/controllers/HostedContentController.scala
+++ b/commercial/app/controllers/HostedContentController.scala
@@ -152,13 +152,13 @@ class HostedContentController(
           val itemId = s"advertiser-content/$campaignName/$pageName"
           contentType match {
             case "video" =>
-              val trails = HostedTrails.fromContent(itemId, results)
+              val trails = HostedTrails.fromContent(itemId, results.toSeq)
               Cached(cacheDuration)(onwardView(trails, 1, 1))
             case "article" =>
-              val trails = HostedTrails.fromContent(itemId, results)
+              val trails = HostedTrails.fromContent(itemId, results.toSeq)
               Cached(cacheDuration)(onwardView(trails, 2, 4))
             case "gallery" =>
-              val trails = HostedTrails.fromContent(itemId, trailCount = 2, results)
+              val trails = HostedTrails.fromContent(itemId, trailCount = 2, results.toSeq)
               Cached(cacheDuration)(galleryOnwardView(trails))
             case _ =>
               Cached(0)(JsonNotFound())
@@ -188,7 +188,7 @@ class HostedContentController(
           val videoPages = results
             .filter(_.`type` == Video)
           val itemId = s"advertiser-content/$campaignName/$pageName"
-          val trails = HostedTrails.fromContent(itemId, 1, videoPages)
+          val trails = HostedTrails.fromContent(itemId, 1, videoPages.toSeq)
           Cached(cacheDuration)(JsonComponent(hostedVideoAutoplayWrapper(trails)))
         } getOrElse {
           Cached(0)(JsonNotFound())

--- a/commercial/app/model/capi/Lookup.scala
+++ b/commercial/app/model/capi/Lookup.scala
@@ -33,7 +33,7 @@ class Lookup(contentApiClient: ContentApiClient) extends GuLogging with implicit
     if (shortUrls.nonEmpty) {
       val shortIds = shortUrls.map(ShortUrls.shortUrlToShortId).mkString(",")
       contentApiClient.getResponse(contentApiClient.search(defaultEdition).ids(shortIds)) map {
-        _.results map (Content(_))
+        _.results.toSeq map (Content(_))
       }
     } else Future.successful(Nil)
   }
@@ -48,7 +48,7 @@ class Lookup(contentApiClient: ContentApiClient) extends GuLogging with implicit
         .showTags("type,series,paid-content")
         .orderBy("newest"),
     ) map {
-      _.results.getOrElse(Nil) map (Content(_))
+      _.results.getOrElse(Nil).toSeq map (Content(_))
     } recover {
       case e: Exception => {
         log.info(s"CAPI search for item '${keywordId.stringDecoded}' failed: ${e.getMessage}")
@@ -67,7 +67,7 @@ class Lookup(contentApiClient: ContentApiClient) extends GuLogging with implicit
     val baseQuery = contentApiClient.tags.q(term).tagType("keyword").pageSize(50)
     val query = section.foldLeft(baseQuery)((acc, sectionName) => acc section sectionName)
 
-    val result = contentApiClient.getResponse(query).map(_.results) recover {
+    val result = contentApiClient.getResponse(query).map(_.results.toSeq) recover {
       case e =>
         log.warn(s"Failed to look up [$term]: ${e.getMessage}")
         Nil

--- a/commercial/app/model/merchandise/events/LiveEventMembershipInfo.scala
+++ b/commercial/app/model/merchandise/events/LiveEventMembershipInfo.scala
@@ -11,7 +11,7 @@ object LiveEventMembershipInfo {
   implicit val readsLiveEventMembershipInfo = new Reads[Seq[LiveEventMembershipInfo]] {
     override def reads(json: JsValue): JsResult[Seq[LiveEventMembershipInfo]] = {
       json match {
-        case JsArray(jsValues) => JsSuccess(jsValues.flatMap(_.asOpt[LiveEventMembershipInfo]))
+        case JsArray(jsValues) => JsSuccess(jsValues.flatMap(_.asOpt[LiveEventMembershipInfo]).toIndexedSeq)
         case _                 => JsError(JsonValidationError("error.expected.jsarray containing LiveEventMembershipInfo"))
       }
     }

--- a/commercial/app/model/package.scala
+++ b/commercial/app/model/package.scala
@@ -17,7 +17,7 @@ package object model {
        */
       override def reads(json: JsValue): JsResult[Seq[A]] = {
         json match {
-          case JsArray(jsValues) => JsSuccess(jsValues.flatMap(_.asOpt[A]))
+          case JsArray(jsValues) => JsSuccess(jsValues.flatMap(_.asOpt[A]).toIndexedSeq)
           case _                 => JsError(JsonValidationError(s"Expected JsArray but received: ${json}"))
         }
       }

--- a/common/app/common/InlineStyles.scala
+++ b/common/app/common/InlineStyles.scala
@@ -38,7 +38,10 @@ object CSSRule {
       selectors <- rule.headOption
       styles <- rule.lift(1)
     } yield {
-      selectors.split(",").map(selector => CSSRule(selector.trim, styleMapFromString(styles.stripSuffix("}").trim)))
+      selectors
+        .split(",")
+        .map(selector => CSSRule(selector.trim, styleMapFromString(styles.stripSuffix("}").trim)))
+        .toIndexedSeq
     }
   }
 

--- a/common/app/common/QueryParams.scala
+++ b/common/app/common/QueryParams.scala
@@ -3,7 +3,7 @@ package common
 object QueryParams extends implicits.Strings {
   def get(enc: String): Map[String, Seq[String]] = {
     val params = enc.dropWhile(_ != '?').dropWhile(_ == '?')
-    val pairs: Seq[(String, String)] = params.split('&').flatMap {
+    val pairs: Seq[(String, String)] = params.split('&').toIndexedSeq.flatMap {
       _.split('=') match {
         case Array(key, value)       => List((key.stringDecoded, value.stringDecoded))
         case Array(key) if key != "" => List((key.stringDecoded, ""))

--- a/common/app/common/SQSQueues.scala
+++ b/common/app/common/SQSQueues.scala
@@ -88,7 +88,7 @@ case class TextMessageQueue[A](client: AmazonSQSAsync, queueUrl: String)(implici
 
   def receive(request: ReceiveMessageRequest): Future[Seq[Message[String]]] = {
     receiveMessages(request) map { messages =>
-      messages map { message =>
+      messages.toSeq map { message =>
         Message(
           MessageId(message.getMessageId),
           message.getBody,
@@ -121,7 +121,7 @@ case class JsonMessageQueue[A](client: AmazonSQSAsync, queueUrl: String)(implici
 
   def receive(request: ReceiveMessageRequest)(implicit reads: Reads[A]): Future[Seq[Message[A]]] = {
     receiveMessages(request) map { messages =>
-      messages map { message =>
+      messages.toSeq map { message =>
         Message(
           MessageId(message.getMessageId),
           Json.fromJson[A](Json.parse(message.getBody)) getOrElse {

--- a/common/app/common/commercial/hosted/ContentUtils.scala
+++ b/common/app/common/commercial/hosted/ContentUtils.scala
@@ -30,7 +30,7 @@ object ContentUtils {
       val assets = elements.zipWithIndex flatMap {
         case (element, i) => ModelElement(element, i).images.allImages
       }
-      ImageMedia(assets)
+      ImageMedia(assets.toSeq)
     } getOrElse ImageMedia(Nil)
 
   def thumbnailUrl(item: Content): String =

--- a/common/app/common/commercial/hosted/HostedVideoPage.scala
+++ b/common/app/common/commercial/hosted/HostedVideoPage.scala
@@ -55,7 +55,8 @@ object HostedVideoPage extends GuLogging {
           duration = video.duration.map(_.toInt) getOrElse 0,
           posterUrl = video.posterUrl getOrElse "",
           youtubeId = videoVariants.find(_.platform.toString.contains("Youtube")).map(_.id),
-          sources = videoVariants.flatMap(asset => asset.mimeType map (mimeType => Encoding(asset.id, mimeType))).sorted,
+          sources =
+            videoVariants.flatMap(asset => asset.mimeType map (mimeType => Encoding(asset.id, mimeType))).toSeq.sorted,
         ),
         cta = HostedCallToAction.fromAtom(ctaAtom),
         socialShareText = content.fields.flatMap(_.socialShareText),

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -36,7 +36,7 @@ object SystemMetrics extends implicits.Numbers {
   }
 
   lazy val garbageCollectors: Seq[GcRateMetric] =
-    ManagementFactory.getGarbageCollectorMXBeans.asScala.map(new GcRateMetric(_))
+    ManagementFactory.getGarbageCollectorMXBeans.asScala.map(new GcRateMetric(_)).toSeq
 
   val MaxHeapMemoryMetric = GaugeMetric(
     name = "max-heap-memory",

--- a/common/app/html/HtmlTextExtractor.scala
+++ b/common/app/html/HtmlTextExtractor.scala
@@ -31,7 +31,7 @@ object HtmlTextExtractor {
     if (children.exists(child => child.nodeName() == "img" && child.attr("class") == "full-width"))
       Nil
     else
-      node +: children.flatMap(filterImagesAndFlattenNodes)
+      node +: children.flatMap(filterImagesAndFlattenNodes).toSeq
   }
 
   private def removeWhitespace(text: String): String = {

--- a/common/app/model/CardStylePicker.scala
+++ b/common/app/model/CardStylePicker.scala
@@ -10,7 +10,7 @@ import commercial.targeting.CampaignAgent
 object CardStylePicker {
 
   def apply(content: CapiContent, trailMetaData: MetaDataCommonFields): CardStyle = {
-    val tags = content.tags.map(_.id)
+    val tags = content.tags.map(_.id).toSeq
     extractCampaigns(tags) match {
       case Nil => CardStyle(content, TrailMetaData.empty)
       case _   => SpecialReport

--- a/common/app/model/CrosswordData.scala
+++ b/common/app/model/CrosswordData.scala
@@ -18,7 +18,7 @@ object Entry {
     //Adding space between number and direction
     //as well as after comma
     //ex: "2,24across,16" => "2, 24 across, 16"
-    val clues: Seq[Option[String]] = numbers.split(',').map { singleClue =>
+    val clues: Seq[Option[String]] = numbers.split(',').toIndexedSeq.map { singleClue =>
       // Acceptable clue is a number followed by an optional direction
       "([0-9]+)([a-z]+)?".r.findFirstMatchIn(singleClue).map { m =>
         val number: String = m.group(1)
@@ -43,9 +43,9 @@ object Entry {
       entry.clue.getOrElse(""),
       entry.direction.getOrElse(""),
       entry.length.getOrElse(0),
-      entry.group.getOrElse(Seq()),
+      entry.group.getOrElse(Seq()).toSeq,
       entry.position.map(position => CrosswordPosition(position.x, position.y)).getOrElse(CrosswordPosition(0, 0)),
-      entry.separatorLocations.map(_.toMap),
+      entry.separatorLocations.map(_.toMap.map(entry => entry._1 -> entry._2.toSeq)),
       entry.solution,
     )
 }
@@ -156,7 +156,7 @@ object CrosswordData {
       creator = for (creator <- crossword.creator) yield CrosswordCreator(creator.name, creator.webUrl),
       crossword.date.toJoda,
       content.webPublicationDate.fold(crossword.date.toJoda)(_.toJoda),
-      sortedNewEntries,
+      sortedNewEntries.toSeq,
       crossword.solutionAvailable,
       crossword.dateSolutionAvailable.map(_.toJoda),
       CrosswordDimensions(crossword.dimensions.cols, crossword.dimensions.rows),

--- a/common/app/model/Element.scala
+++ b/common/app/model/Element.scala
@@ -52,7 +52,8 @@ object ImageMedia {
       allImages = capiElement.assets
         .filter(_.`type` == AssetType.Image)
         .map(ImageAsset.make(_, properties.index))
-        .sortBy(-_.width),
+        .sortBy(-_.width)
+        .toSeq,
     )
   def make(crops: Seq[ImageAsset]): ImageMedia =
     ImageMedia(
@@ -150,7 +151,8 @@ object EmbedMedia {
     EmbedMedia(
       embedAssets = capiElement.assets
         .filter(_.`type` == AssetType.Embed)
-        .map(EmbedAsset.make),
+        .map(EmbedAsset.make)
+        .toSeq,
     )
   }
 }

--- a/common/app/model/RelatedContent.scala
+++ b/common/app/model/RelatedContent.scala
@@ -25,7 +25,7 @@ object StoryPackages {
 
     val storyPackagesContent: Seq[ApiContent] = response.packages
       .map { packages =>
-        val allContentsPerPackage: Seq[Seq[ApiContent]] = packages.map(_.articles.map(_.content))
+        val allContentsPerPackage: Seq[Seq[ApiContent]] = packages.map(_.articles.map(_.content).toSeq).toSeq
         if (packages.size > 1) { //intermix packages only if more than one
           allContentsPerPackage
             .flatMap(_.zipWithIndex) // zip content with its position

--- a/common/app/model/Tag.scala
+++ b/common/app/model/Tag.scala
@@ -144,7 +144,7 @@ object TagProperties {
       contributorLargeImagePath = tag.bylineLargeImageUrl,
       bylineImageUrl = tag.bylineImageUrl,
       podcast = tag.podcast.map(Podcast.make),
-      references = tag.references.map(Reference.make),
+      references = tag.references.map(Reference.make).toSeq,
       paidContentType = tag.paidContentType,
       commercial = Some(CommercialProperties.fromTag(tag)),
     )

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -428,10 +428,11 @@ object Content {
       allowUserGeneratedContent = apifields.flatMap(_.allowUgc).getOrElse(false),
       isExpired = apiContent.isExpired.getOrElse(false),
       productionOffice = apifields.flatMap(_.productionOffice.map(_.name)),
-      tweets = apiContent.elements.getOrElse(Nil).filter(_.`type`.name == "Tweet").map { tweet =>
+      tweets = apiContent.elements.getOrElse(Nil).filter(_.`type`.name == "Tweet").toSeq.map { tweet =>
         val images = tweet.assets
           .filter(_.`type`.name == "Image")
           .flatMap(asset => asset.typeData.flatMap(_.secureFile).orElse(asset.file))
+          .toSeq
         Tweet(tweet.id, images)
       },
       showInRelated = apifields.flatMap(_.showInRelatedContent).getOrElse(false),
@@ -443,8 +444,9 @@ object Content {
       paFootballTeams = apiContent.references
         .filter(ref => ref.id.contains("pa-football-team"))
         .map(ref => ref.id.split("/").last)
+        .toSeq
         .distinct,
-      javascriptReferences = apiContent.references.map(ref => Reference.toJavaScript(ref.id)),
+      javascriptReferences = apiContent.references.toSeq.map(ref => Reference.toJavaScript(ref.id)),
       wordCount = Jsoup.clean(fields.body, Whitelist.none()).split("\\s+").length,
       showByline =
         fapiutils.ResolvedMetaData.fromContentAndTrailMetaData(apiContent, TrailMetaData.empty, cardStyle).showByline,

--- a/common/app/model/content/Atom.scala
+++ b/common/app/model/content/Atom.scala
@@ -90,7 +90,7 @@ final case class ExplainerAtom(
 object ExplainerAtom {
   def make(atom: AtomApiAtom): ExplainerAtom = {
     val explainer = atom.data.asInstanceOf[AtomData.Explainer].explainer
-    ExplainerAtom(atom.id, explainer.tags.getOrElse(Nil), explainer.title, explainer.body, atom)
+    ExplainerAtom(atom.id, explainer.tags.getOrElse(Nil).toSeq, explainer.title, explainer.body, atom)
   }
 }
 
@@ -214,7 +214,7 @@ object MediaAtom extends common.GuLogging {
     MediaAtom(
       id = id,
       defaultHtml = defaultHtml,
-      assets = mediaAtom.assets.map(mediaAssetMake),
+      assets = mediaAtom.assets.map(mediaAssetMake).toSeq,
       title = mediaAtom.title,
       duration = mediaAtom.duration,
       source = mediaAtom.source,
@@ -226,7 +226,7 @@ object MediaAtom extends common.GuLogging {
   }
 
   def imageMediaMake(capiImage: AtomApiImage, caption: String): ImageMedia = {
-    ImageMedia(capiImage.assets.map(mediaImageAssetMake(_, caption)))
+    ImageMedia(capiImage.assets.map(mediaImageAssetMake(_, caption)).toSeq)
   }
 
   def mediaAssetMake(mediaAsset: AtomApiMediaAsset): MediaAsset = {
@@ -366,7 +366,7 @@ object QuizAtom extends common.GuLogging {
           text = answer.answerText,
           revealText = answer.revealText.flatMap(revealText => if (revealText != "") Some(revealText) else None),
           weight = answer.weight.toInt,
-          buckets = answer.bucket.getOrElse(Nil),
+          buckets = answer.bucket.getOrElse(Nil).toSeq,
           imageMedia = transformAssets(answer.assets.headOption),
         )
       }
@@ -374,10 +374,10 @@ object QuizAtom extends common.GuLogging {
       Question(
         id = question.id,
         text = question.questionText,
-        answers = answers,
+        answers = answers.toSeq,
         imageMedia = transformAssets(question.assets.headOption),
       )
-    }
+    }.toSeq
 
   def extractResultGroups(resultGroups: Option[com.gu.contentatom.thrift.atom.quiz.ResultGroups]): Seq[ResultGroup] =
     resultGroups
@@ -390,6 +390,7 @@ object QuizAtom extends common.GuLogging {
         )
       })
       .getOrElse(Nil)
+      .toSeq
 
   def extractContent(questions: Seq[Question], quiz: atomapi.quiz.QuizAtom): QuizContent =
     QuizContent(
@@ -406,7 +407,8 @@ object QuizAtom extends common.GuLogging {
             )
           })
         })
-        .getOrElse(Nil),
+        .getOrElse(Nil)
+        .toSeq,
     )
 
   def make(path: String, atom: AtomApiAtom, shareLinks: ShareLinkMeta): QuizAtom = {
@@ -541,7 +543,7 @@ object TimelineAtom {
       atom.id,
       atom,
       atom.data.asInstanceOf[AtomData.Timeline].timeline,
-      events = atom.data.asInstanceOf[AtomData.Timeline].timeline.events map TimelineItem.make _,
+      events = atom.data.asInstanceOf[AtomData.Timeline].timeline.events.toSeq map TimelineItem.make,
     )
 
   def renderFormattedDate(date: Long, format: Option[String]): String = {

--- a/common/app/model/content/Atoms.scala
+++ b/common/app/model/content/Atoms.scala
@@ -64,36 +64,36 @@ object Atoms extends common.GuLogging {
 
   def make(content: contentapi.Content, pageShares: ShareLinkMeta = ShareLinkMeta(Nil, Nil)): Option[Atoms] = {
     content.atoms.map { atoms =>
-      val quizzes = extract(atoms.quizzes, atom => { QuizAtom.make(content.id, atom, pageShares) })
+      val quizzes = extract(atoms.quizzes.map(_.toSeq), atom => { QuizAtom.make(content.id, atom, pageShares) })
 
       val media = extract(
-        atoms.media,
+        atoms.media.map(_.toSeq),
         atom => {
           MediaAtom.make(atom)
         },
       )
 
-      val interactives = extract(atoms.interactives, atom => { InteractiveAtom.make(atom) })
+      val interactives = extract(atoms.interactives.map(_.toSeq), atom => { InteractiveAtom.make(atom) })
 
-      val recipes = extract(atoms.recipes, atom => { RecipeAtom.make(atom) })
+      val recipes = extract(atoms.recipes.map(_.toSeq), atom => { RecipeAtom.make(atom) })
 
-      val reviews = extract(atoms.reviews, atom => { ReviewAtom.make(atom) })
+      val reviews = extract(atoms.reviews.map(_.toSeq), atom => { ReviewAtom.make(atom) })
 
-      val explainers = extract(atoms.explainers, atom => { ExplainerAtom.make(atom) })
+      val explainers = extract(atoms.explainers.map(_.toSeq), atom => { ExplainerAtom.make(atom) })
 
-      val qandas = extract(atoms.qandas, atom => { QandaAtom.make(atom) })
+      val qandas = extract(atoms.qandas.map(_.toSeq), atom => { QandaAtom.make(atom) })
 
-      val guides = extract(atoms.guides, atom => { GuideAtom.make(atom) })
+      val guides = extract(atoms.guides.map(_.toSeq), atom => { GuideAtom.make(atom) })
 
-      val profiles = extract(atoms.profiles, atom => { ProfileAtom.make(atom) })
+      val profiles = extract(atoms.profiles.map(_.toSeq), atom => { ProfileAtom.make(atom) })
 
-      val timelines = extract(atoms.timelines, atom => { TimelineAtom.make(atom) })
+      val timelines = extract(atoms.timelines.map(_.toSeq), atom => { TimelineAtom.make(atom) })
 
-      val commonsdivisions = extract(atoms.commonsdivisions, atom => { CommonsDivisionAtom.make(atom) })
+      val commonsdivisions = extract(atoms.commonsdivisions.map(_.toSeq), atom => { CommonsDivisionAtom.make(atom) })
 
-      val audios = extract(atoms.audios, atom => { AudioAtom.make(atom) })
+      val audios = extract(atoms.audios.map(_.toSeq), atom => { AudioAtom.make(atom) })
 
-      val charts = extract(atoms.charts, ChartAtom.make)
+      val charts = extract(atoms.charts.map(_.toSeq), ChartAtom.make)
 
       Atoms(
         quizzes = quizzes,
@@ -126,7 +126,7 @@ object Atoms extends common.GuLogging {
           url = Some(asset.file),
         )
       }
-    }
+    }.toSeq
 
     ImageMedia(imageAssets)
   }

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -197,7 +197,7 @@ object DotcomRenderingDataModel {
         fallbackLogo = Configuration.images.fallbackLogo,
       ),
       mainBlock = blocks.main,
-      bodyBlocks = blocks.body.getOrElse(Nil),
+      bodyBlocks = blocks.body.getOrElse(Nil).toSeq,
       pageType = pageType,
       hasStoryPackage = page.related.hasStoryPackage,
       storyPackage = getStoryPackage(page.related.faciaItems, request),
@@ -228,7 +228,7 @@ object DotcomRenderingDataModel {
       pagination = None,
       linkedData = linkedData,
       mainBlock = blocks.main,
-      bodyBlocks = blocks.body.getOrElse(Nil),
+      bodyBlocks = blocks.body.getOrElse(Nil).toSeq,
       pageType = pageType,
       hasStoryPackage = page.related.hasStoryPackage,
       storyPackage = getStoryPackage(page.related.faciaItems, request),
@@ -247,7 +247,7 @@ object DotcomRenderingDataModel {
       case Some(requestedBlocks) =>
         val keyEvent = requestedBlocks.getOrElse(CanonicalLiveBlog.timeline, Seq.empty[APIBlock])
         val summaryEvent = requestedBlocks.getOrElse(CanonicalLiveBlog.summary, Seq.empty[APIBlock])
-        keyEvent ++ summaryEvent
+        keyEvent.toSeq ++ summaryEvent.toSeq
       case None => Seq.empty[APIBlock]
     }
   }
@@ -283,7 +283,7 @@ object DotcomRenderingDataModel {
     }
 
     val timelineBlocks =
-      orderBlocks(allTimelineBlocks).map(ensureSummaryTitle)
+      orderBlocks(allTimelineBlocks.toSeq).map(ensureSummaryTitle)
 
     val linkedData = LinkedData.forLiveblog(
       liveblog = page,
@@ -295,7 +295,7 @@ object DotcomRenderingDataModel {
     val pinnedPost =
       blocks.requestedBodyBlocks
         .flatMap(_.get("body:pinned"))
-        .getOrElse(blocks.body.fold(Seq.empty[APIBlock])(_.filter(_.attributes.pinned.contains(true))))
+        .getOrElse(blocks.body.fold(Seq.empty[APIBlock])(_.filter(_.attributes.pinned.contains(true)).toSeq))
         .headOption
         .map(ensureSummaryTitle)
 

--- a/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingSupportTypes.scala
@@ -117,7 +117,7 @@ object Block {
       id = block.id,
       attributes = attributes,
       elements = DotcomRenderingUtils.blockElementsToPageElements(
-        block.elements,
+        block.elements.toSeq,
         request,
         content,
         shouldAddAffiliateLinks,
@@ -131,7 +131,7 @@ object Block {
       blockLastUpdated = blockLastUpdated,
       blockLastUpdatedDisplay = blockLastUpdatedDisplay,
       title = block.title,
-      contributors = contributors,
+      contributors = contributors.toSeq,
       blockFirstPublished = blockFirstPublished,
       blockFirstPublishedDisplay = blockFirstPublishedDisplay,
       blockFirstPublishedDisplayNoTimezone = blockFirstPublishedDisplayNoTimezone,

--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -72,7 +72,7 @@ object DotcomRenderingUtils {
         case _                 => None
       }
       sequence
-    }
+    }.map(_.toIndexedSeq)
 
     def entryToDataPair(entry: JsValue): Option[(String, String)] = {
       /*
@@ -156,7 +156,7 @@ object DotcomRenderingUtils {
 
     val ids = liveblog.currentPage.currentPage.blocks.map(_.id).toSet
     relevantBlocks.filter(block => ids(block.id))
-  }
+  }.toSeq
 
   private def addDisclaimer(
       elems: List[PageElement],

--- a/common/app/model/dotcomrendering/ElementsEnhancer.scala
+++ b/common/app/model/dotcomrendering/ElementsEnhancer.scala
@@ -14,7 +14,7 @@ object ElementsEnhancer {
 
   def enhanceElements(elements: JsValue): IndexedSeq[JsValue] = {
     elements.as[JsArray].value.map(element => enhanceElement(element))
-  }
+  }.toIndexedSeq
 
   def enhanceObjectWithElementsAtDepth1(obj: JsValue): JsValue = {
     obj.asOpt[JsObject] match {
@@ -27,7 +27,7 @@ object ElementsEnhancer {
 
   def enhanceObjectsWithElementsAtDepth1(objs: JsValue): IndexedSeq[JsValue] = {
     objs.as[JsArray].value.map(obj => enhanceObjectWithElementsAtDepth1(obj))
-  }
+  }.toIndexedSeq
 
   def enhanceBlocks(obj: JsObject): JsObject = {
     obj ++

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -879,12 +879,12 @@ object PageElement {
                 ImgSrc.srcsetForBreakpoint(
                   b,
                   imageRoleWidthsByBreakpoint.immersive.breakpoints,
-                  maybeImageMedia = Some(ImageMedia(imageAssets)),
+                  maybeImageMedia = Some(ImageMedia(imageAssets.toSeq)),
                 ),
                 ImgSrc.srcsetForBreakpoint(
                   b,
                   imageRoleWidthsByBreakpoint.immersive.breakpoints,
-                  maybeImageMedia = Some(ImageMedia(imageAssets)),
+                  maybeImageMedia = Some(ImageMedia(imageAssets.toSeq)),
                   hidpi = true,
                 ),
               )
@@ -905,7 +905,7 @@ object PageElement {
 
         List(
           ImageBlockElement(
-            ImageMedia(imageAssets),
+            ImageMedia(imageAssets.toSeq),
             imageDataFor(element),
             element.imageTypeData.flatMap(_.displayCredit),
             Role(element.imageTypeData.flatMap(_.role), defaultRole),
@@ -965,10 +965,16 @@ object PageElement {
         if (element.assets.nonEmpty) {
           List(
             GuVideoBlockElement(
-              element.assets.map(VideoAsset.make),
-              ImageMedia(element.assets.filter(_.mimeType.exists(_.startsWith("image"))).zipWithIndex.map {
-                case (a, i) => ImageAsset.make(a, i)
-              }),
+              element.assets.map(VideoAsset.make).toSeq,
+              ImageMedia(
+                element.assets
+                  .filter(_.mimeType.exists(_.startsWith("image")))
+                  .zipWithIndex
+                  .map {
+                    case (a, i) => ImageAsset.make(a, i)
+                  }
+                  .toSeq,
+              ),
               element.videoTypeData.flatMap(_.caption).getOrElse(""),
               element.videoTypeData.flatMap(_.url).getOrElse(""),
               element.videoTypeData.flatMap(_.originalUrl).getOrElse(""),
@@ -1164,16 +1170,18 @@ object PageElement {
                 id = timeline.id,
                 title = timeline.atom.title.getOrElse(""),
                 description = timeline.data.description,
-                events = timeline.data.events.map(event =>
-                  TimelineEvent(
-                    title = event.title,
-                    date = TimelineAtom.renderFormattedDate(event.date, event.dateFormat),
-                    body = event.body,
-                    toDate = event.toDate.map(date => TimelineAtom.renderFormattedDate(date, event.dateFormat)),
-                    unixDate = event.date,
-                    toUnixDate = event.toDate,
-                  ),
-                ),
+                events = timeline.data.events
+                  .map(event =>
+                    TimelineEvent(
+                      title = event.title,
+                      date = TimelineAtom.renderFormattedDate(event.date, event.dateFormat),
+                      body = event.body,
+                      toDate = event.toDate.map(date => TimelineAtom.renderFormattedDate(date, event.dateFormat)),
+                      unixDate = event.date,
+                      toUnixDate = event.toDate,
+                    ),
+                  )
+                  .toSeq,
               ),
             )
           }
@@ -1352,7 +1360,7 @@ object PageElement {
         i.typeData.map(x => WitnessBlockElementAssetsElementTypeData(x.name)),
       ),
     )
-  }
+  }.toSeq
 
   private def makeWitnessBlockElementImage(element: ApiBlockElement, wtd: WitnessElementFields): WitnessBlockElement = {
     WitnessBlockElement(

--- a/common/app/model/liveblog/BlockElement.scala
+++ b/common/app/model/liveblog/BlockElement.scala
@@ -117,22 +117,28 @@ object BlockElement {
       case Image =>
         Some(
           ImageBlockElement(
-            ImageMedia(element.assets.zipWithIndex.map { case (a, i) => ImageAsset.make(a, i) }),
+            ImageMedia(element.assets.zipWithIndex.map { case (a, i) => ImageAsset.make(a, i) }.toSeq),
             imageDataFor(element),
             element.imageTypeData.flatMap(_.displayCredit),
           ),
         )
 
-      case Audio => Some(AudioBlockElement(element, element.assets.map(AudioAsset.make)))
+      case Audio => Some(AudioBlockElement(element, element.assets.map(AudioAsset.make).toSeq))
 
       case Video =>
         if (element.assets.nonEmpty) {
           Some(
             GuVideoBlockElement(
-              element.assets.map(VideoAsset.make),
-              ImageMedia(element.assets.filter(_.mimeType.exists(_.startsWith("image"))).zipWithIndex.map {
-                case (a, i) => ImageAsset.make(a, i)
-              }),
+              element.assets.map(VideoAsset.make).toSeq,
+              ImageMedia(
+                element.assets
+                  .filter(_.mimeType.exists(_.startsWith("image")))
+                  .zipWithIndex
+                  .map {
+                    case (a, i) => ImageAsset.make(a, i)
+                  }
+                  .toSeq,
+              ),
               videoDataFor(element),
             ),
           )

--- a/common/app/model/liveblog/BodyBlock.scala
+++ b/common/app/model/liveblog/BodyBlock.scala
@@ -20,7 +20,7 @@ object Blocks {
     }
 
     val mainBlock: Option[BodyBlock] = blocks.main.map(BodyBlock.make)
-    val bodyBlocks: Seq[BodyBlock] = orderBlocks(blocks.body.toSeq.flatMap(BodyBlock.make))
+    val bodyBlocks: Seq[BodyBlock] = orderBlocks(blocks.body.toSeq.flatMap(blocks => BodyBlock.make(blocks.toSeq)))
     val reqBlocks: Map[String, Seq[BodyBlock]] = blocks.requestedBodyBlocks
       .map { map =>
         map.toMap.mapValues(blocks => orderBlocks(BodyBlock.make(blocks)))
@@ -63,8 +63,8 @@ object BodyBlock {
       bodyBlock.firstPublishedDate.map(_.toJoda),
       bodyBlock.publishedDate.map(_.toJoda),
       bodyBlock.lastModifiedDate.map(_.toJoda),
-      bodyBlock.contributors,
-      bodyBlock.elements.flatMap(BlockElement.make),
+      bodyBlock.contributors.toSeq,
+      bodyBlock.elements.flatMap(BlockElement.make).toSeq,
     )
 
   sealed trait EventType

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -600,7 +600,8 @@ object Elements {
     Elements(
       apiContent.elements
         .map(_.zipWithIndex.map { case (element, index) => Element(element, index) })
-        .getOrElse(Nil),
+        .getOrElse(Nil)
+        .toSeq,
     )
   }
 }

--- a/common/app/services/ophan/SurgingContentAgent.scala
+++ b/common/app/services/ophan/SurgingContentAgent.scala
@@ -41,7 +41,7 @@ object SurgeUtils {
     } yield {
       (url, count)
     }
-  }
+  }.toSeq
 }
 
 class SurgingContentAgentLifecycle(

--- a/common/app/services/repositories.scala
+++ b/common/app/services/repositories.scala
@@ -193,7 +193,7 @@ trait Index extends ConciergeRepository with Collections {
     val commercial = Commercial.empty
     IndexPage(
       page = section,
-      contents = trails,
+      contents = trails.toSeq,
       tags = Tags(Nil),
       date = DateTime.now,
       tzOverride = None,
@@ -217,11 +217,15 @@ trait Index extends ConciergeRepository with Collections {
     val leadContentIds = leadContent.map(_.item.metadata.id)
 
     val latest: Seq[IndexPageItem] =
-      response.results.getOrElse(Nil).map(IndexPageItem(_)).filterNot(c => leadContentIds.contains(c.item.metadata.id))
+      response.results
+        .getOrElse(Nil)
+        .map(IndexPageItem(_))
+        .toSeq
+        .filterNot(c => leadContentIds.contains(c.item.metadata.id))
     val allTrails = (leadContent ++ editorsPicks ++ latest).distinctBy(_.item.metadata.id)
 
     tag map { tag =>
-      IndexPage(page = tag, contents = allTrails, tags = Tags(List(tag)), date = DateTime.now, tzOverride = None)
+      IndexPage(page = tag, contents = allTrails.toSeq, tags = Tags(List(tag)), date = DateTime.now, tzOverride = None)
     }
   }
 

--- a/common/app/views/fragments/atoms/structureddata/filmReview.scala.html
+++ b/common/app/views/fragments/atoms/structureddata/filmReview.scala.html
@@ -28,9 +28,9 @@
     "name": "@entity.title",
     "sameAs": "http://www.imdb.com/title/@entity.imdbId",
     @review.atom.contentChangeDetails.created.map { created => "dateCreated": "@{new DateTime(created.date).toString("yyyy-MM-dd'T'HH:mm:ssZ")}",}
-    "director" : @Html(people(entity.directors.map(_.fullName))),
-    "actor" : @Html(people(entity.actors.map(_.fullName))),
-    @review.data.images.flatMap(ReviewAtom.getLargestImageUrl).map { img => "image": "@img" }
+    "director" : @Html(people(entity.directors.toSeq.map(_.fullName))),
+    "actor" : @Html(people(entity.actors.toSeq.map(_.fullName))),
+    @review.data.images.map(_.toSeq).flatMap(ReviewAtom.getLargestImageUrl).map { img => "image": "@img" }
   },
   "reviewRating": {
     "@@type": "Rating",

--- a/common/app/views/fragments/atoms/structureddata/gameReview.scala.html
+++ b/common/app/views/fragments/atoms/structureddata/gameReview.scala.html
@@ -15,7 +15,7 @@
 
   "itemReviewed": {
     "@@type": "Game",
-    @review.data.images.flatMap(ReviewAtom.getLargestImageUrl).map { img => "image": "@img", }
+    @review.data.images.map(_.toSeq).flatMap(ReviewAtom.getLargestImageUrl).map { img => "image": "@img", }
     "name": "@entity.title"
   },
 

--- a/common/app/views/fragments/atoms/structureddata/recipe.scala.html
+++ b/common/app/views/fragments/atoms/structureddata/recipe.scala.html
@@ -12,7 +12,7 @@
       "@@type": "Recipe",
       "name": "@recipe.data.title",
       @for(category <- recipe.data.tags.category) {"recipeCategory": "@category",}
-      @ReviewAtom.getLargestImageUrl(recipe.data.images).map { img => "image": "@img", }
+      @ReviewAtom.getLargestImageUrl(recipe.data.images.toSeq).map { img => "image": "@img", }
       @recipe.data.credits.headOption.map { name => "author": @fragments.atoms.structureddata.contributor(name, contributors),}
       @recipe.atom.contentChangeDetails.created.map { created => "dateCreated": "@{new DateTime(created.date).toString("yyyy-MM-dd'T'HH:mm:ssZ")}",}
       @recipe.atom.contentChangeDetails.published.map { published => "datePublished": "@{new DateTime(published.date).toString("yyyy-MM-dd'T'HH:mm:ssZ")}",}
@@ -42,7 +42,7 @@
        "fatContent": "20.2 g"
      },
      *@
-     "recipeIngredient": @Html(Json.stringify(Json.toJson(RecipeAtom.formatIngredientValues(recipe.data.ingredientsLists.flatMap(_.ingredients))))),
+     "recipeIngredient": @Html(Json.stringify(Json.toJson(RecipeAtom.formatIngredientValues(recipe.data.ingredientsLists.flatMap(_.ingredients).toSeq)))),
      "recipeInstructions": @Html(Json.stringify(Json.toJson(recipe.data.steps.zipWithIndex.map { case(step,index) => s"${index +1}. $step" })))
     }
 </script>

--- a/common/app/views/fragments/atoms/structureddata/restaurant/restaurantReview.scala.html
+++ b/common/app/views/fragments/atoms/structureddata/restaurant/restaurantReview.scala.html
@@ -27,7 +27,7 @@
     "priceRange": "£££",
     @for(address <- entity.address) { @fragments.atoms.structureddata.restaurant.address(address) }
     @for(geoLocation <- entity.geolocation) { "geo" : @fragments.atoms.structureddata.restaurant.geo(geoLocation), }
-    @review.data.images.flatMap(ReviewAtom.getLargestImageUrl).map { img => "image": "@img" }
+    @review.data.images.map(_.toSeq).flatMap(ReviewAtom.getLargestImageUrl).map { img => "image": "@img" }
   },
   "reviewRating": {
     "@@type": "Rating",

--- a/common/test/services/IndexPageTest.scala
+++ b/common/test/services/IndexPageTest.scala
@@ -35,7 +35,7 @@ import scala.concurrent.Future
         item.section.map(section =>
           IndexPage(
             page = Section.make(section),
-            contents = item.results.getOrElse(Nil).map(IndexPageItem(_)),
+            contents = item.results.getOrElse(Nil).map(IndexPageItem(_)).toSeq,
             tags = Tags(Nil),
             date = DateTime.now,
             tzOverride = None,

--- a/discussion/app/discussion/model/Comment.scala
+++ b/discussion/app/discussion/model/Comment.scala
@@ -81,7 +81,7 @@ object Comment extends implicits.Dates {
     (json \\ "responses").headOption map {
       _.asInstanceOf[JsArray].value map { Comment(_, None, discussionOpt) }
     } getOrElse Nil
-  }
+  }.toSeq
 }
 
 case class ResponseTo(displayName: String, commentId: String)

--- a/discussion/app/discussion/model/comments.scala
+++ b/discussion/app/discussion/model/comments.scala
@@ -28,7 +28,7 @@ object DiscussionComments {
     val comments = (json \ "discussion" \ "comments").as[JsArray].value map { Comment(_, None, Some(discussion)) }
     DiscussionComments(
       discussion = discussion,
-      comments = comments,
+      comments = comments.toSeq,
       pagination = DiscussionPagination(json),
       commentCount = (json \ "discussion" \ "commentCount").asOpt[Int] getOrElse 0,
       topLevelCommentCount = (json \ "discussion" \ "topLevelCommentCount").asOpt[Int] getOrElse 0,
@@ -53,7 +53,7 @@ object ProfileComments {
     val comments = (json \ "comments").as[JsArray].value map { Comment(_, Some(profile), None) }
     ProfileComments(
       profile = profile,
-      comments = comments,
+      comments = comments.toSeq,
       pagination = DiscussionPagination(json),
     )
   }
@@ -65,7 +65,7 @@ object ProfileReplies {
     }
     ProfileComments(
       profile = Profile(json),
-      comments = comments,
+      comments = comments.toSeq,
       pagination = DiscussionPagination(json),
     )
   }
@@ -84,7 +84,7 @@ object ProfileDiscussions {
       val discussion = Discussion(d)
       DiscussionComments(
         discussion = discussion,
-        comments = (d \ "comments").as[JsArray].value.map { Comment(_, Some(profile), Some(discussion)) },
+        comments = (d \ "comments").as[JsArray].value.map { Comment(_, Some(profile), Some(discussion)) }.toSeq,
         pagination = DiscussionPagination(json),
         commentCount = 0,
         topLevelCommentCount = 0,
@@ -96,7 +96,7 @@ object ProfileDiscussions {
     }
     ProfileDiscussions(
       profile = profile,
-      discussions = discussions,
+      discussions = discussions.toIndexedSeq,
       DiscussionPagination(json),
     )
   }

--- a/identity/app/idapiclient/IdApiClient.scala
+++ b/identity/app/idapiclient/IdApiClient.scala
@@ -202,10 +202,10 @@ class IdApiClient(idJsonBodyParser: IdApiJsonBodyParser, conf: IdConfig, httpCli
       tracking: Option[TrackingData] = None,
       extra: Parameters = Iterable.empty,
   ): Parameters =
-    extra ++ clientAuth.parameters ++ auth.map(_.parameters) ++ tracking.map(_.parameters)
+    extra ++ clientAuth.parameters ++ auth.map(_.parameters).toSeq ++ tracking.map(_.parameters).toSeq
 
   private def buildHeaders(auth: Option[Auth] = None, extra: Parameters = Iterable.empty): Parameters = {
-    extra ++ clientAuth.headers ++ auth.map(_.headers)
+    extra ++ clientAuth.headers ++ auth.map(_.headers).toSeq
   }
 
   private def apiUrl(path: String) = urlJoin(apiRootUrl, path)

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -217,7 +217,7 @@ class MostPopularController(
     contentApiClient.getResponse(capiItemWithDate).map { response =>
       val heading = response.section.map(s => "in " + s.webTitle).getOrElse("Across The&nbsp;Guardian")
       val popular = response.mostViewed.getOrElse(Nil) take 10 map (RelatedContentItem(_))
-      if (popular.isEmpty) None else Some(MostPopular(heading, path, popular.map(_.faciaContent)))
+      if (popular.isEmpty) None else Some(MostPopular(heading, path, popular.map(_.faciaContent).toSeq))
     }
   }
 }

--- a/onward/app/controllers/MostViewedSocialController.scala
+++ b/onward/app/controllers/MostViewedSocialController.scala
@@ -59,7 +59,7 @@ class MostViewedSocialController(
                     Fixed(container),
                     CollectionConfigWithId(dataId, config),
                     CollectionEssentials(
-                      items.map(FaciaContentConvert.contentToFaciaContent),
+                      items.map(FaciaContentConvert.contentToFaciaContent).toSeq,
                       Nil,
                       displayName,
                       None,

--- a/onward/app/controllers/SeriesController.scala
+++ b/onward/app/controllers/SeriesController.scala
@@ -83,7 +83,7 @@ class SeriesController(
       response.tag.flatMap { tag =>
         val trails = response.results.getOrElse(Nil) filterNot isCurrentStory map (RelatedContentItem(_))
         if (trails.nonEmpty) {
-          Some(Series(seriesId, Tag.make(tag, None), RelatedContent(trails)))
+          Some(Series(seriesId, Tag.make(tag, None), RelatedContent(trails.toSeq)))
         } else { None }
       }
     }

--- a/onward/app/feed/MostPopularAgent.scala
+++ b/onward/app/feed/MostPopularAgent.scala
@@ -103,7 +103,7 @@ class MostPopularAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi, w
 
     for {
       mostViewedResponse <- futureMostViewed
-      mostViewed = mostViewedResponse.mostViewed.getOrElse(Nil).take(10).map(RelatedContentItem(_))
+      mostViewed = mostViewedResponse.mostViewed.getOrElse(Nil).take(10).map(RelatedContentItem(_)).toSeq
       newMap <- relatedContentsBox.alter(_ + (edition.id -> mostViewed))
     } yield newMap
   }

--- a/onward/app/feed/MostViewedVideoAgent.scala
+++ b/onward/app/feed/MostViewedVideoAgent.scala
@@ -27,7 +27,7 @@ class MostViewedVideoAgent(contentApiClient: ContentApiClient, ophanApi: OphanAp
 
     ophanResponse.flatMap { result =>
       val paths: Seq[String] = for {
-        videoResult <- result.asOpt[JsArray].map(_.value).getOrElse(Nil)
+        videoResult <- result.asOpt[JsArray].map(_.value.toSeq).getOrElse(Nil)
         path <- videoResult.validate[QueryResult].asOpt.map(_.paths).getOrElse(Nil) if path.contains("/video/")
       } yield path
 
@@ -46,7 +46,7 @@ class MostViewedVideoAgent(contentApiClient: ContentApiClient, ophanApi: OphanAp
             .pageSize(20),
         )
         .map { r =>
-          val videoContent: Seq[client.model.v1.Content] = r.results.filter(_.isVideo)
+          val videoContent: Seq[client.model.v1.Content] = r.results.filter(_.isVideo).toSeq
           log.info(s"Number of video content items from CAPI: ${videoContent.size}")
           videoContent.map(Content(_)).collect { case v: Video => v }
         }

--- a/onward/app/services/repositories.scala
+++ b/onward/app/services/repositories.scala
@@ -34,7 +34,7 @@ trait Related extends ConciergeRepository {
         val relatedContentItems = response.relatedContent.getOrElse(Nil) map { item =>
           RelatedContentItem(item)
         }
-        RelatedContent(relatedContentItems)
+        RelatedContent(relatedContentItems.toSeq)
       }
 
       trails recoverApi404With RelatedContent(Nil)
@@ -57,7 +57,7 @@ trait Related extends ConciergeRepository {
         RelatedContentItem(item)
       }
       RelatedContent(
-        items.sortBy(content => -mostReadAgent.getViewCount(content.content.metadata.id).getOrElse(0)).take(10),
+        items.sortBy(content => -mostReadAgent.getViewCount(content.content.metadata.id).getOrElse(0)).take(10).toSeq,
       )
     }
 


### PR DESCRIPTION
In Scala 2.13 `Seq` is now an alias for `collection.immutable.Seq`. Before it was an alias for the possibly-mutable `collection.Seq`. Unfortunately some code will return collections which are `collection.Seq` and those no longer satisfy when we need the `Seq` type because they are not definitely immutable. We can get an immutable copy of the collection by doing `toSeq`.

For example:
In Scala 2.12 we could use a case class with signature: `case class ImageMedia(allImages: Seq[ImageAsset]) ` like that: `ImageMedia(assets)`. In Scala 2.13 calling the class like this gives the following error:

```
[error] /Users/ioanna_kokkini/Projects/frontend/common/app/common/commercial/hosted/ContentUtils.scala:33:18: type mismatch;
[error]  found   : Seq[model.ImageAsset] (in scala.collection)
[error]  required: Seq[model.ImageAsset] (in scala.collection.immutable)
[error]       ImageMedia(assets)
[error]                  ^
[error] one error found
```

because the compiler thinks we are referring to `collection.Seq`. We need to call it like `ImageMedia(assets.toSeq)` for the error to go away.

Pulled from: https://github.com/guardian/frontend/pull/25190

Co-authored-by: Roberto Tyley <roberto.tyley@guardian.co.uk>


