### PR TITLE
DCR JS bundle variant experiment

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -10,6 +10,15 @@ object ActiveExperiments extends ExperimentsDefinition {
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
 
+object DCRJSBundleVariant
+    extends Experiment(
+      name = "dcr-js-bundle-variant",
+      description = "DCR bundle experiment",
+      owners = Seq(Owner.withGithub("guardian/dotcom-platform")),
+      sellByDate = LocalDate.of(2024, 4, 1),
+      participationGroup = Perc1A,
+    )
+
 object DCRFronts
     extends Experiment(
       name = "dcr-fronts",


### PR DESCRIPTION
Co-authored-by: Max Duval <max@mxdvl.com>

## What does this change?

Adds a server side experiment to enable https://github.com/guardian/dotcom-rendering/pull/5598

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)