### PR TITLE
Fix DCR Javascript Bundle experiment

### DIFF
--- a/common/app/experiments/Experiments.scala
+++ b/common/app/experiments/Experiments.scala
@@ -11,14 +11,15 @@ object ActiveExperiments extends ExperimentsDefinition {
       OfferHttp3,
       TableOfContents,
       EuropeNetworkFront,
+      DCRJavascriptBundle,
     )
   implicit val canCheckExperiment = new CanCheckExperiment(this)
 }
 
-object DCRJSBundleVariant
+object DCRJavascriptBundle
     extends Experiment(
-      name = "dcr-js-bundle-variant",
-      description = "DCR bundle experiment",
+      name = "dcr-javascript-bundle",
+      description = "DCR Javascript bundle experiment",
       owners = Seq(Owner.withGithub("guardian/dotcom-platform")),
       sellByDate = LocalDate.of(2024, 4, 1),
       participationGroup = Perc1A,


### PR DESCRIPTION
## What does this change?

Add the DCRJavascript to allExperiments.

Renamed the experiment, as using Variant un a test name
can lead to confusion, as we get the following:
-  DCRJSBundleVariantVariant
- DCRJSBundleVariantControl

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes https://github.com/guardian/dotcom-rendering/pull/6168

### Tested

- [ ] Locally
- [X] On CODE (optional)

<img width="904" alt="image" src="https://user-images.githubusercontent.com/76776/195315520-6966bd23-3950-4863-9a17-8f37da4a62be.png">