### PR TITLE
Add test run for new long-running AB test trial implementation

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -27,6 +27,16 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
+    "ab-sign-in-gate-mandatory-long-test-run",
+    "Mandatory sign in gate to users over 6 weeks",
+    owners = Seq(Owner.withGithub("vlbee")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2022, 12, 1)),
+    exposeClientSide = true,
+  )
+
+  Switch(
+    ABTests,
     "ab-deeply-read-article-footer",
     "Test whether adding deeply read articles have negative impact on recirculation",
     owners = Seq(Owner.withName("dotcom.platform")),

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -27,8 +27,38 @@ trait ABTestSwitches {
 
   Switch(
     ABTests,
-    "ab-sign-in-gate-mandatory-long-test-run",
-    "Mandatory sign in gate to users over 6 weeks",
+    "ab-sign-in-gate-mandatory-long-test-run-uk",
+    "Test run for long mandatory sign in gate trial",
+    owners = Seq(Owner.withGithub("vlbee")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2022, 12, 1)),
+    exposeClientSide = true,
+  )
+
+  Switch(
+    ABTests,
+    "ab-sign-in-gate-mandatory-long-test-run-na",
+    "Test run for long mandatory sign in gate trial",
+    owners = Seq(Owner.withGithub("vlbee")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2022, 12, 1)),
+    exposeClientSide = true,
+  )
+
+  Switch(
+    ABTests,
+    "ab-sign-in-gate-mandatory-long-test-run-aunz",
+    "Test run for long mandatory sign in gate trial",
+    owners = Seq(Owner.withGithub("vlbee")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2022, 12, 1)),
+    exposeClientSide = true,
+  )
+
+  Switch(
+    ABTests,
+    "ab-sign-in-gate-mandatory-long-test-run-eu",
+    "Test run for long mandatory sign in gate trial",
     owners = Seq(Owner.withGithub("vlbee")),
     safeState = Off,
     sellByDate = Some(LocalDate.of(2022, 12, 1)),

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -5,12 +5,14 @@ import { integrateIMA } from './tests/integrate-ima';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
+import { signInGateMandatoryLongTestRun } from './tests/sign-in-gate-mandatory-long';
 
 // keep in sync with ab-tests in dotcom-rendering
 // https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/experiments/ab-tests.ts
 export const concurrentTests: readonly ABTest[] = [
 	signInGateMainVariant,
 	signInGateMainControl,
+	signInGateMandatoryLongTestRun,
 	remoteRRHeaderLinksTest,
 	deeplyReadArticleFooterTest,
 	consentlessAds,

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -5,16 +5,24 @@ import { integrateIMA } from './tests/integrate-ima';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
-import { signInGateMandatoryLongTestRun } from './tests/sign-in-gate-mandatory-long';
+import {
+	signInGateMandatoryLongTestRunAunz,
+	signInGateMandatoryLongTestRunEu,
+	signInGateMandatoryLongTestRunNa,
+	signInGateMandatoryLongTestRunUk,
+} from './tests/sign-in-gate-mandatory-long';
 
 // keep in sync with ab-tests in dotcom-rendering
 // https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/experiments/ab-tests.ts
 export const concurrentTests: readonly ABTest[] = [
 	signInGateMainVariant,
 	signInGateMainControl,
-	signInGateMandatoryLongTestRun,
 	remoteRRHeaderLinksTest,
 	deeplyReadArticleFooterTest,
 	consentlessAds,
 	integrateIMA,
+	signInGateMandatoryLongTestRunAunz,
+	signInGateMandatoryLongTestRunEu,
+	signInGateMandatoryLongTestRunNa,
+	signInGateMandatoryLongTestRunUk,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
@@ -9,7 +9,7 @@ export const signInGateMainVariant = {
 	description:
 		'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Main/Variant Audience.',
 	audience: 0.89,
-	audienceOffset: 0.01,
+	audienceOffset: 0.0,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:
 		'3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
@@ -8,8 +8,8 @@ export const signInGateMainVariant = {
 	author: 'Mahesh Makani',
 	description:
 		'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Main/Variant Audience.',
-	audience: 0.9,
-	audienceOffset: 0.0,
+	audience: 0.8999,
+	audienceOffset: 0.0001,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:
 		'3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-main-variant.js
@@ -8,8 +8,8 @@ export const signInGateMainVariant = {
 	author: 'Mahesh Makani',
 	description:
 		'Show sign in gate to 100% of users on 3rd article view of simple article templates, with higher priority over banners and epic. Main/Variant Audience.',
-	audience: 0.8999,
-	audienceOffset: 0.0001,
+	audience: 0.89,
+	audienceOffset: 0.01,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:
 		'3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-mandatory-long.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-mandatory-long.js
@@ -5,8 +5,8 @@ export const signInGateMandatoryLongTestRunUk = {
 	author: 'vlbee',
 	description:
 		'Test run for long mandatory test - Show sign in gate to global users on 3rd article view of simple article templates, with higher priority over banners and epic.',
-	audience: 0.01,
-	audienceOffset: 0.0,
+	audience: 0.0025,
+	audienceOffset: 0.89,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:
 		'Global, 3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
@@ -30,8 +30,8 @@ export const signInGateMandatoryLongTestRunNa = {
 	author: 'vlbee',
 	description:
 		'Test run for long mandatory test - Show sign in gate to global users on 3rd article view of simple article templates, with higher priority over banners and epic.',
-	audience: 0.01,
-	audienceOffset: 0.0,
+	audience: 0.0025,
+	audienceOffset: 0.8925,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:
 		'Global, 3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
@@ -55,8 +55,8 @@ export const signInGateMandatoryLongTestRunAunz = {
 	author: 'vlbee',
 	description:
 		'Test run for long mandatory test - Show sign in gate to global users on 3rd article view of simple article templates, with higher priority over banners and epic.',
-	audience: 0.01,
-	audienceOffset: 0.0,
+	audience: 0.0025,
+	audienceOffset: 0.895,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:
 		'Global, 3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
@@ -80,8 +80,8 @@ export const signInGateMandatoryLongTestRunEu = {
 	author: 'vlbee',
 	description:
 		'Test run for long mandatory test - Show sign in gate to global users on 3rd article view of simple article templates, with higher priority over banners and epic.',
-	audience: 0.01,
-	audienceOffset: 0.0,
+	audience: 0.0025,
+	audienceOffset: 0.8975,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:
 		'Global, 3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-mandatory-long.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-mandatory-long.js
@@ -1,23 +1,98 @@
-export const signInGateMandatoryLongTestRun = {
-	id: 'SignInGateMandatoryLongTestRun',
-	start: '2022-08-01',
+export const signInGateMandatoryLongTestRunUk = {
+	id: 'SignInGateMandatoryLongTestRunUk',
+	start: '2022-09-20',
 	expiry: '2022-10-01',
 	author: 'vlbee',
 	description:
-		'Show mandatory sign in gate to global users on 3rd article view of simple article templates, with higher priority over banners and epic.',
-	audience: 0.0001, // todo
-	audienceOffset: 0.0, // todo
+		'Test run for long mandatory test - Show sign in gate to global users on 3rd article view of simple article templates, with higher priority over banners and epic.',
+	audience: 0.01,
+	audienceOffset: 0.0,
 	successMeasure: 'Users sign in or create a Guardian account',
 	audienceCriteria:
 		'Global, 3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
-	dataLinkNames: 'SignInGateMandatoryLongTestVariant',
+	dataLinkNames: 'SignInGateMandatoryLongTestRunUk',
 	idealOutcome:
 		'Increase the number of users signed in whilst running at a reasonable scale',
 	showForSensitive: false,
 	canRun: () => true,
 	variants: [
 		{
-			id: 'mandatory-long-testrun',
+			id: 'mandatory-long-testrun-uk',
+			test: () => {},
+		},
+	],
+};
+
+export const signInGateMandatoryLongTestRunNa = {
+	id: 'SignInGateMandatoryLongTestRunNa',
+	start: '2022-09-20',
+	expiry: '2022-10-01',
+	author: 'vlbee',
+	description:
+		'Test run for long mandatory test - Show sign in gate to global users on 3rd article view of simple article templates, with higher priority over banners and epic.',
+	audience: 0.01,
+	audienceOffset: 0.0,
+	successMeasure: 'Users sign in or create a Guardian account',
+	audienceCriteria:
+		'Global, 3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
+	dataLinkNames: 'SignInGateMandatoryLongTestRunNA',
+	idealOutcome:
+		'Increase the number of users signed in whilst running at a reasonable scale',
+	showForSensitive: false,
+	canRun: () => true,
+	variants: [
+		{
+			id: 'mandatory-long-testrun-na',
+			test: () => {},
+		},
+	],
+};
+
+export const signInGateMandatoryLongTestRunAunz = {
+	id: 'SignInGateMandatoryLongTestRunAunz',
+	start: '2022-09-20',
+	expiry: '2022-10-01',
+	author: 'vlbee',
+	description:
+		'Test run for long mandatory test - Show sign in gate to global users on 3rd article view of simple article templates, with higher priority over banners and epic.',
+	audience: 0.01,
+	audienceOffset: 0.0,
+	successMeasure: 'Users sign in or create a Guardian account',
+	audienceCriteria:
+		'Global, 3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
+	dataLinkNames: 'SignInGateMandatoryLongTestRunAunz',
+	idealOutcome:
+		'Increase the number of users signed in whilst running at a reasonable scale',
+	showForSensitive: false,
+	canRun: () => true,
+	variants: [
+		{
+			id: 'mandatory-long-testrun-aunz',
+			test: () => {},
+		},
+	],
+};
+
+export const signInGateMandatoryLongTestRunEu = {
+	id: 'SignInGateMandatoryLongTestRunEu',
+	start: '2022-09-20',
+	expiry: '2022-10-01',
+	author: 'vlbee',
+	description:
+		'Test run for long mandatory test - Show sign in gate to global users on 3rd article view of simple article templates, with higher priority over banners and epic.',
+	audience: 0.01,
+	audienceOffset: 0.0,
+	successMeasure: 'Users sign in or create a Guardian account',
+	audienceCriteria:
+		'Global, 3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
+	dataLinkNames: 'SignInGateMandatoryLongTestRunEu',
+	idealOutcome:
+		'Increase the number of users signed in whilst running at a reasonable scale',
+	showForSensitive: false,
+	canRun: () => true,
+	variants: [
+		{
+			id: 'mandatory-long-testrun-eu',
 			test: () => {},
 		},
 	],

--- a/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-mandatory-long.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/sign-in-gate-mandatory-long.js
@@ -1,0 +1,24 @@
+export const signInGateMandatoryLongTestRun = {
+	id: 'SignInGateMandatoryLongTestRun',
+	start: '2022-08-01',
+	expiry: '2022-10-01',
+	author: 'vlbee',
+	description:
+		'Show mandatory sign in gate to global users on 3rd article view of simple article templates, with higher priority over banners and epic.',
+	audience: 0.0001, // todo
+	audienceOffset: 0.0, // todo
+	successMeasure: 'Users sign in or create a Guardian account',
+	audienceCriteria:
+		'Global, 3rd article of the day, lower priority than consent banner, simple articles (not gallery, live etc.), not signed in, not shown after dismiss, not on help, info sections etc. Exclude iOS 9 and guardian-live-australia. Suppresses other banners, and appears over epics',
+	dataLinkNames: 'SignInGateMandatoryLongTestVariant',
+	idealOutcome:
+		'Increase the number of users signed in whilst running at a reasonable scale',
+	showForSensitive: false,
+	canRun: () => true,
+	variants: [
+		{
+			id: 'mandatory-long-testrun',
+			test: () => {},
+		},
+	],
+};


### PR DESCRIPTION
## What does this change?

Adds AB test switch and definition required for this AB test - https://github.com/guardian/dotcom-rendering/pull/5891

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
