### PR TITLE
fix: Remove old GU_territory cookie when new one is set.

### DIFF
--- a/static/src/javascripts/projects/facia/modules/ui/au-region-selector.ts
+++ b/static/src/javascripts/projects/facia/modules/ui/au-region-selector.ts
@@ -1,4 +1,4 @@
-import { setCookie } from '@guardian/libs';
+import { removeCookie, setCookie } from '@guardian/libs';
 import { $$ } from '../../../../lib/$$';
 
 const toggle = (e: HTMLElement): void => {
@@ -41,6 +41,7 @@ export const init = (): void => {
 					// fastly will ignore the cookie & use the users locations
 					const value =
 						attrValue === 'AU-hide-thrasher' ? 'Other' : attrValue;
+					removeCookie({ name: 'GU_territory' });
 					setCookie({ name: 'GU_territory', value });
 					location.reload();
 				}


### PR DESCRIPTION
## What does this change?

Removes old `GU_territory` cookie before setting new one.

## Why?

On the old thrasher it was setting the GU_territory cookie on just the www.theguardian.com domain, whereas on the new platform implementation we set it on the wildcard .theguardian.com domain. This causes 2 different cookies, one for each domain, to be present if a user already selected a region with the previous implementation as we don't override the www.theguardian.com cookie when setting the new wildcard cookie.