### PR TITLE
Bump `@guardian/libs` to ^7.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@guardian/braze-components": "^7.3.0",
     "@guardian/commercial-core": "4.8.0",
     "@guardian/consent-management-platform": "^10.7.1",
-    "@guardian/libs": "^3.6.1",
+    "@guardian/libs": "^7.1.3",
     "@guardian/shimport": "^1.0.2",
     "@guardian/source-foundations": "^4.0.3",
     "@guardian/source-react-components": "^4.0.2",

--- a/static/src/javascripts/lib/geolocation.ts
+++ b/static/src/javascripts/lib/geolocation.ts
@@ -26,9 +26,7 @@ let locale: CountryCode | null;
 const getCountryCode = (): CountryCode => {
 	const pageEdition = config.get<string>('page.edition');
 
-	const maybeCountryOverride = storage.local.get(
-		countryOverrideName,
-	) as unknown;
+	const maybeCountryOverride = storage.local.get(countryOverrideName);
 	const countryOverride = isString(maybeCountryOverride)
 		? (maybeCountryOverride as CountryCode)
 		: null;

--- a/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/coreVitals.ts
@@ -11,7 +11,7 @@ const coreVitals = (): void => {
 	const { isDev } = window.guardian.config.page;
 	const sampling = 1 / 100;
 
-	initCoreWebVitals({
+	void initCoreWebVitals({
 		browserId,
 		pageViewId,
 		isDev,
@@ -19,7 +19,9 @@ const coreVitals = (): void => {
 		team: 'dotcom',
 	});
 
-	if (shouldCaptureMetrics()) bypassCoreWebVitalsSampling('commercial');
+	if (shouldCaptureMetrics()) {
+		void bypassCoreWebVitalsSampling('commercial');
+	}
 };
 
 export { coreVitals };

--- a/static/src/javascripts/projects/common/modules/experiments/utils.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/utils.ts
@@ -3,5 +3,5 @@ import { bypassCoreWebVitalsSampling } from '@guardian/libs';
 
 export const bypassMetricsSampling = (): void => {
 	void bypassCommercialMetricsSampling();
-	bypassCoreWebVitalsSampling();
+	void bypassCoreWebVitalsSampling();
 };

--- a/static/src/javascripts/projects/common/modules/support/articleCount.ts
+++ b/static/src/javascripts/projects/common/modules/support/articleCount.ts
@@ -20,7 +20,6 @@ const isDailyArticleHistory = (data: unknown): data is DailyArticleHistory =>
 	Array.isArray(data);
 
 const getDailyArticleHistory = (): DailyArticleHistory | undefined => {
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- reading from local storage
 	const item = storage.local.get(storageKeyDailyArticleCount);
 	if (isDailyArticleHistory(item)) {
 		return item;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2125,15 +2125,15 @@
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-3.3.0.tgz#fa98c7b8216ab35b8cf3087cd9ba336958fac99a"
   integrity sha512-XB9o8qtDOg+KlPh1sjEr4u+Ai3RFTRr2riZ/HJpdlh8Cu4ZpYjCSGUZXSGkxp1CwFWT9sduANnsWSqZ97iBloQ==
 
-"@guardian/libs@^3.6.1":
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-3.9.0.tgz#330ef270b87f0262e09a5f9964b916c21d1f987a"
-  integrity sha512-2i/AvgeIVCdowSJuc/RnXVBZUROjNT48EbdQY5OtUSzgcR0o1EFoibVX7OAd6Y4nIFHULbx5XDhnH1ymYSSYlA==
-
 "@guardian/libs@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-4.1.0.tgz#a189f524379b71a19143050d364f9447ed70524b"
   integrity sha512-aCpwmw93fbiY8ZpEdKl1pefknrm6BmlrRzMm7at0/UMKMZbwBidqRnj1YnzEiWzwKPm8A00WKXhhzr3U5CEEpg==
+
+"@guardian/libs@^7.1.3":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-7.1.3.tgz#ce3a388de89ece01d2feb3860b5cf911cad9d38e"
+  integrity sha512-JAEW9J+o9QB6Aypu0Eu34WL+/1wJqQBSRj8pXroI51tJvVjv/o90Vfk4W9JpD2jO8b1IBDPwRB2c1O7yMYukeg==
 
 "@guardian/prettier@^1.0.0":
   version "1.0.0"


### PR DESCRIPTION
## What does this change?

Bump `@guardian/libs` to ^7.1.3

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [ ] Locally
- [x] On CODE (optional)
