### PR TITLE
Seperate consentless ad label code

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/consentless/define-slot.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/define-slot.ts
@@ -1,4 +1,4 @@
-import { renderAdvertLabel } from '../dfp/render-advert-label';
+import { renderConsentlessAdvertLabel } from './render-advert-label';
 
 const defineSlot = (slotId: string, slotName: string): void => {
 	window.ootag.queue.push(() => {
@@ -9,7 +9,7 @@ const defineSlot = (slotId: string, slotName: string): void => {
 			filledCallback: () => {
 				const slotElement = document.getElementById(slotId);
 				if (slotElement) {
-					void renderAdvertLabel(slotElement);
+					void renderConsentlessAdvertLabel(slotElement);
 				}
 				console.log(`filled consentless ${slotId}`);
 			},

--- a/static/src/javascripts/projects/commercial/modules/consentless/render-advert-label.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/render-advert-label.spec.ts
@@ -1,0 +1,113 @@
+import { renderConsentlessAdvertLabel } from './render-advert-label';
+
+jest.mock('../../../../lib/detect', (): void => {
+	return;
+});
+jest.mock('../../../common/modules/commercial/commercial-features', () => ({
+	commercialFeatures: {},
+}));
+
+const adSelector = '.js-ad-slot';
+const labelSelector = '.ad-slot__label';
+
+const adverts: Record<string, string> = {
+	withLabel: `
+        <div class="js-ad-slot"></div>`,
+	labelDisabled: `
+        <div class="js-ad-slot" data-label="false"></div>`,
+	alreadyLabelled: `
+        <div class="js-ad-slot">
+            <div class="ad-slot__label">Advertisement</div>
+        </div>`,
+	frame: `
+        <div class="js-ad-slot ad-slot--frame"></div>`,
+	uh: `
+        <div class="js-ad-slot u-h"></div>`,
+	topAboveNav: `
+        <div class="js-ad-slot" id="dfp-ad--top-above-nav"></div>`,
+	topAboveNavToggleLabel: `
+        <div>
+            <div class="js-ad-slot" id="dfp-ad--top-above-nav">
+				<div class="ad-slot__label ad-slot__label--toggle hidden">Advertisement</div>
+			</div>
+        </div>`,
+};
+
+const createAd = (html: string) => {
+	document.body.innerHTML = html;
+};
+
+const getAd = (): HTMLElement =>
+	document.querySelector(adSelector) as HTMLElement;
+
+describe('Rendering advert labels', () => {
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	it('Can add a label', async () => {
+		createAd(adverts['withLabel']);
+		return renderConsentlessAdvertLabel(getAd()).then(() => {
+			const label = getAd().querySelector(labelSelector);
+			expect(label).not.toBeNull();
+		});
+	});
+
+	it('The label has a message', async () => {
+		createAd(adverts['withLabel']);
+		return renderConsentlessAdvertLabel(getAd()).then(() => {
+			const label = getAd().querySelector(labelSelector) as Element;
+			expect(label.textContent).toBe('Advertisement');
+		});
+	});
+
+	it('Will not add a label if it has an attribute data-label="false"', async () => {
+		createAd(adverts['labelDisabled']);
+		return renderConsentlessAdvertLabel(getAd()).then(() => {
+			const label = getAd().querySelector(labelSelector);
+			expect(label).toBeNull();
+		});
+	});
+
+	it('Will not add a label if the adSlot already has one', async () => {
+		createAd(adverts['alreadyLabelled']);
+		return renderConsentlessAdvertLabel(getAd()).then(() => {
+			const label = getAd().querySelectorAll(labelSelector);
+			expect(label.length).toBe(1);
+		});
+	});
+
+	it('Will not add a label to frame ads', async () => {
+		createAd(adverts['frame']);
+		return renderConsentlessAdvertLabel(getAd()).then(() => {
+			const label = getAd().querySelector(labelSelector);
+			expect(label).toBeNull();
+		});
+	});
+
+	it('Will not add a label to an ad slot with a hidden u-h class', async () => {
+		createAd(adverts['uh']);
+		return renderConsentlessAdvertLabel(getAd()).then(() => {
+			const label = getAd().querySelector(labelSelector);
+			expect(label).toBeNull();
+		});
+	});
+
+	it('When the ad is top above nav and the label is toggleable, make the label visible', async () => {
+		createAd(adverts['topAboveNavToggleLabel']);
+		return renderConsentlessAdvertLabel(getAd()).then(() => {
+			const adSlotLabel = getAd().querySelector(labelSelector);
+			expect(adSlotLabel).not.toBeNull();
+			const label = document.querySelector(labelSelector) as HTMLElement;
+			expect(label.classList.contains('visible')).toBe(true);
+		});
+	});
+
+	it('When the ad is top above nav and the label is NOT toggleable, render the label dynamically', async () => {
+		createAd(adverts['topAboveNav']);
+		return renderConsentlessAdvertLabel(getAd()).then(() => {
+			const label = getAd().querySelector(labelSelector) as HTMLElement;
+			expect(label.textContent).toEqual('Advertisement');
+		});
+	});
+});

--- a/static/src/javascripts/projects/commercial/modules/consentless/render-advert-label.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/render-advert-label.ts
@@ -1,0 +1,74 @@
+import fastdom from '../../../../lib/fastdom-promise';
+import { createAdLabel, shouldRenderLabel } from '../dfp/render-advert-label';
+
+// TODO: flesh out this function once we have a better idea of what we want it to look like
+// const insertConsentlessLabelInfo = (adLabelNode: HTMLElement): void => {
+// 	const consentlessLabelInfo = document.createElement('button');
+// 	consentlessLabelInfo.className = 'ad-slot__consentless-info u-button-reset';
+// 	consentlessLabelInfo.setAttribute(
+// 		'title',
+// 		`Because of your choice this advertising sets no cookies and doesn't track you.`,
+// 	);
+// 	consentlessLabelInfo.innerHTML = `Opt Out: Why am I seeing this?`;
+// 	adLabelNode.appendChild(consentlessLabelInfo);
+// };
+
+/**
+ *  **Dynamic labels:**
+ *  Advert labels are historically inserted dynamically as a child of the advert slot node.
+ *  This causes a cumulative layout shift (CLS) as content below is pushed down. This is
+ *  particularly noticeable when ads are refreshed as the advert slot contents are deleted.
+ *
+ *  **Toggled labels:**
+ *  To prevent CLS the label inserted on the server with its visibility initially hidden.
+ *  Its visibility and width is toggled once the ad and its width is known.
+ *  Currently only for dfp-ad--top-above-nav.
+ * @param {HTMLElement} adSlotNode
+ */
+export const renderConsentlessAdvertLabel = (
+	adSlotNode: HTMLElement,
+): Promise<Promise<void>> => {
+	let renderDynamic = true;
+	const shouldRender = shouldRenderLabel(adSlotNode);
+
+	// eslint-disable-next-line @typescript-eslint/no-misused-promises -- fastdom miss-typed
+	return fastdom.measure(async () => {
+		if (adSlotNode.id === 'dfp-ad--top-above-nav') {
+			const labelToggle = document.querySelector<HTMLElement>(
+				'.ad-slot__label.ad-slot__label--toggle',
+			);
+			// const adLabelNode =
+			// adSlotNode.querySelector<HTMLElement>('.ad-slot__label');
+
+			// if (adLabelNode) {
+			// insertConsentlessLabelInfo(adLabelNode);
+			// }
+
+			if (labelToggle) {
+				// found a toggled label so don't render dynamically
+				renderDynamic = false;
+				if (shouldRender) {
+					await fastdom.mutate(() => {
+						labelToggle.classList.remove('hidden');
+						labelToggle.classList.add('visible');
+					});
+				} else {
+					// some ads should not have a label
+					// for example fabric ads can have an embedded label
+					// so don't display and remove from layout
+					await fastdom.mutate(() => {
+						labelToggle.style.display = 'none';
+					});
+				}
+			}
+		}
+
+		if (renderDynamic && shouldRender) {
+			const adLabelNode = createAdLabel();
+			await fastdom.mutate(() => {
+				adSlotNode.prepend(adLabelNode);
+				// insertConsentlessLabelInfo(adLabelNode);
+			});
+		}
+	});
+};

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert-label.ts
@@ -6,7 +6,7 @@
 import crossIcon from 'svgs/icon/cross.svg';
 import fastdom from '../../../../lib/fastdom-promise';
 
-const shouldRenderLabel = (adSlotNode: HTMLElement) =>
+const shouldRenderLabel = (adSlotNode: HTMLElement): boolean =>
 	!(
 		adSlotNode.classList.contains('ad-slot--fluid') ||
 		adSlotNode.classList.contains('ad-slot--frame') ||
@@ -22,7 +22,7 @@ const shouldRenderLabel = (adSlotNode: HTMLElement) =>
 		).length
 	);
 
-const createAdCloseDiv = () => {
+const createAdCloseDiv = (): HTMLElement => {
 	const closeDiv: HTMLElement = document.createElement('button');
 	closeDiv.className = 'ad-slot__close-button';
 	closeDiv.innerHTML = crossIcon.markup;
@@ -35,7 +35,7 @@ const createAdCloseDiv = () => {
 	return closeDiv;
 };
 
-const createAdLabel = () => {
+const createAdLabel = (): HTMLElement => {
 	const adLabel = document.createElement('div');
 	adLabel.className = 'ad-slot__label';
 	adLabel.innerHTML = 'Advertisement';
@@ -55,9 +55,7 @@ const createAdLabel = () => {
  *  Currently only for dfp-ad--top-above-nav.
  * @param {HTMLElement} adSlotNode
  */
-export const renderAdvertLabel = (
-	adSlotNode: HTMLElement,
-): Promise<Promise<void>> => {
+const renderAdvertLabel = (adSlotNode: HTMLElement): Promise<Promise<void>> => {
 	let renderDynamic = true;
 	const shouldRender = shouldRenderLabel(adSlotNode);
 
@@ -94,9 +92,7 @@ export const renderAdvertLabel = (
 	});
 };
 
-export const renderInterscrollerAdLabel = (
-	adSlotNode: HTMLElement,
-): Promise<void> =>
+const renderInterscrollerAdLabel = (adSlotNode: HTMLElement): Promise<void> =>
 	fastdom.measure(() => {
 		const adSlotLabel: HTMLElement = document.createElement('div');
 		adSlotLabel.classList.add('ad-slot__label');
@@ -109,7 +105,7 @@ export const renderInterscrollerAdLabel = (
 		adSlotNode.appendChild(adSlotLabel);
 	});
 
-export const renderStickyScrollForMoreLabel = (
+const renderStickyScrollForMoreLabel = (
 	adSlotNode: HTMLElement,
 ): Promise<void> =>
 	fastdom.mutate(() => {
@@ -126,3 +122,12 @@ export const renderStickyScrollForMoreLabel = (
 		};
 		adSlotNode.appendChild(scrollForMoreLabel);
 	});
+
+export {
+	renderAdvertLabel,
+	renderInterscrollerAdLabel,
+	renderStickyScrollForMoreLabel,
+	shouldRenderLabel,
+	createAdCloseDiv,
+	createAdLabel,
+};

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -130,7 +130,7 @@
   "../projects/common/modules/commercial/commercial-features.ts"
  ],
  "../projects/commercial/modules/consentless/define-slot.ts": [
-  "../projects/commercial/modules/dfp/render-advert-label.ts"
+  "../projects/commercial/modules/consentless/render-advert-label.ts"
  ],
  "../projects/commercial/modules/consentless/dynamic/article-inline.ts": [
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
@@ -166,6 +166,10 @@
   "../lib/geolocation.ts",
   "../projects/common/modules/commercial/commercial-features.ts",
   "../projects/common/modules/experiments/ab.ts"
+ ],
+ "../projects/commercial/modules/consentless/render-advert-label.ts": [
+  "../lib/fastdom-promise.js",
+  "../projects/commercial/modules/dfp/render-advert-label.ts"
  ],
  "../projects/commercial/modules/creatives/page-skin.ts": [
   "../../../../node_modules/fastdom/fastdom.d.ts",


### PR DESCRIPTION
## What does this change?
Copy the ad label render code and lay the ground work for consentless ad labels with additional information.

Follow-up to this will be adding the actual info dropdown, we also need to think about how this will be hidden on narrow ad sizes.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
