### PR TITLE
Remove `CommercialEndOfQuarterMegaTest`

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -10,7 +10,6 @@ object ActiveExperiments extends ExperimentsDefinition {
       DCRFronts,
       OfferHttp3,
       TableOfContents,
-      CommercialEndOfQuarterMegaTest,
       EuropeNetworkFront,
     )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
@@ -50,15 +49,6 @@ object TableOfContents
       owners = Seq(Owner.withName("journalism team")),
       sellByDate = LocalDate.of(2022, 12, 7),
       participationGroup = Perc0C,
-    )
-
-object CommercialEndOfQuarterMegaTest
-    extends Experiment(
-      name = "commercial-end-of-quarter-mega-test",
-      description = "Measure the revenue uplift of the various changes introduced by the commercial team in Q1",
-      owners = Seq(Owner.withGithub("commercial-dev")),
-      sellByDate = LocalDate.of(2022, 10, 10),
-      participationGroup = Perc10A,
     )
 
 object DCROnwardsData

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -223,13 +223,9 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 		(sfdebug === '1' && isInline1) || (sfdebug === '2' && !isInline1);
 
 	const insertAds: SpacefinderWriter = async (paras) => {
-		const tests = window.guardian.config.tests;
-		const isInMegaTestControlGroup =
-			tests && !!tests['commercialEndOfQuarterMegaTestControl'];
-
 		// Make ads sticky on the non-inline1 pass
 		// i.e. inline2, inline3, etc...
-		const isSticky = !isInline1 && !isInMegaTestControlGroup;
+		const isSticky = !isInline1;
 
 		if (isSticky) {
 			const stickyContainerHeights = await computeStickyHeights(

--- a/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/lazy-load.ts
@@ -1,4 +1,3 @@
-import { log } from '@guardian/libs';
 import { once } from 'lodash-es';
 import type { Advert } from './Advert';
 import { dfpEnv } from './dfp-env';
@@ -36,16 +35,9 @@ const onIntersect = (
 };
 
 const getObserver = once(() => {
-	const tests = window.guardian.config.tests;
-	const isInMegaTestControlGroup =
-		tests && !!tests['commercialEndOfQuarterMegaTestControl'];
-
-	const lazyLoadMargin = isInMegaTestControlGroup ? '200px' : '20%';
-	log('commercial', 'Using lazy load margin', lazyLoadMargin);
-
 	return Promise.resolve(
 		new window.IntersectionObserver(onIntersect, {
-			rootMargin: `${lazyLoadMargin} 0px`,
+			rootMargin: '20% 0px',
 		}),
 	);
 });

--- a/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
+++ b/static/src/javascripts/projects/common/modules/analytics/shouldCaptureMetrics.ts
@@ -7,8 +7,7 @@ const defaultClientSideTests: ABTest[] = [
 ];
 
 const serverSideTests: ServerSideABTest[] = [
-	'commercialEndOfQuarterMegaTestControl',
-	'commercialEndOfQuarterMegaTestVariant',
+	/* linter, please keep this array multi-line */
 ];
 
 /**

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -248,7 +248,6 @@
   "../projects/commercial/modules/dfp/dfp-env.ts"
  ],
  "../projects/commercial/modules/dfp/lazy-load.ts": [
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../../../../node_modules/@types/lodash-es/index.d.ts",
   "../projects/commercial/modules/dfp/Advert.ts",
   "../projects/commercial/modules/dfp/dfp-env.ts",


### PR DESCRIPTION
## What does this change?

Removes `CommercialEndOfQuarterMegaTest`

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes https://github.com/guardian/dotcom-rendering/pull/6156

## What is the value of this and can you measure success?

The test has concluded so we can safely remove this test now.

### Tested

- [ ] Locally
- [x] On CODE
