### PR TITLE
Fix `dev-build` remove `DeeplyReadAgent`

### DIFF
--- a/dev-build/app/AppLoader.scala
+++ b/dev-build/app/AppLoader.scala
@@ -34,7 +34,6 @@ import services.dotcomrendering.OnwardsPicker
 import services.newsletters.{NewsletterApi, NewsletterSignupAgent, NewsletterSignupLifecycle}
 import services.ophan.SurgingContentAgentLifecycle
 import agents.CuratedContentAgent
-import agents.DeeplyReadAgent
 
 class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents =
@@ -123,6 +122,4 @@ trait AppComponents
   override lazy val httpFilters = wire[DevFilters].filters
   override lazy val httpRequestHandler = wire[DevBuildParametersHttpRequestHandler]
   override lazy val httpErrorHandler = wire[CorsHttpErrorHandler]
-
-  override lazy val articleDeeplyReadAgent = wire[DeeplyReadAgent]
 }


### PR DESCRIPTION
## What does this change?

It looks like `DeeplyReadAgent` was removed in the following PR for all controllers: https://github.com/guardian/frontend/pull/25458

However `dev-build` was missed so this causes exceptions when attempting to use `dev-build` locally.

This change updates `dev-build` to reflect the change.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [x] Locally
- [ ] On CODE (optional)

