### PR TITLE
Report duplicate slot errors

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/add-slot.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/add-slot.ts
@@ -1,4 +1,5 @@
 import type { SizeMapping } from '@guardian/commercial-core';
+import reportError from 'lib/report-error';
 import type { Advert } from './Advert';
 import { createAdvert } from './create-advert';
 import { dfpEnv } from './dfp-env';
@@ -28,6 +29,17 @@ const addSlot = (
 
 			// dynamically add ad slot
 			displayAd(advert, forceDisplay);
+		} else {
+			const errorMessage = `Attempting to add slot with exisiting id ${adSlot.id}`;
+			reportError(
+				Error(errorMessage),
+				{
+					feature: 'commercial',
+					slotId: adSlot.id,
+				},
+				false,
+			);
+			console.error(errorMessage);
 		}
 	});
 };

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -181,6 +181,7 @@
  ],
  "../projects/commercial/modules/dfp/add-slot.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
+  "../lib/report-error.js",
   "../projects/commercial/modules/dfp/Advert.ts",
   "../projects/commercial/modules/dfp/create-advert.ts",
   "../projects/commercial/modules/dfp/dfp-env.ts",
@@ -700,7 +701,8 @@
   "../projects/common/modules/experiments/tests/integrate-ima.ts",
   "../projects/common/modules/experiments/tests/remote-header-test.js",
   "../projects/common/modules/experiments/tests/sign-in-gate-main-control.js",
-  "../projects/common/modules/experiments/tests/sign-in-gate-main-variant.js"
+  "../projects/common/modules/experiments/tests/sign-in-gate-main-variant.js",
+  "../projects/common/modules/experiments/tests/sign-in-gate-mandatory-long.js"
  ],
  "../projects/common/modules/experiments/ab-url.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
@@ -735,6 +737,7 @@
  "../projects/common/modules/experiments/tests/remote-header-test.js": [],
  "../projects/common/modules/experiments/tests/sign-in-gate-main-control.js": [],
  "../projects/common/modules/experiments/tests/sign-in-gate-main-variant.js": [],
+ "../projects/common/modules/experiments/tests/sign-in-gate-mandatory-long.js": [],
  "../projects/common/modules/identity/api.ts": [
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/config.d.ts",


### PR DESCRIPTION
## What does this change?

Currently when we attempt to 'add' a new slot with a slot ID that's already been added we get a silent failure. We simply never make a request to GAM, and leave the DOM littered with the duplicate slot / container.

This PR will instead log an error and report it to Sentry.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

For example, on a page when you dismiss the sign-in-gate:

![Screenshot 2022-09-22 at 10 20 35](https://user-images.githubusercontent.com/8000415/191709723-e2872a04-8e29-49e0-8b9e-d5add45a93fc.png)

## What is the value of this and can you measure success?

This should surface more errors that occur when we're inserting too many slots into the page. Currently this fails silently, leaving empty ad slot divs in the DOM without erroring.

### Tested

- [X] Locally
- [ ] On CODE (optional)