### PR TITLE
Bump commercial core to 4.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@guardian/atom-renderer": "1.2.2",
     "@guardian/automat-modules": "^0.3.8",
     "@guardian/braze-components": "^7.3.0",
-    "@guardian/commercial-core": "4.9.0",
+    "@guardian/commercial-core": "4.10.0",
     "@guardian/consent-management-platform": "^10.11.1",
     "@guardian/libs": "^7.1.4",
     "@guardian/shimport": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2089,10 +2089,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-7.3.0.tgz#9c4908fa5d439d85b2024735575435b0a5cd369f"
   integrity sha512-Py2FZ6aHi/inOIF4+4xZqNmbJur3cevtWRMQeFLjNjgN7zR7hMB6Dsd8uurEym6Qd3yxBAGPx/+rS3xVbTKz4w==
 
-"@guardian/commercial-core@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.9.0.tgz#a2d18d92cedaf1a6770c0057e183162554d37b95"
-  integrity sha512-zA58x817sXHCZqgEjo96sVfHuz8c+jxCQKfPgYVljhsWQ+7wqOL9nw4X2HJ2NHswR0/rso44AIFBFqoiQRqaNA==
+"@guardian/commercial-core@4.10.0":
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.10.0.tgz#a1c2797ba8118da206b671dee27fa333524053d1"
+  integrity sha512-rhMdCSWLiRURcCc4rDLK1k7a/Q3+Hk55K5/e1l7w4WgzfTvYr7P0gvaG5sr6C93OVeQFDzisOR6pLj6tHo8kZw==
 
 "@guardian/consent-management-platform@^10.11.1":
   version "10.11.1"


### PR DESCRIPTION
## What does this change?

Bumps commercial core to `4.10.0`

This brings in the changes from: https://github.com/guardian/commercial-core/pull/670

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [ ] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
