### PR TITLE
Start tracking labs containers

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@guardian/atom-renderer": "1.2.2",
     "@guardian/automat-modules": "^0.3.8",
     "@guardian/braze-components": "^7.3.0",
-    "@guardian/commercial-core": "4.8.0",
+    "@guardian/commercial-core": "4.9.0",
     "@guardian/consent-management-platform": "^10.11.1",
     "@guardian/libs": "^7.1.4",
     "@guardian/shimport": "^1.0.2",

--- a/static/src/javascripts/bootstraps/standalone.commercial.ts
+++ b/static/src/javascripts/bootstraps/standalone.commercial.ts
@@ -51,6 +51,7 @@ import { removeDisabledSlots as closeDisabledSlots } from '../projects/commercia
 import { init as setAdTestCookie } from '../projects/commercial/modules/set-adtest-cookie';
 import { init as initThirdPartyTags } from '../projects/commercial/modules/third-party-tags';
 import { init as initTrackGpcSignal } from '../projects/commercial/modules/track-gpc-signal';
+import { init as initTrackLabsContainer } from '../projects/commercial/modules/track-labs-container';
 import { init as initTrackScrollDepth } from '../projects/commercial/modules/track-scroll-depth';
 import { commercialFeatures } from '../projects/common/modules/commercial/commercial-features';
 import type { Modules } from './types';
@@ -84,6 +85,7 @@ const commercialExtraModules: Modules = [
 	['cm-comscore', initComscore],
 	['cm-ipsosmori', initIpsosMori],
 	['cm-trackScrollDepth', initTrackScrollDepth],
+	['cm-trackLabsContainer', initTrackLabsContainer],
 	['cm-trackGpcSignal', initTrackGpcSignal],
 ];
 

--- a/static/src/javascripts/projects/commercial/modules/track-labs-container.ts
+++ b/static/src/javascripts/projects/commercial/modules/track-labs-container.ts
@@ -1,0 +1,21 @@
+import { initTrackLabsContainer } from '@guardian/commercial-core';
+import { onConsent } from '@guardian/consent-management-platform';
+import { log } from '@guardian/libs';
+
+/**
+ * Initialise labs container tracking if user has consented to relevant purposes.
+ * @returns Promise
+ */
+export const init = async (): Promise<void> => {
+	const state = await onConsent();
+	if (
+		// Purpose 8 - Measure content performance
+		(state.framework == 'tcfv2' && state.tcfv2?.consents[8]) ||
+		state.canTarget
+	) {
+		initTrackLabsContainer();
+		log('commercial', 'Tracking labs container');
+	} else {
+		log('commercial', 'No consent to track labs container');
+	}
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2089,10 +2089,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-7.3.0.tgz#9c4908fa5d439d85b2024735575435b0a5cd369f"
   integrity sha512-Py2FZ6aHi/inOIF4+4xZqNmbJur3cevtWRMQeFLjNjgN7zR7hMB6Dsd8uurEym6Qd3yxBAGPx/+rS3xVbTKz4w==
 
-"@guardian/commercial-core@4.8.0":
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.8.0.tgz#184abda938df34d01cc856d5596555f692ca296d"
-  integrity sha512-AGqoj3Zcmcvyp+XX2MRkqRLpPUPoKtsrA2R7XZG24zYGaeqItc+Wyd1Xx2nkFFMI4JLQ5UMrmF8V94W2nLJY2A==
+"@guardian/commercial-core@4.9.0":
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.9.0.tgz#a2d18d92cedaf1a6770c0057e183162554d37b95"
+  integrity sha512-zA58x817sXHCZqgEjo96sVfHuz8c+jxCQKfPgYVljhsWQ+7wqOL9nw4X2HJ2NHswR0/rso44AIFBFqoiQRqaNA==
 
 "@guardian/consent-management-platform@^10.11.1":
   version "10.11.1"


### PR DESCRIPTION
## What does this change?
- Bumps version of commercial-core to [4.9.0](https://github.com/guardian/commercial-core/pull/665)
- calls `initTrackLabsContainer` to Initialise labs container tracking if the user has consented to [purpose 8](https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/#Purpose_8__Measure_content_performance), "measure content performance"

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

![Screenshot 2022-09-13 at 12 10 49](https://user-images.githubusercontent.com/7423751/189886619-7c2cf079-5e59-4c82-a3b4-edc71bc226a6.png)


## What is the value of this and can you measure success?

The Guardian Labs team would find it useful to understand how successful these containers are at driving traffic, relative to how many times they’re rendered. 

Understanding the success of the containers will help teams iterate on and improve the design, position in the page and how they are used.

### Tested

- [ ] Locally
- [x] On CODE