### PR TITLE
add /onwards/popular-in-tag service

### DIFF
--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -12,13 +12,16 @@ import model.dotcomrendering.{
   DotcomBlocksRenderingDataModel,
   DotcomFrontsRenderingDataModel,
   DotcomRenderingDataModel,
+  DotcomRenderingUtils,
   OnwardCollectionResponse,
   PageType,
+  Trail,
 }
 import services.NewsletterData
 import model.{
   CacheTime,
   Cached,
+  ContentFormat,
   InteractivePage,
   LiveBlogPage,
   NoCache,
@@ -27,6 +30,7 @@ import model.{
   Topic,
   TopicResult,
 }
+import play.api.libs.json.Json
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc.Results.{InternalServerError, NotFound}
 import play.api.mvc.{RequestHeader, Result}
@@ -238,6 +242,44 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
     val dataModel = DotcomRenderingDataModel.forInteractive(page, blocks, request, pageType)
     val json = DotcomRenderingDataModel.toJson(dataModel)
     post(ws, json, Configuration.rendering.baseURL + "/AMPInteractive", page.metadata.cacheTime)
+  }
+
+  // This is complete rubbish, but we need to send format through to
+  // DCR, but aren't aware of what the format is at this stage so we just use the default
+  // TODO: Either remove this from DCR or from here
+  private case class DCROnwardCollectionResponse(
+      heading: String,
+      trails: Seq[Trail],
+      format: ContentFormat,
+  )
+  private object DCROnwardCollectionResponse {
+    implicit val writes = Json.writes[DCROnwardCollectionResponse]
+
+    def toJson(model: DCROnwardCollectionResponse) = {
+      val jsValue = Json.toJson(model)
+      Json.stringify(DotcomRenderingUtils.withoutNull(jsValue))
+    }
+  }
+  def getOnward(ws: WSClient, onwardsCollection: OnwardCollectionResponse)(implicit
+      request: RequestHeader,
+  ): Future[String] = {
+    val json = DCROnwardCollectionResponse.toJson(
+      DCROnwardCollectionResponse(
+        heading = onwardsCollection.heading,
+        trails = onwardsCollection.trails,
+        format = ContentFormat.defaultContentFormat,
+      ),
+    )
+
+    postWithoutHandler(ws, json, Configuration.rendering.baseURL + "/Onwards")
+      .flatMap(response => {
+        if (response.status == 200)
+          Future.successful(response.body)
+        else
+          Future.failed(
+            DCRRenderingException(s"Request to DCR failed: status ${response.status}, body: ${response.body}"),
+          )
+      })
   }
 
 }

--- a/onward/app/AppLoader.scala
+++ b/onward/app/AppLoader.scala
@@ -19,12 +19,13 @@ import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import play.api.libs.ws.WSClient
 import router.Routes
-import services.OphanApi
+import services.{OphanApi, PopularInTagService}
 import weather.WeatherApi
 import _root_.commercial.targeting.TargetingLifecycle
 
 import scala.concurrent.ExecutionContext
 import agents.DeeplyReadAgent
+import renderers.DotcomRenderingService
 
 class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents =
@@ -51,6 +52,8 @@ trait OnwardServices {
   lazy val mostViewedGalleryAgent = wire[MostViewedGalleryAgent]
   lazy val mostViewedVideoAgent = wire[MostViewedVideoAgent]
   lazy val deeplyReadAgent = wire[DeeplyReadAgent]
+  lazy val remoteRenderer = wire[DotcomRenderingService]
+  lazy val popularInTagService = wire[PopularInTagService]
 }
 
 trait AppComponents extends FrontendComponents with OnwardControllers with OnwardServices {

--- a/onward/app/controllers/OnwardControllers.scala
+++ b/onward/app/controllers/OnwardControllers.scala
@@ -11,6 +11,8 @@ import play.api.libs.ws.WSClient
 import play.api.mvc.ControllerComponents
 import weather.WeatherApi
 import agents.DeeplyReadAgent
+import renderers.DotcomRenderingService
+import services.PopularInTagService
 
 trait OnwardControllers {
 
@@ -30,6 +32,8 @@ trait OnwardControllers {
   def mostViewedAudioAgent: MostViewedAudioAgent
   def actorSystem: ActorSystem
   def controllerComponents: ControllerComponents
+  def remoteRenderer: DotcomRenderingService
+  def popularInTagService: PopularInTagService
 
   lazy val navigationController = wire[NavigationController]
   lazy val weatherController = wire[WeatherController]
@@ -51,4 +55,5 @@ trait OnwardControllers {
   lazy val seriesController = wire[SeriesController]
   lazy val stocksController = wire[StocksController]
   lazy val storyPackageController = wire[StoryPackageController]
+  lazy val onwardResponseController = wire[OnwardResponseController]
 }

--- a/onward/app/controllers/OnwardResponseController.scala
+++ b/onward/app/controllers/OnwardResponseController.scala
@@ -1,0 +1,60 @@
+package controllers
+
+import common.{Edition, ImplicitControllerExecutionContext, JsonComponent}
+import feed.MostReadAgent
+import model.{ApplicationContext, Cached}
+import model.dotcomrendering.OnwardCollectionResponse
+import play.api.libs.ws.WSClient
+import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents, RequestHeader, Result}
+import play.twirl.api.Html
+import renderers.DotcomRenderingService
+import services.PopularInTagService
+
+import scala.concurrent.Future
+
+class OnwardResponseController(
+    ws: WSClient,
+    remoteRenderer: DotcomRenderingService,
+    popularInTagService: PopularInTagService,
+    mostReadAgent: MostReadAgent,
+    val controllerComponents: ControllerComponents,
+)(implicit context: ApplicationContext)
+    extends BaseController
+    with ImplicitControllerExecutionContext {
+
+  def popularInTag(tag: String)(implicit request: RequestHeader): Future[OnwardCollectionResponse] = {
+    val edition = Edition(request)
+    val excludeTags = request.queryString.getOrElse("exclude-tag", Nil)
+    val itemViewCounts = mostReadAgent.getViewCounts
+
+    popularInTagService.fetch(edition, tag, excludeTags, itemViewCounts)
+  }
+  def popularInTagJson(tag: String): Action[AnyContent] =
+    Action.async { implicit request =>
+      popularInTag(tag) flatMap renderJson
+    }
+  def popularInTagHtml(tag: String): Action[AnyContent] =
+    Action.async { implicit request =>
+      popularInTag(tag) flatMap renderHtml
+    }
+
+  private def renderJson(
+      onwardsCollection: OnwardCollectionResponse,
+  )(implicit request: RequestHeader): Future[Result] = {
+    Future.successful(Cached(600) {
+      JsonComponent
+        .fromWritable[OnwardCollectionResponse](onwardsCollection)(
+          request,
+          OnwardCollectionResponse.collectionWrites,
+        )
+    })
+  }
+
+  private def renderHtml(
+      onwardsCollection: OnwardCollectionResponse,
+  )(implicit request: RequestHeader): Future[Result] = {
+    remoteRenderer.getOnward(ws, onwardsCollection) map { result =>
+      Cached(600)(JsonComponent("html" -> new Html(result)))
+    }
+  }
+}

--- a/onward/app/controllers/OnwardResponseController.scala
+++ b/onward/app/controllers/OnwardResponseController.scala
@@ -31,7 +31,7 @@ class OnwardResponseController(
   }
   def popularInTagJson(tag: String): Action[AnyContent] =
     Action.async { implicit request =>
-      popularInTag(tag) flatMap renderJson
+      popularInTag(tag) map renderJson
     }
   def popularInTagHtml(tag: String): Action[AnyContent] =
     Action.async { implicit request =>
@@ -40,14 +40,14 @@ class OnwardResponseController(
 
   private def renderJson(
       onwardsCollection: OnwardCollectionResponse,
-  )(implicit request: RequestHeader): Future[Result] = {
-    Future.successful(Cached(600) {
+  )(implicit request: RequestHeader): Result = {
+    Cached(600) {
       JsonComponent
         .fromWritable[OnwardCollectionResponse](onwardsCollection)(
           request,
           OnwardCollectionResponse.collectionWrites,
         )
-    })
+    }
   }
 
   private def renderHtml(

--- a/onward/app/controllers/OnwardResponseController.scala
+++ b/onward/app/controllers/OnwardResponseController.scala
@@ -6,7 +6,6 @@ import model.{ApplicationContext, Cached}
 import model.dotcomrendering.OnwardCollectionResponse
 import play.api.libs.ws.WSClient
 import play.api.mvc.{Action, AnyContent, BaseController, ControllerComponents, RequestHeader, Result}
-import play.twirl.api.Html
 import renderers.DotcomRenderingService
 import services.PopularInTagService
 
@@ -33,10 +32,6 @@ class OnwardResponseController(
     Action.async { implicit request =>
       popularInTag(tag) map renderJson
     }
-  def popularInTagHtml(tag: String): Action[AnyContent] =
-    Action.async { implicit request =>
-      popularInTag(tag) flatMap renderHtml
-    }
 
   private def renderJson(
       onwardsCollection: OnwardCollectionResponse,
@@ -47,14 +42,6 @@ class OnwardResponseController(
           request,
           OnwardCollectionResponse.collectionWrites,
         )
-    }
-  }
-
-  private def renderHtml(
-      onwardsCollection: OnwardCollectionResponse,
-  )(implicit request: RequestHeader): Future[Result] = {
-    remoteRenderer.getOnward(ws, onwardsCollection) map { result =>
-      Cached(600)(JsonComponent("html" -> new Html(result)))
     }
   }
 }

--- a/onward/app/feed/MostReadAgent.scala
+++ b/onward/app/feed/MostReadAgent.scala
@@ -23,4 +23,8 @@ class MostReadAgent(ophanApi: OphanApi) extends GuLogging {
   def getViewCount(id: String): Option[Int] = {
     agent.get().get(id)
   }
+
+  def getViewCounts: Map[String, Int] = {
+    agent.get()
+  }
 }

--- a/onward/app/services/PopularInTagService.scala
+++ b/onward/app/services/PopularInTagService.scala
@@ -1,0 +1,41 @@
+package services
+
+import common.Edition
+import contentapi.ContentApiClient
+import model.RelatedContentItem
+import model.dotcomrendering.{OnwardCollectionResponse, Trail}
+import play.api.mvc.RequestHeader
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class PopularInTagService(contentApiClient: ContentApiClient)(implicit
+    executionContext: ExecutionContext,
+) {
+  // `itemViewCounts` is a Map[Content.id: String, ViewCount:Int]
+  // this is generally fetched from Ophan view the MostPopularAgent, but can come from anywhere
+  // and makes this easy to test
+  def fetch(edition: Edition, tag: String, excludeTags: Seq[String], itemViewCounts: Map[String, Int])(implicit
+      request: RequestHeader,
+  ): Future[OnwardCollectionResponse] = {
+    val tags = (tag +: excludeTags.map(t => s"-$t")).mkString(",")
+
+    val response = contentApiClient.getResponse(
+      contentApiClient
+        .search(edition)
+        .tag(tags)
+        .pageSize(50),
+    )
+
+    response.map { response =>
+      val numberOfCards = if (response.results.length == 5 || response.results.length == 6) 4 else 8
+      val items = response.results.sortBy(content => itemViewCounts.getOrElse(content.id, 0)).map { item =>
+        RelatedContentItem(item)
+      }
+
+      OnwardCollectionResponse(
+        heading = "Related content",
+        trails = items.map(_.faciaContent).map(Trail.pressedContentToTrail).take(numberOfCards).toSeq,
+      )
+    }
+  }
+}

--- a/onward/app/services/PopularInTagService.scala
+++ b/onward/app/services/PopularInTagService.scala
@@ -28,7 +28,7 @@ class PopularInTagService(contentApiClient: ContentApiClient)(implicit
 
     response.map { response =>
       val numberOfCards = if (response.results.length == 5 || response.results.length == 6) 4 else 8
-      val items = response.results.sortBy(content => itemViewCounts.getOrElse(content.id, 0)).map { item =>
+      val items = response.results.sortBy(content => -itemViewCounts.getOrElse(content.id, 0)).map { item =>
         RelatedContentItem(item)
       }
 

--- a/onward/conf/routes
+++ b/onward/conf/routes
@@ -69,7 +69,9 @@ GET        /business-data/stocks.json                 controllers.StocksControll
 
 # DCR
 GET        /story-package/*path.json                  controllers.StoryPackageController.render(path)
-GET        /nav/:editionId.json                     controllers.NavigationController.renderDCRNav(editionId: String)
+GET        /nav/:editionId.json                       controllers.NavigationController.renderDCRNav(editionId: String)
+GET        /onwards/popular-in-tag/*tag.json          controllers.OnwardResponseController.popularInTagJson(tag)
+GET        /onwards/popular-in-tag/*tag               controllers.OnwardResponseController.popularInTagHtml(tag)
 
 # AMP
 GET        /most-read-mf2.json                        controllers.MostPopularController.renderPopularMicroformat2()

--- a/onward/conf/routes
+++ b/onward/conf/routes
@@ -71,7 +71,6 @@ GET        /business-data/stocks.json                 controllers.StocksControll
 GET        /story-package/*path.json                  controllers.StoryPackageController.render(path)
 GET        /nav/:editionId.json                       controllers.NavigationController.renderDCRNav(editionId: String)
 GET        /onwards/popular-in-tag/*tag.json          controllers.OnwardResponseController.popularInTagJson(tag)
-GET        /onwards/popular-in-tag/*tag               controllers.OnwardResponseController.popularInTagHtml(tag)
 
 # AMP
 GET        /most-read-mf2.json                        controllers.MostPopularController.renderPopularMicroformat2()


### PR DESCRIPTION
## What does this change?
Adds a new PopularInTag service, while using a new OnwardResponseController to simplify how we get the content into our onwards containers in DCR.

This will either generate JSON needed for DCR to render the onwards container when we remove the need for an `IMAGE_SALT`, ~and also provides a way for us to render the HTML from DCR. To render the HTML is DCR we would require a change these to plonk the HTML in rather than trying to parse the data into the component.~ <= removed for simplicity of this PR.


## Simplifications

### Controller / service separation
We have a controller - where a request comes in and a response (`Result` in Play land) goes out. The service (`PopularInTagService`) is only interested in some parameters, and returns an `OnwardCollectionResponse`. 

The pattern will make it easier to add new services in this fashion, and way easier to test these services in future.

It's also been written in a way that has fewer coupling to agents, allowing us to write tests for these too.


### No more need for the `?dcr` fork

This endpoint and code is specifically for DCR (DCR first!) and is only used by DCR.

Having the logic fork on the `dcr` is definitely useful in some circumstances, but this piece of work is quite simple, and this now allows us to refactor without having to worry about the coupling to frontend.

Hopefully it has also made the code more understandable so we can refactor it without the fear of introducing bugs. This is important as this code isn't something that is going away, so we need to be able to support it.

It also gives us a way to test this without breaking anything in prod.

This will hopefully make deprecating things easier too where we can just remove the code that isn't DCR this code without less fear.


### JSON rendered from DCR

`GET http://localhost:9000/onwards/popular-in-tag/football/premierleague.json`
<img width="349" alt="Screenshot 2022-09-14 at 17 49 50" src="https://user-images.githubusercontent.com/31692/190215070-47bc61ef-2142-49f2-b456-472f26ca0956.png">

### JSON rendered from branched DCR endpoint

`GET http://localhost:9000/popular-in-tag/football/premierleague.json?dcr`

<img width="349" alt="Screenshot 2022-09-14 at 17 49 50" src="https://user-images.githubusercontent.com/31692/190215279-f81d7bb3-5d71-4873-ae86-4f7b19e6222a.png">
