### PR TITLE
Prevent CLS on refreshing ads

### DIFF
--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -45,6 +45,7 @@ const getSlotSizeMappingsFromDataAttrs = (
 		if (data) {
 			sizes[breakpoint.name] = createSizeMapping(data);
 		}
+
 		return sizes;
 	}, {});
 
@@ -52,11 +53,16 @@ const isSlotName = (slotName: string): slotName is SlotName => {
 	return slotName in slotSizeMappings;
 };
 
+const isAdSize = (size: Advert['size']): size is AdSize => {
+	return size !== null && size !== 'fluid';
+};
+
 const getSlotSizeMapping = (name: string): SizeMapping => {
 	const slotName = name.includes('inline') ? 'inline' : name;
 	if (isSlotName(slotName)) {
 		return slotSizeMappings[slotName];
 	}
+
 	return {};
 };
 
@@ -183,7 +189,7 @@ class Advert {
 	}
 }
 
-export { Advert };
+export { Advert, isAdSize };
 
 export const _ = {
 	getSlotSizeMapping,

--- a/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/Advert.ts
@@ -145,9 +145,10 @@ class Advert {
 			additionalSizeMapping,
 		);
 
-		/** If the size mapping is empty, use the data attributes to create a size mapping,
+		/**
+		 * If the size mapping is empty, use the data attributes to create a size mapping,
 		 * this is used on some interactives e.g. https://www.theguardian.com/education/ng-interactive/2021/sep/11/the-best-uk-universities-2022-rankings
-		 **/
+		 */
 		if (isSizeMappingEmpty(sizeMapping)) {
 			sizeMapping = getSlotSizeMappingsFromDataAttrs(this.node);
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.ts
@@ -1,7 +1,7 @@
-import { log } from '@guardian/libs';
 import { constants, outstreamSizes } from '@guardian/commercial-core';
-import { getUrlVars } from '../../../../lib/url';
+import { log } from '@guardian/libs';
 import fastdom from '../../../../lib/fastdom-promise';
+import { getUrlVars } from '../../../../lib/url';
 import { isAdSize } from './Advert';
 import type { Advert } from './Advert';
 import { getAdvertById } from './get-advert-by-id';
@@ -15,7 +15,7 @@ const ADVERT_REFRESH_RATE = 30_000; // 30 seconds
  * Prevent CLS when an advert is refreshed, by setting the
  * min-height of the ad slot to the height of the ad.
  */
-const setAdSlotMinHeight = async (advert: Advert): Promise<void> => {
+const setAdSlotMinHeight = (advert: Advert): void => {
 	// We need to know the height of the ad to set the min-height
 	if (!isAdSize(advert.size)) {
 		return;
@@ -38,14 +38,14 @@ const setAdSlotMinHeight = async (advert: Advert): Promise<void> => {
 	const isStandardAdSize = !size.isProxy();
 	if (isStandardAdSize) {
 		const adSlotHeight = size.height + constants.AD_LABEL_HEIGHT;
-		fastdom.mutate(() => {
+		void fastdom.mutate(() => {
 			node.setAttribute('style', `min-height:${adSlotHeight}px`);
 		});
 	} else {
 		// For the situation when we load a non-standard size ad, e.g. fluid ad, after
 		// previously loading a standard size ad. Ensure that the previously added min-height is
 		// removed, so that a smaller fluid ad does not have a min-height larger than it is.
-		fastdom.mutate(() => {
+		void fastdom.mutate(() => {
 			node.setAttribute('style', `min-height:unset`);
 		});
 	}

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.ts
@@ -3,7 +3,10 @@ import { getUrlVars } from '../../../../lib/url';
 import { getAdvertById } from './get-advert-by-id';
 import { enableLazyLoad } from './lazy-load';
 import { memoizedFetchNonRefreshableLineItemIds } from './non-refreshable-line-items';
+import { setAdSlotMinHeight } from './render-advert';
 import { shouldRefresh } from './should-refresh';
+
+const ADVERT_REFRESH_RATE = 30_000; // 30 seconds
 
 const setSlotAdRefresh = (
 	event: googletag.events.ImpressionViewableEvent,
@@ -13,7 +16,7 @@ const setSlotAdRefresh = (
 		return;
 	}
 
-	const viewabilityThresholdMs = 30_000; // 30 seconds refresh
+	const viewabilityThresholdMs = ADVERT_REFRESH_RATE;
 
 	// Asynchronously retrieve the non-refreshable line item ids
 	// Only do this if they haven't been attached to the page config
@@ -28,10 +31,14 @@ const setSlotAdRefresh = (
 				// Determine whether ad should refresh
 				// This value will then be checked when the timer has elapsed and
 				// we want to know whether to refresh
-				advert.shouldRefresh = shouldRefresh(
+				const shouldSlotRefresh = shouldRefresh(
 					advert,
 					nonRefreshableLineItemIds,
 				);
+
+				advert.shouldRefresh = shouldSlotRefresh;
+
+				if (shouldSlotRefresh) setAdSlotMinHeight(advert);
 			})
 			.catch((error) => {
 				log(

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.ts
@@ -1,12 +1,55 @@
 import { log } from '@guardian/libs';
+import { constants, outstreamSizes } from '@guardian/commercial-core';
 import { getUrlVars } from '../../../../lib/url';
+import fastdom from '../../../../lib/fastdom-promise';
+import { isAdSize } from './Advert';
+import type { Advert } from './Advert';
 import { getAdvertById } from './get-advert-by-id';
 import { enableLazyLoad } from './lazy-load';
 import { memoizedFetchNonRefreshableLineItemIds } from './non-refreshable-line-items';
-import { setAdSlotMinHeight } from './render-advert';
 import { shouldRefresh } from './should-refresh';
 
 const ADVERT_REFRESH_RATE = 30_000; // 30 seconds
+
+/**
+ * Prevent CLS when an advert is refreshed, by setting the
+ * min-height of the ad slot to the height of the ad.
+ */
+const setAdSlotMinHeight = async (advert: Advert): Promise<void> => {
+	// We need to know the height of the ad to set the min-height
+	if (!isAdSize(advert.size)) {
+		return;
+	}
+
+	const { size, node } = advert;
+
+	// When a passback occurs, a new ad slot is created within the original ad slot.
+	// We don't want to set a min-height on the parent ad slot, as the child ad slot
+	// may load an ad size that we are not aware of at this point. It may be shorter,
+	// which would make the min-height we set here too high.
+	// Therefore it is safer to exclude ad slots where a passback may occur.
+	const canSlotBePassedBack = Object.values(outstreamSizes).some(
+		({ width, height }) => width === size.width && height === size.height,
+	);
+	if (canSlotBePassedBack) {
+		return;
+	}
+
+	const isStandardAdSize = !size.isProxy();
+	if (isStandardAdSize) {
+		const adSlotHeight = size.height + constants.AD_LABEL_HEIGHT;
+		fastdom.mutate(() => {
+			node.setAttribute('style', `min-height:${adSlotHeight}px`);
+		});
+	} else {
+		// For the situation when we load a non-standard size ad, e.g. fluid ad, after
+		// previously loading a standard size ad. Ensure that the previously added min-height is
+		// removed, so that a smaller fluid ad does not have a min-height larger than it is.
+		fastdom.mutate(() => {
+			node.setAttribute('style', `min-height:unset`);
+		});
+	}
+};
 
 const setSlotAdRefresh = (
 	event: googletag.events.ImpressionViewableEvent,
@@ -16,7 +59,7 @@ const setSlotAdRefresh = (
 		return;
 	}
 
-	const viewabilityThresholdMs = ADVERT_REFRESH_RATE;
+	void setAdSlotMinHeight(advert);
 
 	// Asynchronously retrieve the non-refreshable line item ids
 	// Only do this if they haven't been attached to the page config
@@ -31,16 +74,10 @@ const setSlotAdRefresh = (
 				// Determine whether ad should refresh
 				// This value will then be checked when the timer has elapsed and
 				// we want to know whether to refresh
-				const shouldSlotRefresh = shouldRefresh(
+				advert.shouldRefresh = shouldRefresh(
 					advert,
 					nonRefreshableLineItemIds,
 				);
-
-				advert.shouldRefresh = shouldSlotRefresh;
-
-				if (shouldSlotRefresh) {
-					setAdSlotMinHeight(advert);
-				}
 			})
 			.catch((error) => {
 				log(
@@ -50,6 +87,8 @@ const setSlotAdRefresh = (
 				);
 			});
 	}
+
+	const viewabilityThresholdMs = ADVERT_REFRESH_RATE;
 
 	// Event listener that will load an advert once a document becomes visible
 	const onDocumentVisible = () => {
@@ -79,7 +118,7 @@ const setSlotAdRefresh = (
   Returns a function to be used as a callback for GTP 'impressionViewable' event
   Uses URL parameters.
  */
-export const onSlotViewableFunction = (): ((
+const onSlotViewableFunction = (): ((
 	event: googletag.events.ImpressionViewableEvent,
 ) => void) => {
 	const queryParams = getUrlVars();
@@ -91,3 +130,5 @@ export const onSlotViewableFunction = (): ((
 	// Nothing to do. Return an empty callback
 	return () => void 0;
 };
+
+export { onSlotViewableFunction };

--- a/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/on-slot-viewable.ts
@@ -38,7 +38,9 @@ const setSlotAdRefresh = (
 
 				advert.shouldRefresh = shouldSlotRefresh;
 
-				if (shouldSlotRefresh) setAdSlotMinHeight(advert);
+				if (shouldSlotRefresh) {
+					setAdSlotMinHeight(advert);
+				}
 			})
 			.catch((error) => {
 				log(

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.ts
@@ -3,6 +3,7 @@ import { $$ } from '../../../../lib/$$';
 import fastdom from '../../../../lib/fastdom-promise';
 import reportError from '../../../../lib/report-error';
 import type { Advert } from './Advert';
+import { isAdSize } from './Advert';
 import { getAdIframe } from './get-ad-iframe';
 import { renderAdvertLabel } from './render-advert-label';
 
@@ -141,7 +142,7 @@ const addContentClass = (adSlotNode: HTMLElement) => {
  * min-height of the ad slot to the height of the ad.
  */
 const setAdSlotMinHeight = (advert: Advert): void => {
-	if (advert.size === null || advert.size === 'fluid') {
+	if (!advert.shouldRefresh || !isAdSize(advert.size)) {
 		return;
 	}
 
@@ -171,7 +172,6 @@ const renderAdvert = (
 	slotRenderEndedEvent: googletag.events.SlotRenderEndedEvent,
 ): Promise<boolean> => {
 	addContentClass(advert.node);
-	setAdSlotMinHeight(advert);
 
 	return getAdIframe(advert.node)
 		.then((isRendered) => {
@@ -220,4 +220,4 @@ const renderAdvert = (
 		});
 };
 
-export { renderAdvert };
+export { renderAdvert, setAdSlotMinHeight };

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.ts
@@ -1,4 +1,4 @@
-import { adSizes, constants } from '@guardian/commercial-core';
+import { adSizes, constants, outstreamSizes } from '@guardian/commercial-core';
 import { $$ } from '../../../../lib/$$';
 import fastdom from '../../../../lib/fastdom-promise';
 import reportError from '../../../../lib/report-error';
@@ -146,18 +146,29 @@ const setAdSlotMinHeight = (advert: Advert): void => {
 		return;
 	}
 
-	const isStandardAdSize = !advert.size.isProxy();
+	const { size, node } = advert;
+
+	// Don't set a min-height on ad slots that can be passed back.
+	// The ad that loads may be shorter than the original ad height.
+	const canSlotBePassedBack = Object.values(outstreamSizes).some(
+		({ width, height }) => width === size.width && height === size.height,
+	);
+	if (canSlotBePassedBack) {
+		return;
+	}
+
+	const isStandardAdSize = !size.isProxy();
 	if (isStandardAdSize) {
-		const adSlotHeight = advert.size.height + constants.AD_LABEL_HEIGHT;
+		const adSlotHeight = size.height + constants.AD_LABEL_HEIGHT;
 		void fastdom.mutate(() => {
-			advert.node.setAttribute('style', `min-height:${adSlotHeight}px`);
+			node.setAttribute('style', `min-height:${adSlotHeight}px`);
 		});
 	} else {
 		// For the situation when we load a non-standard size ad, e.g. fluid ad, after
 		// previously loading a standard size ad. Ensure that the previously added min-height is
 		// removed, so that a smaller fluid ad does not have a min-height larger than it is.
 		void fastdom.mutate(() => {
-			advert.node.setAttribute('style', `min-height:unset`);
+			node.setAttribute('style', `min-height:unset`);
 		});
 	}
 };

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.ts
@@ -1,9 +1,8 @@
-import { adSizes, constants, outstreamSizes } from '@guardian/commercial-core';
+import { adSizes } from '@guardian/commercial-core';
 import { $$ } from '../../../../lib/$$';
 import fastdom from '../../../../lib/fastdom-promise';
 import reportError from '../../../../lib/report-error';
-import type { Advert } from './Advert';
-import { isAdSize } from './Advert';
+import { Advert } from './Advert';
 import { getAdIframe } from './get-ad-iframe';
 import { renderAdvertLabel } from './render-advert-label';
 
@@ -138,45 +137,6 @@ const addContentClass = (adSlotNode: HTMLElement) => {
 };
 
 /**
- * Prevent CLS when an advert is refreshed, by setting the
- * min-height of the ad slot to the height of the ad.
- */
-const setAdSlotMinHeight = (advert: Advert): void => {
-	if (!advert.shouldRefresh || !isAdSize(advert.size)) {
-		return;
-	}
-
-	const { size, node } = advert;
-
-	// When a passback occurs, a new ad slot is created within the original ad slot.
-	// We don't want to set a min-height on the parent ad slot, as the child ad slot
-	// may load an ad size that we are not aware of at this point. It may be shorter,
-	// which would make the min-height we set here too high.
-	// Therefore it is safer to exclude ad slots where a passback may occur.
-	const canSlotBePassedBack = Object.values(outstreamSizes).some(
-		({ width, height }) => width === size.width && height === size.height,
-	);
-	if (canSlotBePassedBack) {
-		return;
-	}
-
-	const isStandardAdSize = !size.isProxy();
-	if (isStandardAdSize) {
-		const adSlotHeight = size.height + constants.AD_LABEL_HEIGHT;
-		void fastdom.mutate(() => {
-			node.setAttribute('style', `min-height:${adSlotHeight}px`);
-		});
-	} else {
-		// For the situation when we load a non-standard size ad, e.g. fluid ad, after
-		// previously loading a standard size ad. Ensure that the previously added min-height is
-		// removed, so that a smaller fluid ad does not have a min-height larger than it is.
-		void fastdom.mutate(() => {
-			node.setAttribute('style', `min-height:unset`);
-		});
-	}
-};
-
-/**
  * @param advert - as defined in commercial/modules/dfp/Advert
  * @param slotRenderEndedEvent - GPT slotRenderEndedEvent
  * @returns {Promise} - resolves once all necessary rendering is queued up
@@ -233,4 +193,4 @@ const renderAdvert = (
 		});
 };
 
-export { renderAdvert, setAdSlotMinHeight };
+export { renderAdvert };

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.ts
@@ -2,7 +2,7 @@ import { adSizes } from '@guardian/commercial-core';
 import { $$ } from '../../../../lib/$$';
 import fastdom from '../../../../lib/fastdom-promise';
 import reportError from '../../../../lib/report-error';
-import { Advert } from './Advert';
+import type { Advert } from './Advert';
 import { getAdIframe } from './get-ad-iframe';
 import { renderAdvertLabel } from './render-advert-label';
 

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.ts
@@ -218,7 +218,6 @@ const renderAdvert = (
 			return callSizeCallback()
 				.then(() => renderAdvertLabel(advert.node))
 				.then(addRenderedClass)
-				.then(() => setAdSlotMinHeight(advert))
 				.then(() => isRendered);
 		})
 		.catch((err) => {

--- a/static/src/javascripts/projects/commercial/modules/dfp/render-advert.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/render-advert.ts
@@ -148,8 +148,11 @@ const setAdSlotMinHeight = (advert: Advert): void => {
 
 	const { size, node } = advert;
 
-	// Don't set a min-height on ad slots that can be passed back.
-	// The ad that loads may be shorter than the original ad height.
+	// When a passback occurs, a new ad slot is created within the original ad slot.
+	// We don't want to set a min-height on the parent ad slot, as the child ad slot
+	// may load an ad size that we are not aware of at this point. It may be shorter,
+	// which would make the min-height we set here too high.
+	// Therefore it is safer to exclude ad slots where a passback may occur.
 	const canSlotBePassedBack = Object.values(outstreamSizes).some(
 		({ width, height }) => width === size.width && height === size.height,
 	);

--- a/static/src/javascripts/projects/commercial/modules/dfp/should-refresh.spec.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/should-refresh.spec.ts
@@ -1,8 +1,12 @@
 import { adSizes, createAdSize } from '@guardian/commercial-core';
 import { Advert } from './Advert';
-import { _, shouldRefresh } from './should-refresh';
+import { shouldRefresh } from './should-refresh';
 
-const { outstreamSizes } = _;
+const outstreamSizes = [
+	adSizes.outstreamDesktop.toString(),
+	adSizes.outstreamMobile.toString(),
+	adSizes.outstreamGoogleDesktop.toString(),
+];
 
 describe('shouldRefresh', () => {
 	let googleSlot: googletag.Slot;

--- a/static/src/javascripts/projects/commercial/modules/dfp/should-refresh.ts
+++ b/static/src/javascripts/projects/commercial/modules/dfp/should-refresh.ts
@@ -1,12 +1,6 @@
-import type { AdSizeString } from '@guardian/commercial-core';
-import { adSizes } from '@guardian/commercial-core';
+import type { AdSize, AdSizeString } from '@guardian/commercial-core';
+import { outstreamSizes } from '@guardian/commercial-core';
 import type { Advert } from './Advert';
-
-const outstreamSizes = [
-	adSizes.outstreamDesktop.toString(),
-	adSizes.outstreamMobile.toString(),
-	adSizes.outstreamGoogleDesktop.toString(),
-];
 
 /**
  * Determine whether an advert should refresh, taking into account
@@ -37,7 +31,9 @@ export const shouldRefresh = (
 	if (isFluid) return false;
 
 	// Outstream adverts should not refresh
-	const isOutstream = outstreamSizes.includes(sizeString as AdSizeString);
+	const isOutstream = Object.values(outstreamSizes)
+		.map((size: AdSize) => size.toString())
+		.includes(sizeString as AdSizeString);
 	if (isOutstream) return false;
 
 	// If the advert has a line item id included in the array of non refreshable
@@ -52,8 +48,4 @@ export const shouldRefresh = (
 
 	// If none of the other conditions are met then the advert should refresh
 	return true;
-};
-
-export const _ = {
-	outstreamSizes,
 };

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -290,6 +290,7 @@
   "../projects/commercial/modules/dfp/get-advert-by-id.ts",
   "../projects/commercial/modules/dfp/lazy-load.ts",
   "../projects/commercial/modules/dfp/non-refreshable-line-items.ts",
+  "../projects/commercial/modules/dfp/render-advert.ts",
   "../projects/commercial/modules/dfp/should-refresh.ts"
  ],
  "../projects/commercial/modules/dfp/prepare-a9.ts": [

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -285,12 +285,14 @@
   "../projects/commercial/modules/dfp/should-refresh.ts"
  ],
  "../projects/commercial/modules/dfp/on-slot-viewable.ts": [
+  "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
+  "../lib/fastdom-promise.js",
   "../lib/url.ts",
+  "../projects/commercial/modules/dfp/Advert.ts",
   "../projects/commercial/modules/dfp/get-advert-by-id.ts",
   "../projects/commercial/modules/dfp/lazy-load.ts",
   "../projects/commercial/modules/dfp/non-refreshable-line-items.ts",
-  "../projects/commercial/modules/dfp/render-advert.ts",
   "../projects/commercial/modules/dfp/should-refresh.ts"
  ],
  "../projects/commercial/modules/dfp/prepare-a9.ts": [


### PR DESCRIPTION
## What does this change?

- Set min-height for refreshable ad slots that load a standard size ad. This will ensure that the ad container does not shrink to a smaller size than either ad (the original or the one after the refresh) between the original ad being removed and the next ad being loaded.

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots

Before - desktop

https://user-images.githubusercontent.com/9574885/196895485-485c5caa-d64e-4da4-b5ca-9f8ea81747b7.mov

Before - mobile

https://user-images.githubusercontent.com/9574885/196934793-a8383de1-e875-4ff3-80da-9868e4e3f183.mov

After - desktop

https://user-images.githubusercontent.com/9574885/196934772-1279143c-56db-40e7-b1bd-dfc94a0258ea.mov

After - mobile

https://user-images.githubusercontent.com/9574885/196934809-99a4ee26-c56f-4c45-85a0-220140051e66.mov

## What is the value of this and can you measure success?

- This improves user experience when ads refresh, particularly on mobile where ad height is typically a larger proportion of viewport height than on desktop, as you no longer get the flash of content moving up to fill the space left behind by the ad being removed. It handles the general case, an improvement on existing functionality which only considered top-above-nav: [25564](https://github.com/guardian/frontend/pull/25564).

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist

<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [x] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
