### PR TITLE
Revert "Increasing slideshow limit to 10 for the funeral only"

### DIFF
--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -183,7 +183,7 @@ data-test-id="facia-card"
                                 classes = Seq("responsive-img "),
                                 widths = item.mediaWidthsByBreakpoint,
                                 maybePath = Some(imageElement.url),
-                                maybeSrc = if(containerIndex == 0 && index < 9) Some(imageElement.url) else None,
+                                maybeSrc = if(containerIndex == 0 && index < 4) Some(imageElement.url) else None,
                                 caption = imageElement.caption
                             )
                             @imageElements.tail.map { imageElement =>

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -609,7 +609,7 @@ $block-height: 58px;
     }
 }
 
-@for $i from 2 through 10 {
+@for $i from 2 through 5 {
     $hangTime: 5;
     $fadeTime: 1;
     $totalLoopTime: $i * ($hangTime + $fadeTime);

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -315,7 +315,7 @@ $fc-item-gutter: $gs-gutter / 4;
     }
 }
 
-@for $i from 2 through 10 {
+@for $i from 2 through 5 {
     $hangTime: 5;
     $fadeTime: 1;
     $totalLoopTime: $i * ($hangTime + $fadeTime);


### PR DESCRIPTION
## What does this change?

Reverts guardian/frontend#25488
To be merged on 2022-09-20.

## Why

This experiment/feature is time-bound to the Queen’s funeral on Monday, 19th of September, 2022.

See original PR for concerns raised by the P&E department. The key concerns with this change are:

- lack of performance impact assessment
- lack of user research
- lack of audience engagement assessment
- lack of tool support of captions
- lack of accessibility audit