### PR TITLE
Revert "fix: Force embeds to always show ClickToView wrapper on Liveblogs"

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingUtils.scala
@@ -3,7 +3,7 @@ package model.dotcomrendering
 import com.github.nscala_time.time.Imports.DateTime
 import com.gu.contentapi.client.model.v1.ElementType.Text
 import com.gu.contentapi.client.model.v1.{Block => APIBlock, BlockElement => ClientBlockElement, Blocks => APIBlocks}
-import com.gu.contentapi.client.utils.format.{DeadBlogDesign, LiveBlogDesign}
+import com.gu.contentapi.client.utils.format.LiveBlogDesign
 import com.gu.contentapi.client.utils.{AdvertisementFeature, DesignType}
 import common.Edition
 import conf.switches.Switches
@@ -209,7 +209,6 @@ object DotcomRenderingUtils {
           article.elements.thumbnail,
           edition,
           article.trail.webPublicationDate,
-          article.metadata.format.exists(format => format.design == LiveBlogDesign || format.design == DeadBlogDesign),
         ),
       )
       .filter(PageElement.isSupported)

--- a/common/test/model/dotcomrendering/pageElements/PageElementTest.scala
+++ b/common/test/model/dotcomrendering/pageElements/PageElementTest.scala
@@ -8,16 +8,10 @@ import org.scalatest.flatspec.AnyFlatSpec
 
 class PageElementTest extends AnyFlatSpec with Matchers {
   "PageElement" should "classify capi tracking value correctly" in {
-    containsThirdPartyTracking(None, false) should equal(false)
-    containsThirdPartyTracking(Some(EmbedTracking(DoesNotTrack)), false) should equal(false)
-    containsThirdPartyTracking(Some(EmbedTracking(Tracks)), false) should equal(true)
-    containsThirdPartyTracking(Some(EmbedTracking(Unknown)), false) should equal(true)
-    containsThirdPartyTracking(Some(EmbedTracking(EnumUnknownEmbedTracksType(99))), false) should equal(true)
-
-    containsThirdPartyTracking(None, true) should equal(true)
-    containsThirdPartyTracking(Some(EmbedTracking(DoesNotTrack)), true) should equal(true)
-    containsThirdPartyTracking(Some(EmbedTracking(Tracks)), true) should equal(true)
-    containsThirdPartyTracking(Some(EmbedTracking(Unknown)), true) should equal(true)
-    containsThirdPartyTracking(Some(EmbedTracking(EnumUnknownEmbedTracksType(99))), true) should equal(true)
+    containsThirdPartyTracking(None) should equal(false)
+    containsThirdPartyTracking(Some(EmbedTracking(DoesNotTrack))) should equal(false)
+    containsThirdPartyTracking(Some(EmbedTracking(Tracks))) should equal(true)
+    containsThirdPartyTracking(Some(EmbedTracking(Unknown))) should equal(true)
+    containsThirdPartyTracking(Some(EmbedTracking(EnumUnknownEmbedTracksType(99)))) should equal(true)
   }
 }


### PR DESCRIPTION
Reverts guardian/frontend#25460

To be merged once the underlying issue is fixed in CAPI.