### PR TITLE
Upgrade DFP API to use `v202208`

### DIFF
--- a/admin/app/dfp/AdUnitAgent.scala
+++ b/admin/app/dfp/AdUnitAgent.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202108.StatementBuilder
+import com.google.api.ads.admanager.axis.utils.v202208.StatementBuilder
 import common.dfp.GuAdUnit
 import conf.Configuration
 import ApiHelper.toSeq

--- a/admin/app/dfp/ApiHelper.scala
+++ b/admin/app/dfp/ApiHelper.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.v202108._
+import com.google.api.ads.admanager.axis.v202208._
 import common.GuLogging
 import org.joda.time.{DateTime => JodaDateTime, DateTimeZone}
 

--- a/admin/app/dfp/CustomFieldAgent.scala
+++ b/admin/app/dfp/CustomFieldAgent.scala
@@ -1,7 +1,7 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202108.StatementBuilder
-import com.google.api.ads.admanager.axis.v202108.{CustomFieldValue, LineItem, TextValue}
+import com.google.api.ads.admanager.axis.utils.v202208.StatementBuilder
+import com.google.api.ads.admanager.axis.v202208.{CustomFieldValue, LineItem, TextValue}
 import common.dfp.GuCustomField
 import concurrent.BlockingOperations
 

--- a/admin/app/dfp/CustomTargetingAgent.scala
+++ b/admin/app/dfp/CustomTargetingAgent.scala
@@ -1,7 +1,7 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202108.StatementBuilder
-import com.google.api.ads.admanager.axis.v202108.{CustomTargetingKey, CustomTargetingValue}
+import com.google.api.ads.admanager.axis.utils.v202208.StatementBuilder
+import com.google.api.ads.admanager.axis.v202208.{CustomTargetingKey, CustomTargetingValue}
 import common.GuLogging
 import common.dfp.{GuCustomTargeting, GuCustomTargetingValue}
 import concurrent.BlockingOperations

--- a/admin/app/dfp/DataMapper.scala
+++ b/admin/app/dfp/DataMapper.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.v202108._
+import com.google.api.ads.admanager.axis.v202208._
 import common.dfp._
 import dfp.ApiHelper.{isPageSkin, optJavaInt, toJodaTime, toSeq}
 

--- a/admin/app/dfp/DataValidation.scala
+++ b/admin/app/dfp/DataValidation.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.v202108._
+import com.google.api.ads.admanager.axis.v202208._
 import common.dfp._
 import dfp.ApiHelper.toSeq
 

--- a/admin/app/dfp/DfpApi.scala
+++ b/admin/app/dfp/DfpApi.scala
@@ -2,8 +2,8 @@ package dfp
 
 // StatementBuilder query language is PQL defined here:
 // https://developers.google.com/ad-manager/api/pqlreference
-import com.google.api.ads.admanager.axis.utils.v202108.StatementBuilder
-import com.google.api.ads.admanager.axis.v202108._
+import com.google.api.ads.admanager.axis.utils.v202208.StatementBuilder
+import com.google.api.ads.admanager.axis.v202208._
 import com.madgag.scala.collection.decorators.MapDecorator
 import common.GuLogging
 import common.dfp._

--- a/admin/app/dfp/PlacementAgent.scala
+++ b/admin/app/dfp/PlacementAgent.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202108.StatementBuilder
+import com.google.api.ads.admanager.axis.utils.v202208.StatementBuilder
 import common.dfp.GuAdUnit
 import concurrent.BlockingOperations
 

--- a/admin/app/dfp/Reader.scala
+++ b/admin/app/dfp/Reader.scala
@@ -1,8 +1,8 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202108.StatementBuilder
-import com.google.api.ads.admanager.axis.utils.v202108.StatementBuilder.SUGGESTED_PAGE_LIMIT
-import com.google.api.ads.admanager.axis.v202108._
+import com.google.api.ads.admanager.axis.utils.v202208.StatementBuilder
+import com.google.api.ads.admanager.axis.utils.v202208.StatementBuilder.SUGGESTED_PAGE_LIMIT
+import com.google.api.ads.admanager.axis.v202208._
 
 import scala.annotation.tailrec
 

--- a/admin/app/dfp/ServicesWrapper.scala
+++ b/admin/app/dfp/ServicesWrapper.scala
@@ -1,7 +1,7 @@
 package dfp
 
 import com.google.api.ads.admanager.axis.factory.AdManagerServices
-import com.google.api.ads.admanager.axis.v202108._
+import com.google.api.ads.admanager.axis.v202208._
 import com.google.api.ads.admanager.lib.client.AdManagerSession
 
 private[dfp] class ServicesWrapper(session: AdManagerSession) {

--- a/admin/app/dfp/SessionLogger.scala
+++ b/admin/app/dfp/SessionLogger.scala
@@ -1,7 +1,7 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202108.StatementBuilder
-import com.google.api.ads.admanager.axis.v202108._
+import com.google.api.ads.admanager.axis.utils.v202208.StatementBuilder
+import com.google.api.ads.admanager.axis.v202208._
 import common.GuLogging
 
 import scala.util.control.NonFatal

--- a/admin/app/dfp/SessionWrapper.scala
+++ b/admin/app/dfp/SessionWrapper.scala
@@ -2,8 +2,8 @@ package dfp
 
 import com.google.api.ads.common.lib.auth.OfflineCredentials
 import com.google.api.ads.common.lib.auth.OfflineCredentials.Api
-import com.google.api.ads.admanager.axis.utils.v202108.{ReportDownloader, StatementBuilder}
-import com.google.api.ads.admanager.axis.v202108._
+import com.google.api.ads.admanager.axis.utils.v202208.{ReportDownloader, StatementBuilder}
+import com.google.api.ads.admanager.axis.v202208._
 import com.google.api.ads.admanager.lib.client.AdManagerSession
 import com.google.common.io.CharSource
 import common.GuLogging

--- a/admin/app/jobs/CommercialDfpReporting.scala
+++ b/admin/app/jobs/CommercialDfpReporting.scala
@@ -3,10 +3,10 @@ package jobs
 import java.time.{LocalDate, LocalDateTime}
 
 import app.LifecycleComponent
-import com.google.api.ads.admanager.axis.v202108.Column.{AD_SERVER_IMPRESSIONS, AD_SERVER_WITHOUT_CPD_AVERAGE_ECPM}
-import com.google.api.ads.admanager.axis.v202108.DateRangeType.CUSTOM_DATE
-import com.google.api.ads.admanager.axis.v202108.Dimension.{CUSTOM_CRITERIA, DATE}
-import com.google.api.ads.admanager.axis.v202108._
+import com.google.api.ads.admanager.axis.v202208.Column.{AD_SERVER_IMPRESSIONS, AD_SERVER_WITHOUT_CPD_AVERAGE_ECPM}
+import com.google.api.ads.admanager.axis.v202208.DateRangeType.CUSTOM_DATE
+import com.google.api.ads.admanager.axis.v202208.Dimension.{CUSTOM_CRITERIA, DATE}
+import com.google.api.ads.admanager.axis.v202208._
 import common.{AkkaAsync, Box, JobScheduler, GuLogging}
 import dfp.DfpApi
 import play.api.inject.ApplicationLifecycle

--- a/admin/test/dfp/DfpApiValidationTest.scala
+++ b/admin/test/dfp/DfpApiValidationTest.scala
@@ -2,7 +2,7 @@ package dfp
 
 import concurrent.BlockingOperations
 import common.dfp.{GuAdUnit, GuLineItem, GuTargeting, Sponsorship}
-import com.google.api.ads.admanager.axis.v202108._
+import com.google.api.ads.admanager.axis.v202208._
 import org.joda.time.DateTime
 import akka.actor.ActorSystem
 import org.scalatest.flatspec.AnyFlatSpec

--- a/admin/test/dfp/ReaderTest.scala
+++ b/admin/test/dfp/ReaderTest.scala
@@ -1,6 +1,6 @@
 package dfp
 
-import com.google.api.ads.admanager.axis.utils.v202108.StatementBuilder
+import com.google.api.ads.admanager.axis.utils.v202208.StatementBuilder
 import dfp.Reader.read
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,7 +31,7 @@ object Dependencies {
   val commonsIo = "commons-io" % "commons-io" % "2.5"
   val cssParser = "net.sourceforge.cssparser" % "cssparser" % "0.9.23"
   val contentApiClient = "com.gu" %% "content-api-client" % capiVersion
-  val dfpAxis = "com.google.api-ads" % "dfp-axis" % "4.15.1"
+  val dfpAxis = "com.google.api-ads" % "dfp-axis" % "4.19.0"
   val faciaFapiScalaClient = "com.gu" %% "fapi-client-play27" % faciaVersion
   val identityCookie = "com.gu.identity" %% "identity-cookie" % identityLibVersion
   val identityModel = "com.gu.identity" %% "identity-model" % identityLibVersion


### PR DESCRIPTION
## What does this change?

Upgrade the DFP API to the latest available version: bump the `dfp-axis` package to `4.19.0` and update the imports to use `v202208`.

We last did this upgrade in https://github.com/guardian/frontend/pull/24245.

## Does this change need to be reproduced in dotcom-rendering ?

- [X] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## What is the value of this and can you measure success?

Fix errors related to DFP API deprecation on Frontend. See the [deprecation schedule](https://developers.google.com/ad-manager/api/deprecation) for more info on when these packages are deprecated.

### Tested

- [X] Locally
- [x] On CODE (optional)