### PR TITLE
add expiry date for newsletter signup layout switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -499,7 +499,7 @@ trait FeatureSwitches {
     "When ON, we replace the standard article layout with the new signup layout for newsletter sign up pages",
     owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
     safeState = Off,
-    sellByDate = never,
+    sellByDate = LocalDate.of(2022, 10, 15),
     exposeClientSide = true,
   )
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -499,7 +499,7 @@ trait FeatureSwitches {
     "When ON, we replace the standard article layout with the new signup layout for newsletter sign up pages",
     owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
     safeState = Off,
-    sellByDate = LocalDate.of(2022, 10, 15),
+    sellByDate = LocalDate.of(2022, 10, 14),
     exposeClientSide = true,
   )
 }


### PR DESCRIPTION
## What does this change?

Adds expiry date for newsletter signup layout feature switch one month from now in case we forget to remove it