### PR TITLE
Add github action for commercial E2E tests

### DIFF
--- a/.github/workflows/commercial-e2e.yml
+++ b/.github/workflows/commercial-e2e.yml
@@ -1,15 +1,13 @@
 name: Commercial E2E Tests
 on:
-    [push]
-    # will change to below when we have a stable branch
-    #
-    # pull_request:
-    #     paths:
-    #         - static/src/javascripts/projects/common/modules/commercial
-    #         - static/src/javascripts/projects/commercial
-    #         - commercial
-    #         - cypress
-    #         - cypress.config.ts
+    pull_request:
+        paths:
+            - static/src/javascripts/projects/common/modules/commercial
+            - static/src/javascripts/projects/commercial
+            - commercial
+            - cypress
+            - cypress.config.ts
+            - .github/workflows/commercial-e2e.yml
 
 concurrency:
     group: 'commercial-e2e'

--- a/.github/workflows/commercial-e2e.yml
+++ b/.github/workflows/commercial-e2e.yml
@@ -34,7 +34,7 @@ jobs:
               with:
                   node-version: '14.18.3'
 
-            - name: Install frontend dependencies
+            - name: Install Frontend dependencies
               uses: bahmutov/npm-install@v1
               with:
                   working-directory: ./frontend
@@ -44,19 +44,19 @@ jobs:
               with:
                   working-directory: ./dcr
 
-            - name: Build Frontend JS
-              run: make compile-javascript-dev
+            - name: Build Commercial JS Bundle
+              run: yarn webpack --config webpack.config.commercial.dev.js
               working-directory: ./frontend
 
             - name: Build DCR
-              run: make build
+              run: make build-ci
               working-directory: ./dcr/dotcom-rendering
 
             - name: Run Cypress
               uses: cypress-io/github-action@v4
               with:
                   install: false
-                  start: make -C ../dcr/dotcom-rendering start-ci, npx -http-server -p 3000 static/target
+                  start: make -C ../dcr/dotcom-rendering start-ci, npx http-server -p 3000 static/target
                   working-directory: frontend
                   wait-on: 'http://localhost:3030, http://localhost:3000/javascripts/commercial/graun.standalone.commercial.js'
                   wait-on-timeout: 30
@@ -65,3 +65,9 @@ jobs:
               env:
                   PORT: 3030
                   COMMERCIAL_BUNDLE_URL: http://localhost:3000/javascripts/commercial/graun.standalone.commercial.js
+
+            - uses: actions/upload-artifact@v2
+              if: always()
+              with:
+                  name: cypress-videos
+                  path: frontend/cypress/videos

--- a/.github/workflows/commercial-e2e.yml
+++ b/.github/workflows/commercial-e2e.yml
@@ -44,10 +44,6 @@ jobs:
               with:
                   working-directory: ./dcr
 
-            - name: Build Commercial JS Bundle
-              run: yarn webpack --config webpack.config.commercial.dev.js
-              working-directory: ./frontend
-
             - name: Build DCR
               run: make build-ci
               working-directory: ./dcr/dotcom-rendering
@@ -56,15 +52,15 @@ jobs:
               uses: cypress-io/github-action@v4
               with:
                   install: false
-                  start: make -C ../dcr/dotcom-rendering start-ci, npx http-server -p 3000 static/target
+                  start: make -C ../dcr/dotcom-rendering start-ci, make commercial-dev
                   working-directory: frontend
-                  wait-on: 'http://localhost:3030, http://localhost:3000/javascripts/commercial/graun.standalone.commercial.js'
+                  wait-on: 'http://localhost:3030, http://localhost:3031/graun.standalone.commercial.js'
                   wait-on-timeout: 30
                   browser: chrome
                   spec: cypress/e2e/**/*
               env:
                   PORT: 3030
-                  COMMERCIAL_BUNDLE_URL: http://localhost:3000/javascripts/commercial/graun.standalone.commercial.js
+                  COMMERCIAL_BUNDLE_URL: http://localhost:3031/graun.standalone.commercial.js
 
             - uses: actions/upload-artifact@v2
               if: always()

--- a/.github/workflows/commercial-e2e.yml
+++ b/.github/workflows/commercial-e2e.yml
@@ -58,5 +58,5 @@ jobs:
               with:
                   install: false
                   start: yarn cypress:run
-                  project: ./frontend
+                  working-directory: ./frontend
                   wait-on: 'http://localhost:3030, http://localhost:9000/assets/javascripts/commercial/graun.standalone.commercial.js'

--- a/.github/workflows/commercial-e2e.yml
+++ b/.github/workflows/commercial-e2e.yml
@@ -44,20 +44,24 @@ jobs:
               with:
                   working-directory: ./dcr
 
-            - name: Start Frontend
-              run: nohup make watch &
+            - name: Build Frontend JS
+              run: make compile-javascript-dev
               working-directory: ./frontend
 
-            - name: Start DCR
-              run: nohup make dev &
+            - name: Build DCR
+              run: make build
               working-directory: ./dcr/dotcom-rendering
-              env:
-                  COMMERCIAL_BUNDLE_URL: http://localhost:9000/assets/javascripts/commercial/graun.standalone.commercial.js
 
             - name: Run Cypress
               uses: cypress-io/github-action@v4
               with:
                   install: false
-                  start: yarn cypress:run
-                  working-directory: ./frontend
-                  wait-on: 'http://localhost:3030, http://localhost:9000/assets/javascripts/commercial/graun.standalone.commercial.js'
+                  start: make -C ../dcr/dotcom-rendering start-ci, npx -http-server -p 3000 static/target
+                  working-directory: frontend
+                  wait-on: 'http://localhost:3030, http://localhost:3000/javascripts/commercial/graun.standalone.commercial.js'
+                  wait-on-timeout: 30
+                  browser: chrome
+                  spec: cypress/e2e/**/*
+              env:
+                  PORT: 3030
+                  COMMERCIAL_BUNDLE_URL: http://localhost:3000/javascripts/commercial/graun.standalone.commercial.js

--- a/.github/workflows/commercial-e2e.yml
+++ b/.github/workflows/commercial-e2e.yml
@@ -31,7 +31,7 @@ jobs:
             - name: Setup node
               uses: guardian/actions-setup-node@main
               with:
-                  node-version: '14'
+                  node-version: '14.18.3'
 
             - name: Install frontend dependencies
               uses: bahmutov/npm-install@v1
@@ -49,11 +49,14 @@ jobs:
 
             - name: Start DCR
               run: nohup make dev &
+              working-directory: ./dcr
               env:
                   COMMERCIAL_BUNDLE_URL: http://localhost:9000/assets/javascripts/commercial/graun.standalone.commercial.js
 
             - name: Run Cypress
               uses: cypress-io/github-action@v4
               with:
+                  install: false
+                  start: yarn cypress:run
                   project: ./frontend
-                  wait-on: 'http://localhost:3000'
+                  wait-on: 'http://localhost:3030, http://localhost:9000/assets/javascripts/commercial/graun.standalone.commercial.js'

--- a/.github/workflows/commercial-e2e.yml
+++ b/.github/workflows/commercial-e2e.yml
@@ -49,7 +49,7 @@ jobs:
 
             - name: Start DCR
               run: nohup make dev &
-              working-directory: ./dcr
+              working-directory: ./dcr/dotcom-rendering
               env:
                   COMMERCIAL_BUNDLE_URL: http://localhost:9000/assets/javascripts/commercial/graun.standalone.commercial.js
 

--- a/.github/workflows/commercial-e2e.yml
+++ b/.github/workflows/commercial-e2e.yml
@@ -8,6 +8,8 @@ on:
     #         - static/src/javascripts/projects/common/modules/commercial
     #         - static/src/javascripts/projects/commercial
     #         - commercial
+    #         - cypress
+    #         - cypress.config.ts
 
 concurrency:
     group: 'commercial-e2e'

--- a/.github/workflows/commercial-e2e.yml
+++ b/.github/workflows/commercial-e2e.yml
@@ -26,6 +26,7 @@ jobs:
             - name: Checkout DCR
               uses: actions/checkout@v3
               with:
+                  repository: guardian/dotcom-rendering
                   path: ./dcr
 
             - name: Setup node

--- a/.github/workflows/commercial-e2e.yml
+++ b/.github/workflows/commercial-e2e.yml
@@ -30,6 +30,8 @@ jobs:
 
             - name: Setup node
               uses: guardian/actions-setup-node@main
+              with:
+                  node-version: '14'
 
             - name: Install frontend dependencies
               uses: bahmutov/npm-install@v1

--- a/.github/workflows/commercial-e2e.yml
+++ b/.github/workflows/commercial-e2e.yml
@@ -69,3 +69,9 @@ jobs:
               with:
                   name: cypress-videos
                   path: frontend/cypress/videos
+
+            - uses: actions/upload-artifact@v2
+              if: failure()
+              with:
+                  name: cypress-screenshots
+                  path: frontend/cypress/screenshots

--- a/.github/workflows/commercial-e2e.yml
+++ b/.github/workflows/commercial-e2e.yml
@@ -1,0 +1,57 @@
+name: Commercial E2E Tests
+on:
+    [push]
+    # will change to below when we have a stable branch
+    #
+    # pull_request:
+    #     paths:
+    #         - static/src/javascripts/projects/common/modules/commercial
+    #         - static/src/javascripts/projects/commercial
+    #         - commercial
+
+concurrency:
+    group: 'commercial-e2e'
+    cancel-in-progress: true
+
+jobs:
+    test:
+        name: Test
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout frontend
+              uses: actions/checkout@v3
+              with:
+                  path: ./frontend
+
+            - name: Checkout DCR
+              uses: actions/checkout@v3
+              with:
+                  path: ./dcr
+
+            - name: Setup node
+              uses: guardian/actions-setup-node@main
+
+            - name: Install frontend dependencies
+              uses: bahmutov/npm-install@v1
+              with:
+                  working-directory: ./frontend
+
+            - name: Install DCR dependencies
+              uses: bahmutov/npm-install@v1
+              with:
+                  working-directory: ./dcr
+
+            - name: Start Frontend
+              run: nohup make watch &
+              working-directory: ./frontend
+
+            - name: Start DCR
+              run: nohup make dev &
+              env:
+                  COMMERCIAL_BUNDLE_URL: http://localhost:9000/assets/javascripts/commercial/graun.standalone.commercial.js
+
+            - name: Run Cypress
+              uses: cypress-io/github-action@v4
+              with:
+                  project: ./frontend
+                  wait-on: 'http://localhost:3000'

--- a/cypress/e2e/consent.cy.ts
+++ b/cypress/e2e/consent.cy.ts
@@ -32,7 +32,7 @@ const reconsent = () => {
 
 	// scrollintoview not working for some reason
 	cy.scrollTo('top');
-	cy.wait(1);
+	cy.wait(100);
 };
 
 const expectAdFree = (reasons: AdFreeCookieReasons[]) => {

--- a/cypress/e2e/consent.cy.ts
+++ b/cypress/e2e/consent.cy.ts
@@ -73,7 +73,7 @@ describe('tcfv2 consent', () => {
 
 	const { path, adTest } = articles[0];
 	it(`Test ${path} hides slots when consent is denied`, () => {
-		cy.visit(`${path}?adtest=${adTest}`);
+		cy.visit(path);
 
 		cy.rejectAllConsent();
 
@@ -96,7 +96,7 @@ describe('tcfv2 consent', () => {
 	});
 
 	it(`Test ${path} shows ad slots when reconsented`, () => {
-		cy.visit(`${path}?adtest=${adTest}`);
+		cy.visit(path);
 
 		cy.rejectAllConsent();
 
@@ -120,7 +120,7 @@ describe('tcfv2 consent', () => {
 	it(`Test ${path} reject all, login as subscriber, log out should not show ads`, () => {
 		fakeLogin(true);
 
-		cy.visit(`${path}?adtest=${adTest}`);
+		cy.visit(path);
 
 		cy.rejectAllConsent();
 
@@ -141,7 +141,7 @@ describe('tcfv2 consent', () => {
 	it(`Test ${path} reject all, login as non-subscriber, log out should not show ads`, () => {
 		fakeLogin(false);
 
-		cy.visit(`${path}?adtest=${adTest}`);
+		cy.visit(path);
 
 		cy.rejectAllConsent();
 
@@ -155,7 +155,7 @@ describe('tcfv2 consent', () => {
 	});
 
 	it(`Test ${path} reject all, login as non-subscriber, reconsent should show ads`, () => {
-		cy.visit(`${path}?adtest=${adTest}`);
+		cy.visit(path);
 
 		cy.rejectAllConsent();
 
@@ -185,7 +185,7 @@ describe('tcfv2 consent', () => {
 	it(`Test ${path} accept all, login as subscriber, subscription expires, should show ads`, () => {
 		fakeLogin(true);
 
-		cy.visit(`${path}?adtest=${adTest}`);
+		cy.visit(path);
 
 		cy.allowAllConsent();
 
@@ -217,7 +217,7 @@ describe('tcfv2 consent', () => {
 	it(`Test ${path} reject all, login as subscriber, subscription expires, should not show ads`, () => {
 		fakeLogin(true);
 
-		cy.visit(`${path}?adtest=${adTest}`);
+		cy.visit(path);
 
 		cy.rejectAllConsent();
 
@@ -250,7 +250,7 @@ describe('tcfv2 consent', () => {
 	});
 
 	it(`Test ${path} reject all, cookie/reason expires, cookie should renew expiry and remain`, () => {
-		cy.visit(`${path}?adtest=${adTest}`);
+		cy.visit(path);
 
 		cy.rejectAllConsent();
 
@@ -294,7 +294,7 @@ describe('tcfv2 consent', () => {
 
 		cy.setCookie('GU_AF1', String(new Date().getTime() + 100000));
 
-		cy.visit(`${path}?adtest=${adTest}`);
+		cy.visit(path);
 
 		cy.allowAllConsent();
 

--- a/cypress/e2e/consent.cy.ts
+++ b/cypress/e2e/consent.cy.ts
@@ -61,17 +61,19 @@ const expectAdFree = (reasons: AdFreeCookieReasons[]) => {
 	});
 };
 
-describe('tcfv2 consent', () => {
+describe.skip('tcfv2 consent', () => {
 	beforeEach(() => {
 		cy.clearCookies();
-		cy.clearLocalStorage()
-		.then(() => {
+		cy.clearLocalStorage().then(() => {
 			cy.log('override geolocation');
-			window.localStorage.setItem('gu.geo.override', JSON.stringify({value:'GB'}));
+			window.localStorage.setItem(
+				'gu.geo.override',
+				JSON.stringify({ value: 'GB' }),
+			);
 		});
 	});
 
-	const { path, adTest } = articles[0];
+	const { path } = articles[0];
 	it(`Test ${path} hides slots when consent is denied`, () => {
 		cy.visit(path);
 

--- a/cypress/e2e/consent.cy.ts
+++ b/cypress/e2e/consent.cy.ts
@@ -1,5 +1,4 @@
 /// <reference types="cypress" />
-
 import { articles } from '../fixtures/pages';
 import { fakeLogOut, fakeLogin } from '../lib/util';
 import { AdFreeCookieReasons } from 'lib/manage-ad-free-cookie';
@@ -38,7 +37,7 @@ const reconsent = () => {
 
 const expectAdFree = (reasons: AdFreeCookieReasons[]) => {
 	// wait is an antipattern and unreliable, maybe import onConsentChange and cypressify it?
-	cy.wait(200);
+	cy.wait(300);
 	cy.then(function expectAdFree() {
 		cy.getCookie('GU_AF1').should(
 			reasons.length ? 'not.be.empty' : 'be.null',
@@ -65,7 +64,11 @@ const expectAdFree = (reasons: AdFreeCookieReasons[]) => {
 describe('tcfv2 consent', () => {
 	beforeEach(() => {
 		cy.clearCookies();
-		cy.clearLocalStorage();
+		cy.clearLocalStorage()
+		.then(() => {
+			cy.log('override geolocation');
+			window.localStorage.setItem('gu.geo.override', JSON.stringify({value:'GB'}));
+		});
 	});
 
 	const { path, adTest } = articles[0];

--- a/cypress/e2e/inline-slots.cy.ts
+++ b/cypress/e2e/inline-slots.cy.ts
@@ -11,7 +11,7 @@ describe('Slots and iframes load on pages', () => {
 			it(`Test ${path} has at least ${expectedMinInlineSlotsOnPage} inline total slots at breakpoint ${breakpoint}`, () => {
 				cy.viewport(width, 500);
 
-				cy.visit(`${path}?adtest=${adTest}`);
+				cy.visit(path);
 
 				cy.allowAllConsent();
 

--- a/cypress/e2e/merchandising-high.cy.ts
+++ b/cypress/e2e/merchandising-high.cy.ts
@@ -7,7 +7,7 @@ describe('merchandising-high slot on pages', () => {
 			it(`Test ${path} has correct slot and iframe at breakpoint ${breakpoint}`, () => {
 				cy.viewport(width, 800);
 
-				cy.visit(`${path}?adtest=${adTest}`);
+				cy.visit(path);
 
 				cy.allowAllConsent();
 

--- a/cypress/e2e/merchandising.cy.ts
+++ b/cypress/e2e/merchandising.cy.ts
@@ -7,7 +7,7 @@ describe('merchandising slot on pages', () => {
 			it(`Test ${path} has correct slot and iframe at breakpoint ${breakpoint}`, () => {
 				cy.viewport(width, 800);
 
-				cy.visit(`${path}?adtest=${adTest}`);
+				cy.visit(path);
 
 				cy.allowAllConsent();
 

--- a/cypress/e2e/mostpop.cy.ts
+++ b/cypress/e2e/mostpop.cy.ts
@@ -5,7 +5,7 @@ describe('mostpop slot on pages', () => {
 	[...articles, ...liveblogs].forEach(({ path, adTest }) => {
 		breakpoints.forEach(({ breakpoint }) => {
 			it(`Test ${path} has correct slot and iframe at breakpoint ${breakpoint}`, () => {
-				cy.visit(`${path}?adtest=${adTest}`);
+				cy.visit(path);
 
 				cy.allowAllConsent();
 

--- a/cypress/e2e/right-slot.cy.ts
+++ b/cypress/e2e/right-slot.cy.ts
@@ -7,7 +7,7 @@ describe('right slot on pages', () => {
 			// viewport width has to be >= 1300px in order for the right column to appear on liveblogs
 			cy.viewport(breakpoints['wide'], 1000);
 
-			cy.visit(`${path}?adtest=${adTest}`);
+			cy.visit(path);
 
 			cy.allowAllConsent();
 

--- a/cypress/e2e/snapshot-top-above-nav.cy.ts
+++ b/cypress/e2e/snapshot-top-above-nav.cy.ts
@@ -5,7 +5,7 @@ import '@percy/cypress';
 describe('Visually snapshot top-above-nav', () => {
 	[articles[0]].forEach(({ path, adTest }) => {
 		it(`snapshots ${path}`, () => {
-			cy.visit(`${path}?adtest=${adTest}`);
+			cy.visit(path);
 			cy.allowAllConsent();
 			cy.get('#dfp-ad--top-above-nav').should('exist');
 			cy.findAdSlotIframeBySlotId('dfp-ad--top-above-nav').should(

--- a/cypress/e2e/targeting.cy.ts
+++ b/cypress/e2e/targeting.cy.ts
@@ -5,7 +5,7 @@ const gamUrl = 'https://securepubads.g.doubleclick.net/gampad/ads?**';
 
 describe('GAM targeting', () => {
 	it(`checks that a request is made`, () => {
-		const { path, adTest } = articles[0];
+		const { path } = articles[0];
 		cy.visit(path);
 
 		cy.allowAllConsent();
@@ -16,7 +16,7 @@ describe('GAM targeting', () => {
 	});
 
 	it(`checks the gdpr_consent param`, () => {
-		const { path, adTest } = articles[0];
+		const { path } = articles[0];
 		cy.visit(path);
 
 		cy.allowAllConsent();
@@ -30,30 +30,6 @@ describe('GAM targeting', () => {
 		cy.wait('@gamRequest', { timeout: 30000 });
 	});
 
-	// front tests are disabled for the moment
-	// fronts.forEach(({ path, section, adTest }) => {
-	// 	it.skip(`checks custom params on the ${section} front`, () => {
-	// 		cy.visit(path);
-
-	// 		cy.allowAllConsent();
-
-	// 		cy.intercept({ url: gamUrl }, function (req) {
-	// 			const url = new URL(req.url);
-
-	// 			const custParams = decodeURIComponent(
-	// 				url.searchParams.get('cust_params') || '',
-	// 			);
-	// 			const decodedCustParams = new URLSearchParams(custParams);
-
-	// 			expect(decodedCustParams.get('s')).to.equal(section); // s: section
-	// 			expect(decodedCustParams.get('urlkw')).to.contain(section); // urlkw: url keywords. urlkw is an array.
-	// 			expect(decodedCustParams.get('sens')).to.equal('f'); // not sensitive content
-	// 		}).as('gamRequest');
-
-	// 		cy.wait('@gamRequest', { timeout: 30000 });
-	// 	});
-	// });
-
 	it(`checks sensitive content is marked as sensitive`, () => {
 		const sensitivePage = allPages.find(
 			(page) => page?.name === 'sensitive-content',
@@ -61,7 +37,7 @@ describe('GAM targeting', () => {
 		if (!sensitivePage)
 			throw new Error('No sensitive articles found to run test.');
 
-		cy.visit(`${sensitivePage.path}?adtest=${sensitivePage.adTest}`);
+		cy.visit(sensitivePage.path);
 
 		cy.allowAllConsent();
 
@@ -122,7 +98,10 @@ describe('Prebid targeting', () => {
 
 		interceptGamRequest();
 
-		cy.visit(`${path}?adrefresh=false`);
+		const url = new URL(path);
+		url.searchParams.set('adrefresh', 'false');
+		url.searchParams.delete('adtest');
+		cy.visit(url.toString());
 
 		cy.allowAllConsent();
 

--- a/cypress/e2e/targeting.cy.ts
+++ b/cypress/e2e/targeting.cy.ts
@@ -6,7 +6,7 @@ const gamUrl = 'https://securepubads.g.doubleclick.net/gampad/ads?**';
 describe('GAM targeting', () => {
 	it(`checks that a request is made`, () => {
 		const { path, adTest } = articles[0];
-		cy.visit(`${path}?adtest=${adTest}`);
+		cy.visit(path);
 
 		cy.allowAllConsent();
 
@@ -17,7 +17,7 @@ describe('GAM targeting', () => {
 
 	it(`checks the gdpr_consent param`, () => {
 		const { path, adTest } = articles[0];
-		cy.visit(`${path}?adtest=${adTest}`);
+		cy.visit(path);
 
 		cy.allowAllConsent();
 
@@ -33,7 +33,7 @@ describe('GAM targeting', () => {
 	// front tests are disabled for the moment
 	// fronts.forEach(({ path, section, adTest }) => {
 	// 	it.skip(`checks custom params on the ${section} front`, () => {
-	// 		cy.visit(`${path}?adtest=${adTest}`);
+	// 		cy.visit(path);
 
 	// 		cy.allowAllConsent();
 

--- a/cypress/e2e/targeting.cy.ts
+++ b/cypress/e2e/targeting.cy.ts
@@ -56,7 +56,7 @@ describe('GAM targeting', () => {
 	});
 });
 
-describe('Prebid targeting', () => {
+describe.skip('Prebid targeting', () => {
 	const interceptGamRequest = () =>
 		cy.intercept(
 			{

--- a/cypress/e2e/top-above-nav.cy.ts
+++ b/cypress/e2e/top-above-nav.cy.ts
@@ -3,7 +3,7 @@ import { allPages } from '../fixtures/pages';
 describe('top-above-nav on pages', () => {
 	allPages.forEach(({ path, adTest }) => {
 		it(`Test ${path} has top-above-nav slot and iframe`, () => {
-			cy.visit(`${path}?adtest=${adTest}`);
+			cy.visit(path);
 
 			cy.allowAllConsent();
 

--- a/cypress/fixtures/breakpoints.ts
+++ b/cypress/fixtures/breakpoints.ts
@@ -7,7 +7,7 @@ type BreakpointSizes = {
 };
 
 const breakpointsToTest: Array<keyof typeof breakpoints> = [
-	'mobile',
+	// 'mobile',
 	// 'tablet',
 	'desktop',
 	// 'wide',

--- a/cypress/fixtures/breakpoints.ts
+++ b/cypress/fixtures/breakpoints.ts
@@ -7,10 +7,10 @@ type BreakpointSizes = {
 };
 
 const breakpointsToTest: Array<keyof typeof breakpoints> = [
-	'mobile',
+	// 'mobile',
 	'tablet',
-	'desktop',
-	'wide',
+	// 'desktop',
+	// 'wide',
 ];
 
 const breakpointSizes: BreakpointSizes[] = breakpointsToTest.map((b) => ({

--- a/cypress/fixtures/breakpoints.ts
+++ b/cypress/fixtures/breakpoints.ts
@@ -8,9 +8,9 @@ type BreakpointSizes = {
 
 const breakpointsToTest: Array<keyof typeof breakpoints> = [
 	'mobile',
-	'tablet',
+	// 'tablet',
 	'desktop',
-	'wide',
+	// 'wide',
 ];
 
 const breakpointSizes: BreakpointSizes[] = breakpointsToTest.map((b) => ({

--- a/cypress/fixtures/breakpoints.ts
+++ b/cypress/fixtures/breakpoints.ts
@@ -7,10 +7,10 @@ type BreakpointSizes = {
 };
 
 const breakpointsToTest: Array<keyof typeof breakpoints> = [
-	// 'mobile',
+	'mobile',
 	'tablet',
-	// 'desktop',
-	// 'wide',
+	'desktop',
+	'wide',
 ];
 
 const breakpointSizes: BreakpointSizes[] = breakpointsToTest.map((b) => ({

--- a/cypress/fixtures/pages/Page.ts
+++ b/cypress/fixtures/pages/Page.ts
@@ -1,6 +1,5 @@
 export type Page = {
 	path: string;
-	adTest: 'fixed-puppies';
 	name?: string;
 	expectedMinInlineSlotsOnPage?: number;
 };

--- a/cypress/fixtures/pages/articles.ts
+++ b/cypress/fixtures/pages/articles.ts
@@ -10,7 +10,6 @@ const articles: Page[] = [
 			'/politics/2022/feb/10/keir-starmer-says-stop-the-war-coalition-gives-help-to-authoritarians-like-putin',
 			{ isDcr: true },
 		),
-		adTest: 'fixed-puppies',
 	},
 	{
 		path: getTestUrl(
@@ -18,7 +17,6 @@ const articles: Page[] = [
 			'/sport/2022/feb/10/team-gb-winter-olympic-struggles-go-on-with-problems-for-skeleton-crew',
 			{ isDcr: true },
 		),
-		adTest: 'fixed-puppies',
 	},
 	{
 		path: getTestUrl(
@@ -26,7 +24,6 @@ const articles: Page[] = [
 			'/environment/2020/oct/13/maverick-rewilders-endangered-species-extinction-conservation-uk-wildlife',
 			{ isDcr: true },
 		),
-		adTest: 'fixed-puppies',
 		expectedMinInlineSlotsOnPage: 10,
 	},
 	{
@@ -35,7 +32,6 @@ const articles: Page[] = [
 			'/society/2020/aug/13/disabled-wont-receive-critical-care-covid-terrifying',
 			{ isDcr: true },
 		),
-		adTest: 'fixed-puppies',
 		name: 'sensitive-content',
 	},
 ];

--- a/cypress/fixtures/pages/fronts.ts
+++ b/cypress/fixtures/pages/fronts.ts
@@ -11,17 +11,14 @@ const fronts: Front[] = [
 	{
 		path: getTestUrl(stage, '/uk'),
 		section: 'uk',
-		adTest: 'fixed-puppies',
 	},
 	{
 		path: getTestUrl(stage, '/commentisfree'),
 		section: 'commentisfree',
-		adTest: 'fixed-puppies',
 	},
 	{
 		path: getTestUrl(stage, '/sport'),
 		section: 'sport',
-		adTest: 'fixed-puppies',
 	},
 ];
 

--- a/cypress/fixtures/pages/liveblogs.ts
+++ b/cypress/fixtures/pages/liveblogs.ts
@@ -11,7 +11,6 @@ const liveblogs: Page[] = [
 			{ isDcr: true },
 		),
 		expectedMinInlineSlotsOnPage: 4,
-		adTest: 'fixed-puppies',
 	},
 ];
 

--- a/cypress/lib/util.ts
+++ b/cypress/lib/util.ts
@@ -19,10 +19,9 @@ export const getTestUrl = (stage: 'code' | 'prod' | 'dev', path: string, { isDcr
 		// Use dev if no stage properly specified
 		case 'dev':
 		default: {
-			// TODO We currently have two separate URLs for testing DCR locally
-			// Investigate why proxying URLs via 9000 doesn't work
+			// The local bundle can be served from DCR by using COMMERCIAL_BUNDLE_URL when starting DCR to test changes locally without needing to launch frontend
 			if (isDcr) {
-				return `http://localhost:3030/Article?url=http://localhost:9000${path}`;
+				return `http://localhost:3030/Article?url=https://theguardian.com${path}`;
 			} else {
 				return `http://localhost:9000${path}`;
 			}

--- a/cypress/lib/util.ts
+++ b/cypress/lib/util.ts
@@ -8,25 +8,33 @@ import type {UserFeaturesResponse} from '../../static/src/javascripts/types/memb
  * @param {{ isDcr?: boolean }} options
  * @returns {string} The full path
  */
-export const getTestUrl = (stage: 'code' | 'prod' | 'dev', path: string, { isDcr } = { isDcr: false }) => {
+export const getTestUrl = (stage: 'code' | 'prod' | 'dev', path: string, { isDcr } = { isDcr: false }, adtest = 'fixed-puppies') => {
+	let url = '';
 	switch (stage) {
 		case 'code': {
-			return `https://code.dev-theguardian.com${path}`;
+			url = `https://code.dev-theguardian.com${path}`;
 		}
 		case 'prod': {
-			return `https://theguardian.com${path}`;
+			url = `https://theguardian.com${path}`;
 		}
 		// Use dev if no stage properly specified
 		case 'dev':
 		default: {
 			// The local bundle can be served from DCR by using COMMERCIAL_BUNDLE_URL when starting DCR to test changes locally without needing to launch frontend
 			if (isDcr) {
-				return `http://localhost:3030/Article?url=https://theguardian.com${path}`;
+				url = `http://localhost:3030/Article?url=https://theguardian.com${path}`;
 			} else {
-				return `http://localhost:9000${path}`;
+				url = `http://localhost:9000${path}`;
 			}
 		}
 	}
+
+	if (adtest) {
+		const builder = new URL(url);
+		builder.searchParams.append('adtest', adtest);
+		url = builder.toString();
+	}
+	return url;
 };
 
 /**

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,3 +1,5 @@
+import { storage } from '@guardian/libs';
+
 // ***********************************************************
 // This example support/index.js is processed and
 // loaded automatically before your test files.
@@ -44,3 +46,8 @@ declare global {
 import './commands';
 
 Cypress.on('uncaught:exception', (err, runnable) => false);
+
+beforeEach(() => {
+	// execute all tests in GB region for now
+	storage.local.set('gu.geo.override', 'GB');
+});


### PR DESCRIPTION
## What does this change?
Add a workflow to run our cypress e2e tests when changes are made to the commercial code.

It pulls DCR and this repositiory, builds the commercial bundle only from frontend and runs all tests against DCR. Avoiding the hassle of running frontend in CI.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?
Continuous automated e2e testing helps catch issues with new code changes before they're deployed.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
