### PR TITLE
fix: test id for no more than 5 slides

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
@@ -9,8 +9,8 @@ const defaultClientSideTests: ABTest[] = [
 const serverSideTests: ServerSideABTest[] = [
 	'commercialEndOfQuarterMegaTestControl',
 	'commercialEndOfQuarterMegaTestVariant',
-	'NoMoreThanFiveSlidesControl',
-	'NoMoreThanFiveSlidesVariant',
+	'noMoreThanFiveSlidesControl',
+	'noMoreThanFiveSlidesVariant',
 ];
 
 /**


### PR DESCRIPTION
## What does this change?

Fix the name of the control groups introduced in #25495.

This ensures we capture client-side performance data for the variant and control group.

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
