### PR TITLE
Scala 2.13: Add toDouble

### DIFF
--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -26,12 +26,12 @@ object SystemMetrics extends implicits.Numbers {
 
     def gcCount: Double = {
       val totalGcCount = bean.getCollectionCount
-      totalGcCount - lastGcCount.getAndSet(totalGcCount)
+      totalGcCount - lastGcCount.getAndSet(totalGcCount).toDouble
     }
 
     def gcTime: Double = {
       val totalGcTime = bean.getCollectionTime
-      totalGcTime - lastGcTime.getAndSet(totalGcTime)
+      totalGcTime - lastGcTime.getAndSet(totalGcTime).toDouble
     }
   }
 
@@ -221,9 +221,14 @@ class CloudWatchMetricsLifecycle(
           s"${gc.name}-gc-count-per-min",
           "Used heap memory (MB)",
           StandardUnit.Count,
-          () => gc.gcCount.toLong,
+          () => gc.gcCount,
         ),
-        GaugeMetric(s"${gc.name}-gc-time-per-min", "Used heap memory (MB)", StandardUnit.Count, () => gc.gcTime.toLong),
+        GaugeMetric(
+          s"${gc.name}-gc-time-per-min",
+          "Used heap memory (MB)",
+          StandardUnit.Count,
+          () => gc.gcTime,
+        ),
       )
     }
 
@@ -256,5 +261,5 @@ class CloudWatchMetricsLifecycle(
 
 object bytesAsMb {
   // divide by 1048576 to convert bytes to MB
-  def apply(bytes: Long): Long = bytes / 1048576
+  def apply(bytes: Long): Double = (bytes / 1048576).toDouble
 }

--- a/common/app/metrics/FrontendMetrics.scala
+++ b/common/app/metrics/FrontendMetrics.scala
@@ -138,7 +138,7 @@ object DurationMetric {
   def withMetrics[A](metric: DurationMetric)(block: => A): A = {
     val stopWatch: StopWatch = new StopWatch
     val result = block
-    metric.recordDuration(stopWatch.elapsed)
+    metric.recordDuration(stopWatch.elapsed.toDouble)
     result
   }
 }

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -278,7 +278,7 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
       case Success(_) =>
         val pressDuration: Long = stopWatch.elapsed
         log.info(s"Successfully pressed $path in $pressDuration ms")
-        FaciaPressMetrics.AllFrontsPressLatencyMetric.recordDuration(pressDuration)
+        FaciaPressMetrics.AllFrontsPressLatencyMetric.recordDuration(pressDuration.toDouble)
 
         /** We record separate metrics for each of the editions' network fronts */
         val metricsByPath = Map(
@@ -288,7 +288,7 @@ trait FapiFrontPress extends EmailFrontPress with GuLogging {
         )
         if (Edition.all.map(_.id.toLowerCase).contains(path)) {
           metricsByPath.get(path).foreach { metric =>
-            metric.recordDuration(pressDuration)
+            metric.recordDuration(pressDuration.toDouble)
           }
         }
       case Failure(error) =>


### PR DESCRIPTION
```
// Scala 2.12. This is fine
Long x = 100000000000000
Double y =  y

// Scala 2.13. It has to be written
Long x = 100000000000000
Double y = x.toDouble
```

Otherwise we're getting errors like:

```
[error] /Users/ioanna_kokkini/Projects/frontend/common/app/common/metrics.scala:29:20: Widening conversion from Long to Double is deprecated because it loses precision. Write `.toDouble` instead.
[error]       totalGcCount - lastGcCount.getAndSet(totalGcCount)
[error]                    ^
```

Pulled from: https://github.com/guardian/frontend/pull/25190