### PR TITLE
On fronts, prioritise replacement images over cutouts for pieces with the Comment tone

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val identityLibVersion = "3.254"
   val awsVersion = "1.12.205"
   val capiVersion = "19.0.4"
-  val faciaVersion = "4.0.1"
+  val faciaVersion = "4.0.2"
   val dispatchVersion = "0.13.1"
   val romeVersion = "1.0"
   val jerseyVersion = "1.19.4"


### PR DESCRIPTION
## What does this change?

Bumps [`fapi-client`](https://github.com/guardian/facia-scala-client) from 4.0.1 to 4.0.2. This includes [a fix](https://github.com/guardian/facia-scala-client/pull/278) where images that have been replaced in the Fronts tool do not correctly override cutouts in pieces with the Comment tone.

For more details, see [the relevant PR.](https://github.com/guardian/facia-scala-client/pull/278)

## How to test

Deploy to CODE, and add [a piece with a Comment tone](https://composer.gutools.co.uk/content/631878878f08aab4f5b4cabd) to a front in CODE. Preview the front. Prior to this change, you will not be able to replace the image in the fronts tool. After it, that should work.

## Does this change need to be reproduced in dotcom-rendering ?

I'm not sure – my assumption would that the DCR fronts renderer uses the output of `fapi-client`. If that's not the case, let's reconsider.

## Screenshots

|Before|After|
|-|-|
|<img width="851" alt="Screenshot 2022-09-15 at 11 34 47" src="https://user-images.githubusercontent.com/7767575/190384006-502f23f8-a0c3-4ff2-b19d-ad13a683fc31.png">|<img width="851" alt="Screenshot 2022-09-15 at 11 39 13" src="https://user-images.githubusercontent.com/7767575/190384013-1a02c739-71c4-413a-9890-1a931a43a8d6.png">|

## What is the value of this and can you measure success?

This should forestall the e-mail we get every few months or so from a rightly confused Fronts editor.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [x] On CODE (optional)
