### PR TITLE
email embed pages inform parent when page loads

### DIFF
--- a/common/app/templates/inlineJS/nonBlocking/signUpIframeCaptcha.scala.js
+++ b/common/app/templates/inlineJS/nonBlocking/signUpIframeCaptcha.scala.js
@@ -49,7 +49,7 @@ function onSubmit(e) {
             script.src =
                 'https://www.google.com/recaptcha/api.js?onload=onRecaptchaScriptLoaded&render=explicit';
             d.getElementsByTagName('head')[0].appendChild(script);
-        })(document);
+        })(document, undefined);
     } else { // grecaptcha has already been loaded and rendered, but been dismissed or expired
         openCaptcha()
     }

--- a/common/app/views/emailEmbed.scala.html
+++ b/common/app/views/emailEmbed.scala.html
@@ -57,7 +57,7 @@
             }
 
             window.addEventListener('DOMContentLoaded', informParentOfLoad);
-            revealPrivacyWordingWhenUserInteractsWithEmailField();
+            revealPrivacyWordingWhenUserInteractsWithEmailField()
         </script>
     }
 

--- a/common/app/views/emailEmbed.scala.html
+++ b/common/app/views/emailEmbed.scala.html
@@ -49,7 +49,15 @@
                 });
             }
 
-            revealPrivacyWordingWhenUserInteractsWithEmailField()
+            function informParentOfLoad(loadEvent) {
+                window.parent.postMessage({
+                    subject: 'emailEmbedPageLoaded',
+                    path: window.location.pathname,
+                }, window.origin);
+            }
+
+            window.addEventListener('DOMContentLoaded', informParentOfLoad);
+            revealPrivacyWordingWhenUserInteractsWithEmailField();
         </script>
     }
 


### PR DESCRIPTION
## What does this change?
Adds function to the page template for email - embed form pages to post a message to the parent window to inform it when a new page loads - I.E. when the form page changes to the "success" or "failure" page.

This is to help address a colour contrast issue in sign-up thrashers. Although the "thrasher" versions form pages can be styled to fit the background used in the thrasher (parent window) - I.E. the form can be styled have white text to contrast with a dark background-  there is only one version of the "success" or "failure" page and always uses black text. 

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

## Screenshots (issue we intend to address)

issue - low contrast on the dark coloured container:
<img width="957" alt="Screenshot 2022-10-17 at 18 13 47" src="https://user-images.githubusercontent.com/30567854/196241117-6ff687d4-fe27-443b-9c74-369d160cc23a.png">


## What is the value of this and can you measure success?
Parent window loading using the forms in iframes will be able to detect when the iframe location change to the success or failure page.

The first application will be for thrashers using dark backgrounds to apply styling to the success / failure pages to improve colour contrasts.

## Checklist

### Does this affect other platforms?

- [ ] AMP <!-- AMP question? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/16-working-with-amp.md -->
- [ ] Apps
- [ ] Other (please specify)

### Does this affect GLabs Paid Content Pages? Should it have support for Paid Content?

<!-- if there are versions of this content with the paid styling (teal and grey) then they will need to be checked -->
<!-- content can be found here: https://www.theguardian.com/tone/advertisement-features -->

- [x] No
- [ ] Yes (please give details)

### Does this change break ad-free?

<!-- The scope for this includes, but is not limited to, ad-slots, page targeting, podcasts, rich links, outbrain, -->
<!-- merchandising, page skins and paid-for content -->
<!-- If there's any chance it could cause problems, please test it with an appropriate test user or add a new test -->
<!-- scenario -->

- [x] No
- [ ] It did, but tests caught it and I fixed it
- [ ] It did, but there was no test coverage so I added that then fixed it

### Does this change update the version of CAPI we're using?

<!-- Please see the notes linked below if you need further info. -->

- [x] No, all the existing database files are just fine
- [ ] Yes, and I have [re-run all the tests locally and checked in all the updated data/database/xyz files](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/15-updating-test-database.md)

### Accessibility test checklist
Although, this PR is intended to resolve a colour contrast issue, it does not make visual changes itself - the thrashers will make those.
<!-- for changes that affect how a page appears in the browser -->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
- [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

### Tested

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
