### PR TITLE
Pass changed switches as flash message

### DIFF
--- a/admin/app/controllers/admin/SwitchboardController.scala
+++ b/admin/app/controllers/admin/SwitchboardController.scala
@@ -86,7 +86,7 @@ class SwitchboardController(akkaAsync: AkkaAsync, val controllerComponents: Cont
       }
 
       Redirect(routes.SwitchboardController.renderSwitchboard()).flashing(
-        "success" -> s"Switches successfully changed: ${changes.mkString("; ")}.",
+        "success" -> changes.mkString("; "),
       )
     } catch {
       case e: Throwable =>

--- a/admin/app/controllers/admin/SwitchboardController.scala
+++ b/admin/app/controllers/admin/SwitchboardController.scala
@@ -85,7 +85,9 @@ class SwitchboardController(akkaAsync: AkkaAsync, val controllerComponents: Cont
         log.info(s"Switch change by $requester: $change")
       }
 
-      Redirect(routes.SwitchboardController.renderSwitchboard())
+      Redirect(routes.SwitchboardController.renderSwitchboard()).flashing(
+        "success" -> s"Switches successfully changed: ${changes.mkString("; ")}",
+      )
     } catch {
       case e: Throwable =>
         log.error("exception saving switches", e)

--- a/admin/app/controllers/admin/SwitchboardController.scala
+++ b/admin/app/controllers/admin/SwitchboardController.scala
@@ -86,7 +86,7 @@ class SwitchboardController(akkaAsync: AkkaAsync, val controllerComponents: Cont
       }
 
       Redirect(routes.SwitchboardController.renderSwitchboard()).flashing(
-        "success" -> s"Switches successfully changed: ${changes.mkString("; ")}",
+        "success" -> s"Switches successfully changed: ${changes.mkString("; ")}.",
       )
     } catch {
       case e: Throwable =>

--- a/admin/app/views/switchboard.scala.html
+++ b/admin/app/views/switchboard.scala.html
@@ -6,8 +6,18 @@
     <link href="@UncachedAssets.at("css/switchboard.css")" rel="stylesheet">
     <link href="@UncachedAssets.at("css/radiator.css")" rel="stylesheet">
         <div class="container__main">
-            @if(flash.get("error").isDefined) { <h1 style="color:#bd362f">@flash.get("error").get</h1> }
-            @if(flash.get("success").isDefined) { <h1 style="color:mediumseagreen">@flash.get("success").get</h1> }
+            @if(flash.get("error").isDefined) {
+                <section class="bg-danger" style="padding: 1em;">
+                    <h2 class="text-danger">Error</h2>
+                    <p>@flash.get("error").get</p>
+                </section>
+            }
+            @if(flash.get("success").isDefined) {
+                <section class="bg-success" style="padding: 1em;">
+                    <h2 class="text-success">Success</h2>
+                    <p>@flash.get("success").get</p>
+                </section>
+            }
             <p>
                 <blockquote>
                     <em>"Death by switches."</em>

--- a/admin/app/views/switchboard.scala.html
+++ b/admin/app/views/switchboard.scala.html
@@ -15,7 +15,14 @@
             @if(flash.get("success").isDefined) {
                 <section class="bg-success" style="padding: 1em;">
                     <h2 class="text-success">Success</h2>
-                    <p>@flash.get("success").get</p>
+                    <ul>
+                    @for(switch <- flash.get("success").get.split("; ")){
+                        <li class="sub-heading">@switch</li>
+                    }
+                    </ul>
+@*                    <p>@flash.get("success").get.split("; ").map(switch => {*@
+@*                    <li>@switch</li>*@
+@*            })</p>*@
                 </section>
             }
             <p>

--- a/admin/app/views/switchboard.scala.html
+++ b/admin/app/views/switchboard.scala.html
@@ -7,22 +7,20 @@
     <link href="@UncachedAssets.at("css/radiator.css")" rel="stylesheet">
         <div class="container__main">
             @if(flash.get("error").isDefined) {
-                <section class="bg-danger" style="padding: 1em;">
+                <section class="bg-danger" style="padding: 1em 1rem 4rem 1rem;">
                     <h2 class="text-danger">Error</h2>
                     <p>@flash.get("error").get</p>
                 </section>
             }
             @if(flash.get("success").isDefined) {
-                <section class="bg-success" style="padding: 1em;">
+                <section class="bg-success" style="padding: 1rem 1rem 4rem 1rem;">
                     <h2 class="text-success">Success</h2>
+                    <p>You have successfully changed the following switches:</p>
                     <ul>
                     @for(switch <- flash.get("success").get.split("; ")){
                         <li class="sub-heading">@switch</li>
                     }
                     </ul>
-@*                    <p>@flash.get("success").get.split("; ").map(switch => {*@
-@*                    <li>@switch</li>*@
-@*            })</p>*@
                 </section>
             }
             <p>

--- a/admin/app/views/switchboard.scala.html
+++ b/admin/app/views/switchboard.scala.html
@@ -7,6 +7,7 @@
     <link href="@UncachedAssets.at("css/radiator.css")" rel="stylesheet">
         <div class="container__main">
             @if(flash.get("error").isDefined) { <h1 style="color:#bd362f">@flash.get("error").get</h1> }
+            @if(flash.get("success").isDefined) { <h1 style="color:mediumseagreen">@flash.get("success").get</h1> }
             <p>
                 <blockquote>
                     <em>"Death by switches."</em>


### PR DESCRIPTION
Co-authored by: Ioanna Kokkini <ioannakok@users.noreply.github.com>

## What does this change?

When changes are successfully saved from the switchboard, pass the changes through as a flash message so that uses get feedback on what they have changed.

<img width="1675" alt="image" src="https://user-images.githubusercontent.com/37048459/196163114-9556f948-382a-4e35-973b-7ad8d74cc08c.png">

Also re-styles the error message slightly, for consistency and semantics.

## Why

I think I will find it useful, personally, and I could imagine that others would too. I'm very open to other opinions on this, though!

## Other considerations

- No-one else asked for this, so I didn't want to spend too long on it. But if it's thought worthwhile I think the UX could be improved (e.g. making the diffing optional).
- A couple of times it seems like the tool has erroneously said that *lots* of switches have changed, when it should only be one or two switches. It seems like this must be a pre-existing bug, because this PR just  re-uses the list of changes that  was already being created for logging. It might be startling for users to see a bit list of erroneous changes. On the other hand, perhaps there's a bug that we should be aware of, here? Again, more time could be spent on this but it looks like a potential rabbit hole so I didn't want to go down it unilaterally.


## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)
