### PR TITLE
Exclude some folders from commercial-bundle-graph

### DIFF
--- a/tools/__tasks__/commercial/graph/index.js
+++ b/tools/__tasks__/commercial/graph/index.js
@@ -8,6 +8,9 @@ const config = {
 	webpackConfig: 'webpack.config.commercial.prod.js',
 	tsConfig: 'tsconfig.json',
 	includeNpm: true,
+    excludeRegExp: [
+        /projects\/common\/modules\/(experiments|identity)/
+    ],
 };
 
 const graphFile = `${__dirname}/output/${filename}.json`;

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -119,8 +119,7 @@
   "../projects/commercial/modules/dfp/add-slot.ts",
   "../projects/commercial/modules/dfp/get-advert-by-id.ts",
   "../projects/commercial/modules/dfp/load-advert.ts",
-  "../projects/common/modules/commercial/commercial-features.ts",
-  "../projects/common/modules/identity/api.ts"
+  "../projects/common/modules/commercial/commercial-features.ts"
  ],
  "../projects/commercial/modules/comscore.ts": [
   "../../../../node_modules/@guardian/consent-management-platform/dist/index.d.ts",
@@ -164,8 +163,7 @@
   "../../../../node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/geolocation.ts",
-  "../projects/common/modules/commercial/commercial-features.ts",
-  "../projects/common/modules/experiments/ab.ts"
+  "../projects/common/modules/commercial/commercial-features.ts"
  ],
  "../projects/commercial/modules/consentless/render-advert-label.ts": [
   "../lib/fastdom-promise.js",
@@ -333,8 +331,7 @@
   "../projects/commercial/modules/messenger/viewport.ts",
   "../projects/commercial/modules/remove-slots.ts",
   "../projects/common/modules/commercial/build-page-targeting.ts",
-  "../projects/common/modules/commercial/commercial-features.ts",
-  "../projects/common/modules/identity/api.ts"
+  "../projects/common/modules/commercial/commercial-features.ts"
  ],
  "../projects/commercial/modules/dfp/prepare-permutive.ts": [
   "../lib/report-error.js"
@@ -620,15 +617,13 @@
   "../../../../node_modules/@types/lodash-es/index.d.ts",
   "../lib/geolocation.ts",
   "../projects/commercial/modules/header-bidding/utils.ts",
-  "../projects/common/modules/commercial/commercial-features.ts",
-  "../projects/common/modules/experiments/ab.ts"
+  "../projects/common/modules/commercial/commercial-features.ts"
  ],
  "../projects/common/modules/commercial/commercial-features.ts": [
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../lib/config.d.ts",
   "../lib/detect.js",
   "../projects/common/modules/commercial/user-features.ts",
-  "../projects/common/modules/identity/api.ts",
   "../projects/common/modules/user-prefs.js"
  ],
  "../projects/common/modules/commercial/contributions-utilities.js": [
@@ -657,94 +652,8 @@
   "../lib/noop.ts",
   "../lib/time-utils.ts",
   "../projects/common/modules/commercial/lib/cookie.ts",
-  "../projects/common/modules/identity/api.ts",
   "../types/dates.ts",
   "../types/membership.ts"
- ],
- "../projects/common/modules/experiments/ab-constants.ts": [],
- "../projects/common/modules/experiments/ab-core.ts": [
-  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
-  "../lib/config.d.ts",
-  "../lib/time-utils.ts",
-  "../projects/common/modules/analytics/mvt-cookie.ts",
-  "../projects/common/modules/experiments/ab-constants.ts",
-  "../projects/common/modules/experiments/ab-local-storage.ts",
-  "../projects/common/modules/experiments/ab-url.ts",
-  "../projects/common/modules/experiments/ab-utils.ts",
-  "../projects/common/modules/experiments/automatLog.ts"
- ],
- "../projects/common/modules/experiments/ab-local-storage.ts": [
-  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../projects/common/modules/experiments/ab-constants.ts",
-  "../projects/common/modules/experiments/ab-utils.ts"
- ],
- "../projects/common/modules/experiments/ab-ophan.ts": [
-  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
-  "../lib/config.d.ts",
-  "../lib/noop.ts",
-  "../lib/report-error.js"
- ],
- "../projects/common/modules/experiments/ab-tests.ts": [
-  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
-  "../projects/common/modules/experiments/tests/consentlessAds.ts",
-  "../projects/common/modules/experiments/tests/deeply-read-article-footer.js",
-  "../projects/common/modules/experiments/tests/integrate-ima.ts",
-  "../projects/common/modules/experiments/tests/remote-header-test.js",
-  "../projects/common/modules/experiments/tests/shady-pie-click-through.ts",
-  "../projects/common/modules/experiments/tests/sign-in-gate-main-control.js",
-  "../projects/common/modules/experiments/tests/sign-in-gate-main-variant.js",
-  "../projects/common/modules/experiments/tests/sign-in-gate-mandatory-long.js"
- ],
- "../projects/common/modules/experiments/ab-url.ts": [
-  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
-  "../projects/common/modules/experiments/ab-utils.ts"
- ],
- "../projects/common/modules/experiments/ab-utils.ts": [
-  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
-  "../../../../node_modules/@types/lodash-es/index.d.ts",
-  "../lib/config.d.ts",
-  "../projects/common/modules/experiments/ab-constants.ts"
- ],
- "../projects/common/modules/experiments/ab.ts": [
-  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
-  "../../../../node_modules/@types/lodash-es/index.d.ts",
-  "../projects/common/modules/experiments/ab-core.ts",
-  "../projects/common/modules/experiments/ab-local-storage.ts",
-  "../projects/common/modules/experiments/ab-ophan.ts",
-  "../projects/common/modules/experiments/ab-tests.ts",
-  "../projects/common/modules/experiments/ab-url.ts",
-  "../projects/common/modules/experiments/ab-utils.ts"
- ],
- "../projects/common/modules/experiments/automatLog.ts": [],
- "../projects/common/modules/experiments/tests/consentlessAds.ts": [
-  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
-  "../lib/noop.ts"
- ],
- "../projects/common/modules/experiments/tests/deeply-read-article-footer.js": [],
- "../projects/common/modules/experiments/tests/integrate-ima.ts": [
-  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
-  "../lib/noop.ts"
- ],
- "../projects/common/modules/experiments/tests/remote-header-test.js": [],
- "../projects/common/modules/experiments/tests/shady-pie-click-through.ts": [
-  "../../../../node_modules/@guardian/ab-core/dist/index.d.ts",
-  "../lib/noop.ts"
- ],
- "../projects/common/modules/experiments/tests/sign-in-gate-main-control.js": [],
- "../projects/common/modules/experiments/tests/sign-in-gate-main-variant.js": [],
- "../projects/common/modules/experiments/tests/sign-in-gate-mandatory-long.js": [],
- "../projects/common/modules/identity/api.ts": [
-  "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../lib/config.d.ts",
-  "../lib/fetch-json.ts",
-  "../lib/mediator.ts",
-  "../lib/url.ts",
-  "../projects/common/modules/async-call-merger.ts",
-  "../projects/common/modules/identity/auth-component-event-params.js"
- ],
- "../projects/common/modules/identity/auth-component-event-params.js": [
-  "../lib/url.ts"
  ],
  "../projects/common/modules/spacefinder-debug-tools.ts": [
   "../projects/common/modules/spacefinder.ts"
@@ -803,8 +712,6 @@
   "../projects/commercial/modules/track-scroll-depth.ts",
   "../projects/common/modules/commercial/commercial-features.ts",
   "../projects/common/modules/commercial/user-features.ts",
-  "../projects/common/modules/experiments/ab.ts",
-  "../projects/common/modules/experiments/tests/consentlessAds.ts",
   "types.ts"
  ],
  "types.ts": []


### PR DESCRIPTION
## What does this change?
Exclude experiments and identity folders from commercial-bundle-graph.

for better accuracy on https://github.com/guardian/commercial-bundle-progress

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

<!-- Please use the following table template to make image comparison easier to parse:

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

-->

## What is the value of this and can you measure success?

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [ ] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [ ] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [ ] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
