### PR TITLE
Fix flaky commercial cypress tests

### DIFF
--- a/cypress/e2e/inline-slots.cy.ts
+++ b/cypress/e2e/inline-slots.cy.ts
@@ -1,29 +1,61 @@
 import { breakpoints } from '../fixtures/breakpoints';
 import { articles, liveblogs } from '../fixtures/pages';
+import { mockIntersectionObserver } from '../lib/util';
 
-const pages = [...articles, ...liveblogs].filter(
+const pages = articles.filter((page) => 'expectedMinInlineSlotsOnPage' in page);
+
+const liveBlogPages = liveblogs.filter(
 	(page) => 'expectedMinInlineSlotsOnPage' in page,
 );
 
-describe('Slots and iframes load on pages', () => {
+describe('Slots and iframes load on article pages', () => {
 	pages.forEach(({ path, expectedMinInlineSlotsOnPage }) => {
-		breakpoints.forEach(({ breakpoint, width }) => {
+		breakpoints.forEach(({ breakpoint, width, height }) => {
 			it(`Test ${path} has at least ${expectedMinInlineSlotsOnPage} inline total slots at breakpoint ${breakpoint}`, () => {
-				cy.viewport(width, 500);
+				cy.viewport(width, height);
 
-				cy.visit(path);
+				cy.visit(path, {
+					onBeforeLoad(win) {
+						mockIntersectionObserver(win, '.ad-slot--inline');
+					},
+				});
 
 				cy.allowAllConsent();
 
-				cy.scrollTo('bottom', { duration: 5000 });
+				cy.get('.ad-slot--inline')
+					.should(
+						'have.length.at.least',
+						expectedMinInlineSlotsOnPage,
+					)
+					.each((slot) => {
+						cy.wrap(slot).scrollIntoView();
+						cy.wrap(slot).find('iframe').should('exist');
+					});
+			});
+		});
+	});
+});
 
-				[...Array(expectedMinInlineSlotsOnPage).keys()].forEach(
-					(item, i) => {
-						cy.get(`[data-name="inline${i + 1}"]`).should(
-							'have.length',
-							1,
+describe('Slots and iframes load on article liveblog pages', () => {
+	liveBlogPages.forEach(({ path, expectedMinInlineSlotsOnPage }) => {
+		breakpoints.forEach(({ breakpoint, width, height }) => {
+			it(`Test ${path} has at least ${expectedMinInlineSlotsOnPage} inline total slots at breakpoint ${breakpoint}`, () => {
+				cy.viewport(width, height);
+
+				cy.visit(path, {
+					onBeforeLoad(win) {
+						mockIntersectionObserver(
+							win,
+							'.ad-slot--liveblog-inline',
 						);
 					},
+				});
+
+				cy.allowAllConsent();
+
+				cy.get('.ad-slot--liveblog-inline').should(
+					'have.length.at.least',
+					expectedMinInlineSlotsOnPage,
 				);
 			});
 		});

--- a/cypress/e2e/inline-slots.cy.ts
+++ b/cypress/e2e/inline-slots.cy.ts
@@ -36,7 +36,7 @@ describe('Slots and iframes load on article pages', () => {
 	});
 });
 
-describe('Slots and iframes load on article liveblog pages', () => {
+describe('Slots and iframes load on liveblog pages', () => {
 	liveBlogPages.forEach(({ path, expectedMinInlineSlotsOnPage }) => {
 		breakpoints.forEach(({ breakpoint, width, height }) => {
 			it(`Test ${path} has at least ${expectedMinInlineSlotsOnPage} inline total slots at breakpoint ${breakpoint}`, () => {

--- a/cypress/e2e/merchandising-high.cy.ts
+++ b/cypress/e2e/merchandising-high.cy.ts
@@ -1,26 +1,27 @@
 import { breakpoints } from '../fixtures/breakpoints';
 import { articles, liveblogs } from '../fixtures/pages';
+import { mockIntersectionObserver } from '../lib/util';
 
 describe('merchandising-high slot on pages', () => {
-	[...articles, ...liveblogs].forEach(({ path, adTest }) => {
-		breakpoints.forEach(({ breakpoint, width }) => {
+	[...articles, ...liveblogs].forEach(({ path }) => {
+		breakpoints.forEach(({ breakpoint, width, height }) => {
 			it(`Test ${path} has correct slot and iframe at breakpoint ${breakpoint}`, () => {
-				cy.viewport(width, 800);
+				cy.viewport(width, height);
 
-				cy.visit(path);
+				cy.visit(path, {
+					onBeforeLoad(win) {
+						mockIntersectionObserver(
+							win,
+							'#dfp-ad--merchandising-high',
+						);
+					},
+				});
 
 				cy.allowAllConsent();
 
-				// Check that the merchandising-high ad slot is on the page
-				cy.get('#dfp-ad--merchandising-high').should('exist');
-
-				// Ensure all lazy loaded items are loaded
-				cy.scrollTo('bottom', { duration: 3000 });
-
-				// creative isn't loaded unless slot is in view
-				cy.get('#dfp-ad--merchandising-high').scrollIntoView({
-					duration: 3000,
-				});
+				cy.get('#dfp-ad--merchandising-high')
+					.scrollIntoView({ duration: 200 })
+					.should('exist');
 
 				// Check that an iframe is placed inside the merchandising-high ad slot
 				cy.findAdSlotIframeBySlotId(

--- a/cypress/e2e/merchandising.cy.ts
+++ b/cypress/e2e/merchandising.cy.ts
@@ -1,26 +1,24 @@
 import { breakpoints } from '../fixtures/breakpoints';
 import { articles, liveblogs } from '../fixtures/pages';
+import { mockIntersectionObserver } from '../lib/util';
 
 describe('merchandising slot on pages', () => {
-	[...articles, ...liveblogs].forEach(({ path, adTest }) => {
-		breakpoints.forEach(({ breakpoint, width }) => {
+	[...articles, ...liveblogs].forEach(({ path }) => {
+		breakpoints.forEach(({ breakpoint, width, height }) => {
 			it(`Test ${path} has correct slot and iframe at breakpoint ${breakpoint}`, () => {
-				cy.viewport(width, 800);
+				cy.viewport(width, height);
 
-				cy.visit(path);
+				cy.visit(path, {
+					onBeforeLoad(win) {
+						mockIntersectionObserver(win, '#dfp-ad--merchandising');
+					},
+				});
 
 				cy.allowAllConsent();
 
-				// Check that the merchandising ad slot is on the page
-				cy.get('#dfp-ad--merchandising').should('exist');
-
-				// Ensure all lazy loaded items are loaded
-				cy.scrollTo('bottom', { duration: 3000 });
-
-				// creative isn't loaded unless slot is in view
-				cy.get('#dfp-ad--merchandising').scrollIntoView({
-					duration: 3000,
-				});
+				cy.get('#dfp-ad--merchandising')
+					.scrollIntoView({ duration: 200 })
+					.should('exist');
 
 				// Check that an iframe is placed inside the merchandising ad slot
 				cy.findAdSlotIframeBySlotId('dfp-ad--merchandising').should(

--- a/cypress/e2e/mostpop.cy.ts
+++ b/cypress/e2e/mostpop.cy.ts
@@ -1,11 +1,18 @@
 import { breakpoints } from '../fixtures/breakpoints';
 import { articles, liveblogs } from '../fixtures/pages';
+import { mockIntersectionObserver } from '../lib/util';
 
 describe('mostpop slot on pages', () => {
-	[...articles, ...liveblogs].forEach(({ path, adTest }) => {
-		breakpoints.forEach(({ breakpoint }) => {
+	[...articles, ...liveblogs].forEach(({ path }) => {
+		breakpoints.forEach(({ breakpoint, width, height }) => {
 			it(`Test ${path} has correct slot and iframe at breakpoint ${breakpoint}`, () => {
-				cy.visit(path);
+				cy.viewport(width, height);
+
+				cy.visit(path, {
+					onBeforeLoad(win) {
+						mockIntersectionObserver(win, '#dfp-ad--mostpop');
+					},
+				});
 
 				cy.allowAllConsent();
 

--- a/cypress/e2e/right-slot.cy.ts
+++ b/cypress/e2e/right-slot.cy.ts
@@ -2,7 +2,7 @@ import { breakpoints } from '@guardian/source-foundations';
 import { articles, liveblogs } from '../fixtures/pages';
 
 describe('right slot on pages', () => {
-	[...articles, ...liveblogs].forEach(({ path, adTest }) => {
+	[...articles, ...liveblogs].forEach(({ path }) => {
 		it(`Test ${path} has correct slot and iframe`, () => {
 			// viewport width has to be >= 1300px in order for the right column to appear on liveblogs
 			cy.viewport(breakpoints['wide'], 1000);

--- a/cypress/e2e/snapshot-top-above-nav.cy.ts
+++ b/cypress/e2e/snapshot-top-above-nav.cy.ts
@@ -3,7 +3,7 @@ import { breakpoints } from '../fixtures/breakpoints';
 import '@percy/cypress';
 
 describe('Visually snapshot top-above-nav', () => {
-	[articles[0]].forEach(({ path, adTest }) => {
+	[articles[0]].forEach(({ path }) => {
 		it(`snapshots ${path}`, () => {
 			cy.visit(path);
 			cy.allowAllConsent();

--- a/cypress/e2e/targeting.cy.ts
+++ b/cypress/e2e/targeting.cy.ts
@@ -56,7 +56,7 @@ describe('GAM targeting', () => {
 	});
 });
 
-describe.skip('Prebid targeting', () => {
+describe('Prebid targeting', () => {
 	const interceptGamRequest = () =>
 		cy.intercept(
 			{

--- a/cypress/e2e/targeting.cy.ts
+++ b/cypress/e2e/targeting.cy.ts
@@ -93,7 +93,8 @@ describe('Prebid targeting', () => {
 		});
 	});
 
-	it(`prebid winner should display ad and send targeting to GAM`, () => {
+	// This test is flaky, so we're skipping it for now
+	it.skip(`prebid winner should display ad and send targeting to GAM`, () => {
 		const { path } = articles[0];
 
 		interceptGamRequest();

--- a/cypress/e2e/top-above-nav.cy.ts
+++ b/cypress/e2e/top-above-nav.cy.ts
@@ -1,7 +1,7 @@
 import { allPages } from '../fixtures/pages';
 
 describe('top-above-nav on pages', () => {
-	allPages.forEach(({ path, adTest }) => {
+	allPages.forEach(({ path }) => {
 		it(`Test ${path} has top-above-nav slot and iframe`, () => {
 			cy.visit(path);
 

--- a/cypress/fixtures/breakpoints.ts
+++ b/cypress/fixtures/breakpoints.ts
@@ -1,21 +1,34 @@
 import { breakpoints } from '@guardian/source-foundations';
 
-type BreakpointKeys = keyof typeof breakpoints;
+type BreakpointKeys = Pick<
+	typeof breakpoints,
+	'mobile' | 'tablet' | 'desktop' | 'wide'
+>;
+
 type BreakpointSizes = {
-	breakpoint: BreakpointKeys;
-	width: typeof breakpoints[BreakpointKeys];
+	breakpoint: keyof BreakpointKeys;
+	width: typeof breakpoints[keyof BreakpointKeys];
+	height: number;
 };
 
-const breakpointsToTest: Array<keyof typeof breakpoints> = [
-	// 'mobile',
-	// 'tablet',
+const breakpointsToTest: Array<keyof BreakpointKeys> = [
+	'mobile',
+	'tablet',
 	'desktop',
-	// 'wide',
+	'wide',
 ];
+
+const heights = {
+	mobile: 600,
+	tablet: 1100,
+	desktop: 1100,
+	wide: 1100,
+} as const;
 
 const breakpointSizes: BreakpointSizes[] = breakpointsToTest.map((b) => ({
 	breakpoint: b,
 	width: breakpoints[b],
+	height: heights[b],
 }));
 
 export { breakpointSizes as breakpoints };

--- a/cypress/lib/util.ts
+++ b/cypress/lib/util.ts
@@ -89,6 +89,14 @@ export const fakeLogOut = () => {
 	cy.reload();
 };
 
+/**
+ * This function will mock the intersection observer API, and will call the callback immediately to trigger lazy-loading behaviour
+ *
+ * Optionally, you can pass in a selector to mock the intersection observer for specific elements, useful for ads because loading them all at once can be quite slow
+ *
+ * @param win window object
+ * @param selector optional selector to target specific elements, if empty, will indiscriminately mock all observers
+ */
 export const mockIntersectionObserver = (win: Window, selector?: string) => {
 	const Original = win.IntersectionObserver;
 	// ts-expect-error

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -39,12 +39,14 @@ Cypress.Commands.add('rejectAllConsent', () => {
 	cy.getIframeBody('iframe[title="SP Consent Message"]')
 		.find(`button[title="${rejectAll}"]`, { timeout: 30000 })
 		.click();
+	cy.wait(100);
 });
 
 Cypress.Commands.add('allowAllConsent', () => {
 	cy.getIframeBody('sp_message_iframe_')
 		.find(`button[title="${allowAll}"]`, { timeout: 30000 })
 		.click();
+	cy.wait(100);
 });
 
 Cypress.Commands.add('hydrate', () => {

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -57,3 +57,14 @@ beforeEach(() => {
 	// execute all tests in GB region for now
 	storage.local.set('gu.geo.override', 'GB');
 });
+
+// Hide fetch/XHR requests
+const app = window.top;
+if (!app.document.head.querySelector('[data-hide-command-log-request]')) {
+	const style = app.document.createElement('style');
+	style.innerHTML =
+		'.command-name-request, .command-name-xhr { display: none }';
+	style.setAttribute('data-hide-command-log-request', '');
+
+	app.document.head.appendChild(style);
+}

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -736,13 +736,15 @@
  "../projects/common/modules/identity/auth-component-event-params.js": [
   "../lib/url.ts"
  ],
- "../projects/common/modules/spacefinder-debug-tools.js": [],
+ "../projects/common/modules/spacefinder-debug-tools.ts": [
+  "../projects/common/modules/spacefinder.ts"
+ ],
  "../projects/common/modules/spacefinder.ts": [
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../../../../node_modules/@types/lodash-es/index.d.ts",
   "../lib/fastdom-promise.js",
   "../projects/commercial/am-i-used.ts",
-  "../projects/common/modules/spacefinder-debug-tools.js"
+  "../projects/common/modules/spacefinder-debug-tools.ts"
  ],
  "../projects/common/modules/ui/sticky.js": [
   "../../../../node_modules/fastdom/fastdom.js",


### PR DESCRIPTION
## What does this change?
Re-enable testing at different breakpoints, consent, and prebid tests.

They should be more reliable now after some tweaks.

Fixes include:
- Mocking the intersection observer class to force lazy-loading
- Spying on localStorage for the consent tests
- General clean up

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
