### PR TITLE
Remove ad container on empty

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/empty-advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/empty-advert.ts
@@ -15,10 +15,20 @@ const removeFromDfpEnv = (advert: Advert) => {
 	});
 };
 
+const removeAd = (advert: Advert) => {
+	const parent: HTMLElement | null = advert.node.parentElement;
+
+	if (parent?.classList.contains('ad-slot-container')) {
+		parent.remove();
+	} else {
+		advert.node.remove();
+	}
+};
+
 const emptyAdvert = (advert: Advert): void => {
 	fastdom.mutate(() => {
 		window.googletag.destroySlots([advert.slot]);
-		advert.node.remove();
+		removeAd(advert);
 		removeFromDfpEnv(advert);
 	});
 };

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -97,8 +97,6 @@
   "../projects/commercial/modules/sticky-inlines.ts",
   "../projects/common/modules/article/space-filler.ts",
   "../projects/common/modules/commercial/commercial-features.ts",
-  "../projects/common/modules/experiments/ab.ts",
-  "../projects/common/modules/experiments/tests/multi-sticky-right-ads.ts",
   "../projects/common/modules/spacefinder.ts"
  ],
  "../projects/commercial/modules/carrot-traffic-driver.ts": [
@@ -645,7 +643,7 @@
  ],
  "../projects/common/modules/experiments/ab-tests.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
-  "../projects/common/modules/experiments/tests/multi-sticky-right-ads.ts",
+  "../projects/common/modules/experiments/tests/deeply-read-article-footer.js",
   "../projects/common/modules/experiments/tests/remote-header-test.js",
   "../projects/common/modules/experiments/tests/sign-in-gate-main-control.js",
   "../projects/common/modules/experiments/tests/sign-in-gate-main-variant.js"
@@ -671,10 +669,7 @@
   "../projects/common/modules/experiments/ab-utils.ts"
  ],
  "../projects/common/modules/experiments/automatLog.ts": [],
- "../projects/common/modules/experiments/tests/multi-sticky-right-ads.ts": [
-  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
-  "../lib/noop.ts"
- ],
+ "../projects/common/modules/experiments/tests/deeply-read-article-footer.js": [],
  "../projects/common/modules/experiments/tests/remote-header-test.js": [],
  "../projects/common/modules/experiments/tests/sign-in-gate-main-control.js": [],
  "../projects/common/modules/experiments/tests/sign-in-gate-main-variant.js": [],


### PR DESCRIPTION
## What does this change?

We started wrapping all ad slots in container divs in [this PR](https://github.com/guardian/frontend/pull/25236). An unintended consequence of this change was that containers were being left in the DOM when ad slots were later removed.

This was a problem because these divs were being considered by spacefinder when deciding where to place ads, which meant some inline ads were being pushed further down the page. 

Example: https://www.theguardian.com/commentisfree/2022/aug/12/liz-truss-boris-johnson-tory-leadership-frontrunner-workaholic

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![Screenshot 2022-08-16 at 09 07 11](https://user-images.githubusercontent.com/7423751/184831040-5bf16278-fb75-45e3-8352-3a2496bf7732.png) |  ![Screenshot 2022-08-16 at 09 07 31](https://user-images.githubusercontent.com/7423751/184831034-216b1d03-251f-4b26-a6e9-7f858fe1c5c5.png)         |

## What is the value of this and can you measure success?

No more empty `.ad-slot-container` elements in the DOM.

### Tested

- [x] Locally
- [ ] On CODE (optional)