### PR TITLE
update URL for uk and aus newsletters

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -172,16 +172,16 @@
         <div class="colophon__section">
         @currentEdition match {
             case Uk => {
-                @fragments.email.signup.emailFooterLink("morning-briefing", "/global/ng-interactive/2022/apr/13/first-edition-sign-up-guardian")
+                @fragments.email.signup.emailFooterLink("morning-briefing", "/global/2022/sep/20/sign-up-for-the-first-edition-newsletter-our-free-news-email")
             }
             case Us => {
                 @fragments.email.signup.emailFooterLink("us-morning-newsletter", "/info/2018/sep/17/guardian-us-morning-briefing-sign-up-to-stay-informed")
             }
             case Au => {
-                @fragments.email.signup.emailFooterLink("morning-mail", "/world/guardian-australia-morning-mail/2014/jun/24/-sp-guardian-australias-morning-mail-subscribe-by-email")
+                @fragments.email.signup.emailFooterLink("morning-mail", "/australia-news/2022/sep/23/morning-mail-newsletter-best-daily-news-email-guardian-australia-free-sign-up-inbox-subscribe")
             }
             case International => {
-                @fragments.email.signup.emailFooterLink("morning-briefing", "/global/ng-interactive/2022/apr/13/first-edition-sign-up-guardian")
+                @fragments.email.signup.emailFooterLink("morning-briefing", "/global/2022/sep/20/sign-up-for-the-first-edition-newsletter-our-free-news-email")
             }
         }
         </div>


### PR DESCRIPTION
## What does this change?
Updates the hard coded relative URLs used on the 'Sign-up for our email' buttons in the footer (UK/INTL and AUS). The old pages are currently redirected to the new ones.

## Does this change need to be reproduced in dotcom-rendering ?

- [ ] No
- [x] Yes (please indicate your plans for DCR Implementation)
will do a separate PR in dotcom-rendering - the same values are hard coded in the footer component.

## What is the value of this and can you measure success?
The button will navigate to the new pages without a redirect.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
