### PR TITLE
10 => 5 slides on slideshows

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -7,7 +7,6 @@ import java.time.LocalDate
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =
     Set(
-      NoMoreThanFiveSlides,
       DCRFronts,
       OfferHttp3,
       LiveBlogMainMediaPosition,
@@ -25,15 +24,6 @@ object DCRJSBundleVariant
       owners = Seq(Owner.withGithub("guardian/dotcom-platform")),
       sellByDate = LocalDate.of(2024, 4, 1),
       participationGroup = Perc1A,
-    )
-
-object NoMoreThanFiveSlides
-    extends Experiment(
-      name = "no-more-than-five-slides",
-      description = "Prevent showing more than five slides in a facia slide show",
-      owners = Seq(Owner.withGithub("guardian/dotcom-platform")),
-      sellByDate = LocalDate.of(2022, 9, 20),
-      participationGroup = Perc1B,
     )
 
 object DCRFronts

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -11,7 +11,6 @@
 @import views.html.fragments.inlineSvg
 @import views.support.{CutOut, GetClasses, RemoveOuterParaHtml, RenderClasses, Video640}
 @import model.ContentDesignType.RichContentDesignType
-@import experiments.{ActiveExperiments, NoMoreThanFiveSlides}
 
 @import Function.const
 
@@ -177,7 +176,7 @@ data-test-id="facia-card"
             }
 
             case Some(InlineSlideshow(imageElements)) => {
-                @defining(imageElements.take(if(ActiveExperiments.isParticipating(NoMoreThanFiveSlides)) 5 else 10)) { slides =>
+                @defining(imageElements.take(5)) { slides =>
                     <div class="fc-item__media-wrapper">
                         <div class="fc-item__image-container u-responsive-ratio fc-item__slideshow fc-item__slideshow--@slides.size">
                             @slides.headOption.map { imageElement =>

--- a/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
@@ -9,8 +9,6 @@ const defaultClientSideTests: ABTest[] = [
 const serverSideTests: ServerSideABTest[] = [
 	'commercialEndOfQuarterMegaTestControl',
 	'commercialEndOfQuarterMegaTestVariant',
-	'noMoreThanFiveSlidesControl',
-	'noMoreThanFiveSlidesVariant',
 ];
 
 /**

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -609,7 +609,7 @@ $block-height: 58px;
     }
 }
 
-@for $i from 2 through 10 {
+@for $i from 2 through 5 {
     $hangTime: 5;
     $fadeTime: 1;
     $totalLoopTime: $i * ($hangTime + $fadeTime);

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -315,7 +315,7 @@ $fc-item-gutter: $gs-gutter / 4;
     }
 }
 
-@for $i from 2 through 10 {
+@for $i from 2 through 5 {
     $hangTime: 5;
     $fadeTime: 1;
     $totalLoopTime: $i * ($hangTime + $fadeTime);


### PR DESCRIPTION
## What does this change?
- Reverts the number of slides in slideshows from 10 => 5. We are waiting on the work to be confirmed in tools that there are no slideshows in the tools with more than 5.
- We have kept the `.take(5)` as a precaution as it is actually coupled with the CSS.
- Removes the test as it's irrelevant

