### PR TITLE
Add curated content test endpoint

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -28,6 +28,7 @@ class ArticleController(
     newsletterService: NewsletterService,
     deeplyReadAgent: DeeplyReadAgent,
     onwardsPicker: OnwardsPicker,
+    curatedContentAgent: CuratedContentAgent,
 )(implicit context: ApplicationContext)
     extends BaseController
     with RendersItemResponse
@@ -83,6 +84,20 @@ class ArticleController(
         .lookup(path, Some(ArticleBlocks))
         .map(_.content.map(_.webTitle))
         .map(responseFromOptionalString)
+    }
+
+  def renderCuratedContentAgentJson(): Action[AnyContent] =
+    Action.async { implicit request =>
+      Future(
+        Cached(900)(
+          JsonComponent.fromWritable(
+            Map(
+              "curatedContent" -> curatedContentAgent.getCuratedContent,
+              "curatedAdFreeContent" -> curatedContentAgent.getCuratedContentAdFree,
+            ),
+          ),
+        ),
+      )
     }
 
   private def getJson(article: ArticlePage)(implicit request: RequestHeader): List[(String, Object)] = {

--- a/article/conf/application.conf
+++ b/article/conf/application.conf
@@ -18,12 +18,12 @@ akka {
   }
 
   blocking-operations {
-        executor = "thread-pool-executor"
-        throughput = 10
-        thread-pool-executor {
-          fixed-pool-size = 128
-        }
-    }
+      executor = "thread-pool-executor"
+      throughput = 10
+      thread-pool-executor {
+        fixed-pool-size = 128
+      }
+  }
 }
 
 play {

--- a/article/conf/routes
+++ b/article/conf/routes
@@ -9,6 +9,9 @@ GET     /_healthcheck               controllers.HealthCheck.healthCheck()
 
 GET     /_cdn_healthcheck           controllers.HealthCheck.healthCheck()
 
+# agent data
+GET     /agent/curated-content-agent.json                 controllers.ArticleController.renderCuratedContentAgentJson()
+
 # liveblogs, minutes.
 # NOTE: if updating the .json endpoint below, you must also update the fastly cache purger path used
 # See https://github.com/guardian/fastly-cache-purger/blob/master/src/main/scala/com/gu/fastly/Lambda.scala

--- a/article/test/ArticleControllerTest.scala
+++ b/article/test/ArticleControllerTest.scala
@@ -28,6 +28,8 @@ import services.newsletters.{NewsletterApi, NewsletterSignupAgent}
   val articleUrl = "environment/2012/feb/22/capitalise-low-carbon-future"
   val liveBlogUrl = "global/middle-east-live/2013/sep/09/syria-crisis-russia-kerry-us-live"
 
+  lazy val curatedContentAgent = new CuratedContentAgent(fapi)
+
   lazy val articleController = new ArticleController(
     testContentApiClient,
     play.api.test.Helpers.stubControllerComponents(),
@@ -35,7 +37,8 @@ import services.newsletters.{NewsletterApi, NewsletterSignupAgent}
     new DCRFake(),
     new NewsletterService(new NewsletterSignupAgent(new NewsletterApi(wsClient))),
     new DeeplyReadAgent(),
-    new OnwardsPicker(new CuratedContentAgent(fapi)),
+    new OnwardsPicker(curatedContentAgent),
+    curatedContentAgent,
   )
 
   "Article Controller" should "200 when content type is article" in {

--- a/article/test/PublicationControllerTest.scala
+++ b/article/test/PublicationControllerTest.scala
@@ -34,6 +34,9 @@ import services.newsletters.{NewsletterApi, NewsletterSignupAgent}
   val bookAgent = mock[NewspaperBookTagAgent]
   val bookSectionAgent = mock[NewspaperBookSectionTagAgent]
   lazy val controllerComponents = play.api.test.Helpers.stubControllerComponents()
+
+  lazy val curatedContentAgent = new CuratedContentAgent(fapi)
+
   lazy val articleController =
     new ArticleController(
       testContentApiClient,
@@ -42,7 +45,8 @@ import services.newsletters.{NewsletterApi, NewsletterSignupAgent}
       new DCRFake(),
       new NewsletterService(new NewsletterSignupAgent(new NewsletterApi(wsClient))),
       new DeeplyReadAgent(),
-      new OnwardsPicker(new CuratedContentAgent(fapi)),
+      new OnwardsPicker(curatedContentAgent),
+      curatedContentAgent,
     )
   lazy val publicationController =
     new PublicationController(bookAgent, bookSectionAgent, articleController, controllerComponents)

--- a/common/app/agents/CuratedContentAgent.scala
+++ b/common/app/agents/CuratedContentAgent.scala
@@ -3,13 +3,15 @@ package agents
 import com.gu.contentapi.client.utils.format.Theme
 import common.{Box, Edition, GuLogging}
 import model.dotcomrendering.Trail
+import model.pressed.PressedContent
 import services.fronts.FrontJsonFapiLive
 
 class CuratedContentAgent(frontJsonFapiLive: FrontJsonFapiLive) extends GuLogging {
-  private lazy val curatedContentAgent = Box[Map[String, Seq[Trail]]](Map.empty)
+  private lazy val curatedContentAgent = Box[Map[String, Seq[PressedContent]]](Map.empty)
+  private lazy val curatedContentAdFreeAgent = Box[Map[String, Seq[PressedContent]]](Map.empty)
 
   val containerIds: Map[Theme, Map[Edition, String]] = Map()
   def getTrails(theme: Theme, edition: Edition): Seq[Trail] = Seq()
-
-  def getCuratedContent: Map[String, Seq[Trail]] = curatedContentAgent.get()
+  def getCuratedContent: Map[String, Seq[PressedContent]] = curatedContentAgent.get()
+  def getCuratedContentAdFree: Map[String, Seq[PressedContent]] = curatedContentAdFreeAgent.get()
 }

--- a/common/app/model/pressedContent.scala
+++ b/common/app/model/pressedContent.scala
@@ -3,7 +3,7 @@ package model.pressed
 import com.gu.commercial.branding.Branding
 import com.gu.facia.api.{models => fapi}
 import common.Edition
-import model.{ContentFormat, Pillar}
+import model.{ContentFormat, Pillar, PressedContentFormat}
 import views.support.ContentOldAgeDescriber
 
 sealed trait PressedContent {
@@ -45,6 +45,7 @@ sealed trait PressedContent {
 }
 
 object PressedContent {
+  implicit val pressedContentFormat = PressedContentFormat.format
   def make(content: fapi.FaciaContent): PressedContent =
     content match {
       case curatedContent: fapi.CuratedContent => CuratedContent.make(curatedContent)

--- a/dev-build/app/AppLoader.scala
+++ b/dev-build/app/AppLoader.scala
@@ -32,7 +32,9 @@ import rugby.controllers.RugbyControllers
 import services._
 import services.newsletters.{NewsletterApi, NewsletterSignupAgent, NewsletterSignupLifecycle}
 import services.ophan.SurgingContentAgentLifecycle
-import agents.DeeplyReadAgent
+import agents.{CuratedContentAgent, DeeplyReadAgent}
+import services.dotcomrendering.OnwardsPicker
+import services.fronts.FrontJsonFapiLive
 
 class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents =
@@ -61,6 +63,9 @@ trait Controllers
   lazy val emailSignupController = wire[EmailSignupController]
   lazy val surveyPageController = wire[SurveyPageController]
   lazy val signupPageController = wire[SignupPageController]
+
+  lazy val onwardsPicker = wire[OnwardsPicker]
+
 }
 
 trait AppComponents
@@ -92,6 +97,7 @@ trait AppComponents
   override def router: Router = wire[Routes]
   override def appIdentity: ApplicationIdentity = ApplicationIdentity("dev-build")
 
+  lazy val curatedContentAgent = wire[CuratedContentAgent]
   override def lifecycleComponents: List[LifecycleComponent] =
     List(
       wire[LogstashLifecycle],

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -318,10 +318,9 @@ GET            /most-read-mf2.json                                              
 GET            /related-mf2/*path.json                                                                                           controllers.RelatedController.renderMf2(path)
 GET            /series-mf2/*path.json                                                                                            controllers.SeriesController.renderMf2SeriesStories(path)
 
-GET            /container/count/:count/offset/:offset/mf2.json                                                                   controllers.FaciaController.renderSomeFrontContainersMf2(count: Int, offset: Int, section = "", edition = "")
-GET            /container/count/:count/offset/:offset/section/:section/mf2.json                                                  controllers.FaciaController.renderSomeFrontContainersMf2(count: Int, offset: Int, section, edition = "")
-GET            /container/count/:count/offset/:offset/edition/:edition/mf2.json                                                  controllers.FaciaController.renderSomeFrontContainersMf2(count: Int, offset: Int, section = "", edition)
-GET            /container/count/:count/offset/:offset/section/:section/edition/:edition/mf2.json                                 controllers.FaciaController.renderSomeFrontContainersMf2(count: Int, offset: Int, section, edition)
+# AMP
+GET             /container/count/:count/offset/:offset/mf2.json                                                                  controllers.FaciaController.renderSomeFrontContainersMf2(count: Int, offset: Int, section = "")
+GET             /container/count/:count/offset/:offset/section/:section/mf2.json                                                 controllers.FaciaController.renderSomeFrontContainersMf2(count: Int, offset: Int, section)
 
 GET            /football-mf2/api/match-summary/:year/:month/:day/:home/:away.json                                                football.controllers.MoreOnMatchController.matchSummaryMf2(year, month, day, home, away)
 


### PR DESCRIPTION
## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

![image](https://user-images.githubusercontent.com/19683595/191322806-a7a07272-6fcf-4ba7-91bc-adf12e0d56f9.png)


<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
