### PR TITLE
Scala-2.13: Use Symbol instead of single-quote syntax

### DIFF
--- a/admin/app/views/commercial/adsDotText.scala.html
+++ b/admin/app/views/commercial/adsDotText.scala.html
@@ -17,7 +17,7 @@
             }
             </ul>
         }
-        @textarea(sellersForm("sellers"), '_label -> "Authorised sellers:", 'rows -> 30, 'cols -> 100, '_help -> "")
+        @textarea(sellersForm("sellers"), Symbol("_label") -> "Authorised sellers:", Symbol("rows") -> 30, Symbol("cols") -> 100, Symbol("_help") -> "")
 
         <input class="btn btn-large btn-success" type="submit" value="Save" />
     }

--- a/admin/app/views/commercial/takeoverWithEmptyMPUsCreate.scala.html
+++ b/admin/app/views/commercial/takeoverWithEmptyMPUsCreate.scala.html
@@ -19,17 +19,17 @@
             }
             </ul>
         }
-        @inputText(takeoverForm("url"), '_label -> "Paste URL here:", 'size -> 100, '_help -> "")
+        @inputText(takeoverForm("url"), Symbol("_label")-> "Paste URL here:", Symbol("size") -> 100, Symbol("_help") -> "")
         @select(
             takeoverForm("editions"),
             options = for(e <- Edition.all) yield { e.id -> e.displayName },
-            'multiple -> true,
-            '_label -> "Editions this applies to (one or multiple):"
+            Symbol("multiple") -> true,
+            Symbol("_label") -> "Editions this applies to (one or multiple):"
         )
-        @input(takeoverForm("startTime"), '_label -> "Takeover starts (UTC):", '_help -> "") { (id, name, value, args) =>
+        @input(takeoverForm("startTime"), Symbol("_label") -> "Takeover starts (UTC):", Symbol("_help") -> "") { (id, name, value, args) =>
             <input type="datetime-local" name="@name" id="@id" @toHtmlArgs(args)>
         }
-        @input(takeoverForm("endTime"), '_label -> "Takeover ends (UTC):", '_help -> "") { (id, name, value, args) =>
+        @input(takeoverForm("endTime"), Symbol("_label") -> "Takeover ends (UTC):", Symbol("_help") -> "") { (id, name, value, args) =>
             <input type="datetime-local" name="@name" id="@id" @toHtmlArgs(args)>
         }
         <input class="btn btn-large btn-success" type="submit" value="Save" />

--- a/applications/test/InteractiveControllerTest.scala
+++ b/applications/test/InteractiveControllerTest.scala
@@ -43,7 +43,8 @@ class DCRFake() extends renderers.DotcomRenderingService {
     play.api.test.Helpers.stubControllerComponents(),
     new DCRFake(),
   )
-  val getWebWorkerPath = PrivateMethod[String]('getWebWorkerPath)
+
+  val getWebWorkerPath = PrivateMethod[String](Symbol("getWebWorkerPath"))
 
   "Interactive Controller" should "200 when content type is 'interactive'" in {
     val result = interactiveController.renderInteractive(url)(TestRequest(url))

--- a/commercial/test/model/events/SingleEventbriteMasterclassParsingTest.scala
+++ b/commercial/test/model/events/SingleEventbriteMasterclassParsingTest.scala
@@ -12,14 +12,14 @@ class SingleEventbriteMasterclassParsingTest extends AnyFlatSpec with Matchers w
   "MasterClass companion object" should
     "not create a masterclass object if there isn't at link to the Guardian with the words 'Click here'" in {
     val event = Json.parse(Fixtures.jsonWithNoLink).as[Event]
-    Masterclass.fromEvent(event) shouldBe 'empty
+    Masterclass.fromEvent(event) shouldBe Symbol("empty")
   }
 
   "MasterClass companion object" should "return an appropriate MasterClass" in {
     val masterclass = Masterclass.fromEvent(Json.parse(Fixtures.json).as[Event]).get
 
     masterclass.name should be("Travel writing weekend")
-    masterclass shouldBe 'open
+    masterclass shouldBe Symbol("open")
     masterclass.displayPriceRange should be(Some("£400.00"))
     masterclass.ratioTicketsLeft should be(Some(0.5))
     masterclass.guardianUrl should be(
@@ -45,7 +45,7 @@ class SingleEventbriteMasterclassParsingTest extends AnyFlatSpec with Matchers w
     val masterclass = Masterclass.fromEvent(Json.parse(Fixtures.jsonWith2Tickets).as[Event]).get
 
     masterclass.name should be("Travel writing weekend")
-    masterclass shouldBe 'open
+    masterclass shouldBe Symbol("open")
     masterclass.displayPriceRange should be(Some("£400.00 to £2,600.00"))
     masterclass.ratioTicketsLeft should be(Some(0.5))
   }

--- a/common/test/common/commercial/hosted/ColourTest.scala
+++ b/common/test/common/commercial/hosted/ColourTest.scala
@@ -11,36 +11,36 @@ class ColourTest extends AnyFlatSpec with Matchers {
 
   "isDark" should "be true for Zootropolis green" in {
     val zootropolisColour = Colour("#2ec869")
-    zootropolisColour shouldBe 'dark
+    zootropolisColour shouldBe Symbol("dark")
   }
 
   it should "be false for a bright colour e.g Renault Yellow" in {
     val renaultColour = Colour("#ffc421")
-    renaultColour should not be 'dark
+    renaultColour should not be Symbol("dark")
   }
 
   it should "be true for a dark colour" in {
     val brown = Colour("#6f5200")
-    brown shouldBe 'dark
+    brown shouldBe Symbol("dark")
   }
 
   it should "be false for white" in {
     val white = Colour("#ffffff")
-    white should not be 'dark
+    white should not be Symbol("dark")
   }
 
   it should "be true for black" in {
     val black = Colour("#000000")
-    black shouldBe 'dark
+    black shouldBe Symbol("dark")
   }
 
   it should "be true for Visit Britain colour" in {
     val visitBritainColour = Colour("#E41F13")
-    visitBritainColour shouldBe 'dark
+    visitBritainColour shouldBe Symbol("dark")
   }
 
   it should "be true for Chester Zoo colour" in {
     val chesterZooColour = Colour("#E31B22")
-    chesterZooColour shouldBe 'dark
+    chesterZooColour shouldBe Symbol("dark")
   }
 }

--- a/common/test/common/dfp/GuLineItemTest.scala
+++ b/common/test/common/dfp/GuLineItemTest.scala
@@ -53,36 +53,36 @@ class GuLineItemTest extends AnyFlatSpec with Matchers {
 
   "isSuitableForTopAboveNavSlot" should
     "be true for a line item that meets all the rules" in {
-    lineItem() shouldBe 'suitableForTopAboveNavSlot
+    lineItem() shouldBe Symbol("suitableForTopAboveNavSlot")
   }
 
   it should
     "be true for a line item that has relevant creative targeting" in {
     val creativePlaceholders =
       Seq(GuCreativePlaceholder(leaderboardSize, targeting = Some(defaultTargeting)))
-    lineItem(creativePlaceholders = creativePlaceholders) shouldBe 'suitableForTopAboveNavSlot
+    lineItem(creativePlaceholders = creativePlaceholders) shouldBe Symbol("suitableForTopAboveNavSlot")
   }
 
   it should "be false for a section front targeted indirectly" in {
     val target = targeting(Seq(GuAdUnit("id", Seq("theguardian.com"), GuAdUnit.ACTIVE)))
-    lineItem(targeting = target) should not be 'suitableForTopAboveNavSlot
+    lineItem(targeting = target) should not be Symbol("suitableForTopAboveNavSlot")
   }
 
   it should "be false for an untargeted section front" in {
     val target = targeting(Seq(GuAdUnit("id", Seq("theguardian.com", "politics"), GuAdUnit.ACTIVE)))
-    lineItem(targeting = target) should not be 'suitableForTopAboveNavSlot
+    lineItem(targeting = target) should not be Symbol("suitableForTopAboveNavSlot")
   }
 
   it should "be false for a front whose section is targeted but front not targeted directly" in {
     val target = targeting(Seq(GuAdUnit("id", Seq("theguardian.com", "business"), GuAdUnit.ACTIVE)))
-    lineItem(targeting = target) should not be 'suitableForTopAboveNavSlot
+    lineItem(targeting = target) should not be Symbol("suitableForTopAboveNavSlot")
   }
 
   it should "be false for a CPM campaign" in {
-    lineItem(costType = "CPM") should not be 'suitableForTopAboveNavSlot
+    lineItem(costType = "CPM") should not be Symbol("suitableForTopAboveNavSlot")
   }
 
   it should "be false for a completed campaign" in {
-    lineItem(endTime = Some(now.minusDays(1))) should not be 'suitableForTopAboveNavSlot
+    lineItem(endTime = Some(now.minusDays(1))) should not be Symbol("suitableForTopAboveNavSlot")
   }
 }

--- a/common/test/renderers/DotcomRenderingServiceTest.scala
+++ b/common/test/renderers/DotcomRenderingServiceTest.scala
@@ -28,7 +28,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 
   val dotcomRenderingService = DotcomRenderingService()
   val articleUrl = "politics/2021/oct/07/coronavirus-report-warned-of-impact-on-uk-four-years-before-pandemic"
-  val post = PrivateMethod[Future[Result]]('post)
+  val post = PrivateMethod[Future[Result]](Symbol("post"))
   val request = TestRequest()
   private val wsMock = mock[WSClient]
   private val wsResponseMock = mock[WSResponse]

--- a/discussion/app/views/fragments/reportCommentForm.scala.html
+++ b/discussion/app/views/fragments/reportCommentForm.scala.html
@@ -11,7 +11,7 @@
     userForm.error("email"),
     userForm.error("reason")
 ) { case (emailInput: Option[String], categoryError: Option[FormError], emailError: Option[FormError], reasonError: Option[FormError]) =>
-                @helper.form(controllers.routes.CommentsController.reportAbuseSubmission(commentId), 'class -> "form") {
+                @helper.form(controllers.routes.CommentsController.reportAbuseSubmission(commentId), Symbol("class") -> "form") {
                     @helper.CSRF.formField
                     <fieldset class="fieldset">
                         <div class="fieldset__heading" />

--- a/identity/app/form/IdFormHelpers.scala
+++ b/identity/app/form/IdFormHelpers.scala
@@ -10,17 +10,35 @@ object IdFormHelpers {
   val nonInputFields = FieldConstructor(multiInputFieldConstructor.f)
 
   def Password(field: Field, args: (Symbol, Any)*): Input = {
-    val updatedArgs = updateArgs(args, 'autocomplete -> "off", 'autocapitalize -> "off", 'autocorrect -> "off")
+    val updatedArgs =
+      updateArgs(
+        args,
+        Symbol("autocomplete") -> "off",
+        Symbol("autocapitalize") -> "off",
+        Symbol("autocorrect") -> "off",
+      )
     new Input("password", field, updatedArgs: _*)
   }
 
   def Email(field: Field, args: (Symbol, Any)*): Input = {
-    val updatedArgs = updateArgs(args, 'autocomplete -> "on", 'autocapitalize -> "off", 'autocorrect -> "off")
+    val updatedArgs =
+      updateArgs(
+        args,
+        Symbol("autocomplete") -> "on",
+        Symbol("autocapitalize") -> "off",
+        Symbol("autocorrect") -> "off",
+      )
     new Input("email", field, updatedArgs: _*)
   }
 
   def Username(field: Field, args: (Symbol, Any)*): Input = {
-    val updatedArgs = updateArgs(args, 'autocomplete -> "off", 'autocapitalize -> "off", 'autocorrect -> "off")
+    val updatedArgs =
+      updateArgs(
+        args,
+        Symbol("autocomplete") -> "off",
+        Symbol("autocapitalize") -> "off",
+        Symbol("autocorrect") -> "off",
+      )
     new Input("text", field, updatedArgs: _*)
   }
 
@@ -37,7 +55,7 @@ object IdFormHelpers {
   }
 
   def Radio(field: Field, values: List[String], args: (Symbol, Any)*): Input = {
-    new Input("radio", field, ('_values -> values :: args.toList): _*)
+    new Input("radio", field, (Symbol("_values") -> values :: args.toList): _*)
   }
 
   def Textarea(field: Field, args: (Symbol, Any)*): Input = {
@@ -55,15 +73,15 @@ object IdFormHelpers {
 }
 
 class Input(val inputType: String, val field: Field, initialArgs: (Symbol, Any)*) {
-  val cls = "text-input " + getArgOrElse('class, "", initialArgs)
-  val autocomplete = getArgOrElse('autocomplete, "on", initialArgs)
-  val autocapitalize = getArgOrElse('autocapitalize, "on", initialArgs)
-  val autocorrect = getArgOrElse('autocorrect, "on", initialArgs)
-  val spellcheck = getArgOrElse('spellcheck, "false", initialArgs)
-  val autofocus = getArgOrElse('autofocus, false, initialArgs)
+  val cls = "text-input " + getArgOrElse(Symbol("class"), "", initialArgs)
+  val autocomplete = getArgOrElse(Symbol("autocomplete"), "on", initialArgs)
+  val autocapitalize = getArgOrElse(Symbol("autocapitalize"), "on", initialArgs)
+  val autocorrect = getArgOrElse(Symbol("autocorrect"), "on", initialArgs)
+  val spellcheck = getArgOrElse(Symbol("spellcheck"), "false", initialArgs)
+  val autofocus = getArgOrElse(Symbol("autofocus"), false, initialArgs)
   val required = field.constraints.exists(constraint => constraint._1 == "constraint.required")
 
-  val args = initialArgs.filter(_._1 != 'type) ++ Seq('_showConstraints -> false)
+  val args = initialArgs.filter(_._1 != Symbol("type")) ++ Seq(Symbol("_showConstraints") -> false)
 
   private def getArgOrElse[T](property: Symbol, default: T, args: Seq[(Symbol, Any)]): T =
     args.toMap.get(property).map(_.asInstanceOf[T]).getOrElse(default)

--- a/identity/app/views/fragments/form/checkboxField.scala.html
+++ b/identity/app/views/fragments/form/checkboxField.scala.html
@@ -6,7 +6,7 @@
 @input(idInput.field, idInput.args:_*) { (id, name, value, htmlArgs) =>
     <label class="check-label" for="@idInput.field.id">
         @fragments.form.checkbox(idInput.field, idInput.args:_*)
-        @idInput.args.toMap.get('_label).map { label =>
+        @idInput.args.toMap.get(Symbol("_label")).map { label =>
             @label
         }
     </label>

--- a/identity/app/views/fragments/form/fieldConstructors/frontendFieldConstructor.scala.html
+++ b/identity/app/views/fragments/form/fieldConstructors/frontendFieldConstructor.scala.html
@@ -1,8 +1,8 @@
 @(elements: views.html.helper.FieldElements)
 
-@elements.args.toMap.get('type)
+@elements.args.toMap.get(Symbol("type"))
 
-<li class="form-field @elements.args.get('_class) @if(elements.hasErrors) {form-field--error}" id="@elements.args.get('_id).getOrElse(elements.id + "_field")">
+<li class="form-field @elements.args.get(Symbol("_class")) @if(elements.hasErrors) {form-field--error}" id="@elements.args.get(Symbol("_id")).getOrElse(elements.id + "_field")">
     <label class="label" for="@elements.id">@elements.label</label>
     <div class="input">
         @if(elements.infos.nonEmpty) {

--- a/identity/app/views/profile/deletion/accountDeletionForm.scala.html
+++ b/identity/app/views/profile/deletion/accountDeletionForm.scala.html
@@ -115,8 +115,8 @@
                 <div class="fieldset__fields">
                     <ul class="u-unstyled">
 
-                        @inputField(Password(accountDeletionForm("password"), '_label -> "Password", 'class -> "js-register-password js-password-strength",
-                            (Symbol("data-test-id"), "account-deletion-password"), 'required -> true))
+                        @inputField(Password(accountDeletionForm("password"), Symbol("_label") -> "Password", Symbol("class") -> "js-register-password js-password-strength",
+                            (Symbol("data-test-id"), "account-deletion-password"), Symbol("required") -> true))
 
                         <li>
                             <button id="deleteButton" type="submit" class="manage-account__button manage-account__button--center delete-input-warn" data-link-name="Delete Account" data-test-id="delete-account">Delete your account</button>

--- a/identity/test/idapiclient/IdApiTest.scala
+++ b/identity/test/idapiclient/IdApiTest.scala
@@ -125,8 +125,8 @@ class IdApiTest
           )
           val cookies = cookiesResponse.values
           cookies.size must equal(1)
-          cookies(0) must have('key ("SC_GU_U"))
-          cookies(0) must have('value ("testCookieValue"))
+          cookies(0) must have(Symbol("key")("SC_GU_U"))
+          cookies(0) must have(Symbol("value")("testCookieValue"))
         }
       }
     }
@@ -154,8 +154,8 @@ class IdApiTest
       whenReady(idApi.user(testUserId)) {
         case Left(result) => fail("Got Left(%s), instead of expected Right".format(result.toString()))
         case Right(user) => {
-          user must have('id (testUserId))
-          user.publicFields must have('username (Some("testUsername")))
+          user must have(Symbol("id")(testUserId))
+          user.publicFields must have(Symbol("username")(Some("testUsername")))
           user.primaryEmailAddress mustEqual "test@example.com"
         }
       }

--- a/identity/test/idapiclient/parser/JsonBodyParserTest.scala
+++ b/identity/test/idapiclient/parser/JsonBodyParserTest.scala
@@ -27,7 +27,7 @@ class JsonBodyParserTest extends PathAnyFreeSpec with Matchers {
     "returns a parse error if the JSON is not valid" in {
       TestJsonBodyParser.extract[TestType]()(Right(invalidJSONResponse)) match {
         case Right(result) => fail("extractJsonOrError did not return a Left, got %s".format(result.toString))
-        case Left(errors)  => errors(0) should have('message ("JSON parsing exception"))
+        case Left(errors)  => errors(0) should have(Symbol("message")("JSON parsing exception"))
       }
     }
 
@@ -41,7 +41,7 @@ class JsonBodyParserTest extends PathAnyFreeSpec with Matchers {
     "extracts the provided type from the JSON body of a successful response" in {
       TestJsonBodyParser.extract[TestType]()(Right(validJSONResponse)) match {
         case Left(result)                => fail("extract did not return a Right, got Left(%s)".format(result.toString()))
-        case Right(testObject: TestType) => testObject should have('test ("value"))
+        case Right(testObject: TestType) => testObject should have(Symbol("test")("value"))
         case Right(result) =>
           fail("extract did not return a Right of the required type, got a %s".format(result.getClass.getName))
       }

--- a/sport/test/football/model/CompetitionStageTest.scala
+++ b/sport/test/football/model/CompetitionStageTest.scala
@@ -106,13 +106,13 @@ import test._
         }
 
         "does not add leagueTableEntries for other rounds to group stage" in {
-          all(leagueTableEntries0) should have('stageNumber ("1"))
-          all(leagueTableEntries1) should have('stageNumber ("2"))
+          all(leagueTableEntries0) should have(Symbol("stageNumber")("1"))
+          all(leagueTableEntries1) should have(Symbol("stageNumber")("2"))
         }
 
         "can get the matches for a given round" in {
           val testRound = Round("1", Some("Group A"))
-          all(stages(0).asInstanceOf[Groups].roundMatches(testRound)) should have('round (testRound))
+          all(stages(0).asInstanceOf[Groups].roundMatches(testRound)) should have(Symbol("round")(testRound))
         }
       }
     }
@@ -139,8 +139,8 @@ import test._
         }
 
         "does not add leagueTableEntries for other stages" in {
-          all(leagueTable0) should have('stageNumber ("1"))
-          all(leagueTable1) should have('stageNumber ("2"))
+          all(leagueTable0) should have(Symbol("stageNumber")("1"))
+          all(leagueTable1) should have(Symbol("stageNumber")("2"))
         }
       }
     }
@@ -169,7 +169,7 @@ import test._
 
         "can get the matches for a given round" in {
           val testRound = Round("1", Some("Quarter Final"))
-          all(stages(0).asInstanceOf[Knockout].roundMatches(testRound)) should have('round (testRound))
+          all(stages(0).asInstanceOf[Knockout].roundMatches(testRound)) should have(Symbol("round")(testRound))
         }
       }
 


### PR DESCRIPTION
In Scala 2.13 [Symbol literals are being deprecated](https://github.com/scala/scala/pull/7395). 

Here's the recommendation from the [Scala 2.13.0 release notes](https://github.com/scala/scala/releases/v2.13.0):

```
Symbol literals deprecated
- Symbols themselves remain supported, only the single-quote syntax is deprecated. (https://github.com/scala/scala/pull/7395)
- Library designers may wish to change their APIs to use String instead.
- Deprecated: 'foo
- Use instead: Symbol("foo")
```

The changes in this PR will help us to avoid errors like the following when switching to 2.13:

```
[error] /Users/ioanna_kokkini/Projects/frontend/admin/app/views/commercial/adsDotText.scala.html:20:43: symbol literal is deprecated; use Symbol("_label") instead
[error]         @textarea(sellersForm("sellers"), '_label -> "Authorised sellers:", 'rows -> 30, 'cols -> 100, '_help -> "")
```

Co-authored-by: Roberto Tyley <roberto.tyley@guardian.co.uk>

Pulled from the mega-PR: https://github.com/guardian/frontend/pull/25190
