### PR TITLE
Doml/prebid other price granularity

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.spec.ts
@@ -50,12 +50,16 @@ describe('initialise', () => {
 			_customPriceBucket: {
 				buckets: [
 					{
+						max: 10,
 						increment: 0.01,
-						max: 100,
 					},
 					{
+						max: 15,
+						increment: 0.1,
+					},
+					{
+						max: 100,
 						increment: 1,
-						max: 500,
 					},
 				],
 			},
@@ -82,12 +86,16 @@ describe('initialise', () => {
 			customPriceBucket: {
 				buckets: [
 					{
+						max: 10,
 						increment: 0.01,
-						max: 100,
 					},
 					{
+						max: 15,
+						increment: 0.1,
+					},
+					{
+						max: 100,
 						increment: 1,
-						max: 500,
 					},
 				],
 			},

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
@@ -16,7 +16,7 @@ import { bids } from './bid-config';
 import type { PrebidPriceGranularity } from './price-config';
 import {
 	criteoPriceGranularity,
-	indexPrebidPriceGranularity,
+	indexPriceGranularity,
 	ozonePriceGranularity,
 	priceGranularity,
 } from './price-config';
@@ -160,12 +160,12 @@ declare global {
 					customPriceBucket?: PrebidPriceGranularity;
 					/**
 					 * This is a custom property that has been added to our fork of prebid.js
-					 * to select a price bucket based on the width and height of the slot
+					 * to select a price bucket based on the width and height of the slot.
 					 */
 					guCustomPriceBucket?: (bid: {
 						width: number;
 						height: number;
-					}) => PrebidPriceGranularity;
+					}) => PrebidPriceGranularity | undefined;
 				};
 			}) => void;
 			getConfig: (item?: string) => PbjsConfig & {
@@ -318,22 +318,22 @@ const initialise = (window: Window, framework: Framework = 'tcfv2'): void => {
 	}
 
 	if (window.guardian.config.switches.prebidOzone) {
-		// Use a custom price granularity for Ozone
-		// This price granularity is based upon the size of the slot being auctioned
+		// Use a custom price granularity, which is based upon the size of the slot being auctioned
 		window.pbjs.setBidderConfig({
 			bidders: ['ozone'],
 			config: {
 				// Select the ozone granularity, use default if not defined for the size
 				guCustomPriceBucket: ({ width, height }) => {
-					const granularity =
-						ozonePriceGranularity(width, height) ??
-						priceGranularity;
+					const ozoneGranularity = ozonePriceGranularity(
+						width,
+						height,
+					);
 					log(
 						'commercial',
-						`Custom Ozone price bucket for size (${width},${height}):`,
-						granularity,
+						`Custom Prebid - Ozone price bucket for size (${width},${height}):`,
+						ozoneGranularity,
 					);
-					return granularity;
+					return ozoneGranularity;
 				},
 			},
 		});
@@ -344,16 +344,17 @@ const initialise = (window: Window, framework: Framework = 'tcfv2'): void => {
 			bidders: ['ix'],
 			config: {
 				guCustomPriceBucket: ({ width, height }) => {
-					const granularity =
-						indexPrebidPriceGranularity(width, height) ??
-						priceGranularity;
+					const indexGranularity = indexPriceGranularity(
+						width,
+						height,
+					);
 					log(
 						'commercial',
-						`Custom Prebid Index price bucket for size (${width},${height}):`,
-						granularity,
+						`Custom Prebid - Index price bucket for size (${width},${height}):`,
+						indexGranularity,
 					);
 
-					return granularity;
+					return indexGranularity;
 				},
 			},
 		});

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/price-config.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/price-config.spec.ts
@@ -1,7 +1,6 @@
 import {
 	criteoPriceGranularity,
-	indexPrebidPriceGranularity,
-	otherPrebidPriceGranularity,
+	indexPriceGranularity,
 	ozonePriceGranularity,
 	priceGranularity,
 } from './price-config';
@@ -11,17 +10,20 @@ describe('price granularity', () => {
 		expect(priceGranularity).toEqual({
 			buckets: [
 				{
-					max: 100,
+					max: 10,
 					increment: 0.01,
 				},
 				{
-					max: 500,
+					max: 15,
+					increment: 0.1,
+				},
+				{
+					max: 100,
 					increment: 1,
 				},
 			],
 		});
 	});
-
 	test('criteo should have correct buckets', () => {
 		expect(criteoPriceGranularity).toEqual({
 			buckets: [
@@ -140,61 +142,7 @@ describe('price granularity', () => {
 		])(
 			'Index Prebid slot with size %s gives correct granularity',
 			([width, height], expectedGranularity) => {
-				expect(indexPrebidPriceGranularity(width, height)).toEqual(
-					expectedGranularity,
-				);
-			},
-		);
-	});
-
-	describe('Other Prebid', () => {
-		const otherPrebidGranularityOption1 = {
-			buckets: [
-				{
-					max: 7,
-					increment: 0.01,
-				},
-				{
-					max: 15,
-					increment: 0.1,
-				},
-				{
-					max: 50,
-					increment: 1,
-				},
-			],
-		};
-
-		const otherPrebidGranularityOption2 = {
-			buckets: [
-				{
-					max: 10,
-					increment: 0.01,
-				},
-				{
-					max: 15,
-					increment: 0.1,
-				},
-				{
-					max: 50,
-					increment: 1,
-				},
-			],
-		};
-
-		test.each([
-			[[100, 100], undefined],
-			[[160, 600], otherPrebidGranularityOption1],
-			[[300, 600], otherPrebidGranularityOption1],
-			[[320, 480], otherPrebidGranularityOption1],
-			[[728, 90], otherPrebidGranularityOption2],
-			[[970, 250], otherPrebidGranularityOption2],
-			[[300, 250], otherPrebidGranularityOption2],
-			[[320, 50], otherPrebidGranularityOption2],
-		])(
-			'Index Prebid slot with size %s gives correct granularity',
-			([width, height], expectedGranularity) => {
-				expect(otherPrebidPriceGranularity(width, height)).toEqual(
+				expect(indexPriceGranularity(width, height)).toEqual(
 					expectedGranularity,
 				);
 			},

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/price-config.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/price-config.ts
@@ -11,11 +11,15 @@ export type PrebidPriceGranularity = {
 export const priceGranularity: PrebidPriceGranularity = {
 	buckets: [
 		{
-			max: 100,
+			max: 10,
 			increment: 0.01,
 		},
 		{
-			max: 500,
+			max: 15,
+			increment: 0.1,
+		},
+		{
+			max: 100,
 			increment: 1,
 		},
 	],
@@ -38,9 +42,6 @@ export const criteoPriceGranularity: PrebidPriceGranularity = {
 	],
 };
 
-/**
- * Compute the price granularity for Ozone based on the width and height of the slot
- */
 export const ozonePriceGranularity = (
 	width: number,
 	height: number,
@@ -97,7 +98,7 @@ export const ozonePriceGranularity = (
 	return undefined;
 };
 
-export const indexPrebidPriceGranularity = (
+export const indexPriceGranularity = (
 	width: number,
 	height: number,
 ): PrebidPriceGranularity | undefined => {
@@ -139,62 +140,6 @@ export const indexPrebidPriceGranularity = (
 				{
 					max: 20,
 					increment: 0.05,
-				},
-				{
-					max: 50,
-					increment: 1,
-				},
-			],
-		};
-	}
-
-	return undefined;
-};
-
-export const otherPrebidPriceGranularity = (
-	width: number,
-	height: number,
-): PrebidPriceGranularity | undefined => {
-	const sizeString = [width, height].join(',');
-
-	if (
-		sizeString === adSizes.skyscraper.toString() ||
-		sizeString === adSizes.halfPage.toString() ||
-		sizeString === '320,480' // TODO find the name of this ad sizing
-	) {
-		return {
-			buckets: [
-				{
-					max: 7,
-					increment: 0.01,
-				},
-				{
-					max: 15,
-					increment: 0.1,
-				},
-				{
-					max: 50,
-					increment: 1,
-				},
-			],
-		};
-	}
-
-	if (
-		sizeString === adSizes.leaderboard.toString() ||
-		sizeString === adSizes.billboard.toString() ||
-		sizeString === adSizes.mpu.toString() ||
-		sizeString === adSizes.mobilesticky.toString()
-	) {
-		return {
-			buckets: [
-				{
-					max: 10,
-					increment: 0.01,
-				},
-				{
-					max: 15,
-					increment: 0.1,
 				},
 				{
 					max: 50,


### PR DESCRIPTION
## What does this change?

Use new price granularity for Prebid-Other. This includes all Prebid bidders, EXCLUDING Criteo, Ozone and Index Exchange.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

We need this change to be able to use our [new bucket distribution](https://github.com/guardian/commercial-tools/pull/146).

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
