### PR TITLE
Fix: Add try/catch to html parsers in Audio atoms

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -1460,23 +1460,23 @@ object PageElement {
   private[this] def getIframeWidth(html: String, fallback: Int = 0): Option[Int] = {
     val doc = Jsoup.parseBodyFragment(html)
 
-    doc.getElementsByTag("iframe")
-      .asScala.headOption
+    doc
+      .getElementsByTag("iframe")
+      .asScala
+      .headOption
       .map(_.attr("width"))
-      .map(
-        attr => Try(attr.toInt).getOrElse(fallback)
-      )
+      .map(attr => Try(attr.toInt).getOrElse(fallback))
   }
 
   private[this] def getIframeHeight(html: String, fallback: Int = 0): Option[Int] = {
     val doc = Jsoup.parseBodyFragment(html)
 
-    doc.getElementsByTag("iframe")
-      .asScala.headOption
+    doc
+      .getElementsByTag("iframe")
+      .asScala
+      .headOption
       .map(_.attr("height"))
-      .map(
-        attr => Try(attr.toInt).getOrElse(fallback)
-      )
+      .map(attr => Try(attr.toInt).getOrElse(fallback))
   }
 
   private def extractSoundcloudBlockElement(
@@ -1559,8 +1559,8 @@ object PageElement {
     } yield {
       SpotifyBlockElement(
         getEmbedUrl(d.html),
-        getIframeHeight(html, fallback=540),
-        getIframeWidth(html, fallback=460),
+        getIframeHeight(html, fallback = 540),
+        getIframeWidth(html, fallback = 460),
         d.title,
         d.caption,
         thirdPartyTracking,

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -1458,12 +1458,20 @@ object PageElement {
 
   private[this] def getIframeWidth(html: String): Option[Int] = {
     val doc = Jsoup.parseBodyFragment(html)
-    doc.getElementsByTag("iframe").asScala.headOption.map(_.attr("width").toInt)
+    try {
+      doc.getElementsByTag("iframe").asScala.headOption.map(_.attr("width").toInt)
+    } catch {
+      case _: Throwable => Some(460)
+    }
   }
 
   private[this] def getIframeHeight(html: String): Option[Int] = {
     val doc = Jsoup.parseBodyFragment(html)
-    doc.getElementsByTag("iframe").asScala.headOption.map(_.attr("height").toInt)
+    try {
+      doc.getElementsByTag("iframe").asScala.headOption.map(_.attr("height").toInt)
+    } catch {
+      case _: Throwable => Some(450)
+    }
   }
 
   private def extractSoundcloudBlockElement(

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -24,6 +24,7 @@ import views.support.cleaner.SoundcloudHelper
 import views.support.{ImgSrc, SrcSet, Video700}
 
 import scala.collection.JavaConverters._
+import scala.util.Try
 
 // ------------------------------------------------------
 // PageElement Supporting Types and Traits
@@ -1456,22 +1457,26 @@ object PageElement {
     doc.getElementsByTag("iframe").asScala.headOption.map(_.attr("src"))
   }
 
-  private[this] def getIframeWidth(html: String): Option[Int] = {
+  private[this] def getIframeWidth(html: String, default: Int = 0): Option[Int] = {
     val doc = Jsoup.parseBodyFragment(html)
-    try {
-      doc.getElementsByTag("iframe").asScala.headOption.map(_.attr("width").toInt)
-    } catch {
-      case _: Throwable => Some(460)
-    }
+
+    doc.getElementsByTag("iframe")
+      .asScala.headOption
+      .map(_.attr("width"))
+      .map(
+        attr => Try(attr.toInt).getOrElse(default)
+      )
   }
 
-  private[this] def getIframeHeight(html: String): Option[Int] = {
+  private[this] def getIframeHeight(html: String, default: Int = 0): Option[Int] = {
     val doc = Jsoup.parseBodyFragment(html)
-    try {
-      doc.getElementsByTag("iframe").asScala.headOption.map(_.attr("height").toInt)
-    } catch {
-      case _: Throwable => Some(450)
-    }
+
+    doc.getElementsByTag("iframe")
+      .asScala.headOption
+      .map(_.attr("height"))
+      .map(
+        attr => Try(attr.toInt).getOrElse(default)
+      )
   }
 
   private def extractSoundcloudBlockElement(
@@ -1554,8 +1559,8 @@ object PageElement {
     } yield {
       SpotifyBlockElement(
         getEmbedUrl(d.html),
-        getIframeHeight(html),
-        getIframeWidth(html),
+        getIframeHeight(html, default=540),
+        getIframeWidth(html, default=460),
         d.title,
         d.caption,
         thirdPartyTracking,

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -1457,25 +1457,25 @@ object PageElement {
     doc.getElementsByTag("iframe").asScala.headOption.map(_.attr("src"))
   }
 
-  private[this] def getIframeWidth(html: String, default: Int = 0): Option[Int] = {
+  private[this] def getIframeWidth(html: String, fallback: Int = 0): Option[Int] = {
     val doc = Jsoup.parseBodyFragment(html)
 
     doc.getElementsByTag("iframe")
       .asScala.headOption
       .map(_.attr("width"))
       .map(
-        attr => Try(attr.toInt).getOrElse(default)
+        attr => Try(attr.toInt).getOrElse(fallback)
       )
   }
 
-  private[this] def getIframeHeight(html: String, default: Int = 0): Option[Int] = {
+  private[this] def getIframeHeight(html: String, fallback: Int = 0): Option[Int] = {
     val doc = Jsoup.parseBodyFragment(html)
 
     doc.getElementsByTag("iframe")
       .asScala.headOption
       .map(_.attr("height"))
       .map(
-        attr => Try(attr.toInt).getOrElse(default)
+        attr => Try(attr.toInt).getOrElse(fallback)
       )
   }
 
@@ -1559,8 +1559,8 @@ object PageElement {
     } yield {
       SpotifyBlockElement(
         getEmbedUrl(d.html),
-        getIframeHeight(html, default=540),
-        getIframeWidth(html, default=460),
+        getIframeHeight(html, fallback=540),
+        getIframeWidth(html, fallback=460),
         d.title,
         d.caption,
         thirdPartyTracking,


### PR DESCRIPTION
Co-authored by: Joshua <joshuathomaslieberman@gmail.com>

## What does this change?

It wraps the `toInt` conversion which is used to extract height and width values from html markup for iframe audio embeds. It also provides a fallback value (`fallback=0`, but this can be set as an optional param).

## Why?

The `attr` method on a jsoup `Node` returns an empty string if the attribute is not found on the node, but `"".toInt` throws an error, which was causing Frontend to `500`. The change in this PR means that this error should be caught, and a fallback value provided instead.

Closes #25422.

## Complications

The Spotify embed is not the only audio atom which uses the functions edited here (`getIframeWidth` and `getIframeHeight`), so this edit may affect how they render. However, the only difference in behaviour should be that if the `toInt` conversion throws an error, the page will render but the iframe containing the audio atom will have a width or height of `0`. This seems preferable to throwing a `500` and being unable to render the page at all. It also looks as though [at least one of the atoms](https://github.com/guardian/frontend/blob/4dc3af3702bf5351c8a5b488551529c587ab32bb/common/app/model/dotcomrendering/pageElements/PageElement.scala#L1327-L1328) was already using `0` as a fallback (although I don't think this existing fallback would prevent the `500` errors).

But if anyone can spot other potential unintended side-effects then please let me know!

## Broader picture

While fixing this, it became apparent that there is also separate issue which prevents some older Spotify embeds on DCR. [DCR will only render the embed if it has a `title`](https://github.com/guardian/dotcom-rendering/blob/0d3bc2d0561b1d7ffdc8d41df5e853b8af85eac2/dotcom-rendering/src/web/components/SpotifyBlockComponent.importable.tsx#L39), and older embeds appear not to have titles when Frontend receives them from CAPI. Having run some tests with CP, it looks as though updating the embed URL in Composer is sufficient to provide a title and allow the embed to be rendered. 

It was agreed that the first priority is to prevent the `500s`, and that CP will re-publish articles with older embeds as and when the embed seems important for a particular article.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [x] On CODE (an earlier version, prior to a refactor which shouldn't have changed functionality)
