### PR TITLE
Use `buildPageTargeting` from commercial core

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/appnexus.ts
@@ -1,5 +1,5 @@
+import type { PageTargeting } from '@guardian/commercial-core';
 import config from '../../../../../lib/config';
-import type { PageTargeting } from '../../../../common/modules/commercial/build-page-targeting';
 import { buildAppNexusTargetingObject } from '../../../../common/modules/commercial/build-page-targeting';
 import { isInAuOrNz } from '../../../../common/modules/commercial/geo-utils';
 import {

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.spec.ts
@@ -1,5 +1,5 @@
 import { createAdSize } from '@guardian/commercial-core';
-import type { PageTargeting } from 'common/modules/commercial/build-page-targeting';
+import type { PageTargeting } from '@guardian/commercial-core';
 import {
 	isInAuOrNz as isInAuOrNz_,
 	isInRow as isInRow_,

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/bid-config.ts
@@ -1,7 +1,7 @@
+import type { PageTargeting } from '@guardian/commercial-core';
 import { log } from '@guardian/libs';
 import config from '../../../../../lib/config';
 import { pbTestNameMap } from '../../../../../lib/url';
-import type { PageTargeting } from '../../../../common/modules/commercial/build-page-targeting';
 import {
 	buildAppNexusTargeting,
 	buildAppNexusTargetingObject,

--- a/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
+++ b/static/src/javascripts/projects/commercial/modules/header-bidding/prebid/prebid.ts
@@ -1,11 +1,10 @@
-import type { AdSize } from '@guardian/commercial-core';
+import type { AdSize, PageTargeting } from '@guardian/commercial-core';
 import { createAdSize, EventTimer } from '@guardian/commercial-core';
 import { PREBID_TIMEOUT } from '@guardian/commercial-core/dist/esm/constants';
 import { onConsent } from '@guardian/consent-management-platform';
 import type { Framework } from '@guardian/consent-management-platform/dist/types';
 import { isString, log } from '@guardian/libs';
 import type { Advert } from 'commercial/modules/dfp/Advert';
-import type { PageTargeting } from 'common/modules/commercial/build-page-targeting';
 import { getPageTargeting } from 'common/modules/commercial/build-page-targeting';
 import config from '../../../../../lib/config';
 import { dfpEnv } from '../../dfp/dfp-env';

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.spec.ts
@@ -2,11 +2,9 @@ import { cmp as cmp_ } from '@guardian/consent-management-platform';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import type { TCFv2ConsentState } from '@guardian/consent-management-platform/dist/types/tcfv2';
 import { setCookie, storage } from '@guardian/libs';
-import { getReferrer as getReferrer_ } from '../../../../lib/detect';
 import { getCountryCode as getCountryCode_ } from '../../../../lib/geolocation';
 import { getPrivacyFramework as getPrivacyFramework_ } from '../../../../lib/getPrivacyFramework';
 import { getSynchronousParticipations as getSynchronousParticipations_ } from '../experiments/ab';
-import { isUserLoggedIn as isUserLoggedIn_ } from '../identity/api';
 import { getPageTargeting } from './build-page-targeting';
 import { commercialFeatures } from './commercial-features';
 
@@ -14,10 +12,6 @@ const getSynchronousParticipations =
 	getSynchronousParticipations_ as jest.MockedFunction<
 		typeof getSynchronousParticipations_
 	>;
-const getReferrer = getReferrer_ as jest.MockedFunction<typeof getReferrer_>;
-const isUserLoggedIn = isUserLoggedIn_ as jest.MockedFunction<
-	typeof isUserLoggedIn_
->;
 const getCountryCode = getCountryCode_ as jest.MockedFunction<
 	typeof getCountryCode_
 >;
@@ -38,7 +32,6 @@ type UnknownFunc = (...args: unknown[]) => unknown;
 
 jest.mock('../../../../lib/config');
 jest.mock('../../../../lib/detect', () => ({
-	getReferrer: jest.fn(),
 	hasPushStateSupport: jest.fn(),
 }));
 jest.mock('../../../../lib/geolocation', () => ({
@@ -197,10 +190,9 @@ describe('Build Page Targeting', () => {
 
 		setCookie({ name: 'adtest', value: 'ng101' });
 
-		getReferrer.mockReturnValue('');
 		mockViewport(0, 0);
 
-		isUserLoggedIn.mockReturnValue(true);
+		setCookie({ name: 'GU_U', value: 'test' });
 
 		getSynchronousParticipations.mockReturnValue({
 			MtMaster: {
@@ -443,35 +435,37 @@ describe('Build Page Targeting', () => {
 
 	describe('Referrer', () => {
 		it('should set ref to Facebook', () => {
-			getReferrer.mockReturnValue(
+			jest.spyOn(document, 'referrer', 'get').mockReturnValue(
 				'https://www.facebook.com/feel-the-force',
 			);
 			expect(getPageTargeting(emptyConsent).ref).toEqual('facebook');
 		});
 
 		it('should set ref to Twitter', () => {
-			getReferrer.mockReturnValue(
+			jest.spyOn(document, 'referrer', 'get').mockReturnValue(
 				'https://t.co/you-must-unlearn-what-you-have-learned',
 			);
 			expect(getPageTargeting(emptyConsent).ref).toEqual('twitter');
 		});
 
 		it('should set ref to reddit', () => {
-			getReferrer.mockReturnValue(
+			jest.spyOn(document, 'referrer', 'get').mockReturnValue(
 				'https://www.reddit.com/its-not-my-fault',
 			);
 			expect(getPageTargeting(emptyConsent).ref).toEqual('reddit');
 		});
 
 		it('should set ref to google', () => {
-			getReferrer.mockReturnValue(
+			jest.spyOn(document, 'referrer', 'get').mockReturnValue(
 				'https://www.google.com/i-find-your-lack-of-faith-distrubing',
 			);
 			expect(getPageTargeting(emptyConsent).ref).toEqual('google');
 		});
 
 		it('should set ref empty string if referrer does not match', () => {
-			getReferrer.mockReturnValue('https://theguardian.com');
+			jest.spyOn(document, 'referrer', 'get').mockReturnValue(
+				'https://theguardian.com',
+			);
 			expect(getPageTargeting(emptyConsent).ref).toEqual(undefined);
 		});
 	});

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.ts
@@ -1,29 +1,11 @@
-import type {
-	ContentTargeting,
-	SessionTargeting,
-	SharedTargeting,
-	ViewportTargeting,
-} from '@guardian/commercial-core';
-import {
-	getContentTargeting,
-	getPersonalisedTargeting,
-	getSessionTargeting,
-	getSharedTargeting,
-	getViewportTargeting,
-} from '@guardian/commercial-core';
-import { cmp } from '@guardian/consent-management-platform';
 import type { PageTargeting } from '@guardian/commercial-core';
+import { buildPageTargeting } from '@guardian/commercial-core';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
-import type { CountryCode } from '@guardian/libs';
-import { getCookie, isString, log } from '@guardian/libs';
+import { log } from '@guardian/libs';
 import { once } from 'lodash-es';
-import config from '../../../../lib/config';
-import { getReferrer as detectGetReferrer } from '../../../../lib/detect';
-import { getViewport } from '../../../../lib/detect-viewport';
 import { getCountryCode } from '../../../../lib/geolocation';
 import { removeFalseyValues } from '../../../commercial/modules/header-bidding/utils';
 import { getSynchronousParticipations } from '../experiments/ab';
-import { isUserLoggedIn } from '../identity/api';
 import { commercialFeatures } from './commercial-features';
 
 const formatAppNexusTargeting = (obj: Record<string, string | string[]>) => {
@@ -60,79 +42,15 @@ const buildAppNexusTargeting = once((pageTargeting: PageTargeting): string =>
 	formatAppNexusTargeting(buildAppNexusTargetingObject(pageTargeting)),
 );
 
-const filterEmptyValues = (pageTargets: Record<string, unknown>) => {
-	const filtered: Record<string, string | string[]> = {};
-	for (const key in pageTargets) {
-		const value = pageTargets[key];
-		if (isString(value)) {
-			filtered[key] = value;
-		} else if (
-			Array.isArray(value) &&
-			value.length > 0 &&
-			value.every(isString)
-		) {
-			filtered[key] = value;
-		}
-	}
-	return filtered;
-};
-
 const getPageTargeting = (consentState: ConsentState): PageTargeting => {
 	const { page } = window.guardian.config;
-	const adFreeTargeting: PageTargeting = commercialFeatures.adFree
-		? { af: 't' }
-		: {};
 
-	const contentTargeting: ContentTargeting = getContentTargeting({
-		eligibleForDCR:
-			window.guardian.config.isDotcomRendering ||
-			config.get<boolean>('page.dcrCouldRender', false),
-		path: `/${page.pageId}`,
-		renderingPlatform: window.guardian.config.isDotcomRendering
-			? 'dotcom-rendering'
-			: 'dotcom-platform',
-		section: page.section,
-		sensitive: page.isSensitive,
-		videoLength: page.videoDuration,
-	});
-
-	const sessionTargeting: SessionTargeting = getSessionTargeting({
-		adTest: getCookie({ name: 'adtest', shouldMemoize: true }),
-		countryCode: getCountryCode(),
-		isSignedIn: isUserLoggedIn(),
-		pageViewId: window.guardian.config.ophan.pageViewId,
-		participations: {
-			clientSideParticipations: getSynchronousParticipations(),
-			serverSideParticipations: window.guardian.config.tests ?? {},
-		},
-		referrer: detectGetReferrer(),
-	});
-
-	const viewportTargeting: ViewportTargeting = getViewportTargeting({
-		viewPortWidth: getViewport().width,
-		cmpBannerWillShow:
-			!cmp.hasInitialised() || cmp.willShowPrivacyMessageSync(),
-	});
-
-	const sharedAdTargeting = page.sharedAdTargeting
-		? // asserting here as we can't import the type into global.d.ts
-		  getSharedTargeting(page.sharedAdTargeting as Partial<SharedTargeting>)
-		: {};
-
-	const personalisedTargeting = getPersonalisedTargeting(consentState);
-
-	const pageTargets: PageTargeting = {
-		...personalisedTargeting,
-		...sharedAdTargeting,
-		...adFreeTargeting,
-		...contentTargeting,
-		...sessionTargeting,
-		...viewportTargeting,
-	};
-
-	// filter out empty values
-	const pageTargeting: Record<string, string | string[]> =
-		filterEmptyValues(pageTargets);
+	const pageTargeting = buildPageTargeting(
+		consentState,
+		commercialFeatures.adFree,
+		getCountryCode(),
+		getSynchronousParticipations(),
+	);
 
 	// third-parties wish to access our page targeting, before the googletag script is loaded.
 	page.appNexusPageTargeting = buildAppNexusTargeting(pageTargeting);

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.ts
@@ -12,6 +12,7 @@ import {
 	getViewportTargeting,
 } from '@guardian/commercial-core';
 import { cmp } from '@guardian/consent-management-platform';
+import type { PageTargeting } from '@guardian/commercial-core';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import type { CountryCode } from '@guardian/libs';
 import { getCookie, isString, log } from '@guardian/libs';
@@ -24,75 +25,6 @@ import { removeFalseyValues } from '../../../commercial/modules/header-bidding/u
 import { getSynchronousParticipations } from '../experiments/ab';
 import { isUserLoggedIn } from '../identity/api';
 import { commercialFeatures } from './commercial-features';
-
-// https://admanager.google.com/59666047#inventory/custom_targeting/list
-
-type TrueOrFalse = 't' | 'f';
-
-type PartialWithNulls<T> = { [P in keyof T]?: T[P] | null };
-
-const frequency = [
-	'0',
-	'1',
-	'2',
-	'3',
-	'4',
-	'5',
-	'6-9',
-	'10-15',
-	'16-19',
-	'20-29',
-	'30plus',
-] as const;
-
-const adManagerGroups = [
-	'1',
-	'2',
-	'3',
-	'4',
-	'5',
-	'6',
-	'7',
-	'8',
-	'9',
-	'10',
-	'11',
-	'12',
-] as const;
-
-type Frequency = typeof frequency[number];
-type AdManagerGroup = typeof adManagerGroups[number];
-
-export type PageTargeting = PartialWithNulls<
-	{
-		ab: string[];
-		af: 't'; // Ad Free
-		amtgrp: AdManagerGroup;
-		at: string; // Ad Test
-		bp: 'mobile' | 'tablet' | 'desktop'; // BreakPoint
-		cc: CountryCode; // Country Code
-		cmp_interaction: string;
-		consent_tcfv2: string;
-		dcre: TrueOrFalse; // DotCom-Rendering Eligible
-		fr: Frequency; // FRequency
-		inskin: TrueOrFalse; // InSkin
-		pa: TrueOrFalse; // Personalised Ads consent
-		permutive: string[]; // predefined segment values
-		pv: string; // ophan Page View id
-		rdp: string;
-		ref: string; // REFerrer
-		rp: 'dotcom-rendering' | 'dotcom-platform'; // Rendering Platform
-		s: string; // site Section
-		sens: TrueOrFalse; // SenSitive
-		si: TrueOrFalse; // Signed In
-		skinsize: 'l' | 's';
-		urlkw: string[]; // URL KeyWords
-		vl: string; // Video Length
-
-		// And more
-		[_: string]: string | string[];
-	} & SharedTargeting
->;
 
 const formatAppNexusTargeting = (obj: Record<string, string | string[]>) => {
 	const asKeyValues = Object.entries(obj).map((entry) => {

--- a/static/src/javascripts/types/global.d.ts
+++ b/static/src/javascripts/types/global.d.ts
@@ -58,7 +58,7 @@ interface CommercialPageConfig {
 	adUnit: AdUnit;
 	appNexusPageTargeting?: string;
 	sharedAdTargeting?: Record<string, string | string[]>;
-	pageAdTargeting?: Record<string, string | string[]>;
+	pageAdTargeting?: PageTargeting;
 	dfpAccountId: string;
 }
 


### PR DESCRIPTION
## What does this change?

Use `buildPageTargeting` from commercial-core

Follows on from https://github.com/guardian/commercial-core/pull/686

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (non-blocker - this will be done next)

## What is the value of this and can you measure success?

Less commercial code in frontend, better consistency between frontend and DCR.

### Tested

- [x] Locally
- [x] On CODE (TODO)