### PR TITLE
feat: Add new DCR /show-more/ endpoint.

### DIFF
--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -355,7 +355,6 @@ trait FaciaController
     Action.async { implicit request =>
       frontJsonFapi.get(path, fullRequestType).flatMap {
         case Some(pressedPage) if request.forceDCR =>
-
           val maybeResponse = for {
             collection <- pressedPage.collections.find(_.id == collectionId)
           } yield {
@@ -369,7 +368,7 @@ trait FaciaController
             })
           }
           maybeResponse.getOrElse { successful(Cached(CacheTime.NotFound)(WithoutRevalidationResult(NotFound))) }
-        case Some(pressedPage)  =>
+        case Some(pressedPage) =>
           val containers = Front.fromPressedPage(pressedPage, Edition(request), adFree = request.isAdFree).containers
           val maybeResponse =
             for {


### PR DESCRIPTION
Co-authored-by: Pete Faulconbridge <peter.faulconbridge@gmail.com>

## What does this change?

Adds a new JSON endpoint that returns all cards for a given path and container. This is part of the DCR Show More implementation RFC

Part of guardian/dotcom-rendering#4604
Part of guardian/dotcom-rendering#6181