### PR TITLE
Scala 2.13: Add () to dev-build routes 

### DIFF
--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -223,7 +223,7 @@ POST           /press/r2/batchupload                                            
 
 GET            /admin/football                                                                                                   controllers.admin.SiteController.index
 GET            /admin/football/browse                                                                                            controllers.admin.PaBrowserController.browse
-POST           /admin/football/browserRedirect                                                                                   controllers.admin.PaBrowserController.browserSubstitution
+POST           /admin/football/browserRedirect                                                                                   controllers.admin.PaBrowserController.browserSubstitution()
 GET            /admin/football/browser/*query                                                                                    controllers.admin.PaBrowserController.browser(query)
 GET            /admin/football/player                                                                                            controllers.admin.PlayerController.playerIndex
 POST           /admin/football/player/card                                                                                       controllers.admin.PlayerController.redirectToCard
@@ -261,13 +261,13 @@ GET            /commercial/books/api/book.json                                  
 GET            /commercial/books/api/books.json                                                                                  commercial.controllers.BookOffersController.getBooks
 GET            /commercial/api/capi-single.json                                                                                  commercial.controllers.ContentApiOffersController.nativeJson
 GET            /commercial/api/capi-multiple.json                                                                                commercial.controllers.ContentApiOffersController.nativeJsonMulti
-GET            /commercial/api/traffic-driver.json                                                                               commercial.controllers.TrafficDriverController.renderJson
-GET            /commercial/api/multi.json                                                                                        commercial.controllers.Multi.getMulti
+GET            /commercial/api/traffic-driver.json                                                                               commercial.controllers.TrafficDriverController.renderJson()
+GET            /commercial/api/multi.json                                                                                        commercial.controllers.Multi.getMulti()
 GET            /$path<commercial-containers>                                                                                     controllers.FaciaController.renderFront(path)
 GET            /advertiser-content/:campaignName/:pageName                                                                       commercial.controllers.HostedContentController.renderHostedPage(campaignName, pageName)
 GET            /advertiser-content/:campaignName/:pageName/:cType/onward.json                                                    commercial.controllers.HostedContentController.renderOnwardComponent(campaignName, pageName, cType)
 GET            /advertiser-content/:campaignName/:pageName/autoplay.json                                                         commercial.controllers.HostedContentController.renderAutoplayComponent(campaignName, pageName)
-GET            /commercial/anx/anxresize.js                                                                                      commercial.controllers.PiggybackPixelController.resize
+GET            /commercial/anx/anxresize.js                                                                                      commercial.controllers.PiggybackPixelController.resize()
 GET            /commercial/cmp/vendorlist.json                                            commercial.controllers.CmpDataController.renderVendorlist()
 GET            /commercial/cmp/shortvendorlist.json                                      commercial.controllers.CmpDataController.renderShortVendorlist()
 GET            /commercial/amp-iframe.html                                                                                       commercial.controllers.AmpIframeHtmlController.renderAmpIframeHtml()


### PR DESCRIPTION
Applies the same change as this PR https://github.com/guardian/frontend/pull/25362 but in `dev-build` this time. If we don't do it `dev-build` used for local development won't compile anymore after the Scala 2.13 switch.

Pulled from: https://github.com/guardian/frontend/pull/25190