### PR TITLE
Extend interactive-picker switch until 10/2022

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -439,7 +439,7 @@ trait FeatureSwitches {
     "Activate the Interactive Picker (routing interactives between frontend and DCR)",
     owners = Seq(Owner.withEmail("dotcom.platform@guardian.co.uk")),
     safeState = Off,
-    sellByDate = LocalDate.of(2022, 8, 25),
+    sellByDate = LocalDate.of(2022, 10, 25),
     exposeClientSide = false,
   )
 


### PR DESCRIPTION
## What does this change?
Extends `interactive-picker` switch until 25/10/2022. 

## Why?
To avoid failing builds as it was previously expiring on the 25/8/2022 at midnight. 
