### PR TITLE
Rename dotcomponents packages to dotcomrendering

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -8,15 +8,14 @@ import experiments.{ActiveExperiments, DCROnwardsData}
 import implicits.{AmpFormat, EmailFormat, HtmlFormat, JsonFormat}
 import model.Cached.{RevalidatableResult, WithoutRevalidationResult}
 import model.dotcomrendering.{DotcomRenderingDataModel, PageType}
-import model.{ContentType, _}
+import model._
 import pages.{ArticleEmailHtmlPage, ArticleHtmlPage}
 import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 import renderers.DotcomRenderingService
 import services.{CAPILookup, NewsletterService}
-import services.dotcomponents.{ArticlePicker, _}
-import services.dotcomrendering.OnwardsPicker
+import services.dotcomrendering.{ArticlePicker, OnwardsPicker, PressedArticle, RemoteRender}
 import views.support._
 
 import scala.concurrent.Future

--- a/article/app/controllers/LiveBlogController.scala
+++ b/article/app/controllers/LiveBlogController.scala
@@ -3,7 +3,7 @@ package controllers
 import agents.DeeplyReadAgent
 import com.gu.contentapi.client.model.v1.{Block, Blocks, ItemResponse, Content => ApiContent}
 import common.`package`.{convertApiExceptions => _, renderFormat => _}
-import common.{JsonComponent, RichRequestHeader, _}
+import common._
 import contentapi.ContentApiClient
 import implicits.{AmpFormat, HtmlFormat}
 import model.Cached.WithoutRevalidationResult
@@ -12,14 +12,14 @@ import model.ParseBlockId.{InvalidFormat, ParsedBlockId}
 import model.dotcomrendering.{DotcomRenderingDataModel, PageType}
 import model.liveblog.BodyBlock
 import model.liveblog.BodyBlock.{KeyEvent, SummaryEvent}
-import model.{ApplicationContext, CanonicalLiveBlog, _}
+import model._
 import pages.{ArticleEmailHtmlPage, LiveBlogHtmlPage, MinuteHtmlPage}
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 import play.twirl.api.Html
 import renderers.DotcomRenderingService
+import services.dotcomrendering.DotcomponentsLogger
 import services.{CAPILookup, NewsletterService}
-import services.dotcomponents.DotcomponentsLogger
 import topics.TopicService
 import views.support.RenderOtherStatus
 

--- a/article/app/pages/StoryHtmlPage.scala
+++ b/article/app/pages/StoryHtmlPage.scala
@@ -13,7 +13,7 @@ import views.html.fragments.page.body._
 import views.html.fragments.page.head.stylesheets.{criticalStyleInline, criticalStyleLink, styles}
 import views.html.fragments.page.head._
 import html.HtmlPageHelpers.ContentCSSFile
-import services.dotcomponents.ArticlePicker.{dcrChecks}
+import services.dotcomrendering.ArticlePicker.dcrChecks
 
 object StoryHtmlPage {
 

--- a/article/app/services/dotcomrendering/ArticlePicker.scala
+++ b/article/app/services/dotcomrendering/ArticlePicker.scala
@@ -1,10 +1,9 @@
-package services.dotcomponents
+package services.dotcomrendering
 
 import com.madgag.scala.collection.decorators.MapDecorator
 import implicits.Requests._
 import model.{ArticlePage, PageWithStoryPackage}
 import play.api.mvc.RequestHeader
-import services.dotcomrendering.PressedContent
 
 object ArticlePageChecks {
 

--- a/article/app/services/dotcomrendering/DotcomponentsLogger.scala
+++ b/article/app/services/dotcomrendering/DotcomponentsLogger.scala
@@ -1,4 +1,4 @@
-package services.dotcomponents
+package services.dotcomrendering
 
 import common.GuLogging
 import common.LoggingField._

--- a/article/app/services/dotcomrendering/RenderType.scala
+++ b/article/app/services/dotcomrendering/RenderType.scala
@@ -1,4 +1,4 @@
-package services.dotcomponents
+package services.dotcomrendering
 
 sealed trait RenderType
 case object RemoteRender extends RenderType

--- a/article/test/package.scala
+++ b/article/test/package.scala
@@ -1,7 +1,8 @@
 package test
 
 import org.scalatest.{Suites, Tag}
-import services.dotcomponents.ArticlePickerTest
+import services.dotcomrendering.ArticlePickerTest
+
 object ArticleComponents extends Tag("article components")
 
 class ArticleTestSuite

--- a/article/test/services/dotcomrendering/ArticlePickerTest.scala
+++ b/article/test/services/dotcomrendering/ArticlePickerTest.scala
@@ -1,8 +1,9 @@
-package services.dotcomponents
+package services.dotcomrendering
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.DoNotDiscover
+import services.dotcomrendering.{ArticlePicker, LocalRenderArticle, PressedArticle, RemoteRender}
 import test.TestRequest
 
 @DoNotDiscover class ArticlePickerTest extends AnyFlatSpec with Matchers {

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -18,12 +18,13 @@ import views.support.FaciaToMicroFormat2Helpers.getCollection
 import conf.switches.Switches.InlineEmailStyles
 import implicits.GUHeaders
 import pages.{FrontEmailHtmlPage, FrontHtmlPage}
-import utils.{FaciaPicker, RemoteRender, TargetedCollections}
+import utils.TargetedCollections
 import conf.Configuration
 import play.api.libs.ws.WSClient
 import renderers.DotcomRenderingService
 import model.dotcomrendering.{DotcomFrontsRenderingDataModel, PageType}
 import experiments.{ActiveExperiments, EuropeNetworkFront}
+import services.dotcomrendering.{FaciaPicker, RemoteRender}
 import services.fronts.{FrontJsonFapi, FrontJsonFapiLive}
 
 import scala.concurrent.Future

--- a/facia/app/services/dotcomrendering/DotcomFrontsLogger.scala
+++ b/facia/app/services/dotcomrendering/DotcomFrontsLogger.scala
@@ -1,4 +1,4 @@
-package utils
+package services.dotcomrendering
 
 import common.GuLogging
 import common.LoggingField._

--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -1,4 +1,4 @@
-package utils
+package services.dotcomrendering
 
 import common.GuLogging
 import experiments.{ActiveExperiments, DCRFronts}

--- a/facia/app/services/dotcomrendering/RenderType.scala
+++ b/facia/app/services/dotcomrendering/RenderType.scala
@@ -1,4 +1,4 @@
-package utils
+package services.dotcomrendering
 
 sealed trait RenderType
 case object RemoteRender extends RenderType

--- a/facia/test/package.scala
+++ b/facia/test/package.scala
@@ -1,17 +1,8 @@
 package test
 
-import java.io.File
-import concurrent.BlockingOperations
-import model.{PressedPage, PressedPageType}
 import org.fluentlenium.core.domain.FluentWebElement
 import org.scalatest.Suites
-import play.api.libs.json.Json
-import recorder.HttpRecorder
-import services.fronts.FrontJsonFapiLive
-import utils.FaciaPickerTest
-
-import scala.concurrent.{ExecutionContext, Future}
-import scala.io.Codec.UTF8
+import services.dotcomrendering.FaciaPickerTest
 
 object `package` {
 

--- a/facia/test/services/dotcomrendering/FaciaPickerTest.scala
+++ b/facia/test/services/dotcomrendering/FaciaPickerTest.scala
@@ -1,4 +1,4 @@
-package utils
+package services.dotcomrendering
 
 import common.facia.{FixtureBuilder, PressedCollectionBuilder}
 import org.scalatest.DoNotDiscover

--- a/onward/app/controllers/RichLinkController.scala
+++ b/onward/app/controllers/RichLinkController.scala
@@ -5,7 +5,7 @@ import common.{Edition, GuLogging, ImplicitControllerExecutionContext, JsonCompo
 import contentapi.ContentApiClient
 import implicits.Requests
 import model.{ApplicationContext, Cached, Content, ContentFormat, ContentType}
-import models.dotcomponents.{RichLink, RichLinkTag}
+import models.dotcomrendering.{RichLink, RichLinkTag}
 import model.dotcomrendering.TrailUtils
 import play.api.mvc.{Action, AnyContent, ControllerComponents, RequestHeader}
 import play.twirl.api.Html

--- a/onward/app/models/dotcomrendering/DotcomponentsOnwardsModels.scala
+++ b/onward/app/models/dotcomrendering/DotcomponentsOnwardsModels.scala
@@ -1,4 +1,4 @@
-package models.dotcomponents
+package models.dotcomrendering
 
 import model.{ContentFormat, DotcomContentType, ImageAsset}
 import play.api.libs.json.Json


### PR DESCRIPTION
## What does this change?
* Renames `article/app/services/dotcomponents` to `article/app/services/dotcomrendering`.
* Renames `article/test/services/dotcomponents` to `article/test/services/dotcomrendering`.
* Creates `facia/app/services/dotcomrendering` package and moves `DotcomFrontsLogger`, `FaciaPicker` and `RenderType` into that from `facia/app/utils`.
* Creates `facia/test/services/dotcomrendering` package and moves `FaciaPickerTest` there from `facia/test/utils`.
* Renames `onward/app/models/dotcomponents` to `onward/app/models/dotcomrendring`

## Why?
For consistency. Now all the DCR related components are inside `dotcomrendring` packages (instead of half in `dotcomrendring` half in `dotcomponents` that it was before). Also `article`, `facia` and `onward` package structure is the same with regards to DCR classes.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
