### PR TITLE
fix: Force embeds to always show ClickToView wrapper on Liveblogs

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -3,7 +3,7 @@ package model.dotcomrendering
 import com.github.nscala_time.time.Imports.DateTime
 import com.gu.contentapi.client.model.v1.ElementType.Text
 import com.gu.contentapi.client.model.v1.{Block => APIBlock, BlockElement => ClientBlockElement, Blocks => APIBlocks}
-import com.gu.contentapi.client.utils.format.LiveBlogDesign
+import com.gu.contentapi.client.utils.format.{DeadBlogDesign, LiveBlogDesign}
 import com.gu.contentapi.client.utils.{AdvertisementFeature, DesignType}
 import common.Edition
 import conf.switches.Switches
@@ -209,6 +209,7 @@ object DotcomRenderingUtils {
           article.elements.thumbnail,
           edition,
           article.trail.webPublicationDate,
+          article.metadata.format.exists(format => format.design == LiveBlogDesign || format.design == DeadBlogDesign),
         ),
       )
       .filter(PageElement.isSupported)

--- a/common/test/model/dotcomrendering/pageElements/PageElementTest.scala
+++ b/common/test/model/dotcomrendering/pageElements/PageElementTest.scala
@@ -8,10 +8,16 @@ import org.scalatest.flatspec.AnyFlatSpec
 
 class PageElementTest extends AnyFlatSpec with Matchers {
   "PageElement" should "classify capi tracking value correctly" in {
-    containsThirdPartyTracking(None) should equal(false)
-    containsThirdPartyTracking(Some(EmbedTracking(DoesNotTrack))) should equal(false)
-    containsThirdPartyTracking(Some(EmbedTracking(Tracks))) should equal(true)
-    containsThirdPartyTracking(Some(EmbedTracking(Unknown))) should equal(true)
-    containsThirdPartyTracking(Some(EmbedTracking(EnumUnknownEmbedTracksType(99)))) should equal(true)
+    containsThirdPartyTracking(None, false) should equal(false)
+    containsThirdPartyTracking(Some(EmbedTracking(DoesNotTrack)), false) should equal(false)
+    containsThirdPartyTracking(Some(EmbedTracking(Tracks)), false) should equal(true)
+    containsThirdPartyTracking(Some(EmbedTracking(Unknown)), false) should equal(true)
+    containsThirdPartyTracking(Some(EmbedTracking(EnumUnknownEmbedTracksType(99))), false) should equal(true)
+
+    containsThirdPartyTracking(None, true) should equal(true)
+    containsThirdPartyTracking(Some(EmbedTracking(DoesNotTrack)), true) should equal(true)
+    containsThirdPartyTracking(Some(EmbedTracking(Tracks)), true) should equal(true)
+    containsThirdPartyTracking(Some(EmbedTracking(Unknown)), true) should equal(true)
+    containsThirdPartyTracking(Some(EmbedTracking(EnumUnknownEmbedTracksType(99))), true) should equal(true)
   }
 }


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

Always enable the Click to View wrapper on Liveblog embeds. This won't affect Tweets or Interactive embeds as we don't check if they need a click to view wrapper in DCR.

## Why?

Currently CAPI isn't setting the `tracking` field on Embeds correctly if you use the Query parameter that liveblogs use, this is potentially a pretty big privacy issue for our users. I go a bit more into detail in this issue: https://github.com/guardian/frontend/issues/25454

Unfortunately this PR is probably going to add Click to View wrappers to some embeds that don't actually track, but without copying CAPI's list of trusted embed sources its not really possible to decide that in DCR.

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/21217225/188616616-b32505b9-82c5-460c-88d2-25489cdcea30.png
[after]: https://user-images.githubusercontent.com/21217225/188616511-7c9d61e5-568d-4796-ada2-93848b70d498.png
