### PR TITLE
Enable ozone prebid in USA with it's own placement ID

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.ts
@@ -10,6 +10,7 @@ import {
 	isInAuOrNz,
 	isInRow,
 	isInUk,
+	isInUsa,
 	isInUsOrCa,
 } from '../../../../common/modules/commercial/geo-utils';
 import {
@@ -294,6 +295,8 @@ const openxClientSideBidder: (pageTargeting: PageTargeting) => PrebidBidder = (
 	},
 });
 
+const getOzonePlacementId = () => (isInUsa() ? '1420436308' : '0420420500');
+
 const ozoneClientSideBidder: (pageTargeting: PageTargeting) => PrebidBidder = (
 	pageTargeting: PageTargeting,
 ) => ({
@@ -302,7 +305,7 @@ const ozoneClientSideBidder: (pageTargeting: PageTargeting) => PrebidBidder = (
 	bidParams: (): PrebidOzoneParams => ({
 		publisherId: 'OZONEGMG0001',
 		siteId: '4204204209',
-		placementId: '0420420500',
+		placementId: getOzonePlacementId(),
 		customData: [
 			{
 				settings: {},

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/utils.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/utils.ts
@@ -6,6 +6,7 @@ import { getBreakpoint, isBreakpoint } from '../../../../lib/detect';
 import { pbTestNameMap } from '../../../../lib/url';
 import {
 	isInAuOrNz,
+	isInCanada,
 	isInRow,
 	isInUk,
 	isInUsOrCa,
@@ -149,7 +150,7 @@ export const shouldIncludeAdYouLike = (
 
 // TODO: Check is we want regional restrictions on where we load the ozoneBidAdapter
 export const shouldUseOzoneAdaptor = (): boolean =>
-	!isInUsOrCa() &&
+	!isInCanada() &&
 	!isInAuOrNz() &&
 	(window.guardian.config.switches.prebidOzone ?? false);
 


### PR DESCRIPTION
## What does this change?
Previously ozone was disabled in the US, Canada, Aus and NZ, we'd like to enable for just the US with it's own placement ID.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/1731150/189099382-7c728c20-723d-4ceb-b774-a381a38de06c.png

[after]: https://user-images.githubusercontent.com/1731150/189102886-e05fef90-44fb-4df8-97dc-f26bb54cb9a4.png


USA:
![Screenshot 2022-09-08 at 11 24 33](https://user-images.githubusercontent.com/1731150/189099758-227bd7da-2cad-4bf5-8034-355d5ec0e8a9.png)

UK:
![Screenshot 2022-09-08 at 11 28 45](https://user-images.githubusercontent.com/1731150/189100318-d84a6cc1-ed8e-4bfc-8222-09dd5b37df0e.png)


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
