### PR TITLE
Fix interscroller ad label

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
@@ -94,11 +94,17 @@ export const renderAdvertLabel = (
 	});
 };
 
-export const renderStickyAdLabel = (adSlotNode: HTMLElement): Promise<void> =>
+export const renderInterscrollerAdLabel = (
+	adSlotNode: HTMLElement,
+): Promise<void> =>
 	fastdom.measure(() => {
 		const adSlotLabel: HTMLElement = document.createElement('div');
 		adSlotLabel.classList.add('ad-slot__label');
-		adSlotLabel.classList.add('sticky');
+		adSlotLabel.style.cssText = `
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;`;
 		adSlotLabel.innerHTML = 'Advertisement';
 		adSlotNode.appendChild(adSlotLabel);
 	});

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.ts
@@ -2,7 +2,7 @@ import { isObject } from '@guardian/libs';
 import once from 'lodash-es/once';
 import fastdom from '../../../../lib/fastdom-promise';
 import {
-	renderStickyAdLabel,
+	renderInterscrollerAdLabel,
 	renderStickyScrollForMoreLabel,
 } from '../dfp/render-advert-label';
 import type { RegisterListener } from '../messenger';
@@ -184,7 +184,7 @@ const setupBackground = async (
 				adSlot.style.position = 'relative';
 			}
 
-			void renderStickyAdLabel(adSlot);
+			void renderInterscrollerAdLabel(adSlot);
 			void renderStickyScrollForMoreLabel(backgroundParent);
 
 			isDCR && renderBottomLine(background, backgroundParent);


### PR DESCRIPTION
## What does this change?
Restores the interscroller ad label

The combination of fixing the click-through (https://github.com/guardian/frontend/pull/25459) and fixing the viewability tracking (https://github.com/guardian/dotcom-rendering/pull/5719) broke this.

Also renamed the `renderStickyAdLabel` to `renderInterscrollerAdLabel` as it is only used for interscroller, and not actually sticky.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/1731150/188869524-6a9a15bf-5866-4e24-be96-d8527b3c488f.png
[after]: https://user-images.githubusercontent.com/1731150/188869574-83d49fdb-9f4c-49c7-b1ef-94c861c6b74c.png


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
