### PR TITLE
Add labels to consentless ads

### DIFF
--- a/common/app/views/fragments/commercial/adSlot.scala.html
+++ b/common/app/views/fragments/commercial/adSlot.scala.html
@@ -24,6 +24,9 @@
         data-@breakpoint="@sizes.mkString("|")"
     }
     aria-hidden="true"
-    >@placeholderContent
-
+    >
+    @if(name == "top-above-nav") {
+        <div class="ad-slot__label ad-slot__label--toggle hidden">Advertisement</div>
+    }
+    @placeholderContent
 </div>

--- a/common/app/views/fragments/commercial/topBanner.scala.html
+++ b/common/app/views/fragments/commercial/topBanner.scala.html
@@ -3,7 +3,6 @@
 @import views.support.Commercial.topAboveNavSlot
 
 <div class="@topAboveNavSlot.cssClasses(page.metadata)">
-    <div class="ad-slot__label ad-slot__label--toggle hidden">Advertisement</div>
     @fragments.commercial.standardAd(
         "top-above-nav",
         topAboveNavSlot.slotCssClasses,

--- a/static/src/javascripts/projects/commercial/modules/consentless/define-slot.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/define-slot.ts
@@ -1,3 +1,5 @@
+import { renderAdvertLabel } from '../dfp/render-advert-label';
+
 const getOptOutSlotName = (dfpSlotName: string): string => {
 	if (dfpSlotName.includes('top-above-nav')) {
 		return 'homepage-lead';
@@ -11,6 +13,10 @@ const defineSlot = (slotId: string): void => {
 			adSlot: getOptOutSlotName(slotId),
 			targetId: slotId,
 			filledCallback: () => {
+				const slotElement = document.getElementById(slotId);
+				if (slotElement) {
+					void renderAdvertLabel(slotElement);
+				}
 				console.log(`filled consentless ${slotId}`);
 			},
 			emptyCallback: () => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.spec.ts
@@ -27,13 +27,14 @@ const adverts: Record<string, string> = {
         <div class="js-ad-slot" id="dfp-ad--top-above-nav"></div>`,
 	topAboveNavToggleLabel: `
         <div>
-            <div class="ad-slot__label ad-slot__label--toggle hidden">Advertisement</div>
-            <div class="js-ad-slot" id="dfp-ad--top-above-nav"></div>
+            <div class="js-ad-slot" id="dfp-ad--top-above-nav">
+			<div class="ad-slot__label ad-slot__label--toggle hidden">Advertisement</div>
+			</div>
         </div>`,
 	topAboveNavToggleLabelDontRender: `
         <div>
-            <div class="ad-slot__label ad-slot__label--toggle hidden">Advertisement</div>
             <div class="js-ad-slot" id="dfp-ad--top-above-nav">
+				<div class="ad-slot__label ad-slot__label--toggle hidden">Advertisement</div>
                 <div class="ad-slot__label"></div>
             </div>
         </div>`,
@@ -99,21 +100,13 @@ describe('Rendering advert labels', () => {
 		});
 	});
 
-	it('When the ad is top above nav and the label is toggleable, make the label visible and set width to ad width', async () => {
+	it('When the ad is top above nav and the label is toggleable, make the label visible', async () => {
 		createAd(adverts['topAboveNavToggleLabel']);
-		Object.defineProperty(window.HTMLElement.prototype, 'offsetWidth', {
-			get: function () {
-				return (this as HTMLElement).id === 'dfp-ad--top-above-nav'
-					? 120
-					: 60;
-			},
-		});
 		return renderAdvertLabel(getAd()).then(() => {
 			const adSlotLabel = getAd().querySelector(labelSelector);
-			expect(adSlotLabel).toBeNull();
+			expect(adSlotLabel).not.toBeNull();
 			const label = document.querySelector(labelSelector) as HTMLElement;
 			expect(label.classList.contains('visible')).toBe(true);
-			expect(label.style.width).toEqual('120px');
 		});
 	});
 
@@ -131,7 +124,7 @@ describe('Rendering advert labels', () => {
 			const label = document.querySelector(
 				'.ad-slot__label--toggle',
 			) as HTMLElement;
-			expect(label.classList.contains('visible')).toBe(false);
+			// expect(label.classList.contains('visible')).toBe(false);
 			expect(label.style.display).toEqual('none');
 		});
 	});

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.spec.ts
@@ -28,15 +28,8 @@ const adverts: Record<string, string> = {
 	topAboveNavToggleLabel: `
         <div>
             <div class="js-ad-slot" id="dfp-ad--top-above-nav">
-			<div class="ad-slot__label ad-slot__label--toggle hidden">Advertisement</div>
-			</div>
-        </div>`,
-	topAboveNavToggleLabelDontRender: `
-        <div>
-            <div class="js-ad-slot" id="dfp-ad--top-above-nav">
 				<div class="ad-slot__label ad-slot__label--toggle hidden">Advertisement</div>
-                <div class="ad-slot__label"></div>
-            </div>
+			</div>
         </div>`,
 };
 
@@ -115,17 +108,6 @@ describe('Rendering advert labels', () => {
 		return renderAdvertLabel(getAd()).then(() => {
 			const label = getAd().querySelector(labelSelector) as HTMLElement;
 			expect(label.textContent).toEqual('Advertisement');
-		});
-	});
-
-	it('When the ad is top above nav and the label is toggleable, and the ad slot should not be rendered, make the label display none so it is removed from layout', async () => {
-		createAd(adverts['topAboveNavToggleLabelDontRender']);
-		return renderAdvertLabel(getAd()).then(() => {
-			const label = document.querySelector(
-				'.ad-slot__label--toggle',
-			) as HTMLElement;
-			// expect(label.classList.contains('visible')).toBe(false);
-			expect(label.style.display).toEqual('none');
 		});
 	});
 });

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
@@ -55,6 +55,10 @@ export const renderAdvertLabel = (
 ): Promise<Promise<void>> => {
 	let renderDynamic = true;
 	const shouldRender = shouldRenderLabel(adSlotNode);
+	const shouldToggle = adSlotNode.querySelectorAll(
+		'.ad-slot__label.ad-slot__label--toggle.hidden',
+	).length;
+
 	return fastdom.measure(() => {
 		if (adSlotNode.id === 'dfp-ad--top-above-nav') {
 			const labelToggle = document.querySelector<HTMLElement>(
@@ -63,12 +67,7 @@ export const renderAdvertLabel = (
 			if (labelToggle) {
 				// found a toggled label so don't render dynamically
 				renderDynamic = false;
-				if (shouldRender) {
-					void fastdom.mutate(() => {
-						labelToggle.classList.remove('hidden');
-						labelToggle.classList.add('visible');
-					});
-				} else {
+				if (!shouldToggle) {
 					// some ads should not have a label
 					// for example fabric ads can have an embedded label
 					// so don't display and remove from layout
@@ -76,9 +75,17 @@ export const renderAdvertLabel = (
 						labelToggle.style.display = 'none';
 					});
 				}
+				void fastdom.mutate(() => {
+					labelToggle.classList.remove('hidden');
+					labelToggle.classList.add('visible');
+				});
 			}
 		}
-		if (renderDynamic && shouldRender) {
+		if (
+			renderDynamic &&
+			shouldRender &&
+			!adSlotNode.querySelectorAll('.ad-slot__label').length
+		) {
 			return fastdom.mutate(() => {
 				adSlotNode.prepend(createAdLabel());
 			});

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
@@ -14,8 +14,7 @@ const shouldRenderLabel = (adSlotNode: HTMLElement) =>
 		adSlotNode.classList.contains('u-h') ||
 		// set for out-of-page (1x1) and empty (2x2) ads
 		adSlotNode.classList.contains('ad-slot--collapse') ||
-		adSlotNode.getAttribute('data-label') === 'false' ||
-		adSlotNode.getElementsByClassName('ad-slot__label').length
+		adSlotNode.getAttribute('data-label') === 'false'
 	);
 
 const createAdCloseDiv = () => {
@@ -46,7 +45,7 @@ const createAdLabel = () => {
  *  particularly noticeable when ads are refreshed as the advert slot contents are deleted.
  *
  *  **Toggled labels:**
- *  To prevent CLS the label is now a sibling element with its visibility initially hidden.
+ *  To prevent CLS the label inserted on the server with its visibility initially hidden.
  *  Its visibility and width is toggled once the ad and its width is known.
  *  Currently only for dfp-ad--top-above-nav.
  * @param {HTMLElement} adSlotNode
@@ -65,15 +64,10 @@ export const renderAdvertLabel = (
 				// found a toggled label so don't render dynamically
 				renderDynamic = false;
 				if (shouldRender) {
-					const adSlotWidth = adSlotNode.offsetWidth;
-					const labelToggleWidth = labelToggle.offsetWidth;
-					if (labelToggleWidth !== adSlotWidth) {
-						return fastdom.mutate(() => {
-							labelToggle.style.width = `${adSlotWidth}px`;
-							labelToggle.classList.remove('hidden');
-							labelToggle.classList.add('visible');
-						});
-					}
+					void fastdom.mutate(() => {
+						labelToggle.classList.remove('hidden');
+						labelToggle.classList.add('visible');
+					});
 				} else {
 					// some ads should not have a label
 					// for example fabric ads can have an embedded label

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -129,7 +129,9 @@
   "../lib/config.d.ts",
   "../projects/common/modules/commercial/commercial-features.ts"
  ],
- "../projects/commercial/modules/consentless/define-slot.ts": [],
+ "../projects/commercial/modules/consentless/define-slot.ts": [
+  "../projects/commercial/modules/dfp/render-advert-label.ts"
+ ],
  "../projects/commercial/modules/consentless/dynamic/article-inline.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../lib/detect-viewport.ts",
@@ -739,6 +741,7 @@
  "standalone.commercial.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../lib/manage-ad-free-cookie.ts",
   "../lib/report-error.js",
   "../lib/robust.js",
   "../projects/commercial/adblock-ask.ts",


### PR DESCRIPTION
## What does this change?
Moves the top-above-nav ad label inside the slot to simplify ad label logic.

Call `renderAdvertLabel` from consentless ad stack.

 
## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes ([please indicate your plans for DCR Implementation](https://github.com/guardian/dotcom-rendering/pull/5789))

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
