### PR TITLE
fix: label story packages directly

### DIFF
--- a/common/app/views/fragments/storyPackagePlaceholder.scala.html
+++ b/common/app/views/fragments/storyPackagePlaceholder.scala.html
@@ -14,7 +14,7 @@
 
 @defining(Seq("related") ++ (if(isPaidContent) Seq("paid-content") else Nil)) { classes =>
     @if(related.hasStoryPackage) {
-        <aside class="@classes.mkString(" ") more-on-this-story js-outbrain-anchor" aria-labelledby="related-content-head">
+        <aside class="@classes.mkString(" ") more-on-this-story js-outbrain-anchor" aria-label="More on this story">
             @container("More on this story", "more-on-this-story", href = None)
         </aside>
     } else {


### PR DESCRIPTION
## What does this change?

Use the `aria-label` directly. Fixes https://github.com/guardian/dotcom-rendering/issues/5036

There’s no id matching `related-content-head`
and the title is already in scope here, so let’s use it.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes https://github.com/guardian/dotcom-rendering/issues/5989
