### PR TITLE
Consentless ads `0%` test

### DIFF
--- a/static/src/javascripts/bootstraps/standalone.commercial.ts
+++ b/static/src/javascripts/bootstraps/standalone.commercial.ts
@@ -14,6 +14,8 @@
 
 import { EventTimer } from '@guardian/commercial-core';
 import { log } from '@guardian/libs';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { consentlessAds } from 'common/modules/experiments/tests/consentlessAds';
 import reportError from '../lib/report-error';
 import { catchErrorsWithContext } from '../lib/robust';
 import { initAdblockAsk } from '../projects/commercial/adblock-ask';
@@ -199,8 +201,14 @@ const bootCommercial = async (): Promise<void> => {
 	}
 };
 
-if (window.guardian.mustardCut || window.guardian.polyfilled) {
-	void bootCommercial();
+if (isInVariantSynchronous(consentlessAds, "variant")){
+	// opt out ads regardless of consent state?
 } else {
-	window.guardian.queue.push(bootCommercial);
+	if (window.guardian.mustardCut || window.guardian.polyfilled) {
+		void bootCommercial();
+	} else {
+		window.guardian.queue.push(bootCommercial);
+	}
 }
+
+

--- a/static/src/javascripts/projects/commercial/modules/consentless/define-slot.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/define-slot.ts
@@ -1,0 +1,23 @@
+const getOptOutSlotName = (dfpSlotName: string): string => {
+	if (dfpSlotName.includes('top-above-nav')) {
+		return 'homepage-lead';
+	}
+	return 'homepage-rect';
+};
+
+const defineSlot = (slotId: string): void => {
+	window.ootag.queue.push(() => {
+		window.ootag.defineSlot({
+			adSlot: getOptOutSlotName(slotId),
+			targetId: slotId,
+			filledCallback: () => {
+				console.log(`filled consentless ${slotId}`);
+			},
+			emptyCallback: () => {
+				console.log(`empty consentless ${slotId}`);
+			},
+		});
+	});
+};
+
+export { defineSlot };

--- a/static/src/javascripts/projects/commercial/modules/consentless/dynamic/article-inline.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/dynamic/article-inline.ts
@@ -1,0 +1,203 @@
+import { adSizes, createAdSlot } from '@guardian/commercial-core';
+import {
+	computeStickyHeights,
+	insertHeightStyles,
+} from 'commercial/modules/sticky-inlines';
+import { spaceFiller } from 'common/modules/article/space-filler';
+import { commercialFeatures } from 'common/modules/commercial/commercial-features';
+import type {
+	SpacefinderItem,
+	SpacefinderRules,
+	SpacefinderWriter,
+} from 'common/modules/spacefinder';
+import { getBreakpoint, getViewport } from 'lib/detect-viewport';
+import { getUrlVars } from 'lib/url';
+import fastdom from '../../../../../lib/fastdom-promise';
+import { defineSlot } from '../define-slot';
+
+type SlotName = Parameters<typeof createAdSlot>[0];
+
+type ContainerOptions = {
+	sticky?: boolean;
+	enableDebug?: boolean;
+	className?: string;
+};
+
+const articleBodySelector = '.article-body-commercial-selector';
+
+const adSlotClassSelectorSizes = {
+	minAbove: 500,
+	minBelow: 500,
+};
+
+const sfdebug = getUrlVars().sfdebug;
+
+/**
+ * Get the classname for an ad slot container
+ *
+ * We add 2 to the index because these are always ads added in the second pass.
+ *
+ * e.g. the 0th container inserted in pass 2 becomes `ad-slot-container--2` to match `inline2`
+ *
+ * @param i Index of winning paragraph
+ * @returns The classname for container
+ */
+const getStickyContainerClassname = (i: number) => `ad-slot-container-${i + 2}`;
+
+const wrapSlotInContainer = (
+	ad: HTMLElement,
+	options: ContainerOptions = {},
+) => {
+	const container = document.createElement('div');
+
+	container.className = `ad-slot-container ${options.className ?? ''}`;
+
+	if (options.sticky) {
+		ad.style.cssText += 'position: sticky; top: 0;';
+	}
+
+	if (options.enableDebug) {
+		container.style.cssText += 'outline: 2px solid red;';
+	}
+
+	container.appendChild(ad);
+	return container;
+};
+
+const insertAdAtPara = (
+	para: Node,
+	name: string,
+	type: SlotName,
+	classes?: string,
+	containerOptions: ContainerOptions = {},
+): Promise<void> => {
+	const ad = createAdSlot(type, {
+		name,
+		classes,
+	});
+
+	const node = wrapSlotInContainer(ad, containerOptions);
+
+	return fastdom
+		.mutate(() => {
+			if (para.parentNode) {
+				para.parentNode.insertBefore(node, para);
+			}
+		})
+		.then(() => {
+			defineSlot(ad.id);
+		});
+};
+
+// this facilitates a second filtering, now taking into account the candidates' position/size relative to the other candidates
+const filterNearbyCandidates =
+	(maximumAdHeight: number) =>
+	(candidate: SpacefinderItem, lastWinner?: SpacefinderItem): boolean => {
+		// No previous winner
+		if (lastWinner === undefined) return true;
+
+		return (
+			Math.abs(candidate.top - lastWinner.top) - maximumAdHeight >=
+			adSlotClassSelectorSizes.minBelow
+		);
+	};
+
+const addMobileInlineAds = async () => {
+	// TODO
+};
+
+const addDesktopInlineAds = async () => {
+	// For any other inline
+	const rules: SpacefinderRules = {
+		bodySelector: articleBodySelector,
+		slotSelector: ' > p',
+		minAbove: 1000,
+		minBelow: 300,
+		selectors: {
+			' .ad-slot': adSlotClassSelectorSizes,
+			' [data-spacefinder-role="immersive"]': {
+				minAbove: 0,
+				minBelow: 600,
+			},
+		},
+		filter: filterNearbyCandidates(adSizes.halfPage.height),
+	};
+
+	const enableDebug = sfdebug === '1';
+
+	const insertAds: SpacefinderWriter = async (paras) => {
+		// Make ads sticky in containers if using containers and in sticky test variant
+		// Compute the height of containers in which ads will remain sticky
+		const includeStickyContainers = !!getUrlVars().multiSticky;
+
+		if (includeStickyContainers) {
+			const stickyContainerHeights = await computeStickyHeights(
+				paras,
+				articleBodySelector,
+			);
+
+			void insertHeightStyles(
+				stickyContainerHeights.map((height, index) => [
+					getStickyContainerClassname(index),
+					height,
+				]),
+			);
+		}
+
+		const slots = paras.map((para, i) => {
+			const inlineId = i + 1;
+
+			if (sfdebug) {
+				para.style.cssText += 'border: thick solid green;';
+			}
+
+			let containerClasses = '';
+
+			if (includeStickyContainers) {
+				containerClasses += getStickyContainerClassname(i);
+			}
+
+			if (inlineId !== 1) {
+				containerClasses +=
+					' offset-right ad-slot--offset-right ad-slot-container--offset-right';
+			}
+
+			const containerOptions = {
+				sticky: includeStickyContainers,
+				className: containerClasses,
+				enableDebug,
+			};
+
+			return insertAdAtPara(
+				para,
+				`inline${inlineId}`,
+				'inline',
+				'inline',
+				containerOptions,
+			);
+		});
+		await Promise.all(slots);
+	};
+
+	return spaceFiller.fillSpace(rules, insertAds, {
+		waitForImages: true,
+		waitForInteractives: true,
+		debug: enableDebug,
+	});
+};
+
+const addInlineAds = (): Promise<boolean | void> =>
+	getBreakpoint(getViewport().width) === 'mobile'
+		? addMobileInlineAds()
+		: addDesktopInlineAds();
+
+const initArticleInline = async (): Promise<void> => {
+	// do we need to rerun for the sign-in gate?
+	if (!commercialFeatures.articleBodyAdverts) {
+		return;
+	}
+
+	await addInlineAds();
+};
+
+export { initArticleInline };

--- a/static/src/javascripts/projects/commercial/modules/consentless/init-fixed-slots.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/init-fixed-slots.ts
@@ -1,0 +1,19 @@
+import { defineSlot } from './define-slot';
+
+const initFixedSlots = (): Promise<void> => {
+	// get slots
+	const adverts = [
+		...document.querySelectorAll<HTMLElement>(
+			'.js-ad-slot:not(.ad-slot--survey)',
+		),
+	];
+
+	// define slots
+	adverts.forEach((slotElement) => {
+		defineSlot(slotElement.id);
+	});
+
+	return Promise.resolve();
+};
+
+export { initFixedSlots };

--- a/static/src/javascripts/projects/commercial/modules/consentless/prepare-ootag.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/prepare-ootag.ts
@@ -1,0 +1,23 @@
+import { loadScript } from '@guardian/libs';
+
+function initConsentless(): Promise<void> {
+	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- This isn't defined yet
+	window.ootag = window.ootag || {};
+	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- This isn't defined yet
+	window.ootag.queue = window.ootag.queue || [];
+	window.ootag.queue.push(function () {
+		window.ootag.initializeOo({
+			publisher: 33,
+			noLogging: 0,
+			// consentTimeOutMS: 5000,
+			onlyNoConsent: 1,
+		});
+		window.ootag.addParameter('test', 'yes');
+	});
+
+	// TODO this seems to be safeframeless version. Ask OptOut how we can use safeframes.
+	void loadScript('//cdn.optoutadvertising.com/script/ootag.min.js');
+	return Promise.resolve();
+}
+
+export { initConsentless };

--- a/static/src/javascripts/projects/commercial/modules/consentless/prepare-ootag.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/prepare-ootag.ts
@@ -1,10 +1,11 @@
 import { loadScript } from '@guardian/libs';
 
 function initConsentless(): Promise<void> {
-	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- This isn't defined yet
-	window.ootag = window.ootag || {};
-	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- This isn't defined yet
-	window.ootag.queue = window.ootag.queue || [];
+	// Stub the command queue
+	// @ts-expect-error -- it’s a stub, not the whole OO tag object
+	window.ootag = {
+		queue: [],
+	};
 	window.ootag.queue.push(function () {
 		window.ootag.initializeOo({
 			publisher: 33,

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -1,4 +1,5 @@
 import type { ABTest } from '@guardian/ab-core';
+import { consentlessAds } from './tests/consentlessAds';
 import { deeplyReadArticleFooterTest } from './tests/deeply-read-article-footer';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
@@ -11,4 +12,5 @@ export const concurrentTests: readonly ABTest[] = [
 	signInGateMainControl,
 	remoteRRHeaderLinksTest,
 	deeplyReadArticleFooterTest,
+	consentlessAds,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/consentlessAds.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/consentlessAds.ts
@@ -1,0 +1,19 @@
+import type { ABTest } from '@guardian/ab-core';
+import { noop } from '../../../../../lib/noop';
+
+export const consentlessAds: ABTest = {
+	id: 'ConsentlessAds',
+	author: '@commercial-dev',
+	start: '2022-08-11',
+	expiry: '2023-06-01',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria: 'All pageviews',
+	successMeasure: 'Testing Opt Out ads in production',
+	description: 'Use consentless ad stack rather than consented / standalone',
+	variants: [
+		{ id: 'control', test: noop },
+		{ id: 'variant', test: noop },
+	],
+	canRun: () => true,
+};

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -256,7 +256,13 @@ interface Window {
 			dfpEnv?: DfpEnv;
 		};
 	};
-
+	// TODO type this properly!
+	ootag: {
+		queue: Array<() => void>;
+		initializeOo: (o: Record<string, unknown>) => void;
+		addParameter: (key: string, value: string) => void;
+		defineSlot: (o: Record<string, unknown>) => void;
+	};
 	confiant?: Confiant;
 	apstag?: Apstag;
 	_comscore?: ComscoreGlobals[];

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -240,6 +240,20 @@ interface IasPET {
 	pubId?: string;
 }
 
+interface OptOutInitializeOptions {
+	publisher: number;
+	onlyNoConsent: 0 | 1;
+	consentTimeOutMS?: 5000;
+	noLogging?: 0 | 1;
+}
+
+interface OptOutDefineSlotOptions {
+	adSlot: string;
+	targetId: string;
+	filledCallback?: () => void;
+	emptyCallback?: () => void;
+}
+
 interface Window {
 	// eslint-disable-next-line id-denylist -- this *is* the guardian object
 	guardian: {
@@ -256,12 +270,11 @@ interface Window {
 			dfpEnv?: DfpEnv;
 		};
 	};
-	// TODO type this properly!
 	ootag: {
 		queue: Array<() => void>;
-		initializeOo: (o: Record<string, unknown>) => void;
+		initializeOo: (o: OptOutInitializeOptions) => void;
 		addParameter: (key: string, value: string) => void;
-		defineSlot: (o: Record<string, unknown>) => void;
+		defineSlot: (o: OptOutDefineSlotOptions) => void;
 	};
 	confiant?: Confiant;
 	apstag?: Apstag;

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -129,6 +129,24 @@
   "../lib/config.d.ts",
   "../projects/common/modules/commercial/commercial-features.ts"
  ],
+ "../projects/commercial/modules/consentless/define-slot.ts": [],
+ "../projects/commercial/modules/consentless/dynamic/article-inline.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../lib/detect-viewport.ts",
+  "../lib/fastdom-promise.js",
+  "../lib/url.ts",
+  "../projects/commercial/modules/consentless/define-slot.ts",
+  "../projects/commercial/modules/sticky-inlines.ts",
+  "../projects/common/modules/article/space-filler.ts",
+  "../projects/common/modules/commercial/commercial-features.ts",
+  "../projects/common/modules/spacefinder.ts"
+ ],
+ "../projects/commercial/modules/consentless/init-fixed-slots.ts": [
+  "../projects/commercial/modules/consentless/define-slot.ts"
+ ],
+ "../projects/commercial/modules/consentless/prepare-ootag.ts": [
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
+ ],
  "../projects/commercial/modules/creatives/page-skin.ts": [
   "../../../../node_modules/fastdom/fastdom.d.ts",
   "../lib/detect.js",
@@ -651,6 +669,7 @@
  ],
  "../projects/common/modules/experiments/ab-tests.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
+  "../projects/common/modules/experiments/tests/consentlessAds.ts",
   "../projects/common/modules/experiments/tests/deeply-read-article-footer.js",
   "../projects/common/modules/experiments/tests/remote-header-test.js",
   "../projects/common/modules/experiments/tests/sign-in-gate-main-control.js",
@@ -677,6 +696,10 @@
   "../projects/common/modules/experiments/ab-utils.ts"
  ],
  "../projects/common/modules/experiments/automatLog.ts": [],
+ "../projects/common/modules/experiments/tests/consentlessAds.ts": [
+  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
+  "../lib/noop.ts"
+ ],
  "../projects/common/modules/experiments/tests/deeply-read-article-footer.js": [],
  "../projects/common/modules/experiments/tests/remote-header-test.js": [],
  "../projects/common/modules/experiments/tests/sign-in-gate-main-control.js": [],
@@ -725,6 +748,9 @@
   "../projects/commercial/modules/article-body-adverts.ts",
   "../projects/commercial/modules/comment-adverts.ts",
   "../projects/commercial/modules/comscore.ts",
+  "../projects/commercial/modules/consentless/dynamic/article-inline.ts",
+  "../projects/commercial/modules/consentless/init-fixed-slots.ts",
+  "../projects/commercial/modules/consentless/prepare-ootag.ts",
   "../projects/commercial/modules/dfp/dfp-env-globals.ts",
   "../projects/commercial/modules/dfp/prepare-a9.ts",
   "../projects/commercial/modules/dfp/prepare-googletag.ts",
@@ -745,6 +771,8 @@
   "../projects/commercial/modules/track-scroll-depth.ts",
   "../projects/common/modules/commercial/commercial-features.ts",
   "../projects/common/modules/commercial/user-features.ts",
+  "../projects/common/modules/experiments/ab.ts",
+  "../projects/common/modules/experiments/tests/consentlessAds.ts",
   "types.ts"
  ],
  "types.ts": []


### PR DESCRIPTION
## What does this change?

This PR adds the broad strokes for setting up _consentless_ advertising, using Opt Out Advertising as a third party.

This is currently hidden behind a 0% test, so no visitors to the website will be exposed to this experience without explicitly opting in via the predefined URL.

### Some notes
- This currently just works with test adverts that were already defined in this [test page](https://cdn.optoutadvertising.com/script/sf/demo.html).
- Currently only setups a subset of our slots - those that are SSRed onto the page and those inserted 'inline' on articles.
- We're attempting to minimise any changes to the consented advertising experience for the purposes of this test (so as not to affect the experience for currently 100% of the audience). Hence, we include a simple high-level variant participation in `standalone.commercial.test`, without moving any of these modules around.
- The Opt Out advertising tag performs its own check for no-consent. So even if you opt into the test you'll only see Opt Out test ads if you reject-all in the CMP. We may adjust this behaviour in the future.
- We're currently porting logic over to the new Opt Out path piece by piece, so as not to too tightly couple ourselves early on to the existing ad stack. This is why there's still lots of duplication in the implementation of article adverts. More thought will be put into how we handle this as we proceed.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation) - [DCR PR](https://github.com/guardian/dotcom-rendering/pull/5706)

## Screenshots

<img width="542" alt="Screenshot 2022-08-12 at 10 13 47" src="https://user-images.githubusercontent.com/7014230/184323887-d00cc65f-1aaf-4c99-933e-d49798c289d2.png">

### Tested

- [X] Locally
- [x] On CODE
