### PR TITLE
Add "canonicalUrl" property to DCR data model

### DIFF
--- a/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
+++ b/common/app/model/dotcomrendering/DotcomRenderingDataModel.scala
@@ -5,7 +5,7 @@ import com.gu.contentapi.client.utils.AdvertisementFeature
 import com.gu.contentapi.client.utils.format.{ImmersiveDisplay, InteractiveDesign}
 import common.Maps.RichMap
 import common.commercial.EditionCommercialProperties
-import common.{Chronos, Edition, Localisation, RichRequestHeader}
+import common.{CanonicalLink, Chronos, Edition, Localisation, RichRequestHeader}
 import conf.Configuration
 import experiments.ActiveExperiments
 import model.dotcomrendering.DotcomRenderingUtils._
@@ -55,6 +55,7 @@ case class DotcomRenderingDataModel(
     editionLongForm: String,
     editionId: String,
     pageId: String,
+    canonicalUrl: String,
     // Format and previous flags
     format: ContentFormat,
     designType: String,
@@ -131,6 +132,7 @@ object DotcomRenderingDataModel {
         "editionLongForm" -> model.editionLongForm,
         "editionId" -> model.editionId,
         "pageId" -> model.pageId,
+        "canonicalUrl" -> model.canonicalUrl,
         "format" -> model.format,
         "designType" -> model.designType,
         "tags" -> model.tags,
@@ -490,6 +492,7 @@ object DotcomRenderingDataModel {
       openGraphData = page.getOpenGraphProperties,
       pageFooter = PageFooter(FooterLinks.getFooterByEdition(Edition(request))),
       pageId = content.metadata.id,
+      canonicalUrl = CanonicalLink(request, content.metadata.webUrl),
       pageType = pageType, // TODO this info duplicates what is already elsewhere in format?
       pagination = pagination,
       pillar = findPillar(content.metadata.pillar, content.metadata.designType),


### PR DESCRIPTION
## What does this change?

Adds a property `canonicalUrl` to DCR's data model.

This enables a key feature required, which is the canonical URL differing by significant URL parameters which change the content of the page. This logic can be sen in [LinkTo.scala](https://github.com/guardian/frontend/blob/main/common/app/common/LinkTo.scala#L95)

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes - DCR PR: https://github.com/guardian/dotcom-rendering/pull/6050

## Screenshots

Url: https://www.theguardian.com/politics/live/2022/sep/23/mini-budget-2022-chancellor-kwasi-kwarteng-tax-cuts-live
<img width="1293" alt="image" src="https://user-images.githubusercontent.com/9575458/191946977-cc6dba00-a3b7-4b06-975c-eeeac14ec093.png">

Url: https://www.theguardian.com/politics/live/2022/sep/23/mini-budget-2022-chancellor-kwasi-kwarteng-tax-cuts-live

Url: http://localhost:9000/politics/live/2022/sep/23/mini-budget-2022-chancellor-kwasi-kwarteng-tax-cuts-live.json?dcr&page=2&test=hello
<img width="1342" alt="image" src="https://user-images.githubusercontent.com/9575458/191947173-0f6143d8-b96a-4cad-aaca-73304843722e.png">


### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
