### PR TITLE
Add the topics parameter to the canonical URL

### DIFF
--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -96,6 +96,7 @@ class CanonicalLink {
     "index",
     "page",
     "filterKeyEvents",
+    "topics",
   )
 
   def apply(implicit request: RequestHeader, webUrl: String): String = {


### PR DESCRIPTION
## What does this change?

Adds the new "topics" parameter to the list of significant parameters such that it is then part of the canonical url. This is because the topics parameter significantly changes the content of a page. 

Related to https://github.com/guardian/frontend/pull/25522
