### PR TITLE
Introduce `CommercialEndOfQuarterMegaTest`

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -6,8 +6,7 @@ import java.time.LocalDate
 
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =
-    Set(DCRFronts, OfferHttp3, LiveBlogMainMediaPosition, TableOfContents)
-
+    Set(DCRFronts, OfferHttp3, LiveBlogMainMediaPosition, TableOfContents, CommercialEndOfQuarterMegaTest)
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
 
@@ -45,4 +44,13 @@ object TableOfContents
       owners = Seq(Owner.withName("journalism team")),
       sellByDate = LocalDate.of(2022, 12, 7),
       participationGroup = Perc0C,
+    )
+
+object CommercialEndOfQuarterMegaTest
+    extends Experiment(
+      name = "commercial-end-of-quarter-mega-test",
+      description = "Measure the revenue uplift of the various changes introduced by the commercial team in Q1",
+      owners = Seq(Owner.withGithub("commercial-dev")),
+      sellByDate = LocalDate.of(2022, 10, 10),
+      participationGroup = Perc10A,
     )

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -218,9 +218,13 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 		(sfdebug === '1' && isInline1) || (sfdebug === '2' && !isInline1);
 
 	const insertAds: SpacefinderWriter = async (paras) => {
+		const tests = window.guardian.config.tests;
+		const isInMegaTestControlGroup =
+			tests && !!tests['commercialEndOfQuarterMegaTestControl'];
+
 		// Make ads sticky on the non-inline1 pass
 		// i.e. inline2, inline3, etc...
-		const isSticky = !isInline1;
+		const isSticky = !isInline1 && !isInMegaTestControlGroup;
 
 		if (isSticky) {
 			const stickyContainerHeights = await computeStickyHeights(

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -218,11 +218,11 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 		(sfdebug === '1' && isInline1) || (sfdebug === '2' && !isInline1);
 
 	const insertAds: SpacefinderWriter = async (paras) => {
-		// Include containers on the non-inline1 pass
+		// Make ads sticky on the non-inline1 pass
 		// i.e. inline2, inline3, etc...
-		const includeContainer = !isInline1;
+		const isSticky = !isInline1;
 
-		if (includeContainer) {
+		if (isSticky) {
 			const stickyContainerHeights = await computeStickyHeights(
 				paras,
 				articleBodySelector,
@@ -248,7 +248,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 
 				let containerClasses = '';
 
-				if (includeContainer) {
+				if (isSticky) {
 					containerClasses += getStickyContainerClassname(i);
 				}
 
@@ -258,7 +258,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 				}
 
 				const containerOptions = {
-					sticky: includeContainer,
+					sticky: isSticky,
 					className: containerClasses,
 					enableDebug,
 				};

--- a/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.ts
@@ -1,3 +1,4 @@
+import { log } from '@guardian/libs';
 import { once } from 'lodash-es';
 import type { Advert } from './Advert';
 import { dfpEnv } from './dfp-env';
@@ -35,9 +36,16 @@ const onIntersect = (
 };
 
 const getObserver = once(() => {
+	const tests = window.guardian.config.tests;
+	const isInMegaTestControlGroup =
+		tests && !!tests['commercialEndOfQuarterMegaTestControl'];
+
+	const lazyLoadMargin = isInMegaTestControlGroup ? '200px' : '20%';
+	log('commercial', 'Using lazy load margin', lazyLoadMargin);
+
 	return Promise.resolve(
 		new window.IntersectionObserver(onIntersect, {
-			rootMargin: '20% 0px',
+			rootMargin: `${lazyLoadMargin} 0px`,
 		}),
 	);
 });

--- a/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
@@ -6,7 +6,10 @@ const defaultClientSideTests: ABTest[] = [
 	/* linter, please keep this array multi-line */
 ];
 
-const serverSideTests: ServerSideABTest[] = [];
+const serverSideTests: ServerSideABTest[] = [
+	'commercialEndOfQuarterMegaTestControl',
+	'commercialEndOfQuarterMegaTestVariant',
+];
 
 /**
  * Function to check whether metrics should be captured for the current page

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -226,6 +226,7 @@
   "../projects/commercial/modules/dfp/dfp-env.ts"
  ],
  "../projects/commercial/modules/dfp/lazy-load.ts": [
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../../../../node_modules/@types/lodash-es/index.d.ts",
   "../projects/commercial/modules/dfp/Advert.ts",
   "../projects/commercial/modules/dfp/dfp-env.ts",

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -740,6 +740,7 @@
  "standalone.commercial.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../lib/manage-ad-free-cookie.ts",
   "../lib/report-error.js",
   "../lib/robust.js",
   "../projects/commercial/adblock-ask.ts",


### PR DESCRIPTION
## What does this change?

Introduces a new server-side test `CommercialEndOfQuarterMegaTest` to measure the revenue uplift of the various changes introduced by the commercial team in Q1. 

10% of the audience will be enrolled in the test. 

The test will work in the same way as the last end-of-quarter test. Namely, the changes from Q1 will be enabled for all pageviews **not in the control group of the test** (that is, the variant of the test and non-participants). The table below summarises this behaviour:

|                 |                 **Behaviour**                 |
|:---------------:|:---------------------------------------------:|
|   **Control** (5% of audience)   |               Q1 changes disabled ❌              |
|   **Variant** (5% of audience)  | Q1 changes enabled ✅ |
| **Not in test** (90% of audience) | Q1 changes enabled ✅ |

\* table stolen from @chrislomaxjones - thanks!

Logic to selectively enable the following Q1 changes are included in this PR:

- Multi Sticky
- Lazy loading

The remaining Q1 changes will be added in subsequent PRs:

- Interactives Idle Loading (https://github.com/guardian/dotcom-rendering/pull/5757)
- Inline 1 container resize (**abandoned - see chat**)

Once all these PRs are in, the test can begin.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

### Tested

- [ ] Locally
- [x] On CODE (optional)
