### PR TITLE
Support `nav/list` in FaciaPicker

### DIFF
--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -61,6 +61,7 @@ object FrontChecks {
       "fixed/medium/fast-XII",
       "fixed/large/slow-XIV",
       "fixed/large/slow-XIV",
+      "nav/list"
     )
 
   def allCollectionsAreSupported(faciaPage: PressedPage): Boolean = {

--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -61,7 +61,7 @@ object FrontChecks {
       "fixed/medium/fast-XII",
       "fixed/large/slow-XIV",
       "fixed/large/slow-XIV",
-      "nav/list"
+      "nav/list",
     )
 
   def allCollectionsAreSupported(faciaPage: PressedPage): Boolean = {


### PR DESCRIPTION
## What does this change?

Add `nav/list` to supported DCR containers. To be merged after https://github.com/guardian/dotcom-rendering/pull/6172

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes https://github.com/guardian/dotcom-rendering/pull/6172
