### PR TITLE
Inline2 ad overlaps Most viewed island

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -190,7 +190,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 
 	/**
 	 * In special cases, inline2 can overlap the "Most viewed" island, so
-	 * we need to make a few adjustments.
+	 * we need to make an adjustment to move the inline2 further down the page.
 	 */
 	if (isPaidContent) {
 		minAbove += 600;
@@ -198,8 +198,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 	// Some old articles don't have a main image, which means the first paragraph is much higher
 	if (!hasImages) {
 		minAbove += 600;
-	}
-	if (hasShowcaseMainElement) {
+	} else if (hasShowcaseMainElement) {
 		minAbove += 100;
 	}
 

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -158,7 +158,8 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 		: ' > :not(p):not(h2):not(.ad-slot):not(#sign-in-gate):not(.sfdebug)';
 
 	const isImmersive = config.get('page.isImmersive');
-	const defaultRules: SpacefinderRules = {
+
+	const firstInlineRules: SpacefinderRules = {
 		bodySelector: articleBodySelector,
 		slotSelector: ' > p',
 		minAbove: isImmersive ? 700 : 300,
@@ -187,17 +188,22 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 
 	let minAbove = 1000;
 
+	/**
+	 * In special cases, inline2 can overlap the "Most viewed" island, so
+	 * we need to make a few adjustments.
+	 */
 	if (isPaidContent) {
 		minAbove += 600;
 	}
-
-	/* On old articles without a main image or articles with a showcase main image, inline2 can sometimes overlap the most viewed articles */
-	if (!hasImages || hasShowcaseMainElement) {
+	// Some old articles don't have a main image, which means the first paragraph is much higher
+	if (!hasImages) {
+		minAbove += 600;
+	}
+	if (hasShowcaseMainElement) {
 		minAbove += 100;
 	}
 
-	// For any other inline
-	const relaxedRules: SpacefinderRules = {
+	const subsequentInlineRules: SpacefinderRules = {
 		bodySelector: articleBodySelector,
 		slotSelector: ' > p',
 		minAbove,
@@ -212,7 +218,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 		filter: filterNearbyCandidates(adSizes.halfPage.height),
 	};
 
-	const rules = isInline1 ? defaultRules : relaxedRules;
+	const rules = isInline1 ? firstInlineRules : subsequentInlineRules;
 
 	const enableDebug =
 		(sfdebug === '1' && isInline1) || (sfdebug === '2' && !isInline1);


### PR DESCRIPTION
## What does this change?

For [articles where there are no images](https://www.theguardian.com/advertising/2018/aug/14/keeping-your-brand-safe-our-policy?sfdebug=2) and inline 1 cannot be placed reasonably high up on the page, the inline2 ad will now be placed at least 1600px from the top of the article content, instead of 1100px. This means that it will no longer be possible for inline2 ads to overlap the Most viewed island on the right.

We had initially given an extra 100px for articles with no images, which solved the problem for a specific use case where the overlap was minor. However, in this extreme case where the inline1 cannot be placed and the inline2 ad can be placed very close to it's "minAbove" limit of 1100px, then we still get significant overlap. Since the sticky right ad and most viewed island combined take ~1600px height, this seems a sensible point from which to display the inline2+ ads.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/9574885/187628628-ae5aab8a-4e2c-4a36-a520-44b9f46b724b.jpg
[after]: https://user-images.githubusercontent.com/9574885/187628481-801a6f8f-4f04-4a23-b7a0-f12a145bb901.jpg

## What is the value of this and can you measure success?

This improves user experience on the rare chance that an article:
 - does not have any images
 - cannot place an inline1 ad high up on the page

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
