### PR TITLE
Add 0% ab test with an update to the Confiant SDK

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -111,7 +111,7 @@ trait ABTestSwitches {
     "Test the updated Confiant SDK",
     owners = Seq(Owner.withGithub("jakeii")),
     safeState = Off,
-    sellByDate = Some(LocalDate.of(2022, 10, 30)),
+    sellByDate = Some(LocalDate.of(2022, 10, 28)),
     exposeClientSide = true,
   )
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -104,4 +104,14 @@ trait ABTestSwitches {
     sellByDate = Some(LocalDate.of(2022, 10, 25)),
     exposeClientSide = true,
   )
+
+  Switch(
+    ABTests,
+    "ab-confiant-sdk-update",
+    "Test the updated Confiant SDK",
+    owners = Seq(Owner.withGithub("jakeii")),
+    safeState = Off,
+    sellByDate = Some(LocalDate.of(2022, 10, 30)),
+    exposeClientSide = true,
+  )
 }

--- a/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.ts
+++ b/static/src/javascripts/projects/commercial/modules/ad-verification/prepare-ad-verification.ts
@@ -3,6 +3,8 @@ import {
 	bypassCommercialMetricsSampling as switchOffSampling,
 } from '@guardian/commercial-core';
 import { loadScript, log } from '@guardian/libs';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { confiantSDKUpdateTest } from 'common/modules/experiments/tests/confiant-sdk-update';
 import { getAdvertById } from '../dfp/get-advert-by-id';
 import { refreshAdvert } from '../dfp/load-advert';
 import { stripDfpAdPrefixFrom } from '../header-bidding/utils';
@@ -67,7 +69,11 @@ const maybeRefreshBlockedSlotOnce: ConfiantCallback = (
  * @returns Promise
  */
 export const init = async (): Promise<void> => {
-	const host = 'confiant-integrations.global.ssl.fastly.net';
+	let host = 'confiant-integrations.global.ssl.fastly.net';
+	if (isInVariantSynchronous(confiantSDKUpdateTest, 'variant')) {
+		host = 'cdn.confiant-integrations.net';
+	}
+
 	const id = '7oDgiTsq88US4rrBG0_Nxpafkrg';
 	const remoteScriptUrl = `//${host}/${id}/gpt_and_prebid/config.js`;
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/ab-tests.ts
@@ -1,4 +1,5 @@
 import type { ABTest } from '@guardian/ab-core';
+import { confiantSDKUpdateTest } from './tests/confiant-sdk-update';
 import { consentlessAds } from './tests/consentlessAds';
 import { deeplyReadArticleFooterTest } from './tests/deeply-read-article-footer';
 import { integrateIMA } from './tests/integrate-ima';
@@ -27,4 +28,5 @@ export const concurrentTests: readonly ABTest[] = [
 	signInGateMandatoryLongTestRunNa,
 	signInGateMandatoryLongTestRunUk,
 	shadyPieClickThrough,
+	confiantSDKUpdateTest,
 ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/confiant-sdk-update.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/confiant-sdk-update.ts
@@ -4,7 +4,7 @@ import { noop } from '../../../../../lib/noop';
 export const confiantSDKUpdateTest: ABTest = {
 	id: 'ConfiantSDKUpdate',
 	start: '2022-10-04',
-	expiry: '2022-10-30',
+	expiry: '2022-10-28',
 	author: 'Jake Lee Kennedy',
 	description: 'Test the new Confiant SDK, to share with the Confiant team',
 	audience: 0,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/confiant-sdk-update.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/confiant-sdk-update.ts
@@ -2,7 +2,7 @@ import type { ABTest } from '@guardian/ab-core';
 import { noop } from '../../../../../lib/noop';
 
 export const confiantSDKUpdateTest: ABTest = {
-	id: 'ConfiantSDKUpdate',
+	id: 'ConfiantSdkUpdate',
 	start: '2022-10-04',
 	expiry: '2022-10-28',
 	author: 'Jake Lee Kennedy',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/confiant-sdk-update.ts
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/confiant-sdk-update.ts
@@ -1,0 +1,21 @@
+import type { ABTest } from '@guardian/ab-core';
+import { noop } from '../../../../../lib/noop';
+
+export const confiantSDKUpdateTest: ABTest = {
+	id: 'ConfiantSDKUpdate',
+	start: '2022-10-04',
+	expiry: '2022-10-30',
+	author: 'Jake Lee Kennedy',
+	description: 'Test the new Confiant SDK, to share with the Confiant team',
+	audience: 0,
+	audienceOffset: 0,
+	audienceCriteria: 'Opt in',
+	successMeasure: 'No change/improved ad load times',
+	canRun: () => true,
+	variants: [
+		{
+			id: 'variant',
+			test: () => noop,
+		},
+	],
+};

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -75,7 +75,9 @@
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../projects/commercial/modules/dfp/get-advert-by-id.ts",
   "../projects/commercial/modules/dfp/load-advert.ts",
-  "../projects/commercial/modules/header-bidding/utils.ts"
+  "../projects/commercial/modules/header-bidding/utils.ts",
+  "../projects/common/modules/experiments/ab.ts",
+  "../projects/common/modules/experiments/tests/confiant-sdk-update.ts"
  ],
  "../projects/commercial/modules/article-aside-adverts.ts": [
   "../lib/$$.ts",
@@ -684,6 +686,7 @@
  ],
  "../projects/common/modules/experiments/ab-tests.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
+  "../projects/common/modules/experiments/tests/confiant-sdk-update.ts",
   "../projects/common/modules/experiments/tests/consentlessAds.ts",
   "../projects/common/modules/experiments/tests/deeply-read-article-footer.js",
   "../projects/common/modules/experiments/tests/integrate-ima.ts",
@@ -714,6 +717,10 @@
   "../projects/common/modules/experiments/ab-utils.ts"
  ],
  "../projects/common/modules/experiments/automatLog.ts": [],
+ "../projects/common/modules/experiments/tests/confiant-sdk-update.ts": [
+  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
+  "../lib/noop.ts"
+ ],
  "../projects/common/modules/experiments/tests/consentlessAds.ts": [
   "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
   "../lib/noop.ts"


### PR DESCRIPTION
## What does this change?
Adds an ab test with an update to the Confiant SDK, we need to be able to send the Confiant team a test to verify it is working as expected.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes https://github.com/guardian/dotcom-rendering/pull/6113


## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
