### PR TITLE
Fix multiple ads inserted when liveblogs live update

### DIFF
--- a/.github/workflows/commercial-e2e.yml
+++ b/.github/workflows/commercial-e2e.yml
@@ -2,10 +2,10 @@ name: Commercial E2E Tests
 on:
     pull_request:
         paths:
-            - static/src/javascripts/projects/common/modules/commercial
-            - static/src/javascripts/projects/commercial
-            - commercial
-            - cypress
+            - static/src/javascripts/projects/common/modules/commercial/**
+            - static/src/javascripts/projects/commercial/**
+            - commercial/**
+            - cypress/**
             - cypress.config.ts
             - .github/workflows/commercial-e2e.yml
 

--- a/cypress/e2e/inline-slots.cy.ts
+++ b/cypress/e2e/inline-slots.cy.ts
@@ -6,7 +6,7 @@ const pages = [...articles, ...liveblogs].filter(
 );
 
 describe('Slots and iframes load on pages', () => {
-	pages.forEach(({ path, adTest, expectedMinInlineSlotsOnPage }) => {
+	pages.forEach(({ path, expectedMinInlineSlotsOnPage }) => {
 		breakpoints.forEach(({ breakpoint, width }) => {
 			it(`Test ${path} has at least ${expectedMinInlineSlotsOnPage} inline total slots at breakpoint ${breakpoint}`, () => {
 				cy.viewport(width, 500);

--- a/cypress/e2e/liveblog-live-update.cy.ts
+++ b/cypress/e2e/liveblog-live-update.cy.ts
@@ -1,5 +1,5 @@
 import { breakpoints } from '../fixtures/breakpoints';
-import { articles, liveblogs } from '../fixtures/pages';
+import { liveblogs } from '../fixtures/pages';
 
 const pages = [...liveblogs];
 

--- a/cypress/e2e/liveblog-live-update.cy.ts
+++ b/cypress/e2e/liveblog-live-update.cy.ts
@@ -1,0 +1,52 @@
+import { breakpoints } from '../fixtures/breakpoints';
+import { articles, liveblogs } from '../fixtures/pages';
+
+const pages = [...liveblogs];
+
+describe('Liveblog live updates', () => {
+	pages.forEach(({ path }) => {
+		breakpoints.forEach(({ breakpoint, width }) => {
+			it(`Test ads are inserted when liveblogs live update, breakpoint: ${breakpoint}`, () => {
+				cy.viewport(width, 500);
+
+				cy.visit(path);
+
+				cy.allowAllConsent();
+
+				cy.get('#liveblog-body .ad-slot').then((adSlots) => {
+					const adSlotCount = adSlots.length;
+
+					cy.window().then((win) => {
+						win.mockLiveUpdate({
+							numNewBlocks: 5,
+							html: `
+							<p style="height:1000px;" class="pending block">New block</p>
+							<p style="height:1000px;" class="pending block">New block</p>
+							<p style="height:1000px;" class="pending block">New block</p>
+							<p style="height:1000px;" class="pending block">New block</p>
+							<p style="height:1000px;" class="pending block">New block</p>
+							`,
+							mostRecentBlockId: 'abc',
+						});
+
+						cy.get('#liveblog-body .block')
+							.first()
+							.should('have.css', 'opacity', '1')
+							.scrollIntoView();
+
+						// eslint-disable-next-line cypress/no-unnecessary-waiting
+						cy.wait(300);
+
+						cy.get('#liveblog-body .ad-slot').then((adSlots) => {
+							const newAdSlotCount = adSlots.length;
+
+							expect(newAdSlotCount).to.be.greaterThan(
+								adSlotCount,
+							);
+						});
+					});
+				});
+			});
+		});
+	});
+});

--- a/cypress/fixtures/pages/liveblogs.ts
+++ b/cypress/fixtures/pages/liveblogs.ts
@@ -7,7 +7,7 @@ const liveblogs: Page[] = [
 	{
 		path: getTestUrl(
 			stage,
-			'/politics/live/2022/jan/31/uk-politics-live-omicron-nhs-workers-coronavirus-vaccines-no-10-sue-gray-report',
+			'/politics/live/2022/jan/31/uk-politics-live-omicron-nhs-workers-coronavirus-vaccines-no-10-sue-gray-report?live=true',
 			{ isDcr: true },
 		),
 		expectedMinInlineSlotsOnPage: 4,

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -38,7 +38,13 @@ declare global {
 		 * Include properties that we expect on the window when testing Guardian pages
 		 * e.g. `window.guardian.page`
 		 */
-		interface ApplicationWindow extends Window {}
+		interface ApplicationWindow extends Window {
+			mockLiveUpdate: (options: {
+				numNewBlocks: number;
+				html: string;
+				mostRecentBlockId: string;
+			}) => void;
+		}
 	}
 }
 

--- a/static/src/javascripts/projects/commercial/modules/liveblog-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/liveblog-adverts.ts
@@ -137,7 +137,7 @@ const fill = (rules: SpacefinderRules) => {
 	return spaceFiller.fillSpace(rules, insertAds, options).then(() => {
 		if (AD_COUNTER < MAX_ADS) {
 			const el = document.querySelector(
-				`${rules.bodySelector} > .ad-slot`,
+				`${rules.bodySelector} > .ad-slot-container`,
 			);
 			if (el && el.previousSibling instanceof HTMLElement) {
 				firstSlot = el.previousSibling;

--- a/static/src/javascripts/projects/common/modules/spacefinder-debug-tools.js
+++ b/static/src/javascripts/projects/common/modules/spacefinder-debug-tools.js
@@ -84,16 +84,19 @@ const markCandidates = (exclusions, winners, options) => {
 		arr.forEach((exclusion) => {
 			const type = exclusionTypes[key];
 
+            const element = exclusion instanceof Element ? exclusion : exclusion.element;
+            const meta = exclusion instanceof Element ? null : exclusion;
+
 			if (type) {
-				addExplainer(exclusion.element, type.reason);
-				exclusion.element.style.cssText += `background:${type.colour}`;
-			} else if (exclusion.meta.tooClose.length > 0) {
-				addExplainer(exclusion.element, 'Too close to other element');
-				exclusion.element.style.cssText += `background:${colours.blue}`;
-				addHoverListener(exclusion.element, exclusion.meta.tooClose);
+				addExplainer(element, type.reason);
+				element.style.cssText += `background:${type.colour}`;
+			} else if (meta?.tooClose.length > 0) {
+				addExplainer(element, 'Too close to other element');
+				element.style.cssText += `background:${colours.blue}`;
+				addHoverListener(element, meta?.tooClose);
 			} else {
-				addExplainer(exclusion.element, `Unknown key: ${key}`);
-				exclusion.element.style.cssText += `background:${colours.pink}`;
+				addExplainer(element, `Unknown key: ${key}`);
+				element.style.cssText += `background:${colours.pink}`;
 			}
 		});
 	}

--- a/static/src/javascripts/projects/common/modules/spacefinder-debug-tools.js
+++ b/static/src/javascripts/projects/common/modules/spacefinder-debug-tools.js
@@ -1,126 +1,130 @@
 const markCandidates = (exclusions, winners, options, rules) => {
 	if (!options?.debug) return winners;
 
-	const colours = {
-		red: 'rgb(255 178 178)',
-		orange: 'rgb(255 213 178)',
-		yellow: 'rgb(254 255 178)',
-		blue: 'rgb(178 248 255)',
-        purple: 'rgb(178 178 255)',
-		pink: 'rgb(255 178 242)',
-		green: 'rgb(178 255 184)',
-	};
+    try {
+        const colours = {
+            red: 'rgb(255 178 178)',
+            orange: 'rgb(255 213 178)',
+            yellow: 'rgb(254 255 178)',
+            blue: 'rgb(178 248 255)',
+            purple: 'rgb(178 178 255)',
+            pink: 'rgb(255 178 242)',
+            green: 'rgb(178 255 184)',
+        };
 
-	const exclusionTypes = {
-		absoluteMinAbove: {
-			colour: colours.red,
-			reason: 'Too close to the top of page',
-		},
-		aboveAndBelow: {
-			colour: colours.orange,
-			reason: 'Too close to top or bottom of article',
-		},
-        isStartAt: {
-            colour: colours.purple,
-            reason: 'Spacefinder is starting from this position',
-        },
-        startAt: {
-            colour: colours.orange,
-            reason: 'Before the starting element',
-        },
-		custom: {
-			colour: colours.yellow,
-			reason: 'Too close to other winner',
-		},
-	};
+        const exclusionTypes = {
+            absoluteMinAbove: {
+                colour: colours.red,
+                reason: 'Too close to the top of page',
+            },
+            aboveAndBelow: {
+                colour: colours.orange,
+                reason: 'Too close to top or bottom of article',
+            },
+            isStartAt: {
+                colour: colours.purple,
+                reason: 'Spacefinder is starting from this position',
+            },
+            startAt: {
+                colour: colours.orange,
+                reason: 'Before the starting element',
+            },
+            custom: {
+                colour: colours.yellow,
+                reason: 'Too close to other winner',
+            },
+        };
 
-	const addDistanceExplainer = (element, text) => {
-		const explainer = document.createElement('div');
-		explainer.className = 'distanceExplainer sfdebug';
-		explainer.appendChild(document.createTextNode(text));
-		explainer.style.cssText = `
-            position:absolute;
-            right:0;
-            background-color:${colours.red};
-            padding:5px 5px 10px 20px;
-            font-family: sans-serif;
-            z-index:20;
-        `;
-		element.before(explainer);
-	};
+        const addDistanceExplainer = (element, text) => {
+            const explainer = document.createElement('div');
+            explainer.className = 'distanceExplainer sfdebug';
+            explainer.appendChild(document.createTextNode(text));
+            explainer.style.cssText = `
+                position:absolute;
+                right:0;
+                background-color:${colours.red};
+                padding:5px 5px 10px 20px;
+                font-family: sans-serif;
+                z-index:20;
+            `;
+            element.before(explainer);
+        };
 
-	const addHoverListener = (candidate, tooClose) => {
-		tooClose.forEach((opponent) => {
-			candidate.addEventListener('mouseenter', () => {
-				opponent.element.style.cssText = `
-                    box-shadow: 0px 0px 0px 10px ${colours.red};
-                    z-index:10;
-                    position:relative
-                `;
+        const addHoverListener = (candidate, tooClose) => {
+            tooClose.forEach((opponent) => {
+                candidate.addEventListener('mouseenter', () => {
+                    opponent.element.style.cssText = `
+                        box-shadow: 0px 0px 0px 10px ${colours.red};
+                        z-index:10;
+                        position:relative
+                    `;
 
-				addDistanceExplainer(
-					opponent.element,
-					`${opponent.actual}px/${opponent.required}px`,
-				);
-			});
+                    addDistanceExplainer(
+                        opponent.element,
+                        `${opponent.actual}px/${opponent.required}px`,
+                    );
+                });
 
-			candidate.addEventListener('mouseleave', () => {
-				opponent.element.style.cssText = '';
-				document
-					.querySelectorAll('.distanceExplainer')
-					.forEach((el) => el.remove());
-			});
-		});
-	};
+                candidate.addEventListener('mouseleave', () => {
+                    opponent.element.style.cssText = '';
+                    document
+                        .querySelectorAll('.distanceExplainer')
+                        .forEach((el) => el.remove());
+                });
+            });
+        };
 
-	const addExplainer = (element, text) => {
-		const explainer = document.createElement('div');
-		explainer.className = 'sfdebug';
-		explainer.appendChild(document.createTextNode(text));
-		explainer.style.cssText = `
-            position:absolute;
-            right:0;
-            background-color:#fffffff7;
-            padding:10px;
-            border-radius:0 0 0 10px;
-            font-family: sans-serif;
-        `;
-		element.before(explainer);
-	};
+        const addExplainer = (element, text) => {
+            const explainer = document.createElement('div');
+            explainer.className = 'sfdebug';
+            explainer.appendChild(document.createTextNode(text));
+            explainer.style.cssText = `
+                position:absolute;
+                right:0;
+                background-color:#fffffff7;
+                padding:10px;
+                border-radius:0 0 0 10px;
+                font-family: sans-serif;
+            `;
+            element.before(explainer);
+        };
 
-	// Mark losing candidates
-	for (const [key, arr] of Object.entries(exclusions)) {
-		arr.forEach((exclusion) => {
-			const type = exclusionTypes[key];
+        // Mark losing candidates
+        for (const [key, arr] of Object.entries(exclusions)) {
+            arr.forEach((exclusion) => {
+                const type = exclusionTypes[key];
 
-            const element = exclusion instanceof Element ? exclusion : exclusion.element;
-            const meta = exclusion instanceof Element ? null : exclusion;
+                const element = exclusion instanceof Element ? exclusion : exclusion.element;
+                const meta = exclusion instanceof Element ? null : exclusion;
 
-            if (element == rules?.startAt) {
-                const type = exclusionTypes.isStartAt;
-                addExplainer(element, type.reason);
-                element.style.cssText += `background:${type.colour}`;
-            }else if (type) {
-				addExplainer(element, type.reason);
-				element.style.cssText += `background:${type.colour}`;
-			} else if (meta?.tooClose.length > 0) {
-				addExplainer(element, 'Too close to other element');
-				element.style.cssText += `background:${colours.blue}`;
-				addHoverListener(element, meta?.tooClose);
-			} else {
-				addExplainer(element, `Unknown key: ${key}`);
-				element.style.cssText += `background:${colours.pink}`;
-			}
-		});
-	}
+                if (element == rules?.startAt) {
+                    const type = exclusionTypes.isStartAt;
+                    addExplainer(element, type.reason);
+                    element.style.cssText += `background:${type.colour}`;
+                }else if (type) {
+                    addExplainer(element, type.reason);
+                    element.style.cssText += `background:${type.colour}`;
+                } else if (meta?.tooClose?.length > 0) {
+                    addExplainer(element, 'Too close to other element');
+                    element.style.cssText += `background:${colours.blue}`;
+                    addHoverListener(element, meta?.tooClose);
+                } else {
+                    addExplainer(element, `Unknown key: ${key}`);
+                    element.style.cssText += `background:${colours.pink}`;
+                }
+            });
+        }
 
-	// Mark winning candidates
-	winners.forEach((winner) => {
-		addExplainer(winner.element, 'Winner');
-		winner.element.style.cssText += `background:${colours.green};`;
-	});
+        // Mark winning candidates
+        winners.forEach((winner) => {
+            addExplainer(winner.element, 'Winner');
+            winner.element.style.cssText += `background:${colours.green};`;
+        });
 
-	return winners;
+        return winners;
+    } catch (e) {
+        console.error('SFDebug Error', e);
+    }
 };
 
 const debugMinAbove = (body, minAbove) => {

--- a/static/src/javascripts/projects/common/modules/spacefinder-debug-tools.js
+++ b/static/src/javascripts/projects/common/modules/spacefinder-debug-tools.js
@@ -95,7 +95,7 @@ const markCandidates = (exclusions, winners, options, rules) => {
                 const type = exclusionTypes[key];
 
                 const element = exclusion instanceof Element ? exclusion : exclusion.element;
-                const meta = exclusion instanceof Element ? null : exclusion;
+                const meta = exclusion instanceof Element ? null : exclusion.meta;
 
                 if (element == rules?.startAt) {
                     const type = exclusionTypes.isStartAt;

--- a/static/src/javascripts/projects/common/modules/spacefinder-debug-tools.js
+++ b/static/src/javascripts/projects/common/modules/spacefinder-debug-tools.js
@@ -19,6 +19,10 @@ const markCandidates = (exclusions, winners, options) => {
 			colour: colours.orange,
 			reason: 'Too close to top or bottom of article',
 		},
+        startAt: {
+            colour: colours.orange,
+            reason: 'Skipped because start at was specified',
+        },
 		custom: {
 			colour: colours.yellow,
 			reason: 'Too close to other winner',

--- a/static/src/javascripts/projects/common/modules/spacefinder-debug-tools.js
+++ b/static/src/javascripts/projects/common/modules/spacefinder-debug-tools.js
@@ -1,4 +1,4 @@
-const markCandidates = (exclusions, winners, options) => {
+const markCandidates = (exclusions, winners, options, rules) => {
 	if (!options?.debug) return winners;
 
 	const colours = {
@@ -6,6 +6,7 @@ const markCandidates = (exclusions, winners, options) => {
 		orange: 'rgb(255 213 178)',
 		yellow: 'rgb(254 255 178)',
 		blue: 'rgb(178 248 255)',
+        purple: 'rgb(178 178 255)',
 		pink: 'rgb(255 178 242)',
 		green: 'rgb(178 255 184)',
 	};
@@ -19,9 +20,13 @@ const markCandidates = (exclusions, winners, options) => {
 			colour: colours.orange,
 			reason: 'Too close to top or bottom of article',
 		},
+        isStartAt: {
+            colour: colours.purple,
+            reason: 'Spacefinder is starting from this position',
+        },
         startAt: {
             colour: colours.orange,
-            reason: 'Skipped because start at was specified',
+            reason: 'Before the starting element',
         },
 		custom: {
 			colour: colours.yellow,
@@ -91,7 +96,11 @@ const markCandidates = (exclusions, winners, options) => {
             const element = exclusion instanceof Element ? exclusion : exclusion.element;
             const meta = exclusion instanceof Element ? null : exclusion;
 
-			if (type) {
+            if (element == rules?.startAt) {
+                const type = exclusionTypes.isStartAt;
+                addExplainer(element, type.reason);
+                element.style.cssText += `background:${type.colour}`;
+            }else if (type) {
 				addExplainer(element, type.reason);
 				element.style.cssText += `background:${type.colour}`;
 			} else if (meta?.tooClose.length > 0) {

--- a/static/src/javascripts/projects/common/modules/spacefinder.ts
+++ b/static/src/javascripts/projects/common/modules/spacefinder.ts
@@ -457,6 +457,7 @@ const findSpace = async (
 		exclusions,
 		winners,
 		options,
+		rules,
 	) as SpacefinderItem[];
 
 	// TODO Is this really an error condition?


### PR DESCRIPTION
## What does this change?
A a bug was introduced when we started adding containers around ad slots on live blogs, which is fixed in this PR.

There was also a bug with spacefinder debug, there was an error being thrown in the debug code that is swallowed by a try catch, it was preventing ads being inserted when the blog updates when running `sfdebug=1`

Added a test to test ad insertion on live updating

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/1731150/187638669-89a8aef1-5220-4ca8-88db-214c7bc2d8b2.jpeg
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
