### PR TITLE
Increasing slideshow limit to 10 for the funeral only

### DIFF
--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -183,7 +183,7 @@ data-test-id="facia-card"
                                 classes = Seq("responsive-img "),
                                 widths = item.mediaWidthsByBreakpoint,
                                 maybePath = Some(imageElement.url),
-                                maybeSrc = if(containerIndex == 0 && index < 4) Some(imageElement.url) else None,
+                                maybeSrc = if(containerIndex == 0 && index < 9) Some(imageElement.url) else None,
                                 caption = imageElement.caption
                             )
                             @imageElements.tail.map { imageElement =>

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -609,7 +609,7 @@ $block-height: 58px;
     }
 }
 
-@for $i from 2 through 5 {
+@for $i from 2 through 10 {
     $hangTime: 5;
     $fadeTime: 1;
     $totalLoopTime: $i * ($hangTime + $fadeTime);

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -315,7 +315,7 @@ $fc-item-gutter: $gs-gutter / 4;
     }
 }
 
-@for $i from 2 through 5 {
+@for $i from 2 through 10 {
     $hangTime: 5;
     $fadeTime: 1;
     $totalLoopTime: $i * ($hangTime + $fadeTime);


### PR DESCRIPTION
## What does this change?

Increases the slideshow picture limit from 5 to 10 in the Slideshow component on fronts. This is a change that we have agreed to make for the day of the funeral only as there are some performance implications documented here: 

https://docs.google.com/document/d/1bidkbgASsxzmDHpKW7EQRDL7CEH8yseqKC8yzCvY9to/edit#

I have made the minimum amount of changes in this PR but perhaps we could avoid hardcoding the size of the list. 

I have tested on CODE with the slideshow on the culture front. 

We will roll back on Tuesday. 
