### PR TITLE
chore: measure impact of long slideshows

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -7,6 +7,7 @@ import java.time.LocalDate
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =
     Set(
+      NoMoreThanFiveSlides,
       DCRFronts,
       OfferHttp3,
       LiveBlogMainMediaPosition,
@@ -24,6 +25,15 @@ object DCRJSBundleVariant
       owners = Seq(Owner.withGithub("guardian/dotcom-platform")),
       sellByDate = LocalDate.of(2024, 4, 1),
       participationGroup = Perc1A,
+    )
+
+object NoMoreThanFiveSlides
+    extends Experiment(
+      name = "no-more-than-five-slides",
+      description = "Prevent showing more than five slides in a facia slide show",
+      owners = Seq(Owner.withGithub("guardian/dotcom-platform")),
+      sellByDate = LocalDate.of(2022, 9, 20),
+      participationGroup = Perc1B,
     )
 
 object DCRFronts

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -11,6 +11,7 @@
 @import views.html.fragments.inlineSvg
 @import views.support.{CutOut, GetClasses, RemoveOuterParaHtml, RenderClasses, Video640}
 @import model.ContentDesignType.RichContentDesignType
+@import experiments.{ActiveExperiments, NoMoreThanFiveSlides}
 
 @import Function.const
 
@@ -176,27 +177,29 @@ data-test-id="facia-card"
             }
 
             case Some(InlineSlideshow(imageElements)) => {
-                <div class="fc-item__media-wrapper">
-                    <div class="fc-item__image-container u-responsive-ratio fc-item__slideshow fc-item__slideshow--@imageElements.size">
-                        @imageElements.headOption.map { imageElement =>
-                            @captionedImage(
-                                classes = Seq("responsive-img "),
-                                widths = item.mediaWidthsByBreakpoint,
-                                maybePath = Some(imageElement.url),
-                                maybeSrc = if(containerIndex == 0 && index < 9) Some(imageElement.url) else None,
-                                caption = imageElement.caption
-                            )
-                            @imageElements.tail.map { imageElement =>
+                @defining(imageElements.take(if(ActiveExperiments.isParticipating(NoMoreThanFiveSlides)) 5 else 10)) { slides =>
+                    <div class="fc-item__media-wrapper">
+                        <div class="fc-item__image-container u-responsive-ratio fc-item__slideshow fc-item__slideshow--@slides.size">
+                            @slides.headOption.map { imageElement =>
                                 @captionedImage(
                                     classes = Seq("responsive-img "),
                                     widths = item.mediaWidthsByBreakpoint,
                                     maybePath = Some(imageElement.url),
+                                    maybeSrc = if(containerIndex == 0 && index < 9) Some(imageElement.url) else None,
                                     caption = imageElement.caption
                                 )
+                                @slides.tail.map { imageElement =>
+                                    @captionedImage(
+                                        classes = Seq("responsive-img "),
+                                        widths = item.mediaWidthsByBreakpoint,
+                                        maybePath = Some(imageElement.url),
+                                        caption = imageElement.caption
+                                    )
+                                }
                             }
-                        }
+                        </div>
                     </div>
-                </div>
+                }
             }
 
             case _ => {}

--- a/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
@@ -9,6 +9,8 @@ const defaultClientSideTests: ABTest[] = [
 const serverSideTests: ServerSideABTest[] = [
 	'commercialEndOfQuarterMegaTestControl',
 	'commercialEndOfQuarterMegaTestVariant',
+	'NoMoreThanFiveSlidesControl',
+	'NoMoreThanFiveSlidesVariant',
 ];
 
 /**


### PR DESCRIPTION
## What does this change?

Allows us to measure the impact of #25488 by having a small subset of users be in a control group.

For 1% of users, this caps the number of slides allowed in a slideshow to 5. This way, we can measure any variance to our web vitals and audience metrics.

This addresses one of the issues raised in the change as it currently implemented.

Once the test is over, we should keep the logic of taking only five slides, as this adds guarantees if the fronts tool were to send in a higher number of slides.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [X] Locally
- [ ] On CODE (optional)