### PR TITLE
Fix Commercial dev-server override path

### DIFF
--- a/webpack.config.commercial.dev.js
+++ b/webpack.config.commercial.dev.js
@@ -3,7 +3,7 @@ const webpackMerge = require('webpack-merge');
 const config = require('./webpack.config.commercial.js');
 
 const port = 3031;
-const overrideBundlePath = `http://localhost:${port}`;
+const overrideBundlePath = `http://localhost:${port}/`;
 const shouldOverrideBundle = !!process.env.OVERRIDE_BUNDLE;
 
 module.exports = webpackMerge.smart(config, {


### PR DESCRIPTION
## What does this change?

Fix the path that the commercial dev server uses to include a `/` after localhost.

## What is the value of this and can you measure success?

Need this for assets / dynamic imports to work. This should've been the last commit in #25335 but I didn't push my changes 😅 

### Tested

- [X] Locally
- [ ] On CODE (optional)