### PR TITLE
feat(nav): add obituaries front

### DIFF
--- a/common/app/navigation/NavLinks.scala
+++ b/common/app/navigation/NavLinks.scala
@@ -61,7 +61,7 @@ private object NavLinks {
   val savings = NavLink("Savings", "/money/savings")
   val borrowing = NavLink("Borrowing", "/money/debt")
   val careers = NavLink("Careers", "/money/work-and-careers")
-  val obituaries = NavLink("Obituaries", "/tone/obituaries")
+  val obituaries = NavLink("Obituaries", "/obituaries")
   val greenLight = NavLink("Green light", "/environment/series/green-light")
   val fightToVote = NavLink("Fight to vote", "/us-news/series/the-fight-to-vote")
   val ukNews = NavLink(
@@ -175,7 +175,7 @@ private object NavLinks {
     "Today's paper",
     "/theguardian",
     children = List(
-      NavLink("Obituaries", "/tone/obituaries"),
+      NavLink("Obituaries", "/obituaries"),
       NavLink("G2", "/theguardian/g2"),
       NavLink("Journal", "/theguardian/journal"),
       NavLink("Saturday", "/theguardian/saturday"),

--- a/common/test/resources/reference-navigation.json
+++ b/common/test/resources/reference-navigation.json
@@ -323,7 +323,7 @@
         "classList" : [ ]
       }, {
         "title" : "Obituaries",
-        "url" : "/tone/obituaries",
+        "url" : "/obituaries",
         "children" : [ ],
         "classList" : [ ]
       } ],
@@ -647,7 +647,7 @@
       "url" : "/theguardian",
       "children" : [ {
         "title" : "Obituaries",
-        "url" : "/tone/obituaries",
+        "url" : "/obituaries",
         "children" : [ ],
         "classList" : [ ]
       }, {
@@ -2252,7 +2252,7 @@
         "classList" : [ ]
       }, {
         "title" : "Obituaries",
-        "url" : "/tone/obituaries",
+        "url" : "/obituaries",
         "children" : [ ],
         "classList" : [ ]
       } ],
@@ -2556,7 +2556,7 @@
       "url" : "/theguardian",
       "children" : [ {
         "title" : "Obituaries",
-        "url" : "/tone/obituaries",
+        "url" : "/obituaries",
         "children" : [ ],
         "classList" : [ ]
       }, {


### PR DESCRIPTION
## What does this change?

Link Obituaries to `/obituaries` instead of `/tone/obituaries`, so we can have a better front.

According to Gabriel Smith, the old page will be removed.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)


## What is the value of this and can you measure success?

Request from Central Production.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [X] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [X] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [X] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)