### PR TITLE
Remove implicits.Collections file

### DIFF
--- a/admin/app/football/model/PA.scala
+++ b/admin/app/football/model/PA.scala
@@ -1,11 +1,10 @@
 package football.model
 
 import pa.{Season, Team}
-import implicits.Collections
 
 import java.time.ZoneId
 
-object PA extends Collections {
+object PA {
 
   val competitionNames = Map[String, String](
     ("100", "Premier League"),

--- a/commercial/app/controllers/BookOffersController.scala
+++ b/commercial/app/controllers/BookOffersController.scala
@@ -17,7 +17,6 @@ class BookOffersController(
 ) extends BaseController
     with ImplicitControllerExecutionContext
     with GuLogging
-    with implicits.Collections
     with implicits.Requests {
 
   private def booksSample(isbns: Seq[String], segment: Segment): Seq[Book] =

--- a/common/app/common/TrailsToRss.scala
+++ b/common/app/common/TrailsToRss.scala
@@ -27,7 +27,7 @@ object RssDates {
   }
 }
 
-object TrailsToRss extends implicits.Collections {
+object TrailsToRss {
 
   // The CAPI blocks we would like consumers to request to build our item intro text from
   val BlocksToGenerateRssIntro = "body:oldest:10"

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -14,7 +14,7 @@ case class Front(
     containers: Seq[FaciaContainer],
 )
 
-object Front extends implicits.Collections {
+object Front {
   type TrailUrl = String
 
   def itemsVisible(containerDefinition: ContainerDefinition): Int =

--- a/common/app/model/facia/PressedCollection.scala
+++ b/common/app/model/facia/PressedCollection.scala
@@ -5,7 +5,6 @@ import com.gu.facia.api.{models => fapi}
 import com.gu.facia.api.utils.ContainerBrandingFinder
 import com.gu.facia.client.models.{Branded, TargetedTerritory}
 import common.Edition
-import implicits.CollectionsOps._
 import model.pressed._
 import org.joda.time.DateTime
 import services.CollectionConfigWithId

--- a/common/app/services/repositories.scala
+++ b/common/app/services/repositories.scala
@@ -5,14 +5,13 @@ import com.gu.contentapi.client.model.ContentApiError
 import com.gu.contentapi.client.model.v1.{ItemResponse, SearchResponse, Section => ApiSection}
 import common._
 import contentapi.{ContentApiClient, QueryDefaults, SectionTagLookUp, SectionsLookUp}
-import implicits.Collections
 import model._
 import org.joda.time.DateTime
 import play.api.mvc.{RequestHeader, Result => PlayResult}
 
 import scala.concurrent.Future
 
-trait Index extends ConciergeRepository with Collections {
+trait Index extends ConciergeRepository {
 
   implicit val context: ApplicationContext
 

--- a/common/app/views/support/MostPopularTags.scala
+++ b/common/app/views/support/MostPopularTags.scala
@@ -5,7 +5,7 @@ import model.Tag
 import model.pressed.PressedContent
 import implicits.FaciaContentFrontendHelpers.FaciaContentFrontendHelper
 
-object MostPopularTags extends implicits.Collections {
+object MostPopularTags {
 
   /** A descending list of the tags that occur most frequently within the given items of content and how frequently
     * they occur

--- a/sport/app/football/feed/agent.scala
+++ b/sport/app/football/feed/agent.scala
@@ -88,7 +88,7 @@ trait Fixtures extends GuLogging {
   }
 }
 
-trait Results extends GuLogging with implicits.Collections {
+trait Results extends GuLogging {
 
   def footballClient: FootballClient
   def teamNameBuilder: TeamNameBuilder


### PR DESCRIPTION
## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
