### PR TITLE
Enable DCR rendering of AMP immersive

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -94,7 +94,7 @@ final case class Content(
         AmpLiveBlogSwitch.isSwitchedOn
       } else if (tags.isArticle) {
         val hasBodyBlocks: Boolean = fields.blocks.exists(b => b.body.nonEmpty)
-        AmpArticleSwitch.isSwitchedOn && hasBodyBlocks && !isImmersive && !tags.isQuiz
+        AmpArticleSwitch.isSwitchedOn && hasBodyBlocks && !tags.isQuiz
       } else {
         false
       }


### PR DESCRIPTION
## What does this change?

Enable Immersive articles to be “Amplified“. AMP is perfectly capable of rendering 199 of the last 200 pieces based off the following query:

http://content.guardianapis.com/search?type=article&display-hint=immersive&page-size=200


## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [X] Yes – we need to start showing the `ampLink` again

--- 

Script to assert the ability of DCR to render articles:

```ts
deno run --allow-net https://gist.githubusercontent.com/mxdvl/ace928d0ea34302031d825a970782cda/raw/amp-immersives.ts
```

<img width="453" alt="image" src="https://user-images.githubusercontent.com/76776/188580550-de487e65-b17b-4ec3-8af5-e096d8082608.png">