### PR TITLE
Add support for image alts for quiz atoms on DCR data model

### DIFF
--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -1215,7 +1215,7 @@ object PageElement {
                   .flatMap(i => i.imageMedia.masterImage.flatMap(_.altText))
                   // Remove surrounding quotes from alt text, e.g
                   // "hello world" => hello world
-                  .map(alt => alt.substring(1, alt.length() - 1)),
+                  .map(_.replaceAll("^\"|\"$", "")),
               )
             }
             Some(

--- a/common/app/model/dotcomrendering/pageElements/PageElement.scala
+++ b/common/app/model/dotcomrendering/pageElements/PageElement.scala
@@ -423,7 +423,13 @@ case class QuizAtomAnswer(
     isCorrect: Boolean,
 )
 case class QuizAtomResultBucket(id: String, title: String, description: String)
-case class QuizAtomQuestion(id: String, text: String, answers: Seq[QuizAtomAnswer], imageUrl: Option[String])
+case class QuizAtomQuestion(
+    id: String,
+    text: String,
+    answers: Seq[QuizAtomAnswer],
+    imageUrl: Option[String],
+    imageAlt: Option[String],
+)
 case class QuizAtomResultGroup(id: String, title: String, shareText: String, minScore: Int)
 case class QuizAtomBlockElement(
     id: String,
@@ -1205,6 +1211,11 @@ object PageElement {
                   ),
                 ),
                 imageUrl = q.imageMedia.flatMap(i => ImgSrc.getAmpImageUrl(i.imageMedia)),
+                imageAlt = q.imageMedia
+                  .flatMap(i => i.imageMedia.masterImage.flatMap(_.altText))
+                  // Remove surrounding quotes from alt text, e.g
+                  // "hello world" => hello world
+                  .map(alt => alt.substring(1, alt.length() - 1)),
               )
             }
             Some(


### PR DESCRIPTION
## What does this change?

Adds 'imageAlt' as a property on quiz question type. 

Atoms-rendering PR: https://github.com/guardian/atoms-rendering/pull/459

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes - DCR Will be updated after this PR is merged

## Screenshots


| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |


[before]: https://user-images.githubusercontent.com/9575458/189885533-ce50cee5-d61f-4136-a881-f10675d223cf.png
[after]: https://user-images.githubusercontent.com/9575458/189885337-5e639e41-1a6f-4fa2-85c1-c72101c8871f.png



## What is the value of this and can you measure success?

## Checklist

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
