### PR TITLE
Update SDC

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"@guardian/source-foundations": "^4.0.3",
 		"@guardian/source-react-components": "^4.0.2",
 		"@guardian/source-react-components-development-kitchen": "^0.0.33",
-		"@guardian/support-dotcom-components": "1.0.4",
+		"@guardian/support-dotcom-components": "1.0.5",
 		"bean": "~1.0.14",
 		"bonzo": "~2.0.0",
 		"bootstrap-sass": "^3.4.1",

--- a/static/src/javascripts/projects/common/modules/support/banner.ts
+++ b/static/src/javascripts/projects/common/modules/support/banner.ts
@@ -15,6 +15,7 @@ import { getMvtValue } from 'common/modules/analytics/mvt-cookie';
 import { submitComponentEvent } from 'common/modules/commercial/acquisitions-ophan';
 import { getVisitCount } from 'common/modules/commercial/contributions-utilities';
 import {
+	getLastOneOffContributionDate,
 	getPurchaseInfo,
 	shouldHideSupportMessaging,
 } from 'common/modules/commercial/user-features';
@@ -161,6 +162,8 @@ const buildBannerPayload = async (
 		browserId: (await hasCmpConsentForBrowserId()) ? browserId : undefined,
 		purchaseInfo,
 		isSignedIn: !!isSignedIn,
+		lastOneOffContributionDate:
+			getLastOneOffContributionDate() ?? undefined,
 	};
 
 	return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2164,10 +2164,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-3.12.0.tgz#52d11d2fff649e04934033473b3ed7c7bf4a1639"
   integrity sha512-JIFBybaCd69tf+zJZZ7KNLdqaVePOAc36wGFor0I60vc9Ib0jMuzYVffMjMhF6LHSXMdoOcqGwiPdFucObVYAA==
 
-"@guardian/support-dotcom-components@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@guardian/support-dotcom-components/-/support-dotcom-components-1.0.4.tgz#1d09ce408bcfa435eb2411255688e22a2eede032"
-  integrity sha512-g23KJoJiJVIC75DZW87zyblmNMnjujCgCKntLVLblKoSxIzOBLhzkPUnJqzPtG3aztTPRbqmhLzqgzm6M56/qw==
+"@guardian/support-dotcom-components@1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@guardian/support-dotcom-components/-/support-dotcom-components-1.0.5.tgz#659720c332c62b211efab9a45350c042184a5082"
+  integrity sha512-BVvGeyS5dAD9Qu7NwFUsDou9LN5o9LZH5I4BnVf2Tg7Rj/mxdnO5qPygwI0dKFEbNHql4BEhJqSBdWI9MUSPWw==
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"


### PR DESCRIPTION
<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?

There is a new version of the support-dotcom-components library.
This adds the `lastOneOffContributionDate` field for banner targeting.

See [SDC PR](https://github.com/guardian/support-dotcom-components/pull/757) for details.