### PR TITLE
Zero percent test YouTube IMA integration

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -45,4 +45,13 @@ trait ABTestSwitches {
     exposeClientSide = true,
   )
 
+  Switch(
+    ABTests,
+    "ab-integrate-ima",
+    "Test the commercial impact of replacing YouTube ads with Interactive Media Ads on first-party videos",
+    owners = Seq(Owner.withGithub("zekehuntergreen")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2022, 12, 31)),
+    exposeClientSide = true,
+  )
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -51,7 +51,7 @@ trait ABTestSwitches {
     "Test the commercial impact of replacing YouTube ads with Interactive Media Ads on first-party videos",
     owners = Seq(Owner.withGithub("zekehuntergreen")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2022, 12, 31)),
+    sellByDate = Some(LocalDate.of(2022, 12, 30)),
     exposeClientSide = true,
   )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -1,6 +1,7 @@
 import type { ABTest } from '@guardian/ab-core';
 import { consentlessAds } from './tests/consentlessAds';
 import { deeplyReadArticleFooterTest } from './tests/deeply-read-article-footer';
+import { integrateIMA } from './tests/integrate-ima';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
 import { signInGateMainVariant } from './tests/sign-in-gate-main-variant';
@@ -13,4 +14,5 @@ export const concurrentTests: readonly ABTest[] = [
 	remoteRRHeaderLinksTest,
 	deeplyReadArticleFooterTest,
 	consentlessAds,
+	integrateIMA,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/integrate-ima.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/integrate-ima.ts
@@ -4,7 +4,7 @@ import { noop } from '../../../../../lib/noop';
 export const integrateIMA: ABTest = {
 	id: 'IntegrateIMA',
 	start: '2022-07-14',
-	expiry: '2022-12-31',
+	expiry: '2022-12-30',
 	author: 'Zeke Hunter-Green',
 	description:
 		'Test the commercial impact of replacing YouTube ads with Interactive Media Ads on first-party videos',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/integrate-ima.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/integrate-ima.ts
@@ -1,0 +1,23 @@
+import type { ABTest } from '@guardian/ab-core';
+import { noop } from '../../../../../lib/noop';
+
+export const integrateIMA: ABTest = {
+	id: 'IntegrateIMA',
+	start: '2022-07-14',
+	expiry: '2022-12-31',
+	author: 'Zeke Hunter-Green',
+	description:
+		'Test the commercial impact of replacing YouTube ads with Interactive Media Ads on first-party videos',
+	audience: 0,
+	audienceOffset: 0,
+	audienceCriteria: 'Opt in',
+	successMeasure:
+		'IMA integration works as expected without adversely affecting pages with videos',
+	canRun: () => true,
+	variants: [
+		{
+			id: 'variant',
+			test: () => noop,
+		},
+	],
+};

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -590,6 +590,11 @@
   "../../../../node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
  ],
+ "../projects/commercial/modules/track-labs-container.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
+  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts"
+ ],
  "../projects/commercial/modules/track-scroll-depth.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
@@ -691,6 +696,7 @@
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
   "../projects/common/modules/experiments/tests/consentlessAds.ts",
   "../projects/common/modules/experiments/tests/deeply-read-article-footer.js",
+  "../projects/common/modules/experiments/tests/integrate-ima.ts",
   "../projects/common/modules/experiments/tests/remote-header-test.js",
   "../projects/common/modules/experiments/tests/sign-in-gate-main-control.js",
   "../projects/common/modules/experiments/tests/sign-in-gate-main-variant.js"
@@ -721,6 +727,10 @@
   "../lib/noop.ts"
  ],
  "../projects/common/modules/experiments/tests/deeply-read-article-footer.js": [],
+ "../projects/common/modules/experiments/tests/integrate-ima.ts": [
+  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
+  "../lib/noop.ts"
+ ],
  "../projects/common/modules/experiments/tests/remote-header-test.js": [],
  "../projects/common/modules/experiments/tests/sign-in-gate-main-control.js": [],
  "../projects/common/modules/experiments/tests/sign-in-gate-main-variant.js": [],
@@ -793,6 +803,7 @@
   "../projects/commercial/modules/set-adtest-cookie.ts",
   "../projects/commercial/modules/third-party-tags.ts",
   "../projects/commercial/modules/track-gpc-signal.ts",
+  "../projects/commercial/modules/track-labs-container.ts",
   "../projects/commercial/modules/track-scroll-depth.ts",
   "../projects/common/modules/commercial/commercial-features.ts",
   "../projects/common/modules/commercial/user-features.ts",


### PR DESCRIPTION
## What does this change?
- adds a zero percent test so that users can opt in to see the [PfP / Interactive Media Ads integration](https://github.com/guardian/atoms-rendering/pull/447)
- users who aren't in the 0% test should see no change in youtube players' behaviour

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes https://github.com/guardian/dotcom-rendering/pull/5714

## Screenshots

![ima demo 480p](https://user-images.githubusercontent.com/17057932/185203958-8f259f74-d15b-486d-815f-5ab754485895.gif)

## What is the value of this and can you measure success?

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
