### PR TITLE
add lastmodified field to news and video sitemaps

### DIFF
--- a/applications/app/services/NewsSiteMap.scala
+++ b/applications/app/services/NewsSiteMap.scala
@@ -29,11 +29,14 @@ class NewsSiteMap(contentApiClient: ContentApiClient) {
       genres: String,
       webPublicationDate: DateTime,
       imageUrl: String,
+      lastModified: DateTime,
   ) {
 
     def xml(): Elem = {
       <url>
         <loc>{location}</loc>
+        <lastmod>
+          {lastModified.withZone(DateTimeZone.UTC).toISODateTimeNoMillisString}</lastmod>
         <image:image>
           <image:loc>{imageUrl}</image:loc>
         </image:image>
@@ -61,7 +64,7 @@ class NewsSiteMap(contentApiClient: ContentApiClient) {
       .pageSize(200)
       .tag("-tone/sponsoredfeatures,-type/crossword,-extra/extra,-tone/advertisement-features")
       .orderBy("newest")
-      .showFields("headline")
+      .showFields("headline, lastModified")
       .showTags("all")
       .showReferences("all")
       .showElements("all")
@@ -106,6 +109,7 @@ class NewsSiteMap(contentApiClient: ContentApiClient) {
           genres = genres,
           webPublicationDate = item.trail.webPublicationDate,
           imageUrl = imageUrl,
+          lastModified = item.fields.lastModified,
         )
       }
 

--- a/applications/app/services/VideoSiteMap.scala
+++ b/applications/app/services/VideoSiteMap.scala
@@ -32,11 +32,14 @@ class VideoSiteMap(contentApiClient: ContentApiClient) {
       publication: DateTime,
       tags: Seq[String],
       category: String,
+      lastModified: DateTime,
   ) {
 
     def xml(): Elem = {
       <url>
         <loc>{location}</loc>
+        <lastmod>
+          {lastModified.withZone(DateTimeZone.UTC).toISODateTimeNoMillisString}</lastmod>
         <video:video>
           {thumbnail_loc.map(thumbnail => <video:thumbnail_loc>{thumbnail}</video:thumbnail_loc>).getOrElse(Nil)}
           <video:title>{title}</video:title>
@@ -61,7 +64,7 @@ class VideoSiteMap(contentApiClient: ContentApiClient) {
       .pageSize(200)
       .tag("type/video,-tone/sponsoredfeatures,-tone/advertisement-features")
       .orderBy("newest")
-      .showFields("headline")
+      .showFields("headline, lastModified")
       .showTags("all")
       .showReferences("all")
       .showElements("all")
@@ -104,6 +107,7 @@ class VideoSiteMap(contentApiClient: ContentApiClient) {
           publication = item.trail.webPublicationDate,
           tags = keywordTags ++ sectionTag,
           category = item.metadata.sectionId,
+          lastModified = item.fields.lastModified,
         )
       }
 


### PR DESCRIPTION
## What does this change?

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

Implementing solution for [this issue](https://github.com/guardian/frontend/issues/25557)

Verified the sitemaps using [this tool](https://www.xml-sitemaps.com/validate-xml-sitemap.html?op=validate-xml-sitemap&go=1&sitemapurl=https%3A%2F%2Fm.code.dev-theguardian.com%2Fsitemaps%2Fvideo.xml&submit=Validate+Sitemap) - both https://m.code.dev-theguardian.com/sitemaps/news.xml and https://m.code.dev-theguardian.com/sitemaps/video.xml are coming up green and correctly displaying the last modified field:

<img width="1105" alt="image" src="https://user-images.githubusercontent.com/102960844/194903884-21338ad4-d0ce-49d4-9c71-04380567d64f.png">


## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [X] Locally
- [X] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
