### PR TITLE
Bump `commercial-core` to `4.17.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@guardian/atom-renderer": "1.2.2",
 		"@guardian/automat-modules": "^0.3.8",
 		"@guardian/braze-components": "^7.4.0",
-		"@guardian/commercial-core": "4.15.0",
+		"@guardian/commercial-core": "4.17.0",
 		"@guardian/consent-management-platform": "^10.11.1",
 		"@guardian/libs": "^7.1.4",
 		"@guardian/shimport": "^1.0.2",
@@ -220,8 +220,8 @@
 		"test": "jest",
 		"cypress:open": "cypress open --e2e --browser=chrome",
 		"cypress:run": "cypress run --spec 'cypress/e2e/**/*'",
-    "cypress:open:snapshot": "cypress open --e2e --browser=chrome --config specPattern='cypress/snapshot/**/*'",
-    "cypress:run:snapshot": "percy exec -- cypress run --config specPattern='cypress/snapshot/**/*'"
+		"cypress:open:snapshot": "cypress open --e2e --browser=chrome --config specPattern='cypress/snapshot/**/*'",
+		"cypress:run:snapshot": "percy exec -- cypress run --config specPattern='cypress/snapshot/**/*'"
 	},
 	"prettier": "@guardian/prettier"
 }

--- a/static/src/javascripts/projects/commercial/modules/consentless/prepare-ootag.ts
+++ b/static/src/javascripts/projects/commercial/modules/consentless/prepare-ootag.ts
@@ -3,7 +3,6 @@ import type { ConsentState } from '@guardian/consent-management-platform/dist/ty
 import { loadScript } from '@guardian/libs';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { getSynchronousParticipations } from 'common/modules/experiments/ab';
-import { getCountryCode } from 'lib/geolocation';
 
 function initConsentless(consentState: ConsentState): Promise<void> {
 	// Stub the command queue
@@ -22,7 +21,6 @@ function initConsentless(consentState: ConsentState): Promise<void> {
 			buildPageTargetingConsentless(
 				consentState,
 				commercialFeatures.adFree,
-				getCountryCode(),
 				getSynchronousParticipations(),
 			),
 		).forEach(([key, value]) => {

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.ts
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.ts
@@ -3,7 +3,6 @@ import { buildPageTargeting } from '@guardian/commercial-core';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import { log } from '@guardian/libs';
 import { once } from 'lodash-es';
-import { getCountryCode } from '../../../../lib/geolocation';
 import { removeFalseyValues } from '../../../commercial/modules/header-bidding/utils';
 import { getSynchronousParticipations } from '../experiments/ab';
 import { commercialFeatures } from './commercial-features';
@@ -48,7 +47,6 @@ const getPageTargeting = (consentState: ConsentState): PageTargeting => {
 	const pageTargeting = buildPageTargeting(
 		consentState,
 		commercialFeatures.adFree,
-		getCountryCode(),
 		getSynchronousParticipations(),
 	);
 

--- a/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
+++ b/tools/__tasks__/commercial/graph/output/standalone.commercial.ts.json
@@ -164,7 +164,6 @@
   "../../../../node_modules/@guardian/commercial-core/dist/cjs/index.d.ts",
   "../../../../node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
-  "../lib/geolocation.ts",
   "../projects/common/modules/commercial/commercial-features.ts"
  ],
  "../projects/commercial/modules/consentless/render-advert-label.ts": [
@@ -616,7 +615,6 @@
   "../../../../node_modules/@guardian/consent-management-platform/dist/types/index.d.ts",
   "../../../../node_modules/@guardian/libs/dist/types/index.d.ts",
   "../../../../node_modules/@types/lodash-es/index.d.ts",
-  "../lib/geolocation.ts",
   "../projects/commercial/modules/header-bidding/utils.ts",
   "../projects/common/modules/commercial/commercial-features.ts"
  ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2089,10 +2089,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/braze-components/-/braze-components-7.4.0.tgz#cccd1e39156a12ca4304bfb4f6113d41521af753"
   integrity sha512-r3+yM/qh45g1gI/FCD1ooCwOntcHnemcjo/E+phgYLvXGGDG82l6AzdMVyC8c4ZGfeFu2EnUPhHALUMyaT/qdg==
 
-"@guardian/commercial-core@4.15.0":
-  version "4.15.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.15.0.tgz#9876db3a0f1cc750c91f1382d95a0f845778e857"
-  integrity sha512-Wq3PGsKOqi3KAtLSVMR6CatATnkGwSVyW8S5Usaks+z0DxpQCkTBwNm4ZSVztL9ROHS6GHfv3hsUnX/3dwXDDw==
+"@guardian/commercial-core@4.17.0":
+  version "4.17.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.17.0.tgz#b1edaa320f842a70f49a0b472795c8d7460009cd"
+  integrity sha512-YO87L8O8dELF584xbiCvX+ngeEpweyhtdxpihgH3WqOE0V2WWN52jzL+HQ+7T2LhPBBe7SVxPL32hAiVYtgs2Q==
 
 "@guardian/consent-management-platform@^10.11.1":
   version "10.11.1"


### PR DESCRIPTION
## What does this change?

Bumps `commercial-core` to `4.17.0`.

This means we no longer need to pass `countryCode` into:

- `buildPageTargeting()`
- `buildPageTargetingConsentless()`

See: https://github.com/guardian/commercial-core/pull/694

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

- [ ] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
