### PR TITLE
add fixed/video comment to unsupported facia containers

### DIFF
--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -47,6 +47,11 @@ object FrontChecks {
       pending https://github.com/guardian/dotcom-rendering/issues/5782
        */
 
+      /*
+    "fixed/video"
+      pending https://github.com/guardian/dotcom-rendering/issues/5149
+       */
+
       "dynamic/slow",
       "fixed/small/slow-I",
       "fixed/small/slow-III",


### PR DESCRIPTION
## What does this change?

Adds the unsupported `fixed/video` container type as a comment as I was searching for it and couldn't find it.
 
Points to this issue: https://github.com/guardian/dotcom-rendering/issues/5149

