### PR TITLE
feat: override default styles for afternoon update thrasher form

### DIFF
--- a/static/src/stylesheets/module/email-signup/_form.scss
+++ b/static/src/stylesheets/module/email-signup/_form.scss
@@ -255,6 +255,7 @@
 
 .email-sub__form--thrasher-us-morning-newsletter,
 .email-sub__form--thrasher-morning-mail,
+.email-sub__form--thrasher-afternoon-update,
 .email-sub__form--thrasher-first-edition,
 .email-sub__form--thrasher-morning-briefing {
 


### PR DESCRIPTION
## What does this change?

Overrides styles for newsletter sign up label (white -> black) and submit button (white -> blue) for use in thrashers

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/43961396/195120643-8343a22f-1664-476a-ae34-b9c002963f35.png
[after]: https://user-images.githubusercontent.com/43961396/195120635-1fdd35d3-7053-4a29-ba27-4c102035dffd.png


### Tested

- [x] Locally
- [ ] On CODE (optional)


