### PR TITLE
Fronts with containers targeting AU region are not supported by DCR

### DIFF
--- a/common/test/common/facia/PressedCollectionBuilder.scala
+++ b/common/test/common/facia/PressedCollectionBuilder.scala
@@ -1,6 +1,7 @@
 package common.facia
 
 import FixtureBuilder.mkPressedContent
+import com.gu.facia.client.models.TargetedTerritory
 import model.facia.PressedCollection
 import model.pressed.{CollectionConfig, PressedContent}
 
@@ -13,6 +14,7 @@ object PressedCollectionBuilder {
       curated: List[PressedContent] = defaultCurated,
       backfill: List[PressedContent] = defaultBackfill,
       hideShowMore: Boolean = false,
+      targetedTerritory: Option[TargetedTerritory] = None,
   ): PressedCollection = {
 
     val config: CollectionConfig = CollectionConfig(
@@ -56,7 +58,7 @@ object PressedCollectionBuilder {
       showLatestUpdate = false,
       config,
       hasMore = false,
-      targetedTerritory = None,
+      targetedTerritory = targetedTerritory,
     )
   }
 }

--- a/facia/app/services/dotcomrendering/FaciaPicker.scala
+++ b/facia/app/services/dotcomrendering/FaciaPicker.scala
@@ -104,6 +104,19 @@ object FrontChecks {
     !faciaPage.collections.exists(collection => collection.curated.exists(card => card.isPaidFor))
   }
 
+  def hasNoRegionalAusTargetedContainers(faciaPage: PressedPage): Boolean = {
+    // We don't support the Aus region selector component
+    // https://github.com/guardian/dotcom-rendering/issues/6234
+    !faciaPage.collections.exists(collection =>
+      collection.targetedTerritory.exists(_.id match {
+        case "AU-VIC" => true
+        case "AU-QLD" => true
+        case "AU-NSW" => true
+        case _        => false
+      }),
+    )
+  }
+
 }
 
 class FaciaPicker extends GuLogging {
@@ -117,6 +130,7 @@ class FaciaPicker extends GuLogging {
       ("hasNoSlideshows", FrontChecks.hasNoSlideshows(faciaPage)),
       ("isNotPaidContent", FrontChecks.isNotPaidContent(faciaPage)),
       ("hasNoPaidForCards", FrontChecks.hasNoPaidForCards(faciaPage)),
+      ("hasNoRegionalAusTargetedContainers", FrontChecks.hasNoRegionalAusTargetedContainers(faciaPage)),
     )
   }
 

--- a/facia/test/services/dotcomrendering/FaciaPickerTest.scala
+++ b/facia/test/services/dotcomrendering/FaciaPickerTest.scala
@@ -1,6 +1,8 @@
 package services.dotcomrendering
 
 import common.facia.{FixtureBuilder, PressedCollectionBuilder}
+import com.gu.facia.client.models.{AUQueenslandTerritory}
+
 import org.scalatest.DoNotDiscover
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -85,5 +87,16 @@ import org.scalatestplus.mockito.MockitoSugar
 
     val tier = FaciaPicker.decideTier(isRSS, forceDCROff, forceDCR, participatingInTest, dcrCouldRender)
     tier should be(LocalRender)
+  }
+
+  "Facia Picker hasNoRegionalAusTargetedContainers" should
+    "return false if there is a container with targetedTerritory set to an AU region" in {
+    val unsupportedPressedCollection =
+      List(
+        PressedCollectionBuilder.mkPressedCollection(targetedTerritory = Some(AUQueenslandTerritory)),
+      )
+
+    val faciaPage = FixtureBuilder.mkPressedPage(unsupportedPressedCollection)
+    FrontChecks.hasNoRegionalAusTargetedContainers(faciaPage) should be(false)
   }
 }


### PR DESCRIPTION

## What does this change?

Updates facia-picker so it knows not to render these fronts on DCR

## Does this change need to be reproduced in dotcom-rendering ?

- [x] No
- [ ] Yes (please indicate your plans for DCR Implementation)

### Tested

I've written unit tests for this func

- [x] Locally
- [ ] On CODE (optional)

<!-- AB test? https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md -->
<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/frontend/blob/main/.github/CONTRIBUTING.md -->

<!-- Unsure who to ask for a review? Tag https://github.com/orgs/guardian/teams/guardian-frontend-team to reach the team -->
