### PR TITLE
Fix ad stickiness being lost after dismissing the sign in gate

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -65,10 +65,6 @@ const wrapSlotInContainer = (
 
 	container.className = `${adSlotContainerClass} ${options.className ?? ''}`;
 
-	/*if (options.sticky) {
-		ad.style.cssText += 'position: sticky; top: 0;';
-	}*/
-
 	if (options.enableDebug) {
 		container.style.cssText += 'outline: 2px solid red;';
 	}

--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -65,9 +65,9 @@ const wrapSlotInContainer = (
 
 	container.className = `${adSlotContainerClass} ${options.className ?? ''}`;
 
-	if (options.sticky) {
+	/*if (options.sticky) {
 		ad.style.cssText += 'position: sticky; top: 0;';
-	}
+	}*/
 
 	if (options.enableDebug) {
 		container.style.cssText += 'outline: 2px solid red;';

--- a/static/src/javascripts/projects/commercial/modules/consentless/dynamic/article-inline.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/dynamic/article-inline.ts
@@ -18,7 +18,6 @@ import { defineSlot } from '../define-slot';
 type SlotName = Parameters<typeof createAdSlot>[0];
 
 type ContainerOptions = {
-	sticky?: boolean;
 	enableDebug?: boolean;
 	className?: string;
 };
@@ -51,10 +50,6 @@ const wrapSlotInContainer = (
 	const container = document.createElement('div');
 
 	container.className = `ad-slot-container ${options.className ?? ''}`;
-
-	if (options.sticky) {
-		ad.style.cssText += 'position: sticky; top: 0;';
-	}
 
 	if (options.enableDebug) {
 		container.style.cssText += 'outline: 2px solid red;';
@@ -182,7 +177,6 @@ const addDesktopInlineAds = async () => {
 
 		const slots = paras.map((para, i) => {
 			const inlineId = i + 1;
-			const makeContainerSticky = inlineId !== 1;
 
 			if (sfdebug) {
 				para.style.cssText += 'border: thick solid green;';
@@ -190,17 +184,12 @@ const addDesktopInlineAds = async () => {
 
 			let containerClasses = '';
 
-			if (makeContainerSticky) {
-				containerClasses += getStickyContainerClassname(i);
-			}
-
 			if (inlineId !== 1) {
 				containerClasses +=
 					' offset-right ad-slot--offset-right ad-slot-container--offset-right';
 			}
 
 			const containerOptions = {
-				sticky: makeContainerSticky,
 				className: containerClasses,
 				enableDebug,
 			};

--- a/static/src/javascripts/projects/commercial/modules/sticky-inlines.ts
+++ b/static/src/javascripts/projects/commercial/modules/sticky-inlines.ts
@@ -42,7 +42,8 @@ const insertHeightStyles = (
 	heightMapping: Array<[string, number]>,
 ): Promise<void> => {
 	const heightClasses = heightMapping.reduce(
-		(css, [name, height]) => `${css} .${name} { min-height: ${height}px; }`,
+		(css, [name, height]) =>
+			`${css} .${name} { min-height: ${height}px; } .${name} > * { position: sticky; top: 0; }`,
 		'',
 	);
 


### PR DESCRIPTION
## What does this change?
Fixes a bug where stickiness was sometimes removed from ads when the sign in gate was dismissed. Changes the way in which we apply the sticky style to ads so that the styling isn't removed upon the dismissal of the sign in gate.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [X] Locally
- [ ] On CODE (optional)