### PR TITLE
Unset adfree cookie for users in constentless ads test

### DIFF
--- a/static/src/javascripts/bootstraps/standalone.commercial.ts
+++ b/static/src/javascripts/bootstraps/standalone.commercial.ts
@@ -209,7 +209,14 @@ const bootCommercial = async (): Promise<void> => {
 };
 
 const bootConsentless = async (): Promise<void> => {
+	/*  In the consented ad stack, we set the ad free cookie for users who
+		don't consent to targeted ads in order to hide empty ads slots.
+		We remove the cookie here so that we can show Opt Out ads.
+		TODO: Stop setting ad free cookie for users who opt out when
+		consentless ads are rolled out to all users.
+ 	*/
 	maybeUnsetAdFreeCookie(AdFreeCookieReasons.ConsentOptOut);
+
 	await Promise.all([
 		initConsentless(),
 		initFixedSlots(),

--- a/static/src/javascripts/bootstraps/standalone.commercial.ts
+++ b/static/src/javascripts/bootstraps/standalone.commercial.ts
@@ -19,6 +19,10 @@ import { initFixedSlots } from 'commercial/modules/consentless/init-fixed-slots'
 import { initConsentless } from 'commercial/modules/consentless/prepare-ootag';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { consentlessAds } from 'common/modules/experiments/tests/consentlessAds';
+import {
+	AdFreeCookieReasons,
+	maybeUnsetAdFreeCookie,
+} from 'lib/manage-ad-free-cookie';
 import reportError from '../lib/report-error';
 import { catchErrorsWithContext } from '../lib/robust';
 import { initAdblockAsk } from '../projects/commercial/adblock-ask';
@@ -205,6 +209,7 @@ const bootCommercial = async (): Promise<void> => {
 };
 
 const bootConsentless = async (): Promise<void> => {
+	maybeUnsetAdFreeCookie(AdFreeCookieReasons.ConsentOptOut);
 	await Promise.all([
 		initConsentless(),
 		initFixedSlots(),


### PR DESCRIPTION
## What does this change?
- #25091 introduced a feature that hides ad slots that won't be populated because the user has opted out of targeted advertising.
- This behavior conflicts with the consentless ads 0% test (#25380); currently a user who rejects all before having opted in to the `ConsentlessAds` test won't be shown the top-above-nav or inline article ad slots. We want to show all ad slots for users who have opted in to the test, regardless of consent state. 
- This PR fixes the bug by removing the ad free cookie for users in the variant group of the test if there is no other reason for the cookie to be set (i.e. if they are not a subscriber).

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)
