### PR TITLE
Use www. url in `linkedData` when rendering non amp pages

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -365,6 +365,10 @@ class GuardianConfiguration extends GuLogging {
     lazy val flushPublicKey = configuration.getMandatoryStringProperty("google.amp.flush.key.public")
   }
 
+  object dotcom {
+    lazy val baseUrl = "https://www.theguardian.com"
+  }
+
   object id {
     lazy val url = configuration.getStringProperty("id.url").getOrElse("")
     lazy val apiRoot = configuration.getStringProperty("id.apiRoot").getOrElse("")

--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -190,13 +190,15 @@ object DotcomRenderingDataModel {
       request: RequestHeader,
       pageType: PageType,
   ): DotcomRenderingDataModel = {
+    val baseUrl = if (request.isAmp) Configuration.amp.baseUrl else Configuration.dotcom.baseUrl
+
     apply(
       page = page,
       request = request,
       pagination = None,
       linkedData = LinkedData.forInteractive(
         interactive = page.item,
-        baseURL = Configuration.amp.baseUrl,
+        baseURL = baseUrl,
         fallbackLogo = Configuration.images.fallbackLogo,
       ),
       mainBlock = blocks.main,
@@ -220,11 +222,13 @@ object DotcomRenderingDataModel {
       newsletter: Option[NewsletterData],
       onwards: Option[Seq[OnwardCollectionResponse]],
   ): DotcomRenderingDataModel = {
-    val linkedData = LinkedData.forArticle(
-      article = page.article,
-      baseURL = Configuration.amp.baseUrl,
-      fallbackLogo = Configuration.images.fallbackLogo,
-    )
+    val baseUrl = if (request.isAmp) Configuration.amp.baseUrl else Configuration.dotcom.baseUrl
+    val linkedData =
+      LinkedData.forArticle(
+        article = page.article,
+        baseURL = baseUrl,
+        fallbackLogo = Configuration.images.fallbackLogo,
+      )
 
     apply(
       page = page,
@@ -290,10 +294,11 @@ object DotcomRenderingDataModel {
     val timelineBlocks =
       orderBlocks(allTimelineBlocks.toSeq).map(ensureSummaryTitle)
 
+    val baseUrl = if (request.isAmp) Configuration.amp.baseUrl else Configuration.dotcom.baseUrl
     val linkedData = LinkedData.forLiveblog(
       liveblog = page,
       blocks = bodyBlocks,
-      baseURL = Configuration.amp.baseUrl,
+      baseURL = baseUrl,
       fallbackLogo = Configuration.images.fallbackLogo,
     )
 

--- a/common/app/model/dotcomrendering/LinkedData.scala
+++ b/common/app/model/dotcomrendering/LinkedData.scala
@@ -83,7 +83,6 @@ object LinkedData {
       baseURL: String,
       fallbackLogo: String,
   ): List[LinkedData] = {
-
     val authors = getAuthors(article.tags)
 
     article match {


### PR DESCRIPTION
## What does this change?
Fixes https://github.com/guardian/frontend/issues/25262

Changes the `@id` of the Schema JSON from `https://amp.theguardian.com/{id}` to `https://www.theguardian.com/{id}` when we are not on AMP pages.

This is how it was represented on frontend, and is also best practise. 

## Screenshots

### Frontend
URL: https://www.theguardian.com/politics/2022/sep/21/liz-truss-dismisses-putins-nuclear-threats-as-statement-of-weakness?dcr=false

<img width="1028" alt="Screenshot 2022-09-22 at 11 57 56" src="https://user-images.githubusercontent.com/31692/191729382-2126f4b7-e975-47a4-ad62-3efd3f278743.png">

### Before
![before][] 

### After
![after][]

[before]: https://user-images.githubusercontent.com/31692/191728375-1ea7e8ec-90eb-477c-8a9c-1bfc53893bb7.png

[after]: https://user-images.githubusercontent.com/31692/191728428-2ead416d-b3f4-409e-8d81-cdcc4d2b2c62.png


