### PR TITLE
Update a9 ad size arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@guardian/atom-renderer": "1.2.2",
     "@guardian/automat-modules": "^0.3.8",
     "@guardian/braze-components": "^7.3.0",
-    "@guardian/commercial-core": "4.7.0",
+    "@guardian/commercial-core": "4.8.0",
     "@guardian/consent-management-platform": "^10.7.1",
     "@guardian/libs": "^3.6.1",
     "@guardian/shimport": "^1.0.2",

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/a9/a9.ts
@@ -12,12 +12,12 @@ import { getHeaderBiddingAdSlots } from '../slot-config';
 class A9AdUnit implements A9AdUnitInterface {
 	slotID: string;
 	slotName?: string;
-	sizes: HeaderBiddingSize[];
+	sizes: number[][];
 
 	constructor(advert: Advert, slot: HeaderBiddingSlot) {
 		this.slotID = advert.id;
 		this.slotName = config.get('page.adUnit');
-		this.sizes = slot.sizes;
+		this.sizes = slot.sizes.map((size) => size.toArray());
 	}
 }
 

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -177,7 +177,7 @@ interface Confiant extends Record<string, unknown> {
 interface A9AdUnitInterface {
 	slotID: string;
 	slotName?: string;
-	sizes: HeaderBiddingSize[];
+	sizes: number[][];
 }
 
 type ApstagInitConfig = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2089,10 +2089,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-7.3.0.tgz#9c4908fa5d439d85b2024735575435b0a5cd369f"
   integrity sha512-Py2FZ6aHi/inOIF4+4xZqNmbJur3cevtWRMQeFLjNjgN7zR7hMB6Dsd8uurEym6Qd3yxBAGPx/+rS3xVbTKz4w==
 
-"@guardian/commercial-core@4.7.0":
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.7.0.tgz#86fd3db63df2cb9afc64218e090cbaabd13db618"
-  integrity sha512-ckGwpr/RPBGpwExFCBcEy6v4GRBHM5LB8O2jF8tHuie+O515TZoTZno31unU8imgqJo8cz5XXQBNtmAaKrEzvA==
+"@guardian/commercial-core@4.8.0":
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.8.0.tgz#184abda938df34d01cc856d5596555f692ca296d"
+  integrity sha512-AGqoj3Zcmcvyp+XX2MRkqRLpPUPoKtsrA2R7XZG24zYGaeqItc+Wyd1Xx2nkFFMI4JLQ5UMrmF8V94W2nLJY2A==
 
 "@guardian/consent-management-platform@^10.7.1":
   version "10.7.1"


### PR DESCRIPTION
## What does this change?
Updated the a9.ts file to use arrays of sizes rather than the specific AdSize type. This means the size arrays are no longer limited by the constructor, allowing array methods such as splice to be called.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
Should fix an error that has been caused by the splice method not being inherited through the prototype chain.

### Tested

- [X] Locally
- [ ] On CODE (optional)

