### PR TITLE
Enhance `FaciaPicker` to include more checks

### DIFF
--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -207,7 +207,7 @@ trait FaciaController
       case Some((faciaPage, _)) if nonHtmlEmail(request) =>
         successful(Cached(CacheTime.RecentlyUpdated)(renderEmail(faciaPage)))
       case Some((faciaPage: PressedPage, targetedTerritories))
-          if FaciaPicker.getTier(faciaPage)(request) == RemoteRender
+          if FaciaPicker.getTier(faciaPage) == RemoteRender
             && !request.isJson =>
         val pageType = PageType(faciaPage, request, context)
         withVaryHeader(remoteRenderer.getFront(ws, faciaPage, pageType)(request), targetedTerritories)

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -207,7 +207,7 @@ trait FaciaController
       case Some((faciaPage, _)) if nonHtmlEmail(request) =>
         successful(Cached(CacheTime.RecentlyUpdated)(renderEmail(faciaPage)))
       case Some((faciaPage: PressedPage, targetedTerritories))
-          if FaciaPicker.getTier(faciaPage, path)(request) == RemoteRender
+          if FaciaPicker.getTier(faciaPage)(request) == RemoteRender
             && !request.isJson =>
         val pageType = PageType(faciaPage, request, context)
         withVaryHeader(remoteRenderer.getFront(ws, faciaPage, pageType)(request), targetedTerritories)

--- a/facia/app/utils/FaciaPicker.scala
+++ b/facia/app/utils/FaciaPicker.scala
@@ -40,11 +40,10 @@ class FaciaPicker extends GuLogging {
       participatingInTest: Boolean,
       dcrCouldRender: Boolean,
   ): RenderType = {
-    if (forceDCR || participatingInTest && dcrCouldRender && !forceDCROff) {
-      RemoteRender
-    } else {
-      LocalRender
-    }
+    if (forceDCROff) LocalRender
+    else if (forceDCR) RemoteRender
+    else if (dcrCanRender && participatingInTest) RemoteRender
+    else LocalRender
   }
 
   def logTier(

--- a/facia/app/utils/FaciaPicker.scala
+++ b/facia/app/utils/FaciaPicker.scala
@@ -134,7 +134,7 @@ class FaciaPicker extends GuLogging {
         "tier" -> tierReadable,
       ) ++ checksToString
 
-    DotcomFrontsLogger.logger.logRequest(s"front executing in $tierReadable", properties, checks, faciaPage)
+    DotcomFrontsLogger.logger.logRequest(s"front executing in $tierReadable", properties, faciaPage)
   }
 }
 

--- a/facia/app/utils/FaciaPicker.scala
+++ b/facia/app/utils/FaciaPicker.scala
@@ -5,6 +5,7 @@ import experiments.{ActiveExperiments, DCRFronts}
 import implicits.Requests._
 import model.PressedPage
 import play.api.mvc.RequestHeader
+import views.support.Commercial
 
 object FrontChecks {
 
@@ -65,10 +66,10 @@ object FrontChecks {
     false
   }
 
-  def isNotSignedIn(faciaPage: PressedPage): Boolean = {
+  def isNotAdFree(faciaPage: PressedPage)(implicit request: RequestHeader): Boolean = {
     // We don't support the signed in experience
     // See: https://github.com/guardian/dotcom-rendering/issues/5926
-    false
+    !Commercial.isAdFree(request)
   }
 
   def hasNoPageSkin(faciaPage: PressedPage): Boolean = {
@@ -87,11 +88,11 @@ object FrontChecks {
 
 class FaciaPicker extends GuLogging {
 
-  private def dcrChecks(faciaPage: PressedPage): Map[String, Boolean] = {
+  private def dcrChecks(faciaPage: PressedPage)(implicit request: RequestHeader): Map[String, Boolean] = {
     Map(
       ("allCollectionsAreSupported", FrontChecks.allCollectionsAreSupported(faciaPage)),
       ("hasNoWeatherWidget", FrontChecks.hasNoWeatherWidget(faciaPage)),
-      ("isNotSignedIn", FrontChecks.isNotSignedIn(faciaPage)),
+      ("isNotAdFree", FrontChecks.isNotAdFree(faciaPage)),
       ("hasNoPageSkin", FrontChecks.hasNoPageSkin(faciaPage)),
       ("hasNoSlideshows", FrontChecks.hasNoSlideshows(faciaPage)),
     )

--- a/facia/app/utils/FaciaPicker.scala
+++ b/facia/app/utils/FaciaPicker.scala
@@ -11,12 +11,50 @@ class FaciaPicker extends GuLogging {
   // To check which collections are supported by DCR and update this set please check:
   // https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/lib/DecideContainer.tsx
   // and https://github.com/guardian/dotcom-rendering/issues/4720
-  val SUPPORTED_COLLECTIONS: Set[String] =
-    Set("dynamic/fast", "dynamic/slow", "fixed/small/slow-IV", "fixed/large/slow-XIV")
+  private val SUPPORTED_COLLECTIONS: Set[String] =
+    Set(
+      /*
+        "dynamic/slow-mpu",
+          pending https://github.com/guardian/dotcom-rendering/issues/5926 and
+          https://github.com/guardian/dotcom-rendering/issues/5821
+      */
 
-  def dcrSupportsAllCollectionTypes(faciaPage: PressedPage): Boolean = {
-    faciaPage.collections.forall(collection => SUPPORTED_COLLECTIONS.contains(collection.collectionType))
-  }
+      /*
+        "fixed/small/slow-V-mpu",
+          pending https://github.com/guardian/dotcom-rendering/issues/5926
+      */
+
+      /*
+        "fixed/medium/slow-XII-mpu",
+          pending https://github.com/guardian/dotcom-rendering/issues/5926
+      */
+
+      /*
+        "dynamic/package",
+          pending https://github.com/guardian/dotcom-rendering/issues/5196 and
+          https://github.com/guardian/dotcom-rendering/issues/5267
+      */
+
+      /*
+        "news/most-popular"
+          pending https://github.com/guardian/frontend/issues/25448 and
+          https://github.com/guardian/dotcom-rendering/issues/5902
+      */
+
+      /*
+        "dynamic/fast"
+          pending https://github.com/guardian/dotcom-rendering/issues/5782
+      */
+
+      "dynamic/slow",
+      "fixed/small/slow-I",
+      "fixed/small/slow-III",
+      "fixed/small/slow-IV",
+      "fixed/small/slow-V-third",
+      "fixed/medium/slow-VI",
+      "fixed/large/slow-XIV",
+      "fixed/large/slow-XIV"
+    )
 
   def getTier(faciaPage: PressedPage, path: String)(implicit request: RequestHeader): RenderType = {
     val participatingInTest = ActiveExperiments.isParticipating(DCRFronts)

--- a/facia/app/utils/FaciaPicker.scala
+++ b/facia/app/utils/FaciaPicker.scala
@@ -103,8 +103,8 @@ class FaciaPicker extends GuLogging {
     val dcrCouldRender = checks.values.forall(checkValue => checkValue == true)
 
     val tier = {
-      if (forceDCROff) LocalRender
-      else if (forceDCR) RemoteRender
+      if (request.forceDCROff) LocalRender
+      else if (request.forceDCR) RemoteRender
       else if (dcrCouldRender && participatingInTest) RemoteRender
       else LocalRender
     }

--- a/facia/app/utils/FaciaPicker.scala
+++ b/facia/app/utils/FaciaPicker.scala
@@ -72,7 +72,7 @@ class FaciaPicker extends GuLogging {
     tier
   }
 
-  def logTier(
+  private def logTier(
       faciaPage: PressedPage,
       path: String,
       participatingInTest: Boolean,

--- a/facia/app/utils/FaciaPicker.scala
+++ b/facia/app/utils/FaciaPicker.scala
@@ -58,34 +58,34 @@ class FaciaPicker extends GuLogging {
         "dynamic/slow-mpu",
           pending https://github.com/guardian/dotcom-rendering/issues/5926 and
           https://github.com/guardian/dotcom-rendering/issues/5821
-      */
+       */
 
       /*
         "fixed/small/slow-V-mpu",
           pending https://github.com/guardian/dotcom-rendering/issues/5926
-      */
+       */
 
       /*
         "fixed/medium/slow-XII-mpu",
           pending https://github.com/guardian/dotcom-rendering/issues/5926
-      */
+       */
 
       /*
         "dynamic/package",
           pending https://github.com/guardian/dotcom-rendering/issues/5196 and
           https://github.com/guardian/dotcom-rendering/issues/5267
-      */
+       */
 
       /*
         "news/most-popular"
           pending https://github.com/guardian/frontend/issues/25448 and
           https://github.com/guardian/dotcom-rendering/issues/5902
-      */
+       */
 
       /*
         "dynamic/fast"
           pending https://github.com/guardian/dotcom-rendering/issues/5782
-      */
+       */
 
       "dynamic/slow",
       "fixed/small/slow-I",
@@ -94,7 +94,7 @@ class FaciaPicker extends GuLogging {
       "fixed/small/slow-V-third",
       "fixed/medium/slow-VI",
       "fixed/large/slow-XIV",
-      "fixed/large/slow-XIV"
+      "fixed/large/slow-XIV",
     )
 
   def getTier(faciaPage: PressedPage, path: String)(implicit request: RequestHeader): RenderType = {

--- a/facia/app/utils/FaciaPicker.scala
+++ b/facia/app/utils/FaciaPicker.scala
@@ -86,6 +86,17 @@ object FrontChecks {
     )
   }
 
+  def isNotPaidContent(faciaPage: PressedPage): Boolean = {
+    // We don't support paid content
+    !faciaPage.frontProperties.isPaidContent
+  }
+
+  def hasNoPaidForCards(faciaPage: PressedPage): Boolean = {
+    // We don't support labs containers
+    // See: https://github.com/guardian/dotcom-rendering/issues/5150
+    !faciaPage.collections.exists(collection => collection.curated.exists(card => card.isPaidFor))
+  }
+
 }
 
 class FaciaPicker extends GuLogging {
@@ -97,6 +108,8 @@ class FaciaPicker extends GuLogging {
       ("isNotAdFree", FrontChecks.isNotAdFree()),
       ("hasNoPageSkin", FrontChecks.hasNoPageSkin(faciaPage)),
       ("hasNoSlideshows", FrontChecks.hasNoSlideshows(faciaPage)),
+      ("isNotPaidContent", FrontChecks.isNotPaidContent(faciaPage)),
+      ("hasNoPaidForCards", FrontChecks.hasNoPaidForCards(faciaPage)),
     )
   }
 

--- a/facia/app/utils/FaciaPicker.scala
+++ b/facia/app/utils/FaciaPicker.scala
@@ -126,9 +126,10 @@ class FaciaPicker extends GuLogging {
       tier: RenderType,
   )(implicit request: RequestHeader): Unit = {
     val tierReadable = if (tier == RemoteRender) "dotcomcomponents" else "web"
-    val checksToString = checks.map(check => {
-      (check._1, check._2.toString)
-    })
+    val checksToString = checks.map {
+      case (key, value) =>
+        (key, value.toString)
+    }
     val properties =
       Map(
         "participatingInTest" -> participatingInTest.toString,

--- a/facia/app/utils/FaciaPicker.scala
+++ b/facia/app/utils/FaciaPicker.scala
@@ -8,6 +8,54 @@ import play.api.mvc.RequestHeader
 
 object FrontChecks {
 
+  // To check which collections are supported by DCR and update this set please check:
+  // https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/lib/DecideContainer.tsx
+  // and https://github.com/guardian/dotcom-rendering/issues/4720
+  private val SUPPORTED_COLLECTIONS: Set[String] =
+    Set(
+      /*
+      "dynamic/slow-mpu",
+        pending https://github.com/guardian/dotcom-rendering/issues/5926 and
+        https://github.com/guardian/dotcom-rendering/issues/5821
+       */
+
+      /*
+      "fixed/small/slow-V-mpu",
+        pending https://github.com/guardian/dotcom-rendering/issues/5926
+       */
+
+      /*
+      "fixed/medium/slow-XII-mpu",
+        pending https://github.com/guardian/dotcom-rendering/issues/5926
+       */
+
+      /*
+      "dynamic/package",
+        pending https://github.com/guardian/dotcom-rendering/issues/5196 and
+        https://github.com/guardian/dotcom-rendering/issues/5267
+       */
+
+      /*
+      "news/most-popular"
+        pending https://github.com/guardian/frontend/issues/25448 and
+        https://github.com/guardian/dotcom-rendering/issues/5902
+       */
+
+      /*
+      "dynamic/fast"
+        pending https://github.com/guardian/dotcom-rendering/issues/5782
+       */
+
+      "dynamic/slow",
+      "fixed/small/slow-I",
+      "fixed/small/slow-III",
+      "fixed/small/slow-IV",
+      "fixed/small/slow-V-third",
+      "fixed/medium/slow-VI",
+      "fixed/large/slow-XIV",
+      "fixed/large/slow-XIV",
+    )
+
   def allCollectionsAreSupported(faciaPage: PressedPage): Boolean = {
     faciaPage.collections.forall(collection => SUPPORTED_COLLECTIONS.contains(collection.collectionType))
   }
@@ -48,54 +96,6 @@ class FaciaPicker extends GuLogging {
       ("hasNoSlideshows", FrontChecks.hasNoSlideshows(faciaPage)),
     )
   }
-
-  // To check which collections are supported by DCR and update this set please check:
-  // https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/web/lib/DecideContainer.tsx
-  // and https://github.com/guardian/dotcom-rendering/issues/4720
-  private val SUPPORTED_COLLECTIONS: Set[String] =
-    Set(
-      /*
-        "dynamic/slow-mpu",
-          pending https://github.com/guardian/dotcom-rendering/issues/5926 and
-          https://github.com/guardian/dotcom-rendering/issues/5821
-       */
-
-      /*
-        "fixed/small/slow-V-mpu",
-          pending https://github.com/guardian/dotcom-rendering/issues/5926
-       */
-
-      /*
-        "fixed/medium/slow-XII-mpu",
-          pending https://github.com/guardian/dotcom-rendering/issues/5926
-       */
-
-      /*
-        "dynamic/package",
-          pending https://github.com/guardian/dotcom-rendering/issues/5196 and
-          https://github.com/guardian/dotcom-rendering/issues/5267
-       */
-
-      /*
-        "news/most-popular"
-          pending https://github.com/guardian/frontend/issues/25448 and
-          https://github.com/guardian/dotcom-rendering/issues/5902
-       */
-
-      /*
-        "dynamic/fast"
-          pending https://github.com/guardian/dotcom-rendering/issues/5782
-       */
-
-      "dynamic/slow",
-      "fixed/small/slow-I",
-      "fixed/small/slow-III",
-      "fixed/small/slow-IV",
-      "fixed/small/slow-V-third",
-      "fixed/medium/slow-VI",
-      "fixed/large/slow-XIV",
-      "fixed/large/slow-XIV",
-    )
 
   def getTier(faciaPage: PressedPage, path: String)(implicit request: RequestHeader): RenderType = {
     val participatingInTest = ActiveExperiments.isParticipating(DCRFronts)

--- a/facia/app/utils/FaciaPicker.scala
+++ b/facia/app/utils/FaciaPicker.scala
@@ -123,8 +123,8 @@ class FaciaPicker extends GuLogging {
       tier: RenderType,
   )(implicit request: RequestHeader): Unit = {
     val tierReadable = if (tier == RemoteRender) "dotcomcomponents" else "web";
-    val checksToString = checks.map(case(key, value) => {
-      (key, value.toString)
+    val checksToString = checks.map(check => {
+      (check._1, check._2.toString)
     })
     val properties =
       Map(

--- a/facia/app/utils/FaciaPicker.scala
+++ b/facia/app/utils/FaciaPicker.scala
@@ -15,36 +15,36 @@ object FrontChecks {
   private val SUPPORTED_COLLECTIONS: Set[String] =
     Set(
       /*
-      "dynamic/slow-mpu",
-        pending https://github.com/guardian/dotcom-rendering/issues/5926 and
-        https://github.com/guardian/dotcom-rendering/issues/5821
+    "dynamic/slow-mpu",
+      pending https://github.com/guardian/dotcom-rendering/issues/5926 and
+      https://github.com/guardian/dotcom-rendering/issues/5821
        */
 
       /*
-      "fixed/small/slow-V-mpu",
-        pending https://github.com/guardian/dotcom-rendering/issues/5926
+    "fixed/small/slow-V-mpu",
+      pending https://github.com/guardian/dotcom-rendering/issues/5926
        */
 
       /*
-      "fixed/medium/slow-XII-mpu",
-        pending https://github.com/guardian/dotcom-rendering/issues/5926
+    "fixed/medium/slow-XII-mpu",
+      pending https://github.com/guardian/dotcom-rendering/issues/5926
        */
 
       /*
-      "dynamic/package",
-        pending https://github.com/guardian/dotcom-rendering/issues/5196 and
-        https://github.com/guardian/dotcom-rendering/issues/5267
+    "dynamic/package",
+      pending https://github.com/guardian/dotcom-rendering/issues/5196 and
+      https://github.com/guardian/dotcom-rendering/issues/5267
        */
 
       /*
-      "news/most-popular"
-        pending https://github.com/guardian/frontend/issues/25448 and
-        https://github.com/guardian/dotcom-rendering/issues/5902
+    "news/most-popular"
+      pending https://github.com/guardian/frontend/issues/25448 and
+      https://github.com/guardian/dotcom-rendering/issues/5902
        */
 
       /*
-      "dynamic/fast"
-        pending https://github.com/guardian/dotcom-rendering/issues/5782
+    "dynamic/fast"
+      pending https://github.com/guardian/dotcom-rendering/issues/5782
        */
 
       "dynamic/slow",

--- a/facia/app/utils/FaciaPicker.scala
+++ b/facia/app/utils/FaciaPicker.scala
@@ -63,7 +63,7 @@ class FaciaPicker extends GuLogging {
         "tier" -> tierReadable,
       )
 
-    DotcomFrontsLogger.logger.logRequest(s"front executing in $tierReadable: $path, $properties", properties, faciaPage)
+    DotcomFrontsLogger.logger.logRequest(s"front executing in $tierReadable", properties, faciaPage)
   }
 }
 

--- a/facia/app/utils/FaciaPicker.scala
+++ b/facia/app/utils/FaciaPicker.scala
@@ -88,6 +88,7 @@ object FrontChecks {
 
   def isNotPaidContent(faciaPage: PressedPage): Boolean = {
     // We don't support paid content
+    // See: https://github.com/guardian/dotcom-rendering/issues/5945
     !faciaPage.frontProperties.isPaidContent
   }
 

--- a/facia/app/utils/FaciaPicker.scala
+++ b/facia/app/utils/FaciaPicker.scala
@@ -122,7 +122,7 @@ class FaciaPicker extends GuLogging {
       checks: Map[String, Boolean],
       tier: RenderType,
   )(implicit request: RequestHeader): Unit = {
-    val tierReadable = if (tier == RemoteRender) "dotcomcomponents" else "web";
+    val tierReadable = if (tier == RemoteRender) "dotcomcomponents" else "web"
     val checksToString = checks.map(check => {
       (check._1, check._2.toString)
     })

--- a/facia/app/utils/FaciaPicker.scala
+++ b/facia/app/utils/FaciaPicker.scala
@@ -22,7 +22,7 @@ class FaciaPicker extends GuLogging {
     val participatingInTest = ActiveExperiments.isParticipating(DCRFronts)
     val dcrCouldRender = dcrSupportsAllCollectionTypes(faciaPage)
 
-    val tier = getTier(
+    val tier = decideTier(
       forceDCROff = request.forceDCROff,
       forceDCR = request.forceDCR,
       participatingInTest = participatingInTest,
@@ -34,7 +34,7 @@ class FaciaPicker extends GuLogging {
     tier
   }
 
-  def getTier(
+  def decideTier(
       forceDCROff: Boolean,
       forceDCR: Boolean,
       participatingInTest: Boolean,

--- a/facia/app/utils/FaciaPicker.scala
+++ b/facia/app/utils/FaciaPicker.scala
@@ -100,7 +100,7 @@ class FaciaPicker extends GuLogging {
     )
   }
 
-  def getTier(faciaPage: PressedPage, path: String)(implicit request: RequestHeader): RenderType = {
+  def getTier(faciaPage: PressedPage)(implicit request: RequestHeader): RenderType = {
     val participatingInTest = ActiveExperiments.isParticipating(DCRFronts)
     val checks = dcrChecks(faciaPage)
     val dcrCouldRender = checks.values.forall(checkValue => checkValue == true)
@@ -112,14 +112,13 @@ class FaciaPicker extends GuLogging {
       else LocalRender
     }
 
-    logTier(faciaPage, path, participatingInTest, dcrCouldRender, checks, tier)
+    logTier(faciaPage, participatingInTest, dcrCouldRender, checks, tier)
 
     tier
   }
 
   private def logTier(
       faciaPage: PressedPage,
-      path: String,
       participatingInTest: Boolean,
       dcrCouldRender: Boolean,
       checks: Map[String, Boolean],

--- a/facia/app/utils/FaciaPicker.scala
+++ b/facia/app/utils/FaciaPicker.scala
@@ -60,28 +60,16 @@ class FaciaPicker extends GuLogging {
     val participatingInTest = ActiveExperiments.isParticipating(DCRFronts)
     val dcrCouldRender = dcrSupportsAllCollectionTypes(faciaPage)
 
-    val tier = decideTier(
-      forceDCROff = request.forceDCROff,
-      forceDCR = request.forceDCR,
-      participatingInTest = participatingInTest,
-      dcrCouldRender = dcrCouldRender,
-    )
+    val tier = {
+      if (forceDCROff) LocalRender
+      else if (forceDCR) RemoteRender
+      else if (dcrCouldRender && participatingInTest) RemoteRender
+      else LocalRender
+    }
 
     logTier(faciaPage, path, participatingInTest, dcrCouldRender, tier)
 
     tier
-  }
-
-  def decideTier(
-      forceDCROff: Boolean,
-      forceDCR: Boolean,
-      participatingInTest: Boolean,
-      dcrCouldRender: Boolean,
-  ): RenderType = {
-    if (forceDCROff) LocalRender
-    else if (forceDCR) RemoteRender
-    else if (dcrCanRender && participatingInTest) RemoteRender
-    else LocalRender
   }
 
   def logTier(

--- a/facia/app/utils/FaciaPicker.scala
+++ b/facia/app/utils/FaciaPicker.scala
@@ -63,25 +63,27 @@ object FrontChecks {
 
   def hasNoWeatherWidget(faciaPage: PressedPage): Boolean = {
     // See: https://github.com/guardian/dotcom-rendering/issues/4602
-    false
+    !faciaPage.isNetworkFront
   }
 
-  def isNotAdFree(faciaPage: PressedPage)(implicit request: RequestHeader): Boolean = {
+  def isNotAdFree()(implicit request: RequestHeader): Boolean = {
     // We don't support the signed in experience
     // See: https://github.com/guardian/dotcom-rendering/issues/5926
     !Commercial.isAdFree(request)
   }
 
-  def hasNoPageSkin(faciaPage: PressedPage): Boolean = {
+  def hasNoPageSkin(faciaPage: PressedPage)(implicit request: RequestHeader): Boolean = {
     // We don't support page skin ads
     // See: https://github.com/guardian/dotcom-rendering/issues/5490
-    false
+    !faciaPage.metadata.hasPageSkin(request)
   }
 
   def hasNoSlideshows(faciaPage: PressedPage): Boolean = {
     // We don't support image slideshows
     // See: https://github.com/guardian/dotcom-rendering/issues/4612
-    false
+    !faciaPage.collections.exists(collection =>
+      collection.curated.exists(card => card.properties.imageSlideshowReplace),
+    )
   }
 
 }
@@ -92,7 +94,7 @@ class FaciaPicker extends GuLogging {
     Map(
       ("allCollectionsAreSupported", FrontChecks.allCollectionsAreSupported(faciaPage)),
       ("hasNoWeatherWidget", FrontChecks.hasNoWeatherWidget(faciaPage)),
-      ("isNotAdFree", FrontChecks.isNotAdFree(faciaPage)),
+      ("isNotAdFree", FrontChecks.isNotAdFree()),
       ("hasNoPageSkin", FrontChecks.hasNoPageSkin(faciaPage)),
       ("hasNoSlideshows", FrontChecks.hasNoSlideshows(faciaPage)),
     )

--- a/facia/test/utils/FaciaPickerTest.scala
+++ b/facia/test/utils/FaciaPickerTest.scala
@@ -1,25 +1,26 @@
 package utils
 
 import common.facia.{FixtureBuilder, PressedCollectionBuilder}
+import org.scalatest.DoNotDiscover
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.DoNotDiscover
+import org.scalatestplus.mockito.MockitoSugar
 
-@DoNotDiscover class FaciaPickerTest extends AnyFlatSpec with Matchers {
+@DoNotDiscover class FaciaPickerTest extends AnyFlatSpec with Matchers with MockitoSugar {
 
-  "Facia Picker dcrSupportsAllCollectionTypes" should "return false if at least one collection type of the faciaPage collections is not supported" in {
+  "Facia Picker allCollectionsAreSupported" should "return false if at least one collection type of the faciaPage collections is not supported" in {
     val unsupportedPressedCollection =
       List(
-        PressedCollectionBuilder.mkPressedCollection(collectionType = FaciaPicker.SUPPORTED_COLLECTIONS.head),
+        PressedCollectionBuilder.mkPressedCollection(collectionType = FrontChecks.SUPPORTED_COLLECTIONS.head),
         PressedCollectionBuilder.mkPressedCollection(collectionType = "non-supported-collection-type"),
       )
 
     val faciaPage = FixtureBuilder.mkPressedPage(unsupportedPressedCollection)
-    FaciaPicker.dcrSupportsAllCollectionTypes(faciaPage) should be(false)
+    FrontChecks.allCollectionsAreSupported(faciaPage) should be(false)
   }
 
   it should "return true if all collection types of a facia page are supported" in {
-    val supportedTypes = FaciaPicker.SUPPORTED_COLLECTIONS.take(3).toList
+    val supportedTypes = FrontChecks.SUPPORTED_COLLECTIONS.take(3).toList
     val supportedPressedCollection =
       List(
         PressedCollectionBuilder.mkPressedCollection(collectionType = supportedTypes(0)),
@@ -28,16 +29,16 @@ import org.scalatest.DoNotDiscover
       )
 
     val faciaPage = FixtureBuilder.mkPressedPage(supportedPressedCollection)
-    FaciaPicker.dcrSupportsAllCollectionTypes(faciaPage) should be(true)
+    FrontChecks.allCollectionsAreSupported(faciaPage) should be(true)
   }
 
-  "Facia Picker getTier" should "return LocalRender if dcr=false" in {
+  "Facia Picker decideTier" should "return LocalRender if dcr=false" in {
     val forceDCROff = true
     val forceDCR = false
     val participatingInTest = true
     val dcrCouldRender = true
 
-    val tier = FaciaPicker.getTier(forceDCROff, forceDCR, participatingInTest, dcrCouldRender)
+    val tier = FaciaPicker.decideTier(forceDCROff, forceDCR, participatingInTest, dcrCouldRender)
     tier should be(LocalRender)
   }
 
@@ -47,7 +48,7 @@ import org.scalatest.DoNotDiscover
     val participatingInTest = false
     val dcrCouldRender = false
 
-    val tier = FaciaPicker.getTier(forceDCROff, forceDCR, participatingInTest, dcrCouldRender)
+    val tier = FaciaPicker.decideTier(forceDCROff, forceDCR, participatingInTest, dcrCouldRender)
     tier should be(RemoteRender)
   }
 
@@ -57,7 +58,7 @@ import org.scalatest.DoNotDiscover
     val participatingInTest = false
     val dcrCouldRender = true
 
-    val tier = FaciaPicker.getTier(forceDCROff, forceDCR, participatingInTest, dcrCouldRender)
+    val tier = FaciaPicker.decideTier(forceDCROff, forceDCR, participatingInTest, dcrCouldRender)
     tier should be(LocalRender)
   }
 
@@ -67,7 +68,7 @@ import org.scalatest.DoNotDiscover
     val participatingInTest = true
     val dcrCouldRender = true
 
-    val tier = FaciaPicker.getTier(forceDCROff, forceDCR, participatingInTest, dcrCouldRender)
+    val tier = FaciaPicker.decideTier(forceDCROff, forceDCR, participatingInTest, dcrCouldRender)
     tier should be(RemoteRender)
   }
 }


### PR DESCRIPTION
## What does this change?
This PR adds additional checks to the `FaciaPicker` file and logs these booleans out to elastic

## Why?
Because we want to be able to focus on what needs to be done to execute a DCR fronts test and having more ability to filter traffic helps us target the pages that DCR can render better