### PR TITLE
Add europe network front

### DIFF
--- a/admin/app/views/commercial/takeoverWithEmptyMPUsCreate.scala.html
+++ b/admin/app/views/commercial/takeoverWithEmptyMPUsCreate.scala.html
@@ -22,7 +22,7 @@
         @inputText(takeoverForm("url"), Symbol("_label")-> "Paste URL here:", Symbol("size") -> 100, Symbol("_help") -> "")
         @select(
             takeoverForm("editions"),
-            options = for(e <- Edition.all) yield { e.id -> e.displayName },
+            options = for(e <- Edition.allWithEurope) yield { e.id -> e.displayName },
             Symbol("multiple") -> true,
             Symbol("_label") -> "Editions this applies to (one or multiple):"
         )

--- a/admin/project/build.properties
+++ b/admin/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.6.2

--- a/common/app/common/Edition.scala
+++ b/common/app/common/Edition.scala
@@ -50,6 +50,7 @@ object Edition {
     editions.Us,
     editions.Au,
     editions.International,
+    editions.Europe
   )
 
   lazy val editionFronts = Edition.all.map { e => "/" + e.id.toLowerCase }

--- a/common/app/common/commercial/CommercialProperties.scala
+++ b/common/app/common/commercial/CommercialProperties.scala
@@ -40,7 +40,7 @@ case class CommercialProperties(
       .getOrElse(Set.empty)
 
   def perEdition: Map[Edition, EditionCommercialProperties] = {
-    Edition.all.map { edition =>
+    Edition.allWithEurope.map { edition =>
       (
         edition,
         EditionCommercialProperties(
@@ -83,7 +83,7 @@ object CommercialProperties {
       prebidIndexSites = PrebidIndexSite.fromTag(tag),
     )
 
-  private def isNetworkFront(frontId: String): Boolean = Edition.all.map(_.networkFrontId).contains(frontId)
+  private def isNetworkFront(frontId: String): Boolean = Edition.allWithEurope.map(_.networkFrontId).contains(frontId)
 
   def forNetworkFront(frontId: String): Option[CommercialProperties] = {
     if (isNetworkFront(frontId)) {

--- a/common/app/common/commercial/EditionAdTargeting.scala
+++ b/common/app/common/commercial/EditionAdTargeting.scala
@@ -72,7 +72,7 @@ object EditionAdTargeting {
   )
 
   private def editionTargeting(targeting: Edition => Set[AdTargetParam]): Set[EditionAdTargeting] =
-    for (edition <- Edition.all.toSet[Edition]) yield EditionAdTargeting(edition, paramSet = Some(targeting(edition)))
+    for (edition <- Edition.allWithEurope.toSet[Edition]) yield EditionAdTargeting(edition, paramSet = Some(targeting(edition)))
 
   def fromContent(item: Content): Set[EditionAdTargeting] =
     editionTargeting { edition =>

--- a/common/app/common/commercial/EditionBranding.scala
+++ b/common/app/common/commercial/EditionBranding.scala
@@ -45,17 +45,17 @@ object EditionBranding {
   implicit val editionBrandingFormat = Json.format[EditionBranding]
 
   def fromContent(item: Content): Set[EditionBranding] =
-    Edition.all.toSet[Edition] map { edition =>
+    Edition.allWithEurope.toSet[Edition] map { edition =>
       EditionBranding(edition, BrandingFinder.findBranding(edition.id)(item))
     }
 
   def fromSection(section: Section): Set[EditionBranding] =
-    Edition.all.toSet[Edition] map { edition =>
+    Edition.allWithEurope.toSet[Edition] map { edition =>
       EditionBranding(edition, BrandingFinder.findBranding(edition.id)(section))
     }
 
   def fromTag(tag: Tag): Set[EditionBranding] =
-    Edition.all.toSet[Edition] map { edition =>
+    Edition.allWithEurope.toSet[Edition] map { edition =>
       EditionBranding(edition, BrandingFinder.findBranding(edition.id)(tag))
     }
 }

--- a/common/app/common/editions/Europe.scala
+++ b/common/app/common/editions/Europe.scala
@@ -1,0 +1,18 @@
+package common.editions
+
+import java.util.Locale
+import common._
+import org.joda.time.DateTimeZone
+
+object Europe
+    extends Edition(
+      id = "EUR",
+      displayName = "Europe edition",
+      timezone = DateTimeZone.forID("Europe/London"),
+      locale = Locale.forLanguageTag("en"),
+      networkFrontId = "europe",
+      editionalisedSections = Seq(""), // only the home page
+    ) {
+
+  implicit val EUR = Europe
+}

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -46,3 +46,12 @@ object TableOfContents
       sellByDate = LocalDate.of(2022, 12, 7),
       participationGroup = Perc0C,
     )
+
+object EuropeNetworkFront
+  extends Experiment(
+    name = "europe-network-front",
+    description = "Test new europe network front",
+    owners = Seq(Owner.withGithub("rowannekabalan")),
+    sellByDate = LocalDate.of(2022, 09, 30),
+    participationGroup = Perc0D,
+  )

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -6,7 +6,7 @@ import java.time.LocalDate
 
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =
-    Set(DCRFronts, OfferHttp3, LiveBlogMainMediaPosition, TableOfContents)
+    Set(DCRFronts, OfferHttp3, LiveBlogMainMediaPosition, TableOfContents, EuropeNetworkFront)
 
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -52,6 +52,6 @@ object EuropeNetworkFront
     name = "europe-network-front",
     description = "Test new europe network front",
     owners = Seq(Owner.withGithub("rowannekabalan")),
-    sellByDate = LocalDate.of(2022, 09, 30),
+    sellByDate = LocalDate.of(2022, 9, 30),
     participationGroup = Perc0D,
   )

--- a/common/app/model/PressedPage.scala
+++ b/common/app/model/PressedPage.scala
@@ -25,7 +25,7 @@ object PressedPage {
     def optionalMapEntry(key: String, o: Option[String]): Map[String, String] =
       o.map(value => Map(key -> value)).getOrElse(Map())
 
-    val isNetworkFront: Boolean = Edition.all.exists(_.networkFrontId == id)
+    val isNetworkFront: Boolean = Edition.allWithEurope.exists(_.networkFrontId == id)
     val keywordIds: Seq[String] = frontKeywordIds(id)
     val contentType: DotcomContentType =
       if (isNetworkFront) DotcomContentType.NetworkFront else DotcomContentType.Section
@@ -120,7 +120,7 @@ case class PressedPage(
   lazy val filterEmpty: PressedPage = copy(collections = collections.filterNot(_.isEmpty))
 
   override val metadata: MetaData = PressedPage.makeMetadata(id, seoData, frontProperties, collections)
-  val isNetworkFront: Boolean = Edition.all.exists(_.networkFrontId == id)
+  val isNetworkFront: Boolean = Edition.allWithEurope.exists(_.networkFrontId == id)
 
   /** If a Facia front is a tag or section page, it ought to exist as a tag or section ID for one of its pieces of
     * content.

--- a/common/app/model/facia.scala
+++ b/common/app/model/facia.scala
@@ -18,7 +18,7 @@ case class SeoData(id: String, navSection: String, webTitle: String, title: Opti
 object SeoData extends GuLogging {
   implicit val seoFormatter = Json.format[SeoData]
 
-  val editions = Edition.all.map(_.id.toLowerCase)
+  val editions = Edition.allWithEurope.map(_.id.toLowerCase)
 
   def fromPath(path: String): SeoData =
     path.split('/').toList match {

--- a/common/app/model/package.scala
+++ b/common/app/model/package.scala
@@ -34,7 +34,7 @@ object `package` {
   }
 
   def frontKeywordIds(pageId: String): Seq[String] = {
-    val editions = Edition.all.map(_.id.toLowerCase).toSet
+    val editions = Edition.allWithEurope.map(_.id.toLowerCase).toSet
 
     val parts = pageId.split("/").toList match {
       case edition :: rest if editions.contains(edition) => rest

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -760,5 +760,15 @@ case class NavigationData(
       NavLinks.intOtherLinks,
       NavLinks.intBrandExtensions,
     ),
+  // Europe will have the same navigation links as International
+    europe: EditionNavLinks = EditionNavLinks(
+      NavLinks.intNewsPillar,
+      NavLinks.intOpinionPillar,
+      NavLinks.intSportPillar,
+      NavLinks.intCulturePillar,
+      NavLinks.intLifestylePillar,
+      NavLinks.intOtherLinks,
+      NavLinks.intBrandExtensions,
+    ),
     tagPages: List[String] = NavLinks.tagPages,
 )

--- a/common/app/navigation/Navigation.scala
+++ b/common/app/navigation/Navigation.scala
@@ -170,6 +170,7 @@ object NavMenu {
       case editions.Us            => navigationData.us
       case editions.Au            => navigationData.au
       case editions.International => navigationData.international
+      case editions.Europe        => navigationData.europe
     }
 
     NavRoot(
@@ -202,7 +203,7 @@ object NavMenu {
       "type/cartoon",
       "cartoons/archive",
     )
-    val networkFronts = Seq("uk", "us", "au", "international")
+    val networkFronts = Seq("uk", "us", "au", "international", "europe")
     val tags = getTagsFromPage(page)
     val commonKeywords = tags.keywordIds
       .intersect(navigationData.tagPages)

--- a/common/app/navigation/Navigation.scala
+++ b/common/app/navigation/Navigation.scala
@@ -106,7 +106,7 @@ object NavMenu {
    * UsSportsPillar
    */
   private[navigation] def getChildrenFromOtherEditions(edition: Edition): Seq[NavLink] = {
-    Edition.others(edition).flatMap(edition => NavMenu.navRoot(edition).children ++ NavMenu.navRoot(edition).otherLinks)
+    Edition.othersWithEurope(edition).flatMap(edition => NavMenu.navRoot(edition).children ++ NavMenu.navRoot(edition).otherLinks)
   }
 
   @tailrec

--- a/common/app/views/fragments/nav/editionPicker.scala.html
+++ b/common/app/views/fragments/nav/editionPicker.scala.html
@@ -13,7 +13,7 @@
     </button>
 
     <ul class="menu-group">
-        @Edition.all.map { edition =>
+        @Edition.allWithEurope.map { edition =>
              @if((edition != Edition(request))) {
                  <li class="menu-item">
                      <a data-link-name="nav2 : edition-picker: @edition.id"

--- a/common/project/build.properties
+++ b/common/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.6.2

--- a/common/test/common/EditionTest.scala
+++ b/common/test/common/EditionTest.scala
@@ -42,7 +42,7 @@ class EditionTest extends AnyFlatSpec with Matchers {
     // because they are used as defaults for other editions that do not override them
 
     val defaultSections = Edition.defaultEdition.editionalisedSections.sorted
-    val allSections = Edition.all.flatMap(_.editionalisedSections).distinct.sorted
+    val allSections = Edition.allWithEurope.flatMap(_.editionalisedSections).distinct.sorted
 
     allSections should equal(defaultSections)
   }

--- a/common/test/common/LinkToTest.scala
+++ b/common/test/common/LinkToTest.scala
@@ -1,7 +1,7 @@
 package common
 
 import org.scalatest.matchers.should.Matchers
-import common.editions.{Au, International, Uk, Us}
+import common.editions.{Au, International, Uk, Us, Europe}
 import org.scalatest.flatspec.AnyFlatSpec
 import test._
 import play.api.test.FakeRequest
@@ -89,6 +89,10 @@ class LinkToTest extends AnyFlatSpec with Matchers with implicits.FakeRequests {
     TheGuardianLinkTo("/", International) should be("https://www.theguardian.com/international")
   }
 
+  it should "correctly editionalise the Europe front" in {
+    TheGuardianLinkTo("/", Europe) should be("https://www.theguardian.com/europe")
+  }
+
   it should "correctly link editionalised sections" in {
     for (edition <- editions) {
       for (section <- edition.editionalisedSections) {
@@ -104,6 +108,13 @@ class LinkToTest extends AnyFlatSpec with Matchers with implicits.FakeRequests {
     // Only the front page is different in the international edition, the others go to UK...
     for (section <- International.editionalisedSections.filterNot(_.isEmpty)) {
       TheGuardianLinkTo(s"/$section", International) should endWith(s"www.theguardian.com/uk/$section")
+    }
+  }
+
+  it should "correctly link editionalised sections to the UK version for the Europe edition" in {
+    // Only the front page is different in the europe edition, the others go to UK...
+    for (section <- Europe.editionalisedSections.filterNot(_.isEmpty)) {
+      TheGuardianLinkTo(s"/$section", Europe) should endWith(s"www.theguardian.com/uk/$section")
     }
   }
 

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -286,7 +286,7 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
           "us" -> FaciaPressMetrics.UsPressLatencyMetric,
           "au" -> FaciaPressMetrics.AuPressLatencyMetric,
         )
-        if (Edition.all.map(_.id.toLowerCase).contains(path)) {
+        if (Edition.allWithEurope.map(_.id.toLowerCase).contains(path)) {
           metricsByPath.get(path).foreach { metric =>
             metric.recordDuration(pressDuration.toDouble)
           }
@@ -506,7 +506,7 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
   //This will turn au/culture into culture. We want to stay consistent with the manual entry and autogeneration
   private def removeLeadEditionFromSectionId(sectionId: String): String =
     sectionId.split('/').toList match {
-      case edition :: tail if Edition.all.map(_.id.toLowerCase).contains(edition.toLowerCase) => tail.mkString("/")
+      case edition :: tail if Edition.allWithEurope.map(_.id.toLowerCase).contains(edition.toLowerCase) => tail.mkString("/")
       case _                                                                                  => sectionId
     }
 

--- a/facia/app/controllers/front/Front.scala
+++ b/facia/app/controllers/front/Front.scala
@@ -5,7 +5,7 @@ import common._
 class Front extends GuLogging {
 
   def idFromEditionKey(section: String): String = {
-    val editions = Edition.all.map { _.id.toLowerCase }
+    val editions = Edition.allWithEurope.map { _.id.toLowerCase }
     val sectionId = section.split("/").last
     if (editions.contains(sectionId)) "" else sectionId
   }

--- a/onward/app/feed/MostPopularAgent.scala
+++ b/onward/app/feed/MostPopularAgent.scala
@@ -112,7 +112,7 @@ class MostPopularAgent(contentApiClient: ContentApiClient, ophanApi: OphanApi, w
 
   // Note that here we are in procedural land here (not functional)
   def refresh()(implicit ec: ExecutionContext): Unit = {
-    MostPopularRefresh.refreshAll(Edition.all)(refresh)
+    MostPopularRefresh.refreshAll(Edition.allWithEurope)(refresh)
     refreshGlobal()
   }
 }


### PR DESCRIPTION
## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
