### PR TITLE
Add empty alt tag to non-responsive images

### DIFF
--- a/common/app/views/fragments/items/elements/facia_cards/itemImage.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/itemImage.scala.html
@@ -17,7 +17,7 @@
             }
 
             case _ => {
-                <img src="@ImgSrc.getFallbackUrl(imageMedia)">
+                <img src="@ImgSrc.getFallbackUrl(imageMedia)" alt="">
             }
         }
     </div>


### PR DESCRIPTION
- Cards which have images that don't have a `width` property are
  rendered using a fallback image tag, which didn't have an `alt`
  attribute.
- An example is the `Other sports` container on `uk/sports`.
- This adds an empty alt attribute to the fallback image tag.
- The motive here is to improve accessibility. Having an empty tag here 
  seems justified because in the cases we're aware of the image is basically
  decorative. Having an empty alt tag will mean that screenreaders don't try to read out the image url.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
