### PR TITLE
feat: create and wireup OnwardsPicker

### DIFF
--- a/article/app/agents/CuratedContentAgent.scala
+++ b/article/app/agents/CuratedContentAgent.scala
@@ -1,0 +1,10 @@
+package agents
+
+import com.gu.contentapi.client.utils.format.Theme
+import common.{Edition, GuLogging}
+import model.dotcomrendering.Trail
+
+class CuratedContentAgent() extends GuLogging {
+  val containerIds: Map[Theme, Map[Edition, String]] = Map()
+  def getTrails(theme: Theme, edition: Edition): Seq[Trail] = Seq()
+}

--- a/article/app/controllers/ArticleControllers.scala
+++ b/article/app/controllers/ArticleControllers.scala
@@ -1,12 +1,13 @@
 package controllers
 
-import agents.DeeplyReadAgent
+import agents.{CuratedContentAgent, DeeplyReadAgent}
 import com.softwaremill.macwire._
 import contentapi.ContentApiClient
 import model.ApplicationContext
 import play.api.libs.ws.WSClient
 import play.api.mvc.ControllerComponents
 import renderers.DotcomRenderingService
+import services.dotcomponents.OnwardsPicker
 import services.{NewsletterService, NewspaperBookSectionTagAgent, NewspaperBookTagAgent}
 import services.newsletters.NewsletterSignupAgent
 import topics.{TopicS3Client, TopicService}
@@ -28,4 +29,6 @@ trait ArticleControllers {
   lazy val liveBlogController = wire[LiveBlogController]
   lazy val newsletterService = wire[NewsletterService]
   lazy val deeplyReadAgent = wire[DeeplyReadAgent]
+  lazy val curatedContentAgent = wire[CuratedContentAgent]
+  lazy val onwardsPicker = wire[OnwardsPicker]
 }

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -196,6 +196,7 @@ class LiveBlogController(
                 newsletter = None,
                 topicResult,
                 mostPopular = Some(mostPopular),
+                onwards = None,
               )
             } else {
               DotcomponentsLogger.logger.logRequest(s"liveblog executing in web", properties, page)

--- a/article/app/services/dotcomponents/OnwardsPicker.scala
+++ b/article/app/services/dotcomponents/OnwardsPicker.scala
@@ -1,0 +1,20 @@
+package services.dotcomponents
+
+import agents.CuratedContentAgent
+import common.Edition
+import model.dotcomrendering.OnwardCollectionResponse
+import model.{ArticlePage, ContentFormat}
+
+class OnwardsPicker(curatedContentAgent: CuratedContentAgent) {
+  def forArticle(article: ArticlePage, edition: Edition): Seq[OnwardCollectionResponse] = {
+    val format = article.article.content.metadata.format.getOrElse(ContentFormat.defaultContentFormat)
+    val curatedContent = curatedContentAgent.getTrails(format.theme, edition)
+
+    Seq(
+      OnwardCollectionResponse(
+        heading = s"More from ${format.theme}",
+        trails = curatedContent,
+      ),
+    )
+  }
+}

--- a/article/test/ArticleControllerTest.scala
+++ b/article/test/ArticleControllerTest.scala
@@ -1,6 +1,6 @@
 package test
 
-import agents.DeeplyReadAgent
+import agents.{CuratedContentAgent, DeeplyReadAgent}
 import controllers.ArticleController
 import org.apache.commons.codec.digest.DigestUtils
 import org.scalatest.flatspec.AnyFlatSpec
@@ -10,6 +10,7 @@ import org.scalatest.matchers.should.Matchers
 import play.api.test.Helpers._
 import play.api.test._
 import services.NewsletterService
+import services.dotcomponents.OnwardsPicker
 import services.newsletters.{NewsletterApi, NewsletterSignupAgent}
 
 @DoNotDiscover class ArticleControllerTest
@@ -33,6 +34,7 @@ import services.newsletters.{NewsletterApi, NewsletterSignupAgent}
     new DCRFake(),
     new NewsletterService(new NewsletterSignupAgent(new NewsletterApi(wsClient))),
     new DeeplyReadAgent(),
+    new OnwardsPicker(new CuratedContentAgent()),
   )
 
   "Article Controller" should "200 when content type is article" in {

--- a/article/test/DCRFake.scala
+++ b/article/test/DCRFake.scala
@@ -29,6 +29,7 @@ class DCRFake(implicit context: ApplicationContext) extends renderers.DotcomRend
       newsletter: Option[NewsletterData],
       topicResult: Option[TopicResult],
       mostPopular: Option[Seq[OnwardCollectionResponse]],
+      onwards: Option[Seq[OnwardCollectionResponse]],
   )(implicit request: RequestHeader): Future[Result] = {
     implicit val ec = ExecutionContext.global
     requestedBlogs.enqueue(article)

--- a/article/test/PublicationControllerTest.scala
+++ b/article/test/PublicationControllerTest.scala
@@ -1,6 +1,6 @@
 package test
 
-import agents.DeeplyReadAgent
+import agents.{CuratedContentAgent, DeeplyReadAgent}
 import controllers.{ArticleController, PublicationController}
 import model.TagDefinition
 import org.mockito.Mockito._
@@ -11,6 +11,7 @@ import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.Helpers._
 import services.{NewspaperBookSectionTagAgent, NewspaperBookTagAgent}
 import services.NewsletterService
+import services.dotcomponents.OnwardsPicker
 import services.newsletters.{NewsletterApi, NewsletterSignupAgent}
 
 @DoNotDiscover class PublicationControllerTest
@@ -40,6 +41,7 @@ import services.newsletters.{NewsletterApi, NewsletterSignupAgent}
       new DCRFake(),
       new NewsletterService(new NewsletterSignupAgent(new NewsletterApi(wsClient))),
       new DeeplyReadAgent(),
+      new OnwardsPicker(new CuratedContentAgent()),
     )
   lazy val publicationController =
     new PublicationController(bookAgent, bookSectionAgent, articleController, controllerComponents)

--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -54,3 +54,15 @@ object CommercialEndOfQuarterMegaTest
       sellByDate = LocalDate.of(2022, 10, 10),
       participationGroup = Perc10A,
     )
+
+object DCROnwardsData
+    extends Experiment(
+      name = "dcr-onwards-data",
+      // DCR will already render the data if we send it down the pipes.
+      // This will allow us to iterate on the feature.
+      // see: https://github.com/guardian/dotcom-rendering/blob/b649a00fc9e5d2ba158f82b7c4b152106579f6a9/dotcom-rendering/src/web/layouts/StandardLayout.tsx#L793-L798
+      description = "Switch to iterate on adding onwards data to be sent to DCR to be server rendered",
+      owners = Seq(Owner.withGithub("guardian/dotcom-platform")),
+      sellByDate = LocalDate.of(2023, 6, 2),
+      participationGroup = Perc0C,
+    )

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -98,6 +98,7 @@ case class DotcomRenderingDataModel(
     isSpecialReport: Boolean, // Indicates whether the page is a special report.
     promotedNewsletter: Option[NewsletterData],
     mostPopular: Option[Seq[OnwardCollectionResponse]],
+    onwards: Option[Seq[OnwardCollectionResponse]],
 )
 
 object DotcomRenderingDataModel {
@@ -217,6 +218,7 @@ object DotcomRenderingDataModel {
       request: RequestHeader,
       pageType: PageType,
       newsletter: Option[NewsletterData],
+      onwards: Option[Seq[OnwardCollectionResponse]],
   ): DotcomRenderingDataModel = {
     val linkedData = LinkedData.forArticle(
       article = page.article,
@@ -239,6 +241,7 @@ object DotcomRenderingDataModel {
       availableTopics = None,
       newsletter = newsletter,
       topicResult = None,
+      onwards = onwards,
     )
   }
 
@@ -343,6 +346,7 @@ object DotcomRenderingDataModel {
       newsletter: Option[NewsletterData],
       topicResult: Option[TopicResult],
       mostPopular: Option[Seq[OnwardCollectionResponse]] = None,
+      onwards: Option[Seq[OnwardCollectionResponse]] = None,
   ): DotcomRenderingDataModel = {
 
     val edition = Edition.edition(request)
@@ -516,6 +520,7 @@ object DotcomRenderingDataModel {
       webURL = content.metadata.webUrl,
       promotedNewsletter = newsletter,
       mostPopular = mostPopular,
+      onwards = onwards,
     )
   }
 }

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -140,7 +140,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
           newsletter = newsletter,
           topicResult = None,
         )
-      case _ => DotcomRenderingDataModel.forArticle(page, blocks, request, pageType, newsletter)
+      case _ => DotcomRenderingDataModel.forArticle(page, blocks, request, pageType, newsletter, None)
     }
     val json = DotcomRenderingDataModel.toJson(dataModel)
 
@@ -158,6 +158,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       newsletter: Option[NewsletterData],
       topicResult: Option[TopicResult],
       mostPopular: Option[Seq[OnwardCollectionResponse]],
+      onwards: Option[Seq[OnwardCollectionResponse]],
   )(implicit request: RequestHeader): Future[Result] = {
     val dataModel = page match {
       case liveblog: LiveBlogPage =>
@@ -172,7 +173,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
           newsletter,
           topicResult,
         )
-      case _ => DotcomRenderingDataModel.forArticle(page, blocks, request, pageType, newsletter)
+      case _ => DotcomRenderingDataModel.forArticle(page, blocks, request, pageType, newsletter, onwards)
     }
 
     val modelWithAgentData = dataModel.copy(mostPopular = mostPopular)


### PR DESCRIPTION
## What does this change?
- Adds `OnwardsPicker` that will take the different agents and return a `Seq[OnwardCollectionResponse]`.
- Adds a basic, do nothing `CuratedContentAgent` to start this wiring up
- add `DCROnwardsData` switch as is we send this down the pipes, it will render https://github.com/guardian/dotcom-rendering/pull/5578

This pattern should then be available for all other agents.

This logic currently lives in `getGuuiJson` as we only care about it in DCR, but we might need to replicate it in `LiveBlogController`.

Co-authored-by: Ioanna Kokkini [ioannakok@users.noreply.github.com](mailto:ioannakok@users.noreply.github.com)
Co-authored-by: Pete Faulconbridge [bryophyta@users.noreply.github.com](mailto:bryophyta@users.noreply.github.com)