### PR TITLE
Use our own ad slot definitions and ads in opt out test

### DIFF
--- a/static/src/javascripts/bootstraps/standalone.commercial.ts
+++ b/static/src/javascripts/bootstraps/standalone.commercial.ts
@@ -219,6 +219,7 @@ const bootConsentless = async (): Promise<void> => {
 	maybeUnsetAdFreeCookie(AdFreeCookieReasons.ConsentOptOut);
 
 	await Promise.all([
+		setAdTestCookie(),
 		initConsentless(),
 		initFixedSlots(),
 		initArticleInline(),

--- a/static/src/javascripts/projects/commercial/modules/consentless/build-page-parameters.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/build-page-parameters.ts
@@ -1,0 +1,22 @@
+import { getCookie } from '@guardian/libs';
+
+type PartialWithNulls<T> = { [P in keyof T]?: T[P] | null };
+
+type PageParameters = PartialWithNulls<{
+	keyword: string;
+	section: string;
+}>;
+
+const buildPageParameters = (): PageParameters => {
+	const adtest = getCookie({ name: 'adtest', shouldMemoize: true });
+
+	// at the moment only the keyword is used for targeting
+	if (adtest) {
+		return {
+			keyword: adtest,
+		};
+	}
+	return {};
+};
+
+export { buildPageParameters };

--- a/static/src/javascripts/projects/commercial/modules/consentless/define-slot.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/define-slot.ts
@@ -1,29 +1,9 @@
 import { renderAdvertLabel } from '../dfp/render-advert-label';
 
-const isArticle = window.guardian.config.page.contentType === 'Article';
-const isFront = window.guardian.config.page.isFront;
-
-const getOptOutSlotName = (slotName: string, inlineId?: number): string => {
-	// front, liveblog, article inlines all have slightly different mappings, so we prefix them
-	if (slotName === 'inline') {
-		if (isArticle) {
-			// article inlines are suffixed with 1 for inline1 and 2-plus for all other inlines as they have different size mappings
-			return `article-inline${inlineId === 1 ? '1' : '2-plus'}`;
-		}
-		return `${isFront ? 'front-' : 'liveblog-'}${slotName}`;
-	} else {
-		return slotName;
-	}
-};
-
-const defineSlot = (
-	slotId: string,
-	slotName: string,
-	inlineId?: number,
-): void => {
+const defineSlot = (slotId: string, slotName: string): void => {
 	window.ootag.queue.push(() => {
 		window.ootag.defineSlot({
-			adSlot: getOptOutSlotName(slotName, inlineId),
+			adSlot: slotName,
 			targetId: slotId,
 			filledCallback: () => {
 				const slotElement = document.getElementById(slotId);

--- a/static/src/javascripts/projects/commercial/modules/consentless/define-slot.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/define-slot.ts
@@ -1,16 +1,30 @@
 import { renderAdvertLabel } from '../dfp/render-advert-label';
 
-const getOptOutSlotName = (dfpSlotName: string): string => {
-	if (dfpSlotName.includes('top-above-nav')) {
-		return 'homepage-lead';
+const getOptOutSlotName = (slotName: string, inlineId?: number): string => {
+	if (window.guardian.config.page.isFront && slotName === 'inline') {
+		return 'front-inline';
+	} else if (slotName === 'inline') {
+		if (window.guardian.config.page.contentType === 'Article') {
+			if (inlineId === 1) {
+				return 'article-inline1';
+			} else {
+				return 'article-inline2-plus';
+			}
+		} else if (window.guardian.config.page.isLiveBlog) {
+			return 'liveblog-inline';
+		}
 	}
-	return 'homepage-rect';
+	return slotName;
 };
 
-const defineSlot = (slotId: string): void => {
+const defineSlot = (
+	slotId: string,
+	slotName: string,
+	inlineId?: number,
+): void => {
 	window.ootag.queue.push(() => {
 		window.ootag.defineSlot({
-			adSlot: getOptOutSlotName(slotId),
+			adSlot: getOptOutSlotName(slotName, inlineId),
 			targetId: slotId,
 			filledCallback: () => {
 				const slotElement = document.getElementById(slotId);

--- a/static/src/javascripts/projects/commercial/modules/consentless/define-slot.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/define-slot.ts
@@ -1,20 +1,19 @@
 import { renderAdvertLabel } from '../dfp/render-advert-label';
 
+const isArticle = window.guardian.config.page.contentType === 'Article';
+const isFront = window.guardian.config.page.isFront;
+
 const getOptOutSlotName = (slotName: string, inlineId?: number): string => {
-	if (window.guardian.config.page.isFront && slotName === 'inline') {
-		return 'front-inline';
-	} else if (slotName === 'inline') {
-		if (window.guardian.config.page.contentType === 'Article') {
-			if (inlineId === 1) {
-				return 'article-inline1';
-			} else {
-				return 'article-inline2-plus';
-			}
-		} else if (window.guardian.config.page.isLiveBlog) {
-			return 'liveblog-inline';
+	// front, liveblog, article inlines all have slightly different mappings, so we prefix them
+	if (slotName === 'inline') {
+		if (isArticle) {
+			// article inlines are suffixed with 1 for inline1 and 2-plus for all other inlines as they have different size mappings
+			return `article-inline${inlineId === 1 ? '1' : '2-plus'}`;
 		}
+		return `${isFront ? 'front-' : 'liveblog-'}${slotName}`;
+	} else {
+		return slotName;
 	}
-	return slotName;
 };
 
 const defineSlot = (

--- a/static/src/javascripts/projects/commercial/modules/consentless/dynamic/article-inline.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/dynamic/article-inline.ts
@@ -68,7 +68,7 @@ const insertAdAtPara = (
 	para: Node,
 	name: string,
 	type: SlotName,
-	classes?: string,
+	classes = '',
 	containerOptions: ContainerOptions = {},
 	inlineId: number,
 ): Promise<void> => {
@@ -126,7 +126,14 @@ const addMobileInlineAds = async () => {
 
 	const insertAds: SpacefinderWriter = async (paras) => {
 		const slots = paras.map((para, i) =>
-			insertAdAtPara(para, `inline${i + 1}`, 'inline', 'inline'),
+			insertAdAtPara(
+				para,
+				`inline${i + 1}`,
+				'inline',
+				'inline',
+				{},
+				i + 1,
+			),
 		);
 		await Promise.all(slots);
 	};

--- a/static/src/javascripts/projects/commercial/modules/consentless/dynamic/article-inline.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/dynamic/article-inline.ts
@@ -70,6 +70,7 @@ const insertAdAtPara = (
 	type: SlotName,
 	classes?: string,
 	containerOptions: ContainerOptions = {},
+	inlineId: number,
 ): Promise<void> => {
 	const ad = createAdSlot(type, {
 		name,
@@ -85,7 +86,7 @@ const insertAdAtPara = (
 			}
 		})
 		.then(() => {
-			defineSlot(ad.id);
+			defineSlot(ad.id, 'inline', inlineId);
 		});
 };
 
@@ -207,6 +208,7 @@ const addDesktopInlineAds = async () => {
 				'inline',
 				'inline',
 				containerOptions,
+				inlineId,
 			);
 		});
 		await Promise.all(slots);

--- a/static/src/javascripts/projects/commercial/modules/consentless/dynamic/article-inline.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/dynamic/article-inline.ts
@@ -86,7 +86,7 @@ const insertAdAtPara = (
 			}
 		})
 		.then(() => {
-			defineSlot(ad.id, 'inline', inlineId);
+			defineSlot(ad.id, inlineId === 1 ? 'inline' : 'inline-right');
 		});
 };
 

--- a/static/src/javascripts/projects/commercial/modules/consentless/dynamic/liveblog-inline.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/dynamic/liveblog-inline.ts
@@ -103,7 +103,7 @@ const insertAdAtPara = (para: Node): Promise<void> => {
 			}
 		})
 		.then(() => {
-			defineSlot(ad.id);
+			defineSlot(ad.id, 'inline');
 		});
 };
 

--- a/static/src/javascripts/projects/commercial/modules/consentless/init-fixed-slots.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/init-fixed-slots.ts
@@ -10,7 +10,12 @@ const initFixedSlots = (): Promise<void> => {
 
 	// define slots
 	adverts.forEach((slotElement) => {
-		defineSlot(slotElement.id);
+		const slotName = slotElement.dataset.name?.includes('inline')
+			? 'inline'
+			: slotElement.dataset.name;
+		if (slotName) {
+			defineSlot(slotElement.id, slotName);
+		}
 	});
 
 	return Promise.resolve();

--- a/static/src/javascripts/projects/commercial/modules/consentless/prepare-ootag.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/prepare-ootag.ts
@@ -1,4 +1,5 @@
 import { loadScript } from '@guardian/libs';
+import { buildPageParameters } from './build-page-parameters';
 
 function initConsentless(): Promise<void> {
 	// Stub the command queue
@@ -14,6 +15,13 @@ function initConsentless(): Promise<void> {
 			onlyNoConsent: 1,
 		});
 		window.ootag.addParameter('test', 'yes');
+
+		Object.entries(buildPageParameters()).forEach(([key, value]) => {
+			if (!value) {
+				return;
+			}
+			window.ootag.addParameter(key, value);
+		});
 	});
 
 	// TODO this seems to be safeframeless version. Ask OptOut how we can use safeframes.

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -99,6 +99,7 @@ interface PageConfig extends CommercialPageConfig {
 	isFront: boolean; // https://github.com/guardian/frontend/blob/201cc764/common/app/model/meta.scala#L352
 	isHosted: boolean; // https://github.com/guardian/frontend/blob/66afe02e/common/app/common/commercial/hosted/HostedMetadata.scala#L37
 	isImmersive?: boolean;
+	isLiveBlog?: boolean;
 	isPaidContent: boolean;
 	isProd: boolean; // https://github.com/guardian/frontend/blob/33db7bbd/common/app/views/support/JavaScriptPage.scala
 	isSensitive: boolean;

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -129,6 +129,9 @@
   "../lib/config.d.ts",
   "../projects/common/modules/commercial/commercial-features.ts"
  ],
+ "../projects/commercial/modules/consentless/build-page-parameters.ts": [
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
+ ],
  "../projects/commercial/modules/consentless/define-slot.ts": [
   "../projects/commercial/modules/dfp/render-advert-label.ts"
  ],
@@ -156,7 +159,8 @@
   "../projects/commercial/modules/consentless/define-slot.ts"
  ],
  "../projects/commercial/modules/consentless/prepare-ootag.ts": [
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../projects/commercial/modules/consentless/build-page-parameters.ts"
  ],
  "../projects/commercial/modules/creatives/page-skin.ts": [
   "../../../../node_modules/fastdom/fastdom.d.ts",


### PR DESCRIPTION
## What does this change?
Setup ad slots in opt-out and use them in define-slot, for the moment setup as follows:

We can no longer override slot size mappings (🙃), so each set of size mappings must have a unique name.

Using the data-name attribute in most cases, except for `inline-right` AKA `inline2+` as they have additional sizes.

Add adtest url as a keyword targeting parameter, and setup an `adtest=fixed-puppies` test campaign.

This currently gets set as a 'keyword' as we need to ask opt out to add other params for us.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->
![Screenshot 2022-08-23 at 16 14 44](https://user-images.githubusercontent.com/1731150/186195969-89380a2e-f46f-4380-b6fa-9739eaca8399.png)


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
