### PR TITLE
Call SpaceFinder debug tools after ad slots have been created

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
+++ b/static/src/javascripts/projects/commercial/modules/article-body-adverts.ts
@@ -1,5 +1,6 @@
 import type { AdSize, SizeMapping } from '@guardian/commercial-core';
 import { adSizes, createAdSlot } from '@guardian/commercial-core';
+import { createAdvertBorder } from 'common/modules/spacefinder-debug-tools';
 import { getBreakpoint, getTweakpoint, getViewport } from 'lib/detect-viewport';
 import { getUrlVars } from 'lib/url';
 import config from '../../../lib/config';
@@ -66,7 +67,7 @@ const wrapSlotInContainer = (
 	container.className = `${adSlotContainerClass} ${options.className ?? ''}`;
 
 	if (options.enableDebug) {
-		container.style.cssText += 'outline: 2px solid red;';
+		createAdvertBorder(container);
 	}
 
 	container.appendChild(ad);
@@ -247,10 +248,6 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 				const inlineId = i + (isInline1 ? 1 : 2);
 				const isLastInline = i === paras.length - 1;
 
-				if (sfdebug == '1' || sfdebug == '2') {
-					para.style.cssText += 'outline: thick solid green;';
-				}
-
 				let containerClasses = '';
 
 				if (isSticky) {
@@ -295,6 +292,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 					containerOptions,
 				);
 			});
+
 		await Promise.all(slots);
 	};
 

--- a/static/src/javascripts/projects/commercial/modules/consentless/dynamic/article-inline.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/dynamic/article-inline.ts
@@ -10,6 +10,7 @@ import type {
 	SpacefinderRules,
 	SpacefinderWriter,
 } from 'common/modules/spacefinder';
+import { createAdvertBorder } from 'common/modules/spacefinder-debug-tools';
 import { getBreakpoint, getViewport } from 'lib/detect-viewport';
 import { getUrlVars } from 'lib/url';
 import fastdom from '../../../../../lib/fastdom-promise';
@@ -52,7 +53,7 @@ const wrapSlotInContainer = (
 	container.className = `ad-slot-container ${options.className ?? ''}`;
 
 	if (options.enableDebug) {
-		container.style.cssText += 'outline: 2px solid red;';
+		createAdvertBorder(container);
 	}
 
 	container.appendChild(ad);
@@ -177,10 +178,6 @@ const addDesktopInlineAds = async () => {
 
 		const slots = paras.map((para, i) => {
 			const inlineId = i + 1;
-
-			if (sfdebug) {
-				para.style.cssText += 'border: thick solid green;';
-			}
 
 			let containerClasses = '';
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/fill-advert-slots.ts
@@ -39,6 +39,7 @@ const fillAdvertSlots = async (): Promise<void> => {
 	const isDCRMobile =
 		window.guardian.config.isDotcomRendering &&
 		getBreakpoint() === 'mobile';
+
 	// Get all ad slots
 	const adverts = [
 		...document.querySelectorAll<HTMLElement>(dfpEnv.adSlotSelector),
@@ -72,6 +73,7 @@ const fillAdvertSlots = async (): Promise<void> => {
 	adverts.forEach((advert, index) => {
 		dfpEnv.advertIds[advert.id] = currentLength + index;
 	});
+
 	adverts.forEach(queueAdvert);
 	if (dfpEnv.shouldLazyLoad()) {
 		displayLazyAds();

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-render.ts
@@ -1,7 +1,6 @@
 import type { AdSize } from '@guardian/commercial-core';
 import { createAdSize } from '@guardian/commercial-core';
 import { isString } from '@guardian/libs';
-import { mediator } from '../../../../lib/mediator';
 import reportError from '../../../../lib/report-error';
 import { dfpEnv } from './dfp-env';
 import { emptyAdvert } from './empty-advert';
@@ -50,17 +49,12 @@ export const onSlotRender = (
 		return;
 	}
 
-	const emitRenderEvents = (isRendered: boolean) => {
-		advert.finishedRendering(isRendered);
-		mediator.emit('modules:commercial:dfp:rendered', event);
-	};
-
 	advert.isEmpty = event.isEmpty;
 
 	if (event.isEmpty) {
 		emptyAdvert(advert);
 		reportEmptyResponse(advert.id, event);
-		emitRenderEvents(false);
+		advert.finishedRendering(false);
 	} else {
 		/**
 		 * if advert.hasPrebidSize is false we use size
@@ -93,6 +87,8 @@ export const onSlotRender = (
 			advert.lineItemId = event.lineItemId;
 		}
 
-		void renderAdvert(advert, event).then(emitRenderEvents);
+		void renderAdvert(advert, event).then((isRendered) => {
+			advert.finishedRendering(isRendered);
+		});
 	}
 };

--- a/static/src/javascripts/projects/common/modules/article/space-filler.ts
+++ b/static/src/javascripts/projects/common/modules/article/space-filler.ts
@@ -25,7 +25,7 @@ class SpaceFiller {
 				.then((paragraphs: HTMLElement[]) => writer(paragraphs))
 				.then(() => {
 					if (options?.debug) {
-						const event = new Event('adverts-created');
+						const event = new CustomEvent('adverts-created');
 						document.dispatchEvent(event);
 					}
 				})

--- a/static/src/javascripts/projects/common/modules/article/space-filler.ts
+++ b/static/src/javascripts/projects/common/modules/article/space-filler.ts
@@ -24,6 +24,12 @@ class SpaceFiller {
 			findSpace(rules, options)
 				.then((paragraphs: HTMLElement[]) => writer(paragraphs))
 				.then(() => {
+					if (options?.debug) {
+						const event = new Event('adverts-created');
+						document.dispatchEvent(event);
+					}
+				})
+				.then(() => {
 					return true;
 				})
 				.catch((ex) => {

--- a/static/src/javascripts/projects/common/modules/spacefinder-debug-tools.ts
+++ b/static/src/javascripts/projects/common/modules/spacefinder-debug-tools.ts
@@ -1,154 +1,103 @@
 import type {
 	SpacefinderExclusions,
 	SpacefinderItem,
-	SpacefinderOptions,
 	SpacefinderRules,
 } from './spacefinder';
 
-const markCandidates = (
-	exclusions: SpacefinderExclusions,
-	winners: SpacefinderItem[],
-	options: SpacefinderOptions,
-	rules: SpacefinderRules,
-): SpacefinderItem[] => {
-	if (!options.debug) return winners;
+const colours = {
+	red: 'rgb(255 178 178)',
+	darkRed: 'rgb(200 0 0)',
+	orange: 'rgb(255 213 178)',
+	yellow: 'rgb(254 255 178)',
+	blue: 'rgb(178 248 255)',
+	darkBlue: 'rgb(0 0 178)',
+	purple: 'rgb(178 178 255)',
+	pink: 'rgb(255 178 242)',
+	green: 'rgb(178 255 184)',
+	darkGreen: 'rgb(0 128 0)',
+};
 
-	try {
-		const colours = {
-			red: 'rgb(255 178 178)',
-			orange: 'rgb(255 213 178)',
-			yellow: 'rgb(254 255 178)',
-			blue: 'rgb(178 248 255)',
-			purple: 'rgb(178 178 255)',
-			pink: 'rgb(255 178 242)',
-			green: 'rgb(178 255 184)',
-		};
+const exclusionTypes = {
+	absoluteMinAbove: {
+		colour: colours.red,
+		reason: 'Too close to the top of page',
+	},
+	aboveAndBelow: {
+		colour: colours.orange,
+		reason: 'Too close to top or bottom of article',
+	},
+	isStartAt: {
+		colour: colours.purple,
+		reason: 'Spacefinder is starting from this position',
+	},
+	startAt: {
+		colour: colours.orange,
+		reason: 'Before the starting element',
+	},
+	custom: {
+		colour: colours.yellow,
+		reason: 'Too close to other winner',
+	},
+} as const;
 
-		const exclusionTypes = {
-			absoluteMinAbove: {
-				colour: colours.red,
-				reason: 'Too close to the top of page',
-			},
-			aboveAndBelow: {
-				colour: colours.orange,
-				reason: 'Too close to top or bottom of article',
-			},
-			isStartAt: {
-				colour: colours.purple,
-				reason: 'Spacefinder is starting from this position',
-			},
-			startAt: {
-				colour: colours.orange,
-				reason: 'Before the starting element',
-			},
-			custom: {
-				colour: colours.yellow,
-				reason: 'Too close to other winner',
-			},
-		} as const;
+const isExclusionType = (type: string): type is keyof typeof exclusionTypes =>
+	type in exclusionTypes;
 
-		const isExclusionType = (
-			type: string,
-		): type is keyof typeof exclusionTypes => type in exclusionTypes;
+const addDistanceExplainer = (element: HTMLElement, text: string) => {
+	const explainer = document.createElement('div');
+	explainer.className = 'distanceExplainer sfdebug';
+	explainer.appendChild(document.createTextNode(text));
+	explainer.style.cssText = `
+		position:absolute;
+		right:0;
+		background-color:${colours.red};
+		padding:5px 5px 10px 20px;
+		font-family: sans-serif;
+		z-index:20;
+	`;
+	element.before(explainer);
+};
 
-		const addDistanceExplainer = (element: HTMLElement, text: string) => {
-			const explainer = document.createElement('div');
-			explainer.className = 'distanceExplainer sfdebug';
-			explainer.appendChild(document.createTextNode(text));
-			explainer.style.cssText = `
-                position:absolute;
-                right:0;
-                background-color:${colours.red};
-                padding:5px 5px 10px 20px;
-                font-family: sans-serif;
-                z-index:20;
-            `;
-			element.before(explainer);
-		};
+const addHoverListener = (
+	candidate: HTMLElement,
+	tooClose: Exclude<SpacefinderItem['meta'], undefined>['tooClose'],
+) => {
+	tooClose.forEach((opponent) => {
+		candidate.addEventListener('mouseenter', () => {
+			opponent.element.style.cssText = `
+				box-shadow: 0px 0px 0px 10px ${colours.red};
+				z-index:10;
+				position:relative
+			`;
 
-		const addHoverListener = (
-			candidate: HTMLElement,
-			tooClose: Exclude<SpacefinderItem['meta'], undefined>['tooClose'],
-		) => {
-			tooClose.forEach((opponent) => {
-				candidate.addEventListener('mouseenter', () => {
-					opponent.element.style.cssText = `
-                        box-shadow: 0px 0px 0px 10px ${colours.red};
-                        z-index:10;
-                        position:relative
-                    `;
-
-					addDistanceExplainer(
-						opponent.element,
-						`${opponent.actual}px/${opponent.required}px`,
-					);
-				});
-
-				candidate.addEventListener('mouseleave', () => {
-					opponent.element.style.cssText = '';
-					document
-						.querySelectorAll('.distanceExplainer')
-						.forEach((el) => el.remove());
-				});
-			});
-		};
-
-		const addExplainer = (element: HTMLElement, text: string) => {
-			const explainer = document.createElement('div');
-			explainer.className = 'sfdebug';
-			explainer.appendChild(document.createTextNode(text));
-			explainer.style.cssText = `
-                position:absolute;
-                right:0;
-                background-color:#fffffff7;
-                padding:10px;
-                border-radius:0 0 0 10px;
-                font-family: sans-serif;
-            `;
-			element.before(explainer);
-		};
-
-		// Mark losing candidates
-		for (const [key, arr] of Object.entries(exclusions)) {
-			arr.forEach((exclusion) => {
-				const type = isExclusionType(key) && exclusionTypes[key];
-
-				const element =
-					exclusion instanceof Element
-						? exclusion
-						: exclusion.element;
-				const meta =
-					exclusion instanceof Element ? null : exclusion.meta;
-
-				if (element == rules.startAt) {
-					const type = exclusionTypes.isStartAt;
-					addExplainer(element, type.reason);
-					element.style.cssText += `background:${type.colour}`;
-				} else if (type) {
-					addExplainer(element, type.reason);
-					element.style.cssText += `background:${type.colour}`;
-				} else if (meta && meta.tooClose.length > 0) {
-					addExplainer(element, 'Too close to other element');
-					element.style.cssText += `background:${colours.blue}`;
-					addHoverListener(element, meta.tooClose);
-				} else {
-					addExplainer(element, `Unknown key: ${key}`);
-					element.style.cssText += `background:${colours.pink}`;
-				}
-			});
-		}
-
-		// Mark winning candidates
-		winners.forEach((winner) => {
-			addExplainer(winner.element, 'Winner');
-			winner.element.style.cssText += `background:${colours.green};`;
+			addDistanceExplainer(
+				opponent.element,
+				`${opponent.actual}px/${opponent.required}px`,
+			);
 		});
 
-		return winners;
-	} catch (e) {
-		console.error('SFDebug Error', e);
-		return winners;
-	}
+		candidate.addEventListener('mouseleave', () => {
+			opponent.element.style.cssText = '';
+			document
+				.querySelectorAll('.distanceExplainer')
+				.forEach((el) => el.remove());
+		});
+	});
+};
+
+const addExplainer = (element: HTMLElement, text: string) => {
+	const explainer = document.createElement('div');
+	explainer.className = 'sfdebug';
+	explainer.appendChild(document.createTextNode(text));
+	explainer.style.cssText = `
+		position:absolute;
+		right:0;
+		background-color:#fffffff7;
+		padding:10px;
+		border-radius:0 0 0 10px;
+		font-family: sans-serif;
+	`;
+	element.before(explainer);
 };
 
 const debugMinAbove = (body: HTMLElement, minAbove: number): void => {
@@ -161,13 +110,103 @@ const debugMinAbove = (body: HTMLElement, minAbove: number): void => {
 		position: absolute;
 		top: ${minAbove}px;
 		width: 100%;
-		background-color: red;
+		background-color: ${colours.darkBlue};
 		height: 5px;
 	`;
 
-	minAboveIndicator.innerHTML = `<div class="sfdebug" style="position: absolute; right: 0px; background-color: rgba(255, 255, 255, 0.97); padding: 10px; border-radius: 0px 0px 0px 10px; font-family: sans-serif; font-size: 0.7rem;">Threshold for slot to be too close to top (minAbove: ${minAbove}px)</div>`;
+	minAboveIndicator.innerHTML = `
+		<div class="sfdebug"
+		     style="position: absolute;
+			 		right: 0px;
+					background-color: rgba(255, 255, 255, 0.97);
+					padding: 10px;
+					border-radius: 0px 0px 0px 10px;
+					font-family: sans-serif;
+					font-size: 0.7rem;">
+			Threshold for slot to be too close to top (minAbove: ${minAbove}px)
+		</div>`;
 
 	body.appendChild(minAboveIndicator);
 };
 
-export { markCandidates, debugMinAbove };
+const markLosingCandidates = (
+	exclusions: SpacefinderExclusions,
+	rules: SpacefinderRules,
+) => {
+	for (const [key, arr] of Object.entries(exclusions)) {
+		arr.forEach((exclusion) => {
+			const type = isExclusionType(key) && exclusionTypes[key];
+
+			const element =
+				exclusion instanceof Element ? exclusion : exclusion.element;
+			const meta = exclusion instanceof Element ? null : exclusion.meta;
+
+			if (element == rules.startAt) {
+				const type = exclusionTypes.isStartAt;
+				addExplainer(element, type.reason);
+				element.style.cssText += `background:${type.colour}`;
+			} else if (type) {
+				addExplainer(element, type.reason);
+				element.style.cssText += `background:${type.colour}`;
+			} else if (meta && meta.tooClose.length > 0) {
+				addExplainer(element, 'Too close to other element');
+				element.style.cssText += `background:${colours.blue}`;
+				addHoverListener(element, meta.tooClose);
+			} else {
+				addExplainer(element, `Unknown key: ${key}`);
+				element.style.cssText += `background:${colours.pink}`;
+			}
+		});
+	}
+};
+
+const markWinningCandidates = (winners: SpacefinderItem[]) => {
+	winners.forEach((winner) => {
+		addExplainer(winner.element, 'Winner');
+		winner.element.style.cssText += `background:${colours.green};`;
+		winner.element.style.cssText += `outline: thick solid ${colours.darkGreen};`;
+	});
+};
+
+const annotateCandidates = (
+	exclusions: SpacefinderExclusions,
+	winners: SpacefinderItem[],
+	rules: SpacefinderRules,
+): void => {
+	try {
+		markLosingCandidates(exclusions, rules);
+		markWinningCandidates(winners);
+	} catch (e) {
+		console.error('SFDebug Error', e);
+	}
+};
+
+const runDebugTool = (
+	exclusions: SpacefinderExclusions = {},
+	winners: SpacefinderItem[],
+	rules: SpacefinderRules,
+): void => {
+	document.addEventListener(
+		'adverts-created',
+		() => {
+			if (rules.minAbove && rules.body instanceof HTMLElement) {
+				debugMinAbove(rules.body, rules.minAbove);
+			}
+
+			annotateCandidates(exclusions, winners, rules);
+		},
+		{ once: true }, // Don't run when adverts refresh
+	);
+};
+
+const createAdvertBorder = (advert: HTMLElement): void => {
+	document.addEventListener(
+		'adverts-created',
+		() => {
+			advert.style.cssText += `outline: 4px solid ${colours.darkRed};`;
+		},
+		{ once: true }, // Don't run when adverts refresh
+	);
+};
+
+export { createAdvertBorder, runDebugTool };

--- a/static/src/javascripts/projects/common/modules/spacefinder.ts
+++ b/static/src/javascripts/projects/common/modules/spacefinder.ts
@@ -4,7 +4,7 @@ import { log } from '@guardian/libs';
 import { memoize } from 'lodash-es';
 import { amIUsed } from 'commercial/am-i-used';
 import fastdom from '../../../lib/fastdom-promise';
-import { debugMinAbove, markCandidates } from './spacefinder-debug-tools';
+import { runDebugTool } from './spacefinder-debug-tools';
 
 type RuleSpacing = {
 	minAbove: number;
@@ -184,6 +184,7 @@ const partitionCandidates = <T>(
 ) => {
 	const filtered: T[] = [];
 	const exclusions: T[] = [];
+
 	list.forEach((element) => {
 		if (filterElement(element, filtered[filtered.length - 1])) {
 			filtered.push(element);
@@ -191,6 +192,7 @@ const partitionCandidates = <T>(
 			exclusions.push(element);
 		}
 	});
+
 	return [filtered, exclusions];
 };
 
@@ -444,22 +446,22 @@ const findSpace = async (
 			document.querySelector<HTMLElement>(rules.bodySelector)) ||
 		document;
 
-	if (options.debug && rules.minAbove && rules.body instanceof HTMLElement) {
-		debugMinAbove(rules.body, rules.minAbove);
-	}
-
 	await getReady(rules, options);
 
 	const candidates = getCandidates(rules, exclusions);
 	const measurements = await getMeasurements(rules, candidates);
 	const winners = enforceRules(measurements, rules, exclusions);
-	const markedWinners = markCandidates(exclusions, winners, options, rules);
+
+	if (options.debug) {
+		runDebugTool(exclusions, winners, rules);
+	}
 
 	// TODO Is this really an error condition?
-	if (!markedWinners.length) {
+	if (!winners.length) {
 		throw new SpaceError(rules);
 	}
-	return markedWinners.map((candidate) => candidate.element);
+
+	return winners.map((candidate) => candidate.element);
 };
 
 export const _ = {

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -280,7 +280,6 @@
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../lib/mediator.ts",
   "../lib/report-error.js",
   "../projects/commercial/modules/dfp/dfp-env.ts",
   "../projects/commercial/modules/dfp/empty-advert.ts",
@@ -749,7 +748,6 @@
   "../lib/url.ts"
  ],
  "../projects/common/modules/spacefinder-debug-tools.ts": [
-  "../lib/mediator.ts",
   "../projects/common/modules/spacefinder.ts"
  ],
  "../projects/common/modules/spacefinder.ts": [

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -97,6 +97,7 @@
   "../projects/commercial/modules/sticky-inlines.ts",
   "../projects/common/modules/article/space-filler.ts",
   "../projects/common/modules/commercial/commercial-features.ts",
+  "../projects/common/modules/spacefinder-debug-tools.ts",
   "../projects/common/modules/spacefinder.ts"
  ],
  "../projects/commercial/modules/carrot-traffic-driver.ts": [
@@ -141,6 +142,7 @@
   "../projects/commercial/modules/sticky-inlines.ts",
   "../projects/common/modules/article/space-filler.ts",
   "../projects/common/modules/commercial/commercial-features.ts",
+  "../projects/common/modules/spacefinder-debug-tools.ts",
   "../projects/common/modules/spacefinder.ts"
  ],
  "../projects/commercial/modules/consentless/dynamic/liveblog-inline.ts": [
@@ -747,6 +749,7 @@
   "../lib/url.ts"
  ],
  "../projects/common/modules/spacefinder-debug-tools.ts": [
+  "../lib/mediator.ts",
   "../projects/common/modules/spacefinder.ts"
  ],
  "../projects/common/modules/spacefinder.ts": [


### PR DESCRIPTION
## What does this change?

- Waits until SpaceFinder has run and all the advert slots it creates have been inserted in to the DOM before running the debug tools
- Removes the unused `modules:commercial:dfp:rendered` mediator event
- Moves some debug functionality to the `spacefinder-debug-tools.ts` file
- Add a few more colours to debug tools: the min-above line and inline1 ad were the same colour - mildly confusing

## Why?

- The label "Winner" which should sit in the top right of each winning paragraph is appearing in the top right of the advert instead of the paragraph.
- We're looking to move away from mediator in favour of custom events
- Ideally, all spacefinder debug code should live in the `spacefinder-debug-tools.ts` file

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

| Before      | After      |
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/9574885/195569048-538e0f6d-e99e-47e6-9fcd-aacd3a2a5278.png) | ![image](https://user-images.githubusercontent.com/9574885/195568141-86da2cfd-32f3-4c3a-8a4d-0c184b2fc9cc.png) |