### PR TITLE
Consentless Liveblog inline ads

### DIFF
--- a/static/src/javascripts/bootstraps/standalone.commercial.ts
+++ b/static/src/javascripts/bootstraps/standalone.commercial.ts
@@ -15,6 +15,7 @@
 import { EventTimer } from '@guardian/commercial-core';
 import { log } from '@guardian/libs';
 import { initArticleInline } from 'commercial/modules/consentless/dynamic/article-inline';
+import { initLiveblogInline } from 'commercial/modules/consentless/dynamic/liveblog-inline';
 import { initFixedSlots } from 'commercial/modules/consentless/init-fixed-slots';
 import { initConsentless } from 'commercial/modules/consentless/prepare-ootag';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
@@ -221,6 +222,7 @@ const bootConsentless = async (): Promise<void> => {
 		initConsentless(),
 		initFixedSlots(),
 		initArticleInline(),
+		initLiveblogInline(),
 	]);
 };
 

--- a/static/src/javascripts/projects/commercial/modules/consentless/dynamic/liveblog-inline.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/dynamic/liveblog-inline.ts
@@ -1,0 +1,166 @@
+import { createAdSlot } from '@guardian/commercial-core';
+import { getUrlVars } from 'lib/url';
+import fastdom from '../../../../../lib/fastdom-promise';
+import { spaceFiller } from '../../../../common/modules/article/space-filler';
+import { commercialFeatures } from '../../../../common/modules/commercial/commercial-features';
+import type {
+	SpacefinderItem,
+	SpacefinderOptions,
+	SpacefinderRules,
+	SpacefinderWriter,
+} from '../../../../common/modules/spacefinder';
+import { defineSlot } from '../define-slot';
+
+/**
+ * Maximum number of inline ads to display on the page.
+ */
+const MAX_ADS = 8;
+
+/**
+ * Multiplier of screen height that determines the distance from
+ * the top of the page that we can start placing ads.
+ */
+const PAGE_TOP_MULTIPLIER = 1.5;
+
+/**
+ * Multiplier of screen height that sets the minimum distance that two ads can be placed.
+ */
+const AD_SPACE_MULTIPLIER = 2;
+
+let AD_COUNTER = 0;
+let WINDOWHEIGHT: number;
+let firstSlot: HTMLElement | undefined;
+
+const sfdebug = getUrlVars().sfdebug;
+
+const startListening = () => {
+	document.addEventListener('liveblog:blocks-updated', onUpdate);
+};
+
+const stopListening = () => {
+	document.removeEventListener('liveblog:blocks-updated', onUpdate);
+};
+
+const getWindowHeight = (doc = document) => {
+	if (doc.documentElement.clientHeight) {
+		return doc.documentElement.clientHeight;
+	}
+	return 0; // #? zero, or throw an error?
+};
+
+const getSpaceFillerRules = (
+	windowHeight: number,
+	shouldUpdate = false,
+): SpacefinderRules => {
+	let prevSlot: SpacefinderItem | undefined;
+
+	const isEnoughSpaceBetweenSlots = (
+		prevSlot: SpacefinderItem,
+		slot: SpacefinderItem,
+	) => Math.abs(slot.top - prevSlot.top) > windowHeight * AD_SPACE_MULTIPLIER;
+
+	const filterSlot = (slot: SpacefinderItem) => {
+		if (!prevSlot) {
+			prevSlot = slot;
+			return !shouldUpdate;
+		} else if (isEnoughSpaceBetweenSlots(prevSlot, slot)) {
+			prevSlot = slot;
+			return true;
+		}
+		return false;
+	};
+
+	return {
+		bodySelector: '.js-liveblog-body',
+		slotSelector: ' > .block',
+		fromBottom: shouldUpdate,
+		startAt: shouldUpdate ? firstSlot : undefined,
+		absoluteMinAbove: shouldUpdate ? 0 : WINDOWHEIGHT * PAGE_TOP_MULTIPLIER,
+		minAbove: 0,
+		minBelow: 0,
+		clearContentMeta: 0,
+		selectors: {},
+		filter: filterSlot,
+	};
+};
+
+const insertAdAtPara = (para: Node): Promise<void> => {
+	const container: HTMLElement = document.createElement('div');
+	container.className = `ad-slot-container`;
+
+	const ad = createAdSlot('inline', {
+		name: `inline${AD_COUNTER + 1}`,
+		classes: 'liveblog-inline',
+	});
+
+	container.appendChild(ad);
+
+	return fastdom
+		.mutate(() => {
+			if (para.parentNode) {
+				/* ads are inserted after the block on liveblogs */
+				para.parentNode.insertBefore(container, para.nextSibling);
+			}
+		})
+		.then(() => {
+			defineSlot(ad.id);
+		});
+};
+
+const insertAds: SpacefinderWriter = async (paras) => {
+	const fastdomPromises = [];
+	for (let i = 0; i < paras.length && AD_COUNTER < MAX_ADS; i += 1) {
+		const para = paras[i];
+		if (para.parentNode) {
+			const result = insertAdAtPara(para);
+			fastdomPromises.push(result);
+			AD_COUNTER += 1;
+		}
+	}
+	await Promise.all(fastdomPromises);
+};
+
+const fill = (rules: SpacefinderRules) => {
+	const options: SpacefinderOptions = { debug: sfdebug === '1' };
+
+	return spaceFiller.fillSpace(rules, insertAds, options).then(() => {
+		if (AD_COUNTER < MAX_ADS) {
+			const el = document.querySelector(
+				`${rules.bodySelector} > .ad-slot`,
+			);
+			if (el && el.previousSibling instanceof HTMLElement) {
+				firstSlot = el.previousSibling;
+			} else {
+				firstSlot = undefined;
+			}
+			startListening();
+		} else {
+			firstSlot = undefined;
+		}
+	});
+};
+
+const onUpdate = () => {
+	stopListening();
+	const rules = getSpaceFillerRules(WINDOWHEIGHT, true);
+	void fill(rules);
+};
+
+/**
+ * Initialise liveblog ad slots
+ */
+const initLiveblogInline = (): Promise<void> => {
+	if (!commercialFeatures.liveblogAdverts) {
+		return Promise.resolve();
+	}
+
+	return fastdom
+		.measure(() => {
+			WINDOWHEIGHT = getWindowHeight();
+			return WINDOWHEIGHT;
+		})
+		.then(getSpaceFillerRules)
+		.then(fill);
+};
+
+export { initLiveblogInline };

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -141,6 +141,15 @@
   "../projects/common/modules/commercial/commercial-features.ts",
   "../projects/common/modules/spacefinder.ts"
  ],
+ "../projects/commercial/modules/consentless/dynamic/liveblog-inline.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../lib/fastdom-promise.js",
+  "../lib/url.ts",
+  "../projects/commercial/modules/consentless/define-slot.ts",
+  "../projects/common/modules/article/space-filler.ts",
+  "../projects/common/modules/commercial/commercial-features.ts",
+  "../projects/common/modules/spacefinder.ts"
+ ],
  "../projects/commercial/modules/consentless/init-fixed-slots.ts": [
   "../projects/commercial/modules/consentless/define-slot.ts"
  ],
@@ -739,6 +748,7 @@
  "standalone.commercial.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../lib/manage-ad-free-cookie.ts",
   "../lib/report-error.js",
   "../lib/robust.js",
   "../projects/commercial/adblock-ask.ts",
@@ -749,6 +759,7 @@
   "../projects/commercial/modules/comment-adverts.ts",
   "../projects/commercial/modules/comscore.ts",
   "../projects/commercial/modules/consentless/dynamic/article-inline.ts",
+  "../projects/commercial/modules/consentless/dynamic/liveblog-inline.ts",
   "../projects/commercial/modules/consentless/init-fixed-slots.ts",
   "../projects/commercial/modules/consentless/prepare-ootag.ts",
   "../projects/commercial/modules/dfp/dfp-env-globals.ts",


### PR DESCRIPTION
## What does this change?

Adds consentless inline ads to liveblog pages.

On mobile, the highest inline advert in the page is now called `inline1` for consentless ads. For consented ads, this is still `top-above-nav`.

The code is in `liveblog-inline` is almost entirely similar to `/commercial/modules/liveblog-adverts.ts`. The differences are the function we call to display ads belongs to Opt-Out instead of GPT and we no longer call the top inline ad on mobile `top-above-nav`. This should make it easy to extract out common logic when we come to do that.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

![image](https://user-images.githubusercontent.com/9574885/185952005-bb91a982-d3c6-4ca4-8e56-37ad39edd96c.png)

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

This is a small part of the work to display consentless ads to users who reject cookies.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
