### PR TITLE
Scala 2.13: Fix various syntax errors

### DIFF
--- a/admin/app/tools/charts/charts.scala
+++ b/admin/app/tools/charts/charts.scala
@@ -47,7 +47,7 @@ class ChartTable(private val labels: Seq[String]) {
       ChartRow(dateFormat(new DateTime(row._1)), row._2)
     }
 
-    chartRows.seq
+    chartRows
   }
 }
 

--- a/common/app/common/StringEncodings.scala
+++ b/common/app/common/StringEncodings.scala
@@ -16,7 +16,6 @@ object StringEncodings {
     */
   def jsonToJS(json: String): String =
     json
-      .replaceAll("""\u2028""", """\\u2028""")
-      .replaceAll("""\u2029""", """\\u2029""")
-
+      .replaceAll("\u2028", """\\u2028""")
+      .replaceAll("\u2029", """\\u2029""")
 }

--- a/common/app/common/TrailsToShowcase.scala
+++ b/common/app/common/TrailsToShowcase.scala
@@ -505,7 +505,7 @@ object TrailsToShowcase {
   }
 
   private def extractBulletsFrom(trailText: String): Either[Seq[String], BulletList] = {
-    val lines = new WrappedString(trailText).lines.toSeq
+    val lines = trailText.linesIterator.toSeq
 
     val proposedBulletTexts = lines
       .map(_.stripLeading)

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -210,13 +210,24 @@ class GuardianConfiguration extends GuLogging {
 
     lazy val key: Option[String] = configuration.getStringProperty("content.api.key")
     lazy val timeout: FiniteDuration =
-      Duration.create(configuration.getIntegerProperty("content.api.timeout.millis").getOrElse(2000), MILLISECONDS)
+      Duration.create(
+        configuration
+          .getIntegerProperty("content.api.timeout.millis")
+          .getOrElse(2000L)
+          .asInstanceOf[Number]
+          .longValue(),
+        MILLISECONDS,
+      )
 
     lazy val circuitBreakerErrorThreshold: Int =
       configuration.getIntegerProperty("content.api.circuit_breaker.max_failures").getOrElse(30)
     lazy val circuitBreakerResetTimeout: FiniteDuration =
       FiniteDuration(
-        configuration.getIntegerProperty("content.api.circuit_breaker.reset_timeout").getOrElse(2000),
+        configuration
+          .getIntegerProperty("content.api.circuit_breaker.reset_timeout")
+          .getOrElse(2000L)
+          .asInstanceOf[Number]
+          .longValue(),
         MILLISECONDS,
       )
 

--- a/common/app/model/Badges.scala
+++ b/common/app/model/Badges.scala
@@ -170,7 +170,7 @@ object Badges {
     badgeForTags(c.tags.tags.map(_.id))
   }
 
-  def badgeForTags(tags: Traversable[String]): Option[Badge] = {
+  def badgeForTags(tags: Iterable[String]): Option[Badge] = {
 
     val badgesForTags =
       for {

--- a/common/app/model/CrosswordGridModel.scala
+++ b/common/app/model/CrosswordGridModel.scala
@@ -1,13 +1,15 @@
 package crosswords
 
 import com.gu.contentapi.client.model.v1.{
-  CrosswordEntry,
-  CrosswordDimensions,
   Crossword,
+  CrosswordDimensions,
+  CrosswordEntry,
   CrosswordPosition => ApiCrosswordPosition,
 }
-import model.{Entry, CrosswordPosition}
+import model.{CrosswordPosition, Entry}
+
 import Function.const
+import scala.collection.compat.immutable.LazyList
 
 trait CrosswordGridDataOrdering {
   implicit val positionOrdering = Ordering.by[CrosswordPosition, (Int, Int)](position => (position.y, position.x))
@@ -15,7 +17,7 @@ trait CrosswordGridDataOrdering {
 
 trait CrosswordGridColumnNotation {
   val columnsByLetters =
-    (('A' to 'Z').toList.zip(Stream from 0) map { case (letter, number) => (number, letter) }).toMap
+    (('A' to 'Z').toList.zip(LazyList from 0) map { case (letter, number) => (number, letter) }).toMap
 }
 
 case class Cell(number: Option[Int])

--- a/common/app/model/facia.scala
+++ b/common/app/model/facia.scala
@@ -21,7 +21,7 @@ object SeoData extends GuLogging {
   val editions = Edition.all.map(_.id.toLowerCase)
 
   def fromPath(path: String): SeoData =
-    path.split('/').toList match {
+    (path.split('/').toList: @unchecked) match { // split() never gives the empty list
       //This case is only to handle the nonevent of uk/technology/games
       case edition :: section :: name :: tail if editions.contains(edition.toLowerCase) =>
         val webTitle: String = webTitleFromTail(name :: tail)

--- a/common/app/pagepresser/HtmlCleaner.scala
+++ b/common/app/pagepresser/HtmlCleaner.scala
@@ -197,7 +197,7 @@ abstract class HtmlCleaner extends GuLogging {
   }
 
   private def secureSource(src: String): String = {
-    src.replaceAllLiterally("http://", "//")
+    src.replace("http://", "//")
   }
 
 }


### PR DESCRIPTION
## What does this change?
This is the last PR that can be pulled in Scala 2.12 from https://github.com/guardian/frontend/pull/25190. Changes the following (see commit messages for the errors we are getting rid off):

* Removes call to deprecated `seq` method of `Iterable`
* Replaces deprecated unicode escapes in triple quoted strings
* Calls `linesIterator` on a `String` instead of `lines` on a `WrappedString`
* Becomes stricter about using a `Long` value 
* Replaces deprecated `Traversable` with `Iterable`
* Replaces deprecated `Stream` with `LazyList` 
* Adds `@unchecked` in superfluous pattern matching check
* Replaces deprecated method `replaceAllLiterally` call with `replace` in a `StringOps`

