### PR TITLE
Editions refactor to make navigation links part of the Edition class

### DIFF
--- a/common/app/common/Edition.scala
+++ b/common/app/common/Edition.scala
@@ -1,5 +1,7 @@
 package common
 
+import navigation.EditionNavLinks
+
 import java.util.Locale
 import org.joda.time.DateTimeZone
 import play.api.libs.json._
@@ -31,6 +33,7 @@ abstract class Edition(
       "travel",
       "tv-and-radio",
     ),
+    val navigationLinks: EditionNavLinks,
 ) {
   val homePagePath: String = s"/$networkFrontId"
 

--- a/common/app/common/editions/Au.scala
+++ b/common/app/common/editions/Au.scala
@@ -3,10 +3,8 @@ package common.editions
 import java.util.Locale
 import org.joda.time.DateTimeZone
 import common._
+import navigation.{EditionNavLinks, NavLinks}
 
-//This object exists to be used with ItemTrailblockDescription and is not a real edition like the others.
-//All that is really being used is Edition.id, which is AU
-//It is not included in the Edition.all sequence
 object Au
     extends Edition(
       id = "AU",
@@ -14,6 +12,15 @@ object Au
       DateTimeZone.forID("Australia/Sydney"),
       locale = Locale.forLanguageTag("en-au"),
       networkFrontId = "au",
+      navigationLinks = EditionNavLinks(
+        NavLinks.auNewsPillar,
+        NavLinks.auOpinionPillar,
+        NavLinks.auSportPillar,
+        NavLinks.auCulturePillar,
+        NavLinks.auLifestylePillar,
+        NavLinks.auOtherLinks,
+        NavLinks.auBrandExtensions,
+      ),
     ) {
 
   implicit val AU = Au

--- a/common/app/common/editions/International.scala
+++ b/common/app/common/editions/International.scala
@@ -2,6 +2,7 @@ package common.editions
 
 import java.util.Locale
 import common._
+import navigation.{EditionNavLinks, NavLinks}
 import org.joda.time.DateTimeZone
 
 object International
@@ -12,6 +13,15 @@ object International
       locale = Locale.forLanguageTag("en"),
       networkFrontId = "international",
       editionalisedSections = Seq(""), // only the home page
+      navigationLinks = EditionNavLinks(
+        NavLinks.intNewsPillar,
+        NavLinks.intOpinionPillar,
+        NavLinks.intSportPillar,
+        NavLinks.intCulturePillar,
+        NavLinks.intLifestylePillar,
+        NavLinks.intOtherLinks,
+        NavLinks.intBrandExtensions,
+      ),
     ) {
 
   implicit val INT = International

--- a/common/app/common/editions/Uk.scala
+++ b/common/app/common/editions/Uk.scala
@@ -2,6 +2,7 @@ package common.editions
 
 import java.util.Locale
 import common._
+import navigation.{EditionNavLinks, NavLinks}
 import org.joda.time.DateTimeZone
 
 object Uk
@@ -11,6 +12,15 @@ object Uk
       timezone = DateTimeZone.forID("Europe/London"),
       locale = Locale.forLanguageTag("en-gb"),
       networkFrontId = "uk",
+      navigationLinks = EditionNavLinks(
+        NavLinks.ukNewsPillar,
+        NavLinks.ukOpinionPillar,
+        NavLinks.ukSportPillar,
+        NavLinks.ukCulturePillar,
+        NavLinks.ukLifestylePillar,
+        NavLinks.ukOtherLinks,
+        NavLinks.ukBrandExtensions,
+      ),
     ) {
 
   implicit val UK = Uk

--- a/common/app/common/editions/Us.scala
+++ b/common/app/common/editions/Us.scala
@@ -2,6 +2,7 @@ package common.editions
 
 import java.util.Locale
 import common._
+import navigation.{EditionNavLinks, NavLinks}
 import org.joda.time.DateTimeZone
 
 object Us
@@ -11,6 +12,15 @@ object Us
       timezone = DateTimeZone.forID("America/New_York"),
       locale = Locale.forLanguageTag("en-us"),
       networkFrontId = "us",
+      navigationLinks = EditionNavLinks(
+        NavLinks.usNewsPillar,
+        NavLinks.usOpinionPillar,
+        NavLinks.usSportPillar,
+        NavLinks.usCulturePillar,
+        NavLinks.usLifestylePillar,
+        NavLinks.usOtherLinks,
+        NavLinks.usBrandExtensions,
+      ),
     ) {
 
   implicit val US = Us

--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -1,8 +1,10 @@
 package navigation
 
 import play.api.libs.json.{JsValue, Json}
+import common.Edition
+import play.api.libs.json.Json.toJson
 
-private object NavLinks {
+object NavLinks {
 
   /* NEWS */
   val science = NavLink("Science", "/science")
@@ -728,47 +730,9 @@ case class EditionNavLinks(
 object NavigationData {
   implicit val navlinkWrites = Json.writes[NavLink]
   implicit val editionNavLinksWrites = Json.writes[EditionNavLinks]
-  implicit val navlinksInterfaceWrites = Json.writes[NavigationData]
 
-  val nav: JsValue = Json.toJson(NavigationData())
+  val nav: JsValue = toJson(
+    (Edition.all
+      .map(e => e.networkFrontId -> toJson(e.navigationLinks)) :+ "tagPages" -> toJson(NavLinks.tagPages)).toMap,
+  )
 }
-
-case class NavigationData(
-    uk: EditionNavLinks = EditionNavLinks(
-      NavLinks.ukNewsPillar,
-      NavLinks.ukOpinionPillar,
-      NavLinks.ukSportPillar,
-      NavLinks.ukCulturePillar,
-      NavLinks.ukLifestylePillar,
-      NavLinks.ukOtherLinks,
-      NavLinks.ukBrandExtensions,
-    ),
-    us: EditionNavLinks = EditionNavLinks(
-      NavLinks.usNewsPillar,
-      NavLinks.usOpinionPillar,
-      NavLinks.usSportPillar,
-      NavLinks.usCulturePillar,
-      NavLinks.usLifestylePillar,
-      NavLinks.usOtherLinks,
-      NavLinks.usBrandExtensions,
-    ),
-    au: EditionNavLinks = EditionNavLinks(
-      NavLinks.auNewsPillar,
-      NavLinks.auOpinionPillar,
-      NavLinks.auSportPillar,
-      NavLinks.auCulturePillar,
-      NavLinks.auLifestylePillar,
-      NavLinks.auOtherLinks,
-      NavLinks.auBrandExtensions,
-    ),
-    international: EditionNavLinks = EditionNavLinks(
-      NavLinks.intNewsPillar,
-      NavLinks.intOpinionPillar,
-      NavLinks.intSportPillar,
-      NavLinks.intCulturePillar,
-      NavLinks.intLifestylePillar,
-      NavLinks.intOtherLinks,
-      NavLinks.intBrandExtensions,
-    ),
-    tagPages: List[String] = NavLinks.tagPages,
-)

--- a/common/app/navigation/Navigation.scala
+++ b/common/app/navigation/Navigation.scala
@@ -62,8 +62,6 @@ case class NavMenu(
 
 object NavMenu {
 
-  val navigationData = NavigationData()
-
   implicit val navlinkWrites = Json.writes[NavLink]
   implicit val flatSubnavWrites = Json.writes[FlatSubnav]
   implicit val parentSubnavWrites = Json.writes[ParentSubnav]
@@ -159,18 +157,13 @@ object NavMenu {
         None
       } else if (pillars.contains(parent)) {
         currentParent
-      } else findParent(parent, edition, pillars, otherLinks).orElse(Some(navigationData.uk.newsPillar)),
+      } else findParent(parent, edition, pillars, otherLinks).orElse(Some(editions.Uk.navigationLinks.newsPillar)),
     )
   }
 
   def navRoot(edition: Edition): NavRoot = {
 
-    val editionLinks: EditionNavLinks = edition match {
-      case editions.Uk            => navigationData.uk
-      case editions.Us            => navigationData.us
-      case editions.Au            => navigationData.au
-      case editions.International => navigationData.international
-    }
+    val editionLinks: EditionNavLinks = edition.navigationLinks
 
     NavRoot(
       Seq(
@@ -205,9 +198,9 @@ object NavMenu {
     val networkFronts = Seq("uk", "us", "au", "international")
     val tags = getTagsFromPage(page)
     val commonKeywords = tags.keywordIds
-      .intersect(navigationData.tagPages)
+      .intersect(NavLinks.tagPages)
       .sortWith(tags.keywordIds.indexOf(_) < tags.keywordIds.indexOf(_))
-    val isTagPage = (page.metadata.isFront || frontLikePages.contains(page.metadata.id)) && navigationData.tagPages
+    val isTagPage = (page.metadata.isFront || frontLikePages.contains(page.metadata.id)) && NavLinks.tagPages
       .contains(page.metadata.id)
     val isArticleInTagPageSection = commonKeywords.nonEmpty
 


### PR DESCRIPTION
## What does this change?
This follows up on the work introduced in PR #25468 

This moves the definition of edition navigation links into the Edition class forcing all editions to implement this field and in turn removes the need for the NavigationData case class reducing the number of places where changes need to be made when creating a new edition.

This also moved the NavigationData Json generation logic closer to Navigation making it more straightforward to test separately.

## Does this change need to be reproduced in dotcom-rendering ?

- [X ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?
Making the steps to adding a new Edition more clear and concise as well as making it easier to test navigation.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [X ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
