### PR TITLE
Commercial e2e GHA sets Node from DCR and Frontend's .nvmrc separately

### DIFF
--- a/.github/workflows/commercial-e2e.yml
+++ b/.github/workflows/commercial-e2e.yml
@@ -26,7 +26,7 @@ jobs:
                   path: ./frontend
 
             - name: Setup frontend node
-              uses: guardian/actions-setup-node@main
+              uses: actions/setup-node@v3
               with:
                   node-version-file: './frontend/.nvmrc'
 
@@ -43,7 +43,7 @@ jobs:
                   path: ./dcr
 
             - name: Setup DCR node
-              uses: guardian/actions-setup-node@main
+              uses: actions/setup-node@v3
               with:
                   node-version-file: './dcr/.nvmrc'
 

--- a/.github/workflows/commercial-e2e.yml
+++ b/.github/workflows/commercial-e2e.yml
@@ -19,24 +19,33 @@ jobs:
         name: Test
         runs-on: ubuntu-latest
         steps:
+            # Frontend
             - name: Checkout frontend
               uses: actions/checkout@v3
               with:
                   path: ./frontend
 
+            - name: Setup frontend node
+              uses: guardian/actions-setup-node@main
+              with:
+                  node-version-file: './frontend/.nvmrc'
+
+            - name: Install Frontend dependencies
+              uses: bahmutov/npm-install@v1
+              with:
+                  working-directory: ./frontend
+
+            # DCR
             - name: Checkout DCR
               uses: actions/checkout@v3
               with:
                   repository: guardian/dotcom-rendering
                   path: ./dcr
 
-            - name: Setup node
+            - name: Setup DCR node
               uses: guardian/actions-setup-node@main
-
-            - name: Install Frontend dependencies
-              uses: bahmutov/npm-install@v1
               with:
-                  working-directory: ./frontend
+                  node-version-file: './dcr/.nvmrc'
 
             - name: Install DCR dependencies
               uses: bahmutov/npm-install@v1

--- a/.github/workflows/commercial-e2e.yml
+++ b/.github/workflows/commercial-e2e.yml
@@ -32,8 +32,6 @@ jobs:
 
             - name: Setup node
               uses: guardian/actions-setup-node@main
-              with:
-                  node-version: '14.18.3'
 
             - name: Install Frontend dependencies
               uses: bahmutov/npm-install@v1


### PR DESCRIPTION
## What does this change?

Fixes Node version mismatch errors caused by DCR and Frontend diverging versions recently.

- Remove pinned node version 
- Re-order steps so Frontend and DCR steps are grouped together so each use the node version they require
- Use `actions/setup-node@v3` rather than `guardian/actions-setup-node@main` so we can use `with: node-version-file` to tell the action where to read its `.nvmrc` from

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

