### PR TITLE
On-demand DCR rendering for `popular-in-tag` Onwards

### DIFF
--- a/common/app/model/dotcomrendering/MostPopular.scala
+++ b/common/app/model/dotcomrendering/MostPopular.scala
@@ -1,10 +1,17 @@
 package model.dotcomrendering
 
+import com.gu.contentapi.client.utils.format.{ArticleDesign, NewsPillar, StandardDisplay}
+import model.ContentFormat
 import play.api.libs.json._
+
 
 case class OnwardCollectionResponse(
     heading: String,
     trails: Seq[Trail],
+    // todo: remove default if this pattern is adopted
+    onwardsSource: String = "unknown-source", //Option[OnwardSource],
+    // todo: remove default if this pattern is adopted
+    format: ContentFormat = ContentFormat(design = ArticleDesign, theme = NewsPillar, display = StandardDisplay)
 )
 object OnwardCollectionResponse {
   implicit val collectionWrites = Json.writes[OnwardCollectionResponse]

--- a/common/app/model/dotcomrendering/MostPopular.scala
+++ b/common/app/model/dotcomrendering/MostPopular.scala
@@ -4,14 +4,13 @@ import com.gu.contentapi.client.utils.format.{ArticleDesign, NewsPillar, Standar
 import model.ContentFormat
 import play.api.libs.json._
 
-
 case class OnwardCollectionResponse(
     heading: String,
     trails: Seq[Trail],
     // todo: remove default if this pattern is adopted
     onwardsSource: String = "unknown-source", //Option[OnwardSource],
     // todo: remove default if this pattern is adopted
-    format: ContentFormat = ContentFormat(design = ArticleDesign, theme = NewsPillar, display = StandardDisplay)
+    format: ContentFormat = ContentFormat(design = ArticleDesign, theme = NewsPillar, display = StandardDisplay),
 )
 object OnwardCollectionResponse {
   implicit val collectionWrites = Json.writes[OnwardCollectionResponse]

--- a/onward/app/controllers/OnwardControllers.scala
+++ b/onward/app/controllers/OnwardControllers.scala
@@ -39,6 +39,7 @@ trait OnwardControllers {
   lazy val topStoriesController = wire[TopStoriesController]
   lazy val relatedController = wire[RelatedController]
   lazy val popularInTag = wire[PopularInTag]
+  lazy val popularInTagDCR = wire[PopularInTagDCR]
   lazy val changeEditionController = wire[ChangeEditionController]
   lazy val mediaInSectionController = wire[MediaInSectionController]
   lazy val mostViewedVideoController = wire[MostViewedVideoController]

--- a/onward/app/controllers/PopularInTagDCR.scala
+++ b/onward/app/controllers/PopularInTagDCR.scala
@@ -1,0 +1,41 @@
+package controllers
+
+import common._
+import containers.Containers
+import contentapi.ContentApiClient
+import feed.MostReadAgent
+import model._
+import play.api.libs.ws.WSClient
+import play.api.mvc._
+import renderers.DotcomRenderingService
+import services._
+
+import scala.concurrent.Future
+
+class PopularInTagDCR(
+    val contentApiClient: ContentApiClient,
+    val mostReadAgent: MostReadAgent,
+    val controllerComponents: ControllerComponents,
+    val wsClient: WSClient,
+)(implicit context: ApplicationContext)
+    extends BaseController
+    with Related
+    with Containers
+    with GuLogging
+    with ImplicitControllerExecutionContext
+    with GetPopularInTagDCR
+    with implicits.Requests {
+
+  val remoteRenderer: DotcomRenderingService = DotcomRenderingService()
+
+  def render(tag: String): Action[AnyContent] = {
+    Action.async { implicit request =>
+      val edition = Edition(request)
+      val excludeTags = request.queryString.getOrElse("exclude-tag", Nil)
+      getPopularInTagTrails(edition, tag, excludeTags).flatMap {
+        case onwards if onwards.trails.isEmpty => Future.successful(Cached(60)(JsonNotFound()))
+        case onwards                           => remoteRenderer.getOnwardHtml(wsClient, onwards)
+      }
+    }
+  }
+}

--- a/onward/app/services/GetPopularInTagDCR.scala
+++ b/onward/app/services/GetPopularInTagDCR.scala
@@ -17,7 +17,11 @@ trait GetPopularInTagDCR {
 
   def mostReadAgent: MostReadAgent
 
-  def getPopularInTagTrails(edition: Edition, tag: String, excludeTags: Seq[String] = Nil): Future[OnwardCollectionResponse] = {
+  def getPopularInTagTrails(
+      edition: Edition,
+      tag: String,
+      excludeTags: Seq[String] = Nil,
+  ): Future[OnwardCollectionResponse] = {
 
     val tags = (tag +: excludeTags.map(t => s"-$t")).mkString(",")
 

--- a/onward/app/services/GetPopularInTagDCR.scala
+++ b/onward/app/services/GetPopularInTagDCR.scala
@@ -1,0 +1,50 @@
+package services
+
+import com.gu.contentapi.client.utils.format.{ArticleDesign, NewsPillar, StandardDisplay}
+import common.Edition
+import contentapi.ContentApiClient
+import feed.MostReadAgent
+import layout.ContentCard
+import model.ContentFormat
+import model.dotcomrendering.{OnwardCollectionResponse, Trail}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait GetPopularInTagDCR {
+
+  val contentApiClient: ContentApiClient
+  implicit val executionContext: ExecutionContext
+
+  def mostReadAgent: MostReadAgent
+
+  def getPopularInTagTrails(edition: Edition, tag: String, excludeTags: Seq[String] = Nil): Future[OnwardCollectionResponse] = {
+
+    val tags = (tag +: excludeTags.map(t => s"-$t")).mkString(",")
+
+    val response = contentApiClient.getResponse(
+      contentApiClient
+        .search(edition)
+        .tag(tags)
+        .pageSize(50),
+    )
+
+    val trails: Future[OnwardCollectionResponse] = response.map { response =>
+      val items = response.results.flatMap { item =>
+        for {
+          contentCard <- ContentCard.fromApiContent(item)
+          trail <- Trail.contentCardToTrail(contentCard)
+        } yield trail
+      }
+      OnwardCollectionResponse(
+        // todo: not sure if this is the right heading, but it seems to be the one we're currently using
+        heading = "Related content",
+        trails = items.sortBy(trail => -mostReadAgent.getViewCount(trail.url).getOrElse(0)).take(10).toSeq,
+        // todo: find a good pattern for passing format data from the client (what format data does DCR actually *need*?)
+        format = ContentFormat(design = ArticleDesign, theme = NewsPillar, display = StandardDisplay),
+        onwardsSource = "popular-in-tag",
+      )
+    }
+
+    trails
+  }
+}

--- a/onward/conf/routes
+++ b/onward/conf/routes
@@ -35,6 +35,7 @@ GET        /top-stories/trails.json                   controllers.TopStoriesCont
 GET        /related/*path.json                        controllers.RelatedController.render(path)
 
 GET        /popular-in-tag/*tag.json                  controllers.PopularInTag.render(tag)
+GET        /popular-in-tag-dcr/*tag.json              controllers.PopularInTagDCR.render(tag)
 
 GET        /preference/edition/:edition               controllers.ChangeEditionController.render(edition)
 

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -736,13 +736,15 @@
  "../projects/common/modules/identity/auth-component-event-params.js": [
   "../lib/url.ts"
  ],
- "../projects/common/modules/spacefinder-debug-tools.js": [],
+ "../projects/common/modules/spacefinder-debug-tools.ts": [
+  "../projects/common/modules/spacefinder.ts"
+ ],
  "../projects/common/modules/spacefinder.ts": [
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../../../../node_modules/@types/lodash-es/index.d.ts",
   "../lib/fastdom-promise.js",
   "../projects/commercial/am-i-used.ts",
-  "../projects/common/modules/spacefinder-debug-tools.js"
+  "../projects/common/modules/spacefinder-debug-tools.ts"
  ],
  "../projects/common/modules/ui/sticky.js": [
   "../../../../node_modules/fastdom/fastdom.js",


### PR DESCRIPTION
> **Note**
> PR description is in progress.

Co-authored by: Ashleigh Carr <ashcorr20@gmail.com>
Co-authored by: Ioanna Kokkini <ioannakok@users.noreply.github.com>
Co-authored by: James Gorrie <jamesgorrie@users.noreply.github.com>

## What does this change?

Adds a new endpoint, based on the existing `popular-in-tag` endpoint, which returns a DCR-rendered Onward carousel for a given tag.

This is envisaged as a relatively quick fix for part of [server-rendering onwards content](https://github.com/guardian/dotcom-rendering/issues/5349) while we resolve the questions around [storing `popular-in-tag` content in memory](https://github.com/guardian/dotcom-rendering/issues/5568). The reason for using a quick-fix approach here is because server-rendering onwards content is blocking our ability to test DCR-rendered Fronts (which depends on [an update to how we render images](https://github.com/guardian/dotcom-rendering/issues/4611)).

This branch is not complete:

- [ ] Some solution needs to be found for passing the article format from the client to Frontend (and on to DCR). 
- [ ] There is also some refactoring needed, if we use this branch, because it adds mandatory fields to an existing class (`OnwardCollectionResponse`).

I've noted these in inline comments.

This branch is relatively focused, but it does touch a few different files, so it may make sense to cherry-pick some commits.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)

There is a discrepancy between what Frontend is sending and what DCR is expecting, which is causing a bug in the DCR side `Onwards/` endpoint. I think the change needs to be made on the DCR side. See [this PR](https://github.com/guardian/dotcom-rendering/pull/5948).

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
