### PR TITLE
Opt Out advertising: load IAB safeframe API

### DIFF
--- a/static/src/javascripts/bootstraps/standalone.commercial.ts
+++ b/static/src/javascripts/bootstraps/standalone.commercial.ts
@@ -17,6 +17,7 @@ import { log } from '@guardian/libs';
 import { initArticleInline } from 'commercial/modules/consentless/dynamic/article-inline';
 import { initLiveblogInline } from 'commercial/modules/consentless/dynamic/liveblog-inline';
 import { initFixedSlots } from 'commercial/modules/consentless/init-fixed-slots';
+import { initSafeframes } from 'commercial/modules/consentless/init-safeframes';
 import { initConsentless } from 'commercial/modules/consentless/prepare-ootag';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { consentlessAds } from 'common/modules/experiments/tests/consentlessAds';
@@ -220,6 +221,7 @@ const bootConsentless = async (): Promise<void> => {
 
 	await Promise.all([
 		setAdTestCookie(),
+		initSafeframes(),
 		initConsentless(),
 		initFixedSlots(),
 		initArticleInline(),

--- a/static/src/javascripts/projects/commercial/modules/consentless/init-safeframes.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/init-safeframes.ts
@@ -1,0 +1,22 @@
+import { loadScript } from '@guardian/libs';
+
+const initSafeframes = async (): Promise<void> => {
+	const safeframeScripts = [
+		'//cdn.optoutadvertising.com/script/sf/base.min.js',
+		'//cdn.optoutadvertising.com/script/sf/boot.min.js',
+		'//cdn.optoutadvertising.com/script/sf/host.min.js',
+	];
+
+	// These scripts must be loaded in the order set out above
+	// Hence why we await loading one before loading the next
+	for (const script of safeframeScripts) {
+		await loadScript(script);
+	}
+
+	window.conf = new window.$sf.host.Config({
+		renderFile: 'https://cdn.optoutadvertising.com/script/sf/r.html',
+		positions: {},
+	});
+};
+
+export { initSafeframes };

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -255,6 +255,48 @@ interface OptOutDefineSlotOptions {
 	emptyCallback?: () => void;
 }
 
+/**
+ * Describes the configuration options for the Safeframe host API
+ *
+ * Currently typed as `unknown` since we do not consume it ourselves
+ */
+type SafeFrameAPIHostConfig = unknown;
+
+/**
+ * Types for the IAB Safeframe API
+ *
+ * Note this type definition is incomplete.
+ * These types can be refined as/when they are required
+ */
+interface SafeFrameAPI {
+	ver: string;
+	specVersion: string;
+	lib: {
+		lang: Record<string, unknown>;
+		dom: {
+			iframes: Record<string, unknown>;
+			msghost: Record<string, unknown>;
+		};
+		logger: Record<string, unknown>;
+	};
+	env: {
+		isIE: boolean;
+		ua: Record<string, unknown>;
+	};
+	info: {
+		errs: unknown[];
+		list: unknown[];
+	};
+	host: {
+		Config: {
+			new (o: {
+				renderFile: string;
+				positions: Record<string, unknown>;
+			}): SafeFrameAPIHostConfig;
+		};
+	};
+}
+
 interface Window {
 	// eslint-disable-next-line id-denylist -- this *is* the guardian object
 	guardian: {
@@ -281,4 +323,10 @@ interface Window {
 	apstag?: Apstag;
 	_comscore?: ComscoreGlobals[];
 	__iasPET?: IasPET;
+
+	// https://www.iab.com/wp-content/uploads/2014/08/SafeFrames_v1.1_final.pdf
+	$sf: SafeFrameAPI;
+
+	// Safeframe API host config required by Opt Out tag
+	conf: SafeFrameAPIHostConfig;
 }

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -158,6 +158,9 @@
  "../projects/commercial/modules/consentless/init-fixed-slots.ts": [
   "../projects/commercial/modules/consentless/define-slot.ts"
  ],
+ "../projects/commercial/modules/consentless/init-safeframes.ts": [
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
+ ],
  "../projects/commercial/modules/consentless/prepare-ootag.ts": [
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../projects/commercial/modules/consentless/build-page-parameters.ts"
@@ -768,6 +771,7 @@
   "../projects/commercial/modules/consentless/dynamic/article-inline.ts",
   "../projects/commercial/modules/consentless/dynamic/liveblog-inline.ts",
   "../projects/commercial/modules/consentless/init-fixed-slots.ts",
+  "../projects/commercial/modules/consentless/init-safeframes.ts",
   "../projects/commercial/modules/consentless/prepare-ootag.ts",
   "../projects/commercial/modules/dfp/dfp-env-globals.ts",
   "../projects/commercial/modules/dfp/prepare-a9.ts",


### PR DESCRIPTION
## What does this change?

This PR adds a new module to our consentless code path to fetch the Safeframe API and make it available on the window.

Following the example laid out [here](https://cdn.optoutadvertising.com/script/sf/demo.html):
- Add the `base`, `boot` and `host` scripts for the IAB Safeframe API. We add them in this specific order in the HEAD of the document.
- Initialise a new configuration for the Host API (see [IAB Safeframe API docs for more on this](https://www.iab.com/wp-content/uploads/2014/08/SafeFrames_v1.1_final.pdf)).
- Make this configuration available on `window.conf`, (presumably) to be consumed by the Opt Out tag later.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

Since this is not yet used by the Opt Out tag, here is an example showing the presence of the Safeframe API on the window.

![Screenshot 2022-08-30 at 11 34 50](https://user-images.githubusercontent.com/8000415/187415524-e7fdc334-8dfa-4290-8c8c-a6de25f552a7.png)


## What is the value of this and can you measure success?

We'd like to serve all of our Opt Out advertising through safeframes. This is the first step - making the Safeframe API available on the window and setting the host configuration. The next step will be to upgrade the Opt Out tag to one which uses this API.

### Tested

- [X] Locally
- [ ] On CODE (optional)