### PR TITLE
Add CloudWatch metrics for DCR Response time & request rate

### DIFF
--- a/applications/app/AppLoader.scala
+++ b/applications/app/AppLoader.scala
@@ -2,7 +2,7 @@ import akka.actor.ActorSystem
 import app.{FrontendApplicationLoader, FrontendComponents}
 import com.softwaremill.macwire._
 import common.dfp.DfpAgentLifecycle
-import common.{ApplicationMetrics, CloudWatchMetricsLifecycle, ContentApiMetrics, EmailSubsciptionMetrics}
+import common.{ApplicationMetrics, CloudWatchMetricsLifecycle, ContentApiMetrics, DCRMetrics, EmailSubsciptionMetrics}
 import _root_.commercial.targeting.TargetingLifecycle
 import common.Assets.DiscussionExternalAssetsLifecycle
 import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
@@ -88,6 +88,8 @@ trait AppComponents extends FrontendComponents with ApplicationsControllers with
     EmailSubsciptionMetrics.APINetworkError,
     EmailSubsciptionMetrics.ListIDError,
     EmailSubsciptionMetrics.AllEmailSubmission,
+    DCRMetrics.DCRLatencyMetric,
+    DCRMetrics.DCRRequestCountMetric,
   )
 
   override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]

--- a/article/app/AppLoader.scala
+++ b/article/app/AppLoader.scala
@@ -84,8 +84,8 @@ trait AppComponents extends FrontendComponents with ArticleControllers with Topi
     ContentApiMetrics.HttpTimeoutCountMetric,
     ContentApiMetrics.ContentApiErrorMetric,
     ContentApiMetrics.ContentApiRequestsMetric,
-    ArticleRenderingMetrics.RemoteRenderingMetric,
-    ArticleRenderingMetrics.LocalRenderingMetric,
+    DCRMetrics.DCRLatencyMetric,
+    DCRMetrics.DCRRequestCountMetric,
   )
 
   override lazy val httpErrorHandler: HttpErrorHandler = wire[CorsHttpErrorHandler]

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -175,17 +175,17 @@ object ApplicationMetrics {
   def apply(metrics: FrontendMetric*): ApplicationMetrics = ApplicationMetrics(metrics.toList)
 }
 
-object ArticleRenderingMetrics {
-  val RemoteRenderingMetric = TimingMetric(
-    "remote-rendering-time-article",
-    "Remote rendering time for articles",
+object DCRMetrics {
+  val DCRLatencyMetric = TimingMetric(
+    "dcr-latency",
+    "DCR response time",
   )
-  val LocalRenderingMetric = TimingMetric(
-    "local-rendering-time-article",
-    "Local rendering time for articles",
+
+  val DCRRequestCountMetric = CountMetric(
+    "dcr-request-count",
+    "DCR request count",
   )
 }
-
 class CloudWatchMetricsLifecycle(
     appLifecycle: ApplicationLifecycle,
     appIdentity: ApplicationIdentity,

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -2,7 +2,7 @@ package renderers
 
 import akka.actor.ActorSystem
 import com.gu.contentapi.client.model.v1.{Block, Blocks}
-import common.GuLogging
+import common.{DCRMetrics, GuLogging}
 import concurrent.CircuitBreakerRegistry
 import conf.Configuration
 import conf.switches.Switches.CircuitBreakerSwitch
@@ -32,6 +32,7 @@ import play.api.mvc.Results.{InternalServerError, NotFound}
 import play.api.mvc.{RequestHeader, Result}
 import play.twirl.api.Html
 
+import java.lang.System.currentTimeMillis
 import java.net.ConnectException
 import java.util.concurrent.TimeoutException
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -60,11 +61,19 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       endpoint: String,
       timeout: Duration = Configuration.rendering.timeout,
   )(implicit request: RequestHeader): Future[WSResponse] = {
+
+    val start = currentTimeMillis
+
     val resp = ws
       .url(endpoint)
       .withRequestTimeout(timeout)
       .addHttpHeaders("Content-Type" -> "application/json")
       .post(payload)
+
+    resp.foreach(_ => {
+      DCRMetrics.DCRLatencyMetric.recordDuration(currentTimeMillis - start)
+      DCRMetrics.DCRRequestCountMetric.increment()
+    })
 
     resp.recoverWith({
       case _: ConnectException if Configuration.environment.stage == "DEV" =>

--- a/common/app/renderers/DotcomRenderingService.scala
+++ b/common/app/renderers/DotcomRenderingService.scala
@@ -62,7 +62,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       timeout: Duration = Configuration.rendering.timeout,
   )(implicit request: RequestHeader): Future[WSResponse] = {
 
-    val start = currentTimeMillis
+    val start = currentTimeMillis()
 
     val resp = ws
       .url(endpoint)
@@ -71,7 +71,7 @@ class DotcomRenderingService extends GuLogging with ResultWithPreconnectPreload 
       .post(payload)
 
     resp.foreach(_ => {
-      DCRMetrics.DCRLatencyMetric.recordDuration(currentTimeMillis - start)
+      DCRMetrics.DCRLatencyMetric.recordDuration(currentTimeMillis() - start)
       DCRMetrics.DCRRequestCountMetric.increment()
     })
 

--- a/facia/app/AppLoader.scala
+++ b/facia/app/AppLoader.scala
@@ -60,6 +60,8 @@ trait AppComponents extends FrontendComponents with FaciaControllers with FapiSe
   override lazy val appMetrics = ApplicationMetrics(
     FaciaPressMetrics.FrontDecodingLatency,
     FaciaPressMetrics.FrontDownloadLatency,
+    DCRMetrics.DCRLatencyMetric,
+    DCRMetrics.DCRRequestCountMetric,
   )
 
   override lazy val httpFilters: Seq[EssentialFilter] = wire[CommonFilters].filters ++ wire[PreloadFilters].filters

--- a/preview/app/AppLoader.scala
+++ b/preview/app/AppLoader.scala
@@ -7,7 +7,7 @@ import commercial.controllers.CommercialControllers
 import commercial.targeting.TargetingLifecycle
 import common.Logback.{LogbackOperationsPool, LogstashLifecycle}
 import common.dfp.FaciaDfpAgentLifecycle
-import common.{ApplicationMetrics, CloudWatchMetricsLifecycle, ContentApiMetrics}
+import common.{ApplicationMetrics, CloudWatchMetricsLifecycle, ContentApiMetrics, DCRMetrics}
 import conf.switches.SwitchboardLifecycle
 import conf.{CachedHealthCheckLifeCycle, FootballLifecycle}
 import contentapi._
@@ -112,6 +112,8 @@ trait AppComponents
     ContentApiMetrics.HttpTimeoutCountMetric,
     ContentApiMetrics.ContentApiErrorMetric,
     ContentApiMetrics.ContentApiRequestsMetric,
+    DCRMetrics.DCRLatencyMetric,
+    DCRMetrics.DCRRequestCountMetric,
   )
 
   lazy val healthCheck = wire[HealthCheck]


### PR DESCRIPTION
## What does this change?

- Adds a new CloudWatch metric to track what response times & request rate Frontend is seeing when calling DCR.
- Removes 2 old metrics that were un-used
