### PR TITLE
Scala 2.13: Use a stub ContentApiClient rather than a mock

### DIFF
--- a/facia-press/test/frontpress/FaciaClientTest.scala
+++ b/facia-press/test/frontpress/FaciaClientTest.scala
@@ -1,10 +1,12 @@
 package frontpress
 
 import com.gu.contentapi.client.ContentApiClient
-import com.gu.contentapi.client.model.SearchQuery
+import com.gu.contentapi.client.model.{HttpResponse, SearchQuery}
 import org.scalatest.flatspec._
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
+
+import scala.concurrent.{ExecutionContext, Future}
 
 class FaciaClientTest extends AsyncFlatSpec with Matchers with MockitoSugar {
 
@@ -13,13 +15,19 @@ class FaciaClientTest extends AsyncFlatSpec with Matchers with MockitoSugar {
     // versions of FAPI client and CAPI client we are using are incompatible - the FAPI client will have been
     // compiled against a different version of the CAPI client.
 
-    val mockContentApiClient = mock[ContentApiClient]
+    val stubContentApiClient = new ContentApiClient {
+      override def apiKey: String = ""
+      override def get(url: String, headers: Map[String, String])(implicit
+          context: ExecutionContext,
+      ): Future[HttpResponse] =
+        Future.successful(HttpResponse(Array.empty, 500, ""))
+    }
 
     // This is only exercising the code to send the request, not recieve the result, but it's enough to trigger the
     // java.lang.NoSuchMethodError seen in https://github.com/guardian/frontend/pull/25139#issuecomment-1163407402
     noException shouldBe thrownBy(
       com.gu.facia.api.contentapi.ContentApi.getHydrateResponse(
-        mockContentApiClient,
+        stubContentApiClient,
         Seq(
           SearchQuery().tag("profile/roberto-tyley"),
           SearchQuery().tag("stage/comedy"),


### PR DESCRIPTION
This test, introduced with https://github.com/guardian/frontend/pull/25139, is intended to fail if incompatible versions of CAPI & FAPI are used. However, it also failed when we switched to Scala 2.13 - there seems to be some difference in the way Future.traverse behaves between the two versions of Scala - the `null` values returned by the Mockito mock didn't cause a
problem in Scala 2.12, but threw a `NullPointerException` in Scala 2.13 (in `Future.zipwith`).

Easiest fix is to use a stub, that returns non-null objects, rather than a mock. The requests made by this stub ContentApiClient will never succeed, but we've verified that the calls do indeed only fail with an exception when the versions of CAPI & FAPI are incompatible.
