### PR TITLE
fix bug for expired callout rendering

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/CalloutExtraction.scala
+++ b/common/app/model/dotcomrendering/pageElements/CalloutExtraction.scala
@@ -167,6 +167,11 @@ object CalloutExtraction {
     }
   }
 
+  def isCallout(html: String): Boolean = {
+    val doc = Jsoup.parseBodyFragment(html)
+    doc.getElementsByTag("div").asScala.headOption.map(_.attr("data-callout-tagname")).map(_ => true).getOrElse(false)
+  }
+
   def extractCallout(
       html: String,
       campaigns: Option[JsValue],

--- a/common/app/model/dotcomrendering/pageElements/CalloutExtraction.scala
+++ b/common/app/model/dotcomrendering/pageElements/CalloutExtraction.scala
@@ -169,7 +169,13 @@ object CalloutExtraction {
 
   def isCallout(html: String): Boolean = {
     val doc = Jsoup.parseBodyFragment(html)
-    doc.getElementsByTag("div").asScala.headOption.map(_.attr("data-callout-tagname")).map(_ => true).getOrElse(false)
+    val maybeCalloutAttr =
+      doc.getElementsByTag("div").asScala.headOption.map(_.attr("data-callout-tagname")).filter(_.trim.nonEmpty)
+
+    maybeCalloutAttr match {
+      case Some(_) => true
+      case None    => false
+    }
   }
 
   def extractCallout(

--- a/common/test/model/dotcomrendering/pageElements/CalloutExtractionTest.scala
+++ b/common/test/model/dotcomrendering/pageElements/CalloutExtractionTest.scala
@@ -1,0 +1,21 @@
+package model.dotcomrendering.pageElements
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class CalloutExtractionTest extends AnyFlatSpec with Matchers {
+  "CalloutExtraction isCallout" should "return true when data-callout-tagname attribute exists in html and has value" in {
+    val result = CalloutExtraction.isCallout("<div data-callout-tagname='someValue'>some stuff</div>")
+    result should equal(true)
+  }
+
+  "CalloutExtraction isCallout" should "return false when data-callout-tagname attribute exists in html but doesn't have any value" in {
+    val result = CalloutExtraction.isCallout("<div data-callout-tagname>some stuff</div>")
+    result should equal(false)
+  }
+
+  it should "return false when data-callout-tagname attribute doesn't exist in html" in {
+    val result = CalloutExtraction.isCallout("<div some-data='someValue'>some stuff</div>")
+    result should equal(false)
+  }
+}


### PR DESCRIPTION
## What does this change?
This PR fixes a bug related to the expired callouts. 
In frontend whenever there's an embed element within the body, there would always an element would return depending on the following conditions:
- returns SoundcloudBlockElement if possible
- or returns CalloutBlockElement if possible (if possible through the campaign and callout url)
- otherwise returns EmbedBlockElement

But, if the element is a callout, we always need to make sure that we can extract a callout element, otherwise, we shouldn't return anything. CAPI callout element doesn't have the complete callout form, so we need to extract the form using the campaign and callout url. if campaign doesn't exist for the callout tag, that means this callout has expired and shouldn't be rendered in the page. 

# Changes:
- a method `isCallout` was added in `CalloutExtraction` to check if the embed html is a callout (it has the `data-callout-tagname` attribute)
- The logic in `embedToPageElement` was modified, so that if the embed is a callout, it should only return `Some(CalloutBlockElement)` or `None`. (as opposed to returning the default `EmbedBlockElement`). This way the embed won't be rendered in the page if it's a callout and there was no campaign to extract it.
- Added unit tests for the new `isCallout` method

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/15894063/184832791-4a470499-117d-4e4d-8f88-904e44dbd773.png) | ![image](https://user-images.githubusercontent.com/15894063/184833296-500874ac-55b5-4add-9644-fb7c7e5e00bb.png) |

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)


### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
