### PR TITLE
feat: allow newsletter identification from tags for sign up pages

### DIFF
--- a/common/app/services/NewsletterService.scala
+++ b/common/app/services/NewsletterService.scala
@@ -85,12 +85,11 @@ class NewsletterService(newsletterSignupAgent: NewsletterSignupAgent) {
   }
 
   def getNewsletterForArticle(articlePage: ArticlePage): Option[NewsletterData] = {
+    var response = getNewsletterResponseFromTags(articlePage.article.tags.tags)
 
-    var response: Option[NewsletterResponse] = None
-    if (isSignUpPage(articlePage)) {
-      response = getNewsletterResponseFromSignUpPage(articlePage.article.content.metadata.id)
-    } else {
-      response = getNewsletterResponseFromTags(articlePage.article.tags.tags)
+    // TODO: Remove this part when all sign up pages have the correct tag added
+    if (response.isEmpty) {
+      response = getNewsletterResponseFromSignUpPage(articlePage.article.metadata.id)
     }
 
     if (response.isEmpty || !shouldInclude(response.get)) {

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -693,6 +693,7 @@
   "../projects/common/modules/experiments/tests/deeply-read-article-footer.js",
   "../projects/common/modules/experiments/tests/integrate-ima.ts",
   "../projects/common/modules/experiments/tests/remote-header-test.js",
+  "../projects/common/modules/experiments/tests/shady-pie-click-through.ts",
   "../projects/common/modules/experiments/tests/sign-in-gate-main-control.js",
   "../projects/common/modules/experiments/tests/sign-in-gate-main-variant.js",
   "../projects/common/modules/experiments/tests/sign-in-gate-mandatory-long.js"
@@ -728,6 +729,10 @@
   "../lib/noop.ts"
  ],
  "../projects/common/modules/experiments/tests/remote-header-test.js": [],
+ "../projects/common/modules/experiments/tests/shady-pie-click-through.ts": [
+  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
+  "../lib/noop.ts"
+ ],
  "../projects/common/modules/experiments/tests/sign-in-gate-main-control.js": [],
  "../projects/common/modules/experiments/tests/sign-in-gate-main-variant.js": [],
  "../projects/common/modules/experiments/tests/sign-in-gate-mandatory-long.js": [],

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -693,7 +693,6 @@
   "../projects/common/modules/experiments/tests/deeply-read-article-footer.js",
   "../projects/common/modules/experiments/tests/integrate-ima.ts",
   "../projects/common/modules/experiments/tests/remote-header-test.js",
-  "../projects/common/modules/experiments/tests/shady-pie-click-through.ts",
   "../projects/common/modules/experiments/tests/sign-in-gate-main-control.js",
   "../projects/common/modules/experiments/tests/sign-in-gate-main-variant.js",
   "../projects/common/modules/experiments/tests/sign-in-gate-mandatory-long.js"
@@ -729,10 +728,6 @@
   "../lib/noop.ts"
  ],
  "../projects/common/modules/experiments/tests/remote-header-test.js": [],
- "../projects/common/modules/experiments/tests/shady-pie-click-through.ts": [
-  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
-  "../lib/noop.ts"
- ],
  "../projects/common/modules/experiments/tests/sign-in-gate-main-control.js": [],
  "../projects/common/modules/experiments/tests/sign-in-gate-main-variant.js": [],
  "../projects/common/modules/experiments/tests/sign-in-gate-mandatory-long.js": [],


### PR DESCRIPTION
## What does this change?

Allow fetching newsletter data by tags for sign up pages and prioritise this over article ID matching.
Matching the article ID against the newsletters response data still exists for backwards compatibility

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

The process for creating a new newsletter is quite cumbersome at the moment. Currently, editors are confused when they add the correct tag to convert the page type to a sign up page but do not see the newsletter sign up form appear. This was because we were having to exactly match the article ID with the one registered in the newsletters spreadsheet in order to pick the correct ID.

The new process will be to add the individual newsletter signup tag to the article itself in order to render the form.

The old method of retrieving the newsletter data by matching the article ID has been left in for backwards compatibility reasons and will hopefully be removed in the future once we have added the relevant tag for all newsletter sign up pages.

**Example of page that has a DCR sign up tag and an individual newsletter signup tag, where the sign up URL does not exist on the newsletters API response:**
![image](https://user-images.githubusercontent.com/43961396/193280157-19cb524f-19fe-45ea-907f-1dac00d37f07.png)
It can now render the sign up form regardless of whether the article URL matches the one in the newsletters response or not

**Example of unchanged existing article which does not have the individual sign up tag:**
 ![image](https://user-images.githubusercontent.com/43961396/193280494-b5b1113c-c34a-4a39-9973-e8a3ba0c68bd.png)

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Tested

- [x] Locally
- [ ] On CODE (optional)
