### PR TITLE
Api/move test front json fapi to com

### DIFF
--- a/common/app/services/fronts/FrontJsonFapi.scala
+++ b/common/app/services/fronts/FrontJsonFapi.scala
@@ -1,4 +1,4 @@
-package controllers.front
+package services.fronts
 
 import common.{FaciaPressMetrics, GuLogging}
 import concurrent.{BlockingOperations, FutureSemaphore}

--- a/common/test/package.scala
+++ b/common/test/package.scala
@@ -1,14 +1,16 @@
 package test
 
+import akka.actor.ActorSystem
+
 import java.io.File
 import java.net.URL
-
 import akka.stream.Materializer
 import com.gargoylesoftware.htmlunit.html.HtmlPage
 import com.gargoylesoftware.htmlunit.{BrowserVersion, WebClient}
 import common.Lazy
+import concurrent.BlockingOperations
 import contentapi._
-import model.{ApplicationContext, ApplicationIdentity}
+import model.{ApplicationContext, ApplicationIdentity, PressedPage, PressedPageType}
 import org.openqa.selenium.htmlunit.HtmlUnitDriver
 import org.scalatest.{BeforeAndAfterAll, TestSuite}
 import org.scalatestplus.play._
@@ -16,13 +18,16 @@ import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api._
 import play.api.http.HttpConfiguration
 import play.api.libs.crypto.{CSRFTokenSigner, CSRFTokenSignerProvider, CookieSigner, CookieSignerProvider}
+import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
 import play.api.libs.ws.ahc.AhcWSClient
 import play.api.test._
 import play.filters.csrf.{CSRFAddToken, CSRFCheck, CSRFConfig}
-import recorder.ContentApiHttpRecorder
+import recorder.{ContentApiHttpRecorder, HttpRecorder}
+import services.fronts.FrontJsonFapiLive
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.io.Codec.UTF8
 import scala.util.{Failure, Success, Try}
 
 trait ConfiguredTestSuite extends TestSuite with ConfiguredServer with ConfiguredBrowser {
@@ -162,3 +167,39 @@ trait WithTestCSRF {
   lazy val csrfAddToken = new CSRFAddToken(csrfConfig, csrfTokenSigner, httpConfiguration.session)
   lazy val csrfCheck = new CSRFCheck(csrfConfig, csrfTokenSigner, httpConfiguration.session)
 }
+
+
+trait WithTestFrontJsonFapi {
+  // need a front api that stores S3 locally so it can run without deps in the unit tests
+  class TestFrontJsonFapi(override val blockingOperations: BlockingOperations)
+    extends FrontJsonFapiLive(blockingOperations) {
+
+    override def get(path: String, pageType: PressedPageType)(implicit
+                                                              executionContext: ExecutionContext,
+    ): Future[Option[PressedPage]] = {
+      recorder.load(path, Map()) {
+        super.get(path, pageType)
+      }
+    }
+
+    val recorder = new HttpRecorder[Option[PressedPage]] {
+      override lazy val baseDir = new File(System.getProperty("user.dir"), "data/pressedPage")
+
+      //No transformation for now as we only store content that's there.
+      override def toResponse(b: Array[Byte]): Option[PressedPage] =
+        Json.parse(new String(b, UTF8.charSet)).asOpt[PressedPage]
+
+      override def fromResponse(maybeResponse: Option[PressedPage]): Array[Byte] = {
+        val response = maybeResponse getOrElse {
+          throw new RuntimeException("seeing None.get locally? make sure you have S3 credentials")
+        }
+        Json.stringify(Json.toJson(response)).getBytes(UTF8.charSet)
+      }
+    }
+  }
+
+  lazy val actorSystem = ActorSystem()
+  lazy val blockingOperations = new BlockingOperations(actorSystem)
+  lazy val fapi = new TestFrontJsonFapi(blockingOperations)
+}
+

--- a/facia/app/AppLoader.scala
+++ b/facia/app/AppLoader.scala
@@ -7,7 +7,6 @@ import common.dfp.FaciaDfpAgentLifecycle
 import concurrent.BlockingOperations
 import conf.switches.SwitchboardLifecycle
 import conf.CachedHealthCheckLifeCycle
-import controllers.front.{FrontJsonFapiDraft, FrontJsonFapiLive}
 import controllers.{FaciaControllers, HealthCheck}
 import dev.{DevAssetsController, DevParametersHttpRequestHandler}
 import http.{CommonFilters, PreloadFilters}
@@ -20,6 +19,7 @@ import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import play.api.libs.ws.WSClient
 import services._
+import services.fronts.{FrontJsonFapiDraft, FrontJsonFapiLive}
 import router.Routes
 
 class AppLoader extends FrontendApplicationLoader {

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -23,6 +23,7 @@ import conf.Configuration
 import play.api.libs.ws.WSClient
 import renderers.DotcomRenderingService
 import model.dotcomrendering.{DotcomFrontsRenderingDataModel, PageType}
+import services.fronts.{FrontJsonFapi, FrontJsonFapiLive}
 
 import scala.concurrent.Future
 import scala.concurrent.Future.successful

--- a/facia/app/controllers/FaciaControllers.scala
+++ b/facia/app/controllers/FaciaControllers.scala
@@ -1,10 +1,10 @@
 package controllers
 
 import com.softwaremill.macwire._
-import controllers.front.FrontJsonFapiLive
 import model.ApplicationContext
 import play.api.libs.ws.WSClient
 import play.api.mvc.ControllerComponents
+import services.fronts.FrontJsonFapiLive
 
 trait FaciaControllers {
   def frontJsonFapiLive: FrontJsonFapiLive

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -34,11 +34,9 @@ import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
     with BeforeAndAfterEach
     with WithMaterializer
     with WithTestApplicationContext
-    with MockitoSugar {
+    with MockitoSugar
+    with WithTestFrontJsonFapi {
 
-  lazy val actorSystem = ActorSystem()
-  lazy val blockingOperations = new BlockingOperations(actorSystem)
-  lazy val fapi = new TestFrontJsonFapi(blockingOperations)
   lazy val wsClient = mockWsResponse()
 
   lazy val faciaController = new FaciaControllerImpl(fapi, play.api.test.Helpers.stubControllerComponents(), wsClient)

--- a/facia/test/FaciaMetaDataTest.scala
+++ b/facia/test/FaciaMetaDataTest.scala
@@ -26,11 +26,8 @@ import test._
     with WithTestApplicationContext
     with WithMaterializer
     with WithTestWsClient
-    with MockitoSugar {
-
-  lazy val actorSystem = ActorSystem()
-  lazy val blockingOperations = new BlockingOperations(actorSystem)
-  lazy val fapi = new TestFrontJsonFapi(blockingOperations)
+    with MockitoSugar
+    with WithTestFrontJsonFapi {
 
   override def beforeAll(): Unit = {
     val refresh = ConfigAgent.refreshWith(

--- a/facia/test/package.scala
+++ b/facia/test/package.scala
@@ -2,12 +2,12 @@ package test
 
 import java.io.File
 import concurrent.BlockingOperations
-import controllers.front.FrontJsonFapiLive
 import model.{PressedPage, PressedPageType}
 import org.fluentlenium.core.domain.FluentWebElement
 import org.scalatest.Suites
 import play.api.libs.json.Json
 import recorder.HttpRecorder
+import services.fronts.FrontJsonFapiLive
 import utils.FaciaPickerTest
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/facia/test/package.scala
+++ b/facia/test/package.scala
@@ -21,34 +21,6 @@ object `package` {
     def hasAttribute(name: String): Boolean = element.attribute(name) != null
   }
 
-  // need a front api that stores S3 locally so it can run without deps in the unit tests
-  class TestFrontJsonFapi(override val blockingOperations: BlockingOperations)
-      extends FrontJsonFapiLive(blockingOperations) {
-
-    override def get(path: String, pageType: PressedPageType)(implicit
-        executionContext: ExecutionContext,
-    ): Future[Option[PressedPage]] = {
-      recorder.load(path, Map()) {
-        super.get(path, pageType)
-      }
-    }
-
-    val recorder = new HttpRecorder[Option[PressedPage]] {
-      override lazy val baseDir = new File(System.getProperty("user.dir"), "data/pressedPage")
-
-      //No transformation for now as we only store content that's there.
-      override def toResponse(b: Array[Byte]): Option[PressedPage] =
-        Json.parse(new String(b, UTF8.charSet)).asOpt[PressedPage]
-
-      override def fromResponse(maybeResponse: Option[PressedPage]): Array[Byte] = {
-        val response = maybeResponse getOrElse {
-          throw new RuntimeException("seeing None.get locally? make sure you have S3 credentials")
-        }
-        Json.stringify(Json.toJson(response)).getBytes(UTF8.charSet)
-      }
-    }
-  }
-
 }
 
 class FaciaTestSuite

--- a/preview/app/AppLoader.scala
+++ b/preview/app/AppLoader.scala
@@ -11,7 +11,6 @@ import conf.switches.SwitchboardLifecycle
 import conf.{CachedHealthCheckLifeCycle, FootballLifecycle}
 import contentapi._
 import controllers._
-import controllers.front.FrontJsonFapiDraft
 import cricket.conf.CricketLifecycle
 import cricket.controllers.CricketControllers
 import dev.DevAssetsController
@@ -29,6 +28,7 @@ import play.api.{BuiltInComponents, BuiltInComponentsFromContext}
 import router.Routes
 import rugby.conf.RugbyLifecycle
 import rugby.controllers.RugbyControllers
+import services.fronts.FrontJsonFapiDraft
 import services.newsletters.NewsletterSignupLifecycle
 import services.{ConfigAgentLifecycle, OphanApi, SkimLinksCacheLifeCycle}
 

--- a/preview/app/controllers/FaciaDraftController.scala
+++ b/preview/app/controllers/FaciaDraftController.scala
@@ -3,12 +3,12 @@ package controllers
 import com.gu.contentapi.client.model.v1.ItemResponse
 import common.TrailsToShowcase
 import contentapi.{ContentApiClient, SectionsLookUp}
-import controllers.front.FrontJsonFapiDraft
 import model.Cached.RevalidatableResult
 import model.{ApplicationContext, PressedPage}
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 import services.ConfigAgent
+import services.fronts.FrontJsonFapiDraft
 
 import scala.concurrent.Future
 


### PR DESCRIPTION
## What does this change?


Co-authored-by: Ashleigh Carr [ashcorr20@gmail.com](mailto:ashcorr20@gmail.com)
Co-authored-by: Pete Faulconbridge [pete.faulconbridge@guardian.co.uk](mailto:pete.faulconbridge@guardian.co.uk)
Co-authored-by: Pete Faulconbridge [peter.faulconbridge@gmail.com](mailto:peter.faulconbridge@gmail.com)

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
