### PR TITLE
Opt Out advertising: Upgrade tag to v3

### DIFF
--- a/static/src/javascripts/bootstraps/standalone.commercial.ts
+++ b/static/src/javascripts/bootstraps/standalone.commercial.ts
@@ -227,6 +227,10 @@ const bootConsentless = async (): Promise<void> => {
 		initArticleInline(),
 		initLiveblogInline(),
 	]);
+
+	// Since we're in single-request mode
+	// Call this once all ad slots are present on the page
+	window.ootag.makeRequests();
 };
 
 /* Provide consentless advertising in the variant of a zero-percent test,

--- a/static/src/javascripts/projects/commercial/modules/consentless/define-slot.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/define-slot.ts
@@ -5,6 +5,7 @@ const defineSlot = (slotId: string, slotName: string): void => {
 		window.ootag.defineSlot({
 			adSlot: slotName,
 			targetId: slotId,
+			id: slotId,
 			filledCallback: () => {
 				const slotElement = document.getElementById(slotId);
 				if (slotElement) {

--- a/static/src/javascripts/projects/commercial/modules/consentless/init-safeframes.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/init-safeframes.ts
@@ -1,4 +1,28 @@
 import { loadScript } from '@guardian/libs';
+import fastdom from '../../../../lib/fastdom-promise';
+
+/**
+ * Insert styling necessary for Opt-Out served safeframes.
+ *
+ * We insert these dynamically to ensure they are applied across all platforms
+ * and only when in the variant of the consentless test. This could be revisited
+ * in the future, and whether we can apply these styles server-side.
+ *
+ */
+const insertSafeframeStyles = (): Promise<void> => {
+	const css = `
+		.iab_sf {
+			margin: auto;
+		}
+	`;
+
+	const style = document.createElement('style');
+	style.appendChild(document.createTextNode(css));
+
+	return fastdom.mutate(() => {
+		document.head.appendChild(style);
+	});
+};
 
 const initSafeframes = async (): Promise<void> => {
 	const safeframeScripts = [
@@ -17,6 +41,8 @@ const initSafeframes = async (): Promise<void> => {
 		renderFile: 'https://cdn.optoutadvertising.com/script/sf/r.html',
 		positions: {},
 	});
+
+	void insertSafeframeStyles();
 };
 
 export { initSafeframes };

--- a/static/src/javascripts/projects/commercial/modules/consentless/prepare-ootag.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/prepare-ootag.ts
@@ -23,7 +23,7 @@ function initConsentless(): Promise<void> {
 		});
 	});
 
-	void loadScript('//cdn.optoutadvertising.com/script/ooguardian.v2.min.js');
+	void loadScript('//cdn.optoutadvertising.com/script/ooguardian.v3.min.js');
 	return Promise.resolve();
 }
 

--- a/static/src/javascripts/projects/commercial/modules/consentless/prepare-ootag.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/prepare-ootag.ts
@@ -24,8 +24,7 @@ function initConsentless(): Promise<void> {
 		});
 	});
 
-	// TODO this seems to be safeframeless version. Ask OptOut how we can use safeframes.
-	void loadScript('//cdn.optoutadvertising.com/script/ootag.min.js');
+	void loadScript('//cdn.optoutadvertising.com/script/ooguardian.v2.min.js');
 	return Promise.resolve();
 }
 

--- a/static/src/javascripts/projects/commercial/modules/consentless/prepare-ootag.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/prepare-ootag.ts
@@ -11,8 +11,7 @@ function initConsentless(): Promise<void> {
 		window.ootag.initializeOo({
 			publisher: 33,
 			noLogging: 0,
-			// consentTimeOutMS: 5000,
-			onlyNoConsent: 1,
+			alwaysNoConsent: 1,
 		});
 		window.ootag.addParameter('test', 'yes');
 

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -243,16 +243,40 @@ interface IasPET {
 
 interface OptOutInitializeOptions {
 	publisher: number;
-	onlyNoConsent: 0 | 1;
+	onlyNoConsent?: 0 | 1;
+	alwaysNoConsent?: 0 | 1;
 	consentTimeOutMS?: 5000;
 	noLogging?: 0 | 1;
+	lazyLoading?: { fractionInView?: number; viewPortMargin?: string };
 }
 
-interface OptOutDefineSlotOptions {
+interface OptOutResponse {
+	adSlot: string;
+	width: number;
+	height: number;
+	ad: string; // The creative HTML
+	creativeId: string;
+	meta: {
+		networkId: string;
+		networkName: string;
+		agencyId: string;
+		agencyName: string;
+		advertiserId: string;
+		advertiserName: string;
+		advertiserDomains: string[];
+	};
+	optOutExt: {
+		noSafeFrame: boolean;
+		tags: string[];
+	};
+}
+
+interface OptOutAdSlot {
 	adSlot: string;
 	targetId: string;
-	filledCallback?: () => void;
-	emptyCallback?: () => void;
+	filledCallback?: (adSlot: OptOutAdSlot, response: OptOutResponse) => void;
+	emptyCallback?: (adSlot: OptOutAdSlot) => void;
+	adShownCallback?: (adSlot: OptOutAdSlot, response: OptOutResponse) => void;
 }
 
 /**
@@ -317,8 +341,10 @@ interface Window {
 		queue: Array<() => void>;
 		initializeOo: (o: OptOutInitializeOptions) => void;
 		addParameter: (key: string, value: string) => void;
-		defineSlot: (o: OptOutDefineSlotOptions) => void;
+		defineSlot: (o: OptOutAdSlot) => void;
 		makeRequests: () => void;
+		refreshSlot: (slotId: string) => void;
+		refreshAllSlots: () => void;
 	};
 	confiant?: Confiant;
 	apstag?: Apstag;

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -318,6 +318,7 @@ interface Window {
 		initializeOo: (o: OptOutInitializeOptions) => void;
 		addParameter: (key: string, value: string) => void;
 		defineSlot: (o: OptOutDefineSlotOptions) => void;
+		makeRequests: () => void;
 	};
 	confiant?: Confiant;
 	apstag?: Apstag;

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -274,6 +274,7 @@ interface OptOutResponse {
 interface OptOutAdSlot {
 	adSlot: string;
 	targetId: string;
+	id: string;
 	filledCallback?: (adSlot: OptOutAdSlot, response: OptOutResponse) => void;
 	emptyCallback?: (adSlot: OptOutAdSlot) => void;
 	adShownCallback?: (adSlot: OptOutAdSlot, response: OptOutResponse) => void;

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -629,3 +629,8 @@
     margin-bottom: 12px;
     position: relative;
 }
+
+/* Necessary for IAB safeframes served via Opt Out */
+.iab_sf {
+    margin: auto;
+}

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -629,8 +629,3 @@
     margin-bottom: 12px;
     position: relative;
 }
-
-/* Necessary for IAB safeframes served via Opt Out */
-.iab_sf {
-    margin: auto;
-}

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -159,7 +159,8 @@
   "../projects/commercial/modules/consentless/define-slot.ts"
  ],
  "../projects/commercial/modules/consentless/init-safeframes.ts": [
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../lib/fastdom-promise.js"
  ],
  "../projects/commercial/modules/consentless/prepare-ootag.ts": [
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",


### PR DESCRIPTION
## What does this change?
- updates the version of the Opt Out Advertising script we request for users in the consentless ads 0% test from to version 3. This version of the script includes support for [SafeFrames](https://www.iab.com/wp-content/uploads/2014/08/SafeFrames_v1.1_final.pdf) 
- The new version of the script includes an unrelated change to the way that ad slot creatives are requested from the ad server. Rather than a making a request per ad slot when it is defined, this version batches the requests, necessitating a few other changes:
  - call `ootag.makeRequests` after fixed and dynamic slots have been defined. This sends the batched request to Opt Out.
  - pass an additional parameter `id` to `ootag.defineSlot`. In single request mode this is necessary so that the opt out script can populate the correct inline slots, which all share an `adSlot`

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before: opt out inserts a `script` element directly onto the DOM      | After: All contents of the ad slot are wrapped in a safeframe      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/17057932/189364710-8f79c0fe-10c6-42fd-a7cc-9a9f8ca14edf.png
[after]: https://user-images.githubusercontent.com/17057932/189364739-b554cd64-8dfb-4039-8f1e-39cd88885fe9.png

### Tested

- [x] Locally
- [ ] On CODE (optional)
