### PR TITLE
feat(slideshow): cap number of slides to 5

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -7,7 +7,6 @@ import java.time.LocalDate
 object ActiveExperiments extends ExperimentsDefinition {
   override val allExperiments: Set[Experiment] =
     Set(
-      NoMoreThanFiveSlides,
       DCRFronts,
       OfferHttp3,
       LiveBlogMainMediaPosition,
@@ -25,15 +24,6 @@ object DCRJSBundleVariant
       owners = Seq(Owner.withGithub("guardian/dotcom-platform")),
       sellByDate = LocalDate.of(2024, 4, 1),
       participationGroup = Perc1A,
-    )
-
-object NoMoreThanFiveSlides
-    extends Experiment(
-      name = "no-more-than-five-slides",
-      description = "Prevent showing more than five slides in a facia slide show",
-      owners = Seq(Owner.withGithub("guardian/dotcom-platform")),
-      sellByDate = LocalDate.of(2022, 9, 20),
-      participationGroup = Perc1B,
     )
 
 object DCRFronts

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -11,7 +11,6 @@
 @import views.html.fragments.inlineSvg
 @import views.support.{CutOut, GetClasses, RemoveOuterParaHtml, RenderClasses, Video640}
 @import model.ContentDesignType.RichContentDesignType
-@import experiments.{ActiveExperiments, NoMoreThanFiveSlides}
 
 @import Function.const
 
@@ -177,7 +176,7 @@ data-test-id="facia-card"
             }
 
             case Some(InlineSlideshow(imageElements)) => {
-                @defining(imageElements.take(if(ActiveExperiments.isParticipating(NoMoreThanFiveSlides)) 5 else 10)) { slides =>
+                @defining(imageElements.take(5)) { slides =>
                     <div class="fc-item__media-wrapper">
                         <div class="fc-item__image-container u-responsive-ratio fc-item__slideshow fc-item__slideshow--@slides.size">
                             @slides.headOption.map { imageElement =>

--- a/common/app/views/fragments/items/facia_cards/dynamoContentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/dynamoContentCard.scala.html
@@ -186,27 +186,29 @@ data-test-id="facia-card"
             }
 
             case Some(InlineSlideshow(imageElements)) => {
-                <div class="fc-item__media-wrapper">
-                    <div class="fc-item__image-container u-responsive-ratio fc-item__slideshow fc-item__slideshow--@imageElements.size">
-                        @imageElements.headOption.map { imageElement =>
-                            @captionedImage(
-                                classes = Seq("responsive-img "),
-                                widths = item.mediaWidthsByBreakpoint,
-                                maybePath = Some(imageElement.url),
-                                maybeSrc = if(containerIndex == 0 && index < 4) Some(imageElement.url) else None,
-                                caption = imageElement.caption
-                            )
-                            @imageElements.tail.map { imageElement =>
+                @defining(imageElements.take(5)) { slides =>
+                    <div class="fc-item__media-wrapper">
+                        <div class="fc-item__image-container u-responsive-ratio fc-item__slideshow fc-item__slideshow--@imageElements.size">
+                            @imageElements.headOption.map { imageElement =>
                                 @captionedImage(
                                     classes = Seq("responsive-img "),
                                     widths = item.mediaWidthsByBreakpoint,
                                     maybePath = Some(imageElement.url),
+                                    maybeSrc = if(containerIndex == 0 && index < 4) Some(imageElement.url) else None,
                                     caption = imageElement.caption
                                 )
+                                @imageElements.tail.map { imageElement =>
+                                    @captionedImage(
+                                        classes = Seq("responsive-img "),
+                                        widths = item.mediaWidthsByBreakpoint,
+                                        maybePath = Some(imageElement.url),
+                                        caption = imageElement.caption
+                                    )
+                                }
                             }
-                        }
+                        </div>
                     </div>
-                </div>
+                }
             }
 
             case _ => {}

--- a/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
@@ -9,8 +9,6 @@ const defaultClientSideTests: ABTest[] = [
 const serverSideTests: ServerSideABTest[] = [
 	'commercialEndOfQuarterMegaTestControl',
 	'commercialEndOfQuarterMegaTestVariant',
-	'noMoreThanFiveSlidesControl',
-	'noMoreThanFiveSlidesVariant',
 ];
 
 /**

--- a/static/src/stylesheets/module/facia-garnett/_item.scss
+++ b/static/src/stylesheets/module/facia-garnett/_item.scss
@@ -609,7 +609,7 @@ $block-height: 58px;
     }
 }
 
-@for $i from 2 through 10 {
+@for $i from 2 through 5 {
     $hangTime: 5;
     $fadeTime: 1;
     $totalLoopTime: $i * ($hangTime + $fadeTime);

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -315,7 +315,7 @@ $fc-item-gutter: $gs-gutter / 4;
     }
 }
 
-@for $i from 2 through 10 {
+@for $i from 2 through 5 {
     $hangTime: 5;
     $fadeTime: 1;
     $totalLoopTime: $i * ($hangTime + $fadeTime);


### PR DESCRIPTION
## What does this change?

Revert the cap of 10 slides back to 5 from #25488, with the improvements from #25495.

Our CSS will break with any more than five slides, so we cap the number of slides we may receive from tools in an explicit manner by using `take(5)` on the images.

@OllysCoding also discovered that we needed the change in both `contentCard` & `dynamoContentCard`.

## What does the CSS do, anyways?

There a a lot of moving parts in the following Sass rule:

```scss
@mixin fc-slideshow-movement($totalLoopTime, $slideshowSize) {
    figure {
        animation-duration: #{$totalLoopTime}s;
        animation-name: fc-item__slideshow--#{$slideshowSize};
    }

    @for $imageIndex from 2 through $slideshowSize {
        figure:nth-child(#{$imageIndex}) {
            animation-delay: #{($totalLoopTime / $slideshowSize) * ($imageIndex - 1)}s;
        }
    }
}


@for $i from 2 through 5 {
    $hangTime: 5;
    $fadeTime: 1;
    $totalLoopTime: $i * ($hangTime + $fadeTime);
    @keyframes fc-item__slideshow--#{$i} {
        0% {
            opacity: 0;
        }
        #{(100% / $totalLoopTime) * $fadeTime} {
            opacity: 1;
        }
        #{(100% / $totalLoopTime) * ($fadeTime + $hangTime)} {
            opacity: 1;
        }
        #{(100% / $totalLoopTime) * ($fadeTime + $hangTime + $fadeTime)} {
            opacity: 0;
        }
    }
    .fc-item__slideshow--#{$i} {
        @include fc-slideshow-movement($totalLoopTime, $i)
    }
}
```

When evaluated, this generates the following CSS (only shown for `2` & `3`):

```css
@keyframes fc-item__slideshow--2 {
	0% {
		opacity: 0;
	}
	8.33333% {
		opacity: 1;
	}
	50% {
		opacity: 1;
	}
	58.33333% {
		opacity: 0;
	}
}
.fc-item__slideshow--2 figure {
	animation-duration: 12s;
	animation-name: fc-item__slideshow--2;
}
.fc-item__slideshow--2 figure:nth-child(2) {
	animation-delay: 6s;
}
@keyframes fc-item__slideshow--3 {
	0% {
		opacity: 0;
	}
	5.55556% {
		opacity: 1;
	}
	33.33333% {
		opacity: 1;
	}
	38.88889% {
		opacity: 0;
	}
}
.fc-item__slideshow--3 figure {
	animation-duration: 18s;
	animation-name: fc-item__slideshow--3;
}
.fc-item__slideshow--3 figure:nth-child(2) {
	animation-delay: 6s;
}
.fc-item__slideshow--3 figure:nth-child(3) {
	animation-delay: 12s;
}
```

This means that 75% of the generated is unused by a given slideshow: 2,3,4 & 5 are generated, but only a fixed number of slides ever applies.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
