### PR TITLE
Advert.ts cleanup

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.spec.ts
@@ -5,7 +5,7 @@ import { init } from './article-body-adverts';
 const ads = {
 	'dfp-ad--im': true,
 } as const;
-jest.mock('./dfp/track-ad-render', () => (id: keyof typeof ads) => {
+jest.mock('./dfp/wait-for-advert', () => (id: keyof typeof ads) => {
 	return Promise.resolve(ads[id]);
 });
 jest.mock('./dfp/add-slot', () => ({

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -14,7 +14,7 @@ import type {
 } from '../../common/modules/spacefinder';
 import { initCarrot } from './carrot-traffic-driver';
 import { addSlot } from './dfp/add-slot';
-import { trackAdRender } from './dfp/track-ad-render';
+import { waitForAdvert } from './dfp/wait-for-advert';
 import { computeStickyHeights, insertHeightStyles } from './sticky-inlines';
 
 type SlotName = Parameters<typeof createAdSlot>[0];
@@ -424,7 +424,7 @@ const doInit = async (): Promise<boolean> => {
 		? attemptToAddInlineMerchAd()
 		: Promise.resolve(false);
 	const inlineMerchAdded = await im;
-	if (inlineMerchAdded) await trackAdRender('dfp-ad--im');
+	if (inlineMerchAdded) await waitForAdvert('dfp-ad--im');
 	await addInlineAds();
 	await initCarrot();
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.spec.ts
@@ -26,7 +26,7 @@ type MockCommercialCore = {
 	slotSizeMappings: Record<string, unknown>;
 };
 
-const { filterClasses, getSlotSizeMapping } = _;
+const { getSlotSizeMapping } = _;
 
 jest.mock('../../../../lib/raven');
 jest.mock('ophan/ng', () => null);
@@ -42,33 +42,6 @@ jest.mock('@guardian/commercial-core', (): MockCommercialCore => {
 			...slots,
 		},
 	};
-});
-describe('Filter classes', () => {
-	it('should return nil for empty class lists', () => {
-		const result = filterClasses([], []);
-		expect(result.length).toBe(0);
-	});
-
-	it('should return one class to be removed', () => {
-		const result = filterClasses(['old-class'], []);
-		expect(result.length).toBe(1);
-		expect(result).toContain('old-class');
-	});
-
-	it('should return nil classes to be removed', () => {
-		const result = filterClasses([], ['new-class']);
-		expect(result.length).toBe(0);
-	});
-
-	it('should remove two unused classes', () => {
-		const result = filterClasses(
-			['old-class', 'old-class-2', 'old-class-3'],
-			['old-class-2'],
-		);
-		expect(result.length).toBe(2);
-		expect(result).toContain('old-class');
-		expect(result).toContain('old-class-3');
-	});
 });
 
 describe('Advert', () => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -106,8 +106,8 @@ class Advert {
 	}
 
 	/**
-	 * Update the "extra" classes for this slot e.g. `ad-slot--outstream`, so that the main one's
-	 * like `ad-slot` etc. are not affected
+	 * Update the "extra" classes for this slot e.g. `ad-slot--outstream`, so that the base classes
+	 * like `ad-slot` etc. are never removed
 	 *
 	 * @param newClasses An array of classes to set on the slot
 	 **/

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -8,18 +8,6 @@ import { breakpoints } from '../../../../lib/detect';
 import { breakpointNameToAttribute } from './breakpoint-name-to-attribute';
 import { buildGoogletagSizeMapping, defineSlot } from './define-slot';
 
-type Resolver = (x: boolean) => void;
-
-type Timings = {
-	createTime: number | null;
-	startLoading: number | null;
-	stopLoading: number | null;
-	startRendering: number | null;
-	stopRendering: number | null;
-	loadingMethod: number | null;
-	lazyWaitComplete: number | null;
-};
-
 const stringToTuple = (size: string): AdSizeTuple => {
 	const dimensions = size.split(',', 2).map(Number);
 
@@ -89,21 +77,8 @@ class Advert {
 	isLoaded = false;
 	isRendered = false;
 	shouldRefresh = false;
-	whenLoaded: Promise<boolean>;
-	whenLoadedResolver: Resolver | null = null;
-	whenRendered: Promise<boolean>;
-	whenRenderedResolver: Resolver | null = null;
 	whenSlotReady: Promise<void>;
 	extraNodeClasses: string[] = [];
-	timings: Timings = {
-		createTime: null,
-		startLoading: null,
-		stopLoading: null,
-		startRendering: null,
-		stopRendering: null,
-		loadingMethod: null,
-		lazyWaitComplete: null,
-	};
 	hasPrebidSize = false;
 	lineItemId: number | null = null;
 
@@ -119,20 +94,6 @@ class Advert {
 
 		this.slot = slotDefinition.slot;
 		this.whenSlotReady = slotDefinition.slotReady;
-
-		this.whenLoaded = new Promise((resolve: Resolver) => {
-			this.whenLoadedResolver = resolve;
-		}).then((isLoaded: boolean): boolean => {
-			this.isLoaded = isLoaded;
-			return isLoaded;
-		});
-
-		this.whenRendered = new Promise((resolve: Resolver) => {
-			this.whenRenderedResolver = resolve;
-		}).then((isRendered) => {
-			this.isRendered = isRendered;
-			return isRendered;
-		});
 	}
 
 	static filterClasses = (
@@ -140,31 +101,6 @@ class Advert {
 		newClasses: string[],
 	): string[] =>
 		oldClasses.filter((oldClass) => !newClasses.includes(oldClass));
-
-	startLoading(): void {
-		this.isLoading = true;
-		this.timings.startLoading = window.performance.now();
-	}
-
-	stopLoading(isLoaded: boolean): void {
-		this.isLoading = false;
-		if (this.whenLoadedResolver) {
-			this.whenLoadedResolver(isLoaded);
-		}
-		this.timings.stopLoading = window.performance.now();
-	}
-
-	startRendering(): void {
-		this.isRendering = true;
-		this.timings.startRendering = window.performance.now();
-	}
-
-	stopRendering(isRendered: boolean): void {
-		this.isRendering = false;
-		if (this.whenRenderedResolver) {
-			this.whenRenderedResolver(isRendered);
-		}
-	}
 
 	updateExtraSlotClasses(...newClasses: string[]): void {
 		const classesToRemove = Advert.filterClasses(

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -107,9 +107,8 @@ class Advert {
 			this.extraNodeClasses,
 			newClasses,
 		);
-		// IE11 does not support multiple arguments to classList.add/remove so do these one-by-ones
-		classesToRemove.forEach((cls) => this.node.classList.remove(cls));
-		newClasses.forEach((cls) => this.node.classList.add(cls));
+		this.node.classList.remove(...classesToRemove);
+		this.node.classList.add(...newClasses);
 		this.extraNodeClasses = newClasses;
 	}
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -111,8 +111,8 @@ class Advert {
 		void fastdom.mutate(() => {
 			this.node.classList.remove(...classesToRemove);
 			this.node.classList.add(...newClasses);
+			this.extraNodeClasses = newClasses;
 		});
-		this.extraNodeClasses = newClasses;
 	}
 
 	/**

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -5,6 +5,7 @@ import {
 } from '@guardian/commercial-core';
 import type { AdSize, SizeMapping, SlotName } from '@guardian/commercial-core';
 import { breakpoints } from '../../../../lib/detect';
+import fastdom from '../../../../lib/fastdom-promise';
 import { breakpointNameToAttribute } from './breakpoint-name-to-attribute';
 import { buildGoogletagSizeMapping, defineSlot } from './define-slot';
 
@@ -107,8 +108,11 @@ class Advert {
 			this.extraNodeClasses,
 			newClasses,
 		);
-		this.node.classList.remove(...classesToRemove);
-		this.node.classList.add(...newClasses);
+
+		void fastdom.mutate(() => {
+			this.node.classList.remove(...classesToRemove);
+			this.node.classList.add(...newClasses);
+		});
 		this.extraNodeClasses = newClasses;
 	}
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -95,6 +95,17 @@ class Advert {
 	}
 
 	/**
+	 * Call this method once the ad has been rendered, it will set the
+	 * `isRendered` flag to true, which is used to determine whether to load
+	 * or refresh the ad
+	 *
+	 * @param isRendered was an advert rendered
+	 */
+	finishedRendering(isRendered: boolean): void {
+		this.isRendered = isRendered;
+	}
+
+	/**
 	 * Update the "extra" classes for this slot e.g. `ad-slot--outstream`, so that the main one's
 	 * like `ad-slot` etc. are not affected
 	 *

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -111,16 +111,17 @@ class Advert {
 	 *
 	 * @param newClasses An array of classes to set on the slot
 	 **/
-	updateExtraSlotClasses(...newClasses: string[]): void {
+	async updateExtraSlotClasses(...newClasses: string[]): Promise<void> {
 		const classesToRemove = this.extraNodeClasses.filter(
 			(c) => !newClasses.includes(c),
 		);
 
-		void fastdom.mutate(() => {
+		await fastdom.mutate(() => {
 			this.node.classList.remove(...classesToRemove);
 			this.node.classList.add(...newClasses);
-			this.extraNodeClasses = newClasses;
 		});
+
+		this.extraNodeClasses = newClasses;
 	}
 
 	/**

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -73,9 +73,6 @@ class Advert {
 	size: AdSize | 'fluid' | null = null;
 	slot: googletag.Slot;
 	isEmpty: boolean | null = null;
-	isLoading = false;
-	isRendering = false;
-	isLoaded = false;
 	isRendered = false;
 	shouldRefresh = false;
 	whenSlotReady: Promise<void>;

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -97,16 +97,15 @@ class Advert {
 		this.whenSlotReady = slotDefinition.slotReady;
 	}
 
-	static filterClasses = (
-		oldClasses: string[],
-		newClasses: string[],
-	): string[] =>
-		oldClasses.filter((oldClass) => !newClasses.includes(oldClass));
-
+	/**
+	 * Update the "extra" classes for this slot e.g. `ad-slot--outstream`, so that the main one's
+	 * like `ad-slot` etc. are not affected
+	 *
+	 * @param newClasses An array of classes to set on the slot
+	 **/
 	updateExtraSlotClasses(...newClasses: string[]): void {
-		const classesToRemove = Advert.filterClasses(
-			this.extraNodeClasses,
-			newClasses,
+		const classesToRemove = this.extraNodeClasses.filter(
+			(c) => !newClasses.includes(c),
 		);
 
 		void fastdom.mutate(() => {
@@ -175,6 +174,5 @@ class Advert {
 export { Advert };
 
 export const _ = {
-	filterClasses: Advert.filterClasses,
 	getSlotSizeMapping,
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/load-advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/load-advert.ts
@@ -42,7 +42,6 @@ export const loadAdvert = (advert: Advert): void => {
 		})
 		.then(() => {
 			eventTimer.trigger('slotReady', adName);
-			advert.startLoading();
 			return Promise.all([
 				prebid.requestBids(advert),
 				a9.requestBids(advert),

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.spec.ts
@@ -14,8 +14,6 @@ jest.mock('../../../../lib/raven');
 
 jest.mock('./empty-advert');
 
-// const renderAdvert = jest.fn().mockReturnValue(Promise.resolve(true));
-
 jest.mock('./render-advert', () => ({
 	renderAdvert: jest.fn().mockReturnValue(Promise.resolve(true)),
 }));
@@ -35,7 +33,6 @@ describe('onSlotRender', () => {
 		};
 		// @ts-expect-error - we are mocking the function
 		onSlotRender(event);
-		// expect(advert.finishedRendering).toBeCalledWith(true);
 	});
 
 	it('if not rendered call set call finishedRendering on the advert', () => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.spec.ts
@@ -1,0 +1,55 @@
+import type { Advert } from './Advert';
+import { onSlotRender } from './on-slot-render';
+
+let advert: Partial<Advert>;
+
+const baseEvent = {
+	isEmpty: false,
+	slot: {
+		getSlotElementId: jest.fn().mockReturnValue('dfp-ad--top-above-nav'),
+	},
+};
+
+jest.mock('../../../../lib/raven');
+
+jest.mock('./empty-advert');
+
+// const renderAdvert = jest.fn().mockReturnValue(Promise.resolve(true));
+
+jest.mock('./render-advert', () => ({
+	renderAdvert: jest.fn().mockReturnValue(Promise.resolve(true)),
+}));
+
+jest.mock('./get-advert-by-id', () => ({
+	getAdvertById: jest.fn().mockImplementation(() => advert),
+}));
+
+describe('onSlotRender', () => {
+	it('if rendered call set call finishedRendering on the advert', () => {
+		const event = { ...baseEvent, size: [300, 250], isEmpty: false };
+		advert = {
+			id: 'dfp-ad--top-above-nav',
+			finishedRendering: (isRendered: boolean) => {
+				expect(isRendered).toBe(true);
+			},
+		};
+		// @ts-expect-error - we are mocking the function
+		onSlotRender(event);
+		// expect(advert.finishedRendering).toBeCalledWith(true);
+	});
+
+	it('if not rendered call set call finishedRendering on the advert', () => {
+		const event = {
+			...baseEvent,
+			isEmpty: true,
+		};
+		advert = {
+			id: 'dfp-ad--top-above-nav',
+			finishedRendering: (isRendered: boolean) => {
+				expect(isRendered).toBe(false);
+			},
+		};
+		// @ts-expect-error - we are mocking the function
+		onSlotRender(event);
+	});
+});

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.ts
@@ -50,7 +50,8 @@ export const onSlotRender = (
 		return;
 	}
 
-	const emitRenderEvents = () => {
+	const emitRenderEvents = (isRendered: boolean) => {
+		advert.finishedRendering(isRendered);
 		mediator.emit('modules:commercial:dfp:rendered', event);
 	};
 
@@ -59,7 +60,7 @@ export const onSlotRender = (
 	if (event.isEmpty) {
 		emptyAdvert(advert);
 		reportEmptyResponse(advert.id, event);
-		emitRenderEvents();
+		emitRenderEvents(false);
 	} else {
 		/**
 		 * if advert.hasPrebidSize is false we use size

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.ts
@@ -50,7 +50,7 @@ export const onSlotRender = (
 		return;
 	}
 
-	const emitRenderEvents = (isRendered: boolean) => {
+	const emitRenderEvents = () => {
 		mediator.emit('modules:commercial:dfp:rendered', event);
 	};
 
@@ -59,7 +59,7 @@ export const onSlotRender = (
 	if (event.isEmpty) {
 		emptyAdvert(advert);
 		reportEmptyResponse(advert.id, event);
-		emitRenderEvents(false);
+		emitRenderEvents();
 	} else {
 		/**
 		 * if advert.hasPrebidSize is false we use size

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.ts
@@ -51,12 +51,9 @@ export const onSlotRender = (
 	}
 
 	const emitRenderEvents = (isRendered: boolean) => {
-		advert.stopRendering(isRendered);
 		mediator.emit('modules:commercial:dfp:rendered', event);
 	};
 
-	advert.stopLoading(true);
-	advert.startRendering();
 	advert.isEmpty = event.isEmpty;
 
 	if (event.isEmpty) {

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.ts
@@ -71,39 +71,25 @@ sizeCallbacks[adSizes.fluid.toString()] = (advert: Advert) =>
 	);
 
 sizeCallbacks[adSizes.mpu.toString()] = (advert: Advert): Promise<void> =>
-	fastdom.mutate(() => {
-		advert.updateExtraSlotClasses();
-	});
+	advert.updateExtraSlotClasses();
 
 sizeCallbacks[adSizes.halfPage.toString()] = (advert: Advert) =>
-	fastdom.mutate(() => {
-		advert.updateExtraSlotClasses();
-	});
+	advert.updateExtraSlotClasses();
 
 sizeCallbacks[adSizes.skyscraper.toString()] = (advert: Advert) =>
-	fastdom.mutate(() => {
-		advert.updateExtraSlotClasses('ad-slot--sky');
-	});
+	advert.updateExtraSlotClasses('ad-slot--sky');
 
 sizeCallbacks[adSizes.outstreamDesktop.toString()] = (advert: Advert) =>
-	fastdom.mutate(() => {
-		advert.updateExtraSlotClasses('ad-slot--outstream');
-	});
+	advert.updateExtraSlotClasses('ad-slot--outstream');
 
 sizeCallbacks[adSizes.outstreamGoogleDesktop.toString()] = (advert: Advert) =>
-	fastdom.mutate(() => {
-		advert.updateExtraSlotClasses('ad-slot--outstream');
-	});
+	advert.updateExtraSlotClasses('ad-slot--outstream');
 
 sizeCallbacks[adSizes.outstreamMobile.toString()] = (advert: Advert) =>
-	fastdom.mutate(() => {
-		advert.updateExtraSlotClasses('ad-slot--outstream');
-	});
+	advert.updateExtraSlotClasses('ad-slot--outstream');
 
 sizeCallbacks[adSizes.googleCard.toString()] = (advert: Advert) =>
-	fastdom.mutate(() => {
-		advert.updateExtraSlotClasses('ad-slot--gc');
-	});
+	advert.updateExtraSlotClasses('ad-slot--gc');
 
 /**
  * Out of page adverts - creatives that aren't directly shown on the page - need to be hidden,
@@ -183,9 +169,7 @@ export const renderAdvert = (
 					return Promise.resolve(
 						sizeCallback !== undefined
 							? sizeCallback(advert, slotRenderEndedEvent)
-							: fastdom.mutate(() => {
-									advert.updateExtraSlotClasses();
-							  }),
+							: advert.updateExtraSlotClasses(),
 					);
 				}
 				return Promise.resolve();

--- a/static/src/javascripts/projects/commercial/modules/dfp/track-ad-render.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/track-ad-render.ts
@@ -1,4 +1,0 @@
-import { waitForAdvert } from './wait-for-advert';
-
-export const trackAdRender = (id: string): Promise<boolean> =>
-	waitForAdvert(id).then((advert) => advert.whenRendered);

--- a/static/src/javascripts/projects/common/modules/spacefinder.spec.js
+++ b/static/src/javascripts/projects/common/modules/spacefinder.spec.js
@@ -1,6 +1,6 @@
 import { _ } from 'common/modules/spacefinder';
 
-jest.mock('commercial/modules/dfp/track-ad-render', () =>
+jest.mock('commercial/modules/dfp/wait-for-advert', () =>
     Promise.resolve(true)
 );
 jest.mock('ophan/ng', () => null);

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -93,7 +93,7 @@
   "../lib/url.ts",
   "../projects/commercial/modules/carrot-traffic-driver.ts",
   "../projects/commercial/modules/dfp/add-slot.ts",
-  "../projects/commercial/modules/dfp/track-ad-render.ts",
+  "../projects/commercial/modules/dfp/wait-for-advert.ts",
   "../projects/commercial/modules/sticky-inlines.ts",
   "../projects/common/modules/article/space-filler.ts",
   "../projects/common/modules/commercial/commercial-features.ts",
@@ -383,9 +383,6 @@
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../projects/commercial/modules/dfp/Advert.ts"
- ],
- "../projects/commercial/modules/dfp/track-ad-render.ts": [
-  "../projects/commercial/modules/dfp/wait-for-advert.ts"
  ],
  "../projects/commercial/modules/dfp/wait-for-advert.ts": [
   "../../../../node_modules/@types/lodash-es/index.d.ts",

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -176,6 +176,7 @@
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../lib/detect.js",
+  "../lib/fastdom-promise.js",
   "../projects/commercial/modules/dfp/breakpoint-name-to-attribute.ts",
   "../projects/commercial/modules/dfp/define-slot.ts"
  ],


### PR DESCRIPTION
## What does this change?

- Removes some old timing stuff that was left behind when the rest of it's functionality was removed in #20745
- remove an IE11 fallback
- Make `updateExtraSlotClasses a bit clearer with a comment
- remove `filterClasses` and it's test and inlined it, it's just an array intersection, and makes more sense inline, but happy to revert.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
