### PR TITLE
Rename `ParseResult` to `ParseBlockResult` to avoid shadowing a nested class of a parent class

### DIFF
--- a/article/app/model/ParseBlockId.scala
+++ b/article/app/model/ParseBlockId.scala
@@ -7,9 +7,9 @@ import scala.util.parsing.combinator.RegexParsers
 
 object ParseBlockId extends RegexParsers {
 
-  sealed trait ParseResult { def toOption: Option[String] }
-  case object InvalidFormat extends ParseResult { val toOption = None }
-  case class ParsedBlockId(blockId: String) extends ParseResult { val toOption = Some(blockId) }
+  sealed trait ParseBlockResult { def toOption: Option[String] }
+  case object InvalidFormat extends ParseBlockResult { val toOption = None }
+  case class ParsedBlockId(blockId: String) extends ParseBlockResult { val toOption = Some(blockId) }
 
   private def withParser: Parser[Unit] = "with:" ^^ { _ => () }
   private def block: Parser[Unit] = "block-" ^^ { _ => () }
@@ -18,7 +18,7 @@ object ParseBlockId extends RegexParsers {
 
   // get Id from page parameter
 
-  def fromPageParam(input: String): ParseResult = {
+  def fromPageParam(input: String): ParseBlockResult = {
     def expr: Parser[String] = withParser ~> blockId
 
     parse(expr, input) match {
@@ -29,7 +29,7 @@ object ParseBlockId extends RegexParsers {
 
   // get Id from block id string
 
-  def fromBlockId(input: String): ParseResult = {
+  def fromBlockId(input: String): ParseBlockResult = {
     parse(blockId, input) match {
       case Success(matched, _) => ParsedBlockId(matched)
       case _                   => InvalidFormat


### PR DESCRIPTION
In Scala 2.13, we see this compilation error: _"shadowing a nested class of a parent is deprecated but trait ParseResult shadows class ParseResult defined in trait Parsers; rename the class to something else"_

```
[error] /Users/roberto/guardian/frontend/article/app/model/ParseBlockId.scala:10:16: shadowing a nested class of a parent is deprecated but trait ParseResult shadows class ParseResult defined in trait Parsers; rename the class to something else
[error]   sealed trait ParseResult { def toOption: Option[String] }
[error]                ^
```

`ParseBlockId` extends `RegexParsers`, which itself extends `scala.util.parsing.combinator.Parsers`, a class that has a nested class called `ParseResult` inside it! So we don't want to have a new nested class called `ParseResult` inside `ParseBlockId` - best to rename it.
