### PR TITLE
Remove unused Edition-based AMP `mf2.json` paths

### DIFF
--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -41,14 +41,6 @@ trait FaciaController
 
   implicit val context: ApplicationContext
 
-  private def getEditionFromString(edition: String): Edition = {
-    val editionToFilterBy = edition match {
-      case "international" => "int"
-      case _               => edition
-    }
-    Edition.all.find(_.id.toLowerCase() == editionToFilterBy).getOrElse(Edition.all.head)
-  }
-
   def applicationsRedirect(path: String)(implicit request: RequestHeader): Future[Result] = {
     successful(InternalRedirect.internalRedirect("applications", path, request.rawQueryStringOption.map("?" + _)))
   }
@@ -92,10 +84,9 @@ trait FaciaController
       count: Int,
       offset: Int,
       section: String = "",
-      edition: String = "",
   ): Action[AnyContent] =
     Action.async { implicit request =>
-      val e = if (edition.isEmpty) Edition(request) else getEditionFromString(edition)
+      val e = Edition(request)
       val collectionsPath = if (section.isEmpty) e.id.toLowerCase else Editionalise(section, e)
       getSomeCollections(collectionsPath, count, offset, "none").map { collections =>
         Cached(CacheTime.Facia) {

--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -19,10 +19,8 @@ GET        /.well-known/security.txt.asc                                        
 GET        /.well-known/amphtml/apikey.pub                                          controllers.FaciaController.ampRsaPublicKey()
 
 # AMP
-GET        /container/count/:count/offset/:offset/mf2.json                                      controllers.FaciaController.renderSomeFrontContainersMf2(count: Int, offset: Int, section = "", edition = "")
-GET        /container/count/:count/offset/:offset/section/:section/mf2.json                     controllers.FaciaController.renderSomeFrontContainersMf2(count: Int, offset: Int, section, edition = "")
-GET        /container/count/:count/offset/:offset/edition/:edition/mf2.json                     controllers.FaciaController.renderSomeFrontContainersMf2(count: Int, offset: Int, section = "", edition)
-GET        /container/count/:count/offset/:offset/section/:section/edition/:edition/mf2.json    controllers.FaciaController.renderSomeFrontContainersMf2(count: Int, offset: Int, section, edition)
+GET        /container/count/:count/offset/:offset/mf2.json                                      controllers.FaciaController.renderSomeFrontContainersMf2(count: Int, offset: Int, section = "")
+GET        /container/count/:count/offset/:offset/section/:section/mf2.json                     controllers.FaciaController.renderSomeFrontContainersMf2(count: Int, offset: Int, section)
 
 #Facia Press
 GET        /collection/*id/rss                                                      controllers.FaciaController.renderCollectionRss(id)

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -197,25 +197,6 @@ import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
     (contentAsJson(result) \ "items").as[JsArray].value.size should be(count)
   }
 
-  it should "render fronts in mf2 format (no section provided)" in {
-    val edition = "uk"
-    val count = 2
-    val request = FakeRequest("GET", s"/container/count/$count/offset/0/edition/$edition/mf2.json")
-    val result = faciaController.renderSomeFrontContainersMf2(count, 0, edition = edition)(request)
-    status(result) should be(200)
-    (contentAsJson(result) \ "items").as[JsArray].value.size should be(count)
-  }
-
-  it should "render fronts in mf2 format" in {
-    val section = "media" // has to be an editionalised section
-    val edition = "au"
-    val count = 2
-    val request = FakeRequest("GET", s"/container/count/$count/offset/0/section/$section/edition/$edition/mf2.json")
-    val result = faciaController.renderSomeFrontContainersMf2(count, 0, section, edition)(request)
-    status(result) should be(200)
-    (contentAsJson(result) \ "items").as[JsArray].value.size should be(count)
-  }
-
   it should "render json email fronts" in {
     val emailRequest = FakeRequest("GET", "/email/uk/daily.emailjson")
     val emailJsonResponse = faciaController.renderFront("email/uk/daily")(emailRequest)


### PR DESCRIPTION
PR https://github.com/guardian/frontend/pull/12000 in February 2016 introduced these new paths:

```
/container/count/:count/offset/:offset/edition/:edition/mf2.json
/container/count/:count/offset/:offset/section/:section/edition/:edition/mf2.json
```

(we don't actually know what `mf2` stands for, it seems to be [something to do with Google AMP](https://github.com/guardian/frontend/pull/22042)?)

However, when we check [the Frontend access logs](https://logs.gutools.co.uk/s/dotcom/goto/71a24b60-3382-11ed-b789-f1f3fdb7292e), we can see no indication of these variants (that contain `edition` in the path) being used anywhere in the last 7 days:

![image](https://user-images.githubusercontent.com/52038/189958924-ddfc918d-0200-44fb-936e-e0e695cb2855.png)

It looks like maybe the some of the work was reverted quite soon after it was implemented? https://github.com/guardian/fastly-edge-cache/pull/566

As the paths aren't used, **we'd like to delete them**, as that means we can delete the `getEditionFromString()` method, which has strange logic for the edition strings and isn't used anywhere else. Otherwise, as part of https://github.com/guardian/frontend/pull/25463 we'd have to add support for the Europe edition to that method (and of course, that would be the case for any new editions that came along).
