### PR TITLE
Do not filter section label name tag for immersives

### DIFF
--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -745,7 +745,7 @@ object SubMetaLinks {
     val sectionLabels = List(sectionLink, secondaryLink).flatten
     val keywordSubMetaLinks = tags.keywords
       .filterNot(_.isSectionTag)
-      .filterNot(k => sectionLabelName.contains(k.name))
+      .filterNot(k => sectionLink.exists(_.text == k.name))
       .filterNot(t => blogOrSeriesTag.map(_.id).contains(t.id))
       .take(6)
       .map(tag => SubMetaLink(tag.metadata.url, makeKeywordName(tag, tags.keywords), Some(s"keyword: ${tag.id}")))


### PR DESCRIPTION
This should fix an issue flagged where top tags for articles set to immersive are not appearing on the page.

## What does this change?

On regular articles, the submeta includes Section links and Keyword links.  The first subMetaSectionLink is generally the webtitle of the first keyword tag (e.g. History), and the second subMetaSectionLink is the webtitle of the first blog or series tag (e.g. The long read).

Since the first subMetaSectionLink is also the first subMetaKeywordLinks tag, we exclude keyword tags with the same webtitle as the first subMetaSectionLink.

![Screenshot 2022-08-12 at 17 17 36](https://user-images.githubusercontent.com/2619836/184399781-b5115eca-d2d8-4bdd-957c-0b5de51a6250.png)

Regular article: https://www.theguardian.com/education/2016/mar/02/cult-of-memory-when-history-does-more-harm-than-good

The exception to this is immersive articles, which only have the blog/series subMetaSectionLink. But in this case we still exclude the first keyword tag. The first keyword tag of the example below is "Second world war" but this is not displayed.

![Screenshot 2022-08-12 at 17 27 07](https://user-images.githubusercontent.com/2619836/184402132-9d7745e4-2e17-4d1e-b160-995b761965e5.png)

Immersive article: https://www.theguardian.com/world/2022/aug/11/bolivia-tin-baron-moritz-hochschild-saved-thousands-of-jewish-refugees

This PR changes the behaviour to only exclude the the keyword tag from the subMetaKeywordLinks if it is going to be included in the subMetaSectionLinks.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally (json only)
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
