### PR TITLE
dynamic-package-change-single-image-to-100

### DIFF
--- a/common/app/layout/slices/DynamicPackage.scala
+++ b/common/app/layout/slices/DynamicPackage.scala
@@ -18,7 +18,7 @@ object DynamicPackage extends DynamicContainer {
 
     storiesIncludingBackfill.length match {
       case 0     => Nil
-      case 1     => Seq(FullMedia75)
+      case 1     => Seq(FullMedia100)
       case 2     => Seq(ThreeQuarterQuarter)
       case 3     => Seq(ThreeQuarterTallQuarter2)
       case 4     => Seq(ThreeQuarterTallQuarter1Ql2)


### PR DESCRIPTION
Co-Authored-By: Ashleigh Carr <ashcorr20@gmail.com>

## What does this change?
When only one story exists main image takes up full width
Resolves issue: https://github.com/guardian/frontend/issues/25194
## Does this change need to be reproduced in dotcom-rendering ?
Yes. Will be done in a separate PR.

## Screenshots



| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/110032454/184354842-791c0063-8cfa-426c-8aa1-f21f022da1d4.png
[after]: https://user-images.githubusercontent.com/110032454/184353807-d82e1186-7438-49ea-baf4-6f63bcf231da.png



