### PR TITLE
Fix "Show more" on Football tag fixture pages

### DIFF
--- a/sport/app/football/containers/FixturesAndResults.scala
+++ b/sport/app/football/containers/FixturesAndResults.scala
@@ -70,7 +70,7 @@ class FixturesAndResults(competitions: Competitions) extends Football {
       val fixturesComponent = if (fixtureExists) {
         Some(
           matchesComponent(
-            TeamFixturesList(now, competitions.competitions, teamId, 2),
+            TeamFixturesList(now, competitions.competitions, teamId, tagId, 2),
             Some(s"Show more $teamName fixtures", s"/football/$tagId/fixtures"),
           ),
         )

--- a/sport/app/football/controllers/FixturesController.scala
+++ b/sport/app/football/controllers/FixturesController.scala
@@ -66,14 +66,14 @@ class FixturesController(
       .map(comp =>
         (
           Left(comp),
-          CompetitionFixturesList(date, competitionsService.competitions, comp.id),
+          CompetitionFixturesList(date, competitionsService.competitions, comp.id, tag),
         ),
       )
       .orElse {
         lookupTeam(tag).map(team =>
           (
             Right(team),
-            TeamFixturesList(date, competitionsService.competitions, team.id),
+            TeamFixturesList(date, competitionsService.competitions, team.id, tag),
           ),
         )
       }

--- a/sport/app/football/controllers/FixturesController.scala
+++ b/sport/app/football/controllers/FixturesController.scala
@@ -100,22 +100,4 @@ class FixturesController(
       case None => Action(NotFound)
     }
   }
-
-  def teamFixturesComponentJson(teamId: String): Action[AnyContent] = teamFixturesComponent(teamId)
-  def teamFixturesComponent(teamId: String): Action[AnyContent] =
-    Action { implicit request =>
-      competitionsService
-        .findTeam(teamId)
-        .map { team =>
-          val now = LocalDate.now(Edition.defaultEdition.timezoneId)
-          val fixtures = TeamFixturesList(now, competitionsService.competitions, teamId)
-          val page = new FootballPage(
-            s"football/${team.id}/fixtures",
-            "football",
-            s"${team.name} fixtures",
-          )
-          renderMatchList(page, fixtures, filters)
-        }
-        .getOrElse(NotFound)
-    }
 }

--- a/sport/app/football/model/matches.scala
+++ b/sport/app/football/model/matches.scala
@@ -127,19 +127,31 @@ case class FixturesList(date: LocalDate, competitions: Seq[Competition]) extends
   override def filterMatches(fMatch: FootballMatch, competition: Competition): Boolean =
     fMatch.isFixture
 }
-case class CompetitionFixturesList(date: LocalDate, competitions: Seq[Competition], competitionId: String)
-    extends Fixtures
+case class CompetitionFixturesList(
+    date: LocalDate,
+    competitions: Seq[Competition],
+    competitionId: String,
+    competitionTag: String,
+) extends Fixtures
     with CompetitionList {
   override val daysToDisplay = 20
   override def filterMatches(fMatch: FootballMatch, competition: Competition): Boolean =
     competition.id == competitionId && fMatch.isFixture
+  override val baseUrl: String = s"/football/$competitionTag/fixtures"
 }
 
-case class TeamFixturesList(date: LocalDate, competitions: Seq[Competition], teamId: String, daysToDisplay: Int = 20)
-    extends Fixtures
+case class TeamFixturesList(
+    date: LocalDate,
+    competitions: Seq[Competition],
+    teamId: String,
+    teamTag: String,
+    daysToDisplay: Int = 20,
+) extends Fixtures
     with TeamList {
   override def filterMatches(fMatch: FootballMatch, competition: Competition): Boolean =
     fMatch.isFixture && fMatch.hasTeam(teamId)
+
+  override val baseUrl: String = s"/football/$teamTag/fixtures"
 }
 
 case class ResultsList(date: LocalDate, competitions: Seq[Competition]) extends Results {

--- a/sport/conf/routes
+++ b/sport/conf/routes
@@ -19,6 +19,8 @@ GET        /football/fixtures/:year/:month/:day.json                            
 GET        /football/fixtures/:year/:month/:day                                                football.controllers.FixturesController.allFixturesFor(year, month, day)
 GET        /football/fixtures                                                                  football.controllers.FixturesController.allFixtures()
 GET        /football/fixtures.json                                                             football.controllers.FixturesController.allFixturesJson()
+GET        /football/:tag/fixtures/more/:year/:month/:day.json                                 football.controllers.FixturesController.moreTagFixturesForJson(year, month, day, tag)
+GET        /football/:tag/fixtures/more/:year/:month/:day                                      football.controllers.FixturesController.moreTagFixturesFor(year, month, day, tag)
 GET        /football/:tag/fixtures/:year/:month/:day.json                                      football.controllers.FixturesController.tagFixturesForJson(year, month, day, tag)
 GET        /football/:tag/fixtures/:year/:month/:day                                           football.controllers.FixturesController.tagFixturesFor(year, month, day, tag)
 GET        /football/:tag/fixtures                                                             football.controllers.FixturesController.tagFixturesJson(tag)

--- a/sport/test/football/model/FixturesListTest.scala
+++ b/sport/test/football/model/FixturesListTest.scala
@@ -154,7 +154,7 @@ import java.time.format.DateTimeFormatter
 
   "the competition fixtures list" - {
     "given competition 500" - {
-      val fixtures = CompetitionFixturesList(today, competitions.competitions, "500")
+      val fixtures = CompetitionFixturesList(today, competitions.competitions, "500", "Champions League")
 
       "should be showing the correct matches from the test data" in {
         fixtures.relevantMatches
@@ -183,7 +183,7 @@ import java.time.format.DateTimeFormatter
     }
 
     "given competition 100" - {
-      val fixtures = CompetitionFixturesList(today, competitions.competitions, "100")
+      val fixtures = CompetitionFixturesList(today, competitions.competitions, "100", "Premier League")
 
       "should be showing the correct matches from the test data" in {
         fixtures.relevantMatches
@@ -205,7 +205,7 @@ import java.time.format.DateTimeFormatter
 
   "the team fixtures list" - {
     "given spurs" - {
-      val fixtures = TeamFixturesList(today, competitions.competitions, spurs.id)
+      val fixtures = TeamFixturesList(today, competitions.competitions, spurs.id, spurs.name)
 
       "should be showing the correct matches from the test data" in {
         fixtures.relevantMatches


### PR DESCRIPTION
## What does this change?

- Adds a new "Show more" endpoint which supports filtering fixtures by team or competition tag
- Updates link used by pagination button on a competition/team fixtures page to use the new endpoint
- Refactors fixtures controller to allow a bit more flexibility when fetching fixtures by tag

Fixes #25410

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

Taken from https://www.theguardian.com/football/premierleague/fixtures

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/21217225/187669014-31952764-28fa-437b-92b9-86a668e741f2.gif
[after]: https://user-images.githubusercontent.com/21217225/187669074-edd4488c-a4bd-4f35-ba12-34a60d0dcc6b.gif
