### PR TITLE
Replace `zip(LazyList from 0)` with `zipWithIndex`

### DIFF
--- a/common/app/model/CrosswordGridModel.scala
+++ b/common/app/model/CrosswordGridModel.scala
@@ -9,15 +9,13 @@ import com.gu.contentapi.client.model.v1.{
 import model.{CrosswordPosition, Entry}
 
 import Function.const
-import scala.collection.compat.immutable.LazyList
 
 trait CrosswordGridDataOrdering {
   implicit val positionOrdering = Ordering.by[CrosswordPosition, (Int, Int)](position => (position.y, position.x))
 }
 
 trait CrosswordGridColumnNotation {
-  val columnsByLetters =
-    (('A' to 'Z').toList.zip(LazyList from 0) map { case (letter, number) => (number, letter) }).toMap
+  val columnsByLetters = ('A' to 'Z').toList.zipWithIndex.map(_.swap).toMap
 }
 
 case class Cell(number: Option[Int])


### PR DESCRIPTION
Closes https://github.com/guardian/frontend/issues/25551

## What does this change?
Removes `LazyList` and re-writes the code using `zipWithIndex`.

## Why?
Although `LazyList` is not used here for serialisation purposes, hence we're not vulnerable to https://nvd.nist.gov/vuln/detail/CVE-2022-36944, it is a good idea to rewrite this code using `zipWithIndex`.

We are going to upgrade to Scala 2.13.10 when it is available: https://github.com/guardian/frontend/issues/25548

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots
This code is used to create the [blank lines](https://github.com/guardian/frontend/blob/main/applications/app/crosswords/AccessibleCrosswordRows.scala#L20) and [positions](https://github.com/guardian/frontend/blob/main/common/app/model/CrosswordData.scala#L65) in accessible crosswords. After making the change everything is the same.

| Before      | After      |
|-------------|------------|
| ![Screenshot 2022-10-04 at 14 50 55](https://user-images.githubusercontent.com/19683595/193837704-a282b5c6-cfa0-4f22-a953-a8471665c16a.png) | ![image](https://user-images.githubusercontent.com/19683595/193837911-47864168-d419-459b-9fde-309c4911d4e9.png) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
