### PR TITLE
Use new price granularity for Prebid-Index

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
@@ -16,6 +16,7 @@ import { bids } from './bid-config';
 import type { PrebidPriceGranularity } from './price-config';
 import {
 	criteoPriceGranularity,
+	indexPrebidPriceGranularity,
 	ozonePriceGranularity,
 	priceGranularity,
 } from './price-config';
@@ -225,8 +226,8 @@ let initialised = false;
 
 const initialise = (window: Window, framework: Framework = 'tcfv2'): void => {
 	if (!window.pbjs) {
-		console.warn('window.pbjs not found on window');
-		return void 0; // We couldn’t initialise
+		log('commercial', 'window.pbjs not found on window');
+		return; // We couldn’t initialise
 	}
 	initialised = true;
 
@@ -332,6 +333,26 @@ const initialise = (window: Window, framework: Framework = 'tcfv2'): void => {
 						`Custom Ozone price bucket for size (${width},${height}):`,
 						granularity,
 					);
+					return granularity;
+				},
+			},
+		});
+	}
+
+	if (window.guardian.config.switches.prebidIndexExchange) {
+		window.pbjs.setBidderConfig({
+			bidders: ['ix'],
+			config: {
+				guCustomPriceBucket: ({ width, height }) => {
+					const granularity =
+						indexPrebidPriceGranularity(width, height) ??
+						priceGranularity;
+					log(
+						'commercial',
+						`Custom Prebid Index price bucket for size (${width},${height}):`,
+						granularity,
+					);
+
 					return granularity;
 				},
 			},

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/price-config.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/price-config.spec.ts
@@ -1,10 +1,12 @@
 import {
 	criteoPriceGranularity,
+	indexPrebidPriceGranularity,
+	otherPrebidPriceGranularity,
 	ozonePriceGranularity,
 	priceGranularity,
 } from './price-config';
 
-describe('priceGranularity', () => {
+describe('price granularity', () => {
 	test('default should have correct buckets', () => {
 		expect(priceGranularity).toEqual({
 			buckets: [
@@ -39,55 +41,163 @@ describe('priceGranularity', () => {
 		});
 	});
 
-	const granularityOption1 = {
-		buckets: [
-			{
-				max: 10,
-				increment: 0.01,
-			},
-			{
-				max: 15,
-				increment: 0.1,
-			},
-			{
-				max: 50,
-				increment: 1,
-			},
-		],
-	};
+	describe('ozone', () => {
+		const ozoneGranularityOption1 = {
+			buckets: [
+				{
+					max: 10,
+					increment: 0.01,
+				},
+				{
+					max: 15,
+					increment: 0.1,
+				},
+				{
+					max: 50,
+					increment: 1,
+				},
+			],
+		};
 
-	const granularityOption2 = {
-		buckets: [
-			{
-				max: 12,
-				increment: 0.01,
-			},
-			{
-				max: 20,
-				increment: 0.1,
-			},
-			{
-				max: 50,
-				increment: 1,
-			},
-		],
-	};
+		const ozoneGranularityOption2 = {
+			buckets: [
+				{
+					max: 12,
+					increment: 0.01,
+				},
+				{
+					max: 20,
+					increment: 0.1,
+				},
+				{
+					max: 50,
+					increment: 1,
+				},
+			],
+		};
 
-	test.each([
-		[[100, 100], undefined],
-		[[160, 600], granularityOption1],
-		[[300, 600], granularityOption1],
-		[[728, 90], granularityOption2],
-		[[970, 250], granularityOption2],
-		[[300, 250], granularityOption2],
-		[[620, 350], granularityOption2],
-		[[300, 197], granularityOption2],
-	])(
-		'Ozone slot with size %s gives correct granularity',
-		([width, height], expectedGranularity) => {
-			expect(ozonePriceGranularity(width, height)).toEqual(
-				expectedGranularity,
-			);
-		},
-	);
+		test.each([
+			[[100, 100], undefined],
+			[[160, 600], ozoneGranularityOption1],
+			[[300, 600], ozoneGranularityOption1],
+			[[728, 90], ozoneGranularityOption2],
+			[[970, 250], ozoneGranularityOption2],
+			[[300, 250], ozoneGranularityOption2],
+			[[620, 350], ozoneGranularityOption2],
+			[[300, 197], ozoneGranularityOption2],
+		])(
+			'Ozone slot with size %s gives correct granularity',
+			([width, height], expectedGranularity) => {
+				expect(ozonePriceGranularity(width, height)).toEqual(
+					expectedGranularity,
+				);
+			},
+		);
+	});
+
+	describe('Index Prebid', () => {
+		const indexPrebidGranularityOption1 = {
+			buckets: [
+				{
+					max: 10,
+					increment: 0.01,
+				},
+				{
+					max: 15,
+					increment: 0.05,
+				},
+				{
+					max: 50,
+					increment: 1,
+				},
+			],
+		};
+
+		const indexPrebidGranularityOption2 = {
+			buckets: [
+				{
+					max: 12,
+					increment: 0.01,
+				},
+				{
+					max: 20,
+					increment: 0.05,
+				},
+				{
+					max: 50,
+					increment: 1,
+				},
+			],
+		};
+
+		test.each([
+			[[100, 100], undefined],
+			[[160, 600], indexPrebidGranularityOption1],
+			[[300, 600], indexPrebidGranularityOption1],
+			[[728, 90], indexPrebidGranularityOption2],
+			[[970, 250], indexPrebidGranularityOption2],
+			[[300, 250], indexPrebidGranularityOption2],
+		])(
+			'Index Prebid slot with size %s gives correct granularity',
+			([width, height], expectedGranularity) => {
+				expect(indexPrebidPriceGranularity(width, height)).toEqual(
+					expectedGranularity,
+				);
+			},
+		);
+	});
+
+	describe('Other Prebid', () => {
+		const otherPrebidGranularityOption1 = {
+			buckets: [
+				{
+					max: 7,
+					increment: 0.01,
+				},
+				{
+					max: 15,
+					increment: 0.1,
+				},
+				{
+					max: 50,
+					increment: 1,
+				},
+			],
+		};
+
+		const otherPrebidGranularityOption2 = {
+			buckets: [
+				{
+					max: 10,
+					increment: 0.01,
+				},
+				{
+					max: 15,
+					increment: 0.1,
+				},
+				{
+					max: 50,
+					increment: 1,
+				},
+			],
+		};
+
+		test.each([
+			[[100, 100], undefined],
+			[[160, 600], otherPrebidGranularityOption1],
+			[[300, 600], otherPrebidGranularityOption1],
+			[[320, 480], otherPrebidGranularityOption1],
+			[[728, 90], otherPrebidGranularityOption2],
+			[[970, 250], otherPrebidGranularityOption2],
+			[[300, 250], otherPrebidGranularityOption2],
+			[[320, 50], otherPrebidGranularityOption2],
+		])(
+			'Index Prebid slot with size %s gives correct granularity',
+			([width, height], expectedGranularity) => {
+				expect(otherPrebidPriceGranularity(width, height)).toEqual(
+					expectedGranularity,
+				);
+			},
+		);
+	});
 });

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/price-config.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/price-config.ts
@@ -96,3 +96,113 @@ export const ozonePriceGranularity = (
 
 	return undefined;
 };
+
+export const indexPrebidPriceGranularity = (
+	width: number,
+	height: number,
+): PrebidPriceGranularity | undefined => {
+	const sizeString = [width, height].join(',');
+
+	if (
+		sizeString === adSizes.skyscraper.toString() ||
+		sizeString === adSizes.halfPage.toString()
+	) {
+		return {
+			buckets: [
+				{
+					max: 10,
+					increment: 0.01,
+				},
+				{
+					max: 15,
+					increment: 0.05,
+				},
+				{
+					max: 50,
+					increment: 1,
+				},
+			],
+		};
+	}
+
+	if (
+		sizeString === adSizes.leaderboard.toString() ||
+		sizeString === adSizes.billboard.toString() ||
+		sizeString === adSizes.mpu.toString()
+	) {
+		return {
+			buckets: [
+				{
+					max: 12,
+					increment: 0.01,
+				},
+				{
+					max: 20,
+					increment: 0.05,
+				},
+				{
+					max: 50,
+					increment: 1,
+				},
+			],
+		};
+	}
+
+	return undefined;
+};
+
+export const otherPrebidPriceGranularity = (
+	width: number,
+	height: number,
+): PrebidPriceGranularity | undefined => {
+	const sizeString = [width, height].join(',');
+
+	if (
+		sizeString === adSizes.skyscraper.toString() ||
+		sizeString === adSizes.halfPage.toString() ||
+		sizeString === '320,480' // TODO find the name of this ad sizing
+	) {
+		return {
+			buckets: [
+				{
+					max: 7,
+					increment: 0.01,
+				},
+				{
+					max: 15,
+					increment: 0.1,
+				},
+				{
+					max: 50,
+					increment: 1,
+				},
+			],
+		};
+	}
+
+	if (
+		sizeString === adSizes.leaderboard.toString() ||
+		sizeString === adSizes.billboard.toString() ||
+		sizeString === adSizes.mpu.toString() ||
+		sizeString === adSizes.mobilesticky.toString()
+	) {
+		return {
+			buckets: [
+				{
+					max: 10,
+					increment: 0.01,
+				},
+				{
+					max: 15,
+					increment: 0.1,
+				},
+				{
+					max: 50,
+					increment: 1,
+				},
+			],
+		};
+	}
+
+	return undefined;
+};


### PR DESCRIPTION
## What does this change?

- Adds new price granularities for Prebid Index and Prebid-other (i.e. not index, criteo or ozone).
- Uses the new price granularities for Prebid Index (Prebid other will be used in a separate PR)

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

We need this change to be able to use our [new bucket distribution](https://github.com/guardian/commercial-tools/pull/146) for Prebid and Prebid Index

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
