### PR TITLE
remove feature switch for newsletter signup page

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -492,14 +492,4 @@ trait FeatureSwitches {
     sellByDate = never,
     exposeClientSide = false,
   )
-
-  val NewsletterSignupLayout = Switch(
-    SwitchGroup.Feature,
-    "newsletter-signup-layout",
-    "When ON, we replace the standard article layout with the new signup layout for newsletter sign up pages",
-    owners = Seq(Owner.withEmail("newsletters.dev@guardian.co.uk")),
-    safeState = Off,
-    sellByDate = LocalDate.of(2022, 10, 14),
-    exposeClientSide = true,
-  )
 }


### PR DESCRIPTION
## What does this change?
Removes feature switch logic to determine whether to use the new NewsletterSignupLayout or not

### Why?
We're happy with the new NewsletterSignupLayout so can turn this feature on properly now

### Tested

- [x] Locally
- [ ] On CODE (optional)
