### PR TITLE
Enable multi-sticky for consentless advertising

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/consentless/dynamic/article-inline.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/dynamic/article-inline.ts
@@ -167,26 +167,22 @@ const addDesktopInlineAds = async () => {
 	const enableDebug = sfdebug === '1';
 
 	const insertAds: SpacefinderWriter = async (paras) => {
-		// Make ads sticky in containers if using containers and in sticky test variant
 		// Compute the height of containers in which ads will remain sticky
-		const includeStickyContainers = !!getUrlVars().multiSticky;
+		const stickyContainerHeights = await computeStickyHeights(
+			paras,
+			articleBodySelector,
+		);
 
-		if (includeStickyContainers) {
-			const stickyContainerHeights = await computeStickyHeights(
-				paras,
-				articleBodySelector,
-			);
-
-			void insertHeightStyles(
-				stickyContainerHeights.map((height, index) => [
-					getStickyContainerClassname(index),
-					height,
-				]),
-			);
-		}
+		void insertHeightStyles(
+			stickyContainerHeights.map((height, index) => [
+				getStickyContainerClassname(index),
+				height,
+			]),
+		);
 
 		const slots = paras.map((para, i) => {
 			const inlineId = i + 1;
+			const makeContainerSticky = inlineId !== 1;
 
 			if (sfdebug) {
 				para.style.cssText += 'border: thick solid green;';
@@ -194,7 +190,7 @@ const addDesktopInlineAds = async () => {
 
 			let containerClasses = '';
 
-			if (includeStickyContainers) {
+			if (makeContainerSticky) {
 				containerClasses += getStickyContainerClassname(i);
 			}
 
@@ -204,7 +200,7 @@ const addDesktopInlineAds = async () => {
 			}
 
 			const containerOptions = {
-				sticky: includeStickyContainers,
+				sticky: makeContainerSticky,
 				className: containerClasses,
 				enableDebug,
 			};


### PR DESCRIPTION
## What does this change?

Enable stickiness for article adverts in the right column when using the consentless advertising.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

When porting this logic over we left stickiness disabled, except for using the query string parameter. This PR aligns both to use the same stickiness, reducing the disparity when using the two different ad tags.

### Tested

- [X] Locally
- [ ] On CODE (optional)