### PR TITLE
Fabric parallax scroll fix

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/messenger/background.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.ts
@@ -39,12 +39,15 @@ interface BackgroundSpecs {
 const isBackgroundSpecs = (specs: unknown): specs is BackgroundSpecs =>
 	isObject(specs) && 'backgroundImage' in specs;
 
-const createParent = (scrollType: BackgroundSpecs['scrollType']) => {
-	let backgroundParent = document.querySelector<HTMLDivElement>(
-		'creative__background-parent',
+const createParent = (
+	adSlot: HTMLElement,
+	scrollType: BackgroundSpecs['scrollType'],
+) => {
+	let backgroundParent = adSlot.querySelector<HTMLDivElement>(
+		'.creative__background-parent',
 	);
-	let background = document.querySelector<HTMLDivElement>(
-		'creative__background',
+	let background = adSlot.querySelector<HTMLDivElement>(
+		'.creative__background',
 	);
 
 	if (!backgroundParent || !background) {
@@ -163,7 +166,10 @@ const setupBackground = async (
 	specs: BackgroundSpecs,
 	adSlot: HTMLElement,
 ): Promise<void> => {
-	const { backgroundParent, background } = createParent(specs.scrollType);
+	const { backgroundParent, background } = createParent(
+		adSlot,
+		specs.scrollType,
+	);
 
 	return fastdom.mutate(() => {
 		setBackgroundStyles(specs, background);

--- a/static/src/javascripts/projects/commercial/modules/messenger/background.ts
+++ b/static/src/javascripts/projects/commercial/modules/messenger/background.ts
@@ -1,6 +1,5 @@
 import type { RegisterListener } from '@guardian/commercial-core';
 import { isObject } from '@guardian/libs';
-import once from 'lodash-es/once';
 import fastdom from '../../../../lib/fastdom-promise';
 import {
 	renderInterscrollerAdLabel,
@@ -40,35 +39,43 @@ interface BackgroundSpecs {
 const isBackgroundSpecs = (specs: unknown): specs is BackgroundSpecs =>
 	isObject(specs) && 'backgroundImage' in specs;
 
-// using once, because some native templates send the 'background' message multiple times
-const createParent = once((scrollType: BackgroundSpecs['scrollType']) => {
-	const backgroundParent = document.createElement('div');
-	const background = document.createElement('div');
+const createParent = (scrollType: BackgroundSpecs['scrollType']) => {
+	let backgroundParent = document.querySelector<HTMLDivElement>(
+		'creative__background-parent',
+	);
+	let background = document.querySelector<HTMLDivElement>(
+		'creative__background',
+	);
 
-	backgroundParent.classList.add('creative__background-parent');
-	background.classList.add('creative__background');
+	if (!backgroundParent || !background) {
+		backgroundParent = document.createElement('div');
+		background = document.createElement('div');
 
-	if (scrollType) {
-		backgroundParent.classList.add(
-			`creative__background-parent--${scrollType}`,
-		);
-		background.classList.add(`creative__background--${scrollType}`);
-	}
+		backgroundParent.classList.add('creative__background-parent');
+		background.classList.add('creative__background');
 
-	backgroundParent.appendChild(background);
+		if (scrollType) {
+			backgroundParent.classList.add(
+				`creative__background-parent--${scrollType}`,
+			);
+			background.classList.add(`creative__background--${scrollType}`);
+		}
 
-	if (isDCR) {
-		backgroundParent.style.zIndex = '-1';
-		backgroundParent.style.position = 'absolute';
-		backgroundParent.style.inset = '0';
-		backgroundParent.style.clip = 'rect(0, auto, auto, 0)';
+		backgroundParent.appendChild(background);
 
-		background.style.inset = '0';
-		background.style.transition = 'background 100ms ease';
+		if (isDCR) {
+			backgroundParent.style.zIndex = '-1';
+			backgroundParent.style.position = 'absolute';
+			backgroundParent.style.inset = '0';
+			backgroundParent.style.clip = 'rect(0, auto, auto, 0)';
+
+			background.style.inset = '0';
+			background.style.transition = 'background 100ms ease';
+		}
 	}
 
 	return { backgroundParent, background };
-});
+};
 
 const setBackgroundStyles = (
 	specs: BackgroundSpecs,

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -481,7 +481,6 @@
  "../projects/commercial/modules/messenger/background.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../../../../node_modules/@types/lodash-es/once.d.ts",
   "../lib/fastdom-promise.js",
   "../projects/commercial/modules/dfp/render-advert-label.ts"
  ],


### PR DESCRIPTION
## What does this change?
When scrolling fabric parallax native ads, the background is disappearing.

This is occurring if there are multiple parallax ads on the same page because of the `once` wrapper around `createParent`, effectively forcing all the ads to use the same element for the background and moving it to the last ad to be loaded.

Instead of using once, we now check if the the background already exists in the ad slot.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
