### PR TITLE
Remove FrontsSlideshowMobileSupport switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -443,16 +443,6 @@ trait FeatureSwitches {
     exposeClientSide = false,
   )
 
-  val FrontsSlideshowMobileSupport = Switch(
-    SwitchGroup.Feature,
-    "fronts-slideshow-mobile-support",
-    "Enables using captions and slideshows on fronts mobile displays",
-    owners = Seq(Owner.withEmail("dotcom.platform@guardian.co.uk")),
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = false,
-  )
-
   val StickyVideos = Switch(
     SwitchGroup.Feature,
     "sticky-videos",

--- a/common/app/views/fragments/items/elements/facia_cards/captionedImage.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/captionedImage.scala.html
@@ -1,7 +1,6 @@
 @import layout.WidthsByBreakpoint
 @import model.ImageMedia
 @import implicits.Requests._
-@import conf.switches.Switches.FrontsSlideshowMobileSupport
 
 @(
     classes: Seq[String],
@@ -23,7 +22,7 @@
         shouldLazyLoadIndex = shouldLazyLoadIndex
     )
     @caption.map { captionText =>
-        <figcaption class="@if(FrontsSlideshowMobileSupport.isSwitchedOn) {fc-item__captioned-image-mobile-support}">
+        <figcaption>
             @captionText
         </figcaption>
     }

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -11,7 +11,6 @@
 @import views.html.fragments.inlineSvg
 @import views.support.{CutOut, GetClasses, RemoveOuterParaHtml, RenderClasses, Video640}
 @import model.ContentDesignType.RichContentDesignType
-@import conf.switches.Switches.FrontsSlideshowMobileSupport
 
 @import Function.const
 
@@ -178,7 +177,7 @@ data-test-id="facia-card"
 
             case Some(InlineSlideshow(imageElements)) => {
                 <div class="fc-item__media-wrapper">
-                    <div class="fc-item__image-container u-responsive-ratio fc-item__slideshow fc-item__slideshow--@imageElements.size @if(FrontsSlideshowMobileSupport.isSwitchedOn) {fc-item__slideshow-mobile-support}">
+                    <div class="fc-item__image-container u-responsive-ratio fc-item__slideshow fc-item__slideshow--@imageElements.size">
                         @imageElements.headOption.map { imageElement =>
                             @captionedImage(
                                 classes = Seq("responsive-img "),

--- a/common/app/views/fragments/items/facia_cards/dynamoContentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/dynamoContentCard.scala.html
@@ -10,7 +10,6 @@
 @import views.html.fragments.inlineSvg
 @import views.support.{CutOut, GetClasses, RemoveOuterParaHtml, RenderClasses, Video640}
 @import model.ContentDesignType.RichContentDesignType
-@import conf.switches.Switches.FrontsSlideshowMobileSupport
 
 @import Function.const
 
@@ -188,7 +187,7 @@ data-test-id="facia-card"
 
             case Some(InlineSlideshow(imageElements)) => {
                 <div class="fc-item__media-wrapper">
-                    <div class="fc-item__image-container u-responsive-ratio fc-item__slideshow fc-item__slideshow--@imageElements.size @if(FrontsSlideshowMobileSupport.isSwitchedOn) {fc-item__slideshow-mobile-support}">
+                    <div class="fc-item__image-container u-responsive-ratio fc-item__slideshow fc-item__slideshow--@imageElements.size">
                         @imageElements.headOption.map { imageElement =>
                             @captionedImage(
                                 classes = Seq("responsive-img "),

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -569,12 +569,6 @@ $block-height: 58px;
         background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%,  rgba(0, 0, 0, .8) 100%);
         color: $brightness-100;
         padding: 60px 8px 8px;
-        
-        &:not(.fc-item__captioned-image-mobile-support) {
-            @include mq($until: tablet) {
-                display: none;
-            }
-        }
 
         .fc-item--list-media-mobile & {
             @include mq($until: tablet) {
@@ -595,22 +589,7 @@ $block-height: 58px;
 }
 
 .fc-item__slideshow {
-    &:not(.fc-item__slideshow-mobile-support) figure {
-        @include mq($until: tablet) {
-            &:nth-child(1n+2) {
-                display: none;
-            }
-        }
-
-        @include mq(tablet) {
-            animation-timing-function: linear;
-            animation-iteration-count: infinite;
-            animation-direction: normal;
-            opacity: 0;
-        }
-    }
-
-    &.fc-item__slideshow-mobile-support figure {
+    figure {
         animation-timing-function: linear;
         animation-iteration-count: infinite;
         animation-direction: normal;
@@ -649,12 +628,6 @@ $block-height: 58px;
         }
     }
     .fc-item__slideshow--#{$i} {
-        @include mq(tablet) {
-            @include fc-slideshow-movement($totalLoopTime, $i)
-        }
-
-        &.fc-item__slideshow-mobile-support {
-            @include fc-slideshow-movement($totalLoopTime, $i)
-        }
+        @include fc-slideshow-movement($totalLoopTime, $i)
     }
 }


### PR DESCRIPTION
## What does this change?

This switch was originally created to disable all slideshows from rendering on mobile web before we were able to selectively render Slideshows that were large enough on Mobile. Its CSS is now clashing with the CSS that we use to conditionally render large enough slideshows.

Seeing as Apps now supports Slideshows and we conditionally render slideshows on mobile web based on size I don't think this switch is needed anymore. This fixes a bug where a slideshow with a small image was being rendered on mobile web when it should have been disabled below tablet.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |
| ![before2][] | ![after2][] |

[before]: https://user-images.githubusercontent.com/21217225/184926514-2895df5e-68c4-4f0f-88d6-b0788413c5e2.gif
[after]: https://user-images.githubusercontent.com/21217225/184926204-fdc6e907-1189-45ff-9dab-7e8b94a84bb0.png
[before2]: https://user-images.githubusercontent.com/21217225/184933925-ff37f7bd-95b3-4afa-b8cf-bcc780d1c4ee.gif

[after2]: https://user-images.githubusercontent.com/21217225/184933958-ae09ff61-c78c-461d-97b4-c68063d48c73.gif

