### PR TITLE
Dblatcher/suppress holidays consent in signup journey

### DIFF
--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -50,7 +50,7 @@
                     The conditional for special casing 'holidays' can be removed after the Identity data source is
                     re-released without 'holidays' in the data.
                 */ }
-                @if(!isChannel(consentField) && !isProduct(consentField)) {
+                @if(!isChannel(consentField) && !isProduct(consentField) && !isHolidays(consentField)) {
                     @if(index == 0) {
                         <li>
                             @fragments.consentSwitch(consentField, consentHint, skin = skin)(messages)

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -43,7 +43,7 @@
             <ul>
             @helper.repeatWithIndex(forms.privacyForm("consents"), min = 1) { (consentField, index) =>
                 @{ /*
-                    Temporary fix - the 'HOLIDAYS' marketing email is going to be replaced, so we don't want to include it
+                    Temporary fix - the 'holidays' marketing email is going to be replaced, so we don't want to include it
                     on the list inviting new users to sign-up for it.
                     But, the consentOption for holidays cannot be removed from the data source in Identity as we need to
                     render the option to unsubscribe on the 'manage you account' page.

--- a/identity/app/views/consentJourney.scala.html
+++ b/identity/app/views/consentJourney.scala.html
@@ -42,6 +42,14 @@
         <div class="manage-account__switches manage-account__switches--single-column">
             <ul>
             @helper.repeatWithIndex(forms.privacyForm("consents"), min = 1) { (consentField, index) =>
+                @{ /*
+                    Temporary fix - the 'HOLIDAYS' marketing email is going to be replaced, so we don't want to include it
+                    on the list inviting new users to sign-up for it.
+                    But, the consentOption for holidays cannot be removed from the data source in Identity as we need to
+                    render the option to unsubscribe on the 'manage you account' page.
+                    The conditional for special casing 'holidays' can be removed after the Identity data source is
+                    re-released without 'holidays' in the data.
+                */ }
                 @if(!isChannel(consentField) && !isProduct(consentField)) {
                     @if(index == 0) {
                         <li>

--- a/identity/app/views/support/fragment/ConsentChannel.scala
+++ b/identity/app/views/support/fragment/ConsentChannel.scala
@@ -73,4 +73,8 @@ object ConsentChannel {
   def isProduct(consentField: Field): Boolean = {
     consentField("id").value.exists { id => productIds.contains(id) }
   }
+
+  def isHolidays(consentField: Field): Boolean = {
+    consentField("id").value.exists { id => id == Consent.Holidays.id }
+  }
 }


### PR DESCRIPTION
## What does this change?
Removes "Guardian Holidays" from the list of products new users are invited to consent to emails for on /consents/thank-you.
The marketing emails for "Guardian Holidays" are being replaced with a new editorial newsletter "Guardian Traveller" see
https://github.com/guardian/identity/pull/2148 for details.

This is a temporary change to the frontend until the the data source in Identity can be re-released without the "Holidays" consent option, which cannot happen until after the marketing newsletter is replaced.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots



| Before      | After      |
|-------------|------------|
| <img width="949" alt="Screenshot 2022-10-05 at 14 13 16" src="https://user-images.githubusercontent.com/30567854/194068895-246747a7-f920-462a-8ab5-92e9723d997f.png">| <img width="949" alt="Screenshot 2022-10-05 at 14 12 12" src="https://user-images.githubusercontent.com/30567854/194068929-990e4666-353b-43ea-9246-485ccbece65d.png"> |


## What is the value of this and can you measure success?
Users will not be invited to subscribe to Guardian Holidays after it is discontinued, but before the  [update to Identity](https://github.com/guardian/identity/pull/2148) described above.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [x] Other (please specify)

Not directly affect by this PR, but a similar PR will be submitted for manage-frontend.

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
