### PR TITLE
Use outline instead of border in spacefinder debug mode

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -252,7 +252,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 				const isLastInline = i === paras.length - 1;
 
 				if (sfdebug == '1' || sfdebug == '2') {
-					para.style.cssText += 'border: thick solid green;';
+					para.style.cssText += 'outline: thick solid green;';
 				}
 
 				let containerClasses = '';


### PR DESCRIPTION
## What does this change?
Uses outline instead of border in spacefinder debug mode

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?
Prevents layout shift and changing ad positions caused by the borders in spacefinder debug mode.

## Checklist

### Tested

- [X] Locally
- [ ] On CODE (optional)
