### PR TITLE
Add 250px min height for merchandising slots on Fronts

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -457,6 +457,10 @@
     }
 }
 
+.ad-slot--merchandising {
+    min-height: 250px;
+}
+
 // See implementation on DCR
 // mark: dca5c7dd-dda4-4922-9317-a55a3789fe4c
 .ad-slot--carrot {

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -457,7 +457,8 @@
     }
 }
 
-.ad-slot--merchandising {
+.ad-slot--merchandising,
+.ad-slot--merchandising-high {
     min-height: 250px;
 }
 


### PR DESCRIPTION
## What does this change?

This adds a minimum height of 250px for the merchandising and merchandising-high ad slots on Fronts.

This change has been made in DCR for Article and Liveblog page types.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes [here](https://github.com/guardian/dotcom-rendering/pull/5561) and [here](https://github.com/guardian/dotcom-rendering/pull/5679)

## Screenshots

Before - see how the merchandising slot "jumps in"

https://user-images.githubusercontent.com/9574885/182183021-6ee3ed29-8361-436c-9c28-3d257348c823.mp4


After - 250px of space is reserved, so the "jumpiness" is reduced (network: fast 3G for illustration purposes)

https://user-images.githubusercontent.com/9574885/182185723-1d8d347e-244f-43ff-9226-f19a8e0d9511.mov

## What is the value of this and can you measure success?

We expect our CLS score to improve given that there is now a much lower probability that a merchandising slot will be in the viewport when the height jumps from 0px to the height of the ad.

We expect the user experience to improve given the expected reduction in "jumpiness".

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No, as the ad slot is not present on the page for ad-free
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
